### PR TITLE
feat(cli): comprehensive CLI overhaul — help, completion, accounting/swap commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ const { sphere, created, generatedMnemonic } = await Sphere.init({
   autoGenerate: true,   // Generate mnemonic if no wallet exists
   nametag: 'alice',     // Optional: register @alice for receiving payments
   password: 'secret',   // Optional: encrypt mnemonic (plaintext if omitted)
+  accounting: true,     // Enable accounting/invoicing module
+  swap: true,           // Enable token swap module
 });
 
 if (created && generatedMnemonic) {
@@ -112,6 +114,18 @@ sphere.payments.onPaymentRequest((req) => {
   sphere.payments.payPaymentRequest(req.id);  // or rejectPaymentRequest()
 });
 
+// 12a. Invoicing (requires accounting: true in init)
+const invoice = await sphere.accounting.createInvoice({
+  targets: [{ address: identity.directAddress!, assets: [{ coin: ['UCT', '1000000'] }] }],
+  memo: 'Order #1234',
+});
+
+// 12b. Token swaps (requires swap: true in init)
+const swap = await sphere.swap.proposeSwap({
+  give: { currency: 'UCT', amount: '1000000' },
+  receive: { currency: 'USDU', amount: '500000' },
+}, { recipient: '@bob', escrowAddress: 'DIRECT://escrow...' });
+
 // 13. Cleanup
 await sphere.destroy();
 ```
@@ -120,141 +134,22 @@ await sphere.destroy();
 
 ## Connect Protocol (dApp ↔ Wallet Integration)
 
-The SDK ships a full **Connect Protocol** — a typed RPC layer that allows web dApps to communicate with the Sphere wallet without exposing private keys.
-
-> Full guide: [`docs/CONNECT.md`](docs/CONNECT.md)
-
-### Key Concepts
+Typed RPC layer for dApp ↔ wallet communication. Full guide: [`docs/CONNECT.md`](docs/CONNECT.md)
 
 | Role | Class | Where it runs |
 |------|-------|--------------|
 | dApp (client) | `ConnectClient` | any web page / app |
 | Wallet (host) | `ConnectHost` | Sphere app / extension background |
 
-### Transport Types
+**Transports:** `PostMessageTransport` (iframe/popup), `ExtensionTransport` (browser extension), `WebSocketTransport` (Node.js).
 
-| Transport | Import path | When to use |
-|-----------|-------------|-------------|
-| `PostMessageTransport` | `@unicitylabs/sphere-sdk/connect/browser` | dApp inside iframe OR wallet popup |
-| `ExtensionTransport` | `@unicitylabs/sphere-sdk/connect/browser` | Sphere browser extension installed |
-| `WebSocketTransport` | `@unicitylabs/sphere-sdk/connect/nodejs` | Node.js server-side wallet host |
+**Queries:** `sphere_getIdentity`, `sphere_getBalance`, `sphere_getFiatBalance`, `sphere_l1GetBalance`, `sphere_getAssets`, `sphere_getTokens`, `sphere_getHistory`, `sphere_l1GetHistory`, `sphere_resolve`.
 
-### ConnectClient (dApp side)
+**Intents:** `send`, `l1_send`, `dm`, `payment_request`, `receive`, `sign_message`.
 
-```typescript
-import { ConnectClient } from '@unicitylabs/sphere-sdk/connect';
-import { ExtensionTransport, PostMessageTransport } from '@unicitylabs/sphere-sdk/connect/browser';
+**Permissions:** `identity:read`, `balance:read`, `history:read`, `assets:read`, `intent:send`, `intent:l1_send`, `intent:dm`, `intent:payment_request`, `intent:receive`, `intent:sign_message`.
 
-// Priority-based transport selection
-let transport: ConnectTransport;
-if (isInIframe())       transport = PostMessageTransport.forClient();          // P1
-else if (hasExt())      transport = ExtensionTransport.forClient();            // P2
-else                    transport = PostMessageTransport.forClient({ target: popup, targetOrigin: WALLET_URL }); // P3
-
-const client = new ConnectClient({
-  transport,
-  dapp: { name: 'My App', description: '...', url: location.origin },
-  silent: true,      // fast-fail if not approved yet (no popup, no UI)
-  resumeSessionId,   // optional: resume popup session across reloads
-});
-
-const { identity, permissions, sessionId } = await client.connect();
-
-// Queries (read-only, no user interaction)
-const balance = await client.query('sphere_getBalance');
-const assets  = await client.query('sphere_getAssets');
-
-// Intents (require user confirmation in wallet)
-await client.intent('send', { recipient: '@alice', amount: 100, coinId: 'USDC' });
-await client.intent('sign_message', { message: 'I agree to ToS' });
-
-// Events (real-time push from wallet)
-const unsub = client.on('transfer:incoming', (data) => { ... });
-
-await client.disconnect();
-```
-
-### ConnectHost (wallet side)
-
-```typescript
-import { ConnectHost } from '@unicitylabs/sphere-sdk/connect';
-import { ExtensionTransport } from '@unicitylabs/sphere-sdk/connect/browser';
-
-const host = new ConnectHost({
-  sphere,          // Sphere instance (unlocked wallet)
-  transport: ExtensionTransport.forHost(chromeApi),
-  onConnectionRequest: async (dapp, requestedPermissions, silent) => {
-    // silent=true → fast-check approved list, no popup
-    // silent=false → show approval UI
-    return { approved: true, grantedPermissions: requestedPermissions };
-  },
-  onIntent: async (action, params, session) => {
-    // Route to correct UI (send modal, sign modal, etc.)
-    return { result: { ... } };
-  },
-  onDisconnect: async (session) => {
-    // dApp called disconnect() — revoke approval if needed
-  },
-});
-
-host.destroy(); // call on wallet lock
-```
-
-### Silent Mode (auto-connect on page load)
-
-```typescript
-// On mount: check silently if origin already approved
-const client = new ConnectClient({ transport, dapp, silent: true });
-try {
-  const result = await client.connect(); // instant success if approved
-} catch {
-  // Not approved — show Connect button, no error displayed
-}
-```
-
-**Extension behavior with `silent=true`:**
-- Origin in approved storage → approve immediately (no popup)
-- Origin NOT in storage → reject immediately (no popup)
-
-### Available RPC Methods
-
-| Method | Description |
-|--------|-------------|
-| `sphere_getIdentity` | Public identity (nametag, addresses) |
-| `sphere_getBalance` | L3 token balances |
-| `sphere_getFiatBalance` | USD value |
-| `sphere_l1GetBalance` | L1 (ALPHA) balance |
-| `sphere_getAssets` | Assets grouped by coin |
-| `sphere_getTokens` | Individual tokens |
-| `sphere_getHistory` | Transaction history |
-| `sphere_l1GetHistory` | L1 transaction history |
-| `sphere_resolve` | Resolve nametag/address |
-
-### Available Intent Actions
-
-| Action | User sees | Description |
-|--------|-----------|-------------|
-| `send` | Send modal | Send L3 tokens |
-| `l1_send` | L1 send modal | Send L1 transaction |
-| `dm` | DM modal | Send direct message |
-| `payment_request` | Request modal | Create payment request |
-| `receive` | Receive modal | Show receive address |
-| `sign_message` | Sign modal | Sign arbitrary message |
-
-### Permission Scopes
-
-| Scope | Grants access to |
-|-------|-----------------|
-| `identity:read` | Public identity info |
-| `balance:read` | Balance queries |
-| `history:read` | Transaction history |
-| `assets:read` | Asset/token list |
-| `intent:send` | Send intent |
-| `intent:l1_send` | L1 send intent |
-| `intent:dm` | DM intent |
-| `intent:payment_request` | Payment request intent |
-| `intent:receive` | Receive intent |
-| `intent:sign_message` | Sign message intent |
+**Silent mode:** `new ConnectClient({ ..., silent: true })` — fast-check approved list without UI popup.
 
 ---
 
@@ -296,6 +191,16 @@ try {
 | `sphere.switchToAddress(index)` | `void` | Switch HD address |
 | `sphere.getActiveAddresses()` | `TrackedAddress[]` | Non-hidden tracked addresses |
 | `sphere.on(event, handler)` | `() => void` (unsubscribe) | Subscribe to events |
+| `sphere.accounting.createInvoice(request)` | `CreateInvoiceResult` | Mint a new invoice token |
+| `sphere.accounting.importInvoice(token)` | `InvoiceTerms` | Import a received invoice TXF token |
+| `sphere.accounting.getInvoiceStatus(invoiceId)` | `InvoiceStatus` | Full status with per-target balances |
+| `sphere.accounting.payInvoice(invoiceId, params)` | `TransferResult` | Send payment referencing an invoice |
+| `sphere.accounting.closeInvoice(invoiceId)` | `void` | Explicitly close (terminal state) |
+| `sphere.accounting.cancelInvoice(invoiceId)` | `void` | Cancel and optionally auto-return |
+| `sphere.swap.proposeSwap(deal, options?)` | `SwapProposalResult` | Propose a token swap |
+| `sphere.swap.acceptSwap(swapId)` | `void` | Accept a swap proposal |
+| `sphere.swap.deposit(swapId)` | `TransferResult` | Deposit into a swap |
+| `sphere.swap.getSwaps(filter?)` | `SwapRef[]` | List swaps with filter |
 
 ### Key Events
 
@@ -310,6 +215,16 @@ try {
 | `address:activated` | `{ address: TrackedAddress }` | New address tracked |
 | `sync:provider` | `{ providerId, success, added, removed }` | Per-provider sync result |
 | `payment_request:incoming` | `IncomingPaymentRequest` | Received payment request |
+| `invoice:created` | `{ invoiceId, confirmed }` | Invoice token minted or imported |
+| `invoice:payment` | `{ invoiceId, transfer, paymentDirection, confirmed }` | Payment attributed to invoice |
+| `invoice:covered` | `{ invoiceId, confirmed }` | All targets fully covered |
+| `invoice:closed` | `{ invoiceId, explicit }` | Invoice moved to CLOSED |
+| `invoice:cancelled` | `{ invoiceId }` | Invoice moved to CANCELLED |
+| `swap:proposal_received` | `{ swapId, deal, senderPubkey, senderNametag? }` | Incoming swap proposal |
+| `swap:accepted` | `{ swapId, role }` | Swap accepted |
+| `swap:deposit_confirmed` | `{ swapId, party, amount, coinId }` | Deposit confirmed by escrow |
+| `swap:completed` | `{ swapId, payoutVerified }` | Swap completed (terminal) |
+| `swap:cancelled` | `{ swapId, reason, depositsReturned? }` | Swap cancelled (terminal) |
 
 See [QUICKSTART-BROWSER.md](docs/QUICKSTART-BROWSER.md) and [QUICKSTART-NODEJS.md](docs/QUICKSTART-NODEJS.md) for detailed guides.
 
@@ -321,7 +236,7 @@ See [QUICKSTART-BROWSER.md](docs/QUICKSTART-BROWSER.md) and [QUICKSTART-NODEJS.m
 - **L1 (ALPHA blockchain)** - UTXO-based blockchain transactions via Electrum
 - **L3 (Unicity state transition network)** - Token transfers with state proofs via Aggregator
 
-**Version:** 0.3.3
+**Version:** 0.6.14
 **License:** MIT
 **Target:** Node.js >= 18.0.0, Browser (ESM/CJS)
 
@@ -348,6 +263,19 @@ sphere-sdk/
 │   │   ├── TokenSplitCalculator.ts
 │   │   ├── TokenSplitExecutor.ts
 │   │   └── NametagMinter.ts       # On-chain nametag minting
+│   ├── accounting/
+│   │   ├── AccountingModule.ts    # Invoice lifecycle and payment attribution
+│   │   ├── types.ts               # InvoiceTerms, InvoiceStatus, etc.
+│   │   ├── balance-computer.ts    # Per-target status computation
+│   │   ├── auto-return.ts         # Automatic refund management
+│   │   ├── memo.ts                # Invoice memo encoding + hashInvoiceId
+│   │   └── serialization.ts       # Canonical invoice serialization
+│   ├── swap/
+│   │   ├── SwapModule.ts          # P2P token swap lifecycle
+│   │   ├── dm-protocol.ts         # NIP-17 swap DM message protocol
+│   │   ├── escrow-client.ts       # Escrow service interaction
+│   │   ├── manifest.ts            # Swap manifest signing/verification
+│   │   └── state-machine.ts       # Swap progress transitions
 │   ├── groupchat/
 │   │   ├── GroupChatModule.ts     # NIP-29 group chat (relay-based)
 │   │   ├── types.ts               # GroupData, GroupMessageData, etc.
@@ -621,10 +549,32 @@ TxfStorageDataBase {
 }
 ```
 
+### Accounting / Invoicing
+
+`AccountingModule` (`sphere.accounting`) manages the full invoice lifecycle.
+
+**Invoice IS a token.** Minted as an L3 token with `tokenType = INVOICE_TOKEN_TYPE_HEX`. Terms serialized into `genesis.data.tokenData`.
+
+**State machine:** `OPEN -> PARTIAL -> COVERED -> CLOSED` (or `CANCELLED`, `EXPIRED`). Terminal states freeze balances.
+
+**Privacy: hashed invoice IDs.** On-chain memos embed `SHA-256(invoiceId)` instead of the raw ID. Third parties cannot correlate tokens to invoices. Recipients verify by re-hashing their known ID. Backward-compatible with legacy raw-ID memos via `resolveInvoiceRef()`.
+
+**Auto-return.** When enabled, automatically refunds payments to closed/cancelled invoices with dedup ledger to prevent double-refunds.
+
+### Token Swaps
+
+`SwapModule` (`sphere.swap`) orchestrates P2P token swaps via an escrow service.
+
+**Protocol v2:** Proposals include signed manifests with nametag binding proofs. All messages use NIP-17 encrypted DMs. Escrow holds deposits and executes payouts.
+
+**State machine:** `proposed -> accepted -> announced -> depositing -> concluding -> completed` (or `cancelled`, `failed` at any point).
+
+**Deposit via invoice.** Each party deposits by paying an escrow-created invoice. Payout is verified locally via `verifyPayout()`.
+
 ## Testing
 
 **Framework:** Vitest
-**Total tests:** 1613 (63 test files)
+**Total tests:** 2539 (124 test files)
 
 Key test files:
 - `tests/unit/core/Sphere.nametag-sync.test.ts` - Nametag sync/recovery
@@ -634,6 +584,8 @@ Key test files:
 - `tests/unit/modules/NametagMinter.test.ts` - Nametag minting
 - `tests/unit/modules/CommunicationsModule.storage.test.ts` - DM per-address storage, migration, pagination
 - `tests/unit/modules/CommunicationsModule.resolve.test.ts` - Peer nametag resolution via transport fallback
+- `tests/unit/modules/AccountingModule.*.test.ts` - Invoice lifecycle, status, auto-return, receipts, etc.
+- `tests/unit/modules/SwapModule.*.test.ts` - Swap lifecycle, deposits, payouts, cancellation
 - `tests/unit/registry/TokenRegistry.test.ts` - Token registry: remote fetch, caching, auto-refresh, waitForReady
 - `tests/unit/price/CoinGeckoPriceProvider.test.ts` - Price provider: caching, deduplication, rate-limit backoff, persistent storage, unlisted tokens
 - `tests/unit/l1/*.test.ts` - L1 blockchain utilities (incl. vesting Node.js fallback)
@@ -669,9 +621,10 @@ RELAY_URL=wss://sphere-relay.unicity.network npm run test:relay
 ## File Size Reference
 
 Largest files (for context):
-- `modules/payments/PaymentsModule.ts` - 88KB (main payment logic)
-- `core/Sphere.ts` - 72KB (wallet lifecycle)
-- `transport/NostrTransportProvider.ts` - ~15KB (Nostr messaging)
+- `modules/payments/PaymentsModule.ts` - ~200KB (main payment logic)
+- `core/Sphere.ts` - ~160KB (wallet lifecycle)
+- `modules/swap/SwapModule.ts` - ~150KB (swap lifecycle)
+- `modules/accounting/AccountingModule.ts` - ~130KB (invoice lifecycle)
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ A modular TypeScript SDK for Unicity wallet operations supporting both Layer 1 (
 
 - **Wallet Management** - BIP39/BIP32 key derivation, AES-256 encryption
 - **L1 Payments** - ALPHA blockchain transactions via Fulcrum WebSocket
-- **L3 Payments** - Token transfers with state transition proofs
+- **L3 Payments** - Token transfers with state transition proofs, concurrent-send safety (SpendQueue)
+- **Invoicing / Accounting** - On-chain invoice lifecycle with payment attribution, auto-return, privacy-preserving hashed invoice IDs
+- **Token Swaps** - P2P atomic swaps via escrow with DM-based negotiation protocol
 - **Payment Requests** - Request payments with async response tracking
 - **Group Chat** - NIP-29 relay-based group messaging with moderation
-- **Nostr Transport** - P2P messaging with NIP-04 encryption
+- **Nostr Transport** - Resilient P2P messaging with verified publish, health checks, NIP-17 gift-wrap
 - **IPFS Storage** - Decentralized token backup via HTTP API (browser + Node.js)
-- **Token Splitting** - Partial transfer amount calculations
 - **Multi-Address** - HD address derivation (BIP32/BIP44)
-- **TXF Serialization** - Token eXchange Format for storage and transfer
 - **Token Validation** - Aggregator-based token verification
-- **Core Utilities** - Crypto, currency, bech32, base58 functions
 - **Connect Protocol** - dApp ↔ wallet communication via `ConnectClient` / `ConnectHost` (browser extension + popup)
+- **CLI** - Comprehensive command-line interface with shell auto-completion
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ npm run cli -- receive
 npm run cli -- receive --finalize
 
 # Send tokens (instant mode, default)
-npm run cli -- send @alice 1 --coin UCT --instant
+npm run cli -- send @alice 1 UCT --instant
 
 # Send tokens (conservative mode — collect all proofs first)
-npm run cli -- send @alice 1 --coin UCT --conservative
+npm run cli -- send @alice 1 UCT --conservative
 
 # Request test tokens from faucet
 npm run cli -- topup
@@ -101,9 +101,9 @@ npm run cli -- verify-balance
 | **Balance** | `balance [--finalize]` | Show L3 token balance (--finalize: fetch pending + resolve) |
 | | `tokens` | List all tokens with details |
 | | `l1-balance` | Show L1 (ALPHA) balance |
-| | `topup [coin] [amount]` | Request test tokens from faucet |
+| | `topup [<amount> <symbol>]` | Request test tokens from faucet |
 | | `verify-balance [--remove] [-v]` | Verify tokens against aggregator |
-| **Transfers** | `send <to> <amount> [--coin SYM] [--instant\|--conservative]` | Send tokens |
+| **Transfers** | `send <to> <amount> <symbol> [--instant\|--conservative]` | Send tokens |
 | | `receive [--finalize]` | Check for incoming transfers |
 | | `history [limit]` | Show transaction history |
 | **Nametags** | `nametag <name>` | Register a nametag |
@@ -115,6 +115,8 @@ npm run cli -- verify-balance
 | | `parse-wallet <file>` | Parse wallet file |
 
 CLI data is stored in `./.sphere-cli/` directory.
+
+> **Shell completion:** Run `npm link && sphere-cli completions bash >> ~/.bashrc` for tab-completion of all commands. See [CLI Quickstart](docs/QUICKSTART-CLI.md) for details.
 
 ## Quick Start
 

--- a/cli/bin.mjs
+++ b/cli/bin.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// Wrapper for sphere-cli that uses tsx to run TypeScript directly
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, 'index.ts');
+
+try {
+  execFileSync('npx', ['tsx', cliPath, ...process.argv.slice(2)], {
+    stdio: 'inherit',
+    cwd: join(__dirname, '..'),
+  });
+} catch (err) {
+  process.exit(err.status || 1);
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -189,6 +189,8 @@ async function getSphere(options?: { autoGenerate?: boolean; mnemonic?: string; 
     nametag: options?.nametag,
     market: true,
     groupChat: true,
+    accounting: true,
+    swap: true,
   });
 
   sphereInstance = result.sphere;
@@ -208,19 +210,131 @@ async function closeSphere(): Promise<void> {
   }
 }
 
-async function syncIfEnabled(sphere: Sphere, skip: boolean): Promise<void> {
-  if (skip) return;
+/** Push local state changes to IPFS after write operations. Tolerates failures. */
+async function syncAfterWrite(sphere: Sphere): Promise<void> {
   try {
-    console.log('Syncing with IPFS...');
-    const result = await sphere.payments.sync();
-    if (result.added > 0 || result.removed > 0) {
-      console.log(`  Synced: +${result.added} added, -${result.removed} removed`);
-    } else {
-      console.log('  Up to date.');
-    }
-  } catch (err) {
-    console.warn(`  Sync warning: ${err instanceof Error ? err.message : err}`);
+    await sphere.payments.sync();
+  } catch {
+    // Tolerated — IPFS may be unavailable
   }
+}
+
+/**
+ * Resolve a coin identifier (symbol, name, or hex ID) to its registry definition.
+ * Tries symbol first, then name, then raw hex ID.
+ * Exits with error if not found.
+ */
+function resolveCoin(identifier: string): { coinId: string; symbol: string; decimals: number; name: string } {
+  const registry = TokenRegistry.getInstance();
+  let def = registry.getDefinitionBySymbol(identifier);
+  if (!def) def = registry.getDefinitionByName(identifier);
+  if (!def) def = registry.getDefinition(identifier);
+  if (!def) {
+    console.error(`Unknown asset: "${identifier}"`);
+    console.error('Use "npm run cli -- assets" to list all registered assets.');
+    process.exit(1);
+  }
+  return {
+    coinId: def.id,
+    symbol: def.symbol || identifier,
+    decimals: def.decimals ?? 8,
+    name: def.name || identifier,
+  };
+}
+
+/**
+ * Parse an asset argument in "<amount> <symbol>" format.
+ * Examples: "1000000 UCT", "10.5 BTC", "500000 USDU"
+ */
+/**
+ * Resolve a swap ID prefix to a full 64-char swap ID.
+ * Accepts full IDs or unique prefixes (like invoice commands do).
+ */
+
+function parseAssetArg(value: string): { amount: string; coin: string } {
+  const parts = value.trim().split(/\s+/);
+  if (parts.length !== 2) {
+    console.error(`Invalid asset format: "${value}". Expected "<amount> <symbol>" (e.g., "1000000 UCT")`);
+    process.exit(1);
+  }
+  return { amount: parts[0], coin: parts[1] };
+}
+
+/** Map common symbols to faucet coin names. */
+const FAUCET_COIN_MAP: Record<string, string> = {
+  'UCT': 'unicity', 'BTC': 'bitcoin', 'ETH': 'ethereum',
+  'SOL': 'solana', 'USDT': 'tether', 'USDC': 'usd-coin',
+  'USDU': 'unicity-usd', 'EURU': 'unicity-eur', 'ALPHT': 'alpha-token',
+};
+
+/**
+ * Ensure wallet state is synced before reading:
+ * 1. Wait for Nostr transport to deliver pending wallet events (DMs, transfers)
+ * 2. Process incoming transfers (receive)
+ * 3. Sync with IPFS
+ *
+ * Replaces the old syncIfEnabled(). All CLI commands that read wallet state
+ * should call this before accessing in-memory data.
+ */
+/**
+ * Sync wallet state before executing a command.
+ * All sync steps tolerate failures (Nostr timeout, IPFS unreachable).
+ * Nostr WRITES (sendDM in swap-propose, swap-accept) propagate errors
+ * naturally through the SwapModule — they are NOT part of this sync.
+ *
+ * Two sync modes:
+ *
+ * - **'nostr'**: Fetch pending Nostr events only (DMs: swap proposals,
+ *   invoice receipts, escrow messages, transfer notifications).
+ *   Used by: swap-list, swap-accept, swap-status, receive, dm-inbox, dm-history.
+ *
+ * - **'full'**: Nostr fetch + receive incoming transfers + IPFS sync.
+ *   Gives the most up-to-date token inventory and invoice state.
+ *   Used by: send, balance, tokens, history, verify-balance, sync,
+ *   invoice-pay, invoice-close, invoice-cancel, invoice-transfers, swap-deposit.
+ */
+async function ensureSync(sphere: Sphere, mode: 'nostr' | 'full'): Promise<void> {
+  console.log('Syncing...');
+
+  // Step 1: Always fetch pending Nostr events through the multi-address
+  // transport mux. This ensures DMs (swap proposals, invoice receipts,
+  // escrow messages) are delivered to all module handlers.
+  // Tolerates relay being down — continues after timeout.
+  try {
+    await sphere.fetchPendingEvents();
+    // Allow async DM handlers (swap proposal processing, invoice import, etc.)
+    // to complete before reading in-memory state. These fire-and-forget handlers
+    // resolve addresses, validate manifests, and persist state asynchronously.
+    await new Promise(resolve => setTimeout(resolve, 500));
+  } catch {
+    // Tolerated — relay may be unreachable for reads
+  }
+
+  if (mode === 'full') {
+    // Step 2: Process incoming token transfers via Nostr.
+    // Tolerates failures — tokens may arrive later.
+    try {
+      const result = await sphere.payments.receive();
+      if (result.transfers?.length > 0) {
+        console.log(`  Received ${result.transfers.length} transfer(s)`);
+      }
+    } catch {
+      // Tolerated
+    }
+
+    // Step 3: Sync with IPFS remote storage.
+    // Tolerates IPFS being down for both read and write.
+    try {
+      const result = await sphere.payments.sync();
+      if (result.added > 0 || result.removed > 0) {
+        console.log(`  IPFS: +${result.added} added, -${result.removed} removed`);
+      }
+    } catch {
+      // Tolerated — IPFS may be unavailable
+    }
+  }
+
+  console.log('  Ready.');
 }
 
 // =============================================================================
@@ -240,202 +354,1137 @@ function _prompt(question: string): Promise<string> {
   });
 }
 
