### PR TITLE
fix(payments): preserve nametags when sync data omits _nametags (#136)

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -7254,10 +7254,8 @@ export class PaymentsModule {
       let totalAdded = 0;
       let totalRemoved = 0;
 
-      // Preserve nametags — sync providers may not include _nametags in merged data
-      const savedNametags = [...this.nametags];
-
-      // Sync with each provider
+      // Sync with each provider. Nametag preservation when merged data
+      // omits `_nametags` is handled inside `loadFromStorageData` (#136).
       for (const [providerId, provider] of providers) {
         try {
           const result = await provider.sync(localData);
@@ -7316,11 +7314,6 @@ export class PaymentsModule {
             }
             if (restoredCount > 0) {
               logger.debug('Payments', `Sync: restored ${restoredCount} token(s) lost by loadFromStorageData`);
-            }
-
-            // Restore nametags if sync wiped them
-            if (this.nametags.length === 0 && savedNametags.length > 0) {
-              this.nametags = savedNametags;
             }
 
             // Rebuild parsedTokenCache for spend queue (loadFromStorageData bypasses addToken)
@@ -9759,7 +9752,20 @@ export class PaymentsModule {
     // Load other data
     this.archivedTokens = parsed.archivedTokens;
     this.forkedTokens = parsed.forkedTokens;
-    this.nametags = parsed.nametags;
+
+    // Nametag preservation guard (#136). Some sync providers strip
+    // `_nametags` from merged data — overriding would transiently empty
+    // `this.nametags` and any concurrent `finalizeTransferToken` would
+    // throw "no Unicity ID token". Only override when the incoming data
+    // actually carries nametag information. An explicit `_nametags: []`
+    // (or legacy `_nametag`) from a different device still clears, as
+    // expected.
+    const rawData = data as unknown as Record<string, unknown>;
+    const incomingHasNametags =
+      Array.isArray(rawData._nametags) || rawData._nametag != null;
+    if (incomingHasNametags || this.nametags.length === 0) {
+      this.nametags = parsed.nametags;
+    }
   }
 
   // ===========================================================================

--- a/tests/unit/modules/PaymentsModule.test.ts
+++ b/tests/unit/modules/PaymentsModule.test.ts
@@ -1116,6 +1116,48 @@ describe('Nametag preservation during sync', () => {
     expect(module.getNametag()?.name).toBe('updateduser');
   });
 
+  it('should clear nametags when sync provider returns explicit empty _nametags array', async () => {
+    // Intentional cross-device removal: another device cleared its nametag
+    // and synced. The merged payload carries `_nametags: []` (explicit,
+    // not absent). We MUST clear locally — preservation only kicks in
+    // when the field is absent. (#136 boundary case)
+    const mockProvider = {
+      id: 'test-provider',
+      name: 'Test Provider',
+      type: 'local' as const,
+      setIdentity: vi.fn(),
+      initialize: vi.fn().mockResolvedValue(true),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      isConnected: vi.fn().mockReturnValue(true),
+      getStatus: vi.fn().mockReturnValue('connected' as const),
+      save: vi.fn().mockResolvedValue({ success: true, timestamp: Date.now() }),
+      load: vi.fn().mockResolvedValue({ success: true, data: { _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: Date.now() } }, source: 'local', timestamp: Date.now() }),
+      sync: vi.fn().mockResolvedValue({
+        success: true,
+        merged: {
+          _meta: { version: 2, address: '', formatVersion: '2.0', updatedAt: Date.now() },
+          _nametags: [],
+        },
+        added: 0,
+        removed: 0,
+        conflicts: 0,
+      }),
+    };
+
+    const providers = new Map([['test', mockProvider]]);
+    const module = createInitializedModule(providers);
+
+    await module.setNametag(TEST_NAMETAG);
+    expect(module.hasNametag()).toBe(true);
+
+    await module.sync();
+
+    // Explicit empty array → cleared.
+    expect(module.hasNametag()).toBe(false);
+  });
+
   it('should recover nametags from storage via reloadNametagsFromStorage', async () => {
     const mockProvider = {
       id: 'test-provider',


### PR DESCRIPTION
## Problem

`PaymentsModule.loadFromStorageData` unconditionally set:

```ts
this.nametags = parsed.nametags;
```

When a sync provider's merged payload didn't carry `_nametags`,
`parseTxfStorageData` produced an empty array and we **wiped a known-good
in-memory nametag**. `_doSync` had an after-the-fact restore:

```ts
if (this.nametags.length === 0 && savedNametags.length > 0) {
  this.nametags = savedNametags;
}
```

Two problems with that:
1. **Every other caller** of `loadFromStorageData` (notably `load()`) was
   not protected.
2. The clear-then-restore widened the window in which a concurrent
   `finalizeTransferToken` could observe `this.nametags === []`,
   `reloadNametagsFromStorage()` might still be mid-flight, and the call
   threw `Cannot finalize PROXY transfer - no Unicity ID token` — the
   symptom seen on the registering wallet in
   `profile-live-concurrent-sync` (#136).

## Fix

Centralize the guard inside `loadFromStorageData`. Only override
`this.nametags` when the **raw** incoming data actually carries nametag
information — i.e. `_nametags` is an array OR legacy `_nametag` is
present. An explicit `_nametags: []` (intentional cross-device clear) is
still honored — preservation only kicks in when the field is **absent**.

```ts
const rawData = data as unknown as Record<string, unknown>;
const incomingHasNametags =
  Array.isArray(rawData._nametags) || rawData._nametag != null;
if (incomingHasNametags || this.nametags.length === 0) {
  this.nametags = parsed.nametags;
}
```

Removed the now-redundant `savedNametags` capture + post-load restore in
`_doSync` — the new guard makes the path atomic by construction.

## Test plan

- [x] Existing test ``"should preserve nametags when sync provider returns merged data without _nametags"`` still passes — the contract it was already encoding is now enforced inside `loadFromStorageData` rather than at the call site.
- [x] Existing test ``"should update nametags when sync provider returns valid _nametags"`` still passes — explicit incoming nametags override as before.
- [x] **New** boundary test ``"should clear nametags when sync provider returns explicit empty _nametags array"`` — pins the cross-device removal contract (`_nametags: []` ≠ absent).
- [x] `npx vitest run tests/unit/modules/` — 1499 tests pass (80 files).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` — no new warnings.
- [ ] `RUN_UXF_E2E=1 npm run test:e2e tests/e2e/profile-live-concurrent-sync.test.ts` — needs testnet env.

Closes #136.