### PR TITLE
fix(accounting): migrate tokenInvoiceMap on importInvoice

### DIFF
--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -1692,6 +1692,35 @@ export class AccountingModule {
         this.balanceCache.delete(hashedKey);
         logger.debug(LOG_TAG, `Migrated ${orphanedLedger.size} ledger entries from hash-keyed to real ID: ${tokenId.slice(0, 16)}...`);
       }
+
+      // R20 fix: migrate tokenInvoiceMap entries from the hashed key to the
+      // real invoice id. Without this, _handleIncomingTransfer's orphan-buffer
+      // path leaves tokens pointing at hash(invoiceId), and verifyPayout's
+      // getTokenIdsForInvoice(realInvoiceId) returns an empty Set even after
+      // importInvoice runs — tripping its security fail-closed branch and
+      // hanging swap-payout verification forever.
+      // Diagnosed in HMA-trade-settlement round 20: handleIncomingTransfer ENTRY
+      // probe fired with memo "INV:<hash>" for the swap payout, but the
+      // syntheticLedger / historyEvent probes did not, AND verifyPayout saw
+      // tokenInvoiceMap empty. The orphan-path populates the map under the
+      // hashed key; the migration here moves it to the real key.
+      let migratedTokenMapEntries = 0;
+      for (const [tokId, invoiceSet] of this.tokenInvoiceMap) {
+        if (invoiceSet.has(hashedKey)) {
+          invoiceSet.delete(hashedKey);
+          invoiceSet.add(tokenId);
+          migratedTokenMapEntries++;
+          // If the entry now points at nothing, drop the row to keep the
+          // map tight (parallel to the load-time defensive checks).
+          if (invoiceSet.size === 0) this.tokenInvoiceMap.delete(tokId);
+        }
+      }
+      if (migratedTokenMapEntries > 0) {
+        logger.debug(
+          LOG_TAG,
+          `Migrated ${migratedTokenMapEntries} tokenInvoiceMap entries from hash-keyed to real ID: ${tokenId.slice(0, 16)}...`,
+        );
+      }
     }
 
     if (!this.invoiceLedger.has(tokenId)) {


### PR DESCRIPTION
## Summary

The orphan-buffer in `_handleIncomingTransfer` indexes `tokenInvoiceMap` under `hash(invoiceId)` when a transfer arrives BEFORE the corresponding invoice token is imported. `importInvoice`'s existing migration block (line 1681) moved `invoiceLedger` entries from the hashed key to the real key, but did NOT migrate `tokenInvoiceMap` — leaving tokens linked to a hash key that downstream consumers (notably `verifyPayout`'s `getTokenIdsForInvoice` lookup) can't find.

## Fix

Add a parallel migration loop in `importInvoice` that moves `tokenInvoiceMap` entries from the hashed key to the real invoice id, mirroring the existing `invoiceLedger` migration.

## Defense-in-depth

With the deps-facade fix in #128, this code path is no longer load-bearing for the headline e2e flow. But keeping it makes the orphan-buffer race harmless even on older callers and ensures the reverse-index stays consistent regardless of arrival order.

## Files

- `modules/accounting/AccountingModule.ts` — single migration block (~29 lines added)

## Test plan

- [x] `npx tsup` — build succeeds
- [x] `npx vitest run` — all 2763 unit tests pass
- [x] HMA-trade-settlement.e2e-live verified end-to-end with this fix in place