### PR TITLE
feat: add getAssets() method for aggregated token balances by coinId

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -82,6 +82,16 @@ export interface TokenBalance {
   readonly decimals: number;
 }
 
+export interface Asset {
+  readonly coinId: string;
+  readonly symbol: string;
+  readonly name: string;
+  readonly decimals: number;
+  readonly iconUrl?: string;
+  readonly totalAmount: string;
+  readonly tokenCount: number;
+}
+
 // =============================================================================
 // Transfer Types
 // =============================================================================


### PR DESCRIPTION
Add Asset interface and getAssets() method to PaymentsModule that groups confirmed tokens by coinId, sums amounts via BigInt, and returns aggregated asset list with symbol, name, decimals, iconUrl and token count.