### PR TITLE
feat(accounting): expose transferMode passthrough on payInvoice

### DIFF
--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -2479,6 +2479,10 @@ export class AccountingModule {
         memo,
         invoiceRefundAddress: params.refundAddress,
         invoiceContact: effectiveContact,
+        // R23 fix: forward transferMode so callers can opt into
+        // 'conservative' (proof-on-sender) delivery for forwarding flows
+        // like withdraw. Undefined preserves existing instant-mode default.
+        ...(params.transferMode !== undefined ? { transferMode: params.transferMode } : {}),
       });
 
       let timer: ReturnType<typeof setTimeout> | undefined;

--- a/modules/accounting/types.ts
+++ b/modules/accounting/types.ts
@@ -748,6 +748,26 @@ export interface PayInvoiceParams {
    * `contacts[0].address → refundAddress → senderAddress → null`
    */
   readonly contact?: { address: string; url?: string };
+  /**
+   * Optional transfer-delivery mode forwarded to PaymentsModule.send.
+   *
+   * `'instant'` (default): ships a V6 combined-transfer bundle. The
+   * recipient saves the token at status='submitted' with the SENDER's
+   * sdkData and finalizes via background proof-polling. Lower latency,
+   * but the recipient cannot spend the token until finalization
+   * completes.
+   *
+   * `'conservative'`: collects the inclusion proof on the SENDER's
+   * side before delivering. The recipient receives a fully-finalized
+   * {sourceToken, transferTx} bundle and produces a 'confirmed' Token
+   * immediately bound to the recipient's predicate. Higher latency,
+   * but enables chained spends without racing background proof-polls.
+   *
+   * Use `'conservative'` for forwarding flows (faucet → trader →
+   * deposit, escrow payouts, withdraws). Default `'instant'` is fine
+   * for low-latency UX where the recipient won't immediately re-spend.
+   */
+  readonly transferMode?: 'instant' | 'conservative';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `transferMode?: 'instant' | 'conservative'` to `PayInvoiceParams` and forward it to `PaymentsModule.send`.
- Lets callers opt into proof-on-sender delivery for forwarding flows where the recipient must spend the incoming token immediately without racing the recipient-side proof-poll.
- Default behavior is unchanged: when `transferMode` is undefined, the parameter is omitted from the send call and PaymentsModule's existing `'instant'` default applies.

## Why
Discovered while debugging the trader withdraw flake under HMA settlement e2e. Faucet and escrow already use `'conservative'` on their direct `payments.send` paths; the trader's invoiced withdraw was the only forwarding flow still using `'instant'`, causing intermittent **"Authenticator does not match source state predicate"** errors when the trader's spend queue picked a not-yet-finalized swap-payout token.

## Test plan
- [x] Live HMA settlement e2e (Pair-1 + Pair-2): both pairs ✓ end-to-end with `transferMode: 'conservative'` opt-in from the trader.
- [ ] Existing accounting/payments unit tests still green (CI).