+// =============================================================================
+// Per-command help definitions
+// =============================================================================
+
+interface CommandHelp {
+  usage: string;
+  description: string;
+  flags?: Array<{ flag: string; description: string; default?: string }>;
+  examples: string[];
+  notes?: string[];
+}
+
+const COMMAND_HELP: Record<string, CommandHelp> = {
+  // --- WALLET ---
+  'init': {
+    usage: 'init [--network <net>] [--mnemonic "<words>"] [--nametag <name>]',
+    description: 'Create a new wallet or import an existing one from a mnemonic phrase. If no mnemonic is provided, a new 24-word mnemonic is generated automatically.',
+    flags: [
+      { flag: '--network <net>', description: 'Network to use (mainnet, testnet, dev)', default: 'testnet' },
+      { flag: '--mnemonic "<words>"', description: 'Import wallet from BIP-39 mnemonic phrase (24 words in quotes)' },
+      { flag: '--nametag <name>', description: 'Register a nametag during initialization (mints on-chain)' },
+      { flag: '--no-nostr', description: 'Disable Nostr transport (use no-op transport)' },
+    ],
+    examples: [
+      'npm run cli -- init --network testnet',
+      'npm run cli -- init --mnemonic "word1 word2 ... word24"',
+      'npm run cli -- init --nametag alice --network mainnet',
+    ],
+    notes: [
+      'If a wallet already exists in the current profile, it will be loaded instead of creating a new one.',
+      'Back up the generated mnemonic immediately -- it cannot be retrieved later.',
+    ],
+  },
+  'status': {
+    usage: 'status',
+    description: 'Show wallet identity information including L1 address, Direct address, chain public key, nametag, and current network/profile.',
+    examples: [
+      'npm run cli -- status',
+    ],
+  },
+  'config': {
+    usage: 'config [set <key> <value>]',
+    description: 'Show current CLI configuration or update a specific setting. Without arguments, displays all config values as JSON.',
+    flags: [
+      { flag: 'set network <value>', description: 'Set network (mainnet, testnet, dev)' },
+      { flag: 'set dataDir <path>', description: 'Set wallet data directory path' },
+      { flag: 'set tokensDir <path>', description: 'Set token storage directory path' },
+    ],
+    examples: [
+      'npm run cli -- config',
+      'npm run cli -- config set network mainnet',
+      'npm run cli -- config set dataDir ./.my-wallet',
+    ],
+  },
+  'clear': {
+    usage: 'clear',
+    description: 'Delete all wallet data including keys, tokens, and storage. This is irreversible -- make sure you have your mnemonic backed up.',
+    examples: [
+      'npm run cli -- clear',
+    ],
+    notes: [
+      'This deletes everything in the current profile data and token directories.',
+    ],
+  },
+  'wallet': {
+    usage: 'wallet <subcommand>',
+    description: 'Manage wallet profiles. Each profile has its own data directory, token storage, and network configuration.',
+    examples: [
+      'npm run cli -- wallet list',
+      'npm run cli -- wallet create myprofile',
+      'npm run cli -- wallet use myprofile',
+      'npm run cli -- wallet current',
+      'npm run cli -- wallet delete myprofile',
+    ],
+    notes: [
+      'Subcommands: list, create, use, current, delete',
+      'Use "help wallet <subcommand>" for detailed help on each.',
+    ],
+  },
+  'wallet list': {
+    usage: 'wallet list',
+    description: 'List all wallet profiles with their network and data directory. The current active profile is marked with an arrow.',
+    examples: [
+      'npm run cli -- wallet list',
+    ],
+  },
+  'wallet create': {
+    usage: 'wallet create <name> [--network <net>]',
+    description: 'Create a new wallet profile and switch to it. The profile stores its data in .sphere-cli-<name>/. After creating, run "init" to initialize the wallet.',
+    flags: [
+      { flag: '--network <net>', description: 'Network for the profile (mainnet, testnet, dev)', default: 'testnet' },
+    ],
+    examples: [
+      'npm run cli -- wallet create alice',
+      'npm run cli -- wallet create bob --network mainnet',
+    ],
+    notes: [
+      'Profile names must be unique. After creation, initialize with: npm run cli -- init --nametag <name>',
+    ],
+  },
+  'wallet use': {
+    usage: 'wallet use <name>',
+    description: 'Switch the active wallet profile. All subsequent commands will operate on this profile.',
+    examples: [
+      'npm run cli -- wallet use alice',
+    ],
+  },
+  'wallet current': {
+    usage: 'wallet current',
+    description: 'Show the currently active wallet profile, its network, data directory, and identity (if initialized).',
+    examples: [
+      'npm run cli -- wallet current',
+    ],
+  },
+  'wallet delete': {
+    usage: 'wallet delete <name>',
+    description: 'Remove a wallet profile from the profiles list. The on-disk data directory is NOT deleted -- remove it manually if needed.',
+    examples: [
+      'npm run cli -- wallet delete bob',
+    ],
+    notes: [
+      'Cannot delete the currently active profile. Switch to a different profile first.',
+    ],
+  },
+
+  // --- BALANCE & TOKENS ---
+  'balance': {
+    usage: 'balance [--finalize] [--no-sync]',
+    description: 'Show L3 token balance grouped by coin. Receives any pending incoming transfers before displaying. Shows confirmed and unconfirmed amounts, token counts, and USD value.',
+    flags: [
+      { flag: '--finalize', description: 'Wait for unconfirmed tokens to be finalized (may take several seconds)' },
+      { flag: '--no-sync', description: 'Skip IPFS sync before showing balance' },
+    ],
+    examples: [
+      'npm run cli -- balance',
+      'npm run cli -- balance --finalize',
+      'npm run cli -- balance --no-sync',
+    ],
+  },
+  'tokens': {
+    usage: 'tokens [--no-sync]',
+    description: 'List all individual tokens with their ID, coin type, amount, and status.',
+    flags: [
+      { flag: '--no-sync', description: 'Skip IPFS sync before listing tokens' },
+    ],
+    examples: [
+      'npm run cli -- tokens',
+      'npm run cli -- tokens --no-sync',
+    ],
+  },
+  'assets': {
+    usage: 'assets [--type <fungible|nft>]',
+    description: 'List all registered assets (coins and NFTs) from the token registry. Shows symbol, name, kind, decimals, and coin ID.',
+    flags: [
+      { flag: '--type <kind>', description: 'Filter by asset kind: fungible (or coin/coins), nft (or nfts/non-fungible)' },
+    ],
+    examples: [
+      'npm run cli -- assets',
+      'npm run cli -- assets --type fungible',
+      'npm run cli -- assets --type nft',
+    ],
+    notes: [
+      'Requires wallet initialization (to load the token registry from the network).',
+      'The registry is fetched from a remote URL and cached locally.',
+    ],
+  },
+  'asset-info': {
+    usage: 'asset-info <symbol|name|coinId>',
+    description: 'Show detailed information for a specific asset. Looks up by symbol (UCT), name (bitcoin), or coin ID hex.',
+    examples: [
+      'npm run cli -- asset-info UCT',
+      'npm run cli -- asset-info bitcoin',
+      'npm run cli -- asset-info 0a1b2c3d4e5f...',
+    ],
+    notes: [
+      'Use "assets" command first to see all available assets.',
+      'Lookup is case-insensitive for symbols and names.',
+    ],
+  },
+  'l1-balance': {
+    usage: 'l1-balance',
+    description: 'Show L1 (ALPHA blockchain) balance including confirmed and unconfirmed amounts. Connects to Fulcrum electrum server on first use.',
+    examples: [
+      'npm run cli -- l1-balance',
+    ],
+  },
+  'topup': {
+    usage: 'topup [<amount> <coin>]',
+    description: 'Request test tokens from the Unicity faucet. Without arguments, requests default amounts of all supported coins. With amount and coin, requests a specific coin.',
+    flags: [
+      { flag: '<amount>', description: 'Amount to request (numeric)' },
+      { flag: '<coin>', description: 'Coin symbol (UCT, BTC, ETH, SOL, USDT, USDC, USDU, EURU, ALPHT) or faucet name (unicity, bitcoin, ethereum, solana, tether, usd-coin, unicity-usd)' },
+    ],
+    examples: [
+      'npm run cli -- topup',
+      'npm run cli -- topup 100 UCT',
+      'npm run cli -- topup 2 BTC',
+      'npm run cli -- topup 42 ETH',
+    ],
+    notes: [
+      'Requires a registered nametag. The faucet is only available on testnet.',
+      'Also accessible as "top-up" or "faucet".',
+    ],
+  },
+  'top-up': {
+    usage: 'top-up [<amount> <coin>]',
+    description: 'Alias for "topup". Request test tokens from the Unicity faucet.',
+    examples: [
+      'npm run cli -- top-up',
+      'npm run cli -- top-up 2 BTC',
+    ],
+    notes: [
+      'This is an alias for the "topup" command. See "help topup" for full details.',
+    ],
+  },
+  'faucet': {
+    usage: 'faucet [<amount> <coin>]',
+    description: 'Alias for "topup". Request test tokens from the Unicity faucet.',
+    examples: [
+      'npm run cli -- faucet',
+      'npm run cli -- faucet 100 ETH',
+    ],
+    notes: [
+      'This is an alias for the "topup" command. See "help topup" for full details.',
+    ],
+  },
+  'verify-balance': {
+    usage: 'verify-balance [--remove] [-v|--verbose]',
+    description: 'Verify all tokens against the aggregator to detect spent tokens that were not properly removed from local storage. Useful for cleaning up stale token state.',
+    flags: [
+      { flag: '--remove', description: 'Move detected spent tokens to the Sent (archive) folder' },
+      { flag: '-v, --verbose', description: 'Show all tokens, not just spent ones; show progress and errors' },
+    ],
+    examples: [
+      'npm run cli -- verify-balance',
+      'npm run cli -- verify-balance --verbose',
+      'npm run cli -- verify-balance --remove',
+    ],
+  },
+  'sync': {
+    usage: 'sync',
+    description: 'Sync tokens with IPFS remote storage. Uploads local tokens and downloads any tokens stored remotely.',
+    examples: [
+      'npm run cli -- sync',
+    ],
+  },
+
+  // --- TRANSFERS ---
+  'send': {
+    usage: 'send <recipient> <amount> <coin> [--direct|--proxy] [--instant|--conservative] [--no-sync]',
+    description: 'Send L3 tokens to a recipient. The recipient can be a @nametag, DIRECT:// address, chain public key (02/03 prefix), or alpha1... L1 address. Amount is in decimal (e.g., 0.5) and is converted to smallest units automatically.',
+    flags: [
+      { flag: '<coin>', description: 'Asset symbol (UCT, BTC) as positional argument after amount', default: 'UCT' },
+      { flag: '--direct', description: 'Force DirectAddress transfer (requires nametag with directAddress)' },
+      { flag: '--proxy', description: 'Force PROXY address transfer (works with any nametag)' },
+      { flag: '--instant', description: 'Send immediately via Nostr; receiver gets unconfirmed token', default: 'yes' },
+      { flag: '--conservative', description: 'Collect all proofs first; receiver gets confirmed token' },
+      { flag: '--no-sync', description: 'Skip IPFS sync after sending' },
+    ],
+    examples: [
+      'npm run cli -- send @alice 10 UCT',
+      'npm run cli -- send @alice 0.5 BTC',
+      'npm run cli -- send DIRECT://0000be36... 500000 UCT --conservative',
+      'npm run cli -- send @bob 100 USDU --no-sync',
+    ],
+    notes: [
+      'Cannot use both --direct and --proxy simultaneously.',
+      'Cannot use both --instant and --conservative simultaneously.',
+    ],
+  },
+  'receive': {
+    usage: 'receive [--finalize] [--no-sync]',
+    description: 'Check for incoming token transfers via Nostr. Displays receive addresses and fetches any pending transfers.',
+    flags: [
+      { flag: '--finalize', description: 'Wait for unconfirmed tokens to be finalized before returning' },
+      { flag: '--no-sync', description: 'Skip IPFS sync after receiving' },
+    ],
+    examples: [
+      'npm run cli -- receive',
+      'npm run cli -- receive --finalize',
+    ],
+  },
+  'history': {
+    usage: 'history [limit] [--no-sync]',
+    description: 'Show transaction history ordered by most recent first. Each entry shows date, direction, amount, coin, and counterparty.',
+    flags: [
+      { flag: '<limit>', description: 'Maximum number of transactions to show', default: '10' },
+      { flag: '--no-sync', description: 'Skip sync before showing history' },
+    ],
+    examples: [
+      'npm run cli -- history',
+      'npm run cli -- history 20',
+    ],
+  },
+
+  // --- ADDRESSES ---
+  'addresses': {
+    usage: 'addresses',
+    description: 'List all tracked HD addresses with their index, L1 address, DIRECT address, nametag, and hidden status. The currently active address is marked with an arrow.',
+    examples: [
+      'npm run cli -- addresses',
+    ],
+  },
+  'switch': {
+    usage: 'switch <index>',
+    description: 'Switch to a different HD-derived address by index. Index 0 is the default. New addresses are created on first switch.',
+    examples: [
+      'npm run cli -- switch 1',
+      'npm run cli -- switch 0',
+    ],
+  },
+  'hide': {
+    usage: 'hide <index>',
+    description: 'Hide an address from the active address list. Hidden addresses are excluded from getActiveAddresses() but still tracked.',
+    examples: [
+      'npm run cli -- hide 2',
+    ],
+  },
+  'unhide': {
+    usage: 'unhide <index>',
+    description: 'Unhide a previously hidden address, making it visible in the active address list again.',
+    examples: [
+      'npm run cli -- unhide 2',
+    ],
+  },
+
+  // --- NAMETAGS ---
+  'nametag': {
+    usage: 'nametag <name>',
+    description: 'Register a nametag (@name) for the current address. Mints a nametag token on-chain and publishes to Nostr relay. The name should not include the @ prefix.',
+    examples: [
+      'npm run cli -- nametag alice',
+      'npm run cli -- nametag myname',
+    ],
+  },
+  'nametag-info': {
+    usage: 'nametag-info <name>',
+    description: 'Look up information about a nametag, including the associated public key and addresses. Resolves via the Nostr relay.',
+    examples: [
+      'npm run cli -- nametag-info alice',
+      'npm run cli -- nametag-info bob',
+    ],
+  },
+  'my-nametag': {
+    usage: 'my-nametag',
+    description: 'Show the nametag registered for the current address.',
+    examples: [
+      'npm run cli -- my-nametag',
+    ],
+  },
+  'nametag-sync': {
+    usage: 'nametag-sync',
+    description: 'Re-publish the current nametag identity binding with chainPubkey. Useful for fixing legacy nametags that were registered without the chainPubkey field.',
+    examples: [
+      'npm run cli -- nametag-sync',
+    ],
+  },
+
+  // --- MESSAGING ---
+  'dm': {
+    usage: 'dm <@nametag|pubkey> <message>',
+    description: 'Send an encrypted direct message to a peer via Nostr (NIP-17 gift-wrapped).',
+    examples: [
+      'npm run cli -- dm @alice "Hello, how are you?"',
+      'npm run cli -- dm @bob "Payment sent for order #42"',
+    ],
+  },
+  'dm-inbox': {
+    usage: 'dm-inbox',
+    description: 'List all DM conversations with unread counts and last message preview.',
+    examples: [
+      'npm run cli -- dm-inbox',
+    ],
+  },
+  'dm-history': {
+    usage: 'dm-history <@nametag|pubkey> [--limit <n>]',
+    description: 'Show message history for a specific conversation. Resolves @nametag to pubkey automatically.',
+    flags: [
+      { flag: '--limit <n>', description: 'Maximum number of messages to display', default: '50' },
+    ],
+    examples: [
+      'npm run cli -- dm-history @alice',
+      'npm run cli -- dm-history @alice --limit 20',
+    ],
+  },
+
+  // --- GROUP CHAT ---
+  'group-create': {
+    usage: 'group-create <name> [--description <text>] [--private]',
+    description: 'Create a new NIP-29 group chat on the relay.',
+    flags: [
+      { flag: '--description <text>', description: 'Group description text' },
+      { flag: '--private', description: 'Create a private (invite-only) group' },
+    ],
+    examples: [
+      'npm run cli -- group-create "Trading Chat"',
+      'npm run cli -- group-create "Team Alpha" --description "Internal team chat" --private',
+    ],
+  },
+  'group-list': {
+    usage: 'group-list',
+    description: 'List all available public groups on the relay with their names, IDs, descriptions, and member counts.',
+    examples: [
+      'npm run cli -- group-list',
+    ],
+  },
+  'group-my': {
+    usage: 'group-my',
+    description: 'List groups you have joined, with unread message counts and last message preview.',
+    examples: [
+      'npm run cli -- group-my',
+    ],
+  },
+  'group-join': {
+    usage: 'group-join <groupId> [--invite <code>]',
+    description: 'Join a group by its ID. Private groups require an invite code.',
+    flags: [
+      { flag: '--invite <code>', description: 'Invite code for private groups' },
+    ],
+    examples: [
+      'npm run cli -- group-join tradingchat',
+      'npm run cli -- group-join privatechat --invite abc123',
+    ],
+  },
+  'group-leave': {
+    usage: 'group-leave <groupId>',
+    description: 'Leave a group you have previously joined.',
+    examples: [
+      'npm run cli -- group-leave tradingchat',
+    ],
+  },
+  'group-send': {
+    usage: 'group-send <groupId> <message> [--reply <eventId>]',
+    description: 'Send a message to a group. Optionally reply to a specific message by event ID.',
+    flags: [
+      { flag: '--reply <eventId>', description: 'Event ID of the message to reply to' },
+    ],
+    examples: [
+      'npm run cli -- group-send tradingchat "Hello everyone!"',
+      'npm run cli -- group-send tradingchat "I agree" --reply abc123def',
+    ],
+  },
+  'group-messages': {
+    usage: 'group-messages <groupId> [--limit <n>]',
+    description: 'Show recent messages in a group. Fetches from relay and marks the group as read.',
+    flags: [
+      { flag: '--limit <n>', description: 'Maximum number of messages to display', default: '50' },
+    ],
+    examples: [
+      'npm run cli -- group-messages tradingchat',
+      'npm run cli -- group-messages tradingchat --limit 20',
+    ],
+  },
+  'group-members': {
+    usage: 'group-members <groupId>',
+    description: 'List members of a group with their nametags, roles (ADMIN/MOD), and join dates.',
+    examples: [
+      'npm run cli -- group-members tradingchat',
+    ],
+  },
+  'group-info': {
+    usage: 'group-info <groupId>',
+    description: 'Show detailed information about a group including name, visibility, description, member count, creation date, and relay URL.',
+    examples: [
+      'npm run cli -- group-info tradingchat',
+    ],
+  },
+
+  // --- MARKET ---
+  'market-post': {
+    usage: 'market-post <description> --type <type> [options]',
+    description: 'Post an intent to the market bulletin board. Type is required.',
+    flags: [
+      { flag: '--type <type>', description: 'Intent type: buy, sell, service, announcement, other (required)' },
+      { flag: '--category <cat>', description: 'Intent category for filtering' },
+      { flag: '--price <n>', description: 'Price amount (numeric)' },
+      { flag: '--currency <code>', description: 'Currency code (USD, UCT, etc.)' },
+      { flag: '--location <loc>', description: 'Location for geographic filtering' },
+      { flag: '--contact <handle>', description: 'Contact handle (e.g., @nametag, email)' },
+      { flag: '--expires <days>', description: 'Expiration in days', default: '30' },
+    ],
+    examples: [
+      'npm run cli -- market-post "Buying 100 UCT" --type buy',
+      'npm run cli -- market-post "Selling ETH" --type sell --price 50 --currency USD',
+      'npm run cli -- market-post "Web dev services" --type service --contact @alice',
+    ],
+  },
+  'market-search': {
+    usage: 'market-search <query> [options]',
+    description: 'Search the market bulletin board using semantic search. Returns intents ranked by relevance score.',
+    flags: [
+      { flag: '--type <type>', description: 'Filter by intent type' },
+      { flag: '--category <cat>', description: 'Filter by category' },
+      { flag: '--min-price <n>', description: 'Minimum price filter' },
+      { flag: '--max-price <n>', description: 'Maximum price filter' },
+      { flag: '--min-score <0-1>', description: 'Minimum similarity score threshold' },
+      { flag: '--location <loc>', description: 'Location filter' },
+      { flag: '--limit <n>', description: 'Maximum results to return', default: '10' },
+    ],
+    examples: [
+      'npm run cli -- market-search "UCT tokens" --type sell --limit 5',
+      'npm run cli -- market-search "tokens" --min-score 0.7',
+      'npm run cli -- market-search "services" --min-price 10 --max-price 100',
+    ],
+  },
+  'market-my': {
+    usage: 'market-my',
+    description: 'List all intents you have posted to the market.',
+    examples: [
+      'npm run cli -- market-my',
+    ],
+  },
+  'market-close': {
+    usage: 'market-close <id>',
+    description: 'Close (delete) one of your market intents by its ID.',
+    examples: [
+      'npm run cli -- market-close abc123',
+    ],
+  },
+  'market-feed': {
+    usage: 'market-feed [--rest]',
+    description: 'Watch the live market listing feed via WebSocket. Shows new intents in real time. Use --rest for a one-shot fetch instead.',
+    flags: [
+      { flag: '--rest', description: 'Use REST fallback: fetch recent listings once and exit' },
+    ],
+    examples: [
+      'npm run cli -- market-feed',
+      'npm run cli -- market-feed --rest',
+    ],
+    notes: [
+      'WebSocket mode runs indefinitely. Press Ctrl+C to stop.',
+    ],
+  },
+
+  // --- INVOICES ---
+  'invoice-create': {
+    usage: 'invoice-create --target <address> --asset "<amount> <coin>" [options]',
+    description: 'Create a new invoice by specifying a target address and requested payment. Alternatively, load full terms from a JSON file with --terms. The invoice is minted as an on-chain token.',
+    flags: [
+      { flag: '--target <address>', description: 'Target address (@nametag or DIRECT:// address) (required unless --terms)' },
+      { flag: '--asset "<amount> <coin>"', description: 'Requested asset in "<amount> <symbol>" format (e.g., "1000000 UCT")' },
+      { flag: '--nft <id>', description: 'Request a specific NFT by token ID (instead of coin+amount)' },
+      { flag: '--due <ISO-date>', description: 'Due date in ISO-8601 format (e.g., 2026-12-31)' },
+      { flag: '--memo <text>', description: 'Invoice memo text' },
+      { flag: '--delivery <method>', description: 'Delivery method description' },
+      { flag: '--terms <json-file>', description: 'Load full CreateInvoiceRequest from a JSON file (overrides other flags)' },
+    ],
+    examples: [
+      'npm run cli -- invoice-create --target @alice --asset "1000000 UCT"',
+      'npm run cli -- invoice-create --target @alice --asset "500000 BTC" --memo "Order #42" --due 2026-12-31',
+      'npm run cli -- invoice-create --terms invoice-terms.json',
+    ],
+    notes: [
+      'Amounts must be positive integers in smallest units (no decimals, no leading zeros).',
+    ],
+  },
+  'invoice-import': {
+    usage: 'invoice-import <token-file>',
+    description: 'Import an invoice from a TXF token JSON file. Parses the invoice terms from the token data and adds it to local tracking.',
+    examples: [
+      'npm run cli -- invoice-import ./received-invoice.json',
+    ],
+  },
+  'invoice-list': {
+    usage: 'invoice-list [--state <states>] [--role <creator|payer>] [--limit <n>]',
+    description: 'List invoices with optional filtering by state and role. States can be comma-separated.',
+    flags: [
+      { flag: '--state <states>', description: 'Filter by state: OPEN, PARTIAL, COVERED, CLOSED, CANCELLED, EXPIRED (comma-separated)' },
+      { flag: '--role <role>', description: 'Filter by role: "creator" (invoices you created) or "payer" (invoices targeting you)' },
+      { flag: '--limit <n>', description: 'Maximum number of invoices to return' },
+    ],
+    examples: [
+      'npm run cli -- invoice-list',
+      'npm run cli -- invoice-list --state OPEN,PARTIAL --limit 5',
+      'npm run cli -- invoice-list --role creator',
+    ],
+  },
+  'invoice-status': {
+    usage: 'invoice-status <id-or-prefix>',
+    description: 'Show detailed invoice status including state, per-target balance breakdown, total forward/back payments, and confirmation status. Accepts full ID or unique prefix.',
+    examples: [
+      'npm run cli -- invoice-status a1b2c3d4',
+      'npm run cli -- invoice-status a1b2c3d4e5f6...',
+    ],
+  },
+  'invoice-close': {
+    usage: 'invoice-close <id-or-prefix> [--auto-return]',
+    description: 'Close an invoice (terminal state). Freezes balances and stops dynamic recomputation. Optionally triggers auto-return for overpayments.',
+    flags: [
+      { flag: '--auto-return', description: 'Trigger auto-return of excess payments on close' },
+    ],
+    examples: [
+      'npm run cli -- invoice-close a1b2c3d4',
+      'npm run cli -- invoice-close a1b2c3d4 --auto-return',
+    ],
+  },
+  'invoice-cancel': {
+    usage: 'invoice-cancel <id-or-prefix>',
+    description: 'Cancel an invoice (terminal state). If auto-return is enabled, payments will be automatically refunded.',
+    examples: [
+      'npm run cli -- invoice-cancel a1b2c3d4',
+    ],
+  },
+  'invoice-pay': {
+    usage: 'invoice-pay <id-or-prefix> [--amount <value>] [--target-index <n>]',
+    description: 'Pay an invoice. By default pays the remaining amount for the first target. For multi-target invoices, specify --target-index.',
+    flags: [
+      { flag: '--amount <value>', description: 'Amount to pay in smallest units (positive integer). Defaults to remaining amount.' },
+      { flag: '--target-index <n>', description: 'Target index for multi-target invoices (0-based)', default: '0' },
+    ],
+    examples: [
+      'npm run cli -- invoice-pay a1b2c3d4',
+      'npm run cli -- invoice-pay a1b2c3d4 --amount 500000',
+      'npm run cli -- invoice-pay a1b2c3d4 --target-index 1 --amount 250000',
+    ],
+  },
+  'invoice-return': {
+    usage: 'invoice-return <id-or-prefix> --recipient <address> --asset "<amount> <coin>"',
+    description: 'Manually return a payment to a sender for a specific invoice.',
+    flags: [
+      { flag: '--recipient <address>', description: 'Recipient address or @nametag (required)' },
+      { flag: '--asset "<amount> <coin>"', description: 'Asset to return in "<amount> <symbol>" format (e.g., "100000 UCT")' },
+    ],
+    examples: [
+      'npm run cli -- invoice-return a1b2c3d4 --recipient @bob --asset "100000 UCT"',
+    ],
+  },
+  'invoice-receipts': {
+    usage: 'invoice-receipts <id-or-prefix>',
+    description: 'Send payment receipts via DM to each sender who contributed to this invoice. Typically used after closing an invoice.',
+    examples: [
+      'npm run cli -- invoice-receipts a1b2c3d4',
+    ],
+  },
+  'invoice-notices': {
+    usage: 'invoice-notices <id-or-prefix>',
+    description: 'Send cancellation notice DMs to each sender who contributed to a cancelled invoice.',
+    examples: [
+      'npm run cli -- invoice-notices a1b2c3d4',
+    ],
+  },
+  'invoice-auto-return': {
+    usage: 'invoice-auto-return [--enable|--disable] [--invoice <id>]',
+    description: 'Show or configure auto-return settings. Without flags, displays current settings. Auto-return automatically refunds payments received against closed or cancelled invoices.',
+    flags: [
+      { flag: '--enable', description: 'Enable auto-return' },
+      { flag: '--disable', description: 'Disable auto-return' },
+      { flag: '--invoice <id>', description: 'Target a specific invoice (default: global "*" scope)' },
+    ],
+    examples: [
+      'npm run cli -- invoice-auto-return',
+      'npm run cli -- invoice-auto-return --enable',
+      'npm run cli -- invoice-auto-return --disable --invoice a1b2c3d4',
+    ],
+  },
+  'invoice-transfers': {
+    usage: 'invoice-transfers <id-or-prefix>',
+    description: 'List all transfers related to an invoice in chronological order, including forward payments and returns.',
+    examples: [
+      'npm run cli -- invoice-transfers a1b2c3d4',
+    ],
+  },
+  'invoice-export': {
+    usage: 'invoice-export <id-or-prefix>',
+    description: 'Export an invoice to a JSON file. The file is saved as invoice-<prefix>.json in the current directory.',
+    examples: [
+      'npm run cli -- invoice-export a1b2c3d4',
+    ],
+  },
+  'invoice-parse-memo': {
+    usage: 'invoice-parse-memo <memo-string>',
+    description: 'Parse an invoice memo string (INV:...) and display its decoded fields.',
+    examples: [
+      'npm run cli -- invoice-parse-memo "INV:a1b2c3d4...:F"',
+    ],
+  },
+
+  // --- SWAPS ---
+  'swap-propose': {
+    usage: 'swap-propose --to <recipient> --offer "<amount> <coin>" --want "<amount> <coin>" [options]',
+    description: 'Propose a token swap deal to a counterparty. Both parties deposit tokens into an escrow, which executes the swap atomically.',
+    flags: [
+      { flag: '--to <recipient>', description: 'Counterparty @nametag or address (required)' },
+      { flag: '--offer "<amount> <coin>"', description: 'Asset you are offering (e.g., "10 BTC", "0.5 ETH")' },
+      { flag: '--want "<amount> <coin>"', description: 'Asset you want in return (e.g., "100 USDU", "5 UCT")' },
+      { flag: '--escrow <address>', description: 'Custom escrow address (optional, uses config default)' },
+      { flag: '--timeout <seconds>', description: 'Swap timeout in seconds (60-86400)', default: '3600' },
+      { flag: '--message <text>', description: 'Optional message to the counterparty' },
+    ],
+    examples: [
+      'npm run cli -- swap-propose --to @bob --offer "10 UCT" --want "5 USDU"',
+      'npm run cli -- swap-propose --to @bob --offer "1 BTC" --want "10 ETH" --timeout 7200 --message "Quick trade?"',
+    ],
+    notes: [
+      'Amounts are in human-readable units (e.g., "10 BTC" = 10 whole BTC). Decimals are supported (e.g., "0.5 ETH").',
+    ],
+  },
+  'swap-list': {
+    usage: 'swap-list [--all] [--role <proposer|acceptor>] [--progress <state>]',
+    description: 'List swap deals. By default shows only open and in-progress swaps. Use --all to include completed/cancelled/failed swaps.',
+    flags: [
+      { flag: '--all', description: 'Include terminal states (completed, cancelled, failed)' },
+      { flag: '--role <role>', description: 'Filter by your role: "proposer" or "acceptor"' },
+      { flag: '--progress <state>', description: 'Filter by progress state' },
+    ],
+    examples: [
+      'npm run cli -- swap-list',
+      'npm run cli -- swap-list --all',
+      'npm run cli -- swap-list --role proposer',
+      'npm run cli -- swap-list --all --role proposer',
+    ],
+  },
+  'swap-accept': {
+    usage: 'swap-accept <swap_id_or_prefix> [--deposit] [--no-wait]',
+    description: 'Accept a proposed swap deal. Announces acceptance to the escrow.',
+    flags: [
+      { flag: '--deposit', description: 'Immediately deposit after accepting' },
+      { flag: '--no-wait', description: 'Do not wait for swap completion after depositing (only with --deposit)' },
+    ],
+    examples: [
+      'npm run cli -- swap-accept 3611a464',
+      'npm run cli -- swap-accept 3611a464 --deposit',
+      'npm run cli -- swap-accept 3611a464 --deposit --no-wait',
+    ],
+    notes: [
+      'Accepts full 64-char swap ID or a unique prefix (min 4 chars).',
+      'Without --deposit, run "swap-deposit <id>" separately when ready.',
+    ],
+  },
+  'swap-status': {
+    usage: 'swap-status <swap_id_or_prefix> [--query-escrow]',
+    description: 'Show detailed status of a swap deal including progress, deal terms, and deposit information.',
+    flags: [
+      { flag: '--query-escrow', description: 'Query the escrow service for the latest status' },
+    ],
+    examples: [
+      'npm run cli -- swap-status 3611a464',
+      'npm run cli -- swap-status 3611a464 --query-escrow',
+    ],
+    notes: [
+      'Accepts full 64-char swap ID or a unique prefix (min 4 chars).',
+      'If the swap has an associated deposit invoice, its status is also displayed.',
+    ],
+  },
+  'swap-deposit': {
+    usage: 'swap-deposit <swap_id_or_prefix>',
+    description: 'Deposit tokens into an accepted swap. The swap must be in the "announced" state (accepted and awaiting deposits).',
+    examples: [
+      'npm run cli -- swap-deposit 3611a464',
+    ],
+    notes: [
+      'Accepts full 64-char swap ID or a unique prefix (min 4 chars).',
+    ],
+  },
+
+  'swap-reject': {
+    usage: 'swap-reject <swap_id_or_prefix> [reason]',
+    description: 'Reject an incoming swap proposal. Sends a rejection DM to the proposer and marks the swap as cancelled.',
+    examples: [
+      'npm run cli -- swap-reject 3611a464',
+      'npm run cli -- swap-reject 3611a464 "Price too high"',
+    ],
+    notes: [
+      'Accepts full 64-char swap ID or a unique prefix (min 4 chars).',
+      'Only works on proposals you received (role: acceptor, progress: proposed).',
+      'The optional reason is included in the rejection DM sent to the proposer.',
+    ],
+  },
+  'swap-cancel': {
+    usage: 'swap-cancel <swap_id_or_prefix>',
+    description: 'Cancel a swap you proposed or accepted. Works before deposits are confirmed by the escrow.',
+    examples: [
+      'npm run cli -- swap-cancel 3611a464',
+    ],
+    notes: [
+      'Accepts full 64-char swap ID or a unique prefix (min 4 chars).',
+      'Pre-deposit cancellation is local only (no escrow notification).',
+      'Post-deposit cancellation: escrow handles timeout and returns deposits automatically.',
+    ],
+  },
+
+  // --- DAEMON ---
+  'daemon': {
+    usage: 'daemon <start|stop|status> [options]',
+    description: 'Manage the persistent event listener daemon. The daemon listens for wallet events and triggers configured actions.',
+    examples: [
+      'npm run cli -- daemon start --event transfer:incoming --action auto-receive',
+      'npm run cli -- daemon start --detach --event "*" --action "log:./events.jsonl"',
+      'npm run cli -- daemon stop',
+      'npm run cli -- daemon status',
+    ],
+  },
+  'daemon start': {
+    usage: 'daemon start [options]',
+    description: 'Start the persistent event listener. Can subscribe to specific events and trigger actions (auto-receive, webhook, bash command, or log file).',
+    flags: [
+      { flag: '--config <path>', description: 'Config file path', default: '.sphere-cli/daemon.json' },
+      { flag: '--detach', description: 'Run in background (fork process, PID file, redirect logs)' },
+      { flag: '--log <path>', description: 'Override log file path' },
+      { flag: '--pid <path>', description: 'Override PID file path' },
+      { flag: '--event <type>', description: 'Event type to subscribe to (repeatable). Use "*" for all events.' },
+      { flag: '--action <spec>', description: 'Action to trigger: auto-receive, bash:<cmd>, webhook:<url>, log:<path>' },
+      { flag: '--market-feed', description: 'Also subscribe to the market WebSocket feed' },
+      { flag: '--verbose', description: 'Print full event JSON in logs' },
+    ],
+    examples: [
+      'npm run cli -- daemon start --event transfer:incoming --action auto-receive',
+      'npm run cli -- daemon start --event "transfer:*" --action "webhook:https://example.com/hook" --detach',
+      'npm run cli -- daemon start --event "*" --action "log:./events.jsonl" --verbose',
+      'npm run cli -- daemon start --event message:dm --action "bash:echo DM from \\$SPHERE_SENDER"',
+      'npm run cli -- daemon start --config ./my-daemon.json --detach',
+    ],
+  },
+  'daemon stop': {
+    usage: 'daemon stop',
+    description: 'Stop the running daemon process.',
+    examples: [
+      'npm run cli -- daemon stop',
+    ],
+  },
+  'daemon status': {
+    usage: 'daemon status',
+    description: 'Check if the daemon is currently running and show its PID.',
+    examples: [
+      'npm run cli -- daemon status',
+    ],
+  },
+
+  // --- ENCRYPTION ---
+  'encrypt': {
+    usage: 'encrypt <data> <password>',
+    description: 'Encrypt a string with AES using a password. Outputs the encrypted result as JSON.',
+    examples: [
+      'npm run cli -- encrypt "my secret data" mypassword',
+    ],
+  },
+  'decrypt': {
+    usage: 'decrypt <encrypted-json> <password>',
+    description: 'Decrypt an AES-encrypted JSON blob using a password. Outputs the original plaintext.',
+    examples: [
+      'npm run cli -- decrypt \'{"iv":"...","data":"..."}\' mypassword',
+    ],
+  },
+
+  // --- WALLET PARSING ---
+  'parse-wallet': {
+    usage: 'parse-wallet <file> [password]',
+    description: 'Parse a wallet backup file (.txt or .dat format). If the file is encrypted, a password is required.',
+    examples: [
+      'npm run cli -- parse-wallet wallet.txt',
+      'npm run cli -- parse-wallet wallet.txt mypassword',
+      'npm run cli -- parse-wallet wallet.dat',
+    ],
+  },
+  'wallet-info': {
+    usage: 'wallet-info <file>',
+    description: 'Show metadata about a wallet file: format (.txt, .dat, .json), whether it is encrypted, and other format-specific info.',
+    examples: [
+      'npm run cli -- wallet-info wallet.txt',
+      'npm run cli -- wallet-info backup.dat',
+    ],
+  },
+
+  // --- KEY OPERATIONS ---
+  'generate-key': {
+    usage: 'generate-key',
+    description: 'Generate a random secp256k1 private key and derive the public key, WIF, and L1 address from it.',
+    examples: [
+      'npm run cli -- generate-key',
+    ],
+  },
+  'validate-key': {
+    usage: 'validate-key <hex>',
+    description: 'Validate whether a hex string is a valid secp256k1 private key. Exits with code 0 if valid, 1 if invalid.',
+    examples: [
+      'npm run cli -- validate-key 0a1b2c3d...',
+    ],
+  },
+  'hex-to-wif': {
+    usage: 'hex-to-wif <hex>',
+    description: 'Convert a hex private key to Wallet Import Format (WIF).',
+    examples: [
+      'npm run cli -- hex-to-wif 0a1b2c3d...',
+    ],
+  },
+  'derive-pubkey': {
+    usage: 'derive-pubkey <private-key-hex>',
+    description: 'Derive the compressed secp256k1 public key from a private key.',
+    examples: [
+      'npm run cli -- derive-pubkey 0a1b2c3d...',
+    ],
+  },
+  'derive-address': {
+    usage: 'derive-address <private-key-hex> [index]',
+    description: 'Derive an L1 (alpha1...) address from a private key at the given HD derivation index.',
+    flags: [
+      { flag: '<index>', description: 'HD derivation index', default: '0' },
+    ],
+    examples: [
+      'npm run cli -- derive-address 0a1b2c3d...',
+      'npm run cli -- derive-address 0a1b2c3d... 3',
+    ],
+  },
+
+  // --- CURRENCY ---
+  'to-smallest': {
+    usage: 'to-smallest <amount> <coin>',
+    description: 'Convert a human-readable amount to the smallest unit. Use the coin symbol to apply the correct decimals for a specific asset. Default uses 8 decimals if no coin specified.',
+    flags: [
+      { flag: '<coin>', description: 'Asset symbol (UCT, BTC), name (bitcoin), or hex coin ID. Determines decimal precision.' },
+    ],
+    examples: [
+      'npm run cli -- to-smallest 1.5 UCT',
+      'npm run cli -- to-smallest 0.001 BTC',
+      'npm run cli -- to-smallest 100.5 USDT',
+    ],
+    notes: [
+      'When a coin is provided, the wallet is loaded briefly to access the token registry.',
+    ],
+  },
+  'to-human': {
+    usage: 'to-human <amount> <coin>',
+    description: 'Convert an amount in smallest units back to human-readable format. Use the coin symbol to apply the correct decimals for a specific asset. Default uses 8 decimals if no coin specified.',
+    flags: [
+      { flag: '<coin>', description: 'Asset symbol (UCT, BTC), name (bitcoin), or hex coin ID. Determines decimal precision.' },
+    ],
+    examples: [
+      'npm run cli -- to-human 150000000 UCT',
+      'npm run cli -- to-human 1000000 BTC',
+      'npm run cli -- to-human 1000000 USDT',
+    ],
+    notes: [
+      'When a coin is provided, the wallet is loaded briefly to access the token registry.',
+    ],
+  },
+  'format': {
+    usage: 'format <amount> [decimals]',
+    description: 'Format an amount with the specified number of decimal places.',
+    flags: [
+      { flag: '<decimals>', description: 'Number of decimal places', default: '8' },
+    ],
+    examples: [
+      'npm run cli -- format 150000000',
+      'npm run cli -- format 150000000 6',
+    ],
+  },
+
+  // --- ENCODING ---
+  'base58-encode': {
+    usage: 'base58-encode <hex>',
+    description: 'Encode a hex string to Base58.',
+    examples: [
+      'npm run cli -- base58-encode 0a1b2c3d',
+    ],
+  },
+  'base58-decode': {
+    usage: 'base58-decode <string>',
+    description: 'Decode a Base58 string to hex.',
+    examples: [
+      'npm run cli -- base58-decode 2NEpo7TZRhna',
+    ],
+  },
+};
+
+function printCommandHelp(cmdName: string): void {
+  const help = COMMAND_HELP[cmdName];
+  if (!help) {
+    console.error(`No help available for command: ${cmdName}`);
+    console.error('Run "npm run cli -- help" for a list of all commands.');
+    process.exit(1);
+  }
+
+  console.log(`\n  ${cmdName}\n`);
+  console.log(`  Usage: npm run cli -- ${help.usage}\n`);
+  console.log(`  ${help.description}\n`);
+
+  if (help.flags && help.flags.length > 0) {
+    console.log('  Flags:');
+    const maxFlagLen = Math.max(...help.flags.map(f => f.flag.length));
+    for (const f of help.flags) {
+      const defaultStr = f.default ? ` (default: ${f.default})` : '';
+      console.log(`    ${f.flag.padEnd(maxFlagLen + 2)}${f.description}${defaultStr}`);
+    }
+    console.log('');
+  }
+
+  if (help.examples.length > 0) {
+    console.log('  Examples:');
+    for (const ex of help.examples) {
+      console.log(`    ${ex}`);
+    }
+    console.log('');
+  }
+
+  if (help.notes && help.notes.length > 0) {
+    console.log('  Notes:');
+    for (const note of help.notes) {
+      console.log(`    - ${note}`);
+    }
+    console.log('');
+  }
+}
+
 function printUsage() {
   console.log(`
-Sphere SDK CLI v0.2.2
+Sphere SDK CLI v0.3.0
 
 Usage: npm run cli -- <command> [args...]
    or: npx tsx cli/index.ts <command> [args...]
+   or: npm run cli -- help <command>     Show detailed help for a command
 
-WALLET MANAGEMENT:
-  init [--network <net>]            Create new wallet (mainnet|testnet|dev)
-  init --mnemonic "<words>"         Import wallet from mnemonic
-  status                            Show wallet status and identity
-  clear                             Delete all wallet data (keys + tokens)
-  config                            Show current configuration
-  config set <key> <value>          Set configuration (network, dataDir, tokensDir)
+WALLET:
+  init                              Create or import wallet
+  status                            Show wallet identity
+  config                            Show or set CLI configuration
+  clear                             Delete all wallet data
 
 WALLET PROFILES:
   wallet list                       List all wallet profiles
+  wallet create <name>              Create a new wallet profile
   wallet use <name>                 Switch to a wallet profile
-  wallet create <name> [--network]  Create a new wallet profile
+  wallet current                    Show active profile
   wallet delete <name>              Delete a wallet profile
-  wallet current                    Show current wallet profile
 
 BALANCE & TOKENS:
-  balance [--finalize] [--no-sync]  Show L3 token balance
-                                    --finalize: wait for unconfirmed tokens to be finalized
-                                    --no-sync: skip IPFS sync before showing balance
-  tokens [--no-sync]                List all tokens with details
-  l1-balance                        Show L1 (ALPHA) balance
-  topup [coin] [amount]             Request test tokens from faucet
-                                    Without args: requests all supported coins
-                                    With coin: requests specific coin (bitcoin, ethereum, etc.)
-  verify-balance [--remove] [-v]    Verify tokens against aggregator
-                                    Detects spent tokens not removed from storage
-                                    --remove: Remove spent tokens from storage
-                                    -v/--verbose: Show all tokens, not just spent
-  sync                              Sync tokens with IPFS remote storage
+  balance                           Show L3 token balance
+  tokens                            List individual tokens
+  assets                            List all registered assets (coins & NFTs)
+  asset-info <id>                   Show detailed info for an asset
+  l1-balance                        L1 (ALPHA) balance
+  topup [<amount> <coin>]            Request test tokens from faucet
+  verify-balance                    Detect spent tokens via aggregator
+  sync                              Sync tokens with IPFS
 
 TRANSFERS:
-  send <to> <amount> [options]      Send tokens (to: @nametag or address)
-                                    --coin SYM       Token symbol (UCT/BTC/ETH/SOL)
-                                    --direct         Force DirectAddress transfer
-                                    --proxy          Force PROXY address transfer
-                                    --instant        Send immediately via Nostr (default)
-                                    --conservative   Collect all proofs first, then send
-                                    --no-sync        Skip IPFS sync after sending
-  receive [--finalize] [--no-sync]  Check for incoming transfers
-                                    --finalize: wait for unconfirmed tokens to be finalized
-                                    --no-sync: skip IPFS sync after receiving
-  history [limit]                   Show transaction history
+  send <to> <amount> <coin>         Send L3 tokens
+  receive                           Check for incoming transfers
+  history [limit]                   Transaction history
 
 ADDRESSES:
-  addresses                         List all tracked addresses
-  switch <index>                    Switch to address at HD index
-  hide <index>                      Hide address from active list
+  addresses                         List tracked addresses
+  switch <index>                    Switch to HD address
+  hide <index>                      Hide address
   unhide <index>                    Unhide address
 
 NAMETAGS:
-  nametag <name>                    Register a nametag (@name)
-  nametag-info <name>               Lookup nametag info
+  nametag <name>                    Register a nametag
+  nametag-info <name>               Look up nametag info
   my-nametag                        Show current nametag
-  nametag-sync                      Re-publish nametag with chainPubkey (fixes legacy nametags)
+  nametag-sync                      Re-publish nametag binding to Nostr
 
-MESSAGING (Direct Messages):
-  dm <@nametag> <message>            Send a direct message
-  dm-inbox                           List conversations and unread counts
-  dm-history <@nametag|pubkey>       Show conversation history
-                                     --limit <n>  Max messages (default: 50)
+MESSAGING:
+  dm <@nametag> <message>           Send a direct message
+  dm-inbox                          List conversations and unread counts
+  dm-history <@nametag|pubkey>      Show conversation history
 
-GROUP CHAT (NIP-29):
-  group-create <name>                Create a new group
-                                     --description <text>  Group description
-                                     --private             Create private group
-  group-list                         List available groups on relay
-  group-my                           List your joined groups
-  group-join <groupId>               Join a group
-                                     --invite <code>       Invite code (for private groups)
-  group-leave <groupId>              Leave a group
-  group-send <groupId> <message>     Send a message to a group
-                                     --reply <eventId>     Reply to a message
-  group-messages <groupId>           Show group messages
-                                     --limit <n>           Max messages (default: 50)
-  group-members <groupId>            List group members
-  group-info <groupId>               Show group details
+GROUP CHAT:
+  group-create <name>               Create a new group
+  group-list                        List available groups on relay
+  group-my                          List your joined groups
+  group-join <groupId>              Join a group
+  group-leave <groupId>             Leave a group
+  group-send <groupId> <message>    Send a message to a group
+  group-messages <groupId>          Show group messages
+  group-members <groupId>           List group members
+  group-info <groupId>              Show group details
 
-MARKET (Intent Bulletin Board):
-  market-post <desc> --type <type>     Post an intent (buy, sell, service, announcement, other)
-                                      --category <cat>   Intent category
-                                      --price <n>        Price amount
-                                      --currency <code>  Currency (USD, UCT, etc.)
-                                      --location <loc>   Location filter
-                                      --contact <handle> Contact handle
-                                      --expires <days>   Expiration in days (default: 30)
-  market-search <query>               Search intents (semantic)
-                                      --type <type>      Filter by type
-                                      --category <cat>   Filter by category
-                                      --min-price <n>    Min price filter
-                                      --max-price <n>    Max price filter
-                                      --min-score <0-1>  Min similarity score
-                                      --location <loc>   Location filter
-                                      --limit <n>        Max results (default: 10)
-  market-my                           List your own intents
-  market-close <id>                   Close (delete) an intent
-  market-feed                         Watch the live listing feed (WebSocket)
-                                      --rest              Use REST fallback instead of WebSocket
+MARKET:
+  market-post <desc> --type <type>  Post an intent
+  market-search <query>             Search intents (semantic)
+  market-my                         List your own intents
+  market-close <id>                 Close (delete) an intent
+  market-feed                       Watch the live listing feed
+
+INVOICES:
+  invoice-create                    Create invoice
+  invoice-import <file>             Import invoice from token file
+  invoice-list                      List invoices
+  invoice-status <id>               Show invoice status
+  invoice-pay <id>                  Pay an invoice
+  invoice-close <id>                Close an invoice
+  invoice-cancel <id>               Cancel an invoice
+  invoice-return <id>               Return payment to sender
+  invoice-receipts <id>             Send receipts
+  invoice-notices <id>              Send cancellation notices
+  invoice-auto-return               Show/set auto-return settings
+  invoice-transfers <id>            List related transfers
+  invoice-export <id>               Export invoice to JSON file
+  invoice-parse-memo <memo>         Parse invoice memo string
+
+SWAPS:
+  swap-propose                      Propose a token swap deal
+  swap-list                         List swap deals
+  swap-accept <id|prefix>            Accept a swap deal
+  swap-status <id|prefix>            Show swap status
+  swap-deposit <id|prefix>           Deposit into a swap
+  swap-reject <id|prefix> [reason]  Reject a swap proposal
+  swap-cancel <id|prefix>           Cancel a swap
 
 EVENT DAEMON:
-  daemon start [options]              Start persistent event listener
-                                      --config <path>    Config file (default: .sphere-cli/daemon.json)
-                                      --detach           Run in background (fork, PID file, log redirect)
-                                      --log <path>       Override log file path
-                                      --pid <path>       Override PID file path
-                                      --event <type>     Quick mode: subscribe to event (repeatable)
-                                      --action <spec>    Quick mode: auto-receive, bash:cmd, webhook:url, log:path
-                                      --market-feed      Subscribe to market WebSocket feed
-                                      --verbose          Print full event JSON in logs
-  daemon stop                         Stop running daemon
-  daemon status                       Check if daemon is running
+  daemon start                      Start persistent event listener
+  daemon stop                       Stop running daemon
+  daemon status                     Check if daemon is running
 
-ENCRYPTION:
+UTILITIES:
   encrypt <data> <password>         Encrypt data with password
   decrypt <json> <password>         Decrypt encrypted JSON data
-
-WALLET PARSING:
   parse-wallet <file> [password]    Parse wallet file (.txt, .dat)
-  wallet-info <file>                Show wallet file info (encrypted?, format)
+  wallet-info <file>                Show wallet file info
+  generate-key                      Generate new private key
+  validate-key <key>                Validate a private key
+  hex-to-wif <hex>                  Convert hex to WIF
+  derive-pubkey <key>               Derive public key
+  derive-address <key> [index]      Derive L1 address
+  to-smallest <amount> <coin>       Convert to smallest unit
+  to-human <amount> <coin>          Convert to human-readable
+  format <amount> [decimals]        Format amount
+  base58-encode <hex>               Base58 encode
+  base58-decode <b58>               Base58 decode
 
-KEY OPERATIONS:
-  generate-key                      Generate random private key
-  validate-key <hex>                Validate secp256k1 private key
-  hex-to-wif <hex>                  Convert hex to WIF format
-  derive-pubkey <hex>               Derive public key from private
-  derive-address <hex> [index]      Derive address at index (default: 0)
-
-CURRENCY:
-  to-smallest <amount>              Convert to smallest unit (satoshi)
-  to-human <amount>                 Convert from smallest to human readable
-  format <amount> [decimals]        Format amount with decimals
-
-ENCODING:
-  base58-encode <hex>               Encode hex to base58
-  base58-decode <string>            Decode base58 to hex
+Run "npm run cli -- help <command>" for detailed help on any command.
 
 Examples:
   npm run cli -- init --network testnet
   npm run cli -- init --mnemonic "word1 word2 ... word24"
   npm run cli -- status
   npm run cli -- balance
-  npm run cli -- send @alice 1000000 --coin ETH
+  npm run cli -- send @alice 1000000 ETH
   npm run cli -- nametag myname
   npm run cli -- history 10
-
-Wallet Profile Examples:
-  npm run cli -- wallet create alice              Create profile "alice"
-  npm run cli -- init --nametag alice             Initialize wallet in profile
-  npm run cli -- wallet create bob                Create another profile
-  npm run cli -- init --nametag bob               Initialize second wallet
-  npm run cli -- wallet list                      List all profiles
-  npm run cli -- wallet use alice                 Switch to alice
-  npm run cli -- send @bob 0.1 --coin BTC         Send from alice to bob
-  npm run cli -- wallet use bob                   Switch to bob
-  npm run cli -- balance                          Check bob's balance
-
-Messaging Examples:
-  npm run cli -- dm @alice "Hello, how are you?"
-  npm run cli -- dm-inbox
-  npm run cli -- dm-history @alice --limit 20
-
-Group Chat Examples:
-  npm run cli -- group-list
-  npm run cli -- group-create "Trading Chat" --description "Discuss trades"
-  npm run cli -- group-join <groupId>
-  npm run cli -- group-send <groupId> "Hello everyone!"
-  npm run cli -- group-messages <groupId> --limit 20
-  npm run cli -- group-members <groupId>
-  npm run cli -- group-leave <groupId>
-
-Market Examples:
-  npm run cli -- market-post "Buying 100 UCT" --type buy             Post buy intent
-  npm run cli -- market-post "Selling ETH" --type sell --price 50 --currency USD   Post sell intent
-  npm run cli -- market-post "Web dev services" --type service       Post service intent
-  npm run cli -- market-post "New feature release" --type announcement   Post announcement
-  npm run cli -- market-search "UCT tokens" --type sell --limit 5    Search intents
-  npm run cli -- market-search "tokens" --min-score 0.7              Search with score threshold
-  npm run cli -- market-my                                           List own intents
-  npm run cli -- market-close <id>                                   Close an intent
-  npm run cli -- market-feed                                         Watch live feed
-  npm run cli -- market-feed --rest                                  Fetch recent (REST fallback)
-
-Daemon Examples:
-  npm run cli -- daemon start --event transfer:incoming --action auto-receive
-  npm run cli -- daemon start --event "transfer:*" --action "webhook:https://example.com/hook" --detach
-  npm run cli -- daemon start --event "*" --action "log:./events.jsonl" --verbose
-  npm run cli -- daemon start --event message:dm --action "bash:echo DM from \\$SPHERE_SENDER"
-  npm run cli -- daemon start --config ./my-daemon.json --detach
-  npm run cli -- daemon status
-  npm run cli -- daemon stop
+  npm run cli -- help send
 `);
 }
 
