### PR TITLE
fix(accounting): flush provisional ledger before payInvoice/returnInvoicePayment return

### DIFF
--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -2471,6 +2471,54 @@ export class AccountingModule {
           this.dirtyLedgerEntries.add(invoiceId);
           // Invalidate balance cache for this invoice
           this.balanceCache.delete(invoiceId);
+
+          // BUG-002 Fix 2 (durability extension): Force the provisional entry to disk
+          // before payInvoice returns. Without this, BUG-002 Fix 2's in-memory provisional
+          // entry would protect concurrent in-process callers from double-spend, but a
+          // crash between this `send()` returning and the next deferred-flush trigger
+          // (e.g. an incoming-transfer event in `_handleTokenChange`) would lose the
+          // provisional entry. On recovery the on-disk ledger has no record of the
+          // committed `send()`, so callers that recompute `remaining = expected - covered`
+          // see `remaining = expected` and re-issue the full amount — producing a
+          // distinct second on-chain transferId and over-coverage on the receiver.
+          // The crash-mid-conclude race in escrow-service `_concludeSwap` → `_resumePayouts`
+          // is exactly this pattern (see escrow-service crash-recovery audit, May 2026).
+          //
+          // Implementation notes (review feedback):
+          //
+          // (a) We schedule via the existing `_flushPromise` chain to serialize
+          //     against other in-flight flushes, then `await` THIS flush directly
+          //     rather than `_drainFlushPromise()`. Draining the whole chain would
+          //     spin while concurrent `_handleTokenChange` events keep replacing
+          //     `_flushPromise`, holding the per-invoice gate for an unbounded
+          //     number of additional flushes. We only need OUR provisional entry
+          //     durable; subsequent chain entries are someone else's responsibility.
+          //
+          // (b) `_flushDirtyLedgerEntries` itself catches its per-invoice
+          //     `storage.set` rejection and aborts internally (sets a local
+          //     `step1Failed` flag), leaving the dirty entry on the in-memory
+          //     set without re-throwing. So awaiting the flush is not enough —
+          //     we must detect post-flush whether OUR specific invoice still
+          //     sits in `dirtyLedgerEntries` and surface that as a rejection
+          //     of `payInvoice`. Otherwise `payInvoice` would silently return
+          //     success while the durability goal is silently broken.
+          const flushTrigger = (this._flushPromise ?? Promise.resolve())
+            .then(() => this._flushDirtyLedgerEntries());
+          const tracked: Promise<void> = flushTrigger.catch(() => {/* swallow for chain */}).finally(() => {
+            if (this._flushPromise === tracked) this._flushPromise = null;
+          });
+          this._flushPromise = tracked;
+          await flushTrigger;
+          // Verify durability: if our invoice is still dirty after the flush,
+          // its persistence failed. Propagate as a rejection so the caller can
+          // retry or compensate (the in-memory entry remains so the next flush
+          // attempt — explicit or via `_handleTokenChange` — will retry).
+          if (this.dirtyLedgerEntries.has(invoiceId)) {
+            throw new SphereError(
+              `payInvoice: provisional ledger entry for invoice ${invoiceId} failed to persist — caller should retry`,
+              'STORAGE_ERROR',
+            );
+          }
         }
 
         return result;
@@ -2713,6 +2761,28 @@ export class AccountingModule {
           }
           // Invalidate balance cache for this invoice
           this.balanceCache.delete(invoiceId);
+
+          // Force the provisional entry to disk before returning. Same rationale
+          // and review-feedback constraints as `payInvoice` above:
+          // (a) await OUR flush directly (not `_drainFlushPromise`) so we don't
+          //     spin while concurrent `_handleTokenChange` events keep extending
+          //     the chain.
+          // (b) detect post-flush whether OUR invoice is still dirty (the helper
+          //     swallows storage errors internally) and propagate as a rejection
+          //     so the caller learns when durability fails — never silently OK.
+          const flushTrigger = (this._flushPromise ?? Promise.resolve())
+            .then(() => this._flushDirtyLedgerEntries());
+          const tracked: Promise<void> = flushTrigger.catch(() => {/* swallow for chain */}).finally(() => {
+            if (this._flushPromise === tracked) this._flushPromise = null;
+          });
+          this._flushPromise = tracked;
+          await flushTrigger;
+          if (this.dirtyLedgerEntries.has(invoiceId)) {
+            throw new SphereError(
+              `returnInvoicePayment: provisional ledger entry for invoice ${invoiceId} failed to persist — caller should retry`,
+              'STORAGE_ERROR',
+            );
+          }
         }
 
         return result;

