### PR TITLE
fix: payment request senderNametag and docs cleanup

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -305,7 +305,7 @@ interface PaymentRequest {
   amount: string;           // Amount in smallest units
   coinId: string;           // Token type (e.g., 'ALPHA')
   message?: string;         // Optional message
-  recipientNametag?: string; // Who should pay
+  recipientNametag?: string; // Where tokens should be sent
   metadata?: Record<string, unknown>;
 }
 
@@ -339,10 +339,11 @@ interface IncomingPaymentRequest {
   coinId: string;              // Token type
   symbol: string;              // Token symbol for display
   message?: string;            // Request message
-  recipientNametag?: string;   // Our nametag (if specified)
+  recipientNametag?: string;   // Requester's nametag (where to send tokens)
   requestId: string;           // Original request ID
   timestamp: number;           // Request timestamp
   status: PaymentRequestStatus;
+  metadata?: Record<string, unknown>; // Custom metadata
 }
 
 // Example

--- a/docs/QUICKSTART-NODEJS.md
+++ b/docs/QUICKSTART-NODEJS.md
@@ -265,7 +265,7 @@ console.log(addr.address, addr.publicKey);
 sphere.on('transfer:incoming', handler);
 sphere.on('transfer:sent', handler);
 sphere.on('transfer:pending', handler);
-sphere.on('payment_request:received', handler);
+sphere.on('payment_request:incoming', handler);
 sphere.on('payment_request:paid', handler);
 sphere.on('message:dm', handler);
 sphere.on('message:broadcast', handler);

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -157,7 +157,7 @@ async function parseTokenInfo(tokenData: unknown): Promise<ParsedTokenInfo> {
 
       // Try to get token ID
       if (sdkToken.id) {
-        defaultInfo.tokenId = sdkToken.id.toString();
+        defaultInfo.tokenId = sdkToken.id.toJSON();
       }
 
       // Extract coinId from SDK token's coins structure (lottery-compatible)
@@ -1510,12 +1510,17 @@ export class PaymentsModule {
     }
 
     // Convert transport request to IncomingPaymentRequest
+    const coinId = transportRequest.request.coinId;
+    const registry = TokenRegistry.getInstance();
+    const coinDef = registry.getDefinition(coinId);
+
     const request: IncomingPaymentRequest = {
       id: transportRequest.id,
       senderPubkey: transportRequest.senderTransportPubkey,
+      senderNametag: transportRequest.senderNametag,
       amount: transportRequest.request.amount,
-      coinId: transportRequest.request.coinId,
-      symbol: transportRequest.request.coinId, // Use coinId as symbol for now
+      coinId,
+      symbol: coinDef?.symbol || coinId.slice(0, 8),
       message: transportRequest.request.message,
       recipientNametag: transportRequest.request.recipientNametag,
       requestId: transportRequest.request.requestId,

--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -1323,6 +1323,7 @@ export class NostrTransportProvider implements TransportProvider {
       const request: IncomingPaymentRequest = {
         id: event.id,
         senderTransportPubkey: event.pubkey,
+        senderNametag: requestData.recipientNametag,
         request: {
           requestId: requestData.requestId,
           amount: requestData.amount,

--- a/transport/transport-provider.ts
+++ b/transport/transport-provider.ts
@@ -324,6 +324,8 @@ export interface IncomingPaymentRequest {
   id: string;
   /** Transport-specific pubkey of sender */
   senderTransportPubkey: string;
+  /** Sender's nametag (if included in encrypted content) */
+  senderNametag?: string;
   /** Parsed request data */
   request: {
     requestId: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -152,7 +152,7 @@ export interface PaymentRequest {
   readonly coinId: string;
   /** Optional message/memo */
   readonly message?: string;
-  /** Recipient nametag (who should pay) */
+  /** Where tokens should be sent */
   readonly recipientNametag?: string;
   /** Custom metadata */
   readonly metadata?: Record<string, unknown>;
@@ -180,7 +180,7 @@ export interface IncomingPaymentRequest {
   readonly symbol: string;
   /** Message from sender */
   readonly message?: string;
-  /** Who this request is for (our nametag) */
+  /** Requester's nametag (where tokens should be sent) */
   readonly recipientNametag?: string;
   /** Original request ID from sender */
   readonly requestId: string;


### PR DESCRIPTION
- Use recipientNametag as senderNametag on receiver side (works for both sphere-sdk and nostr-js-sdk senders)
- Remove redundant senderNametag from encrypted payload in sendPaymentRequest
- Remove unused senderNametag from parsed type in handlePaymentRequest
- Fix recipientNametag JSDoc in PaymentRequest: "who should pay" → "where tokens should be sent"
- Fix recipientNametag JSDoc in IncomingPaymentRequest: "our nametag" → "requester's nametag"
- Fix event name in QUICKSTART-NODEJS.md: payment_request:received → payment_request:incoming
- Add missing metadata field to IncomingPaymentRequest in API.md