### PR TITLE
fix: add diagnostics for silent failures in E2E test scripts

### DIFF
--- a/tests/scripts/test-e2e-cli-ipfs-sync.ts
+++ b/tests/scripts/test-e2e-cli-ipfs-sync.ts
@@ -237,6 +237,7 @@ function parseSyncOutput(stdout: string): { added: number; removed: number } {
   if (stdout.includes('Up to date')) {
     return { added: 0, removed: 0 };
   }
+  console.warn(`    [sync] Unrecognized sync output format: ${stdout.trim().split('\n')[0]}`);
   return { added: 0, removed: 0 };
 }
 

--- a/tests/scripts/test-e2e-transfers.ts
+++ b/tests/scripts/test-e2e-transfers.ts
@@ -495,6 +495,9 @@ async function runTransferTest(config: TransferTestConfig): Promise<TransferTest
       await sender.payments.load();
       senderAfter = getBalance(sender, coinSymbol);
     }
+    if (senderAfter.total < expectedSenderTotal) {
+      console.warn(`    WARNING: Sender change token wait timed out (15s). Balance: ${senderAfter.total}, expected: ${expectedSenderTotal}`);
+    }
     const senderDelta = senderBefore.total - senderAfter.total;
     const receiverDelta = receiveResult.finalBalance.total - receiverBefore.total;
     result.senderDelta = senderDelta;


### PR DESCRIPTION
## Summary
- Add timeout warning when sender change token wait expires (`test-e2e-transfers`)
- Add `requireParsedBalance()` helper that throws on parse failure instead of silently defaulting to `0n` (`test-e2e-cli`)
- Log transient CLI errors and timeouts in `waitForBalance()` (`test-e2e-cli`)
- Warn on unrecognized sync output format in `parseSyncOutput()` (`test-e2e-cli-ipfs-sync`)

## Test plan
- [x] All 1174 unit tests pass (48 test files)
- [ ] E2E transfer tests pass (`npx tsx tests/scripts/test-e2e-transfers.ts --cleanup`)
- [ ] CLI E2E tests pass (`npx tsx tests/scripts/test-e2e-cli.ts --cleanup`)
- [ ] IPFS sync tests pass (`npx tsx tests/scripts/test-e2e-cli-ipfs-sync.ts --cleanup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)