### PR TITLE
fix(transport): bump NostrTransportProvider query timeout from 5s to 20s

### DIFF
--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -240,6 +240,16 @@ export class NostrTransportProvider implements TransportProvider {
         reconnectIntervalMs: this.config.reconnectDelay,
         maxReconnectIntervalMs: this.config.reconnectDelay * 16, // exponential backoff cap
         pingIntervalMs: 15000, // 15 second keepalive pings (more aggressive to prevent drops)
+        // Bump query timeout from the SDK default of 5s to 20s.
+        // Real-world testnet observation (2026-05-01): under transient
+        // relay overload, kind:30078 (nametag binding) queries take 5-7s
+        // to return EVENT messages, even though the binding is on the
+        // relay. The default 5s timeout fires before the event arrives,
+        // resolveNametag returns null, and downstream sendDM throws
+        // INVALID_RECIPIENT — causing every np.propose_deal to fail. 20s
+        // gives the slow path enough headroom to complete while still
+        // bailing reasonably fast on a truly broken relay.
+        queryTimeoutMs: 20000,
       });
 
       // Add connection event listener for logging
@@ -464,6 +474,7 @@ export class NostrTransportProvider implements TransportProvider {
         reconnectIntervalMs: this.config.reconnectDelay,
         maxReconnectIntervalMs: this.config.reconnectDelay * 16,
         pingIntervalMs: 15000, // 15 second keepalive pings
+        queryTimeoutMs: 20000, // see same option above for rationale
       });
 
       // Add connection event listener


### PR DESCRIPTION
## Summary
- Bumps `queryTimeoutMs` passed to `NostrClient` from the SDK default of 5s to 20s
- Both `NostrClient` construction sites (initial connect + identity-changed reconnect) updated
- Pure defensive change — no API surface impact

## Why

Real-world testnet observation on 2026-05-01: under transient relay overload, kind:30078 (nametag binding) queries take **5-7 seconds** to return EVENT messages, even though the binding is verifiably on the relay. The 5s default fires first → `resolveNametag()` returns null → `sendDM()` throws `INVALID_RECIPIENT`.

Symptoms in `trader-service` e2e-live tests with the unpatched timeout:

```
np_propose_send_failed: Unicity ID not found: @t-tradere2e96d067ea2
```

repeated for minutes despite the binding being present on the relay.

## Test plan
- [x] Type-check + lint clean
- [x] Both construction sites symmetrically updated
- [ ] Re-validate trader-service e2e-live partial-fill timing once relay is healthy (was 45s with healthy relay, 11min with degraded relay + 5s timeout — should narrow that gap)

## Related

This is a defensive workaround. Underlying relay degradation tracked in trader-service `docs/bug-reports/2026-05-01-testnet-relay-silent-write-failure.md`.