### PR TITLE
test(e2e): fix profile-sync token.genesis assertion (#138)

### DIFF
--- a/tests/e2e/profile-sync.test.ts
+++ b/tests/e2e/profile-sync.test.ts
@@ -267,10 +267,13 @@ describe.skipIf(SKIP_INFRA)('Profile (OrbitDB + IPFS) Sync E2E', () => {
     expect(originalTokens.length).toBeGreaterThan(0);
     const originalIds = new Set(originalTokens.map((t) => t.id));
     const originalAmounts = new Map(originalTokens.map((t) => [t.id, t.amount]));
-    // Sanity check: real testnet tokens have a genesis field — synthetic
-    // stubs don't. This guards against accidental regression to fake shapes.
+    // Sanity check: real testnet tokens carry a TXF genesis inside sdkData
+    // (the public Token type doesn't expose `genesis` directly). Guards
+    // against accidental regression to synthetic stubs.
     for (const t of originalTokens) {
-      expect((t as unknown as { genesis?: unknown }).genesis).toBeTruthy();
+      expect(t.sdkData).toBeTruthy();
+      const parsed = JSON.parse(t.sdkData!) as { genesis?: unknown };
+      expect(parsed.genesis).toBeTruthy();
     }
 
     // Explicit sync flush — drains the debounced write-behind buffer so
@@ -336,10 +339,13 @@ describe.skipIf(SKIP_INFRA)('Profile (OrbitDB + IPFS) Sync E2E', () => {
       expect(recoveredIds.has(id)).toBe(true);
       expect(recoveredAmounts.get(id)).toBe(originalAmounts.get(id));
     }
-    // And every recovered token still carries its real `genesis` —
-    // confirms the CAR encoded the full UXF schema, not a stub.
+    // And every recovered token still carries its real `genesis` (parsed
+    // out of sdkData) — confirms the CAR encoded the full UXF schema, not
+    // a stub.
     for (const t of recoveredTokens) {
-      expect((t as unknown as { genesis?: unknown }).genesis).toBeTruthy();
+      expect(t.sdkData).toBeTruthy();
+      const parsed = JSON.parse(t.sdkData!) as { genesis?: unknown };
+      expect(parsed.genesis).toBeTruthy();
     }
 
     console.log(`[Test 2] PASSED: real testnet tokens round-tripped through CAR pin/reload`);


### PR DESCRIPTION
## Problem

`profile-sync.test.ts` had two assertions that have always been false:

```ts
for (const t of originalTokens) {
  expect((t as unknown as { genesis?: unknown }).genesis).toBeTruthy();
}
```

The cast tells TypeScript to ignore the type, but at runtime the public
`Token` type doesn't expose `genesis` directly — it's inside the TXF JSON
embedded in `t.sdkData`. The same bug repeated at the post-recovery site.

When test 2 finally got to that assertion (after the testnet setup), it
failed with `expected undefined to be truthy` — because `t.genesis` is in
fact `undefined`.

## Fix

Parse `t.sdkData` and assert `parsed.genesis` is truthy. This matches how
production code accesses the genesis (see `parseSdkDataCached` at
`modules/payments/PaymentsModule.ts:598`).

Updated both occurrences (lines 270-274 and 342-346).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint tests/e2e/profile-sync.test.ts` — clean
- [ ] `RUN_UXF_E2E=1 npm run test:e2e tests/e2e/profile-sync.test.ts` — needs testnet env (CI / manual)

Closes #138.