### PR TITLE
fix: remove non-existent re-exports from index.ts

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -104,7 +104,7 @@ import { HashAlgorithm } from '@unicitylabs/state-transition-sdk/lib/hash/HashAl
 import { UnmaskedPredicateReference } from '@unicitylabs/state-transition-sdk/lib/predicate/embedded/UnmaskedPredicateReference';
 import { normalizeNametag, isPhoneNumber } from '@unicitylabs/nostr-js-sdk';
 
-function isValidNametag(nametag: string): boolean {
+export function isValidNametag(nametag: string): boolean {
   if (isPhoneNumber(nametag)) return true;
   return /^[a-z0-9_-]{3,20}$/.test(nametag);
 }

--- a/index.ts
+++ b/index.ts
@@ -365,13 +365,12 @@ export type {
 
 export {
   normalizeNametag,
-  isValidNametag,
   isPhoneNumber,
   hashNametag,
   areSameNametag,
-  NAMETAG_MIN_LENGTH,
-  NAMETAG_MAX_LENGTH,
 } from '@unicitylabs/nostr-js-sdk';
+
+export { isValidNametag } from './core/Sphere';
 
 // =============================================================================
 // Price Provider


### PR DESCRIPTION
## Summary
- `index.ts` re-exported `isValidNametag`, `NAMETAG_MIN_LENGTH`, and `NAMETAG_MAX_LENGTH` from `@unicitylabs/nostr-js-sdk`, which doesn't have them — causing `tsc --noEmit` to fail
- Removed `NAMETAG_MIN_LENGTH`/`NAMETAG_MAX_LENGTH` re-exports (already in `constants.ts`)
- Re-exported `isValidNametag` from the local implementation in `core/Sphere.ts`

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors (122 pre-existing warnings)
- [x] `npm run test:run` — 1107 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)