### PR TITLE
feat(market): retry + circuit breaker for transient API failures

### DIFF
--- a/modules/market/MarketModule.ts
+++ b/modules/market/MarketModule.ts
@@ -12,6 +12,14 @@ import { bytesToHex } from '@noble/hashes/utils.js';
 
 import { SphereError } from '../../core/errors';
 import { logger } from '../../core/logger';
+import {
+  CircuitBreaker,
+  TransientMarketError,
+  isRetryableStatus,
+  isTransientNetworkError,
+  runWithRetry,
+} from './retry';
+import type { RetryConfig } from './retry';
 
 /** Default Market API URL (intent bulletin board) */
 export const DEFAULT_MARKET_API_URL = 'https://market-api.unicity.network';
@@ -161,10 +169,20 @@ export class MarketModule {
   private readonly timeout: number;
   private identity: FullIdentity | null = null;
   private registered = false;
+  /** Shared breaker — once tripped, all operations on this module fail fast. */
+  private readonly breaker: CircuitBreaker;
+  /** Optional retry-policy overrides for tests. */
+  private readonly retryConfig: RetryConfig | undefined;
 
-  constructor(config?: MarketModuleConfig) {
+  constructor(config?: MarketModuleConfig & { retryConfig?: RetryConfig }) {
     this.apiUrl = (config?.apiUrl ?? DEFAULT_MARKET_API_URL).replace(/\/+$/, '');
     this.timeout = config?.timeout ?? 30000;
+    this.retryConfig = config?.retryConfig;
+    this.breaker = new CircuitBreaker({
+      threshold: config?.retryConfig?.breakerThreshold,
+      cooldownMs: config?.retryConfig?.breakerCooldownMs,
+      now: config?.retryConfig?.now,
+    });
   }
 
   /** Called by Sphere after construction */
@@ -221,10 +239,11 @@ export class MarketModule {
 
   /** Fetch the most recent listings via REST (public — no auth required) */
   async getRecentListings(): Promise<FeedListing[]> {
-    const res = await fetch(`${this.apiUrl}/api/feed/recent`, {
-      signal: AbortSignal.timeout(this.timeout),
-    });
-    const data = await this.parseResponse(res);
+    const data = await this.withRetry(() =>
+      this.attemptFetch(`${this.apiUrl}/api/feed/recent`, {
+        signal: AbortSignal.timeout(this.timeout),
+      }),
+    );
     return (data.listings ?? []).map(mapFeedListing);
   }
 
@@ -321,82 +340,161 @@ export class MarketModule {
     const body: Record<string, string> = { public_key: publicKey };
     if (this.identity!.nametag) body.nametag = this.identity!.nametag;
 
-    const res = await fetch(`${this.apiUrl}/api/agent/register`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(this.timeout),
+    await this.withRetry(async () => {
+      let res: Response;
+      try {
+        res = await fetch(`${this.apiUrl}/api/agent/register`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(this.timeout),
+        });
+      } catch (err) {
+        if (isTransientNetworkError(err)) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw new TransientMarketError(
+            new SphereError(`Agent registration failed: ${message}`, 'NETWORK_ERROR'),
+          );
+        }
+        throw err;
+      }
+
+      // 201 = created, 409 = already registered — both are fine
+      if (res.ok || res.status === 409) return;
+
+      const text = await res.text();
+      let data: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+      try { data = JSON.parse(text); } catch { /* ignore */ }
+      const final = new SphereError(
+        data?.error ?? `Agent registration failed: HTTP ${res.status}`,
+        'NETWORK_ERROR',
+      );
+      if (isRetryableStatus(res.status)) throw new TransientMarketError(final, res.status);
+      throw final;
     });
 
-    // 201 = created, 409 = already registered — both are fine
-    if (res.ok || res.status === 409) {
-      this.registered = true;
-      return;
-    }
-
-    const text = await res.text();
-    let data: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-    try { data = JSON.parse(text); } catch { /* ignore */ }
-    throw new SphereError(data?.error ?? `Agent registration failed: HTTP ${res.status}`, 'NETWORK_ERROR');
+    this.registered = true;
   }
 
+  /**
+   * Parse a fetch Response into JSON.
+   *
+   * Throws either:
+   *   - {@link TransientMarketError} for HTTP statuses we want to retry
+   *     (502/503/504/408). The `final` SphereError mirrors the historical
+   *     error shape so callers see the same message after retries exhaust.
+   *   - {@link SphereError} for permanent failures (4xx other than 408).
+   */
   private async parseResponse(res: Response): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
     const text = await res.text();
     let data: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let parseFailed = false;
     try {
       data = JSON.parse(text);
     } catch {
-      throw new SphereError(`Market API error: HTTP ${res.status} — unexpected response (not JSON)`, 'NETWORK_ERROR');
+      parseFailed = true;
     }
-    if (!res.ok) throw new SphereError(data.error ?? `HTTP ${res.status}`, 'NETWORK_ERROR');
+
+    if (parseFailed) {
+      // Non-JSON body — most often an HTML error page from a load balancer
+      // during a 502/503. Treat as transient if the status itself is transient,
+      // otherwise treat as permanent.
+      const final = new SphereError(
+        `Market API error: HTTP ${res.status} — unexpected response (not JSON)`,
+        'NETWORK_ERROR',
+      );
+      if (isRetryableStatus(res.status)) throw new TransientMarketError(final, res.status);
+      throw final;
+    }
+
+    if (!res.ok) {
+      const final = new SphereError(data?.error ?? `HTTP ${res.status}`, 'NETWORK_ERROR');
+      if (isRetryableStatus(res.status)) throw new TransientMarketError(final, res.status);
+      throw final;
+    }
     return data;
+  }
+
+  /**
+   * Execute a single HTTP attempt, translating fetch-level network errors
+   * (timeouts, connection resets) into TransientMarketError so the retry
+   * layer can re-issue the request.
+   */
+  private async attemptFetch(
+    url: string,
+    init: RequestInit,
+  ): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
+    let res: Response;
+    try {
+      res = await fetch(url, init);
+    } catch (err) {
+      if (isTransientNetworkError(err)) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new TransientMarketError(
+          new SphereError(`Market API network error: ${message}`, 'NETWORK_ERROR'),
+        );
+      }
+      throw err;
+    }
+    return this.parseResponse(res);
+  }
+
+  /** Run an authenticated request through the retry + breaker layer. */
+  private async withRetry<T>(op: () => Promise<T>): Promise<T> {
+    return runWithRetry(op, this.breaker, this.retryConfig);
   }
 
   private async apiPost(path: string, body: unknown): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
     this.ensureIdentity();
     await this.ensureRegistered();
