### PR TITLE
fix: use only unicity-ipfs1.dyndns.org as default IPFS gateway

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -213,9 +213,7 @@ export const DEFAULT_AGGREGATOR_API_KEY = 'sk_06365a9c44654841a366068bcfc68986' 
 
 /** Default IPFS gateways */
 export const DEFAULT_IPFS_GATEWAYS = [
-  'https://ipfs.unicity.network',
-  'https://dweb.link',
-  'https://ipfs.io',
+  'https://unicity-ipfs1.dyndns.org',
 ] as const;
 
 /** Unicity IPFS bootstrap peers */


### PR DESCRIPTION
## Summary
- Remove public IPFS gateways (`ipfs.unicity.network`, `dweb.link`, `ipfs.io`) from `DEFAULT_IPFS_GATEWAYS`
- Ensure all IPFS operations (upload, fetch, IPNS resolve/publish) use exclusively `https://unicity-ipfs1.dyndns.org`
- Affects all network configs (mainnet, testnet, dev)

## Test plan
- [x] Build passes
- [x] All 1399 tests pass (54 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)