### PR TITLE
fix: implement isValidNametag locally for missing nostr-js-sdk export

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -102,7 +102,12 @@ import { SigningService } from '@unicitylabs/state-transition-sdk/lib/sign/Signi
 import { TokenType } from '@unicitylabs/state-transition-sdk/lib/token/TokenType';
 import { HashAlgorithm } from '@unicitylabs/state-transition-sdk/lib/hash/HashAlgorithm';
 import { UnmaskedPredicateReference } from '@unicitylabs/state-transition-sdk/lib/predicate/embedded/UnmaskedPredicateReference';
-import { normalizeNametag, isValidNametag } from '@unicitylabs/nostr-js-sdk';
+import { normalizeNametag, isPhoneNumber } from '@unicitylabs/nostr-js-sdk';
+
+function isValidNametag(nametag: string): boolean {
+  if (isPhoneNumber(nametag)) return true;
+  return /^[a-z0-9_-]{3,20}$/.test(nametag);
+}
 
 import type {
   LegacyFileType,


### PR DESCRIPTION
## Summary
- `nostr-js-sdk` 0.3.2 does not export `isValidNametag`, causing 23 test failures across `nametag-normalization.test.ts` and `tracked-addresses.test.ts`
- Replaced the import with a local implementation using `isPhoneNumber` from the same package
- Validates: lowercase alphanumeric/underscore/hyphen, 3–20 chars, or a valid phone number

## Test plan
- [x] `npm run test:run` — all 1107 tests pass (45 files, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)