-    const signed = signRequest(body, this.identity!.privateKey);
-    const res = await fetch(`${this.apiUrl}${path}`, {
-      method: 'POST',
-      headers: signed.headers,
-      body: signed.body,
-      signal: AbortSignal.timeout(this.timeout),
+    return this.withRetry(() => {
+      // Re-sign on each attempt so the timestamp stays fresh and the server
+      // can't reject a retry as a stale signature.
+      const signed = signRequest(body, this.identity!.privateKey);
+      return this.attemptFetch(`${this.apiUrl}${path}`, {
+        method: 'POST',
+        headers: signed.headers,
+        body: signed.body,
+        signal: AbortSignal.timeout(this.timeout),
+      });
     });
-    return this.parseResponse(res);
   }
 
   private async apiGet(path: string): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
     this.ensureIdentity();
     await this.ensureRegistered();
-    const signed = signRequest({}, this.identity!.privateKey);
-    const res = await fetch(`${this.apiUrl}${path}`, {
-      method: 'GET',
-      headers: signed.headers,
-      signal: AbortSignal.timeout(this.timeout),
+    return this.withRetry(() => {
+      const signed = signRequest({}, this.identity!.privateKey);
+      return this.attemptFetch(`${this.apiUrl}${path}`, {
+        method: 'GET',
+        headers: signed.headers,
+        signal: AbortSignal.timeout(this.timeout),
+      });
     });
-    return this.parseResponse(res);
   }
 
   private async apiDelete(path: string): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
     this.ensureIdentity();
     await this.ensureRegistered();
-    const signed = signRequest({}, this.identity!.privateKey);
-    const res = await fetch(`${this.apiUrl}${path}`, {
-      method: 'DELETE',
-      headers: signed.headers,
-      signal: AbortSignal.timeout(this.timeout),
+    return this.withRetry(() => {
+      const signed = signRequest({}, this.identity!.privateKey);
+      return this.attemptFetch(`${this.apiUrl}${path}`, {
+        method: 'DELETE',
+        headers: signed.headers,
+        signal: AbortSignal.timeout(this.timeout),
+      });
     });
-    return this.parseResponse(res);
   }
 
   private async apiPublicPost(path: string, body: unknown): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
-    const res = await fetch(`${this.apiUrl}${path}`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(this.timeout),
-    });
-    return this.parseResponse(res);
+    return this.withRetry(() =>
+      this.attemptFetch(`${this.apiUrl}${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(this.timeout),
+      }),
+    );
   }
 
 }

--- a/modules/market/retry.ts
+++ b/modules/market/retry.ts
@@ -1,0 +1,304 @@
+/**
+ * Retry + Circuit Breaker for the Market API.
+ *
+ * Why this exists:
+ * The Market API sits behind a load balancer that occasionally returns
+ * transient errors (HTTP 502/503/504/408) or drops connections during
+ * deploys. Without tolerance, a single 502 from the testnet Market API
+ * kills an in-progress test or trader operation even when the rest of
+ * the protocol is working fine.
+ *
+ * Policy:
+ *  - Retry on:    HTTP 502, 503, 504, 408 and network/abort errors.
+ *  - Don't retry: 400, 401, 403, 404, 422 — anything 4xx that isn't 408
+ *                 indicates a caller bug, not an outage.
+ *  - Backoff:     exponential with full jitter, schedule 200/500/1000/2000/4000 ms,
+ *                 capped at 5 attempts and a 10s total budget.
+ *  - Breaker:     after N consecutive failures across operations, fail fast
+ *                 for `cooldownMs` before allowing the next attempt.
+ */
+
+import { SphereError } from '../../core/errors';
+import { logger } from '../../core/logger';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface RetryConfig {
+  /** Maximum number of attempts (including the first). Default: 5. */
+  maxAttempts?: number;
+  /** Per-attempt delays in ms. Length should equal maxAttempts - 1. */
+  delaysMs?: number[];
+  /** Maximum total time spent retrying before giving up. Default: 10_000. */
+  totalBudgetMs?: number;
+  /** Failures across operations needed to open the breaker. Default: 5. */
+  breakerThreshold?: number;
+  /** How long the breaker stays open after tripping. Default: 30_000. */
+  breakerCooldownMs?: number;
+  /** Inject for tests: override the wall-clock used for backoff/breaker. */
+  now?: () => number;
+  /** Inject for tests: override the sleep implementation. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Inject for tests: override jitter (0..1). Default: Math.random. */
+  random?: () => number;
+}
+
+/**
+ * Marker error used internally to signal "this status looked transient".
+ * The retry layer catches it and re-issues the request; if all attempts are
+ * exhausted, the original {@link SphereError} produced by the request body
+ * is re-thrown so callers see the same shape they saw before this was added.
+ */
+export class TransientMarketError extends Error {
+  /** Optional HTTP status, when the trigger was an HTTP response. */
+  readonly status?: number;
+  /** Underlying SphereError that should surface if retries are exhausted. */
+  readonly final: SphereError;
+
+  constructor(final: SphereError, status?: number) {
+    super(final.message);
+    this.name = 'TransientMarketError';
+    this.status = status;
+    this.final = final;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+/** HTTP statuses that should be retried. */
+export const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([408, 502, 503, 504]);
+
+/** Returns true if `status` is a retryable transient HTTP status. */
+export function isRetryableStatus(status: number): boolean {
+  return RETRYABLE_STATUSES.has(status);
+}
+
+/**
+ * Returns true if `err` looks like a transient network failure
+ * (timeout, connection reset, abort, generic fetch failure).
+ *
+ * We can't enumerate every shape the platform throws, so we look at
+ * the common signals:
+ *   - DOMException with name 'AbortError' or 'TimeoutError' (AbortSignal.timeout)
+ *   - Error.name === 'AbortError' / 'TimeoutError' (older runtimes)
+ *   - Node-style code: ECONNRESET / ETIMEDOUT / ENOTFOUND / EAI_AGAIN /
+ *     ECONNREFUSED / EPIPE / UND_ERR_SOCKET
+ *   - The vague but very real "TypeError: fetch failed" (undici / browsers)
+ */
+export function isTransientNetworkError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+
+  const name = (err as { name?: unknown }).name;
+  if (name === 'AbortError' || name === 'TimeoutError') return true;
+
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === 'string') {
+    if (
+      code === 'ECONNRESET' ||
+      code === 'ETIMEDOUT' ||
+      code === 'ECONNREFUSED' ||
+      code === 'ENOTFOUND' ||
+      code === 'EAI_AGAIN' ||
+      code === 'EPIPE' ||
+      code === 'UND_ERR_SOCKET' ||
+      code === 'UND_ERR_CONNECT_TIMEOUT' ||
+      code === 'UND_ERR_HEADERS_TIMEOUT' ||
+      code === 'UND_ERR_BODY_TIMEOUT'
+    ) {
+      return true;
+    }
+  }
+
+  // The browser/undici TypeError("fetch failed") case — common in Node 20+
+  // when the upstream resets mid-request.
+  if (err instanceof TypeError) {
+    const msg = err.message.toLowerCase();
+    if (msg.includes('fetch failed') || msg.includes('network') || msg.includes('socket')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Backoff schedule
+// ---------------------------------------------------------------------------
+
+/** Default per-attempt base delays in ms. Total ≤ 7.7s leaves slack under 10s budget. */
+export const DEFAULT_DELAYS_MS: readonly number[] = [200, 500, 1000, 2000, 4000];
+export const DEFAULT_MAX_ATTEMPTS = 5;
+export const DEFAULT_TOTAL_BUDGET_MS = 10_000;
+export const DEFAULT_BREAKER_THRESHOLD = 5;
+export const DEFAULT_BREAKER_COOLDOWN_MS = 30_000;
+
+/**
+ * Compute the delay before attempt `attemptIndex` (0-based among _retries_,
+ * so 0 means "delay before the first retry, i.e. between attempt 1 and 2").
+ *
+ * Uses full jitter: `random(0, base)`. This avoids thundering herd while
+ * still tightening the average wait.
+ */
+export function backoffDelay(
+  attemptIndex: number,
+  delaysMs: readonly number[],
+  random: () => number,
+): number {
+  const idx = Math.min(attemptIndex, delaysMs.length - 1);
+  const base = delaysMs[idx] ?? 0;
+  // Full jitter: a random number in [0, base].
+  return Math.floor(random() * base);
+}
+
+// ---------------------------------------------------------------------------
+// Circuit breaker
+// ---------------------------------------------------------------------------
+
+type BreakerState = 'closed' | 'open' | 'half-open';
+
+/**
+ * Lightweight in-process circuit breaker.
+ *
+ * Closed → requests flow through and we count consecutive failures.
+ * Once the threshold is hit we open the breaker and start a cooldown.
+ * Open → all calls fail fast with a SphereError (`NETWORK_ERROR`).
+ * After cooldown the next call goes through in `half-open`; if it succeeds
+ * we close the breaker; if it fails we re-open with a fresh cooldown.
+ */
+export class CircuitBreaker {
+  private state: BreakerState = 'closed';
+  private consecutiveFailures = 0;
+  private openedAt = 0;
+  private readonly threshold: number;
+  private readonly cooldownMs: number;
+  private readonly now: () => number;
+
+  constructor(opts?: { threshold?: number; cooldownMs?: number; now?: () => number }) {
+    this.threshold = opts?.threshold ?? DEFAULT_BREAKER_THRESHOLD;
+    this.cooldownMs = opts?.cooldownMs ?? DEFAULT_BREAKER_COOLDOWN_MS;
+    this.now = opts?.now ?? Date.now;
+  }
+
+  /** Throws SphereError('NETWORK_ERROR') when the breaker is open. */
+  assertCanProceed(): void {
+    if (this.state === 'open') {
+      const elapsed = this.now() - this.openedAt;
+      if (elapsed < this.cooldownMs) {
+        throw new SphereError(
+          `Market API circuit breaker open — backing off ${Math.max(0, this.cooldownMs - elapsed)}ms before retrying`,
+          'NETWORK_ERROR',
+        );
+      }
+      // Cooldown elapsed → allow a single trial request.
+      this.state = 'half-open';
+    }
+  }
+
+  /** Record a successful operation; closes a half-open breaker. */
+  recordSuccess(): void {
+    if (this.state === 'half-open') {
+      logger.warn('Market', 'market_circuit_closed — Market API recovered, resuming normal operation');
+    }
+    this.state = 'closed';
+    this.consecutiveFailures = 0;
+    this.openedAt = 0;
+  }
+
+  /** Record a transient failure; may open the breaker. */
+  recordFailure(): void {
+    this.consecutiveFailures += 1;
+    if (this.state === 'half-open' || this.consecutiveFailures >= this.threshold) {
+      if (this.state !== 'open') {
+        logger.warn(
+          'Market',
+          `market_circuit_open — ${this.consecutiveFailures} consecutive transient failures; failing fast for ${this.cooldownMs}ms`,
+        );
+      }
+      this.state = 'open';
+      this.openedAt = this.now();
+    }
+  }
+
+  /** Inspect (for tests + logging). */
+  getState(): BreakerState {
+    return this.state;
+  }
+
+  /** Inspect (for tests). */
+  getConsecutiveFailures(): number {
+    return this.consecutiveFailures;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// runWithRetry
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `op`, retrying on TransientMarketError up to the configured budget.
+ * Permanent errors propagate immediately without consuming retries.
+ *
+ * The breaker is recorded at the boundary:
+ *   - `recordSuccess()` once `op` returns,
+ *   - `recordFailure()` once we give up retrying (NOT per attempt — we count
+ *     "failed operations", not "failed HTTP roundtrips", so a flapping API
+ *     that eventually answers doesn't trip the breaker).
+ */
+export async function runWithRetry<T>(
+  op: () => Promise<T>,
+  breaker: CircuitBreaker,
+  config: RetryConfig = {},
+): Promise<T> {
+  const maxAttempts = config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const delaysMs = config.delaysMs ?? DEFAULT_DELAYS_MS;
+  const totalBudgetMs = config.totalBudgetMs ?? DEFAULT_TOTAL_BUDGET_MS;
+  const now = config.now ?? Date.now;
+  const sleep =
+    config.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const random = config.random ?? Math.random;
+
+  breaker.assertCanProceed();
+
+  const startedAt = now();
+  let lastTransient: TransientMarketError | null = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const result = await op();
+      breaker.recordSuccess();
+      return result;
+    } catch (err) {
+      if (err instanceof TransientMarketError) {
+        lastTransient = err;
+        // Out of attempts?
+        if (attempt >= maxAttempts) break;
+        // Out of time budget?
+        const nextDelay = backoffDelay(attempt - 1, delaysMs, random);
+        const elapsed = now() - startedAt;
+        if (elapsed + nextDelay >= totalBudgetMs) break;
+
+        logger.debug(
+          'Market',
+          `Transient Market API failure (attempt ${attempt}/${maxAttempts}) — retrying in ${nextDelay}ms`,
+          { status: err.status, message: err.message },
+        );
+        await sleep(nextDelay);
+        continue;
+      }
+      // Non-transient — propagate immediately, no breaker bookkeeping.
+      throw err;
+    }
+  }
+
+  // Exhausted retries → record failure + surface the original error.
+  breaker.recordFailure();
+  // Defensive: lastTransient should always be set when we hit this branch, but
+  // narrow the type for TS strict mode.
+  if (!lastTransient) {
+    throw new SphereError('Market API retry loop exited without a recorded error', 'NETWORK_ERROR');
+  }
+  throw lastTransient.final;
+}

--- a/tests/unit/modules/MarketModule.test.ts
+++ b/tests/unit/modules/MarketModule.test.ts
@@ -48,9 +48,25 @@ function hexToBytes(hex: string): Uint8Array {
   return bytes;
 }
 
+/**
+ * Tight retry config for tests that exercise transient-failure error shapes.
+ * Zero delays, zero jitter, two attempts → fail fast without flaking the suite.
+ */
+const FAST_RETRY = {
+  maxAttempts: 2,
+  delaysMs: [0],
+  totalBudgetMs: 1000,
+  sleep: () => Promise.resolve(),
+  random: () => 0,
+};
+
 /** Create a module that's already "registered" so tests don't trigger registration fetches */
-function createRegisteredModule(config?: Parameters<typeof createMarketModule>[0]): MarketModule {
-  const mod = createMarketModule(config);
+function createRegisteredModule(
+  config?: Parameters<typeof createMarketModule>[0] & { retryConfig?: unknown },
+): MarketModule {
+  // The constructor accepts an optional retryConfig (test-only escape hatch);
+  // the public factory signature doesn't expose it, so we cast through new directly.
+  const mod = new MarketModule(config as any);
   mod.initialize(mockDeps());
   // Skip auto-registration in unit tests — registration is tested separately
   (mod as any).registered = true;
@@ -285,8 +301,10 @@ describe('MarketModule', () => {
     });
 
     it('should throw generic HTTP error when no error field', async () => {
-      fetchSpy.mockResolvedValue(jsonResponse({}, 503));
-      const mod = createRegisteredModule();
+      // Fresh Response per attempt — 503 is retryable, so retries consume bodies.
+      // Use a tight retry config to keep the test fast.
+      fetchSpy.mockImplementation(async () => jsonResponse({}, 503));
+      const mod = createRegisteredModule({ retryConfig: FAST_RETRY } as any);
 
       await expect(mod.postIntent({ description: 'test', intentType: 'buy' })).rejects.toThrow('HTTP 503');
     });
@@ -1015,15 +1033,17 @@ describe('MarketModule', () => {
     });
 
     it('should fallback to HTTP status code when no error field', async () => {
-      fetchSpy.mockResolvedValue(jsonResponse({}, 503));
-      const mod = createRegisteredModule();
+      // Fresh Response per attempt — 503 is retryable.
+      fetchSpy.mockImplementation(async () => jsonResponse({}, 503));
+      const mod = createRegisteredModule({ retryConfig: FAST_RETRY } as any);
 
       await expect(mod.postIntent({ description: 'test', intentType: 'buy' })).rejects.toThrow('HTTP 503');
     });
 
     it('should throw descriptive error on non-JSON response', async () => {
-      fetchSpy.mockResolvedValue(new Response('Bad Gateway', { status: 502 }));
-      const mod = createRegisteredModule();
+      // Fresh Response per attempt — 502 is retryable.
+      fetchSpy.mockImplementation(async () => new Response('Bad Gateway', { status: 502 }));
+      const mod = createRegisteredModule({ retryConfig: FAST_RETRY } as any);
 
       await expect(mod.postIntent({ description: 'test', intentType: 'buy' })).rejects.toThrow('unexpected response (not JSON)');
     });

--- a/tests/unit/modules/MarketModule.tolerance.test.ts
+++ b/tests/unit/modules/MarketModule.tolerance.test.ts
@@ -1,0 +1,512 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Tolerance tests for MarketModule:
+ *  - Retry on transient HTTP failures (502/503/504/408) and network errors.
+ *  - Permanent failures (400/401/403/404/422) propagate immediately.
+ *  - Circuit breaker opens after N consecutive operation-level failures and
+ *    fails fast during the cooldown.
+ *  - Existing public error shapes are preserved when retries exhaust.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MarketModule } from '../../../modules/market/MarketModule';
+import {
+  CircuitBreaker,
+  TransientMarketError,
+  backoffDelay,
+  isRetryableStatus,
+  isTransientNetworkError,
+  runWithRetry,
+} from '../../../modules/market/retry';
+import { SphereError } from '../../../core/errors';
+import type { FullIdentity } from '../../../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_PRIVATE_KEY = 'a'.repeat(64);
+
+function mockIdentity(): FullIdentity {
+  return {
+    chainPubkey: '02' + 'ab'.repeat(32),
+    l1Address: 'alpha1test',
+    directAddress: 'DIRECT://test',
+    privateKey: TEST_PRIVATE_KEY,
+  };
+}
+
+function mockDeps() {
+  return { identity: mockIdentity(), emitEvent: vi.fn() };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function htmlResponse(html: string, status: number): Response {
+  return new Response(html, { status, headers: { 'content-type': 'text/html' } });
+}
+
+/**
+ * Build a MarketModule that's pre-registered (skips the agent/register
+ * roundtrip) and uses tight, deterministic retry settings for tests.
+ */
+function makeModule(opts?: {
+  maxAttempts?: number;
+  breakerThreshold?: number;
+  breakerCooldownMs?: number;
+  now?: () => number;
+}): MarketModule {
+  const mod = new MarketModule({
+    apiUrl: 'https://market.test',
+    timeout: 5000,
+    retryConfig: {
+      maxAttempts: opts?.maxAttempts ?? 3,
+      delaysMs: [1, 1, 1, 1, 1],
+      totalBudgetMs: 1000,
+      breakerThreshold: opts?.breakerThreshold ?? 5,
+      breakerCooldownMs: opts?.breakerCooldownMs ?? 30_000,
+      now: opts?.now,
+      sleep: () => Promise.resolve(),
+      random: () => 0, // zero jitter — deterministic
+    },
+  } as any);
+  mod.initialize(mockDeps());
+  // Skip auto-registration in tolerance tests — registration is exercised
+  // separately and would otherwise consume the first fetch mock.
+  (mod as any).registered = true;
+  return mod;
+}
+
+// =============================================================================
+// Pure helpers (classification + backoff)
+// =============================================================================
+
+describe('retry helpers', () => {
+  describe('isRetryableStatus', () => {
+    it('marks 502/503/504/408 as retryable', () => {
+      expect(isRetryableStatus(502)).toBe(true);
+      expect(isRetryableStatus(503)).toBe(true);
+      expect(isRetryableStatus(504)).toBe(true);
+      expect(isRetryableStatus(408)).toBe(true);
+    });
+
+    it('does NOT retry 4xx caller-side errors', () => {
+      for (const s of [400, 401, 403, 404, 405, 409, 410, 422, 429]) {
+        expect(isRetryableStatus(s)).toBe(false);
+      }
+    });
+
+    it('does NOT retry success codes', () => {
+      expect(isRetryableStatus(200)).toBe(false);
+      expect(isRetryableStatus(201)).toBe(false);
+      expect(isRetryableStatus(204)).toBe(false);
+    });
+  });
+
+  describe('isTransientNetworkError', () => {
+    it('detects AbortError / TimeoutError DOMException', () => {
+      const abort = new DOMException('aborted', 'AbortError');
+      const timeout = new DOMException('timeout', 'TimeoutError');
+      expect(isTransientNetworkError(abort)).toBe(true);
+      expect(isTransientNetworkError(timeout)).toBe(true);
+    });
+
+    it('detects Node-style ECONNRESET / ETIMEDOUT etc.', () => {
+      const codes = ['ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'EPIPE'];
+      for (const code of codes) {
+        const err = Object.assign(new Error('net'), { code });
+        expect(isTransientNetworkError(err)).toBe(true);
+      }
+    });
+
+    it('detects undici "fetch failed" TypeError', () => {
+      expect(isTransientNetworkError(new TypeError('fetch failed'))).toBe(true);
+    });
+
+    it('returns false for plain SphereError (already classified)', () => {
+      expect(isTransientNetworkError(new SphereError('nope', 'NETWORK_ERROR'))).toBe(false);
+    });
+
+    it('returns false for null / non-objects', () => {
+      expect(isTransientNetworkError(null)).toBe(false);
+      expect(isTransientNetworkError('boom')).toBe(false);
+      expect(isTransientNetworkError(undefined)).toBe(false);
+    });
+  });
+
+  describe('backoffDelay', () => {
+    it('respects schedule index, capped at last entry', () => {
+      const schedule = [100, 200, 400];
+      // random=1 → returns floor(base) − 1 (because Math.floor(1*base) === base, but spec uses [0, base))
+      // We use the deterministic random=0 → 0; random=0.99 → just under base
+      expect(backoffDelay(0, schedule, () => 0)).toBe(0);
+      expect(backoffDelay(1, schedule, () => 0)).toBe(0);
+      expect(backoffDelay(0, schedule, () => 0.5)).toBe(50);
+      expect(backoffDelay(2, schedule, () => 0.5)).toBe(200);
+      // index past the schedule clamps to the last entry
+      expect(backoffDelay(99, schedule, () => 0.25)).toBe(100);
+    });
+  });
+});
+
+// =============================================================================
+// runWithRetry behavior
+// =============================================================================
+
+describe('runWithRetry', () => {
+  it('retries TransientMarketError up to maxAttempts and eventually succeeds', async () => {
+    const breaker = new CircuitBreaker();
+    let calls = 0;
+    const op = async () => {
+      calls++;
+      if (calls < 3) {
+        throw new TransientMarketError(new SphereError('HTTP 502', 'NETWORK_ERROR'), 502);
+      }
+      return 'ok';
+    };
+    const result = await runWithRetry(op, breaker, {
+      maxAttempts: 5,
+      delaysMs: [0, 0, 0, 0, 0],
+      sleep: () => Promise.resolve(),
+      random: () => 0,
+    });
+    expect(result).toBe('ok');
+    expect(calls).toBe(3);
+    expect(breaker.getConsecutiveFailures()).toBe(0);
+  });
+
+  it('throws the original SphereError when retries are exhausted', async () => {
+    const breaker = new CircuitBreaker();
+    const finalErr = new SphereError(
+      'Market API error: HTTP 502 — unexpected response (not JSON)',
+      'NETWORK_ERROR',
+    );
+    const op = async () => {
+      throw new TransientMarketError(finalErr, 502);
+    };
+
+    await expect(
+      runWithRetry(op, breaker, {
+        maxAttempts: 3,
+        delaysMs: [0, 0],
+        sleep: () => Promise.resolve(),
+        random: () => 0,
+      }),
+    ).rejects.toThrow(finalErr.message);
+  });
+
+  it('does not retry when op throws a non-transient error', async () => {
+    const breaker = new CircuitBreaker();
+    let calls = 0;
+    const op = async () => {
+      calls++;
+      throw new SphereError('HTTP 400', 'NETWORK_ERROR');
+    };
+    await expect(runWithRetry(op, breaker, { maxAttempts: 5, delaysMs: [0, 0] })).rejects.toThrow(
+      'HTTP 400',
+    );
+    expect(calls).toBe(1);
+    // Permanent errors must not affect the breaker.
+    expect(breaker.getConsecutiveFailures()).toBe(0);
+  });
+
+  it('aborts the loop once the total time budget is exhausted', async () => {
+    const breaker = new CircuitBreaker();
+    let calls = 0;
+    let virtualNow = 0;
+    const sleep = (ms: number) => {
+      virtualNow += ms;
+      return Promise.resolve();
+    };
+    const op = async () => {
+      calls++;
+      throw new TransientMarketError(new SphereError('HTTP 503', 'NETWORK_ERROR'), 503);
+    };
+    await expect(
+      runWithRetry(op, breaker, {
+        maxAttempts: 100,
+        delaysMs: [50, 50, 50, 50, 50],
+        totalBudgetMs: 100,
+        sleep,
+        now: () => virtualNow,
+        random: () => 1, // pick max base each time
+      }),
+    ).rejects.toThrow('HTTP 503');
+    // We should stop well before 100 attempts.
+    expect(calls).toBeLessThan(10);
+  });
+});
+
+// =============================================================================
+// Circuit breaker
+// =============================================================================
+
+describe('CircuitBreaker', () => {
+  it('stays closed on successes', () => {
+    const breaker = new CircuitBreaker({ threshold: 3 });
+    breaker.recordSuccess();
+    breaker.recordSuccess();
+    expect(breaker.getState()).toBe('closed');
+  });
+
+  it('opens after N consecutive failures', () => {
+    const breaker = new CircuitBreaker({ threshold: 3 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.getState()).toBe('closed');
+    breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+  });
+
+  it('resets the failure counter on success', () => {
+    const breaker = new CircuitBreaker({ threshold: 3 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordSuccess();
+    expect(breaker.getConsecutiveFailures()).toBe(0);
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.getState()).toBe('closed');
+  });
+
+  it('fails fast while open', () => {
+    const now = 1000;
+    const breaker = new CircuitBreaker({ threshold: 1, cooldownMs: 5000, now: () => now });
+    breaker.recordFailure(); // opens
+    expect(breaker.getState()).toBe('open');
+    expect(() => breaker.assertCanProceed()).toThrow(/circuit breaker open/i);
+  });
+
+  it('moves to half-open after cooldown, closes on success', () => {
+    let now = 1000;
+    const breaker = new CircuitBreaker({ threshold: 1, cooldownMs: 5000, now: () => now });
+    breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+    now += 6000;
+    expect(() => breaker.assertCanProceed()).not.toThrow();
+    expect(breaker.getState()).toBe('half-open');
+    breaker.recordSuccess();
+    expect(breaker.getState()).toBe('closed');
+  });
+
+  it('re-opens immediately if the half-open trial fails', () => {
+    let now = 1000;
+    const breaker = new CircuitBreaker({ threshold: 1, cooldownMs: 5000, now: () => now });
+    breaker.recordFailure();
+    now += 6000;
+    breaker.assertCanProceed(); // → half-open
+    breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+    // Still inside the new cooldown window.
+    expect(() => breaker.assertCanProceed()).toThrow(/circuit breaker open/i);
+  });
+});
+
+// =============================================================================
+// MarketModule wired with retry + breaker
+// =============================================================================
+
+describe('MarketModule transient-failure tolerance', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({}));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  // ---------- Retry on transient HTTP -------------------------------------
+
+  it('retries 502 (HTML body) and eventually succeeds', async () => {
+    const mod = makeModule({ maxAttempts: 3 });
+    fetchSpy
+      .mockResolvedValueOnce(htmlResponse('<html>502 Bad Gateway</html>', 502))
+      .mockResolvedValueOnce(htmlResponse('<html>502 Bad Gateway</html>', 502))
+      .mockResolvedValueOnce(jsonResponse({ intents: [], count: 0 }));
+
+    const result = await mod.search('widgets');
+    expect(result.intents).toEqual([]);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries 503 JSON-shaped error and eventually succeeds', async () => {
+    const mod = makeModule({ maxAttempts: 3 });
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ error: 'unavailable' }, 503))
+      .mockResolvedValueOnce(jsonResponse({ intents: [], count: 0 }));
+
+    const result = await mod.search('widgets');
+    expect(result.intents).toEqual([]);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries 504 / 408 too', async () => {
+    const mod = makeModule({ maxAttempts: 3 });
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ error: 'gateway timeout' }, 504))
+      .mockResolvedValueOnce(jsonResponse({ error: 'request timeout' }, 408))
+      .mockResolvedValueOnce(jsonResponse({ intents: [], count: 0 }));
+
+    await expect(mod.search('q')).resolves.toBeDefined();
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries on network-level errors (ECONNRESET)', async () => {
+    const mod = makeModule({ maxAttempts: 3 });
+    const netErr = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    fetchSpy
+      .mockRejectedValueOnce(netErr)
+      .mockRejectedValueOnce(netErr)
+      .mockResolvedValueOnce(jsonResponse({ intents: [] }));
+
+    await expect(mod.search('q')).resolves.toBeDefined();
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries on AbortSignal.timeout DOMException', async () => {
+    const mod = makeModule({ maxAttempts: 2 });
+    fetchSpy
+      .mockRejectedValueOnce(new DOMException('timeout', 'TimeoutError'))
+      .mockResolvedValueOnce(jsonResponse({ intents: [] }));
+
+    await expect(mod.search('q')).resolves.toBeDefined();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  // ---------- Permanent errors ------------------------------------------
+
+  it('does NOT retry on HTTP 400 — fails immediately', async () => {
+    const mod = makeModule({ maxAttempts: 5 });
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ error: 'bad request' }, 400));
+
+    await expect(mod.search('q')).rejects.toThrow('bad request');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT retry on 401/403/404/422', async () => {
+    for (const status of [401, 403, 404, 422]) {
+      fetchSpy.mockReset();
+      const mod = makeModule({ maxAttempts: 5 });
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ error: `e${status}` }, status));
+      await expect(mod.search('q')).rejects.toThrow(`e${status}`);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('does NOT retry on a non-network programming error', async () => {
+    const mod = makeModule({ maxAttempts: 5 });
+    fetchSpy.mockRejectedValueOnce(new RangeError('not a network problem'));
+    await expect(mod.search('q')).rejects.toThrow('not a network problem');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------- Retries exhausted: error shape preserved -----------------
+
+  it('preserves the original SphereError message after retries exhaust', async () => {
+    const mod = makeModule({ maxAttempts: 3 });
+    fetchSpy.mockImplementation(async () => htmlResponse('<html>502</html>', 502));
+
+    let caught: unknown;
+    try {
+      await mod.search('q');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SphereError);
+    expect((caught as SphereError).code).toBe('NETWORK_ERROR');
+    expect((caught as SphereError).message).toBe(
+      'Market API error: HTTP 502 — unexpected response (not JSON)',
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('preserves the API-provided error message after JSON 503 exhausts', async () => {
+    const mod = makeModule({ maxAttempts: 2 });
+    // Fresh Response per call — Response bodies are single-shot.
+    fetchSpy.mockImplementation(async () =>
+      jsonResponse({ error: 'service unavailable' }, 503),
+    );
+
+    await expect(mod.search('q')).rejects.toThrow('service unavailable');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  // ---------- Circuit breaker ------------------------------------------
+
+  it('opens the circuit after N consecutive failed operations and fails fast during cooldown', async () => {
+    let virtualNow = 0;
+    const mod = makeModule({
+      maxAttempts: 1, // single attempt per op so each failure counts cleanly
+      breakerThreshold: 3,
+      breakerCooldownMs: 30_000,
+      now: () => virtualNow,
+    });
+    fetchSpy.mockImplementation(async () => jsonResponse({ error: 'down' }, 503));
+
+    // Three failed ops → breaker opens.
+    for (let i = 0; i < 3; i++) {
+      await expect(mod.search('q')).rejects.toThrow();
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+    // Next call must fail fast WITHOUT a network roundtrip.
+    fetchSpy.mockClear();
+    await expect(mod.search('q')).rejects.toThrow(/circuit breaker open/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // Advance past cooldown — the breaker enters half-open and lets one through.
+    virtualNow += 31_000;
+    fetchSpy.mockImplementationOnce(async () => jsonResponse({ intents: [], count: 0 }));
+    const ok = await mod.search('q');
+    expect(ok.intents).toEqual([]);
+  });
+
+  it('resumes normal operation after a successful half-open trial', async () => {
+    let virtualNow = 0;
+    const mod = makeModule({
+      maxAttempts: 1,
+      breakerThreshold: 2,
+      breakerCooldownMs: 1000,
+      now: () => virtualNow,
+    });
+    fetchSpy.mockImplementation(async () => jsonResponse({ error: 'down' }, 503));
+
+    await expect(mod.search('q')).rejects.toThrow();
+    await expect(mod.search('q')).rejects.toThrow();
+    // Breaker is now open.
+    fetchSpy.mockClear();
+    await expect(mod.search('q')).rejects.toThrow(/circuit breaker open/i);
+
+    // Advance past cooldown, succeed once → breaker closes.
+    virtualNow += 2000;
+    fetchSpy.mockImplementationOnce(async () => jsonResponse({ intents: [], count: 0 }));
+    await expect(mod.search('q')).resolves.toBeDefined();
+
+    // Subsequent calls flow through normally.
+    fetchSpy.mockImplementationOnce(async () => jsonResponse({ intents: [], count: 0 }));
+    await expect(mod.search('q')).resolves.toBeDefined();
+  });
+
+  it('does not count permanent (non-retryable) failures toward the breaker', async () => {
+    const mod = makeModule({
+      maxAttempts: 1,
+      breakerThreshold: 2,
+    });
+    fetchSpy.mockImplementation(async () => jsonResponse({ error: 'bad' }, 400));
+
+    // Many permanent failures should NEVER trip the breaker.
+    for (let i = 0; i < 5; i++) {
+      await expect(mod.search('q')).rejects.toThrow('bad');
+    }
+    // Now a success should flow through cleanly.
+    fetchSpy.mockImplementationOnce(async () => jsonResponse({ intents: [] }));
+    await expect(mod.search('q')).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add bounded retry with exponential backoff + jitter for transient Market API failures (502/503/504/408 + network-level errors).
- Add a 5-failure / 30s circuit breaker so a sustained outage fails fast instead of stalling for the whole budget on every call.
- Permanent client errors (400/401/403/404/422) bypass retry — they indicate caller bugs, not outages.

## Why
The Market API sits behind a load balancer that occasionally returns transient errors during deploys. A single 502 from the testnet Market API was enough to kill an in-progress trader run or e2e test even when the rest of the protocol was working fine. Recent live runs of hma-trade-settlement.e2e-live failed at createIntent / scan_search / close_expired_intent with **"HTTP 502 — unexpected response (not JSON)"**.

## Policy
- **Retry:** HTTP 502/503/504/408 and network errors (AbortError, TimeoutError, ECONNRESET/REFUSED/TIMEDOUT, ENOTFOUND, EAI_AGAIN, EPIPE, undici socket errors, "fetch failed" TypeError).
- **Don't retry:** 400/401/403/404/422.
- **Backoff:** exponential + full jitter, schedule 200/500/1000/2000/4000 ms, max 5 attempts, total budget ≤ 10s.
- **Breaker:** trips after 5 consecutive failed ops, fails fast for 30s, then half-open trial. Logs market_circuit_open / market_circuit_closed at warn level.

## Test plan
- [x] 32 new unit tests in MarketModule.tolerance.test.ts covering classification, runWithRetry semantics, circuit breaker state machine, and end-to-end MarketModule wiring.
- [x] npx tsc --noEmit clean.
- [x] npx eslint clean.
- [x] Full npx vitest run green (130 files / 2795 tests).
- [x] npx tsup build succeeds.

## Caveat
createIntent is not strictly idempotent — a retry could in theory create a duplicate intent. The bounded budget (≤10s / ≤5 attempts) caps the blast radius; future work could add an Idempotency-Key header server-side.