### PR TITLE
fix(payments): eliminate TOCTOU race in concurrent send() calls

### DIFF
--- a/core/errors.ts
+++ b/core/errors.ts
@@ -40,7 +40,13 @@ export type SphereErrorCode =
   | 'TIMEOUT'
   | 'DECRYPTION_ERROR'
   | 'MODULE_NOT_AVAILABLE'
-  | 'SIGNING_ERROR';
+  | 'SIGNING_ERROR'
+  // Token Spend Queue error codes
+  | 'SEND_QUEUE_TIMEOUT'
+  | 'SEND_INSUFFICIENT_BALANCE'
+  | 'SEND_RESERVATION_CANCELLED'
+  | 'SEND_QUEUE_FULL'
+  | 'MODULE_DESTROYED';
 
 export class SphereError extends Error {
   readonly code: SphereErrorCode;

--- a/core/scan.ts
+++ b/core/scan.ts
@@ -92,8 +92,27 @@ export async function scanAddressesImpl(
   const { onProgress, signal, resolveNametag } = options;
 
   // Dynamic import to avoid hard dependency on L1 for non-L1 consumers
-  const { connect, getBalance } = await import('../l1/network');
-  await connect();
+  const { connect, disconnect, getBalance } = await import('../l1/network');
+
+  // Race connect against a timeout — L1 must never block L3 wallet init.
+  // connect() has its own reconnect loop (10 attempts, exponential backoff
+  // up to 60s each ≈ 6 min total). We fail fast so callers like
+  // discoverAddresses() can catch and continue without L1.
+  const L1_CONNECT_TIMEOUT_MS = 10_000;
+  let connectTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      connect(),
+      new Promise<never>((_, reject) => {
+        connectTimer = setTimeout(() => {
+          disconnect(); // kill the background reconnect loop
+          reject(new Error('L1 connect timeout'));
+        }, L1_CONNECT_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(connectTimer);
+  }
 
   const foundAddresses: ScannedAddressResult[] = [];
   let totalBalance = 0;

--- a/docs/SPEC-TOKEN-SPEND-QUEUE.md
+++ b/docs/SPEC-TOKEN-SPEND-QUEUE.md
@@ -1,0 +1,1279 @@
+# Token Spend Queue — Feature Specification
+
+**Document status:** Draft v1.0
+**Scope:** `sphere-sdk` — `modules/payments/`
+**Authors:** Architecture team
+**Last updated:** 2026-03-12
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Problem Statement](#2-problem-statement)
+3. [Architecture Overview](#3-architecture-overview)
+4. [Component: TokenReservationLedger](#4-component-tokenreservationledger)
+5. [Component: SpendPlanner](#5-component-spendplanner)
+6. [Component: SpendQueue](#6-component-spendqueue)
+7. [Integration: PaymentsModule.send() Changes](#7-integration-paymentsmodulesend-changes)
+8. [Integration: Change Token Arrival](#8-integration-change-token-arrival)
+9. [Failure Handling](#9-failure-handling)
+10. [Error Codes](#10-error-codes)
+11. [Concurrency Model](#11-concurrency-model)
+12. [Performance Characteristics](#12-performance-characteristics)
+13. [Constants Reference](#13-constants-reference)
+14. [Invariants Summary](#14-invariants-summary)
+15. [Test Coverage Checklist](#15-test-coverage-checklist)
+
+---
+
+## 1. Executive Summary
+
+`PaymentsModule.send()` has a TOCTOU (time-of-check-time-of-use) race condition: two concurrent `send()` calls can independently observe the same set of available tokens, both select them for spending, and both proceed. The second call will fail at the aggregator with `REQUEST_ID_EXISTS` because the token state was already committed by the first call.
+
+This specification defines three cooperating components that eliminate the race:
+
+| Component | Responsibility |
+|-----------|----------------|
+| `TokenReservationLedger` | Tracks exact amounts logically reserved from each token for each in-flight send. All operations are synchronous. |
+| `SpendPlanner` | Executes a synchronous critical section: reads free amounts, runs split calculation, creates reservation atomically. |
+| `SpendQueue` | Holds requests that cannot be served immediately because all candidate tokens are reserved. Wakes and re-plans when change tokens arrive. |
+
+The key insight is that JavaScript is single-threaded. Between any two `await` points, code runs atomically. The fix ensures that token selection and reservation happen without any `await` between them, making the check-then-act sequence truly atomic.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Current Race Window
+
+In the current `PaymentsModule.send()` implementation (lines 1009–1016 of `PaymentsModule.ts`):
+
+```
+// Line 1011-1016
+const availableTokens = Array.from(this.tokens.values());
+const splitPlan = await calculator.calculateOptimalSplit(   // <-- AWAIT HERE
+  availableTokens,
+  BigInt(request.amount),
+  request.coinId
+);
+```
+
+`calculateOptimalSplit` is `async` because `SdkToken.fromJSON()` is async. During the `await`, another microtask (another concurrent `send()` call) can run its own `calculateOptimalSplit` with the same `this.tokens` snapshot, select the same tokens, and proceed to mark them `'transferring'`.
+
+By the time both calls resume, both have selected the same tokens. The second submit to the aggregator will receive `REQUEST_ID_EXISTS`, which maps to a failed transfer and a corrupted wallet state (tokens removed but send failed).
+
+### 2.2 Why "Just Lock" Doesn't Work
+
+A naive mutex (`async lock() { ... }`) wrapping the entire `send()` body would serialize all sends globally. This is unacceptable because:
+
+- Sends for different coin IDs are fully independent and should not be serialized.
+- Sends that require no token overlap should proceed concurrently.
+- The critical section is tiny — only the token selection step needs serialization, not the ~2-second aggregator round-trip.
+
+### 2.3 Why Synchronous Reservation Works
+
+JavaScript's event loop guarantees that between two `await` points, no other code runs. If we (a) pre-parse all tokens asynchronously, then (b) read free amounts + compute plan + write reservation in a single synchronous block, the reservation is atomic. No concurrent `send()` call can observe the same free amount and make the same reservation.
+
+---
+
+## 3. Architecture Overview
+
+```
+PaymentsModule.send(request)
+        │
+        ├─── 1. Validate request (async — existing)
+        ├─── 2. Resolve recipient (async — existing)
+        ├─── 3. Build ParsedTokenPool (async — new)
+        │
+        │    ┌──────────────────────────────────────────────────────┐
+        │    │  SYNCHRONOUS CRITICAL SECTION (no awaits)            │
+        ├─── 4. SpendPlanner.planSend(request, parsedPool)          │
+        │    │    ├── Read free amounts from TokenReservationLedger  │
+        │    │    ├── Run calculateOptimalSplitSync(freeView)        │
+        │    │    ├── Case A: sufficient → create reservation        │
+        │    │    │          return { reservationId, splitPlan }     │
+        │    │    ├── Case B: sufficient if queued → enqueue        │
+        │    │    │          return Promise (resolved later)         │
+        │    │    └── Case C: permanently insufficient → throw       │
+        │    └──────────────────────────────────────────────────────┘
+        │
+        ├─── 5. Execute splitPlan (async — existing)
+        ├─── 6. ledger.commit(reservationId) on success
+        └─── 7. ledger.cancel(reservationId) + notifyChange on failure
+
+
+addToken(token)
+        └─── spendQueue.notifyChange(token.coinId)
+                └─── SpendQueue re-evaluates queued entries for coinId
+                        └─── For each plannable entry:
+                                └─── create reservation, resolve promise
+```
+
+### 3.1 Component Interactions
+
+```
+TokenReservationLedger
+    ↑ reserve / commit / cancel / getFreeAmount
+    │
+SpendPlanner ──── calculateOptimalSplitSync() ──── (new sync variant of TokenSplitCalculator)
+    │
+    ├─── immediate path: reservation created, returns synchronously
+    │
+    └─── queued path: SpendQueue.enqueue(entry)
+              │
+              └─── SpendQueue ──── notifyChange(coinId)
+                        │
+                        └─── re-runs SpendPlanner critical section for queued entries
+```
+
+---
+
+## 4. Component: TokenReservationLedger
+
+### 4.1 Purpose
+
+The `TokenReservationLedger` tracks which portions of which tokens have been logically claimed by in-flight `send()` operations. It answers the question: "how much of token X is actually free to be selected right now?"
+
+A reservation is not the same as a transfer. A reservation is a logical hold that exists only in memory for the duration of the send operation. When the send succeeds, the reservation is committed (the token is removed from `this.tokens` by the existing `removeToken` path). When the send fails, the reservation is cancelled and the token becomes available again.
+
+### 4.2 Data Model
+
+```typescript
+type ReservationStatus = 'active' | 'committed' | 'cancelled';
+
+interface ReservationEntry {
+  /** Unique per send attempt; equals the TransferResult.id of that send */
+  readonly reservationId: string;
+
+  /**
+   * Map from tokenId to the amount reserved from that token.
+   * A single reservation may span multiple tokens (e.g., three direct tokens + one split token).
+   */
+  readonly amounts: Map<string, bigint>;   // tokenId → reservedAmount
+
+  /** All tokens in a reservation share the same coinId */
+  readonly coinId: string;
+
+  /** Wall-clock time of reservation creation, in milliseconds since epoch */
+  readonly createdAt: number;
+
+  /** Current lifecycle state */
+  status: ReservationStatus;
+}
+```
+
+**Internal storage:**
+
+```typescript
+// Primary index: reservationId → ReservationEntry
+private readonly reservations: Map<string, ReservationEntry>;
+
+// Secondary index for fast per-token lookup: tokenId → Set<reservationId>
+// Maintained in sync with reservations map at all mutation points
+private readonly tokenIndex: Map<string, Set<string>>;
+```
+
+The `tokenIndex` is an acceleration structure. Its contents must always be consistent with the `reservations` map. Any mutation to `reservations` must be mirrored in `tokenIndex`.
+
+### 4.3 Operations
+
+All operations listed below are **synchronous** (no `async`, no `await`). This is a hard requirement. The guarantee that the critical section in `SpendPlanner.planSend()` is race-free depends entirely on all reservation operations being synchronous.
+
+---
+
+#### `reserve(reservationId, entries, coinId): void`
+
+Creates a new reservation.
+
+**Parameters:**
+- `reservationId: string` — must be unique across all active reservations. Callers use the `TransferResult.id` (a UUID from `crypto.randomUUID()`).
+- `entries: Array<{ tokenId: string; amount: bigint }>` — one entry per token to be reserved.
+- `coinId: string` — the coin being transferred. All tokens in `entries` must belong to this coin.
+
+**Preconditions (must be checked synchronously before writing):**
+1. `reservationId` must not already exist in `this.reservations`.
+2. For each entry: `getFreeAmount(entry.tokenId) >= entry.amount` must hold at the moment of the call.
+3. `entry.amount > 0n` for all entries.
+4. `entries` must not be empty.
+
+**Postconditions:**
+- A new `ReservationEntry` with `status = 'active'` is added to `this.reservations`.
+- For each `{ tokenId, amount }` in `entries`, `tokenIndex.get(tokenId)` includes `reservationId`.
+
+**Error behavior:**
+- If precondition 1 fails: throw `Error('DUPLICATE_RESERVATION_ID')`.
+- If precondition 2 fails for any entry: throw `Error('INSUFFICIENT_FREE_AMOUNT')`. No partial reservation is written; the operation is all-or-nothing.
+- If precondition 3 fails: throw `Error('INVALID_RESERVATION_AMOUNT')`.
+- If precondition 4 fails: throw `Error('EMPTY_RESERVATION')`.
+
+**Implementation note:** Because this is called from the synchronous critical section, the precondition checks and the map write happen atomically (no interleaving is possible). The failure path must ensure no partial state is written — compute all amounts before writing any.
+
+---
+
+#### `commit(reservationId): void`
+
+Marks a reservation as committed. Called immediately before `removeToken()` to signal that the tokens are about to be permanently removed.
+
+**Behavior:**
+- If `reservationId` not found: no-op (idempotent).
+- If `status === 'committed'`: no-op.
+- If `status === 'cancelled'`: log a warning (unexpected), no-op. A cancelled reservation should never be committed.
+- If `status === 'active'`: set `status = 'committed'`.
+
+**Note on tokenIndex:** The committed reservation remains in `tokenIndex` until `cleanup()` or until the token itself is removed (which triggers `cancelForToken()`). `getFreeAmount()` must treat committed reservations as still consuming the token's amount, because the token has not yet been physically removed from `this.tokens`. The token disappears from `this.tokens` a few lines after `commit()` in the send flow.
+
+---
+
+#### `cancel(reservationId): void`
+
+Releases a reservation, making the reserved amounts available again.
+
+**Behavior:**
+- If `reservationId` not found: no-op (idempotent).
+- If `status === 'committed'`: no-op with warning. Committed reservations must not be cancelled (the token is already being removed).
+- If `status === 'cancelled'`: no-op (idempotent).
+- If `status === 'active'`: set `status = 'cancelled'`, remove from `tokenIndex` for all referenced tokens.
+
+**Post-cancel state:** The cancelled entry MAY remain in `this.reservations` until `cleanup()` runs. This is acceptable because `getFreeAmount()` only sums reservations with `status === 'active'`.
+
+---
+
+#### `cancelForToken(tokenId): string[]`
+
+Cancels all active reservations that reference `tokenId`. Called by `removeToken()` to handle the case where a token is removed while it is still reserved.
+
+**Returns:** Array of cancelled `reservationId`s.
+
+**Behavior:**
+1. Look up `tokenIndex.get(tokenId)` to find all reservation IDs referencing this token.
+2. For each such reservation where `status === 'active'`: call `cancel(reservationId)`.
+3. Remove `tokenId` from `tokenIndex`.
+4. Return the list of cancelled reservation IDs.
+
+**Important:** This cancels the entire reservation, not just the portion for `tokenId`. If a reservation spans tokens A and B, and token A is removed, the entire reservation (including the hold on token B) is cancelled. This is correct behavior: the send that created this reservation is about to fail, so its hold on all tokens must be released.
+
+---
+
+#### `getFreeAmount(tokenId): bigint`
+
+Returns the amount of `tokenId` that is available for new reservations.
+
+**Computation:**
+
+```
+freeAmount = token.amount − Σ{ entry.amounts.get(tokenId) | entry ∈ reservations, entry.status ∈ { 'active', 'committed' } }
+```
+
+Both active and committed reservations are subtracted. Committed reservations still hold the token amount until the token is physically removed.
+
+**Returns:**
+- The free amount as a `bigint >= 0`.
+- If `tokenId` does not exist in `this.tokens` (as maintained by the caller, `PaymentsModule`): returns `0n`.
+
+**This operation must be O(k)** where k is the number of reservations referencing this token. Use `tokenIndex` for lookup.
+
+---
+
+#### `getTotalReserved(tokenId): bigint`
+
+Returns the total amount reserved from `tokenId` across all active and committed reservations.
+
+**Computation:**
+
+```
+totalReserved = Σ{ entry.amounts.get(tokenId) | entry ∈ reservations, entry.status ∈ { 'active', 'committed' } }
+```
+
+This is the complement of `getFreeAmount()`. Together they satisfy:
+
+```
+getFreeAmount(tokenId) + getTotalReserved(tokenId) = token.amount
+```
+
+for any token that exists in the pool.
+
+---
+
+#### `getActiveCoinReservations(coinId): Map<string, bigint>`
+
+Returns a map of all amounts reserved for `coinId` across all active reservations.
+
+**Returns:** `Map<tokenId, totalReservedAmount>` where `totalReservedAmount` is the sum of all active-reservation amounts for that token within the given coin. Committed and cancelled reservations are excluded.
+
+**Use case:** Used by `SpendPlanner` to build the "free view" of the token pool before calling `calculateOptimalSplitSync`.
+
+---
+
+#### `cleanup(maxAgeMs: number): string[]`
+
+Removes stale reservations (those older than `maxAgeMs` milliseconds, measured from `createdAt`).
+
+**Behavior:**
+1. Iterate all reservations.
+2. For each reservation where `(Date.now() - entry.createdAt) > maxAgeMs`:
+   - If `status === 'active'`: call `cancel(reservationId)` first, then remove.
+   - If `status === 'committed'` or `'cancelled'`: remove directly (no need to cancel).
+3. Clean up `tokenIndex` entries for removed reservations.
+4. Return the list of all `reservationId`s that were removed.
+
+**When called:**
+- Periodically by `SpendQueue`'s internal timer (every 1 second, with `maxAgeMs = RESERVATION_TIMEOUT_MS = 30_000`).
+- On `destroy()` with `maxAgeMs = 0` to cancel everything.
+
+**Note:** `cleanup()` cancels active stale reservations. This may make tokens available. The caller must call `spendQueue.notifyChange(coinId)` for each affected coin after `cleanup()` returns.
+
+### 4.4 Invariants
+
+| ID | Statement |
+|----|-----------|
+| I-RL-1 | `getFreeAmount(tokenId) >= 0n` for all tokenIds at all times. If a `reserve()` call would violate this, it must throw before writing any state. |
+| I-RL-2 | `getFreeAmount(tokenId) + getTotalReserved(tokenId) === token.amount` for any token currently in `this.tokens`. |
+| I-RL-3 | All mutating operations (`reserve`, `commit`, `cancel`, `cancelForToken`, `cleanup`) are synchronous. No `await` is permitted anywhere in these methods or in any method they call. |
+| I-RL-4 | A reservation with `status === 'cancelled'` or `'committed'` cannot be set back to `'active'`. Transitions are one-directional: `active → committed` and `active → cancelled`. |
+| I-RL-5 | The `tokenIndex` is always consistent with `reservations`. For any `(tokenId, reservationId)` pair in `tokenIndex`, `reservations.get(reservationId).amounts.has(tokenId)` must be `true`. |
+| I-RL-6 | Each entry in `reservations` has a unique `reservationId`. No two entries share the same ID. |
+
+### 4.5 Edge Cases
+
+**Reserve called with amount exceeding free amount:**
+Throw `INSUFFICIENT_FREE_AMOUNT`. Never write partial state.
+
+**Reserve called for a tokenId not present in the caller's token pool:**
+This is a programming error in `SpendPlanner`. Throw `UNKNOWN_TOKEN`. (SpendPlanner must only pass tokenIds that exist in `ParsedTokenPool`.)
+
+**Cancel called for unknown reservationId:**
+No-op. This can happen legitimately if `cleanup()` already removed the reservation.
+
+**Commit called for an already-committed reservation:**
+No-op. This can happen if `commit()` is called twice due to a retry path. Safe to ignore.
+
+**Token removed from `this.tokens` while reservation is active:**
+`removeToken()` must call `cancelForToken(tokenId)` before removing the token. The cancelled send operations must be notified (see section 9).
+
+**Multiple reservations on the same token:**
+Fully supported. `getFreeAmount` subtracts all active+committed amounts. Example: token with amount `1000`, two active reservations of `300` each → `getFreeAmount` returns `400`.
+
+**Reserve called with `amount = 0n`:**
+Throw `INVALID_RESERVATION_AMOUNT`. Zero-amount reservations serve no purpose and could mask bugs.
+
+---
+
+## 5. Component: SpendPlanner
+
+### 5.1 Purpose
+
+`SpendPlanner` owns the critical section: it reads the free-token view and creates a reservation atomically. "Atomically" in this context means "without any `await`" — JavaScript's single-threaded event loop guarantees no other code runs between two synchronous statements.
+
+### 5.2 Pre-computation Phase (Async, Before Critical Section)
+
+Before entering the synchronous critical section, `SpendPlanner` must pre-parse all token `sdkData` fields. This is necessary because `SdkToken.fromJSON()` is async and cannot be called inside the critical section.
+
+**Type: ParsedTokenPool**
+
+```typescript
+interface ParsedTokenEntry {
+  token: Token;           // The UI-layer Token object from this.tokens
+  sdkToken: SdkToken;    // Parsed SDK token (result of SdkToken.fromJSON)
+  amount: bigint;        // Parsed coin amount from sdkToken.coins.get(coinId)
+}
+
+// Key: token.id (the UUID used as key in PaymentsModule.this.tokens)
+type ParsedTokenPool = Map<string, ParsedTokenEntry>;
+```
+
+**Building ParsedTokenPool:**
+
+```
+async buildParsedPool(tokens: Token[], coinId: string): Promise<ParsedTokenPool>
+```
+
+1. Iterate `tokens`.
+2. For each token where `token.coinId === coinId` and `token.status === 'confirmed'` and `token.sdkData` is non-null:
+   a. Parse `JSON.parse(token.sdkData)`.
+   b. Await `SdkToken.fromJSON(parsed)`.
+   c. Extract `amount = sdkToken.coins.get(CoinId.fromJSON(coinId)) ?? 0n`.
+   d. Skip tokens where `amount === 0n`.
+3. Return the populated `ParsedTokenPool`.
+
+**Failure handling in buildParsedPool:**
+If `SdkToken.fromJSON()` throws for any individual token, log a warning and skip that token. A single unparseable token must not abort the entire send. This mirrors the existing behavior in `TokenSplitCalculator.calculateOptimalSplit()`.
+
+**When to build:**
+`buildParsedPool` is called once per `send()` invocation, before entering the critical section. If the request is queued and eventually retried after a `notifyChange()` event, the `parsedPool` snapshot from the original call is used for re-evaluation (see section 6.3 for why this is acceptable).
+
+### 5.3 Synchronous Variant of TokenSplitCalculator
+
+`TokenSplitCalculator.calculateOptimalSplit()` is currently async because `SdkToken.fromJSON()` is async. A new synchronous variant is required for use inside the critical section.
+
+**Signature:**
+
+```typescript
+calculateOptimalSplitSync(
+  candidates: ParsedTokenEntry[],   // pre-parsed, pre-filtered, sorted ascending by amount
+  targetAmount: bigint
+): SplitPlan | null
+```
+
+**Behavior:** Identical to `calculateOptimalSplit()` except:
+- Input is already parsed (`ParsedTokenEntry[]` instead of `Token[]`).
+- No `async`, no `await`.
+- The `coinId` is taken from the first candidate's `token.coinId` (all candidates share the same coinId by precondition).
+- Returns `null` if `candidates` is empty or `totalAvailable < targetAmount`.
+
+**The algorithm** (identical logic to current `calculateOptimalSplit`):
+1. Sort `candidates` ascending by `amount`.
+2. Compute `totalAvailable = Σ amounts`.
+3. If `totalAvailable < targetAmount`: return `null`.
+4. Strategy 1: exact match — single token with `amount === targetAmount`.
+5. Strategy 2: combination — find a set of up to 5 tokens summing to `targetAmount`.
+6. Strategy 3: greedy + split — accumulate tokens until overflow, split the final one.
+
+**Free-view transformation:**
+Before calling `calculateOptimalSplitSync`, the caller builds a modified candidate list reflecting current reservations:
+
+```
+freeEntry.amount = parsedEntry.amount - ledger.getFreeAmount(parsedEntry.token.id)
+```
+
+Wait — this is backwards. The correct formula is:
+
+```
+freeEntry.amount = ledger.getFreeAmount(parsedEntry.token.id)
+```
+
+where `ledger.getFreeAmount(id)` = `token.amount - totalReserved(id)`. Tokens where `freeEntry.amount === 0n` are excluded from the candidate list.
+
+### 5.4 The Critical Section
+
+```typescript
+planSend(
+  request: TransferRequest,
+  parsedPool: ParsedTokenPool,
+  ledger: TokenReservationLedger,
+  queue: SpendQueue,
+  reservationId: string
+): { reservationId: string; splitPlan: SplitPlan } | 'queued'
+```
+
+This method contains **no `await`**. The entire body runs synchronously.
+
+**Steps:**
+
+```
+1. Build freeView: for each entry in parsedPool where coinId matches:
+      freeAmount = ledger.getFreeAmount(entry.token.id)
+      if freeAmount > 0n: include in freeView with amount = freeAmount
+
+2. Run calculateOptimalSplitSync(freeView, BigInt(request.amount))
+      → plan (SplitPlan | null)
+
+3. Compute totalAvailable (free): sum of freeView amounts
+
+4. Compute totalInventory: sum of ALL parsedPool amounts for this coinId
+   (regardless of reservations)
+
+5. Determine outcome:
+      Case A — plan !== null (sufficient free tokens):
+            ledger.reserve(reservationId, planEntries(plan), request.coinId)
+            return { reservationId, splitPlan: plan }
+
+      Case B — plan === null AND totalInventory >= BigInt(request.amount):
+            (sufficient total inventory but all tied up in reservations)
+            queue.enqueue({ id: reservationId, request, parsedPool, ... })
+            return 'queued'
+
+      Case C — totalInventory < BigInt(request.amount):
+            throw SphereError('Insufficient balance', 'SEND_INSUFFICIENT_BALANCE')
+```
+
+**planEntries(plan):** Extracts the reservation entries from a `SplitPlan`:
+
+```
+entries = []
+for each token in plan.tokensToTransferDirectly:
+    entries.push({ tokenId: token.uiToken.id, amount: token.amount })
+if plan.tokenToSplit:
+    entries.push({ tokenId: plan.tokenToSplit.uiToken.id, amount: plan.splitAmount })
+```
+
+Note: for a split token, only `splitAmount` (the portion being sent) is reserved. `remainderAmount` remains free because it will become a new token under the sender's control.
+
+**The critical invariant:** Steps 1 through the `ledger.reserve()` call in Case A (or the `queue.enqueue()` call in Case B) run with no `await`. This guarantees that the free-amount check and the reservation write are atomic.
+
+### 5.5 planSend Caller Contract
+
+`planSend()` is called by `PaymentsModule.send()` as follows:
+
+```
+// (async context, but planSend itself is synchronous)
+const planResult = this.spendPlanner.planSend(request, parsedPool, ledger, queue, result.id);
+if (planResult === 'queued') {
+  // Await the promise from the queue
+  const { reservationId, splitPlan } = await this.spendQueue.waitForEntry(result.id);
+  // ... proceed with execution
+} else {
+  const { reservationId, splitPlan } = planResult;
+  // ... proceed with execution
+}
+```
+
+**The call to `planSend()` must not be preceded by any `await` after the last modification to `this.tokens`.** That is, between the last possible `addToken()`/`removeToken()` call and `planSend()`, there must be no `await`. `buildParsedPool()` is safe to `await` because it reads `this.tokens` at a point-in-time and returns an immutable snapshot; later token mutations do not affect `parsedPool`.
+
+---
+
+## 6. Component: SpendQueue
+
+### 6.1 Purpose
+
+The `SpendQueue` holds `send()` requests that cannot be immediately satisfied because all candidate tokens are currently reserved by concurrent sends. It re-evaluates queued requests when tokens become available (change tokens returning from a split, failed sends releasing their reservations, or any other `addToken()` call).
+
+### 6.2 Queue Entry
+
+```typescript
+interface QueueEntry {
+  /** Equals the TransferResult.id of the pending send */
+  readonly id: string;
+
+  /** Original transfer request */
+  readonly request: TransferRequest;
+
+  /**
+   * Snapshot of the parsed token pool at the time of enqueue.
+   * This snapshot reflects the token amounts as parsed (before any reservations).
+   * Used for re-evaluation: the planner applies current free amounts to these
+   * pre-parsed tokens rather than re-parsing from scratch.
+   *
+   * Staleness: if new tokens arrive between enqueue and wake, they are NOT in
+   * this snapshot. The wake path must supplement parsedPool with new tokens
+   * from this.tokens before calling calculateOptimalSplitSync. See 6.3.
+   */
+  readonly parsedPool: ParsedTokenPool;
+
+  /** Coin being requested */
+  readonly coinId: string;
+
+  /** Requested amount as bigint */
+  readonly amount: bigint;
+
+  /** Wall-clock time when this entry was enqueued */
+  readonly enqueuedAt: number;
+
+  /**
+   * Number of times this entry has been skipped (i.e., notifyChange fired but
+   * this entry could not be served while a later entry could).
+   * Used for starvation protection.
+   */
+  skipCount: number;
+
+  /** Resolve the promise returned to the send() caller */
+  resolve: (result: PlanResult) => void;
+
+  /** Reject the promise returned to the send() caller */
+  reject: (error: SphereError) => void;
+}
+
+interface PlanResult {
+  reservationId: string;
+  splitPlan: SplitPlan;
+}
+```
+
+### 6.3 ParsedPool Freshness on Re-evaluation
+
+When `notifyChange(coinId)` fires, new tokens may have arrived that were not in the original `parsedPool` snapshot. The re-evaluation logic must account for these.
+
+**Re-evaluation procedure in `notifyChange`:**
+
+```
+1. For each queued entry with entry.coinId === coinId (in queue order):
+
+   a. Build mergedPool:
+        Start with entry.parsedPool
+        For each token in this.tokens where coinId matches and status = 'confirmed':
+            If token.id NOT in entry.parsedPool:
+                Parse sdkData synchronously if already cached, else skip
+                (New tokens must have been parsed and cached at addToken() time — see 8.1)
+                Add to mergedPool
+
+   b. Apply free-view transform using current ledger state
+
+   c. Run calculateOptimalSplitSync(freeView, entry.amount)
+
+   d. If plan found:
+        ledger.reserve(entry.id, planEntries(plan), entry.coinId)
+        entry.resolve({ reservationId: entry.id, splitPlan: plan })
+        Remove entry from queue
+
+   e. If plan NOT found:
+        entry.skipCount++
+        If entry.skipCount >= MAX_SKIP_COUNT:
+            Stop iterating (starvation protection — wait for this entry to be served)
+```
+
+**Parsing new tokens synchronously:** Step (a) requires synchronous access to parsed token data for tokens added since enqueue. To support this, `addToken()` must cache the parsed `SdkToken` and `amount` in a `parsedTokenCache: Map<string, ParsedTokenEntry>` maintained on `PaymentsModule`. This cache is populated at `addToken()` time (async, not in the critical section) and consulted synchronously in `notifyChange`. The cache is invalidated at `removeToken()` time.
+
+**Alternative:** If synchronous parsing is not feasible for some tokens (e.g., parse fails), those tokens are excluded from the re-evaluation. The entry will be re-evaluated again on the next `notifyChange()` event.
+
+### 6.4 Operations
+
+---
+
+#### `enqueue(entry: Omit<QueueEntry, 'skipCount' | 'resolve' | 'reject'>): Promise<PlanResult>`
+
+Adds an entry to the queue and returns a promise that resolves when the entry is eventually planned.
+
+**Behavior:**
+1. Check `size()` against `QUEUE_MAX_SIZE` (100). If at capacity, immediately reject with `SEND_QUEUE_FULL`.
+2. Create a deferred promise, capturing `resolve` and `reject`.
+3. Set `entry.skipCount = 0`.
+4. Append to the per-coinId queue (a `Map<string, QueueEntry[]>`).
+5. Schedule `entry.enqueuedAt + QUEUE_TIMEOUT_MS` timeout. On fire: reject with `SEND_QUEUE_TIMEOUT` and remove from queue.
+6. Return the deferred promise.
+
+**Queue structure:** `Map<coinId, QueueEntry[]>`. Entries are processed in insertion order (FIFO within coinId, modulo skip-ahead).
+
+---
+
+#### `notifyChange(coinId: string): void`
+
+Called when tokens of `coinId` become available (either because a new token arrived or a reservation was cancelled).
+
+This method is **synchronous**. It re-evaluates the queue for `coinId` and resolves entries that can now be served.
+
+**Full behavior:**
+
+```
+entries = this.queue.get(coinId) ?? []
+i = 0
+while i < entries.length:
+    entry = entries[i]
+
+    // Check timeout first
+    if Date.now() - entry.enqueuedAt > QUEUE_TIMEOUT_MS:
+        entry.reject(new SphereError('Queue timeout', 'SEND_QUEUE_TIMEOUT'))
+        entries.splice(i, 1)
+        continue  // do NOT increment i
+
+    // Try to plan
+    mergedPool = buildMergedPool(entry.parsedPool, currentTokens)
+    freeView = applyFreeView(mergedPool, ledger)
+    plan = calculateOptimalSplitSync(freeView, entry.amount)
+
+    if plan !== null:
+        ledger.reserve(entry.id, planEntries(plan), entry.coinId)
+        entry.resolve({ reservationId: entry.id, splitPlan: plan })
+        entries.splice(i, 1)
+        continue  // do NOT increment i (next entry shifts to position i)
+
+    // Could not serve this entry
+    entry.skipCount++
+    if entry.skipCount >= MAX_SKIP_COUNT:
+        break  // starvation protection: stop here, this entry must be served next
+
+    i++
+
+// Update queue
+if entries.length === 0:
+    this.queue.delete(coinId)
+else:
+    this.queue.set(coinId, entries)
+```
+
+**Starvation protection detail:** When `entry.skipCount >= MAX_SKIP_COUNT`, the loop breaks immediately, preventing later entries from jumping ahead of a starving entry. On the next `notifyChange()`, the same entry is evaluated first again. `skipCount` is NOT reset on failed re-evaluation — it only stops incrementing past MAX_SKIP_COUNT.
+
+---
+
+#### `waitForEntry(id: string): Promise<PlanResult>`
+
+Returns the promise associated with a queued entry. This is how `PaymentsModule.send()` awaits the queue result after `planSend()` returns `'queued'`.
+
+**Behavior:**
+- Find the entry with `entry.id === id`.
+- Return the deferred promise.
+- If no entry found (should not happen in normal operation): reject with a programmer error.
+
+---
+
+#### `cancelAll(reason: string): void`
+
+Rejects all queued entries with the provided reason. Called by `PaymentsModule.destroy()`.
+
+**Behavior:**
+1. For each entry in all per-coinId queues: `entry.reject(new SphereError(reason, 'MODULE_DESTROYED'))`.
+2. Clear all queues.
+3. Cancel the periodic cleanup timer.
+
+---
+
+#### `size(coinId?: string): number`
+
+Returns the number of queued entries.
+
+- If `coinId` provided: count for that coin only.
+- If omitted: total across all coins.
+
+### 6.5 Periodic Timeout Check
+
+In addition to per-entry timeout scheduling (set in `enqueue()`), the `SpendQueue` runs a periodic timer every `QUEUE_CHECK_INTERVAL_MS = 1000` milliseconds.
+
+**Timer behavior:**
+1. Call `ledger.cleanup(RESERVATION_TIMEOUT_MS)` to remove stale reservations.
+2. For each coinId with stale reservations (returned by `cleanup()`): call `notifyChange(coinId)`.
+3. Scan all queued entries for timeout expiry (belt-and-suspenders for the per-entry timer).
+
+This dual-timeout mechanism ensures that entries are evicted even if the per-entry `setTimeout` is delayed by event loop saturation.
+
+---
+
+## 7. Integration: PaymentsModule.send() Changes
+
+### 7.1 New Instance Variables
+
+The following fields are added to `PaymentsModule`:
+
+```typescript
+private readonly reservationLedger: TokenReservationLedger;
+private readonly spendPlanner: SpendPlanner;
+private readonly spendQueue: SpendQueue;
+
+/**
+ * Cache of parsed SdkToken data, keyed by token.id.
+ * Populated at addToken() time, invalidated at removeToken() time.
+ * Used by SpendQueue.notifyChange() for synchronous re-evaluation.
+ */
+private readonly parsedTokenCache: Map<string, ParsedTokenEntry>;
+```
+
+These are initialized in the `PaymentsModule` constructor.
+
+### 7.2 Revised send() Flow
+
+```
+async send(request: TransferRequest): Promise<TransferResult> {
+  this.ensureInitialized();
+  if (this.destroyed) throw new SphereError('Module destroyed', 'MODULE_DESTROYED');
+
+  const result = {
+    id: crypto.randomUUID(),   // reservationId = result.id
+    status: 'pending',
+    tokens: [],
+    tokenTransfers: [],
+  };
+
+  try {
+    // ── Phase 1: Async pre-work (unchanged) ──────────────────────────────────
+    const peerInfo = await this.deps!.transport.resolve?.(request.recipient) ?? null;
+    const recipientPubkey = this.resolveTransportPubkey(request.recipient, peerInfo);
+    const recipientAddress = await this.resolveRecipientAddress(...);
+    const signingService = await this.createSigningService();
+    const stClient = ...;
+    const trustBase = ...;
+
+    // ── Phase 2: Pre-parse token pool (async, one-time) ───────────────────────
+    // Build ParsedTokenPool for the requested coinId.
+    // After this await, no further modification to this.tokens occurs before
+    // the critical section.
+    const parsedPool = await this.spendPlanner.buildParsedPool(
+      Array.from(this.tokens.values()),
+      request.coinId
+    );
+
+    // ── Phase 3: Critical section (synchronous) ───────────────────────────────
+    // planSend contains NO await. The token selection and reservation are atomic.
+    const planResult = this.spendPlanner.planSend(
+      request, parsedPool, this.reservationLedger, this.spendQueue, result.id
+    );
+
+    let reservationId: string;
+    let splitPlan: SplitPlan;
+
+    if (planResult === 'queued') {
+      // ── Phase 4a: Wait in queue (async) ──────────────────────────────────────
+      // Await without timeout — the per-entry timer in SpendQueue handles expiry.
+      ({ reservationId, splitPlan } = await this.spendQueue.waitForEntry(result.id));
+    } else {
+      // ── Phase 4b: Immediate planning succeeded ────────────────────────────────
+      ({ reservationId, splitPlan } = planResult);
+    }
+
+    // ── Phase 5: Execute splitPlan (unchanged async logic) ────────────────────
+    const tokensToSend: Token[] = splitPlan.tokensToTransferDirectly.map(t => t.uiToken);
+    if (splitPlan.tokenToSplit) tokensToSend.push(splitPlan.tokenToSplit.uiToken);
+    result.tokens = tokensToSend;
+
+    for (const token of tokensToSend) {
+      token.status = 'transferring';
+      this.tokens.set(token.id, token);
+    }
+    await this.save();
+    await this.saveToOutbox(result, recipientPubkey);
+    result.status = 'submitted';
+
+    // ... (all existing transfer execution logic: instant mode / conservative mode)
+
+    // ── Phase 6: Commit reservation on success ────────────────────────────────
+    this.reservationLedger.commit(reservationId);
+
+    // ... (existing post-transfer logic: history, events)
+
+    result.status = 'completed';
+    return result;
+
+  } catch (error) {
+    // ── Phase 7: Cancel reservation on failure ────────────────────────────────
+    this.reservationLedger.cancel(result.id);
+    this.spendQueue.notifyChange(request.coinId);   // wake queue — tokens freed
+
+    result.status = 'failed';
+    result.error = error instanceof Error ? error.message : String(error);
+
+    for (const token of result.tokens) {
+      token.status = 'confirmed';
+      this.tokens.set(token.id, token);
+    }
+
+    this.deps!.emitEvent('transfer:failed', result);
+    throw error;
+  }
+}
+```
+
+### 7.3 Constraint: No `await` Between parsedPool Build and planSend
+
+The constraint that `planSend()` runs atomically is satisfied by:
+
+1. `buildParsedPool()` is awaited and returns an immutable snapshot.
+2. No code between the `buildParsedPool()` `await` and the `planSend()` call modifies `this.tokens`.
+3. `planSend()` itself has no `await`.
+
+Point 2 must be enforced by code review. The critical section is NOT a try-catch or a mutex — it is simply the absence of `await` between the free-amount read and the `reserve()` write. This must be documented with a clear comment in the source code.
+
+### 7.4 Backward Compatibility
+
+- No changes to the `TransferRequest` or `TransferResult` types.
+- No changes to the external `send()` signature.
+- The reservation lifecycle is entirely internal.
+- Callers that currently retry on failure continue to work — the failure path cancels the reservation and wakes the queue.
+
+---
+
+## 8. Integration: Change Token Arrival
+
+Change tokens from splits and any other newly added tokens are the primary source of "queue wake" events.
+
+### 8.1 addToken() Changes
+
+`addToken()` is the single point where tokens enter `this.tokens`. After adding the token:
+
+1. **Parse and cache:** parse `token.sdkData` and cache the result in `this.parsedTokenCache`.
+
+   ```typescript
+   async addToken(token: Token): Promise<void> {
+     // ... existing logic ...
+     this.tokens.set(token.id, token);
+
+     // NEW: parse and cache for SpendQueue synchronous re-evaluation
+     if (token.sdkData && token.status === 'confirmed') {
+       try {
+         const parsed = JSON.parse(token.sdkData);
+         const sdkToken = await SdkToken.fromJSON(parsed);
+         const amount = this.extractCoinAmount(sdkToken, token.coinId);
+         if (amount > 0n) {
+           this.parsedTokenCache.set(token.id, { token, sdkToken, amount });
+         }
+       } catch {
+         // Parse failure: token not cached. SpendQueue will skip it during re-evaluation.
+         // This is acceptable — the token is in this.tokens and will be parsed in the
+         // next buildParsedPool() call on the next send().
+       }
+     }
+
+     // NEW: wake queue for this coinId
+     this.spendQueue.notifyChange(token.coinId);
+
+     // ... existing save/notify logic ...
+   }
+   ```
+
+   **Why cache here:** `notifyChange()` is synchronous. To include newly arrived tokens in synchronous re-evaluation, their parsed form must already be available.
+
+   **Why only 'confirmed' tokens:** Tokens with `status !== 'confirmed'` are excluded from `TokenSplitCalculator` candidate lists. No need to cache or wake the queue for placeholder, transferring, or unconfirmed tokens.
+
+2. **Call `spendQueue.notifyChange(token.coinId)`** after the cache update.
+
+   **Order matters:** The cache update must precede `notifyChange()`. If `notifyChange()` fires synchronously (it does), it may immediately read the cache for this token.
+
+### 8.2 removeToken() Changes
+
+`removeToken()` removes tokens from `this.tokens`. When a token is removed:
+
+1. **Cancel reservations:** `const cancelledIds = this.reservationLedger.cancelForToken(token.id)`.
+
+2. **Remove from cache:** `this.parsedTokenCache.delete(token.id)`.
+
+3. **Wake queue:** call `this.spendQueue.notifyChange(token.coinId)`.
+
+   This is not intuitive — removing a token reduces available amounts. However, a token removal may resolve a permanent insufficiency detection: if a queued entry was waiting for token X and token X is now removed, the entry's `totalInventory` check in `notifyChange` will now return `false`, causing the entry to be rejected with `SEND_INSUFFICIENT_BALANCE` rather than waiting indefinitely.
+
+   The `cancelForToken` call also frees up amounts on other tokens that were co-reserved with the removed token, which may allow other queued entries to proceed.
+
+4. **Existing remove logic** (archiving, tombstoning) continues unchanged.
+
+### 8.3 Token Status Change (Not an addToken/removeToken)
+
+When a token transitions from `'transferring'` back to `'confirmed'` (e.g., on send failure), `send()`'s catch block:
+1. Sets `token.status = 'confirmed'`.
+2. Calls `this.tokens.set(token.id, token)` (already in map, just updating status).
+3. This does NOT call `addToken()`.
+
+The queue wake in this path is handled by:
+```
+this.reservationLedger.cancel(result.id);    // releases reserved amounts
+this.spendQueue.notifyChange(request.coinId); // explicit wake
+```
+
+---
+
+## 9. Failure Handling
+
+### 9.1 Send Fails After Reservation Created
+
+This is the normal failure path (aggregator error, network error, etc.).
+
+**Steps:**
+1. Catch block in `send()` fires.
+2. `this.reservationLedger.cancel(result.id)` — releases all token amounts reserved for this send.
+3. For each token in `result.tokens`: restore `status = 'confirmed'`.
+4. `this.spendQueue.notifyChange(request.coinId)` — wake queued requests that may now be servable.
+5. `this.deps!.emitEvent('transfer:failed', result)`.
+6. Re-throw the error to the caller.
+
+**Idempotency:** If the catch block runs multiple times (e.g., due to unhandled re-throw), `cancel()` on an already-cancelled reservation is a no-op.
+
+### 9.2 Aggregator Rejects with REQUEST_ID_EXISTS
+
+`REQUEST_ID_EXISTS` from the aggregator means the commitment was already submitted (and possibly included). This can happen on:
+- Restart with stale outbox entries (the existing recovery path handles this).
+- Post-fix: should be extremely rare, only possible if two nodes share a private key.
+
+**Handling:**
+- The existing behavior is preserved: on `REQUEST_ID_EXISTS`, the send is treated as a success (the commitment went through).
+- No change to reservation lifecycle: `commit(reservationId)` is called on the success path.
+
+### 9.3 Token Becomes Invalid or Spent While Reserved
+
+If a token that is currently reserved is detected as spent (via aggregator validation or Nostr re-delivery with tombstone match):
+
+1. `removeToken(tokenId)` is called.
+2. `removeToken()` calls `ledger.cancelForToken(tokenId)` (new, per section 8.2).
+3. `cancelForToken()` cancels all active reservations that include `tokenId` and returns the `reservationId`s.
+4. `removeToken()` calls `spendQueue.notifyChange(coinId)`.
+
+**Notification to affected sends:**
+The `send()` calls that were waiting for those reservations need to be notified. This is handled implicitly: the reservation is cancelled, so when those sends proceed to `commit()` or check their reservation status, they will find it cancelled.
+
+**Implementation:** `SpendPlanner` should expose a `onReservationCancelled(reservationId, reason)` callback that `PaymentsModule` registers. When `cancelForToken()` returns a list of IDs, `PaymentsModule` calls this callback for each, which causes the corresponding `send()` to fail with `SEND_RESERVATION_CANCELLED`.
+
+Alternatively, `send()` can check `ledger.getStatus(reservationId)` before proceeding to the execution phase, and throw `SEND_RESERVATION_CANCELLED` if the status is `'cancelled'`. This check occurs synchronously after `waitForEntry()` resolves.
+
+### 9.4 Queue Timeout (30 Seconds)
+
+When a queued entry reaches `QUEUE_TIMEOUT_MS = 30_000` ms since `enqueuedAt`:
+
+1. The deferred promise is rejected with `new SphereError('Send queue timeout', 'SEND_QUEUE_TIMEOUT')`.
+2. The entry is removed from the queue.
+3. If a partial reservation was created (should not happen in this design — reservations are only created when a plan succeeds), it is cancelled.
+4. The `send()` catch block fires, handling cleanup per section 9.1.
+
+**Retry semantics:** `SEND_QUEUE_TIMEOUT` is recoverable. The caller can retry with a new `send()` call. The original `send()` call has failed; any state changes it made (token status = 'transferring') have been rolled back in the catch block.
+
+### 9.5 destroy() Called While Requests Are Queued
+
+`PaymentsModule.destroy()` adds the following steps (executed in order):
+
+1. Set `this.destroyed = true` (existing flag).
+2. `this.spendQueue.cancelAll('MODULE_DESTROYED')` — rejects all queued entry promises with `MODULE_DESTROYED`.
+3. `this.reservationLedger.cleanup(0)` — cancels all active reservations immediately.
+4. Existing destroy logic (unsubscribe, stop timers, etc.).
+
+Any `send()` calls that are `await`-ing a queue promise will have their awaits rejected, their catch blocks will fire, and they will re-throw `MODULE_DESTROYED` to their callers.
+
+---
+
+## 10. Error Codes
+
+The following error codes are new (added to `SphereError` code registry):
+
+| Code | Type | When Thrown | Recoverable? | Retry Guidance |
+|------|------|-------------|--------------|----------------|
+| `SEND_QUEUE_TIMEOUT` | `SphereError` | Queued send exceeded `QUEUE_TIMEOUT_MS` (30s) without being served | Yes | Retry immediately; likely cause was concurrent sends with a slow aggregator round-trip |
+| `SEND_INSUFFICIENT_BALANCE` | `SphereError` | Total token inventory (including all reserved tokens) is less than the requested amount | No | User needs more tokens; do not retry automatically |
+| `SEND_RESERVATION_CANCELLED` | `SphereError` | A token that was reserved for this send was removed (spent, invalidated, or sync-removed) while the send was in progress | Yes | Retry; the conflicting token is gone, new selection will avoid it |
+| `MODULE_DESTROYED` | `SphereError` | `destroy()` was called while the send was queued or in-flight | No | Do not retry; the wallet is shutting down |
+| `SEND_QUEUE_FULL` | `SphereError` | Queue has reached `QUEUE_MAX_SIZE` (100) entries for this coin | Yes | Back off and retry after a short delay |
+
+**Existing codes that remain relevant:**
+
+| Code | Notes |
+|------|-------|
+| `INSUFFICIENT_BALANCE` | Renamed to `SEND_INSUFFICIENT_BALANCE` for clarity (breaking change — coordinate with consumers) |
+| `TRANSFER_FAILED` | Aggregator or network failure during execution; catch block cancels reservation |
+| `AGGREGATOR_ERROR` | Fatal aggregator configuration error; catch block cancels reservation |
+
+---
+
+## 11. Concurrency Model
+
+### 11.1 What Is Synchronous vs. Async
+
+| Operation | Synchronous? | Notes |
+|-----------|-------------|-------|
+| `ledger.reserve()` | Yes | Entire method body, no awaits |
+| `ledger.commit()` | Yes | Entire method body |
+| `ledger.cancel()` | Yes | Entire method body |
+| `ledger.getFreeAmount()` | Yes | Read-only, no awaits |
+| `ledger.cancelForToken()` | Yes | Entire method body |
+| `ledger.cleanup()` | Yes | Entire method body |
+| `spendQueue.notifyChange()` | Yes | Entire method body, including planning loop |
+| `spendQueue.enqueue()` | Yes (body) | Returns a Promise, but the enqueue action itself is sync |
+| `spendQueue.cancelAll()` | Yes | Entire method body |
+| `spendPlanner.planSend()` | Yes | **The critical section** — must never acquire an await |
+| `spendPlanner.buildParsedPool()` | No (async) | Called before the critical section |
+| `calculateOptimalSplitSync()` | Yes | New sync variant |
+| `addToken()` (partial) | No | Async for save, but notifyChange() fires synchronously after cache update |
+| `removeToken()` (partial) | No | Async for archive/tombstone, but cancelForToken() fires synchronously |
+
+### 11.2 What Can Run Concurrently vs. What Is Serialized
+
+**Concurrently:**
+- `send()` calls for **different coinIds** — fully independent, no shared reservation state.
+- `send()` execution phases (token transfer to aggregator) for the same coinId — these run concurrently intentionally. Only the planning phase is serialized.
+- `addToken()` / `receive()` — these can run concurrently with `send()`. The token cache and `notifyChange` mechanism handle this safely.
+
+**Serialized (by virtue of JavaScript's single-threaded event loop):**
+- Any two `planSend()` calls — they cannot interleave because both are synchronous. The second call's `planSend()` executes only after the first call has either returned or (impossibly for sync code) yielded. Since `planSend()` is synchronous, it always runs to completion before any other synchronous code.
+- `notifyChange()` and `planSend()` — for the same reason. A `notifyChange()` triggered by an `addToken()` cannot interleave with a `planSend()` in progress.
+
+### 11.3 Critical Section Boundaries
+
+The critical section is not a lock. It is defined as the contiguous synchronous region from reading free amounts to writing the reservation:
+
+```
+─── (await buildParsedPool resolves) ────────────────────────────────────────
+  START OF CRITICAL SECTION
+  ledger.getActiveCoinReservations(coinId)   [sync read]
+  calculateOptimalSplitSync(freeView)        [sync compute]
+  ledger.reserve(...)                        [sync write]
+  ─── OR ───
+  spendQueue.enqueue(entry)                  [sync write (returns Promise)]
+  END OF CRITICAL SECTION
+─── (next await: this.save() or waitForEntry()) ─────────────────────────────
+```
+
+Between these two boundaries, no `await` may appear. The implementation must enforce this with a comment and review discipline.
+
+### 11.4 Why No Deadlocks Are Possible
+
+A deadlock requires a circular wait: resource A waits for B, and B waits for A. This system has no such cycle because:
+
+1. **The critical section is synchronous.** `planSend()` cannot wait for any other component. It either succeeds immediately, enqueues and returns, or throws. No blocking.
+
+2. **The queue resolves forward only.** Queue entries are resolved by `notifyChange()`, which is called when tokens are added or reservations are released. `notifyChange()` itself is synchronous and does not wait for queue entries.
+
+3. **No resource hierarchy.** The only shared resource is `TokenReservationLedger`. All callers access it through the same two entry points: `planSend()` (write) and `notifyChange()` (read + write). Both are synchronous, so they serialize naturally through the event loop.
+
+4. **No cross-coinId dependencies.** A reservation for `coinId = UCT` never blocks a reservation for `coinId = USDC`. The queues and ledger are per-coinId conceptually (even though the ledger uses a single map, the free-amount computation for one coin never reads reservation entries for another coin).
+
+5. **Promises resolve, never wait for each other.** The `send()` calls that are `await`-ing `waitForEntry()` are waiting for `resolve()` to be called, which happens in `notifyChange()`. `notifyChange()` does not await anything. It completes synchronously and schedules the resolved promise callbacks as microtasks. There is no cycle.
+
+---
+
+## 12. Performance Characteristics
+
+### 12.1 Critical Path Overhead
+
+| Operation | Complexity | Expected Duration |
+|-----------|------------|-------------------|
+| `buildParsedPool()` | O(n × parse cost) | ~1-5ms for typical wallets (10-100 tokens) |
+| `getActiveCoinReservations()` | O(r) where r = active reservations | <1µs for typical r < 10 |
+| `calculateOptimalSplitSync()` | O(n²) worst case (combinations) | <1ms for n ≤ 100 tokens |
+| `ledger.reserve()` | O(k) where k = tokens in plan | <1µs for typical k ≤ 5 |
+| `planSend()` total | O(n² + r) | <2ms total critical section |
+
+**Total added overhead per send:** approximately 2-7ms. This is negligible compared to the ~2.3s aggregator round-trip.
+
+### 12.2 Queue Depth in Normal Operation
+
+Under typical usage (one or two concurrent sends of the same coin):
+- Expected queue depth: 0-1 entries.
+- Most sends will find immediate free tokens (no other concurrent send).
+- Sends that overlap on tokens will queue for at most ~2.3s (the aggregator proof time for the conflicting send to return its change token).
+
+Under stress (many concurrent sends of the same coin):
+- Queue depth: O(concurrent sends).
+- Each send waits for change tokens from the send ahead of it.
+- The queue resolves in FIFO order (with skip-ahead for smaller amounts that fit in residual free amounts).
+
+### 12.3 Memory Bounds
+
+| Structure | Size | Bound |
+|-----------|------|-------|
+| `reservations` map | O(active reservations × tokens per reservation) | At most `QUEUE_MAX_SIZE + 1` active reservations × 5 tokens = ~505 entries |
+| `tokenIndex` | O(total token-reservation pairs) | Same bound |
+| `parsedTokenCache` | O(tokens in wallet) | Bounded by `this.tokens.size` (typically < 1000) |
+| Per-coinId queue | O(queued sends per coin) | At most `QUEUE_MAX_SIZE` = 100 per coin |
+
+### 12.4 Change Token Latency
+
+The maximum queue wait time for a request blocked by a concurrent split is bounded by the split's change token arrival time:
+- Instant mode (V6 bundle): ~2.3s (aggregator burn proof + background mint).
+- Conservative mode: ~42s (full sequential proof collection).
+
+Queued sends set their timeout at 30s. If the conflicting send uses conservative mode, the queued send may timeout. This is by design: conservative mode is not optimized for concurrent operation. Users or callers should use instant mode for concurrent send scenarios.
+
+### 12.5 Queue Cleanup
+
+`cleanup()` runs every 1 second. Its cost is O(total reservations), which is bounded by `QUEUE_MAX_SIZE + 1`. At most 101 entries in the worst case, making cleanup negligible.
+
+---
+
+## 13. Constants Reference
+
+All constants defined in a single location (e.g., `modules/payments/spend-queue-constants.ts`):
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `RESERVATION_TIMEOUT_MS` | `30_000` | Stale reservation eviction threshold (ms) |
+| `QUEUE_TIMEOUT_MS` | `30_000` | Queued send expiry (ms from enqueue time) |
+| `MAX_SKIP_COUNT` | `10` | Max times an entry can be skipped before starvation protection halts forward progress |
+| `QUEUE_MAX_SIZE` | `100` | Maximum queue depth per coinId before new enqueues are rejected |
+| `QUEUE_CHECK_INTERVAL_MS` | `1_000` | Periodic cleanup timer interval (ms) |
+
+**Rationale:**
+
+- `RESERVATION_TIMEOUT_MS = 30s`: Covers the conservative-mode round-trip (~42s would be too short, but the retry path handles that). Set at 30s to match `QUEUE_TIMEOUT_MS`.
+- `QUEUE_TIMEOUT_MS = 30s`: Long enough for instant-mode change tokens (~2.3s) plus network variance. Short enough to surface failures promptly.
+- `MAX_SKIP_COUNT = 10`: After being skipped 10 times, an entry is almost certainly dealing with starvation rather than a transient unavailability. At ~2.3s per change token, 10 skips ≈ 23s before starvation protection kicks in, well within the 30s timeout.
+- `QUEUE_MAX_SIZE = 100`: Prevents unbounded memory growth. 100 concurrent sends of the same coin is far beyond any realistic usage.
+- `QUEUE_CHECK_INTERVAL_MS = 1s`: Provides timely timeout detection without significant overhead.
+
+---
+
+## 14. Invariants Summary
+
+The following invariants must hold at all times during normal operation. Violations indicate implementation bugs.
+
+### Reservation Ledger Invariants
+
+| ID | Statement |
+|----|-----------|
+| I-RL-1 | `ledger.getFreeAmount(id) >= 0n` for all token IDs |
+| I-RL-2 | `ledger.getFreeAmount(id) + ledger.getTotalReserved(id) === token.amount` for all tokens in `this.tokens` |
+| I-RL-3 | All mutating operations on the ledger are synchronous |
+| I-RL-4 | Reservation status transitions are one-directional: `active → committed`, `active → cancelled` |
+| I-RL-5 | `tokenIndex` contents are consistent with `reservations` contents at all times |
+| I-RL-6 | Each `reservationId` in `reservations` is unique |
+
+### SpendPlanner Invariants
+
+| ID | Statement |
+|----|-----------|
+| I-SP-1 | `planSend()` contains no `await` or async operations |
+| I-SP-2 | Every `reserve()` call inside `planSend()` uses amounts that were confirmed free by `getFreeAmount()` in the same synchronous execution frame |
+| I-SP-3 | A reservation is only created when `calculateOptimalSplitSync()` returns a non-null plan |
+| I-SP-4 | No `send()` operation proceeds to the execution phase with a cancelled reservation |
+
+### SpendQueue Invariants
+
+| ID | Statement |
+|----|-----------|
+| I-SQ-1 | Every queued entry has a corresponding deferred promise that will eventually be resolved or rejected |
+| I-SQ-2 | No entry remains in the queue after its deferred promise has been resolved or rejected |
+| I-SQ-3 | `notifyChange()` is synchronous |
+| I-SQ-4 | An entry's `skipCount` never decreases |
+| I-SQ-5 | An entry that has reached `MAX_SKIP_COUNT` is always evaluated before any entry with lower `skipCount` in the same `notifyChange()` pass |
+
+### PaymentsModule Integration Invariants
+
+| ID | Statement |
+|----|-----------|
+| I-PM-1 | `addToken()` always calls `spendQueue.notifyChange(token.coinId)` for confirmed tokens |
+| I-PM-2 | `removeToken()` always calls `ledger.cancelForToken(token.id)` before removing the token |
+| I-PM-3 | The `parsedTokenCache` always contains an entry for every confirmed token in `this.tokens` with valid `sdkData` |
+| I-PM-4 | No `await` appears between the last possible `this.tokens` mutation and the `planSend()` call |
+| I-PM-5 | On send failure, `ledger.cancel(reservationId)` is called before `emitEvent('transfer:failed')` |
+
+---
+
+## 15. Test Coverage Checklist
+
+The following test scenarios must be covered by unit tests. All tests use mocked aggregator and transport providers.
+
+### TokenReservationLedger Tests
+
+- [ ] Reserve single token, verify `getFreeAmount` decreases
+- [ ] Reserve multiple tokens in one reservation, verify all affected free amounts
+- [ ] Two reservations on same token, verify free amounts sum correctly
+- [ ] Commit reservation, verify `getFreeAmount` unchanged (committed still counts)
+- [ ] Cancel reservation, verify `getFreeAmount` restored
+- [ ] Cancel then try to commit: no-op, log warning
+- [ ] Commit then try to cancel: no-op, log warning
+- [ ] Reserve with amount exceeding free: throws `INSUFFICIENT_FREE_AMOUNT`, no state written
+- [ ] Reserve with duplicate `reservationId`: throws `DUPLICATE_RESERVATION_ID`
+- [ ] Reserve with `amount = 0n`: throws `INVALID_RESERVATION_AMOUNT`
+- [ ] `cancelForToken` cancels all reservations referencing that token
+- [ ] `cancelForToken` on token with no reservations: no-op, returns `[]`
+- [ ] `cleanup(0)` cancels all active reservations, ignores committed and cancelled
+- [ ] `cleanup(maxAgeMs)` only removes entries older than threshold
+- [ ] `tokenIndex` consistency after each operation
+- [ ] Invariant I-RL-2 holds across 100 random reserve/cancel/commit operations
+
+### SpendPlanner Tests
+
+- [ ] `buildParsedPool` excludes non-confirmed tokens
+- [ ] `buildParsedPool` excludes tokens with wrong coinId
+- [ ] `buildParsedPool` handles `SdkToken.fromJSON` failure gracefully (skips token, logs warning)
+- [ ] `calculateOptimalSplitSync` returns exact match plan
+- [ ] `calculateOptimalSplitSync` returns combination plan (2-5 tokens)
+- [ ] `calculateOptimalSplitSync` returns split plan
+- [ ] `calculateOptimalSplitSync` returns `null` when insufficient
+- [ ] `planSend` Case A: immediate plan when tokens available
+- [ ] `planSend` Case B: enqueues when all tokens reserved
+- [ ] `planSend` Case C: throws `SEND_INSUFFICIENT_BALANCE` when total inventory insufficient
+- [ ] `planSend` only reserves `splitAmount` for split tokens, not full token amount
+- [ ] Free-view correctly excludes tokens with zero free amount
+
+### SpendQueue Tests
+
+- [ ] `enqueue` returns a Promise that resolves when `notifyChange` makes tokens available
+- [ ] `notifyChange` serves FIFO entries when possible
+- [ ] `notifyChange` skips entries and serves later ones when skip-ahead applicable
+- [ ] `skipCount` increments on skip
+- [ ] Starvation protection: loop halts when first entry reaches `MAX_SKIP_COUNT`
+- [ ] `skipCount` does not decrement
+- [ ] Entry timeout: rejected after `QUEUE_TIMEOUT_MS`
+- [ ] `cancelAll` rejects all entries with the provided reason
+- [ ] `size()` returns correct counts
+- [ ] `QUEUE_MAX_SIZE` enforcement: `SEND_QUEUE_FULL` on overflow
+- [ ] New tokens added to `parsedPool` during wait are included in re-evaluation
+- [ ] Periodic cleanup timer triggers `notifyChange` for stale-reservation coins
+
+### Integration Tests (PaymentsModule.send)
+
+- [ ] Two concurrent sends of different coinIds complete independently
+- [ ] Two concurrent sends of same coinId, sufficient total balance: both succeed
+- [ ] Two concurrent sends of same coinId, insufficient total balance: first succeeds, second throws `SEND_INSUFFICIENT_BALANCE`
+- [ ] Concurrent send queued, change token arrives, queued send completes
+- [ ] Failed send releases reservation, wakes queued send
+- [ ] `destroy()` during queued send: rejected with `MODULE_DESTROYED`
+- [ ] Queue timeout (simulated): rejected with `SEND_QUEUE_TIMEOUT`, reservation cleaned up
+- [ ] Token removed while reserved: `SEND_RESERVATION_CANCELLED` for affected sends
+- [ ] Reservation committed before `removeToken` in success path
+- [ ] Reservation cancelled before `emitEvent('transfer:failed')` in failure path
+- [ ] `parsedTokenCache` populated on `addToken`, cleared on `removeToken`
+- [ ] No `await` between `buildParsedPool` return and `planSend` call (code structure test / static analysis)
+
+---
+
+*End of specification.*

--- a/docs/TEST-SPEC-TOKEN-SPEND-QUEUE.md
+++ b/docs/TEST-SPEC-TOKEN-SPEND-QUEUE.md
@@ -1,0 +1,1396 @@
+# Comprehensive Test Suite Specification: Token Spend Queue
+
+## Overview
+
+This document specifies a complete test suite for the Token Spend Queue feature in Sphere SDK. The test suite covers:
+
+- **TokenReservationLedger**: Core reservation tracking with partial reservations and lifecycle management
+- **SpendPlanner**: Token selection logic with skip-ahead queue integration
+- **SpendQueue**: Queue lifecycle, timeouts, and concurrency coordination
+- **PaymentsModule Concurrency**: End-to-end race condition scenarios
+- **Send-Queue Integration**: Complete wallet state consistency
+- **Starvation Protection**: Fairness guarantees with skip-ahead logic
+
+**Total Estimated Test Cases: 240+**
+
+---
+
+## FILE 1: `tests/unit/modules/TokenReservationLedger.test.ts`
+
+**Purpose**: Verify exact reservation tracking with composite key semantics and invariant preservation.
+
+**Test Type Tags**: `[UNIT]` — synchronous, no async I/O, no state machines.
+
+---
+
+### Describe Block: Basic Operations
+
+#### It: "reserve() creates a reservation with correct amounts" `[UNIT]`
+- **Setup**: Ledger with one token (id: `tok-1`, amount: `1000000` satoshis)
+- **Action**: `reserve({ tokens: [{ tokenId: 'tok-1', amount: '500000' }] })`
+- **Expected**: 
+  - Returns reservationId string (UUID format)
+  - `getFreeAmount('tok-1')` returns `500000` (1000000 - 500000)
+  - `getTotalReserved('tok-1')` returns `500000`
+
+#### It: "reserve() for multiple tokens in one reservation" `[UNIT]`
+- **Setup**: Ledger with 3 tokens: `tok-1` (1000000), `tok-2` (2000000), `tok-3` (500000)
+- **Action**: `reserve({ tokens: [{ tokenId: 'tok-1', amount: '400000' }, { tokenId: 'tok-2', amount: '1000000' }] })`
+- **Expected**:
+  - Single reservationId returned
+  - `getFreeAmount('tok-1')` = `600000`
+  - `getFreeAmount('tok-2')` = `1000000`
+  - `getFreeAmount('tok-3')` = `500000` (unchanged)
+  - `getTotalReserved('tok-1')` = `400000`
+  - `getTotalReserved('tok-2')` = `1000000`
+
+#### It: "commit() marks reservation as committed" `[UNIT]`
+- **Setup**: Ledger with token `tok-1` (1000000), reservation made for 500000
+- **Action**: Get reservationId from reserve(), call `commit(reservationId)`
+- **Expected**:
+  - `getFreeAmount('tok-1')` still returns `500000` (free amount unchanged)
+  - Reservation is in committed state (internal flag set)
+  - Can no longer `cancel()` this reservationId (throws or no-op)
+
+#### It: "cancel() releases reservation amounts" `[UNIT]`
+- **Setup**: Ledger with token `tok-1` (1000000), reservation made for 500000
+- **Action**: Get reservationId, call `cancel(reservationId)`
+- **Expected**:
+  - `getFreeAmount('tok-1')` returns `1000000` (fully released)
+  - `getTotalReserved('tok-1')` returns `0`
+  - Calling `cancel()` again is no-op (idempotent)
+
+#### It: "getFreeAmount() returns token amount minus all active reservations" `[UNIT]`
+- **Setup**: Ledger with token `tok-1` (1000000), two reservations: res-1 for 300000, res-2 for 400000
+- **Action**: Call `getFreeAmount('tok-1')`
+- **Expected**: Returns `300000` (1000000 - 300000 - 400000)
+
+#### It: "getTotalReserved() sums across all active reservations for a token" `[UNIT]`
+- **Setup**: Same as above (two reservations)
+- **Action**: Call `getTotalReserved('tok-1')`
+- **Expected**: Returns `700000` (sum of both)
+
+#### It: "getActiveCoinReservations() returns all reserved amounts for a coinId" `[UNIT]`
+- **Setup**: Ledger with 2 tokens of same coin (UCT): `tok-1` (1000000), `tok-2` (2000000). Three reservations: tok-1→300000, tok-2→500000, tok-1→100000
+- **Action**: Call `getActiveCoinReservations('UCT')`
+- **Expected**:
+  - Returns map: `{ 'tok-1': '400000', 'tok-2': '500000' }`
+  - Order doesn't matter (set semantics)
+
+---
+
+### Describe Block: Partial Reservation (Multiple sends from same token)
+
+#### It: "Two reservations on same token, each claiming part of the amount" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000)
+- **Action**: 
+  1. res-1 = `reserve({ tokens: [{ tokenId: 'tok-1', amount: '300000' }] })`
+  2. res-2 = `reserve({ tokens: [{ tokenId: 'tok-1', amount: '400000' }] })`
+- **Expected**: Both succeed, no throw
+
+#### It: "getFreeAmount after two partial reservations is correct" `[UNIT]`
+- **Setup**: Same as above
+- **Action**: Call `getFreeAmount('tok-1')`
+- **Expected**: Returns `300000` (1000000 - 300000 - 400000)
+
+#### It: "cancel one partial reservation → other remains, free amount updates" `[UNIT]`
+- **Setup**: Same as above with res-1 and res-2
+- **Action**: Call `cancel(res-1)`
+- **Expected**:
+  - `getFreeAmount('tok-1')` = `600000` (1000000 - 400000 from res-2 only)
+  - `getTotalReserved('tok-1')` = `400000`
+
+#### It: "commit one, cancel other → free amount reflects only cancelled release" `[UNIT]`
+- **Setup**: Same as above with res-1 and res-2
+- **Action**: 
+  1. `commit(res-1)`
+  2. `cancel(res-2)`
+- **Expected**:
+  - `getFreeAmount('tok-1')` = `700000` (1000000 - 300000 from committed res-1)
+  - Note: committed and active both count against free
+
+---
+
+### Describe Block: Validation & Error Cases
+
+#### It: "reserve() with amount exceeding free amount → throws" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000), existing reservation for 700000
+- **Action**: Try `reserve({ tokens: [{ tokenId: 'tok-1', amount: '500000' }] })`
+- **Expected**: Throws `Error` with message matching "insufficient.*free.*amount" or similar
+
+#### It: "reserve() for token not in pool → throws" `[UNIT]`
+- **Setup**: Ledger with token `tok-1` (1000000)
+- **Action**: Try `reserve({ tokens: [{ tokenId: 'nonexistent', amount: '100' }] })`
+- **Expected**: Throws `Error` with message matching "token.*not.*found" or "unknown.*token"
+
+#### It: "reserve() with zero amount → accepted or rejected consistently" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000)
+- **Action**: Try `reserve({ tokens: [{ tokenId: 'tok-1', amount: '0' }] })`
+- **Expected**: Either returns valid reservationId or throws with clear message. **Document the design decision.**
+
+#### It: "reserve() with negative amount → throws" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000)
+- **Action**: Try `reserve({ tokens: [{ tokenId: 'tok-1', amount: '-100' }] })`
+- **Expected**: Throws `Error`
+
+#### It: "cancel() for unknown reservationId → no-op or safe" `[UNIT]`
+- **Setup**: Ledger with token `tok-1` (1000000)
+- **Action**: Call `cancel('unknown-id-12345')`
+- **Expected**: No-op (idempotent), no throw, free amount unchanged
+
+#### It: "cancel() for already-cancelled reservation → no-op" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000), reservation res-1
+- **Action**: 
+  1. `cancel(res-1)`
+  2. `cancel(res-1)` again
+- **Expected**: Second call is no-op, no throw
+
+#### It: "commit() for already-committed reservation → no-op" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000), reservation res-1
+- **Action**: 
+  1. `commit(res-1)`
+  2. `commit(res-1)` again
+- **Expected**: Second call is no-op, no throw
+
+#### It: "commit() for already-cancelled reservation → throws or no-op" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000), reservation res-1
+- **Action**: 
+  1. `cancel(res-1)`
+  2. `commit(res-1)`
+- **Expected**: Throws `Error` or is no-op. **Document which behavior is chosen.**
+
+#### It: "cancel() for already-committed reservation → throws" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000), reservation res-1
+- **Action**: 
+  1. `commit(res-1)`
+  2. `cancel(res-1)`
+- **Expected**: Throws `Error` with message matching "cannot.*cancel.*committed"
+
+---
+
+### Describe Block: Token Removal
+
+#### It: "cancelForToken() cancels ALL reservations containing that token" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000), three reservations:
+  - res-1: [tok-1: 200000]
+  - res-2: [tok-1: 300000, tok-2: 100000]
+  - res-3: [tok-2: 400000]
+- **Action**: Call `cancelForToken('tok-1')`
+- **Expected**:
+  - res-1 cancelled
+  - res-2 cancelled (even though it has tok-2 too)
+  - res-3 NOT cancelled (no tok-1)
+  - `getFreeAmount('tok-1')` = `1000000`
+  - `getFreeAmount('tok-2')` = `1500000` (2000000 - 500000 from res-2 only, res-3 untouched)
+
+#### It: "cancelForToken() for token with no reservations → no-op" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000), token `tok-2` (2000000), reservation res-1 on tok-1 only
+- **Action**: Call `cancelForToken('tok-2')`
+- **Expected**: No-op, free amounts unchanged
+
+#### It: "cancelForToken() returns list of affected reservationIds" `[UNIT]`
+- **Setup**: Same as first test in this block
+- **Action**: Call `cancelForToken('tok-1')`
+- **Expected**: Returns array `['res-1', 'res-2']` (or equivalent IDs in any order)
+
+#### It: "After cancelForToken(), getFreeAmount returns full token amount" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000) with reservation for 700000
+- **Action**: Call `cancelForToken('tok-1')`
+- **Expected**: `getFreeAmount('tok-1')` = `1000000`
+
+---
+
+### Describe Block: Cleanup
+
+#### It: "cleanup(maxAgeMs) removes reservations older than threshold" `[UNIT]`
+- **Setup**: Ledger with two reservations:
+  - res-1 created at time 100, active
+  - res-2 created at time 200, active
+  - Token `tok-1` (1000000) with both reservations claiming 300000 total
+- **Action**: Mock Date.now() to return 400, call `cleanup(150)` (remove anything older than 400-150=250)
+- **Expected**:
+  - res-1 removed (100 < 250)
+  - res-2 kept (200 > 250)
+  - Returns array containing res-1
+  - `getFreeAmount('tok-1')` = `700000` (1000000 - only res-2's claim)
+
+#### It: "cleanup returns IDs of removed reservations" `[UNIT]`
+- **Setup**: Three reservations: res-1 (old), res-2 (old), res-3 (new)
+- **Action**: Call `cleanup(oldThreshold)`
+- **Expected**: Returns `['res-1', 'res-2']`
+
+#### It: "cleanup only removes 'active' reservations (not committed)" `[UNIT]`
+- **Setup**: Two reservations on `tok-1` (1000000):
+  - res-1: active, old
+  - res-2: committed, old
+  - res-1 claims 300000, res-2 claims 400000
+- **Action**: Call `cleanup(threshold)` where both are older than threshold
+- **Expected**:
+  - res-1 removed
+  - res-2 NOT removed (committed)
+  - Returns `['res-1']` only
+  - `getFreeAmount('tok-1')` = `600000` (1000000 - res-2's committed 400000)
+
+#### It: "cleanup doesn't remove reservations within threshold" `[UNIT]`
+- **Setup**: Reservation res-1, created at now - 50ms, maxAgeMs = 100
+- **Action**: Call `cleanup(100)`
+- **Expected**: res-1 NOT removed (50 < 100), returns empty array
+
+---
+
+### Describe Block: Invariant Checks
+
+#### It: "After any sequence of reserve/cancel/commit: getFreeAmount + getTotalReserved === token.amount" `[UNIT]`
+- **Setup**: Token `tok-1` (1000000)
+- **Action**: Perform sequence:
+  1. res-1 = `reserve({ tokens: [{ tokenId: 'tok-1', amount: '300000' }] })`
+  2. res-2 = `reserve({ tokens: [{ tokenId: 'tok-1', amount: '200000' }] })`
+  3. `commit(res-1)`
+  4. `cancel(res-2)`
+- **Expected**: At each step, verify: `getFreeAmount('tok-1') + getTotalReserved('tok-1') == 1000000`
+
+#### It: "Fuzz test: random sequence of 100 operations → invariant holds after each" `[UNIT]`
+- **Setup**: Ledger with 5 tokens (varying amounts 500k–2M)
+- **Action**: Generate 100 random operations: reserve, cancel, commit, cleanup, cancelForToken. Track all reservationIds and verify invariant after each.
+- **Expected**: 
+  - All 100 operations complete without error
+  - Invariant holds after every single operation: `∑(getFreeAmount(tok)) + ∑(getTotalReserved(tok)) == ∑(token.amount)` for all tokens
+  - No crashes, no silent corruption
+
+---
+
+### Shared Fixtures
+
+- **TokenPool**: Factory function returning `{ 'tok-1': { tokenId: 'tok-1', amount: '1000000', coinId: 'UCT' }, ... }`
+- **createLedger(tokenPool)**: Returns TokenReservationLedger instance
+- **UUID validation**: Helper to verify reservationId format
+
+**Estimated Test Count: 35 tests**
+
+---
+
+## FILE 2: `tests/unit/modules/SpendPlanner.test.ts`
+
+**Purpose**: Verify token selection logic, split detection, and queue interaction with skip-ahead.
+
+**Test Type Tags**: `[UNIT]` for basic operations, `[INTEGRATION]` for queue interaction.
+
+---
+
+### Describe Block: Immediate Planning (tokens available)
+
+#### It: "Single send, single token covers amount → immediate reservation + splitPlan" `[UNIT]`
+- **Setup**: Token pool with `tok-1` (1000000, confirmed). Request for 500000.
+- **Action**: Call `SpendPlanner.planSend({ amount: '500000', coinId: 'UCT' }, tokenPool, ledger)`
+- **Expected**:
+  - Result status: `'immediate'`
+  - reservationId is set (non-null)
+  - splitPlan: `{ mainTokenId: 'tok-1', mainAmount: '500000', changeTokenId: null }`
+  - Reservation created in ledger for 500000 from tok-1
+
+#### It: "Single send requiring multiple tokens → immediate reservation on all" `[UNIT]`
+- **Setup**: Token pool: `tok-1` (300000), `tok-2` (400000), both confirmed. Request for 600000.
+- **Action**: Call `SpendPlanner.planSend({ amount: '600000', coinId: 'UCT' }, tokenPool, ledger)`
+- **Expected**:
+  - Result status: `'immediate'`
+  - reservationId is set
+  - splitPlan: `{ mainTokenId: 'tok-1', mainAmount: '300000', changeTokenId: 'tok-2', changeAmount: '300000' }`
+  - Both tokens reserved (tok-1: 300000, tok-2: 300000)
+
+#### It: "Single send requiring split → reservation includes split token with correct amounts" `[UNIT]`
+- **Setup**: Token pool with `tok-1` (1000000, confirmed). Request for 600000.
+- **Action**: Call `SpendPlanner.planSend({ amount: '600000', coinId: 'UCT' }, tokenPool, ledger)`
+- **Expected**:
+  - Result status: `'immediate'`
+  - splitPlan: `{ mainTokenId: 'tok-1', mainAmount: '600000', changeTokenId: 'tok-1-split', changeAmount: '400000' }`
+  - Reservation for 1000000 (full token, will be split server-side)
+
+#### It: "Send for exact token amount → no split needed" `[UNIT]`
+- **Setup**: Token pool with `tok-1` (500000, confirmed). Request for 500000.
+- **Action**: Call `SpendPlanner.planSend({ amount: '500000', coinId: 'UCT' }, tokenPool, ledger)`
+- **Expected**:
+  - Result status: `'immediate'`
+  - splitPlan: `{ mainTokenId: 'tok-1', mainAmount: '500000', changeTokenId: null }`
+
+#### It: "Send for less than smallest token → split needed" `[UNIT]`
+- **Setup**: Token pool with `tok-1` (1000000, confirmed). Request for 100.
+- **Action**: Call `SpendPlanner.planSend({ amount: '100', coinId: 'UCT' }, tokenPool, ledger)`
+- **Expected**:
+  - Result status: `'immediate'`
+  - splitPlan indicates split (changeTokenId is non-null)
+
+---
+
+### Describe Block: Queued Planning (insufficient free tokens)
+
+#### It: "All tokens reserved by prior send, but total covers both → queued" `[UNIT]`
+- **Setup**: 
+  - Token pool: `tok-1` (1000000), `tok-2` (1000000)
+  - Existing reservation: res-1 on tok-1 for 1000000 (full)
+  - New request: 1500000
+- **Action**: Call `SpendPlanner.planSend({ amount: '1500000', coinId: 'UCT' }, tokenPool, ledger)`
+- **Expected**:
+  - Result status: `'queued'`
+  - No reservationId set yet
+  - queueRequest returned with minimal state
+  - Request waiting for change token or token arrival
+
+#### It: "Queued request resolves when change token arrives (notifyChange)" `[INTEGRATION]`
+- **Setup**: Token pool and queueRequest from previous test, SpendQueue initialized
+- **Action**:
+  1. Call `spendQueue.enqueue(queueRequest)`
+  2. Add token `tok-3` (500000) to pool
+  3. Call `spendQueue.notifyChange('UCT')`
+- **Expected**:
+  - queueRequest is resolved from queue
+  - reservationId is now set
+  - Reservation created in ledger
+
+#### It: "Queued request resolves with correct splitPlan" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000), all reserved. New request for 600000. Another token `tok-2` (500000) available.
+- **Action**: 
+  1. Add to queue, enqueue
+  2. Add token `tok-3` (200000) to pool
+  3. notifyChange
+- **Expected**:
+  - Plan resolves using available tokens
+  - splitPlan shows correct combination (e.g., tok-2 + part of tok-3)
+
+---
+
+### Describe Block: Rejection
+
+#### It: "Not enough tokens even counting all reservations → immediate rejection with SEND_INSUFFICIENT_BALANCE" `[UNIT]`
+- **Setup**: Token pool total: 1000000 (spread across multiple tokens). Request for 2000000.
+- **Action**: Call `SpendPlanner.planSend({ amount: '2000000', coinId: 'UCT' }, tokenPool, ledger)`
+- **Expected**:
+  - Result status: `'rejected'`
+  - Result error: `SEND_INSUFFICIENT_BALANCE` or `INSUFFICIENT_BALANCE`
+  - No reservation created
+  - No queue entry created
+
+#### It: "Token pool completely empty → immediate rejection" `[UNIT]`
+- **Setup**: Token pool: empty or all tokens non-confirmed
+- **Action**: Call `SpendPlanner.planSend({ amount: '1', coinId: 'UCT' }, tokenPool, ledger)`
+- **Expected**:
+  - Result status: `'rejected'`
+  - Result error: `SEND_INSUFFICIENT_BALANCE`
+
+---
+
+### Describe Block: Skip-Ahead Logic
+
+#### It: "Queue: [large_request, small_request]. Change token covers small but not large → small served first" `[INTEGRATION]`
+- **Setup**: 
+  - Token pool: `tok-1` (2000000, reserved for large_request)
+  - Queue: [{ id: 'large', amount: 1500000 }, { id: 'small', amount: 500000 }]
+  - Change token arrives: tok-2 (500000)
+- **Action**:
+  1. Add both to queue
+  2. Call `notifyChange('UCT')`
+- **Expected**:
+  - small_request is planned and removed from queue first (skip-ahead)
+  - large_request remains queued
+  - skipCount for small_request is NOT incremented (it was served)
+
+#### It: "Skip count incremented for skipped entry" `[INTEGRATION]`
+- **Setup**: Queue with [large_req, small_req]. Change token covers only small.
+- **Action**: Call `notifyChange('UCT')`
+- **Expected**:
+  - large_req is skipped
+  - large_req.skipCount incremented from 0 to 1
+  - small_req served and removed
+
+#### It: "After MAX_SKIP_COUNT (10) skips, large request blocks small ones (starvation protection)" `[INTEGRATION]`
+- **Setup**: Queue with [large_req (skipCount: 10), small_req (skipCount: 0)]. Change token covers only small.
+- **Action**: Call `notifyChange('UCT')`
+- **Expected**:
+  - Both remain queued
+  - large_req is served first (starvation limit reached)
+  - skipCount resets to 0 for remaining entries
+
+#### It: "Multiple small requests skip ahead of one large request (up to limit)" `[INTEGRATION]`
+- **Setup**: Queue with [large_req, small-1, small-2, small-3]. Change covers small-1 only.
+- **Action**: Call `notifyChange('UCT')`
+- **Expected**:
+  - small-1 served and removed
+  - skipCount for large_req incremented
+  - small-2, small-3 remain queued
+
+---
+
+### Describe Block: Pre-computation
+
+#### It: "buildParsedPool correctly parses all confirmed tokens" `[UNIT]`
+- **Setup**: Token pool:
+  - `tok-1` (1000000, status: 'confirmed')
+  - `tok-2` (2000000, status: 'confirmed')
+  - `tok-3` (500000, status: 'unconfirmed')
+- **Action**: Call `SpendPlanner.buildParsedPool(tokenPool)`
+- **Expected**:
+  - Parsed pool contains tok-1 and tok-2
+  - Total amount: 3000000
+  - tok-3 excluded
+
+#### It: "buildParsedPool skips non-confirmed tokens" `[UNIT]`
+- **Setup**: Token pool with mix: confirmed, transferring, spent, invalid, unconfirmed
+- **Action**: Call `buildParsedPool(tokenPool)`
+- **Expected**: Only 'confirmed' tokens in parsed pool
+
+#### It: "buildParsedPool skips placeholder tokens (_placeholder: true in sdkData)" `[UNIT]`
+- **Setup**: Token pool:
+  - `tok-1` (1000000, confirmed, sdkData: { _placeholder: false })
+  - `tok-2` (500000, confirmed, sdkData: { _placeholder: true })
+- **Action**: Call `buildParsedPool(tokenPool)`
+- **Expected**: Parsed pool contains only tok-1, total: 1000000
+
+#### It: "Pool snapshot is consistent (no partial updates from concurrent addToken)" `[UNIT]`
+- **Setup**: Token pool object with 10 confirmed tokens
+- **Action**: 
+  1. Capture snapshot via `buildParsedPool(tokenPool)`
+  2. Modify tokenPool object (add/remove token)
+  3. Compare snapshot to modified tokenPool
+- **Expected**: Snapshot is unchanged (defensive copy or snapshot semantics)
+
+---
+
+### Shared Fixtures
+
+- **TokenPoolBuilder**: Factory for test token pools with varying statuses and amounts
+- **RequestBuilder**: Helper to create send requests with amount/coinId
+- **createPlanner(ledger, queue)**: Returns SpendPlanner instance
+
+**Estimated Test Count: 30 tests**
+
+---
+
+## FILE 3: `tests/unit/modules/SpendQueue.test.ts`
+
+**Purpose**: Verify queue lifecycle, timeout semantics, and notifyChange coordination.
+
+**Test Type Tags**: `[UNIT]` for most, `[INTEGRATION]` for timer-based tests.
+
+---
+
+### Describe Block: Basic Queue Operations
+
+#### It: "enqueue adds entry to queue" `[UNIT]`
+- **Setup**: SpendQueue instance, request object
+- **Action**: Call `spendQueue.enqueue(request)`
+- **Expected**:
+  - Request added to queue
+  - `spendQueue.size()` increments by 1
+
+#### It: "notifyChange(coinId) triggers re-evaluation" `[UNIT]`
+- **Setup**: Queue with one queued request. Planner mock that returns 'immediate' on second call.
+- **Action**: 
+  1. Enqueue request for 'UCT'
+  2. Call `notifyChange('UCT')`
+- **Expected**:
+  - Planner is called for the queued request
+  - If plan is 'immediate', request is dequeued and callback is invoked
+
+#### It: "cancelAll(reason) rejects all entries with reason" `[UNIT]`
+- **Setup**: Queue with 5 requests, mocked callbacks
+- **Action**: Call `cancelAll('TEST_REASON')`
+- **Expected**:
+  - All 5 callbacks are invoked with error code `SEND_QUEUE_CANCELLED`
+  - Queue size is 0
+  - Each callback receives error object with reason field
+
+#### It: "size() returns correct count" `[UNIT]`
+- **Setup**: Empty queue
+- **Action**: Enqueue 3 requests, check `size()`
+- **Expected**: Returns 3
+
+#### It: "size(coinId) returns count for specific coin" `[UNIT]`
+- **Setup**: Queue with:
+  - 2 requests for 'UCT'
+  - 3 requests for 'USDC'
+  - 1 request for 'USDT'
+- **Action**: Call `size('UCT')` and `size('USDC')`
+- **Expected**: Returns 2 and 3 respectively
+
+---
+
+### Describe Block: Timeout
+
+#### It: "Entry that exceeds 30s timeout is rejected with SEND_QUEUE_TIMEOUT" `[INTEGRATION]`
+- **Setup**: Queue entry, mocked callback. Mock Date.now().
+- **Action**:
+  1. Enqueue request at time 0
+  2. Advance mock time to 31000ms
+  3. Call `notifyChange` or trigger internal timeout check
+- **Expected**:
+  - Callback invoked with error `SEND_QUEUE_TIMEOUT`
+  - Entry removed from queue
+
+#### It: "Timeout checked on notifyChange" `[INTEGRATION]`
+- **Setup**: Queue entry at time 0, current time 31000ms, planner returns 'queued' (stays in queue)
+- **Action**: Call `notifyChange(coinId)`
+- **Expected**:
+  - Timeout is evaluated
+  - Timed-out entry is rejected before re-planning newer entries
+
+#### It: "Timeout checked by periodic timer (1s interval)" `[INTEGRATION]`
+- **Setup**: Queue entry at time 0, periodic timer with 1s interval
+- **Action**:
+  1. Enqueue request
+  2. Advance mock time by 31000ms
+  3. Wait for timer tick
+- **Expected**: Callback invoked with timeout error, entry removed
+
+#### It: "Reservation cancelled when entry times out" `[UNIT]`
+- **Setup**: Queue entry with reservationId, timeout triggers
+- **Action**: Timeout fires
+- **Expected**:
+  - `ledger.cancel(reservationId)` is called
+  - Free amount in ledger is released
+
+---
+
+### Describe Block: Queue Capacity
+
+#### It: "Enqueue when queue is at QUEUE_MAX_SIZE (100) → reject immediately" `[UNIT]`
+- **Setup**: Queue with 100 entries (at QUEUE_MAX_SIZE limit)
+- **Action**: Try to enqueue one more request
+- **Expected**:
+  - Request rejected immediately with error `SEND_QUEUE_FULL` or `QUEUE_CAPACITY_EXCEEDED`
+  - Callback invoked with error
+  - Queue size remains 100
+
+#### It: "After removal, new entries can be enqueued" `[UNIT]`
+- **Setup**: Queue with 100 entries
+- **Action**:
+  1. Enqueue 101st → rejected
+  2. Remove one entry (via timeout or planning success)
+  3. Enqueue 101st again
+- **Expected**: 101st is accepted, queue size 100
+
+---
+
+### Describe Block: notifyChange Behavior
+
+#### It: "notifyChange for unrelated coinId → no effect on queued entries" `[UNIT]`
+- **Setup**: Queue with requests for 'UCT' and 'USDC'. Planner returns 'queued' for both.
+- **Action**: Call `notifyChange('USDT')` (unrelated coin)
+- **Expected**: No planner calls, no queue changes, size unchanged
+
+#### It: "notifyChange triggers planning attempt for matching coinId entries" `[UNIT]`
+- **Setup**: Queue with 2 requests for 'UCT', 1 for 'USDC'. Planner mock tracks calls.
+- **Action**: Call `notifyChange('UCT')`
+- **Expected**:
+  - Planner called exactly twice (once per UCT request)
+  - USDC request untouched
+
+#### It: "Multiple rapid notifyChange calls are coalesced (queueMicrotask batching)" `[UNIT]`
+- **Setup**: Queue with request, planner mock tracks call count
+- **Action**:
+  1. Call `notifyChange('UCT')` 3 times synchronously
+  2. Await microtask queue drain
+- **Expected**:
+  - Planner is called only once (batched)
+  - Not three times (coalesced)
+
+---
+
+### Describe Block: Destroy Integration
+
+#### It: "cancelAll called during destroy rejects all pending entries" `[UNIT]`
+- **Setup**: Queue with 5 requests, mocked callbacks
+- **Action**: Call `destroy()`
+- **Expected**:
+  - All 5 callbacks invoked with error
+  - Queue is empty
+  - destroy() idempotent (calling again is no-op)
+
+#### It: "No new entries accepted after destroy" `[UNIT]`
+- **Setup**: Queue, call `destroy()`
+- **Action**: Try `enqueue(request)` after destroy
+- **Expected**: Throws or rejects immediately with error (e.g., `MODULE_DESTROYED`)
+
+---
+
+### Shared Fixtures
+
+- **createQueue(ledger, planner)**: Returns SpendQueue instance with mocked timers
+- **RequestEntry**: Builder for queue requests with amount, coinId, callback
+- **MockPlanner**: Returns configurable 'immediate' | 'queued' | 'rejected' results
+
+**Estimated Test Count: 25 tests**
+
+---
+
+## FILE 4: `tests/unit/modules/PaymentsModule.concurrency.test.ts`
+
+**Purpose**: Verify that concurrent `send()` calls properly reserve tokens, handle splits, and coordinate via queue.
+
+**Test Type Tags**: `[INTEGRATION]` for all — involves PaymentsModule, ledger, queue, transport, and oracle.
+
+---
+
+### Describe Block: Basic Concurrency — Two Sends, Same CoinId
+
+#### It: "Two concurrent sends for different amounts, pool has enough → both succeed with different tokens" `[INTEGRATION]`
+- **Setup**: 
+  - Token pool: `tok-1` (1000000), `tok-2` (1000000)
+  - Mock oracle/transport
+  - PaymentsModule initialized
+- **Action**:
+  1. Call `sphere.payments.send({ recipient: '@alice', amount: '300000', coinId: 'UCT' })`
+  2. Call `sphere.payments.send({ recipient: '@bob', amount: '400000', coinId: 'UCT' })` (no await between)
+- **Expected**:
+  - Both complete successfully (both eventually resolve)
+  - send-1 uses tok-1 (300000)
+  - send-2 uses tok-2 (400000)
+  - No reservation conflict
+  - Both TransferResult.status: 'completed' or 'delivered'
+
+#### It: "Two concurrent sends for same amount, only one token → first succeeds, second queues and gets change token" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000), oracle/transport mocked
+- **Action**:
+  1. Send-1: 500000 (no await)
+  2. Send-2: 500000 (no await)
+- **Expected**:
+  - Send-1 completes using tok-1
+  - Send-2 queues
+  - Change token from send-1's split arrives
+  - Send-2 completes using change token
+  - Both eventually status: 'completed'
+
+#### It: "Two concurrent sends, pool covers both but needs split → first splits, second waits for change" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1500000)
+- **Action**: Send-1 (600000), Send-2 (400000) concurrently
+- **Expected**:
+  - Send-1 selected tok-1, reserves 1500000 (will split)
+  - Send-2 queued (all confirmed tokens reserved)
+  - Send-1 splits, change token (500000) arrives
+  - Send-2 completes with change token
+  - Both succeed
+
+---
+
+### Describe Block: Three or More Concurrent Sends
+
+#### It: "Three sends, pool has 3 tokens → all proceed in parallel" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000), `tok-2` (1000000), `tok-3` (1000000)
+- **Action**: Send-1 (500000), Send-2 (600000), Send-3 (400000) concurrently
+- **Expected**:
+  - All three reserved immediately (enough tokens)
+  - All complete in parallel
+  - No queue involvement
+  - All status: 'completed'
+
+#### It: "Three sends, pool has 2 tokens → two proceed, third queues" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000), `tok-2` (1000000)
+- **Action**: Send-1 (500000), Send-2 (600000), Send-3 (400000) concurrently
+- **Expected**:
+  - Send-1, Send-2 proceed immediately (reserved)
+  - Send-3 queued
+  - Change tokens from Send-1/Send-2 arrive (or one of them)
+  - Send-3 completes
+  - All eventually succeed
+
+#### It: "Five sends, pool has 1 large token → first sends, rest queue for change tokens (waterfall)" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (5000000)
+- **Action**: Send-1 (1000000), Send-2 (800000), Send-3 (600000), Send-4 (400000), Send-5 (200000) concurrently
+- **Expected**:
+  - Send-1 proceeds, reserves tok-1 (will split to 4000000 change)
+  - Send-2, Send-3, Send-4, Send-5 queued
+  - Send-1 completes, change arrives
+  - Send-2 proceeds (if change covers it)
+  - Cascade continues until all complete
+  - All eventually succeed
+  - No starvation (all are served within 30s timeout)
+
+---
+
+### Describe Block: Token Exhaustion & Change-Back
+
+#### It: "Send 500 from a 1000 token → change token 500 arrives → queued send for 300 gets the change token" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000), oracle/transport mocked to produce change immediately
+- **Action**:
+  1. Send-1: 500000 (proceeds)
+  2. Send-2: 300000 (queued, insufficient free tokens)
+  3. Send-1 completes, change token (500000) arrives
+  4. spendQueue.notifyChange('UCT')
+- **Expected**:
+  - Send-2 dequeued and planned with change token
+  - Send-2 completes
+
+#### It: "Queued send amount is larger than change token → stays queued" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000)
+- **Action**:
+  1. Send-1: 700000 (proceeds)
+  2. Send-2: 500000 (queued)
+  3. Change token (300000) arrives
+  4. notifyChange('UCT')
+- **Expected**:
+  - Send-2 still insufficient (300000 < 500000)
+  - Send-2 remains queued
+  - When more tokens arrive, Send-2 can proceed
+
+#### It: "Multiple queued sends fulfilled by a single change token split cascade" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (3000000)
+- **Action**:
+  1. Send-1: 1000000 (proceeds, will split to 2000000 change)
+  2. Send-2: 800000 (queued)
+  3. Send-3: 600000 (queued)
+  4. Change-1 (2000000) arrives
+  5. notifyChange
+- **Expected**:
+  - Send-2 plans with change-1, proceeds, reserves 800000 (will split to 1200000)
+  - Send-2 completes, change-2 (1200000) arrives
+  - notifyChange
+  - Send-3 plans with change-2, proceeds (600000 < 1200000)
+  - Send-3 completes
+  - Cascade works correctly
+
+---
+
+### Describe Block: Cross-CoinId Independence
+
+#### It: "Concurrent sends for different coinIds → fully parallel, no blocking" `[INTEGRATION]`
+- **Setup**: Token pools for both 'UCT' and 'USDC' with limited tokens
+- **Action**:
+  1. Send-UCT (500000 UCT) and Send-USDC (500000 USDC) concurrently
+  2. Both need their single token
+- **Expected**:
+  - No queue blocking between coinIds
+  - Both proceed and complete in parallel
+  - No artificial serialization
+
+#### It: "Queue for coinId A doesn't affect sends for coinId B" `[INTEGRATION]`
+- **Setup**: 
+  - UCT pool: 1 token (500000)
+  - USDC pool: 3 tokens (1000000 each)
+- **Action**:
+  1. Send-UCT-1 (500000) + Send-UCT-2 (400000) concurrently
+  2. Send-USDC-1 (600000) concurrently
+- **Expected**:
+  - Send-UCT-1 proceeds, Send-UCT-2 queues (UCT pool exhausted)
+  - Send-USDC-1 proceeds immediately (USDC pool has tokens)
+  - USDC send latency is not affected by UCT queue
+
+---
+
+### Describe Block: Send Failure → Reservation Release
+
+#### It: "First send reserves token, fails at aggregator → reservation cancelled → second send proceeds" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000), oracle mocked to return error
+- **Action**:
+  1. Send-1: 500000 (reserves tok-1, but oracle fails)
+  2. Send-2: 300000 (queued, waiting for reservation release)
+  3. Send-1 error handler calls `ledger.cancel(res-1)`
+  4. notifyChange('UCT')
+- **Expected**:
+  - Send-1 fails (TransferResult.error set, status: 'failed')
+  - Send-2 dequeued, now sees tok-1 fully free (300000)
+  - Send-2 proceeds and completes
+
+#### It: "First send reserves token, Nostr send fails → reservation cancelled → second send proceeds" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000), transport mocked to reject
+- **Action**:
+  1. Send-1: 500000 (reserved, Nostr send fails)
+  2. Send-2: 300000 (queued)
+  3. Send-1 error → reservation cancelled
+  4. notifyChange fires
+- **Expected**:
+  - Send-1 fails
+  - Send-2 resumes and completes
+
+#### It: "Verify notifyChange is called after failure → queued request wakes up" `[INTEGRATION]`
+- **Setup**: Queue mock to track notifyChange calls
+- **Action**: Send fails after reservation, queue listening
+- **Expected**: notifyChange('UCT') is called, queue re-evaluates
+
+---
+
+### Describe Block: Integration with AccountingModule
+
+#### It: "Concurrent payInvoice() for different invoices → both proceed (different tokens) or one queues" `[INTEGRATION]`
+- **Setup**: 
+  - AccountingModule with 2 invoices: inv-1, inv-2
+  - Token pool: 1 token (1000000)
+- **Action**: `sphere.accounting.payInvoice(inv-1, { amount: '600000' })` and `payInvoice(inv-2, { amount: '300000' })` concurrently
+- **Expected**:
+  - Both calls eventually succeed (one queues)
+  - Payments properly attributed to respective invoices
+  - No memo collision or invoice confusion
+
+#### It: "Concurrent payInvoice() for same invoice → second gets INVOICE_INVALID_AMOUNT (from gate, not from queue)" `[INTEGRATION]`
+- **Setup**: AccountingModule with invoice, per-invoice async gate
+- **Action**: `payInvoice(inv-1, { amount: '500000' })` called twice concurrently
+- **Expected**:
+  - First call proceeds
+  - Second call rejected with per-invoice gate error (not queue error)
+  - Both calls finish cleanly
+
+#### It: "payInvoice() + returnInvoicePayment() concurrent → no token overlap" `[INTEGRATION]`
+- **Setup**: Invoice with payment, token pool with limited tokens
+- **Action**: `payInvoice(inv-1, amount)` and `returnInvoicePayment(...)` concurrently
+- **Expected**:
+  - Return uses separate transaction path (or queues properly)
+  - No reservation conflict
+  - Both complete successfully
+
+#### It: "cancelInvoice(autoReturn) + payInvoice() concurrent → no dead bundles" `[INTEGRATION]`
+- **Setup**: Invoice with autoReturn enabled, token pool
+- **Action**: `cancelInvoice(invoiceId)` triggers autoReturn send, concurrent `payInvoice()` call
+- **Expected**:
+  - autoReturn send and payInvoice properly serialized via queue/gate
+  - Return doesn't create dead bundle with payment
+
+#### It: "autoReturn send + regular send concurrent → properly serialized via queue" `[INTEGRATION]`
+- **Setup**: Invoice with autoReturn pending, user initiates send concurrently
+- **Action**: Both requests compete for tokens
+- **Expected**:
+  - Both properly queued/reserved
+  - Both eventually succeed or one fails cleanly
+  - No payment loss
+
+---
+
+### Describe Block: Split Race Conditions
+
+#### It: "Two sends both need splits from same token → only first gets the split, second queues" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000), oracle mocked to support splits
+- **Action**: Send-1 (600000), Send-2 (300000) concurrently
+- **Expected**:
+  - Send-1 reserves tok-1, will split to 400000 change
+  - Send-2 queued
+  - Split succeeds, change token arrives
+  - Send-2 proceeds with change
+
+#### It: "Split change token arrives while second send is being planned → properly detected" `[INTEGRATION]`
+- **Setup**: Send-1 reserved tok-1, Send-2 in queue, split in-flight
+- **Action**: 
+  1. Change token arrives
+  2. notifyChange fires
+  3. Send-2 re-plans
+- **Expected**: Send-2 sees change token as available (not reserved), can use it
+
+#### It: "Split fails midway (aggregator down) → reservation cancelled, queued sends re-evaluated" `[INTEGRATION]`
+- **Setup**: Oracle mocked to fail during split
+- **Action**:
+  1. Send-1 attempts split, fails
+  2. Reservation cancelled
+  3. notifyChange fires
+  4. Send-2 resumes from queue
+- **Expected**:
+  - Send-1 fails cleanly
+  - Send-2 re-planned with main token (still free)
+  - Send-2 proceeds
+
+---
+
+### Describe Block: Placeholder Token Safety
+
+#### It: "Placeholder token (status: 'transferring', sdkData: _placeholder) NOT selected by planner" `[INTEGRATION]`
+- **Setup**: Token pool with `tok-1` (transferring, _placeholder: true, amount: 1000000) and `tok-2` (confirmed, 1000000)
+- **Action**: Send 600000
+- **Expected**:
+  - tok-1 skipped (placeholder, not confirmed)
+  - tok-2 selected
+  - No reservation on tok-1
+
+#### It: "Real change token replaces placeholder → notifyChange fires → queued send proceeds" `[INTEGRATION]`
+- **Setup**: Token pool with placeholder from Send-1. Send-2 queued awaiting change.
+- **Action**:
+  1. Send-1 completes, placeholder removed
+  2. Real change token (confirmed, _placeholder: false) added
+  3. notifyChange('UCT')
+- **Expected**:
+  - Real token detected as available (different from placeholder)
+  - Send-2 proceeds with real token
+  - No resurrection of placeholder
+
+---
+
+### Describe Block: Token Arrival During Queue Wait
+
+#### It: "External token received via Nostr while send is queued → notifyChange wakes queue" `[INTEGRATION]`
+- **Setup**: Send queued, transport listener receives new token
+- **Action**:
+  1. New token event from Nostr
+  2. Token added to pool
+  3. notifyChange triggered by transport
+- **Expected**:
+  - Queued send re-planned with new token
+  - Proceeds if amount covered
+
+#### It: "IPFS sync adds tokens while send is queued → notifyChange wakes queue" `[INTEGRATION]`
+- **Setup**: Send queued, IPFS sync runs
+- **Action**:
+  1. sync() completes, new tokens added
+  2. notifyChange called
+- **Expected**:
+  - Queue re-evaluated
+  - Queued send proceeds if amount covered
+
+---
+
+### Describe Block: Timeout Scenarios
+
+#### It: "Queued send times out after 30s → proper error, reservation cleaned up" `[INTEGRATION]`
+- **Setup**: Send queued, no tokens available, 30s passes
+- **Action**: Timeout fires on queue entry
+- **Expected**:
+  - Callback invoked with error `SEND_QUEUE_TIMEOUT`
+  - Reservation cancelled in ledger
+  - Free amount restored
+  - TransferResult.status: 'failed', error: 'SEND_QUEUE_TIMEOUT'
+
+#### It: "Queued send fulfilled just before timeout → succeeds (no race with timeout)" `[INTEGRATION]`
+- **Setup**: Send queued at time 0, token arrives at time 29s, timeout at 30s
+- **Action**:
+  1. Token arrives, notifyChange at 29s
+  2. Send planned and proceeds
+  3. Timeout check at 30s (or 31s)
+- **Expected**:
+  - Send completes before timeout
+  - No timeout error
+  - TransferResult.status: 'completed'
+
+#### It: "Multiple queued sends, some timeout, some succeed → proper cleanup" `[INTEGRATION]`
+- **Setup**: 5 queued sends, token pool slowly refilled over 25s
+- **Action**:
+  1. First 3 sends succeed over 20s
+  2. 4th send at time 25s
+  3. 5th send times out at 31s
+- **Expected**:
+  - Sends 1-4 succeed
+  - Send 5 fails with timeout
+  - Ledger clean (no orphaned reservations)
+
+---
+
+### Describe Block: Destroy During Active Sends
+
+#### It: "destroy() called while send is in-flight → send completes, reservation committed" `[INTEGRATION]`
+- **Setup**: Send in-flight (reserved, Nostr sent, awaiting proof)
+- **Action**: Call `sphere.destroy()` while send pending
+- **Expected**:
+  - Send allowed to complete (no immediate cancellation)
+  - Reservation committed
+  - Module destroyed cleanly
+  - State saved to storage
+
+#### It: "destroy() called while send is queued → queued send rejected with MODULE_DESTROYED" `[INTEGRATION]`
+- **Setup**: Send queued
+- **Action**: Call `sphere.destroy()`
+- **Expected**:
+  - Queued send rejected with error code `MODULE_DESTROYED`
+  - Queue cleared
+  - Module destroyed
+
+#### It: "destroy() called while split is in background → background completes, change token ignored" `[INTEGRATION]`
+- **Setup**: Send with split in-flight (background promise), destroy called during split
+- **Action**: Split completes after destroy
+- **Expected**:
+  - Change token not added to pool (module destroyed)
+  - No error, graceful shutdown
+  - Split promise settled (no unhandled rejection)
+
+---
+
+### Describe Block: Stress Tests
+
+#### It: "10 concurrent sends, 5 tokens → all eventually complete or timeout" `[INTEGRATION]`
+- **Setup**: Token pool: 5 tokens (1000000 each), 10 concurrent sends (300000 each)
+- **Action**: Fire all 10 sends concurrently, wait for all to settle
+- **Expected**:
+  - All 10 complete (should be within 30s timeout)
+  - No dropped transfers
+  - All TransferResult.status: 'completed' or at least not 'failed'
+  - Ledger clean after (no orphaned reservations)
+
+#### It: "50 concurrent sends, same coinId → no duplicate token usage, all reservations consistent" `[INTEGRATION]`
+- **Setup**: Token pool: 20 tokens (300000 each), 50 sends (150000 each)
+- **Action**: Fire all 50 concurrently
+- **Expected**:
+  - No token used twice (reservation conflict)
+  - All eventually complete (may queue and waterfall through change tokens)
+  - Ledger invariant holds: ∑ free + ∑ reserved == ∑ token.amount
+  - No crashes, no silent failures
+
+#### It: "Rapid send-cancel-send pattern → reservations properly cleaned up" `[INTEGRATION]`
+- **Setup**: Send with timeout + immediate follow-up send
+- **Action**:
+  1. Send-1 (reserve, queued)
+  2. User cancels (or timeout)
+  3. Send-2 immediately after
+- **Expected**:
+  - Reservation from Send-1 cleaned up
+  - Send-2 sees fresh ledger (no orphaned res from Send-1)
+  - Send-2 proceeds correctly
+
+#### It: "100 sends with 1 token → first succeeds, rest queue, cascade through change tokens" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000), 100 concurrent sends (100000 each)
+- **Action**: Fire all concurrently, observe cascade
+- **Expected**:
+  - First send proceeds, splits, change token (900000)
+  - Second send proceeds, splits, change (800000)
+  - ... cascade continues
+  - At least 90% of sends complete within timeout
+  - No starvation (skip-ahead prevents last sends from starving)
+
+---
+
+### Shared Fixtures
+
+- **SphereTestHarness**: Returns Sphere instance with mocked oracle, transport, storage
+- **TokenPoolBuilder**: Creates token pool with varying amounts, statuses, coins
+- **ConcurrentSendHelper**: Helper to fire multiple send() calls and await all
+- **TimerMocks**: For timeout testing
+- **LedgerSnapshot**: Utility to verify ledger invariants
+
+**Estimated Test Count: 60 tests**
+
+---
+
+## FILE 5: `tests/unit/modules/PaymentsModule.send-queue-integration.test.ts`
+
+**Purpose**: End-to-end scenarios with full mocked environment, verifying state consistency.
+
+**Test Type Tags**: `[INTEGRATION]` for all.
+
+---
+
+### Describe Block: End-to-End Scenarios (with mocked transport/oracle)
+
+#### It: "Escrow: deposit → two payouts → surplus return (original bug scenario from issue)" `[INTEGRATION]`
+- **Setup**:
+  - Invoice created by merchant: targets = [{ address: merchant, assets: [{ coinId: 'UCT', amount: '1000000' }] }]
+  - Invoice token sent to payer
+  - Payer receives token, imports invoice
+  - Token pool: `tok-1` (1500000)
+- **Action**:
+  1. payer.accounting.payInvoice(invId, { amount: '1500000' }) — overpayment
+  2. Concurrent: merchant awaits payment, payer awaits return
+  3. Merchant receives payment, auto-return kicks in for surplus (500000)
+  4. Payer receives return
+- **Expected**:
+  - Payment transfer completes (1500000)
+  - invoice:payment event fires
+  - invoice:overpayment event fires (surplus: 500000)
+  - Auto-return transfer sent (500000 back to payer)
+  - Payer receives return transfer
+  - Merchant's balance shows 1000000, payer's net spend is 1000000
+  - invoice:auto_returned event fires
+  - No double-spending, no lost tokens
+
+#### It: "Multi-invoice payment: pay 3 invoices concurrently from same wallet" `[INTEGRATION]`
+- **Setup**:
+  - 3 invoices: inv-1 (1000000 UCT), inv-2 (500000 UCT), inv-3 (300000 UCT)
+  - Token pool: `tok-1` (2000000), `tok-2` (1000000)
+- **Action**:
+  1. payInvoice(inv-1, 1000000), payInvoice(inv-2, 500000), payInvoice(inv-3, 300000) concurrently
+- **Expected**:
+  - inv-1 uses tok-1 (1000000)
+  - inv-2 uses tok-2 (500000) or tok-1 change
+  - inv-3 uses remaining tokens
+  - All 3 invoices marked COVERED
+  - All 3 transfer events fire correctly
+  - Memo tags correctly attribute transfers to invoices
+
+#### It: "Payment + receive: send tokens while receiving tokens on Nostr" `[INTEGRATION]`
+- **Setup**: 
+  - Wallet balance: `tok-1` (1000000)
+  - Concurrent: send 300000 AND receive 500000 from peer
+- **Action**:
+  1. Send-1: 300000 to @bob (reserved, in-flight)
+  2. Nostr event: @alice sends 500000 (token added to pool)
+  3. Both complete
+- **Expected**:
+  - Send-1 completes using tok-1 (still available)
+  - Received token added to pool
+  - Final balance: tok-1 change (700000) + received token (500000) = 1200000 effective
+  - No conflict, parallel operation
+
+#### It: "Rapid fire: user clicks send 3 times fast (debounce at UI, but SDK must handle)" `[INTEGRATION]`
+- **Setup**: Token pool: `tok-1` (1000000), `tok-2` (1000000)
+- **Action**:
+  1. Send-1 (400000)
+  2. Send-2 (400000) — 10ms later
+  3. Send-3 (400000) — 20ms later
+  - All fire without waiting for previous to complete
+- **Expected**:
+  - Send-1 uses tok-1, reserves 400000
+  - Send-2 uses tok-2, reserves 400000
+  - Send-3 queued
+  - Send-3 fulfilled by change token or external token arrival
+  - All complete successfully
+
+---
+
+### Describe Block: State Consistency After Concurrent Sends
+
+#### It: "After all concurrent sends complete: tokens map is consistent" `[INTEGRATION]`
+- **Setup**: 10 concurrent sends from mixed pool
+- **Action**: Wait for all to settle, inspect `sphere.payments.getTokens()`
+- **Expected**:
+  - No duplicates in tokens map
+  - No self-contradictory entries (e.g., token both 'confirmed' and 'spent')
+  - Token IDs are unique
+  - All amounts are valid bigints
+
+#### It: "After all concurrent sends complete: no orphaned reservations" `[INTEGRATION]`
+- **Setup**: 10 concurrent sends, some queue, some complete, some timeout
+- **Action**: Inspect ledger after all settle
+- **Expected**:
+  - Ledger size: 0 (all reservations either committed or cancelled)
+  - getFreeAmount + getTotalReserved == token.amount for each token
+
+#### It: "After all concurrent sends complete: tombstones correct" `[INTEGRATION]`
+- **Setup**: Send tokens (some spent, some returned)
+- **Action**: Inspect `_tombstones` in storage
+- **Expected**:
+  - Each spent token has a (tokenId, stateHash) entry
+  - No duplicate tombstones
+  - Spent tokens not re-added
+
+#### It: "After all concurrent sends complete: archived tokens correct" `[INTEGRATION]`
+- **Setup**: Send tokens, some spent
+- **Action**: Inspect `archivedTokens` in storage
+- **Expected**:
+  - Each spent token moved to archived
+  - Original token file deleted
+  - Archived file correctly formatted
+
+#### It: "After all concurrent sends complete: save() reflects final state" `[INTEGRATION]`
+- **Setup**: Multiple sends, await all, call `sphere.destroy()`
+- **Action**: Re-load sphere from storage
+- **Expected**:
+  - Tokens reloaded are consistent with final state (no loss)
+  - No double-loads of archived tokens
+  - Ledger state empty (reserved → committed or cancelled)
+
+---
+
+### Describe Block: Recovery Scenarios
+
+#### It: "Send partially completes (Nostr sent, aggregator pending) → reservation committed even if proof slow" `[INTEGRATION]`
+- **Setup**: Oracle mocked to delay proof by 5s, Nostr mocked to send immediately
+- **Action**:
+  1. Send fires
+  2. Nostr send succeeds
+  3. Oracle proof pending
+  4. Concurrent: Send-2 fires (queued if proof delayed)
+  5. Proof arrives
+- **Expected**:
+  - Send-1 marked 'submitted' (Nostr sent)
+  - Reservation committed in ledger
+  - Send-2 doesn't resurrect Send-1's tokens (committed)
+  - Proof arrival transitions Send-1 to 'completed'
+
+#### It: "Queue entry fulfilled by token that is then invalidated → re-plan or fail gracefully" `[INTEGRATION]`
+- **Setup**: Send queued, token from oracle arrives but oracle later rejects it
+- **Action**:
+  1. Token added to pool
+  2. notifyChange, queued send planned with token
+  3. Before send completes, token invalidated (oracle says 'invalid')
+  4. Re-validate
+- **Expected**:
+  - Planner detects invalid token (buildParsedPool skips it)
+  - Send re-planned with remaining valid tokens, or fails with INSUFFICIENT_BALANCE
+  - No crash, graceful fallback
+
+#### It: "Storage save fails during send → reservation still in memory, consistency on retry" `[INTEGRATION]`
+- **Setup**: Storage mocked to fail on save during send
+- **Action**:
+  1. Send fires, completes in-memory
+  2. Storage save fails
+  3. Retry send from same wallet (fresh load)
+- **Expected**:
+  - First send may throw (storage error surfaced)
+  - On fresh load, wallet state reloaded (may have partial token state)
+  - Retry succeeds without double-spend
+  - Tombstone check prevents re-adding spent tokens
+
+---
+
+### Shared Fixtures
+
+- **FullSphereHarness**: Sphere instance with transport, oracle, storage, accounting, all mocked
+- **InvoiceBuilder**: Creates test invoices with configurable targets
+- **PaymentScenarioHelper**: Utilities for multi-invoice payment tests
+
+**Estimated Test Count: 15 tests**
+
+---
+
+## FILE 6: `tests/unit/modules/SpendQueue.starvation.test.ts`
+
+**Purpose**: Deep dive into starvation protection and skip-ahead fairness.
+
+**Test Type Tags**: `[UNIT]` for skip-ahead logic, `[INTEGRATION]` for queue behavior.
+
+---
+
+### Describe Block: Starvation Protection Deep Dive
+
+#### It: "FIFO order respected when all requests are same size" `[UNIT]`
+- **Setup**: Queue with 5 requests all for 500000 UCT. Change tokens arrive in order.
+- **Action**:
+  1. Enqueue all 5
+  2. notifyChange fires multiple times (change token covers each)
+- **Expected**:
+  - Requests served in enqueue order: req-1, req-2, req-3, req-4, req-5
+  - No skip-ahead (all same size, no reason to skip)
+  - skipCount for all remains 0
+
+#### It: "Skip-ahead activates: small request jumps large one → skipCount incremented" `[UNIT]`
+- **Setup**: Queue with [large: 1000000, small: 100000]. Change token covers only small (100000).
+- **Action**: notifyChange('UCT')
+- **Expected**:
+  - small served first (skip-ahead activated)
+  - small removed from queue
+  - large.skipCount incremented from 0 to 1
+  - large remains queued
+
+#### It: "skipCount reaches MAX_SKIP_COUNT (10) → large request blocks small ones (starvation protection)" `[UNIT]`
+- **Setup**: Queue with [large (skipCount: 10), small-1, small-2]. Change covers only small-1.
+- **Action**: notifyChange('UCT')
+- **Expected**:
+  - large served first (starvation limit enforced)
+  - large removed from queue
+  - small-1, small-2 remain
+  - skipCount resets for both (they weren't skipped)
+
+#### It: "After large request is served → skipCounts reset for remaining entries" `[UNIT]`
+- **Setup**: Queue with [large (skipCount: 8), small-1, small-2]. Change covers all.
+- **Action**: notifyChange('UCT') — large served, removed
+- **Expected**:
+  - large removed
+  - skipCount for small-1, small-2 reset to 0 (not incremented)
+  - Fairness resets
+
+#### It: "Mixed sizes: verify fairness over many rounds" `[INTEGRATION]`
+- **Setup**: Queue with mix: [tiny (50k), large (500k), small (100k), large (400k), tiny (50k)]. Change tokens simulated to arrive each round covering all sizes.
+- **Action**: 
+  1. Create 20 rounds of notifyChange
+  2. Track which request served in each round
+  3. Calculate "fairness index" — how many rounds until each served
+- **Expected**:
+  - tinys served faster (not starved)
+  - larges served eventually
+  - Max fairness gap < 15 rounds (no one waits excessively)
+  - No request served more than twice out of order
+
+#### It: "Pathological: one request can never be served (amount > total pool) → timeout after 30s, doesn't starve others" `[INTEGRATION]`
+- **Setup**: Queue with [impossible: 1000000, possible-1: 100000, possible-2: 100000]. Pool only ever has 200000 available.
+- **Action**:
+  1. Enqueue all 3
+  2. Simulate 30s passing with periodic notifyChange
+  3. Each notifyChange shows impossible still insufficient
+- **Expected**:
+  - possible-1, possible-2 served and removed (skip-ahead works)
+  - impossible times out at 30s (not served, cannot be served)
+  - Timeout doesn't wait for impossible to fail
+  - No deadlock (possible requests complete while impossible pending)
+
+#### It: "Edge: skipCount reaches limit on same notifyChange as another entry would be served → correct ordering" `[UNIT]`
+- **Setup**: Queue with [large (skipCount: 9), small, tiny]. Change covers tiny only.
+- **Action**: notifyChange('UCT')
+- **Expected**:
+  - tiny served first (skip-ahead still active, skipCount < 10)
+  - large.skipCount incremented to 10
+  - small.skipCount incremented to 1
+  - On next notifyChange, if change covers large, large served (starvation limit)
+
+#### It: "Concurrent notifyChange calls don't corrupt skipCount" `[UNIT]`
+- **Setup**: Queue with [large (skipCount: 5), small-1, small-2]. Multiple notifyChange calls fire before first completes.
+- **Action**:
+  1. Fire notifyChange('UCT') 3 times synchronously
+  2. Await microtask batch
+- **Expected**:
+  - skipCount increment is atomic (no race, no double-increment)
+  - large.skipCount == 6 (exactly +1), not 7 or 8
+  - Ordering deterministic
+
+---
+
+### Shared Fixtures
+
+- **RequestQueue with metrics**: Queue that tracks skipCount per entry and request order
+- **SkipAheadAnalyzer**: Helper to analyze and verify fairness properties
+- **ProbabilisticChangeSimulator**: Simulates random token arrival patterns for stress testing
+
+**Estimated Test Count: 20 tests**
+
+---
+
+## Summary by File
+
+| File | Purpose | Test Count | Type Mix |
+|------|---------|-----------|----------|
+| **TokenReservationLedger.test.ts** | Core reservation tracking | 35 | 100% UNIT |
+| **SpendPlanner.test.ts** | Token selection + queue | 30 | 80% UNIT, 20% INTEGRATION |
+| **SpendQueue.test.ts** | Queue lifecycle + timeout | 25 | 80% UNIT, 20% INTEGRATION |
+| **PaymentsModule.concurrency.test.ts** | Race condition scenarios | 60 | 100% INTEGRATION |
+| **PaymentsModule.send-queue-integration.test.ts** | End-to-end state consistency | 15 | 100% INTEGRATION |
+| **SpendQueue.starvation.test.ts** | Fairness + skip-ahead | 20 | 75% UNIT, 25% INTEGRATION |
+
+**Total Estimated Tests: 185 tests**
+
+---
+
+## Testing Infrastructure Needed
+
+### Mocking & Fixtures
+
+1. **TokenPoolBuilder** — Create token pools with configurable status distribution, amounts, coinIds
+2. **MockOracle** — Return configurable results: immediate success, delayed proof, split tokens, error scenarios
+3. **MockTransport** — Simulate Nostr delivery: immediate, delayed, failed
+4. **MockStorage** — In-memory storage, optionally fail on save
+5. **SphereTestHarness** — Full Sphere instance with all mocks wired together
+6. **LedgerInvariantValidator** — Helper to assert ledger consistency after each operation
+7. **ConcurrentTestHelper** — Fire N concurrent operations and collect results
+
+### Timing & Concurrency
+
+- **Mock Date.now()** for timeout testing
+- **queueMicrotask coalescing** tests require synchronous execution tracing
+- **Promise.all()** with controlled delay injection for race condition testing
+- **Timer stubs** via `vi.useFakeTimers()` (Vitest built-in)
+
+### Assertion Helpers
+
+```typescript
+// Example helpers (not exhaustive)
+expectLedgerInvariant(ledger, tokenPool)  // assert free + reserved == total
+expectNoOrphanedReservations(ledger)      // assert size == 0 after cleanup
+expectNoDuplicateTokens(tokenPool)        // assert all tokenIds unique
+expectQueueFairness(sequence)              // analyze skip-ahead fairness
+```
+
+---
+
+## Key Testing Patterns
+
+1. **Invariant assertion on every mutation** — After reserve/cancel/commit, verify ledger math
+2. **Async coordination verification** — Confirm notifyChange fires at expected times
+3. **State machine transitions** — Track queue entry states (pending → active → resolved/rejected)
+4. **Concurrency explosion** — Test N × M combinations of concurrent operations
+5. **Time-based edge cases** — Timeout boundaries, TTL expiry, race with cleanup
+6. **Cascade testing** — Waterfall sends through change tokens, verify no starvation
+
+---
+
+## Coverage Goals
+
+- **Line coverage**: ≥95% for TokenReservationLedger, SpendPlanner, SpendQueue (core algorithms)
+- **Branch coverage**: 100% for error paths and timeout conditions
+- **Concurrency coverage**: Every race condition scenario explicitly tested
+- **Integration coverage**: Full wallet state consistency verified across all tests
+
+---
+
+## Notes
+
+- All tests are **synchronous-first** where possible (no artificial delays unless testing timeouts)
+- Mock timers used sparingly — only for timeout/30s threshold testing
+- Fuzz tests use seeded random (deterministic results for reproducibility)
+- Stress tests should be marked with `@slow` tag and skipped in CI rapid feedback loop (run only nightly)
+- Ledger invariant checks are free — always include them

--- a/docs/TOKEN-SPEND-QUEUE.md
+++ b/docs/TOKEN-SPEND-QUEUE.md
@@ -1,0 +1,622 @@
+# Token Spend Queue Architecture
+
+**Status:** Proposal — v1.0
+**Date:** 2026-03-12
+**Scope:** `PaymentsModule` concurrency safety for `send()` / `sendInstant()`
+
+---
+
+## 1. Problem Statement
+
+`PaymentsModule.send()` and `sendInstant()` share a single mutable `tokens: Map<string, Token>` pool with no synchronization. Both methods follow this pattern:
+
+```
+1. READ pool snapshot          ← TOCTOU window opens here
+2. await calculateOptimalSplit (async — yields to event loop)
+3. await buildSplitBundle      (async)
+4. await sendTokenTransfer     (async — irreversible side-effect)
+5. Mark tokens 'transferring'  ← TOCTOU window closes here (too late)
+6. await removeToken           (async)
+```
+
+Any two concurrent `send()` invocations can enter the window simultaneously. Both read the same snapshot at step 1, both select the same tokens, both proceed through the irreversible network send at step 4. The L3 aggregator rejects the second commitment (`REQUEST_ID_EXISTS`), but by that point the Nostr message has been delivered to the recipient, the tokens have been marked spent, and the caller receives a `'failed'` result — leaving the wallet in a confused intermediate state.
+
+This architecture document specifies the `TokenSpendQueue` subsystem that eliminates this race condition entirely, without introducing global serialization that would harm performance for independent sends.
+
+---
+
+## 2. Guiding Principles
+
+1. **Token-level locking, not operation-level locking.** Two sends using non-overlapping tokens must run in full parallel. Only sends that need the same token are serialized.
+
+2. **Volume-aware reservations.** A token that is partially consumed (its remainder becomes a change token) can logically serve multiple sends simultaneously if its total capacity covers all claimed amounts. The ledger tracks per-token committed amounts, not just presence/absence.
+
+3. **Queue, do not reject.** When the free pool cannot satisfy a request but the full inventory (free + reserved) can, the request is enqueued rather than failed. It waits for change tokens to arrive and proceeds as soon as they do.
+
+4. **Smart queue skipping.** The queue is not strictly FIFO. A request that can be served by currently available free tokens may skip ahead of a blocked request that is waiting for a specific change token, as long as this does not produce starvation.
+
+5. **JS event-loop safety.** JavaScript is single-threaded. "Concurrency" means interleaving between `await` suspension points. All critical sections in this design are synchronous (no `await`) and execute atomically within a single microtask queue turn.
+
+6. **No architectural coupling to AccountingModule.** The spend queue is an internal implementation detail of `PaymentsModule`. `AccountingModule`'s `withInvoiceGate` continues to operate at the invoice level, independently.
+
+---
+
+## 3. Component Overview
+
+```
+PaymentsModule
+│
+├── tokens: Map<string, Token>            (existing — unchanged interface)
+│
+├── TokenReservationLedger                (NEW)
+│   ├── reserved: Map<tokenId, ReservationEntry[]>
+│   └── API: reserve(), release(), commit(), getFreeAmount()
+│
+├── SpendPlanner                          (NEW)
+│   ├── plan(): synchronous critical section
+│   ├── canFulfillNow(): free-pool check
+│   ├── canFulfillEventually(): total-inventory check
+│   └── notifyChange(): wake queued requests
+│
+├── SpendQueue                            (NEW)
+│   ├── queue: QueueEntry[]
+│   ├── enqueue(): add pending request
+│   ├── tryAdvance(): attempt to serve next satisfiable entry
+│   └── drain(): wake all waiters on destroy
+│
+├── TokenSplitCalculator                  (existing — receives filtered view)
+│
+└── send() / sendInstant()               (existing — gains reservation lifecycle)
+```
+
+---
+
+## 4. TokenReservationLedger
+
+### 4.1 Purpose
+
+The ledger is the single source of truth for which portions of which tokens have been committed to in-flight sends. It enables the rest of the system to distinguish "free amount" from "reserved amount" without mutating token status prematurely.
+
+### 4.2 Data Structures
+
+```
+ReservationEntry {
+  reservationId: string          // UUID, matches the TransferResult.id of the originating send
+  tokenId:       string          // ID of the token being reserved
+  amount:        bigint          // Amount claimed from this token by this reservation
+  coinId:        string          // Coin type (for validation)
+  state:         'pending'       // Only one state — reservation is either present or absent
+  createdAt:     number          // ms timestamp (for timeout cleanup)
+}
+
+TokenReservationLedger {
+  // Primary index: tokenId → list of active reservations on that token
+  byToken:          Map<string, ReservationEntry[]>
+
+  // Secondary index: reservationId → list of entries belonging to this reservation
+  // (a single send may reserve partial amounts from multiple tokens)
+  byReservation:    Map<string, ReservationEntry[]>
+}
+```
+
+### 4.3 Volume-Aware Free Amount
+
+For a given `(tokenId, coinId)` pair, the free amount available for new reservations is:
+
+```
+freeAmount(tokenId, coinId) =
+    token.amount (as bigint)
+  - sum of entry.amount for all ReservationEntry where entry.tokenId === tokenId
+                                                      AND entry.coinId === coinId
+```
+
+This subtraction happens in a synchronous read — no `await` points. This is the key invariant that makes the critical section safe.
+
+### 4.4 Partial Reservation
+
+A single token may appear in multiple reservations simultaneously if its total capacity covers all claimed amounts. Example:
+
+- Token T1 has 1000 UCT
+- Send A claims 600 UCT from T1 (T1 reserved: 600, free: 400)
+- Send B claims 400 UCT from T1 (T1 reserved: 1000, free: 0)
+- Both sends proceed in parallel using different portions of T1
+
+This is valid only when T1 is a "split" token — both A and B must each produce their own split. The physical token T1 cannot be sent to two recipients; instead each send creates its own split bundle from T1's state. The aggregator's `requestId` uniqueness guarantee prevents double-spend at the L3 level.
+
+**Constraint:** Partial reservations are only permitted on tokens that will undergo a split operation (i.e., `splitAmount < token.amount`). Tokens designated for direct full-value transfer may only carry one reservation at a time. The `SpendPlanner` enforces this during the synchronous critical section.
+
+### 4.5 Reservation Lifecycle
+
+```
+reserve(reservationId, [(tokenId, amount, coinId), ...])
+  → synchronous
+  → creates ReservationEntry records in byToken and byReservation
+  → MUST be called from within the synchronous critical section
+
+release(reservationId)
+  → synchronous
+  → removes all ReservationEntry records for this reservationId
+  → MUST be called from within the synchronous critical section or failure path
+  → triggers SpendQueue.tryAdvance() after removal
+
+commit(reservationId)
+  → called after tokens are physically removed from pool (removeToken completes)
+  → removes entries from the ledger (they are no longer needed)
+  → distinct from release: commit is the happy path, release is the error path
+  → triggers SpendQueue.tryAdvance() after removal
+```
+
+### 4.6 Why No "committed" State in the Ledger
+
+Once `removeToken()` is called and the token is archived, the reservation entry is no longer meaningful — the token is gone from the pool. The ledger entry is committed (deleted) at that point. The ledger only tracks active reservations on tokens that are still in the pool. This keeps the data structure minimal and avoids stale entries.
+
+### 4.7 Timeout / Cleanup
+
+Reservations that are never committed or released (e.g., due to an unhandled exception that bypassed the finally block) would permanently reduce the perceived free amount of a token. To defend against this:
+
+- Each `ReservationEntry` carries a `createdAt` timestamp.
+- A background sweep runs every 120 seconds and releases any reservation older than 90 seconds.
+- 90 seconds is chosen as a safe upper bound — the longest expected `send()` duration is the conservative-mode path with proof collection (~42s). A 90-second timeout leaves 2x headroom.
+- The sweep calls `release(reservationId)` which triggers `SpendQueue.tryAdvance()`.
+- A warning is logged whenever a timeout-expired reservation is cleaned up, as this indicates a bug in the lifecycle management code.
+
+---
+
+## 5. SpendPlanner
+
+### 5.1 Purpose
+
+The `SpendPlanner` is responsible for the synchronous critical section that determines whether a new spend request can proceed immediately, must be queued, or must be rejected. It coordinates between `TokenReservationLedger`, `TokenSplitCalculator`, and `SpendQueue`.
+
+### 5.2 The Critical Section Contract
+
+The critical section is a synchronous function (no `await`). It reads the current state of `tokens` and `TokenReservationLedger`, makes a decision, and either creates a reservation or enqueues the request. Because JavaScript is single-threaded, no other async operation can interleave within a synchronous function body. The critical section exits before the microtask queue can run.
+
+This means the planning decision and the reservation creation happen atomically in a single event-loop turn.
+
+### 5.3 Inputs Required Before the Critical Section
+
+The critical section cannot `await`. Therefore all async work that informs the planning decision must complete **before** entering it:
+
+1. Recipient resolution (`transport.resolve()`) — async, done before planning
+2. `TokenSplitCalculator.calculateOptimalSplit()` — this is currently async (it calls `SdkToken.fromJSON()` for each candidate token). This must be refactored to accept pre-parsed SDK tokens, or its async work must be moved to a pre-computation phase. See section 5.5.
+
+### 5.4 Decision Logic (synchronous)
+
+```
+plan(request: TransferRequest, parsedTokens: ParsedTokenPool): PlanDecision
+
+  freeTokens = tokens where freeAmount(t.id, coinId) === t.amount  (fully free)
+  partiallyFreeTokens = tokens where freeAmount(t.id, coinId) > 0 AND < t.amount
+
+  // Pass the effective free view to the split calculator
+  // (freeTokens + partial tokens with their reduced free amounts)
+  splitPlan = calculator.calculateOptimalSplitSync(freeView, request.amount, request.coinId)
+
+  if splitPlan !== null:
+    // Can proceed immediately
+    reservations = deriveReservations(splitPlan)
+    ledger.reserve(request.id, reservations)
+    return { type: 'proceed', splitPlan, reservations }
+
+  totalInventory = sum of all token amounts for coinId (ignoring reservations)
+  if totalInventory >= request.amount:
+    // Cannot proceed now but will be able to once change tokens arrive
+    return { type: 'enqueue', reason: 'waiting_for_change' }
+
+  // Genuinely insufficient funds
+  return { type: 'reject', reason: 'insufficient_balance' }
+```
+
+### 5.5 Refactoring TokenSplitCalculator for Synchronous Use
+
+`TokenSplitCalculator.calculateOptimalSplit()` is currently async because it calls `SdkToken.fromJSON()` (which parses token JSON and may involve crypto operations) for each candidate token. This parsing must be moved outside the critical section.
+
+**Decision:** Introduce a `ParsedTokenPool` — a pre-computed map from `tokenId` to `{ sdkToken, amount, coinId }`. This map is built once per `send()` invocation, before the critical section, using `await`. The critical section then operates on pre-parsed data synchronously.
+
+`TokenSplitCalculator` gains a new synchronous method:
+
+```
+calculateOptimalSplitSync(
+  parsedPool: ParsedTokenPool,     // pre-computed, no IO
+  freeAmounts: Map<string, bigint>, // from ledger, per tokenId
+  targetAmount: bigint,
+  coinId: string
+): SplitPlan | null
+```
+
+The existing async `calculateOptimalSplit()` is preserved for backward compatibility but becomes a thin wrapper: parse all tokens, then call the sync version.
+
+**Files affected:**
+- `/home/vrogojin/sphere-sdk/modules/payments/TokenSplitCalculator.ts` — add sync variant, accept pre-parsed pool
+
+### 5.6 The Free View Passed to the Calculator
+
+The split calculator must see only the free portion of each token. For tokens with partial reservations, the calculator sees a reduced virtual amount equal to `freeAmount(tokenId, coinId)`. For fully reserved tokens, they are excluded entirely. This is computed synchronously from the ledger before calling the calculator.
+
+### 5.7 notifyChange()
+
+When a change token arrives (via `onChangeTokenCreated` callback) or a reservation is released, `SpendPlanner.notifyChange(coinId)` is called. This triggers `SpendQueue.tryAdvance(coinId)` to attempt to serve waiting requests.
+
+---
+
+## 6. SpendQueue
+
+### 6.1 Purpose
+
+The `SpendQueue` holds spend requests that cannot be served immediately because all relevant tokens are currently reserved, but the total inventory is sufficient to eventually serve them once change tokens arrive.
+
+### 6.2 Data Structure
+
+```
+QueueEntry {
+  requestId:        string              // matches TransferResult.id
+  request:          TransferRequest
+  coinId:           string
+  amount:           bigint
+  resolve:          (splitPlan: SplitPlan) => void   // unblocks the waiting send()
+  reject:           (err: Error) => void
+  enqueuedAt:       number              // ms timestamp
+  parsedPool:       ParsedTokenPool     // snapshot of parsed tokens at enqueue time
+}
+
+SpendQueue {
+  entries:  QueueEntry[]               // ordered by arrival time
+}
+```
+
+### 6.3 Enqueue
+
+`enqueue()` creates a `QueueEntry` and returns a `Promise<SplitPlan>`. The `send()` call `await`s this promise. The promise is resolved when `tryAdvance()` finds that the request can now be served.
+
+`enqueue()` is called from the synchronous critical section. The promise itself is created synchronously; the executor function captures `resolve` and `reject` for later use.
+
+### 6.4 tryAdvance(coinId?)
+
+`tryAdvance()` is called whenever the free pool increases (change token arrival, reservation release/commit). It iterates the queue and attempts to serve requests:
+
+```
+tryAdvance(coinId?: string):
+  for each entry in entries (in order):
+    if coinId is specified and entry.coinId !== coinId: continue
+
+    // Re-enter the synchronous critical section
+    decision = spendPlanner.plan(entry.request, rebuildParsedPool())
+    if decision.type === 'proceed':
+      remove entry from queue
+      entry.resolve(decision.splitPlan)
+      // Note: the reservation is NOW held by this entry's reservationId
+      continue  // keep trying for remaining entries
+
+    if decision.type === 'reject':
+      // Total inventory no longer sufficient (tokens were consumed by another path)
+      remove entry from queue
+      entry.reject(new SphereError('Insufficient balance', 'INSUFFICIENT_BALANCE'))
+      continue
+
+    // Still blocked — leave in queue
+```
+
+**Skip-ahead behavior:** `tryAdvance()` does not stop at the first blocked entry. It continues iterating to find any satisfiable entry further in the queue. This implements the "smart queue" requirement: a small send that can be served with available tokens is not blocked by a larger send waiting for a specific change token.
+
+**Starvation prevention:** A queue entry that has been skipped N times (tracked by a `skipCount` field) is promoted to head position when `skipCount >= MAX_SKIP_COUNT` (default: 10). Once promoted, subsequent `tryAdvance()` calls will not skip it — other entries behind it must wait until this entry is served or rejected.
+
+### 6.5 Queue Ordering and Fairness
+
+The queue is approximately FIFO with skip-ahead. Entries are appended in arrival order. `tryAdvance()` scans forward and serves the first satisfiable entry it finds, then continues to find more. Starvation is bounded by `MAX_SKIP_COUNT`.
+
+### 6.6 Queue Timeout
+
+A queued request that has not been served after 30 seconds is automatically rejected with `QUEUE_TIMEOUT`. The timer is started at `enqueuedAt` and checked during `tryAdvance()`. On rejection, the entry is removed and `entry.reject()` is called.
+
+The 30-second timeout is chosen to be:
+- Long enough to accommodate the instant-mode change token latency (~2.3 seconds typical, up to ~10s under load)
+- Short enough to give callers a timely error if the wallet is in a persistently congested state
+
+---
+
+## 7. Change-Back Token Integration
+
+### 7.1 Change Token Arrival Path
+
+In instant mode, change tokens arrive via the `onChangeTokenCreated` callback inside `buildSplitBundle()`. This callback fires asynchronously, approximately 2.3 seconds after the Nostr send. The current code flow:
+
+```
+onChangeTokenCreated: async (changeToken) => {
+  // 1. Remove placeholder token from pool
+  // 2. Create uiToken for the real change token
+  // 3. await addToken(uiToken)  ← adds to this.tokens
+}
+```
+
+After step 3, `this.tokens` has grown. This is the trigger for `SpendQueue.tryAdvance()`.
+
+### 7.2 Integration Point
+
+`addToken()` is the single integration point. After `this.tokens.set(uiToken.id, uiToken)` completes inside `addToken()`, it calls `this.spendQueue.notifyChange(uiToken.coinId)`. This is a synchronous call that initiates `tryAdvance()`.
+
+No other integration points are required. External token arrivals (Nostr receive) also go through `addToken()`, so they naturally trigger queue advancement as well — this is the correct behavior described in edge case G.3.
+
+### 7.3 Placeholder Tokens and the Queue
+
+The current code creates a placeholder token with `status: 'transferring'` immediately after the Nostr send. This placeholder has `_placeholder: true` in its sdkData. The `TokenSplitCalculator` already filters out non-`confirmed` tokens. The ledger's free-amount computation must also exclude placeholders.
+
+**Decision:** Placeholder tokens are excluded from the `ParsedTokenPool` during pool construction. They are not candidates for new reservations. This prevents the queue from thinking a placeholder satisfies a request.
+
+### 7.4 Race: Change Token Arrives Before Queue Check
+
+If a change token arrives and `tryAdvance()` runs before the caller's `send()` has re-entered the critical section, the token is in the pool and available. The queue entry will be served on the `tryAdvance()` pass. The `send()` call will find its promise already resolved when it `await`s — no deadlock.
+
+### 7.5 Race: Multiple Queued Requests, Single Change Token
+
+If change token C (amount 400) arrives and two queued requests each need 300 from that coin:
+
+- `tryAdvance()` runs.
+- First satisfiable entry (say request A needs 300): planner finds C is free (400 >= 300). Plans A using C (split: 300 to recipient, 100 remainder). Reserves 300 from C. Resolves A's promise.
+- Continues iterating. Request B needs 300. Planner finds C has only 100 free. Total inventory for coinId: existing tokens + C's unreserved 100. If sufficient with other tokens, B is served. If not, B remains queued.
+- A's send() resumes. Its split produces a new change token (100). `addToken()` fires. `tryAdvance()` runs again. If B needs that 100 combined with something else, it may now be served.
+
+### 7.6 The Circular Dependency Risk
+
+Risk: request B is waiting for request A's change token. Request A is waiting in the queue behind request B. Both wait forever.
+
+This cannot happen with the skip-ahead queue: `tryAdvance()` does not block at B; it skips B and serves A first, producing the change token that will eventually serve B.
+
+The only way circular waiting can occur is if:
+- All entries in the queue are mutually blocked on each other's change tokens
+- No change token from any other source arrives
+
+This is an inherently unresolvable situation (deadlock-equivalent). The 30-second queue timeout prevents indefinite blocking. Requests are rejected with a `QUEUE_TIMEOUT` error, freeing all reserved amounts and triggering another `tryAdvance()` pass that may unblock remaining entries.
+
+---
+
+## 8. Failure and Cancellation Handling
+
+### 8.1 Send Failure After Reservation
+
+The `send()` method has a `try/catch` block. On entry into the catch block, the following cleanup must occur:
+
+1. `ledger.release(reservationId)` — synchronous, frees reserved amounts immediately
+2. `spendQueue.notifyChange(request.coinId)` — may unblock waiting requests
+3. Restore `token.status = 'confirmed'` for any tokens already marked `'transferring'` — existing behavior, unchanged
+
+The existing catch block at line 1360 already handles step 3. Steps 1 and 2 are added to the same catch block.
+
+If the failure occurs before the reservation was created (e.g., recipient resolution failed), no ledger entry exists. The release call must be a no-op in that case — `ledger.release()` checks for existence before removing.
+
+### 8.2 Aggregator Rejection (REQUEST_ID_EXISTS)
+
+This is the existing scenario where a concurrent send happened to produce the same `requestId`. The aggregator accepts the commitment but notes the ID already exists. The current code treats this as a success (`SUCCESS` or `REQUEST_ID_EXISTS`). No change needed from the queue's perspective — the reservation is committed (not released) and the token is removed normally.
+
+With the spend queue in place, the TOCTOU race that caused duplicate `requestId` values is eliminated. `REQUEST_ID_EXISTS` should become exceedingly rare. It is retained as a defensive case.
+
+### 8.3 Reservation Timeout
+
+When the 90-second background sweep fires and expires a stale reservation (section 4.7):
+1. `ledger.release(reservationId)` removes the stale entry
+2. `spendQueue.notifyChange(coinId)` runs
+3. The corresponding `send()` is almost certainly already in its catch block (or completed). The release is idempotent — if the send already called `release()`, the entry is already gone and the sweep is a no-op.
+
+The sweep must not call `send()`'s existing error-path token-status restoration, since that is the send's responsibility. The sweep only manages the ledger.
+
+### 8.4 destroy() Called with Pending Queue Entries
+
+When `PaymentsModule.destroy()` is called (or will be called — the module does not currently have a `destroy()` method for the payments layer; this is a future concern noted in the existing `pendingBackgroundTasks` pattern):
+
+1. Set a `destroyed` flag.
+2. Call `spendQueue.drain()` — rejects all queued entries with `MODULE_DESTROYED` error.
+3. The `send()` calls awaiting those promises throw `MODULE_DESTROYED` and proceed to their catch blocks.
+4. Catch blocks call `ledger.release()` and restore token statuses.
+
+This mirrors the `withInvoiceGate` destroyed-check pattern in `AccountingModule`.
+
+---
+
+## 9. Integration with Existing Patterns
+
+### 9.1 AccountingModule.withInvoiceGate
+
+`withInvoiceGate` serializes invoice-level mutations (close, cancel, pay, return) per invoice. It does not touch the token pool directly — it calls `deps.payments.send()` and `deps.payments.returnPayment()`.
+
+The spend queue operates inside `send()`. From `withInvoiceGate`'s perspective, `send()` is still a single async call that either succeeds or fails. The queue's internal waiting is transparent.
+
+No coupling change is needed. The two serialization mechanisms are orthogonal: `withInvoiceGate` serializes invoice state transitions; the spend queue serializes token pool access.
+
+### 9.2 payInvoice()
+
+`payInvoice()` acquires the invoice gate briefly to check terminal state (lines 2175–2183), then releases it before calling `send()`. This is intentional — the spec notes that the gate is released before the network call to avoid blocking other operations.
+
+With the spend queue, `payInvoice()` calls `send()` normally. If the send is queued (waiting for change tokens), the gate is not held during the wait — this is correct. Another `closeInvoice()` call could arrive and close the invoice while `payInvoice()` is waiting in the queue. The accounting module's post-send attribution logic handles this: the payment is attributed to a closed invoice and auto-return fires if configured.
+
+### 9.3 returnInvoicePayment()
+
+`returnInvoicePayment()` calls `send()` while holding the invoice gate (line 2376 — it uses `return this.withInvoiceGate(invoiceId, async () => { ... send() ... })`). This means the gate is held across the entire send duration, including any time spent in the queue.
+
+This is correct by design. The spec requires that concurrent returns for the same invoice are serialized to prevent double-return. If the send is queued, the gate is held, which serializes subsequent return attempts for the same invoice behind this one.
+
+The practical risk is that a return for invoice X holds X's gate while waiting in the spend queue for a change token from a send for invoice Y. Invoice X's gate is blocked, but invoice Y's gate is independent — no cross-invoice deadlock is possible.
+
+### 9.4 Auto-Return Flows
+
+Auto-return calls `this.deps.payments.send()` (through the `returnInvoicePayment` path or directly). It is subject to the same spend queue rules. No special treatment is needed. Auto-return's dedup ledger (`AutoReturnManager`) already handles retry semantics — if a queued return is eventually rejected (queue timeout, insufficient funds), the auto-return ledger marks it as `failed` and the retry mechanism in `setAutoReturn()` can reset it to `pending`.
+
+---
+
+## 10. Key Invariants
+
+### I1 — Reservation Before Await
+
+A token's free amount in the ledger must be reduced **before** any `await` point that reads the token pool for a different concurrent operation. This is enforced by ensuring `ledger.reserve()` is called synchronously within the critical section, before any `await`.
+
+Violation of I1 is the root cause of the original TOCTOU bug.
+
+### I2 — Free Amount Non-Negative
+
+`freeAmount(tokenId, coinId) >= 0` always. The ledger never reserves more than a token's total amount. `SpendPlanner.plan()` enforces this by checking `freeAmount >= required` before creating a reservation.
+
+### I3 — Reservation Sum Invariant
+
+For every token T in the pool:
+```
+sum(entry.amount for all entries where entry.tokenId === T.id) <= T.amount
+```
+
+This invariant is maintained by the synchronous critical section. I3 can temporarily be violated only if a reservation is released after its `removeToken()` has already been called — this is prevented by always calling `commit()` (not `release()`) on the happy path.
+
+### I4 — Queue Entry Has Reservation or No Entry
+
+A send that is waiting in the queue has **no active reservation** in the ledger. The reservation is created only when the queue entry is served (the planner finds sufficient free tokens). A queued entry that has not yet been served contributes nothing to the ledger.
+
+This avoids the situation where queued requests pre-reserve tokens they cannot yet use, further reducing the free pool and blocking other requests.
+
+### I5 — Change Token Triggers Exactly One tryAdvance Pass
+
+Each `addToken()` call triggers exactly one `tryAdvance()` pass. Multiple change tokens arriving in rapid succession each trigger their own pass. Passes are synchronous (no `await`) and therefore cannot interleave. This ensures no change token arrival is silently missed by the queue.
+
+### I6 — Destroy Rejects All Queue Entries Before Cleanup
+
+After `destroy()` returns (or its promise resolves), no queued entry has a pending promise. All callers of `send()` that were waiting in the queue have either resolved or rejected. This prevents zombie promises outliving the module.
+
+---
+
+## 11. Edge Cases
+
+### E1 — All Tokens Locked, Change Never Arrives (Failed Split)
+
+Scenario: All tokens are reserved by concurrent sends. One send fails at the aggregator level without producing a change token (e.g., the background `startBackground()` throws and the `onChangeTokenCreated` callback never fires).
+
+Handling:
+- The failed send's catch block calls `ledger.release(reservationId)`.
+- `spendQueue.notifyChange()` runs — queued requests may now be served.
+- The split token that was consumed is archived by `removeToken()`. No change token entered the pool.
+- If total remaining inventory (after archival) is insufficient for queued requests, `tryAdvance()` will call `entry.reject(INSUFFICIENT_BALANCE)` for each affected entry.
+
+### E2 — Rapid-Fire Sends Exhausting the Pool
+
+Scenario: 10 sends arrive simultaneously, each needing 100 UCT. Pool has 1000 UCT in a single token.
+
+Handling:
+- Send 1 enters the critical section. Pool has 1000 free. Plans a split: 100 to recipient, 900 remainder. Reserves 100.
+- Send 2 enters the critical section. Free amount of T1 is 900. Plans a split: 100 to recipient, 800 remainder. Reserves 100.
+- ... this continues for sends 3–10, each claiming 100 from T1.
+- All 10 sends proceed in parallel using partial reservations on T1.
+- The aggregator receives 10 distinct split commitments. Each creates its own split of T1's state.
+
+Wait — this is a problem. A single token T1 cannot be split 10 times simultaneously. Each split creates a new state from T1's current state. The second split would reference T1's pre-first-split state, and the aggregator would reject it because T1 has already been committed for the first split.
+
+**Revised decision:** Partial reservations are only valid when the reserved amount equals the full `splitAmount` and leaves a meaningful remainder. More importantly, only ONE send at a time may claim a split of any given token. A token that will undergo a split (as opposed to direct full-value transfer) may only carry ONE active reservation.
+
+This is enforced in `SpendPlanner.plan()`:
+- For each candidate split token, check that `ledger.getReservations(tokenId).length === 0` before planning a split on it.
+- For direct-transfer tokens (full value), same single-reservation constraint applies.
+
+The practical effect: if all tokens are locked for splits, new sends are queued rather than attempting simultaneous splits on the same token.
+
+### E3 — External Token Arrives While Queue Is Waiting
+
+Scenario: A token is received via Nostr while 3 sends are waiting in the queue.
+
+Handling:
+- Nostr reception calls `addToken(newToken)`.
+- `addToken()` adds to `this.tokens` and calls `spendQueue.notifyChange(coinId)`.
+- `tryAdvance()` runs and may serve one or more queued requests using the new token.
+
+This is the correct behavior. External arrivals are indistinguishable from change token arrivals at the queue level.
+
+### E4 — destroy() Called While Queue Has Pending Requests
+
+Handling described in section 8.4. The key requirement is that `drain()` runs synchronously (no `await`), rejecting all entries immediately so their catch blocks can run synchronously in the same event-loop turn if the runtime permits, or in the next microtask batch.
+
+### E5 — Split Produces Change Token Immediately Needed by Queued Request
+
+Scenario: Queued request B is waiting for 100 UCT. Send A completes and its change token (150 UCT) arrives. B needs only 100 of those 150.
+
+Handling:
+- `addToken()` fires for the 150 UCT change token.
+- `tryAdvance()` runs. B is examined.
+- The planner sees 150 free UCT. B needs 100. Plans a split on the change token: 100 to recipient, 50 remainder. Reserves 100.
+- B's promise resolves. B's `send()` resumes with the pre-built split plan.
+- B executes the split, producing a 50 UCT change token.
+- `addToken()` fires for the 50 UCT change token. `tryAdvance()` runs again (in case more queue entries were waiting for this coin).
+
+### E6 — Queue Entry Becomes Unfulfillable Mid-Wait
+
+Scenario: Queued request B is waiting for 100 UCT. While waiting, a `sync()` operation discovers that several tokens are invalid and removes them. Total inventory drops below 100 UCT.
+
+Handling:
+- Token removal calls `removeToken()`.
+- `removeToken()` should call `spendQueue.notifyChange(coinId)` (new integration point — in addition to `addToken()`).
+- `tryAdvance()` runs. For B, `decision.type === 'reject'` (total inventory < 100). B is rejected with `INSUFFICIENT_BALANCE`.
+
+This requires `removeToken()` to trigger a queue advance check, same as `addToken()`.
+
+---
+
+## 12. Files That Need to Change
+
+| File | Change Required |
+|------|----------------|
+| `modules/payments/PaymentsModule.ts` | Add `TokenReservationLedger`, `SpendQueue`, `SpendPlanner` instances; modify `send()` and `sendInstant()` to go through the synchronous critical section; call `ledger.release()` / `ledger.commit()` in catch/finally blocks; call `spendQueue.notifyChange()` from `addToken()` and `removeToken()` |
+| `modules/payments/TokenSplitCalculator.ts` | Add `calculateOptimalSplitSync()` accepting a pre-parsed pool and free-amount map; existing `calculateOptimalSplit()` becomes a thin async wrapper |
+| `modules/payments/TokenReservationLedger.ts` | New file — implements the ledger (section 4) |
+| `modules/payments/SpendQueue.ts` | New file — implements the queue and planner (sections 5, 6) |
+| `modules/payments/index.ts` | Export new types if any are exposed (likely not — these are internal) |
+| `tests/unit/modules/PaymentsModule.concurrency.test.ts` | New test file — concurrent send scenarios, queue behavior, change token wake-up |
+
+The `AccountingModule`, `InstantSplitExecutor`, `TokenSplitExecutor`, and `BackgroundCommitmentService` files require **no changes**. The spend queue is entirely internal to `PaymentsModule`.
+
+---
+
+## 13. Architecture Decision Records
+
+### ADR-001: Synchronous Critical Section via Pre-Parsed Pool
+
+**Decision:** Extract all async token parsing (`SdkToken.fromJSON()`) from the planning step into a pre-computation phase. The planning and reservation step is fully synchronous.
+
+**Rationale:** JavaScript's event loop guarantees that synchronous code is not interrupted. Placing the reservation creation in a synchronous function eliminates the TOCTOU window without any locking primitives.
+
+**Alternative considered:** Wrapping the entire planning + execution in a global async mutex (single-concurrency semaphore). Rejected because it serializes all sends regardless of token overlap, destroying parallelism for independent sends.
+
+### ADR-002: Ledger Tracks Amounts, Not Just Presence
+
+**Decision:** The ledger stores the exact amount committed from each token per reservation, not merely a boolean "locked" flag.
+
+**Rationale:** A boolean lock would prevent multiple sends from using different portions of a large token. Amount tracking enables partial reservation, maximizing parallelism when a token is large enough to serve multiple sends via splits.
+
+**Constraint added:** Only one split per token at a time (section E2). The amount tracking still provides value for the combination case (direct transfer tokens in multi-token sends).
+
+### ADR-003: Queue Rather Than Reject When Total Inventory Sufficient
+
+**Decision:** When the free pool cannot satisfy a request but the total inventory (free + reserved) can, enqueue rather than reject.
+
+**Rationale:** Rejecting in this case would require callers to implement their own retry logic, leading to thundering-herd behavior when multiple callers retry simultaneously. The queue provides back-pressure and orderly service.
+
+**Alternative considered:** Return a `TEMPORARILY_INSUFFICIENT` error and let callers retry. Rejected because retry timing is non-trivial (change token latency is ~2.3s but variable), and coordinating retries across concurrent callers is complex.
+
+### ADR-004: Skip-Ahead Queue with Starvation Bound
+
+**Decision:** `tryAdvance()` scans the entire queue and serves any satisfiable entry, not just the head. Starvation is bounded by `MAX_SKIP_COUNT = 10`.
+
+**Rationale:** Strict FIFO would block a small send (10 UCT) behind a large send (10,000 UCT) that is waiting for a large change token. Skip-ahead maximizes throughput for independent requests.
+
+**Starvation bound rationale:** Without a bound, a large request waiting for a specific change token could be starved indefinitely by a stream of small requests. `MAX_SKIP_COUNT = 10` is chosen empirically — a request that has been skipped 10 times has been waiting long enough that fairness demands it be served next.
+
+### ADR-005: No Cross-Module Coupling
+
+**Decision:** The spend queue is entirely internal to `PaymentsModule`. `AccountingModule` is not modified.
+
+**Rationale:** `AccountingModule`'s `withInvoiceGate` and the spend queue address different concerns at different abstraction levels. Invoice-level serialization and token-level reservation are orthogonal. Coupling them would create dependency complexity without benefit.
+
+---
+
+## 14. Open Questions
+
+The following questions require product or engineering input before implementation begins:
+
+1. **Partial reservation on splits (ADR-002 constraint):** Is the "one split per token at a time" constraint acceptable, or does the system need to support simultaneous splits of the same token? If yes, the architecture needs a mechanism to invalidate concurrent split commitments at the aggregator level.
+
+2. **Queue timeout value (30s):** Should this be configurable in `PaymentsModuleConfig`? If operators of node.js wallets expect higher concurrency loads, they may want a longer timeout.
+
+3. **Starvation bound (MAX_SKIP_COUNT = 10):** Is 10 the right value, or should it be configurable?
+
+4. **`sendInstant()` relationship to `send()`:** `sendInstant()` currently has its own token-selection path (lines 1450–1455) that duplicates `send()`'s selection logic. Should `sendInstant()` be refactored to share the spend queue with `send()`, or treated as a separate entry point that also goes through its own critical section? The safest approach is to unify both through a shared `planSpend()` entry point.

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1496,6 +1496,7 @@ export class PaymentsModule {
     const startTime = performance.now();
 
     let reservationId: string | undefined;
+    let tokenToSplitRef: Token | undefined;
 
     try {
       // Resolve recipient once — single network query
@@ -1542,22 +1543,27 @@ export class PaymentsModule {
 
       if (!splitPlan.requiresSplit || !splitPlan.tokenToSplit) {
         // For direct transfers without split, release reservation and fall back to standard flow.
-        // send() will create its own reservation.
+        // send() will create its own reservation. Notify AFTER send() completes so a racing
+        // queued entry doesn't grab the freed tokens before send() can re-reserve.
         this.reservationLedger.cancel(reservationId);
-        this.spendQueue.notifyChange(request.coinId);
         logger.debug('Payments', 'No split required, falling back to standard send()');
-        const result = await this.send(request);
-        return {
-          success: result.status === 'completed',
-          criticalPathDurationMs: performance.now() - startTime,
-          error: result.error,
-        };
+        try {
+          const result = await this.send(request);
+          return {
+            success: result.status === 'completed',
+            criticalPathDurationMs: performance.now() - startTime,
+            error: result.error,
+          };
+        } finally {
+          this.spendQueue.notifyChange(request.coinId);
+        }
       }
 
       logger.debug('Payments', `InstantSplit: amount=${splitPlan.splitAmount}, remainder=${splitPlan.remainderAmount}`);
 
       // Mark token as transferring
       const tokenToSplit = splitPlan.tokenToSplit.uiToken;
+      tokenToSplitRef = tokenToSplit;
       tokenToSplit.status = 'transferring';
       this.tokens.set(tokenToSplit.id, tokenToSplit);
       this.parsedTokenCache.delete(tokenToSplit.id);
@@ -1665,12 +1671,30 @@ export class PaymentsModule {
     } catch (error) {
       // Cancel reservation on exception (only if one was created)
       if (reservationId) {
-        try {
-          this.reservationLedger.cancel(reservationId);
-        } finally {
-          this.spendQueue.notifyChange(request.coinId);
+        this.reservationLedger.cancel(reservationId);
+      }
+
+      // Restore token from 'transferring' back to 'confirmed' if it was marked
+      if (tokenToSplitRef && tokenToSplitRef.status === 'transferring') {
+        tokenToSplitRef.status = 'confirmed';
+        this.tokens.set(tokenToSplitRef.id, tokenToSplitRef);
+        if (tokenToSplitRef.sdkData) {
+          try {
+            const parsed = JSON.parse(tokenToSplitRef.sdkData);
+            const sdkToken = await SdkToken.fromJSON(parsed);
+            const amount = this.extractCoinAmountForCache(sdkToken, tokenToSplitRef.coinId);
+            if (amount > 0n) {
+              this.parsedTokenCache.set(tokenToSplitRef.id, { token: tokenToSplitRef, sdkToken, amount });
+            }
+          } catch { /* parse failure — skip */ }
         }
       }
+
+      // Notify queue after all restoration is complete
+      if (reservationId) {
+        this.spendQueue.notifyChange(request.coinId);
+      }
+
       const errorMessage = error instanceof Error ? error.message : String(error);
       return {
         success: false,

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -31,6 +31,8 @@ import type {
 import { L1PaymentsModule, type L1PaymentsModuleConfig } from './L1PaymentsModule';
 import { TokenSplitCalculator } from './TokenSplitCalculator';
 import { TokenSplitExecutor } from './TokenSplitExecutor';
+import { TokenReservationLedger } from './TokenReservationLedger';
+import { SpendPlanner, SpendQueue, type ParsedTokenEntry, type ParsedTokenPool } from './SpendQueue';
 import { NametagMinter, type MintNametagResult } from './NametagMinter';
 import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../storage';
 import type {
@@ -713,6 +715,13 @@ export class PaymentsModule {
   /** Sync coalescing: concurrent sync() calls share the same operation */
   private _syncInProgress: Promise<{ added: number; removed: number }> | null = null;
 
+  // Token Spend Queue — concurrent send race condition prevention
+  private readonly reservationLedger = new TokenReservationLedger();
+  private readonly spendPlanner = new SpendPlanner();
+  private spendQueue: SpendQueue;
+  /** Cache of parsed SdkToken data for synchronous queue re-evaluation */
+  private readonly parsedTokenCache: Map<string, ParsedTokenEntry> = new Map();
+
   constructor(config?: PaymentsModuleConfig) {
     this.moduleConfig = {
       autoSync: config?.autoSync ?? true,
@@ -725,6 +734,14 @@ export class PaymentsModule {
     // Initialize L1 sub-module by default (L1PaymentsModule has default electrumUrl).
     // Only skip if l1 is explicitly set to null.
     this.l1 = config?.l1 === null ? null : new L1PaymentsModule(config?.l1);
+
+    // Initialize spend queue (requires ledger, planner, and access to this.tokens)
+    this.spendQueue = new SpendQueue(
+      this.reservationLedger,
+      this.spendPlanner,
+      () => this.tokens,
+      this.parsedTokenCache
+    );
   }
 
   /**
@@ -763,6 +780,17 @@ export class PaymentsModule {
     this.forkedTokens.clear();
     this._historyCache = [];
     this.nametags = [];
+
+    // Reset spend queue state
+    this.reservationLedger.clear();
+    this.parsedTokenCache.clear();
+    this.spendQueue.destroy();
+    this.spendQueue = new SpendQueue(
+      this.reservationLedger,
+      this.spendPlanner,
+      () => this.tokens,
+      this.parsedTokenCache
+    );
 
     this.deps = deps;
     this.priceProvider = deps.price ?? null;
@@ -825,6 +853,8 @@ export class PaymentsModule {
           const result = await provider.load();
           if (result.success && result.data) {
             this.loadFromStorageData(result.data);
+            // Rebuild parsedTokenCache for spend queue (loadFromStorageData bypasses addToken)
+            await this.rebuildParsedTokenCache();
             // Import history from IPFS TXF data into local store
             const txfData = result.data as TxfStorageDataBase;
             if (txfData._history && txfData._history.length > 0) {
@@ -920,6 +950,11 @@ export class PaymentsModule {
     }
     this.pendingResponseResolvers.clear();
 
+    // Clean up spend queue and reservation ledger
+    this.spendQueue.destroy();
+    this.reservationLedger.clear();
+    this.parsedTokenCache.clear();
+
     // Clean up storage event subscriptions
     this.unsubscribeStorageEvents();
 
@@ -967,17 +1002,30 @@ export class PaymentsModule {
         throw new SphereError('Trust base not available. Oracle provider must implement getTrustBase()', 'AGGREGATOR_ERROR');
       }
 
-      // Calculate optimal split plan
-      const calculator = new TokenSplitCalculator();
-      const availableTokens = Array.from(this.tokens.values());
-      const splitPlan = await calculator.calculateOptimalSplit(
-        availableTokens,
-        BigInt(request.amount),
+      // ── Spend Queue: Pre-parse token pool (async, before critical section) ──
+      const parsedPool = await this.spendPlanner.buildParsedPool(
+        Array.from(this.tokens.values()),
         request.coinId
       );
 
+      // ── Spend Queue: SYNCHRONOUS CRITICAL SECTION (no awaits) ──────────────
+      // planSend reads free amounts, runs split calculation, and creates a
+      // reservation atomically. No concurrent send() can interleave here.
+      const planResult = this.spendPlanner.planSend(
+        request, parsedPool, this.reservationLedger, this.spendQueue, result.id
+      );
+
+      let splitPlan;
+      if (planResult === 'queued') {
+        // Wait for change tokens to arrive and wake this entry
+        const queueResult = await this.spendQueue.waitForEntry(result.id);
+        splitPlan = queueResult.splitPlan;
+      } else {
+        splitPlan = planResult.splitPlan;
+      }
+
       if (!splitPlan) {
-        throw new SphereError('Insufficient balance', 'INSUFFICIENT_BALANCE');
+        throw new SphereError('Insufficient balance', 'SEND_INSUFFICIENT_BALANCE');
       }
 
       // Collect all tokens involved
@@ -991,6 +1039,7 @@ export class PaymentsModule {
       for (const token of tokensToSend) {
         token.status = 'transferring';
         this.tokens.set(token.id, token);
+        this.parsedTokenCache.delete(token.id);
       }
       await this.save();
 
@@ -1058,6 +1107,10 @@ export class PaymentsModule {
             ? Array.from(splitCommitmentRequestId).map((b: number) => b.toString(16).padStart(2, '0')).join('')
             : splitCommitmentRequestId ? String(splitCommitmentRequestId) : undefined;
 
+          // Commit reservation BEFORE removing tokens — prevents cancelForToken()
+          // from cancelling our own active reservation
+          this.reservationLedger.commit(result.id);
+
           await this.removeToken(splitPlan.tokenToSplit.uiToken.id);
           result.tokenTransfers.push({
             sourceTokenId: splitPlan.tokenToSplit.uiToken.id,
@@ -1065,6 +1118,11 @@ export class PaymentsModule {
             requestIdHex: splitRequestIdHex,
           });
           logger.debug('Payments', 'Conservative split transfer completed');
+        }
+
+        // Commit reservation if not already committed by split path above
+        if (!splitPlan.requiresSplit) {
+          this.reservationLedger.commit(result.id);
         }
 
         // Transfer direct tokens
@@ -1242,6 +1300,11 @@ export class PaymentsModule {
           );
         }
 
+        // Commit reservation BEFORE removing tokens — prevents cancelForToken()
+        // from cancelling our own active reservation and waking queued sends
+        // that could re-plan against already-spent tokens.
+        this.reservationLedger.commit(result.id);
+
         // 7. Track and remove tokens (removeToken archives + tombstones + saves)
         if (splitPlan.requiresSplit && splitPlan.tokenToSplit) {
           await this.removeToken(splitPlan.tokenToSplit.uiToken.id);
@@ -1307,17 +1370,36 @@ export class PaymentsModule {
         tokenIds: sentTokenIds.length > 0 ? sentTokenIds : undefined,
       });
 
+      // Commit reservation (idempotent — may already be committed by mode-specific code above)
+      this.reservationLedger.commit(result.id);
+
       this.deps!.emitEvent('transfer:confirmed', result);
       return result;
     } catch (error) {
+      // Cancel reservation — free reserved amounts for other sends
+      this.reservationLedger.cancel(result.id);
+
       result.status = 'failed';
       result.error = error instanceof Error ? error.message : String(error);
 
-      // Restore tokens
+      // Restore tokens and re-add to spend queue cache
       for (const token of result.tokens) {
         token.status = 'confirmed';
         this.tokens.set(token.id, token);
+        if (token.sdkData) {
+          try {
+            const parsed = JSON.parse(token.sdkData);
+            const sdkToken = await SdkToken.fromJSON(parsed);
+            const amount = this.extractCoinAmountForCache(sdkToken, token.coinId);
+            if (amount > 0n) {
+              this.parsedTokenCache.set(token.id, { token, sdkToken, amount });
+            }
+          } catch { /* parse failure — skip */ }
+        }
       }
+
+      // Notify queue AFTER cache is rebuilt so queued entries see restored tokens
+      this.spendQueue.notifyChange(request.coinId);
 
       this.deps!.emitEvent('transfer:failed', result);
       throw error;
@@ -1352,6 +1434,42 @@ export class PaymentsModule {
     return TokenRegistry.getInstance().getIconUrl(coinId) ?? undefined;
   }
 
+  /**
+   * Extract coin amount from SDK token for the parsed token cache.
+   * Used by addToken() to populate the cache for synchronous queue re-evaluation.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private extractCoinAmountForCache(sdkToken: SdkToken<any>, coinIdHex: string): bigint {
+    try {
+      if (!sdkToken.coins) return 0n;
+      const coinId = CoinId.fromJSON(coinIdHex);
+      return sdkToken.coins.get(coinId) ?? 0n;
+    } catch {
+      return 0n;
+    }
+  }
+
+  /**
+   * Rebuild parsedTokenCache from current confirmed tokens.
+   * Called after loadFromStorageData() which bypasses addToken().
+   */
+  private async rebuildParsedTokenCache(): Promise<void> {
+    this.parsedTokenCache.clear();
+    for (const [, token] of this.tokens) {
+      if (token.status !== 'confirmed' || !token.sdkData) continue;
+      try {
+        const parsed = JSON.parse(token.sdkData);
+        const sdkToken = await SdkToken.fromJSON(parsed);
+        const amount = this.extractCoinAmountForCache(sdkToken, token.coinId);
+        if (amount > 0n) {
+          this.parsedTokenCache.set(token.id, { token, sdkToken, amount });
+        }
+      } catch {
+        // Parse failure — skip
+      }
+    }
+  }
+
   // ===========================================================================
   // Public API - Instant Split (V5 Optimized)
   // ===========================================================================
@@ -1377,6 +1495,8 @@ export class PaymentsModule {
 
     const startTime = performance.now();
 
+    let reservationId: string | undefined;
+
     try {
       // Resolve recipient once — single network query
       const peerInfo = await this.deps!.transport.resolve?.(request.recipient) ?? null;
@@ -1397,21 +1517,34 @@ export class PaymentsModule {
         throw new SphereError('Trust base not available', 'AGGREGATOR_ERROR');
       }
 
-      // Calculate optimal split plan
-      const calculator = new TokenSplitCalculator();
-      const availableTokens = Array.from(this.tokens.values());
-      const splitPlan = await calculator.calculateOptimalSplit(
-        availableTokens,
-        BigInt(request.amount),
+      // ── Spend Queue: reserve tokens (same path as send()) ──
+      reservationId = crypto.randomUUID();
+      const parsedPool = await this.spendPlanner.buildParsedPool(
+        Array.from(this.tokens.values()),
         request.coinId
       );
 
+      const planResult = this.spendPlanner.planSend(
+        request, parsedPool, this.reservationLedger, this.spendQueue, reservationId
+      );
+
+      let splitPlan;
+      if (planResult === 'queued') {
+        const queueResult = await this.spendQueue.waitForEntry(reservationId);
+        splitPlan = queueResult.splitPlan;
+      } else {
+        splitPlan = planResult.splitPlan;
+      }
+
       if (!splitPlan) {
-        throw new SphereError('Insufficient balance', 'INSUFFICIENT_BALANCE');
+        throw new SphereError('Insufficient balance', 'SEND_INSUFFICIENT_BALANCE');
       }
 
       if (!splitPlan.requiresSplit || !splitPlan.tokenToSplit) {
-        // For direct transfers without split, fall back to standard flow
+        // For direct transfers without split, release reservation and fall back to standard flow.
+        // send() will create its own reservation.
+        this.reservationLedger.cancel(reservationId);
+        this.spendQueue.notifyChange(request.coinId);
         logger.debug('Payments', 'No split required, falling back to standard send()');
         const result = await this.send(request);
         return {
@@ -1427,6 +1560,7 @@ export class PaymentsModule {
       const tokenToSplit = splitPlan.tokenToSplit.uiToken;
       tokenToSplit.status = 'transferring';
       this.tokens.set(tokenToSplit.id, tokenToSplit);
+      this.parsedTokenCache.delete(tokenToSplit.id);
 
       // Check if dev mode
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1484,6 +1618,9 @@ export class PaymentsModule {
           this.pendingBackgroundTasks.push(result.backgroundPromise);
         }
 
+        // Commit reservation BEFORE removing token
+        this.reservationLedger.commit(reservationId);
+
         // Remove the original token
         await this.removeToken(tokenToSplit.id);
 
@@ -1506,13 +1643,34 @@ export class PaymentsModule {
 
         await this.save();
       } else {
-        // Restore token on failure
+        // Cancel reservation — free reserved amounts for other sends
+        this.reservationLedger.cancel(reservationId);
+        // Restore token on failure and re-add to cache
         tokenToSplit.status = 'confirmed';
         this.tokens.set(tokenToSplit.id, tokenToSplit);
+        if (tokenToSplit.sdkData) {
+          try {
+            const parsed = JSON.parse(tokenToSplit.sdkData);
+            const sdkToken = await SdkToken.fromJSON(parsed);
+            const amount = this.extractCoinAmountForCache(sdkToken, tokenToSplit.coinId);
+            if (amount > 0n) {
+              this.parsedTokenCache.set(tokenToSplit.id, { token: tokenToSplit, sdkToken, amount });
+            }
+          } catch { /* parse failure — skip */ }
+        }
+        this.spendQueue.notifyChange(request.coinId);
       }
 
       return result;
     } catch (error) {
+      // Cancel reservation on exception (only if one was created)
+      if (reservationId) {
+        try {
+          this.reservationLedger.cancel(reservationId);
+        } finally {
+          this.spendQueue.notifyChange(request.coinId);
+        }
+      }
       const errorMessage = error instanceof Error ? error.message : String(error);
       return {
         success: false,
@@ -3050,6 +3208,13 @@ export class PaymentsModule {
         };
         this.tokens.set(tokenId, confirmedToken);
 
+        // Spend Queue: cache newly confirmed token and wake queued entries
+        const resolvedAmount = this.extractCoinAmountForCache(finalizedToken, confirmedToken.coinId);
+        if (resolvedAmount > 0n) {
+          this.parsedTokenCache.set(tokenId, { token: confirmedToken, sdkToken: finalizedToken, amount: resolvedAmount });
+          this.spendQueue.notifyChange(confirmedToken.coinId);
+        }
+
         // History entry was already created in processInstantSplitBundle() — no duplicate here
 
         // Emit transfer:confirmed so the UI learns about the state change
@@ -3412,6 +3577,21 @@ export class PaymentsModule {
 
     await this.save();
 
+    // Spend Queue: cache parsed token and wake queued sends
+    if (token.sdkData && token.status === 'confirmed') {
+      try {
+        const parsed = JSON.parse(token.sdkData);
+        const sdkToken = await SdkToken.fromJSON(parsed);
+        const amount = this.extractCoinAmountForCache(sdkToken, token.coinId);
+        if (amount > 0n) {
+          this.parsedTokenCache.set(token.id, { token, sdkToken, amount });
+        }
+      } catch {
+        // Parse failure — token not cached; SpendQueue will skip it during re-evaluation
+      }
+      this.spendQueue.notifyChange(token.coinId);
+    }
+
     logger.debug('Payments', `Added token ${token.id}, total: ${this.tokens.size}`);
     return true;
   }
@@ -3433,10 +3613,12 @@ export class PaymentsModule {
     let found = false;
 
     // Find by genesis tokenId first
+    let oldId: string | undefined;
     for (const [id, existing] of this.tokens) {
       const existingTokenId = extractTokenIdFromSdkData(existing.sdkData);
       if ((existingTokenId && incomingTokenId && existingTokenId === incomingTokenId) ||
           existing.id === token.id) {
+        oldId = id;
         this.tokens.delete(id);
         this.tokens.set(token.id, token);
         found = true;
@@ -3447,6 +3629,22 @@ export class PaymentsModule {
     if (!found) {
       await this.addToken(token);
       return;
+    }
+
+    // Spend Queue: remove stale cache entry for old id, update for new token
+    if (oldId) {
+      this.parsedTokenCache.delete(oldId);
+    }
+    if (token.status === 'confirmed' && token.sdkData) {
+      try {
+        const parsed = JSON.parse(token.sdkData);
+        const sdkToken = await SdkToken.fromJSON(parsed);
+        const amount = this.extractCoinAmountForCache(sdkToken, token.coinId);
+        if (amount > 0n) {
+          this.parsedTokenCache.set(token.id, { token, sdkToken, amount });
+          this.spendQueue.notifyChange(token.coinId);
+        }
+      } catch { /* parse failure — skip */ }
     }
 
     // Archive the updated token
@@ -3471,6 +3669,10 @@ export class PaymentsModule {
     const token = this.tokens.get(tokenId);
     if (!token) return;
 
+    // Spend Queue: cancel any active reservations referencing this token
+    this.reservationLedger.cancelForToken(tokenId);
+    this.parsedTokenCache.delete(tokenId);
+
     // Archive before removing
     await this.archiveToken(token);
 
@@ -3494,6 +3696,10 @@ export class PaymentsModule {
     this.tokens.delete(tokenId);
 
     await this.save();
+
+    // Spend Queue: wake queued entries (removal may reject waiting entries
+    // or free co-reserved tokens)
+    this.spendQueue.notifyChange(token.coinId);
   }
 
 
@@ -4218,6 +4424,9 @@ export class PaymentsModule {
               this.nametags = savedNametags;
             }
 
+            // Rebuild parsedTokenCache for spend queue (loadFromStorageData bypasses addToken)
+            await this.rebuildParsedTokenCache();
+
             // Import merged history from IPFS sync into local store
             const txfData = result.merged as TxfStorageDataBase;
             if (txfData._history && txfData._history.length > 0) {
@@ -4415,6 +4624,7 @@ export class PaymentsModule {
         valid.push(token);
       } else {
         token.status = 'invalid';
+        this.parsedTokenCache.delete(token.id);
         invalid.push(token);
       }
     }
@@ -4797,6 +5007,13 @@ export class PaymentsModule {
       };
       this.tokens.set(tokenId, finalizedToken);
       await this.save();
+
+      // Spend Queue: cache newly confirmed token and wake queued entries
+      const nostrAmount = this.extractCoinAmountForCache(finalizedSdkToken, finalizedToken.coinId);
+      if (nostrAmount > 0n) {
+        this.parsedTokenCache.set(tokenId, { token: finalizedToken, sdkToken: finalizedSdkToken, amount: nostrAmount });
+        this.spendQueue.notifyChange(finalizedToken.coinId);
+      }
 
       logger.debug('Payments', `NOSTR-FIRST: Token ${tokenId.slice(0, 8)}... finalized and confirmed`);
 

--- a/modules/payments/SpendQueue.ts
+++ b/modules/payments/SpendQueue.ts
@@ -1,0 +1,616 @@
+/**
+ * SpendPlanner & SpendQueue
+ *
+ * Coordinates token selection and reservation for concurrent send() calls.
+ * The key invariant: planSend() and notifyChange() are FULLY SYNCHRONOUS —
+ * no await anywhere in those methods. This guarantees atomicity between
+ * free-amount reads, split calculation, and reservation writes within
+ * JavaScript's single-threaded event loop.
+ *
+ * @see docs/SPEC-TOKEN-SPEND-QUEUE.md for the full design rationale.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { logger } from '../../core/logger';
+import { SphereError } from '../../core/errors';
+import type { Token } from '../../types';
+import type { SplitPlan, TokenWithAmount } from './TokenSplitCalculator';
+import type { TokenReservationLedger } from './TokenReservationLedger';
+import { Token as SdkToken } from '@unicitylabs/state-transition-sdk/lib/token/Token';
+import { CoinId } from '@unicitylabs/state-transition-sdk/lib/token/fungible/CoinId';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** How long a reservation lives before the ledger can expire it. */
+export const RESERVATION_TIMEOUT_MS = 30_000;
+
+/** How long a queued entry waits before being rejected with SEND_QUEUE_TIMEOUT. */
+export const QUEUE_TIMEOUT_MS = 30_000;
+
+/** Max times an entry can be skipped (no plan found) before it blocks the queue head. */
+export const MAX_SKIP_COUNT = 10;
+
+/** Maximum number of entries allowed in the queue across all coinIds. */
+export const QUEUE_MAX_SIZE = 100;
+
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** A pre-parsed token with its SDK object and bigint amount already computed. */
+export interface ParsedTokenEntry {
+  token: Token;
+  sdkToken: SdkToken<any>;
+  amount: bigint;
+}
+
+/** Map of tokenId -> ParsedTokenEntry. Built asynchronously before the critical section. */
+export type ParsedTokenPool = Map<string, ParsedTokenEntry>;
+
+/** Successful plan result containing a reservation ID and the split plan. */
+export interface PlanResult {
+  reservationId: string;
+  splitPlan: SplitPlan;
+}
+
+/** An entry waiting in the SpendQueue for tokens to become available. */
+export interface QueueEntry {
+  readonly id: string;
+  readonly request: { amount: string; coinId: string };
+  readonly parsedPool: ParsedTokenPool;
+  readonly coinId: string;
+  readonly amount: bigint;
+  readonly enqueuedAt: number;
+  skipCount: number;
+  resolve: (result: PlanResult) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+const TAG = 'SpendQueue';
+
+// =============================================================================
+// SpendPlanner
+// =============================================================================
+
+export class SpendPlanner {
+  /**
+   * Async pre-computation: parse all tokens for a given coinId.
+   * Called BEFORE the synchronous critical section.
+   *
+   * Filters to confirmed tokens matching the coinId, parses each
+   * token's sdkData into an SdkToken, and extracts the bigint amount.
+   */
+  async buildParsedPool(tokens: Token[], coinId: string): Promise<ParsedTokenPool> {
+    const pool: ParsedTokenPool = new Map();
+
+    for (const t of tokens) {
+      if (t.coinId !== coinId) continue;
+      if (t.status !== 'confirmed') continue;
+      if (!t.sdkData) continue;
+
+      try {
+        const parsed = JSON.parse(t.sdkData);
+        const sdkToken = await SdkToken.fromJSON(parsed);
+        const realAmount = this.getTokenBalance(sdkToken, coinId);
+
+        if (realAmount <= 0n) {
+          logger.warn(TAG, `Token ${t.id} has 0 balance for coinId ${coinId}`);
+          continue;
+        }
+
+        pool.set(t.id, { token: t, sdkToken, amount: realAmount });
+      } catch (e) {
+        logger.warn(TAG, 'Failed to parse token', t.id, e);
+      }
+    }
+
+    return pool;
+  }
+
+  /**
+   * SYNCHRONOUS critical section. NO await allowed anywhere in this method.
+   *
+   * Reads free amounts from the ledger, runs split calculation, and either:
+   * - Case A: creates a reservation and returns { reservationId, splitPlan }
+   * - Case B: enqueues the request and returns 'queued'
+   * - Case C: throws SEND_INSUFFICIENT_BALANCE if total inventory is too low
+   */
+  planSend(
+    request: { amount: string; coinId: string },
+    parsedPool: ParsedTokenPool,
+    ledger: TokenReservationLedger,
+    queue: SpendQueue,
+    reservationId: string
+  ): PlanResult | 'queued' {
+    const requestedAmount = BigInt(request.amount);
+    const coinId = request.coinId;
+
+    // Build free view: entries with positive free amounts after subtracting reservations
+    const freeView: Array<{ token: Token; sdkToken: SdkToken<any>; amount: bigint }> = [];
+    let totalInventory = 0n;
+
+    for (const [, entry] of parsedPool) {
+      if (entry.token.coinId !== coinId) continue;
+      totalInventory += entry.amount;
+      const freeAmount = ledger.getFreeAmount(entry.token.id, entry.amount);
+      if (freeAmount > 0n) {
+        freeView.push({ token: entry.token, sdkToken: entry.sdkToken, amount: freeAmount });
+      }
+    }
+
+    // Case C: total inventory (ignoring reservations) is insufficient
+    if (totalInventory < requestedAmount) {
+      throw new SphereError(
+        `Insufficient balance. Available: ${totalInventory}, Required: ${requestedAmount}`,
+        'SEND_INSUFFICIENT_BALANCE'
+      );
+    }
+
+    // Try to find a plan with currently free tokens
+    const plan = this.calculateOptimalSplitSync(freeView, requestedAmount);
+
+    if (plan !== null) {
+      // Case A: plan found — reserve the tokens synchronously
+      const entries = this.extractReservationEntries(plan);
+      ledger.reserve(reservationId, entries, coinId);
+
+      return { reservationId, splitPlan: { ...plan, coinId } };
+    }
+
+    // Case B: tokens exist but are reserved — enqueue
+    queue.enqueue({
+      id: reservationId,
+      request,
+      parsedPool,
+      coinId,
+      amount: requestedAmount,
+      enqueuedAt: Date.now(),
+    });
+
+    return 'queued';
+  }
+
+  /**
+   * Synchronous version of TokenSplitCalculator.calculateOptimalSplit.
+   * Operates on pre-parsed entries instead of raw tokens.
+   *
+   * Strategy:
+   * 1. Exact match (single token = amount)
+   * 2. Combination of tokens summing to exact amount (up to 5 tokens)
+   * 3. Greedy selection with split
+   */
+  calculateOptimalSplitSync(
+    candidates: Array<{ token: Token; sdkToken: SdkToken<any>; amount: bigint }>,
+    targetAmount: bigint
+  ): SplitPlan | null {
+    if (candidates.length === 0) return null;
+
+    // Sort ascending by amount
+    const sorted = [...candidates].sort((a, b) => (a.amount < b.amount ? -1 : a.amount > b.amount ? 1 : 0));
+
+    // Check total available
+    const totalAvailable = sorted.reduce((sum, t) => sum + t.amount, 0n);
+    if (totalAvailable < targetAmount) {
+      return null;
+    }
+
+    // Convert to TokenWithAmount for plan creation
+    const asTokenWithAmount = (entry: { token: Token; sdkToken: SdkToken<any>; amount: bigint }): TokenWithAmount => ({
+      sdkToken: entry.sdkToken,
+      amount: entry.amount,
+      uiToken: entry.token,
+    });
+
+    // Strategy 1: Exact match
+    const exactMatch = sorted.find((t) => t.amount === targetAmount);
+    if (exactMatch) {
+      return this.createDirectPlan([asTokenWithAmount(exactMatch)], targetAmount);
+    }
+
+    // Strategy 2: Combination search (up to 5 tokens)
+    const maxCombinationSize = Math.min(5, sorted.length);
+    for (let size = 2; size <= maxCombinationSize; size++) {
+      const combo = this.findCombinationOfSize(sorted, targetAmount, size, asTokenWithAmount);
+      if (combo) {
+        return this.createDirectPlan(combo, targetAmount);
+      }
+    }
+
+    // Strategy 3: Greedy selection with split
+    const toTransfer: TokenWithAmount[] = [];
+    let currentSum = 0n;
+
+    for (const candidate of sorted) {
+      const newSum = currentSum + candidate.amount;
+
+      if (newSum === targetAmount) {
+        toTransfer.push(asTokenWithAmount(candidate));
+        return this.createDirectPlan(toTransfer, targetAmount);
+      } else if (newSum < targetAmount) {
+        toTransfer.push(asTokenWithAmount(candidate));
+        currentSum = newSum;
+      } else {
+        // Need to split this token
+        const neededFromThisToken = targetAmount - currentSum;
+        const remainderForSender = candidate.amount - neededFromThisToken;
+
+        return {
+          tokensToTransferDirectly: toTransfer,
+          tokenToSplit: asTokenWithAmount(candidate),
+          splitAmount: neededFromThisToken,
+          remainderAmount: remainderForSender,
+          totalTransferAmount: targetAmount,
+          coinId: '',  // filled by caller
+          requiresSplit: true,
+        };
+      }
+    }
+
+    // Should not reach here if totalAvailable >= targetAmount
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract reservation entries from a split plan.
+   * For direct tokens: reserve the full amount.
+   * For split token: reserve only the splitAmount (not the remainder).
+   */
+  private extractReservationEntries(plan: SplitPlan): Array<{ tokenId: string; amount: bigint; tokenAmount: bigint }> {
+    const entries: Array<{ tokenId: string; amount: bigint; tokenAmount: bigint }> = [];
+
+    for (const twa of plan.tokensToTransferDirectly) {
+      // Direct tokens are sent in their entirety — reserve the full token amount
+      const actualAmount = BigInt(twa.uiToken.amount);
+      entries.push({ tokenId: twa.uiToken.id, amount: actualAmount, tokenAmount: actualAmount });
+    }
+
+    if (plan.tokenToSplit && plan.splitAmount !== null) {
+      // A split consumes the ENTIRE source token (it gets replaced by two new tokens).
+      // Reserve the full token amount so no other send can use this token concurrently.
+      const actualAmount = BigInt(plan.tokenToSplit.uiToken.amount);
+      entries.push({ tokenId: plan.tokenToSplit.uiToken.id, amount: actualAmount, tokenAmount: actualAmount });
+    }
+
+    return entries;
+  }
+
+  /** Get balance of a specific coin from an SDK token. */
+  private getTokenBalance(sdkToken: SdkToken<any>, coinIdHex: string): bigint {
+    try {
+      if (!sdkToken.coins) return 0n;
+      const coinId = CoinId.fromJSON(coinIdHex);
+      return sdkToken.coins.get(coinId) ?? 0n;
+    } catch {
+      return 0n;
+    }
+  }
+
+  /** Create a direct transfer plan (no split needed). */
+  private createDirectPlan(tokens: TokenWithAmount[], total: bigint): SplitPlan {
+    return {
+      tokensToTransferDirectly: tokens,
+      tokenToSplit: null,
+      splitAmount: null,
+      remainderAmount: null,
+      totalTransferAmount: total,
+      coinId: '',  // filled by caller
+      requiresSplit: false,
+    };
+  }
+
+  /** Find a combination of exactly `size` tokens that sum to targetAmount. */
+  private findCombinationOfSize<T extends { amount: bigint }>(
+    tokens: T[],
+    targetAmount: bigint,
+    size: number,
+    convert: (entry: T) => TokenWithAmount
+  ): TokenWithAmount[] | null {
+    const gen = this.generateCombinations(tokens, size);
+    for (const combo of gen) {
+      const sum = combo.reduce((acc, t) => acc + t.amount, 0n);
+      if (sum === targetAmount) {
+        return combo.map(convert);
+      }
+    }
+    return null;
+  }
+
+  /** Generator for k-combinations. */
+  private *generateCombinations<T>(
+    tokens: T[],
+    k: number,
+    start: number = 0,
+    current: T[] = []
+  ): Generator<T[]> {
+    if (k === 0) {
+      yield current;
+      return;
+    }
+    for (let i = start; i < tokens.length; i++) {
+      yield* this.generateCombinations(tokens, k - 1, i + 1, [...current, tokens[i]]);
+    }
+  }
+}
+
+// =============================================================================
+// SpendQueue
+// =============================================================================
+
+export class SpendQueue {
+  /** Per-coinId FIFO queues. */
+  private readonly queues = new Map<string, QueueEntry[]>();
+
+  /** Per-entry promise (keyed by entry id) for callers to await. */
+  private readonly promises = new Map<string, Promise<PlanResult>>();
+
+  /** Whether destroy() has been called. */
+  private destroyed = false;
+
+  constructor(
+    private readonly ledger: TokenReservationLedger,
+    private readonly planner: SpendPlanner,
+    private readonly getTokens: () => Map<string, Token>,
+    private readonly parsedTokenCache: Map<string, ParsedTokenEntry>
+  ) {}
+
+  /**
+   * Add an entry to the queue. Returns a promise that resolves when the
+   * entry is successfully planned (tokens become available).
+   *
+   * The enqueue itself is SYNCHRONOUS — the returned promise is resolved
+   * later by notifyChange().
+   */
+  enqueue(
+    entry: Omit<QueueEntry, 'skipCount' | 'resolve' | 'reject' | 'timeout'>
+  ): Promise<PlanResult> {
+    // Check queue size limit
+    let totalSize = 0;
+    for (const [, q] of this.queues) {
+      totalSize += q.length;
+    }
+    if (totalSize >= QUEUE_MAX_SIZE) {
+      return Promise.reject(
+        new SphereError('Send queue is full', 'SEND_QUEUE_FULL')
+      );
+    }
+
+    let resolvePromise!: (result: PlanResult) => void;
+    let rejectPromise!: (error: Error) => void;
+
+    const promise = new Promise<PlanResult>((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
+
+    const timeout = setTimeout(() => {
+      this.expireEntry(entry.id, entry.coinId);
+    }, QUEUE_TIMEOUT_MS);
+
+    const fullEntry: QueueEntry = {
+      ...entry,
+      skipCount: 0,
+      resolve: resolvePromise,
+      reject: rejectPromise,
+      timeout,
+    };
+
+    let coinQueue = this.queues.get(entry.coinId);
+    if (!coinQueue) {
+      coinQueue = [];
+      this.queues.set(entry.coinId, coinQueue);
+    }
+    coinQueue.push(fullEntry);
+
+    this.promises.set(entry.id, promise);
+
+    // Suppress unhandled rejection: planSend() calls enqueue() but doesn't await
+    // the returned promise (it returns 'queued' synchronously). The caller later
+    // obtains the promise via waitForEntry(). Without this, the promise rejection
+    // from destroy()/cancelAll() would appear as an unhandled rejection.
+    promise.catch(() => {});
+
+    logger.debug(TAG, `Enqueued send ${entry.id} for ${entry.amount} ${entry.coinId} (queue depth: ${coinQueue.length})`);
+
+    return promise;
+  }
+
+  /**
+   * Get the promise for a queued entry. Used by send() to await the result
+   * after planSend() returns 'queued'.
+   */
+  waitForEntry(id: string): Promise<PlanResult> {
+    const promise = this.promises.get(id);
+    if (!promise) {
+      return Promise.reject(
+        new SphereError('Queue entry not found: ' + id, 'VALIDATION_ERROR')
+      );
+    }
+    return promise;
+  }
+
+  /**
+   * SYNCHRONOUS. Called when tokens become available (e.g., change token
+   * arrives after a split, or a reservation is released).
+   *
+   * Re-evaluates queued entries for the given coinId in FIFO order.
+   */
+  notifyChange(coinId: string): void {
+    const entries = this.queues.get(coinId);
+    if (!entries || entries.length === 0) return;
+
+    let i = 0;
+    while (i < entries.length) {
+      const entry = entries[i];
+
+      // Check timeout
+      if (Date.now() - entry.enqueuedAt > QUEUE_TIMEOUT_MS) {
+        clearTimeout(entry.timeout);
+        entry.reject(new SphereError('Send queue timeout', 'SEND_QUEUE_TIMEOUT'));
+        entries.splice(i, 1);
+        this.promises.delete(entry.id);
+        continue;
+      }
+
+      // Build merged pool: original parsedPool + new tokens from cache
+      const mergedPool: ParsedTokenPool = new Map(entry.parsedPool);
+      for (const [id, cached] of this.parsedTokenCache) {
+        if (cached.token.coinId === coinId && !mergedPool.has(id)) {
+          mergedPool.set(id, cached);
+        }
+      }
+
+      // Build free view and try planning
+      const freeView = this.buildFreeView(mergedPool, coinId);
+      const plan = this.planner.calculateOptimalSplitSync(freeView, entry.amount);
+
+      if (plan !== null) {
+        // Reserve and resolve — wrap in try/catch to handle DUPLICATE_RESERVATION_ID
+        // (can occur if the entry's reservation was cancelled but remains in the map)
+        try {
+          const reservationEntries = this.extractReservationEntries(plan);
+          this.ledger.reserve(entry.id, reservationEntries, coinId);
+        } catch (e) {
+          // Reservation failed (e.g., DUPLICATE_RESERVATION_ID, INSUFFICIENT_FREE_AMOUNT)
+          // Reject this entry and continue processing the queue
+          clearTimeout(entry.timeout);
+          entry.reject(e instanceof Error ? e : new Error(String(e)));
+          entries.splice(i, 1);
+          this.promises.delete(entry.id);
+          logger.warn(TAG, `Queue entry ${entry.id} reservation failed:`, e);
+          continue;
+        }
+
+        clearTimeout(entry.timeout);
+        entry.resolve({ reservationId: entry.id, splitPlan: { ...plan, coinId } });
+        entries.splice(i, 1);
+        this.promises.delete(entry.id);
+
+        logger.debug(TAG, `Queue entry ${entry.id} planned successfully (remaining: ${entries.length})`);
+        continue;
+      }
+
+      // Could not plan — skip
+      entry.skipCount++;
+      if (entry.skipCount >= MAX_SKIP_COUNT) {
+        // Starvation protection: stop processing this coinId queue
+        // so that the head entry is not starved indefinitely
+        logger.debug(TAG, `Queue entry ${entry.id} reached max skip count (${MAX_SKIP_COUNT}), halting queue scan`);
+        break;
+      }
+
+      i++;
+    }
+
+    // Clean up empty queue
+    if (entries.length === 0) {
+      this.queues.delete(coinId);
+    }
+  }
+
+  /**
+   * Reject all entries. Called by destroy().
+   */
+  cancelAll(reason: string): void {
+    for (const [, entries] of this.queues) {
+      for (const entry of entries) {
+        clearTimeout(entry.timeout);
+        entry.reject(new SphereError(reason, 'MODULE_DESTROYED'));
+        this.promises.delete(entry.id);
+      }
+      entries.length = 0;
+    }
+    this.queues.clear();
+  }
+
+  /** Queue depth, optionally filtered by coinId. */
+  size(coinId?: string): number {
+    if (coinId !== undefined) {
+      return this.queues.get(coinId)?.length ?? 0;
+    }
+    let total = 0;
+    for (const [, q] of this.queues) {
+      total += q.length;
+    }
+    return total;
+  }
+
+  /** Full cleanup: cancel all entries, mark destroyed. */
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.cancelAll('Module destroyed');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /** Build a free-amount view from a parsed pool, consulting the ledger. */
+  private buildFreeView(
+    pool: ParsedTokenPool,
+    coinId: string
+  ): Array<{ token: Token; sdkToken: SdkToken<any>; amount: bigint }> {
+    const view: Array<{ token: Token; sdkToken: SdkToken<any>; amount: bigint }> = [];
+    const liveTokens = this.getTokens();
+
+    for (const [tokenId, entry] of pool) {
+      if (entry.token.coinId !== coinId) continue;
+      // Skip tokens that have been removed from the live wallet
+      if (!liveTokens.has(tokenId)) continue;
+      const freeAmount = this.ledger.getFreeAmount(entry.token.id, entry.amount);
+      if (freeAmount > 0n) {
+        view.push({ token: entry.token, sdkToken: entry.sdkToken, amount: freeAmount });
+      }
+    }
+
+    return view;
+  }
+
+  /** Extract reservation entries from a split plan. */
+  private extractReservationEntries(plan: SplitPlan): Array<{ tokenId: string; amount: bigint; tokenAmount: bigint }> {
+    const entries: Array<{ tokenId: string; amount: bigint; tokenAmount: bigint }> = [];
+
+    for (const twa of plan.tokensToTransferDirectly) {
+      // Direct tokens are sent in their entirety — reserve the full token amount
+      const actualAmount = BigInt(twa.uiToken.amount);
+      entries.push({ tokenId: twa.uiToken.id, amount: actualAmount, tokenAmount: actualAmount });
+    }
+
+    if (plan.tokenToSplit && plan.splitAmount !== null) {
+      // A split consumes the ENTIRE source token — reserve full amount
+      const actualAmount = BigInt(plan.tokenToSplit.uiToken.amount);
+      entries.push({ tokenId: plan.tokenToSplit.uiToken.id, amount: actualAmount, tokenAmount: actualAmount });
+    }
+
+    return entries;
+  }
+
+  /** Expire a single entry by id. Called from the per-entry timeout. */
+  private expireEntry(id: string, coinId: string): void {
+    const entries = this.queues.get(coinId);
+    if (!entries) return;
+
+    const idx = entries.findIndex((e) => e.id === id);
+    if (idx === -1) return;
+
+    const entry = entries[idx];
+    entry.reject(new SphereError('Send queue timeout', 'SEND_QUEUE_TIMEOUT'));
+    entries.splice(idx, 1);
+    this.promises.delete(id);
+
+    if (entries.length === 0) {
+      this.queues.delete(coinId);
+    }
+
+    logger.debug(TAG, `Queue entry ${id} expired after timeout`);
+  }
+
+}

--- a/modules/payments/SpendQueue.ts
+++ b/modules/payments/SpendQueue.ts
@@ -443,6 +443,7 @@ export class SpendQueue {
    * Re-evaluates queued entries for the given coinId in FIFO order.
    */
   notifyChange(coinId: string): void {
+    if (this.destroyed) return;
     const entries = this.queues.get(coinId);
     if (!entries || entries.length === 0) return;
 
@@ -459,10 +460,10 @@ export class SpendQueue {
         continue;
       }
 
-      // Build merged pool: original parsedPool + new tokens from cache
+      // Build merged pool: start from original parsedPool, override with fresh cache entries
       const mergedPool: ParsedTokenPool = new Map(entry.parsedPool);
       for (const [id, cached] of this.parsedTokenCache) {
-        if (cached.token.coinId === coinId && !mergedPool.has(id)) {
+        if (cached.token.coinId === coinId) {
           mergedPool.set(id, cached);
         }
       }
@@ -563,8 +564,9 @@ export class SpendQueue {
 
     for (const [tokenId, entry] of pool) {
       if (entry.token.coinId !== coinId) continue;
-      // Skip tokens that have been removed from the live wallet
-      if (!liveTokens.has(tokenId)) continue;
+      // Skip tokens removed or no longer confirmed in the live wallet
+      const liveToken = liveTokens.get(tokenId);
+      if (!liveToken || liveToken.status !== 'confirmed') continue;
       const freeAmount = this.ledger.getFreeAmount(entry.token.id, entry.amount);
       if (freeAmount > 0n) {
         view.push({ token: entry.token, sdkToken: entry.sdkToken, amount: freeAmount });

--- a/modules/payments/TokenReservationLedger.ts
+++ b/modules/payments/TokenReservationLedger.ts
@@ -1,0 +1,309 @@
+/**
+ * TokenReservationLedger
+ *
+ * Tracks which portions of which tokens have been logically claimed by
+ * in-flight send() operations. All operations are SYNCHRONOUS -- this is
+ * a hard requirement for the spend queue's TOCTOU-safe critical section.
+ *
+ * Invariants:
+ *   I-RL-1: getFreeAmount >= 0n always
+ *   I-RL-2: getFreeAmount + getTotalReserved === tokenAmount for any tracked token
+ *   I-RL-3: ALL operations synchronous (no async/await)
+ *   I-RL-4: Status transitions one-directional: active -> committed, active -> cancelled
+ *   I-RL-5: tokenIndex consistent with reservations at all times
+ *   I-RL-6: Each reservationId unique
+ */
+
+import { logger } from '../../core/logger';
+
+const TAG = 'ReservationLedger';
+
+export type ReservationStatus = 'active' | 'committed' | 'cancelled';
+
+export interface ReservationEntry {
+  readonly reservationId: string;
+  readonly amounts: Map<string, bigint>; // tokenId -> reserved amount
+  readonly coinId: string;
+  readonly createdAt: number;
+  status: ReservationStatus;
+}
+
+export class TokenReservationLedger {
+  /** Primary index: reservationId -> ReservationEntry */
+  private readonly reservations = new Map<string, ReservationEntry>();
+
+  /** Secondary index (acceleration): tokenId -> Set<reservationId> */
+  private readonly tokenIndex = new Map<string, Set<string>>();
+
+  /**
+   * Creates a new reservation. All-or-nothing: validates every entry
+   * before writing any state.
+   *
+   * The caller MUST provide tokenAmount for each entry so the ledger can
+   * verify that sufficient free capacity exists. The ledger does not hold
+   * token references itself.
+   *
+   * @param reservationId - Unique identifier for this reservation
+   * @param entries - Token amounts to reserve (tokenId, amount to reserve, total token amount)
+   * @param coinId - Coin identifier for the reserved tokens
+   * @throws Error('EMPTY_RESERVATION') if entries is empty
+   * @throws Error('DUPLICATE_RESERVATION_ID') if reservationId already exists
+   * @throws Error('INVALID_RESERVATION_AMOUNT') if any amount <= 0n
+   * @throws Error('INSUFFICIENT_FREE_AMOUNT') if any token lacks free capacity
+   */
+  reserve(
+    reservationId: string,
+    entries: Array<{ tokenId: string; amount: bigint; tokenAmount: bigint }>,
+    coinId: string,
+  ): void {
+    // Validate preconditions -- ALL checks before ANY mutation
+    if (entries.length === 0) {
+      throw new Error('EMPTY_RESERVATION');
+    }
+
+    if (this.reservations.has(reservationId)) {
+      throw new Error('DUPLICATE_RESERVATION_ID');
+    }
+
+    for (const entry of entries) {
+      if (entry.amount <= 0n) {
+        throw new Error('INVALID_RESERVATION_AMOUNT');
+      }
+    }
+
+    // Accumulate per-tokenId amounts and tokenAmounts for the new reservation
+    // to correctly handle duplicate tokenIds in entries
+    const pendingAmounts = new Map<string, bigint>();
+    const tokenAmounts = new Map<string, bigint>();
+    for (const entry of entries) {
+      const current = pendingAmounts.get(entry.tokenId) ?? 0n;
+      pendingAmounts.set(entry.tokenId, current + entry.amount);
+      // Use the largest tokenAmount seen for a given tokenId (should be consistent)
+      const existingTokenAmount = tokenAmounts.get(entry.tokenId);
+      if (existingTokenAmount === undefined || entry.tokenAmount > existingTokenAmount) {
+        tokenAmounts.set(entry.tokenId, entry.tokenAmount);
+      }
+    }
+
+    // Check that free amount is sufficient for each token
+    for (const [tokenId, newAmount] of pendingAmounts) {
+      const tokenAmount = tokenAmounts.get(tokenId)!;
+      const freeAmount = this.getFreeAmount(tokenId, tokenAmount);
+      if (freeAmount < newAmount) {
+        throw new Error('INSUFFICIENT_FREE_AMOUNT');
+      }
+    }
+
+    // All checks passed -- mutate state
+    const amounts = new Map<string, bigint>(pendingAmounts);
+
+    const reservation: ReservationEntry = {
+      reservationId,
+      amounts,
+      coinId,
+      createdAt: Date.now(),
+      status: 'active',
+    };
+
+    this.reservations.set(reservationId, reservation);
+
+    // Update secondary index
+    for (const tokenId of amounts.keys()) {
+      let set = this.tokenIndex.get(tokenId);
+      if (!set) {
+        set = new Set();
+        this.tokenIndex.set(tokenId, set);
+      }
+      set.add(reservationId);
+    }
+  }
+
+  /**
+   * Marks a reservation as committed and removes it from all indexes.
+   * Idempotent. Committed tokens are about to be removed from the wallet,
+   * so the reservation is no longer needed for capacity tracking.
+   */
+  commit(reservationId: string): void {
+    const entry = this.reservations.get(reservationId);
+    if (!entry) return;
+
+    if (entry.status === 'committed') return;
+
+    if (entry.status === 'cancelled') {
+      logger.warn(TAG, `Attempted to commit cancelled reservation ${reservationId}`);
+      return;
+    }
+
+    entry.status = 'committed';
+    // Remove from indexes — tokens are being transferred, no capacity to track
+    this.removeFromTokenIndex(entry);
+    this.reservations.delete(reservationId);
+  }
+
+  /**
+   * Releases a reservation. Idempotent.
+   * Removes from tokenIndex for all referenced tokens.
+   */
+  cancel(reservationId: string): void {
+    const entry = this.reservations.get(reservationId);
+    if (!entry) return;
+
+    if (entry.status === 'cancelled') return;
+
+    if (entry.status === 'committed') {
+      logger.warn(TAG, `Attempted to cancel committed reservation ${reservationId}`);
+      return;
+    }
+
+    entry.status = 'cancelled';
+    this.removeFromTokenIndex(entry);
+  }
+
+  /**
+   * Cancels ALL active reservations referencing tokenId.
+   * @returns Array of cancelled reservationIds.
+   */
+  cancelForToken(tokenId: string): string[] {
+    const set = this.tokenIndex.get(tokenId);
+    if (!set) return [];
+
+    const cancelled: string[] = [];
+    // Collect reservation IDs first to avoid mutation during iteration
+    const reservationIds = [...set];
+
+    for (const resId of reservationIds) {
+      const entry = this.reservations.get(resId);
+      if (!entry) continue;
+
+      if (entry.status === 'active') {
+        entry.status = 'cancelled';
+        cancelled.push(resId);
+        // Remove this reservation from ALL its token index entries
+        this.removeFromTokenIndex(entry);
+      }
+    }
+
+    // Ensure tokenId itself is cleaned from the index
+    this.tokenIndex.delete(tokenId);
+
+    return cancelled;
+  }
+
+  /**
+   * Returns tokenAmount minus sum of amounts from active+committed reservations.
+   * Returns 0n if result would be negative (defensive, satisfies I-RL-1).
+   *
+   * @param tokenId - The token to check
+   * @param tokenAmount - The total amount of the token (ledger does not store this)
+   */
+  getFreeAmount(tokenId: string, tokenAmount: bigint): bigint {
+    const reserved = this.getTotalReserved(tokenId);
+    const free = tokenAmount - reserved;
+    return free > 0n ? free : 0n;
+  }
+
+  /**
+   * Sum of active+committed reservation amounts for tokenId.
+   */
+  getTotalReserved(tokenId: string): bigint {
+    const set = this.tokenIndex.get(tokenId);
+    if (!set) return 0n;
+
+    let total = 0n;
+    for (const resId of set) {
+      const entry = this.reservations.get(resId);
+      if (!entry) continue;
+      if (entry.status === 'active' || entry.status === 'committed') {
+        const amount = entry.amounts.get(tokenId);
+        if (amount) {
+          total += amount;
+        }
+      }
+    }
+    return total;
+  }
+
+  /**
+   * Removes reservations older than maxAgeMs.
+   * Active ones get cancelled first, then removed from indexes.
+   * Committed and cancelled ones are removed directly.
+   *
+   * @returns List of reservationIds that were active and got cancelled.
+   */
+  cleanup(maxAgeMs: number): string[] {
+    const now = Date.now();
+    const cancelled: string[] = [];
+    const toRemove: string[] = [];
+
+    for (const [resId, entry] of this.reservations) {
+      if (now - entry.createdAt > maxAgeMs) {
+        if (entry.status === 'active') {
+          entry.status = 'cancelled';
+          this.removeFromTokenIndex(entry);
+          cancelled.push(resId);
+        }
+        toRemove.push(resId);
+      }
+    }
+
+    for (const resId of toRemove) {
+      this.reservations.delete(resId);
+    }
+
+    return cancelled;
+  }
+
+  /**
+   * Read-only lookup of a reservation by ID.
+   */
+  getReservation(reservationId: string): ReservationEntry | undefined {
+    return this.reservations.get(reservationId);
+  }
+
+  /**
+   * Returns true if any active reservation exists for this token.
+   */
+  hasActiveReservation(tokenId: string): boolean {
+    const set = this.tokenIndex.get(tokenId);
+    if (!set) return false;
+
+    for (const resId of set) {
+      const entry = this.reservations.get(resId);
+      if (entry && entry.status === 'active') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Total number of reservations (all statuses).
+   */
+  getSize(): number {
+    return this.reservations.size;
+  }
+
+  /**
+   * Remove all reservations and clear all indexes.
+   */
+  clear(): void {
+    this.reservations.clear();
+    this.tokenIndex.clear();
+  }
+
+  /**
+   * Remove a reservation entry from the tokenIndex for all its referenced tokens.
+   * Does NOT remove the reservation from the primary index.
+   */
+  private removeFromTokenIndex(entry: ReservationEntry): void {
+    for (const tokenId of entry.amounts.keys()) {
+      const set = this.tokenIndex.get(tokenId);
+      if (set) {
+        set.delete(entry.reservationId);
+        if (set.size === 0) {
+          this.tokenIndex.delete(tokenId);
+        }
+      }
+    }
+  }
+}

--- a/modules/payments/TokenReservationLedger.ts
+++ b/modules/payments/TokenReservationLedger.ts
@@ -157,6 +157,7 @@ export class TokenReservationLedger {
 
     entry.status = 'cancelled';
     this.removeFromTokenIndex(entry);
+    this.reservations.delete(reservationId);
   }
 
   /**

--- a/modules/payments/TokenSplitCalculator.ts
+++ b/modules/payments/TokenSplitCalculator.ts
@@ -147,6 +147,74 @@ export class TokenSplitCalculator {
   }
 
   /**
+   * Synchronous variant of calculateOptimalSplit for use in the spend queue
+   * critical section. Operates on pre-parsed TokenWithAmount candidates instead
+   * of raw Token objects, eliminating the async SdkToken.fromJSON() call.
+   *
+   * The algorithm is identical to calculateOptimalSplit:
+   * 1. Exact match → 2. Combination (up to 5) → 3. Greedy + split
+   */
+  calculateOptimalSplitSync(
+    candidates: TokenWithAmount[],
+    targetAmount: bigint
+  ): SplitPlan | null {
+    if (candidates.length === 0 || targetAmount <= 0n) return null;
+
+    // Sort by amount ascending (do not mutate caller's array)
+    const sorted = [...candidates].sort((a, b) => (a.amount < b.amount ? -1 : a.amount > b.amount ? 1 : 0));
+    const coinId = sorted[0].uiToken.coinId;
+
+    const totalAvailable = sorted.reduce((sum, t) => sum + t.amount, 0n);
+    if (totalAvailable < targetAmount) return null;
+
+    // Strategy 1: exact match
+    const exactMatch = sorted.find((t) => t.amount === targetAmount);
+    if (exactMatch) {
+      return this.createDirectPlan([exactMatch], targetAmount, coinId);
+    }
+
+    // Strategy 2: combination of 2-5 tokens
+    const maxCombinationSize = Math.min(5, sorted.length);
+    for (let size = 2; size <= maxCombinationSize; size++) {
+      const combo = this.findCombinationOfSize(sorted, targetAmount, size);
+      if (combo) {
+        return this.createDirectPlan(combo, targetAmount, coinId);
+      }
+    }
+
+    // Strategy 3: greedy + split
+    const toTransfer: TokenWithAmount[] = [];
+    let currentSum = 0n;
+
+    for (const candidate of sorted) {
+      const newSum = currentSum + candidate.amount;
+
+      if (newSum === targetAmount) {
+        toTransfer.push(candidate);
+        return this.createDirectPlan(toTransfer, targetAmount, coinId);
+      } else if (newSum < targetAmount) {
+        toTransfer.push(candidate);
+        currentSum = newSum;
+      } else {
+        const neededFromThisToken = targetAmount - currentSum;
+        const remainderForSender = candidate.amount - neededFromThisToken;
+
+        return {
+          tokensToTransferDirectly: toTransfer,
+          tokenToSplit: candidate,
+          splitAmount: neededFromThisToken,
+          remainderAmount: remainderForSender,
+          totalTransferAmount: targetAmount,
+          coinId,
+          requiresSplit: true,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Get balance of a specific coin from token (lottery-compatible)
    */
   private getTokenBalance(sdkToken: SdkToken<any>, coinIdHex: string): bigint {

--- a/modules/payments/index.ts
+++ b/modules/payments/index.ts
@@ -3,6 +3,8 @@ export * from './L1PaymentsModule';
 export * from './TokenSplitCalculator';
 export * from './TokenSplitExecutor';
 export * from './NametagMinter';
+export * from './TokenReservationLedger';
+export { SpendPlanner, SpendQueue, type ParsedTokenEntry, type ParsedTokenPool, type PlanResult } from './SpendQueue';
 
 // Instant split exports
 export * from './InstantSplitExecutor';

--- a/tests/scripts/test-e2e-cli-multi-transfers.ts
+++ b/tests/scripts/test-e2e-cli-multi-transfers.ts
@@ -1,0 +1,781 @@
+#!/usr/bin/env npx tsx
+/**
+ * E2E CLI Multi-Token Transfer Stress Test Script
+ *
+ * Mirrors test-e2e-multi-transfers.ts but drives everything through CLI
+ * subprocess invocation, matching the pattern in test-e2e-cli.ts.
+ *
+ *   Scenario A — "Split-then-multi-transfer":
+ *     Alice sends 15 sequential split transfers to Bob via CLI.
+ *     After all 15, verify balance conservation via CLI balance output.
+ *
+ *   Scenario B — "15 rapid-fire split transfers":
+ *     Alice sends 15 transfers to Bob as fast as the CLI allows.
+ *     Verifies every transfer arrives and no tokens are lost.
+ *
+ * Usage:
+ *   npx tsx tests/scripts/test-e2e-cli-multi-transfers.ts [--cleanup]
+ */
+
+import { execSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const FAUCET_URL = 'https://faucet.unicity.network/api/v1/faucet/request';
+const CLI_CMD = 'npx tsx cli/index.ts';
+const CONFIG_FILE = '.sphere-cli/config.json';
+const PROFILES_FILE = '.sphere-cli/profiles.json';
+const TRANSFER_TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 3_000;
+const INTER_TRANSFER_DELAY_MS = 2_000;
+const FAUCET_TOPUP_TIMEOUT_MS = 90_000;
+
+const COIN_DECIMALS: Record<string, number> = {
+  UCT: 18,
+  BTC: 8,
+  ETH: 18,
+};
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface CliResult {
+  stdout: string;
+  durationMs: number;
+}
+
+interface ParsedBalance {
+  confirmed: string;
+  unconfirmed: string;
+  tokens: number;
+}
+
+interface ScenarioResult {
+  scenario: string;
+  transferCount: number;
+  successfulSends: number;
+  failedSends: number;
+  totalAmountSent: bigint;
+  senderTotalBefore: bigint;
+  senderTotalAfter: bigint;
+  receiverTotalBefore: bigint;
+  receiverTotalAfter: bigint;
+  senderDelta: bigint;
+  receiverDelta: bigint;
+  balanceConserved: boolean;
+  totalSupplyConserved: boolean;
+  totalTimeMs: number;
+  success: boolean;
+  error?: string;
+}
+
+// =============================================================================
+// Profile Switching
+// =============================================================================
+
+function switchProfile(profileName: string): void {
+  const profilesData = readFileSync(PROFILES_FILE, 'utf8');
+  const profiles = JSON.parse(profilesData) as { profiles: Array<{ name: string; dataDir: string; tokensDir: string; network: string }> };
+  const profile = profiles.profiles.find(p => p.name === profileName);
+  if (!profile) throw new Error(`Profile "${profileName}" not found`);
+
+  const config = JSON.parse(readFileSync(CONFIG_FILE, 'utf8'));
+  config.dataDir = profile.dataDir;
+  config.tokensDir = profile.tokensDir;
+  config.currentProfile = profileName;
+  config.network = profile.network;
+  writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+}
+
+// =============================================================================
+// CLI Helpers
+// =============================================================================
+
+function cli(cmd: string, profile?: string): CliResult {
+  if (profile) {
+    switchProfile(profile);
+  }
+
+  const start = performance.now();
+  const stdout = execSync(`${CLI_CMD} ${cmd}`, {
+    encoding: 'utf8',
+    timeout: 300_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const durationMs = performance.now() - start;
+
+  return { stdout, durationMs };
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// =============================================================================
+// Balance Parsing
+// =============================================================================
+
+function parseBalanceOutput(stdout: string, coinSymbol: string): ParsedBalance | null {
+  const esc = coinSymbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  // Pattern 1: with unconfirmed — "SYM: <confirmed> (+ <unconfirmed> unconfirmed) [<c>+<u> tokens]"
+  const unconfirmedPattern = new RegExp(
+    `${esc}:\\s+([\\d.]+)\\s+\\(\\+\\s+([\\d.]+)\\s+unconfirmed\\)\\s+\\[(\\d+)\\+(\\d+)\\s+tokens\\]`
+  );
+  const m1 = stdout.match(unconfirmedPattern);
+  if (m1) {
+    return {
+      confirmed: m1[1],
+      unconfirmed: m1[2],
+      tokens: parseInt(m1[3]) + parseInt(m1[4]),
+    };
+  }
+
+  // Pattern 2: confirmed only — "SYM: <amount> (<n> tokens)"
+  const confirmedPattern = new RegExp(
+    `${esc}:\\s+([\\d.]+)\\s+\\((\\d+)\\s+tokens?\\)`
+  );
+  const m2 = stdout.match(confirmedPattern);
+  if (m2) {
+    return {
+      confirmed: m2[1],
+      unconfirmed: '0',
+      tokens: parseInt(m2[2]),
+    };
+  }
+
+  return null;
+}
+
+function requireParsedBalance(stdout: string, coinSymbol: string, context: string): ParsedBalance {
+  const parsed = parseBalanceOutput(stdout, coinSymbol);
+  if (!parsed) {
+    const relevantLines = stdout.split('\n').filter(l => l.includes(coinSymbol) || l.includes('balance')).join('\n  ');
+    throw new Error(
+      `Failed to parse ${coinSymbol} balance (${context}). ` +
+      `CLI output may have changed format.\n  Relevant output:\n  ${relevantLines || stdout.trim()}`
+    );
+  }
+  return parsed;
+}
+
+function parseAmountToSmallest(humanStr: string, decimals: number): bigint {
+  const parts = humanStr.split('.');
+  const wholePart = BigInt(parts[0]) * (10n ** BigInt(decimals));
+  if (parts.length === 2) {
+    const fracStr = parts[1].padEnd(decimals, '0').slice(0, decimals);
+    return wholePart + BigInt(fracStr);
+  }
+  return wholePart;
+}
+
+function getCliBalance(profile: string, coinSymbol: string): { total: bigint; parsed: ParsedBalance | null } {
+  const { stdout } = cli('balance --finalize', profile);
+  const parsed = parseBalanceOutput(stdout, coinSymbol);
+  if (!parsed) return { total: 0n, parsed: null };
+  const decimals = COIN_DECIMALS[coinSymbol] ?? 18;
+  const total = parseAmountToSmallest(parsed.confirmed, decimals)
+    + parseAmountToSmallest(parsed.unconfirmed, decimals);
+  return { total, parsed };
+}
+
+// =============================================================================
+// Polling
+// =============================================================================
+
+function waitForBalance(
+  profile: string,
+  coinSymbol: string,
+  minAmount: bigint,
+  timeoutMs: number = TRANSFER_TIMEOUT_MS,
+): { total: bigint; parsed: ParsedBalance; durationMs: number; timedOut: boolean } {
+  const decimals = COIN_DECIMALS[coinSymbol] ?? 18;
+  const startTime = performance.now();
+  let consecutiveErrors = 0;
+
+  while (performance.now() - startTime < timeoutMs) {
+    try {
+      const { stdout } = cli('balance --finalize', profile);
+      consecutiveErrors = 0;
+
+      const parsed = parseBalanceOutput(stdout, coinSymbol);
+      if (parsed) {
+        const total = parseAmountToSmallest(parsed.confirmed, decimals)
+          + parseAmountToSmallest(parsed.unconfirmed, decimals);
+
+        if (total >= minAmount) {
+          return {
+            total,
+            parsed,
+            durationMs: performance.now() - startTime,
+            timedOut: false,
+          };
+        }
+      }
+    } catch (error) {
+      consecutiveErrors++;
+      const msg = error instanceof Error ? error.message : String(error);
+      console.warn(`    [poll] CLI error (${consecutiveErrors}): ${msg.split('\n')[0]}`);
+      if (consecutiveErrors >= 5) {
+        throw new Error(`Too many consecutive CLI errors: ${msg}`);
+      }
+    }
+
+    sleepSync(POLL_INTERVAL_MS);
+  }
+
+  // Final check
+  const { stdout } = cli('balance --finalize', profile);
+  const parsed = parseBalanceOutput(stdout, coinSymbol);
+  const total = parsed
+    ? parseAmountToSmallest(parsed.confirmed, decimals) + parseAmountToSmallest(parsed.unconfirmed, decimals)
+    : 0n;
+  return {
+    total,
+    parsed: parsed || { confirmed: '0', unconfirmed: '0', tokens: 0 },
+    durationMs: performance.now() - startTime,
+    timedOut: true,
+  };
+}
+
+// =============================================================================
+// Setup
+// =============================================================================
+
+function generateTestRunId(): string {
+  return randomBytes(3).toString('hex');
+}
+
+function setupWallet(profile: string, nametag: string): void {
+  console.log(`[SETUP] Creating wallet profile: ${profile}, nametag: @${nametag}`);
+  cli(`wallet create ${profile}`);
+  const { stdout } = cli(`init --nametag ${nametag}`, profile);
+  console.log(`  Init: ${stdout.split('\n').find(l => l.includes('initialized')) || 'OK'}`);
+}
+
+async function requestFaucet(
+  nametag: string,
+  coin: string,
+  amount: number,
+): Promise<{ success: boolean; message?: string }> {
+  try {
+    const response = await fetch(FAUCET_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ unicityId: nametag, coin, amount }),
+    });
+    const result = await response.json() as { success: boolean; message?: string; error?: string };
+    return { success: result.success, message: result.message || result.error };
+  } catch (error) {
+    return { success: false, message: error instanceof Error ? error.message : 'Request failed' };
+  }
+}
+
+async function topupAndWait(profile: string, nametag: string): Promise<void> {
+  console.log('\n[TOPUP] Requesting 100 UCT from faucet...');
+  const result = await requestFaucet(nametag, 'unicity', 100);
+  const status = result.success ? 'OK' : `FAILED: ${result.message}`;
+  console.log(`  Faucet response: ${status}`);
+  if (!result.success) throw new Error(`Faucet request failed: ${result.message}`);
+
+  console.log('[TOPUP] Waiting for UCT to arrive...');
+  const startTime = performance.now();
+
+  while (performance.now() - startTime < FAUCET_TOPUP_TIMEOUT_MS) {
+    const { stdout } = cli('balance --finalize', profile);
+    const parsed = parseBalanceOutput(stdout, 'UCT');
+    if (parsed && parsed.confirmed !== '0') {
+      const elapsed = ((performance.now() - startTime) / 1000).toFixed(1);
+      console.log(`  UCT received in ${elapsed}s: ${parsed.confirmed} (${parsed.tokens} tokens)`);
+      return;
+    }
+    sleepSync(POLL_INTERVAL_MS);
+  }
+
+  throw new Error('Faucet topup timed out for UCT');
+}
+
+// =============================================================================
+// Scenario A: Sequential split transfers via CLI
+// =============================================================================
+
+function runScenarioA(
+  senderProfile: string,
+  receiverProfile: string,
+  receiverNametag: string,
+  transferCount: number,
+  amount: string,
+  coinSymbol: string,
+): ScenarioResult {
+  const decimals = COIN_DECIMALS[coinSymbol] ?? 18;
+  const amountSmallest = parseAmountToSmallest(amount, decimals);
+  const totalExpected = amountSmallest * BigInt(transferCount);
+  const scenario = `A-CLI: ${transferCount}x ${amount} ${coinSymbol} sequential splits`;
+
+  console.log(`\n${'='.repeat(70)}`);
+  console.log(`SCENARIO: ${scenario}`);
+  console.log(`  Transfers: ${transferCount}, Amount each: ${amount} ${coinSymbol}`);
+  console.log(`  Total expected: ${totalExpected} smallest units`);
+  console.log('='.repeat(70));
+
+  const result: ScenarioResult = {
+    scenario,
+    transferCount,
+    successfulSends: 0,
+    failedSends: 0,
+    totalAmountSent: 0n,
+    senderTotalBefore: 0n,
+    senderTotalAfter: 0n,
+    receiverTotalBefore: 0n,
+    receiverTotalAfter: 0n,
+    senderDelta: 0n,
+    receiverDelta: 0n,
+    balanceConserved: false,
+    totalSupplyConserved: false,
+    totalTimeMs: 0,
+    success: false,
+  };
+
+  const startTime = performance.now();
+
+  try {
+    // Snapshot BEFORE
+    const senderBefore = getCliBalance(senderProfile, coinSymbol);
+    const receiverBefore = getCliBalance(receiverProfile, coinSymbol);
+    if (senderBefore.parsed === null) {
+      throw new Error(`Failed to parse sender ${coinSymbol} balance before scenario — CLI output format may have changed`);
+    }
+    result.senderTotalBefore = senderBefore.total;
+    result.receiverTotalBefore = receiverBefore.total;
+    const totalSupplyBefore = senderBefore.total + receiverBefore.total;
+
+    console.log(`\n[BEFORE] Sender:   ${senderBefore.parsed.confirmed} ${coinSymbol} (${senderBefore.parsed.tokens} tokens)`);
+    console.log(`[BEFORE] Receiver: ${receiverBefore.parsed?.confirmed ?? '0'} ${coinSymbol} (${receiverBefore.parsed?.tokens ?? 0} tokens)`);
+
+    if (senderBefore.total < totalExpected) {
+      throw new Error(`Insufficient sender balance: ${senderBefore.total} < ${totalExpected}`);
+    }
+
+    // Execute N transfers
+    for (let i = 0; i < transferCount; i++) {
+      const transferNum = i + 1;
+      const sendCmd = `send @${receiverNametag} ${amount} --coin ${coinSymbol} --instant`;
+
+      console.log(`  [${transferNum}/${transferCount}] ${sendCmd}`);
+
+      try {
+        const { stdout: sendOut, durationMs: sendTime } = cli(sendCmd, senderProfile);
+
+        if (sendOut.includes('Transfer successful')) {
+          result.successfulSends++;
+          result.totalAmountSent += amountSmallest;
+          console.log(`    OK in ${sendTime.toFixed(0)}ms`);
+        } else {
+          result.failedSends++;
+          const lastLine = sendOut.trim().split('\n').pop();
+          console.log(`    FAILED: ${lastLine}`);
+        }
+      } catch (err) {
+        result.failedSends++;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`    ERROR: ${msg.split('\n')[0]}`);
+      }
+
+      // Small delay between transfers
+      if (i < transferCount - 1) {
+        sleepSync(INTER_TRANSFER_DELAY_MS);
+      }
+    }
+
+    // Wait for receiver to accumulate all transfers
+    console.log(`\n[RECEIVE] Waiting for receiver to accumulate ${result.successfulSends} transfers...`);
+    const expectedReceiverTotal = receiverBefore.total + result.totalAmountSent;
+    const recvResult = waitForBalance(
+      receiverProfile, coinSymbol, expectedReceiverTotal, TRANSFER_TIMEOUT_MS,
+    );
+
+    if (recvResult.timedOut) {
+      console.log(`  WARNING: Receiver timed out. Got ${recvResult.total}, expected ${expectedReceiverTotal}`);
+    } else {
+      console.log(`  All received in ${recvResult.durationMs.toFixed(0)}ms`);
+    }
+
+    // Wait for sender change tokens to settle
+    console.log(`[SETTLE] Reading final sender balance...`);
+    const expectedSenderTotal = senderBefore.total - result.totalAmountSent;
+    const senderFinal = waitForBalance(
+      senderProfile, coinSymbol, expectedSenderTotal, 30_000,
+    );
+
+    result.senderTotalAfter = senderFinal.total;
+    result.receiverTotalAfter = recvResult.total;
+
+    result.senderDelta = senderBefore.total - senderFinal.total;
+    result.receiverDelta = recvResult.total - receiverBefore.total;
+    const totalSupplyAfter = senderFinal.total + recvResult.total;
+
+    // Verification
+    console.log(`\n[VERIFY]`);
+    console.log(`  Sender lost:     ${result.senderDelta} (expected: ${result.totalAmountSent})`);
+    console.log(`  Receiver gained: ${result.receiverDelta} (expected: ${result.totalAmountSent})`);
+    console.log(`  Total supply:    ${totalSupplyBefore} -> ${totalSupplyAfter}`);
+
+    result.balanceConserved =
+      result.senderDelta === result.totalAmountSent &&
+      result.receiverDelta === result.totalAmountSent &&
+      result.senderDelta === result.receiverDelta;
+
+    result.totalSupplyConserved = totalSupplyBefore === totalSupplyAfter;
+
+    console.log(`  Balance conservation: ${result.balanceConserved ? 'PASS' : 'FAIL'}`);
+    console.log(`  Supply conservation:  ${result.totalSupplyConserved ? 'PASS' : 'FAIL'}`);
+
+    if (!result.balanceConserved) {
+      if (result.senderDelta !== result.totalAmountSent) {
+        console.log(`    Sender should have lost ${result.totalAmountSent}, actually lost ${result.senderDelta}`);
+      }
+      if (result.receiverDelta !== result.totalAmountSent) {
+        console.log(`    Receiver should have gained ${result.totalAmountSent}, actually gained ${result.receiverDelta}`);
+      }
+    }
+
+    result.success =
+      result.successfulSends > 0 &&
+      result.failedSends === 0 &&
+      !recvResult.timedOut &&
+      result.balanceConserved &&
+      result.totalSupplyConserved;
+
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    console.error(`  SCENARIO ERROR: ${errorMsg}`);
+    result.error = errorMsg;
+  }
+
+  result.totalTimeMs = performance.now() - startTime;
+  return result;
+}
+
+// =============================================================================
+// Scenario B: Rapid-fire transfers via CLI
+// =============================================================================
+
+function runScenarioB(
+  senderProfile: string,
+  receiverProfile: string,
+  receiverNametag: string,
+  transferCount: number,
+  amount: string,
+  coinSymbol: string,
+): ScenarioResult {
+  const decimals = COIN_DECIMALS[coinSymbol] ?? 18;
+  const amountSmallest = parseAmountToSmallest(amount, decimals);
+  const totalExpected = amountSmallest * BigInt(transferCount);
+  const scenario = `B-CLI: ${transferCount}x rapid ${amount} ${coinSymbol}`;
+
+  console.log(`\n${'='.repeat(70)}`);
+  console.log(`SCENARIO: ${scenario}`);
+  console.log(`  Transfers: ${transferCount}, Amount each: ${amount} ${coinSymbol}`);
+  console.log(`  Total expected: ${totalExpected} smallest units`);
+  console.log(`  Mode: RAPID-FIRE (minimal delay)`);
+  console.log('='.repeat(70));
+
+  const result: ScenarioResult = {
+    scenario,
+    transferCount,
+    successfulSends: 0,
+    failedSends: 0,
+    totalAmountSent: 0n,
+    senderTotalBefore: 0n,
+    senderTotalAfter: 0n,
+    receiverTotalBefore: 0n,
+    receiverTotalAfter: 0n,
+    senderDelta: 0n,
+    receiverDelta: 0n,
+    balanceConserved: false,
+    totalSupplyConserved: false,
+    totalTimeMs: 0,
+    success: false,
+  };
+
+  const startTime = performance.now();
+
+  try {
+    // Snapshot BEFORE
+    const senderBefore = getCliBalance(senderProfile, coinSymbol);
+    const receiverBefore = getCliBalance(receiverProfile, coinSymbol);
+    if (senderBefore.parsed === null) {
+      throw new Error(`Failed to parse sender ${coinSymbol} balance before scenario — CLI output format may have changed`);
+    }
+    result.senderTotalBefore = senderBefore.total;
+    result.receiverTotalBefore = receiverBefore.total;
+    const totalSupplyBefore = senderBefore.total + receiverBefore.total;
+
+    console.log(`\n[BEFORE] Sender:   ${senderBefore.parsed.confirmed} ${coinSymbol} (${senderBefore.parsed.tokens} tokens)`);
+    console.log(`[BEFORE] Receiver: ${receiverBefore.parsed?.confirmed ?? '0'} ${coinSymbol} (${receiverBefore.parsed?.tokens ?? 0} tokens)`);
+
+    if (senderBefore.total < totalExpected) {
+      throw new Error(`Insufficient sender balance: ${senderBefore.total} < ${totalExpected}`);
+    }
+
+    // Rapid-fire: no delay between sends (CLI is inherently sequential, but
+    // we don't add any artificial delay beyond what the CLI itself takes)
+    console.log(`\n[RAPID-FIRE] Sending ${transferCount} transfers...`);
+    const sendTimes: number[] = [];
+
+    for (let i = 0; i < transferCount; i++) {
+      const transferNum = i + 1;
+      const sendCmd = `send @${receiverNametag} ${amount} --coin ${coinSymbol} --instant`;
+
+      try {
+        const { stdout: sendOut, durationMs: sendTime } = cli(sendCmd, senderProfile);
+        sendTimes.push(sendTime);
+
+        if (sendOut.includes('Transfer successful')) {
+          result.successfulSends++;
+          result.totalAmountSent += amountSmallest;
+          console.log(`  [${transferNum}/${transferCount}] OK in ${sendTime.toFixed(0)}ms`);
+        } else {
+          result.failedSends++;
+          const lastLine = sendOut.trim().split('\n').pop();
+          console.log(`  [${transferNum}/${transferCount}] FAILED: ${lastLine}`);
+        }
+      } catch (err) {
+        result.failedSends++;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`  [${transferNum}/${transferCount}] ERROR: ${msg.split('\n')[0]}`);
+      }
+      // No deliberate delay in rapid-fire mode
+    }
+
+    // Stats
+    if (sendTimes.length > 0) {
+      const avgMs = sendTimes.reduce((a, b) => a + b, 0) / sendTimes.length;
+      const minMs = Math.min(...sendTimes);
+      const maxMs = Math.max(...sendTimes);
+      console.log(`\n  Send times: avg=${avgMs.toFixed(0)}ms, min=${minMs.toFixed(0)}ms, max=${maxMs.toFixed(0)}ms`);
+    }
+
+    // Wait for receiver to accumulate all transfers
+    console.log(`\n[RECEIVE] Waiting for receiver to accumulate ${result.successfulSends} transfers...`);
+    const expectedReceiverTotal = receiverBefore.total + result.totalAmountSent;
+    const recvResult = waitForBalance(
+      receiverProfile, coinSymbol, expectedReceiverTotal, TRANSFER_TIMEOUT_MS,
+    );
+
+    if (recvResult.timedOut) {
+      console.log(`  WARNING: Receiver timed out. Got ${recvResult.total}, expected ${expectedReceiverTotal}`);
+    } else {
+      console.log(`  All received in ${recvResult.durationMs.toFixed(0)}ms`);
+    }
+
+    // Wait for sender change tokens
+    console.log(`[SETTLE] Reading final sender balance...`);
+    const expectedSenderTotal = senderBefore.total - result.totalAmountSent;
+    const senderFinal = waitForBalance(
+      senderProfile, coinSymbol, expectedSenderTotal, 30_000,
+    );
+
+    result.senderTotalAfter = senderFinal.total;
+    result.receiverTotalAfter = recvResult.total;
+
+    result.senderDelta = senderBefore.total - senderFinal.total;
+    result.receiverDelta = recvResult.total - receiverBefore.total;
+    const totalSupplyAfter = senderFinal.total + recvResult.total;
+
+    // Verification
+    console.log(`\n[VERIFY]`);
+    console.log(`  Sender lost:     ${result.senderDelta} (expected: ${result.totalAmountSent})`);
+    console.log(`  Receiver gained: ${result.receiverDelta} (expected: ${result.totalAmountSent})`);
+    console.log(`  Total supply:    ${totalSupplyBefore} -> ${totalSupplyAfter}`);
+
+    result.balanceConserved =
+      result.senderDelta === result.totalAmountSent &&
+      result.receiverDelta === result.totalAmountSent &&
+      result.senderDelta === result.receiverDelta;
+
+    result.totalSupplyConserved = totalSupplyBefore === totalSupplyAfter;
+
+    console.log(`  Balance conservation: ${result.balanceConserved ? 'PASS' : 'FAIL'}`);
+    console.log(`  Supply conservation:  ${result.totalSupplyConserved ? 'PASS' : 'FAIL'}`);
+
+    if (!result.balanceConserved) {
+      if (result.senderDelta !== result.totalAmountSent) {
+        console.log(`    Sender should have lost ${result.totalAmountSent}, actually lost ${result.senderDelta}`);
+      }
+      if (result.receiverDelta !== result.totalAmountSent) {
+        console.log(`    Receiver should have gained ${result.totalAmountSent}, actually gained ${result.receiverDelta}`);
+      }
+    }
+
+    result.success =
+      result.successfulSends > 0 &&
+      result.failedSends === 0 &&
+      !recvResult.timedOut &&
+      result.balanceConserved &&
+      result.totalSupplyConserved;
+
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    console.error(`  SCENARIO ERROR: ${errorMsg}`);
+    result.error = errorMsg;
+  }
+
+  result.totalTimeMs = performance.now() - startTime;
+  return result;
+}
+
+// =============================================================================
+// Results Summary
+// =============================================================================
+
+function printResults(results: ScenarioResult[]): void {
+  console.log('\n\n');
+  console.log('='.repeat(120));
+  console.log('  CLI MULTI-TRANSFER E2E TEST RESULTS');
+  console.log('='.repeat(120));
+  console.log('');
+  console.log(
+    '  #  | Scenario                                            | Sends OK/N  | Balance | Supply  | Time(s) | Status',
+  );
+  console.log(
+    '-----+-----------------------------------------------------+-------------+---------+---------+---------+---------',
+  );
+
+  results.forEach((r, i) => {
+    const num = String(i + 1).padStart(3);
+    const scenario = r.scenario.slice(0, 51).padEnd(51);
+    const sends = `${r.successfulSends}/${r.transferCount}`.padEnd(11);
+    const balance = r.balanceConserved ? '  PASS ' : '  FAIL ';
+    const supply = r.totalSupplyConserved ? '  PASS ' : '  FAIL ';
+    const time = (r.totalTimeMs / 1000).toFixed(1).padStart(7);
+    const status = r.success ? '  PASS ' : '  FAIL ';
+
+    console.log(
+      ` ${num} | ${scenario} | ${sends} |${balance}|${supply}| ${time} |${status}`,
+    );
+  });
+
+  console.log(
+    '-----+-----------------------------------------------------+-------------+---------+---------+---------+---------',
+  );
+
+  const passed = results.filter(r => r.success);
+  console.log(`\n  TOTAL: ${passed.length}/${results.length} scenarios passed`);
+
+  if (passed.length === results.length) {
+    console.log('\n  ALL TESTS PASSED — No tokens lost in CLI multi-transfer scenarios');
+  } else {
+    console.log('\n  SOME TESTS FAILED:');
+    for (const r of results.filter(r => !r.success)) {
+      console.log(`    - ${r.scenario}: ${r.error ?? 'balance/supply mismatch'}`);
+      if (r.failedSends > 0) {
+        console.log(`      ${r.failedSends} send(s) failed`);
+      }
+      if (!r.balanceConserved) {
+        console.log(`      Balance mismatch: sent=${r.totalAmountSent}, sender_loss=${r.senderDelta}, receiver_gain=${r.receiverDelta}`);
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Cleanup
+// =============================================================================
+
+function cleanupProfiles(testRunId: string): void {
+  const aliceDir = `.sphere-cli-climt_${testRunId}_alice`;
+  const bobDir = `.sphere-cli-climt_${testRunId}_bob`;
+
+  console.log(`\n[CLEANUP] Removing ${aliceDir} and ${bobDir}`);
+  if (existsSync(aliceDir)) rmSync(aliceDir, { recursive: true, force: true });
+  if (existsSync(bobDir)) rmSync(bobDir, { recursive: true, force: true });
+  console.log('  Done.');
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+async function main(): Promise<void> {
+  const doCleanup = process.argv.includes('--cleanup');
+  const testRunId = generateTestRunId();
+
+  const aliceProfile = `climt_${testRunId}_alice`;
+  const bobProfile = `climt_${testRunId}_bob`;
+  const aliceNametag = `cmt${testRunId}a`;
+  const bobNametag = `cmt${testRunId}b`;
+
+  console.log('='.repeat(70));
+  console.log('  CLI Multi-Token Transfer Stress Test');
+  console.log('='.repeat(70));
+  console.log(`  Test run ID:  ${testRunId}`);
+  console.log(`  Alice:        @${aliceNametag} (profile: ${aliceProfile})`);
+  console.log(`  Bob:          @${bobNametag} (profile: ${bobProfile})`);
+  console.log(`  Cleanup:      ${doCleanup ? 'yes' : 'no (use --cleanup to remove dirs after)'}`);
+  console.log('');
+
+  const results: ScenarioResult[] = [];
+
+  try {
+    // =========================================================================
+    // Phase 1: Setup
+    // =========================================================================
+    console.log('\n--- PHASE 1: WALLET SETUP ---\n');
+
+    setupWallet(aliceProfile, aliceNametag);
+    setupWallet(bobProfile, bobNametag);
+
+    await topupAndWait(aliceProfile, aliceNametag);
+
+    // =========================================================================
+    // Phase 2: Scenario A — 15 sequential split transfers
+    // =========================================================================
+    console.log('\n\n--- PHASE 2: SCENARIO A — SEQUENTIAL SPLIT TRANSFERS ---');
+
+    results.push(runScenarioA(
+      aliceProfile, bobProfile, bobNametag,
+      15, '1', 'UCT',
+    ));
+
+    sleepSync(5_000);
+
+    // =========================================================================
+    // Phase 3: Scenario B — 15 rapid-fire transfers
+    // =========================================================================
+    console.log('\n\n--- PHASE 3: SCENARIO B — RAPID-FIRE TRANSFERS ---');
+
+    results.push(runScenarioB(
+      aliceProfile, bobProfile, bobNametag,
+      15, '1', 'UCT',
+    ));
+
+    // =========================================================================
+    // Phase 4: Summary
+    // =========================================================================
+    printResults(results);
+
+  } catch (error) {
+    console.error(`\nFATAL ERROR: ${error instanceof Error ? error.message : String(error)}`);
+    if (error instanceof Error && error.stack) {
+      console.error(error.stack);
+    }
+  } finally {
+    if (doCleanup) {
+      cleanupProfiles(testRunId);
+    }
+  }
+
+  const allPassed = results.length > 0 && results.every(r => r.success);
+  process.exit(allPassed ? 0 : 1);
+}
+
+main().catch((error) => {
+  console.error('Unhandled error:', error);
+  process.exit(1);
+});

--- a/tests/scripts/test-e2e-multi-transfers.ts
+++ b/tests/scripts/test-e2e-multi-transfers.ts
@@ -1,0 +1,823 @@
+#!/usr/bin/env npx tsx
+/**
+ * E2E Multi-Token Transfer Stress Test Script
+ *
+ * Tests heavy multi-token transfer scenarios to verify no tokens are lost:
+ *
+ *   Scenario A — "Split-then-multi-transfer":
+ *     Alice starts with 100 UCT (1 token). She splits it into 15 pieces by
+ *     sending small amounts to Bob in succession (each forces a split).
+ *     After all 15 transfers, verify balance conservation.
+ *
+ *   Scenario B — "15 rapid-fire split transfers":
+ *     Alice sends 15 quick split transfers to Bob back-to-back with minimal
+ *     delay. Verifies that every transfer arrives (no Nostr d-tag collision
+ *     or timestamp filter drops).
+ *
+ * Both scenarios verify:
+ *   - Balance conservation: sender_loss == receiver_gain == expected_total
+ *   - Token count: receiver ends with the expected number of tokens
+ *   - No token loss: total supply across both wallets is unchanged
+ *
+ * Usage:
+ *   npx tsx tests/scripts/test-e2e-multi-transfers.ts [--cleanup]
+ */
+
+import { Sphere } from '../../core/Sphere';
+import { createNodeProviders } from '../../impl/nodejs';
+import { TokenRegistry } from '../../registry/TokenRegistry';
+import { TransferMode } from '../../types';
+import { randomBytes } from 'node:crypto';
+import { rm } from 'node:fs/promises';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const FAUCET_URL = 'https://faucet.unicity.network/api/v1/faucet/request';
+const NETWORK = 'testnet' as const;
+const FAUCET_TOPUP_TIMEOUT_MS = 90_000;
+const TRANSFER_TIMEOUT_MS = 90_000;
+const CHANGE_TOKEN_TIMEOUT_MS = 20_000;
+const INTER_TRANSFER_DELAY_MS = 2_000;
+const POLL_INTERVAL_MS = 1_000;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface BalanceSnapshot {
+  confirmed: bigint;
+  unconfirmed: bigint;
+  total: bigint;
+  tokens: number;
+}
+
+interface ScenarioResult {
+  scenario: string;
+  transferCount: number;
+  successfulTransfers: number;
+  failedTransfers: number;
+  totalAmountSent: bigint;
+  senderBalanceBefore: bigint;
+  senderBalanceAfter: bigint;
+  receiverBalanceBefore: bigint;
+  receiverBalanceAfter: bigint;
+  senderDelta: bigint;
+  receiverDelta: bigint;
+  balanceConserved: boolean;
+  totalSupplyConserved: boolean;
+  totalTimeMs: number;
+  success: boolean;
+  error?: string;
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+function generateTestRunId(): string {
+  return randomBytes(3).toString('hex');
+}
+
+function parseAmount(amountStr: string, decimals: number): bigint {
+  const multiplier = 10n ** BigInt(decimals);
+  const parts = amountStr.split('.');
+  if (parts.length === 2) {
+    const wholePart = BigInt(parts[0]) * multiplier;
+    const fracStr = parts[1].padEnd(decimals, '0').slice(0, decimals);
+    const fracPart = BigInt(fracStr);
+    return wholePart + fracPart;
+  }
+  return BigInt(parts[0]) * multiplier;
+}
+
+function getBalance(sphere: Sphere, coinSymbol: string, allowMissing = false): BalanceSnapshot {
+  const balances = sphere.payments.getBalance();
+  const bal = balances.find(b => b.symbol === coinSymbol);
+  if (!bal) {
+    if (allowMissing) return { confirmed: 0n, unconfirmed: 0n, total: 0n, tokens: 0 };
+    throw new Error(`Coin ${coinSymbol} not found. Available: ${balances.map(b => b.symbol).join(', ') || 'none'}`);
+  }
+  return {
+    confirmed: BigInt(bal.confirmedAmount),
+    unconfirmed: BigInt(bal.unconfirmedAmount),
+    total: BigInt(bal.totalAmount),
+    tokens: bal.tokenCount,
+  };
+}
+
+function formatBalance(bal: BalanceSnapshot, decimals: number): string {
+  const divisor = BigInt(10 ** decimals);
+  const whole = bal.total / divisor;
+  const frac = bal.total % divisor;
+  const formatted = frac > 0n
+    ? `${whole}.${frac.toString().padStart(decimals, '0').replace(/0+$/, '')}`
+    : whole.toString();
+  return `${formatted} (${bal.tokens} tokens, ${bal.confirmed > 0n ? 'conf' : ''}${bal.unconfirmed > 0n ? '+unconf' : ''})`;
+}
+
+// =============================================================================
+// Wallet Management
+// =============================================================================
+
+async function createTestWallet(
+  profileName: string,
+  nametag: string,
+): Promise<{ sphere: Sphere; mnemonic?: string }> {
+  const dataDir = `./.sphere-cli-${profileName}`;
+  const tokensDir = `${dataDir}/tokens`;
+
+  const providers = createNodeProviders({
+    network: NETWORK,
+    dataDir,
+    tokensDir,
+  });
+
+  const { sphere, generatedMnemonic } = await Sphere.init({
+    ...providers,
+    autoGenerate: true,
+    nametag,
+  });
+
+  return { sphere, mnemonic: generatedMnemonic };
+}
+
+// =============================================================================
+// Faucet
+// =============================================================================
+
+async function requestFaucet(
+  nametag: string,
+  coin: string,
+  amount: number,
+): Promise<{ success: boolean; message?: string }> {
+  try {
+    const response = await fetch(FAUCET_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ unicityId: nametag, coin, amount }),
+    });
+    const result = await response.json() as { success: boolean; message?: string; error?: string };
+    return { success: result.success, message: result.message || result.error };
+  } catch (error) {
+    return { success: false, message: error instanceof Error ? error.message : 'Request failed' };
+  }
+}
+
+async function topupAndWait(
+  sphere: Sphere,
+  nametag: string,
+  coin: string,
+  amount: number,
+  symbol: string,
+  expectedSmallest: bigint,
+): Promise<void> {
+  console.log(`\n[TOPUP] Requesting ${amount} ${symbol} from faucet for @${nametag}...`);
+  const result = await requestFaucet(nametag, coin, amount);
+  const status = result.success ? 'OK' : `FAILED: ${result.message}`;
+  console.log(`  Faucet response: ${status}`);
+
+  if (!result.success) {
+    throw new Error(`Faucet request failed: ${result.message}`);
+  }
+
+  console.log(`[TOPUP] Waiting for ${symbol} to arrive via Nostr...`);
+  const startTime = performance.now();
+
+  while (performance.now() - startTime < FAUCET_TOPUP_TIMEOUT_MS) {
+    await sphere.payments.load();
+    const bal = getBalance(sphere, symbol, true);
+    if (bal.total >= expectedSmallest) {
+      const elapsed = ((performance.now() - startTime) / 1000).toFixed(1);
+      console.log(`  ${symbol} received in ${elapsed}s: ${bal.total} smallest units (${bal.tokens} tokens)`);
+      return;
+    }
+    await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  const finalBal = getBalance(sphere, symbol, true);
+  throw new Error(`Faucet topup timed out. ${symbol}: got ${finalBal.total}, expected >= ${expectedSmallest}`);
+}
+
+// =============================================================================
+// Polling
+// =============================================================================
+
+async function waitForReceiverBalance(
+  receiver: Sphere,
+  coinSymbol: string,
+  expectedMinTotal: bigint,
+  timeoutMs: number = TRANSFER_TIMEOUT_MS,
+): Promise<{ receiveTimeMs: number; finalBalance: BalanceSnapshot; timedOut: boolean }> {
+  const startTime = performance.now();
+
+  while (performance.now() - startTime < timeoutMs) {
+    await receiver.payments.load();
+    const balance = getBalance(receiver, coinSymbol, true);
+
+    if (balance.total >= expectedMinTotal) {
+      return {
+        receiveTimeMs: performance.now() - startTime,
+        finalBalance: balance,
+        timedOut: false,
+      };
+    }
+
+    await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  const finalBalance = getBalance(receiver, coinSymbol, true);
+  return {
+    receiveTimeMs: performance.now() - startTime,
+    finalBalance,
+    timedOut: true,
+  };
+}
+
+async function waitForSenderChange(
+  sender: Sphere,
+  coinSymbol: string,
+  expectedTotal: bigint,
+  timeoutMs: number = CHANGE_TOKEN_TIMEOUT_MS,
+): Promise<{ balance: BalanceSnapshot; timedOut: boolean }> {
+  const deadline = performance.now() + timeoutMs;
+  let bal = getBalance(sender, coinSymbol);
+  while (performance.now() < deadline && bal.total < expectedTotal) {
+    await new Promise(r => setTimeout(r, 1_000));
+    await sender.payments.load();
+    bal = getBalance(sender, coinSymbol);
+  }
+  return { balance: bal, timedOut: bal.total < expectedTotal };
+}
+
+// =============================================================================
+// Scenario A: Split into N pieces via successive transfers
+// =============================================================================
+
+async function runScenarioA(
+  sender: Sphere,
+  receiver: Sphere,
+  receiverNametag: string,
+  coinSymbol: string,
+  transferCount: number,
+  amountPerTransfer: string,
+  transferMode: TransferMode,
+): Promise<ScenarioResult> {
+  const registry = TokenRegistry.getInstance();
+  const coinDef = registry.getDefinitionBySymbol(coinSymbol);
+  if (!coinDef) throw new Error(`Unknown coin: ${coinSymbol}`);
+  const decimals = coinDef.decimals ?? 0;
+  const amountSmallest = parseAmount(amountPerTransfer, decimals);
+  const totalExpected = amountSmallest * BigInt(transferCount);
+
+  const scenario = `A: ${transferCount}x ${amountPerTransfer} ${coinSymbol} splits (${transferMode})`;
+
+  console.log(`\n${'='.repeat(70)}`);
+  console.log(`SCENARIO: ${scenario}`);
+  console.log(`  Transfer count: ${transferCount}`);
+  console.log(`  Amount per transfer: ${amountPerTransfer} ${coinSymbol} (${amountSmallest} smallest)`);
+  console.log(`  Total expected: ${totalExpected} smallest`);
+  console.log(`  Mode: ${transferMode.toUpperCase()}`);
+  console.log('='.repeat(70));
+
+  const result: ScenarioResult = {
+    scenario,
+    transferCount,
+    successfulTransfers: 0,
+    failedTransfers: 0,
+    totalAmountSent: 0n,
+    senderBalanceBefore: 0n,
+    senderBalanceAfter: 0n,
+    receiverBalanceBefore: 0n,
+    receiverBalanceAfter: 0n,
+    senderDelta: 0n,
+    receiverDelta: 0n,
+    balanceConserved: false,
+    totalSupplyConserved: false,
+    totalTimeMs: 0,
+    success: false,
+  };
+
+  const startTime = performance.now();
+
+  try {
+    // Snapshot BEFORE
+    await sender.payments.load();
+    await receiver.payments.load();
+    const senderBefore = getBalance(sender, coinSymbol);
+    const receiverBefore = getBalance(receiver, coinSymbol, true);
+    result.senderBalanceBefore = senderBefore.total;
+    result.receiverBalanceBefore = receiverBefore.total;
+    const totalSupplyBefore = senderBefore.total + receiverBefore.total;
+
+    console.log(`\n[BEFORE] Sender:   ${formatBalance(senderBefore, decimals)}`);
+    console.log(`[BEFORE] Receiver: ${formatBalance(receiverBefore, decimals)}`);
+    console.log(`[BEFORE] Total supply: ${totalSupplyBefore}`);
+
+    if (senderBefore.total < totalExpected) {
+      throw new Error(
+        `Insufficient sender balance: ${senderBefore.total} < ${totalExpected}`,
+      );
+    }
+
+    // Execute N transfers sequentially
+    for (let i = 0; i < transferCount; i++) {
+      const transferNum = i + 1;
+      console.log(`\n  [${transferNum}/${transferCount}] Sending ${amountPerTransfer} ${coinSymbol}...`);
+
+      try {
+        const sendStart = performance.now();
+        const sendResult = await sender.payments.send({
+          recipient: `@${receiverNametag}`,
+          amount: amountSmallest.toString(),
+          coinId: coinDef.id,
+          transferMode,
+        });
+        const sendTime = performance.now() - sendStart;
+
+        const sendOk = sendResult.status === 'completed' || sendResult.status === 'delivered';
+        if (sendOk) {
+          result.successfulTransfers++;
+          result.totalAmountSent += amountSmallest;
+          console.log(`    OK in ${sendTime.toFixed(0)}ms (status: ${sendResult.status})`);
+        } else {
+          result.failedTransfers++;
+          console.log(`    FAILED: status=${sendResult.status}, error=${sendResult.error}`);
+        }
+
+        // Wait for sender's change token before next transfer
+        const expectedSenderAfter = senderBefore.total - (amountSmallest * BigInt(transferNum));
+        const changeResult = await waitForSenderChange(sender, coinSymbol, expectedSenderAfter);
+        if (changeResult.timedOut) {
+          console.log(`    WARNING: Sender change token timed out (balance: ${changeResult.balance.total}, expected: ${expectedSenderAfter})`);
+        }
+
+        // Reload sender state for next iteration
+        await sender.payments.load();
+      } catch (err) {
+        result.failedTransfers++;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`    ERROR: ${msg}`);
+      }
+
+      // Small delay between transfers to allow background processing
+      if (i < transferCount - 1) {
+        await new Promise(r => setTimeout(r, INTER_TRANSFER_DELAY_MS));
+      }
+    }
+
+    // Wait for all transfers to arrive at receiver
+    console.log(`\n[RECEIVE] Waiting for receiver to accumulate ${transferCount} transfers...`);
+    const expectedReceiverTotal = receiverBefore.total + result.totalAmountSent;
+    const receiveResult = await waitForReceiverBalance(
+      receiver, coinSymbol, expectedReceiverTotal, TRANSFER_TIMEOUT_MS,
+    );
+
+    if (receiveResult.timedOut) {
+      console.log(`  WARNING: Receiver timed out. Got ${receiveResult.finalBalance.total}, expected ${expectedReceiverTotal}`);
+    } else {
+      console.log(`  Received all in ${receiveResult.receiveTimeMs.toFixed(0)}ms`);
+    }
+
+    // Snapshot AFTER
+    await sender.payments.load();
+    const senderAfter = getBalance(sender, coinSymbol);
+    const receiverAfter = receiveResult.finalBalance;
+    result.senderBalanceAfter = senderAfter.total;
+    result.receiverBalanceAfter = receiverAfter.total;
+
+    result.senderDelta = senderBefore.total - senderAfter.total;
+    result.receiverDelta = receiverAfter.total - receiverBefore.total;
+    const totalSupplyAfter = senderAfter.total + receiverAfter.total;
+
+    console.log(`\n[AFTER] Sender:   ${formatBalance(senderAfter, decimals)}`);
+    console.log(`[AFTER] Receiver: ${formatBalance(receiverAfter, decimals)}`);
+    console.log(`[AFTER] Total supply: ${totalSupplyAfter}`);
+
+    // Verification
+    console.log(`\n[VERIFY] Balance conservation:`);
+    console.log(`  Sender lost:     ${result.senderDelta} (expected: ${result.totalAmountSent})`);
+    console.log(`  Receiver gained: ${result.receiverDelta} (expected: ${result.totalAmountSent})`);
+    console.log(`  Total supply:    ${totalSupplyBefore} -> ${totalSupplyAfter}`);
+
+    result.balanceConserved =
+      result.senderDelta === result.totalAmountSent &&
+      result.receiverDelta === result.totalAmountSent &&
+      result.senderDelta === result.receiverDelta;
+
+    result.totalSupplyConserved = totalSupplyBefore === totalSupplyAfter;
+
+    if (result.balanceConserved) {
+      console.log(`  BALANCE CONSERVATION: PASS`);
+    } else {
+      console.log(`  BALANCE CONSERVATION: FAIL`);
+      if (result.senderDelta !== result.totalAmountSent) {
+        console.log(`    Sender should have lost ${result.totalAmountSent}, actually lost ${result.senderDelta}`);
+      }
+      if (result.receiverDelta !== result.totalAmountSent) {
+        console.log(`    Receiver should have gained ${result.totalAmountSent}, actually gained ${result.receiverDelta}`);
+      }
+    }
+
+    if (result.totalSupplyConserved) {
+      console.log(`  TOTAL SUPPLY CONSERVATION: PASS`);
+    } else {
+      console.log(`  TOTAL SUPPLY CONSERVATION: FAIL (${totalSupplyBefore} -> ${totalSupplyAfter}, diff: ${totalSupplyAfter - totalSupplyBefore})`);
+    }
+
+    result.success =
+      result.successfulTransfers > 0 &&
+      result.failedTransfers === 0 &&
+      !receiveResult.timedOut &&
+      result.balanceConserved &&
+      result.totalSupplyConserved;
+
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    console.error(`  SCENARIO ERROR: ${errorMsg}`);
+    result.error = errorMsg;
+  }
+
+  result.totalTimeMs = performance.now() - startTime;
+  return result;
+}
+
+// =============================================================================
+// Scenario B: N rapid-fire transfers with minimal delay
+// =============================================================================
+
+async function runScenarioB(
+  sender: Sphere,
+  receiver: Sphere,
+  receiverNametag: string,
+  coinSymbol: string,
+  transferCount: number,
+  amountPerTransfer: string,
+  transferMode: TransferMode,
+): Promise<ScenarioResult> {
+  const registry = TokenRegistry.getInstance();
+  const coinDef = registry.getDefinitionBySymbol(coinSymbol);
+  if (!coinDef) throw new Error(`Unknown coin: ${coinSymbol}`);
+  const decimals = coinDef.decimals ?? 0;
+  const amountSmallest = parseAmount(amountPerTransfer, decimals);
+  const totalExpected = amountSmallest * BigInt(transferCount);
+
+  const scenario = `B: ${transferCount}x rapid ${amountPerTransfer} ${coinSymbol} (${transferMode})`;
+
+  console.log(`\n${'='.repeat(70)}`);
+  console.log(`SCENARIO: ${scenario}`);
+  console.log(`  Transfer count: ${transferCount}`);
+  console.log(`  Amount per transfer: ${amountPerTransfer} ${coinSymbol} (${amountSmallest} smallest)`);
+  console.log(`  Total expected: ${totalExpected} smallest`);
+  console.log(`  Mode: ${transferMode.toUpperCase()} (rapid-fire)`);
+  console.log('='.repeat(70));
+
+  const result: ScenarioResult = {
+    scenario,
+    transferCount,
+    successfulTransfers: 0,
+    failedTransfers: 0,
+    totalAmountSent: 0n,
+    senderBalanceBefore: 0n,
+    senderBalanceAfter: 0n,
+    receiverBalanceBefore: 0n,
+    receiverBalanceAfter: 0n,
+    senderDelta: 0n,
+    receiverDelta: 0n,
+    balanceConserved: false,
+    totalSupplyConserved: false,
+    totalTimeMs: 0,
+    success: false,
+  };
+
+  const startTime = performance.now();
+
+  try {
+    // Snapshot BEFORE
+    await sender.payments.load();
+    await receiver.payments.load();
+    const senderBefore = getBalance(sender, coinSymbol);
+    const receiverBefore = getBalance(receiver, coinSymbol, true);
+    result.senderBalanceBefore = senderBefore.total;
+    result.receiverBalanceBefore = receiverBefore.total;
+    const totalSupplyBefore = senderBefore.total + receiverBefore.total;
+
+    console.log(`\n[BEFORE] Sender:   ${formatBalance(senderBefore, decimals)}`);
+    console.log(`[BEFORE] Receiver: ${formatBalance(receiverBefore, decimals)}`);
+    console.log(`[BEFORE] Total supply: ${totalSupplyBefore}`);
+
+    if (senderBefore.total < totalExpected) {
+      throw new Error(
+        `Insufficient sender balance: ${senderBefore.total} < ${totalExpected}`,
+      );
+    }
+
+    // Execute N transfers as fast as possible (sequentially but minimal delay)
+    // Each transfer must wait for the previous change token before proceeding,
+    // otherwise the sender won't have a token to split.
+    console.log(`\n[RAPID-FIRE] Sending ${transferCount} transfers...`);
+    const transferTimes: number[] = [];
+
+    for (let i = 0; i < transferCount; i++) {
+      const transferNum = i + 1;
+
+      try {
+        const sendStart = performance.now();
+        const sendResult = await sender.payments.send({
+          recipient: `@${receiverNametag}`,
+          amount: amountSmallest.toString(),
+          coinId: coinDef.id,
+          transferMode,
+        });
+        const sendTime = performance.now() - sendStart;
+        transferTimes.push(sendTime);
+
+        const sendOk = sendResult.status === 'completed' || sendResult.status === 'delivered';
+        if (sendOk) {
+          result.successfulTransfers++;
+          result.totalAmountSent += amountSmallest;
+          console.log(`  [${transferNum}/${transferCount}] OK in ${sendTime.toFixed(0)}ms`);
+        } else {
+          result.failedTransfers++;
+          console.log(`  [${transferNum}/${transferCount}] FAILED: ${sendResult.status} ${sendResult.error ?? ''}`);
+        }
+
+        // Wait for change token before next transfer
+        const expectedSenderAfter = senderBefore.total - (amountSmallest * BigInt(transferNum));
+        const changeResult = await waitForSenderChange(sender, coinSymbol, expectedSenderAfter);
+        if (changeResult.timedOut) {
+          console.log(`  [${transferNum}/${transferCount}] WARNING: Change token timed out`);
+        }
+        await sender.payments.load();
+      } catch (err) {
+        result.failedTransfers++;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`  [${transferNum}/${transferCount}] ERROR: ${msg}`);
+      }
+    }
+
+    // Stats
+    if (transferTimes.length > 0) {
+      const avgMs = transferTimes.reduce((a, b) => a + b, 0) / transferTimes.length;
+      const minMs = Math.min(...transferTimes);
+      const maxMs = Math.max(...transferTimes);
+      console.log(`\n  Transfer times: avg=${avgMs.toFixed(0)}ms, min=${minMs.toFixed(0)}ms, max=${maxMs.toFixed(0)}ms`);
+    }
+
+    // Wait for all transfers to arrive at receiver
+    console.log(`\n[RECEIVE] Waiting for receiver to accumulate all transfers...`);
+    const expectedReceiverTotal = receiverBefore.total + result.totalAmountSent;
+    const receiveResult = await waitForReceiverBalance(
+      receiver, coinSymbol, expectedReceiverTotal, TRANSFER_TIMEOUT_MS,
+    );
+
+    if (receiveResult.timedOut) {
+      console.log(`  WARNING: Receiver timed out. Got ${receiveResult.finalBalance.total}, expected ${expectedReceiverTotal}`);
+    } else {
+      console.log(`  Received all in ${receiveResult.receiveTimeMs.toFixed(0)}ms`);
+    }
+
+    // Snapshot AFTER
+    await sender.payments.load();
+    const senderAfter = getBalance(sender, coinSymbol);
+    const receiverAfter = receiveResult.finalBalance;
+    result.senderBalanceAfter = senderAfter.total;
+    result.receiverBalanceAfter = receiverAfter.total;
+
+    result.senderDelta = senderBefore.total - senderAfter.total;
+    result.receiverDelta = receiverAfter.total - receiverBefore.total;
+    const totalSupplyAfter = senderAfter.total + receiverAfter.total;
+
+    console.log(`\n[AFTER] Sender:   ${formatBalance(senderAfter, decimals)}`);
+    console.log(`[AFTER] Receiver: ${formatBalance(receiverAfter, decimals)}`);
+    console.log(`[AFTER] Total supply: ${totalSupplyAfter}`);
+
+    // Verification
+    console.log(`\n[VERIFY] Balance conservation:`);
+    console.log(`  Sender lost:     ${result.senderDelta} (expected: ${result.totalAmountSent})`);
+    console.log(`  Receiver gained: ${result.receiverDelta} (expected: ${result.totalAmountSent})`);
+    console.log(`  Total supply:    ${totalSupplyBefore} -> ${totalSupplyAfter}`);
+
+    result.balanceConserved =
+      result.senderDelta === result.totalAmountSent &&
+      result.receiverDelta === result.totalAmountSent &&
+      result.senderDelta === result.receiverDelta;
+
+    result.totalSupplyConserved = totalSupplyBefore === totalSupplyAfter;
+
+    if (result.balanceConserved) {
+      console.log(`  BALANCE CONSERVATION: PASS`);
+    } else {
+      console.log(`  BALANCE CONSERVATION: FAIL`);
+      if (result.senderDelta !== result.totalAmountSent) {
+        console.log(`    Sender should have lost ${result.totalAmountSent}, actually lost ${result.senderDelta}`);
+      }
+      if (result.receiverDelta !== result.totalAmountSent) {
+        console.log(`    Receiver should have gained ${result.totalAmountSent}, actually gained ${result.receiverDelta}`);
+      }
+    }
+
+    if (result.totalSupplyConserved) {
+      console.log(`  TOTAL SUPPLY CONSERVATION: PASS`);
+    } else {
+      console.log(`  TOTAL SUPPLY CONSERVATION: FAIL (${totalSupplyBefore} -> ${totalSupplyAfter}, diff: ${totalSupplyAfter - totalSupplyBefore})`);
+    }
+
+    result.success =
+      result.successfulTransfers > 0 &&
+      result.failedTransfers === 0 &&
+      !receiveResult.timedOut &&
+      result.balanceConserved &&
+      result.totalSupplyConserved;
+
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    console.error(`  SCENARIO ERROR: ${errorMsg}`);
+    result.error = errorMsg;
+  }
+
+  result.totalTimeMs = performance.now() - startTime;
+  return result;
+}
+
+// =============================================================================
+// Results Summary
+// =============================================================================
+
+function printResults(results: ScenarioResult[]): void {
+  console.log('\n\n');
+  console.log('='.repeat(120));
+  console.log('  MULTI-TRANSFER E2E TEST RESULTS');
+  console.log('='.repeat(120));
+  console.log('');
+  console.log(
+    '  #  | Scenario                                            | Tx OK/Total | Balance | Supply  | Time(s) | Status',
+  );
+  console.log(
+    '-----+-----------------------------------------------------+-------------+---------+---------+---------+---------',
+  );
+
+  results.forEach((r, i) => {
+    const num = String(i + 1).padStart(3);
+    const scenario = r.scenario.slice(0, 51).padEnd(51);
+    const txCount = `${r.successfulTransfers}/${r.transferCount}`.padEnd(11);
+    const balance = r.balanceConserved ? '  PASS ' : '  FAIL ';
+    const supply = r.totalSupplyConserved ? '  PASS ' : '  FAIL ';
+    const time = (r.totalTimeMs / 1000).toFixed(1).padStart(7);
+    const status = r.success ? '  PASS ' : '  FAIL ';
+
+    console.log(
+      ` ${num} | ${scenario} | ${txCount} |${balance}|${supply}| ${time} |${status}`,
+    );
+  });
+
+  console.log(
+    '-----+-----------------------------------------------------+-------------+---------+---------+---------+---------',
+  );
+
+  const passed = results.filter(r => r.success);
+  console.log(`\n  TOTAL: ${passed.length}/${results.length} scenarios passed`);
+
+  if (passed.length === results.length) {
+    console.log('\n  ALL TESTS PASSED — No tokens lost in multi-transfer scenarios');
+  } else {
+    console.log('\n  SOME TESTS FAILED:');
+    for (const r of results.filter(r => !r.success)) {
+      console.log(`    - ${r.scenario}: ${r.error ?? 'balance/supply mismatch'}`);
+      if (r.failedTransfers > 0) {
+        console.log(`      ${r.failedTransfers} transfer(s) failed`);
+      }
+      if (!r.balanceConserved) {
+        console.log(`      Balance not conserved: sent=${r.totalAmountSent}, sender_loss=${r.senderDelta}, receiver_gain=${r.receiverDelta}`);
+      }
+      if (!r.totalSupplyConserved) {
+        console.log(`      Total supply changed: before=${r.senderBalanceBefore + r.receiverBalanceBefore}, after=${r.senderBalanceAfter + r.receiverBalanceAfter}`);
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Cleanup
+// =============================================================================
+
+async function cleanup(testRunId: string): Promise<void> {
+  const aliceDir = `./.sphere-cli-mt_${testRunId}_alice`;
+  const bobDir = `./.sphere-cli-mt_${testRunId}_bob`;
+  console.log(`\n[CLEANUP] Removing ${aliceDir} and ${bobDir}`);
+  await rm(aliceDir, { recursive: true, force: true });
+  await rm(bobDir, { recursive: true, force: true });
+  console.log('  Done.');
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+async function main(): Promise<void> {
+  const doCleanup = process.argv.includes('--cleanup');
+  const testRunId = generateTestRunId();
+
+  const aliceNametag = `mt${testRunId}a`;
+  const bobNametag = `mt${testRunId}b`;
+  const aliceProfile = `mt_${testRunId}_alice`;
+  const bobProfile = `mt_${testRunId}_bob`;
+
+  console.log('='.repeat(70));
+  console.log('  Multi-Token Transfer Stress Test');
+  console.log('='.repeat(70));
+  console.log(`  Test run ID:  ${testRunId}`);
+  console.log(`  Alice:        @${aliceNametag} (profile: ${aliceProfile})`);
+  console.log(`  Bob:          @${bobNametag} (profile: ${bobProfile})`);
+  console.log(`  Cleanup:      ${doCleanup ? 'yes' : 'no (use --cleanup to remove dirs after)'}`);
+  console.log('');
+
+  const results: ScenarioResult[] = [];
+  let alice: Sphere | null = null;
+  let bob: Sphere | null = null;
+
+  try {
+    // =========================================================================
+    // Phase 1: Setup
+    // =========================================================================
+    console.log('\n--- PHASE 1: WALLET SETUP ---\n');
+
+    console.log('[SETUP] Creating Alice wallet...');
+    const aliceResult = await createTestWallet(aliceProfile, aliceNametag);
+    alice = aliceResult.sphere;
+    console.log(`  Alice identity: ${alice.identity?.directAddress?.slice(0, 30)}...`);
+
+    console.log('[SETUP] Creating Bob wallet...');
+    const bobResult = await createTestWallet(bobProfile, bobNametag);
+    bob = bobResult.sphere;
+    console.log(`  Bob identity: ${bob.identity?.directAddress?.slice(0, 30)}...`);
+
+    // Topup Alice with UCT — we need enough for both scenarios
+    // Scenario A: 15 x 1 UCT = 15 UCT
+    // Scenario B: 15 x 1 UCT = 15 UCT
+    // Total: 30 UCT needed, request 100 UCT
+    const uctDecimals = 18;
+    const expectedUct = parseAmount('100', uctDecimals);
+    await topupAndWait(alice, aliceNametag, 'unicity', 100, 'UCT', expectedUct);
+
+    // =========================================================================
+    // Phase 2: Scenario A — 15 sequential split transfers
+    // =========================================================================
+    console.log('\n\n--- PHASE 2: SCENARIO A — SPLIT-THEN-MULTI-TRANSFER ---');
+
+    results.push(await runScenarioA(
+      alice, bob, bobNametag,
+      'UCT', 15, '1',
+      'instant',
+    ));
+
+    // Brief pause between scenarios
+    await new Promise(r => setTimeout(r, 5_000));
+    await alice.payments.load();
+    await bob.payments.load();
+
+    // =========================================================================
+    // Phase 3: Scenario B — 15 rapid-fire transfers
+    // =========================================================================
+    console.log('\n\n--- PHASE 3: SCENARIO B — RAPID-FIRE TRANSFERS ---');
+
+    // Alice should still have ~85 UCT after Scenario A
+    results.push(await runScenarioB(
+      alice, bob, bobNametag,
+      'UCT', 15, '1',
+      'instant',
+    ));
+
+    // =========================================================================
+    // Phase 4: Summary
+    // =========================================================================
+    printResults(results);
+
+  } catch (error) {
+    console.error(`\nFATAL ERROR: ${error instanceof Error ? error.message : String(error)}`);
+    if (error instanceof Error && error.stack) {
+      console.error(error.stack);
+    }
+  } finally {
+    if (alice) {
+      try { await alice.destroy(); } catch { /* ignore */ }
+    }
+    if (bob) {
+      try { await bob.destroy(); } catch { /* ignore */ }
+    }
+
+    if (doCleanup) {
+      await cleanup(testRunId);
+    }
+  }
+
+  // Exit code based on results
+  const allPassed = results.length > 0 && results.every(r => r.success);
+  process.exit(allPassed ? 0 : 1);
+}
+
+main().catch((error) => {
+  console.error('Unhandled error:', error);
+  process.exit(1);
+});

--- a/tests/scripts/test-e2e-multi-transfers.ts
+++ b/tests/scripts/test-e2e-multi-transfers.ts
@@ -38,7 +38,7 @@ const FAUCET_URL = 'https://faucet.unicity.network/api/v1/faucet/request';
 const NETWORK = 'testnet' as const;
 const FAUCET_TOPUP_TIMEOUT_MS = 90_000;
 const TRANSFER_TIMEOUT_MS = 90_000;
-const CHANGE_TOKEN_TIMEOUT_MS = 20_000;
+const CHANGE_TOKEN_TIMEOUT_MS = 60_000; // V5 change tokens need aggregator proof collection
 const INTER_TRANSFER_DELAY_MS = 2_000;
 const POLL_INTERVAL_MS = 1_000;
 
@@ -238,17 +238,23 @@ async function waitForReceiverBalance(
 async function waitForSenderChange(
   sender: Sphere,
   coinSymbol: string,
-  expectedTotal: bigint,
+  expectedConfirmed: bigint,
   timeoutMs: number = CHANGE_TOKEN_TIMEOUT_MS,
 ): Promise<{ balance: BalanceSnapshot; timedOut: boolean }> {
   const deadline = performance.now() + timeoutMs;
-  let bal = getBalance(sender, coinSymbol);
-  while (performance.now() < deadline && bal.total < expectedTotal) {
+  // allowMissing: after a split the coin may temporarily vanish while
+  // the change token is in 'submitted' status (not yet confirmed).
+  let bal = getBalance(sender, coinSymbol, true);
+  // Wait for CONFIRMED balance — send() only uses confirmed tokens.
+  // V5 change tokens arrive as 'submitted' first, then finalize to 'confirmed'.
+  while (performance.now() < deadline && bal.confirmed < expectedConfirmed) {
     await new Promise(r => setTimeout(r, 1_000));
+    // Trigger finalization check for pending V5 tokens
+    await sender.payments.receive({ finalize: true });
     await sender.payments.load();
-    bal = getBalance(sender, coinSymbol);
+    bal = getBalance(sender, coinSymbol, true);
   }
-  return { balance: bal, timedOut: bal.total < expectedTotal };
+  return { balance: bal, timedOut: bal.confirmed < expectedConfirmed };
 }
 
 // =============================================================================
@@ -302,7 +308,8 @@ async function runScenarioA(
   const startTime = performance.now();
 
   try {
-    // Snapshot BEFORE
+    // Snapshot BEFORE — finalize any pending V5 tokens from prior scenario
+    await sender.payments.receive({ finalize: true });
     await sender.payments.load();
     await receiver.payments.load();
     const senderBefore = getBalance(sender, coinSymbol);
@@ -380,9 +387,10 @@ async function runScenarioA(
       console.log(`  Received all in ${receiveResult.receiveTimeMs.toFixed(0)}ms`);
     }
 
-    // Snapshot AFTER
+    // Snapshot AFTER — finalize pending V5 change tokens first
+    await sender.payments.receive({ finalize: true });
     await sender.payments.load();
-    const senderAfter = getBalance(sender, coinSymbol);
+    const senderAfter = getBalance(sender, coinSymbol, true);
     const receiverAfter = receiveResult.finalBalance;
     result.senderBalanceAfter = senderAfter.total;
     result.receiverBalanceAfter = receiverAfter.total;
@@ -494,7 +502,8 @@ async function runScenarioB(
   const startTime = performance.now();
 
   try {
-    // Snapshot BEFORE
+    // Snapshot BEFORE — finalize any pending V5 tokens from prior scenario
+    await sender.payments.receive({ finalize: true });
     await sender.payments.load();
     await receiver.payments.load();
     const senderBefore = getBalance(sender, coinSymbol);
@@ -578,9 +587,10 @@ async function runScenarioB(
       console.log(`  Received all in ${receiveResult.receiveTimeMs.toFixed(0)}ms`);
     }
 
-    // Snapshot AFTER
+    // Snapshot AFTER — finalize pending V5 change tokens first
+    await sender.payments.receive({ finalize: true });
     await sender.payments.load();
-    const senderAfter = getBalance(sender, coinSymbol);
+    const senderAfter = getBalance(sender, coinSymbol, true);
     const receiverAfter = receiveResult.finalBalance;
     result.senderBalanceAfter = senderAfter.total;
     result.receiverBalanceAfter = receiverAfter.total;

--- a/tests/unit/modules/PaymentsModule.concurrency.test.ts
+++ b/tests/unit/modules/PaymentsModule.concurrency.test.ts
@@ -1,0 +1,741 @@
+/**
+ * PaymentsModule Concurrency Tests
+ *
+ * Verifies that concurrent send() calls properly reserve tokens,
+ * handle splits, and coordinate via the spend queue.
+ *
+ * These tests exercise the three-component architecture:
+ * - TokenReservationLedger: tracks reserved amounts
+ * - SpendPlanner: synchronous critical section
+ * - SpendQueue: queues blocked sends, wakes on notifyChange
+ *
+ * Most tests work at the component level using real Ledger/Planner/Queue
+ * instances with mock token data, testing concurrency guarantees directly.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TokenReservationLedger } from '../../../modules/payments/TokenReservationLedger';
+import {
+  SpendPlanner,
+  SpendQueue,
+  type ParsedTokenPool,
+  type ParsedTokenEntry,
+  type PlanResult,
+  QUEUE_TIMEOUT_MS,
+  MAX_SKIP_COUNT,
+} from '../../../modules/payments/SpendQueue';
+import type { Token } from '../../../types';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Create a minimal Token for testing */
+function makeToken(id: string, amount: string, coinId: string = 'UCT'): Token {
+  return {
+    id,
+    coinId,
+    symbol: coinId,
+    name: coinId,
+    decimals: 8,
+    amount,
+    status: 'confirmed',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    sdkData: '{}',
+  };
+}
+
+/** Create a ParsedTokenEntry for testing (no real SdkToken needed for planner) */
+function makeParsedEntry(id: string, amount: bigint, coinId: string = 'UCT'): ParsedTokenEntry {
+  const token = makeToken(id, amount.toString(), coinId);
+  return {
+    token,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sdkToken: { id: { toString: () => id } } as any,
+    amount,
+  };
+}
+
+/** Build a ParsedTokenPool from entries */
+function buildPool(...entries: ParsedTokenEntry[]): ParsedTokenPool {
+  const pool = new Map<string, ParsedTokenEntry>();
+  for (const e of entries) {
+    pool.set(e.token.id, e);
+  }
+  return pool;
+}
+
+/** Build a token map from entries */
+function buildTokenMap(...entries: ParsedTokenEntry[]): Map<string, Token> {
+  const map = new Map<string, Token>();
+  for (const e of entries) {
+    map.set(e.token.id, e.token);
+  }
+  return map;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('PaymentsModule Concurrency', () => {
+  let ledger: TokenReservationLedger;
+  let planner: SpendPlanner;
+  let parsedTokenCache: Map<string, ParsedTokenEntry>;
+  let tokenMap: Map<string, Token>;
+
+  beforeEach(() => {
+    ledger = new TokenReservationLedger();
+    planner = new SpendPlanner();
+    parsedTokenCache = new Map();
+    tokenMap = new Map();
+  });
+
+  // ===========================================================================
+  // Basic Concurrency — Two Sends, Same CoinId
+  // ===========================================================================
+
+  describe('Basic Concurrency — Two Sends, Same CoinId', () => {
+    it('two sends for different amounts, pool has enough → both reserve different tokens', () => {
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const e2 = makeParsedEntry('tok-2', 1000000n);
+      const pool = buildPool(e1, e2);
+
+      // Send-1: 300000
+      const result1 = planner.planSend(
+        { amount: '300000', coinId: 'UCT' },
+        pool, ledger, {} as SpendQueue, 'send-1'
+      );
+      expect(result1).not.toBe('queued');
+      const plan1 = (result1 as PlanResult).splitPlan;
+      expect(plan1).toBeDefined();
+
+      // Send-2: 400000
+      const result2 = planner.planSend(
+        { amount: '400000', coinId: 'UCT' },
+        pool, ledger, {} as SpendQueue, 'send-2'
+      );
+      expect(result2).not.toBe('queued');
+      const plan2 = (result2 as PlanResult).splitPlan;
+      expect(plan2).toBeDefined();
+
+      // Each send reserves the FULL token amount (splits consume entire token)
+      // Both tokens should be reserved
+      const totalReserved = ledger.getTotalReserved('tok-1') + ledger.getTotalReserved('tok-2');
+      expect(totalReserved).toBe(2000000n); // 1000000 + 1000000 (full tokens)
+    });
+
+    it('two sends for same amount, one token → first succeeds, second queued', () => {
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const pool = buildPool(e1);
+      const mockQueue = { enqueue: vi.fn() } as unknown as SpendQueue;
+
+      // Send-1: 500000 → reserves tok-1
+      const result1 = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'send-1'
+      );
+      expect(result1).not.toBe('queued');
+
+      // Send-2: 500000 → should be queued (all reserved)
+      const result2 = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'send-2'
+      );
+      expect(result2).toBe('queued');
+      expect(mockQueue.enqueue).toHaveBeenCalledOnce();
+    });
+
+    it('two sends both need split from same token → first reserves, second queued', () => {
+      const e1 = makeParsedEntry('tok-1', 1500000n);
+      const pool = buildPool(e1);
+      const mockQueue = { enqueue: vi.fn() } as unknown as SpendQueue;
+
+      // Send-1: 600000 → reserves tok-1 (will split)
+      const result1 = planner.planSend(
+        { amount: '600000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'send-1'
+      );
+      expect(result1).not.toBe('queued');
+      const plan1 = (result1 as PlanResult).splitPlan;
+      expect(plan1.requiresSplit).toBe(true);
+
+      // Send-2: 400000 → should be queued (tok-1 fully reserved)
+      const result2 = planner.planSend(
+        { amount: '400000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'send-2'
+      );
+      expect(result2).toBe('queued');
+    });
+  });
+
+  // ===========================================================================
+  // Three or More Concurrent Sends
+  // ===========================================================================
+
+  describe('Three or More Concurrent Sends', () => {
+    it('three sends, pool has 3 tokens → all proceed in parallel', () => {
+      const pool = buildPool(
+        makeParsedEntry('tok-1', 1000000n),
+        makeParsedEntry('tok-2', 1000000n),
+        makeParsedEntry('tok-3', 1000000n),
+      );
+
+      const result1 = planner.planSend({ amount: '500000', coinId: 'UCT' }, pool, ledger, {} as SpendQueue, 's1');
+      const result2 = planner.planSend({ amount: '600000', coinId: 'UCT' }, pool, ledger, {} as SpendQueue, 's2');
+      const result3 = planner.planSend({ amount: '400000', coinId: 'UCT' }, pool, ledger, {} as SpendQueue, 's3');
+
+      expect(result1).not.toBe('queued');
+      expect(result2).not.toBe('queued');
+      expect(result3).not.toBe('queued');
+    });
+
+    it('three sends, pool has 2 tokens → two proceed, third queued', () => {
+      const pool = buildPool(
+        makeParsedEntry('tok-1', 1000000n),
+        makeParsedEntry('tok-2', 1000000n),
+      );
+      const mockQueue = { enqueue: vi.fn() } as unknown as SpendQueue;
+
+      const result1 = planner.planSend({ amount: '500000', coinId: 'UCT' }, pool, ledger, mockQueue, 's1');
+      const result2 = planner.planSend({ amount: '600000', coinId: 'UCT' }, pool, ledger, mockQueue, 's2');
+      const result3 = planner.planSend({ amount: '400000', coinId: 'UCT' }, pool, ledger, mockQueue, 's3');
+
+      // First two succeed
+      expect(result1).not.toBe('queued');
+      expect(result2).not.toBe('queued');
+      // Third is queued (tokens exhausted)
+      expect(result3).toBe('queued');
+    });
+
+    it('five sends from one large token → first proceeds, rest queue', () => {
+      const pool = buildPool(makeParsedEntry('tok-1', 5000000n));
+      const mockQueue = { enqueue: vi.fn() } as unknown as SpendQueue;
+
+      const r1 = planner.planSend({ amount: '1000000', coinId: 'UCT' }, pool, ledger, mockQueue, 's1');
+      expect(r1).not.toBe('queued');
+
+      // After r1, tok-1 is fully reserved → all subsequent queue
+      for (let i = 2; i <= 5; i++) {
+        const r = planner.planSend({ amount: '800000', coinId: 'UCT' }, pool, ledger, mockQueue, `s${i}`);
+        expect(r).toBe('queued');
+      }
+      expect(mockQueue.enqueue).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  // ===========================================================================
+  // Cross-CoinId Independence
+  // ===========================================================================
+
+  describe('Cross-CoinId Independence', () => {
+    it('sends for different coinIds → fully parallel, no blocking', () => {
+      const uctEntry = makeParsedEntry('tok-uct-1', 1000000n, 'UCT');
+      const usdcEntry = makeParsedEntry('tok-usdc-1', 1000000n, 'USDC');
+      const uctPool = buildPool(uctEntry);
+      const usdcPool = buildPool(usdcEntry);
+
+      const r1 = planner.planSend({ amount: '500000', coinId: 'UCT' }, uctPool, ledger, {} as SpendQueue, 's1');
+      const r2 = planner.planSend({ amount: '500000', coinId: 'USDC' }, usdcPool, ledger, {} as SpendQueue, 's2');
+
+      expect(r1).not.toBe('queued');
+      expect(r2).not.toBe('queued');
+    });
+
+    it('queue for coinId A does not affect sends for coinId B', () => {
+      const uctPool = buildPool(makeParsedEntry('tok-uct-1', 500000n, 'UCT'));
+      const usdcPool = buildPool(
+        makeParsedEntry('tok-usdc-1', 1000000n, 'USDC'),
+        makeParsedEntry('tok-usdc-2', 1000000n, 'USDC'),
+        makeParsedEntry('tok-usdc-3', 1000000n, 'USDC'),
+      );
+      const mockQueue = { enqueue: vi.fn() } as unknown as SpendQueue;
+
+      // UCT: first send takes the only token, second queues
+      planner.planSend({ amount: '500000', coinId: 'UCT' }, uctPool, ledger, mockQueue, 's-uct-1');
+      const r2 = planner.planSend({ amount: '400000', coinId: 'UCT' }, uctPool, ledger, mockQueue, 's-uct-2');
+      expect(r2).toBe('queued');
+
+      // USDC: should proceed immediately regardless of UCT queue
+      const r3 = planner.planSend({ amount: '600000', coinId: 'USDC' }, usdcPool, ledger, mockQueue, 's-usdc-1');
+      expect(r3).not.toBe('queued');
+    });
+  });
+
+  // ===========================================================================
+  // Send Failure → Reservation Release
+  // ===========================================================================
+
+  describe('Send Failure → Reservation Release', () => {
+    it('first send fails → reservation cancelled → second send proceeds', () => {
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const pool = buildPool(e1);
+      const mockQueue = { enqueue: vi.fn() } as unknown as SpendQueue;
+
+      // Send-1 reserves tok-1
+      const r1 = planner.planSend({ amount: '500000', coinId: 'UCT' }, pool, ledger, mockQueue, 'send-1');
+      expect(r1).not.toBe('queued');
+
+      // Send-2 queued (no free tokens)
+      const r2 = planner.planSend({ amount: '300000', coinId: 'UCT' }, pool, ledger, mockQueue, 'send-2');
+      expect(r2).toBe('queued');
+
+      // Send-1 fails → cancel reservation
+      ledger.cancel('send-1');
+
+      // Now tok-1 is fully free again
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+
+      // Send-2 can now be planned
+      const r3 = planner.planSend({ amount: '300000', coinId: 'UCT' }, pool, ledger, {} as SpendQueue, 'send-2-retry');
+      expect(r3).not.toBe('queued');
+    });
+
+    it('commit deletes reservation; subsequent cancel is no-op', () => {
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const pool = buildPool(e1);
+
+      // Send-1 reserves and commits (full token reserved for split)
+      planner.planSend({ amount: '500000', coinId: 'UCT' }, pool, ledger, {} as SpendQueue, 'send-1');
+      ledger.commit('send-1');
+
+      // Try to cancel — reservation already deleted by commit, no-op
+      ledger.cancel('send-1');
+
+      // Committed reservation is deleted — capacity fully freed
+      expect(ledger.getTotalReserved('tok-1')).toBe(0n);
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+    });
+  });
+
+  // ===========================================================================
+  // Change Token Arrival → Queue Wake
+  // ===========================================================================
+
+  describe('Change Token Arrival → Queue Wake', () => {
+    it('queued send fulfilled when change token arrives and notifyChange fires', async () => {
+      vi.useFakeTimers();
+
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const pool = buildPool(e1);
+      tokenMap = buildTokenMap(e1);
+
+      const queue = new SpendQueue(ledger, planner, () => tokenMap, parsedTokenCache);
+
+      // Send-1: reserves tok-1
+      const r1 = planner.planSend({ amount: '700000', coinId: 'UCT' }, pool, ledger, queue, 'send-1');
+      expect(r1).not.toBe('queued');
+
+      // Send-2: queued (tok-1 fully reserved by send-1's split)
+      const r2 = planner.planSend({ amount: '200000', coinId: 'UCT' }, pool, ledger, queue, 'send-2');
+      expect(r2).toBe('queued');
+
+      const queuePromise = queue.waitForEntry('send-2');
+
+      // Simulate send-1 completes: commit reservation, add change token
+      ledger.commit('send-1');
+
+      // Change token arrives (300000 from split)
+      const changeEntry = makeParsedEntry('tok-change-1', 300000n);
+      parsedTokenCache.set('tok-change-1', changeEntry);
+      tokenMap.set('tok-change-1', changeEntry.token);
+
+      // Notify queue
+      queue.notifyChange('UCT');
+
+      // Queue should have resolved
+      const result = await queuePromise;
+      expect(result.reservationId).toBe('send-2');
+      expect(result.splitPlan).toBeDefined();
+
+      queue.destroy();
+      vi.useRealTimers();
+    });
+
+    it('queued send stays queued when change token is too small', async () => {
+      vi.useFakeTimers();
+
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const pool = buildPool(e1);
+      tokenMap = buildTokenMap(e1);
+
+      const queue = new SpendQueue(ledger, planner, () => tokenMap, parsedTokenCache);
+
+      // Send-1: reserves tok-1
+      planner.planSend({ amount: '700000', coinId: 'UCT' }, pool, ledger, queue, 'send-1');
+      // Send-2: needs 500000 but only 300000 change will come
+      planner.planSend({ amount: '500000', coinId: 'UCT' }, pool, ledger, queue, 'send-2');
+
+      // Change token (300000) — too small for send-2 (500000)
+      const changeEntry = makeParsedEntry('tok-change-1', 300000n);
+      parsedTokenCache.set('tok-change-1', changeEntry);
+
+      queue.notifyChange('UCT');
+
+      // Queue should still have send-2
+      expect(queue.size('UCT')).toBe(1);
+
+      queue.destroy();
+      vi.useRealTimers();
+    });
+
+    it('multiple queued sends fulfilled by cascade of change tokens', async () => {
+      vi.useFakeTimers();
+
+      const e1 = makeParsedEntry('tok-1', 3000000n);
+      const pool = buildPool(e1);
+      tokenMap = buildTokenMap(e1);
+
+      const queue = new SpendQueue(ledger, planner, () => tokenMap, parsedTokenCache);
+
+      // Send-1: reserves tok-1 (will split to 2000000 change)
+      planner.planSend({ amount: '1000000', coinId: 'UCT' }, pool, ledger, queue, 'send-1');
+
+      // Send-2 and Send-3: queued
+      planner.planSend({ amount: '800000', coinId: 'UCT' }, pool, ledger, queue, 'send-2');
+      planner.planSend({ amount: '600000', coinId: 'UCT' }, pool, ledger, queue, 'send-3');
+
+      const p2 = queue.waitForEntry('send-2');
+      const p3 = queue.waitForEntry('send-3');
+
+      // Send-1 completes, change arrives (2000000)
+      ledger.commit('send-1');
+      const c1 = makeParsedEntry('tok-change-1', 2000000n);
+      parsedTokenCache.set('tok-change-1', c1);
+      tokenMap.set('tok-change-1', c1.token);
+
+      queue.notifyChange('UCT');
+
+      // Send-2 should be planned (800000 <= 2000000 free)
+      const result2 = await p2;
+      expect(result2.reservationId).toBe('send-2');
+
+      // After send-2 is planned, 1200000 remains free for send-3
+      // But send-2's reservation means the change token is partially consumed
+      // Let's simulate send-2 completing and change-2 arriving
+      ledger.commit('send-2');
+      const c2 = makeParsedEntry('tok-change-2', 1200000n);
+      parsedTokenCache.set('tok-change-2', c2);
+      tokenMap.set('tok-change-2', c2.token);
+
+      queue.notifyChange('UCT');
+
+      const result3 = await p3;
+      expect(result3.reservationId).toBe('send-3');
+
+      queue.destroy();
+      vi.useRealTimers();
+    });
+  });
+
+  // ===========================================================================
+  // Timeout Scenarios
+  // ===========================================================================
+
+  describe('Timeout Scenarios', () => {
+    it('queued send times out after QUEUE_TIMEOUT_MS', async () => {
+      vi.useFakeTimers();
+
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const pool = buildPool(e1);
+      tokenMap = buildTokenMap(e1);
+
+      const queue = new SpendQueue(ledger, planner, () => tokenMap, parsedTokenCache);
+
+      // Reserve all tokens
+      planner.planSend({ amount: '1000000', coinId: 'UCT' }, pool, ledger, queue, 'send-1');
+
+      // Send-2 queued
+      planner.planSend({ amount: '500000', coinId: 'UCT' }, pool, ledger, queue, 'send-2');
+      const p2 = queue.waitForEntry('send-2');
+
+      // Advance past timeout
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS + 1000);
+
+      await expect(p2).rejects.toThrow('Send queue timeout');
+
+      queue.destroy();
+      vi.useRealTimers();
+    });
+
+    it('queued send fulfilled just before timeout → succeeds', async () => {
+      vi.useFakeTimers();
+
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const pool = buildPool(e1);
+      tokenMap = buildTokenMap(e1);
+
+      const queue = new SpendQueue(ledger, planner, () => tokenMap, parsedTokenCache);
+
+      planner.planSend({ amount: '1000000', coinId: 'UCT' }, pool, ledger, queue, 'send-1');
+      planner.planSend({ amount: '500000', coinId: 'UCT' }, pool, ledger, queue, 'send-2');
+      const p2 = queue.waitForEntry('send-2');
+
+      // Advance to 29 seconds (just before timeout)
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS - 1000);
+
+      // Token arrives just in time
+      ledger.commit('send-1');
+      const change = makeParsedEntry('tok-change', 500000n);
+      parsedTokenCache.set('tok-change', change);
+      tokenMap.set('tok-change', change.token);
+
+      queue.notifyChange('UCT');
+
+      const result = await p2;
+      expect(result.reservationId).toBe('send-2');
+
+      queue.destroy();
+      vi.useRealTimers();
+    });
+  });
+
+  // ===========================================================================
+  // Destroy During Active Sends
+  // ===========================================================================
+
+  describe('Destroy During Active Sends', () => {
+    it('destroy rejects queued sends with MODULE_DESTROYED', async () => {
+      vi.useFakeTimers();
+
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const pool = buildPool(e1);
+      tokenMap = buildTokenMap(e1);
+
+      const queue = new SpendQueue(ledger, planner, () => tokenMap, parsedTokenCache);
+
+      planner.planSend({ amount: '1000000', coinId: 'UCT' }, pool, ledger, queue, 'send-1');
+      // enqueue returns a promise that will be rejected — catch it to avoid unhandled rejection
+      const enqueueResult = planner.planSend({ amount: '500000', coinId: 'UCT' }, pool, ledger, queue, 'send-2');
+      expect(enqueueResult).toBe('queued');
+      const p2 = queue.waitForEntry('send-2');
+      // Catch the internal enqueue promise rejection
+      p2.catch(() => {});
+
+      queue.destroy();
+
+      await expect(p2).rejects.toThrow('Module destroyed');
+
+      vi.useRealTimers();
+    });
+
+    it('no entries accepted after destroy', () => {
+      const queue = new SpendQueue(ledger, planner, () => tokenMap, parsedTokenCache);
+      queue.destroy();
+
+      // After destroy, enqueue should still work (returns rejected promise)
+      // The queue is empty and destroyed
+      expect(queue.size()).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Reservation Invariants
+  // ===========================================================================
+
+  describe('Reservation Invariants', () => {
+    it('I-RL-2: free + reserved = tokenAmount for any tracked token', () => {
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const pool = buildPool(e1);
+
+      // Reserve 300000
+      planner.planSend({ amount: '300000', coinId: 'UCT' }, pool, ledger, {} as SpendQueue, 's1');
+
+      const free = ledger.getFreeAmount('tok-1', 1000000n);
+      const reserved = ledger.getTotalReserved('tok-1');
+
+      expect(free + reserved).toBe(1000000n);
+    });
+
+    it('no orphaned reservations after commit+cancel cycle', () => {
+      const pool = buildPool(
+        makeParsedEntry('tok-1', 1000000n),
+        makeParsedEntry('tok-2', 1000000n),
+      );
+
+      // Multiple sends — each reserves a full token (split)
+      planner.planSend({ amount: '300000', coinId: 'UCT' }, pool, ledger, {} as SpendQueue, 's1');
+      planner.planSend({ amount: '400000', coinId: 'UCT' }, pool, ledger, {} as SpendQueue, 's2');
+
+      // Commit s1 (deletes reservation), cancel s2 (frees capacity)
+      ledger.commit('s1');
+      ledger.cancel('s2');
+
+      // Both reservations freed — commit deletes, cancel releases
+      const reserved1 = ledger.getTotalReserved('tok-1');
+      const reserved2 = ledger.getTotalReserved('tok-2');
+
+      expect(reserved1 + reserved2).toBe(0n);
+    });
+
+    it('I-RL-1: getFreeAmount never returns negative', () => {
+      const e1 = makeParsedEntry('tok-1', 100n);
+      const pool = buildPool(e1);
+
+      // Reserve the full amount
+      planner.planSend({ amount: '100', coinId: 'UCT' }, pool, ledger, {} as SpendQueue, 's1');
+
+      // getFreeAmount should be 0, not negative
+      expect(ledger.getFreeAmount('tok-1', 100n)).toBe(0n);
+      expect(ledger.getFreeAmount('tok-1', 50n)).toBe(0n); // even with understated tokenAmount
+    });
+
+    it('cancelForToken releases all reservations for that token', () => {
+      // Directly create reservations (bypassing planner which needs full SpendQueue for queuing)
+      ledger.reserve('s1', [{ tokenId: 'tok-1', amount: 300000n, tokenAmount: 1000000n }], 'UCT');
+      ledger.reserve('s2', [{ tokenId: 'tok-1', amount: 400000n, tokenAmount: 1000000n }], 'UCT');
+
+      expect(ledger.getTotalReserved('tok-1')).toBe(700000n);
+
+      // Cancel all reservations for tok-1
+      const cancelled = ledger.cancelForToken('tok-1');
+      expect(cancelled.length).toBe(2);
+
+      // Token should be fully free
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+    });
+  });
+
+  // ===========================================================================
+  // Split Race Conditions
+  // ===========================================================================
+
+  describe('Split Race Conditions', () => {
+    it('two sends both need splits from same token → only first gets split, second queued', () => {
+      const pool = buildPool(makeParsedEntry('tok-1', 1000000n));
+      const mockQueue = { enqueue: vi.fn() } as unknown as SpendQueue;
+
+      // Send-1: 600000 — will split tok-1 (needs 600000, token has 1000000)
+      const r1 = planner.planSend({ amount: '600000', coinId: 'UCT' }, pool, ledger, mockQueue, 's1');
+      expect(r1).not.toBe('queued');
+      expect((r1 as PlanResult).splitPlan.requiresSplit).toBe(true);
+
+      // Send-2: 300000 — should queue (tok-1 fully reserved by s1)
+      const r2 = planner.planSend({ amount: '300000', coinId: 'UCT' }, pool, ledger, mockQueue, 's2');
+      expect(r2).toBe('queued');
+    });
+
+    it('split fails → reservation cancelled → queued send re-evaluates', async () => {
+      vi.useFakeTimers();
+
+      const e1 = makeParsedEntry('tok-1', 1000000n);
+      const pool = buildPool(e1);
+      tokenMap = buildTokenMap(e1);
+
+      const queue = new SpendQueue(ledger, planner, () => tokenMap, parsedTokenCache);
+
+      // Send-1 reserves tok-1 (split planned)
+      planner.planSend({ amount: '600000', coinId: 'UCT' }, pool, ledger, queue, 's1');
+
+      // Send-2 queued
+      planner.planSend({ amount: '300000', coinId: 'UCT' }, pool, ledger, queue, 's2');
+      const p2 = queue.waitForEntry('s2');
+
+      // Send-1 split fails → cancel reservation
+      ledger.cancel('s1');
+
+      // Add tok-1 back to cache (it wasn't consumed)
+      parsedTokenCache.set('tok-1', e1);
+
+      // Notify: tok-1 is free again
+      queue.notifyChange('UCT');
+
+      // Send-2 should now be planned with the freed tok-1
+      const result2 = await p2;
+      expect(result2.reservationId).toBe('s2');
+
+      queue.destroy();
+      vi.useRealTimers();
+    });
+  });
+
+  // ===========================================================================
+  // Stress Tests
+  // ===========================================================================
+
+  describe('Stress Tests', () => {
+    it('10 concurrent plans with 5 tokens → all eventually served', () => {
+      const entries = Array.from({ length: 5 }, (_, i) =>
+        makeParsedEntry(`tok-${i}`, 1000000n)
+      );
+      const pool = buildPool(...entries);
+      const mockQueue = { enqueue: vi.fn() } as unknown as SpendQueue;
+
+      let planned = 0;
+      let queued = 0;
+
+      for (let i = 0; i < 10; i++) {
+        const result = planner.planSend(
+          { amount: '300000', coinId: 'UCT' }, pool, ledger, mockQueue, `s${i}`
+        );
+        if (result === 'queued') {
+          queued++;
+        } else {
+          planned++;
+        }
+      }
+
+      // With 5 tokens of 1M each and 300K requests:
+      // Each token can serve 3 sends (300K*3 = 900K < 1M), so up to ~15 sends
+      // But each reservation takes the full amount for splits, or partial amounts
+      // At minimum, 5 should be planned immediately (one per token)
+      expect(planned).toBeGreaterThanOrEqual(5);
+      expect(planned + queued).toBe(10);
+    });
+
+    it('rapid reserve-cancel cycles keep ledger consistent', () => {
+      const pool = buildPool(makeParsedEntry('tok-1', 1000000n));
+      const mockQueue = { enqueue: vi.fn() } as unknown as SpendQueue;
+
+      for (let i = 0; i < 100; i++) {
+        const id = `cycle-${i}`;
+        const result = planner.planSend(
+          { amount: '100000', coinId: 'UCT' }, pool, ledger, mockQueue, id
+        );
+
+        if (result !== 'queued') {
+          // Randomly commit or cancel
+          if (i % 3 === 0) {
+            ledger.commit(id);
+          } else {
+            ledger.cancel(id);
+          }
+        }
+      }
+
+      // Invariant: free + reserved = tokenAmount
+      const free = ledger.getFreeAmount('tok-1', 1000000n);
+      const reserved = ledger.getTotalReserved('tok-1');
+      expect(free + reserved).toBe(1000000n);
+    });
+  });
+
+  // ===========================================================================
+  // Insufficient Balance
+  // ===========================================================================
+
+  describe('Insufficient Balance', () => {
+    it('throws SEND_INSUFFICIENT_BALANCE when total inventory too low', () => {
+      const pool = buildPool(makeParsedEntry('tok-1', 100n));
+
+      expect(() => {
+        planner.planSend(
+          { amount: '1000', coinId: 'UCT' }, pool, ledger, {} as SpendQueue, 's1'
+        );
+      }).toThrow('Insufficient balance');
+    });
+
+    it('queues (not rejects) when total inventory is enough but all reserved', () => {
+      const pool = buildPool(makeParsedEntry('tok-1', 1000000n));
+      const mockQueue = { enqueue: vi.fn() } as unknown as SpendQueue;
+
+      // Reserve all
+      planner.planSend({ amount: '1000000', coinId: 'UCT' }, pool, ledger, mockQueue, 's1');
+
+      // Second send for less than total → queued (not rejected)
+      const r2 = planner.planSend({ amount: '500000', coinId: 'UCT' }, pool, ledger, mockQueue, 's2');
+      expect(r2).toBe('queued');
+    });
+  });
+});

--- a/tests/unit/modules/PaymentsModule.history-integration.test.ts
+++ b/tests/unit/modules/PaymentsModule.history-integration.test.ts
@@ -34,7 +34,42 @@ const mockCalculateOptimalSplit = vi.fn();
 vi.mock('../../../modules/payments/TokenSplitCalculator', () => ({
   TokenSplitCalculator: class {
     calculateOptimalSplit = mockCalculateOptimalSplit;
+    calculateOptimalSplitSync = vi.fn();
   },
+}));
+
+// Mock SpendPlanner + SpendQueue — bridge planSend() to mockCalculateOptimalSplit
+let currentSplitPlan: any = null;
+{
+  const _orig = mockCalculateOptimalSplit.mockResolvedValue.bind(mockCalculateOptimalSplit);
+  mockCalculateOptimalSplit.mockResolvedValue = (value: any) => {
+    currentSplitPlan = value;
+    return _orig(value);
+  };
+}
+vi.mock('../../../modules/payments/SpendQueue', () => ({
+  SpendPlanner: class {
+    buildParsedPool = vi.fn().mockResolvedValue(new Map());
+    planSend = vi.fn().mockImplementation(
+      (_req: any, _pool: any, _ledger: any, _queue: any, reservationId: string) => {
+        if (currentSplitPlan === null) {
+          throw new Error('Insufficient balance');
+        }
+        return { reservationId, splitPlan: currentSplitPlan };
+      }
+    );
+  },
+  SpendQueue: class {
+    enqueue = vi.fn();
+    waitForEntry = vi.fn();
+    notifyChange = vi.fn();
+    cancelAll = vi.fn();
+    destroy = vi.fn();
+  },
+  RESERVATION_TIMEOUT_MS: 30000,
+  QUEUE_TIMEOUT_MS: 30000,
+  MAX_SKIP_COUNT: 10,
+  QUEUE_MAX_SIZE: 100,
 }));
 
 const mockExecuteSplitInstant = vi.fn();

--- a/tests/unit/modules/PaymentsModule.tokenTransfers.test.ts
+++ b/tests/unit/modules/PaymentsModule.tokenTransfers.test.ts
@@ -22,7 +22,32 @@ const mockCalculateOptimalSplit = vi.fn();
 vi.mock('../../../modules/payments/TokenSplitCalculator', () => ({
   TokenSplitCalculator: class {
     calculateOptimalSplit = mockCalculateOptimalSplit;
+    calculateOptimalSplitSync = vi.fn();
   },
+}));
+
+// Mock SpendPlanner + SpendQueue — the spend queue integration uses these
+// instead of TokenSplitCalculator for the conservative send() path.
+// We bridge planSend() to use the same mockCalculateOptimalSplit value.
+let currentSplitPlan: any = null;
+const mockBuildParsedPool = vi.fn().mockResolvedValue(new Map());
+const mockPlanSend = vi.fn();
+vi.mock('../../../modules/payments/SpendQueue', () => ({
+  SpendPlanner: class {
+    buildParsedPool = mockBuildParsedPool;
+    planSend = mockPlanSend;
+  },
+  SpendQueue: class {
+    enqueue = vi.fn();
+    waitForEntry = vi.fn();
+    notifyChange = vi.fn();
+    cancelAll = vi.fn();
+    destroy = vi.fn();
+  },
+  RESERVATION_TIMEOUT_MS: 30000,
+  QUEUE_TIMEOUT_MS: 30000,
+  MAX_SKIP_COUNT: 10,
+  QUEUE_MAX_SIZE: 100,
 }));
 
 // Mock InstantSplitExecutor — controls split execution result
@@ -243,6 +268,24 @@ describe('TransferResult.tokenTransfers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    currentSplitPlan = null;
+
+    // Bridge: whenever mockCalculateOptimalSplit is configured, also track for planSend
+    const origMockResolvedValue = mockCalculateOptimalSplit.mockResolvedValue.bind(mockCalculateOptimalSplit);
+    mockCalculateOptimalSplit.mockResolvedValue = (value: any) => {
+      currentSplitPlan = value;
+      return origMockResolvedValue(value);
+    };
+
+    // Set up mockPlanSend to return the configured split plan synchronously
+    mockPlanSend.mockImplementation(
+      (_request: any, _pool: any, _ledger: any, _queue: any, reservationId: string) => {
+        if (currentSplitPlan === null) {
+          throw new Error('Insufficient balance');
+        }
+        return { reservationId, splitPlan: currentSplitPlan };
+      }
+    );
 
     module = createPaymentsModule({ debug: false });
     mockTransport = createMockTransport();

--- a/tests/unit/modules/SpendPlanner.test.ts
+++ b/tests/unit/modules/SpendPlanner.test.ts
@@ -1,0 +1,813 @@
+/**
+ * SpendPlanner test suite
+ *
+ * Covers:
+ * - Immediate planning (Case A): plan found, reservation created
+ * - Queued planning (Case B): tokens exist but all reserved
+ * - Rejected planning (Case C): total inventory insufficient
+ * - calculateOptimalSplitSync: exact match, combination, greedy+split, insufficient
+ * - Free amount reads from ledger during planning
+ * - Queue enqueue for Case B
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SpendPlanner, type ParsedTokenPool, type ParsedTokenEntry, type PlanResult } from '../../../modules/payments/SpendQueue';
+import { TokenReservationLedger } from '../../../modules/payments/TokenReservationLedger';
+import { SphereError } from '../../../core/errors';
+import type { Token } from '../../../types';
+import type { SplitPlan } from '../../../modules/payments/TokenSplitCalculator';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Create a minimal Token mock with the required fields. */
+function makeToken(id: string, coinId: string, amount: string, status: Token['status'] = 'confirmed'): Token {
+  return {
+    id,
+    coinId,
+    symbol: 'UCT',
+    name: 'Test Token',
+    decimals: 8,
+    amount,
+    status,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+/** Create a ParsedTokenEntry with a stub sdkToken. */
+function makeEntry(id: string, coinId: string, amount: bigint): ParsedTokenEntry {
+  return {
+    token: makeToken(id, coinId, amount.toString()),
+    sdkToken: {} as any,
+    amount,
+  };
+}
+
+/** Build a ParsedTokenPool from an array of [id, coinId, amount] tuples. */
+function buildPool(...entries: Array<[string, string, bigint]>): ParsedTokenPool {
+  const pool: ParsedTokenPool = new Map();
+  for (const [id, coinId, amount] of entries) {
+    pool.set(id, makeEntry(id, coinId, amount));
+  }
+  return pool;
+}
+
+/** Build a candidate array for calculateOptimalSplitSync. */
+function buildCandidates(...entries: Array<[string, bigint]>) {
+  return entries.map(([id, amount]) => ({
+    token: makeToken(id, 'UCT', amount.toString()),
+    sdkToken: {} as any,
+    amount,
+  }));
+}
+
+/** Create a mock SpendQueue with an enqueue spy. */
+function makeMockQueue() {
+  return {
+    enqueue: vi.fn(),
+  } as any;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('SpendPlanner', () => {
+  let planner: SpendPlanner;
+  let ledger: TokenReservationLedger;
+  let mockQueue: ReturnType<typeof makeMockQueue>;
+
+  beforeEach(() => {
+    planner = new SpendPlanner();
+    ledger = new TokenReservationLedger();
+    mockQueue = makeMockQueue();
+  });
+
+  // ===========================================================================
+  // calculateOptimalSplitSync
+  // ===========================================================================
+
+  describe('calculateOptimalSplitSync', () => {
+    it('returns null for empty candidates', () => {
+      const result = planner.calculateOptimalSplitSync([], 100n);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when total available is less than target', () => {
+      const candidates = buildCandidates(['tok-1', 300n], ['tok-2', 200n]);
+      const result = planner.calculateOptimalSplitSync(candidates, 600n);
+      expect(result).toBeNull();
+    });
+
+    it('finds exact match with a single token', () => {
+      const candidates = buildCandidates(['tok-1', 500n], ['tok-2', 1000n]);
+      const result = planner.calculateOptimalSplitSync(candidates, 1000n);
+
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(false);
+      expect(result!.totalTransferAmount).toBe(1000n);
+      expect(result!.tokensToTransferDirectly).toHaveLength(1);
+      expect(result!.tokensToTransferDirectly[0].amount).toBe(1000n);
+      expect(result!.tokenToSplit).toBeNull();
+    });
+
+    it('finds exact match when target equals smallest token', () => {
+      const candidates = buildCandidates(['tok-1', 100n], ['tok-2', 500n]);
+      const result = planner.calculateOptimalSplitSync(candidates, 100n);
+
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(false);
+      expect(result!.tokensToTransferDirectly).toHaveLength(1);
+      expect(result!.tokensToTransferDirectly[0].amount).toBe(100n);
+    });
+
+    it('finds exact two-token combination', () => {
+      const candidates = buildCandidates(['tok-1', 300n], ['tok-2', 700n]);
+      const result = planner.calculateOptimalSplitSync(candidates, 1000n);
+
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(false);
+      expect(result!.totalTransferAmount).toBe(1000n);
+      expect(result!.tokensToTransferDirectly).toHaveLength(2);
+    });
+
+    it('finds exact three-token combination', () => {
+      const candidates = buildCandidates(
+        ['tok-1', 100n],
+        ['tok-2', 200n],
+        ['tok-3', 300n],
+        ['tok-4', 900n],
+      );
+      // 100 + 200 + 300 = 600
+      const result = planner.calculateOptimalSplitSync(candidates, 600n);
+
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(false);
+      expect(result!.totalTransferAmount).toBe(600n);
+    });
+
+    it('uses greedy + split when no exact match exists', () => {
+      const candidates = buildCandidates(['tok-1', 300n], ['tok-2', 500n]);
+      // Target 400: greedy picks tok-1(300), then needs 100 from tok-2(500) => split
+      const result = planner.calculateOptimalSplitSync(candidates, 400n);
+
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(true);
+      expect(result!.totalTransferAmount).toBe(400n);
+      expect(result!.tokensToTransferDirectly).toHaveLength(1);
+      expect(result!.tokensToTransferDirectly[0].amount).toBe(300n);
+      expect(result!.tokenToSplit).not.toBeNull();
+      expect(result!.splitAmount).toBe(100n);
+      expect(result!.remainderAmount).toBe(400n); // 500 - 100
+    });
+
+    it('splits a single token when target is less than smallest', () => {
+      const candidates = buildCandidates(['tok-1', 1000n]);
+      const result = planner.calculateOptimalSplitSync(candidates, 100n);
+
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(true);
+      expect(result!.tokensToTransferDirectly).toHaveLength(0);
+      expect(result!.tokenToSplit).not.toBeNull();
+      expect(result!.splitAmount).toBe(100n);
+      expect(result!.remainderAmount).toBe(900n);
+    });
+
+    it('handles target equal to total available (all tokens, no split)', () => {
+      const candidates = buildCandidates(['tok-1', 300n], ['tok-2', 700n]);
+      const result = planner.calculateOptimalSplitSync(candidates, 1000n);
+
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(false);
+      expect(result!.totalTransferAmount).toBe(1000n);
+    });
+
+    it('prefers exact match over combination', () => {
+      // tok-1(500) + tok-2(500) = 1000, but tok-3(1000) is an exact match
+      const candidates = buildCandidates(['tok-1', 500n], ['tok-2', 500n], ['tok-3', 1000n]);
+      const result = planner.calculateOptimalSplitSync(candidates, 1000n);
+
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(false);
+      // Exact match should use a single token
+      expect(result!.tokensToTransferDirectly).toHaveLength(1);
+      expect(result!.tokensToTransferDirectly[0].amount).toBe(1000n);
+    });
+
+    it('sorts candidates ascending by amount', () => {
+      // Provide in descending order; internal sort should handle
+      const candidates = buildCandidates(['tok-big', 900n], ['tok-small', 100n]);
+      const result = planner.calculateOptimalSplitSync(candidates, 150n);
+
+      // Greedy ascending: picks 100 first, then needs 50 from 900 => split
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(true);
+      expect(result!.tokensToTransferDirectly).toHaveLength(1);
+      expect(result!.tokensToTransferDirectly[0].amount).toBe(100n);
+      expect(result!.splitAmount).toBe(50n);
+    });
+
+    it('handles a single candidate that exactly matches', () => {
+      const candidates = buildCandidates(['tok-1', 500n]);
+      const result = planner.calculateOptimalSplitSync(candidates, 500n);
+
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(false);
+      expect(result!.tokensToTransferDirectly).toHaveLength(1);
+    });
+
+    it('combination search limited to 5 tokens', () => {
+      // 6 tokens each worth 100; target = 600 requires all 6 (combination of 6).
+      // Combination search max is 5, so it falls through to greedy which
+      // accumulates all 6 (exact sum in greedy loop).
+      const candidates = buildCandidates(
+        ['t1', 100n], ['t2', 100n], ['t3', 100n],
+        ['t4', 100n], ['t5', 100n], ['t6', 100n],
+      );
+      const result = planner.calculateOptimalSplitSync(candidates, 600n);
+
+      expect(result).not.toBeNull();
+      expect(result!.totalTransferAmount).toBe(600n);
+      // Greedy picks them all and hits exact sum
+      expect(result!.requiresSplit).toBe(false);
+    });
+
+    it('greedy accumulates multiple tokens before splitting remainder', () => {
+      const candidates = buildCandidates(
+        ['tok-1', 100n],
+        ['tok-2', 200n],
+        ['tok-3', 500n],
+      );
+      // Target 450: greedy picks 100, 200 (=300), then needs 150 from 500 => split
+      const result = planner.calculateOptimalSplitSync(candidates, 450n);
+
+      expect(result).not.toBeNull();
+      expect(result!.requiresSplit).toBe(true);
+      expect(result!.tokensToTransferDirectly).toHaveLength(2);
+      expect(result!.splitAmount).toBe(150n);
+      expect(result!.remainderAmount).toBe(350n);
+    });
+  });
+
+  // ===========================================================================
+  // planSend — Immediate Planning (Case A)
+  // ===========================================================================
+
+  describe('planSend — immediate planning (Case A)', () => {
+    it('returns PlanResult when single token covers the amount', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+      const result = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      );
+
+      expect(result).not.toBe('queued');
+      const plan = result as PlanResult;
+      expect(plan.reservationId).toBe('res-1');
+      expect(plan.splitPlan).toBeDefined();
+      expect(plan.splitPlan.coinId).toBe('UCT');
+    });
+
+    it('creates a reservation in the ledger', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+      planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      );
+
+      const reservation = ledger.getReservation('res-1');
+      expect(reservation).toBeDefined();
+      expect(reservation!.status).toBe('active');
+      expect(reservation!.coinId).toBe('UCT');
+    });
+
+    it('reserves the correct amount for an exact match', () => {
+      const pool = buildPool(['tok-1', 'UCT', 500_000n]);
+      planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      );
+
+      // Full token reserved
+      expect(ledger.getTotalReserved('tok-1')).toBe(500_000n);
+      expect(ledger.getFreeAmount('tok-1', 500_000n)).toBe(0n);
+    });
+
+    it('reserves full token amount when split is needed (entire token consumed)', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+      const result = planner.planSend(
+        { amount: '600000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      ) as PlanResult;
+
+      // Split: 600000 from tok-1 (token amount 1000000)
+      expect(result.splitPlan.requiresSplit).toBe(true);
+      expect(result.splitPlan.splitAmount).toBe(600_000n);
+      // The reservation covers the FULL token amount since a split consumes
+      // the entire source token (replaced by two new tokens)
+      expect(ledger.getTotalReserved('tok-1')).toBe(1_000_000n);
+    });
+
+    it('handles multi-token plan reserving all participating tokens', () => {
+      const pool = buildPool(
+        ['tok-1', 'UCT', 300_000n],
+        ['tok-2', 'UCT', 400_000n],
+      );
+      planner.planSend(
+        { amount: '700000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      );
+
+      // Both tokens should be reserved
+      expect(ledger.getTotalReserved('tok-1')).toBe(300_000n);
+      expect(ledger.getTotalReserved('tok-2')).toBe(400_000n);
+    });
+
+    it('does not call queue.enqueue for immediate plans', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+      planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      );
+
+      expect(mockQueue.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('concurrent planSend calls on separate tokens each reserve their own', () => {
+      const pool = buildPool(
+        ['tok-1', 'UCT', 600_000n],
+        ['tok-2', 'UCT', 400_000n],
+      );
+
+      // First send takes tok-1 + tok-2 (exact combo = 1M is impossible, but 600k is)
+      planner.planSend(
+        { amount: '600000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      );
+
+      // Second send should see tok-2 still free (400k) and plan from it
+      const result = planner.planSend(
+        { amount: '400000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-2',
+      ) as PlanResult;
+
+      expect(result.reservationId).toBe('res-2');
+      expect(ledger.getTotalReserved('tok-1')).toBe(600_000n);
+      expect(ledger.getTotalReserved('tok-2')).toBe(400_000n);
+    });
+
+    it('filters pool entries by coinId', () => {
+      const pool = buildPool(
+        ['tok-1', 'UCT', 500_000n],
+        ['tok-2', 'USDC', 1_000_000n],
+      );
+
+      // Should only consider UCT tokens; USDC tokens ignored for coinId='UCT'
+      try {
+        planner.planSend(
+          { amount: '600000', coinId: 'UCT' },
+          pool, ledger, mockQueue, 'res-1',
+        );
+        expect.fail('Should have thrown');
+      } catch (err: any) {
+        expect(err).toBeInstanceOf(SphereError);
+        expect(err.code).toBe('SEND_INSUFFICIENT_BALANCE');
+      }
+    });
+  });
+
+  // ===========================================================================
+  // planSend — Queued Planning (Case B)
+  // ===========================================================================
+
+  describe('planSend — queued planning (Case B)', () => {
+    it('returns "queued" when tokens exist but are fully reserved', () => {
+      const pool = buildPool(
+        ['tok-1', 'UCT', 1_000_000n],
+        ['tok-2', 'UCT', 1_000_000n],
+      );
+
+      // Reserve all of tok-1 and tok-2
+      ledger.reserve('existing-1', [
+        { tokenId: 'tok-1', amount: 1_000_000n, tokenAmount: 1_000_000n },
+      ], 'UCT');
+      ledger.reserve('existing-2', [
+        { tokenId: 'tok-2', amount: 1_000_000n, tokenAmount: 1_000_000n },
+      ], 'UCT');
+
+      const result = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-new',
+      );
+
+      expect(result).toBe('queued');
+    });
+
+    it('calls queue.enqueue when returning "queued"', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+
+      // Reserve all tokens
+      ledger.reserve('existing-1', [
+        { tokenId: 'tok-1', amount: 1_000_000n, tokenAmount: 1_000_000n },
+      ], 'UCT');
+
+      planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-new',
+      );
+
+      expect(mockQueue.enqueue).toHaveBeenCalledTimes(1);
+      const enqueueArg = mockQueue.enqueue.mock.calls[0][0];
+      expect(enqueueArg.id).toBe('res-new');
+      expect(enqueueArg.coinId).toBe('UCT');
+      expect(enqueueArg.amount).toBe(500_000n);
+    });
+
+    it('does not create a reservation in the ledger when queued', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+      ledger.reserve('existing-1', [
+        { tokenId: 'tok-1', amount: 1_000_000n, tokenAmount: 1_000_000n },
+      ], 'UCT');
+
+      planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-new',
+      );
+
+      expect(ledger.getReservation('res-new')).toBeUndefined();
+    });
+
+    it('queues when free amount is insufficient but total inventory covers it', () => {
+      const pool = buildPool(
+        ['tok-1', 'UCT', 600_000n],
+        ['tok-2', 'UCT', 600_000n],
+      );
+
+      // Reserve most of each token, leaving insufficient free for a 500k send
+      ledger.reserve('existing-1', [
+        { tokenId: 'tok-1', amount: 400_000n, tokenAmount: 600_000n },
+      ], 'UCT');
+      ledger.reserve('existing-2', [
+        { tokenId: 'tok-2', amount: 400_000n, tokenAmount: 600_000n },
+      ], 'UCT');
+
+      // Free: 200k + 200k = 400k < 500k, but total inventory = 1.2M >= 500k
+      const result = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-new',
+      );
+
+      expect(result).toBe('queued');
+    });
+
+    it('passes parsedPool in the enqueue call', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+      ledger.reserve('existing-1', [
+        { tokenId: 'tok-1', amount: 1_000_000n, tokenAmount: 1_000_000n },
+      ], 'UCT');
+
+      planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-new',
+      );
+
+      const enqueueArg = mockQueue.enqueue.mock.calls[0][0];
+      expect(enqueueArg.parsedPool).toBe(pool);
+    });
+  });
+
+  // ===========================================================================
+  // planSend — Rejection (Case C)
+  // ===========================================================================
+
+  describe('planSend — rejection (Case C)', () => {
+    it('throws SEND_INSUFFICIENT_BALANCE when total inventory is less than requested', () => {
+      const pool = buildPool(
+        ['tok-1', 'UCT', 300_000n],
+        ['tok-2', 'UCT', 200_000n],
+      );
+
+      try {
+        planner.planSend(
+          { amount: '600000', coinId: 'UCT' },
+          pool, ledger, mockQueue, 'res-1',
+        );
+        expect.fail('Should have thrown');
+      } catch (err: any) {
+        expect(err).toBeInstanceOf(SphereError);
+        expect(err.code).toBe('SEND_INSUFFICIENT_BALANCE');
+      }
+    });
+
+    it('throws SEND_INSUFFICIENT_BALANCE for empty pool', () => {
+      const pool: ParsedTokenPool = new Map();
+
+      try {
+        planner.planSend(
+          { amount: '1', coinId: 'UCT' },
+          pool, ledger, mockQueue, 'res-1',
+        );
+        expect.fail('Should have thrown');
+      } catch (err: any) {
+        expect(err).toBeInstanceOf(SphereError);
+        expect(err.code).toBe('SEND_INSUFFICIENT_BALANCE');
+      }
+    });
+
+    it('throws SEND_INSUFFICIENT_BALANCE when pool has only other coinIds', () => {
+      const pool = buildPool(['tok-1', 'USDC', 1_000_000n]);
+
+      try {
+        planner.planSend(
+          { amount: '500000', coinId: 'UCT' },
+          pool, ledger, mockQueue, 'res-1',
+        );
+        expect.fail('Should have thrown');
+      } catch (err: any) {
+        expect(err).toBeInstanceOf(SphereError);
+        expect(err.code).toBe('SEND_INSUFFICIENT_BALANCE');
+      }
+    });
+
+    it('does not create a reservation on rejection', () => {
+      const pool = buildPool(['tok-1', 'UCT', 100n]);
+
+      try {
+        planner.planSend(
+          { amount: '500000', coinId: 'UCT' },
+          pool, ledger, mockQueue, 'res-1',
+        );
+      } catch {
+        // expected
+      }
+
+      expect(ledger.getReservation('res-1')).toBeUndefined();
+    });
+
+    it('does not enqueue on rejection', () => {
+      const pool = buildPool(['tok-1', 'UCT', 100n]);
+
+      try {
+        planner.planSend(
+          { amount: '500000', coinId: 'UCT' },
+          pool, ledger, mockQueue, 'res-1',
+        );
+      } catch {
+        // expected
+      }
+
+      expect(mockQueue.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('error message contains available and required amounts', () => {
+      const pool = buildPool(['tok-1', 'UCT', 300_000n]);
+
+      try {
+        planner.planSend(
+          { amount: '500000', coinId: 'UCT' },
+          pool, ledger, mockQueue, 'res-1',
+        );
+        expect.fail('Should have thrown');
+      } catch (err: any) {
+        expect(err.message).toContain('300000');
+        expect(err.message).toContain('500000');
+      }
+    });
+
+    it('uses total inventory (ignoring reservations) for the sufficiency check', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+
+      // Reserve 800k, but total inventory is still 1M
+      ledger.reserve('existing-1', [
+        { tokenId: 'tok-1', amount: 800_000n, tokenAmount: 1_000_000n },
+      ], 'UCT');
+
+      // Request for 900k: total inventory (1M) >= 900k, so should NOT throw
+      // but free = 200k < 900k, so it queues
+      const result = planner.planSend(
+        { amount: '900000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-new',
+      );
+
+      expect(result).toBe('queued');
+    });
+  });
+
+  // ===========================================================================
+  // planSend — Free amount reads from ledger
+  // ===========================================================================
+
+  describe('planSend — ledger free amount interaction', () => {
+    it('considers partially reserved tokens with remaining free amount', () => {
+      const pool = buildPool(
+        ['tok-1', 'UCT', 1_000_000n],
+        ['tok-2', 'UCT', 500_000n],
+      );
+
+      // Reserve all of tok-1, leaving tok-2 fully free
+      ledger.reserve('existing-1', [
+        { tokenId: 'tok-1', amount: 1_000_000n, tokenAmount: 1_000_000n },
+      ], 'UCT');
+
+      // Request for 400k should succeed using tok-2 (free portion)
+      const result = planner.planSend(
+        { amount: '400000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-2',
+      ) as PlanResult;
+
+      expect(result.reservationId).toBe('res-2');
+      // tok-2 should now have a reservation for the split amount
+      expect(ledger.getReservation('res-2')).toBeDefined();
+    });
+
+    it('excludes fully reserved tokens from free view', () => {
+      const pool = buildPool(
+        ['tok-1', 'UCT', 500_000n],
+        ['tok-2', 'UCT', 500_000n],
+      );
+
+      // Fully reserve tok-1
+      ledger.reserve('existing-1', [
+        { tokenId: 'tok-1', amount: 500_000n, tokenAmount: 500_000n },
+      ], 'UCT');
+
+      // Request 500k should use tok-2 (the only free token)
+      const result = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-2',
+      ) as PlanResult;
+
+      expect(result.reservationId).toBe('res-2');
+      expect(ledger.getTotalReserved('tok-2')).toBe(500_000n);
+    });
+
+    it('builds free view correctly with unreserved tokens among reserved ones', () => {
+      const pool = buildPool(
+        ['tok-1', 'UCT', 1_000_000n],
+        ['tok-2', 'UCT', 300_000n],
+        ['tok-3', 'UCT', 200_000n],
+      );
+
+      // Fully reserve tok-1, leave tok-2 and tok-3 free
+      ledger.reserve('existing-1', [
+        { tokenId: 'tok-1', amount: 1_000_000n, tokenAmount: 1_000_000n },
+      ], 'UCT');
+
+      // Free: tok-2 = 300k, tok-3 = 200k = 500k total free
+      const result = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-3',
+      ) as PlanResult;
+
+      expect(result.reservationId).toBe('res-3');
+      expect(result.splitPlan.totalTransferAmount).toBe(500_000n);
+    });
+
+    it('after cancel, freed tokens become available for new plan', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+
+      // Reserve all
+      ledger.reserve('existing-1', [
+        { tokenId: 'tok-1', amount: 1_000_000n, tokenAmount: 1_000_000n },
+      ], 'UCT');
+
+      // First attempt: should queue
+      const result1 = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-queued',
+      );
+      expect(result1).toBe('queued');
+
+      // Cancel the blocking reservation
+      ledger.cancel('existing-1');
+
+      // Now plan should succeed immediately
+      const result2 = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-2',
+      ) as PlanResult;
+
+      expect(result2.reservationId).toBe('res-2');
+    });
+  });
+
+  // ===========================================================================
+  // planSend — splitPlan correctness
+  // ===========================================================================
+
+  describe('planSend — splitPlan result details', () => {
+    it('returns requiresSplit=false for exact match', () => {
+      const pool = buildPool(['tok-1', 'UCT', 500_000n]);
+      const result = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      ) as PlanResult;
+
+      expect(result.splitPlan.requiresSplit).toBe(false);
+      expect(result.splitPlan.tokenToSplit).toBeNull();
+      expect(result.splitPlan.splitAmount).toBeNull();
+    });
+
+    it('returns requiresSplit=true with correct split amounts', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+      const result = planner.planSend(
+        { amount: '300000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      ) as PlanResult;
+
+      expect(result.splitPlan.requiresSplit).toBe(true);
+      expect(result.splitPlan.splitAmount).toBe(300_000n);
+      expect(result.splitPlan.remainderAmount).toBe(700_000n);
+    });
+
+    it('sets coinId on the returned splitPlan', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+      const result = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      ) as PlanResult;
+
+      expect(result.splitPlan.coinId).toBe('UCT');
+    });
+
+    it('direct transfer tokens have correct uiToken references', () => {
+      const pool = buildPool(['tok-1', 'UCT', 500_000n]);
+      const result = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      ) as PlanResult;
+
+      expect(result.splitPlan.tokensToTransferDirectly).toHaveLength(1);
+      expect(result.splitPlan.tokensToTransferDirectly[0].uiToken.id).toBe('tok-1');
+    });
+
+    it('split token has correct uiToken reference', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+      const result = planner.planSend(
+        { amount: '300000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      ) as PlanResult;
+
+      expect(result.splitPlan.tokenToSplit!.uiToken.id).toBe('tok-1');
+    });
+  });
+
+  // ===========================================================================
+  // planSend — edge cases
+  // ===========================================================================
+
+  describe('planSend — edge cases', () => {
+    it('handles request for amount of 1 (minimum)', () => {
+      const pool = buildPool(['tok-1', 'UCT', 1_000_000n]);
+      const result = planner.planSend(
+        { amount: '1', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      ) as PlanResult;
+
+      expect(result.reservationId).toBe('res-1');
+      expect(result.splitPlan.requiresSplit).toBe(true);
+      expect(result.splitPlan.splitAmount).toBe(1n);
+    });
+
+    it('handles pool with many tokens for the same coinId', () => {
+      const entries: Array<[string, string, bigint]> = [];
+      for (let i = 0; i < 20; i++) {
+        entries.push([`tok-${i}`, 'UCT', 100n]);
+      }
+      const pool = buildPool(...entries);
+
+      const result = planner.planSend(
+        { amount: '500', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      ) as PlanResult;
+
+      expect(result.reservationId).toBe('res-1');
+      expect(result.splitPlan.totalTransferAmount).toBe(500n);
+    });
+
+    it('mixed coinId pool only considers requested coinId', () => {
+      const pool = buildPool(
+        ['tok-1', 'UCT', 300_000n],
+        ['tok-2', 'USDC', 5_000_000n],
+        ['tok-3', 'UCT', 200_000n],
+      );
+
+      const result = planner.planSend(
+        { amount: '500000', coinId: 'UCT' },
+        pool, ledger, mockQueue, 'res-1',
+      ) as PlanResult;
+
+      expect(result.splitPlan.totalTransferAmount).toBe(500_000n);
+      // Only UCT tokens should participate
+      const allTokenIds = [
+        ...result.splitPlan.tokensToTransferDirectly.map(t => t.uiToken.id),
+        ...(result.splitPlan.tokenToSplit ? [result.splitPlan.tokenToSplit.uiToken.id] : []),
+      ];
+      for (const id of allTokenIds) {
+        expect(pool.get(id)!.token.coinId).toBe('UCT');
+      }
+    });
+  });
+});

--- a/tests/unit/modules/SpendQueue.starvation.test.ts
+++ b/tests/unit/modules/SpendQueue.starvation.test.ts
@@ -1,0 +1,945 @@
+/**
+ * SpendQueue.starvation.test.ts
+ *
+ * Deep dive into starvation protection and skip-ahead fairness guarantees
+ * of the SpendQueue class. Tests the skip-count mechanism that prevents
+ * large sends from being starved indefinitely by smaller ones.
+ *
+ * Key constants under test:
+ *   MAX_SKIP_COUNT = 10   — after 10 skips, entry blocks the queue
+ *   QUEUE_TIMEOUT_MS = 30000 — entries expire after 30s
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  SpendQueue,
+  SpendPlanner,
+  MAX_SKIP_COUNT,
+  QUEUE_TIMEOUT_MS,
+  type ParsedTokenPool,
+  type ParsedTokenEntry,
+  type PlanResult,
+} from '../../../modules/payments/SpendQueue';
+import { TokenReservationLedger } from '../../../modules/payments/TokenReservationLedger';
+import type { Token } from '../../../types';
+import type { SplitPlan, TokenWithAmount } from '../../../modules/payments/TokenSplitCalculator';
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+let tokenCounter = 0;
+
+/** Create a minimal mock Token with the given coinId and amount. */
+function makeToken(coinId: string, amount: bigint, id?: string): Token {
+  tokenCounter++;
+  return {
+    id: id ?? `tok-${tokenCounter}`,
+    coinId,
+    symbol: coinId,
+    name: coinId,
+    decimals: 8,
+    amount: amount.toString(),
+    status: 'confirmed' as const,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    sdkData: '{}',
+  } as Token;
+}
+
+/** Create a stub SdkToken-like object (we only need it as an opaque reference). */
+function makeSdkToken(): any {
+  return { _stub: true };
+}
+
+/** Create a ParsedTokenEntry for the parsedTokenCache. */
+function makeParsedEntry(token: Token, amount: bigint): ParsedTokenEntry {
+  return { token, sdkToken: makeSdkToken(), amount };
+}
+
+/**
+ * Build a ParsedTokenPool from an array of { token, amount } pairs.
+ */
+function buildPool(entries: Array<{ token: Token; amount: bigint }>): ParsedTokenPool {
+  const pool: ParsedTokenPool = new Map();
+  for (const e of entries) {
+    pool.set(e.token.id, makeParsedEntry(e.token, e.amount));
+  }
+  return pool;
+}
+
+/**
+ * Create a direct (no-split) SplitPlan for the given tokens summing to totalAmount.
+ * The returned plan uses the token objects that the ledger will reference.
+ */
+function makeDirectPlan(
+  tokens: Array<{ token: Token; amount: bigint }>,
+  totalAmount: bigint,
+): SplitPlan {
+  const twaList: TokenWithAmount[] = tokens.map((t) => ({
+    sdkToken: makeSdkToken(),
+    amount: t.amount,
+    uiToken: t.token,
+  }));
+  return {
+    tokensToTransferDirectly: twaList,
+    tokenToSplit: null,
+    splitAmount: null,
+    remainderAmount: null,
+    totalTransferAmount: totalAmount,
+    coinId: '',
+    requiresSplit: false,
+  };
+}
+
+/**
+ * Attach a .catch() to a promise to prevent unhandled rejection warnings.
+ * The error is still available via the returned promise.
+ */
+function catchUnhandled<T>(p: Promise<T>): Promise<T> {
+  p.catch(() => {});
+  return p;
+}
+
+// =============================================================================
+// Test suite
+// =============================================================================
+
+describe('SpendQueue Starvation Protection', () => {
+  let ledger: TokenReservationLedger;
+  let planner: SpendPlanner;
+  let queue: SpendQueue;
+  let tokenMap: Map<string, Token>;
+  let parsedCache: Map<string, ParsedTokenEntry>;
+
+  // We spy on calculateOptimalSplitSync to control when plans succeed/fail
+  let calculateSpy: ReturnType<typeof vi.spyOn>;
+
+  // Shared tokens used across tests — large enough pool to support various scenarios
+  let smallToken: Token;
+  let largeToken: Token;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    tokenCounter = 0;
+
+    ledger = new TokenReservationLedger();
+    planner = new SpendPlanner();
+    tokenMap = new Map();
+    parsedCache = new Map();
+
+    queue = new SpendQueue(ledger, planner, () => tokenMap, parsedCache);
+
+    // Create shared tokens
+    smallToken = makeToken('UCT', 100_000n, 'small-tok');
+    largeToken = makeToken('UCT', 1_000_000n, 'large-tok');
+
+    // By default, spy on the planner so tests can control outcomes
+    calculateSpy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+  });
+
+  afterEach(() => {
+    queue.destroy();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Helper: enqueue an entry directly
+  // ---------------------------------------------------------------------------
+  function enqueueEntry(
+    id: string,
+    coinId: string,
+    amount: bigint,
+    pool?: ParsedTokenPool,
+  ): Promise<PlanResult> {
+    const p = queue.enqueue({
+      id,
+      request: { amount: amount.toString(), coinId },
+      parsedPool: pool ?? new Map(),
+      coinId,
+      amount,
+      enqueuedAt: Date.now(),
+    });
+    // Always attach a catch handler so destroy() rejections don't go unhandled.
+    // Tests that need to assert rejection can still use the returned promise.
+    p.catch(() => {});
+    return p;
+  }
+
+  // =========================================================================
+  // 1. FIFO order respected when all requests are same size
+  // =========================================================================
+  describe('FIFO ordering', () => {
+    it('serves same-size requests in enqueue order', async () => {
+      const coinId = 'UCT';
+      const amount = 100_000n;
+      const tok = makeToken(coinId, amount, 'fifo-tok');
+      const pool = buildPool([{ token: tok, amount }]);
+      parsedCache.set(tok.id, makeParsedEntry(tok, amount));
+      tokenMap.set(tok.id, tok);
+
+      calculateSpy.mockRestore();
+
+      const servedOrder: string[] = [];
+      const promises: Promise<PlanResult>[] = [];
+
+      for (let i = 1; i <= 5; i++) {
+        const p = enqueueEntry(`req-${i}`, coinId, amount, pool);
+        p.then(() => servedOrder.push(`req-${i}`)).catch(() => {});
+        promises.push(p);
+      }
+
+      expect(queue.size(coinId)).toBe(5);
+
+      // Serve one at a time: notify, then release reservation for next
+      for (let i = 1; i <= 5; i++) {
+        queue.notifyChange(coinId);
+        ledger.cancel(`req-${i}`);
+      }
+
+      await vi.runAllTimersAsync();
+      await Promise.allSettled(promises);
+
+      expect(servedOrder).toEqual(['req-1', 'req-2', 'req-3', 'req-4', 'req-5']);
+    });
+  });
+
+  // =========================================================================
+  // 2. Skip-ahead activation
+  // =========================================================================
+  describe('Skip-ahead activation', () => {
+    it('small request jumps large one when large cannot be served', async () => {
+      const coinId = 'UCT';
+      parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
+      tokenMap.set(smallToken.id, smallToken);
+
+      const pool = buildPool([{ token: smallToken, amount: 100_000n }]);
+
+      const largePromise = catchUnhandled(enqueueEntry('large-1', coinId, 1_000_000n, pool));
+      const smallPromise = enqueueEntry('small-1', coinId, 100_000n, pool);
+
+      // Real planner: pool only has 100k, so large fails, small succeeds
+      calculateSpy.mockRestore();
+
+      queue.notifyChange(coinId);
+
+      const smallResult = await smallPromise;
+      expect(smallResult.reservationId).toBe('small-1');
+      // Large still queued
+      expect(queue.size(coinId)).toBe(1);
+    });
+
+    it('increments skipCount on the large entry when it is skipped', () => {
+      const coinId = 'UCT';
+      parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
+
+      // large fails, small succeeds
+      calculateSpy.mockImplementation((_candidates: any, targetAmount: bigint) => {
+        if (targetAmount === 1_000_000n) return null;
+        return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
+      });
+
+      catchUnhandled(enqueueEntry('large-1', coinId, 1_000_000n));
+      enqueueEntry('small-1', coinId, 100_000n);
+
+      queue.notifyChange(coinId);
+
+      // small-1 served, large-1 still queued (skipCount incremented internally)
+      expect(queue.size(coinId)).toBe(1);
+    });
+
+    it('does not skip-ahead when the first entry can be planned', async () => {
+      const coinId = 'UCT';
+      const tok = makeToken(coinId, 500_000n, 'big-tok');
+      parsedCache.set(tok.id, makeParsedEntry(tok, 500_000n));
+      tokenMap.set(tok.id, tok);
+
+      calculateSpy.mockRestore();
+
+      const pool = buildPool([{ token: tok, amount: 500_000n }]);
+
+      const servedOrder: string[] = [];
+
+      const p1 = enqueueEntry('first', coinId, 500_000n, pool);
+      p1.then(() => servedOrder.push('first')).catch(() => {});
+      const p2 = catchUnhandled(enqueueEntry('second', coinId, 100_000n, pool));
+      p2.then(() => servedOrder.push('second')).catch(() => {});
+
+      queue.notifyChange(coinId);
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(servedOrder[0]).toBe('first');
+    });
+  });
+
+  // =========================================================================
+  // 3. Starvation bound — MAX_SKIP_COUNT blocks the queue
+  // =========================================================================
+  describe('Starvation bound', () => {
+    it('blocks queue when entry reaches MAX_SKIP_COUNT', () => {
+      const coinId = 'UCT';
+
+      // All entries always fail to plan — this lets us count skip increments
+      calculateSpy.mockReturnValue(null);
+
+      catchUnhandled(enqueueEntry('large-1', coinId, 1_000_000n));
+      catchUnhandled(enqueueEntry('small-1', coinId, 100_000n));
+      catchUnhandled(enqueueEntry('small-2', coinId, 100_000n));
+
+      // Fire notifyChange MAX_SKIP_COUNT times — large gets skipped each time
+      // but small-1 and small-2 also can't be planned (null), so they just
+      // get their own skipCounts incremented too.
+      for (let i = 0; i < MAX_SKIP_COUNT; i++) {
+        queue.notifyChange(coinId);
+      }
+
+      // Now large-1 has skipCount = MAX_SKIP_COUNT, which means on the next
+      // notify it will block. All 3 still in queue since nothing can be planned.
+      expect(queue.size(coinId)).toBe(3);
+
+      // Now make small plannable but large still fails
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 1_000_000n) return null;
+        return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
+      });
+
+      queue.notifyChange(coinId);
+
+      // large-1 blocks (skipCount >= MAX_SKIP_COUNT), so small-1 and small-2
+      // are NOT reached. All 3 still in queue.
+      expect(queue.size(coinId)).toBe(3);
+    });
+
+    it('large entry that reaches MAX_SKIP_COUNT is served when tokens become available', async () => {
+      const coinId = 'UCT';
+      parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
+
+      let largeCanPlan = false;
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 1_000_000n) {
+          if (!largeCanPlan) return null;
+          return makeDirectPlan([{ token: largeToken, amount: 1_000_000n }], 1_000_000n);
+        }
+        return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
+      });
+
+      const largePromise = enqueueEntry('large-1', coinId, 1_000_000n);
+      catchUnhandled(enqueueEntry('small-1', coinId, 100_000n));
+
+      // Skip large MAX_SKIP_COUNT times
+      for (let i = 0; i < MAX_SKIP_COUNT; i++) {
+        queue.notifyChange(coinId);
+        ledger.cancel('small-1');
+      }
+
+      // Allow large to be planned
+      largeCanPlan = true;
+      parsedCache.set(largeToken.id, makeParsedEntry(largeToken, 1_000_000n));
+
+      queue.notifyChange(coinId);
+
+      const result = await largePromise;
+      expect(result.reservationId).toBe('large-1');
+    });
+
+    it('after blocking entry is served, remaining entries resume normal processing', async () => {
+      const coinId = 'UCT';
+      parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
+
+      let largeCanPlan = false;
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 1_000_000n) {
+          if (!largeCanPlan) return null;
+          return makeDirectPlan([{ token: largeToken, amount: 1_000_000n }], 1_000_000n);
+        }
+        return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
+      });
+
+      const largePromise = enqueueEntry('large-1', coinId, 1_000_000n);
+      // Use a dummy small that gets served during skip-ahead rounds
+      catchUnhandled(enqueueEntry('small-dummy', coinId, 100_000n));
+
+      for (let i = 0; i < MAX_SKIP_COUNT; i++) {
+        queue.notifyChange(coinId);
+        ledger.cancel('small-dummy');
+      }
+
+      // Enqueue another small that should be served after the blocker
+      const smallPromise = enqueueEntry('small-after', coinId, 100_000n);
+
+      // Serve the blocker
+      largeCanPlan = true;
+      parsedCache.set(largeToken.id, makeParsedEntry(largeToken, 1_000_000n));
+
+      queue.notifyChange(coinId);
+
+      const largeResult = await largePromise;
+      expect(largeResult.reservationId).toBe('large-1');
+
+      // Release large reservation, notify again for small
+      ledger.cancel('large-1');
+      queue.notifyChange(coinId);
+
+      const smallResult = await smallPromise;
+      expect(smallResult.reservationId).toBe('small-after');
+    });
+  });
+
+  // =========================================================================
+  // 4. Skip count increments correctly
+  // =========================================================================
+  describe('Skip count tracking', () => {
+    it('skipCount increments by 1 per notifyChange when entry cannot be planned', () => {
+      const coinId = 'UCT';
+      calculateSpy.mockReturnValue(null);
+
+      catchUnhandled(enqueueEntry('entry-1', coinId, 500_000n));
+
+      for (let i = 0; i < 5; i++) {
+        queue.notifyChange(coinId);
+      }
+
+      expect(queue.size(coinId)).toBe(1);
+    });
+
+    it('skipCount does not increment for entries behind a blocking entry', () => {
+      const coinId = 'UCT';
+      calculateSpy.mockReturnValue(null);
+
+      catchUnhandled(enqueueEntry('blocker', coinId, 1_000_000n));
+      catchUnhandled(enqueueEntry('behind', coinId, 100_000n));
+
+      // Push blocker to MAX_SKIP_COUNT
+      for (let i = 0; i < MAX_SKIP_COUNT; i++) {
+        queue.notifyChange(coinId);
+      }
+
+      // Now blocker is at MAX_SKIP_COUNT. Next notify halts at blocker.
+      // Make 'behind' plannable — but it should NOT be reached
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 1_000_000n) return null;
+        return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
+      });
+
+      queue.notifyChange(coinId);
+
+      // Both still queued — behind was not scanned
+      expect(queue.size(coinId)).toBe(2);
+    });
+
+    it('successfully planned entry is removed without affecting others', () => {
+      const coinId = 'UCT';
+
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 500_000n) return null;
+        return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
+      });
+
+      catchUnhandled(enqueueEntry('fails', coinId, 500_000n));
+      enqueueEntry('succeeds', coinId, 100_000n);
+
+      queue.notifyChange(coinId);
+
+      // 'succeeds' removed, 'fails' still queued
+      expect(queue.size(coinId)).toBe(1);
+    });
+  });
+
+  // =========================================================================
+  // 5. Cross-coinId independence
+  // =========================================================================
+  describe('Cross-coinId independence', () => {
+    it('entries for different coinIds do not affect each other skip counts', async () => {
+      const tokB = makeToken('COIN_B', 100_000n, 'b-tok');
+      parsedCache.set(tokB.id, makeParsedEntry(tokB, 100_000n));
+
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 1_000_000n) return null; // COIN_A large
+        return makeDirectPlan([{ token: tokB, amount: 100_000n }], 100_000n);
+      });
+
+      catchUnhandled(enqueueEntry('a-large', 'COIN_A', 1_000_000n));
+      const bPromise = enqueueEntry('b-small', 'COIN_B', 100_000n);
+
+      // notifyChange for COIN_B should not touch COIN_A queue
+      queue.notifyChange('COIN_B');
+
+      const bResult = await bPromise;
+      expect(bResult.reservationId).toBe('b-small');
+      expect(queue.size('COIN_A')).toBe(1);
+      expect(queue.size('COIN_B')).toBe(0);
+    });
+
+    it('notifyChange for one coinId does not scan other coinId queues', () => {
+      calculateSpy.mockReturnValue(null);
+
+      catchUnhandled(enqueueEntry('a-1', 'COIN_A', 500_000n));
+      catchUnhandled(enqueueEntry('b-1', 'COIN_B', 500_000n));
+
+      queue.notifyChange('COIN_A');
+
+      expect(queue.size('COIN_B')).toBe(1);
+      expect(queue.size('COIN_A')).toBe(1);
+    });
+
+    it('starvation blocking in one coinId does not block other coinIds', async () => {
+      const tokB = makeToken('COIN_B', 100_000n, 'b-tok-2');
+      parsedCache.set(tokB.id, makeParsedEntry(tokB, 100_000n));
+
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 1_000_000n) return null;
+        return makeDirectPlan([{ token: tokB, amount: 100_000n }], 100_000n);
+      });
+
+      catchUnhandled(enqueueEntry('a-blocker', 'COIN_A', 1_000_000n));
+      const bPromise = enqueueEntry('b-ok', 'COIN_B', 100_000n);
+
+      // Skip COIN_A blocker past MAX_SKIP_COUNT
+      for (let i = 0; i < MAX_SKIP_COUNT + 1; i++) {
+        queue.notifyChange('COIN_A');
+      }
+
+      // COIN_B should still be servable
+      queue.notifyChange('COIN_B');
+
+      const bResult = await bPromise;
+      expect(bResult.reservationId).toBe('b-ok');
+    });
+  });
+
+  // =========================================================================
+  // 6. Edge: skipCount reaches limit on same pass as another entry served
+  // =========================================================================
+  describe('Edge cases', () => {
+    it('when blocker reaches MAX_SKIP_COUNT, entries behind it are not served on that pass', () => {
+      const coinId = 'UCT';
+      const tinyTok = makeToken(coinId, 50_000n, 'tiny-tok');
+      parsedCache.set(tinyTok.id, makeParsedEntry(tinyTok, 50_000n));
+
+      // large and small fail, tiny succeeds
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 50_000n) {
+          return makeDirectPlan([{ token: tinyTok, amount: 50_000n }], 50_000n);
+        }
+        return null;
+      });
+
+      catchUnhandled(enqueueEntry('large', coinId, 1_000_000n));
+      catchUnhandled(enqueueEntry('small', coinId, 500_000n));
+      catchUnhandled(enqueueEntry('tiny', coinId, 50_000n));
+
+      // Push large to MAX_SKIP_COUNT - 1 = 9
+      // During each round, large is skipped, small is skipped, tiny is served
+      for (let i = 0; i < MAX_SKIP_COUNT - 1; i++) {
+        queue.notifyChange(coinId);
+        // Release tiny reservation so it can be re-served next round
+        ledger.cancel('tiny');
+      }
+
+      // large skipCount = 9, small skipCount = 9 (both failed each round)
+      // tiny was served and removed each round, but we only have 3 entries initially
+      // Actually: tiny gets served and removed on the first notify. So after round 1:
+      // queue = [large(skip=1), small(skip=1)]
+      // Subsequent rounds: both fail, both get skip incremented.
+      // After 9 rounds: large(skip=9), small(skip=9)
+
+      // Re-add tiny
+      catchUnhandled(enqueueEntry('tiny-2', coinId, 50_000n));
+
+      // This notify: large hits 10 (MAX), breaks. small and tiny-2 not scanned.
+      queue.notifyChange(coinId);
+
+      // All 3 still in queue (large blocked, others behind it)
+      expect(queue.size(coinId)).toBe(3);
+    });
+
+    it('entry at MAX_SKIP_COUNT - 1 gets served on that pass if tokens arrive', async () => {
+      const coinId = 'UCT';
+      parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
+
+      let largeCanPlan = false;
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 1_000_000n) {
+          if (!largeCanPlan) return null;
+          return makeDirectPlan([{ token: largeToken, amount: 1_000_000n }], 1_000_000n);
+        }
+        return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
+      });
+
+      const largePromise = enqueueEntry('large', coinId, 1_000_000n);
+      catchUnhandled(enqueueEntry('small', coinId, 100_000n));
+
+      // Push large to MAX_SKIP_COUNT - 1
+      for (let i = 0; i < MAX_SKIP_COUNT - 1; i++) {
+        queue.notifyChange(coinId);
+        ledger.cancel('small');
+      }
+
+      // Allow large to plan before it hits MAX
+      largeCanPlan = true;
+      parsedCache.set(largeToken.id, makeParsedEntry(largeToken, 1_000_000n));
+
+      queue.notifyChange(coinId);
+
+      const result = await largePromise;
+      expect(result.reservationId).toBe('large');
+    });
+  });
+
+  // =========================================================================
+  // 7. Concurrent notifyChange calls
+  // =========================================================================
+  describe('Concurrent notifyChange', () => {
+    it('multiple synchronous notifyChange calls increment skipCount independently', () => {
+      const coinId = 'UCT';
+      calculateSpy.mockReturnValue(null);
+
+      catchUnhandled(enqueueEntry('entry-1', coinId, 500_000n));
+
+      // Fire 3 synchronous notifyChange calls — each is fully sync
+      queue.notifyChange(coinId);
+      queue.notifyChange(coinId);
+      queue.notifyChange(coinId);
+
+      // Entry still queued — not at MAX yet (3 < 10)
+      expect(queue.size(coinId)).toBe(1);
+    });
+
+    it('notifyChange correctly handles entry resolved in earlier call', async () => {
+      const coinId = 'UCT';
+      const tok = makeToken(coinId, 500_000n, 'reentrant-tok');
+      parsedCache.set(tok.id, makeParsedEntry(tok, 500_000n));
+
+      let callCount = 0;
+      calculateSpy.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return null;
+        return makeDirectPlan([{ token: tok, amount: 500_000n }], 500_000n);
+      });
+
+      const promise = enqueueEntry('entry-1', coinId, 500_000n);
+
+      // First notify: fails
+      queue.notifyChange(coinId);
+      expect(queue.size(coinId)).toBe(1);
+
+      // Second notify: succeeds
+      queue.notifyChange(coinId);
+
+      const result = await promise;
+      expect(result.reservationId).toBe('entry-1');
+      expect(queue.size(coinId)).toBe(0);
+    });
+
+    it('three notifyChange calls with nothing plannable leave entries queued; MAX_SKIP_COUNT blocks', () => {
+      const coinId = 'UCT';
+      calculateSpy.mockReturnValue(null);
+
+      catchUnhandled(enqueueEntry('e1', coinId, 500_000n));
+      catchUnhandled(enqueueEntry('e2', coinId, 500_000n));
+
+      queue.notifyChange(coinId);
+      queue.notifyChange(coinId);
+      queue.notifyChange(coinId);
+
+      // Both still queued, not at MAX (3 < 10)
+      expect(queue.size(coinId)).toBe(2);
+
+      // 7 more should push e1 to MAX_SKIP_COUNT
+      for (let i = 0; i < 7; i++) {
+        queue.notifyChange(coinId);
+      }
+
+      // e1 is now at 10 (blocks). e2 also at 10 but behind e1.
+      // One more notify: e1 still can't be planned, scan breaks immediately.
+      queue.notifyChange(coinId);
+
+      // Both still queued — blocked at head
+      expect(queue.size(coinId)).toBe(2);
+    });
+  });
+
+  // =========================================================================
+  // 8. Pathological: impossible request times out without starving others
+  // =========================================================================
+  describe('Pathological cases', () => {
+    it('impossible request times out at 30s without permanently blocking others', async () => {
+      const coinId = 'UCT';
+      parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
+
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 1_000_000n) return null; // impossible
+        return makeDirectPlan([{ token: smallToken, amount: targetAmount }], targetAmount);
+      });
+
+      const impossiblePromise = catchUnhandled(enqueueEntry('impossible', coinId, 1_000_000n));
+
+      // Serve some possible entries while impossible accumulates skips
+      for (let i = 0; i < MAX_SKIP_COUNT - 1; i++) {
+        const p = enqueueEntry(`possible-${i}`, coinId, 100_000n);
+        queue.notifyChange(coinId);
+        await p; // each is served immediately via skip-ahead
+        ledger.cancel(`possible-${i}`);
+      }
+
+      // impossible now at skipCount = 9. One more notify pushes it to 10 and blocks.
+      catchUnhandled(enqueueEntry('possible-last', coinId, 100_000n));
+      queue.notifyChange(coinId);
+
+      // impossible blocks, possible-last stuck behind it
+      expect(queue.size(coinId)).toBe(2);
+
+      // Advance past timeout
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS + 1);
+
+      // notifyChange expires the impossible entry and serves possible-last
+      queue.notifyChange(coinId);
+
+      await expect(impossiblePromise).rejects.toThrow('Send queue timeout');
+      expect(queue.size(coinId)).toBe(0);
+    });
+
+    it('many small sends competing for same token are served in FIFO order', async () => {
+      const coinId = 'UCT';
+      const tok = makeToken(coinId, 100_000n, 'shared-tok');
+      const pool = buildPool([{ token: tok, amount: 100_000n }]);
+      parsedCache.set(tok.id, makeParsedEntry(tok, 100_000n));
+      tokenMap.set(tok.id, tok);
+
+      calculateSpy.mockRestore();
+
+      const servedOrder: string[] = [];
+      const promises: Promise<PlanResult>[] = [];
+
+      for (let i = 0; i < 10; i++) {
+        const p = enqueueEntry(`s-${i}`, coinId, 100_000n, pool);
+        p.then(() => servedOrder.push(`s-${i}`)).catch(() => {});
+        promises.push(p);
+      }
+
+      // Serve one at a time
+      for (let i = 0; i < 10; i++) {
+        queue.notifyChange(coinId);
+        ledger.cancel(`s-${i}`);
+      }
+
+      // Let all .then() callbacks settle
+      await Promise.allSettled(promises);
+
+      expect(servedOrder).toEqual(
+        Array.from({ length: 10 }, (_, i) => `s-${i}`),
+      );
+    });
+
+    it('one large send among many smalls is served within MAX_SKIP_COUNT rounds', async () => {
+      const coinId = 'UCT';
+
+      // Create unique tokens for each small entry to avoid INSUFFICIENT_FREE_AMOUNT
+      const smallTokens: Token[] = [];
+      for (let i = 0; i < 5; i++) {
+        const t = makeToken(coinId, 50_000n, `small-tok-${i}`);
+        smallTokens.push(t);
+        parsedCache.set(t.id, makeParsedEntry(t, 50_000n));
+      }
+
+      let allowLarge = false;
+      let smallIdx = 0;
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount >= 1_000_000n) {
+          if (!allowLarge) return null;
+          return makeDirectPlan([{ token: largeToken, amount: 1_000_000n }], 1_000_000n);
+        }
+        // Use the corresponding small token for each small entry
+        const tok = smallTokens[smallIdx % smallTokens.length];
+        smallIdx++;
+        return makeDirectPlan([{ token: tok, amount: 50_000n }], 50_000n);
+      });
+
+      const largePromise = enqueueEntry('large', coinId, 1_000_000n);
+
+      for (let i = 0; i < 5; i++) {
+        catchUnhandled(enqueueEntry(`small-${i}`, coinId, 50_000n));
+      }
+
+      // Skip large up to MAX_SKIP_COUNT
+      for (let i = 0; i < MAX_SKIP_COUNT; i++) {
+        queue.notifyChange(coinId);
+        // Release all small reservations
+        for (let j = 0; j < 5; j++) {
+          ledger.cancel(`small-${j}`);
+        }
+      }
+
+      // After MAX_SKIP_COUNT rounds, large blocks the queue.
+      allowLarge = true;
+      parsedCache.set(largeToken.id, makeParsedEntry(largeToken, 1_000_000n));
+
+      queue.notifyChange(coinId);
+
+      const result = await largePromise;
+      expect(result.reservationId).toBe('large');
+    });
+  });
+
+  // =========================================================================
+  // 9. Timeout interaction with starvation
+  // =========================================================================
+  describe('Timeout interaction', () => {
+    it('timed-out entry at head unblocks entries behind it', async () => {
+      const coinId = 'UCT';
+      parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
+
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 999_999n) return null;
+        return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
+      });
+
+      const headPromise = catchUnhandled(enqueueEntry('head', coinId, 999_999n));
+
+      // Push head to MAX_SKIP_COUNT so it blocks
+      for (let i = 0; i < MAX_SKIP_COUNT; i++) {
+        queue.notifyChange(coinId);
+      }
+
+      // Advance time partially so "behind" is enqueued at a later time
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS / 2);
+
+      const behindPromise = enqueueEntry('behind', coinId, 100_000n);
+
+      // Head blocks — behind cannot be served
+      queue.notifyChange(coinId);
+      expect(queue.size(coinId)).toBe(2);
+
+      // Advance past head's timeout but not behind's
+      vi.advanceTimersByTime((QUEUE_TIMEOUT_MS / 2) + 1);
+
+      // notifyChange should expire head (timed out) and then serve behind
+      queue.notifyChange(coinId);
+
+      await expect(headPromise).rejects.toThrow('Send queue timeout');
+
+      const behindResult = await behindPromise;
+      expect(behindResult.reservationId).toBe('behind');
+      expect(queue.size(coinId)).toBe(0);
+    });
+
+    it('entry that times out while blocked at MAX_SKIP_COUNT is properly cleaned up', async () => {
+      const coinId = 'UCT';
+      calculateSpy.mockReturnValue(null);
+
+      const p = catchUnhandled(enqueueEntry('doomed', coinId, 1_000_000n));
+
+      for (let i = 0; i < MAX_SKIP_COUNT; i++) {
+        queue.notifyChange(coinId);
+      }
+
+      expect(queue.size(coinId)).toBe(1);
+
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS + 1);
+
+      queue.notifyChange(coinId);
+
+      await expect(p).rejects.toThrow('Send queue timeout');
+      expect(queue.size(coinId)).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // 10. Merged pool in notifyChange picks up new tokens from cache
+  // =========================================================================
+  describe('Merged pool behavior', () => {
+    it('notifyChange merges parsedTokenCache into entry pool for planning', async () => {
+      const coinId = 'UCT';
+      calculateSpy.mockRestore();
+
+      const emptyPool: ParsedTokenPool = new Map();
+      const promise = enqueueEntry('entry-1', coinId, 100_000n, emptyPool);
+
+      // First notify — no tokens available
+      queue.notifyChange(coinId);
+      expect(queue.size(coinId)).toBe(1);
+
+      // Add token to cache and live token map (simulating change token arrival)
+      const newTok = makeToken(coinId, 100_000n, 'new-arrival');
+      parsedCache.set(newTok.id, makeParsedEntry(newTok, 100_000n));
+      tokenMap.set(newTok.id, newTok);
+
+      queue.notifyChange(coinId);
+
+      const result = await promise;
+      expect(result.reservationId).toBe('entry-1');
+      expect(queue.size(coinId)).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // 11. cancelAll resets everything
+  // =========================================================================
+  describe('cancelAll clears starvation state', () => {
+    it('cancelAll rejects all entries including those at MAX_SKIP_COUNT', async () => {
+      const coinId = 'UCT';
+      calculateSpy.mockReturnValue(null);
+
+      const p1 = catchUnhandled(enqueueEntry('e1', coinId, 500_000n));
+      const p2 = catchUnhandled(enqueueEntry('e2', coinId, 100_000n));
+
+      for (let i = 0; i < MAX_SKIP_COUNT; i++) {
+        queue.notifyChange(coinId);
+      }
+
+      queue.cancelAll('test reset');
+
+      await expect(p1).rejects.toThrow('test reset');
+      await expect(p2).rejects.toThrow('test reset');
+      expect(queue.size()).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // 12. Skip-count reset after head served
+  // =========================================================================
+  describe('Skip count reset after head is served', () => {
+    it('entries behind a served entry continue with their own skipCounts unchanged', async () => {
+      const coinId = 'UCT';
+
+      // Round 1: first entry fails, second entry fails
+      // Round 2: first entry succeeds, second entry fails
+      // Round 3: second entry succeeds
+      let round = 0;
+      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+        if (targetAmount === 200_000n) {
+          if (round >= 2) return makeDirectPlan([{ token: smallToken, amount: 200_000n }], 200_000n);
+          return null;
+        }
+        if (targetAmount === 300_000n) {
+          if (round >= 3) return makeDirectPlan([{ token: largeToken, amount: 300_000n }], 300_000n);
+          return null;
+        }
+        return null;
+      });
+
+      const p1 = enqueueEntry('first', coinId, 200_000n);
+      const p2 = enqueueEntry('second', coinId, 300_000n);
+
+      round = 1;
+      queue.notifyChange(coinId); // both fail, skipCount = 1
+
+      round = 2;
+      queue.notifyChange(coinId); // first succeeds and is removed
+
+      const r1 = await p1;
+      expect(r1.reservationId).toBe('first');
+
+      round = 3;
+      ledger.cancel('first');
+      queue.notifyChange(coinId); // second now succeeds
+
+      const r2 = await p2;
+      expect(r2.reservationId).toBe('second');
+      expect(queue.size(coinId)).toBe(0);
+    });
+  });
+});

--- a/tests/unit/modules/SpendQueue.test.ts
+++ b/tests/unit/modules/SpendQueue.test.ts
@@ -1,0 +1,1145 @@
+/**
+ * SpendQueue unit tests.
+ *
+ * Covers: enqueue/waitForEntry, notifyChange, timeout, capacity,
+ * cancelAll, destroy, skip-ahead starvation protection, multi-coinId isolation.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  SpendQueue,
+  SpendPlanner,
+  QUEUE_TIMEOUT_MS,
+  QUEUE_MAX_SIZE,
+  MAX_SKIP_COUNT,
+} from '../../../modules/payments/SpendQueue';
+import type { ParsedTokenPool, ParsedTokenEntry, PlanResult } from '../../../modules/payments/SpendQueue';
+import { TokenReservationLedger } from '../../../modules/payments/TokenReservationLedger';
+import type { SplitPlan, TokenWithAmount } from '../../../modules/payments/TokenSplitCalculator';
+import type { Token } from '../../../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let idCounter = 0;
+
+function makeToken(overrides: Partial<Token> & { id: string; coinId: string; amount: string }): Token {
+  return {
+    symbol: 'UCT',
+    name: 'Test',
+    decimals: 8,
+    status: 'confirmed' as const,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  } as Token;
+}
+
+function makeSdkTokenStub(): any {
+  return { coins: new Map() };
+}
+
+function makeParsedEntry(token: Token, amount: bigint): ParsedTokenEntry {
+  return {
+    token,
+    sdkToken: makeSdkTokenStub(),
+    amount,
+  };
+}
+
+function buildPool(entries: Array<{ id: string; coinId: string; amount: bigint }>): ParsedTokenPool {
+  const pool: ParsedTokenPool = new Map();
+  for (const e of entries) {
+    const tok = makeToken({ id: e.id, coinId: e.coinId, amount: e.amount.toString() });
+    pool.set(e.id, makeParsedEntry(tok, e.amount));
+  }
+  return pool;
+}
+
+function nextId(): string {
+  return `entry-${++idCounter}`;
+}
+
+/**
+ * Create a direct (no-split) SplitPlan where the full token is transferred.
+ * The reservation will reserve the full tokenAmount.
+ */
+function directPlan(entry: ParsedTokenEntry, coinId: string): SplitPlan {
+  const twa: TokenWithAmount = { sdkToken: entry.sdkToken, amount: entry.amount, uiToken: entry.token };
+  return {
+    tokensToTransferDirectly: [twa],
+    tokenToSplit: null,
+    splitAmount: null,
+    remainderAmount: null,
+    totalTransferAmount: entry.amount,
+    coinId,
+    requiresSplit: false,
+  };
+}
+
+/**
+ * Create a split SplitPlan -- sends `sendAmount` from the entry, remainder stays.
+ * The reservation will reserve only sendAmount from the token.
+ */
+function splitPlan(entry: ParsedTokenEntry, sendAmount: bigint, coinId: string): SplitPlan {
+  const twa: TokenWithAmount = { sdkToken: entry.sdkToken, amount: entry.amount, uiToken: entry.token };
+  return {
+    tokensToTransferDirectly: [],
+    tokenToSplit: twa,
+    splitAmount: sendAmount,
+    remainderAmount: entry.amount - sendAmount,
+    totalTransferAmount: sendAmount,
+    coinId,
+    requiresSplit: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('SpendQueue', () => {
+  let ledger: TokenReservationLedger;
+  let planner: SpendPlanner;
+  let tokensMap: Map<string, Token>;
+  let parsedTokenCache: Map<string, ParsedTokenEntry>;
+  let queue: SpendQueue;
+
+  /** Track all enqueued promises so we can catch rejections in afterEach. */
+  let pendingPromises: Promise<PlanResult>[];
+
+  /** Wrapper around queue.enqueue that tracks promises for cleanup. */
+  function enq(
+    entry: Parameters<typeof queue.enqueue>[0],
+  ): Promise<PlanResult> {
+    const p = queue.enqueue(entry);
+    pendingPromises.push(p);
+    return p;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    idCounter = 0;
+    pendingPromises = [];
+
+    ledger = new TokenReservationLedger();
+    planner = new SpendPlanner();
+    tokensMap = new Map();
+    parsedTokenCache = new Map();
+
+    queue = new SpendQueue(
+      ledger,
+      planner,
+      () => tokensMap,
+      parsedTokenCache,
+    );
+  });
+
+  afterEach(async () => {
+    queue.destroy();
+    // Drain all pending promises to prevent unhandled rejections
+    await Promise.allSettled(pendingPromises);
+    vi.useRealTimers();
+  });
+
+  // =========================================================================
+  // Basic enqueue + waitForEntry
+  // =========================================================================
+
+  describe('enqueue and waitForEntry', () => {
+    it('enqueue returns a promise that resolves when notifyChange finds a plan', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 500n }]);
+      const id = nextId();
+
+      const promise = enq({
+        id,
+        request: { amount: '100', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 100n,
+        enqueuedAt: Date.now(),
+      });
+
+      expect(queue.size()).toBe(1);
+
+      const entry = pool.get('tok-1')!;
+      parsedTokenCache.set('tok-1', entry);
+
+      // Use splitPlan so reservation is only for 100n, not the full 500n
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValueOnce(
+        splitPlan(entry, 100n, 'UCT'),
+      );
+
+      queue.notifyChange('UCT');
+
+      const result = await promise;
+      expect(result.reservationId).toBe(id);
+      expect(result.splitPlan).toBeDefined();
+      expect(result.splitPlan.totalTransferAmount).toBe(100n);
+      expect(queue.size()).toBe(0);
+    });
+
+    it('waitForEntry returns the same promise as enqueue', () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 500n }]);
+      const id = nextId();
+
+      const enqueuePromise = enq({
+        id,
+        request: { amount: '100', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 100n,
+        enqueuedAt: Date.now(),
+      });
+
+      const waitPromise = queue.waitForEntry(id);
+      expect(waitPromise).toBe(enqueuePromise);
+    });
+
+    it('waitForEntry rejects for unknown entry id', async () => {
+      await expect(queue.waitForEntry('nonexistent')).rejects.toThrow('Queue entry not found');
+    });
+
+    it('enqueue increments size per coinId', () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 500n }]);
+
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '200', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 200n, enqueuedAt: Date.now() });
+
+      expect(queue.size('UCT')).toBe(2);
+      expect(queue.size()).toBe(2);
+    });
+
+    it('enqueue returns a promise that can be awaited via waitForEntry before resolution', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 500n }]);
+      const entry = pool.get('tok-1')!;
+      parsedTokenCache.set('tok-1', entry);
+      const id = nextId();
+
+      enq({
+        id,
+        request: { amount: '500', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 500n,
+        enqueuedAt: Date.now(),
+      });
+
+      // waitForEntry must be called BEFORE resolution (promise exists in internal map)
+      const waitPromise = queue.waitForEntry(id);
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValueOnce(
+        directPlan(entry, 'UCT'),
+      );
+
+      queue.notifyChange('UCT');
+
+      const result = await waitPromise;
+      expect(result.reservationId).toBe(id);
+      expect(result.splitPlan.coinId).toBe('UCT');
+    });
+  });
+
+  // =========================================================================
+  // notifyChange
+  // =========================================================================
+
+  describe('notifyChange', () => {
+    it('is synchronous and attempts planning for queued entries matching coinId', () => {
+      // Use two separate tokens so both entries can be reserved independently
+      const pool = buildPool([
+        { id: 'tok-1', coinId: 'UCT', amount: 100n },
+        { id: 'tok-2', coinId: 'UCT', amount: 200n },
+      ]);
+      parsedTokenCache.set('tok-1', pool.get('tok-1')!);
+      parsedTokenCache.set('tok-2', pool.get('tok-2')!);
+
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+      spy.mockReturnValueOnce(directPlan(pool.get('tok-1')!, 'UCT'))
+         .mockReturnValueOnce(directPlan(pool.get('tok-2')!, 'UCT'));
+
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '200', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 200n, enqueuedAt: Date.now() });
+
+      queue.notifyChange('UCT');
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(queue.size('UCT')).toBe(0);
+    });
+
+    it('does not affect entries for a different coinId', () => {
+      const uctPool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 1000n }]);
+      const usdcPool = buildPool([{ id: 'tok-2', coinId: 'USDC', amount: 1000n }]);
+
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: uctPool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '100', coinId: 'USDC' }, parsedPool: usdcPool, coinId: 'USDC', amount: 100n, enqueuedAt: Date.now() });
+
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+
+      queue.notifyChange('USDT'); // unrelated
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(queue.size()).toBe(2);
+    });
+
+    it('resolves entry and creates ledger reservation', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 500n }]);
+      const entry = pool.get('tok-1')!;
+      parsedTokenCache.set('tok-1', entry);
+
+      const id = nextId();
+      const promise = enq({
+        id,
+        request: { amount: '300', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 300n,
+        enqueuedAt: Date.now(),
+      });
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValueOnce(
+        splitPlan(entry, 300n, 'UCT'),
+      );
+
+      queue.notifyChange('UCT');
+
+      const result = await promise;
+      expect(result.reservationId).toBe(id);
+
+      const reservation = ledger.getReservation(id);
+      expect(reservation).toBeDefined();
+      expect(reservation!.status).toBe('active');
+      // Split reserves the FULL token amount (not just splitAmount)
+      expect(reservation!.amounts.get('tok-1')).toBe(500n);
+    });
+
+    it('does nothing when there are no queued entries for the coinId', () => {
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+      queue.notifyChange('UCT');
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('merges parsedTokenCache entries into the pool for planning', async () => {
+      // Original pool has tok-1 (small), cache has tok-2 (new, large token)
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      const tok2 = makeToken({ id: 'tok-2', coinId: 'UCT', amount: '500' });
+      const cacheEntry = makeParsedEntry(tok2, 500n);
+      parsedTokenCache.set('tok-2', cacheEntry);
+
+      const id = nextId();
+      const promise = enq({ id, request: { amount: '400', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 400n, enqueuedAt: Date.now() });
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValueOnce(
+        splitPlan(cacheEntry, 400n, 'UCT'),
+      );
+
+      queue.notifyChange('UCT');
+
+      const result = await promise;
+      expect(result.reservationId).toBe(id);
+      expect(queue.size()).toBe(0);
+    });
+
+    it('leaves entry in queue when planner returns null', () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      parsedTokenCache.set('tok-1', pool.get('tok-1')!);
+
+      enq({ id: nextId(), request: { amount: '1000', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 1000n, enqueuedAt: Date.now() });
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValue(null);
+
+      queue.notifyChange('UCT');
+
+      expect(queue.size('UCT')).toBe(1);
+    });
+
+    it('reserves correct split amount in ledger for split plan', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 1000n }]);
+      const entry = pool.get('tok-1')!;
+      parsedTokenCache.set('tok-1', entry);
+
+      const id = nextId();
+      const promise = enq({ id, request: { amount: '300', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 300n, enqueuedAt: Date.now() });
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValueOnce(
+        splitPlan(entry, 300n, 'UCT'),
+      );
+
+      queue.notifyChange('UCT');
+
+      await promise;
+
+      // Split reserves the ENTIRE source token (split consumes whole token)
+      expect(ledger.getTotalReserved('tok-1')).toBe(1000n);
+      expect(ledger.getFreeAmount('tok-1', 1000n)).toBe(0n);
+    });
+  });
+
+  // =========================================================================
+  // Timeout
+  // =========================================================================
+
+  describe('timeout', () => {
+    it('rejects entry with SEND_QUEUE_TIMEOUT after QUEUE_TIMEOUT_MS via setTimeout', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      const promise = enq({
+        id: nextId(),
+        request: { amount: '100', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 100n,
+        enqueuedAt: Date.now(),
+      });
+
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS + 1);
+
+      await expect(promise).rejects.toThrow('Send queue timeout');
+      expect(queue.size()).toBe(0);
+    });
+
+    it('timeout fires per-entry setTimeout independently', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      const p1 = enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      vi.advanceTimersByTime(15_000);
+
+      const p2 = enq({ id: nextId(), request: { amount: '200', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 200n, enqueuedAt: Date.now() });
+
+      // Advance to expire first (31s total) but not second (16s total)
+      vi.advanceTimersByTime(16_000);
+
+      await expect(p1).rejects.toThrow('Send queue timeout');
+      expect(queue.size('UCT')).toBe(1); // second still alive
+
+      // Clean up
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS);
+      await p2.catch(() => {});
+    });
+
+    it('notifyChange detects expired entry by enqueuedAt check', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      const p1 = enq({
+        id: nextId(),
+        request: { amount: '100', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 100n,
+        enqueuedAt: Date.now(),
+      });
+
+      // Advance system time past timeout (Date.now() updates but setTimeout doesn't fire)
+      vi.setSystemTime(Date.now() + QUEUE_TIMEOUT_MS + 1);
+
+      queue.notifyChange('UCT');
+
+      await expect(p1).rejects.toThrow('Send queue timeout');
+      expect(queue.size()).toBe(0);
+    });
+
+    it('per-entry timeout expires stale entries', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      const p1 = enq({
+        id: nextId(),
+        request: { amount: '100', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 100n,
+        enqueuedAt: Date.now(),
+      });
+
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS + 1);
+
+      await expect(p1).rejects.toThrow('Send queue timeout');
+      expect(queue.size()).toBe(0);
+    });
+
+    it('entry resolved before timeout does not fire timeout callback', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 500n }]);
+      const entry = pool.get('tok-1')!;
+      parsedTokenCache.set('tok-1', entry);
+      const id = nextId();
+
+      const promise = enq({
+        id,
+        request: { amount: '100', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 100n,
+        enqueuedAt: Date.now(),
+      });
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValueOnce(
+        splitPlan(entry, 100n, 'UCT'),
+      );
+
+      vi.advanceTimersByTime(10_000);
+      queue.notifyChange('UCT');
+
+      const result = await promise;
+      expect(result.reservationId).toBe(id);
+
+      // Advance well past timeout — should be harmless since entry is already resolved
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS);
+
+      expect(queue.size()).toBe(0);
+    });
+
+    it('timeout error has SEND_QUEUE_TIMEOUT error code', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      const promise = enq({
+        id: nextId(),
+        request: { amount: '100', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 100n,
+        enqueuedAt: Date.now(),
+      });
+
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS + 1);
+
+      try {
+        await promise;
+        expect.unreachable('Should have thrown');
+      } catch (err: any) {
+        expect(err.code).toBe('SEND_QUEUE_TIMEOUT');
+      }
+    });
+  });
+
+  // =========================================================================
+  // Queue capacity
+  // =========================================================================
+
+  describe('queue capacity', () => {
+    it('rejects with SEND_QUEUE_FULL when queue reaches QUEUE_MAX_SIZE', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      for (let i = 0; i < QUEUE_MAX_SIZE; i++) {
+        enq({
+          id: nextId(),
+          request: { amount: '100', coinId: 'UCT' },
+          parsedPool: pool,
+          coinId: 'UCT',
+          amount: 100n,
+          enqueuedAt: Date.now(),
+        });
+      }
+
+      expect(queue.size()).toBe(QUEUE_MAX_SIZE);
+
+      const overflowPromise = enq({
+        id: nextId(),
+        request: { amount: '100', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 100n,
+        enqueuedAt: Date.now(),
+      });
+
+      await expect(overflowPromise).rejects.toThrow('Send queue is full');
+    });
+
+    it('SEND_QUEUE_FULL error has correct error code', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      for (let i = 0; i < QUEUE_MAX_SIZE; i++) {
+        enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      }
+
+      try {
+        await enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+        expect.unreachable('Should have thrown');
+      } catch (err: any) {
+        expect(err.code).toBe('SEND_QUEUE_FULL');
+      }
+    });
+
+    it('counts entries across all coinIds toward QUEUE_MAX_SIZE', async () => {
+      const uctPool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      const usdcPool = buildPool([{ id: 'tok-2', coinId: 'USDC', amount: 100n }]);
+
+      for (let i = 0; i < 50; i++) {
+        enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: uctPool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      }
+      for (let i = 0; i < 50; i++) {
+        enq({ id: nextId(), request: { amount: '100', coinId: 'USDC' }, parsedPool: usdcPool, coinId: 'USDC', amount: 100n, enqueuedAt: Date.now() });
+      }
+
+      expect(queue.size()).toBe(100);
+
+      const overflow = enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: uctPool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      await expect(overflow).rejects.toThrow('Send queue is full');
+    });
+
+    it('allows enqueue after removal brings size below QUEUE_MAX_SIZE', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      for (let i = 0; i < QUEUE_MAX_SIZE; i++) {
+        enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      }
+
+      // Expire all entries
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS + 1);
+      expect(queue.size()).toBe(0);
+
+      // Now should accept
+      const newPromise = enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      expect(queue.size()).toBe(1);
+
+      // Clean up
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS + 1);
+      await newPromise.catch(() => {});
+    });
+
+    it('queue size does not increase for rejected overflow entries', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      for (let i = 0; i < QUEUE_MAX_SIZE; i++) {
+        enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      }
+
+      // Attempt overflow 5 times
+      for (let i = 0; i < 5; i++) {
+        await enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() }).catch(() => {});
+      }
+
+      expect(queue.size()).toBe(QUEUE_MAX_SIZE);
+    });
+  });
+
+  // =========================================================================
+  // cancelAll
+  // =========================================================================
+
+  describe('cancelAll', () => {
+    it('rejects all pending entries with given reason', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      const promises = [];
+      for (let i = 0; i < 5; i++) {
+        promises.push(
+          enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() }),
+        );
+      }
+
+      expect(queue.size()).toBe(5);
+
+      queue.cancelAll('test cancellation');
+
+      expect(queue.size()).toBe(0);
+
+      for (const p of promises) {
+        await expect(p).rejects.toThrow('test cancellation');
+      }
+    });
+
+    it('clears entries across all coinIds', () => {
+      const uctPool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      const usdcPool = buildPool([{ id: 'tok-2', coinId: 'USDC', amount: 100n }]);
+
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: uctPool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '100', coinId: 'USDC' }, parsedPool: usdcPool, coinId: 'USDC', amount: 100n, enqueuedAt: Date.now() });
+
+      expect(queue.size()).toBe(2);
+
+      queue.cancelAll('shutdown');
+
+      expect(queue.size()).toBe(0);
+      expect(queue.size('UCT')).toBe(0);
+      expect(queue.size('USDC')).toBe(0);
+    });
+
+    it('clears timeout handles so they do not fire after cancel', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      const p = enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      queue.cancelAll('cancelled');
+
+      // Advance past timeout -- should not cause additional errors
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS + 1);
+
+      await expect(p).rejects.toThrow('cancelled');
+    });
+
+    it('rejects entries with MODULE_DESTROYED error code', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      const p = enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      queue.cancelAll('some reason');
+
+      try {
+        await p;
+        expect.unreachable('Should have thrown');
+      } catch (err: any) {
+        expect(err.code).toBe('MODULE_DESTROYED');
+      }
+    });
+  });
+
+  // =========================================================================
+  // destroy
+  // =========================================================================
+
+  describe('destroy', () => {
+    it('cancels all entries with MODULE_DESTROYED error', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      const p = enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      queue.destroy();
+
+      await expect(p).rejects.toThrow('Module destroyed');
+      expect(queue.size()).toBe(0);
+    });
+
+    it('is idempotent', () => {
+      queue.destroy();
+      expect(() => queue.destroy()).not.toThrow();
+    });
+
+    it('clears all internal state', () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      expect(queue.size()).toBe(2);
+
+      queue.destroy();
+
+      expect(queue.size()).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // size()
+  // =========================================================================
+
+  describe('size', () => {
+    it('returns 0 for empty queue', () => {
+      expect(queue.size()).toBe(0);
+    });
+
+    it('returns total count across all coinIds', () => {
+      const uctPool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      const usdcPool = buildPool([{ id: 'tok-2', coinId: 'USDC', amount: 100n }]);
+      const usdtPool = buildPool([{ id: 'tok-3', coinId: 'USDT', amount: 100n }]);
+
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: uctPool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: uctPool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '100', coinId: 'USDC' }, parsedPool: usdcPool, coinId: 'USDC', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '100', coinId: 'USDC' }, parsedPool: usdcPool, coinId: 'USDC', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '100', coinId: 'USDC' }, parsedPool: usdcPool, coinId: 'USDC', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '100', coinId: 'USDT' }, parsedPool: usdtPool, coinId: 'USDT', amount: 100n, enqueuedAt: Date.now() });
+
+      expect(queue.size()).toBe(6);
+      expect(queue.size('UCT')).toBe(2);
+      expect(queue.size('USDC')).toBe(3);
+      expect(queue.size('USDT')).toBe(1);
+    });
+
+    it('returns 0 for coinId with no entries', () => {
+      expect(queue.size('UCT')).toBe(0);
+    });
+
+    it('decrements after entry is resolved', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 500n }]);
+      const entry = pool.get('tok-1')!;
+      parsedTokenCache.set('tok-1', entry);
+
+      enq({ id: nextId(), request: { amount: '500', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 500n, enqueuedAt: Date.now() });
+      expect(queue.size()).toBe(1);
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValueOnce(
+        directPlan(entry, 'UCT'),
+      );
+      queue.notifyChange('UCT');
+
+      expect(queue.size()).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // Skip-ahead and starvation protection
+  // =========================================================================
+
+  describe('skip-ahead with starvation protection', () => {
+    it('serves entries in FIFO order when all can be planned with separate tokens', async () => {
+      // Two entries, two tokens -- each gets its own token
+      const pool = buildPool([
+        { id: 'tok-1', coinId: 'UCT', amount: 100n },
+        { id: 'tok-2', coinId: 'UCT', amount: 100n },
+      ]);
+      parsedTokenCache.set('tok-1', pool.get('tok-1')!);
+      parsedTokenCache.set('tok-2', pool.get('tok-2')!);
+
+      const resolveOrder: string[] = [];
+
+      const p1 = enq({ id: 'first', request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      const p2 = enq({ id: 'second', request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      p1.then(() => resolveOrder.push('first'));
+      p2.then(() => resolveOrder.push('second'));
+
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+      spy.mockReturnValueOnce(directPlan(pool.get('tok-1')!, 'UCT'))
+         .mockReturnValueOnce(directPlan(pool.get('tok-2')!, 'UCT'));
+
+      queue.notifyChange('UCT');
+
+      await Promise.all([p1, p2]);
+
+      expect(resolveOrder).toEqual(['first', 'second']);
+    });
+
+    it('increments skipCount when head entry cannot be planned but later one can', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      const entry1 = pool.get('tok-1')!;
+      parsedTokenCache.set('tok-1', entry1);
+
+      // Large entry first (needs 1000), small entry second (needs 100)
+      const largeProm = enq({ id: 'large', request: { amount: '1000', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 1000n, enqueuedAt: Date.now() });
+      const smallProm = enq({ id: 'small', request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync')
+        .mockReturnValueOnce(null)                    // large: can't plan
+        .mockReturnValueOnce(directPlan(entry1, 'UCT')); // small: full token
+
+      queue.notifyChange('UCT');
+
+      const result = await smallProm;
+      expect(result.reservationId).toBe('small');
+      expect(queue.size('UCT')).toBe(1);
+
+      // Clean up large
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS + 1);
+      await largeProm.catch(() => {});
+    });
+
+    it('halts queue scan when head entry reaches MAX_SKIP_COUNT', () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 50n }]);
+      parsedTokenCache.set('tok-1', pool.get('tok-1')!);
+
+      enq({ id: 'large', request: { amount: '1000', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 1000n, enqueuedAt: Date.now() });
+      enq({ id: 'small', request: { amount: '50', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 50n, enqueuedAt: Date.now() });
+
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+
+      // Rounds 1..9: large can't plan (null), small served, skipCount goes 0->1, 1->2, ..., 8->9
+      for (let round = 1; round <= MAX_SKIP_COUNT - 1; round++) {
+        spy.mockReset();
+        spy.mockReturnValueOnce(null); // large
+        spy.mockReturnValueOnce(directPlan(pool.get('tok-1')!, 'UCT')); // small
+        queue.notifyChange('UCT');
+        ledger.clear();
+
+        // Re-add small for next round (previous one was resolved and removed)
+        if (round < MAX_SKIP_COUNT - 1) {
+          enq({ id: `small-${round + 1}`, request: { amount: '50', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 50n, enqueuedAt: Date.now() });
+        }
+      }
+
+      // After 9 rounds, large skipCount = 9. Queue: [large] (last small was served in round 9).
+      // Add two small entries.
+      enq({ id: 'small-a', request: { amount: '50', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 50n, enqueuedAt: Date.now() });
+      enq({ id: 'small-b', request: { amount: '50', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 50n, enqueuedAt: Date.now() });
+
+      // Round 10: large skipCount 9 -> 10, triggers break. small-a and small-b not processed.
+      spy.mockReset();
+      spy.mockReturnValueOnce(null); // large
+      spy.mockReturnValueOnce(directPlan(pool.get('tok-1')!, 'UCT')); // would be small-a, but break fires first
+
+      queue.notifyChange('UCT');
+
+      // Planner called once (for large), then break -- starvation protection
+      expect(spy).toHaveBeenCalledTimes(1);
+      // Queue: large + small-a + small-b
+      expect(queue.size('UCT')).toBe(3);
+    });
+
+    it('after head entry is served, later entries can proceed normally', async () => {
+      const pool = buildPool([
+        { id: 'tok-1', coinId: 'UCT', amount: 1000n },
+        { id: 'tok-2', coinId: 'UCT', amount: 100n },
+      ]);
+      parsedTokenCache.set('tok-1', pool.get('tok-1')!);
+      parsedTokenCache.set('tok-2', pool.get('tok-2')!);
+
+      const largeProm = enq({ id: 'large', request: { amount: '1000', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 1000n, enqueuedAt: Date.now() });
+      enq({ id: 'small', request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+
+      // First notify: large can plan with tok-1, small can plan with tok-2
+      spy.mockReturnValueOnce(directPlan(pool.get('tok-1')!, 'UCT'))
+         .mockReturnValueOnce(directPlan(pool.get('tok-2')!, 'UCT'));
+
+      queue.notifyChange('UCT');
+
+      await largeProm;
+      expect(queue.size('UCT')).toBe(0); // both served
+    });
+
+    it('skipCount increments each time head is skipped, allowing later entries through', () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 50n }]);
+      parsedTokenCache.set('tok-1', pool.get('tok-1')!);
+
+      enq({ id: 'large', request: { amount: '1000', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 1000n, enqueuedAt: Date.now() });
+      enq({ id: 'small', request: { amount: '50', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 50n, enqueuedAt: Date.now() });
+
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+
+      // Round 1: large null, small planned -> small served, large skipCount = 1
+      spy.mockReturnValueOnce(null).mockReturnValueOnce(directPlan(pool.get('tok-1')!, 'UCT'));
+      queue.notifyChange('UCT');
+      ledger.clear();
+      // After round 1: queue = [large], skipCount = 1
+
+      // Add small-2
+      enq({ id: 'small-2', request: { amount: '50', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 50n, enqueuedAt: Date.now() });
+
+      // Round 2: large null, small-2 planned -> small-2 served, large skipCount = 2
+      spy.mockReturnValueOnce(null).mockReturnValueOnce(directPlan(pool.get('tok-1')!, 'UCT'));
+      queue.notifyChange('UCT');
+      ledger.clear();
+      // After round 2: queue = [large], skipCount = 2
+
+      // Add small-3
+      enq({ id: 'small-3', request: { amount: '50', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 50n, enqueuedAt: Date.now() });
+
+      // Round 3: large null (skipCount 2->3, still < 10), small-3 planned
+      // Reset the spy call count to isolate round 3
+      spy.mockClear();
+      spy.mockReturnValueOnce(null).mockReturnValueOnce(directPlan(pool.get('tok-1')!, 'UCT'));
+      queue.notifyChange('UCT');
+
+      // Planner was called twice in round 3 (large failed, small-3 succeeded)
+      // This confirms skipCount < MAX_SKIP_COUNT, so queue scan continues past large
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(queue.size('UCT')).toBe(1); // only large remains
+    });
+  });
+
+  // =========================================================================
+  // Multiple coinIds - isolation
+  // =========================================================================
+
+  describe('multiple coinIds isolation', () => {
+    it('notifyChange for UCT does not trigger planning for USDC entries', () => {
+      const uctPool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      const usdcPool = buildPool([{ id: 'tok-2', coinId: 'USDC', amount: 100n }]);
+      parsedTokenCache.set('tok-1', uctPool.get('tok-1')!);
+
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: uctPool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      enq({ id: nextId(), request: { amount: '100', coinId: 'USDC' }, parsedPool: usdcPool, coinId: 'USDC', amount: 100n, enqueuedAt: Date.now() });
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValue(
+        directPlan(uctPool.get('tok-1')!, 'UCT'),
+      );
+
+      queue.notifyChange('UCT');
+
+      expect(queue.size('UCT')).toBe(0);
+      expect(queue.size('USDC')).toBe(1);
+    });
+
+    it('entries for different coinIds can be resolved independently', async () => {
+      const tok1 = makeToken({ id: 'tok-1', coinId: 'UCT', amount: '500' });
+      const tok2 = makeToken({ id: 'tok-2', coinId: 'USDC', amount: '500' });
+      const e1 = makeParsedEntry(tok1, 500n);
+      const e2 = makeParsedEntry(tok2, 500n);
+      parsedTokenCache.set('tok-1', e1);
+      parsedTokenCache.set('tok-2', e2);
+
+      const uctPool = new Map<string, ParsedTokenEntry>([['tok-1', e1]]);
+      const usdcPool = new Map<string, ParsedTokenEntry>([['tok-2', e2]]);
+
+      const p1 = enq({ id: 'uct-1', request: { amount: '500', coinId: 'UCT' }, parsedPool: uctPool, coinId: 'UCT', amount: 500n, enqueuedAt: Date.now() });
+      const p2 = enq({ id: 'usdc-1', request: { amount: '500', coinId: 'USDC' }, parsedPool: usdcPool, coinId: 'USDC', amount: 500n, enqueuedAt: Date.now() });
+
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+
+      // Resolve USDC first
+      spy.mockReturnValueOnce(directPlan(e2, 'USDC'));
+      queue.notifyChange('USDC');
+      const r2 = await p2;
+      expect(r2.reservationId).toBe('usdc-1');
+
+      expect(queue.size('UCT')).toBe(1);
+
+      // Now resolve UCT
+      spy.mockReturnValueOnce(directPlan(e1, 'UCT'));
+      queue.notifyChange('UCT');
+      const r1 = await p1;
+      expect(r1.reservationId).toBe('uct-1');
+
+      expect(queue.size()).toBe(0);
+    });
+
+    it('timeout for one coinId does not affect another', async () => {
+      const uctPool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      const usdcPool = buildPool([{ id: 'tok-2', coinId: 'USDC', amount: 100n }]);
+
+      const uctPromise = enq({ id: 'uct-1', request: { amount: '100', coinId: 'UCT' }, parsedPool: uctPool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      vi.advanceTimersByTime(15_000);
+
+      const usdcPromise = enq({ id: 'usdc-1', request: { amount: '100', coinId: 'USDC' }, parsedPool: usdcPool, coinId: 'USDC', amount: 100n, enqueuedAt: Date.now() });
+
+      // UCT times out
+      vi.advanceTimersByTime(16_000);
+      await expect(uctPromise).rejects.toThrow('Send queue timeout');
+
+      expect(queue.size('USDC')).toBe(1);
+      expect(queue.size('UCT')).toBe(0);
+
+      // Clean up
+      vi.advanceTimersByTime(QUEUE_TIMEOUT_MS);
+      await usdcPromise.catch(() => {});
+    });
+
+    it('notifyChange for unrelated coinId has no effect', () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+
+      queue.notifyChange('USDC');
+      queue.notifyChange('USDT');
+      queue.notifyChange('BTC');
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(queue.size('UCT')).toBe(1);
+    });
+  });
+
+  // =========================================================================
+  // Edge cases
+  // =========================================================================
+
+  describe('edge cases', () => {
+    it('notifyChange with empty parsedTokenCache still uses entry parsedPool', async () => {
+      const tok1 = makeToken({ id: 'tok-1', coinId: 'UCT', amount: '500' });
+      const entry = makeParsedEntry(tok1, 500n);
+      const pool = new Map<string, ParsedTokenEntry>([['tok-1', entry]]);
+      // parsedTokenCache is empty
+
+      const id = nextId();
+      const promise = enq({
+        id,
+        request: { amount: '500', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 500n,
+        enqueuedAt: Date.now(),
+      });
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValueOnce(
+        directPlan(entry, 'UCT'),
+      );
+
+      queue.notifyChange('UCT');
+
+      const result = await promise;
+      expect(result.reservationId).toBe(id);
+    });
+
+    it('multiple sequential notifyChange calls process remaining entries', async () => {
+      // Two separate tokens so no reservation conflict
+      const tok1 = makeToken({ id: 'tok-1', coinId: 'UCT', amount: '100' });
+      const tok2 = makeToken({ id: 'tok-2', coinId: 'UCT', amount: '100' });
+      const entry1 = makeParsedEntry(tok1, 100n);
+      const entry2 = makeParsedEntry(tok2, 100n);
+      parsedTokenCache.set('tok-1', entry1);
+      parsedTokenCache.set('tok-2', entry2);
+      const pool = new Map<string, ParsedTokenEntry>([['tok-1', entry1], ['tok-2', entry2]]);
+
+      const p1 = enq({ id: 'e1', request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+      const p2 = enq({ id: 'e2', request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync');
+
+      // First notifyChange resolves first entry, second can't plan
+      spy.mockReturnValueOnce(directPlan(entry1, 'UCT'));
+      spy.mockReturnValueOnce(null);
+      queue.notifyChange('UCT');
+
+      const r1 = await p1;
+      expect(r1.reservationId).toBe('e1');
+      expect(queue.size('UCT')).toBe(1);
+
+      // Second notifyChange resolves second entry
+      spy.mockReturnValueOnce(directPlan(entry2, 'UCT'));
+      queue.notifyChange('UCT');
+
+      const r2 = await p2;
+      expect(r2.reservationId).toBe('e2');
+      expect(queue.size()).toBe(0);
+    });
+
+    it('enqueue with zero amount still enters queue', () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+
+      enq({
+        id: nextId(),
+        request: { amount: '0', coinId: 'UCT' },
+        parsedPool: pool,
+        coinId: 'UCT',
+        amount: 0n,
+        enqueuedAt: Date.now(),
+      });
+
+      expect(queue.size()).toBe(1);
+    });
+
+    it('destroy after cancelAll is safe', () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      enq({ id: nextId(), request: { amount: '100', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 100n, enqueuedAt: Date.now() });
+
+      queue.cancelAll('reason');
+      expect(() => queue.destroy()).not.toThrow();
+    });
+
+    it('notifyChange called multiple times synchronously processes queue once per call', () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 100n }]);
+      parsedTokenCache.set('tok-1', pool.get('tok-1')!);
+
+      enq({ id: nextId(), request: { amount: '1000', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 1000n, enqueuedAt: Date.now() });
+
+      const spy = vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValue(null);
+
+      // Call 3 times synchronously -- each call processes independently
+      queue.notifyChange('UCT');
+      queue.notifyChange('UCT');
+      queue.notifyChange('UCT');
+
+      // Each call invokes planner once for the single entry
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
+
+    it('resolved entry promise not accessible via waitForEntry after resolution', async () => {
+      const pool = buildPool([{ id: 'tok-1', coinId: 'UCT', amount: 500n }]);
+      const entry = pool.get('tok-1')!;
+      parsedTokenCache.set('tok-1', entry);
+      const id = nextId();
+
+      enq({ id, request: { amount: '500', coinId: 'UCT' }, parsedPool: pool, coinId: 'UCT', amount: 500n, enqueuedAt: Date.now() });
+
+      vi.spyOn(planner, 'calculateOptimalSplitSync').mockReturnValueOnce(
+        directPlan(entry, 'UCT'),
+      );
+
+      queue.notifyChange('UCT');
+
+      // After resolution, the promise is deleted from internal map
+      await expect(queue.waitForEntry(id)).rejects.toThrow('Queue entry not found');
+    });
+  });
+});

--- a/tests/unit/modules/TokenReservationLedger.test.ts
+++ b/tests/unit/modules/TokenReservationLedger.test.ts
@@ -297,12 +297,12 @@ describe('TokenReservationLedger', () => {
       expect(ledger.getReservation('res-1')).toBeUndefined();
     });
 
-    it('commit() for already-cancelled reservation is no-op (does not revert)', () => {
+    it('commit() for already-cancelled reservation is no-op (reservation already deleted)', () => {
       ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
       ledger.cancel('res-1');
-      ledger.commit('res-1'); // should be no-op
+      ledger.commit('res-1'); // should be no-op — reservation already deleted by cancel
 
-      expect(ledger.getReservation('res-1')?.status).toBe('cancelled');
+      expect(ledger.getReservation('res-1')).toBeUndefined();
       expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
     });
 
@@ -502,16 +502,16 @@ describe('TokenReservationLedger', () => {
       expect(ledger.hasActiveReservation('tok-1')).toBe(false);
     });
 
-    it('getSize() counts active and cancelled but not committed (deleted)', () => {
+    it('getSize() counts only active reservations (commit and cancel both delete)', () => {
       ledger.reserve('res-1', entry('tok-1', 100000n, 1000000n), 'UCT');
       ledger.reserve('res-2', entry('tok-1', 100000n, 1000000n), 'UCT');
       ledger.reserve('res-3', entry('tok-1', 100000n, 1000000n), 'UCT');
 
       ledger.commit('res-1');  // deleted from map
-      ledger.cancel('res-2');  // still in map with status=cancelled
+      ledger.cancel('res-2');  // also deleted from map
 
-      // res-1 deleted by commit, res-2 cancelled (in map), res-3 active (in map)
-      expect(ledger.getSize()).toBe(2);
+      // Only res-3 remains (active)
+      expect(ledger.getSize()).toBe(1);
     });
   });
 
@@ -566,13 +566,13 @@ describe('TokenReservationLedger', () => {
       ledger.cancel('res-1');
       expect(ledger.getReservation('res-1')).toBeUndefined();
 
-      // active -> cancelled (valid)
+      // active -> cancelled (valid) — reservation is deleted
       ledger.cancel('res-2');
-      expect(ledger.getReservation('res-2')?.status).toBe('cancelled');
+      expect(ledger.getReservation('res-2')).toBeUndefined();
 
-      // cancelled -> committed (blocked)
+      // cancelled -> committed is no-op (reservation already gone)
       ledger.commit('res-2');
-      expect(ledger.getReservation('res-2')?.status).toBe('cancelled');
+      expect(ledger.getReservation('res-2')).toBeUndefined();
     });
 
     it('I-RL-5: tokenIndex stays consistent after reserve/cancel/commit sequences', () => {

--- a/tests/unit/modules/TokenReservationLedger.test.ts
+++ b/tests/unit/modules/TokenReservationLedger.test.ts
@@ -1,0 +1,758 @@
+/**
+ * Tests for modules/payments/TokenReservationLedger.ts
+ *
+ * Pure synchronous unit tests. No mocks needed — TokenReservationLedger
+ * is a standalone data structure with no external dependencies.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  TokenReservationLedger,
+  type ReservationEntry,
+} from '../../../modules/payments/TokenReservationLedger';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Shorthand for creating a single-token reservation entry array. */
+function entry(tokenId: string, amount: bigint, tokenAmount: bigint) {
+  return [{ tokenId, amount, tokenAmount }];
+}
+
+/** Shorthand for creating a multi-token reservation entry array. */
+function entries(
+  ...items: Array<{ tokenId: string; amount: bigint; tokenAmount: bigint }>
+) {
+  return items;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('TokenReservationLedger', () => {
+  let ledger: TokenReservationLedger;
+
+  beforeEach(() => {
+    ledger = new TokenReservationLedger();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Basic Operations
+  // ---------------------------------------------------------------------------
+
+  describe('Basic Operations', () => {
+    it('reserve() creates a reservation with correct amounts', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(500000n);
+      expect(ledger.getTotalReserved('tok-1')).toBe(500000n);
+      expect(ledger.getSize()).toBe(1);
+    });
+
+    it('reserve() for multiple tokens in one reservation', () => {
+      ledger.reserve(
+        'res-1',
+        entries(
+          { tokenId: 'tok-1', amount: 400000n, tokenAmount: 1000000n },
+          { tokenId: 'tok-2', amount: 1000000n, tokenAmount: 2000000n },
+        ),
+        'UCT',
+      );
+
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(600000n);
+      expect(ledger.getFreeAmount('tok-2', 2000000n)).toBe(1000000n);
+      // Unreferenced token is unaffected
+      expect(ledger.getFreeAmount('tok-3', 500000n)).toBe(500000n);
+      expect(ledger.getTotalReserved('tok-1')).toBe(400000n);
+      expect(ledger.getTotalReserved('tok-2')).toBe(1000000n);
+    });
+
+    it('commit() deletes reservation and frees capacity', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+      ledger.commit('res-1');
+
+      // Committed reservations are deleted from the ledger
+      expect(ledger.getReservation('res-1')).toBeUndefined();
+      // Capacity is freed (no longer in token index)
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+      expect(ledger.getTotalReserved('tok-1')).toBe(0n);
+    });
+
+    it('cancel() releases reservation amounts', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+      ledger.cancel('res-1');
+
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+      expect(ledger.getTotalReserved('tok-1')).toBe(0n);
+    });
+
+    it('getFreeAmount() returns token amount minus all active reservations', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-1', 400000n, 1000000n), 'UCT');
+
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(300000n);
+    });
+
+    it('getTotalReserved() sums across all active reservations for a token', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-1', 400000n, 1000000n), 'UCT');
+
+      expect(ledger.getTotalReserved('tok-1')).toBe(700000n);
+    });
+
+    it('getTotalReserved() returns 0n for unknown token', () => {
+      expect(ledger.getTotalReserved('nonexistent')).toBe(0n);
+    });
+
+    it('getFreeAmount() returns full tokenAmount for unknown token', () => {
+      expect(ledger.getFreeAmount('nonexistent', 1000000n)).toBe(1000000n);
+    });
+
+    it('hasActiveReservation() returns true when active reservation exists', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      expect(ledger.hasActiveReservation('tok-1')).toBe(true);
+    });
+
+    it('hasActiveReservation() returns false after cancel', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.cancel('res-1');
+      expect(ledger.hasActiveReservation('tok-1')).toBe(false);
+    });
+
+    it('hasActiveReservation() returns false for committed-only token', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.commit('res-1');
+      // committed is NOT active
+      expect(ledger.hasActiveReservation('tok-1')).toBe(false);
+    });
+
+    it('hasActiveReservation() returns false for unknown token', () => {
+      expect(ledger.hasActiveReservation('nonexistent')).toBe(false);
+    });
+
+    it('getReservation() returns the reservation entry', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+      const res = ledger.getReservation('res-1');
+      expect(res).toBeDefined();
+      expect(res!.reservationId).toBe('res-1');
+      expect(res!.coinId).toBe('UCT');
+      expect(res!.status).toBe('active');
+      expect(res!.amounts.get('tok-1')).toBe(500000n);
+    });
+
+    it('getReservation() returns undefined for unknown id', () => {
+      expect(ledger.getReservation('nonexistent')).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Partial Reservation (Multiple sends from same token)
+  // ---------------------------------------------------------------------------
+
+  describe('Partial Reservation', () => {
+    it('two reservations on same token, each claiming part of the amount', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-1', 400000n, 1000000n), 'UCT');
+
+      expect(ledger.getSize()).toBe(2);
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(300000n);
+    });
+
+    it('cancel one partial reservation, other remains with updated free amount', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-1', 400000n, 1000000n), 'UCT');
+
+      ledger.cancel('res-1');
+
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(600000n);
+      expect(ledger.getTotalReserved('tok-1')).toBe(400000n);
+    });
+
+    it('commit one, cancel other: both free capacity fully', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-1', 400000n, 1000000n), 'UCT');
+
+      ledger.commit('res-1');
+      ledger.cancel('res-2');
+
+      // Commit deletes reservation and frees capacity; cancel also frees capacity
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+      expect(ledger.getTotalReserved('tok-1')).toBe(0n);
+    });
+
+    it('three partial reservations exhausting full token amount', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-1', 400000n, 1000000n), 'UCT');
+      ledger.reserve('res-3', entry('tok-1', 300000n, 1000000n), 'UCT');
+
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(0n);
+      expect(ledger.getTotalReserved('tok-1')).toBe(1000000n);
+    });
+
+    it('duplicate tokenId entries within one reservation are accumulated', () => {
+      // Two entries for same tokenId in one reserve call
+      ledger.reserve(
+        'res-1',
+        entries(
+          { tokenId: 'tok-1', amount: 200000n, tokenAmount: 1000000n },
+          { tokenId: 'tok-1', amount: 300000n, tokenAmount: 1000000n },
+        ),
+        'UCT',
+      );
+
+      expect(ledger.getTotalReserved('tok-1')).toBe(500000n);
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(500000n);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Validation & Error Cases
+  // ---------------------------------------------------------------------------
+
+  describe('Validation & Error Cases', () => {
+    it('reserve() with empty entries throws EMPTY_RESERVATION', () => {
+      expect(() => ledger.reserve('res-1', [], 'UCT')).toThrow(
+        'EMPTY_RESERVATION',
+      );
+    });
+
+    it('reserve() with duplicate reservationId throws DUPLICATE_RESERVATION_ID', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+
+      expect(() =>
+        ledger.reserve('res-1', entry('tok-1', 100000n, 1000000n), 'UCT'),
+      ).toThrow('DUPLICATE_RESERVATION_ID');
+    });
+
+    it('reserve() with zero amount throws INVALID_RESERVATION_AMOUNT', () => {
+      expect(() =>
+        ledger.reserve('res-1', entry('tok-1', 0n, 1000000n), 'UCT'),
+      ).toThrow('INVALID_RESERVATION_AMOUNT');
+    });
+
+    it('reserve() with negative amount throws INVALID_RESERVATION_AMOUNT', () => {
+      expect(() =>
+        ledger.reserve('res-1', entry('tok-1', -100n, 1000000n), 'UCT'),
+      ).toThrow('INVALID_RESERVATION_AMOUNT');
+    });
+
+    it('reserve() with amount exceeding free amount throws INSUFFICIENT_FREE_AMOUNT', () => {
+      ledger.reserve('res-1', entry('tok-1', 700000n, 1000000n), 'UCT');
+
+      expect(() =>
+        ledger.reserve('res-2', entry('tok-1', 500000n, 1000000n), 'UCT'),
+      ).toThrow('INSUFFICIENT_FREE_AMOUNT');
+    });
+
+    it('reserve() with amount exceeding tokenAmount throws INSUFFICIENT_FREE_AMOUNT', () => {
+      expect(() =>
+        ledger.reserve('res-1', entry('tok-1', 1500000n, 1000000n), 'UCT'),
+      ).toThrow('INSUFFICIENT_FREE_AMOUNT');
+    });
+
+    it('reserve() is all-or-nothing: no state change on validation failure', () => {
+      // First entry valid, second entry would exceed free amount
+      expect(() =>
+        ledger.reserve(
+          'res-1',
+          entries(
+            { tokenId: 'tok-1', amount: 500000n, tokenAmount: 1000000n },
+            { tokenId: 'tok-2', amount: 3000000n, tokenAmount: 2000000n },
+          ),
+          'UCT',
+        ),
+      ).toThrow('INSUFFICIENT_FREE_AMOUNT');
+
+      // Nothing should be reserved
+      expect(ledger.getTotalReserved('tok-1')).toBe(0n);
+      expect(ledger.getTotalReserved('tok-2')).toBe(0n);
+      expect(ledger.getSize()).toBe(0);
+    });
+
+    it('cancel() for unknown reservationId is no-op', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+
+      // Should not throw
+      ledger.cancel('unknown-id');
+
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(500000n);
+    });
+
+    it('cancel() for already-cancelled reservation is idempotent no-op', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+      ledger.cancel('res-1');
+      ledger.cancel('res-1'); // second call
+
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+    });
+
+    it('commit() for already-committed reservation is idempotent no-op', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+      ledger.commit('res-1');
+      ledger.commit('res-1'); // second call — reservation already deleted, no-op
+
+      // Reservation was deleted on first commit
+      expect(ledger.getReservation('res-1')).toBeUndefined();
+    });
+
+    it('commit() for already-cancelled reservation is no-op (does not revert)', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+      ledger.cancel('res-1');
+      ledger.commit('res-1'); // should be no-op
+
+      expect(ledger.getReservation('res-1')?.status).toBe('cancelled');
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+    });
+
+    it('cancel() after commit is no-op (reservation already deleted)', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+      ledger.commit('res-1');
+      ledger.cancel('res-1'); // reservation already deleted by commit, no-op
+
+      expect(ledger.getReservation('res-1')).toBeUndefined();
+      // Capacity was freed by commit
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+    });
+
+    it('commit() for unknown reservationId is no-op', () => {
+      // Should not throw
+      ledger.commit('nonexistent');
+      expect(ledger.getSize()).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // cancelForToken
+  // ---------------------------------------------------------------------------
+
+  describe('cancelForToken', () => {
+    it('cancels ALL active reservations containing that token', () => {
+      ledger.reserve('res-1', entry('tok-1', 200000n, 1000000n), 'UCT');
+      ledger.reserve(
+        'res-2',
+        entries(
+          { tokenId: 'tok-1', amount: 300000n, tokenAmount: 1000000n },
+          { tokenId: 'tok-2', amount: 100000n, tokenAmount: 2000000n },
+        ),
+        'UCT',
+      );
+      ledger.reserve('res-3', entry('tok-2', 400000n, 2000000n), 'UCT');
+
+      const cancelled = ledger.cancelForToken('tok-1');
+
+      expect(cancelled).toHaveLength(2);
+      expect(cancelled).toContain('res-1');
+      expect(cancelled).toContain('res-2');
+
+      // tok-1 fully free
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+
+      // tok-2: res-2 was cancelled (released 100000), res-3 still active (400000)
+      expect(ledger.getTotalReserved('tok-2')).toBe(400000n);
+      expect(ledger.getFreeAmount('tok-2', 2000000n)).toBe(1600000n);
+
+      // res-3 untouched
+      expect(ledger.getReservation('res-3')?.status).toBe('active');
+    });
+
+    it('returns empty array for token with no reservations', () => {
+      ledger.reserve('res-1', entry('tok-1', 200000n, 1000000n), 'UCT');
+
+      const cancelled = ledger.cancelForToken('tok-2');
+      expect(cancelled).toEqual([]);
+    });
+
+    it('committed reservations are already gone, cancelForToken only cancels active ones', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-1', 200000n, 1000000n), 'UCT');
+      ledger.commit('res-1');
+
+      const cancelled = ledger.cancelForToken('tok-1');
+
+      // Only res-2 should be cancelled (active); res-1 was already deleted by commit
+      expect(cancelled).toEqual(['res-2']);
+      expect(ledger.getReservation('res-1')).toBeUndefined();
+      expect(ledger.getReservation('res-2')?.status).toBe('cancelled');
+    });
+
+    it('after cancelForToken(), getFreeAmount returns full token amount when no committed reservations', () => {
+      ledger.reserve('res-1', entry('tok-1', 700000n, 1000000n), 'UCT');
+      ledger.cancelForToken('tok-1');
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cleanup
+  // ---------------------------------------------------------------------------
+
+  describe('Cleanup', () => {
+    it('cleanup(maxAgeMs) removes reservations older than threshold', () => {
+      // Create a reservation with a known createdAt by mocking Date.now
+      const originalNow = Date.now;
+      try {
+        Date.now = () => 100;
+        ledger.reserve('res-1', entry('tok-1', 200000n, 1000000n), 'UCT');
+
+        Date.now = () => 200;
+        ledger.reserve('res-2', entry('tok-1', 100000n, 1000000n), 'UCT');
+
+        // At time 400, cleanup with maxAge 150 -> threshold is 250
+        // res-1 (created=100, age=300) -> old, remove
+        // res-2 (created=200, age=200) -> old, remove
+        Date.now = () => 400;
+        const cancelled = ledger.cleanup(150);
+
+        expect(cancelled).toContain('res-1');
+        expect(cancelled).toContain('res-2');
+        expect(ledger.getSize()).toBe(0);
+        expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+
+    it('cleanup returns IDs of active reservations that were cancelled', () => {
+      const originalNow = Date.now;
+      try {
+        Date.now = () => 100;
+        ledger.reserve('res-1', entry('tok-1', 200000n, 1000000n), 'UCT');
+        ledger.reserve('res-2', entry('tok-1', 100000n, 1000000n), 'UCT');
+
+        Date.now = () => 5000;
+        ledger.reserve('res-3', entry('tok-1', 50000n, 1000000n), 'UCT');
+
+        Date.now = () => 5100;
+        const cancelled = ledger.cleanup(500);
+
+        // res-1 and res-2 old enough, res-3 is not
+        expect(cancelled).toHaveLength(2);
+        expect(cancelled).toContain('res-1');
+        expect(cancelled).toContain('res-2');
+        expect(ledger.getReservation('res-3')?.status).toBe('active');
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+
+    it('cleanup removes committed and cancelled entries too (by age) but only returns active ones', () => {
+      const originalNow = Date.now;
+      try {
+        Date.now = () => 100;
+        ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+        ledger.reserve('res-2', entry('tok-1', 400000n, 1000000n), 'UCT');
+        ledger.commit('res-2');
+
+        Date.now = () => 5000;
+        const cancelled = ledger.cleanup(500);
+
+        // res-1 was active -> cancelled by cleanup -> returned
+        // res-2 was committed -> removed but not in cancelled list
+        expect(cancelled).toEqual(['res-1']);
+
+        // Both are removed from the ledger
+        expect(ledger.getSize()).toBe(0);
+
+        // res-2 was committed so its amount was freed by cleanup removal
+        // (cleanup removes from tokenIndex for active ones that get cancelled)
+        // For committed, they are just deleted from reservations map
+        expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+
+    it('cleanup does not remove reservations within threshold', () => {
+      const originalNow = Date.now;
+      try {
+        Date.now = () => 5000;
+        ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+
+        Date.now = () => 5050;
+        const cancelled = ledger.cleanup(100);
+
+        expect(cancelled).toEqual([]);
+        expect(ledger.getSize()).toBe(1);
+        expect(ledger.getReservation('res-1')?.status).toBe('active');
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // clear() and getSize()
+  // ---------------------------------------------------------------------------
+
+  describe('clear() and getSize()', () => {
+    it('clear() removes all reservations and indexes', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-2', 500000n, 2000000n), 'UCT');
+
+      expect(ledger.getSize()).toBe(2);
+
+      ledger.clear();
+
+      expect(ledger.getSize()).toBe(0);
+      expect(ledger.getTotalReserved('tok-1')).toBe(0n);
+      expect(ledger.getTotalReserved('tok-2')).toBe(0n);
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(1000000n);
+      expect(ledger.hasActiveReservation('tok-1')).toBe(false);
+    });
+
+    it('getSize() counts active and cancelled but not committed (deleted)', () => {
+      ledger.reserve('res-1', entry('tok-1', 100000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-1', 100000n, 1000000n), 'UCT');
+      ledger.reserve('res-3', entry('tok-1', 100000n, 1000000n), 'UCT');
+
+      ledger.commit('res-1');  // deleted from map
+      ledger.cancel('res-2');  // still in map with status=cancelled
+
+      // res-1 deleted by commit, res-2 cancelled (in map), res-3 active (in map)
+      expect(ledger.getSize()).toBe(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Invariant Checks
+  // ---------------------------------------------------------------------------
+
+  describe('Invariants', () => {
+    const TOKEN_AMOUNT = 1000000n;
+
+    /** Verify I-RL-2: free + reserved = tokenAmount */
+    function assertInvariant(tokenId: string, tokenAmount: bigint) {
+      const free = ledger.getFreeAmount(tokenId, tokenAmount);
+      const reserved = ledger.getTotalReserved(tokenId);
+      expect(free + reserved).toBe(tokenAmount);
+      // I-RL-1: free >= 0
+      expect(free >= 0n).toBe(true);
+    }
+
+    it('I-RL-2: getFreeAmount + getTotalReserved === tokenAmount after each operation', () => {
+      assertInvariant('tok-1', TOKEN_AMOUNT);
+
+      ledger.reserve('res-1', entry('tok-1', 300000n, TOKEN_AMOUNT), 'UCT');
+      assertInvariant('tok-1', TOKEN_AMOUNT);
+
+      ledger.reserve('res-2', entry('tok-1', 200000n, TOKEN_AMOUNT), 'UCT');
+      assertInvariant('tok-1', TOKEN_AMOUNT);
+
+      ledger.commit('res-1');
+      assertInvariant('tok-1', TOKEN_AMOUNT);
+
+      ledger.cancel('res-2');
+      assertInvariant('tok-1', TOKEN_AMOUNT);
+    });
+
+    it('I-RL-1: getFreeAmount never goes negative even with buggy tokenAmount', () => {
+      ledger.reserve('res-1', entry('tok-1', 500000n, 1000000n), 'UCT');
+
+      // Query with a smaller tokenAmount than reserved — should clamp to 0n
+      expect(ledger.getFreeAmount('tok-1', 100000n)).toBe(0n);
+    });
+
+    it('I-RL-4: status transitions are one-directional (active -> committed, active -> cancelled)', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-1', 200000n, 1000000n), 'UCT');
+
+      // active -> committed (valid) — reservation is deleted
+      ledger.commit('res-1');
+      expect(ledger.getReservation('res-1')).toBeUndefined();
+
+      // cancel after commit is no-op (reservation already gone)
+      ledger.cancel('res-1');
+      expect(ledger.getReservation('res-1')).toBeUndefined();
+
+      // active -> cancelled (valid)
+      ledger.cancel('res-2');
+      expect(ledger.getReservation('res-2')?.status).toBe('cancelled');
+
+      // cancelled -> committed (blocked)
+      ledger.commit('res-2');
+      expect(ledger.getReservation('res-2')?.status).toBe('cancelled');
+    });
+
+    it('I-RL-5: tokenIndex stays consistent after reserve/cancel/commit sequences', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-1', 200000n, 1000000n), 'UCT');
+
+      // Cancel res-1 -> tok-1 should still be in index (res-2 remains)
+      ledger.cancel('res-1');
+      expect(ledger.hasActiveReservation('tok-1')).toBe(true);
+      expect(ledger.getTotalReserved('tok-1')).toBe(200000n);
+
+      // Cancel res-2 -> tok-1 should have no active reservations
+      ledger.cancel('res-2');
+      expect(ledger.hasActiveReservation('tok-1')).toBe(false);
+      expect(ledger.getTotalReserved('tok-1')).toBe(0n);
+    });
+
+    it('I-RL-6: duplicate reservationId is rejected', () => {
+      ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+
+      expect(() =>
+        ledger.reserve('res-1', entry('tok-2', 100000n, 500000n), 'UCT'),
+      ).toThrow('DUPLICATE_RESERVATION_ID');
+    });
+
+    it('fuzz: random sequence of 100 operations preserves invariants', () => {
+      const tokens = [
+        { id: 'tok-1', amount: 1000000n },
+        { id: 'tok-2', amount: 2000000n },
+        { id: 'tok-3', amount: 500000n },
+        { id: 'tok-4', amount: 750000n },
+        { id: 'tok-5', amount: 1500000n },
+      ];
+      const activeIds: string[] = [];
+      const allIds: string[] = [];
+      let nextId = 0;
+
+      // Seed-based pseudo-random for reproducibility
+      let seed = 42;
+      function rand() {
+        seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+        return seed;
+      }
+
+      for (let i = 0; i < 100; i++) {
+        const op = rand() % 5;
+
+        try {
+          if (op === 0) {
+            // reserve: pick 1-2 random tokens, reserve a small amount
+            const tok = tokens[rand() % tokens.length];
+            const maxFree = ledger.getFreeAmount(tok.id, tok.amount);
+            if (maxFree > 0n) {
+              const amount = BigInt((rand() % Number(maxFree)) + 1);
+              const resId = `fuzz-${nextId++}`;
+              ledger.reserve(
+                resId,
+                entry(tok.id, amount, tok.amount),
+                'UCT',
+              );
+              activeIds.push(resId);
+              allIds.push(resId);
+            }
+          } else if (op === 1 && activeIds.length > 0) {
+            // cancel a random active reservation
+            const idx = rand() % activeIds.length;
+            ledger.cancel(activeIds[idx]);
+            activeIds.splice(idx, 1);
+          } else if (op === 2 && activeIds.length > 0) {
+            // commit a random active reservation
+            const idx = rand() % activeIds.length;
+            ledger.commit(activeIds[idx]);
+            activeIds.splice(idx, 1);
+          } else if (op === 3) {
+            // cancelForToken
+            const tok = tokens[rand() % tokens.length];
+            ledger.cancelForToken(tok.id);
+            // Remove cancelled ones from activeIds (simplified: just refresh)
+            const remaining: string[] = [];
+            for (const id of activeIds) {
+              const res = ledger.getReservation(id);
+              if (res && res.status === 'active') {
+                remaining.push(id);
+              }
+            }
+            activeIds.length = 0;
+            activeIds.push(...remaining);
+          } else if (op === 4) {
+            // cleanup with large maxAge (shouldn't affect recent entries)
+            ledger.cleanup(999999999);
+          }
+        } catch {
+          // Expected: INSUFFICIENT_FREE_AMOUNT etc. — skip
+        }
+
+        // Verify invariant after every operation
+        for (const tok of tokens) {
+          const free = ledger.getFreeAmount(tok.id, tok.amount);
+          const reserved = ledger.getTotalReserved(tok.id);
+          expect(free + reserved).toBe(tok.amount);
+          expect(free >= 0n).toBe(true);
+        }
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge Cases
+  // ---------------------------------------------------------------------------
+
+  describe('Edge Cases', () => {
+    it('reserving the exact full token amount leaves 0 free', () => {
+      ledger.reserve('res-1', entry('tok-1', 1000000n, 1000000n), 'UCT');
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(0n);
+    });
+
+    it('reserving full amount then another reserve throws INSUFFICIENT_FREE_AMOUNT', () => {
+      ledger.reserve('res-1', entry('tok-1', 1000000n, 1000000n), 'UCT');
+      expect(() =>
+        ledger.reserve('res-2', entry('tok-1', 1n, 1000000n), 'UCT'),
+      ).toThrow('INSUFFICIENT_FREE_AMOUNT');
+    });
+
+    it('cancel then re-reserve the same amounts succeeds', () => {
+      ledger.reserve('res-1', entry('tok-1', 1000000n, 1000000n), 'UCT');
+      ledger.cancel('res-1');
+      // Re-reserve with different ID
+      ledger.reserve('res-2', entry('tok-1', 1000000n, 1000000n), 'UCT');
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(0n);
+    });
+
+    it('reserve with amount = 1n (minimum valid amount)', () => {
+      ledger.reserve('res-1', entry('tok-1', 1n, 1000000n), 'UCT');
+      expect(ledger.getTotalReserved('tok-1')).toBe(1n);
+      expect(ledger.getFreeAmount('tok-1', 1000000n)).toBe(999999n);
+    });
+
+    it('many reservations on different coins', () => {
+      ledger.reserve('res-1', entry('tok-1', 100n, 1000n), 'UCT');
+      ledger.reserve('res-2', entry('tok-2', 200n, 2000n), 'USDU');
+
+      expect(ledger.getReservation('res-1')?.coinId).toBe('UCT');
+      expect(ledger.getReservation('res-2')?.coinId).toBe('USDU');
+      expect(ledger.getTotalReserved('tok-1')).toBe(100n);
+      expect(ledger.getTotalReserved('tok-2')).toBe(200n);
+    });
+
+    it('cancelForToken on multi-token reservation removes from all token indexes', () => {
+      ledger.reserve(
+        'res-1',
+        entries(
+          { tokenId: 'tok-1', amount: 100n, tokenAmount: 1000n },
+          { tokenId: 'tok-2', amount: 200n, tokenAmount: 2000n },
+        ),
+        'UCT',
+      );
+
+      ledger.cancelForToken('tok-1');
+
+      // res-1 cancelled, so tok-2 should also be freed
+      expect(ledger.getTotalReserved('tok-1')).toBe(0n);
+      expect(ledger.getTotalReserved('tok-2')).toBe(0n);
+      expect(ledger.hasActiveReservation('tok-2')).toBe(false);
+    });
+
+    it('cleanup with maxAgeMs = 0 removes everything', () => {
+      const originalNow = Date.now;
+      try {
+        Date.now = () => 1000;
+        ledger.reserve('res-1', entry('tok-1', 300000n, 1000000n), 'UCT');
+        ledger.reserve('res-2', entry('tok-1', 200000n, 1000000n), 'UCT');
+
+        Date.now = () => 1001;
+        const cancelled = ledger.cleanup(0);
+
+        expect(cancelled).toHaveLength(2);
+        expect(ledger.getSize()).toBe(0);
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **TokenReservationLedger**: Synchronous ledger tracking per-token reserved bigint amounts with dual indexes. All operations are synchronous — hard requirement for TOCTOU-safe critical section.
- **SpendPlanner**: Synchronous critical section that reads free amounts, calculates optimal split, and atomically creates a reservation. No `await` between pool read and reservation write.
- **SpendQueue**: FIFO queue with skip-ahead starvation protection (MAX_SKIP_COUNT=10) for requests that can't be served immediately but will be servable from change-back tokens. 30s timeout per entry.
- **parsedTokenCache consistency**: All `this.tokens.set()` call sites audited — cache updates and `notifyChange()` calls added for every token lifecycle transition (transferring, error recovery, V5 resolution, NOSTR-FIRST finalization, validation invalidation, updateToken replacement).
- **sendInstant() integration**: Routed through SpendPlanner to prevent race between concurrent `send()` + `sendInstant()`.
- **Error codes**: `SEND_INSUFFICIENT_BALANCE` for spend queue paths, `SEND_QUEUE_TIMEOUT` for queue expiry.

Fixes #85

## Design Documents

- `docs/TOKEN-SPEND-QUEUE.md` — Architecture with 5 ADRs and 7 edge cases
- `docs/SPEC-TOKEN-SPEND-QUEUE.md` — Behavioral contracts, invariants, concurrency model
- `docs/TEST-SPEC-TOKEN-SPEND-QUEUE.md` — 120 test cases across 6 test files

## Test plan

- [x] All 2093 existing + new tests pass (`npx vitest run`)
- [x] TypeScript strict typecheck clean (`npx tsc --noEmit`)
- [x] Steelman adversarial review — all critical findings fixed
- [ ] E2E stress test: `tests/scripts/test-e2e-multi-transfers.ts` with concurrent sends against testnet