### PR TITLE
fix: await background tasks before process exit in CLI

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -935,6 +935,8 @@ async function main() {
           console.error('\n✗ Transfer failed:', result.error || result.status);
         }
 
+        // Wait for background tasks (e.g., change token creation from instant split)
+        await sphere.payments.waitForPendingOperations();
         await closeSphere();
         break;
       }
@@ -1537,4 +1539,4 @@ async function main() {
   }
 }
 
-main();
+main().then(() => process.exit(0));

--- a/types/instant-split.ts
+++ b/types/instant-split.ts
@@ -261,6 +261,9 @@ export interface InstantSplitResult {
 
   /** Whether background processing was started */
   backgroundStarted?: boolean;
+
+  /** Promise that resolves when background processing completes (change token saved) */
+  backgroundPromise?: Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- CLI commands hung ~10s after completion due to lingering Nostr WebSocket handles keeping Node.js alive
- Adding `process.exit(0)` fixed the hang but killed instant split background tasks before the change token was saved, causing sender balance loss after splits
- Background promises are now tracked in `PaymentsModule` and awaited via `waitForPendingOperations()` before the CLI exits

## Changes

- **cli.ts**: Add `process.exit(0)` after `main()` to prevent WebSocket linger; await `waitForPendingOperations()` in `send` command before closing
- **InstantSplitExecutor.ts**: `submitBackgroundV5` now returns `Promise<void>` instead of fire-and-forget; background promise exposed on `InstantSplitResult`
- **PaymentsModule.ts**: Track background promises in `pendingBackgroundTasks`; add public `waitForPendingOperations()` method
- **types/instant-split.ts**: Add optional `backgroundPromise` field to `InstantSplitResult`

## Test plan

- [x] `npx tsc --noEmit` — type check passes
- [x] `npx vitest run` — 914/914 unit tests pass
- [x] `npx tsx test-e2e-transfers.ts` — 8/8 pass (balance + tombstone verified)
- [x] `npx tsx test-e2e-cli.ts --cleanup` — 8/8 pass (instant + conservative, all coins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)