### PR TITLE
fix: exclude relay tests from default vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
-    exclude: ['tests/e2e/**'],
+    exclude: ['tests/e2e/**', 'tests/relay/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'json'],


### PR DESCRIPTION
## Summary
- Exclude `tests/relay/**` from the default `vitest.config.ts` include pattern
- Relay tests have their own config (`vitest.relay.config.ts`) with longer timeouts and require the `testcontainers` package, which is not a standard dev dependency
- Without this fix, `npm run test:run` fails due to missing `testcontainers` module

## Test plan
- [x] `npm run test:run` passes (48 files, 1174 tests)
- [x] Relay tests remain runnable via `vitest run --config vitest.relay.config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)