@@ -443,8 +1492,28 @@ async function main() {
   // Global flag: --no-nostr disables Nostr transport (uses no-op)
   noNostrGlobal = args.includes('--no-nostr');
 
-  if (!command || command === 'help' || command === '--help' || command === '-h') {
+  if (!command || command === '--help' || command === '-h') {
     printUsage();
+    process.exit(0);
+  }
+
+  if (command === 'help') {
+    const helpTarget = args[1];
+    if (!helpTarget || helpTarget === '--help' || helpTarget === '-h' || helpTarget === 'help') {
+      printUsage();
+      process.exit(0);
+    }
+    // Try compound key first (e.g., "wallet create", "daemon start")
+    const compoundKey = args[2] ? `${helpTarget} ${args[2]}` : undefined;
+    if (compoundKey && COMMAND_HELP[compoundKey]) {
+      printCommandHelp(compoundKey);
+    } else if (COMMAND_HELP[helpTarget]) {
+      printCommandHelp(helpTarget);
+    } else {
+      console.error(`No help available for command: ${helpTarget}`);
+      console.error('Run "npm run cli -- help" for a list of all commands.');
+      process.exit(1);
+    }
     process.exit(0);
   }
 
@@ -775,7 +1844,7 @@ async function main() {
         const noSync = args.includes('--no-sync');
         const sphere = await getSphere();
 
-        await syncIfEnabled(sphere, noSync);
+        if (!noSync) await ensureSync(sphere, 'full');
 
         console.log(finalize ? '\nFetching and finalizing tokens...' : '\nFetching tokens...');
         const result = await sphere.payments.receive({
@@ -842,7 +1911,7 @@ async function main() {
         const noSync = args.includes('--no-sync');
         const sphere = await getSphere();
 
-        await syncIfEnabled(sphere, noSync);
+        if (!noSync) await ensureSync(sphere, 'full');
 
         const tokens = sphere.payments.getTokens();
         const registry = TokenRegistry.getInstance();
@@ -863,6 +1932,104 @@ async function main() {
             console.log(`  Amount: ${formatted} ${symbol}`);
             console.log(`  Status: ${token.status || 'active'}`);
             console.log('');
+          }
+        }
+        console.log('─'.repeat(50));
+
+        await closeSphere();
+        break;
+      }
+
+      case 'assets': {
+        // Initialize Sphere so TokenRegistry is loaded with remote data
+        const sphere = await getSphere();
+        const registry = TokenRegistry.getInstance();
+        const allDefs = registry.getAllDefinitions();
+
+        const typeFilter = args.indexOf('--type');
+        const filterValue = typeFilter !== -1 ? args[typeFilter + 1] : undefined;
+
+        let defs = allDefs;
+        if (filterValue === 'fungible' || filterValue === 'coin' || filterValue === 'coins') {
+          defs = registry.getFungibleTokens();
+        } else if (filterValue === 'nft' || filterValue === 'nfts' || filterValue === 'non-fungible') {
+          defs = registry.getNonFungibleTokens();
+        }
+
+        if (defs.length === 0) {
+          console.log('No registered assets found.');
+          console.log('The token registry may not have loaded yet. Try again in a moment.');
+        } else {
+          // Table header
+          console.log('');
+          console.log(`${'SYMBOL'.padEnd(10)} ${'NAME'.padEnd(20)} ${'KIND'.padEnd(14)} ${'DECIMALS'.padEnd(10)} ${'COIN ID'}`);
+          console.log('─'.repeat(90));
+
+          // Sort: fungible first (by symbol), then NFTs (by name)
+          const sorted = [...defs].sort((a, b) => {
+            if (a.assetKind !== b.assetKind) return a.assetKind === 'fungible' ? -1 : 1;
+            const aLabel = a.symbol || a.name || a.id;
+            const bLabel = b.symbol || b.name || b.id;
+            return aLabel.localeCompare(bLabel);
+          });
+
+          for (const def of sorted) {
+            const symbol = (def.symbol || '—').padEnd(10);
+            const name = (def.name ? def.name.charAt(0).toUpperCase() + def.name.slice(1) : '—').padEnd(20);
+            const kind = def.assetKind.padEnd(14);
+            const decimals = (def.decimals !== undefined ? String(def.decimals) : '—').padEnd(10);
+            const coinId = def.id.slice(0, 16) + '...';
+            console.log(`${symbol} ${name} ${kind} ${decimals} ${coinId}`);
+          }
+
+          console.log('─'.repeat(90));
+          console.log(`Total: ${defs.length} asset(s)`);
+        }
+
+        await closeSphere();
+        break;
+      }
+
+      case 'asset-info': {
+        const identifier = args[1];
+        if (!identifier) {
+          console.error('Usage: asset-info <symbol|name|coinId>');
+          console.error('Examples:');
+          console.error('  npm run cli -- asset-info UCT');
+          console.error('  npm run cli -- asset-info bitcoin');
+          console.error('  npm run cli -- asset-info 0a1b2c3d...');
+          process.exit(1);
+        }
+
+        // Initialize Sphere so TokenRegistry is loaded
+        const sphere = await getSphere();
+        const registry = TokenRegistry.getInstance();
+
+        // Try multiple lookup strategies
+        let def = registry.getDefinitionBySymbol(identifier);
+        if (!def) def = registry.getDefinitionByName(identifier);
+        if (!def) def = registry.getDefinition(identifier); // by coinId hex
+
+        if (!def) {
+          console.error(`Asset not found: "${identifier}"`);
+          console.error('Use "assets" command to list all registered assets.');
+          process.exit(1);
+        }
+
+        console.log('');
+        console.log('Asset Details');
+        console.log('─'.repeat(50));
+        console.log(`  Symbol:      ${def.symbol || '—'}`);
+        console.log(`  Name:        ${def.name ? def.name.charAt(0).toUpperCase() + def.name.slice(1) : '—'}`);
+        console.log(`  Kind:        ${def.assetKind}`);
+        console.log(`  Decimals:    ${def.decimals !== undefined ? def.decimals : '—'}`);
+        console.log(`  Coin ID:     ${def.id}`);
+        console.log(`  Network:     ${def.network}`);
+        console.log(`  Description: ${def.description || '—'}`);
+        if (def.icons && def.icons.length > 0) {
+          console.log(`  Icons:`);
+          for (const icon of def.icons) {
+            console.log(`    - ${icon.url}`);
           }
         }
         console.log('─'.repeat(50));
@@ -898,6 +2065,7 @@ async function main() {
         const verbose = args.includes('--verbose') || args.includes('-v');
 
         const sphere = await getSphere();
+        await ensureSync(sphere, 'full');
         const tokens = sphere.payments.getTokens();
         const identity = sphere.identity;
 
@@ -1026,7 +2194,7 @@ async function main() {
 
       case 'sync': {
         const sphere = await getSphere();
-        await syncIfEnabled(sphere, false);
+        await ensureSync(sphere, 'full');
         await closeSphere();
         break;
       }
@@ -1035,10 +2203,10 @@ async function main() {
       case 'send': {
         const [, recipient, amountStr] = args;
         if (!recipient || !amountStr) {
-          console.error('Usage: send <recipient> <amount> [--coin <symbol>] [--direct|--proxy] [--instant|--conservative]');
+          console.error('Usage: send <recipient> <amount> <coin> [--direct|--proxy] [--instant|--conservative]');
           console.error('  recipient: @nametag or DIRECT:// address');
           console.error('  amount: decimal amount (e.g., 0.5, 100)');
-          console.error('  --coin: token symbol (e.g., UCT, BTC, ETH, SOL) - default: UCT');
+          console.error('  coin: token symbol (e.g., UCT, BTC, ETH, SOL) - default: UCT');
           console.error('  --direct: force DirectAddress transfer (requires new nametag with directAddress)');
           console.error('  --proxy: force PROXY address transfer (works with any nametag)');
           console.error('  --instant: send via Nostr immediately (default, receiver gets unconfirmed token)');
@@ -1046,9 +2214,13 @@ async function main() {
           process.exit(1);
         }
 
-        // Parse --coin option (symbol like UCT, BTC, ETH)
-        const coinIndex = args.indexOf('--coin');
-        const coinSymbol = coinIndex !== -1 && args[coinIndex + 1] ? args[coinIndex + 1] : 'UCT';
+        // Parse coin: positional arg[3]
+        let coinSymbol: string;
+        if (args[3] && !args[3].startsWith('--')) {
+          coinSymbol = args[3];
+        } else {
+          coinSymbol = 'UCT'; // default
+        }
 
         // Parse --direct and --proxy options
         const forceDirect = args.includes('--direct');
@@ -1069,25 +2241,21 @@ async function main() {
         const transferMode = forceConservative ? 'conservative' as const : 'instant' as const;
 
         // Initialize Sphere first so TokenRegistry is loaded
+        const noSyncSend = args.includes('--no-sync');
         const sphere = await getSphere();
 
-        // Resolve symbol to coinId hex and get decimals
-        const registry = TokenRegistry.getInstance();
-        const coinDef = registry.getDefinitionBySymbol(coinSymbol);
-        if (!coinDef) {
-          console.error(`Unknown coin symbol: ${coinSymbol}`);
-          console.error('Available symbols: UCT, BTC, ETH, SOL, USDT, USDC, USDU, EURU, ALPHT');
-          process.exit(1);
-        }
-        const coinIdHex = coinDef.id;
-        const decimals = coinDef.decimals ?? 8;
+        // Sync token inventory (need latest state for spending)
+        if (!noSyncSend) await ensureSync(sphere, 'full');
+
+        // Resolve symbol/name/hex to coinId and get decimals
+        const { coinId: coinIdHex, symbol: resolvedSymbol, decimals } = resolveCoin(coinSymbol);
 
         // Convert amount to smallest units (supports decimal input like "0.2")
         const amountSmallest = toSmallestUnit(amountStr, decimals).toString();
 
         const modeLabel = addressMode === 'auto' ? '' : ` (${addressMode})`;
         const txModeLabel = forceConservative ? ' [conservative]' : '';
-        console.log(`\nSending ${amountStr} ${coinSymbol} to ${recipient}${modeLabel}${txModeLabel}...`);
+        console.log(`\nSending ${amountStr} ${resolvedSymbol} to ${recipient}${modeLabel}${txModeLabel}...`);
 
         const result = await sphere.payments.send({
           recipient,
@@ -1107,8 +2275,7 @@ async function main() {
 
         // Wait for background tasks (e.g., change token creation from instant split)
         await sphere.payments.waitForPendingOperations();
-        const noSyncSend = args.includes('--no-sync');
-        await syncIfEnabled(sphere, noSyncSend);
+        await syncAfterWrite(sphere);
         await closeSphere();
         break;
       }
@@ -1117,6 +2284,10 @@ async function main() {
         const finalize = args.includes('--finalize');
         const noSyncRecv = args.includes('--no-sync');
         const sphere = await getSphere();
+
+        // Sync from Nostr to get incoming transfers
+        if (!noSyncRecv) await ensureSync(sphere, 'nostr');
+
         const identity = sphere.identity;
 
         if (!identity) {
@@ -1168,16 +2339,18 @@ async function main() {
           console.log(`\nAll tokens finalized in ${(result.finalizationDurationMs / 1000).toFixed(1)}s.`);
         }
 
-        await syncIfEnabled(sphere, noSyncRecv);
+        await syncAfterWrite(sphere);
         await closeSphere();
         break;
       }
 
       case 'history': {
-        const [, limitStr = '10'] = args;
+        const limitStr = (args[1] && !args[1].startsWith('--')) ? args[1] : '10';
         const limit = parseInt(limitStr);
+        const noSync = args.includes('--no-sync');
 
         const sphere = await getSphere();
+        if (!noSync) await ensureSync(sphere, 'full');
         const history = sphere.payments.getHistory();
         const limited = history.slice(0, limit);
 
@@ -1561,20 +2734,34 @@ async function main() {
       case 'to-smallest': {
         const [, amount] = args;
         if (!amount) {
-          console.error('Usage: to-smallest <amount>');
+          console.error('Usage: to-smallest <amount> <coin>');
           process.exit(1);
         }
-        console.log(toSmallestUnit(amount));
+        const coinArgSmallest: string | undefined = (args[2] && !args[2].startsWith('--')) ? args[2] : undefined;
+        let decimalsSmallest = 8;
+        if (coinArgSmallest) {
+          await getSphere();
+          decimalsSmallest = resolveCoin(coinArgSmallest).decimals;
+          await closeSphere();
+        }
+        console.log(toSmallestUnit(amount, decimalsSmallest));
         break;
       }
 
       case 'to-human': {
         const [, amount] = args;
         if (!amount) {
-          console.error('Usage: to-human <amount>');
+          console.error('Usage: to-human <amount> <coin>');
           process.exit(1);
         }
-        console.log(toHumanReadable(amount));
+        const coinArgHuman: string | undefined = (args[2] && !args[2].startsWith('--')) ? args[2] : undefined;
+        let decimalsHuman = 8;
+        if (coinArgHuman) {
+          await getSphere();
+          decimalsHuman = resolveCoin(coinArgHuman).decimals;
+          await closeSphere();
+        }
+        console.log(toHumanReadable(amount, decimalsHuman));
         break;
       }
 
@@ -1623,13 +2810,13 @@ async function main() {
           process.exit(1);
         }
 
-        // Parse options
-        const coinArg = args[1];  // Optional: specific coin
-        const amountArg = args[2]; // Optional: specific amount
+        // Parse options: topup [<amount> <coin>]
+        const amountArg: string | undefined = args[1];
+        const coinArg: string | undefined = args[2];
 
         const FAUCET_URL = 'https://faucet.unicity.network/api/v1/faucet/request';
 
-        // Default amounts for all coins
+        // Default amounts in whole coins (the faucet API converts to smallest units internally).
         const DEFAULT_COINS: Record<string, number> = {
           'unicity': 100,
           'bitcoin': 1,
@@ -1663,10 +2850,11 @@ async function main() {
         }
 
         if (coinArg) {
-          // Request specific coin
-          const coin = coinArg.toLowerCase();
+          // Request specific coin — accept symbols (UCT, BTC) as well as faucet names (unicity, bitcoin)
+          const coin = FAUCET_COIN_MAP[coinArg.toUpperCase()] || coinArg.toLowerCase();
           const amount = amountArg ? parseFloat(amountArg) : (DEFAULT_COINS[coin] || 1);
 
+          // The faucet API converts whole-coin amounts to smallest units internally.
           console.log(`Requesting ${amount} ${coin} from faucet for @${nametag}...`);
           const result = await requestFaucet(coin, amount);
 
@@ -1725,6 +2913,7 @@ async function main() {
 
       case 'dm-inbox': {
         const sphere = await getSphere();
+        await ensureSync(sphere, 'nostr');
         const conversations = sphere.communications.getConversations();
         const totalUnread = sphere.communications.getUnreadCount();
 
@@ -1769,6 +2958,7 @@ async function main() {
         const limit = limitIndex !== -1 && args[limitIndex + 1] ? parseInt(args[limitIndex + 1]) : 50;
 
         const sphere = await getSphere();
+        await ensureSync(sphere, 'nostr');
 
         // Resolve @nametag to pubkey if needed
         let peerPubkey = peer;
@@ -2371,6 +3561,1140 @@ async function main() {
         break;
       }
 
+      // =================================================================
+      // INVOICE MANAGEMENT (AccountingModule)
+      // =================================================================
+
+      case 'invoice-create': {
+        const sphere = await getSphere();
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled. Initialize with accounting support.');
+          process.exit(1);
+        }
+
+        // Parse options
+        const targetIdx = args.indexOf('--target');
+        const assetIdx = args.indexOf('--asset');
+        const nftIdx = args.indexOf('--nft');
+        const dueIdx = args.indexOf('--due');
+        const memoIdx = args.indexOf('--memo');
+        const deliveryIdx = args.indexOf('--delivery');
+        const termsIdx = args.indexOf('--terms');
+
+        if (termsIdx !== -1 && args[termsIdx + 1]) {
+          // Load terms from JSON file
+          const termsFile = args[termsIdx + 1];
+          let termsJson: unknown;
+          try {
+            const resolvedPath = path.resolve(termsFile);
+            const raw = fs.readFileSync(resolvedPath, 'utf8');
+            termsJson = JSON.parse(raw);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            // Sanitize: only show whether it was a file read or JSON parse error
+            if (msg.includes('ENOENT')) {
+              console.error(`File not found: "${termsFile}"`);
+            } else if (msg.includes('EACCES') || msg.includes('EPERM')) {
+              console.error(`Access denied: "${termsFile}"`);
+            } else if (msg.includes('Unexpected token') || msg.includes('JSON')) {
+              console.error(`Invalid JSON in terms file "${termsFile}"`);
+            } else {
+              console.error(`Failed to read terms file "${termsFile}"`);
+            }
+            process.exit(1);
+          }
+          let result;
+          try {
+            result = await sphere.accounting.createInvoice(termsJson as import('../modules/accounting/types').CreateInvoiceRequest);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error(`Failed to create invoice from terms file: ${msg}`);
+            process.exit(1);
+          }
+          console.log('Invoice created:');
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          // Build from individual options
+          if (targetIdx === -1 || !args[targetIdx + 1]) {
+            console.error('Usage: invoice-create --target <address> --asset "<amount> <coin>" [--nft <id>] [--due <ISO-date>] [--memo <text>] [--delivery <method>] [--terms <json-file>]');
+            process.exit(1);
+          }
+          const targetAddress = args[targetIdx + 1];
+          const nftId = nftIdx !== -1 ? args[nftIdx + 1] : undefined;
+          const dueDate = dueIdx !== -1 ? new Date(args[dueIdx + 1]).getTime() : undefined;
+          if (dueDate !== undefined && isNaN(dueDate)) {
+            console.error('Invalid due date format. Use ISO-8601, e.g. 2026-12-31');
+            process.exit(1);
+          }
+          const memo = memoIdx !== -1 ? args[memoIdx + 1] : undefined;
+          const delivery = deliveryIdx !== -1 ? args[deliveryIdx + 1] : undefined;
+
+          const assets: import('../modules/accounting/types').InvoiceRequestedAsset[] = [];
+          if (assetIdx !== -1 && args[assetIdx + 1]) {
+            const parsed = parseAssetArg(args[assetIdx + 1]);
+            if (!/^[1-9][0-9]*$/.test(parsed.amount)) {
+              console.error(`Invalid amount "${parsed.amount}" — must be a positive integer in smallest units (no decimals, no leading zeros)`);
+              process.exit(1);
+            }
+            const { coinId: resolvedCoinId } = resolveCoin(parsed.coin);
+            assets.push({ coin: [resolvedCoinId, parsed.amount] });
+          } else if (nftId) {
+            assets.push({ nft: { tokenId: nftId } });
+          }
+
+          const request: import('../modules/accounting/types').CreateInvoiceRequest = {
+            targets: [{ address: targetAddress, assets }],
+            dueDate,
+            memo,
+            deliveryMethods: delivery ? [delivery] : undefined,
+          };
+          const result = await sphere.accounting.createInvoice(request);
+          console.log('Invoice created:');
+          console.log(JSON.stringify(result, null, 2));
+        }
+
+        await syncAfterWrite(sphere);
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-import': {
+        const tokenFile = args[1];
+        if (!tokenFile) {
+          console.error('Usage: invoice-import <token-file>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+
+        let tokenJson: unknown;
+        try {
+          tokenJson = JSON.parse(fs.readFileSync(path.resolve(tokenFile), 'utf8'));
+        } catch (err: unknown) {
+          // W23-R2 fix: Sanitize error messages to avoid leaking file system paths
+          const code = (err as NodeJS.ErrnoException)?.code;
+          if (code === 'ENOENT') {
+            console.error(`Token file not found: "${tokenFile}"`);
+          } else if (code === 'EACCES') {
+            console.error(`Permission denied reading: "${tokenFile}"`);
+          } else if (err instanceof SyntaxError) {
+            console.error(`Invalid JSON in token file: "${tokenFile}"`);
+          } else {
+            console.error(`Failed to read token file: "${tokenFile}"`);
+          }
+          process.exit(1);
+        }
+
+        let terms;
+        try {
+          terms = await sphere.accounting.importInvoice(tokenJson as import('../types/txf').TxfToken);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`Failed to import invoice: ${msg}`);
+          process.exit(1);
+        }
+        console.log('Invoice imported:');
+        console.log(JSON.stringify(terms, null, 2));
+
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-list': {
+        const sphere = await getSphere();
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+        await ensureSync(sphere, 'nostr');
+
+        const stateIdx = args.indexOf('--state');
+        const limitIdx2 = args.indexOf('--limit');
+        const createdByMe = args.includes('--role') && args[args.indexOf('--role') + 1] === 'creator';
+        const targetingMe = args.includes('--role') && args[args.indexOf('--role') + 1] === 'payer';
+        const stateFilter = stateIdx !== -1 ? args[stateIdx + 1] : undefined;
+
+        const validStates = new Set(['OPEN', 'PARTIAL', 'COVERED', 'CLOSED', 'CANCELLED', 'EXPIRED']);
+        const options: import('../modules/accounting/types').GetInvoicesOptions = {};
+        if (createdByMe) options.createdByMe = true;
+        if (targetingMe) options.targetingMe = true;
+        if (stateFilter) {
+          const stateValues = stateFilter.split(',').map(s => s.trim());
+          const invalid = stateValues.filter(s => !validStates.has(s));
+          if (invalid.length > 0) {
+            console.error(`Invalid state(s): ${invalid.join(', ')}. Valid: ${[...validStates].join(', ')}`);
+            process.exit(1);
+          }
+          options.state = stateValues.length === 1 ? stateValues[0] as any : stateValues as any;
+        }
+        if (limitIdx2 !== -1 && args[limitIdx2 + 1]) {
+          const limit = parseInt(args[limitIdx2 + 1], 10);
+          if (!Number.isNaN(limit) && limit > 0) {
+            options.limit = limit;
+          }
+        }
+
+        const invoices = await sphere.accounting.getInvoices(options);
+
+        if (invoices.length === 0) {
+          console.log('No invoices found.');
+        } else {
+          console.log(`Invoices (${invoices.length}):`);
+          console.log('─'.repeat(60));
+          for (const inv of invoices) {
+            console.log(`ID:        ${inv.invoiceId}`);
+            console.log(`Creator:   ${inv.isCreator ? 'yes' : 'no'}`);
+            console.log(`Cancelled: ${inv.cancelled}`);
+            console.log(`Closed:    ${inv.closed}`);
+            if (inv.terms.dueDate) console.log(`Due:       ${new Date(inv.terms.dueDate).toISOString()}`);
+            if (inv.terms.memo) console.log(`Memo:      ${inv.terms.memo}`);
+            console.log('─'.repeat(60));
+          }
+        }
+
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-status': {
+        const idOrPrefix = args[1];
+        if (!idOrPrefix) {
+          console.error('Usage: invoice-status <id-or-prefix>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+        await ensureSync(sphere, 'nostr');
+
+        // Resolve ID from prefix
+        const allInvoices = await sphere.accounting.getInvoices();
+        const matched = allInvoices.filter(inv => inv.invoiceId.startsWith(idOrPrefix));
+        if (matched.length === 0) {
+          console.error(`No invoice found matching prefix: ${idOrPrefix}`);
+          process.exit(1);
+        }
+        if (matched.length > 1) {
+          console.error(`Ambiguous prefix "${idOrPrefix}" matches ${matched.length} invoices. Use more characters.`);
+          process.exit(1);
+        }
+        const invoiceId = matched[0].invoiceId;
+
+        const status = await sphere.accounting.getInvoiceStatus(invoiceId);
+        console.log('Invoice Status:');
+        console.log(JSON.stringify(status, null, 2));
+
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-close': {
+        const idOrPrefix = args[1];
+        if (!idOrPrefix) {
+          console.error('Usage: invoice-close <id-or-prefix>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        await ensureSync(sphere, 'full');
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+
+        const allInvoices = await sphere.accounting.getInvoices();
+        const matched = allInvoices.filter(inv => inv.invoiceId.startsWith(idOrPrefix));
+        if (matched.length === 0) {
+          console.error(`No invoice found matching prefix: ${idOrPrefix}`);
+          process.exit(1);
+        }
+        if (matched.length > 1) {
+          console.error(`Ambiguous prefix "${idOrPrefix}" matches ${matched.length} invoices.`);
+          process.exit(1);
+        }
+        const invoiceId = matched[0].invoiceId;
+
+        const autoReturn = args.includes('--auto-return');
+        await sphere.accounting.closeInvoice(invoiceId, autoReturn ? { autoReturn: true } : undefined);
+        console.log(`Invoice ${invoiceId} closed.${autoReturn ? ' Auto-return triggered.' : ''}`);
+
+        await syncAfterWrite(sphere);
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-cancel': {
+        const idOrPrefix = args[1];
+        if (!idOrPrefix) {
+          console.error('Usage: invoice-cancel <id-or-prefix>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        await ensureSync(sphere, 'full');
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+
+        const allInvoices = await sphere.accounting.getInvoices();
+        const matched = allInvoices.filter(inv => inv.invoiceId.startsWith(idOrPrefix));
+        if (matched.length === 0) {
+          console.error(`No invoice found matching prefix: ${idOrPrefix}`);
+          process.exit(1);
+        }
+        if (matched.length > 1) {
+          console.error(`Ambiguous prefix "${idOrPrefix}" matches ${matched.length} invoices.`);
+          process.exit(1);
+        }
+        const invoiceId = matched[0].invoiceId;
+
+        await sphere.accounting.cancelInvoice(invoiceId);
+        console.log(`Invoice ${invoiceId} cancelled.`);
+
+        await syncAfterWrite(sphere);
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-pay': {
+        const idOrPrefix = args[1];
+        if (!idOrPrefix) {
+          console.error('Usage: invoice-pay <id-or-prefix> [--amount <value>] [--target-index <n>]');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+        await ensureSync(sphere, 'full');
+
+        const allInvoices = await sphere.accounting.getInvoices();
+        const matched = allInvoices.filter(inv => inv.invoiceId.startsWith(idOrPrefix));
+        if (matched.length === 0) {
+          console.error(`No invoice found matching prefix: ${idOrPrefix}`);
+          process.exit(1);
+        }
+        if (matched.length > 1) {
+          console.error(`Ambiguous prefix "${idOrPrefix}" matches ${matched.length} invoices.`);
+          process.exit(1);
+        }
+        const invoiceId = matched[0].invoiceId;
+
+        const amountIdx2 = args.indexOf('--amount');
+        const targetIndexIdx = args.indexOf('--target-index');
+
+        const rawTargetIdx = targetIndexIdx !== -1 ? args[targetIndexIdx + 1] : undefined;
+        const targetIndex = rawTargetIdx !== undefined ? parseInt(rawTargetIdx, 10) : 0;
+        if (isNaN(targetIndex) || targetIndex < 0) {
+          console.error('--target-index must be a non-negative integer');
+          process.exit(1);
+        }
+
+        const payParams: import('../modules/accounting/types').PayInvoiceParams = {
+          targetIndex,
+        };
+        if (amountIdx2 !== -1 && args[amountIdx2 + 1]) {
+          const rawAmount = args[amountIdx2 + 1];
+          if (!/^[1-9][0-9]*$/.test(rawAmount)) {
+            console.error(`Invalid amount "${rawAmount}" — must be a positive integer in smallest units (no decimals, no leading zeros)`);
+            process.exit(1);
+          }
+          payParams.amount = rawAmount;
+        }
+
+        const result = await sphere.accounting.payInvoice(invoiceId, payParams);
+        console.log('Payment result:');
+        console.log(JSON.stringify({ id: result.id, status: result.status }, null, 2));
+
+        await syncAfterWrite(sphere);
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-return': {
+        const idOrPrefix = args[1];
+        if (!idOrPrefix) {
+          console.error('Usage: invoice-return <id-or-prefix> --recipient <address> --asset "<amount> <coin>"');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        await ensureSync(sphere, 'full');
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+
+        const allInvoices = await sphere.accounting.getInvoices();
+        const matched = allInvoices.filter(inv => inv.invoiceId.startsWith(idOrPrefix));
+        if (matched.length === 0) {
+          console.error(`No invoice found matching prefix: ${idOrPrefix}`);
+          process.exit(1);
+        }
+        if (matched.length > 1) {
+          console.error(`Ambiguous prefix "${idOrPrefix}" matches ${matched.length} invoices.`);
+          process.exit(1);
+        }
+        const invoiceId = matched[0].invoiceId;
+
+        const recipientIdx = args.indexOf('--recipient');
+        const assetIdx3 = args.indexOf('--asset');
+
+        if (recipientIdx === -1 || !args[recipientIdx + 1]) {
+          console.error('--recipient <address> is required for invoice-return');
+          process.exit(1);
+        }
+
+        let returnAmount: string;
+        let returnCoinId: string;
+
+        if (assetIdx3 !== -1 && args[assetIdx3 + 1]) {
+          const parsed = parseAssetArg(args[assetIdx3 + 1]);
+          returnAmount = parsed.amount;
+          returnCoinId = resolveCoin(parsed.coin).coinId;
+        } else {
+          console.error('--asset "<amount> <coin>" is required for invoice-return');
+          process.exit(1);
+        }
+
+        if (!/^[1-9][0-9]*$/.test(returnAmount)) {
+          console.error(`Invalid amount "${returnAmount}" — must be a positive integer string (smallest unit, no leading zeros, e.g. 1000000)`);
+          process.exit(1);
+        }
+
+        const returnParams: import('../modules/accounting/types').ReturnPaymentParams = {
+          recipient: args[recipientIdx + 1],
+          amount: returnAmount,
+          coinId: returnCoinId,
+        };
+
+        const result = await sphere.accounting.returnInvoicePayment(invoiceId, returnParams);
+        console.log('Return payment result:');
+        console.log(JSON.stringify({ id: result.id, status: result.status }, null, 2));
+
+        await syncAfterWrite(sphere);
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-receipts': {
+        const idOrPrefix = args[1];
+        if (!idOrPrefix) {
+          console.error('Usage: invoice-receipts <id-or-prefix>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+
+        const allInvoices = await sphere.accounting.getInvoices();
+        const matched = allInvoices.filter(inv => inv.invoiceId.startsWith(idOrPrefix));
+        if (matched.length === 0) {
+          console.error(`No invoice found matching prefix: ${idOrPrefix}`);
+          process.exit(1);
+        }
+        if (matched.length > 1) {
+          console.error(`Ambiguous prefix "${idOrPrefix}" matches ${matched.length} invoices.`);
+          process.exit(1);
+        }
+        const invoiceId = matched[0].invoiceId;
+
+        const result = await sphere.accounting.sendInvoiceReceipts(invoiceId);
+        console.log('Receipts result:');
+        console.log(JSON.stringify(result, null, 2));
+
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-notices': {
+        const idOrPrefix = args[1];
+        if (!idOrPrefix) {
+          console.error('Usage: invoice-notices <id-or-prefix>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+
+        const allInvoices = await sphere.accounting.getInvoices();
+        const matched = allInvoices.filter(inv => inv.invoiceId.startsWith(idOrPrefix));
+        if (matched.length === 0) {
+          console.error(`No invoice found matching prefix: ${idOrPrefix}`);
+          process.exit(1);
+        }
+        if (matched.length > 1) {
+          console.error(`Ambiguous prefix "${idOrPrefix}" matches ${matched.length} invoices.`);
+          process.exit(1);
+        }
+        const invoiceId = matched[0].invoiceId;
+
+        const result = await sphere.accounting.sendCancellationNotices(invoiceId);
+        console.log('Cancellation notices result:');
+        console.log(JSON.stringify(result, null, 2));
+
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-auto-return': {
+        const sphere = await getSphere();
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+
+        const enableFlag = args.includes('--enable');
+        const disableFlag = args.includes('--disable');
+        const invoiceIdx = args.indexOf('--invoice');
+        // W7-R17 fix: Validate --invoice has a following argument
+        if (invoiceIdx !== -1 && !args[invoiceIdx + 1]) {
+          console.error('--invoice requires an invoice ID');
+          process.exit(1);
+        }
+        const specificInvoice = invoiceIdx !== -1 ? args[invoiceIdx + 1] : undefined;
+
+        if (!enableFlag && !disableFlag) {
+          // Show current settings
+          const settings = sphere.accounting.getAutoReturnSettings();
+          console.log('Auto-return settings:');
+          console.log(JSON.stringify(settings, null, 2));
+        } else if (enableFlag && disableFlag) {
+          console.error('Cannot use both --enable and --disable');
+          process.exit(1);
+        } else {
+          const enabled = enableFlag;
+          const invoiceId = specificInvoice ?? '*';
+          await sphere.accounting.setAutoReturn(invoiceId, enabled);
+          const scope = invoiceId === '*' ? 'globally' : `for invoice ${invoiceId}`;
+          console.log(`Auto-return ${enabled ? 'enabled' : 'disabled'} ${scope}.`);
+        }
+
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-transfers': {
+        const idOrPrefix = args[1];
+        if (!idOrPrefix) {
+          console.error('Usage: invoice-transfers <id-or-prefix>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        await ensureSync(sphere, 'full');
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+
+        const allInvoices = await sphere.accounting.getInvoices();
+        const matched = allInvoices.filter(inv => inv.invoiceId.startsWith(idOrPrefix));
+        if (matched.length === 0) {
+          console.error(`No invoice found matching prefix: ${idOrPrefix}`);
+          process.exit(1);
+        }
+        if (matched.length > 1) {
+          console.error(`Ambiguous prefix "${idOrPrefix}" matches ${matched.length} invoices.`);
+          process.exit(1);
+        }
+        const invoiceId = matched[0].invoiceId;
+
+        const transfers = sphere.accounting.getRelatedTransfers(invoiceId);
+        if (transfers.length === 0) {
+          console.log('No related transfers found.');
+        } else {
+          console.log(`Related transfers (${transfers.length}):`);
+          console.log(JSON.stringify(transfers, null, 2));
+        }
+
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-export': {
+        const idOrPrefix = args[1];
+        if (!idOrPrefix) {
+          console.error('Usage: invoice-export <id-or-prefix>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+
+        const allInvoices = await sphere.accounting.getInvoices();
+        const matched = allInvoices.filter(inv => inv.invoiceId.startsWith(idOrPrefix));
+        if (matched.length === 0) {
+          console.error(`No invoice found matching prefix: ${idOrPrefix}`);
+          process.exit(1);
+        }
+        if (matched.length > 1) {
+          console.error(`Ambiguous prefix "${idOrPrefix}" matches ${matched.length} invoices.`);
+          process.exit(1);
+        }
+        const invoiceId = matched[0].invoiceId;
+
+        // Get the invoice ref via getInvoice
+        const invoiceRef = sphere.accounting.getInvoice(invoiceId);
+        if (!invoiceRef) {
+          console.error(`Invoice ${invoiceId} not found in memory.`);
+          process.exit(1);
+        }
+
+        const outFile = `invoice-${invoiceId.slice(0, 8)}.json`;
+        fs.writeFileSync(outFile, JSON.stringify(invoiceRef, null, 2));
+        console.log(`Invoice exported to: ${outFile}`);
+
+        await closeSphere();
+        break;
+      }
+
+      case 'invoice-parse-memo': {
+        const memoStr = args[1];
+        if (!memoStr) {
+          console.error('Usage: invoice-parse-memo <memo-string>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        if (!sphere.accounting) {
+          console.error('Accounting module not enabled.');
+          process.exit(1);
+        }
+
+        const parsed = sphere.accounting.parseInvoiceMemo(memoStr);
+        if (!parsed) {
+          console.log('Not a valid invoice memo.');
+        } else {
+          console.log('Parsed invoice memo:');
+          console.log(JSON.stringify(parsed, null, 2));
+        }
+
+        await closeSphere();
+        break;
+      }
+
+      // =====================================================================
+      // Swap Commands
+      // =====================================================================
+
+      case 'swap-propose': {
+        const toIdx = args.indexOf('--to');
+        const escrowIdx = args.indexOf('--escrow');
+        const timeoutIdx = args.indexOf('--timeout');
+        const messageIdx = args.indexOf('--message');
+
+        // Combined format: --offer "<amount> <coin>" --want "<amount> <coin>"
+        const offerIdx = args.indexOf('--offer');
+        const wantIdx = args.indexOf('--want');
+
+        if (toIdx === -1 || !args[toIdx + 1] ||
+            offerIdx === -1 || !args[offerIdx + 1] || args[offerIdx + 1].startsWith('--') ||
+            wantIdx === -1 || !args[wantIdx + 1] || args[wantIdx + 1].startsWith('--')) {
+          console.error('Usage: swap-propose --to <recipient> --offer "<amount> <coin>" --want "<amount> <coin>" [--escrow <address>] [--timeout <seconds>] [--message <text>]');
+          process.exit(1);
+        }
+
+        const offer = parseAssetArg(args[offerIdx + 1]);
+        const want = parseAssetArg(args[wantIdx + 1]);
+
+        let timeout = 3600;
+        if (timeoutIdx !== -1 && args[timeoutIdx + 1]) {
+          timeout = parseInt(args[timeoutIdx + 1], 10);
+          if (isNaN(timeout) || timeout < 60 || timeout > 86400) {
+            console.error('--timeout must be an integer between 60 and 86400 seconds');
+            process.exit(1);
+          }
+        }
+
+        const sphere = await getSphere();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const swapModule = (sphere as any).swap;
+        if (!swapModule) {
+          console.error('Swap module not enabled. Initialize with swap support.');
+          process.exit(1);
+        }
+
+        // Resolve coin symbols and convert human-readable amounts to smallest units
+        // (e.g., "10 BTC" → 10 * 10^8 = 1000000000 smallest units)
+        const offerCoin = resolveCoin(offer.coin);
+        const wantCoin = resolveCoin(want.coin);
+        const offerSmallest = toSmallestUnit(offer.amount, offerCoin.decimals);
+        const wantSmallest = toSmallestUnit(want.amount, wantCoin.decimals);
+        if (offerSmallest <= 0n) {
+          console.error(`Invalid offer amount "${offer.amount}" — must be a positive number`);
+          process.exit(1);
+        }
+        if (wantSmallest <= 0n) {
+          console.error(`Invalid want amount "${want.amount}" — must be a positive number`);
+          process.exit(1);
+        }
+
+        const escrow = escrowIdx !== -1 ? args[escrowIdx + 1] : undefined;
+        const message = messageIdx !== -1 ? args[messageIdx + 1] : undefined;
+
+        const deal = {
+          partyA: sphere.identity!.directAddress!,
+          partyB: args[toIdx + 1],
+          partyACurrency: offerCoin.symbol,
+          partyAAmount: offerSmallest.toString(),
+          partyBCurrency: wantCoin.symbol,
+          partyBAmount: wantSmallest.toString(),
+          timeout: timeout,
+          escrowAddress: escrow,
+        };
+
+        const result = await swapModule.proposeSwap(deal, message ? { message } : undefined);
+        console.log('Swap proposed:');
+        console.log(JSON.stringify({
+          swap_id: result.swapId,
+          counterparty: args[toIdx + 1],
+          offer: `${offer.amount} ${offerCoin.symbol}`,
+          want: `${want.amount} ${wantCoin.symbol}`,
+          escrow: deal.escrowAddress ?? '(config default)',
+          timeout: timeout,
+          status: result.swap?.progress ?? 'proposed',
+        }, null, 2));
+
+        await closeSphere();
+        break;
+      }
+
+      case 'swap-list': {
+        const allFlag = args.includes('--all');
+        const roleIdx = args.indexOf('--role');
+        const progressIdx = args.indexOf('--progress');
+
+        const sphere = await getSphere();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const swapModule = (sphere as any).swap;
+        if (!swapModule) {
+          console.error('Swap module not enabled.');
+          process.exit(1);
+        }
+        await ensureSync(sphere, 'nostr');
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const filter: any = {};
+        if (roleIdx !== -1 && args[roleIdx + 1]) {
+          const role = args[roleIdx + 1];
+          if (role !== 'proposer' && role !== 'acceptor') {
+            console.error('--role must be "proposer" or "acceptor"');
+            process.exit(1);
+          }
+          filter.role = role;
+        }
+        if (progressIdx !== -1 && args[progressIdx + 1]) {
+          filter.progress = args[progressIdx + 1];
+        }
+        if (!allFlag && !filter.progress) {
+          filter.excludeTerminal = true;
+        }
+
+        const swaps = await swapModule.getSwaps(filter);
+        if (!swaps || swaps.length === 0) {
+          console.log('No swaps found.');
+        } else {
+          const isTTY = process.stdout.isTTY;
+          const green = isTTY ? '\x1b[32m' : '';
+          const red = isTTY ? '\x1b[31m' : '';
+          const yellow = isTTY ? '\x1b[33m' : '';
+          const reset = isTTY ? '\x1b[0m' : '';
+
+          const header = [
+            'SWAP ID'.padEnd(10),
+            'ROLE'.padEnd(12),
+            'PROGRESS'.padEnd(20),
+            'OFFER'.padEnd(18),
+            'WANT'.padEnd(18),
+            'COUNTERPARTY'.padEnd(16),
+            'CREATED',
+          ].join('');
+          console.log(header);
+
+          for (const swap of swaps) {
+            const id = (swap.swapId || '').slice(0, 8);
+            const role = swap.role || '';
+            const progress = swap.progress || '';
+
+            // Determine counterparty display
+            const isProposer = role === 'proposer';
+            // Format amounts back to human-readable (manifest stores smallest units)
+            const fmtSwapAmt = (amount: string | undefined, currency: string | undefined): string => {
+              if (!amount || !currency) return '';
+              try {
+                const def = resolveCoin(currency);
+                return `${toHumanReadable(amount, def.decimals)} ${def.symbol}`;
+              } catch {
+                return `${amount} ${currency} (raw)`;
+              }
+            };
+            const offerStr = isProposer
+              ? fmtSwapAmt(swap.deal?.partyAAmount, swap.deal?.partyACurrency)
+              : fmtSwapAmt(swap.deal?.partyBAmount, swap.deal?.partyBCurrency);
+            const wantStr = isProposer
+              ? fmtSwapAmt(swap.deal?.partyBAmount, swap.deal?.partyBCurrency)
+              : fmtSwapAmt(swap.deal?.partyAAmount, swap.deal?.partyACurrency);
+            // Show nametag if available, otherwise truncated address
+            let counterparty: string;
+            if (swap.counterpartyNametag) {
+              counterparty = '@' + swap.counterpartyNametag;
+            } else if (isProposer) {
+              counterparty = (swap.deal?.partyB ?? '').slice(0, 14);
+            } else {
+              counterparty = (swap.deal?.partyA ?? '').slice(0, 14);
+            }
+
+            // Relative time
+            const elapsed = Date.now() - (swap.createdAt || 0);
+            let timeStr: string;
+            if (elapsed < 60_000) timeStr = 'just now';
+            else if (elapsed < 3_600_000) timeStr = `${Math.floor(elapsed / 60_000)} min ago`;
+            else if (elapsed < 86_400_000) timeStr = `${Math.floor(elapsed / 3_600_000)} hour ago`;
+            else timeStr = `${Math.floor(elapsed / 86_400_000)} days ago`;
+
+            // Color progress
+            let coloredProgress = progress;
+            if (progress === 'completed') coloredProgress = `${green}${progress}${reset}`;
+            else if (progress === 'failed' || progress === 'cancelled') coloredProgress = `${red}${progress}${reset}`;
+            else coloredProgress = `${yellow}${progress}${reset}`;
+
+            const row = [
+              id.padEnd(10),
+              role.padEnd(12),
+              // Pad the raw progress (color codes are zero-width for terminal)
+              coloredProgress + ' '.repeat(Math.max(0, 20 - progress.length)),
+              offerStr.padEnd(18),
+              wantStr.padEnd(18),
+              counterparty.padEnd(16),
+              timeStr,
+            ].join('');
+            console.log(row);
+          }
+        }
+
+        await closeSphere();
+        break;
+      }
+
+      case 'swap-accept': {
+        const swapIdArg = args[1];
+        if (!swapIdArg) {
+          console.error('Usage: swap-accept <swap_id_or_prefix> [--deposit] [--no-wait]');
+          process.exit(1);
+        }
+
+        const depositFlag = args.includes('--deposit');
+        const noWaitFlag = args.includes('--no-wait');
+
+        const sphere = await getSphere();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const swapModule = (sphere as any).swap;
+        if (!swapModule) {
+          console.error('Swap module not enabled.');
+          process.exit(1);
+        }
+        await ensureSync(sphere, 'nostr');
+
+        const swapId = swapModule.resolveSwapId(swapIdArg);
+        await swapModule.acceptSwap(swapId);
+        console.log('Swap accepted. Announced to escrow. Waiting for deposit invoice...');
+
+        if (depositFlag) {
+          // acceptSwap() sends the announce to the escrow but the escrow's invoice_delivery
+          // DM arrives asynchronously. Wait for swap:announced before depositing.
+          const acceptAnnounced = await new Promise<boolean>((resolve) => {
+            const acceptUnsubs: (() => void)[] = [];
+            const timeout = setTimeout(() => {
+              acceptUnsubs.forEach(u => u());
+              resolve(false);
+            }, 60_000);
+            const done = (ok: boolean) => {
+              clearTimeout(timeout);
+              acceptUnsubs.forEach(u => u());
+              resolve(ok);
+            };
+            acceptUnsubs.push(sphere.on('swap:announced', (e: { swapId: string }) => {
+              if (e.swapId === swapId) done(true);
+            }));
+            acceptUnsubs.push(sphere.on('swap:failed', (e: { swapId: string }) => {
+              if (e.swapId === swapId) done(false);
+            }));
+            acceptUnsubs.push(sphere.on('swap:cancelled', (e: { swapId: string }) => {
+              if (e.swapId === swapId) done(false);
+            }));
+          });
+          if (!acceptAnnounced) {
+            const finalStatus = await swapModule.getSwapStatus(swapId);
+            console.error(`Swap did not reach 'announced' state (current: ${finalStatus?.progress ?? 'unknown'}). Check swap-status for details.`);
+            await closeSphere();
+            process.exit(1);
+          }
+
+          const depositResult = await swapModule.deposit(swapId);
+          console.log(`Deposit sent: ${depositResult.id}`);
+
+          if (!noWaitFlag) {
+            // Wait for terminal event
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const swapRef = await swapModule.getSwapStatus(swapId);
+            const waitTimeout = 2 * (swapRef?.deal?.timeout ?? 3600) * 1000;
+            const unsubs: (() => void)[] = [];
+            await new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(() => {
+                unsubs.forEach(u => u());
+                reject(new Error(`Swap did not complete within timeout. Current progress: ${swapRef?.progress ?? 'unknown'}`));
+              }, waitTimeout);
+
+              const done = (msg: string) => {
+                clearTimeout(timer);
+                unsubs.forEach(u => u());
+                console.log(msg);
+                resolve();
+              };
+
+              unsubs.push(sphere.on('swap:completed', (e: { swapId: string }) => {
+                if (e.swapId === swapId) done('[swap] Swap completed!');
+              }));
+              unsubs.push(sphere.on('swap:cancelled', (e: { swapId: string }) => {
+                if (e.swapId === swapId) done('[swap] Swap cancelled.');
+              }));
+              unsubs.push(sphere.on('swap:failed', (e: { swapId: string; error: string }) => {
+                if (e.swapId === swapId) done(`[swap] Swap failed: ${e.error}`);
+              }));
+              unsubs.push(sphere.on('swap:deposit_confirmed', (e: { swapId: string }) => {
+                if (e.swapId === swapId) console.log('[swap] Deposit confirmed by escrow.');
+              }));
+              unsubs.push(sphere.on('swap:deposits_covered', (e: { swapId: string }) => {
+                if (e.swapId === swapId) console.log('[swap] All deposits covered. Escrow concluding...');
+              }));
+              unsubs.push(sphere.on('swap:payout_received', (e: { swapId: string }) => {
+                if (e.swapId === swapId) console.log('[swap] Payout received. Verifying...');
+              }));
+            });
+          }
+        } else {
+          console.log(`Run 'swap-deposit ${swapId}' to deposit when ready.`);
+        }
+
+        await closeSphere();
+        break;
+      }
+
+      case 'swap-ping': {
+        const escrowAddr = args[1];
+        if (!escrowAddr) {
+          console.error('Usage: swap-ping <@nametag_or_address>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const swapModule = (sphere as any).swap;
+        if (!swapModule) {
+          console.error('Swap module not enabled.');
+          await closeSphere();
+          process.exit(1);
+        }
+        await ensureSync(sphere, 'nostr');
+
+        try {
+          const pong = await swapModule.pingEscrow(escrowAddr);
+          console.log('Escrow is online:');
+          console.log(JSON.stringify(pong, null, 2));
+        } catch (err) {
+          console.error('Escrow ping failed:', err instanceof Error ? err.message : err);
+          await closeSphere();
+          process.exit(1);
+        }
+
+        await closeSphere();
+        break;
+      }
+
+      case 'swap-status': {
+        const swapIdArg = args[1];
+        if (!swapIdArg) {
+          console.error('Usage: swap-status <swap_id_or_prefix> [--query-escrow]');
+          process.exit(1);
+        }
+
+        const queryEscrow = args.includes('--query-escrow');
+
+        const sphere = await getSphere();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const swapModule = (sphere as any).swap;
+        if (!swapModule) {
+          console.error('Swap module not enabled.');
+          process.exit(1);
+        }
+        await ensureSync(sphere, 'nostr');
+
+        const swapId = swapModule.resolveSwapId(swapIdArg);
+        const status = await swapModule.getSwapStatus(swapId, queryEscrow ? { queryEscrow: true } : undefined);
+        console.log('Swap Status:');
+        console.log(JSON.stringify(status, null, 2));
+
+        if (status.depositInvoiceId && sphere.accounting) {
+          try {
+            const invoiceStatus = await sphere.accounting.getInvoiceStatus(status.depositInvoiceId);
+            console.log('\nDeposit Invoice Status:');
+            console.log(JSON.stringify(invoiceStatus, null, 2));
+          } catch {
+            // Non-fatal: invoice may not be imported yet
+          }
+        }
+
+        await closeSphere();
+        break;
+      }
+
+      case 'swap-deposit': {
+        const swapIdArg = args[1];
+        if (!swapIdArg) {
+          console.error('Usage: swap-deposit <swap_id_or_prefix>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const swapModule = (sphere as any).swap;
+        if (!swapModule) {
+          console.error('Swap module not enabled.');
+          process.exit(1);
+        }
+        await ensureSync(sphere, 'full');
+
+        const swapId = swapModule.resolveSwapId(swapIdArg);
+
+        // If the swap is still in 'accepted' (crash recovery re-announced to escrow but
+        // the escrow's invoice_delivery DM hasn't arrived yet), wait for swap:announced
+        // before calling deposit(). Crash recovery fires fire-and-forget after module load
+        // so the escrow response may arrive slightly after ensureSync completes.
+        const swapStatusBefore = await swapModule.getSwapStatus(swapId);
+        // Guard: if already deposited, don't re-deposit
+        if (swapStatusBefore?.progress === 'depositing' || swapStatusBefore?.progress === 'awaiting_counter' ||
+            swapStatusBefore?.progress === 'concluding' || swapStatusBefore?.progress === 'completed') {
+          console.log(`Deposit already submitted (current state: ${swapStatusBefore.progress})`);
+          await closeSphere();
+          break;
+        }
+        if (swapStatusBefore?.progress === 'proposed' || swapStatusBefore?.progress === 'accepted') {
+          const waitLabel = swapStatusBefore.progress === 'proposed'
+            ? 'Waiting for Bob to accept and escrow to confirm (up to 120s)...'
+            : 'Waiting for escrow to deliver deposit invoice (up to 60s)...';
+          console.log(waitLabel);
+          const waitMs = swapStatusBefore.progress === 'proposed' ? 120_000 : 60_000;
+          const announced = await new Promise<boolean>((resolve) => {
+            const announceUnsubs: (() => void)[] = [];
+            const timeout = setTimeout(() => {
+              announceUnsubs.forEach(u => u());
+              resolve(false);
+            }, waitMs);
+            const done = (ok: boolean) => {
+              clearTimeout(timeout);
+              announceUnsubs.forEach(u => u());
+              resolve(ok);
+            };
+            announceUnsubs.push(sphere.on('swap:announced', (e: { swapId: string }) => {
+              if (e.swapId === swapId) done(true);
+            }));
+            announceUnsubs.push(sphere.on('swap:failed', (e: { swapId: string }) => {
+              if (e.swapId === swapId) done(false);
+            }));
+            announceUnsubs.push(sphere.on('swap:cancelled', (e: { swapId: string }) => {
+              if (e.swapId === swapId) done(false);
+            }));
+          });
+          if (!announced) {
+            const finalStatus = await swapModule.getSwapStatus(swapId);
+            console.error(`Swap did not reach 'announced' state (current: ${finalStatus?.progress ?? 'unknown'}). Try again shortly or check swap-status.`);
+            await closeSphere();
+            process.exit(1);
+          }
+        }
+
+        const result = await swapModule.deposit(swapId);
+        console.log('Deposit result:');
+        console.log(JSON.stringify({ id: result.id, status: result.status }, null, 2));
+
+        // Wait for background tasks (e.g., change token creation from instant split)
+        await sphere.payments.waitForPendingOperations();
+        await syncAfterWrite(sphere);
+        await closeSphere();
+        break;
+      }
+
+      case 'swap-reject': {
+        const swapIdArg = args[1];
+        if (!swapIdArg) {
+          console.error('Usage: swap-reject <swap_id_or_prefix> [reason]');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const swapModule = (sphere as any).swap;
+        if (!swapModule) {
+          console.error('Swap module not enabled.');
+          process.exit(1);
+        }
+        await ensureSync(sphere, 'nostr');
+
+        const swapId = swapModule.resolveSwapId(swapIdArg);
+        // Optional reason from remaining args
+        const reason = args.slice(2).filter((a: string) => !a.startsWith('--')).join(' ') || undefined;
+
+        await swapModule.rejectSwap(swapId, reason);
+        console.log(`Swap ${swapId.slice(0, 8)}... rejected.${reason ? ` Reason: ${reason}` : ''}`);
+
+        await closeSphere();
+        break;
+      }
+
+      case 'swap-cancel': {
+        const swapIdArg = args[1];
+        if (!swapIdArg) {
+          console.error('Usage: swap-cancel <swap_id_or_prefix>');
+          process.exit(1);
+        }
+
+        const sphere = await getSphere();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const swapModule = (sphere as any).swap;
+        if (!swapModule) {
+          console.error('Swap module not enabled.');
+          process.exit(1);
+        }
+        await ensureSync(sphere, 'nostr');
+
+        const swapId = swapModule.resolveSwapId(swapIdArg);
+        await swapModule.cancelSwap(swapId);
+        console.log(`Swap ${swapId.slice(0, 8)}... cancelled.`);
+
+        await closeSphere();
+        break;
+      }
+
       case 'daemon': {
         const sub = args[1] || 'start';
         const { runDaemon, stopDaemon, statusDaemon } = await import('./daemon.js');
@@ -2392,6 +4716,25 @@ async function main() {
         break;
       }
 
+      case 'completions': {
+        const shell = args[1];
+        if (!shell || !['bash', 'zsh', 'fish'].includes(shell)) {
+          console.error('Usage: completions <bash|zsh|fish>');
+          console.error('Generate shell completion script for tab-completion.');
+          console.error('\nSetup:');
+          console.error('  sphere-cli completions bash >> ~/.bashrc');
+          console.error('  sphere-cli completions zsh > ~/.zsh/completions/_sphere-cli');
+          console.error('  sphere-cli completions fish > ~/.config/fish/completions/sphere-cli.fish');
+          process.exit(1);
+        }
+        switch (shell) {
+          case 'bash': console.log(generateBashCompletions()); break;
+          case 'zsh': console.log(generateZshCompletions()); break;
+          case 'fish': console.log(generateFishCompletions()); break;
+        }
+        break;
+      }
+
       default:
         console.error('Unknown command:', command);
         console.error('Run with --help for usage');
@@ -2401,6 +4744,267 @@ async function main() {
     console.error('Error:', e instanceof Error ? e.message : e);
     process.exit(1);
   }
+}
+
+// =============================================================================
+// Shell Completion Generators
+// =============================================================================
+
+interface CompletionCommand {
+  name: string;
+  description: string;
+  flags?: string[];
+  subcommands?: CompletionCommand[];
+}
+
+function getCompletionCommands(): CompletionCommand[] {
+  return [
+    { name: 'init', description: 'Create or import wallet', flags: ['--network', '--mnemonic', '--nametag', '--password', '--no-nostr'] },
+    { name: 'status', description: 'Show wallet identity' },
+    { name: 'config', description: 'Show or set CLI configuration' },
+    { name: 'clear', description: 'Delete all wallet data' },
+    { name: 'wallet', description: 'Manage wallet profiles', subcommands: [
+      { name: 'list', description: 'List all wallet profiles' },
+      { name: 'create', description: 'Create a new wallet profile', flags: ['--network'] },
+      { name: 'use', description: 'Switch to a wallet profile' },
+      { name: 'current', description: 'Show active profile' },
+      { name: 'delete', description: 'Delete a wallet profile' },
+    ]},
+    { name: 'balance', description: 'Show L3 token balance', flags: ['--finalize', '--no-sync'] },
+    { name: 'tokens', description: 'List all tokens', flags: ['--no-sync'] },
+    { name: 'assets', description: 'List registered assets (coins & NFTs)', flags: ['--type'] },
+    { name: 'asset-info', description: 'Show detailed info for an asset' },
+    { name: 'l1-balance', description: 'Show L1 (ALPHA) balance' },
+    { name: 'topup', description: 'Request test tokens from faucet' },
+    { name: 'top-up', description: 'Alias for topup' },
+    { name: 'faucet', description: 'Alias for topup' },
+    { name: 'verify-balance', description: 'Verify tokens against aggregator', flags: ['--remove', '-v', '--verbose'] },
+    { name: 'sync', description: 'Sync tokens with IPFS' },
+    { name: 'send', description: 'Send L3 tokens', flags: ['--direct', '--proxy', '--instant', '--conservative', '--no-sync'] },
+    { name: 'receive', description: 'Check for incoming transfers', flags: ['--finalize', '--no-sync'] },
+    { name: 'history', description: 'Show transaction history' },
+    { name: 'addresses', description: 'List tracked addresses' },
+    { name: 'switch', description: 'Switch to HD address' },
+    { name: 'hide', description: 'Hide address' },
+    { name: 'unhide', description: 'Unhide address' },
+    { name: 'nametag', description: 'Register a nametag' },
+    { name: 'nametag-info', description: 'Look up nametag info' },
+    { name: 'my-nametag', description: 'Show current nametag' },
+    { name: 'nametag-sync', description: 'Re-publish nametag binding' },
+    { name: 'dm', description: 'Send a direct message' },
+    { name: 'dm-inbox', description: 'List conversations' },
+    { name: 'dm-history', description: 'Show conversation history', flags: ['--limit'] },
+    { name: 'group-create', description: 'Create a new group', flags: ['--description', '--private'] },
+    { name: 'group-list', description: 'List available groups' },
+    { name: 'group-my', description: 'List your joined groups' },
+    { name: 'group-join', description: 'Join a group', flags: ['--invite'] },
+    { name: 'group-leave', description: 'Leave a group' },
+    { name: 'group-send', description: 'Send a message to a group', flags: ['--reply'] },
+    { name: 'group-messages', description: 'Show group messages', flags: ['--limit'] },
+    { name: 'group-members', description: 'List group members' },
+    { name: 'group-info', description: 'Show group details' },
+    { name: 'invoice-create', description: 'Create an invoice', flags: ['--target', '--asset', '--nft', '--due', '--memo', '--delivery', '--anonymous', '--terms'] },
+    { name: 'invoice-import', description: 'Import invoice from token file' },
+    { name: 'invoice-list', description: 'List invoices', flags: ['--state', '--limit'] },
+    { name: 'invoice-status', description: 'Show invoice status' },
+    { name: 'invoice-close', description: 'Close an invoice' },
+    { name: 'invoice-cancel', description: 'Cancel an invoice' },
+    { name: 'invoice-pay', description: 'Pay an invoice', flags: ['--target-index', '--amount'] },
+    { name: 'invoice-return', description: 'Return payment to sender', flags: ['--recipient', '--asset'] },
+    { name: 'invoice-receipts', description: 'Send payment receipts' },
+    { name: 'invoice-notices', description: 'Send cancellation notices' },
+    { name: 'invoice-auto-return', description: 'Show/set auto-return settings', flags: ['--enable', '--disable', '--invoice'] },
+    { name: 'invoice-transfers', description: 'List related transfers' },
+    { name: 'invoice-export', description: 'Export invoice to JSON file' },
+    { name: 'invoice-parse-memo', description: 'Parse invoice memo string' },
+    { name: 'swap-propose', description: 'Propose a token swap', flags: ['--to', '--offer', '--want', '--escrow', '--timeout', '--message'] },
+    { name: 'swap-list', description: 'List swap deals', flags: ['--all', '--role', '--progress'] },
+    { name: 'swap-accept', description: 'Accept a swap deal', flags: ['--deposit', '--no-wait'] },
+    { name: 'swap-status', description: 'Show swap status', flags: ['--query-escrow'] },
+    { name: 'swap-deposit', description: 'Deposit into a swap' },
+    { name: 'swap-reject', description: 'Reject a swap proposal' },
+    { name: 'swap-cancel', description: 'Cancel a swap' },
+    { name: 'market-post', description: 'Post a market intent', flags: ['--type', '--category', '--price', '--currency', '--location', '--contact', '--expires'] },
+    { name: 'market-search', description: 'Search market intents', flags: ['--type', '--category', '--min-price', '--max-price', '--limit'] },
+    { name: 'market-my', description: 'List your intents' },
+    { name: 'market-close', description: 'Close an intent' },
+    { name: 'market-feed', description: 'Watch live listing feed', flags: ['--rest'] },
+    { name: 'daemon', description: 'Manage event daemon', subcommands: [
+      { name: 'start', description: 'Start daemon', flags: ['--config', '--detach', '--log', '--pid', '--event', '--action', '--verbose'] },
+      { name: 'stop', description: 'Stop daemon' },
+      { name: 'status', description: 'Check daemon status' },
+    ]},
+    { name: 'encrypt', description: 'Encrypt data with password' },
+    { name: 'decrypt', description: 'Decrypt encrypted data' },
+    { name: 'parse-wallet', description: 'Parse wallet file' },
+    { name: 'wallet-info', description: 'Show wallet file info' },
+    { name: 'generate-key', description: 'Generate random private key' },
+    { name: 'validate-key', description: 'Validate a private key' },
+    { name: 'hex-to-wif', description: 'Convert hex to WIF' },
+    { name: 'derive-pubkey', description: 'Derive public key' },
+    { name: 'derive-address', description: 'Derive L1 address' },
+    { name: 'to-smallest', description: 'Convert to smallest unit' },
+    { name: 'to-human', description: 'Convert to human-readable' },
+    { name: 'format', description: 'Format amount' },
+    { name: 'base58-encode', description: 'Encode hex to base58' },
+    { name: 'base58-decode', description: 'Decode base58 to hex' },
+    { name: 'completions', description: 'Generate shell completion script' },
+    { name: 'help', description: 'Show help for a command' },
+  ];
+}
+
+function generateBashCompletions(): string {
+  const cmds = getCompletionCommands();
+  const topLevel = cmds.map(c => c.name).join(' ');
+
+  const subcommandCases: string[] = [];
+  const flagCases: string[] = [];
+
+  for (const cmd of cmds) {
+    if (cmd.subcommands) {
+      const subs = cmd.subcommands.map(s => s.name).join(' ');
+      subcommandCases.push(`    ${cmd.name})\n      if [[ $cword -eq 2 ]]; then\n        COMPREPLY=($(compgen -W "${subs}" -- "$cur"))\n        return\n      fi\n      ;;`);
+      for (const sub of cmd.subcommands) {
+        if (sub.flags?.length) {
+          flagCases.push(`    "${cmd.name} ${sub.name}") flags="${sub.flags.join(' ')}" ;;`);
+        }
+      }
+    }
+    if (cmd.flags?.length) {
+      flagCases.push(`    ${cmd.name}) flags="${cmd.flags.join(' ')}" ;;`);
+    }
+  }
+
+  return `# Bash completion for sphere-cli
+# Generated by: sphere-cli completions bash
+#
+# Installation:
+#   sphere-cli completions bash >> ~/.bashrc
+#   # or
+#   sphere-cli completions bash > /etc/bash_completion.d/sphere-cli
+#   # or with npm:
+#   eval "$(npm run --silent cli -- completions bash)"
+
+_sphere_cli() {
+  local cur prev words cword
+  _init_completion || return
+
+  local commands="${topLevel}"
+
+  if [[ $cword -eq 1 ]]; then
+    COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+    return
+  fi
+
+  # Subcommands
+  case "\${words[1]}" in
+${subcommandCases.join('\n')}
+  esac
+
+  # Flag completion
+  if [[ "$cur" == -* ]]; then
+    local flags=""
+    local cmd_key="\${words[1]}"
+    if [[ $cword -ge 3 ]]; then
+      cmd_key="\${words[1]} \${words[2]}"
+    fi
+    case "$cmd_key" in
+${flagCases.join('\n')}
+    esac
+    if [[ -n "$flags" ]]; then
+      COMPREPLY=($(compgen -W "$flags" -- "$cur"))
+    fi
+  fi
+}
+
+complete -F _sphere_cli sphere-cli
+# Also complete for npm run cli -- usage:
+complete -F _sphere_cli npx
+`;
+}
+
+function generateZshCompletions(): string {
+  const cmds = getCompletionCommands();
+
+  const commandList = cmds.map(c => `    '${c.name}:${c.description.replace(/'/g, "'\\''")}'`).join('\n');
+
+  const subcases: string[] = [];
+  for (const cmd of cmds) {
+    if (cmd.subcommands) {
+      const subList = cmd.subcommands.map(s => `'${s.name}:${s.description.replace(/'/g, "'\\''")}'`).join(' ');
+      subcases.push(`        ${cmd.name})\n          _describe 'subcommand' ${subList}\n          ;;`);
+    } else {
+      const flagArgs = (cmd.flags || []).map(f => `'${f}[${cmd.description.replace(/'/g, "'\\''").slice(0, 30)}]'`).join(' ');
+      if (flagArgs) {
+        subcases.push(`        ${cmd.name})\n          _arguments ${flagArgs}\n          ;;`);
+      }
+    }
+  }
+
+  return `#compdef sphere-cli
+# Zsh completion for sphere-cli
+# Generated by: sphere-cli completions zsh
+#
+# Installation:
+#   mkdir -p ~/.zsh/completions
+#   sphere-cli completions zsh > ~/.zsh/completions/_sphere-cli
+#   # Add to .zshrc: fpath=(~/.zsh/completions $fpath) && autoload -Uz compinit && compinit
+
+_sphere_cli() {
+  local -a commands
+  commands=(
+${commandList}
+  )
+
+  _arguments -C \\
+    '1:command:->command' \\
+    '*::arg:->args'
+
+  case "$state" in
+    command)
+      _describe 'command' commands
+      ;;
+    args)
+      case "\${words[1]}" in
+${subcases.join('\n')}
+      esac
+      ;;
+  esac
+}
+
+_sphere_cli "$@"
+`;
+}
+
+function generateFishCompletions(): string {
+  const cmds = getCompletionCommands();
+  const lines: string[] = [
+    '# Fish completion for sphere-cli',
+    '# Generated by: sphere-cli completions fish',
+    '#',
+    '# Installation:',
+    '#   sphere-cli completions fish > ~/.config/fish/completions/sphere-cli.fish',
+    '',
+  ];
+
+  for (const cmd of cmds) {
+    if (cmd.subcommands) {
+      lines.push(`complete -c sphere-cli -n '__fish_use_subcommand' -a '${cmd.name}' -d '${cmd.description}'`);
+      for (const sub of cmd.subcommands) {
+        lines.push(`complete -c sphere-cli -n '__fish_seen_subcommand_from ${cmd.name}' -a '${sub.name}' -d '${sub.description}'`);
+        for (const flag of sub.flags || []) {
+          lines.push(`complete -c sphere-cli -n '__fish_seen_subcommand_from ${cmd.name}' -l '${flag.replace(/^--/, '')}' -d '${sub.description}'`);
+        }
+      }
+    } else {
+      lines.push(`complete -c sphere-cli -n '__fish_use_subcommand' -a '${cmd.name}' -d '${cmd.description}'`);
+      for (const flag of cmd.flags || []) {
+        lines.push(`complete -c sphere-cli -n '__fish_seen_subcommand_from ${cmd.name}' -l '${flag.replace(/^--/, '')}' -d '${flag}'`);
+      }
+    }
+  }
+
+  return lines.join('\n') + '\n';
 }
 
 main().then(() => process.exit(0));

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1531,8 +1531,18 @@ async function main() {
         if (networkIndex !== -1 && args[networkIndex + 1]) {
           network = args[networkIndex + 1] as NetworkType;
         }
-        if (mnemonicIndex !== -1 && args[mnemonicIndex + 1]) {
-          mnemonic = args[mnemonicIndex + 1];
+        if (mnemonicIndex !== -1) {
+          if (args[mnemonicIndex + 1] && !args[mnemonicIndex + 1].startsWith('--')) {
+            mnemonic = args[mnemonicIndex + 1];
+            // Clear from argv to reduce exposure in /proc/<pid>/cmdline
+            args[mnemonicIndex + 1] = '***';
+          } else {
+            // Interactive prompt — mnemonic never appears in process args
+            const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+            mnemonic = await new Promise<string>((resolve) => {
+              rl.question('Enter mnemonic phrase: ', (answer) => { rl.close(); resolve(answer.trim()); });
+            });
+          }
         }
 
         const nametagIndex = args.indexOf('--nametag');
@@ -1641,6 +1651,17 @@ async function main() {
       }
 
       case 'clear': {
+        if (!flags['yes'] && !flags['y']) {
+          const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+          const answer = await new Promise<string>((resolve) => {
+            rl.question('This will permanently delete ALL wallet data (keys, tokens, history). Type "yes" to confirm: ', (a) => { rl.close(); resolve(a.trim()); });
+          });
+          if (answer !== 'yes') {
+            console.log('Aborted.');
+            break;
+          }
+        }
+
         const config = loadConfig();
         const providers = createNodeProviders({
           network: config.network,
@@ -1721,6 +1742,10 @@ async function main() {
             if (!profileName) {
               console.error('Usage: wallet create <name> [--network testnet|mainnet|dev]');
               console.error('Example: npm run cli -- wallet create mywalletname');
+              process.exit(1);
+            }
+            if (!/^[a-zA-Z0-9_-]+$/.test(profileName)) {
+              console.error('Profile name must contain only letters, digits, hyphens, and underscores.');
               process.exit(1);
             }
 
@@ -2676,12 +2701,18 @@ async function main() {
         const wif = hexToWIF(privateKey);
         const addressInfo = generateAddressFromMasterKey(privateKey, 0);
 
-        console.log(JSON.stringify({
-          privateKey,
-          publicKey,
-          wif,
-          address: addressInfo.address,
-        }, null, 2));
+        if (flags['unsafe-print']) {
+          console.log(JSON.stringify({
+            privateKey,
+            publicKey,
+            wif,
+            address: addressInfo.address,
+          }, null, 2));
+        } else {
+          console.log(`Public Key: ${publicKey}`);
+          console.log(`Address: ${addressInfo.address}`);
+          console.log('(private key and WIF hidden — use --unsafe-print to display)');
+        }
         break;
       }
 
@@ -5007,4 +5038,8 @@ function generateFishCompletions(): string {
   return lines.join('\n') + '\n';
 }
 
-main().then(() => process.exit(0));
+main().then(() => process.exit(0)).catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`Fatal error: ${msg}`);
+  process.exit(1);
+});

--- a/core/currency.ts
+++ b/core/currency.ts
@@ -52,6 +52,7 @@ export function toSmallestUnit(amount: number | string, decimals: number = DEFAU
  * ```
  */
 export function toHumanReadable(amount: bigint | string, decimals: number = DEFAULT_TOKEN_DECIMALS): string {
+  if (!decimals || decimals < 0 || !Number.isFinite(decimals)) return amount.toString();
   const str = amount.toString().padStart(decimals + 1, '0');
   const integer = str.slice(0, -decimals) || '0';
   const fraction = str.slice(-decimals).replace(/0+$/, '');

--- a/core/scan.ts
+++ b/core/scan.ts
@@ -92,8 +92,27 @@ export async function scanAddressesImpl(
   const { onProgress, signal, resolveNametag } = options;
 
   // Dynamic import to avoid hard dependency on L1 for non-L1 consumers
-  const { connect, getBalance } = await import('../l1/network');
-  await connect();
+  const { connect, disconnect, getBalance } = await import('../l1/network');
+
+  // Race connect against a timeout — L1 must never block L3 wallet init.
+  // connect() has its own reconnect loop (10 attempts, exponential backoff
+  // up to 60s each ≈ 6 min total). We fail fast so callers like
+  // discoverAddresses() can catch and continue without L1.
+  const L1_CONNECT_TIMEOUT_MS = 10_000;
+  let connectTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      connect(),
+      new Promise<never>((_, reject) => {
+        connectTimer = setTimeout(() => {
+          disconnect(); // kill the background reconnect loop
+          reject(new Error('L1 connect timeout'));
+        }, L1_CONNECT_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(connectTimer);
+  }
 
   const foundAddresses: ScannedAddressResult[] = [];
   let totalBalance = 0;

--- a/docs/API.md
+++ b/docs/API.md
@@ -20,6 +20,8 @@ const { sphere, created, generatedMnemonic } = await Sphere.init({
   nametag: 'alice',          // Optional: register @alice on create
   l1: { electrumUrl: '...' }, // Optional L1 config (enabled by default)
   price: priceProvider,      // Optional PriceProvider
+  accounting: true,          // Optional: enable invoicing module
+  swap: true,                // Optional: enable swap module (requires accounting)
   derivationPath: "m/44'/0'/0'", // Optional custom path
   dmSince: Math.floor(Date.now() / 1000) - 86400, // Optional: DM history fallback (unix seconds)
 });
@@ -66,6 +68,8 @@ await Sphere.clear(storage);
 | `payments` | `PaymentsModule` | L3 token operations + L1 via `.l1` |
 | `payments.l1` | `L1PaymentsModule` | L1 ALPHA operations |
 | `communications` | `CommunicationsModule` | Messaging operations |
+| `accounting` | `AccountingModule \| null` | Invoice lifecycle and payment attribution |
+| `swap` | `SwapModule \| null` | P2P token swap orchestration |
 
 ### Instance Methods
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1856,6 +1856,93 @@ interface AggregatorClient {
 
 ---
 
+## TokenRegistry
+
+Singleton that provides token metadata (symbol, name, decimals, icons, asset kind) by coin ID. Data is fetched from a remote registry URL and cached locally.
+
+### Setup
+
+`TokenRegistry` is configured automatically by `createBrowserProviders()` / `createNodeProviders()` and by `Sphere.init()`. No manual setup is needed for typical usage.
+
+```typescript
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+
+const registry = TokenRegistry.getInstance();
+```
+
+### Static Methods
+
+```typescript
+// Get the singleton instance (creates one if needed)
+TokenRegistry.getInstance(): TokenRegistry
+
+// Configure the registry (called automatically by Sphere.init)
+TokenRegistry.configure(options: TokenRegistryConfig): void
+
+// Wait until initial data is loaded (from cache or remote)
+TokenRegistry.waitForReady(timeoutMs?: number): Promise<boolean>
+
+// Stop auto-refresh and reset singleton
+TokenRegistry.destroy(): void
+```
+
+### Instance Methods
+
+```typescript
+// Look up by coin ID (hex string)
+getDefinition(coinId: string): TokenDefinition | undefined
+
+// Look up by symbol (e.g., 'UCT') — case-insensitive
+getDefinitionBySymbol(symbol: string): TokenDefinition | undefined
+
+// Look up by name (e.g., 'bitcoin') — case-insensitive
+getDefinitionByName(name: string): TokenDefinition | undefined
+
+// Shorthand accessors (return fallback values if not found)
+getSymbol(coinId: string): string      // fallback: truncated coinId
+getDecimals(coinId: string): number    // fallback: 0
+
+// List all definitions
+getAllDefinitions(): TokenDefinition[]
+
+// Filtered lists
+getFungibleDefinitions(): TokenDefinition[]
+getNonFungibleDefinitions(): TokenDefinition[]
+
+// Reverse lookups (symbol/name → coinId)
+getCoinIdBySymbol(symbol: string): string | undefined
+getCoinIdByName(name: string): string | undefined
+
+// Force refresh from remote
+refreshFromRemote(): Promise<boolean>
+```
+
+### TokenDefinition
+
+```typescript
+interface TokenDefinition {
+  id: string;               // Hex coin identifier (64 characters)
+  symbol: string;           // Short symbol (e.g., 'UCT')
+  name: string;             // Full name (e.g., 'Unicity Token')
+  decimals: number;         // Decimal places
+  assetKind: 'fungible' | 'non-fungible';
+  iconUrl?: string;         // Icon URL
+  coingeckoId?: string;     // CoinGecko identifier (for price lookups)
+}
+```
+
+### Standalone Helpers
+
+```typescript
+import { getTokenDefinition, getTokenSymbol, getTokenDecimals } from '@unicitylabs/sphere-sdk';
+
+const def = getTokenDefinition(coinId);   // TokenDefinition | undefined
+const sym = getTokenSymbol(coinId);       // string (with fallback)
+const dec = getTokenDecimals(coinId);     // number (with fallback)
+```
+
+---
+
 ## PriceProvider
 
 Optional provider for fetching token market prices. Enables `getBalance()` (total USD value) and price enrichment in `getAssets()`.
@@ -2210,6 +2297,827 @@ Sync Flow:
 ```
 
 See [IPFS Storage Guide](./IPFS-STORAGE.md) for complete documentation.
+
+---
+
+## AccountingModule (Invoicing)
+
+Access via `sphere.accounting` (once registered on the `Sphere` instance).
+
+Manages the full invoice lifecycle: creation, import, payment attribution, status tracking, balance computation, auto-return, and receipt/cancellation-notice delivery. Persists invoice tokens, terminal-state sets, frozen balances, and an incremental invoice-transfer index (§5.4).
+
+### Lifecycle
+
+```typescript
+import { AccountingModule } from '@unicitylabs/sphere-sdk';
+
+// 1. Construct (once, optional config)
+const accounting = new AccountingModule({ debug: false });
+
+// 2. Inject dependencies (must come before load())
+accounting.initialize({
+  payments,        // PaymentsModule
+  tokenStorage,    // TokenStorageProvider
+  oracle,          // OracleProvider
+  trustBase,       // aggregator trust base (from oracle config)
+  identity,        // FullIdentity
+  getActiveAddresses: () => sphere.getActiveAddresses(),
+  emitEvent: (type, data) => sphere.emit(type, data),
+  on: (type, handler) => sphere.on(type, handler),
+  storage,         // StorageProvider
+  communications,  // CommunicationsModule (optional, enables receipt DMs)
+});
+
+// 3. Load persisted state and subscribe to events
+await accounting.load();
+
+// 4. Use public API methods (see below)
+
+// 5. Cleanup on wallet lock / app shutdown
+await accounting.destroy();
+```
+
+### Quick Usage Example
+
+```typescript
+// --- Invoice creator (seller) ---
+
+// Create an invoice requesting 1 000 000 UCT to your DIRECT address
+const { invoiceId, token, terms } = await accounting.createInvoice({
+  targets: [{
+    address: identity.directAddress!,
+    assets: [{ coin: ['UCT', '1000000'] }],
+  }],
+  memo: 'Order #42 — coffee beans',
+  dueDate: Date.now() + 7 * 24 * 60 * 60 * 1000,  // 7 days
+});
+
+// Export the raw TXF token to share with the buyer
+const txfToken = await sphere.payments.getTokens().find(t => t.id === invoiceId);
+
+// --- Payer (buyer) ---
+
+// Import the invoice token received out-of-band
+const terms = await accounting.importInvoice(txfToken);
+
+// Pay the first target's first asset
+const result = await accounting.payInvoice(invoiceId!, {
+  targetIndex: 0,
+  assetIndex: 0,
+  refundAddress: identity.directAddress,  // enables auto-return if invoice is cancelled
+});
+
+// --- Invoice creator (after payment arrives) ---
+
+// Query status
+const status = await accounting.getInvoiceStatus(invoiceId!);
+console.log(status.state);  // 'COVERED' or 'CLOSED'
+
+// Explicitly close the invoice and send receipts to payers
+await accounting.closeInvoice(invoiceId!);
+const receipts = await accounting.sendInvoiceReceipts(invoiceId!, {
+  memo: 'Thank you for your order!',
+});
+console.log(`Sent ${receipts.sent} receipt(s)`);
+```
+
+---
+
+### Lifecycle Methods
+
+#### `initialize(deps: AccountingModuleDependencies): void`
+
+Inject dependencies. Must be called before `load()`. Calling again replaces deps without resetting in-memory state — always follow with `load()`.
+
+#### `load(): Promise<void>`
+
+Load persisted state (invoice tokens, terminal sets, frozen balances, auto-return settings) and subscribe to `PaymentsModule` and `CommunicationsModule` event streams.
+
+Calling `load()` while already loading returns the same promise (re-entry safe). Calling `load()` again after initial load re-runs the full restore sequence.
+
+**Throws:**
+- `NOT_INITIALIZED` — `initialize()` has not been called.
+- `MODULE_DESTROYED` — module has been destroyed.
+
+#### `destroy(): Promise<void>`
+
+Unsubscribe from all events, drain in-flight operations, and mark the module as destroyed. After this call all public API methods throw `MODULE_DESTROYED`. Safe to call multiple times.
+
+---
+
+### Invoice CRUD
+
+#### `createInvoice(request: CreateInvoiceRequest): Promise<CreateInvoiceResult>`
+
+Mint a new invoice token on-chain via the Aggregator. The token IS the invoice: its genesis `tokenData` field contains the serialized `InvoiceTerms`.
+
+```typescript
+interface CreateInvoiceRequest {
+  /** Payment targets — at least one required, at most 100. */
+  readonly targets: InvoiceTarget[];
+  /** Optional due date (ms). Must be in the future if provided. */
+  readonly dueDate?: number;
+  /** Optional free-text memo (max 4096 chars). */
+  readonly memo?: string;
+  /**
+   * Ordered delivery method URLs (placeholder — Nostr delivery only in v1).
+   * Max 10 entries, each https:// or wss://, max 2048 chars.
+   */
+  readonly deliveryMethods?: string[];
+  /**
+   * If false, omit the creator's chain pubkey from InvoiceTerms.
+   * Defaults to true (identified invoice).
+   */
+  readonly anonymous?: boolean;
+}
+
+interface InvoiceTarget {
+  /** Destination DIRECT:// address. */
+  readonly address: string;
+  /** Assets to request at this address. */
+  readonly assets: InvoiceRequestedAsset[];
+}
+
+interface InvoiceRequestedAsset {
+  /** Fungible: [coinId, amount in smallest units]. */
+  readonly coin?: CoinEntry;  // [string, string]
+  /** NFT (placeholder — not implemented in v1). */
+  readonly nft?: NFTEntry;
+}
+
+interface CreateInvoiceResult {
+  readonly success: boolean;
+  readonly invoiceId?: string;     // Invoice token ID (64-char hex)
+  readonly token?: TxfToken;       // Raw TXF token
+  readonly terms?: InvoiceTerms;   // Parsed invoice terms
+  readonly error?: string;
+}
+```
+
+**Throws:**
+- `INVOICE_NO_TARGETS` — targets array is empty.
+- `INVOICE_TOO_MANY_TARGETS` — more than 100 targets.
+- `INVOICE_INVALID_ADDRESS` — a target address is not a valid `DIRECT://` address.
+- `INVOICE_NO_ASSETS` — a target has no assets.
+- `INVOICE_TOO_MANY_ASSETS` — a target has more than 10 assets.
+- `INVOICE_INVALID_ASSET` — an asset has neither `coin` nor `nft`, or has both.
+- `INVOICE_INVALID_AMOUNT` — a coin amount is not a positive integer string.
+- `INVOICE_INVALID_COIN` — a coin ID is empty or not a string.
+- `INVOICE_DUPLICATE_ADDRESS` — duplicate target addresses.
+- `INVOICE_DUPLICATE_COIN` — duplicate coin IDs within a target.
+- `INVOICE_PAST_DUE_DATE` — `dueDate` is not in the future.
+- `INVOICE_MEMO_TOO_LONG` — memo exceeds 4096 characters.
+- `INVOICE_TERMS_TOO_LARGE` — serialized terms exceed storage limit.
+- `INVOICE_INVALID_DELIVERY_METHOD` — delivery method fails scheme/length validation.
+- `INVOICE_MINT_FAILED` — aggregator submission failed after retries.
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+#### `importInvoice(token: TxfToken): Promise<InvoiceTerms>`
+
+Import an invoice token received out-of-band (e.g., shared by a creator via IPFS, DM, or QR code). Validates token type and parses `InvoiceTerms`. Persists the token in `TokenStorage` and adds it to the in-memory cache. Idempotent for the same token but fails if already exists with a different state.
+
+**Returns:** Parsed `InvoiceTerms`.
+
+**Throws:**
+- `INVOICE_WRONG_TOKEN_TYPE` — token's `tokenType` is not the invoice type constant.
+- `INVOICE_INVALID_DATA` — `tokenData` field is missing or cannot be parsed as `InvoiceTerms`.
+- `INVOICE_ALREADY_EXISTS` — an invoice with this token ID is already stored locally.
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+#### `getInvoice(invoiceId: string): InvoiceRef | null`
+
+Get a lightweight invoice reference by token ID. **Synchronous** — reads from in-memory cache populated during `load()`.
+
+```typescript
+interface InvoiceRef {
+  readonly invoiceId: string;
+  readonly terms: InvoiceTerms;
+  /** True if terms.creator matches the current wallet's chainPubkey. */
+  readonly isCreator: boolean;
+  readonly cancelled: boolean;
+  readonly closed: boolean;
+}
+```
+
+Returns `null` if the invoice is not found locally. Does **not** throw `INVOICE_NOT_FOUND`.
+
+**Throws:**
+- `NOT_INITIALIZED`
+
+#### `getInvoices(options?: GetInvoicesOptions): Promise<InvoiceRef[]>`
+
+List all locally known invoices with optional filtering and sorting. Status (OPEN, PARTIAL, COVERED, etc.) is **not** included in `InvoiceRef` — call `getInvoiceStatus()` per invoice when needed.
+
+```typescript
+interface GetInvoicesOptions {
+  /** Filter by computed state (requires status computation — may be slower). */
+  readonly state?: InvoiceState | InvoiceState[];
+  /** Only invoices created by this wallet. */
+  readonly createdByMe?: boolean;
+  /** Only invoices where this wallet is a target. */
+  readonly targetingMe?: boolean;
+  readonly limit?: number;
+  readonly offset?: number;
+  /** Sort field. Invoices without dueDate sort last when sortBy='dueDate'. */
+  readonly sortBy?: 'createdAt' | 'dueDate';
+  readonly sortOrder?: 'asc' | 'desc';
+}
+```
+
+**Throws:**
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+#### `getInvoiceStatus(invoiceId: string): Promise<InvoiceStatus>`
+
+Compute the current status of an invoice. For non-terminal invoices (OPEN, PARTIAL, COVERED, EXPIRED) the status is derived fresh on every call from the in-memory invoice-transfer index. For terminal invoices (CLOSED, CANCELLED) the persisted frozen balances are returned.
+
+**Side effect:** if the invoice reaches implicit close (state=COVERED and all tokens confirmed), this call acquires the per-invoice gate, freezes balances, persists them, and may trigger surplus auto-return.
+
+```typescript
+type InvoiceState = 'OPEN' | 'PARTIAL' | 'COVERED' | 'CLOSED' | 'CANCELLED' | 'EXPIRED';
+
+interface InvoiceStatus {
+  readonly invoiceId: string;
+  readonly state: InvoiceState;
+  /** Per-target breakdown. */
+  readonly targets: InvoiceTargetStatus[];
+  /** Transfers referencing this invoice that do not match any target or asset. */
+  readonly irrelevantTransfers: IrrelevantTransfer[];
+  /** Sum of all forward payments per coinId (across all targets). */
+  readonly totalForward: Record<string, string>;
+  /** Sum of all back/return payments per coinId (across all targets). */
+  readonly totalBack: Record<string, string>;
+  /** Whether ALL related tokens are confirmed (always dynamic, never frozen). */
+  readonly allConfirmed: boolean;
+  /** Timestamp of the most recent related transfer. */
+  readonly lastActivityAt: number;
+  /** Whether the invoice was explicitly closed (true) or implicitly (false). Only meaningful when state=CLOSED. */
+  readonly explicitClose?: boolean;
+}
+```
+
+**Throws:**
+- `INVOICE_NOT_FOUND` — invoice not in local cache.
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+---
+
+### Invoice Termination
+
+Both methods require the calling wallet to be a **target** of the invoice.
+
+#### `closeInvoice(invoiceId: string, options?: { autoReturn?: boolean }): Promise<void>`
+
+Explicitly close an invoice. Freezes current balances, persists the CLOSED state, and fires `invoice:closed` with `{ explicit: true }`. If `options.autoReturn` is `true`, enables auto-return for this invoice and immediately returns any surplus to payers.
+
+**Throws:**
+- `INVOICE_NOT_FOUND` / `INVOICE_NOT_TARGET` / `INVOICE_ALREADY_CLOSED` / `INVOICE_ALREADY_CANCELLED`
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+#### `cancelInvoice(invoiceId: string, options?: { autoReturn?: boolean }): Promise<void>`
+
+Cancel an invoice. Freezes current balances, persists the CANCELLED state, and fires `invoice:cancelled`. If `options.autoReturn` is `true`, enables auto-return and immediately returns all forwarded payments to payers.
+
+**Throws:**
+- `INVOICE_NOT_FOUND` / `INVOICE_NOT_TARGET` / `INVOICE_ALREADY_CLOSED` / `INVOICE_ALREADY_CANCELLED`
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+---
+
+### Payments
+
+#### `payInvoice(invoiceId: string, params: PayInvoiceParams): Promise<TransferResult>`
+
+Send a payment toward an invoice. Builds the structured memo (`INV:<invoiceId>:F`), optionally embeds a refund address and contact info in the on-chain `TransferMessagePayload`, and delegates to `PaymentsModule.send()`.
+
+```typescript
+interface PayInvoiceParams {
+  /** Index into invoice.terms.targets[]. */
+  readonly targetIndex: number;
+  /** Index into target.assets[]. Defaults to 0. */
+  readonly assetIndex?: number;
+  /**
+   * Amount in smallest units. Defaults to the remaining amount needed to
+   * fully cover the requested asset (i.e., requested − already paid).
+   */
+  readonly amount?: string;
+  /** Optional free text appended after the structured memo prefix. */
+  readonly freeText?: string;
+  /**
+   * Explicit refund address (DIRECT:// format). Embedded on-chain in the
+   * TransferMessagePayload inv.ra field — not in the transport memo.
+   * Required for masked-predicate wallets that cannot be resolved for return.
+   * Auto-populated from identity.directAddress when omitted.
+   */
+  readonly refundAddress?: string;
+  /**
+   * Contact info for the target to reach the payer (receipts, notices).
+   * Embedded on-chain in inv.ct. Not in transport memo.
+   * Auto-populated from identity.directAddress when omitted.
+   */
+  readonly contact?: { address: string; url?: string };
+}
+```
+
+Returns the `TransferResult` from `PaymentsModule.send()`.
+
+**Throws:**
+- `INVOICE_NOT_FOUND` — invoice not found locally.
+- `INVOICE_TERMINATED` — invoice is already closed or cancelled.
+- `INVOICE_INVALID_TARGET` — targetIndex out of range.
+- `INVOICE_INVALID_ASSET_INDEX` — assetIndex out of range.
+- `INVOICE_INVALID_REFUND_ADDRESS` — not a valid `DIRECT://` address.
+- `INVOICE_INVALID_CONTACT` — contact.address or contact.url fails validation.
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+#### `returnInvoicePayment(invoiceId: string, params: ReturnPaymentParams): Promise<TransferResult>`
+
+Manually return a payment to a payer. Requires the calling wallet to be a target. Validates that the return amount does not exceed the payer's net balance for the given coin. Serialized inside the per-invoice gate to prevent concurrent over-refunds.
+
+```typescript
+interface ReturnPaymentParams {
+  /** The payer's effective address (DIRECT:// format) to return funds to. */
+  readonly recipient: string;
+  /** Amount in smallest units. */
+  readonly amount: string;
+  readonly coinId: string;
+  /** Optional free text appended to the return memo. */
+  readonly freeText?: string;
+}
+```
+
+**Throws:**
+- `INVOICE_NOT_FOUND` / `INVOICE_NOT_TARGET`
+- `INVOICE_RETURN_EXCEEDS_BALANCE` — amount exceeds the payer's net balance.
+- `INVOICE_INVALID_AMOUNT` — amount is not a positive integer string.
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+---
+
+### Auto-Return
+
+Auto-return automatically sends back surplus or full payments to payers when an invoice is terminated (closed or cancelled). It operates on frozen per-sender balances.
+
+#### `setAutoReturn(invoiceId: string | '*', enabled: boolean): Promise<void>`
+
+Enable or disable auto-return.
+
+- **`invoiceId`**: Enable/disable auto-return for a specific invoice. If enabling on a terminated invoice, surplus return is triggered immediately.
+- **`'*'`**: Enable/disable globally for all terminated invoices. Enabling `'*'` immediately triggers return on all currently terminated invoices (up to 100). Rate-limited to one call per 5 seconds.
+
+**Throws:**
+- `INVOICE_NOT_FOUND` — `invoiceId` is not `'*'` and the invoice does not exist.
+- `RATE_LIMITED` — `'*'` was called within the 5-second cooldown.
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+#### `getAutoReturnSettings(): AutoReturnSettings`
+
+Get current auto-return settings. **Synchronous**.
+
+```typescript
+interface AutoReturnSettings {
+  /** Global flag — applies to all terminated invoices unless overridden. */
+  readonly global: boolean;
+  /** Per-invoice overrides: invoiceId → enabled. */
+  readonly perInvoice: Record<string, boolean>;
+}
+```
+
+**Throws:**
+- `NOT_INITIALIZED`
+
+---
+
+### Receipts and Cancellation Notices
+
+Both methods require `CommunicationsModule` to be provided in `AccountingModuleDependencies`. They send structured DMs to each payer who contributed to the invoice.
+
+#### `sendInvoiceReceipts(invoiceId: string, options?: SendInvoiceReceiptsOptions): Promise<SendReceiptsResult>`
+
+Send receipt DMs to payers of a terminated invoice (CLOSED or CANCELLED). One DM per unique effective sender address per target. Requires `CommunicationsModule`.
+
+```typescript
+interface SendInvoiceReceiptsOptions {
+  /** Optional memo / deal description included in each receipt. Max 4096 chars. */
+  readonly memo?: string;
+  /** Send receipts to senders with net balance of 0 (default: false). */
+  readonly includeZeroBalance?: boolean;
+}
+
+interface SendReceiptsResult {
+  readonly sent: number;
+  readonly failed: number;
+  readonly sentReceipts: SentReceiptInfo[];
+  readonly failedReceipts: FailedReceiptInfo[];
+}
+```
+
+**Throws:**
+- `INVOICE_NOT_FOUND` / `INVOICE_NOT_TARGET`
+- `INVOICE_NOT_TERMINATED` — invoice is not in CLOSED or CANCELLED state.
+- `COMMUNICATIONS_UNAVAILABLE` — `CommunicationsModule` not provided.
+- `INVOICE_MEMO_TOO_LONG` — memo exceeds 4096 characters.
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+#### `sendCancellationNotices(invoiceId: string, options?: SendCancellationNoticesOptions): Promise<SendNoticesResult>`
+
+Send cancellation notice DMs to payers of a CANCELLED invoice. Unlike receipts (which apply to both terminal states), cancellation notices carry cancellation-specific context.
+
+```typescript
+interface SendCancellationNoticesOptions {
+  /** Free-text cancellation reason. Max 4096 chars. */
+  readonly reason?: string;
+  /** Context about the deal/service being cancelled. Max 4096 chars. */
+  readonly dealDescription?: string;
+  /** Send notices to senders with net balance of 0 (default: false). */
+  readonly includeZeroBalance?: boolean;
+}
+
+interface SendNoticesResult {
+  readonly sent: number;
+  readonly failed: number;
+  readonly sentNotices: SentNoticeInfo[];
+  readonly failedNotices: FailedNoticeInfo[];
+}
+```
+
+**Throws:**
+- `INVOICE_NOT_FOUND` / `INVOICE_NOT_TARGET`
+- `INVOICE_NOT_CANCELLED` — invoice is not in CANCELLED state (use `sendInvoiceReceipts()` for CLOSED).
+- `COMMUNICATIONS_UNAVAILABLE` — `CommunicationsModule` not provided.
+- `INVOICE_MEMO_TOO_LONG` — reason or dealDescription exceeds 4096 characters.
+- `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+---
+
+### Utilities
+
+#### `getRelatedTransfers(invoiceId: string): (InvoiceTransferRef | IrrelevantTransfer)[]`
+
+Get all transfers indexed for an invoice, sorted by timestamp ascending. Includes both relevant (forward/back/return) and irrelevant transfers. **Synchronous**.
+
+```typescript
+interface InvoiceTransferRef {
+  readonly transferId: string;
+  readonly direction: 'inbound' | 'outbound';
+  readonly paymentDirection: 'forward' | 'back' | 'return_closed' | 'return_cancelled';
+  readonly coinId: string;
+  readonly amount: string;
+  readonly destinationAddress: string;
+  readonly timestamp: number;
+  readonly confirmed: boolean;
+  readonly senderAddress: string | null;  // null if sender predicate is masked
+  readonly refundAddress?: string;
+  readonly contact?: { address: string; url?: string };
+  readonly senderPubkey?: string;
+  readonly senderNametag?: string;
+  readonly recipientPubkey?: string;
+  readonly recipientNametag?: string;
+}
+
+interface IrrelevantTransfer extends InvoiceTransferRef {
+  readonly reason:
+    | 'unknown_address'
+    | 'unknown_asset'
+    | 'unknown_address_and_asset'
+    | 'self_payment'
+    | 'no_coin_data'
+    | 'unauthorized_return';
+}
+```
+
+**Throws:**
+- `INVOICE_NOT_FOUND` / `NOT_INITIALIZED` / `MODULE_DESTROYED`
+
+#### `parseInvoiceMemo(memo: string): InvoiceMemoRef | null`
+
+Parse a transfer memo string and extract invoice reference information. Pure function — no side effects, no state requirements.
+
+```typescript
+interface InvoiceMemoRef {
+  readonly invoiceId: string;  // 64-char hex token ID
+  readonly paymentDirection: 'forward' | 'back' | 'return_closed' | 'return_cancelled';
+  readonly freeText?: string;  // Optional text after the structured prefix
+}
+
+// Memo format: 'INV:<invoiceId>:<direction>[:<freeText>]'
+// Direction codes: F=forward, B=back, RC=return-closed, RX=return-cancelled
+```
+
+Returns `null` if the memo does not match the `INV:` format.
+
+---
+
+### Invoice Events
+
+All invoice events are emitted via `sphere.on(eventType, handler)`.
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `invoice:created` | `{ invoiceId, confirmed }` | Invoice token minted and saved |
+| `invoice:payment` | `{ invoiceId, transfer, paymentDirection, confirmed }` | New payment transfer indexed |
+| `invoice:asset_covered` | `{ invoiceId, address, coinId, confirmed }` | A single coin asset fully covered |
+| `invoice:target_covered` | `{ invoiceId, address, confirmed }` | All assets for a target covered |
+| `invoice:covered` | `{ invoiceId, confirmed }` | All targets covered (full invoice) |
+| `invoice:closed` | `{ invoiceId, explicit }` | Invoice closed (explicit=false if auto-closed on COVERED+confirmed) |
+| `invoice:cancelled` | `{ invoiceId }` | Invoice cancelled |
+| `invoice:expired` | `{ invoiceId }` | Invoice passed its dueDate while OPEN or PARTIAL |
+| `invoice:unknown_reference` | `{ invoiceId, transfer }` | Transfer references an unknown invoice (not in local cache) |
+| `invoice:overpayment` | `{ invoiceId, address, coinId, surplus, confirmed }` | Payment exceeds requested amount |
+| `invoice:irrelevant` | `{ invoiceId, transfer, reason, confirmed }` | Transfer references invoice but matches no target/asset |
+| `invoice:auto_returned` | `{ invoiceId, originalTransfer, returnTransfer }` | Auto-return sent successfully |
+| `invoice:auto_return_failed` | `{ invoiceId, transferId, reason, refundAddress?, contactAddresses? }` | Auto-return failed |
+| `invoice:return_received` | `{ invoiceId, transfer, returnReason }` | Payer received a return transfer |
+| `invoice:over_refund_warning` | `{ invoiceId, senderAddress, coinId, forwardedAmount, returnedAmount }` | Returned amount would exceed forwarded (defense event) |
+| `invoice:receipt_sent` | `{ invoiceId, sent, failed }` | Receipt DMs sent |
+| `invoice:receipt_received` | `{ invoiceId, receipt }` | Payer received a receipt DM |
+| `invoice:cancellation_sent` | `{ invoiceId, sent, failed }` | Cancellation notice DMs sent |
+| `invoice:cancellation_received` | `{ invoiceId, notice }` | Payer received a cancellation notice DM |
+
+---
+
+### Invoice Error Codes
+
+| Code | Description |
+|------|-------------|
+| `INVOICE_NO_TARGETS` | `CreateInvoiceRequest.targets` is empty |
+| `INVOICE_TOO_MANY_TARGETS` | More than 100 targets |
+| `INVOICE_INVALID_ADDRESS` | Target address is not a valid `DIRECT://` address |
+| `INVOICE_NO_ASSETS` | A target has no assets |
+| `INVOICE_TOO_MANY_ASSETS` | A target has more than 10 assets |
+| `INVOICE_INVALID_ASSET` | Asset has neither `coin` nor `nft`, or has both |
+| `INVOICE_INVALID_AMOUNT` | Amount is not a positive integer string (max 78 digits) |
+| `INVOICE_INVALID_COIN` | Coin ID is empty or not a string |
+| `INVOICE_INVALID_NFT` | NFT entry is malformed |
+| `INVOICE_PAST_DUE_DATE` | `dueDate` is not in the future |
+| `INVOICE_DUPLICATE_ADDRESS` | Duplicate target addresses in one invoice |
+| `INVOICE_DUPLICATE_COIN` | Duplicate coin IDs within a single target |
+| `INVOICE_DUPLICATE_NFT` | Duplicate NFT IDs within a single target |
+| `INVOICE_MEMO_TOO_LONG` | Memo, reason, or dealDescription exceeds 4096 characters |
+| `INVOICE_TERMS_TOO_LARGE` | Serialized `InvoiceTerms` exceeds the storage size limit |
+| `INVOICE_INVALID_DELIVERY_METHOD` | Delivery method fails scheme (`https://`/`wss://`) or length validation |
+| `INVOICE_INVALID_REFUND_ADDRESS` | refundAddress is not a valid `DIRECT://` address |
+| `INVOICE_INVALID_CONTACT` | contact.address or contact.url is malformed |
+| `INVOICE_MINT_FAILED` | Aggregator token mint failed after retries |
+| `INVOICE_INVALID_PROOF` | Aggregator inclusion proof is invalid |
+| `INVOICE_WRONG_TOKEN_TYPE` | Token type does not match the invoice type constant |
+| `INVOICE_INVALID_DATA` | `tokenData` is missing, not JSON, or not a valid `InvoiceTerms` object |
+| `INVOICE_ALREADY_EXISTS` | Invoice with this token ID already exists locally |
+| `INVOICE_NOT_FOUND` | Invoice token not found in local cache |
+| `INVOICE_NOT_TARGET` | Calling wallet is not a target of this invoice |
+| `INVOICE_ALREADY_CLOSED` | Invoice is already in CLOSED state |
+| `INVOICE_ALREADY_CANCELLED` | Invoice is already in CANCELLED state |
+| `INVOICE_TERMINATED` | Invoice is in a terminal state (CLOSED or CANCELLED) |
+| `INVOICE_NOT_TERMINATED` | Invoice is not yet in a terminal state |
+| `INVOICE_NOT_CANCELLED` | Invoice is not in CANCELLED state (sendCancellationNotices only) |
+| `INVOICE_ORACLE_REQUIRED` | Oracle provider is required but not configured |
+| `INVOICE_INVALID_TARGET` | `targetIndex` is out of range |
+| `INVOICE_INVALID_ASSET_INDEX` | `assetIndex` is out of range |
+| `INVOICE_RETURN_EXCEEDS_BALANCE` | Return amount exceeds the payer's net balance |
+| `INVOICE_INVALID_ID` | Invoice ID is not a valid 64-character hex string |
+| `INVOICE_STORAGE_FAILED` | A storage read/write operation failed |
+
+---
+
+## SwapModule (Token Swaps)
+
+Orchestrates two-party atomic token swaps via an escrow service. The module manages the wallet-side state machine, DM-based negotiation with the counterparty, escrow interaction, deposit payment (via AccountingModule invoices), and payout verification.
+
+The module is a **client** of the escrow service -- it does not hold funds or execute payouts. Those responsibilities belong to the escrow.
+
+### Lifecycle
+
+```typescript
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  accounting: true,   // Required -- swap uses invoices internally
+  swap: true,         // Enable with defaults
+  // swap: { defaultEscrowAddress: '@escrow-testnet', proposalTimeoutMs: 300000 },
+});
+
+const swap = sphere.swap!;
+```
+
+### Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `defaultEscrowAddress` | `string` | `undefined` | Default escrow `@nametag` or `DIRECT://` address |
+| `proposalTimeoutMs` | `number` | `300000` (5 min) | Client-side timeout for proposal acceptance |
+| `maxPendingSwaps` | `number` | `100` | Max non-terminal swaps tracked simultaneously |
+| `announceTimeoutMs` | `number` | `30000` (30 sec) | Timeout for escrow announce response |
+| `terminalPurgeTtlMs` | `number` | `604800000` (7 days) | TTL before completed/cancelled swaps are purged from storage |
+
+### Core Types
+
+#### `SwapDeal`
+
+User-facing description of what is being exchanged. Passed to `proposeSwap()`.
+
+```typescript
+interface SwapDeal {
+  readonly partyA: string;          // Proposer address: @nametag, DIRECT://, or chain pubkey
+  readonly partyB: string;          // Counterparty address
+  readonly partyACurrency: string;  // Coin ID party A deposits (e.g., 'UCT')
+  readonly partyAAmount: string;    // Amount in smallest units (positive integer string)
+  readonly partyBCurrency: string;  // Coin ID party B deposits
+  readonly partyBAmount: string;    // Amount in smallest units
+  readonly timeout: number;         // Swap timeout in seconds [60, 86400]
+  readonly escrowAddress?: string;  // Escrow service address (falls back to config default)
+}
+```
+
+#### `SwapRef`
+
+The persistent swap record stored locally. Contains all state needed to resume across restarts.
+
+```typescript
+interface SwapRef {
+  readonly swapId: string;           // 64 hex chars, content-addressed from manifest
+  readonly deal: SwapDeal;
+  readonly manifest: SwapManifest;   // Wire-format manifest (DIRECT:// addresses)
+  readonly role: SwapRole;           // 'proposer' | 'acceptor'
+  progress: SwapProgress;            // Current state in the client-side state machine
+  depositInvoiceId?: string;         // Set after escrow announcement
+  payoutInvoiceId?: string;          // Set after escrow delivers payout
+  escrowState?: string;              // Last known escrow state (informational)
+  counterpartyPubkey?: string;       // Resolved counterparty chain pubkey
+  localDepositTransferId?: string;   // Transfer ID of local deposit
+  escrowPubkey?: string;             // Resolved escrow chain pubkey
+  payoutVerified: boolean;           // Whether payout was verified
+  readonly createdAt: number;        // ms timestamp
+  announcedAt?: number;              // ms timestamp when escrow acknowledged
+  updatedAt: number;                 // ms timestamp of last state change
+  error?: string;                    // Error message if progress is 'failed'
+}
+```
+
+#### `SwapProgress`
+
+Client-side state machine:
+
+```
+proposed -> accepted -> announced -> depositing -> awaiting_counter
+  -> concluding -> completed
+
+Terminal states: completed, cancelled, failed
+```
+
+| State | Description |
+|-------|-------------|
+| `proposed` | Proposal sent (proposer) or received (acceptor) |
+| `accepted` | Counterparty accepted, announcing to escrow |
+| `announced` | Escrow acknowledged, deposit invoice available |
+| `depositing` | Local deposit sent, awaiting confirmation |
+| `awaiting_counter` | Local deposit confirmed, waiting for counterparty |
+| `concluding` | Both deposited, escrow executing payouts |
+| `completed` | Swap done, tokens exchanged (terminal) |
+| `cancelled` | Swap cancelled (terminal) |
+| `failed` | Unrecoverable error (terminal) |
+
+### Methods
+
+#### `proposeSwap(deal: SwapDeal, options?: ProposeSwapOptions): Promise<SwapProposalResult>`
+
+Propose a swap to a counterparty. Resolves addresses, computes the content-addressed swap ID, sends a proposal DM, and creates a local `SwapRef` with `progress='proposed'`.
+
+```typescript
+const result = await swap.proposeSwap({
+  partyA: sphere.identity!.directAddress!,
+  partyB: '@bob',
+  partyACurrency: 'UCT',
+  partyAAmount: '1000000',
+  partyBCurrency: 'USDU',
+  partyBAmount: '500000',
+  timeout: 3600,
+  escrowAddress: '@escrow-testnet',
+}, { message: 'Trading 1 UCT for 0.5 USDU' });
+
+console.log(result.swapId);     // 64-char hex
+console.log(result.manifest);   // Wire-format manifest
+console.log(result.swap);       // SwapRef
+```
+
+**Throws:** `SWAP_LIMIT_EXCEEDED`, `INVALID_RECIPIENT`, `TRANSPORT_ERROR`
+
+#### `acceptSwap(swapId: string): Promise<void>`
+
+Accept a swap proposal. Sends an acceptance DM to the proposer, announces the manifest to the escrow, and waits for the escrow's `announce_result`. After successful announcement, the swap transitions to `announced` and a deposit invoice is available.
+
+```typescript
+await swap.acceptSwap(swapId);
+// swap.progress is now 'announced'
+```
+
+**Throws:** `SWAP_NOT_FOUND`, `SWAP_INVALID_STATE` (if not in `proposed` state)
+
+#### `rejectSwap(swapId: string, reason?: string): Promise<void>`
+
+Reject a swap proposal. Sends a rejection DM to the proposer. The swap transitions to `cancelled` locally.
+
+```typescript
+await swap.rejectSwap(swapId, 'Price too high');
+```
+
+#### `deposit(swapId: string): Promise<TransferResult>`
+
+Deposit into an announced swap. Pays the escrow's deposit invoice with the correct currency and amount for this party's role.
+
+```typescript
+const result = await swap.deposit(swapId);
+console.log(result.id, result.status);
+```
+
+**Throws:** `SWAP_NOT_FOUND`, `SWAP_INVALID_STATE` (if not `announced` or `awaiting_counter`), `INSUFFICIENT_BALANCE`
+
+#### `getSwapStatus(swapId: string, options?: GetSwapStatusOptions): Promise<SwapRef>`
+
+Get the current swap status. By default, queries the escrow for active swaps (not for terminal swaps).
+
+```typescript
+const ref = await swap.getSwapStatus(swapId, { queryEscrow: true });
+console.log(ref.progress, ref.escrowState);
+```
+
+**Options:**
+- `queryEscrow?: boolean` -- If true, sends a status DM to the escrow and merges the response.
+
+#### `getSwaps(filter?: GetSwapsFilter): SwapRef[]`
+
+List swaps with optional filtering.
+
+```typescript
+// All active swaps
+const active = swap.getSwaps({ excludeTerminal: true });
+
+// Only swaps where I am the proposer
+const proposed = swap.getSwaps({ role: 'proposer' });
+
+// Specific progress state
+const depositing = swap.getSwaps({ progress: 'depositing' });
+
+// Multiple progress states
+const pending = swap.getSwaps({ progress: ['proposed', 'accepted', 'announced'] });
+```
+
+**Filter options:**
+- `progress?: SwapProgress | SwapProgress[]` -- Filter by state(s)
+- `role?: SwapRole` -- Filter by `'proposer'` or `'acceptor'`
+- `excludeTerminal?: boolean` -- Exclude completed/cancelled/failed swaps
+
+#### `verifyPayout(swapId: string): Promise<boolean>`
+
+Verify that the payout invoice has been correctly fulfilled. Checks that the payout invoice terms match the swap manifest and that the invoice is covered. Returns `true` if verification passes, `false` otherwise.
+
+```typescript
+const verified = await swap.verifyPayout(swapId);
+console.log('Payout verified:', verified);
+```
+
+#### `cancelSwap(swapId: string): Promise<void>`
+
+Cancel a swap locally. The swap transitions to `cancelled`. This does NOT communicate with the escrow -- use this for local cleanup of swaps that are stuck in non-terminal states.
+
+```typescript
+await swap.cancelSwap(swapId);
+```
+
+**Throws:** `SWAP_NOT_FOUND`, `SWAP_INVALID_STATE` (if already terminal)
+
+### Swap Events
+
+| Event | Payload | When |
+|-------|---------|------|
+| `swap:proposal_received` | `{ swapId, deal, senderPubkey, senderNametag? }` | Incoming swap proposal DM |
+| `swap:proposed` | `{ swapId, deal, recipientPubkey }` | Outgoing proposal sent |
+| `swap:accepted` | `{ swapId, role }` | Swap accepted (either side) |
+| `swap:rejected` | `{ swapId, reason? }` | Swap rejected (either side) |
+| `swap:announced` | `{ swapId, depositInvoiceId }` | Escrow acknowledged, deposit invoice ready |
+| `swap:deposit_sent` | `{ swapId, transferResult }` | Local deposit payment sent |
+| `swap:deposit_confirmed` | `{ swapId, party, amount, coinId }` | Deposit confirmed by escrow |
+| `swap:deposits_covered` | `{ swapId }` | Both deposits fully covered |
+| `swap:concluding` | `{ swapId }` | Escrow executing payouts |
+| `swap:payout_received` | `{ swapId, payoutInvoiceId }` | Payout invoice token received |
+| `swap:completed` | `{ swapId, payoutVerified }` | Swap completed (terminal) |
+| `swap:cancelled` | `{ swapId, reason, depositsReturned? }` | Swap cancelled (terminal) |
+| `swap:failed` | `{ swapId, error }` | Swap failed (terminal) |
+| `swap:deposit_returned` | `{ swapId, transfer, returnReason }` | Deposit returned after cancellation |
+| `swap:bounce_received` | `{ swapId, reason, returnedAmount, returnedCurrency }` | Wrong-currency deposit bounced back |
+
+### Escrow Communication
+
+The swap module communicates with the escrow service via encrypted DMs (NIP-17). The escrow sends the following message types:
+
+| Type | When | Key Fields |
+|------|------|------------|
+| `announce_result` | After manifest announcement | `swap_id`, `state`, `deposit_invoice_id` |
+| `invoice_delivery` | Deposit or payout invoice token | `swap_id`, `invoice_type`, `invoice_token` |
+| `status_result` | In response to status query | `swap_id`, `state` |
+| `payment_confirmation` | After escrow pays payout invoice | `swap_id`, `party` |
+| `swap_cancelled` | Swap cancelled (timeout/manual) | `swap_id`, `reason`, `deposits_returned?` |
+| `bounce_notification` | Wrong-currency deposit returned | `swap_id`, `reason`, `returned_amount` |
+| `error` | Escrow-side error | `error`, `swap_id?` |
 
 ---
 

--- a/docs/CONNECT.md
+++ b/docs/CONNECT.md
@@ -302,6 +302,8 @@ The wallet's `onConnectionRequest` receives `silent=true` and must return `{ app
 | `sphere_l1GetBalance` | — | L1 balance |
 | `sphere_l1GetHistory` | `limit?` | L1 history |
 | `sphere_resolve` | `identifier` | resolved address info |
+| `sphere_getInvoices` | `state?, createdByMe?, targetingMe?, limit?, offset?, sortBy?, sortOrder?` | `InvoiceRef[]` |
+| `sphere_getInvoiceStatus` | `invoiceId` | `InvoiceStatus` |
 | `sphere_subscribe` | `event` | `{ subscribed, event }` |
 | `sphere_unsubscribe` | `event` | `{ unsubscribed, event }` |
 | `sphere_disconnect` | — | `{ disconnected }` |
@@ -316,6 +318,15 @@ The wallet's `onConnectionRequest` receives `silent=true` and must return `{ app
 | `payment_request` | `amount, coinId, description?` |
 | `receive` | `coinId?` |
 | `sign_message` | `message` |
+| `create_invoice` | `targets, dueDate?, memo?, deliveryMethods?, anonymous?` |
+| `close_invoice` | `invoiceId, autoReturn?` |
+| `cancel_invoice` | `invoiceId, autoReturn?` |
+| `pay_invoice` | `invoiceId, targetIndex, assetIndex?, amount?, freeText?, refundAddress?, contact?` |
+| `return_invoice_payment` | `invoiceId, recipient, amount, coinId, freeText?` |
+| `import_invoice` | `token` |
+| `send_invoice_receipts` | `invoiceId, memo?, includeZeroBalance?` |
+| `send_cancellation_notices` | `invoiceId, reason?, dealDescription?, includeZeroBalance?` |
+| `set_auto_return` | `invoiceId, enabled` |
 
 ### sign_message Intent
 
@@ -413,6 +424,8 @@ Permissions are requested during handshake and checked on every request:
 | `intent:sign_message` | `sign_message` intent |
 | `comms:read` | DM conversations |
 | `comms:write` | send DMs |
+| `invoice:read` | `sphere_getInvoices`, `sphere_getInvoiceStatus` |
+| `invoice:write` | `create_invoice`, `close_invoice`, `cancel_invoice`, `import_invoice`, `send_invoice_receipts`, `send_cancellation_notices`, `set_auto_return` intents |
 
 ---
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -15,10 +15,11 @@
 4. [Payment Requests](#payment-requests)
 5. [L1 Payments](#l1-payments)
 6. [Communications](#communications)
-7. [Custom Providers](#custom-providers)
-8. [Events](#events)
-9. [Error Handling](#error-handling)
-10. [Testing](#testing)
+7. [Invoicing / Accounting](#invoicing--accounting)
+8. [Custom Providers](#custom-providers)
+9. [Events](#events)
+10. [Error Handling](#error-handling)
+11. [Testing](#testing)
 
 ---
 
@@ -857,6 +858,523 @@ sphere.communications.onBroadcast((broadcast) => {
 ```typescript
 await sphere.communications.broadcast('Hello world!', ['general']);
 ```
+
+---
+
+## Invoicing / Accounting
+
+The `AccountingModule` manages the full lifecycle of on-chain invoices: creation, sharing, payment attribution, status tracking, returns, and receipts. An invoice is a special token minted on the Unicity aggregator. Its terms (payment targets, amounts, due date, memo) are embedded in the token's genesis data, making them tamper-evident and independently verifiable by any party who holds the token.
+
+### Enable the Accounting Module
+
+The module is opt-in. Pass `accounting: true` (or a config object) when initializing the wallet:
+
+```typescript
+import { Sphere } from '@unicitylabs/sphere-sdk';
+import { createNodeProviders } from '@unicitylabs/sphere-sdk/impl/nodejs';
+
+const providers = createNodeProviders({ network: 'testnet', dataDir: './wallet', tokensDir: './tokens' });
+
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  accounting: true,  // Enable with defaults
+});
+
+// Access the module
+const accounting = sphere.accounting!;
+```
+
+Custom configuration:
+
+```typescript
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  accounting: {
+    debug: true,                    // Enable debug logging
+    autoTerminateOnReturn: false,   // Do not auto-close invoice when a return arrives (default)
+    maxCoinDataEntries: 50,         // Max coin entries processed per token transaction (default)
+  },
+});
+```
+
+> `sphere.accounting` is `null` when the module is not configured.
+
+### Create an Invoice
+
+An invoice specifies one or more payment targets. Each target has a `DIRECT://` destination address and a list of assets (coin type + amount) it expects to receive.
+
+```typescript
+// Create a simple single-target invoice requesting 1 000 000 UCT
+const result = await accounting.createInvoice({
+  targets: [
+    {
+      address: sphere.identity!.directAddress!,  // Pay to this wallet
+      assets: [
+        { coin: ['UCT', '1000000'] },  // [coinId, amount in smallest units]
+      ],
+    },
+  ],
+  memo: 'Payment for order #1234',
+  dueDate: Date.now() + 7 * 24 * 60 * 60 * 1000,  // Due in 7 days
+});
+
+if (!result.success) {
+  console.error('Invoice creation failed:', result.error);
+} else {
+  console.log('Invoice ID:', result.invoiceId);      // 64-char hex token ID
+  console.log('Terms:', result.terms);               // Parsed InvoiceTerms
+  console.log('Token (TXF):', result.token);         // Raw TxfToken for sharing
+}
+```
+
+Multi-target invoices — where separate parties each receive a different asset — are supported by adding more entries to `targets`. Each target address must be a valid `DIRECT://` address and must appear only once.
+
+### Share an Invoice
+
+The `result.token` is a plain `TxfToken` object (JSON-serializable). Share it with payers over any channel — DM, email, QR code, file, etc.:
+
+```typescript
+// Serialize for transmission
+const invoiceJson = JSON.stringify(result.token);
+
+// Send over DM (example — use your preferred transport)
+await sphere.communications.sendDM('@bob', invoiceJson);
+```
+
+### Import an Invoice (Payer Side)
+
+The payer imports the token to start tracking the invoice locally:
+
+```typescript
+import type { TxfToken } from '@unicitylabs/sphere-sdk';
+
+const token: TxfToken = JSON.parse(receivedJson);
+
+const terms = await accounting.importInvoice(token);
+console.log('Invoice creator:', terms.creator);     // Chain pubkey of issuer
+console.log('Due date:', terms.dueDate ? new Date(terms.dueDate) : 'none');
+console.log('Targets:', terms.targets.length);
+```
+
+`importInvoice()` validates the inclusion proof embedded in the token and rejects tokens with an invalid or tampered proof chain.
+
+### Pay an Invoice
+
+Use `payInvoice()` to send tokens against a specific target and asset within the invoice. The module constructs the correct memo automatically and embeds your return address so the payee can issue refunds.
+
+```typescript
+// Pay the first target's first asset (index 0, 0)
+const transfer = await accounting.payInvoice(invoiceId, {
+  targetIndex: 0,    // Which target to pay
+  assetIndex: 0,     // Which asset within that target (default: 0)
+  // amount is optional — defaults to the remaining uncovered amount
+});
+
+console.log('Transfer ID:', transfer.id);
+console.log('Status:', transfer.status);  // 'pending' | 'submitted' | 'delivered' | 'completed' | 'failed'
+```
+
+Paying a specific amount (partial payment):
+
+```typescript
+await accounting.payInvoice(invoiceId, {
+  targetIndex: 0,
+  amount: '500000',          // Pay half now
+  freeText: 'First tranche', // Optional note appended to the memo
+  refundAddress: sphere.identity!.directAddress!,  // Explicit refund destination
+});
+```
+
+### Check Invoice Status
+
+`getInvoiceStatus()` computes the current payment state from local transaction history. It returns a full breakdown per target and per coin asset.
+
+```typescript
+const status = await accounting.getInvoiceStatus(invoiceId);
+
+console.log('State:', status.state);
+// 'OPEN'      — no payments yet
+// 'PARTIAL'   — some targets partially covered
+// 'COVERED'   — all targets fully covered, awaiting confirmation
+// 'CLOSED'    — explicitly or implicitly closed
+// 'CANCELLED' — cancelled by a target party
+// 'EXPIRED'   — due date passed, not yet covered
+
+console.log('All confirmed:', status.allConfirmed);
+console.log('Last activity:', new Date(status.lastActivityAt));
+
+// Per-target breakdown
+for (const target of status.targets) {
+  console.log(`Target ${target.address}: covered=${target.isCovered}`);
+  for (const coinAsset of target.coinAssets) {
+    const [coinId, requested] = coinAsset.coin;
+    console.log(`  ${coinId}: ${coinAsset.netCoveredAmount}/${requested}`);
+    if (coinAsset.surplusAmount !== '0') {
+      console.log(`  Surplus: ${coinAsset.surplusAmount}`);
+    }
+  }
+}
+```
+
+`getInvoiceStatus()` has a side effect: when the invoice transitions from `COVERED` to fully confirmed (`allConfirmed === true`), it implicitly closes the invoice, freezes balances, and fires `invoice:closed`.
+
+### List Invoices
+
+`getInvoices()` returns lightweight `InvoiceRef` objects (no status computed unless a state filter is passed):
+
+```typescript
+// All invoices
+const all = await accounting.getInvoices();
+
+// Only open invoices created by this wallet
+const mine = await accounting.getInvoices({
+  state: 'OPEN',
+  createdByMe: true,
+  sortBy: 'dueDate',
+  sortOrder: 'asc',
+  limit: 20,
+  offset: 0,
+});
+
+for (const ref of mine) {
+  console.log(`${ref.invoiceId}: creator=${ref.isCreator} closed=${ref.closed} cancelled=${ref.cancelled}`);
+  console.log(`  Memo: ${ref.terms.memo ?? 'none'}`);
+  console.log(`  Due: ${ref.terms.dueDate ? new Date(ref.terms.dueDate) : 'none'}`);
+}
+
+// Single invoice by ID (synchronous, in-memory)
+const ref = accounting.getInvoice(invoiceId);
+if (!ref) {
+  console.log('Invoice not found locally');
+}
+```
+
+### Close an Invoice (Payee Side)
+
+Only a wallet whose address appears in `terms.targets` can close an invoice. Closing freezes the current balance snapshot and stops further dynamic recomputation.
+
+```typescript
+// Explicit close — balance is frozen at this moment
+await accounting.closeInvoice(invoiceId);
+
+// Close and immediately return any surplus to payers
+await accounting.closeInvoice(invoiceId, { autoReturn: true });
+```
+
+Implicit close happens automatically when `getInvoiceStatus()` detects `state === 'COVERED'` with `allConfirmed === true`.
+
+### Cancel an Invoice
+
+Cancellation is also restricted to target parties. All received payments become eligible for return.
+
+```typescript
+// Cancel and return all payments to payers
+await accounting.cancelInvoice(invoiceId, { autoReturn: true });
+```
+
+### Return a Payment (Manual)
+
+The payee can return tokens to a specific payer at any time. The amount is capped at that payer's net balance for the given coin.
+
+```typescript
+// Return 250 000 UCT to the original payer
+const result = await accounting.returnInvoicePayment(invoiceId, {
+  recipient: 'DIRECT://...',  // Payer's address (from status.targets[i].coinAssets[j].senderBalances)
+  amount: '250000',
+  coinId: 'UCT',
+  freeText: 'Partial refund — order cancelled',
+});
+```
+
+### Auto-Return Setup
+
+Auto-return automatically sends tokens back to payers when an invoice is terminated (closed or cancelled). It can be enabled globally or per invoice.
+
+```typescript
+// Enable for all terminated invoices (global setting)
+await accounting.setAutoReturn('*', true);
+
+// Enable for a specific invoice only
+await accounting.setAutoReturn(invoiceId, true);
+
+// Check current settings
+const settings = accounting.getAutoReturnSettings();
+console.log('Global:', settings.global);
+console.log('Per-invoice:', settings.perInvoice);
+```
+
+When enabled, auto-return fires immediately for invoices already in a terminal state, and continues to process new forward payments that arrive after termination.
+
+### Send Receipts (Payee Side)
+
+After closing or cancelling an invoice, the payee can send structured receipt DMs to each payer confirming their contribution:
+
+```typescript
+// Send receipt to all payers after close
+const result = await accounting.sendInvoiceReceipts(invoiceId, {
+  memo: 'Thank you for your payment — order dispatched',
+  includeZeroBalance: false,  // Skip payers with net balance of 0 (default)
+});
+
+console.log(`Sent: ${result.sent}, Failed: ${result.failed}`);
+```
+
+### Send Cancellation Notices
+
+After cancelling an invoice, the payee can notify payers with a structured cancellation DM:
+
+```typescript
+const result = await accounting.sendCancellationNotices(invoiceId, {
+  reason: 'Item out of stock',
+  dealDescription: 'Limited edition UCT merchandise',
+  includeZeroBalance: false,
+});
+
+console.log(`Notices sent: ${result.sent}, Failed: ${result.failed}`);
+```
+
+### Listen to Invoice Events
+
+Subscribe via `sphere.on()` — the same event bus used by all other modules:
+
+```typescript
+// Invoice created or imported
+sphere.on('invoice:created', ({ invoiceId, confirmed }) => {
+  console.log(`New invoice: ${invoiceId} (confirmed: ${confirmed})`);
+});
+
+// Incoming payment against an invoice
+sphere.on('invoice:payment', ({ invoiceId, transfer, paymentDirection, confirmed }) => {
+  console.log(`Payment on ${invoiceId}: direction=${paymentDirection}`);
+});
+
+// Asset fully covered (requested amount reached for a coin)
+sphere.on('invoice:asset_covered', ({ invoiceId, address, coinId, confirmed }) => {
+  console.log(`${coinId} covered for ${address} on invoice ${invoiceId}`);
+});
+
+// All assets for a target covered
+sphere.on('invoice:target_covered', ({ invoiceId, address, confirmed }) => {
+  console.log(`Target ${address} covered on invoice ${invoiceId}`);
+});
+
+// All targets covered
+sphere.on('invoice:covered', ({ invoiceId, confirmed }) => {
+  console.log(`Invoice ${invoiceId} fully covered`);
+});
+
+// Invoice closed (explicit: user called closeInvoice(); implicit: auto-close after COVERED+confirmed)
+sphere.on('invoice:closed', ({ invoiceId, explicit }) => {
+  console.log(`Invoice ${invoiceId} closed (explicit: ${explicit})`);
+});
+
+// Invoice cancelled
+sphere.on('invoice:cancelled', ({ invoiceId }) => {
+  console.log(`Invoice ${invoiceId} cancelled`);
+});
+
+// Overpayment detected on a coin asset
+sphere.on('invoice:overpayment', ({ invoiceId, address, coinId, surplus, confirmed }) => {
+  console.log(`Overpayment of ${surplus} ${coinId} on invoice ${invoiceId}`);
+});
+
+// Auto-return executed
+sphere.on('invoice:auto_returned', ({ invoiceId, originalTransfer, returnTransfer }) => {
+  console.log(`Auto-return sent for invoice ${invoiceId}`);
+});
+
+// Auto-return failed
+sphere.on('invoice:auto_return_failed', ({ invoiceId, transferId, reason }) => {
+  console.warn(`Auto-return failed for ${invoiceId}: ${reason}`);
+});
+
+// Return received by the payer
+sphere.on('invoice:return_received', ({ invoiceId, transfer, returnReason }) => {
+  console.log(`Return received on ${invoiceId}: reason=${returnReason}`);
+});
+
+// Receipt received (payer side — sent by the payee after close/cancel)
+sphere.on('invoice:receipt_received', ({ invoiceId, receipt }) => {
+  console.log(`Receipt for ${invoiceId} from ${receipt.targetAddress}`);
+  console.log(`State: ${receipt.receipt.terminalState}`);
+  for (const asset of receipt.receipt.senderContribution.assets) {
+    console.log(`  ${asset.coinId}: forwarded=${asset.forwardedAmount} returned=${asset.returnedAmount}`);
+  }
+});
+
+// Cancellation notice received (payer side)
+sphere.on('invoice:cancellation_received', ({ invoiceId, notice }) => {
+  console.log(`Invoice ${invoiceId} was cancelled: ${notice.notice.reason ?? 'no reason given'}`);
+});
+```
+
+### Complete Workflow Example
+
+The following example walks through the full lifecycle from the payee's perspective (creating and closing) and the payer's perspective (importing and paying):
+
+```typescript
+// ---- PAYEE SIDE ----
+
+const { sphere: payee } = await Sphere.init({
+  ...payeeProviders,
+  autoGenerate: true,
+  nametag: 'shop',
+  accounting: true,
+});
+const payeeAccounting = payee.accounting!;
+
+// 1. Create the invoice
+const { invoiceId, token } = await payeeAccounting.createInvoice({
+  targets: [{
+    address: payee.identity!.directAddress!,
+    assets: [{ coin: ['UCT', '2000000'] }],
+  }],
+  memo: 'Order #5678 — 2 items',
+  dueDate: Date.now() + 3 * 24 * 60 * 60 * 1000,
+});
+
+// 2. Share with payer (here via DM)
+await payee.communications.sendDM('@customer', JSON.stringify(token));
+
+// 3. Listen for payments
+payee.on('invoice:covered', async ({ invoiceId: id }) => {
+  // All targets are paid — send receipt
+  await payeeAccounting.sendInvoiceReceipts(id, { memo: 'Your order has been dispatched.' });
+});
+
+// ---- PAYER SIDE ----
+
+const { sphere: payer } = await Sphere.init({
+  ...payerProviders,
+  autoGenerate: true,
+  nametag: 'customer',
+  accounting: true,
+});
+const payerAccounting = payer.accounting!;
+
+// 4. Receive the invoice token via DM
+payer.communications.onDirectMessage(async (msg) => {
+  let token;
+  try { token = JSON.parse(msg.content); } catch { return; }
+
+  // 5. Import and pay
+  await payerAccounting.importInvoice(token);
+
+  const status = await payerAccounting.getInvoiceStatus(token.id);
+  console.log('Invoice state before payment:', status.state);  // 'OPEN'
+
+  await payerAccounting.payInvoice(token.id, { targetIndex: 0 });
+});
+
+// 6. Payer receives a receipt DM once payee confirms
+payer.on('invoice:receipt_received', ({ invoiceId: id, receipt }) => {
+  console.log(`Invoice ${id} settled. Memo: ${receipt.receipt.memo}`);
+});
+```
+
+### Get Related Transfers
+
+Inspect the full transfer history attributed to an invoice, including transfers the module classified as irrelevant (wrong address, wrong asset, self-payment):
+
+```typescript
+const transfers = accounting.getRelatedTransfers(invoiceId);
+
+for (const t of transfers) {
+  console.log(`${t.transferId}: direction=${t.direction} paymentDirection=${t.paymentDirection}`);
+  console.log(`  Amount: ${t.amount} ${t.coinId}`);
+  if ('reason' in t) {
+    // IrrelevantTransfer — did not count toward coverage
+    console.log(`  Irrelevant: ${t.reason}`);
+  }
+}
+```
+
+### Parse an Invoice Memo
+
+When inspecting raw transaction history (e.g., from `sphere.payments.getHistory()`), use `parseInvoiceMemo()` to check whether a memo references an invoice:
+
+```typescript
+const parsed = accounting.parseInvoiceMemo('INV:abc123:F');
+if (parsed) {
+  console.log('Invoice ID:', parsed.invoiceId);           // 'abc123'
+  console.log('Direction:', parsed.paymentDirection);     // 'forward'
+  console.log('Free text:', parsed.freeText ?? 'none');
+}
+```
+
+### Accounting Error Codes
+
+All accounting errors are `SphereError` instances with a typed `.code`. Use `isSphereError()` to handle them:
+
+```typescript
+import { isSphereError } from '@unicitylabs/sphere-sdk';
+
+try {
+  await accounting.closeInvoice(invoiceId);
+} catch (err) {
+  if (isSphereError(err)) {
+    switch (err.code) {
+      case 'INVOICE_NOT_FOUND':
+        console.error('Invoice not found locally — was it imported?');
+        break;
+      case 'INVOICE_NOT_TARGET':
+        console.error('Only target parties can close an invoice');
+        break;
+      case 'INVOICE_ALREADY_CLOSED':
+        console.error('Invoice is already closed');
+        break;
+      case 'INVOICE_ALREADY_CANCELLED':
+        console.error('Invoice is already cancelled');
+        break;
+      case 'INVOICE_TERMINATED':
+        console.error('Cannot pay a closed or cancelled invoice');
+        break;
+      case 'INVOICE_RETURN_EXCEEDS_BALANCE':
+        console.error('Return amount exceeds the payer\'s net balance for this coin');
+        break;
+      case 'INVOICE_MINT_FAILED':
+        console.error('Aggregator submission failed — check network connection');
+        break;
+      case 'INVOICE_NOT_TERMINATED':
+        console.error('Receipts can only be sent for closed or cancelled invoices');
+        break;
+      case 'COMMUNICATIONS_UNAVAILABLE':
+        console.error('DM receipts require the CommunicationsModule to be available');
+        break;
+      default:
+        console.error(err.message);
+    }
+  }
+}
+```
+
+**Full list of accounting error codes:**
+
+| Code | Thrown by | Meaning |
+|------|-----------|---------|
+| `INVOICE_NO_TARGETS` | `createInvoice` | Targets array is empty |
+| `INVOICE_NO_ASSETS` | `createInvoice` | A target has no assets |
+| `INVOICE_INVALID_AMOUNT` | `createInvoice`, `payInvoice` | Asset amount is not a positive integer, or zero-amount send |
+| `INVOICE_INVALID_ADDRESS` | `createInvoice` | A target address is not a valid `DIRECT://` address |
+| `INVOICE_ORACLE_REQUIRED` | `createInvoice` | Oracle provider is not available (required for minting) |
+| `INVOICE_MINT_FAILED` | `createInvoice` | Aggregator submission failed after retries |
+| `INVOICE_INVALID_PROOF` | `importInvoice` | Inclusion proof is invalid or tampered |
+| `INVOICE_WRONG_TOKEN_TYPE` | `importInvoice` | Token is not an invoice token |
+| `INVOICE_INVALID_DATA` | `importInvoice` | `tokenData` cannot be parsed as `InvoiceTerms` |
+| `INVOICE_ALREADY_EXISTS` | `importInvoice` | Invoice token already held locally |
+| `INVOICE_NOT_FOUND` | Most methods | Invoice is not known locally |
+| `INVOICE_NOT_TARGET` | `closeInvoice`, `cancelInvoice`, `returnInvoicePayment`, `sendInvoiceReceipts`, `sendCancellationNotices` | Wallet is not one of the invoice targets |
+| `INVOICE_ALREADY_CLOSED` | `closeInvoice` | Invoice is already in CLOSED state |
+| `INVOICE_ALREADY_CANCELLED` | `cancelInvoice` | Invoice is already in CANCELLED state |
+| `INVOICE_TERMINATED` | `payInvoice` | Invoice is CLOSED or CANCELLED — no further payments accepted |
+| `INVOICE_RETURN_EXCEEDS_BALANCE` | `returnInvoicePayment` | Return amount exceeds per-sender net balance |
+| `INVOICE_NOT_TERMINATED` | `sendInvoiceReceipts` | Invoice must be CLOSED or CANCELLED before sending receipts |
+| `INVOICE_NOT_CANCELLED` | `sendCancellationNotices` | Invoice must be in CANCELLED state |
+| `COMMUNICATIONS_UNAVAILABLE` | `sendInvoiceReceipts`, `sendCancellationNotices` | `CommunicationsModule` is not available |
+| `INVOICE_MEMO_TOO_LONG` | `createInvoice`, `sendInvoiceReceipts`, `sendCancellationNotices` | Memo or reason exceeds 4096 characters |
+| `RATE_LIMITED` | `setAutoReturn('*', ...)` | Global auto-return setting changed within 5-second cooldown |
 
 ---
 

--- a/docs/QUICKSTART-BROWSER.md
+++ b/docs/QUICKSTART-BROWSER.md
@@ -278,6 +278,30 @@ document.getElementById('balance').textContent =
 const l1Balance = await sphere.payments.l1.getBalance();
 ```
 
+### Look Up Asset Metadata
+
+The `TokenRegistry` provides metadata (symbol, name, decimals, icons) for all registered assets on the network:
+
+```typescript
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+
+const registry = TokenRegistry.getInstance();
+
+// List all registered assets
+const allAssets = registry.getAllDefinitions();
+const coins = registry.getFungibleDefinitions();
+const nfts = registry.getNonFungibleDefinitions();
+
+// Look up a specific asset
+const uct = registry.getDefinitionBySymbol('UCT');
+console.log(uct?.name, uct?.decimals);  // 'Unicity Token', 8
+
+// Reverse lookup: symbol → coin ID
+const coinId = registry.getCoinIdBySymbol('UCT');
+```
+
+> **Note:** The registry is configured automatically by `createBrowserProviders()` and `Sphere.init()`. Data is fetched from the network and cached in `localStorage`.
+
 ### Send Tokens
 
 ```typescript
@@ -357,6 +381,164 @@ sphere.on('connection:changed', (event) => {
 
 ```typescript
 await sphere.communications.sendDM('@alice', 'Hello from the browser!');
+```
+
+### Invoicing
+
+Enable the accounting module when initializing the wallet:
+
+```typescript
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  accounting: true,  // Enable with defaults
+});
+```
+
+**Create an invoice** (mints a token on-chain via the aggregator):
+
+```typescript
+const result = await sphere.accounting!.createInvoice({
+  targets: [
+    {
+      address: sphere.identity!.directAddress!,  // Pay to self (your DIRECT:// address)
+      assets: [
+        { coin: ['UCT', '5000000'] },             // Request 5 UCT (in smallest units)
+      ],
+    },
+  ],
+  memo: 'Order #1234',
+  dueDate: Date.now() + 7 * 24 * 60 * 60 * 1000, // Due in 7 days
+});
+
+console.log('Invoice ID:', result.invoiceId);
+```
+
+**Check invoice status:**
+
+```typescript
+const status = await sphere.accounting!.getInvoiceStatus(result.invoiceId!);
+// status.state: 'OPEN' | 'PARTIAL' | 'COVERED' | 'CLOSED' | 'CANCELLED' | 'EXPIRED'
+console.log('State:', status.state);
+```
+
+**Pay an invoice** (as the payer, after importing the invoice token):
+
+```typescript
+const transferResult = await sphere.accounting!.payInvoice(invoiceId, {
+  targetIndex: 0,  // Which target to pay (index into invoice.targets)
+  // amount: '5000000',  // Omit to pay the full remaining amount
+});
+```
+
+**Close an invoice** (only target parties may close):
+
+```typescript
+await sphere.accounting!.closeInvoice(invoiceId);
+```
+
+**List invoices:**
+
+```typescript
+const invoices = await sphere.accounting!.getInvoices({ createdByMe: true });
+for (const ref of invoices) {
+  console.log(ref.invoiceId, ref.terms.memo, ref.closed ? 'CLOSED' : 'OPEN');
+}
+```
+
+**Listen for invoice events:**
+
+```typescript
+sphere.on('invoice:payment', (event) => {
+  console.log(`Payment received for invoice ${event.data.invoiceId}`);
+});
+
+sphere.on('invoice:covered', (event) => {
+  console.log(`Invoice ${event.data.invoiceId} fully covered!`);
+});
+```
+
+> **Note:** `createInvoice()` requires the Oracle (Aggregator) provider, which is included automatically by `createBrowserProviders()`.
+
+### Token Swaps
+
+The swap module enables trustless two-party token exchanges via an escrow service. Enable it when initializing:
+
+```typescript
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  accounting: true,  // Required (swap uses invoices internally)
+  swap: true,        // Enable swap module
+});
+```
+
+**Propose a swap:**
+
+```typescript
+const result = await sphere.swap!.proposeSwap({
+  partyA: sphere.identity!.directAddress!,
+  partyB: '@bob',
+  partyACurrency: 'UCT',
+  partyAAmount: '1000000',
+  partyBCurrency: 'USDU',
+  partyBAmount: '500000',
+  timeout: 3600,
+  escrowAddress: '@escrow-testnet',
+});
+
+console.log('Swap ID:', result.swapId);
+// result.swap.progress === 'proposed'
+```
+
+**Listen for incoming proposals and accept:**
+
+```typescript
+sphere.on('swap:proposal_received', async (data) => {
+  console.log('Swap proposal from:', data.senderNametag ?? data.senderPubkey);
+  console.log('Deal:', data.deal);
+
+  // Accept and deposit
+  await sphere.swap!.acceptSwap(data.swapId);
+  await sphere.swap!.deposit(data.swapId);
+});
+```
+
+**Deposit into a swap (proposer side, after counterparty accepts):**
+
+```typescript
+sphere.on('swap:announced', async (data) => {
+  // Escrow is ready, deposit now
+  const transferResult = await sphere.swap!.deposit(data.swapId);
+  console.log('Deposit sent:', transferResult.id);
+});
+```
+
+**Monitor progress:**
+
+```typescript
+sphere.on('swap:completed', (data) => {
+  console.log('Swap completed!', data.swapId, 'Payout verified:', data.payoutVerified);
+});
+
+sphere.on('swap:cancelled', (data) => {
+  console.log('Swap cancelled:', data.swapId, 'Reason:', data.reason);
+});
+
+sphere.on('swap:failed', (data) => {
+  console.log('Swap failed:', data.swapId, data.error);
+});
+```
+
+**List and query swaps:**
+
+```typescript
+// All active swaps
+const swaps = sphere.swap!.getSwaps({ excludeTerminal: true });
+
+// Detailed status (optionally query the escrow for its view)
+const status = await sphere.swap!.getSwapStatus(swapId, { queryEscrow: true });
+console.log('Progress:', status.progress, 'Escrow state:', status.escrowState);
 ```
 
 ## Import Existing Wallet

--- a/docs/QUICKSTART-CLI.md
+++ b/docs/QUICKSTART-CLI.md
@@ -1,0 +1,1612 @@
+# Sphere SDK - CLI Quick Start
+
+The Sphere SDK includes a built-in CLI for wallet management, payments, messaging, and invoicing — no code required. All data is stored locally in `.sphere-cli/`.
+
+**Node.js version:** 18.0.0 or higher required.
+
+```bash
+# Full help
+npm run cli -- --help
+```
+
+> **Asset amount convention:** All CLI commands that reference assets use the format `<amount> <symbol>`.
+> Examples: `10 UCT`, `0.5 BTC`, `1000000 USDU`. This format is used consistently:
+>
+> ```
+> send @alice 10 UCT
+> topup 10 UCT
+> swap-propose --to @bob --offer "1000000 UCT" --want "500000 USDU"
+> invoice-create --target @alice --asset "1000000 UCT"
+> invoice-return <id> --recipient <addr> --asset "500 UCT"
+> ```
+
+---
+
+## Shell Auto-Completion (Optional)
+
+Enable tab-completion for all sphere-cli commands and flags.
+
+### Step 1: Install the CLI globally
+
+```bash
+cd /path/to/sphere-sdk
+npm link
+```
+
+This makes `sphere-cli` available as a global command (instead of `npm run cli --`).
+
+### Step 2: Generate and install completions
+
+**Bash:**
+```bash
+sphere-cli completions bash >> ~/.bashrc
+source ~/.bashrc
+```
+
+**Zsh:**
+```bash
+mkdir -p ~/.zsh/completions
+sphere-cli completions zsh > ~/.zsh/completions/_sphere-cli
+# Add to ~/.zshrc if not already there:
+# fpath=(~/.zsh/completions $fpath)
+# autoload -Uz compinit && compinit
+source ~/.zshrc
+```
+
+**Fish:**
+```bash
+sphere-cli completions fish > ~/.config/fish/completions/sphere-cli.fish
+```
+
+### Without `npm link` (using `npm run cli`)
+
+```bash
+eval "$(npm run --silent cli -- completions bash)"  # bash
+eval "$(npm run --silent cli -- completions zsh)"   # zsh
+npm run --silent cli -- completions fish > ~/.config/fish/completions/sphere-cli.fish  # fish
+```
+
+### What it provides
+
+After setup, press Tab to auto-complete:
+```
+sphere-cli <TAB>                    # all commands
+sphere-cli swap-<TAB>               # swap-propose swap-list swap-accept ...
+sphere-cli swap-propose --<TAB>     # --to --offer --want --escrow --timeout --message
+sphere-cli invoice-<TAB>            # invoice-create invoice-list ...
+sphere-cli wallet <TAB>             # list create use current delete
+```
+
+---
+
+## Command Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `init` | Create or import wallet |
+| `status` | Show wallet identity |
+| `config` | Show or set CLI configuration |
+| `clear` | Delete all wallet data |
+| `wallet list` | List wallet profiles |
+| `wallet create <name>` | Create a new wallet profile |
+| `wallet use <name>` | Switch to a wallet profile |
+| `wallet delete <name>` | Delete a wallet profile |
+| `wallet current` | Show active profile |
+| `balance` | Show L3 token balance |
+| `tokens` | List individual tokens |
+| `assets` | List registered assets (coins & NFTs) |
+| `asset-info <id>` | Show asset details |
+| `verify-balance` | Detect spent tokens via aggregator |
+| `sync` | Sync tokens with IPFS |
+| `send <to> <amount> <symbol>` | Send L3 tokens |
+| `receive` | Check for incoming transfers |
+| `history [limit]` | Transaction history |
+| `l1-balance` | L1 (ALPHA) balance |
+| `topup [<amount> <symbol>]` | Request test tokens from faucet |
+| `addresses` | List tracked addresses |
+| `switch <index>` | Switch to HD address |
+| `hide <index>` | Hide address |
+| `unhide <index>` | Unhide address |
+| `nametag <name>` | Register a nametag |
+| `nametag-info <name>` | Look up nametag info |
+| `my-nametag` | Show current nametag |
+| `nametag-sync` | Re-publish nametag binding |
+| `dm <to> <msg>` | Send direct message |
+| `dm-inbox` | List conversations |
+| `dm-history <peer>` | Show conversation history |
+| `group-create <name>` | Create NIP-29 group |
+| `group-list` | List groups on relay |
+| `group-my` | List your groups |
+| `group-join <id>` | Join a group |
+| `group-leave <id>` | Leave a group |
+| `group-send <id> <msg>` | Send group message |
+| `group-messages <id>` | Show group messages |
+| `group-members <id>` | List group members |
+| `group-info <id>` | Show group details |
+| `market-post <desc>` | Post a market intent |
+| `market-search <query>` | Search market intents |
+| `market-my` | Your posted intents |
+| `market-close <id>` | Close a market intent |
+| `market-feed` | Watch live market feed |
+| `invoice-create` | Create invoice |
+| `invoice-import <file>` | Import invoice from token file |
+| `invoice-list` | List invoices |
+| `invoice-status <id>` | Show invoice status |
+| `invoice-pay <id>` | Pay an invoice |
+| `invoice-close <id>` | Close an invoice |
+| `invoice-cancel <id>` | Cancel an invoice |
+| `invoice-return <id>` | Return payment to sender |
+| `invoice-receipts <id>` | Send receipts |
+| `invoice-notices <id>` | Send cancellation notices |
+| `invoice-auto-return` | Show/set auto-return settings |
+| `invoice-transfers <id>` | List related transfers |
+| `invoice-export <id>` | Export invoice to JSON file |
+| `invoice-parse-memo <memo>` | Parse an invoice memo string |
+| `swap-propose` | Propose a swap deal (`--offer`, `--want`) |
+| `swap-list` | List swap deals |
+| `swap-accept <id>` | Accept a swap deal |
+| `swap-reject <id> [reason]` | Reject a swap proposal |
+| `swap-status <id>` | Show detailed swap status |
+| `swap-deposit <id>` | Deposit into an announced swap |
+| `swap-cancel <id>` | Cancel a swap |
+| `daemon start` | Start persistent event listener |
+| `daemon stop` | Stop running daemon |
+| `daemon status` | Check daemon status |
+| `encrypt <data> <pass>` | Encrypt data with password |
+| `decrypt <json> <pass>` | Decrypt encrypted data |
+| `parse-wallet <file>` | Parse wallet backup file |
+| `wallet-info <file>` | Show wallet file metadata |
+| `generate-key` | Generate random private key |
+| `validate-key <hex>` | Validate secp256k1 key |
+| `hex-to-wif <hex>` | Convert hex to WIF |
+| `derive-pubkey <hex>` | Derive public key |
+| `derive-address <hex>` | Derive address at index |
+| `to-smallest <amount>` | Convert to smallest unit |
+| `to-human <amount>` | Convert from smallest unit |
+| `format <amount>` | Format amount with decimals |
+| `base58-encode <hex>` | Encode hex to base58 |
+| `base58-decode <str>` | Decode base58 to hex |
+
+---
+
+## 1. Installation and Setup
+
+### Prerequisites
+
+- Node.js 18.0.0 or higher
+- Clone or install the SDK:
+
+```bash
+git clone <repo>
+cd sphere-sdk
+npm install
+```
+
+### First-Time Wallet Initialization
+
+The `init` command creates a new wallet or imports an existing one. It is the single entry point for both paths.
+
+```bash
+# Create a new wallet on testnet (default)
+npm run cli -- init
+
+# Specify network: mainnet | testnet | dev
+npm run cli -- init --network testnet
+
+# Create wallet and immediately register a nametag
+# NOTE: --nametag mints a token on-chain using the Aggregator
+npm run cli -- init --network testnet --nametag alice
+
+# Import an existing wallet from a 12 or 24-word mnemonic
+npm run cli -- init --mnemonic "word1 word2 word3 ... word24"
+
+# Import with a nametag registration in one step
+npm run cli -- init --mnemonic "word1 ..." --nametag alice
+```
+
+> **Important:** When a new wallet is created without `--mnemonic`, a 24-word mnemonic is generated and printed once to the terminal. Save it immediately — it cannot be recovered.
+
+> **Important:** `--nametag` and the standalone `nametag` command both mint a token on-chain. This requires the Aggregator (Oracle) provider, which is included by default on `testnet` and `mainnet`.
+
+On first run, `init` prints the full wallet identity:
+
+```
+Wallet initialized successfully!
+
+Identity:
+{
+  "l1Address": "alpha1qxy...",
+  "directAddress": "DIRECT://0000be36...",
+  "chainPubkey": "02abc123...",
+  "nametag": "alice"
+}
+
+⚠️  BACKUP YOUR MNEMONIC (24 words):
+──────────────────────────────────────────────────
+abandon ability able about above absent ...
+──────────────────────────────────────────────────
+Store this safely! You will need it to recover your wallet.
+```
+
+### Where Data is Stored
+
+All CLI data is stored in the current working directory under `.sphere-cli/`:
+
+```
+.sphere-cli/
+  config.json          # Active network, dataDir, tokensDir
+  profiles.json        # Named wallet profiles
+  wallet.json          # Wallet keys (plaintext or encrypted mnemonic)
+  tokens/              # Token storage (one JSON file per token)
+  daemon.json          # Daemon config (if used)
+  daemon.log           # Daemon log file
+  daemon.pid           # Daemon PID file
+
+.sphere-cli-alice/     # Per-profile directory (if using wallet profiles)
+  wallet.json
+  tokens/
+```
+
+### Show Wallet Status
+
+```bash
+npm run cli -- status
+```
+
+```
+Wallet Status:
+──────────────────────────────────────────────────
+Profile:       alice
+Network:       testnet
+L1 Address:    alpha1qxy...
+Direct Addr:   DIRECT://0000be36...
+Chain Pubkey:  02abc123...
+Nametag:       alice
+──────────────────────────────────────────────────
+```
+
+### Configuration
+
+```bash
+# Show current configuration
+npm run cli -- config
+
+# Change the network
+npm run cli -- config set network mainnet
+
+# Change data directory
+npm run cli -- config set dataDir ./my-wallet
+
+# Change token storage directory
+npm run cli -- config set tokensDir ./my-tokens
+```
+
+---
+
+## 2. Wallet Profiles
+
+Wallet profiles let you manage multiple independent wallets (e.g., for testing with different identities). Each profile gets its own directory under `.sphere-cli-<name>/`.
+
+```bash
+# Create a new profile (creates .sphere-cli-alice/ and switches to it)
+npm run cli -- wallet create alice
+
+# Create on a specific network
+npm run cli -- wallet create bob --network mainnet
+
+# Initialize the wallet inside the active profile
+npm run cli -- init --nametag alice
+
+# List all profiles (→ marks the active profile)
+npm run cli -- wallet list
+
+# Switch to a different profile
+npm run cli -- wallet use bob
+
+# Show the currently active profile
+npm run cli -- wallet current
+
+# Delete a profile (data directory is NOT deleted automatically)
+npm run cli -- wallet delete bob
+```
+
+> **Note:** Deleting a profile removes the registry entry only. The data directory (e.g., `.sphere-cli-bob/`) is left on disk and must be removed manually if no longer needed.
+
+### Example: Two-Wallet Test Setup
+
+```bash
+# Create alice wallet
+npm run cli -- wallet create alice
+npm run cli -- init --nametag alice
+
+# Create bob wallet
+npm run cli -- wallet create bob
+npm run cli -- init --nametag bob
+
+# Get test tokens for alice
+npm run cli -- wallet use alice
+npm run cli -- topup
+
+# Send from alice to bob
+npm run cli -- send @bob 100 UCT
+
+# Check bob's balance
+npm run cli -- wallet use bob
+npm run cli -- balance --finalize
+```
+
+---
+
+## 3. Wallet Management
+
+### Check Balance
+
+```bash
+# Show L3 token balance (fetches pending transfers first)
+npm run cli -- balance
+
+# Also finalize unconfirmed tokens (waits for aggregator proofs)
+npm run cli -- balance --finalize
+
+# Skip IPFS sync before showing balance
+npm run cli -- balance --no-sync
+```
+
+Example output:
+
+```
+L3 Balance:
+──────────────────────────────────────────────────
+UCT: 100.00000000 (3 tokens)
+ETH: 0.04200000 (1 token) ≈ $131.24
+──────────────────────────────────────────────────
+Total: $131.24
+```
+
+When unconfirmed tokens are present:
+
+```
+UCT: 50.00000000 (+ 50.00000000 unconfirmed) [2+1 tokens]
+```
+
+### List Individual Tokens
+
+```bash
+# List all tokens with details
+npm run cli -- tokens
+
+# Skip IPFS sync
+npm run cli -- tokens --no-sync
+```
+
+Example output:
+
+```
+Tokens:
+──────────────────────────────────────────────────
+ID: a1b2c3d4e5f67890...
+  Coin: UCT (deadbeef...)
+  Amount: 50.00000000 UCT
+  Status: active
+
+ID: 9876543210abcdef...
+  Coin: ETH (cafe1234...)
+  Amount: 0.04200000 ETH
+  Status: active
+──────────────────────────────────────────────────
+```
+
+### Registered Assets
+
+Browse the token registry to see all known coins and NFTs on the network.
+
+```bash
+# List all registered assets
+npm run cli -- assets
+
+# Filter by type
+npm run cli -- assets --type fungible
+npm run cli -- assets --type nft
+
+# Get detailed info for a specific asset (by symbol, name, or coin ID)
+npm run cli -- asset-info UCT
+npm run cli -- asset-info bitcoin
+npm run cli -- asset-info 0a1b2c3d4e5f...
+```
+
+### Verify Tokens Against Aggregator
+
+Detects tokens that have already been spent (transferred out) but are still in local storage due to missed sync or relay redelivery.
+
+```bash
+# Check for spent tokens without removing them
+npm run cli -- verify-balance
+
+# Also remove any spent tokens from storage (moves to archive + creates tombstone)
+npm run cli -- verify-balance --remove
+
+# Show all tokens, not just spent ones
+npm run cli -- verify-balance --verbose
+npm run cli -- verify-balance -v
+```
+
+Example output:
+
+```
+Verifying 3 token(s) against aggregator...
+────────────────────────────────────────────────────────────
+✓ Valid: 50.00000000 UCT (a1b2c3d4e5f6...)
+✗ SPENT: 100.00000000 UCT (deadbeef0123...)
+────────────────────────────────────────────────────────────
+
+Summary:
+  Valid tokens: 2
+  Spent tokens: 1
+
+To move spent tokens to Sent folder, run: npm run cli -- verify-balance --remove
+```
+
+### Sync with IPFS
+
+```bash
+npm run cli -- sync
+```
+
+Merges local tokens with tokens stored on IPFS/IPNS. Useful for recovering tokens after local data loss (re-initialize with the same mnemonic, then sync).
+
+### Transaction History
+
+```bash
+# Show last 10 transactions
+npm run cli -- history
+
+# Show last N transactions
+npm run cli -- history 25
+```
+
+Example output:
+
+```
+Transaction History (last 10):
+────────────────────────────────────────────────────────────
+3/9/2026, 2:15:00 PM → 100.00000000 UCT
+  To: bob
+
+3/9/2026, 1:30:00 PM ← 200.00000000 UCT
+  From: 02abc123def456...
+────────────────────────────────────────────────────────────
+```
+
+### Delete Wallet Data
+
+```bash
+# Delete all wallet data for the active profile (keys + tokens)
+npm run cli -- clear
+```
+
+> **Warning:** This permanently deletes the wallet keys and all tokens from local storage. Only tokens synced to IPFS can be recovered afterward.
+
+---
+
+## 4. Nametags
+
+Nametags (e.g., `@alice`) are human-readable aliases for wallet addresses. They are registered on Nostr and also minted as tokens on-chain.
+
+```bash
+# Register a nametag for the current address
+# NOTE: mints a token on-chain
+npm run cli -- nametag alice
+npm run cli -- nametag @alice   # @ prefix is stripped automatically
+
+# Show your current nametag
+npm run cli -- my-nametag
+
+# Look up another user's nametag
+npm run cli -- nametag-info alice
+npm run cli -- nametag-info @alice
+
+# Re-publish nametag with chainPubkey (fixes legacy nametags registered
+# before the direct-address binding was introduced)
+npm run cli -- nametag-sync
+```
+
+> **Note:** Each derived HD address can have its own nametag. Use `switch` to move to a different address before registering a new nametag.
+
+---
+
+## 5. Address Management
+
+The wallet uses BIP-32 HD derivation. You can generate and track multiple independent addresses from the same mnemonic.
+
+```bash
+# List all tracked addresses
+# → marks the currently active address
+npm run cli -- addresses
+```
+
+Example output:
+
+```
+Tracked Addresses:
+──────────────────────────────────────────────────────────────────────
+→ #0: alpha1qxy... @alice
+    DIRECT: DIRECT://0000be36...
+  #1: alpha1rzp... @alice-work
+    DIRECT: DIRECT://0001cafe...
+  #2: alpha1abc... [hidden]
+    DIRECT: DIRECT://0002dead...
+──────────────────────────────────────────────────────────────────────
+```
+
+```bash
+# Switch to a different HD address index
+npm run cli -- switch 1
+
+# Hide an address from the active list (does not delete data)
+npm run cli -- hide 2
+
+# Unhide an address
+npm run cli -- unhide 2
+```
+
+---
+
+## 6. Payments (L3)
+
+### Send Tokens
+
+```bash
+# Basic send to a nametag
+npm run cli -- send @bob 100 UCT
+
+# Send to a DIRECT:// address
+npm run cli -- send DIRECT://0000be36... 50 UCT
+
+# Send to an L1 address (alpha1...)
+npm run cli -- send alpha1qxy... 0.001 BTC
+
+# Send to a raw chain pubkey (02... or 03...)
+npm run cli -- send 02abc123def456... 1000000 UCT
+```
+
+**Available coin symbols:** UCT, BTC, ETH, SOL, USDT, USDC, USDU, EURU, ALPHT
+
+**Amounts** are specified as human-readable decimals (e.g., `0.5`, `100`, `1000000`). The CLI converts to the smallest unit automatically.
+
+#### Transfer Modes
+
+| Mode | Flag | Behavior |
+|------|------|----------|
+| Instant (default) | `--instant` | Sends tokens via Nostr immediately. Receiver finishes proof collection in the background. Fastest for sender (~2-3s). |
+| Conservative | `--conservative` | Collects all aggregator proofs first, then delivers. Slower but receiver gets immediately confirmed tokens. |
+
+```bash
+# Instant mode (explicit — same as default)
+npm run cli -- send @bob 100 UCT --instant
+
+# Conservative mode
+npm run cli -- send @bob 100 UCT --conservative
+```
+
+#### Address Mode Flags
+
+By default, the CLI resolves the recipient's address automatically. You can force a specific mode:
+
+```bash
+# Force DirectAddress transfer
+npm run cli -- send @bob 100 UCT --direct
+
+# Force PROXY address transfer (compatible with all nametags)
+npm run cli -- send @bob 100 UCT --proxy
+
+# Skip IPFS sync after sending
+npm run cli -- send @bob 100 UCT --no-sync
+```
+
+### Receive Tokens
+
+The `receive` command shows your receive addresses and fetches any pending incoming transfers from the Nostr relay.
+
+```bash
+# Show addresses and fetch pending transfers
+npm run cli -- receive
+
+# Also finalize unconfirmed tokens (waits for aggregator proofs)
+npm run cli -- receive --finalize
+
+# Skip IPFS sync after receiving
+npm run cli -- receive --no-sync
+```
+
+Example output:
+
+```
+Receive Address:
+──────────────────────────────────────────────────
+L3 (Direct): DIRECT://0000be36...
+L1 (ALPHA):  alpha1qxy...
+Nametag:     @alice
+──────────────────────────────────────────────────
+
+Checking for incoming transfers...
+
+Received 2 new transfer(s):
+  100.00000000 UCT
+  0.04200000 ETH [unconfirmed]
+```
+
+### Request Test Tokens (Testnet Faucet)
+
+```bash
+# Request all supported test coins (requires a registered nametag)
+npm run cli -- topup
+
+# Request a specific amount and coin
+npm run cli -- topup 10 UCT
+npm run cli -- topup 13 ETH
+npm run cli -- topup 200 BTC
+
+# Aliases: top-up, faucet
+npm run cli -- faucet
+```
+
+Supported faucet coins: `unicity`, `bitcoin`, `ethereum`, `solana`, `tether`, `usd-coin`, `unicity-usd`
+
+> **Note:** The faucet is only available on testnet. You must have a registered nametag before requesting tokens.
+
+---
+
+## 7. L1 (ALPHA Blockchain)
+
+L1 operations use the ALPHA blockchain (UTXO-based, RandomX PoW). The Fulcrum WebSocket connection is lazy — it only connects when you first run an L1 command.
+
+```bash
+# Check L1 balance
+npm run cli -- l1-balance
+```
+
+```
+L1 (ALPHA) Balance:
+──────────────────────────────────────────────────
+Confirmed: 0.00100000 ALPHA
+Unconfirmed: 0.00000000 ALPHA
+──────────────────────────────────────────────────
+```
+
+> **Note:** L1 send and history operations are available via the SDK (`sphere.payments.l1.send()`, `sphere.payments.l1.getHistory()`) but are not exposed as CLI commands in the current version. Use the API directly for those operations. See [QUICKSTART-NODEJS.md](./QUICKSTART-NODEJS.md) for L1 API examples.
+
+---
+
+## 8. Communications
+
+### Direct Messages
+
+DMs are end-to-end encrypted via NIP-17 (gift-wrapped messages) over the Nostr relay.
+
+```bash
+# Send a direct message to a nametag
+npm run cli -- dm @alice "Hello, how are you?"
+
+# Send to a raw chain pubkey
+npm run cli -- dm 02abc123def456... "Hello!"
+```
+
+```
+# List all conversations and unread counts
+npm run cli -- dm-inbox
+```
+
+Example output:
+
+```
+Inbox (2 conversations, 3 unread):
+────────────────────────────────────────────────────────────
+@bob [2 unread]
+  Last: Hey, did you get my tokens?
+  Time: 3/9/2026, 2:15:00 PM
+
+@carol
+  Last: Thanks for the payment!
+  Time: 3/9/2026, 1:00:00 PM
+────────────────────────────────────────────────────────────
+```
+
+```bash
+# Show conversation history with a peer
+npm run cli -- dm-history @alice
+
+# Limit to last N messages (default: 50)
+npm run cli -- dm-history @alice --limit 20
+npm run cli -- dm-history 02abc123def456... --limit 5
+```
+
+### Group Chat (NIP-29)
+
+Group chat uses the NIP-29 relay protocol for managed groups with roles (ADMIN, MODERATOR, MEMBER).
+
+```bash
+# Create a new public group
+npm run cli -- group-create "Trading Chat"
+
+# Create with description
+npm run cli -- group-create "Trading Chat" --description "Discuss token trades"
+
+# Create a private group (invite-only)
+npm run cli -- group-create "Private Team" --private
+```
+
+```
+✓ Group created!
+  ID: trading-chat-abc123
+  Name: Trading Chat
+  Visibility: PUBLIC
+```
+
+```bash
+# List all groups available on the relay
+npm run cli -- group-list
+
+# List groups you have joined
+npm run cli -- group-my
+
+# Join a group
+npm run cli -- group-join trading-chat-abc123
+
+# Join a private group with invite code
+npm run cli -- group-join private-group-id --invite code123
+
+# Send a message to a group
+npm run cli -- group-send trading-chat-abc123 "Hello everyone!"
+
+# Reply to a specific message (by event ID)
+npm run cli -- group-send trading-chat-abc123 "Agreed!" --reply <eventId>
+
+# Read group messages (fetches from relay and marks as read)
+npm run cli -- group-messages trading-chat-abc123
+npm run cli -- group-messages trading-chat-abc123 --limit 20
+
+# List group members (with roles)
+npm run cli -- group-members trading-chat-abc123
+
+# Show group details
+npm run cli -- group-info trading-chat-abc123
+
+# Leave a group
+npm run cli -- group-leave trading-chat-abc123
+```
+
+---
+
+## 9. Market (Intent Bulletin Board)
+
+The market module lets you post buy/sell/service intents and search for matching offers using semantic search.
+
+### Posting Intents
+
+```bash
+# Post a buy intent
+npm run cli -- market-post "Buying 100 UCT tokens" --type buy
+
+# Post a sell intent with price
+npm run cli -- market-post "Selling ETH" --type sell --price 2500 --currency USD
+
+# Post a service offer
+npm run cli -- market-post "Web development services" --type service
+
+# Post an announcement
+npm run cli -- market-post "New feature released" --type announcement
+
+# Full options
+npm run cli -- market-post "Buying UCT" \
+  --type buy \
+  --category tokens \
+  --price 100 \
+  --currency UCT \
+  --location "Berlin, DE" \
+  --contact @myhandle \
+  --expires 14
+```
+
+**Intent types:** `buy`, `sell`, `service`, `announcement`, `other`
+
+**`--expires <days>`** sets the expiration in days (default: 30).
+
+### Searching Intents
+
+```bash
+# Semantic search
+npm run cli -- market-search "UCT tokens"
+
+# Filter by type
+npm run cli -- market-search "tokens" --type sell
+
+# Filter by price range
+npm run cli -- market-search "ETH" --min-price 2000 --max-price 3000
+
+# Set minimum similarity score (0.0 to 1.0)
+npm run cli -- market-search "tokens" --min-score 0.7
+
+# Filter by location and category
+npm run cli -- market-search "services" --category dev --location Berlin
+
+# Limit results (default: 10)
+npm run cli -- market-search "tokens" --limit 5
+```
+
+### Managing Your Intents
+
+```bash
+# List your posted intents
+npm run cli -- market-my
+
+# Close (delete) an intent by ID
+npm run cli -- market-close <intentId>
+```
+
+### Live Market Feed
+
+```bash
+# Watch the live listing feed via WebSocket (Ctrl+C to stop)
+npm run cli -- market-feed
+
+# Use REST fallback to fetch recent listings once (no persistent connection)
+npm run cli -- market-feed --rest
+```
+
+---
+
+## 10. Invoicing (Accounting Module)
+
+Invoices are on-chain tokens that encode payment terms: target address, coin, amount, due date, and memo. Both issuer and payer can track payment state in real time.
+
+**Invoice states:** `OPEN` → `PARTIAL` → `COVERED` → `CLOSED` (or `CANCELLED`, `EXPIRED`)
+
+> **Note:** The accounting module requires the Aggregator (Oracle) provider, which is included by default.
+
+### Create an Invoice
+
+```bash
+# Create invoice requesting 1 UCT (amount in smallest units)
+npm run cli -- invoice-create --target @alice --asset "1000000 UCT"
+
+# Create targeting a DIRECT address
+npm run cli -- invoice-create --target DIRECT://0000be36... --asset "1000000 UCT"
+
+# With optional metadata
+npm run cli -- invoice-create \
+  --target @alice \
+  --asset "1000000 UCT" \
+  --due 2026-12-31 \
+  --memo "Order #1234"
+
+# Request an NFT token
+npm run cli -- invoice-create --target @alice --nft <tokenId>
+
+# Load full invoice terms from a JSON file
+npm run cli -- invoice-create --terms invoice-terms.json
+```
+
+The `--asset` flag takes a quoted `"<amount> <symbol>"` string. The amount must be a positive integer in the smallest unit (no decimals, no leading zeros). For UCT with 8 decimals: `1000000` = 0.01 UCT.
+
+The `--due` flag accepts ISO-8601 date strings, e.g. `2026-12-31` or `2026-12-31T23:59:59Z`.
+
+Example output:
+
+```json
+{
+  "success": true,
+  "invoiceId": "a1b2c3d4e5f678901234567890abcdef...",
+  "terms": { ... }
+}
+```
+
+### Import an Invoice
+
+```bash
+# Import an invoice from a token JSON file (shared by the issuer)
+npm run cli -- invoice-import invoice-a1b2c3d4.json
+```
+
+### List Invoices
+
+```bash
+# List all invoices
+npm run cli -- invoice-list
+
+# Filter by state (comma-separated)
+npm run cli -- invoice-list --state OPEN
+npm run cli -- invoice-list --state OPEN,PARTIAL
+
+# Filter by role
+npm run cli -- invoice-list --role creator    # Invoices you created
+npm run cli -- invoice-list --role payer      # Invoices targeting you
+
+# Limit results
+npm run cli -- invoice-list --limit 10
+
+# Output as JSON array
+npm run cli -- invoice-list --json
+```
+
+**Valid states:** `OPEN`, `PARTIAL`, `COVERED`, `CLOSED`, `CANCELLED`, `EXPIRED`
+
+### Check Invoice Status
+
+```bash
+# Full ID or a unique prefix (as few characters as needed to be unambiguous)
+npm run cli -- invoice-status a1b2c3d4
+
+# Output as JSON
+npm run cli -- invoice-status a1b2c3d4 --json
+```
+
+Example output:
+
+```json
+{
+  "state": "PARTIAL",
+  "allConfirmed": false,
+  "targets": [
+    {
+      "address": "DIRECT://0000be36...",
+      "assets": [
+        {
+          "coinId": "UCT",
+          "requested": "1000000",
+          "totalForward": "500000",
+          "surplus": "0"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Pay an Invoice
+
+```bash
+# Pay the full remaining amount on the first target
+npm run cli -- invoice-pay a1b2c3d4
+
+# Pay a specific amount (in smallest units)
+npm run cli -- invoice-pay a1b2c3d4 --amount 500000
+
+# Pay a specific target in a multi-target invoice (0-indexed)
+npm run cli -- invoice-pay a1b2c3d4 --target-index 1
+```
+
+### Close an Invoice
+
+```bash
+# Close the invoice (no further payments accepted after this)
+npm run cli -- invoice-close a1b2c3d4
+
+# Close and trigger auto-return for any overpayments
+npm run cli -- invoice-close a1b2c3d4 --auto-return
+```
+
+### Cancel an Invoice
+
+```bash
+# Cancel an invoice as the target (payer-side cancellation)
+npm run cli -- invoice-cancel a1b2c3d4
+```
+
+### Return a Payment
+
+```bash
+# Return a specific amount to the original sender
+npm run cli -- invoice-return a1b2c3d4 \
+  --recipient @bob \
+  --asset "500000 UCT"
+```
+
+Both `--recipient` and `--asset` flags are required.
+
+### Send Receipts and Notices
+
+```bash
+# Send payment receipts for a terminated invoice (CLOSED or COVERED)
+npm run cli -- invoice-receipts a1b2c3d4
+
+# Send cancellation notices to all parties
+npm run cli -- invoice-notices a1b2c3d4
+```
+
+### Auto-Return Settings
+
+Auto-return automatically returns overpayments when an invoice is closed.
+
+```bash
+# Show current auto-return settings
+npm run cli -- invoice-auto-return
+
+# Enable globally (applies to all future close operations)
+npm run cli -- invoice-auto-return --enable
+
+# Disable globally
+npm run cli -- invoice-auto-return --disable
+
+# Enable for a specific invoice
+npm run cli -- invoice-auto-return --enable --invoice a1b2c3d4
+
+# Disable for a specific invoice
+npm run cli -- invoice-auto-return --disable --invoice a1b2c3d4
+```
+
+### List Related Transfers
+
+```bash
+# List all transfers related to an invoice in chronological order
+npm run cli -- invoice-transfers a1b2c3d4
+
+# Output as JSON array
+npm run cli -- invoice-transfers a1b2c3d4 --json
+```
+
+### Export an Invoice
+
+```bash
+# Export invoice data to a JSON file (e.g., invoice-a1b2c3d4.json)
+npm run cli -- invoice-export a1b2c3d4
+```
+
+### Parse an Invoice Memo
+
+Invoice memos embed a compact reference string that can be decoded back to the invoice ID and state.
+
+```bash
+npm run cli -- invoice-parse-memo "INV:a1b2c3d4...:F"
+```
+
+---
+
+## 11. Token Swaps
+
+The swap module enables trustless two-party token swaps via an escrow service. Both parties agree on terms, deposit their tokens into the escrow, and the escrow executes the exchange atomically -- either both parties receive their tokens, or both deposits are returned.
+
+**Prerequisites:**
+- Two wallet profiles set up (or two terminals with different data directories)
+- Both wallets initialized with nametags
+- Tokens available for the swap
+- An escrow service address (e.g., `@escrow-testnet` on testnet)
+
+> **Note:** The swap module requires the Accounting module (for invoice-based deposits) and the Communications module (for DM negotiation). Both are included by default.
+
+### Complete Walkthrough: Two-Party Token Swap
+
+This example shows Alice proposing a swap and Bob accepting it, using two terminals.
+
+**Terminal 1: Alice (@alice) -- the proposer**
+
+```bash
+# 1. Check Alice's balance
+npm run cli -- balance
+# Output: UCT: 10,000,000 (10 UCT)
+
+# 2. Propose a swap: Alice offers 1,000,000 UCT for 500,000 USDU
+npm run cli -- swap-propose \
+  --to @bob \
+  --offer "1000000 UCT" \
+  --want "500000 USDU" \
+  --escrow @escrow-testnet \
+  --timeout 3600 \
+  --message "Trading 1 UCT for 0.5 USDU"
+
+# Output:
+# Swap proposed:
+# {
+#   "swap_id": "a1b2c3d4e5f6...",
+#   "counterparty": "@bob",
+#   "offer": "1000000 UCT",
+#   "want": "500000 USDU",
+#   "escrow": "@escrow-testnet",
+#   "timeout": 3600,
+#   "status": "proposed"
+# }
+
+# 3. Check swap list
+npm run cli -- swap-list
+# SWAP ID   ROLE        PROGRESS            OFFER             WANT              COUNTERPARTY    CREATED
+# a1b2c3d4  proposer    proposed            1000000 UCT       500000 USDU       @bob            just now
+
+# 4. Wait for Bob to accept...
+npm run cli -- swap-status a1b2c3d4e5f6...full64hex...
+```
+
+**Terminal 2: Bob (@bob) -- the acceptor**
+
+```bash
+# 1. Check Bob's balance
+npm run cli -- balance
+# Output: USDU: 5,000,000 (5 USDU)
+
+# 2. Check incoming swap proposals
+npm run cli -- swap-list
+# SWAP ID   ROLE        PROGRESS            OFFER             WANT              COUNTERPARTY    CREATED
+# a1b2c3d4  acceptor    proposed            500000 USDU       1000000 UCT       @alice          30 sec ago
+#
+# Note: from Bob's perspective, "OFFER" is what HE would send (USDU),
+# and "WANT" is what he receives (UCT).
+
+# 3. Accept the swap AND deposit in one command
+npm run cli -- swap-accept a1b2c3d4e5f6...full64hex... --deposit
+# Output:
+# Swap accepted. Announced to escrow. Waiting for deposit invoice...
+# Deposit sent: transfer_xyz789
+# [swap] Deposit confirmed by escrow.
+# [swap] Awaiting counterparty deposit...
+```
+
+**Terminal 1: Alice deposits**
+
+```bash
+# 5. Alice sees the swap is now 'announced' (escrow ready)
+npm run cli -- swap-list
+# SWAP ID   ROLE        PROGRESS            OFFER             WANT              COUNTERPARTY    CREATED
+# a1b2c3d4  proposer    announced           1000000 UCT       500000 USDU       @bob            2 min ago
+
+# 6. Alice deposits her side
+npm run cli -- swap-deposit a1b2c3d4e5f6...full64hex...
+# Output:
+# Deposit result:
+# {
+#   "id": "transfer_abc123",
+#   "status": "delivered"
+# }
+
+# 7. Check progress -- both deposits made
+npm run cli -- swap-status a1b2c3d4e5f6...full64hex...
+# progress: "concluding"
+# escrowState: "CONCLUDING"
+```
+
+**Both terminals: Swap completes**
+
+After the escrow processes payouts, both parties receive their tokens.
+
+```bash
+# Alice checks:
+npm run cli -- swap-list --all
+# a1b2c3d4  proposer    completed           1000000 UCT       500000 USDU       @bob            5 min ago
+
+npm run cli -- balance
+# UCT: 9,000,000 (was 10M, sent 1M)
+# USDU: 500,000 (received from swap!)
+
+# Bob checks:
+npm run cli -- swap-list --all
+# a1b2c3d4  acceptor    completed           500000 USDU       1000000 UCT       @alice          5 min ago
+
+npm run cli -- balance
+# USDU: 4,500,000 (was 5M, sent 0.5M)
+# UCT: 1,000,000 (received from swap!)
+```
+
+### Checking Progress and Troubleshooting
+
+```bash
+# Detailed status with escrow query (asks the escrow for its view)
+npm run cli -- swap-status a1b2c3d4...full64hex... --query-escrow
+
+# Filter swaps by progress state
+npm run cli -- swap-list --progress depositing
+npm run cli -- swap-list --progress announced
+
+# Filter by role
+npm run cli -- swap-list --role proposer
+npm run cli -- swap-list --role acceptor
+
+# Show all swaps including completed/cancelled/failed (default hides terminal)
+npm run cli -- swap-list --all
+```
+
+### Cancellation and Timeouts
+
+Swaps that are not fully deposited within the timeout period are automatically cancelled by the escrow. Any deposits already made are returned.
+
+```bash
+# If you proposed a swap and want to check if it timed out:
+npm run cli -- swap-status a1b2c3d4...full64hex...
+# progress: "cancelled"
+# escrowState: "CANCELLED"
+
+# Deposits are returned automatically by the escrow.
+# Check your balance to confirm tokens were returned:
+npm run cli -- balance
+```
+
+You can also explicitly reject or cancel swaps:
+
+```bash
+# Reject a proposal
+sphere-cli swap-reject 3611a464... "Price too high"
+
+# Cancel your own swap
+sphere-cli swap-cancel 3611a464...
+```
+
+> **Note:** After the escrow is announced but before deposits, you can explicitly cancel with `swap-cancel`. Once both deposits are confirmed, cancellation is no longer possible — the escrow will execute the payout. Before acceptance, the proposal can be rejected with `swap-reject` or simply expires after 5 minutes (client-side timeout).
+
+### All Swap CLI Commands Reference
+
+| Command | Description | Key Flags |
+|---------|-------------|-----------|
+| `swap-propose` | Propose a swap deal | `--to`, `--offer "<amount> <symbol>"`, `--want "<amount> <symbol>"`, `--escrow`, `--timeout`, `--message` |
+| `swap-list` | List swaps | `--all`, `--role <proposer\|acceptor>`, `--progress <state>` |
+| `swap-accept <id>` | Accept a swap | `--deposit` (also deposit immediately), `--no-wait` (do not wait for completion) |
+| `swap-reject <id> [reason]` | Reject a swap proposal | (optional reason as second positional argument) |
+| `swap-status <id>` | Detailed status | `--query-escrow` (query the escrow for its state) |
+| `swap-deposit <id>` | Deposit into swap | (no additional flags) |
+| `swap-cancel <id>` | Cancel a swap | (no additional flags) |
+
+**Swap IDs** are 64-character hex strings (content-addressed from the manifest). The `swap-list` output shows an 8-character prefix for readability. All commands that accept a swap ID require the full 64-character ID.
+
+### Swap Progress States
+
+| State | Meaning |
+|-------|---------|
+| `proposed` | Proposal sent or received, waiting for counterparty |
+| `accepted` | Counterparty accepted, announcing to escrow |
+| `announced` | Escrow acknowledged, deposit invoice available |
+| `depositing` | Local deposit sent, awaiting confirmation |
+| `awaiting_counter` | Local deposit confirmed, waiting for counterparty |
+| `concluding` | Both deposited, escrow processing payouts |
+| `completed` | Swap done -- tokens exchanged (terminal) |
+| `cancelled` | Swap cancelled -- timeout or escrow failure (terminal) |
+| `failed` | Unrecoverable error (terminal) |
+
+### Swap Propose Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--to <recipient>` | Yes | Counterparty: `@nametag`, `DIRECT://...`, or chain pubkey |
+| `--offer "<amount> <symbol>"` | Yes | What you are offering (e.g., `"1000000 UCT"`) |
+| `--want "<amount> <symbol>"` | Yes | What you want in return (e.g., `"500000 USDU"`) |
+| `--escrow <address>` | No | Escrow service address (defaults to module config) |
+| `--timeout <seconds>` | No | Swap timeout in seconds, 60-86400 (default: 3600) |
+| `--message <text>` | No | Human-readable message included in proposal DM |
+
+---
+
+## 12. Event Daemon
+
+The daemon runs in the background and reacts to wallet events — incoming transfers, DMs, payment requests — by triggering actions such as auto-receive, webhook calls, bash scripts, or log writes.
+
+### Quick Start
+
+```bash
+# Listen for incoming transfers and auto-receive them
+npm run cli -- daemon start --event transfer:incoming --action auto-receive
+
+# Start in background (detaches, writes PID and log files)
+npm run cli -- daemon start --event transfer:incoming --action auto-receive --detach
+
+# Check if daemon is running
+npm run cli -- daemon status
+
+# Stop daemon
+npm run cli -- daemon stop
+```
+
+### Start Options
+
+```bash
+npm run cli -- daemon start [options]
+
+  --config <path>      Config file path (default: .sphere-cli/daemon.json)
+  --detach             Fork to background; redirect output to log file
+  --log <path>         Override log file path
+  --pid <path>         Override PID file path
+  --event <type>       Subscribe to event type (repeatable for multiple)
+  --action <spec>      Action to run on matching events (see below)
+  --market-feed        Also subscribe to market WebSocket feed
+  --verbose            Print full event JSON in log output
+```
+
+### Action Specs
+
+| Spec | Description |
+|------|-------------|
+| `auto-receive` | Automatically call `sphere.payments.receive()` on each incoming transfer |
+| `log:<path>` | Append event JSON as newline-delimited JSON to a file |
+| `webhook:<url>` | POST event JSON to the given URL |
+| `bash:<command>` | Run a shell command; event fields available as environment variables |
+
+```bash
+# Auto-receive all incoming transfers
+npm run cli -- daemon start --event transfer:incoming --action auto-receive
+
+# Webhook: POST to URL on any transfer event
+npm run cli -- daemon start \
+  --event "transfer:*" \
+  --action "webhook:https://example.com/hook" \
+  --detach
+
+# Log all events to a file
+npm run cli -- daemon start --event "*" --action "log:./events.jsonl" --verbose
+
+# Bash: run a shell command on DM receipt
+# Environment variables: SPHERE_SENDER, SPHERE_EVENT, SPHERE_DATA, etc.
+npm run cli -- daemon start \
+  --event message:dm \
+  --action "bash:echo DM from \$SPHERE_SENDER"
+
+# Multiple events and actions via config file
+npm run cli -- daemon start --config ./my-daemon.json --detach
+```
+
+### Config File Format
+
+For complex setups, write a JSON config file at `.sphere-cli/daemon.json`:
+
+```json
+{
+  "logFile": ".sphere-cli/daemon.log",
+  "pidFile": ".sphere-cli/daemon.pid",
+  "marketFeed": false,
+  "actionTimeout": 30000,
+  "rules": [
+    {
+      "name": "auto-receive on transfer",
+      "events": ["transfer:incoming"],
+      "actions": [
+        { "type": "builtin", "action": "auto-receive", "finalize": true }
+      ]
+    },
+    {
+      "name": "webhook on DM",
+      "events": ["message:dm"],
+      "actions": [
+        {
+          "type": "webhook",
+          "url": "https://example.com/hook",
+          "headers": { "X-Api-Key": "secret" }
+        }
+      ]
+    },
+    {
+      "name": "log everything",
+      "events": ["*"],
+      "actions": [
+        { "type": "builtin", "action": "log-to-file", "path": "./all-events.jsonl" }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## 13. Utility Commands
+
+### Encryption
+
+```bash
+# Encrypt a string with a password (AES-256-GCM output as JSON)
+npm run cli -- encrypt "my secret data" mypassword
+
+# Decrypt encrypted JSON
+npm run cli -- decrypt '{"ciphertext":"...","iv":"...","tag":"..."}' mypassword
+```
+
+### Wallet File Parsing
+
+```bash
+# Parse a wallet backup file (.txt, .dat, .json)
+npm run cli -- parse-wallet wallet.txt
+npm run cli -- parse-wallet wallet.dat
+npm run cli -- parse-wallet wallet.json
+
+# Parse encrypted wallet (provide password)
+npm run cli -- parse-wallet wallet.txt mypassword
+
+# Show metadata only (format, encrypted?, SQLite?)
+npm run cli -- wallet-info wallet.txt
+npm run cli -- wallet-info wallet.dat
+```
+
+### Key Operations
+
+These commands work without a wallet and are useful for low-level key management and testing.
+
+```bash
+# Generate a fresh secp256k1 private key
+npm run cli -- generate-key
+# Output: { privateKey, publicKey, wif, address }
+
+# Validate a private key
+npm run cli -- validate-key 64-char-hex-string
+
+# Convert private key hex to WIF format
+npm run cli -- hex-to-wif 64-char-hex-string
+
+# Derive the compressed public key from a private key
+npm run cli -- derive-pubkey 64-char-hex-string
+
+# Derive the L1 address at a given HD index (default: 0)
+npm run cli -- derive-address 64-char-hex-string
+npm run cli -- derive-address 64-char-hex-string 3
+```
+
+### Currency Conversion
+
+```bash
+# Convert human-readable amount to smallest unit (default: 8 decimals)
+npm run cli -- to-smallest 1.5
+# Output: 150000000
+
+# Convert smallest unit to human-readable
+npm run cli -- to-human 150000000
+# Output: 1.5
+
+# Format with explicit decimal places
+npm run cli -- format 150000000 8
+# Output: 1.50000000
+```
+
+### Base58 Encoding
+
+```bash
+# Encode a hex string to base58
+npm run cli -- base58-encode deadbeef01234567
+
+# Decode a base58 string back to hex
+npm run cli -- base58-decode Xm4A9...
+```
+
+---
+
+## 14. Global Flags
+
+These flags are accepted by all commands:
+
+| Flag | Description |
+|------|-------------|
+| `--no-nostr` | Disable Nostr transport (uses a no-op stub). Useful for testing IPFS-only recovery. |
+
+```bash
+npm run cli -- balance --no-nostr
+npm run cli -- init --network testnet --no-nostr
+```
+
+---
+
+## 15. Common Workflows
+
+### Create Wallet, Register Nametag, Send Tokens
+
+```bash
+# 1. Initialize wallet with nametag on testnet
+npm run cli -- init --network testnet --nametag alice
+
+# 2. Get test tokens from the faucet
+npm run cli -- topup
+
+# 3. Check your balance
+npm run cli -- balance --finalize
+
+# 4. Send 50 UCT to bob
+npm run cli -- send @bob 50 UCT
+
+# 5. Confirm the transfer is reflected in history
+npm run cli -- history 5
+```
+
+### Import Wallet from Mnemonic
+
+```bash
+# Import and optionally register a nametag in one step
+npm run cli -- init \
+  --mnemonic "abandon ability able about above absent absorb abstract absurd abuse access accident" \
+  --nametag alice \
+  --network testnet
+
+# Sync with IPFS to restore any previously stored tokens
+npm run cli -- sync
+npm run cli -- balance --finalize
+```
+
+### Create Invoice, Share, Pay, Close
+
+```bash
+# Alice creates an invoice requesting 1 UCT from Bob
+npm run cli -- wallet use alice
+npm run cli -- invoice-create --target @alice --asset "100000000 UCT" --memo "Order #1234"
+# Note the invoice ID prefix, e.g., a1b2c3d4
+
+# Alice exports the invoice token to share with Bob
+npm run cli -- invoice-export a1b2c3d4
+# Creates: invoice-a1b2c3d4.json
+
+# Bob imports the invoice
+npm run cli -- wallet use bob
+npm run cli -- invoice-import invoice-a1b2c3d4.json
+
+# Bob pays it
+npm run cli -- invoice-pay a1b2c3d4
+
+# Alice checks status
+npm run cli -- wallet use alice
+npm run cli -- invoice-status a1b2c3d4
+
+# Alice closes the invoice and sends receipts
+npm run cli -- invoice-close a1b2c3d4
+npm run cli -- invoice-receipts a1b2c3d4
+```
+
+### Set Up Daemon for Automated Receiving
+
+```bash
+# Start daemon that auto-receives incoming tokens and finalizes them
+npm run cli -- daemon start \
+  --event transfer:incoming \
+  --action auto-receive \
+  --detach
+
+# Verify it is running
+npm run cli -- daemon status
+
+# Stop when no longer needed
+npm run cli -- daemon stop
+```
+
+---
+
+## Troubleshooting
+
+### "No wallet found. Run: npm run cli -- init"
+
+The active profile directory contains no wallet data. Either:
+- Run `npm run cli -- init` to create a new wallet, or
+- Run `npm run cli -- wallet use <name>` to switch to a profile that has one.
+
+### Unconfirmed tokens not resolving
+
+```bash
+# Force finalization (waits for aggregator proof collection)
+npm run cli -- balance --finalize
+npm run cli -- receive --finalize
+```
+
+### Balance shows old tokens that have already been sent
+
+```bash
+# Detect and remove spent tokens
+npm run cli -- verify-balance --remove
+```
+
+### Nametag not found after registration
+
+```bash
+# Re-publish the nametag binding with chainPubkey
+npm run cli -- nametag-sync
+```
+
+### Recovering tokens after data loss
+
+```bash
+# Re-import from mnemonic, then sync with IPFS
+npm run cli -- init --mnemonic "your mnemonic here ..."
+npm run cli -- sync
+npm run cli -- balance --finalize
+```
+
+### Daemon does not start
+
+Check for an existing PID file:
+```bash
+npm run cli -- daemon status
+# If stale: rm .sphere-cli/daemon.pid
+npm run cli -- daemon start --event transfer:incoming --action auto-receive
+```
+
+---
+
+## Next Steps
+
+- [Node.js Quick Start](./QUICKSTART-NODEJS.md) — SDK integration guide for Node.js applications
+- [Browser Quick Start](./QUICKSTART-BROWSER.md) — SDK integration guide for web applications
+- [API Reference](./API.md) — Full API documentation
+- [IPFS Storage Guide](./IPFS-STORAGE.md) — IPFS/IPNS token sync and recovery
+- [Connect Protocol](./CONNECT.md) — dApp-to-wallet RPC integration

--- a/docs/QUICKSTART-CLI.md
+++ b/docs/QUICKSTART-CLI.md
@@ -86,7 +86,7 @@ sphere-cli wallet <TAB>             # list create use current delete
 | `init` | Create or import wallet |
 | `status` | Show wallet identity |
 | `config` | Show or set CLI configuration |
-| `clear` | Delete all wallet data |
+| `clear` | Delete all wallet data (requires confirmation or `--yes`) |
 | `wallet list` | List wallet profiles |
 | `wallet create <name>` | Create a new wallet profile |
 | `wallet use <name>` | Switch to a wallet profile |
@@ -156,7 +156,7 @@ sphere-cli wallet <TAB>             # list create use current delete
 | `decrypt <json> <pass>` | Decrypt encrypted data |
 | `parse-wallet <file>` | Parse wallet backup file |
 | `wallet-info <file>` | Show wallet file metadata |
-| `generate-key` | Generate random private key |
+| `generate-key` | Generate random key pair (private key hidden; use `--unsafe-print` to show) |
 | `validate-key <hex>` | Validate secp256k1 key |
 | `hex-to-wif <hex>` | Convert hex to WIF |
 | `derive-pubkey <hex>` | Derive public key |
@@ -200,9 +200,15 @@ npm run cli -- init --network testnet --nametag alice
 # Import an existing wallet from a 12 or 24-word mnemonic
 npm run cli -- init --mnemonic "word1 word2 word3 ... word24"
 
+# Interactive mnemonic import (more secure — mnemonic never in process args)
+npm run cli -- init --mnemonic
+# Prompts: "Enter mnemonic phrase: "
+
 # Import with a nametag registration in one step
 npm run cli -- init --mnemonic "word1 ..." --nametag alice
 ```
+
+> **Security:** Using `--mnemonic` without a value prompts interactively, keeping the mnemonic out of shell history and `/proc/<pid>/cmdline`. Prefer this mode for production wallets.
 
 > **Important:** When a new wallet is created without `--mnemonic`, a 24-word mnemonic is generated and printed once to the terminal. Save it immediately — it cannot be recovered.
 
@@ -1411,8 +1417,12 @@ npm run cli -- wallet-info wallet.dat
 These commands work without a wallet and are useful for low-level key management and testing.
 
 ```bash
-# Generate a fresh secp256k1 private key
+# Generate a fresh secp256k1 key pair (private key hidden by default)
 npm run cli -- generate-key
+# Output: Public Key: 02abc... / Address: alpha1...
+
+# Show private key and WIF (use with caution — never in scripts/CI)
+npm run cli -- generate-key --unsafe-print
 # Output: { privateKey, publicKey, wif, address }
 
 # Validate a private key

--- a/docs/QUICKSTART-NODEJS.md
+++ b/docs/QUICKSTART-NODEJS.md
@@ -19,6 +19,8 @@ npm install @unicitylabs/sphere-sdk ws
 
 ## CLI (Quick Testing)
 
+> **Tip:** For shell auto-completion of all CLI commands, run `npm link` then `sphere-cli completions bash >> ~/.bashrc`. See [QUICKSTART-CLI.md](QUICKSTART-CLI.md) for full setup.
+
 The SDK includes a built-in CLI for quick testing without writing code:
 
 ```bash
@@ -38,10 +40,10 @@ npm run cli -- balance
 npm run cli -- balance --finalize
 
 # Send tokens (instant mode — default, ~2-3s sender latency)
-npm run cli -- send @alice 1 --coin UCT --instant
+npm run cli -- send @alice 1 UCT --instant
 
 # Send tokens (conservative mode — collect all proofs first)
-npm run cli -- send @alice 1 --coin UCT --conservative
+npm run cli -- send @alice 1 UCT --conservative
 
 # Show receive address
 npm run cli -- receive
@@ -128,7 +130,7 @@ npm run cli -- wallet create bob                # Create another profile
 npm run cli -- init --nametag bob               # Initialize second wallet
 npm run cli -- wallet list                      # List all profiles
 npm run cli -- wallet use alice                 # Switch to alice
-npm run cli -- send @bob 0.1 --coin BTC         # Send from alice to bob
+npm run cli -- send @bob 0.1 BTC                 # Send from alice to bob
 npm run cli -- wallet use bob                   # Switch to bob
 npm run cli -- balance --finalize               # Check bob's balance (fetch + finalize)
 ```
@@ -286,6 +288,30 @@ console.log('Total USD:', totalUsd); // number | null
 const l1Balance = await sphere.payments.l1.getBalance();
 console.log('L1 Balance:', l1Balance);
 ```
+
+### Look Up Asset Metadata
+
+The `TokenRegistry` provides metadata (symbol, name, decimals, icons) for all registered assets on the network:
+
+```typescript
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+
+const registry = TokenRegistry.getInstance();
+
+// List all registered assets
+const allAssets = registry.getAllDefinitions();
+const coins = registry.getFungibleDefinitions();
+const nfts = registry.getNonFungibleDefinitions();
+
+// Look up a specific asset
+const uct = registry.getDefinitionBySymbol('UCT');
+console.log(uct?.name, uct?.decimals);  // 'Unicity Token', 8
+
+// Reverse lookup: symbol → coin ID
+const coinId = registry.getCoinIdBySymbol('UCT');
+```
+
+> **Note:** The registry is configured automatically by `createNodeProviders()` and `Sphere.init()`. Data is fetched from the network and cached to disk.
 
 ### Send Tokens
 
@@ -488,6 +514,191 @@ sphere.on('identity:changed', handler);
 // Unsubscribe
 const unsubscribe = sphere.on('transfer:incoming', handler);
 unsubscribe(); // Stop listening
+```
+
+## Invoicing
+
+The `AccountingModule` handles the full invoice lifecycle — creation, status queries, payment, and closing. Enable it by passing `accounting: true` to `Sphere.init()`.
+
+> **Note:** The accounting module requires the Oracle (Aggregator) provider, which is included by default with `createNodeProviders()`.
+
+```typescript
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  accounting: true,   // Enable with defaults
+});
+
+const accounting = sphere.accounting!;
+```
+
+### Create an Invoice
+
+```typescript
+const result = await accounting.createInvoice({
+  targets: [
+    {
+      address: sphere.identity!.directAddress!,  // Pay to own address
+      assets: [
+        { coin: ['UCT', '1000000'] },            // 1 UCT in smallest units
+      ],
+    },
+  ],
+  memo: 'Order #1234',
+  dueDate: Date.now() + 7 * 24 * 60 * 60 * 1000, // 7 days from now
+});
+
+if (result.success) {
+  console.log('Invoice ID:', result.invoiceId);
+  console.log('Terms:', result.terms);
+}
+```
+
+### Check Invoice Status
+
+```typescript
+const status = await accounting.getInvoiceStatus(result.invoiceId!);
+
+// state: 'OPEN' | 'PARTIAL' | 'COVERED' | 'CLOSED' | 'CANCELLED' | 'EXPIRED'
+console.log('State:', status.state);
+console.log('All confirmed:', status.allConfirmed);
+
+for (const target of status.targets) {
+  for (const asset of target.assets) {
+    console.log(`  ${asset.coinId}: paid ${asset.totalForward} of ${asset.requested}`);
+  }
+}
+```
+
+### Pay an Invoice
+
+```typescript
+// Pay the first asset of the first target (defaults to the remaining needed amount)
+const transfer = await accounting.payInvoice(invoiceId, {
+  targetIndex: 0,
+  assetIndex: 0,    // Optional, defaults to 0
+});
+
+console.log('Transfer status:', transfer.status);
+```
+
+### List All Invoices
+
+```typescript
+// All invoices
+const all = await accounting.getInvoices();
+
+// Filter by state
+const open = await accounting.getInvoices({ state: 'OPEN' });
+const mine = await accounting.getInvoices({ createdByMe: true });
+```
+
+### Close an Invoice
+
+```typescript
+// Marks invoice as CLOSED; no further payments are attributed
+await accounting.closeInvoice(invoiceId);
+
+// Optionally auto-return any overpayments before closing
+await accounting.closeInvoice(invoiceId, { autoReturn: true });
+```
+
+### Listen to Invoice Events
+
+```typescript
+sphere.on('invoice:created', ({ invoiceId, confirmed }) => {
+  console.log('Invoice minted:', invoiceId, confirmed ? '(confirmed)' : '(unconfirmed)');
+});
+
+sphere.on('invoice:payment', ({ invoiceId, paymentDirection, confirmed }) => {
+  console.log(`Payment on ${invoiceId}: direction=${paymentDirection}`);
+});
+
+sphere.on('invoice:covered', ({ invoiceId, confirmed }) => {
+  console.log('Invoice fully covered:', invoiceId);
+});
+
+sphere.on('invoice:closed', ({ invoiceId, explicit }) => {
+  console.log('Invoice closed:', invoiceId, explicit ? '(by owner)' : '(auto)');
+});
+
+sphere.on('invoice:overpayment', ({ invoiceId, coinId, surplus }) => {
+  console.log(`Overpayment on ${invoiceId}: +${surplus} ${coinId}`);
+});
+```
+
+## Token Swaps
+
+The swap module enables trustless two-party token exchanges via an escrow service. Enable it when initializing:
+
+```typescript
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  accounting: true,  // Required (swap uses invoices internally)
+  swap: true,        // Enable swap module
+});
+```
+
+**Propose a swap:**
+
+```typescript
+const result = await sphere.swap!.proposeSwap({
+  partyA: sphere.identity!.directAddress!,
+  partyB: '@bob',
+  partyACurrency: 'UCT',
+  partyAAmount: '1000000',
+  partyBCurrency: 'USDU',
+  partyBAmount: '500000',
+  timeout: 3600,
+  escrowAddress: '@escrow-testnet',
+});
+
+console.log('Swap ID:', result.swapId);
+```
+
+**Accept and deposit (counterparty side):**
+
+```typescript
+sphere.on('swap:proposal_received', async (data) => {
+  console.log('Swap proposal from:', data.senderNametag ?? data.senderPubkey);
+
+  await sphere.swap!.acceptSwap(data.swapId);
+  const transfer = await sphere.swap!.deposit(data.swapId);
+  console.log('Deposit sent:', transfer.id);
+});
+```
+
+**Deposit (proposer side, after counterparty accepts):**
+
+```typescript
+sphere.on('swap:announced', async (data) => {
+  const transfer = await sphere.swap!.deposit(data.swapId);
+  console.log('Deposit sent:', transfer.id);
+});
+```
+
+**Monitor swap lifecycle:**
+
+```typescript
+sphere.on('swap:completed', ({ swapId, payoutVerified }) => {
+  console.log('Swap completed:', swapId, 'Verified:', payoutVerified);
+});
+
+sphere.on('swap:cancelled', ({ swapId, reason, depositsReturned }) => {
+  console.log('Swap cancelled:', swapId, reason, 'Returned:', depositsReturned);
+});
+
+sphere.on('swap:failed', ({ swapId, error }) => {
+  console.log('Swap failed:', swapId, error);
+});
+```
+
+**List and query:**
+
+```typescript
+const swaps = sphere.swap!.getSwaps({ excludeTerminal: true });
+const status = await sphere.swap!.getSwapStatus(swapId, { queryEscrow: true });
 ```
 
 ## Error Handling

--- a/impl/nodejs/storage/FileStorageProvider.ts
+++ b/impl/nodejs/storage/FileStorageProvider.ts
@@ -58,20 +58,49 @@ export class FileStorageProvider implements StorageProvider {
       fs.mkdirSync(this.dataDir, { recursive: true });
     }
 
-    // Load existing data
+    // Load existing data. If the file is corrupt (partial write from a crash),
+    // try the .tmp backup (which is the pre-rename version from the last
+    // successful atomic write).
     if (fs.existsSync(this.filePath)) {
       try {
         const content = fs.readFileSync(this.filePath, 'utf-8').trim();
         if (this.isTxtMode) {
-          // .txt file: entire content is the mnemonic (plaintext or encrypted)
           if (content) {
             this.data = { [STORAGE_KEYS_GLOBAL.MNEMONIC]: content };
           }
         } else {
           this.data = JSON.parse(content);
         }
-      } catch {
-        this.data = {};
+      } catch (mainErr) {
+        // Main file exists but is corrupt. Try .tmp fallback before failing.
+        const tmpPath = this.filePath + '.tmp';
+        if (fs.existsSync(tmpPath)) {
+          try {
+            const tmpContent = fs.readFileSync(tmpPath, 'utf-8').trim();
+            this.data = this.isTxtMode
+              ? (tmpContent ? { [STORAGE_KEYS_GLOBAL.MNEMONIC]: tmpContent } : {})
+              : JSON.parse(tmpContent);
+            // Preserve the corrupt file for forensic inspection
+            const corruptPath = this.filePath + '.corrupt';
+            try { fs.renameSync(this.filePath, corruptPath); } catch { /* best-effort */ }
+            // Restore from .tmp
+            fs.renameSync(tmpPath, this.filePath);
+          } catch {
+            // Both files corrupt — this is a hard failure, NOT a silent reset.
+            // Silently falling back to {} would cause Sphere.exists() to return
+            // false, leading to accidental identity replacement.
+            throw new Error(
+              `Wallet file "${this.filePath}" is corrupt and no valid backup exists. ` +
+              `Manual recovery required. Check "${this.filePath}.corrupt" for the damaged file.`
+            );
+          }
+        } else {
+          // Main file corrupt, no .tmp fallback — hard failure.
+          throw new Error(
+            `Wallet file "${this.filePath}" is corrupt (${mainErr instanceof Error ? mainErr.message : 'parse error'}). ` +
+            `No backup (.tmp) file found. Manual recovery required.`
+          );
+        }
       }
     }
 
@@ -172,13 +201,27 @@ export class FileStorageProvider implements StorageProvider {
     if (!fs.existsSync(this.dataDir)) {
       fs.mkdirSync(this.dataDir, { recursive: true });
     }
+
+    let content: string;
     if (this.isTxtMode) {
-      // .txt file: persist only the mnemonic
-      const mnemonic = this.data[STORAGE_KEYS_GLOBAL.MNEMONIC] ?? '';
-      fs.writeFileSync(this.filePath, mnemonic);
+      content = this.data[STORAGE_KEYS_GLOBAL.MNEMONIC] ?? '';
     } else {
-      fs.writeFileSync(this.filePath, JSON.stringify(this.data, null, 2));
+      content = JSON.stringify(this.data);
     }
+
+    // Atomic write: write to temp file, fsync, then rename.
+    // This prevents wallet.json corruption on kill/crash — the rename
+    // is atomic on POSIX filesystems, so the file is either fully old
+    // or fully new, never partially written.
+    const tmpPath = this.filePath + '.tmp';
+    const fd = fs.openSync(tmpPath, 'w', 0o600);
+    try {
+      fs.writeSync(fd, content);
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmpPath, this.filePath);
   }
 }
 

--- a/tests/integration/accounting-cli.test.ts
+++ b/tests/integration/accounting-cli.test.ts
@@ -144,8 +144,8 @@ describe('Accounting CLI commands', () => {
       expect(combined).not.toContain('root:');
       expect(combined).not.toContain('/bin/bash');
       expect(combined).not.toContain('/bin/sh');
-      // Should show a sanitized error message (may be a file parse error or wallet init error)
-      expect(combined).toMatch(/Invalid JSON|Access denied|File not found|Failed to read|not initialized/);
+      // Should show a sanitized error message (file parse error, wallet init error, or no-wallet error)
+      expect(combined).toMatch(/Invalid JSON|Access denied|File not found|Failed to read|not initialized|No wallet exists/);
     });
   });
 

--- a/tests/integration/accounting-cli.test.ts
+++ b/tests/integration/accounting-cli.test.ts
@@ -1,0 +1,238 @@
+/**
+ * CLI integration tests for accounting (invoice) commands.
+ *
+ * Spawns the CLI as a subprocess and verifies:
+ * - Help text lists all 14 invoice commands
+ * - invoice-parse-memo parses valid/invalid memos
+ * - Argument validation produces reasonable error messages
+ * - Security: path traversal does not leak file contents
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as path from 'node:path';
+
+const exec = promisify(execFile);
+
+const CLI_PATH = path.resolve(__dirname, '../../cli/index.ts');
+const TSX = 'npx';
+
+/** Run a CLI command via tsx, returns { stdout, stderr, exitCode } */
+async function runCli(
+  args: string[],
+  options?: { timeout?: number },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const result = await exec(TSX, ['tsx', CLI_PATH, ...args], {
+      timeout: options?.timeout ?? 15000,
+      env: { ...process.env, NODE_NO_WARNINGS: '1' },
+    });
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as Record<string, unknown>;
+    return {
+      stdout: (e.stdout as string) ?? '',
+      stderr: (e.stderr as string) ?? '',
+      exitCode: (e.code as number) ?? 1,
+    };
+  }
+}
+
+describe('Accounting CLI commands', () => {
+  // ---------------------------------------------------------------------------
+  // Help text (CLI-030)
+  // ---------------------------------------------------------------------------
+
+  describe('help text', () => {
+    it('CLI-030: --help output lists all 14 invoice commands', async () => {
+      const { stdout } = await runCli(['--help']);
+
+      const invoiceCommands = [
+        'invoice-create',
+        'invoice-import',
+        'invoice-list',
+        'invoice-status',
+        'invoice-close',
+        'invoice-cancel',
+        'invoice-pay',
+        'invoice-return',
+        'invoice-receipts',
+        'invoice-notices',
+        'invoice-auto-return',
+        'invoice-transfers',
+        'invoice-export',
+        'invoice-parse-memo',
+      ];
+
+      for (const cmd of invoiceCommands) {
+        expect(stdout, `help should contain "${cmd}"`).toContain(cmd);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // invoice-parse-memo (CLI-028, CLI-029, CLI-032)
+  // These test the pure parsing utility. Since the current implementation
+  // requires getSphere(), these will fail with a wallet error -- we verify
+  // the CLI exits gracefully and does not crash.
+  // ---------------------------------------------------------------------------
+
+  describe('invoice-parse-memo', () => {
+    it('CLI-028: parses valid invoice memo', async () => {
+      const validMemo = 'INV:a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8:F';
+      const { stdout, stderr, exitCode } = await runCli(['invoice-parse-memo', validMemo]);
+      const combined = stdout + stderr;
+      // The command requires a wallet; verify it exits without crashing
+      // and produces a recognizable error (not a stack trace)
+      if (exitCode !== 0) {
+        // Wallet not found is expected in CI -- just ensure no unhandled crash
+        expect(combined).not.toMatch(/TypeError|ReferenceError|SyntaxError/);
+      } else {
+        // If it succeeds (wallet exists), check parsed output
+        expect(stdout).toContain('invoiceId');
+      }
+    });
+
+    it('CLI-029: invalid memo returns no match', async () => {
+      const { stdout, stderr, exitCode } = await runCli(['invoice-parse-memo', 'not a valid memo']);
+      const combined = stdout + stderr;
+      if (exitCode !== 0) {
+        // Wallet not found is acceptable
+        expect(combined).not.toMatch(/TypeError|ReferenceError|SyntaxError/);
+      } else {
+        expect(stdout).toMatch(/null|Not a valid invoice memo/i);
+      }
+    });
+
+    it('CLI-032: memo with control characters produces safe output', async () => {
+      const dirtyMemo = 'memo\x00with\x1bnull';
+      const { stdout, stderr, exitCode } = await runCli(['invoice-parse-memo', dirtyMemo]);
+      const combined = stdout + stderr;
+      if (exitCode !== 0) {
+        expect(combined).not.toMatch(/TypeError|ReferenceError|SyntaxError/);
+      } else {
+        expect(stdout).toMatch(/null|Not a valid invoice memo/i);
+      }
+    });
+
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-parse-memo']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Argument validation -- wallet-required commands fail gracefully
+  // ---------------------------------------------------------------------------
+
+  describe('invoice-create argument validation', () => {
+    it('should show usage/error when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-create']);
+      expect(exitCode).not.toBe(0);
+      const combined = stderr;
+      // Should produce a usage hint or wallet error, not a crash
+      expect(combined).not.toMatch(/TypeError|ReferenceError|SyntaxError/);
+    });
+
+    it('CLI-031: --terms /etc/passwd should not leak file contents', async () => {
+      const { stdout, stderr, exitCode } = await runCli(['invoice-create', '--terms', '/etc/passwd']);
+      expect(exitCode).not.toBe(0);
+      const combined = stdout + stderr;
+      // Must not contain passwd file content (root:x:0:0 etc.)
+      expect(combined).not.toContain('root:');
+      expect(combined).not.toContain('/bin/bash');
+      expect(combined).not.toContain('/bin/sh');
+      // Should show a sanitized error message (may be a file parse error or wallet init error)
+      expect(combined).toMatch(/Invalid JSON|Access denied|File not found|Failed to read|not initialized/);
+    });
+  });
+
+  describe('invoice-import argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-import']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+
+    it('should show error for nonexistent file', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-import', 'nonexistent-file-abc123.txf']);
+      expect(exitCode).not.toBe(0);
+      const combined = stderr;
+      expect(combined).not.toMatch(/TypeError|ReferenceError|SyntaxError/);
+    });
+  });
+
+  describe('invoice-status argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-status']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+
+  describe('invoice-close argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-close']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+
+  describe('invoice-cancel argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-cancel']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+
+  describe('invoice-pay argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-pay']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+
+  describe('invoice-return argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-return']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+
+  describe('invoice-receipts argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-receipts']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+
+  describe('invoice-notices argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-notices']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+
+  describe('invoice-transfers argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-transfers']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+
+  describe('invoice-export argument validation', () => {
+    it('should show usage when called without arguments', async () => {
+      const { stderr, exitCode } = await runCli(['invoice-export']);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Usage:');
+    });
+  });
+});

--- a/tests/integration/market-cli.test.ts
+++ b/tests/integration/market-cli.test.ts
@@ -2,7 +2,7 @@
  * CLI integration tests for market commands.
  *
  * Spawns the CLI as a subprocess and verifies:
- * - Help text lists all 5 intent types and the market-feed command
+ * - Help text lists market commands in the MARKET section
  * - market-post sends correct intent_type for each type
  * - market-search sends correct type filter for each type
  * - market-feed --rest fetches recent listings
@@ -46,28 +46,30 @@ describe('Market CLI commands', () => {
   // ---------------------------------------------------------------------------
 
   describe('help text', () => {
-    it('should list all 5 intent types in market-post description', async () => {
+    it('should list market-post command with --type flag in help', async () => {
       const { stdout } = await runCli(['--help']);
-      expect(stdout).toContain('buy, sell, service, announcement, other');
+      expect(stdout).toContain('market-post');
+      expect(stdout).toContain('--type');
     });
 
     it('should include market-feed command in help', async () => {
       const { stdout } = await runCli(['--help']);
       expect(stdout).toContain('market-feed');
-      expect(stdout).toContain('--rest');
+      expect(stdout).toContain('Watch the live listing feed');
     });
 
-    it('should include market-feed in examples section', async () => {
+    it('should include market commands in MARKET section', async () => {
       const { stdout } = await runCli(['--help']);
+      expect(stdout).toContain('MARKET:');
+      expect(stdout).toContain('market-post');
+      expect(stdout).toContain('market-search');
       expect(stdout).toContain('market-feed');
-      // Both live and REST examples
-      expect(stdout).toMatch(/market-feed\b/);
-      expect(stdout).toMatch(/market-feed --rest/);
     });
 
-    it('should include announcement example in market examples', async () => {
+    it('should include market-close and market-my in help', async () => {
       const { stdout } = await runCli(['--help']);
-      expect(stdout).toContain('--type announcement');
+      expect(stdout).toContain('market-close');
+      expect(stdout).toContain('market-my');
     });
   });
 

--- a/tests/integration/messaging-cli.test.ts
+++ b/tests/integration/messaging-cli.test.ts
@@ -46,7 +46,7 @@ describe('Messaging CLI commands', () => {
   describe('help text', () => {
     it('should include MESSAGING section', async () => {
       const { stdout } = await runCli(['--help']);
-      expect(stdout).toContain('MESSAGING (Direct Messages)');
+      expect(stdout).toContain('MESSAGING:');
       expect(stdout).toContain('dm <@nametag> <message>');
       expect(stdout).toContain('dm-inbox');
       expect(stdout).toContain('dm-history');
@@ -54,7 +54,7 @@ describe('Messaging CLI commands', () => {
 
     it('should include GROUP CHAT section', async () => {
       const { stdout } = await runCli(['--help']);
-      expect(stdout).toContain('GROUP CHAT (NIP-29)');
+      expect(stdout).toContain('GROUP CHAT:');
       expect(stdout).toContain('group-create');
       expect(stdout).toContain('group-list');
       expect(stdout).toContain('group-my');
@@ -66,18 +66,18 @@ describe('Messaging CLI commands', () => {
       expect(stdout).toContain('group-info');
     });
 
-    it('should include messaging examples', async () => {
+    it('should include messaging commands with descriptions', async () => {
       const { stdout } = await runCli(['--help']);
-      expect(stdout).toContain('Messaging Examples:');
-      expect(stdout).toContain('dm @alice');
-      expect(stdout).toContain('dm-history @alice');
+      expect(stdout).toContain('Send a direct message');
+      expect(stdout).toContain('List conversations');
+      expect(stdout).toContain('Show conversation history');
     });
 
-    it('should include group chat examples', async () => {
+    it('should include group chat commands with descriptions', async () => {
       const { stdout } = await runCli(['--help']);
-      expect(stdout).toContain('Group Chat Examples:');
-      expect(stdout).toContain('group-create');
-      expect(stdout).toContain('group-send');
+      expect(stdout).toContain('Create a new group');
+      expect(stdout).toContain('Send a message to a group');
+      expect(stdout).toContain('Show group messages');
     });
   });
 

--- a/tests/scripts/test-e2e-cli.ts
+++ b/tests/scripts/test-e2e-cli.ts
@@ -406,7 +406,7 @@ function runTransferTest(config: TransferTestConfig): TestResult {
 
     // 3. Send
     const modeFlag = transferMode === 'conservative' ? '--conservative' : '--instant';
-    const sendCmd = `send @${receiverNametag} ${amount} --coin ${coinSymbol} ${modeFlag}`;
+    const sendCmd = `send @${receiverNametag} ${amount} ${coinSymbol} ${modeFlag}`;
     console.log(`[2] Sending: ${sendCmd}`);
 
     const { stdout: sendOut, durationMs: sendTime } = cli(sendCmd, senderProfile);

--- a/vitest.daemon.config.ts
+++ b/vitest.daemon.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Separate vitest config for daemon-cli integration tests.
+ *
+ * These tests spawn real OS processes (npx tsx + wallet init + daemon subprocess)
+ * and fail under resource contention when run in the main test pool alongside
+ * 100+ other test files. Running them in isolation with a single fork ensures
+ * reliable sequential execution without CPU/memory pressure from other workers.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/integration/daemon-cli.test.ts'],
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+    testTimeout: 90000,
+  },
+});


### PR DESCRIPTION
## Summary

Major CLI expansion with unified UX, comprehensive help system, shell auto-completion, and full accounting/swap command surface. Depends on PRs #109 (Accounting) and #110 (Swap).

### What changed

- Comprehensive per-command help system with examples
- Shell auto-completion for bash/zsh/fish (via sphere-cli completions)
- Unified amount-symbol convention across all commands
- Automatic Nostr+IPFS sync on state-reading commands
- 14 invoice commands (create, import, status, list, close, cancel, pay, return, receipts, notices, transfers, export, parse-memo)
- 8 swap commands (propose, accept, reject, cancel, deposit, status, list, verify)
- Token registry commands (assets, asset-info)
- Swap ID prefix matching (min 4 hex chars)

### Supporting changes

- core/currency.ts, core/scan.ts — minor updates
- FileStorageProvider — Node.js fixes
- Docs — API.md, QUICKSTART-CLI.md, CONNECT.md, INTEGRATION.md, QUICKSTART-BROWSER/NODEJS.md updates

## Test plan

- [x] 18 new CLI integration tests (accounting-cli, market-cli, messaging-cli)
- [x] 2539 total tests pass (no regressions)
- [x] TypeScript strict typecheck clean
- [x] Production build succeeds