### PR TITLE
feat: restore market module integration

### DIFF
--- a/impl/browser/index.ts
+++ b/impl/browser/index.ts
@@ -36,6 +36,7 @@ import type { TransportProvider } from '../../transport';
 import type { OracleProvider } from '../../oracle';
 import type { NetworkType } from '../../constants';
 import type { GroupChatModuleConfig } from '../../modules/groupchat';
+import type { MarketModuleConfig } from '../../modules/market';
 import type { PriceProvider } from '../../price';
 import { createPriceProvider } from '../../price';
 import { TokenRegistry } from '../../registry';
@@ -43,6 +44,7 @@ import {
   type BaseTransportConfig,
   type BaseOracleConfig,
   type BasePriceConfig,
+  type BaseMarketConfig,
   type L1Config,
   type BrowserTransportExtensions,
   resolveTransportConfig,
@@ -52,6 +54,7 @@ import {
   resolveArrayConfig,
   getNetworkConfig,
   resolveGroupChatConfig,
+  resolveMarketConfig,
 } from '../shared';
 
 // =============================================================================
@@ -179,6 +182,8 @@ export interface BrowserProvidersConfig {
   price?: BasePriceConfig;
   /** Group chat (NIP-29) configuration. true = enable with defaults, object = custom config */
   groupChat?: { enabled?: boolean; relays?: string[] } | boolean;
+  /** Market module configuration. true = enable with defaults, object = custom config */
+  market?: BaseMarketConfig | boolean;
 }
 
 export interface BrowserProviders {
@@ -195,6 +200,8 @@ export interface BrowserProviders {
   ipfsTokenStorage?: TokenStorageProvider<TxfStorageDataBase>;
   /** Group chat config (resolved, for passing to Sphere.init) */
   groupChat?: GroupChatModuleConfig | boolean;
+  /** Market module config (resolved, for passing to Sphere.init) */
+  market?: MarketModuleConfig | boolean;
   /**
    * Token sync configuration (resolved from tokenSync options)
    * For advanced use cases when additional sync backends are needed
@@ -375,6 +382,9 @@ export function createBrowserProviders(config?: BrowserProvidersConfig): Browser
   // Resolve group chat config
   const groupChat = resolveGroupChatConfig(network, config?.groupChat);
 
+  // Resolve market config
+  const market = resolveMarketConfig(config?.market);
+
   // Configure token registry remote refresh with persistent cache
   const networkConfig = getNetworkConfig(network);
   TokenRegistry.configure({ remoteUrl: networkConfig.tokenRegistryUrl, storage });
@@ -382,6 +392,7 @@ export function createBrowserProviders(config?: BrowserProvidersConfig): Browser
   return {
     storage,
     groupChat,
+    market,
     transport: createNostrTransportProvider({
       relays: transportConfig.relays,
       timeout: transportConfig.timeout,

--- a/impl/nodejs/index.ts
+++ b/impl/nodejs/index.ts
@@ -36,11 +36,13 @@ import { createPriceProvider } from '../../price';
 import { TokenRegistry } from '../../registry';
 import type { NetworkType } from '../../constants';
 import type { GroupChatModuleConfig } from '../../modules/groupchat';
+import type { MarketModuleConfig } from '../../modules/market';
 import type { IpfsStorageConfig } from '../shared/ipfs';
 import {
   type BaseTransportConfig,
   type BaseOracleConfig,
   type BasePriceConfig,
+  type BaseMarketConfig,
   type L1Config,
   type NodeOracleExtensions,
   resolveTransportConfig,
@@ -48,6 +50,7 @@ import {
   resolveL1Config,
   resolvePriceConfig,
   resolveGroupChatConfig,
+  resolveMarketConfig,
   getNetworkConfig,
 } from '../shared';
 
@@ -112,6 +115,8 @@ export interface NodeProvidersConfig {
   tokenSync?: NodeTokenSyncConfig;
   /** Group chat (NIP-29) configuration. true = enable with defaults, object = custom config */
   groupChat?: { enabled?: boolean; relays?: string[] } | boolean;
+  /** Market module configuration. true = enable with defaults, object = custom config */
+  market?: BaseMarketConfig | boolean;
 }
 
 export interface NodeProviders {
@@ -127,6 +132,8 @@ export interface NodeProviders {
   ipfsTokenStorage?: TokenStorageProvider<TxfStorageDataBase>;
   /** Group chat config (resolved, for passing to Sphere.init) */
   groupChat?: GroupChatModuleConfig | boolean;
+  /** Market module config (resolved, for passing to Sphere.init) */
+  market?: MarketModuleConfig | boolean;
 }
 
 // =============================================================================
@@ -192,6 +199,9 @@ export function createNodeProviders(config?: NodeProvidersConfig): NodeProviders
   // Resolve group chat config
   const groupChat = resolveGroupChatConfig(network, config?.groupChat);
 
+  // Resolve market config
+  const market = resolveMarketConfig(config?.market);
+
   // Configure token registry remote refresh with persistent cache
   const networkConfig = getNetworkConfig(network);
   TokenRegistry.configure({ remoteUrl: networkConfig.tokenRegistryUrl, storage });
@@ -199,6 +209,7 @@ export function createNodeProviders(config?: NodeProvidersConfig): NodeProviders
   return {
     storage,
     groupChat,
+    market,
     tokenStorage: createFileTokenStorageProvider({
       tokensDir: config?.tokensDir ?? './sphere-tokens',
     }),

--- a/impl/shared/config.ts
+++ b/impl/shared/config.ts
@@ -108,6 +108,20 @@ export interface BasePriceConfig {
 }
 
 // =============================================================================
+// Market Configuration
+// =============================================================================
+
+/**
+ * Base market module configuration
+ */
+export interface BaseMarketConfig {
+  /** Market API base URL (default: https://market-api.unicity.network) */
+  apiUrl?: string;
+  /** Request timeout in ms (default: 30000) */
+  timeout?: number;
+}
+
+// =============================================================================
 // Provider Configuration
 // =============================================================================
 

--- a/impl/shared/resolvers.ts
+++ b/impl/shared/resolvers.ts
@@ -8,6 +8,7 @@ import type {
   BaseTransportConfig,
   BaseOracleConfig,
   BasePriceConfig,
+  BaseMarketConfig,
   L1Config,
   ResolvedTransportConfig,
   ResolvedOracleConfig,
@@ -15,6 +16,7 @@ import type {
 import type { PriceProviderConfig } from '../../price';
 import type { StorageProvider } from '../../storage';
 import type { GroupChatModuleConfig } from '../../modules/groupchat';
+import type { MarketModuleConfig } from '../../modules/market';
 
 // =============================================================================
 // Network Resolution
@@ -265,4 +267,21 @@ export function resolveGroupChatConfig(
   return {
     relays: config.relays ?? [...netConfig.groupRelays],
   };
+}
+
+// =============================================================================
+// Market Resolution
+// =============================================================================
+
+/**
+ * Resolve market module configuration.
+ * @param config - User-provided market config (true, object, or undefined)
+ * @returns Resolved MarketModuleConfig or undefined if disabled
+ */
+export function resolveMarketConfig(
+  config?: BaseMarketConfig | boolean,
+): MarketModuleConfig | undefined {
+  if (!config) return undefined;
+  if (config === true) return {};
+  return { apiUrl: config.apiUrl, timeout: config.timeout };
 }

--- a/index.ts
+++ b/index.ts
@@ -210,6 +210,25 @@ export type {
   CreateGroupOptions,
 } from './modules/groupchat';
 
+export {
+  MarketModule,
+  createMarketModule,
+  DEFAULT_MARKET_API_URL,
+} from './modules/market';
+export type {
+  MarketModuleConfig,
+  MarketModuleDependencies,
+  PostIntentRequest,
+  PostIntentResult,
+  MarketIntent,
+  SearchIntentResult,
+  SearchFilters,
+  SearchOptions,
+  SearchResult,
+  IntentType,
+  IntentStatus,
+} from './modules/market';
+
 // =============================================================================
 // Constants
 // =============================================================================

--- a/tests/integration/market-cli.test.ts
+++ b/tests/integration/market-cli.test.ts
@@ -1,0 +1,117 @@
+/**
+ * CLI integration tests for market commands.
+ *
+ * Spawns the CLI as a subprocess and verifies:
+ * - Help text lists all 5 intent types and the market-feed command
+ * - market-post sends correct intent_type for each type
+ * - market-search sends correct type filter for each type
+ * - market-feed --rest fetches recent listings
+ * - Error messages reference correct types
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as path from 'node:path';
+
+const exec = promisify(execFile);
+
+const CLI_PATH = path.resolve(__dirname, '../../cli/index.ts');
+const TSX = 'npx';
+
+/** Run a CLI command via tsx, returns { stdout, stderr } */
+async function runCli(
+  args: string[],
+  options?: { timeout?: number },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const result = await exec(TSX, ['tsx', CLI_PATH, ...args], {
+      timeout: options?.timeout ?? 15000,
+      env: { ...process.env, NODE_NO_WARNINGS: '1' },
+    });
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as Record<string, unknown>;
+    return {
+      stdout: (e.stdout as string) ?? '',
+      stderr: (e.stderr as string) ?? '',
+      exitCode: (e.code as number) ?? 1,
+    };
+  }
+}
+
+describe('Market CLI commands', () => {
+  // ---------------------------------------------------------------------------
+  // Help text
+  // ---------------------------------------------------------------------------
+
+  describe('help text', () => {
+    it('should list all 5 intent types in market-post description', async () => {
+      const { stdout } = await runCli(['--help']);
+      expect(stdout).toContain('buy, sell, service, announcement, other');
+    });
+
+    it('should include market-feed command in help', async () => {
+      const { stdout } = await runCli(['--help']);
+      expect(stdout).toContain('market-feed');
+      expect(stdout).toContain('--rest');
+    });
+
+    it('should include market-feed in examples section', async () => {
+      const { stdout } = await runCli(['--help']);
+      expect(stdout).toContain('market-feed');
+      // Both live and REST examples
+      expect(stdout).toMatch(/market-feed\b/);
+      expect(stdout).toMatch(/market-feed --rest/);
+    });
+
+    it('should include announcement example in market examples', async () => {
+      const { stdout } = await runCli(['--help']);
+      expect(stdout).toContain('--type announcement');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // market-post argument parsing
+  // ---------------------------------------------------------------------------
+
+  describe('market-post argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['market-post']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+
+    it('should require --type flag', async () => {
+      const { stderr, exitCode } = await runCli(['market-post', 'Test description']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('--type');
+      // Error message should list all 5 types
+      expect(stderr).toContain('buy, sell, service, announcement, other');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // market-search argument parsing
+  // ---------------------------------------------------------------------------
+
+  describe('market-search argument validation', () => {
+    it('should show usage when called without query', async () => {
+      const { stderr, exitCode } = await runCli(['market-search']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // market-close argument parsing
+  // ---------------------------------------------------------------------------
+
+  describe('market-close argument validation', () => {
+    it('should show usage when called without intent ID', async () => {
+      const { stderr, exitCode } = await runCli(['market-close']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+});

--- a/tests/integration/market-module.test.ts
+++ b/tests/integration/market-module.test.ts
@@ -1,0 +1,883 @@
+/**
+ * Integration tests for MarketModule within Sphere.
+ *
+ * Tests:
+ * 1. Sphere.init() with market config creates/omits market module
+ * 2. Market config resolution (true, custom URL)
+ * 3. Provider factory integration (browser and Node.js)
+ * 4. Module lifecycle (initialize, load, destroy)
+ * 5. Address switching with market module
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Sphere } from '../../core/Sphere';
+import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
+import { FileTokenStorageProvider } from '../../impl/nodejs/storage/FileTokenStorageProvider';
+import { createBrowserProviders } from '../../impl/browser';
+import { createNodeProviders } from '../../impl/nodejs';
+import type { TransportProvider, OracleProvider } from '../../index';
+import type { ProviderStatus } from '../../types';
+
+// =============================================================================
+// Test directories
+// =============================================================================
+
+const TEST_DIR = path.join(__dirname, '.test-market-module');
+const DATA_DIR = path.join(TEST_DIR, 'data');
+const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+
+// =============================================================================
+// Mock providers
+// =============================================================================
+
+function createMockTransport(): TransportProvider {
+  return {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    description: 'Mock transport',
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn().mockResolvedValue('transfer-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('request-id'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('response-id'),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    subscribeToBroadcast: vi.fn().mockReturnValue(() => {}),
+    publishBroadcast: vi.fn().mockResolvedValue('broadcast-id'),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+    resolveNametag: vi.fn().mockResolvedValue(null),
+    publishIdentityBinding: vi.fn().mockResolvedValue(true),
+    registerNametag: vi.fn().mockResolvedValue(true),
+    recoverNametag: vi.fn().mockResolvedValue(null),
+  } as TransportProvider;
+}
+
+function createMockOracle(): OracleProvider {
+  return {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'aggregator' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    submitCommitment: vi.fn().mockResolvedValue({ requestId: 'test-id' }),
+    getProof: vi.fn().mockResolvedValue(null),
+    validate: vi.fn().mockResolvedValue({ valid: [], invalid: [] }),
+  } as OracleProvider;
+}
+
+// =============================================================================
+// Fixtures & Cleanup
+// =============================================================================
+
+function cleanupTestDir(): void {
+  if (fs.existsSync(TEST_DIR)) {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  }
+}
+
+function ensureTestDirs(): void {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+  fs.mkdirSync(TOKENS_DIR, { recursive: true });
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('MarketModule integration with Sphere', () => {
+  beforeEach(() => {
+    cleanupTestDir();
+    ensureTestDirs();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Basic Sphere Integration
+  // ---------------------------------------------------------------------------
+
+  describe('Sphere.init() with market config', () => {
+    it('should create market module when market: true', async () => {
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+        autoGenerate: true,
+      });
+
+      expect(sphere.market).toBeDefined();
+      expect(sphere.market).not.toBeNull();
+
+      await sphere.destroy();
+    });
+
+    it('should not create market module when market not specified', async () => {
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        autoGenerate: true,
+      });
+
+      expect(sphere.market).toBeNull();
+
+      await sphere.destroy();
+    });
+
+    it('should not create market module when market: false (if supported)', async () => {
+      // market: false should be treated as falsy
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: false,
+        autoGenerate: true,
+      });
+
+      expect(sphere.market).toBeNull();
+
+      await sphere.destroy();
+    });
+
+    it('should use custom API URL in market config', async () => {
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: { apiUrl: 'https://custom-market.api' },
+        autoGenerate: true,
+      });
+
+      expect(sphere.market).toBeDefined();
+      expect(sphere.market).not.toBeNull();
+
+      // Verify by calling a method and checking the URL
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ intents: [] }), { status: 200 })
+      );
+
+      await sphere.market!.search('test');
+      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
+      const lastCall = fetchCalls[fetchCalls.length - 1];
+      expect(lastCall[0]).toContain('https://custom-market.api');
+
+      await sphere.destroy();
+    });
+
+    it('should use custom timeout in market config', async () => {
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: { timeout: 5000 },
+        autoGenerate: true,
+      });
+
+      expect(sphere.market).toBeDefined();
+
+      await sphere.destroy();
+    });
+
+    it('should allow both apiUrl and timeout in market config', async () => {
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: {
+          apiUrl: 'https://market.custom',
+          timeout: 10000,
+        },
+        autoGenerate: true,
+      });
+
+      expect(sphere.market).toBeDefined();
+
+      await sphere.destroy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Sphere.load() with market config
+  // ---------------------------------------------------------------------------
+
+  describe('Sphere.load() with market config', () => {
+    it('should load market module when market: true', async () => {
+      // First create wallet
+      const { sphere: initial } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        autoGenerate: true,
+      });
+      await initial.destroy();
+
+      // Then load with market enabled
+      const sphere = await Sphere.load({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+      });
+
+      expect(sphere.market).not.toBeNull();
+
+      await sphere.destroy();
+    });
+
+    it('should not load market module when not specified', async () => {
+      // First create wallet
+      const { sphere: initial } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        autoGenerate: true,
+      });
+      await initial.destroy();
+
+      // Then load without market
+      const sphere = await Sphere.load({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+      });
+
+      expect(sphere.market).toBeNull();
+
+      await sphere.destroy();
+    });
+
+    it('should respect custom market config on load', async () => {
+      // First create wallet
+      const { sphere: initial } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        autoGenerate: true,
+      });
+      await initial.destroy();
+
+      // Then load with custom market config
+      const sphere = await Sphere.load({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: { apiUrl: 'https://market.load.test' },
+      });
+
+      expect(sphere.market).not.toBeNull();
+
+      await sphere.destroy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Sphere.import() with market config
+  // ---------------------------------------------------------------------------
+
+  describe('Sphere.import() with market config', () => {
+    it('should create market module when market: true', async () => {
+      const mnemonic =
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+      const sphere = await Sphere.import({
+        mnemonic,
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+      });
+
+      expect(sphere.market).not.toBeNull();
+
+      await sphere.destroy();
+    });
+
+    it('should use custom market config on import', async () => {
+      const mnemonic =
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+      const sphere = await Sphere.import({
+        mnemonic,
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: { apiUrl: 'https://custom-import.api', timeout: 20000 },
+      });
+
+      expect(sphere.market).not.toBeNull();
+
+      await sphere.destroy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Market module access and nullability
+  // ---------------------------------------------------------------------------
+
+  describe('market module access and nullability', () => {
+    it('sphere.market getter should be nullable', async () => {
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        autoGenerate: true,
+      });
+
+      // Should safely return null without throwing
+      expect(() => {
+        const market = sphere.market;
+        expect(market).toBeNull();
+      }).not.toThrow();
+
+      await sphere.destroy();
+    });
+
+    it('should allow safe optional chaining on market', async () => {
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        autoGenerate: true,
+      });
+
+      // Should not throw with optional chaining
+      expect(() => {
+        // This is valid TypeScript: (sphere.market as any)?.getProfile()
+        if (sphere.market) {
+          throw new Error('Should be null');
+        }
+      }).not.toThrow();
+
+      await sphere.destroy();
+    });
+
+    it('should access market methods when module exists', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ intents: [], count: 0 }), { status: 200 })
+      );
+
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+        autoGenerate: true,
+      });
+
+      expect(sphere.market).not.toBeNull();
+      const result = await sphere.market!.search('test query');
+      expect(result.intents).toEqual([]);
+
+      await sphere.destroy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Address switching with market module
+  // ---------------------------------------------------------------------------
+
+  describe('market module with address switching', () => {
+    it('should maintain market module on address switch', async () => {
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+        autoGenerate: true,
+      });
+
+      // Switch to address 1
+      await sphere.switchToAddress(1);
+
+      // Market module should still exist
+      expect(sphere.market).not.toBeNull();
+
+      await sphere.destroy();
+    });
+
+    it('should reinitialize market module with new identity on address switch', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      fetchSpy.mockImplementation(async () =>
+        new Response(JSON.stringify({ intents: [] }), { status: 200 })
+      );
+
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+        autoGenerate: true,
+      });
+
+      const identity1 = sphere.identity;
+
+      // Call an authenticated market method to capture the public key used
+      fetchSpy.mockClear();
+      fetchSpy.mockImplementation(async () =>
+        new Response(JSON.stringify({ intents: [] }), { status: 200 })
+      );
+      await sphere.market!.getMyIntents();
+      const pubkey1 = (fetchSpy.mock.calls[0][1]?.headers as Record<string, string>)['x-public-key'];
+
+      // Switch to address 1
+      await sphere.switchToAddress(1);
+
+      const identity2 = sphere.identity;
+
+      // Identities should be different
+      expect(identity1?.chainPubkey).not.toBe(identity2?.chainPubkey);
+
+      // Market module should exist
+      expect(sphere.market).not.toBeNull();
+
+      // Call market method again and verify it uses the NEW identity
+      fetchSpy.mockClear();
+      fetchSpy.mockImplementation(async () =>
+        new Response(JSON.stringify({ intents: [] }), { status: 200 })
+      );
+      await sphere.market!.getMyIntents();
+      const pubkey2 = (fetchSpy.mock.calls[0][1]?.headers as Record<string, string>)['x-public-key'];
+
+      // Verify different public keys were used (proving module was reinitialized)
+      expect(pubkey1).not.toBe(pubkey2);
+      expect(pubkey2).toBe(identity2?.chainPubkey);
+
+      await sphere.destroy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Market module lifecycle within Sphere
+  // ---------------------------------------------------------------------------
+
+  describe('market module lifecycle', () => {
+    it('should initialize market module on Sphere creation', async () => {
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+        autoGenerate: true,
+      });
+
+      expect(sphere.market).not.toBeNull();
+
+      // Market should be ready to use
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ intents: [] }), { status: 200 })
+      );
+
+      const result = await sphere.market!.search('test');
+      expect(result.intents).toEqual([]);
+
+      await sphere.destroy();
+    });
+
+    it('should destroy market module on Sphere.destroy()', async () => {
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+        autoGenerate: true,
+      });
+
+      expect(sphere.market).not.toBeNull();
+
+      // Destroy should not throw
+      await expect(sphere.destroy()).resolves.not.toThrow();
+    });
+
+    it('should work after loading wallet with market enabled', async () => {
+      // Create and destroy first wallet
+      let { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+        autoGenerate: true,
+      });
+      await sphere.destroy();
+
+      // Reload with market enabled
+      sphere = await Sphere.load({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+      });
+
+      expect(sphere.market).not.toBeNull();
+
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ intents: [] }), { status: 200 })
+      );
+
+      await sphere.market!.search('test');
+
+      await sphere.destroy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Provider factory integration
+  // ---------------------------------------------------------------------------
+
+  describe('createBrowserProviders with market config', () => {
+    it('should include market config when market: true', () => {
+      const providers = createBrowserProviders({ network: 'testnet', market: true });
+
+      expect(providers.market).toBeDefined();
+      expect(providers.market).not.toBeNull();
+    });
+
+    it('should not include market config when not specified', () => {
+      const providers = createBrowserProviders({ network: 'testnet' });
+
+      expect(providers.market).toBeUndefined();
+    });
+
+    it('should use custom market URL from config', () => {
+      const providers = createBrowserProviders({
+        network: 'testnet',
+        market: { apiUrl: 'https://custom.market.api' },
+      });
+
+      expect(providers.market).toBeDefined();
+      expect(providers.market?.apiUrl).toBe('https://custom.market.api');
+    });
+
+    it('should resolve market: true to empty config (defaults applied by MarketModule)', () => {
+      const providers = createBrowserProviders({
+        network: 'testnet',
+        market: true,
+      });
+
+      expect(providers.market).toBeDefined();
+      // market: true resolves to {} — MarketModule constructor applies DEFAULT_MARKET_API_URL
+    });
+  });
+
+  describe('createNodeProviders with market config', () => {
+    it('should include market config when market: true', () => {
+      const providers = createNodeProviders({
+        network: 'testnet',
+        market: true,
+        dataDir: DATA_DIR,
+        tokensDir: TOKENS_DIR,
+      });
+
+      expect(providers.market).toBeDefined();
+      expect(providers.market).not.toBeNull();
+    });
+
+    it('should not include market config when not specified', () => {
+      const providers = createNodeProviders({
+        network: 'testnet',
+        dataDir: DATA_DIR,
+        tokensDir: TOKENS_DIR,
+      });
+
+      expect(providers.market).toBeUndefined();
+    });
+
+    it('should use custom market URL from config', () => {
+      const providers = createNodeProviders({
+        network: 'testnet',
+        dataDir: DATA_DIR,
+        tokensDir: TOKENS_DIR,
+        market: { apiUrl: 'https://node-custom.market.api' },
+      });
+
+      expect(providers.market).toBeDefined();
+      expect(providers.market?.apiUrl).toBe('https://node-custom.market.api');
+    });
+
+    it('should resolve market: true to empty config (defaults applied by MarketModule)', () => {
+      const providers = createNodeProviders({
+        network: 'testnet',
+        dataDir: DATA_DIR,
+        tokensDir: TOKENS_DIR,
+        market: true,
+      });
+
+      expect(providers.market).toBeDefined();
+      // market: true resolves to {} — MarketModule constructor applies DEFAULT_MARKET_API_URL
+    });
+
+    it('should support custom timeout in provider factory', () => {
+      const providers = createNodeProviders({
+        network: 'testnet',
+        dataDir: DATA_DIR,
+        tokensDir: TOKENS_DIR,
+        market: { timeout: 60000 },
+      });
+
+      expect(providers.market).toBeDefined();
+      expect(providers.market?.timeout).toBe(60000);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // End-to-end flow
+  // ---------------------------------------------------------------------------
+
+  describe('end-to-end flow', () => {
+    it('should create wallet and use market module together', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+        new Response(JSON.stringify({ intents: [] }), { status: 200 })
+      );
+
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: { apiUrl: 'https://test.market' },
+        autoGenerate: true,
+      });
+
+      // Verify identity
+      expect(sphere.identity).toBeDefined();
+      expect(sphere.identity?.chainPubkey).toBeDefined();
+
+      // Verify market
+      expect(sphere.market).not.toBeNull();
+
+      // Use market module (search is public, no auth needed)
+      const result = await sphere.market!.search('goods');
+      expect(result.intents).toEqual([]);
+
+      // Verify it was called with correct URL (find the market search call among all fetch calls)
+      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
+      const searchCall = fetchCalls.find((call) => String(call[0]).includes('/api/search'));
+      expect(searchCall).toBeDefined();
+      expect(searchCall![0]).toContain('https://test.market/api/search');
+
+      await sphere.destroy();
+    });
+
+    it('should work with browser providers', () => {
+      const providers = createBrowserProviders({
+        network: 'testnet',
+        market: true,
+      });
+
+      // All providers should be defined
+      expect(providers.storage).toBeDefined();
+      expect(providers.transport).toBeDefined();
+      expect(providers.oracle).toBeDefined();
+      expect(providers.market).toBeDefined();
+    });
+
+    it('should work with node providers', () => {
+      const providers = createNodeProviders({
+        network: 'testnet',
+        dataDir: DATA_DIR,
+        tokensDir: TOKENS_DIR,
+        market: { apiUrl: 'https://test-node-market.api' },
+      });
+
+      // All providers should be defined
+      expect(providers.storage).toBeDefined();
+      expect(providers.transport).toBeDefined();
+      expect(providers.oracle).toBeDefined();
+      expect(providers.market).toBeDefined();
+
+      // Market should have custom URL
+      expect(providers.market?.apiUrl).toBe('https://test-node-market.api');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // All intent types through Sphere
+  // ---------------------------------------------------------------------------
+
+  describe('posting and searching all intent types', () => {
+    const ALL_TYPES = ['buy', 'sell', 'service', 'announcement', 'other'] as const;
+
+    for (const intentType of ALL_TYPES) {
+      it(`should post a "${intentType}" intent via sphere.market`, async () => {
+        // Use URL-based routing so Sphere.init internal calls don't consume market mocks
+        const capturedBodies: Record<string, unknown>[] = [];
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+          const url = typeof input === 'string' ? input : (input as Request).url;
+          if (url.includes('/api/agent/register')) {
+            return new Response(JSON.stringify({ agentId: 1 }), { status: 201 });
+          }
+          if (url.includes('/api/intents')) {
+            if (init?.body) capturedBodies.push(JSON.parse(init.body as string));
+            return new Response(JSON.stringify({
+              intent_id: `int_${intentType}`,
+              message: 'Created',
+              expires_at: '2025-12-31',
+            }), { status: 201 });
+          }
+          return new Response(JSON.stringify({}), { status: 200 });
+        });
+
+        const { sphere } = await Sphere.init({
+          storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+          tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+          transport: createMockTransport(),
+          oracle: createMockOracle(),
+          market: true,
+          autoGenerate: true,
+        });
+
+        const result = await sphere.market!.postIntent({
+          description: `Test ${intentType} intent`,
+          intentType,
+          category: 'test',
+        });
+
+        expect(result.intentId).toBe(`int_${intentType}`);
+        expect(capturedBodies.length).toBeGreaterThan(0);
+        expect(capturedBodies[0].intent_type).toBe(intentType);
+
+        await sphere.destroy();
+      });
+    }
+
+    for (const intentType of ALL_TYPES) {
+      it(`should search with type filter "${intentType}" via sphere.market`, async () => {
+        const capturedBodies: Record<string, unknown>[] = [];
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+          const url = typeof input === 'string' ? input : (input as Request).url;
+          if (url.includes('/api/search')) {
+            if (init?.body) capturedBodies.push(JSON.parse(init.body as string));
+            return new Response(JSON.stringify({
+              intents: [{
+                id: 'res_1',
+                score: 0.88,
+                agent_public_key: '02ab',
+                description: `A ${intentType} listing`,
+                intent_type: intentType,
+                currency: 'UCT',
+                contact_method: 'nostr',
+                created_at: '2025-01-01',
+                expires_at: '2025-12-31',
+              }],
+            }), { status: 200 });
+          }
+          return new Response(JSON.stringify({}), { status: 200 });
+        });
+
+        const { sphere } = await Sphere.init({
+          storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+          tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+          transport: createMockTransport(),
+          oracle: createMockOracle(),
+          market: true,
+          autoGenerate: true,
+        });
+
+        const result = await sphere.market!.search('test', {
+          filters: { intentType },
+        });
+
+        expect(result.intents).toHaveLength(1);
+        expect(result.intents[0].intentType).toBe(intentType);
+        expect(capturedBodies[0].intent_type).toBe(intentType);
+
+        await sphere.destroy();
+      });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Feed methods through Sphere
+  // ---------------------------------------------------------------------------
+
+  describe('feed methods through Sphere', () => {
+    it('should fetch recent listings via sphere.market.getRecentListings()', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        if (url.includes('/api/feed/recent')) {
+          return new Response(JSON.stringify({
+            listings: [
+              {
+                id: 'lst_1',
+                title: 'Test listing',
+                description_preview: 'Full description here',
+                agent_name: '@seller',
+                agent_id: 1,
+                type: 'sell',
+                created_at: '2026-01-01T00:00:00.000Z',
+              },
+              {
+                id: 'lst_2',
+                title: 'Service listing',
+                description_preview: 'Service description',
+                agent_name: '@provider',
+                agent_id: 2,
+                type: 'service',
+                created_at: '2026-01-01T01:00:00.000Z',
+              },
+            ],
+          }), { status: 200 });
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      });
+
+      const { sphere } = await Sphere.init({
+        storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+        tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+        transport: createMockTransport(),
+        oracle: createMockOracle(),
+        market: true,
+        autoGenerate: true,
+      });
+
+      const listings = await sphere.market!.getRecentListings();
+
+      expect(listings).toHaveLength(2);
+      expect(listings[0].type).toBe('sell');
+      expect(listings[0].descriptionPreview).toBe('Full description here');
+      expect(listings[1].type).toBe('service');
+
+      await sphere.destroy();
+    });
+  });
+});

--- a/tests/integration/market-module.test.ts
+++ b/tests/integration/market-module.test.ts
@@ -100,7 +100,7 @@ describe('MarketModule integration with Sphere', () => {
   beforeEach(() => {
     cleanupTestDir();
     ensureTestDirs();
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
       new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } })
     );
   });

--- a/tests/unit/impl/shared/resolvers.test.ts
+++ b/tests/unit/impl/shared/resolvers.test.ts
@@ -10,6 +10,7 @@ import {
   resolveOracleConfig,
   resolveL1Config,
   resolveArrayConfig,
+  resolveMarketConfig,
 } from '../../../../impl/shared/resolvers';
 import { NETWORKS } from '../../../../constants';
 
@@ -285,6 +286,47 @@ describe('resolveArrayConfig', () => {
     const result = resolveArrayConfig(objDefaults, undefined, [{ id: 3 }]);
     expect(result).toHaveLength(3);
     expect(result[2]).toEqual({ id: 3 });
+  });
+});
+
+// =============================================================================
+// resolveMarketConfig
+// =============================================================================
+
+describe('resolveMarketConfig', () => {
+  it('should return undefined when config is undefined', () => {
+    const result = resolveMarketConfig(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when config is false', () => {
+    const result = resolveMarketConfig(false);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return empty object when config is true', () => {
+    const result = resolveMarketConfig(true);
+    expect(result).toEqual({});
+  });
+
+  it('should pass through apiUrl from object config', () => {
+    const result = resolveMarketConfig({ apiUrl: 'https://custom.market' });
+    expect(result).toEqual({ apiUrl: 'https://custom.market', timeout: undefined });
+  });
+
+  it('should pass through timeout from object config', () => {
+    const result = resolveMarketConfig({ timeout: 5000 });
+    expect(result).toEqual({ apiUrl: undefined, timeout: 5000 });
+  });
+
+  it('should pass through both apiUrl and timeout', () => {
+    const result = resolveMarketConfig({ apiUrl: 'https://api.test', timeout: 10000 });
+    expect(result).toEqual({ apiUrl: 'https://api.test', timeout: 10000 });
+  });
+
+  it('should return object with undefined fields for empty object config', () => {
+    const result = resolveMarketConfig({});
+    expect(result).toEqual({ apiUrl: undefined, timeout: undefined });
   });
 });
 


### PR DESCRIPTION
## Summary

- Re-integrate the MarketModule (intent bulletin board) into Sphere, CLI, and provider factories — removed in PR #49 while standalone module files remained intact
- Wire market config through `Sphere.init()`, `create()`, `load()`, `import()` following the GroupChat pattern
- Add 5 CLI commands: `market-post`, `market-search`, `market-my`, `market-close`, `market-feed`
- Add `BaseMarketConfig` + `resolveMarketConfig` to shared config/resolvers
- Add market support to both browser and Node.js provider factories
- Export `MarketModule`, `createMarketModule`, `DEFAULT_MARKET_API_URL`, and all types from SDK entry point

## Test plan

- [x] 92 unit tests (`MarketModule.test.ts`) — API methods, signing verification, field mapping, minScore filtering, registration payload, error handling, feed
- [x] 48 resolver tests (`resolvers.test.ts`) — includes 7 new `resolveMarketConfig` cases
- [x] 42 integration tests (`market-module.test.ts`) — Sphere lifecycle, provider factories, address switching, all 5 intent types, feed
- [x] 8 CLI validation tests (`market-cli.test.ts`) — help text, argument parsing
- [x] 6 E2E tests (`test-e2e-cli-market.ts`) — full round-trip against live testnet API
- [x] Full suite: 1546 tests / 59 files — all passing
- [x] 0 lint warnings, clean typecheck, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)