### PR TITLE
Expose verifySphereAuth + computeDirectAddressFromChainPubkey for misuse-resistant backend auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,64 @@ sphere.setPriceProvider(createPriceProvider({
 }));
 ```
 
+## Building a Sphere-authenticated backend
+
+If your service needs to authenticate users via their Sphere wallet, use `verifySphereAuth`. It performs signature verification and identity derivation in one misuse-resistant call.
+
+```typescript
+import { randomBytes } from 'crypto';
+import { verifySphereAuth, AuthVerificationError } from '@unicitylabs/sphere-sdk';
+
+const challenges = new Map<string, { challenge: string; expiresAt: number }>();
+
+// POST /auth/challenge — issue a one-shot nonce challenge
+server.post('/auth/challenge', async (req) => {
+  const { chainPubkey } = req.body;
+  const nonce = randomBytes(16).toString('hex');
+  const challenge = `Sign in to MyApp\nPubkey: ${chainPubkey}\nNonce: ${nonce}\nIssued At: ${new Date().toISOString()}`;
+  challenges.set(chainPubkey, { challenge, expiresAt: Date.now() + 5 * 60_000 });
+  return { challenge };
+});
+
+// POST /auth/verify — turn a signed challenge into a session
+server.post('/auth/verify', async (req, reply) => {
+  const { chainPubkey, signature } = req.body;
+  const stored = challenges.get(chainPubkey);
+  if (!stored || Date.now() > stored.expiresAt) {
+    return reply.status(401).send({ error: 'No valid challenge — request a new one' });
+  }
+  challenges.delete(chainPubkey); // one-shot
+
+  try {
+    const { chainPubkey: pk, directAddress } = await verifySphereAuth({
+      challenge: stored.challenge,
+      signature,
+      chainPubkey,
+    });
+    // pk and directAddress are now safe to use as user identifiers —
+    // neither is a client claim, both are derived from cryptographic proof.
+    const token = server.jwt.sign({ sub: pk, addr: directAddress }, { expiresIn: '24h' });
+    return { token };
+  } catch (err) {
+    if (err instanceof AuthVerificationError) {
+      return reply.status(401).send({ error: err.message, code: err.code });
+    }
+    throw err;
+  }
+});
+```
+
+### Why not accept `directAddress` from the client?
+
+`verifySphereAuth` deliberately does not take a `directAddress` parameter. The signature proves that the client owns the privkey to the pubkey they presented — but it does NOT prove that the pubkey corresponds to any particular `directAddress`. If you accept `directAddress` as a separate body field and use it as the user-identifier key, an attacker can pre-bind any unregistered address to their own pubkey — locking the rightful owner out forever. `verifySphereAuth` derives `directAddress` from `chainPubkey` server-side instead, eliminating the bug class.
+
+If you need just the address derivation in a custom flow, use the primitive directly:
+
+```typescript
+import { computeDirectAddressFromChainPubkey } from '@unicitylabs/sphere-sdk';
+const addr = await computeDirectAddressFromChainPubkey(chainPubkey);
+```
+
 ## Testnet Faucet
 
 To get test tokens on testnet, you **must first register a nametag**:

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -403,47 +403,11 @@ export interface SphereInitResult {
 // L3 Predicate Address Derivation
 // =============================================================================
 
-/** Token type for Unicity network (used for L3 predicate address derivation) */
-const UNICITY_TOKEN_TYPE_HEX = 'f8aa13834268d29355ff12183066f0cb902003629bbc5eb9ef0efbe397867509';
-
-/** Compressed secp256k1 pubkey shape: 33 bytes hex (66 chars), leading 02 or 03. */
-const COMPRESSED_PUBKEY_RE = /^(02|03)[0-9a-fA-F]{64}$/;
-
-/**
- * Compute the Unicity L3 DIRECT:// address that corresponds to a given
- * compressed secp256k1 public key.
- *
- * Deterministic — the underlying primitive `UnmaskedPredicateReference.create`
- * only uses the public key, so the private key is never needed. This lets
- * a backend trust only one thing from the client (the chain pubkey, whose
- * ownership the client proves via signature) and derive everything else
- * locally. Closes the entire class of "client claims an identifier the
- * server can't verify" bugs at the API level.
- *
- * @param chainPubkey 33-byte compressed secp256k1 pubkey, hex-encoded
- *                    (66 chars, leading 02 or 03).
- * @throws if chainPubkey doesn't match the compressed-secp256k1 format.
- */
-export async function computeDirectAddressFromChainPubkey(chainPubkey: string): Promise<string> {
-  if (typeof chainPubkey !== 'string' || !COMPRESSED_PUBKEY_RE.test(chainPubkey)) {
-    throw new Error(
-      `computeDirectAddressFromChainPubkey: chainPubkey must be 66-char hex with 02/03 prefix, got "${String(chainPubkey).slice(0, 12)}..."`,
-    );
-  }
-
-  const tokenTypeBytes = Buffer.from(UNICITY_TOKEN_TYPE_HEX, 'hex');
-  const tokenType = new TokenType(tokenTypeBytes);
-  const publicKeyBytes = Buffer.from(chainPubkey, 'hex');
-
-  const predicateRef = await UnmaskedPredicateReference.create(
-    tokenType,
-    'secp256k1',
-    publicKeyBytes,
-    HashAlgorithm.SHA256,
-  );
-
-  return (await predicateRef.toAddress()).toString();
-}
+// Import and re-export the public primitive from its standalone module so
+// callers can reach it via `core/Sphere` without a separate import path, and
+// so `deriveL3PredicateAddress` (below) can call it locally.
+import { computeDirectAddressFromChainPubkey } from './address-derivation';
+export { computeDirectAddressFromChainPubkey } from './address-derivation';
 
 /**
  * Derive L3 predicate address (DIRECT://...) from private key.

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -406,25 +406,55 @@ export interface SphereInitResult {
 /** Token type for Unicity network (used for L3 predicate address derivation) */
 const UNICITY_TOKEN_TYPE_HEX = 'f8aa13834268d29355ff12183066f0cb902003629bbc5eb9ef0efbe397867509';
 
+/** Compressed secp256k1 pubkey shape: 33 bytes hex (66 chars), leading 02 or 03. */
+const COMPRESSED_PUBKEY_RE = /^(02|03)[0-9a-fA-F]{64}$/;
+
 /**
- * Derive L3 predicate address (DIRECT://...) from private key
- * Uses UnmaskedPredicateReference for stable wallet address
+ * Compute the Unicity L3 DIRECT:// address that corresponds to a given
+ * compressed secp256k1 public key.
+ *
+ * Deterministic — the underlying primitive `UnmaskedPredicateReference.create`
+ * only uses the public key, so the private key is never needed. This lets
+ * a backend trust only one thing from the client (the chain pubkey, whose
+ * ownership the client proves via signature) and derive everything else
+ * locally. Closes the entire class of "client claims an identifier the
+ * server can't verify" bugs at the API level.
+ *
+ * @param chainPubkey 33-byte compressed secp256k1 pubkey, hex-encoded
+ *                    (66 chars, leading 02 or 03).
+ * @throws if chainPubkey doesn't match the compressed-secp256k1 format.
+ */
+export async function computeDirectAddressFromChainPubkey(chainPubkey: string): Promise<string> {
+  if (typeof chainPubkey !== 'string' || !COMPRESSED_PUBKEY_RE.test(chainPubkey)) {
+    throw new Error(
+      `computeDirectAddressFromChainPubkey: chainPubkey must be 66-char hex with 02/03 prefix, got "${String(chainPubkey).slice(0, 12)}..."`,
+    );
+  }
+
+  const tokenTypeBytes = Buffer.from(UNICITY_TOKEN_TYPE_HEX, 'hex');
+  const tokenType = new TokenType(tokenTypeBytes);
+  const publicKeyBytes = Buffer.from(chainPubkey, 'hex');
+
+  const predicateRef = await UnmaskedPredicateReference.create(
+    tokenType,
+    'secp256k1',
+    publicKeyBytes,
+    HashAlgorithm.SHA256,
+  );
+
+  return (await predicateRef.toAddress()).toString();
+}
+
+/**
+ * Derive L3 predicate address (DIRECT://...) from private key.
+ * Thin wrapper over `computeDirectAddressFromChainPubkey` — the private key
+ * is only used to derive the public key. Kept for the wallet's internal use.
  */
 async function deriveL3PredicateAddress(privateKey: string): Promise<string> {
   const secret = Buffer.from(privateKey, 'hex');
   const signingService = await SigningService.createFromSecret(secret);
-
-  const tokenTypeBytes = Buffer.from(UNICITY_TOKEN_TYPE_HEX, 'hex');
-  const tokenType = new TokenType(tokenTypeBytes);
-
-  const predicateRef = UnmaskedPredicateReference.create(
-    tokenType,
-    signingService.algorithm,
-    signingService.publicKey,
-    HashAlgorithm.SHA256
-  );
-
-  return (await (await predicateRef).toAddress()).toString();
+  const pubkeyHex = Buffer.from(signingService.publicKey).toString('hex');
+  return computeDirectAddressFromChainPubkey(pubkeyHex);
 }
 
 // =============================================================================

--- a/core/address-derivation.ts
+++ b/core/address-derivation.ts
@@ -1,0 +1,51 @@
+/**
+ * L3 Predicate Address Derivation
+ *
+ * Standalone module so backends can import the derivation primitive without
+ * pulling in the full Sphere wallet (and its heavy module graph).
+ */
+import { TokenType } from '@unicitylabs/state-transition-sdk/lib/token/TokenType';
+import { HashAlgorithm } from '@unicitylabs/state-transition-sdk/lib/hash/HashAlgorithm';
+import { UnmaskedPredicateReference } from '@unicitylabs/state-transition-sdk/lib/predicate/embedded/UnmaskedPredicateReference';
+
+/** Token type for Unicity network (used for L3 predicate address derivation) */
+const UNICITY_TOKEN_TYPE_HEX = 'f8aa13834268d29355ff12183066f0cb902003629bbc5eb9ef0efbe397867509';
+
+/** Compressed secp256k1 pubkey shape: 33 bytes hex (66 chars), leading 02 or 03. */
+export const COMPRESSED_PUBKEY_RE = /^(02|03)[0-9a-fA-F]{64}$/;
+
+/**
+ * Compute the Unicity L3 DIRECT:// address that corresponds to a given
+ * compressed secp256k1 public key.
+ *
+ * Deterministic — the underlying primitive `UnmaskedPredicateReference.create`
+ * only uses the public key, so the private key is never needed. This lets
+ * a backend trust only one thing from the client (the chain pubkey, whose
+ * ownership the client proves via signature) and derive everything else
+ * locally. Closes the entire class of "client claims an identifier the
+ * server can't verify" bugs at the API level.
+ *
+ * @param chainPubkey 33-byte compressed secp256k1 pubkey, hex-encoded
+ *                    (66 chars, leading 02 or 03).
+ * @throws if chainPubkey doesn't match the compressed-secp256k1 format.
+ */
+export async function computeDirectAddressFromChainPubkey(chainPubkey: string): Promise<string> {
+  if (typeof chainPubkey !== 'string' || !COMPRESSED_PUBKEY_RE.test(chainPubkey)) {
+    throw new Error(
+      `computeDirectAddressFromChainPubkey: chainPubkey must be 66-char hex with 02/03 prefix, got "${String(chainPubkey).slice(0, 12)}..."`,
+    );
+  }
+
+  const tokenTypeBytes = Buffer.from(UNICITY_TOKEN_TYPE_HEX, 'hex');
+  const tokenType = new TokenType(tokenTypeBytes);
+  const publicKeyBytes = Buffer.from(chainPubkey, 'hex');
+
+  const predicateRef = await UnmaskedPredicateReference.create(
+    tokenType,
+    'secp256k1',
+    publicKeyBytes,
+    HashAlgorithm.SHA256,
+  );
+
+  return (await predicateRef.toAddress()).toString();
+}

--- a/core/auth.ts
+++ b/core/auth.ts
@@ -16,7 +16,7 @@
  *   // Safe to use either as the user identifier.
  */
 import { verifySignedMessage } from './crypto';
-import { computeDirectAddressFromChainPubkey } from './Sphere';
+import { computeDirectAddressFromChainPubkey } from './address-derivation';
 
 export type AuthVerificationErrorCode = 'SIGNATURE_INVALID' | 'PUBKEY_MALFORMED';
 

--- a/core/auth.ts
+++ b/core/auth.ts
@@ -1,0 +1,71 @@
+/**
+ * Backend wallet-auth recipe — verify a signed challenge and return the
+ * trusted identity. Single misuse-resistant call: combines signature
+ * verification and address derivation, returns only proven values, refuses
+ * any client-supplied identity claims (there is no `directAddress` parameter
+ * on this function, by design).
+ *
+ * Typical usage in a Fastify/Express endpoint:
+ *
+ *   const { chainPubkey, directAddress } = await verifySphereAuth({
+ *     challenge,    // the text we issued from POST /auth/challenge
+ *     signature,    // what the wallet sent back from sign_message
+ *     chainPubkey,  // the pubkey the client claimed
+ *   });
+ *   // chainPubkey is signature-proven; directAddress is math-derived.
+ *   // Safe to use either as the user identifier.
+ */
+import { verifySignedMessage } from './crypto';
+import { computeDirectAddressFromChainPubkey } from './Sphere';
+
+export type AuthVerificationErrorCode = 'SIGNATURE_INVALID' | 'PUBKEY_MALFORMED';
+
+export class AuthVerificationError extends Error {
+  readonly code: AuthVerificationErrorCode;
+  constructor(message: string, code: AuthVerificationErrorCode) {
+    super(message);
+    this.name = 'AuthVerificationError';
+    this.code = code;
+  }
+}
+
+export interface SphereAuthInput {
+  /** The exact text that was presented to the wallet for signing. */
+  readonly challenge: string;
+  /** Hex signature returned by the wallet's sign_message intent. */
+  readonly signature: string;
+  /** Compressed secp256k1 pubkey (66-char hex) the client claims to own. */
+  readonly chainPubkey: string;
+}
+
+export interface SphereAuthResult {
+  /** Pubkey, proven via signature. */
+  readonly chainPubkey: string;
+  /** Unicity L3 DIRECT:// address, derived from chainPubkey (never claimed). */
+  readonly directAddress: string;
+}
+
+export async function verifySphereAuth(input: SphereAuthInput): Promise<SphereAuthResult> {
+  const { challenge, signature, chainPubkey } = input;
+
+  // 1. Derive the address first — this also serves as pubkey format validation.
+  let directAddress: string;
+  try {
+    directAddress = await computeDirectAddressFromChainPubkey(chainPubkey);
+  } catch (err) {
+    throw new AuthVerificationError(
+      `chainPubkey is malformed: ${(err as Error).message}`,
+      'PUBKEY_MALFORMED',
+    );
+  }
+
+  // 2. Verify the signature against the (now-known-valid-format) pubkey.
+  if (!verifySignedMessage(challenge, signature, chainPubkey)) {
+    throw new AuthVerificationError(
+      'Signature does not verify against chainPubkey',
+      'SIGNATURE_INVALID',
+    );
+  }
+
+  return { chainPubkey, directAddress };
+}

--- a/index.ts
+++ b/index.ts
@@ -491,7 +491,7 @@ export type {
 
 // Address parsing
 export { parseAddress, isValidAddress, isValidDirectAddress, normalizeAddress, addressesMatch } from './core/address';
-export { computeDirectAddressFromChainPubkey } from './core/Sphere';
+export { computeDirectAddressFromChainPubkey } from './core/address-derivation';
 export { verifySphereAuth, AuthVerificationError } from './core/auth';
 export type { SphereAuthInput, SphereAuthResult, AuthVerificationErrorCode } from './core/auth';
 export type { AddressType, ParsedAddress } from './core/address';

--- a/index.ts
+++ b/index.ts
@@ -491,6 +491,9 @@ export type {
 
 // Address parsing
 export { parseAddress, isValidAddress, isValidDirectAddress, normalizeAddress, addressesMatch } from './core/address';
+export { computeDirectAddressFromChainPubkey } from './core/Sphere';
+export { verifySphereAuth, AuthVerificationError } from './core/auth';
+export type { SphereAuthInput, SphereAuthResult, AuthVerificationErrorCode } from './core/auth';
 export type { AddressType, ParsedAddress } from './core/address';
 
 // =============================================================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicitylabs/sphere-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Modular TypeScript SDK for Unicity wallet operations",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/tests/unit/core/auth.test.ts
+++ b/tests/unit/core/auth.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { computeDirectAddressFromChainPubkey } from '../../../core/address-derivation';
+import { verifySphereAuth, AuthVerificationError } from '../../../core/auth';
+import { signMessage, getPublicKey } from '../../../core/crypto';
+
+const PRIVKEY_HEX = '0000000000000000000000000000000000000000000000000000000000000001';
+const OTHER_PRIVKEY_HEX = '0000000000000000000000000000000000000000000000000000000000000002';
+
+function pubkeyForPrivkey(privkeyHex: string): string {
+  return getPublicKey(privkeyHex);
+}
+
+describe('computeDirectAddressFromChainPubkey', () => {
+  it('produces a DIRECT:// formatted string', async () => {
+    const pubkey = pubkeyForPrivkey(PRIVKEY_HEX);
+    const addr = await computeDirectAddressFromChainPubkey(pubkey);
+    expect(addr).toMatch(/^DIRECT:\/\/[0-9a-f]+$/);
+  });
+
+  it('is deterministic', async () => {
+    const pubkey = pubkeyForPrivkey(PRIVKEY_HEX);
+    const a = await computeDirectAddressFromChainPubkey(pubkey);
+    const b = await computeDirectAddressFromChainPubkey(pubkey);
+    expect(a).toBe(b);
+  });
+
+  it('different pubkeys produce different addresses', async () => {
+    const pkA = pubkeyForPrivkey(PRIVKEY_HEX);
+    const pkB = pubkeyForPrivkey(OTHER_PRIVKEY_HEX);
+    expect(await computeDirectAddressFromChainPubkey(pkA))
+      .not.toBe(await computeDirectAddressFromChainPubkey(pkB));
+  });
+
+  it('rejects wrong length', async () => {
+    await expect(computeDirectAddressFromChainPubkey('02ab')).rejects.toThrow(/66|length|hex/i);
+  });
+
+  it('rejects non-hex characters', async () => {
+    await expect(computeDirectAddressFromChainPubkey('02' + 'zz'.repeat(32))).rejects.toThrow(/hex/i);
+  });
+
+  it('rejects bad prefix', async () => {
+    await expect(computeDirectAddressFromChainPubkey('04' + 'ab'.repeat(32))).rejects.toThrow(/02|03|prefix/i);
+  });
+});
+
+describe('verifySphereAuth', () => {
+  const challenge = 'Sign in to Test\nNonce: abc123';
+
+  it('returns trusted pair for a valid signature', async () => {
+    const pubkey = pubkeyForPrivkey(PRIVKEY_HEX);
+    const signature = signMessage(PRIVKEY_HEX, challenge);
+
+    const result = await verifySphereAuth({ challenge, signature, chainPubkey: pubkey });
+
+    expect(result.chainPubkey).toBe(pubkey);
+    expect(result.directAddress).toMatch(/^DIRECT:\/\/[0-9a-f]+$/);
+    expect(result.directAddress).toBe(await computeDirectAddressFromChainPubkey(pubkey));
+  });
+
+  it('throws SIGNATURE_INVALID when signature is for a different challenge', async () => {
+    const pubkey = pubkeyForPrivkey(PRIVKEY_HEX);
+    const signature = signMessage(PRIVKEY_HEX, 'a different challenge');
+
+    await expect(verifySphereAuth({ challenge, signature, chainPubkey: pubkey }))
+      .rejects.toMatchObject({ name: 'AuthVerificationError', code: 'SIGNATURE_INVALID' });
+  });
+
+  it('throws SIGNATURE_INVALID when signature is from a different privkey', async () => {
+    const claimedPubkey = pubkeyForPrivkey(PRIVKEY_HEX);
+    const signature = signMessage(OTHER_PRIVKEY_HEX, challenge);
+
+    await expect(verifySphereAuth({ challenge, signature, chainPubkey: claimedPubkey }))
+      .rejects.toMatchObject({ name: 'AuthVerificationError', code: 'SIGNATURE_INVALID' });
+  });
+
+  it('throws PUBKEY_MALFORMED when chainPubkey is invalid', async () => {
+    await expect(verifySphereAuth({ challenge, signature: 'abcd', chainPubkey: 'nope' }))
+      .rejects.toMatchObject({ name: 'AuthVerificationError', code: 'PUBKEY_MALFORMED' });
+  });
+
+  it('AuthVerificationError instances are instanceof Error', async () => {
+    try {
+      await verifySphereAuth({ challenge, signature: 'abcd', chainPubkey: 'nope' });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(AuthVerificationError);
+      expect(e).toBeInstanceOf(Error);
+    }
+  });
+});


### PR DESCRIPTION
Closes #134.

## What this PR adds

Two new public exports for backends that authenticate users via Sphere wallet signature:

```typescript
import { computeDirectAddressFromChainPubkey, verifySphereAuth, AuthVerificationError } from '@unicitylabs/sphere-sdk';
```

- **`computeDirectAddressFromChainPubkey(chainPubkey)`** — primitive. Deterministic derivation, no network round-trip. For callers that need custom flows.
- **`verifySphereAuth({challenge, signature, chainPubkey})`** — recipe. Misuse-resistant. Combines signature verification and address derivation in one call. Notably **has no `directAddress` parameter** — the bug class where a server trusts a client-claimed identifier becomes structurally impossible.

## What this PR refactors

The existing private `deriveL3PredicateAddress(privKey)` in `core/Sphere.ts` now delegates to the new primitive in `core/address-derivation.ts`. The underlying derivation was already deterministic from the public key — the private key was only ever used to construct the SigningService, never for the address derivation itself. DRY refactor, behavior-preserving — existing 2422+ unit tests still pass.

The new primitive lives in `core/address-derivation.ts` (standalone, no heavy module imports) rather than inline in `core/Sphere.ts` to avoid the SwapModule → `canonicalize` import chain in test environments.

## Why

[unicity-sphere/sphere-api#17](https://github.com/unicity-sphere/sphere-api/issues/17) shipped a pre-bind hijack because the Quest API trusted a client-supplied `directAddress`. The SDK's own [SWAP-PROTOCOL-V2.md:790](https://github.com/unicity-sphere/sphere-sdk/blob/main/docs/SWAP-PROTOCOL-V2.md#L790) already says: *"The escrow should import or reimplement `computeDirectAddress(chainPubkey) -> string`."* — that is, the authors knew callers needed this but no public API existed. This PR closes the gap.

## Test plan

- [x] `tests/unit/core/auth.test.ts` — 11 new tests covering both helpers (determinism, malformed input rejection, signature validation, error types).
- [x] Full unit suite passes (2422+ existing tests, the refactor is behavior-preserving).
- [x] Build (`npm run build`) succeeds.
- [ ] After merge: `npm publish` and the dependent PRs (sphere-api, marketplace, connect-example) can switch from `file:link` to `^0.7.1`.