### PR TITLE
chore(impl): soft-deprecate IpfsStorageProvider (IPNS path)

### DIFF
--- a/impl/browser/index.ts
+++ b/impl/browser/index.ts
@@ -79,10 +79,16 @@ export type OracleConfig = BaseOracleConfig;
 // =============================================================================
 
 /**
- * IPFS sync backend configuration
+ * IPFS sync backend configuration.
+ *
+ * @deprecated The IPNS-based mutable-pointer flow this config opts into
+ * is superseded by the Profile token-storage path (OrbitDB + aggregator
+ * pointer + IPFS CAR). See `createBrowserProfileProviders` and the
+ * `IpfsStorageProvider` JSDoc. This config remains functional for
+ * backward compatibility.
  */
 export interface IpfsSyncConfig {
-  /** Enable IPFS sync (default: false) */
+  /** Enable IPFS sync (default: false). @deprecated — see {@link IpfsSyncConfig}. */
   enabled?: boolean;
   /** Replace default gateways entirely */
   gateways?: string[];

--- a/impl/browser/ipfs/index.ts
+++ b/impl/browser/ipfs/index.ts
@@ -22,6 +22,12 @@ function createBrowserWebSocket(url: string): IWebSocket {
 /**
  * Create a browser IPFS storage provider with localStorage-based state persistence.
  * Automatically injects the browser WebSocket factory for IPNS push subscriptions.
+ *
+ * @deprecated Use `createBrowserProfileProviders` (Profile + aggregator pointer)
+ *   instead. The IPNS-based mutable-pointer flow this factory wires up is
+ *   superseded by the aggregator pointer layer, which handles cross-device
+ *   pointer resolution over HTTP without IPNS DHT propagation. See
+ *   `IpfsStorageProvider` JSDoc for the migration rationale.
  */
 export function createBrowserIpfsStorageProvider(config?: IpfsStorageConfig): IpfsStorageProvider {
   return new IpfsStorageProvider(

--- a/impl/nodejs/index.ts
+++ b/impl/nodejs/index.ts
@@ -81,9 +81,17 @@ export type NodeL1Config = L1Config;
 // Node.js Providers Configuration
 // =============================================================================
 
-/** Node.js IPFS sync configuration */
+/**
+ * Node.js IPFS sync configuration.
+ *
+ * @deprecated The IPNS-based mutable-pointer flow this config opts into
+ * is superseded by the Profile token-storage path (OrbitDB + aggregator
+ * pointer + IPFS CAR). See `createNodeProfileProviders` and the
+ * `IpfsStorageProvider` JSDoc. This config remains functional for
+ * backward compatibility.
+ */
 export interface NodeIpfsSyncConfig {
-  /** Enable IPFS sync (default: false) */
+  /** Enable IPFS sync (default: false). @deprecated — see {@link NodeIpfsSyncConfig}. */
   enabled?: boolean;
   /** IPFS storage provider configuration */
   config?: IpfsStorageConfig;

--- a/impl/nodejs/ipfs/index.ts
+++ b/impl/nodejs/ipfs/index.ts
@@ -19,6 +19,12 @@ export type { IpfsStorageConfig as IpfsStorageProviderConfig } from '../../share
  *
  * @param config - IPFS storage configuration
  * @param storageProvider - StorageProvider for persisting state (e.g., FileStorageProvider)
+ *
+ * @deprecated Use `createNodeProfileProviders` (Profile + aggregator pointer)
+ *   instead. The IPNS-based mutable-pointer flow this factory wires up is
+ *   superseded by the aggregator pointer layer, which handles cross-device
+ *   pointer resolution over HTTP without IPNS DHT propagation. See
+ *   `IpfsStorageProvider` JSDoc for the migration rationale.
  */
 export function createNodeIpfsStorageProvider(
   config?: IpfsStorageConfig,

--- a/impl/shared/ipfs/ipfs-storage-provider.ts
+++ b/impl/shared/ipfs/ipfs-storage-provider.ts
@@ -5,6 +5,18 @@
  *
  * Uses a write-behind buffer for non-blocking save() operations.
  * Writes are accepted immediately and flushed to IPFS asynchronously.
+ *
+ * @deprecated Use the Profile token-storage path (OrbitDB + aggregator
+ * pointer + IPFS CAR pin/fetch) instead. The IPNS-based mutable-pointer
+ * flow that this provider implements is superseded by the aggregator's
+ * pointer layer, which handles cross-device mutable-pointer resolution
+ * over the HTTP API without depending on IPNS DHT propagation or
+ * libp2p-pubsub between wallet instances. See `profile/factory.ts`,
+ * `createNodeProfileProviders`, and `createBrowserProfileProviders`.
+ *
+ * The class remains functional for backward compatibility with consumers
+ * who explicitly opt in via `tokenSync.ipfs.enabled: true`. New code
+ * should use Profile.
  */
 
 import { logger } from '../../../core/logger';
@@ -95,10 +107,24 @@ export class IpfsStorageProvider<TData extends TxfStorageDataBase = TxfStorageDa
   private readonly _config: IpfsStorageConfig | undefined;
   private readonly _statePersistenceCtor: IpfsStatePersistence | undefined;
 
+  /** Process-wide flag to emit the deprecation warning at most once. */
+  private static _deprecationWarned = false;
+
   constructor(
     config?: IpfsStorageConfig,
     statePersistence?: IpfsStatePersistence,
   ) {
+    if (!IpfsStorageProvider._deprecationWarned) {
+      IpfsStorageProvider._deprecationWarned = true;
+      console.warn(
+        '[sphere-sdk] IpfsStorageProvider is DEPRECATED. The IPNS-based ' +
+        'mutable-pointer flow it implements is superseded by the Profile ' +
+        'token-storage path (OrbitDB + aggregator pointer + IPFS CAR). ' +
+        'Migrate via createNodeProfileProviders / createBrowserProfileProviders. ' +
+        'This provider remains functional for backward compatibility but is no ' +
+        'longer the recommended path for new code.',
+      );
+    }
     this._config = config;
     this._statePersistenceCtor = statePersistence;
     const gateways = config?.gateways ?? getIpfsGatewayUrls();

--- a/impl/shared/ipfs/ipfs-types.ts
+++ b/impl/shared/ipfs/ipfs-types.ts
@@ -97,7 +97,14 @@ export interface GatewayHealthResult {
 // Configuration Types
 // =============================================================================
 
-/** IPFS storage provider configuration */
+/**
+ * IPFS storage provider configuration.
+ *
+ * @deprecated The {@link IpfsStorageProvider} class this configures is
+ * deprecated in favor of the Profile token-storage path (OrbitDB +
+ * aggregator pointer + IPFS CAR pin/fetch). See `profile/factory.ts`
+ * and `IpfsStorageProvider`'s JSDoc for the migration rationale.
+ */
 export interface IpfsStorageConfig {
   /** Gateway URLs for HTTP API (defaults to Unicity dedicated nodes) */
   gateways?: string[];


### PR DESCRIPTION
## Why

`IpfsStorageProvider` and the IPNS-based mutable-pointer flow it implements are structurally superseded by the **Profile token-storage path** (OrbitDB + aggregator pointer + IPFS CAR). The aggregator's pointer layer handles cross-device mutable-pointer resolution over HTTP — no IPNS DHT propagation latency, no libp2p-pubsub-between-wallets dependency.

Profile mode is already the default in `createNodeProviders` / `createBrowserProviders`. Opting into the IPFS path requires `tokenSync.ipfs.enabled: true`. This PR marks that opt-in surface deprecated **without changing behavior**.

## Diff

`+64 / -5` LOC across 6 files. All edits are JSDoc + one `console.warn` shim.

| File | Change |
|---|---|
| `impl/shared/ipfs/ipfs-storage-provider.ts` | `@deprecated` on the class. Static-flag-gated one-time `console.warn` at first construction. |
| `impl/nodejs/ipfs/index.ts` | `@deprecated` on `createNodeIpfsStorageProvider` factory. |
| `impl/browser/ipfs/index.ts` | `@deprecated` on `createBrowserIpfsStorageProvider` factory. |
| `impl/nodejs/index.ts` | `@deprecated` on `NodeIpfsSyncConfig` + its `enabled` field. |
| `impl/browser/index.ts` | `@deprecated` on `IpfsSyncConfig` + its `enabled` field. |
| `impl/shared/ipfs/ipfs-types.ts` | `@deprecated` on `IpfsStorageConfig`. |

Every deprecation annotation points at the migration target (`createNodeProfileProviders` / `createBrowserProfileProviders` / `Profile`).

## Why soft (not removal)

There may be consumers explicitly opted into the IPFS path. Soft deprecation gives them a build-time signal (TS `@deprecated` warning in IDEs / strictness configs that surface it) and a runtime nudge (one `console.warn` at startup), without breaking them. Hard removal — including deleting the class, the factories, the IPNS client, the write-behind buffer, the 3 legacy `ipfs-*` e2e tests, the 2 unit-test files for the provider — is a separate followup PR after the deprecation has had time to land downstream.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on all touched files.
- [x] Full vitest: **2763 passed / 0 failures / 0 skipped (129 files)**. The 238 tests in `tests/unit/impl/shared/ipfs/**` all pass; the constructor-side `console.warn` fires once and is silent for the rest of the suite (static flag).
- [x] No runtime behavior changes for opted-in callers beyond the one-time warning.

## Followup (separate PR)

- Hard removal of `IpfsStorageProvider`, factories, config option, and the legacy `ipfs-*` e2e tests once we've confirmed no downstream consumers still need the IPNS path.
- `docs/IPFS-STORAGE.md` rewrite or removal, redirecting to Profile docs.