### PR TITLE
fix(storage): separate token storage formats to prevent duplication

### DIFF
--- a/impl/nodejs/storage/FileTokenStorageProvider.ts
+++ b/impl/nodejs/storage/FileTokenStorageProvider.ts
@@ -87,10 +87,23 @@ export class FileTokenStorageProvider implements TokenStorageProvider<TxfStorage
 
       for (const file of files) {
         try {
+          const basename = path.basename(file, '.json');
+          // Skip file-format entries (token-, nametag-) - they are loaded via loadTokensFromFileStorage
+          if (basename.startsWith('token-') || basename.startsWith('nametag-')) {
+            continue;
+          }
+
           const content = fs.readFileSync(path.join(this.tokensDir, file), 'utf-8');
           const token = JSON.parse(content);
-          const key = `_${path.basename(file, '.json')}` as `_${string}`;
-          data[key] = token;
+
+          if (basename.startsWith('archived-')) {
+            // Archived tokens: keep as-is (archived-tokenId key)
+            data[basename as keyof TxfStorageDataBase] = token;
+          } else {
+            // Other entries: add _ prefix for TXF format
+            const key = `_${basename}` as `_${string}`;
+            data[key] = token;
+          }
         } catch {
           // Skip invalid files
         }
@@ -120,12 +133,22 @@ export class FileTokenStorageProvider implements TokenStorageProvider<TxfStorage
         JSON.stringify(data._meta, null, 2)
       );
 
-      // Save each token
+      // Save each token (active tokens start with _, archived with archived-)
+      const reservedKeys = ['_meta', '_tombstones', '_outbox', '_sent', '_invalid'];
       for (const [key, value] of Object.entries(data)) {
-        if (key.startsWith('_') && key !== '_meta' && key !== '_tombstones' && key !== '_outbox' && key !== '_sent' && key !== '_invalid') {
+        if (reservedKeys.includes(key)) continue;
+
+        if (key.startsWith('_')) {
+          // Active token: _tokenId -> tokenId.json
           const tokenId = key.slice(1);
           fs.writeFileSync(
             path.join(this.tokensDir, `${tokenId}.json`),
+            JSON.stringify(value, null, 2)
+          );
+        } else if (key.startsWith('archived-')) {
+          // Archived token: archived-tokenId -> archived-tokenId.json (keep prefix)
+          fs.writeFileSync(
+            path.join(this.tokensDir, `${key}.json`),
             JSON.stringify(value, null, 2)
           );
         }

--- a/types/txf.ts
+++ b/types/txf.ts
@@ -240,7 +240,7 @@ export interface TokenValidationResult {
 // Key Utilities
 // =============================================================================
 
-const ARCHIVED_PREFIX = '_archived_';
+const ARCHIVED_PREFIX = 'archived-';
 const FORKED_PREFIX = '_forked_';
 const RESERVED_KEYS = ['_meta', '_nametag', '_tombstones', '_invalidatedNametags', '_outbox', '_mintOutbox', '_sent', '_invalid', '_integrity'];
 


### PR DESCRIPTION
- Change archived token prefix from _archived_ to archived-
- Active tokens stored only as token-xxx files (not in TXF format)
- Filter token-xxx entries in loadTokensFromFileStorage() to prevent loading archived- and nametag- entries as tokens
- Fix save/load in IndexedDB and File providers to handle archived- prefix correctly

This fixes issues where:
1. Tokens were duplicated (stored in both TXF and token-xxx formats)
2. Archived tokens appeared as active tokens after page reload
3. Wrong tokens displayed due to incorrect parsing of archived- entries