### PR TITLE
feat: persist last wallet event timestamp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,6 +386,14 @@ npm run type-check
 - `transportPubkey`: Derived key for transport messaging (HKDF from private key)
 - Identity binding events include both for cross-resolution
 
+### Event Timestamp Persistence
+- Transport persists last processed wallet event timestamp via `TransportStorageAdapter`
+- Storage key: `last_wallet_event_ts_{pubkey_prefix}` (per-wallet, in `STORAGE_KEYS_GLOBAL`)
+- On reconnect: `since = stored timestamp` (existing wallet) or `since = now` (fresh wallet)
+- Only wallet events update the timestamp (TOKEN_TRANSFER, PAYMENT_REQUEST, PAYMENT_REQUEST_RESPONSE, DIRECT_MESSAGE)
+- Chat events (GIFT_WRAP/NIP-17) have no `since` filter — always real-time
+- Factory functions (`createBrowserProviders`, `createNodeProviders`) pass storage to transport automatically
+
 ### Token Storage (TXF Format)
 ```typescript
 TxfStorageDataBase {
@@ -400,11 +408,11 @@ TxfStorageDataBase {
 ## Testing
 
 **Framework:** Vitest
-**Total tests:** 882 (34 test files)
+**Total tests:** 893 (34 test files)
 
 Key test files:
 - `tests/unit/core/Sphere.nametag-sync.test.ts` - Nametag sync/recovery
-- `tests/unit/transport/NostrTransportProvider.test.ts` - Transport layer
+- `tests/unit/transport/NostrTransportProvider.test.ts` - Transport layer, event timestamp persistence
 - `tests/unit/modules/PaymentsModule.test.ts` - Payment operations
 - `tests/unit/modules/NametagMinter.test.ts` - Nametag minting
 - `tests/unit/price/CoinGeckoPriceProvider.test.ts` - Price provider

--- a/constants.ts
+++ b/constants.ts
@@ -44,6 +44,8 @@ export const STORAGE_KEYS_GLOBAL = {
   ADDRESS_NAMETAGS: 'address_nametags',
   /** Active addresses registry (JSON: TrackedAddressesStorage) */
   TRACKED_ADDRESSES: 'tracked_addresses',
+  /** Last processed Nostr wallet event timestamp (unix seconds), keyed per pubkey */
+  LAST_WALLET_EVENT_TS: 'last_wallet_event_ts',
 } as const;
 
 /**

--- a/docs/API.md
+++ b/docs/API.md
@@ -902,6 +902,7 @@ createIpfsStorageProvider(config?: IpfsStorageProviderConfig): IpfsStorageProvid
 
 // Transport
 createNostrTransportProvider(config?: NostrTransportProviderConfig): NostrTransportProvider
+// NostrTransportProviderConfig accepts optional `storage` for event timestamp persistence
 
 // Oracle
 createUnicityAggregatorProvider(config?: UnicityAggregatorProviderConfig): UnicityAggregatorProvider
@@ -921,6 +922,37 @@ createTokenSplitExecutor(client, trustBase): TokenSplitExecutor
 // Validation
 createTokenValidator(options?: TokenValidatorOptions): TokenValidator
 ```