--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -2472,53 +2472,12 @@ export class AccountingModule {
           // Invalidate balance cache for this invoice
           this.balanceCache.delete(invoiceId);
 
-          // BUG-002 Fix 2 (durability extension): Force the provisional entry to disk
-          // before payInvoice returns. Without this, BUG-002 Fix 2's in-memory provisional
-          // entry would protect concurrent in-process callers from double-spend, but a
-          // crash between this `send()` returning and the next deferred-flush trigger
-          // (e.g. an incoming-transfer event in `_handleTokenChange`) would lose the
-          // provisional entry. On recovery the on-disk ledger has no record of the
-          // committed `send()`, so callers that recompute `remaining = expected - covered`
-          // see `remaining = expected` and re-issue the full amount — producing a
-          // distinct second on-chain transferId and over-coverage on the receiver.
-          // The crash-mid-conclude race in escrow-service `_concludeSwap` → `_resumePayouts`
-          // is exactly this pattern (see escrow-service crash-recovery audit, May 2026).
-          //
-          // Implementation notes (review feedback):
-          //
-          // (a) We schedule via the existing `_flushPromise` chain to serialize
-          //     against other in-flight flushes, then `await` THIS flush directly
-          //     rather than `_drainFlushPromise()`. Draining the whole chain would
-          //     spin while concurrent `_handleTokenChange` events keep replacing
-          //     `_flushPromise`, holding the per-invoice gate for an unbounded
-          //     number of additional flushes. We only need OUR provisional entry
-          //     durable; subsequent chain entries are someone else's responsibility.
-          //
-          // (b) `_flushDirtyLedgerEntries` itself catches its per-invoice
-          //     `storage.set` rejection and aborts internally (sets a local
-          //     `step1Failed` flag), leaving the dirty entry on the in-memory
-          //     set without re-throwing. So awaiting the flush is not enough —
-          //     we must detect post-flush whether OUR specific invoice still
-          //     sits in `dirtyLedgerEntries` and surface that as a rejection
-          //     of `payInvoice`. Otherwise `payInvoice` would silently return
-          //     success while the durability goal is silently broken.
-          const flushTrigger = (this._flushPromise ?? Promise.resolve())
-            .then(() => this._flushDirtyLedgerEntries());
-          const tracked: Promise<void> = flushTrigger.catch(() => {/* swallow for chain */}).finally(() => {
-            if (this._flushPromise === tracked) this._flushPromise = null;
-          });
-          this._flushPromise = tracked;
-          await flushTrigger;
-          // Verify durability: if our invoice is still dirty after the flush,
-          // its persistence failed. Propagate as a rejection so the caller can
-          // retry or compensate (the in-memory entry remains so the next flush
-          // attempt — explicit or via `_handleTokenChange` — will retry).
-          if (this.dirtyLedgerEntries.has(invoiceId)) {
-            throw new SphereError(
-              `payInvoice: provisional ledger entry for invoice ${invoiceId} failed to persist — caller should retry`,
-              'STORAGE_ERROR',
-            );
-          }
+          // BUG-002 Fix 2 (durability extension): Force the provisional entry
+          // to disk before payInvoice returns. The crash-mid-conclude race in
+          // escrow-service `_concludeSwap` → `_resumePayouts` produces
+          // over-coverage on receivers without this — see the audit and the
+          // helper docstring for the full rationale and implementation notes.
+          await this._persistProvisionalAndVerify(invoiceId, 'payInvoice');
         }
 
         return result;
@@ -2762,27 +2721,10 @@ export class AccountingModule {
           // Invalidate balance cache for this invoice
           this.balanceCache.delete(invoiceId);
 
-          // Force the provisional entry to disk before returning. Same rationale
-          // and review-feedback constraints as `payInvoice` above:
-          // (a) await OUR flush directly (not `_drainFlushPromise`) so we don't
-          //     spin while concurrent `_handleTokenChange` events keep extending
-          //     the chain.
-          // (b) detect post-flush whether OUR invoice is still dirty (the helper
-          //     swallows storage errors internally) and propagate as a rejection
-          //     so the caller learns when durability fails — never silently OK.
-          const flushTrigger = (this._flushPromise ?? Promise.resolve())
-            .then(() => this._flushDirtyLedgerEntries());
-          const tracked: Promise<void> = flushTrigger.catch(() => {/* swallow for chain */}).finally(() => {
-            if (this._flushPromise === tracked) this._flushPromise = null;
-          });
-          this._flushPromise = tracked;
-          await flushTrigger;
-          if (this.dirtyLedgerEntries.has(invoiceId)) {
-            throw new SphereError(
-              `returnInvoicePayment: provisional ledger entry for invoice ${invoiceId} failed to persist — caller should retry`,
-              'STORAGE_ERROR',
-            );
-          }
+          // Force the provisional entry to disk before returning. Same
+          // rationale as `payInvoice` above — see `_persistProvisionalAndVerify`
+          // for the full implementation rationale.
+          await this._persistProvisionalAndVerify(invoiceId, 'returnInvoicePayment');
         }
 
         return result;
