### PR TITLE
fix: exclude dm-manual.test.ts from automated e2e suite

### DIFF
--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/e2e/**/*.test.ts'],
+    exclude: ['tests/e2e/dm-manual.test.ts'],
     testTimeout: 180000, // Recovery test needs up to 60s for IPNS propagation
   },
 });


### PR DESCRIPTION
## Summary
- Excluded `tests/e2e/dm-manual.test.ts` from the automated e2e test config
- This test requires a human to manually send a DM within 60s and always times out in CI/automated runs

## Test plan
- [x] `npm run test:e2e` — 3 files, 16 tests pass, dm-manual no longer included

🤖 Generated with [Claude Code](https://claude.com/claude-code)