### PR TITLE
fix: post-UXF test-infrastructure cleanup (75 → 0 failures)

### DIFF
--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -297,9 +297,29 @@ export class LifecycleManager {
     // (no oracle, sticky skip, structurally unavailable), bail
     // immediately so the caller can take the legacy path with full
     // knowledge that no future build will reconcile.
+    //
+    // Wave G.7+ refinement: if no `getPointerLayer` closure is wired at
+    // all, polling is structurally pointless — there is no codepath
+    // that could ever flip the result from null to non-null. Bail
+    // immediately. The previous code waited a full 30s in that case,
+    // which manifested as test-suite hangs on every test fixture that
+    // omitted the pointer wiring (the ProfileTokenStorageProvider unit
+    // tests, the wave-g7-prereq fixtures, etc.). Production wallets
+    // always wire `getPointerLayer` when an oracle is configured, so
+    // this short-circuit only affects test fixtures and degenerate
+    // setups; the slow-build-on-CI scenario is preserved when the
+    // closure IS wired but returns null transiently.
+    const getPointerLayer = this.host.options?.getPointerLayer;
+    if (!getPointerLayer) {
+      this.host.log(
+        'Pointer recover: no getPointerLayer closure wired; ' +
+          'skipping pointer-layer wait, falling through to legacy IPNS migration',
+      );
+      return false;
+    }
     const getStatus = this.host.options?.getPointerBuildStatus;
     const pollDeadline = Date.now() + 30_000;
-    let pointer = this.host.options?.getPointerLayer?.() ?? null;
+    let pointer = getPointerLayer() ?? null;
     while (!pointer && Date.now() < pollDeadline) {
       // If the build status accessor reports a deterministic
       // 'unavailable', skip the wait entirely — polling won't help.
@@ -311,7 +331,7 @@ export class LifecycleManager {
         return false;
       }
       await new Promise((r) => setTimeout(r, 100));
-      pointer = this.host.options?.getPointerLayer?.() ?? null;
+      pointer = getPointerLayer() ?? null;
     }
     if (!pointer) {
       const status = getStatus ? getStatus() : 'unknown';

--- a/tests/integration/cli/uxf-transfer.test.ts
+++ b/tests/integration/cli/uxf-transfer.test.ts
@@ -1,10 +1,25 @@
 /**
  * T.7.C — production call-site migration integration test for CLI.
  *
- * **Goal**: prove the CLI `send` command (and the `invoice-pay` /
- * `invoice-return` commands that delegate through AccountingModule) pass
- * `transferMode` explicitly to `payments.send()`. The migration is a
- * prerequisite for Wave T.1.B.2 (audit shim removal).
+ * SKIPPED — POST-EXTRACTION PLACEHOLDER
+ * --------------------------------------
+ * The Sphere CLI was extracted into a separate package (`sphere-cli`,
+ * tracked in the `sphere-cli` repository). The in-tree `cli/index.ts`
+ * that these tests inspect (both via `--help` subprocess and as a
+ * source-level structural assertion) no longer exists in the SDK
+ * package; only `cli/global-flags.ts` and `cli/storage-mode.ts` (shared
+ * helpers still consumed by the SDK itself) remain.
+ *
+ * These tests are skipped pending migration to the `sphere-cli` repo,
+ * where they belong. The runtime UXF call-site contract for
+ * AccountingModule (`payInvoice` / `returnInvoicePayment`) is still
+ * pinned by `tests/integration/accounting/uxf-transfer.test.ts` in
+ * this repo; the CLI-side delegation pin moves out with the CLI.
+ *
+ * **Original goal**: prove the CLI `send` command (and the `invoice-pay`
+ * / `invoice-return` commands that delegate through AccountingModule)
+ * pass `transferMode` explicitly to `payments.send()`. The migration is
+ * a prerequisite for Wave T.1.B.2 (audit shim removal).
  *
  * **Approach** — two complementary checks:
  *
@@ -85,7 +100,7 @@ async function runCli(args: string[]): Promise<{ stdout: string; stderr: string;
 // 1. Subprocess-driven --help shape check
 // =============================================================================
 
-describe('T.7.C — CLI production call-site UXF migration (--help shape)', () => {
+describe.skip('T.7.C — CLI production call-site UXF migration (--help shape) — SKIPPED: CLI extracted to sphere-cli repo', () => {
   it('IT-CLI-UXF-001: --help still exposes --instant and --conservative mode flags', async () => {
     const { stdout, stderr } = await runCli(['help', 'send']);
     const combined = `${stdout}\n${stderr}`;
@@ -102,7 +117,7 @@ describe('T.7.C — CLI production call-site UXF migration (--help shape)', () =
 // 2. Source-level structural assertions
 // =============================================================================
 
-describe('T.7.C — CLI production call-site UXF migration (source pin)', () => {
+describe.skip('T.7.C — CLI production call-site UXF migration (source pin) — SKIPPED: CLI extracted to sphere-cli repo', () => {
   let cliSource: string;
 
   /** Lazily read the CLI source once per file. */

--- a/tests/integration/operator-escape-hatch-bootstrap.test.ts
+++ b/tests/integration/operator-escape-hatch-bootstrap.test.ts
@@ -129,14 +129,27 @@ function cleanTestDir(): void {
 // =============================================================================
 
 describe('Round 7 (FIX 1): operator escape-hatch bootstrap wiring', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     cleanTestDir();
     if (Sphere.getInstance()) {
-      (Sphere as unknown as { instance: null }).instance = null;
+      try { await Sphere.getInstance()!.destroy(); } catch { /* ignore */ }
+    }
+    (Sphere as unknown as { instance: null }).instance = null;
+    // Defense against full-suite-only race: a prior test's async storage
+    // write can land in DATA_DIR after cleanTestDir() ran. If it did,
+    // Sphere.exists(...) returns true and Sphere.init throws "wallet
+    // already exists". Hard-clear via Sphere.clear which removes both
+    // wallet keys and tokenStorage state idempotently.
+    const probeStorage = new FileStorageProvider({ dataDir: DATA_DIR });
+    if (await Sphere.exists(probeStorage)) {
+      await Sphere.clear({ storage: probeStorage });
     }
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    if (Sphere.getInstance()) {
+      try { await Sphere.getInstance()!.destroy(); } catch { /* ignore */ }
+    }
     (Sphere as unknown as { instance: null }).instance = null;
     cleanTestDir();
   });

--- a/tests/integration/provider-disable-sync.test.ts
+++ b/tests/integration/provider-disable-sync.test.ts
@@ -129,10 +129,20 @@ describe('Provider disable/enable integration', () => {
   let tokenStorageReal: FileTokenStorageProvider;
   let tokenStorageMock: TokenStorageProvider<TxfStorageDataBase>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     cleanTestDir();
     if (Sphere.getInstance()) {
-      (Sphere as unknown as { instance: null }).instance = null;
+      try { await Sphere.getInstance()!.destroy(); } catch { /* ignore */ }
+    }
+    (Sphere as unknown as { instance: null }).instance = null;
+    // Defense against full-suite-only race: a prior test's async storage
+    // write can land in DATA_DIR after cleanTestDir() ran. If it did,
+    // Sphere.exists(...) returns true and Sphere.init throws "wallet
+    // already exists". Hard-clear via Sphere.clear which removes both
+    // wallet keys and tokenStorage state idempotently.
+    const probeStorage = new FileStorageProvider({ dataDir: DATA_DIR });
+    if (await Sphere.exists(probeStorage)) {
+      await Sphere.clear({ storage: probeStorage });
     }
     storage = new FileStorageProvider({ dataDir: DATA_DIR });
     tokenStorageReal = new FileTokenStorageProvider({ tokensDir: TOKENS_DIR });

--- a/tests/unit/cli/entry-point.test.ts
+++ b/tests/unit/cli/entry-point.test.ts
@@ -1,7 +1,20 @@
 /**
  * Regression tests for the CLI entry-point gating logic.
  *
- * History:
+ * SKIPPED — POST-EXTRACTION PLACEHOLDER
+ * --------------------------------------
+ * The Sphere CLI was extracted into a separate package (`sphere-cli`,
+ * tracked in the `sphere-cli` repository). The in-tree `cli/index.ts`
+ * that these tests targeted no longer exists in the SDK package; only
+ * `cli/global-flags.ts` and `cli/storage-mode.ts` (shared helpers
+ * still consumed by the SDK itself) remain.
+ *
+ * These tests are skipped pending migration to the `sphere-cli` repo,
+ * where they belong. The SDK repo's job is the SDK; the CLI's
+ * entry-point semantics (F.18/F.19/F.20 history below) are now the
+ * CLI repo's regression surface.
+ *
+ * Original history (preserved for context — re-apply in `sphere-cli`):
  *   F.18 (steelman¹⁵) introduced `isCliEntryPoint` to prevent
  *        library imports of `cli/index.ts` from running `main()`
  *        and calling `process.exit(1)` against the importer's argv.
@@ -46,7 +59,7 @@ function runCli(scriptPath: string, ...args: string[]): { stdout: string; stderr
   };
 }
 
-describe('CLI entry-point gating (F.18 + F.19)', () => {
+describe.skip('CLI entry-point gating (F.18 + F.19) — SKIPPED: CLI extracted to sphere-cli repo', () => {
   let tmpDir: string;
   let symlinkPath: string;
 

--- a/tests/unit/modules/PaymentsModule.uxf-auto-ingest.test.ts
+++ b/tests/unit/modules/PaymentsModule.uxf-auto-ingest.test.ts
@@ -153,10 +153,19 @@ vi.mock('../../../serialization/txf-serializer', () => ({
 // Stub the acquireBundle export so the auto-installed pool's workers
 // return a synthetic VerifiedBundle without touching real CAR bytes.
 // The stub is updated per-test via `mockAcquireBundle.mockResolvedValue(...)`.
+//
+// Must also re-export `RECIPIENT_MAX_INLINE_CARBASE64_LENGTH` because
+// IngestWorkerPool.enqueue() reads it on the queue admission path
+// (synchronous bound on inline carBase64 length). With the mock missing
+// that export, every enqueue() throws a "No export defined" error and
+// the bundle is rejected before the worker runs.
 const mockAcquireBundle = vi.fn();
 vi.mock('../../../modules/payments/transfer/bundle-acquirer', () => ({
   acquireBundle: (...args: unknown[]) => mockAcquireBundle(...args),
   isReplayOutcome: () => false,
+  // 8 MiB — well above any synthetic carBase64 used in this test file
+  // (the longest is 'AAAA' = 4 chars). Mirrors production-order-of-magnitude.
+  RECIPIENT_MAX_INLINE_CARBASE64_LENGTH: 8 * 1024 * 1024,
 }));
 
 // =============================================================================

--- a/tests/unit/profile/cid-ref-store.test.ts
+++ b/tests/unit/profile/cid-ref-store.test.ts
@@ -69,7 +69,24 @@ function installFakeIpfsGateway(): { store: Map<string, Uint8Array>; cleanup: ()
       }) as unknown as Response;
     }
 
-    // Fetch (GET /ipfs/<cid>)
+    // Fetch via Kubo block API (POST /api/v0/block/get?arg=<cid>).
+    // Production code uses this path (POST first, GET fallback on 405/501)
+    // — the legacy `/ipfs/<cid>` GET path is no longer used by fetchFromIpfs.
+    const blockGetMatch = url.match(/\/api\/v0\/block\/get\?arg=([^&]+)/);
+    if (blockGetMatch) {
+      const cid = decodeURIComponent(blockGetMatch[1]!);
+      const data = store.get(cid);
+      if (!data) {
+        return new Response('not found', { status: 404 }) as unknown as Response;
+      }
+      return new Response(data, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream', 'Content-Length': String(data.byteLength) },
+      }) as unknown as Response;
+    }
+
+    // Legacy /ipfs/<cid> GET path — kept for any code path still using it
+    // (e.g., verifyCidAccessible HEAD checks).
     const match = url.match(/\/ipfs\/([A-Za-z0-9]+)/);
     if (match) {
       const cid = match[1]!;

--- a/tests/unit/profile/profile-token-storage-pointer.test.ts
+++ b/tests/unit/profile/profile-token-storage-pointer.test.ts
@@ -84,6 +84,7 @@ function createMockDb(): ProfileDatabase & { _store: Map<string, Uint8Array> } {
 function createProvider(opts: {
   db: ProfileDatabase;
   getPointerLayer?: () => ProfilePointerLayer | null;
+  getPointerBuildStatus?: () => 'pending' | 'unavailable' | 'ready';
 }): ProfileTokenStorageProvider {
   const provider = new ProfileTokenStorageProvider(
     opts.db,
@@ -97,6 +98,13 @@ function createProvider(opts: {
       addressId: 'test',
       encrypt: true,
       getPointerLayer: opts.getPointerLayer,
+      // When `getPointerLayer` is wired but the test wants pointer
+      // recovery to bail immediately (closure returns null), pair it
+      // with a `getPointerBuildStatus` accessor reporting 'unavailable'.
+      // Production wires both accessors together (see profile/factory.ts);
+      // tests that only wire `getPointerLayer` would otherwise trip the
+      // 30s "wait for slow Helia bootstrap" loop in lifecycle-manager.
+      getPointerBuildStatus: opts.getPointerBuildStatus,
     },
   );
   provider.setIdentity(TEST_IDENTITY);
@@ -195,9 +203,17 @@ describe('ProfileTokenStorageProvider pointer recovery (T-D6 wiring)', () => {
     // Simulates "pointer layer construction was skipped — storage
     // not durable, no oracle, etc." The closure returning null must
     // not trip the recovery path; initialize proceeds cleanly.
+    //
+    // Pair `getPointerLayer: () => null` with a build-status accessor
+    // reporting 'unavailable' to mirror the production path
+    // (factory.ts wires both together). Without the status accessor,
+    // lifecycle-manager would poll up to 30s waiting for the closure
+    // to flip to non-null — fine in production where 'pending' is
+    // distinguishable, but a hard hang in this fixture.
     const provider = createProvider({
       db,
       getPointerLayer: () => null,
+      getPointerBuildStatus: () => 'unavailable',
     });
 
     await expect(provider.initialize()).resolves.toBe(true);

--- a/tests/unit/profile/profile-token-storage-provider.test.ts
+++ b/tests/unit/profile/profile-token-storage-provider.test.ts
@@ -388,7 +388,16 @@ function installMockFetch(
   mockFetchHandler = handler;
   globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
-    return handler(url, init);
+    // Production fetchFromIpfs uses Kubo's POST /api/v0/block/get?arg=<cid>
+    // path (with a GET fallback on 405/501). Existing per-test handlers in
+    // this file pattern-match on the legacy `/ipfs/<cid>` URL shape. To
+    // keep handlers stable, normalize the canonical block-get URL into
+    // the legacy shape before dispatching. The handler itself is unchanged.
+    const blockGetMatch = url.match(/\/api\/v0\/block\/get\?arg=([^&]+)/);
+    const normalizedUrl = blockGetMatch
+      ? `${url.split('/api/v0/')[0]}/ipfs/${decodeURIComponent(blockGetMatch[1]!)}`
+      : url;
+    return handler(normalizedUrl, init);
   };
 }
 


### PR DESCRIPTION
## Summary

Follow-up PR to #105 closing the 75 pre-existing test failures left when the
UXF Inter-Wallet Transfer Protocol PR was opened. After this PR the full
suite is green: **387 files pass / 2 skipped / 0 fail; 6941 tests pass / 21
skipped / 0 fail**.

## What was wrong

The 75 failures clustered into 6 root causes, none of them product
regressions — all were stale test infrastructure that didn't keep up with
production-code changes earlier in the feature branch:

| # | Root cause | Failures | Fix |
|---|---|---|---|
| 1 | Wave G.7 pointer-layer wait ceiling raised from 5 s → 30 s in `ee78b23`. Test fixtures that don't wire `getPointerLayer` hit the full 30 s wait → vitest 30 s `testTimeout` → cascade across `profile-token-storage-provider.test.ts`, `wave-g7-prereq.test.ts`, `per-entry-key-writers.test.ts`, `profile-token-storage-pointer.test.ts`. | 44 | `af1dd66`, `593bf2a` — early-bail pointer recovery when no closure wired + align mocks with production HTTP method/URL |
| 2 | `cid-ref-store.test.ts` mock fetch didn't match production fetch shape — IPFS-client now POSTs to `/ipfs/...` but the mock only intercepted GETs. | 14 | `aae031d` — match production HTTP method/URL |
| 3 | `PaymentsModule.uxf-auto-ingest.test.ts` harness wiring drift — auto-installed IngestWorkerPool from Phase 9.5.E required harness updates the test file never received. | 12 | `abb54ec` — PaymentsModule.uxf-auto-ingest harness wiring |
| 4 | CLI tests (`cli/entry-point.test.ts`, `cli/uxf-transfer.test.ts`) reference in-tree CLI that was extracted to the `sphere-cli` repo. | 8 | `1185e14` — skip in-tree CLI tests with explicit `it.skip` + comment pointing at the new repo |
| 5 | Full-suite-only async-write race in `provider-disable-sync.test.ts`: `afterEach` sync + previous test's pending storage write lands in DATA_DIR after `cleanTestDir()` → 7th test fails with "Wallet already exists". | 1 | `76c18bd` — defensive `beforeEach` (probe `Sphere.exists`, hard-clear via `Sphere.clear` if stale state shows up) |
| 6 | Same async-write race surfaced in `operator-escape-hatch-bootstrap.test.ts` (the Round 8 integration test from #105). | 1 | `d055160` — same defensive pattern + `await destroy()` in `afterEach` |

## Backward compatibility

Test-only changes plus one tiny production tweak (`profile/profile-token-storage/lifecycle-manager.ts`) that early-bails the pointer recovery wait when no `getPointerLayer` closure is wired — that branch was structurally pointless before since no codepath could ever flip the result.

## Test plan

- [x] tsc clean.
- [x] All 7 fix commits pass `npx vitest run` for their targeted files in isolation.
- [x] Full suite: **387 files pass / 2 skipped / 0 fail; 6941 tests pass / 21 skipped / 0 fail**.

## Refs

- Builds on #105 (UXF Inter-Wallet Transfer Protocol).
- Phase-9 8-round adversarial steelman loop wrap-up; closes the test-infrastructure tail flagged in #105's PR description.