+
+---
+
+## NostrTransportProviderConfig
+
+```typescript
+interface NostrTransportProviderConfig {
+  relays?: string[];                // Nostr relay URLs
+  timeout?: number;                 // Connection timeout (ms)
+  autoReconnect?: boolean;          // Auto-reconnect on disconnect
+  reconnectDelay?: number;          // Reconnect delay (ms)
+  maxReconnectAttempts?: number;    // Max reconnect attempts
+  debug?: boolean;                  // Enable debug logging
+  createWebSocket: WebSocketFactory; // Platform-specific WebSocket factory
+  generateUUID?: UUIDGenerator;      // Optional UUID generator
+  storage?: TransportStorageAdapter; // Optional: persist event timestamps
+}
+```
+
+### TransportStorageAdapter
+
+Minimal key-value storage interface for transport persistence. When provided, the transport persists the last processed wallet event timestamp per pubkey. On reconnect, only events newer than the stored timestamp are fetched.
+
+```typescript
+interface TransportStorageAdapter {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+}
+```
+
+**Note:** `createBrowserProviders()` and `createNodeProviders()` automatically pass the storage provider to the transport. Custom setups should pass any `StorageProvider` — it satisfies `TransportStorageAdapter` since it has the required `get`/`set` methods.
 
 ---
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -972,6 +972,22 @@ sphere.on('connection:changed', async ({ provider, connected }) => {
 });
 ```
 
+### 5. Event Timestamp Persistence
+
+The transport layer persists the timestamp of the last processed wallet event. On reconnect or app restart, only events newer than the stored timestamp are fetched — preventing duplicate token processing.
+
+This is handled automatically when using `createBrowserProviders()` or `createNodeProviders()`. The storage provider is passed to the transport, and timestamps are persisted per wallet pubkey.
+
+**Behavior by scenario:**
+
+| Scenario | `since` filter |
+|----------|---------------|
+| Existing wallet with stored timestamp | Resume from last event timestamp |
+| Fresh wallet (no stored timestamp) | `now` — no historical events |
+| No storage adapter (legacy) | `now - 24h` fallback |
+
+**Note:** The `since` filter only applies to wallet events (token transfers, payment requests). Chat messages (NIP-17 GIFT_WRAP) are always real-time with no `since` filter.
+
 ---
 
 ## Testing
@@ -1018,11 +1034,11 @@ npm test -- --coverage
 | `modules/PaymentsModule` | 36 | Payments, nametag, PROXY |
 | `modules/NametagMinter` | 22 | On-chain nametag minting |
 | `price/CoinGeckoPriceProvider` | 29 | Price provider, cache, negative cache |
-| `transport/NostrTransportProvider` | 24 | Nostr P2P messaging |
+| `transport/NostrTransportProvider` | 43 | Nostr P2P messaging, event timestamp persistence |
 | `integration/wallet-import-export` | 20 | Wallet import/export |
 | `integration/nametag-roundtrip` | 9 | Nametag serialization |
 | `impl/shared/resolvers` | 41 | Config resolution utilities |
-| **Total** | **882** | All passing (34 test files) |
+| **Total** | **893** | All passing (34 test files) |
 
 ### Writing Tests
 

--- a/impl/browser/index.ts
+++ b/impl/browser/index.ts
@@ -351,8 +351,10 @@ export function createBrowserProviders(config?: BrowserProvidersConfig): Browser
   const tokenSyncConfig = resolveTokenSyncConfig(network, config?.tokenSync);
   const priceConfig = resolvePriceConfig(config?.price);
 
+  const storage = createLocalStorageProvider(config?.storage);
+
   return {
-    storage: createLocalStorageProvider(config?.storage),
+    storage,
     transport: createNostrTransportProvider({
       relays: transportConfig.relays,
       timeout: transportConfig.timeout,
@@ -360,6 +362,7 @@ export function createBrowserProviders(config?: BrowserProvidersConfig): Browser
       reconnectDelay: transportConfig.reconnectDelay,
       maxReconnectAttempts: transportConfig.maxReconnectAttempts,
       debug: transportConfig.debug,
+      storage,
     }),
     oracle: createUnicityAggregatorProvider({
       url: oracleConfig.url,

--- a/impl/nodejs/index.ts
+++ b/impl/nodejs/index.ts
@@ -148,10 +148,12 @@ export function createNodeProviders(config?: NodeProvidersConfig): NodeProviders
   const l1Config = resolveL1Config(network, config?.l1);
   const priceConfig = resolvePriceConfig(config?.price);
 
+  const storage = createFileStorageProvider({
+    dataDir: config?.dataDir ?? './sphere-data',
+  });
+
   return {
-    storage: createFileStorageProvider({
-      dataDir: config?.dataDir ?? './sphere-data',
-    }),
+    storage,
     tokenStorage: createFileTokenStorageProvider({
       tokensDir: config?.tokensDir ?? './sphere-tokens',
     }),
@@ -160,6 +162,7 @@ export function createNodeProviders(config?: NodeProvidersConfig): NodeProviders
       timeout: transportConfig.timeout,
       autoReconnect: transportConfig.autoReconnect,
       debug: transportConfig.debug,
+      storage,
     }),
     oracle: createUnicityAggregatorProvider({
       url: oracleConfig.url,


### PR DESCRIPTION
…reconnect

Add TransportStorageAdapter interface for persisting the last processed Nostr wallet event timestamp. On reconnect, the transport uses the stored timestamp as the `since` filter — existing wallets resume from the last event, fresh wallets start from now, and legacy setups without storage fall back to 24h. Chat events (NIP-17 GIFT_WRAP) are unaffected and always subscribe in real-time without a `since` filter.

Uses in-memory timestamp tracker to avoid read-before-write race conditions when multiple events arrive in rapid succession.

- Add LAST_WALLET_EVENT_TS to STORAGE_KEYS_GLOBAL
- Add TransportStorageAdapter interface and storage config option
- Make subscribeToEvents async with storage-based since logic
- Add race-safe updateLastEventTimestamp with in-memory monotonic guard
- Pass storage provider to transport in browser and Node.js factories
- Add 13 tests covering since filter, timestamp persistence, and races
- Update API.md, INTEGRATION.md, CLAUDE.md with new feature docs