@@ -4691,6 +4633,55 @@ export class AccountingModule {
   private async _drainFlushPromise(): Promise<void> {
     while (this._flushPromise) {
       await this._flushPromise.catch(() => { /* swallow — flush errors are non-fatal */ });
+    }
+  }
+
+  /**
+   * Synchronously persist any pending provisional ledger entry for `invoiceId`
+   * before returning to the caller. Used by `payInvoice` and
+   * `returnInvoicePayment` to make the in-memory provisional entry durable
+   * inside the same per-invoice gate that wrote it, closing the
+   * crash-mid-conclude race that produces over-coverage on receivers.
+   *
+   * Implementation:
+   *   1. Schedule a flush via the existing `_flushPromise` chain (so
+   *      concurrent `_handleTokenChange` callers waiting on the chain
+   *      observe ours as part of the sequence).
+   *   2. Await OUR flush directly — NOT `_drainFlushPromise()`, which would
+   *      spin while concurrent token changes keep extending the chain and
+   *      hold the per-invoice gate for an unbounded number of additional
+   *      flushes. We only need OUR provisional entry durable.
+   *   3. `_flushDirtyLedgerEntries` swallows per-invoice `storage.set`
+   *      rejections internally (sets a local `step1Failed` flag), leaving
+   *      the dirty entry on the set without re-throwing. So we post-check
+   *      `dirtyLedgerEntries.has(invoiceId)` and throw a `STORAGE_ERROR`
+   *      `SphereError` if our entry is still dirty — propagating to the
+   *      caller so they learn about the durability failure rather than
+   *      receiving a silent "success" return that lies on disk.
+   *
+   * @param invoiceId    The invoice whose provisional entry must be durable.
+   * @param callContext  Used in the error message so the caller is named
+   *                     ('payInvoice' / 'returnInvoicePayment') without
+   *                     forcing a stack-trace inspection.
+   */
+  private async _persistProvisionalAndVerify(
+    invoiceId: string,
+    callContext: string,
+  ): Promise<void> {
+    const flushTrigger = (this._flushPromise ?? Promise.resolve())
+      .then(() => this._flushDirtyLedgerEntries());
+    const tracked: Promise<void> = flushTrigger
+      .catch(() => { /* swallow for chain */ })
+      .finally(() => {
+        if (this._flushPromise === tracked) this._flushPromise = null;
+      });
+    this._flushPromise = tracked;
+    await flushTrigger;
+    if (this.dirtyLedgerEntries.has(invoiceId)) {
+      throw new SphereError(
+        `${callContext}: provisional ledger entry for invoice ${invoiceId} failed to persist — caller should retry`,
+        'STORAGE_ERROR',
+      );
     }
   }
 

--- a/tests/unit/modules/AccountingModule.payInvoice-provisional.test.ts
+++ b/tests/unit/modules/AccountingModule.payInvoice-provisional.test.ts
@@ -348,4 +348,99 @@ describe('AccountingModule.payInvoice() — provisional reservation (BUG-002 Fix
     // After payInvoice, balanceCache for this invoice should be invalidated
     expect(mod.balanceCache.has(INVOICE_ID)).toBe(false);
   });
