### PR TITLE
fix(swap): explicit OVER_COVERAGE rejection in verifyPayout

### DIFF
--- a/modules/swap/SwapModule.ts
+++ b/modules/swap/SwapModule.ts
@@ -1751,7 +1751,18 @@ export class SwapModule {
         try {
           await this.persistSwap(swap);
         } catch (persistErr) {
-          // Storage failed — roll back so next load retries fraud detection.
+          // Storage failure rollback. Note the partial-failure window:
+          // `persistSwap` writes the swap record FIRST then the index. If the
+          // record write succeeded and only the index write failed, the on-disk
+          // record already says `'failed'`; rolling back in-memory creates a
+          // brief in-memory/disk skew until either the index write retries on
+          // next save or the next load picks up the on-disk `'failed'`. The
+          // "next load retries fraud detection" story holds when the
+          // record-write itself failed (the most common case for ENOSPC /
+          // permissions / disk-quota errors); for partial-write failures,
+          // the on-disk state is the source of truth on next load and our
+          // in-memory rollback only restores responsiveness for the current
+          // session.
           swap.progress = prevProgress;
           (swap as { payoutVerified?: boolean }).payoutVerified = prevPayoutVerified;
           (swap as { error?: string }).error = prevError;
@@ -1842,8 +1853,24 @@ export class SwapModule {
     // mix that subsequent state transitions would reject) or hang for the trader's
     // verifyPayout retry budget while `validate()` repeatedly rejects an unrelated
     // wallet token, producing a 20-min opaque hang instead of a clear failure.
-    const netCoveredAmount = BigInt(targetStatus.coinAssets[0].netCoveredAmount);
-    const expectedAmountBigInt = BigInt(expectedAmount);
+    // Parse defensively: a malformed `netCoveredAmount` (non-numeric, undefined,
+    // or NaN-like) from a buggy/compromised accounting backend would synchronously
+    // throw `TypeError`/`SyntaxError` from BigInt(). That escapes the gate and is
+    // swallowed by the auto-verify catch, surfacing as an opaque error rather than
+    // a structured SphereError. Treat parse failures as a settlement-layer fault —
+    // consistent with the rest of the over-coverage rationale below.
+    let netCoveredAmount: bigint;
+    let expectedAmountBigInt: bigint;
+    try {
+      netCoveredAmount = BigInt(targetStatus.coinAssets[0].netCoveredAmount);
+      expectedAmountBigInt = BigInt(expectedAmount);
+    } catch (parseErr) {
+      return failPayout(
+        `MALFORMED_AMOUNT: failed to parse coverage amounts (netCoveredAmount=${
+          targetStatus.coinAssets[0].netCoveredAmount
+        }, expectedAmount=${expectedAmount}): ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+      );
+    }
     if (netCoveredAmount < expectedAmountBigInt) {
       // Not yet fully covered — keep retrying (transient).
       return returnFalse();

--- a/modules/swap/SwapModule.ts
+++ b/modules/swap/SwapModule.ts
@@ -1687,6 +1687,7 @@ export class SwapModule {
           coin: [string, string];
           netCoveredAmount: string;
           isCovered: boolean;
+          surplusAmount?: string;
         }>;
       }>;
     };
@@ -1811,8 +1812,36 @@ export class SwapModule {
       return returnFalse();
     }
 
-    if (BigInt(targetStatus.coinAssets[0].netCoveredAmount) < BigInt(expectedAmount)) {
+    // Coverage equality check (exact-amount enforcement).
+    //
+    // The accounting layer permits the payout invoice to receive more than the
+    // requested amount (`netCoveredAmount > expectedAmount`) — surplus is tracked
+    // per-payer and refunded by the SDK's auto-return mechanism on closeInvoice.
+    // For *swap settlement*, however, over-coverage indicates one of:
+    //   (a) the escrow paid out twice for the same swap (e.g., a crash-mid-conclude
+    //       race in which crash-recovery's `_resumePayouts` re-issued payInvoice
+    //       because the SDK's provisional ledger entry had not yet been flushed);
+    //   (b) a malicious or buggy third party deposited into the same payout invoice;
+    //   (c) some other settlement-layer fault.
+    // In all three cases the swap should NOT silently complete — the surplus must be
+    // returned (auto-return on the receiver) and the swap explicitly failed so the
+    // application layer can recover with a clear reason. Without this check, the
+    // swap would either continue with `verified=true` (accepting an invalid token
+    // mix that subsequent state transitions would reject) or hang for the trader's
+    // verifyPayout retry budget while `validate()` repeatedly rejects an unrelated
+    // wallet token, producing a 20-min opaque hang instead of a clear failure.
+    const netCoveredAmount = BigInt(targetStatus.coinAssets[0].netCoveredAmount);
+    const expectedAmountBigInt = BigInt(expectedAmount);
+    if (netCoveredAmount < expectedAmountBigInt) {
+      // Not yet fully covered — keep retrying (transient).
       return returnFalse();
+    }
+    if (netCoveredAmount > expectedAmountBigInt) {
+      // Over-coverage is a settlement fault — fail explicitly.
+      const surplus = netCoveredAmount - expectedAmountBigInt;
+      return failPayout(
+        `OVER_COVERAGE: net=${netCoveredAmount.toString()}, expected=${expectedAmount}, surplus=${surplus.toString()} — surplus refund expected via auto-return; settlement halted`,
+      );
     }
 
     // Verify escrow creator identity

--- a/modules/swap/SwapModule.ts
+++ b/modules/swap/SwapModule.ts
@@ -68,6 +68,7 @@ import type {
   ManifestAuxiliary,
   ManifestSignatures,
 } from './types.js';
+import type { InvoiceStatus } from '../accounting/types.js';
 
 // Logger tag
 const LOG_TAG = 'Swap';
@@ -1679,18 +1680,11 @@ export class SwapModule {
       return returnFalse();
     }
 
-    // Get invoice status for coverage check
-    const status = await deps.accounting.getInvoiceStatus(swap.payoutInvoiceId) as {
-      state: string;
-      targets: Array<{
-        coinAssets: Array<{
-          coin: [string, string];
-          netCoveredAmount: string;
-          isCovered: boolean;
-          surplusAmount?: string;
-        }>;
-      }>;
-    };
+    // Get invoice status for coverage check. Use the canonical `InvoiceStatus`
+    // type from accounting/types.ts rather than an inline structural cast —
+    // keeps this consumer in lockstep with upstream field changes (e.g. the
+    // `surplusAmount` field is required, not optional, per the canonical type).
+    const status = (await deps.accounting.getInvoiceStatus(swap.payoutInvoiceId)) as InvoiceStatus;
 
     // Determine expected currency and amount based on our role
     const myDirectAddress = deps.identity.directAddress;
@@ -1739,7 +1733,15 @@ export class SwapModule {
         swap.updatedAt = Date.now();
         this.clearLocalTimer(swap.swapId);
         this.terminalSwapIds.add(swap.swapId);
-        const entryIdx = this._storedTerminalEntries.length;
+        // Append our terminal-entry marker. We deliberately DO NOT capture a
+        // positional index here for rollback — `_storedTerminalEntries` is
+        // shared across all swaps in this module, and a concurrent swap's
+        // own `transitionProgress(*, terminal)` can append to this same array
+        // during the `await persistSwap()` below. A `splice(entryIdx, 1)`
+        // rollback would then remove the WRONG entry, silently corrupting an
+        // unrelated swap's terminal record. Roll back by `(swapId, progress)`
+        // identity instead — uniquely identifies our marker regardless of
+        // intervening appends.
         this._storedTerminalEntries.push({
           swapId: swap.swapId,
           progress: 'failed',
@@ -1755,7 +1757,17 @@ export class SwapModule {
           (swap as { error?: string }).error = prevError;
           swap.updatedAt = prevUpdatedAt;
           this.terminalSwapIds.delete(swap.swapId);
-          this._storedTerminalEntries.splice(entryIdx, 1);
+          // Remove BY IDENTITY (swapId + progress), not positional index, so a
+          // concurrent swap's terminal entry that landed during the await is
+          // not accidentally evicted. Iterate from the end since our marker
+          // was the most recent push for this swap.
+          for (let i = this._storedTerminalEntries.length - 1; i >= 0; i--) {
+            const entry = this._storedTerminalEntries[i]!;
+            if (entry.swapId === swap.swapId && entry.progress === 'failed') {
+              this._storedTerminalEntries.splice(i, 1);
+              break;
+            }
+          }
           logger.warn(LOG_TAG, `failPayout: persistSwap failed for ${swapId}; fraud detection will retry on next load:`, persistErr);
           throw persistErr;
         }

--- a/tests/integration/swap-lifecycle.test.ts
+++ b/tests/integration/swap-lifecycle.test.ts
@@ -1147,4 +1147,131 @@ describe('Swap Lifecycle Integration Tests', () => {
     const finalStatus = await ctx.partyA.module.getSwapStatus(swapId, { queryEscrow: false });
     expect(finalStatus.progress).toBe('completed');
   });
+
+  // ---------------------------------------------------------------------------
+  // INT-SWAP-009: Over-coverage detected after escrow status_result drove the
+  // swap to 'completed' — exercises the direct-mutation `completed → failed`
+  // rollback path inside `failPayout()`.
+  //
+  // INT-SWAP-007 left the swap in `concluding` when verifyPayout fired, so the
+  // failure exited via the `else` branch (`transitionProgress('failed', ...)`).
+  // The new direct-mutation path at SwapModule.ts:1725-1761 (which manually
+  // mutates `swap.progress = 'failed'`, captures rollback state, and replicates
+  // every `transitionProgress` side-effect by hand) had no test coverage. This
+  // scenario forces the swap into `completed` + `payoutVerified=false` BEFORE
+  // verifyPayout runs (mirrors what happens when escrow's status_result DM
+  // arrives ahead of the payout-invoice import), then over-coverage triggers
+  // `failPayout`, which MUST take the direct-mutation branch.
+  // ---------------------------------------------------------------------------
+  it('INT-SWAP-009: over-coverage from completed+unverified state takes direct-mutation rollback path', async () => {
+    const deal = createDeal();
+
+    const proposalResult = await ctx.partyA.module.proposeSwap(deal);
+    const swapId = proposalResult.swapId;
+    const manifest = proposalResult.manifest;
+    await settle();
+
+    configureAccountingForDeposit(ctx.partyA, ctx.escrow);
+    configureAccountingForDeposit(ctx.partyB, ctx.escrow);
+    await ctx.partyB.module.acceptSwap(swapId);
+    await settle(150);
+    await ctx.partyA.module.deposit(swapId);
+    await ctx.partyB.module.deposit(swapId);
+    ctx.escrow.simulateDeposit(swapId, PARTY_A_TRANSPORT_PUBKEY);
+    ctx.escrow.simulateDeposit(swapId, PARTY_B_TRANSPORT_PUBKEY);
+    await settle(100);
+
+    const partyAAfterDeposit = await ctx.partyA.module.getSwapStatus(swapId, { queryEscrow: false });
+    expect(partyAAfterDeposit.payoutInvoiceId).toBeTruthy();
+
+    configureAccountingForPayout(
+      ctx.partyA,
+      swapId,
+      partyAAfterDeposit.payoutInvoiceId!,
+      PARTY_A_ADDRESS,
+      manifest.party_b_currency_to_change,
+      manifest.party_b_value_to_change,
+    );
+
+    // Force the swap into the `completed` + `payoutVerified=false` precondition.
+    // This mirrors the production scenario where the escrow's status_result DM
+    // arrives ahead of the payout invoice and drives the swap to `completed`
+    // before the local `verifyPayout` ever sees the funds. We mutate in-memory
+    // state directly because the test fixture's relay simulator doesn't drive
+    // status_result independently.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const swapsMap = (ctx.partyA.module as any).swaps as Map<string, {
+      progress: string;
+      payoutVerified?: boolean;
+    }>;
+    const swapRef = swapsMap.get(swapId)!;
+    expect(swapRef).toBeDefined();
+    swapRef.progress = 'completed';
+    swapRef.payoutVerified = false;
+
+    // Snapshot _storedTerminalEntries before the failure so we can verify
+    // the rollback-by-identity behaviour: any unrelated terminal entries
+    // present before this call MUST survive (we only want our own entry to
+    // be added to it).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const storedTerminalEntries = (ctx.partyA.module as any)._storedTerminalEntries as Array<{
+      swapId: string;
+      progress: string;
+    }>;
+    const beforeLen = storedTerminalEntries.length;
+
+    // Override invoice status to simulate over-coverage.
+    const expectedAmount = manifest.party_b_value_to_change;
+    const overCoveredAmount = (BigInt(expectedAmount) * 2n).toString();
+    const surplus = expectedAmount;
+    const payoutInvoiceId = partyAAfterDeposit.payoutInvoiceId!;
+    const prevStatus = ctx.partyA.accounting.getInvoiceStatus.getMockImplementation();
+    ctx.partyA.accounting.getInvoiceStatus.mockImplementation((invoiceId: string) => {
+      if (invoiceId === payoutInvoiceId) {
+        return {
+          invoiceId,
+          state: 'COVERED',
+          targets: [{
+            coinAssets: [{
+              coin: [manifest.party_b_currency_to_change, expectedAmount],
+              netCoveredAmount: overCoveredAmount,
+              isCovered: true,
+              surplusAmount: surplus,
+            }],
+          }],
+          totalForward: { [manifest.party_b_currency_to_change]: overCoveredAmount },
+          totalBack: {},
+          allConfirmed: true,
+          lastActivityAt: Date.now(),
+        };
+      }
+      return prevStatus ? prevStatus(invoiceId) : null;
+    });
+
+    // Capture event-emit count BEFORE the call so we can assert exactly-one
+    // swap:failed (events are stored as [type, data] tuples — match findEvents helper).
+    const failedEventsBefore = findEvents(ctx.partyA.events, 'swap:failed').length;
+
+    const verified = await ctx.partyA.module.verifyPayout(swapId);
+    expect(verified).toBe(false);
+
+    // The swap MUST have transitioned to 'failed' via the direct-mutation
+    // branch (since transitionProgress would reject `completed → failed` as
+    // an invalid state-machine edge — that's exactly why the branch exists).
+    const finalStatus = await ctx.partyA.module.getSwapStatus(swapId, { queryEscrow: false });
+    expect(finalStatus.progress).toBe('failed');
+    expect((finalStatus as { error?: string }).error).toMatch(/OVER_COVERAGE/);
+
+    // Exactly one swap:failed emission for this call (no double-fire from
+    // direct-mutation + a downstream listener).
+    const failedEventsAfter = findEvents(ctx.partyA.events, 'swap:failed').length;
+    expect(failedEventsAfter - failedEventsBefore).toBe(1);
+
+    // _storedTerminalEntries grew by exactly one entry, and that entry is for
+    // OUR swap. Verifies the direct-mutation branch correctly recorded the
+    // terminal marker.
+    expect(storedTerminalEntries.length).toBe(beforeLen + 1);
+    expect(storedTerminalEntries[storedTerminalEntries.length - 1]!.swapId).toBe(swapId);
+    expect(storedTerminalEntries[storedTerminalEntries.length - 1]!.progress).toBe('failed');
+  });
 });

--- a/tests/integration/swap-lifecycle.test.ts
+++ b/tests/integration/swap-lifecycle.test.ts
@@ -1087,6 +1087,10 @@ describe('Swap Lifecycle Integration Tests', () => {
       return prevStatus ? prevStatus(invoiceId) : null;
     });
 
+    // Snapshot swap:failed event count before — assert exactly-one emission
+    // (no double-fire from direct-mutation + a downstream listener; review W4).
+    const failedEventsBefore = findEvents(ctx.partyA.events, 'swap:failed').length;
+
     // verifyPayout must return false (settlement halted) AND transition the swap
     // to 'failed' with an OVER_COVERAGE error.
     const verified = await ctx.partyA.module.verifyPayout(swapId);
@@ -1098,8 +1102,9 @@ describe('Swap Lifecycle Integration Tests', () => {
     expect((finalStatus as { error?: string }).error).toMatch(new RegExp(`expected=${expectedAmount}`));
     expect((finalStatus as { error?: string }).error).toMatch(new RegExp(`surplus=${surplus}`));
 
-    // Should have emitted swap:failed (not swap:completed with payoutVerified=false).
-    expect(findEvent(ctx.partyA.events, 'swap:failed')).toBeDefined();
+    // Exactly one swap:failed emission for this call.
+    const failedEventsAfter = findEvents(ctx.partyA.events, 'swap:failed').length;
+    expect(failedEventsAfter - failedEventsBefore).toBe(1);
   });
 
   // ---------------------------------------------------------------------------
@@ -1140,6 +1145,37 @@ describe('Swap Lifecycle Integration Tests', () => {
       manifest.party_b_currency_to_change,
       manifest.party_b_value_to_change,
     );
+
+    // Override status mock to assert the exact-equality boundary
+    // (review feedback W3): `netCoveredAmount === expectedAmount` exactly,
+    // not "≥ expectedAmount". A future regression that accidentally tightened
+    // the check (e.g. to `> expectedAmount`) would slip past the original
+    // happy-path assertion but be caught here because the test pins the
+    // exact value path.
+    const expectedAmount = manifest.party_b_value_to_change;
+    const payoutInvoiceId = partyAAfterDeposit.payoutInvoiceId!;
+    const prevStatus = ctx.partyA.accounting.getInvoiceStatus.getMockImplementation();
+    ctx.partyA.accounting.getInvoiceStatus.mockImplementation((invoiceId: string) => {
+      if (invoiceId === payoutInvoiceId) {
+        return {
+          invoiceId,
+          state: 'COVERED',
+          targets: [{
+            coinAssets: [{
+              coin: [manifest.party_b_currency_to_change, expectedAmount],
+              netCoveredAmount: expectedAmount, // EXACT
+              isCovered: true,
+              surplusAmount: '0',
+            }],
+          }],
+          totalForward: { [manifest.party_b_currency_to_change]: expectedAmount },
+          totalBack: {},
+          allConfirmed: true,
+          lastActivityAt: Date.now(),
+        };
+      }
+      return prevStatus ? prevStatus(invoiceId) : null;
+    });
 
     const verified = await ctx.partyA.module.verifyPayout(swapId);
     expect(verified).toBe(true);

--- a/tests/integration/swap-lifecycle.test.ts
+++ b/tests/integration/swap-lifecycle.test.ts
@@ -1008,4 +1008,143 @@ describe('Swap Lifecycle Integration Tests', () => {
     expect(idsA.size).toBe(3);
     expect(idsB.size).toBe(3);
   });
+
+  // ---------------------------------------------------------------------------
+  // INT-SWAP-007: Over-coverage on payout invoice fails fast with OVER_COVERAGE
+  //
+  // Regression coverage for the silent-acceptance path that previously let an
+  // over-paid payout invoice (e.g. from an escrow crash-recovery double-send,
+  // a duplicate `payInvoice()` from any source) progress past the coverage gate
+  // and surface as an opaque 20-min retry-loop hang in the trader's wrapper. The
+  // SwapModule must now treat `netCoveredAmount > expectedAmount` as a terminal
+  // settlement fault (OVER_COVERAGE), failing the swap with an explicit error so
+  // the application layer can recover and surplus auto-return can refund payers.
+  // ---------------------------------------------------------------------------
+  it('INT-SWAP-007: over-coverage on payout fails fast with OVER_COVERAGE error', async () => {
+    const deal = createDeal();
+
+    // Walk the happy-path lifecycle up to the verifyPayout step.
+    const proposalResult = await ctx.partyA.module.proposeSwap(deal);
+    const swapId = proposalResult.swapId;
+    const manifest = proposalResult.manifest;
+    await settle();
+
+    configureAccountingForDeposit(ctx.partyA, ctx.escrow);
+    configureAccountingForDeposit(ctx.partyB, ctx.escrow);
+
+    await ctx.partyB.module.acceptSwap(swapId);
+    await settle(150);
+
+    await ctx.partyA.module.deposit(swapId);
+    await ctx.partyB.module.deposit(swapId);
+
+    ctx.escrow.simulateDeposit(swapId, PARTY_A_TRANSPORT_PUBKEY);
+    ctx.escrow.simulateDeposit(swapId, PARTY_B_TRANSPORT_PUBKEY);
+    await settle(100);
+
+    const partyAAfterDeposit = await ctx.partyA.module.getSwapStatus(swapId, { queryEscrow: false });
+    expect(partyAAfterDeposit.payoutInvoiceId).toBeTruthy();
+
+    // Configure accounting for normal payout — terms expect party_b_value_to_change.
+    configureAccountingForPayout(
+      ctx.partyA,
+      swapId,
+      partyAAfterDeposit.payoutInvoiceId!,
+      PARTY_A_ADDRESS,
+      manifest.party_b_currency_to_change,
+      manifest.party_b_value_to_change,
+    );
+
+    // Override the invoice-status mock to simulate over-coverage:
+    // `netCoveredAmount` is double the expected amount (the symptom seen when the
+    // escrow crash-recovery double-sends a payout). Exact arithmetic, not a
+    // probabilistic check.
+    const expectedAmount = manifest.party_b_value_to_change;
+    const overCoveredAmount = (BigInt(expectedAmount) * 2n).toString();
+    const surplus = (BigInt(expectedAmount)).toString();
+
+    const payoutInvoiceId = partyAAfterDeposit.payoutInvoiceId!;
+    const prevStatus = ctx.partyA.accounting.getInvoiceStatus.getMockImplementation();
+    ctx.partyA.accounting.getInvoiceStatus.mockImplementation((invoiceId: string) => {
+      if (invoiceId === payoutInvoiceId) {
+        return {
+          invoiceId,
+          state: 'COVERED',
+          targets: [{
+            coinAssets: [{
+              coin: [manifest.party_b_currency_to_change, expectedAmount],
+              netCoveredAmount: overCoveredAmount,
+              isCovered: true,
+              surplusAmount: surplus,
+            }],
+          }],
+          totalForward: { [manifest.party_b_currency_to_change]: overCoveredAmount },
+          totalBack: {},
+          allConfirmed: true,
+          lastActivityAt: Date.now(),
+        };
+      }
+      return prevStatus ? prevStatus(invoiceId) : null;
+    });
+
+    // verifyPayout must return false (settlement halted) AND transition the swap
+    // to 'failed' with an OVER_COVERAGE error.
+    const verified = await ctx.partyA.module.verifyPayout(swapId);
+    expect(verified).toBe(false);
+
+    const finalStatus = await ctx.partyA.module.getSwapStatus(swapId, { queryEscrow: false });
+    expect(finalStatus.progress).toBe('failed');
+    expect((finalStatus as { error?: string }).error).toMatch(/OVER_COVERAGE/);
+    expect((finalStatus as { error?: string }).error).toMatch(new RegExp(`expected=${expectedAmount}`));
+    expect((finalStatus as { error?: string }).error).toMatch(new RegExp(`surplus=${surplus}`));
+
+    // Should have emitted swap:failed (not swap:completed with payoutVerified=false).
+    expect(findEvent(ctx.partyA.events, 'swap:failed')).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // INT-SWAP-008: Exact-coverage payout passes verification (regression guard)
+  //
+  // Confirms the equality check at the swap settlement boundary still accepts
+  // exact coverage — i.e. `netCoveredAmount === expectedAmount` is the success
+  // path, not the over-coverage path. Catches accidental tightening that would
+  // reject the happy path.
+  // ---------------------------------------------------------------------------
+  it('INT-SWAP-008: exact coverage on payout passes verification', async () => {
+    const deal = createDeal();
+
+    const proposalResult = await ctx.partyA.module.proposeSwap(deal);
+    const swapId = proposalResult.swapId;
+    const manifest = proposalResult.manifest;
+    await settle();
+
+    configureAccountingForDeposit(ctx.partyA, ctx.escrow);
+    configureAccountingForDeposit(ctx.partyB, ctx.escrow);
+    await ctx.partyB.module.acceptSwap(swapId);
+    await settle(150);
+
+    await ctx.partyA.module.deposit(swapId);
+    await ctx.partyB.module.deposit(swapId);
+    ctx.escrow.simulateDeposit(swapId, PARTY_A_TRANSPORT_PUBKEY);
+    ctx.escrow.simulateDeposit(swapId, PARTY_B_TRANSPORT_PUBKEY);
+    await settle(100);
+
+    const partyAAfterDeposit = await ctx.partyA.module.getSwapStatus(swapId, { queryEscrow: false });
+    expect(partyAAfterDeposit.payoutInvoiceId).toBeTruthy();
+
+    configureAccountingForPayout(
+      ctx.partyA,
+      swapId,
+      partyAAfterDeposit.payoutInvoiceId!,
+      PARTY_A_ADDRESS,
+      manifest.party_b_currency_to_change,
+      manifest.party_b_value_to_change,
+    );
+
+    const verified = await ctx.partyA.module.verifyPayout(swapId);
+    expect(verified).toBe(true);
+
+    const finalStatus = await ctx.partyA.module.getSwapStatus(swapId, { queryEscrow: false });
+    expect(finalStatus.progress).toBe('completed');
+  });
 });


### PR DESCRIPTION
## Summary

`SwapModule.verifyPayout` previously checked `netCoveredAmount < expectedAmount` and silently accepted any value greater-or-equal. With strict-less-than, an over-covered payout invoice (`netCoveredAmount > expectedAmount`) passed the coverage gate and proceeded into `payments.validate()`, where any unrelated invalid token in the wallet would cause `returnFalse()` and trigger the consumer's retry loop — producing an opaque 20-minute hang rather than an explicit settlement failure.

Replace `<` with a tri-state check:
- `net < expected` → `returnFalse()` (transient — keep retrying)
- `net === expected` → proceed (success)
- `net > expected` → `failPayout('OVER_COVERAGE: net=N, expected=N, surplus=N')` with surplus surfaced so the application layer can rely on \`accounting.setAutoReturn\` to refund and recover with a clear reason

## Why this matters

The accounting layer already tracks per-payer surplus and emits \`invoice:overpayment\`. The receiver-side \`setAutoReturn(invoiceId, true)\` + escrow-side \`closeInvoice({ autoReturn: true })\` will refund the surplus back to the over-paying party — but only if the swap explicitly fails, which this patch ensures.

## Test plan

- [x] INT-SWAP-007 (new): override \`getInvoiceStatus\` to return \`netCoveredAmount = 2 * expectedAmount\`; assert \`verifyPayout\` returns false, transitions to \`failed\`, emits \`swap:failed\` with error matching \`/OVER_COVERAGE/\`, \`expected=N\`, \`surplus=N\`
- [x] INT-SWAP-008 (new): regression guard — exact coverage produces \`verified=true\` and \`completed\`
- [x] INT-SWAP-001 (happy path) unchanged
- [x] All 8 swap-lifecycle integration tests pass
- [x] Full SDK suite: 2783/2783 passes (with PR-1 alone), 2784/2784 with PR-1+PR-3 stacked
- [x] **End-to-end validation**: stacked with PR-2 (trader auto-return) + PR-3 (ledger flush) and run trader-service e2e-live suite. Multi-agent test went from **26-min over-coverage hang FAIL → 4.9-min clean PASS**. Full suite 11/11 (+2 opt-in skipped) in 23 min.

## Deferred (separate PR)

Scoping \`payments.validate()\` to invoice-covering tokens (eliminating the unrelated-invalid-token amplifier flagged in the existing comment at lines 1828-1831) requires API additions to \`PaymentsModule\` and a token-by-transferId lookup. Out of scope for this PR.