### PR TITLE
fix(profile): bound OrbitDB/Helia teardown with per-step budget (#137)

### DIFF
--- a/profile/orbitdb-adapter.ts
+++ b/profile/orbitdb-adapter.ts
@@ -689,32 +689,19 @@ export class OrbitDbAdapter implements ProfileDatabase {
     // overwritten them).
     this.localAuthoredKeys.clear();
 
-    try {
-      if (this.db) {
-        await this.db.close();
-        this.db = null;
-      }
-    } catch {
-      // Best-effort close -- log but do not throw
-    }
-
-    try {
-      if (this.orbitdb) {
-        await this.orbitdb.stop();
-        this.orbitdb = null;
-      }
-    } catch {
-      // Best-effort close
-    }
-
-    try {
-      if (this.helia) {
-        await this.helia.stop();
-        this.helia = null;
-      }
-    } catch {
-      // Best-effort close
-    }
+    // Bounded teardown (#137). Each step gets a budget — a hung
+    // libp2p / pubsub / DAG-sync layer must not pin `Sphere.destroy()`
+    // for minutes. Best-effort: on timeout we log, drop the reference,
+    // and proceed; any leaked resources are reclaimed at process exit.
+    await closeWithBudget('db.close', () => this.db?.close(), () => {
+      this.db = null;
+    });
+    await closeWithBudget('orbitdb.stop', () => this.orbitdb?.stop(), () => {
+      this.orbitdb = null;
+    });
+    await closeWithBudget('helia.stop', () => this.helia?.stop(), () => {
+      this.helia = null;
+    });
 
     this.connected = false;
   }
@@ -831,6 +818,40 @@ async function derivePublicKeyShort(privateKeyHex: string): Promise<string> {
     'ORBITDB_CONNECTION_FAILED',
     'Cannot derive public key: @noble/curves and @noble/hashes are required',
   );
+}
+
+/**
+ * Per-step budget for graceful teardown of OrbitDB / Helia layers (#137).
+ * On timeout we DROP the reference instead of awaiting forever — `destroy()`
+ * is a terminal call and the process or test runner will reclaim the rest.
+ */
+const TEARDOWN_STEP_TIMEOUT_MS = 10_000;
+
+async function closeWithBudget(
+  label: string,
+  invoke: () => Promise<void> | undefined,
+  onSettle: () => void,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const op = invoke();
+    if (!op) return; // ref was null
+    const timeout = new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(() => resolve('timeout'), TEARDOWN_STEP_TIMEOUT_MS);
+    });
+    const outcome = await Promise.race([op.then(() => 'ok' as const), timeout]);
+    if (outcome === 'timeout') {
+      logger.warn(
+        'OrbitDB',
+        `${label} exceeded ${TEARDOWN_STEP_TIMEOUT_MS}ms — dropping reference and continuing`,
+      );
+    }
+  } catch {
+    // Best-effort close; swallow underlying errors.
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    onSettle();
+  }
 }
 
 /**

--- a/tests/unit/profile/orbitdb-adapter.test.ts
+++ b/tests/unit/profile/orbitdb-adapter.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ProfileDatabase, OrbitDbConfig } from '../../../profile/types';
+import { OrbitDbAdapter } from '../../../profile/orbitdb-adapter';
 
 // ---------------------------------------------------------------------------
 // Mock ProfileDatabase (in-memory Map-based implementation)
@@ -196,5 +197,103 @@ describe('ProfileDatabase mock (interface contract)', () => {
 
   it('isConnected returns false before connect', () => {
     expect(db.isConnected()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// close() teardown budget (#137)
+//
+// libp2p / gossipsub teardown can hang indefinitely under load (and during
+// e2e cleanup the hang propagated up through Sphere.destroy()). Each step
+// of OrbitDbAdapter.close() now has a 10s budget — on timeout we drop the
+// reference and continue rather than awaiting forever.
+// ---------------------------------------------------------------------------
+
+describe('OrbitDbAdapter.close() teardown budget', () => {
+  const STEP_BUDGET_MS = 10_000;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function newConnectedAdapter(): {
+    adapter: OrbitDbAdapter;
+    handles: { db: { close: ReturnType<typeof vi.fn> }; orbitdb: { stop: ReturnType<typeof vi.fn> }; helia: { stop: ReturnType<typeof vi.fn> } };
+  } {
+    const adapter = new OrbitDbAdapter();
+    const handles = {
+      db: { close: vi.fn(() => new Promise<void>(() => { /* never resolves */ })) },
+      orbitdb: { stop: vi.fn().mockResolvedValue(undefined) },
+      helia: { stop: vi.fn().mockResolvedValue(undefined) },
+    };
+    const internal = adapter as unknown as {
+      connected: boolean;
+      db: unknown;
+      orbitdb: unknown;
+      helia: unknown;
+    };
+    internal.connected = true;
+    internal.db = handles.db;
+    internal.orbitdb = handles.orbitdb;
+    internal.helia = handles.helia;
+    return { adapter, handles };
+  }
+
+  it('returns within budget when db.close() hangs', async () => {
+    const { adapter, handles } = newConnectedAdapter();
+
+    const closePromise = adapter.close();
+    // Advance fake clock past the 10s budget so the race resolves.
+    await vi.advanceTimersByTimeAsync(STEP_BUDGET_MS + 100);
+    await closePromise;
+
+    expect(handles.db.close).toHaveBeenCalled();
+    // Subsequent steps still run after the timeout fires.
+    expect(handles.orbitdb.stop).toHaveBeenCalled();
+    expect(handles.helia.stop).toHaveBeenCalled();
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('proceeds when orbitdb.stop() hangs', async () => {
+    const { adapter, handles } = newConnectedAdapter();
+    handles.db.close.mockResolvedValue(undefined as never);
+    handles.orbitdb.stop.mockImplementation(() => new Promise<void>(() => { /* hang */ }));
+
+    const closePromise = adapter.close();
+    await vi.advanceTimersByTimeAsync(STEP_BUDGET_MS + 100);
+    await closePromise;
+
+    expect(handles.helia.stop).toHaveBeenCalled();
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('proceeds when helia.stop() hangs', async () => {
+    const { adapter, handles } = newConnectedAdapter();
+    handles.db.close.mockResolvedValue(undefined as never);
+    handles.orbitdb.stop.mockResolvedValue(undefined as never);
+    handles.helia.stop.mockImplementation(() => new Promise<void>(() => { /* hang */ }));
+
+    const closePromise = adapter.close();
+    await vi.advanceTimersByTimeAsync(STEP_BUDGET_MS + 100);
+    await closePromise;
+
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('fast-path: all steps resolve immediately', async () => {
+    const { adapter, handles } = newConnectedAdapter();
+    handles.db.close.mockResolvedValue(undefined as never);
+
+    await adapter.close();
+
+    expect(handles.db.close).toHaveBeenCalled();
+    expect(handles.orbitdb.stop).toHaveBeenCalled();
+    expect(handles.helia.stop).toHaveBeenCalled();
+    expect(adapter.isConnected()).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

`profile-token-persistence.test.ts` tests 2 and 3 hung for the full
testTimeout (240s and 180s) and never asserted. The last log was:

```
[Test 2] Destroying wallet A and wiping local storage...
```

— the next `console.log` in the test source never appeared, locating
the hang inside `await sphereA.destroy()`.

Following the call stack: `Sphere.destroy()` → `this._storage.disconnect()`
→ `ProfileStorageProvider.doDisconnect()` → `OrbitDbAdapter.close()`.

Inside `closeInner()`, three teardown awaits had no bound:

```ts
await this.db.close();
await this.orbitdb.stop();
await this.helia.stop();
```

Each of these eventually awaits libp2p / gossipsub graceful shutdown,
which is known to hang indefinitely under load in the OrbitDB v3 / Helia
stack. Whichever one stalled pinned `destroy()` for minutes.

## Fix

Wrap each step in a small `closeWithBudget(label, invoke, onSettle)`
helper with a per-step **10s budget**. On timeout we log, drop the
reference, and proceed — `destroy()` is terminal, so any leaked
Helia/libp2p state is reclaimed at process / test-runner exit.

The fast path (everything resolves immediately) is identical to before.
The slow path now caps total teardown at ~30s worst-case instead of
unbounded.

```ts
await closeWithBudget('db.close', () => this.db?.close(), () => { this.db = null; });
await closeWithBudget('orbitdb.stop', () => this.orbitdb?.stop(), () => { this.orbitdb = null; });
await closeWithBudget('helia.stop', () => this.helia?.stop(), () => { this.helia = null; });
```

The timeout label appears in the warning log, so the next incident pinpoints
the offending step — no separate instrumentation pass needed.

## Why a defensive fix (not a root-cause fix)

The underlying libp2p teardown hang is a well-known class of issue in the
OrbitDB v3 / Helia stack and is not worth chasing inside our SDK. We don't
own those layers; their graceful-shutdown semantics evolve upstream. The
budget is the pragmatic boundary at our integration point.

## Test plan

- [x] 4 new unit tests in `tests/unit/profile/orbitdb-adapter.test.ts`:
  - `returns within budget when db.close() hangs`
  - `proceeds when orbitdb.stop() hangs`
  - `proceeds when helia.stop() hangs`
  - `fast-path: all steps resolve immediately`
- [x] `npx vitest run tests/unit/profile/` — 1313 tests pass (71 files).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` — no new warnings (pre-existing `any` warnings unchanged).
- [ ] `RUN_UXF_E2E=1 npm run test:e2e tests/e2e/profile-token-persistence.test.ts` — needs testnet env to verify the e2e no longer hangs.

Closes #137.