+
+  // UT-PAY-PROV-008
+  // Durability test: the provisional ledger entry must reach disk BEFORE
+  // payInvoice returns. Without this guarantee, a crash between `send()`
+  // returning to the caller and the next deferred-flush trigger would lose
+  // the provisional entry, allowing a recovery-time recompute to re-issue
+  // the same payment as a distinct second on-chain transferId — producing
+  // over-coverage on the receiver. Regression coverage for the audit's #1
+  // hypothesis on Carol's payout-invoice over-coverage in the multi-trader
+  // e2e (escrow-service crash-recovery audit, May 2026).
+  it('UT-PAY-PROV-008: provisional entry is flushed to storage before payInvoice returns', async () => {
+    const terms = makeTerms();
+    const { module, mocks } = createTestAccountingModule();
+    mocks.payments._tokens = [makeInvoiceToken(terms)];
+    await module.load();
+
+    // Snapshot storage.set call count before payInvoice — load() may have
+    // written some bookkeeping entries during initialization.
+    const setCallsBefore = mocks.storage.set.mock.calls.length;
+
+    const result = await module.payInvoice(INVOICE_ID, {
+      targetIndex: 0,
+      assetIndex: 0,
+    });
+
+    // Storage MUST have been written to during the payInvoice call — specifically,
+    // the inv_ledger:{invoiceId} entry containing the provisional forward ref.
+    const setCallsDuring = mocks.storage.set.mock.calls.slice(setCallsBefore);
+    const ledgerWrites = setCallsDuring.filter(([key]) =>
+      typeof key === 'string' && key.includes(`inv_ledger:${INVOICE_ID}`),
+    );
+    expect(ledgerWrites.length).toBeGreaterThanOrEqual(1);
+
+    // The persisted entry must contain the provisional reference. Read the
+    // most recent ledger write and confirm the provisional entry is present.
+    const lastLedgerWrite = ledgerWrites[ledgerWrites.length - 1]!;
+    const persistedJson = lastLedgerWrite[1] as string;
+    const persistedEntries = JSON.parse(persistedJson) as Record<string, InvoiceTransferRef>;
+    const provisionalKey = `provisional:${result.id}::UCT`;
+    expect(persistedEntries[provisionalKey]).toBeDefined();
+    expect(persistedEntries[provisionalKey]!.amount).toBe('1000');
+    expect(persistedEntries[provisionalKey]!.paymentDirection).toBe('forward');
+
+    // After payInvoice returns, _drainFlushPromise must be a no-op — the chain
+    // is already empty because the flush completed inline before return.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = module as any;
+    expect(mod._flushPromise).toBeNull();
+    // dirtyLedgerEntries should be empty (cleared by the flush)
+    expect(mod.dirtyLedgerEntries.size).toBe(0);
+  });
+
+  // UT-PAY-PROV-009
+  // Durability error-propagation test: if the inline flush's `storage.set`
+  // rejects (disk full, EIO, locked DB), `payInvoice` MUST reject — not return
+  // success while `dirtyLedgerEntries` stays populated. Earlier review feedback
+  // flagged a bug where the flush's `.catch(...log...)` silently swallowed the
+  // storage rejection: `payInvoice` returned success, but the on-disk durability
+  // claim was a lie. The exact crash window the durability fix aims to close
+  // would have been reopened the moment a storage error coincided with an OS
+  // crash. This test pins the corrected behavior.
+  it('UT-PAY-PROV-009: payInvoice REJECTS when inline flush storage write fails', async () => {
+    const terms = makeTerms();
+    const { module, mocks } = createTestAccountingModule();
+    mocks.payments._tokens = [makeInvoiceToken(terms)];
+    await module.load();
+
+    // Reject the FIRST `inv_ledger:` storage write that occurs during payInvoice.
+    // We must let earlier load()-time writes (and any pre-payInvoice setup writes)
+    // pass through — only fail the per-invoice ledger persistence.
+    const realSet = mocks.storage.set.getMockImplementation();
+    let rejected = false;
+    mocks.storage.set.mockImplementation((key: string, value: string): Promise<void> => {
+      if (!rejected && key.includes(`inv_ledger:${INVOICE_ID}`)) {
+        rejected = true;
+        return Promise.reject(new Error('mock storage failure: disk full'));
+      }
+      // Delegate to the real backing-map implementation for everything else
+      return realSet ? realSet(key, value) : Promise.resolve();
+    });
+
+    // payInvoice MUST reject — not silently return success. The rejection may
+    // surface either as the original storage error OR as the SDK's
+    // STORAGE_ERROR post-flush detection, depending on whether
+    // `_flushDirtyLedgerEntries` propagated or swallowed the rejection.
+    await expect(
+      module.payInvoice(INVOICE_ID, { targetIndex: 0, assetIndex: 0 }),
+    ).rejects.toThrow(/disk full|storage failure|STORAGE_ERROR|failed to persist/i);
+
+    // After rejection, the in-memory provisional is still marked dirty so a
+    // subsequent payInvoice or process restart can retry the flush. No silent loss.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = module as any;
+    expect(mod.dirtyLedgerEntries.has(INVOICE_ID)).toBe(true);
+  });
 });


### PR DESCRIPTION
Replaces #120 (auto-closed after base branch was deleted on #119 squash-merge). Same content rebased onto main.