### PR TITLE
fix(payments): #144 receiver finalize machinery survives process restart

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -108,6 +108,15 @@ export const STORAGE_KEYS_ADDRESS = {
   INV_LEDGER_INDEX: 'inv_ledger_index',
   /** Token scan state watermarks (JSON: Record<tokenId, txCount>) */
   TOKEN_SCAN_STATE: 'token_scan_state',
+  /**
+   * Persisted NOSTR-FIRST proof-polling jobs. Issue #144: the in-memory
+   * `proofPollingJobs` Map dies with the process; on CLI usage every
+   * `sphere <cmd>` is a fresh Node.js process, so V6-direct receives
+   * whose proof arrives later never finalize. We persist enough state
+   * (genesisTokenId, stateHash, requestIdHex, commitmentJson,
+   * sourceTokenJson) to re-fire `finalizeReceivedToken` on next load().
+   */
+  PROOF_POLLING_JOBS: 'proof_polling_jobs',
   // Swap storage keys
   /** Per-swap key: swap:{swapId} */
   SWAP_RECORD_PREFIX: 'swap:',

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1118,6 +1118,11 @@ export interface ProofPollingJob {
   startedAt: number;
   attemptCount: number;
   lastAttemptAt: number;
+  /** Cumulative attempts across all process lifetimes (steelman FIX G
+   *  #144). Sum of every `attemptCount` value the job ever held before
+   *  being persisted. Used to enforce a hard cap so a permanently-stuck
+   *  receive doesn't poll the aggregator forever. */
+  cumulativeAttempts?: number;
   /** Callback when proof is received */
   onProofReceived?: (tokenId: string) => void;
 }
@@ -1127,6 +1132,13 @@ export interface ProofPollingJob {
  * tokenId + state hash because the in-memory `Token.id` is a UUID at
  * receive time but becomes the genesis tokenId after save→load (see
  * `txfToToken` in `serialization/txf-serializer.ts`).
+ *
+ * `cumulativeAttempts` is preserved across restarts so a token that has
+ * already burned through several `MAX_ATTEMPTS` budgets in prior process
+ * lifetimes can be definitively marked invalid (steelman FIX G #144).
+ * Without this, every restart hands the same stuck token a fresh 60s
+ * budget — an unbounded zombie loop if the aggregator never produces the
+ * proof.
  */
 interface PersistedProofPollingJob {
   genesisTokenId: string;
@@ -1137,6 +1149,9 @@ interface PersistedProofPollingJob {
   startedAt: number;
   attemptCount: number;
   lastAttemptAt: number;
+  /** Cumulative attempts across all process lifetimes. Optional for
+   *  backward compat with older KV payloads (treated as 0). */
+  cumulativeAttempts?: number;
 }
 
 // =============================================================================
@@ -1269,6 +1284,12 @@ export class PaymentsModule {
   private proofPollingInterval: ReturnType<typeof setInterval> | null = null;
   private static readonly PROOF_POLLING_INTERVAL_MS = 2000;  // Poll every 2s
   private static readonly PROOF_POLLING_MAX_ATTEMPTS = 30;   // Max 30 attempts (~60s)
+  /** Steelman FIX G (#144): hard cap on cumulative attempts across
+   *  process lifetimes. Each restart re-resolves a `pending` token via
+   *  `recoverStrandedReceivedTokens`, which would otherwise allow
+   *  unbounded retries (60s × restarts). At 5× MAX_ATTEMPTS (~5min of
+   *  cumulative polling) we mark the token invalid and emit an alert. */
+  private static readonly PROOF_POLLING_MAX_CUMULATIVE_ATTEMPTS = 30 * 5;
 
   // Periodic retry for resolveUnconfirmed (V5 lazy finalization)
   private resolveUnconfirmedTimer: ReturnType<typeof setInterval> | null = null;
@@ -1285,6 +1306,18 @@ export class PaymentsModule {
 
   // Persistent dedup: tracks V6 combined transfer IDs that have been processed.
   private processedCombinedTransferIds: Set<string> = new Set();
+
+  /**
+   * Steelman FIX F (#144): cached PROXY addresses for our held nametags.
+   * Populated lazily by `primeProxyAddressCache()`, consumed
+   * synchronously by `isReceivedLegacyPending` to avoid the pre-FIX-F
+   * "any nametag + any proxyHash => candidate" loose match that opened
+   * a load-time DoS amplification surface (any peer could craft a
+   * PROXY://<garbage> TXF and force recovery polling). Stored as the
+   * full `PROXY://...` address string so we can do exact-equality match.
+   * Cleared on initialize() / destroy().
+   */
+  private proxyAddressCache: Set<string> = new Set();
 
   // Storage event subscriptions (push-based sync)
   private storageEventUnsubscribers: (() => void)[] = [];
@@ -1472,6 +1505,8 @@ export class PaymentsModule {
     this.forkedTokens.clear();
     this._historyCache = [];
     this.nametags = [];
+    // #144 FIX F: clear PROXY-address cache; re-primed in next load().
+    this.proxyAddressCache.clear();
 
     // Reset spend queue state
     this.reservationLedger.clear();
@@ -2614,6 +2649,18 @@ export class PaymentsModule {
       // Restore pending V5 tokens
       await this.loadPendingV5Tokens();
 
+      // Prime the PROXY-address cache so `isReceivedLegacyPending`'s
+      // exact-match (#144 FIX F) recognizes tokens addressed to our
+      // held nametags. Must run BEFORE `restoreProofPollingJobs` and
+      // `recoverStrandedReceivedTokens` because both rely on
+      // `isReceivedLegacyPending` / `hasFinalizationPlan` to decide
+      // which tokens are eligible.
+      try {
+        await this.primeProxyAddressCache();
+      } catch (err) {
+        logger.debug('Payments', '[PROXY-CACHE] primeProxyAddressCache failed:', err);
+      }
+
       // Restore proof-polling jobs (#144 L1). Must run AFTER the active
       // token map is populated so we can resolve persisted
       // (genesisTokenId, stateHash) pairs to in-memory `Token.id`s — and
@@ -3255,6 +3302,8 @@ export class PaymentsModule {
     // Stop proof polling (NOSTR-FIRST)
     this.stopProofPolling();
     this.proofPollingJobs.clear();
+    // #144 FIX F: clear PROXY-address cache (per-address state).
+    this.proxyAddressCache.clear();
 
     // Stop V5 resolve-unconfirmed retry polling
     this.stopResolveUnconfirmedPolling();
@@ -6408,22 +6457,49 @@ export class PaymentsModule {
     const directAddr = this.deps!.identity.directAddress;
     if (directAddr && recipientAddr === directAddr) return true;
 
-    // PROXY match: check if we hold the nametag whose PROXY address
-    // matches. This is best-effort — `getNametag()` returns the in-memory
-    // nametag for the current address. A token addressed via a different
-    // address's nametag won't be recognized here, which matches the
-    // existing finalize path's behavior.
+    // PROXY exact match — steelman FIX F (#144). Requires the
+    // `proxyAddressCache` to have been primed via
+    // `primeProxyAddressCache` (called from `load()`). Tokens addressed
+    // to a PROXY we don't hold are rejected, preventing recover-load
+    // amplification by malicious peers crafting PROXY://<garbage> TXFs.
     if (recipientAddr.startsWith('PROXY://')) {
-      const proxyHash = recipientAddr.slice('PROXY://'.length);
-      // Lazy check: deep PROXY validation requires async ProxyAddress
-      // import + nametag token id derivation. Cheaper synchronous proxy:
-      // if the wallet currently has any nametag, treat as candidate (the
-      // finalize step will reject if the actual proxy doesn't match).
-      const localNametag = this.getNametag();
-      if (localNametag?.token && proxyHash.length > 0) return true;
+      return this.proxyAddressCache.has(recipientAddr);
     }
 
     return false;
+  }
+
+  /**
+   * Steelman FIX F (#144): populate `proxyAddressCache` with the full
+   * PROXY:// address(es) for our held nametag(s). Called from `load()`
+   * after nametags are loaded but BEFORE `recoverStrandedReceivedTokens`
+   * runs, so the recovery scan sees an accurate cache.
+   *
+   * Best-effort: errors are logged and the relevant entry omitted. An
+   * empty cache means PROXY-mode receives can't be recovered, but the
+   * DIRECT-mode path (the common case) is unaffected.
+   */
+  private async primeProxyAddressCache(): Promise<void> {
+    this.proxyAddressCache.clear();
+    for (const nametagRecord of this.nametags) {
+      const tokenJson = nametagRecord?.token as unknown;
+      if (!tokenJson) continue;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const nametagToken = await SdkToken.fromJSON(tokenJson as any) as SdkToken<any>;
+        const { ProxyAddress } = await import(
+          '@unicitylabs/state-transition-sdk/lib/address/ProxyAddress'
+        );
+        const proxy = await ProxyAddress.fromTokenId(nametagToken.id);
+        this.proxyAddressCache.add(proxy.address);
+      } catch (err) {
+        logger.debug(
+          'Payments',
+          `[PROXY-CACHE] Failed to derive PROXY for nametag ${nametagRecord?.name ?? '?'}:`,
+          err,
+        );
+      }
+    }
   }
 
   /**
@@ -6720,6 +6796,17 @@ export class PaymentsModule {
       return 'stillPending';
     }
 
+    // Steelman FIX D (#144): recovery jobs (registered by
+    // `recoverStrandedReceivedTokens`) carry `commitmentJson: ''` — we
+    // can't reconstruct the sender's authenticator, so the polling queue
+    // uses the `getProof(requestIdHex)` fallback for them. Mirror that
+    // here. Pre-FIX-D, `JSON.parse('')` threw, the outer catch swallowed
+    // it, and this 10s defense-in-depth retry was a silent no-op for the
+    // exact migration scenario it was meant to cover.
+    if (!job.commitmentJson) {
+      return await this.resolveLegacyReceivedTokenViaGetProof(tokenId, job);
+    }
+
     try {
       const commitmentInput = JSON.parse(job.commitmentJson);
       const commitment = await TransferCommitment.fromJSON(commitmentInput);
@@ -6778,6 +6865,56 @@ export class PaymentsModule {
       logger.debug(
         'Payments',
         `[V6-RESOLVE] Error resolving legacy receive ${tokenId.slice(0, 12)}: ${(err as Error)?.message ?? err}`,
+      );
+      return 'stillPending';
+    }
+  }
+
+  /**
+   * #144 L3 + steelman FIX D — defense-in-depth retry for recovery jobs
+   * (registered by `recoverStrandedReceivedTokens`). Uses
+   * `getProof(requestIdHex)` since we don't have a `TransferCommitment`
+   * for reconstructed jobs. On success, hands off to
+   * `finalizeStrandedReceivedToken` which patches the inclusion proof
+   * into the source TXF and finalizes.
+   */
+  private async resolveLegacyReceivedTokenViaGetProof(
+    tokenId: string,
+    job: ProofPollingJob,
+  ): Promise<'resolved' | 'stillPending' | 'failed'> {
+    try {
+      const abortController = new AbortController();
+      const timeoutId = setTimeout(() => abortController.abort(), 500);
+      let proofResult: unknown = null;
+      try {
+        proofResult = await Promise.race([
+          this.deps!.oracle.getProof(job.requestIdHex),
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), 500)),
+        ]);
+      } catch {
+        clearTimeout(timeoutId);
+        return 'stillPending';
+      }
+      clearTimeout(timeoutId);
+      if (!proofResult) return 'stillPending';
+
+      // The recovery callback (`finalizeStrandedReceivedToken`) does the
+      // actual patch+finalize using `sourceTokenJson` + the cached
+      // lastTxJson it closed over at registration time. Don't reimplement
+      // that here — just invoke the callback.
+      if (!job.onProofReceived) return 'failed';
+      await job.onProofReceived(tokenId);
+
+      // Clean up; `finalizeStrandedReceivedToken` doesn't remove the job.
+      this.proofPollingJobs.delete(tokenId);
+      this.saveProofPollingJobs().catch((err) =>
+        logger.debug('Payments', '[V6-PERSIST] saveProofPollingJobs after recovery resolve failed:', err),
+      );
+      return 'resolved';
+    } catch (err) {
+      logger.debug(
+        'Payments',
+        `[V6-RESOLVE] Error resolving recovery job ${tokenId.slice(0, 12)}: ${(err as Error)?.message ?? err}`,
       );
       return 'stillPending';
     }
@@ -10038,14 +10175,35 @@ export class PaymentsModule {
 
       // History entry was already created in handleCommitmentOnlyTransfer() — no duplicate here
     } catch (error) {
+      // Steelman FIX H (#144): pre-FIX, this catch unconditionally
+      // flipped status to 'confirmed' on ANY finalize failure — "user
+      // has the token" — but that swallows real integrity failures
+      // (trustBase mismatch, predicate validation, invalid proof) and
+      // leaves a token-shaped placeholder in the active map that fails
+      // every subsequent verification while counting toward balance.
+      // The restart-recovery path (#144 L1 restoreProofPollingJobs)
+      // widens this catch's reach, making the bug user-visible.
+      //
+      // Fixed behavior: leave the token at its current status (typically
+      // 'submitted'/'pending' so the polling queue retries) and emit a
+      // typed operator-alert so the UI / support has a signal.
       logger.error('Payments', 'Failed to finalize received token:', error);
-      // Mark as confirmed anyway (user has the token)
-      const token = this.tokens.get(tokenId);
-      if (token && token.status === 'submitted') {
-        token.status = 'confirmed';
-        token.updatedAt = Date.now();
-        await this.save();
+      try {
+        this.deps!.emitEvent('transfer:operator-alert', {
+          // `proof-throw` matches §5.4's "proof verify threw" — closest
+          // canonical DispositionReason for a finalize-side failure that
+          // we can't cleanly attribute to one of the structural codes.
+          code: 'proof-throw',
+          tokenId,
+          message:
+            `finalizeReceivedToken threw for ${tokenId.slice(0, 12)}...: ` +
+            `${(error as Error)?.message ?? String(error)}. ` +
+            `Token left at current status for retry by the polling queue.`,
+        });
+      } catch {
+        // Event emitter not wired — log only.
       }
+      // Intentionally do NOT mutate token.status here.
     }
   }
 
@@ -10744,13 +10902,32 @@ export class PaymentsModule {
       ) {
         const txf = tokenToTxf(token);
         if (txf?.genesis?.data?.tokenId) {
-          this.archivedTokens.set(txf.genesis.data.tokenId, txf);
+          const archiveTokenId = txf.genesis.data.tokenId;
+          // Steelman FIX E (#144): the archive map can already contain a
+          // record for this tokenId — either from prior archiving (legit
+          // history) or from a FORK (different state of same tokenId).
+          // Pre-FIX-E we silently overwrote, destroying fork-detection
+          // evidence. Now: if archive already has it, skip — the prior
+          // record wins. The active-map removal still happens (we don't
+          // re-add the token to `this.tokens`). Fork resolution should
+          // happen via the explicit `archiveToken()`/`storeForkedToken`
+          // flow, not via load-time invariant enforcement.
+          if (this.archivedTokens.has(archiveTokenId)) {
+            logger.debug(
+              'Payments',
+              `[BALANCE-INVARIANT] Token ${token.id.slice(0, 12)} ` +
+                `already in archive — leaving existing record intact ` +
+                `(possible fork or prior archive). Dropping active copy.`,
+            );
+          } else {
+            this.archivedTokens.set(archiveTokenId, txf);
+            logger.debug(
+              'Payments',
+              `[BALANCE-INVARIANT] Moved token ${token.id.slice(0, 12)} to archive — ` +
+                `latest state predicate not ours, no finalization plan`,
+            );
+          }
           archiveMoved++;
-          logger.debug(
-            'Payments',
-            `[BALANCE-INVARIANT] Moved token ${token.id.slice(0, 12)} to archive — ` +
-              `latest state predicate not ours, no finalization plan`,
-          );
           continue;
         }
         // Couldn't convert to TXF — keep in active to avoid data loss.
@@ -10874,6 +11051,11 @@ export class PaymentsModule {
         startedAt: job.startedAt,
         attemptCount: job.attemptCount,
         lastAttemptAt: job.lastAttemptAt,
+        // Steelman FIX G (#144): persist cumulative attempts across
+        // process lifetimes. The session's current `attemptCount` is
+        // ADDED to the previously-persisted total at restore time, so
+        // we save the running total here (= prior + current).
+        cumulativeAttempts: (job.cumulativeAttempts ?? 0) + job.attemptCount,
       });
     }
 
@@ -10974,6 +11156,39 @@ export class PaymentsModule {
         continue;
       }
 
+      // Steelman FIX G (#144): cumulative-attempts cap. If this token
+      // has already burned through MAX_CUMULATIVE_ATTEMPTS across
+      // prior process lifetimes, mark it invalid and skip restoration.
+      // Without this cap, every restart hands the same stuck token a
+      // fresh 60s budget — an unbounded zombie loop.
+      const cumulativeSoFar = p.cumulativeAttempts ?? 0;
+      if (cumulativeSoFar >= PaymentsModule.PROOF_POLLING_MAX_CUMULATIVE_ATTEMPTS) {
+        logger.debug(
+          'Payments',
+          `[V6-RESTORE] Token ${memoryTokenId.slice(0, 12)} ` +
+            `exceeded cumulative attempt cap (${cumulativeSoFar} >= ` +
+            `${PaymentsModule.PROOF_POLLING_MAX_CUMULATIVE_ATTEMPTS}) — marking invalid`,
+        );
+        if (existingToken && (existingToken.status === 'submitted' || existingToken.status === 'pending')) {
+          existingToken.status = 'invalid';
+          existingToken.updatedAt = Date.now();
+          this.tokens.set(memoryTokenId, existingToken);
+        }
+        try {
+          this.deps!.emitEvent('transfer:operator-alert', {
+            // Same canonical reason as per-process timeout — the
+            // proof never anchored after multiple polling windows.
+            code: 'oracle-rejected',
+            tokenId: memoryTokenId,
+            message:
+              `Token ${memoryTokenId.slice(0, 12)}... exceeded cumulative ` +
+              `proof-polling attempts (${cumulativeSoFar}). Marked invalid; ` +
+              `no further automatic recovery attempts will run for this token.`,
+          });
+        } catch { /* event emitter not wired */ }
+        continue;
+      }
+
       let sourceTokenInput: unknown;
       let commitmentInput: unknown;
       try {
@@ -10994,8 +11209,9 @@ export class PaymentsModule {
         commitmentJson: p.commitmentJson,
         sourceTokenJson: p.sourceTokenJson,
         startedAt: p.startedAt,
-        attemptCount: 0, // reset; prior process's attempts don't count
+        attemptCount: 0, // reset for the current session
         lastAttemptAt: 0,
+        cumulativeAttempts: cumulativeSoFar, // preserve cross-session total
         onProofReceived: async (tid) => {
           await this.finalizeReceivedToken(tid, sourceTokenInput, commitmentInput);
         },
@@ -11056,12 +11272,37 @@ export class PaymentsModule {
         // Check for timeout
         if (job.attemptCount >= PaymentsModule.PROOF_POLLING_MAX_ATTEMPTS) {
           logger.debug('Payments', `Proof polling timeout for token ${tokenId.slice(0, 8)}...`);
-          // Mark token as invalid due to timeout
+          // Mark token as invalid due to timeout.
+          // Steelman FIX C (#144): widen to include 'pending' — RECEIVE
+          // jobs target status='pending' tokens, and pre-fix the timeout
+          // never marked them invalid, leaving them at 'pending' forever
+          // and re-triggering `recoverStrandedReceivedTokens` on every
+          // load (zombie loop).
           const token = this.tokens.get(tokenId);
-          if (token && token.status === 'submitted') {
+          if (token && (token.status === 'submitted' || token.status === 'pending')) {
             token.status = 'invalid';
             token.updatedAt = Date.now();
             this.tokens.set(tokenId, token);
+            // Surface to operator/UI: the token's proof never arrived.
+            // Without this, the only signal is a debug-level log line.
+            try {
+              this.deps!.emitEvent('transfer:operator-alert', {
+                // `oracle-rejected` per §6.1: "sustained PATH_NOT_INCLUDED
+                // past the polling window — the commitment was never
+                // anchored". Closest canonical reason for proof-polling
+                // timeout exhaustion.
+                code: 'oracle-rejected',
+                tokenId,
+                message:
+                  `Proof polling for token ${tokenId.slice(0, 12)}... ` +
+                  `exhausted ${PaymentsModule.PROOF_POLLING_MAX_ATTEMPTS} attempts ` +
+                  `(~${(PaymentsModule.PROOF_POLLING_MAX_ATTEMPTS * PaymentsModule.PROOF_POLLING_INTERVAL_MS) / 1000}s). ` +
+                  `Marked invalid; the aggregator never returned an inclusion proof. ` +
+                  `Manual retry via sphere.payments.sync() may help if the proof becomes available later.`,
+              });
+            } catch {
+              // Event emitter not wired or threw — log only.
+            }
           }
           completedJobs.push(tokenId);
           continue;
@@ -11104,9 +11345,23 @@ export class PaymentsModule {
           continue;
         }
 
-        // Proof received! Update token status
+        // Proof received! Steelman FIX B (#144): distinguish SEND vs
+        // RECEIVE jobs.
+        //   - SEND jobs (no `sourceTokenJson`): the sender's outbound
+        //     commitment was confirmed → flip token to 'spent' here.
+        //   - RECEIVE jobs (`sourceTokenJson` set — V6-direct or L3
+        //     migration): leave status='pending' and let
+        //     `onProofReceived` (`finalizeReceivedToken` /
+        //     `finalizeStrandedReceivedToken`) be the SOLE status
+        //     writer. If `onProofReceived` throws, the token stays
+        //     'pending' so the next tick (or next process's
+        //     recoverStrandedReceivedTokens) can retry. Without this
+        //     guard, a finalize throw would permanently freeze the token
+        //     at 'spent' — un-recoverable, because
+        //     `recoverStrandedReceivedTokens` requires status='pending'.
         const token = this.tokens.get(tokenId);
-        if (token) {
+        const isReceiveJob = !!job.sourceTokenJson;
+        if (token && !isReceiveJob) {
           token.status = 'spent';
           token.updatedAt = Date.now();
           this.tokens.set(tokenId, token);
@@ -11114,9 +11369,25 @@ export class PaymentsModule {
           logger.debug('Payments', `Proof received for token ${tokenId.slice(0, 8)}..., status: spent`);
         }
 
-        // Call callback if provided
-        job.onProofReceived?.(tokenId);
-        completedJobs.push(tokenId);
+        // Await the finalize callback so a throw is observable; on
+        // success the queue removes the job, on failure the job stays
+        // for retry. (Pre-FIX-B: callback was fire-and-forget AND the
+        // job was unconditionally removed via completedJobs.push — both
+        // bugs, both fixed here.)
+        let callbackOk = true;
+        try {
+          await job.onProofReceived?.(tokenId);
+        } catch (cbErr) {
+          callbackOk = false;
+          logger.error(
+            'Payments',
+            `onProofReceived for ${tokenId.slice(0, 8)}... threw — keeping job for retry:`,
+            cbErr,
+          );
+        }
+        if (callbackOk) {
+          completedJobs.push(tokenId);
+        }
       } catch (error) {
         // Most errors mean proof is not ready yet, continue polling
         logger.debug('Payments', `Proof polling attempt ${job.attemptCount} for ${tokenId.slice(0, 8)}...: ${error}`);

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1106,11 +1106,37 @@ export interface ProofPollingJob {
   tokenId: string;
   requestIdHex: string;
   commitmentJson: string;
+  /**
+   * Source token TXF JSON (the `sourceTokenInput` passed to
+   * `finalizeReceivedToken`). Required for V6-direct receive jobs so they
+   * can survive process restarts (#144) — `finalizeReceivedToken` needs
+   * both the source token and the commitment to derive the recipient
+   * predicate and call `stClient.finalizeTransaction`. May be omitted for
+   * legacy callsites that don't participate in persistence.
+   */
+  sourceTokenJson?: string;
   startedAt: number;
   attemptCount: number;
   lastAttemptAt: number;
   /** Callback when proof is received */
   onProofReceived?: (tokenId: string) => void;
+}
+
+/**
+ * Persisted (KV-storage) shape of a proof-polling job. Keyed by genesis
+ * tokenId + state hash because the in-memory `Token.id` is a UUID at
+ * receive time but becomes the genesis tokenId after save→load (see
+ * `txfToToken` in `serialization/txf-serializer.ts`).
+ */
+interface PersistedProofPollingJob {
+  genesisTokenId: string;
+  stateHash: string;
+  requestIdHex: string;
+  commitmentJson: string;
+  sourceTokenJson: string;
+  startedAt: number;
+  attemptCount: number;
+  lastAttemptAt: number;
 }
 
 // =============================================================================
@@ -2587,6 +2613,34 @@ export class PaymentsModule {
 
       // Restore pending V5 tokens
       await this.loadPendingV5Tokens();
+
+      // Restore proof-polling jobs (#144 L1). Must run AFTER the active
+      // token map is populated so we can resolve persisted
+      // (genesisTokenId, stateHash) pairs to in-memory `Token.id`s — and
+      // BEFORE `resolveUnconfirmed` fires so newly-restored jobs are part
+      // of the same accounting.
+      try {
+        await this.restoreProofPollingJobs();
+      } catch (err) {
+        logger.error('Payments', '[V6-RESTORE] Failed to restore proof-polling jobs:', err);
+      }
+
+      // Recover stranded V6-direct receives (#144 L3 migration). Walks
+      // status='pending' tokens that look like received-but-not-finalized
+      // targets for us, and registers proof-polling jobs by deriving the
+      // requestIdHex from each token's last-tx data. Idempotent: skips
+      // tokens already covered by `restoreProofPollingJobs` above.
+      try {
+        const recovered = await this.recoverStrandedReceivedTokens();
+        if (recovered > 0) {
+          logger.debug(
+            'Payments',
+            `[V6-RECOVER] Registered ${recovered} recovery job(s) for stranded V6-direct receives`,
+          );
+        }
+      } catch (err) {
+        logger.error('Payments', '[V6-RECOVER] Failed to scan for stranded receives:', err);
+      }
 
       // Restore processed split group IDs for dedup across reloads
       await this.loadProcessedSplitGroupIds();
@@ -4396,6 +4450,10 @@ export class PaymentsModule {
         tokenId: token.id,
         requestIdHex,
         commitmentJson: JSON.stringify(commitmentInput),
+        // Persist the source token JSON so that on process restart we can
+        // restore the job (#144 layer 1). `sdkData` is the raw source TXF
+        // string — same value that was passed in as `sourceTokenInput`.
+        sourceTokenJson: sdkData,
         startedAt: Date.now(),
         attemptCount: 0,
         lastAttemptAt: 0,
@@ -5966,22 +6024,21 @@ export class PaymentsModule {
 
     const signingService = await this.createSigningService();
 
-    const submittedCount = Array.from(this.tokens.values()).filter(t => t.status === 'submitted').length;
-    logger.debug('Payments', `[V5-RESOLVE] resolveUnconfirmed: ${submittedCount} submitted token(s) to process`);
+    const submittedCount = Array.from(this.tokens.values()).filter(
+      t => t.status === 'submitted' || t.status === 'pending'
+    ).length;
+    logger.debug('Payments', `[V5-RESOLVE] resolveUnconfirmed: ${submittedCount} submitted/pending token(s) to process`);
 
     for (const [tokenId, token] of this.tokens) {
-      if (token.status !== 'submitted') continue;
+      // #144 L2: accept both 'submitted' (in-process V5/V6-direct) and
+      // 'pending' (V6-direct after save→load round-trip — txfToToken flips
+      // the status when the latest tx has `inclusionProof: null`).
+      if (token.status !== 'submitted' && token.status !== 'pending') continue;
 
-      // Check for pending finalization metadata
+      // Check for pending finalization metadata (V5 split bundles).
       const pending = this.parsePendingFinalization(token.sdkData);
-      if (!pending) {
-        // Legacy commitment-only token (existing proof polling handles these)
-        logger.debug('Payments', `[V5-RESOLVE] ${tokenId.slice(0, 16)}: no pending finalization metadata, skipping`);
-        result.stillPending++;
-        continue;
-      }
 
-      if (pending.type === 'v5_bundle') {
+      if (pending?.type === 'v5_bundle') {
         logger.debug('Payments', `[V5-RESOLVE] Processing ${tokenId.slice(0, 16)}... stage=${pending.stage} attempt=${pending.attemptCount}`);
         const progress = await this.resolveV5Token(tokenId, token, pending, stClient, trustBase, signingService);
         logger.debug('Payments', `[V5-RESOLVE] Result for ${tokenId.slice(0, 16)}...: ${progress} (stage now: ${pending.stage})`);
@@ -5989,7 +6046,31 @@ export class PaymentsModule {
         if (progress === 'resolved') result.resolved++;
         else if (progress === 'failed') result.failed++;
         else result.stillPending++;
+        continue;
       }
+
+      // #144 L2: V6-direct legacy entries (no `_pendingFinalization`).
+      // If a persisted proof-polling job is tracking this token, attempt
+      // finalization in our own cadence (defense-in-depth alongside the
+      // ~2s background queue). If no job is registered, the token is
+      // stranded — `recoverStrandedReceivedTokens` (L3 migration) handles
+      // it on first load() after upgrade.
+      if (this.isReceivedLegacyPending(token)) {
+        const progress = await this.resolveLegacyReceivedToken(tokenId, token);
+        const detailStatus: 'resolved' | 'pending' | 'failed' =
+          progress === 'resolved' ? 'resolved'
+          : progress === 'failed' ? 'failed'
+          : 'pending';
+        result.details.push({ tokenId, stage: 'v6_direct', status: detailStatus });
+        if (progress === 'resolved') result.resolved++;
+        else if (progress === 'failed') result.failed++;
+        else result.stillPending++;
+        continue;
+      }
+
+      // Some other shape we don't know about — count as still-pending.
+      logger.debug('Payments', `[V5-RESOLVE] ${tokenId.slice(0, 16)}: no pending finalization metadata, no recipient match — skipping`);
+      result.stillPending++;
     }
 
     // Always save when any token was processed — this persists intermediate
@@ -6011,12 +6092,15 @@ export class PaymentsModule {
     // Don't stack intervals
     if (this.resolveUnconfirmedTimer) return;
 
-    // Only start if there are actually submitted tokens to resolve
+    // Only start if there are unconfirmed tokens to resolve.
+    // #144: include 'pending' status too — V6-direct receives flip from
+    // 'submitted' to 'pending' after save→load and would never re-engage
+    // the periodic retry otherwise.
     const hasUnconfirmed = Array.from(this.tokens.values()).some(
-      (t) => t.status === 'submitted',
+      (t) => t.status === 'submitted' || t.status === 'pending',
     );
     if (!hasUnconfirmed) {
-      logger.debug('Payments', '[V5-RESOLVE] scheduleResolveUnconfirmed: no submitted tokens, not starting timer');
+      logger.debug('Payments', '[V5-RESOLVE] scheduleResolveUnconfirmed: no submitted/pending tokens, not starting timer');
       return;
     }
 
@@ -6287,6 +6371,416 @@ export class PaymentsModule {
 
     // Finalize
     return stClient.finalizeTransaction(trustBase, mintedToken, recipientState, transferTransaction, nametagTokens);
+  }
+
+  /**
+   * #144 L2/L3 — does this token look like a V6-direct received-but-
+   * not-finalized token? Conditions:
+   *   1. sdkData parses as TXF with transactions
+   *   2. last tx has `inclusionProof === null`
+   *   3. last tx's `data.recipient.address` resolves to our wallet
+   *      (DIRECT://<our> or PROXY://<our-nametag>)
+   *
+   * Used by `resolveUnconfirmed` and `recoverStrandedReceivedTokens` to
+   * distinguish stranded receives from sends and from other shapes.
+   */
+  private isReceivedLegacyPending(token: Token): boolean {
+    if (!token.sdkData) return false;
+    let parsed: { transactions?: unknown };
+    try {
+      parsed = JSON.parse(token.sdkData);
+    } catch {
+      return false;
+    }
+    if (!parsed || typeof parsed !== 'object') return false;
+    const txs = (parsed as { transactions?: unknown[] }).transactions;
+    if (!Array.isArray(txs) || txs.length === 0) return false;
+    const lastTx = txs[txs.length - 1] as {
+      inclusionProof?: unknown;
+      data?: { recipient?: { address?: string } };
+    };
+    if (lastTx.inclusionProof !== null) return false;
+    const recipientAddr = lastTx.data?.recipient?.address;
+    if (typeof recipientAddr !== 'string') return false;
+
+    // DIRECT match — `identity.directAddress` is normalized to
+    // `DIRECT://...`; tx recipient should match exactly.
+    const directAddr = this.deps!.identity.directAddress;
+    if (directAddr && recipientAddr === directAddr) return true;
+
+    // PROXY match: check if we hold the nametag whose PROXY address
+    // matches. This is best-effort — `getNametag()` returns the in-memory
+    // nametag for the current address. A token addressed via a different
+    // address's nametag won't be recognized here, which matches the
+    // existing finalize path's behavior.
+    if (recipientAddr.startsWith('PROXY://')) {
+      const proxyHash = recipientAddr.slice('PROXY://'.length);
+      // Lazy check: deep PROXY validation requires async ProxyAddress
+      // import + nametag token id derivation. Cheaper synchronous proxy:
+      // if the wallet currently has any nametag, treat as candidate (the
+      // finalize step will reject if the actual proxy doesn't match).
+      const localNametag = this.getNametag();
+      if (localNametag?.token && proxyHash.length > 0) return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * #144 L3 — does this token have an in-flight finalization plan?
+   * A "plan" is one of:
+   *   1. `_pendingFinalization` marker on sdkData (V5 split bundles)
+   *   2. A live proof-polling job in `this.proofPollingJobs`
+   *   3. The token "looks like a V6-direct received-but-not-finalized"
+   *      target for us (eligible for `recoverStrandedReceivedTokens`)
+   *
+   * Used by `loadFromStorageData`'s balance-model invariant check: tokens
+   * whose latest state isn't ours AND have no plan are moved to the
+   * archive map per the canonical model (see #144 spec §3 and #143's
+   * balance-model state-machine refinement).
+   */
+  private hasFinalizationPlan(token: Token): boolean {
+    if (this.parsePendingFinalization(token.sdkData)) return true;
+    if (this.proofPollingJobs.has(token.id)) return true;
+    if (this.isReceivedLegacyPending(token)) return true;
+    return false;
+  }
+
+  /**
+   * #144 L3 — does the token's latest STATE predicate resolve to this
+   * wallet? Distinct from "is the latest tx's recipient us": this asks
+   * whether the SDK considers us the current owner.
+   *
+   * Conservative implementation: if we can't determine ownership with
+   * confidence, return `true` (keep the token visible). Only return
+   * `false` for the unambiguous case where the latest state's encoded
+   * publicKey differs from our wallet's chainPubkey.
+   */
+  private latestStatePredicateMatchesWallet(token: Token): boolean {
+    if (!token.sdkData) return true;
+    let parsed: { state?: { predicate?: string | { publicKey?: string } } };
+    try {
+      parsed = JSON.parse(token.sdkData);
+    } catch {
+      return true;
+    }
+    const predicate = parsed?.state?.predicate;
+    if (!predicate) return true;
+
+    // Predicate encoding may be CBOR-hex (UnmaskedPredicate) or a JSON
+    // object. We can't reliably hash-compare without spinning up the SDK
+    // — instead, look for our chainPubkey as a substring within a hex-
+    // encoded predicate. False positives would only happen if our pubkey
+    // appears coincidentally in someone else's predicate; for production
+    // wallets this is acceptable for the load-time invariant.
+    const ourPubkey = this.deps!.identity.chainPubkey?.toLowerCase();
+    if (!ourPubkey) return true;
+
+    if (typeof predicate === 'string') {
+      return predicate.toLowerCase().includes(ourPubkey);
+    }
+    if (typeof predicate === 'object' && typeof predicate.publicKey === 'string') {
+      return predicate.publicKey.toLowerCase() === ourPubkey;
+    }
+    return true;
+  }
+
+  /**
+   * #144 L3 migration — recover stranded V6-direct received tokens that
+   * exist in the active map with `status === 'pending'` but have no
+   * persisted proof-polling job (e.g. wallets upgraded from a pre-#144
+   * SDK build). For each, derive `requestIdHex` from the source TXF's
+   * last transaction data and register a fresh proof-polling job.
+   *
+   * The reconstructed job uses an empty `commitmentJson` and is finalized
+   * via `finalizeStrandedReceivedToken` instead of the standard
+   * `finalizeReceivedToken` — the migration path patches the source TXF's
+   * last-tx inclusionProof in place rather than constructing a
+   * `TransferCommitment` (we don't have the sender's authenticator).
+   *
+   * Idempotent: tokens that already have a proof-polling job are skipped.
+   * Tokens that fail to derive requestIdHex (e.g. malformed sdkData) are
+   * left in the active map with a debug log.
+   *
+   * Returns the count of jobs registered.
+   */
+  private async recoverStrandedReceivedTokens(): Promise<number> {
+    let recovered = 0;
+    for (const [tokenId, token] of this.tokens) {
+      if (token.status !== 'pending') continue;
+      if (this.proofPollingJobs.has(tokenId)) continue;
+      if (this.parsePendingFinalization(token.sdkData)) continue;
+      if (!this.isReceivedLegacyPending(token)) continue;
+
+      // Parse sdkData to reach the last tx + source state.
+      if (!token.sdkData) continue;
+      let parsed: {
+        transactions?: Array<{ data?: unknown; inclusionProof?: unknown }>;
+      };
+      try {
+        parsed = JSON.parse(token.sdkData);
+      } catch (err) {
+        logger.debug(
+          'Payments',
+          `[V6-RECOVER] ${tokenId.slice(0, 12)}: sdkData parse failed: ${(err as Error).message}`,
+        );
+        continue;
+      }
+      const txs = parsed.transactions;
+      if (!Array.isArray(txs) || txs.length === 0) continue;
+      const lastTxJson = txs[txs.length - 1];
+      if (!lastTxJson || lastTxJson.data == null) continue;
+
+      try {
+        // Derive requestIdHex from source state's predicate publicKey +
+        // sourceStateHash (mirrors the recipient UXF worker recipe at
+        // line ~1876 — same canonical derivation aggregator uses).
+        const txData = await TransferTransactionData.fromJSON(lastTxJson.data);
+        const senderPredicate = await PredicateEngineService.createPredicate(
+          txData.sourceState.predicate,
+        );
+        const senderPubkey = (senderPredicate as unknown as { publicKey?: Uint8Array }).publicKey;
+        if (!(senderPubkey instanceof Uint8Array) || senderPubkey.length === 0) {
+          logger.debug(
+            'Payments',
+            `[V6-RECOVER] ${tokenId.slice(0, 12)}: sender predicate has no publicKey, skipping`,
+          );
+          continue;
+        }
+        const sourceStateHash = await txData.sourceState.calculateHash();
+        const requestId = await RequestId.create(senderPubkey, sourceStateHash);
+        const requestIdHex = requestId.toJSON();
+
+        // Build the source-at-state-N-1 by stripping the last tx. This is
+        // the same shape `assembleAtState(tokenId, txCount - 1)` produces
+        // for the UXF path. `SdkToken.fromJSON` only accepts source tokens
+        // whose transactions all have inclusionProofs.
+        const sourceTokenJsonObj = {
+          ...parsed,
+          transactions: txs.slice(0, -1),
+        };
+        const sourceTokenJson = JSON.stringify(sourceTokenJsonObj);
+
+        // Register a proof-polling job. `commitmentJson` is empty — the
+        // polling queue's fallback uses `getProof(requestIdHex)` when no
+        // commitment is available (see #144 L3 patch to
+        // `processProofPollingQueue`).
+        const lastTxJsonSnapshot = JSON.parse(JSON.stringify(lastTxJson));
+        this.proofPollingJobs.set(tokenId, {
+          tokenId,
+          requestIdHex,
+          commitmentJson: '',
+          sourceTokenJson,
+          startedAt: Date.now(),
+          attemptCount: 0,
+          lastAttemptAt: 0,
+          onProofReceived: async (tid) => {
+            await this.finalizeStrandedReceivedToken(
+              tid,
+              sourceTokenJson,
+              lastTxJsonSnapshot,
+            );
+          },
+        });
+        recovered++;
+        logger.debug(
+          'Payments',
+          `[V6-RECOVER] Registered recovery job for stranded token ${tokenId.slice(0, 12)} (requestId=${requestIdHex.slice(0, 16)}...)`,
+        );
+      } catch (err) {
+        logger.debug(
+          'Payments',
+          `[V6-RECOVER] ${tokenId.slice(0, 12)}: requestIdHex derivation failed: ${(err as Error)?.message ?? err}`,
+        );
+      }
+    }
+
+    if (recovered > 0) {
+      this.startProofPolling();
+      this.saveProofPollingJobs().catch((err) =>
+        logger.debug('Payments', '[V6-PERSIST] saveProofPollingJobs after recover failed:', err),
+      );
+    }
+    return recovered;
+  }
+
+  /**
+   * #144 L3 migration — finalize a stranded V6-direct received token
+   * once its inclusion proof arrives. Unlike `finalizeReceivedToken`
+   * (which uses a real `TransferCommitment`), this path patches the
+   * lastTx's `inclusionProof` field in place and calls
+   * `TransferTransaction.fromJSON` directly. The patched JSON is then
+   * fed to `finalizeTransferToken` which produces the recipient's
+   * finalized SDK token.
+   */
+  private async finalizeStrandedReceivedToken(
+    tokenId: string,
+    sourceTokenJson: string,
+    lastTxJson: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      const job = this.proofPollingJobs.get(tokenId);
+      const stClient = this.deps!.oracle.getStateTransitionClient?.() as StateTransitionClient | undefined;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const trustBase = (this.deps!.oracle as any).getTrustBase?.();
+      if (!stClient || !trustBase || !job) {
+        logger.debug('Payments', `[V6-RECOVER] Cannot finalize ${tokenId.slice(0, 12)} — missing client/trustBase/job`);
+        return;
+      }
+
+      // Fetch the proof one more time (the queue already saw it, but it
+      // doesn't pass the proof through to the callback).
+      let proofJson: unknown = null;
+      const proof = await this.deps!.oracle.getProof(job.requestIdHex);
+      if (proof) {
+        // proof may be an InclusionProof instance or a plain JSON object —
+        // `TransferTransaction.fromJSON` expects the JSON shape, so
+        // normalize via `toJSON()` when available.
+        const proofWithToJson = proof as { toJSON?: () => unknown };
+        proofJson = typeof proofWithToJson.toJSON === 'function'
+          ? proofWithToJson.toJSON()
+          : proof;
+      }
+      if (!proofJson) {
+        logger.debug('Payments', `[V6-RECOVER] Proof for ${tokenId.slice(0, 12)} unavailable on re-fetch — leaving for next tick`);
+        return;
+      }
+
+      // Patch the lastTxJson with the now-available inclusionProof and
+      // reconstruct the SDK transfer transaction.
+      const finalizedTxJson = { ...lastTxJson, inclusionProof: proofJson };
+      const transferTx = await TransferTransaction.fromJSON(finalizedTxJson);
+
+      // Source token at state N-1 (last tx stripped — see
+      // `recoverStrandedReceivedTokens`).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sourceToken = await SdkToken.fromJSON(JSON.parse(sourceTokenJson)) as SdkToken<any>;
+
+      const finalizedSdkToken = await this.finalizeTransferToken(
+        sourceToken,
+        transferTx,
+        stClient,
+        trustBase,
+      );
+
+      const token = this.tokens.get(tokenId);
+      if (!token) {
+        logger.debug('Payments', `[V6-RECOVER] Token ${tokenId.slice(0, 12)} disappeared before finalize completed`);
+        return;
+      }
+      const finalizedToken: Token = {
+        ...token,
+        status: 'confirmed',
+        updatedAt: Date.now(),
+        sdkData: JSON.stringify(finalizedSdkToken.toJSON()),
+      };
+      this.tokens.set(tokenId, finalizedToken);
+      await this.save();
+
+      // Update spend-queue cache with newly-confirmed token.
+      const amount = this.extractCoinAmountForCache(finalizedSdkToken, finalizedToken.coinId);
+      if (amount > 0n) {
+        this.parsedTokenCache.set(tokenId, { token: finalizedToken, sdkToken: finalizedSdkToken, amount });
+        this.spendQueue.notifyChange(finalizedToken.coinId);
+      }
+
+      this.deps!.emitEvent('transfer:confirmed', {
+        id: crypto.randomUUID(),
+        status: 'completed',
+        tokens: [finalizedToken],
+        tokenTransfers: [],
+      });
+
+      logger.debug('Payments', `[V6-RECOVER] Finalized stranded receive ${tokenId.slice(0, 12)} → confirmed`);
+    } catch (err) {
+      logger.error('Payments', `[V6-RECOVER] Failed to finalize stranded receive ${tokenId.slice(0, 12)}:`, err);
+    }
+  }
+
+  /**
+   * #144 L2 — attempt to finalize a V6-direct legacy token (no
+   * `_pendingFinalization` marker) using a persisted proof-polling job.
+   * Runs from `resolveUnconfirmed`'s slower cadence as defense-in-depth
+   * alongside the ~2s background queue.
+   *
+   * Returns:
+   *   - 'resolved' when proof arrives and finalize succeeds
+   *   - 'stillPending' when proof not ready yet (or no persisted job)
+   *   - 'failed' on hard finalize errors
+   */
+  private async resolveLegacyReceivedToken(
+    tokenId: string,
+    _token: Token,
+  ): Promise<'resolved' | 'stillPending' | 'failed'> {
+    const job = this.proofPollingJobs.get(tokenId);
+    if (!job || !job.sourceTokenJson) {
+      // No job: stranded (#144 L3 migration handles via
+      // recoverStrandedReceivedTokens at load time). Don't fail here —
+      // just report stillPending so the periodic retry stays calm.
+      return 'stillPending';
+    }
+
+    try {
+      const commitmentInput = JSON.parse(job.commitmentJson);
+      const commitment = await TransferCommitment.fromJSON(commitmentInput);
+
+      if (!this.deps!.oracle.waitForProofSdk) {
+        // Can't poll for proof; rely on the background queue and any
+        // explicit finalize callers (already handled in finalizeReceivedToken).
+        return 'stillPending';
+      }
+
+      // Short timeout — resolveUnconfirmed is called every 10s; we don't
+      // want to block other tokens in the loop.
+      const abortController = new AbortController();
+      const timeoutId = setTimeout(() => abortController.abort(), 500);
+      let inclusionProof: unknown = null;
+      try {
+        inclusionProof = await Promise.race([
+          this.deps!.oracle.waitForProofSdk(commitment, abortController.signal),
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), 500)),
+        ]);
+      } catch {
+        // Aggregator timeout / no proof yet — let the next tick try again.
+        clearTimeout(timeoutId);
+        return 'stillPending';
+      }
+      clearTimeout(timeoutId);
+
+      if (!inclusionProof) return 'stillPending';
+
+      // Proof landed — finalize. `finalizeReceivedToken` writes through to
+      // `this.tokens` and persists via `save()`. It also emits the
+      // `transfer:confirmed` event.
+      let sourceTokenInput: unknown;
+      try {
+        sourceTokenInput = JSON.parse(job.sourceTokenJson);
+      } catch (err) {
+        logger.error(
+          'Payments',
+          `[V6-RESOLVE] Failed to parse stored sourceTokenJson for ${tokenId.slice(0, 12)}:`,
+          err,
+        );
+        return 'failed';
+      }
+      await this.finalizeReceivedToken(tokenId, sourceTokenInput, commitmentInput);
+
+      // Clean up the proof-polling job — finalizeReceivedToken doesn't
+      // remove it (the background queue normally does). Persist the
+      // updated map.
+      this.proofPollingJobs.delete(tokenId);
+      this.saveProofPollingJobs().catch((err) =>
+        logger.debug('Payments', '[V6-PERSIST] saveProofPollingJobs after resolve failed:', err),
+      );
+
+      return 'resolved';
+    } catch (err) {
+      logger.debug(
+        'Payments',
+        `[V6-RESOLVE] Error resolving legacy receive ${tokenId.slice(0, 12)}: ${(err as Error)?.message ?? err}`,
+      );
+      return 'stillPending';
+    }
   }
 
   /**
@@ -10218,6 +10712,13 @@ export class PaymentsModule {
       this.tokens.set(id, token);
     }
 
+    // Load other data EARLY so archive-move (below) can write into the
+    // up-to-date archive map.
+    this.archivedTokens = parsed.archivedTokens;
+    this.forkedTokens = parsed.forkedTokens;
+    this.nametags = parsed.nametags;
+
+    let archiveMoved = 0;
     for (const token of parsed.tokens) {
       // Don't overwrite in-flight tokens preserved above
       if (preservedTransferring.has(token.id)) continue;
@@ -10231,13 +10732,38 @@ export class PaymentsModule {
         continue;
       }
 
+      // #144 L3 — balance-model invariant: if the latest state's
+      // predicate isn't ours AND no finalization plan exists, the token
+      // has no place in the active map per #143's mutual-exclusivity
+      // refinement. Move it to archive. Bob's stranded V6-direct receive
+      // (the #144 reproduction case) is preserved because
+      // `isReceivedLegacyPending → hasFinalizationPlan: true`.
+      if (
+        !this.latestStatePredicateMatchesWallet(token) &&
+        !this.hasFinalizationPlan(token)
+      ) {
+        const txf = tokenToTxf(token);
+        if (txf?.genesis?.data?.tokenId) {
+          this.archivedTokens.set(txf.genesis.data.tokenId, txf);
+          archiveMoved++;
+          logger.debug(
+            'Payments',
+            `[BALANCE-INVARIANT] Moved token ${token.id.slice(0, 12)} to archive — ` +
+              `latest state predicate not ours, no finalization plan`,
+          );
+          continue;
+        }
+        // Couldn't convert to TXF — keep in active to avoid data loss.
+      }
+
       this.tokens.set(token.id, token);
     }
-
-    // Load other data
-    this.archivedTokens = parsed.archivedTokens;
-    this.forkedTokens = parsed.forkedTokens;
-    this.nametags = parsed.nametags;
+    if (archiveMoved > 0) {
+      logger.debug(
+        'Payments',
+        `[BALANCE-INVARIANT] loadFromStorageData moved ${archiveMoved} token(s) to archive`,
+      );
+    }
   }
 
   // ===========================================================================
@@ -10298,6 +10824,192 @@ export class PaymentsModule {
     this.proofPollingJobs.set(job.tokenId, job);
     logger.debug('Payments', `Added proof polling job for token ${job.tokenId.slice(0, 8)}...`);
     this.startProofPolling();
+    // Persist for restart recovery (#144 L1). Fire-and-forget — the job is
+    // already in-memory, so a persist failure only affects restart recovery.
+    if (job.sourceTokenJson) {
+      this.saveProofPollingJobs().catch((err) =>
+        logger.debug('Payments', '[V6-PERSIST] saveProofPollingJobs after add failed:', err)
+      );
+    }
+  }
+
+  /**
+   * Persist the current set of proof-polling jobs to KV storage. Only jobs
+   * that have a `sourceTokenJson` (i.e. V6-direct receive jobs) are
+   * eligible for restart recovery — others are skipped. See #144.
+   *
+   * Keyed by genesis tokenId + state hash, not in-memory UUID, because
+   * after save→load the in-memory id is replaced by the genesis tokenId
+   * (see `txfToToken` in `serialization/txf-serializer.ts`).
+   */
+  private async saveProofPollingJobs(): Promise<void> {
+    const persisted: PersistedProofPollingJob[] = [];
+    for (const [tokenId, job] of this.proofPollingJobs) {
+      if (!job.sourceTokenJson) continue;
+      const token = this.tokens.get(tokenId);
+      // Token may be absent if the job was just added in this tick and the
+      // map mutated concurrently. Use the job's stored sdkData as the
+      // canonical source of genesis+state info — it's the same value that
+      // was written to `Token.sdkData` at create time.
+      const sourceTokenJson = job.sourceTokenJson;
+      const genesisTokenId = token
+        ? extractTokenIdFromSdkData(token.sdkData)
+        : extractTokenIdFromSdkData(sourceTokenJson);
+      const stateHash = token
+        ? extractStateHashFromSdkData(token.sdkData)
+        : extractStateHashFromSdkData(sourceTokenJson);
+      if (!genesisTokenId || !stateHash) {
+        logger.debug(
+          'Payments',
+          `[V6-PERSIST] Skipping job for ${tokenId.slice(0, 12)} — missing genesisTokenId or stateHash`
+        );
+        continue;
+      }
+      persisted.push({
+        genesisTokenId,
+        stateHash,
+        requestIdHex: job.requestIdHex,
+        commitmentJson: job.commitmentJson,
+        sourceTokenJson,
+        startedAt: job.startedAt,
+        attemptCount: job.attemptCount,
+        lastAttemptAt: job.lastAttemptAt,
+      });
+    }
+
+    if (persisted.length === 0) {
+      // Clear the KV entry when no eligible jobs remain. Use storage.remove
+      // when available so a stale list doesn't survive.
+      const storage = this.deps!.storage;
+      const removeFn = (storage as { remove?: (k: string) => Promise<void> }).remove;
+      if (typeof removeFn === 'function') {
+        await removeFn.call(storage, STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS);
+      } else {
+        await this.setStorageEntry(
+          STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS,
+          '[]',
+          'cache_index'
+        );
+      }
+      return;
+    }
+
+    await this.setStorageEntry(
+      STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS,
+      JSON.stringify(persisted),
+      'cache_index'
+    );
+  }
+
+  /**
+   * Restore proof-polling jobs from KV storage. Called from `load()` AFTER
+   * `loadFromStorageData` populates `this.tokens`, so we can resolve a
+   * persisted `(genesisTokenId, stateHash)` pair to the post-load in-memory
+   * `Token.id` (which is the genesis tokenId itself, courtesy of
+   * `txfToToken`).
+   *
+   * Each restored job runs with `attemptCount: 0` — the prior process's
+   * attempts don't carry over, so a job that nearly timed out gets a fresh
+   * 60s budget instead of being immediately discarded.
+   */
+  private async restoreProofPollingJobs(): Promise<void> {
+    const data = await this.deps!.storage.get(STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS);
+    if (!data) return;
+
+    let persisted: PersistedProofPollingJob[];
+    try {
+      const parsed = JSON.parse(data);
+      if (!Array.isArray(parsed)) {
+        logger.error('Payments', '[V6-RESTORE] Persisted jobs is not an array; clearing');
+        return;
+      }
+      persisted = parsed as PersistedProofPollingJob[];
+    } catch (err) {
+      logger.error('Payments', '[V6-RESTORE] Failed to parse persisted jobs:', err);
+      return;
+    }
+
+    if (persisted.length === 0) return;
+
+    let restored = 0;
+    for (const p of persisted) {
+      if (
+        !p.genesisTokenId ||
+        !p.stateHash ||
+        !p.requestIdHex ||
+        !p.commitmentJson ||
+        !p.sourceTokenJson
+      ) {
+        logger.debug('Payments', '[V6-RESTORE] Skipping malformed persisted job');
+        continue;
+      }
+
+      // Find matching in-memory token by genesis tokenId + state hash.
+      let memoryTokenId: string | null = null;
+      for (const [id, token] of this.tokens) {
+        const tid = extractTokenIdFromSdkData(token.sdkData);
+        const sh = extractStateHashFromSdkData(token.sdkData);
+        if (tid === p.genesisTokenId && sh === p.stateHash) {
+          memoryTokenId = id;
+          break;
+        }
+      }
+      if (!memoryTokenId) {
+        logger.debug(
+          'Payments',
+          `[V6-RESTORE] No matching token for job ` +
+            `(genesisTokenId=${p.genesisTokenId.slice(0, 12)}, ` +
+            `stateHash=${p.stateHash.slice(0, 12)}), dropping`
+        );
+        continue;
+      }
+
+      // Already finalized in a prior session? Skip.
+      const existingToken = this.tokens.get(memoryTokenId);
+      if (existingToken && existingToken.status === 'confirmed') {
+        logger.debug(
+          'Payments',
+          `[V6-RESTORE] Token ${memoryTokenId.slice(0, 12)} already confirmed, skipping job`
+        );
+        continue;
+      }
+
+      let sourceTokenInput: unknown;
+      let commitmentInput: unknown;
+      try {
+        sourceTokenInput = JSON.parse(p.sourceTokenJson);
+        commitmentInput = JSON.parse(p.commitmentJson);
+      } catch (err) {
+        logger.error(
+          'Payments',
+          `[V6-RESTORE] Failed to parse source/commitment for ${p.genesisTokenId.slice(0, 12)}:`,
+          err
+        );
+        continue;
+      }
+
+      this.proofPollingJobs.set(memoryTokenId, {
+        tokenId: memoryTokenId,
+        requestIdHex: p.requestIdHex,
+        commitmentJson: p.commitmentJson,
+        sourceTokenJson: p.sourceTokenJson,
+        startedAt: p.startedAt,
+        attemptCount: 0, // reset; prior process's attempts don't count
+        lastAttemptAt: 0,
+        onProofReceived: async (tid) => {
+          await this.finalizeReceivedToken(tid, sourceTokenInput, commitmentInput);
+        },
+      });
+      restored++;
+    }
+
+    if (restored > 0) {
+      logger.debug(
+        'Payments',
+        `[V6-RESTORE] Restored ${restored} proof-polling job(s) from storage`
+      );
+      this.startProofPolling();
+    }
   }
 
   /**
@@ -10355,23 +11067,26 @@ export class PaymentsModule {
           continue;
         }
 
-        // Try to get proof from aggregator using a short timeout
-        const commitment = await TransferCommitment.fromJSON(JSON.parse(job.commitmentJson));
-
-        // Try to get proof with a quick timeout (non-blocking check)
+        // Try to get proof with a quick timeout (non-blocking check).
+        //
+        // #144 L3: jobs registered via `recoverStrandedReceivedTokens`
+        // have an empty `commitmentJson` (we can't reconstruct the
+        // sender's authenticator). For those, fall back to the
+        // `getProof(requestIdHex)` path directly — no commitment needed.
         let inclusionProof: unknown = null;
         try {
-          // Create abort controller for quick timeout
           const abortController = new AbortController();
           const timeoutId = setTimeout(() => abortController.abort(), 500);
 
-          if (this.deps!.oracle.waitForProofSdk) {
+          if (job.commitmentJson && this.deps!.oracle.waitForProofSdk) {
+            const commitment = await TransferCommitment.fromJSON(JSON.parse(job.commitmentJson));
             inclusionProof = await Promise.race([
               this.deps!.oracle.waitForProofSdk(commitment, abortController.signal),
               new Promise<null>((resolve) => setTimeout(() => resolve(null), 500)),
             ]);
           } else {
-            // Fallback: use getProof with request ID hex
+            // Fallback: use getProof with request ID hex (also the only
+            // path for #144 L3 migration jobs).
             const proof = await this.deps!.oracle.getProof(job.requestIdHex);
             if (proof) {
               inclusionProof = proof;
@@ -10417,6 +11132,12 @@ export class PaymentsModule {
     if (this.proofPollingJobs.size === 0) {
       this.stopProofPolling();
     }
+
+    // Persist updated queue (attempt counts changed; some jobs removed).
+    // Fire-and-forget — in-memory state is authoritative for this process.
+    this.saveProofPollingJobs().catch((err) =>
+      logger.debug('Payments', '[V6-PERSIST] saveProofPollingJobs after tick failed:', err)
+    );
   }
 
   // ===========================================================================

--- a/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
+++ b/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
@@ -16,7 +16,7 @@
  * in txf-serializer.ts) and `resolveUnconfirmed` silently skipped it.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   createPaymentsModule,
   type PaymentsModuleDependencies,
@@ -293,6 +293,13 @@ describe('#144 L1 — proofPollingJobs persist across process restarts', () => {
     module.initialize(setup.deps);
   });
 
+  afterEach(() => {
+    // Tear down setInterval timers (proofPolling, resolveUnconfirmed)
+    // that initialize/addProofPollingJob may have started. Without this,
+    // intervals leak across files and cause CI flakes (steelman FIX A).
+    try { module.destroy(); } catch { /* ignore */ }
+  });
+
   it('persists a job with sourceTokenJson to KV storage', async () => {
     const sdkData = makeV6DirectReceiveSdkData();
     const token: Token = {
@@ -449,6 +456,13 @@ describe('#144 L2 — resolveUnconfirmed accepts status=pending', () => {
     module.initialize(setup.deps);
   });
 
+  afterEach(() => {
+    // Tear down setInterval timers (proofPolling, resolveUnconfirmed)
+    // that initialize/addProofPollingJob may have started. Without this,
+    // intervals leak across files and cause CI flakes (steelman FIX A).
+    try { module.destroy(); } catch { /* ignore */ }
+  });
+
   it('routes a status=pending V6-direct receive through resolveLegacyReceivedToken', async () => {
     const sdkData = makeV6DirectReceiveSdkData();
     const token: Token = {
@@ -509,6 +523,13 @@ describe('#144 L3 — balance-model invariant + stranded recovery', () => {
     module = createPaymentsModule();
     setup = createDeps();
     module.initialize(setup.deps);
+  });
+
+  afterEach(() => {
+    // Tear down setInterval timers (proofPolling, resolveUnconfirmed)
+    // that initialize/addProofPollingJob may have started. Without this,
+    // intervals leak across files and cause CI flakes (steelman FIX A).
+    try { module.destroy(); } catch { /* ignore */ }
   });
 
   it('hasFinalizationPlan returns true for a V6-direct receive even without a polling job', () => {
@@ -655,6 +676,140 @@ describe('#144 L3 — balance-model invariant + stranded recovery', () => {
     const recovered = await internals(module).recoverStrandedReceivedTokens();
     expect(recovered).toBe(0);
     expect(internals(module).proofPollingJobs.get(GENESIS_TOKEN_ID)?.requestIdHex).toBe('pre-existing');
+  });
+
+  it('processProofPollingQueue does NOT flip RECEIVE jobs to spent (steelman FIX B)', async () => {
+    // Regression for the steelman finding: pre-FIX-B the queue
+    // unconditionally set token.status='spent' on proof receipt,
+    // including for receive jobs. If the onProofReceived callback
+    // then threw, the token was stuck at 'spent' forever.
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    // Mock oracle to return a (fake) proof on the next poll tick.
+    const fakeProof = { toJSON: () => 'fake-proof-json' };
+    (setup.deps.oracle as { waitForProofSdk: ReturnType<typeof vi.fn> }).waitForProofSdk =
+      vi.fn().mockResolvedValue(fakeProof);
+
+    // The onProofReceived callback will THROW — simulating a finalize
+    // failure. After FIX B, the token MUST remain at 'pending' so the
+    // queue retries on the next tick.
+    let callbackInvoked = false;
+    internals(module).proofPollingJobs.set(GENESIS_TOKEN_ID, {
+      tokenId: GENESIS_TOKEN_ID,
+      requestIdHex: '00deadbeef',
+      commitmentJson: '{"requestId":"x","transactionData":{},"authenticator":{}}',
+      sourceTokenJson: sdkData, // ← marks this as a RECEIVE job
+      startedAt: Date.now(),
+      attemptCount: 0,
+      lastAttemptAt: 0,
+      onProofReceived: async () => {
+        callbackInvoked = true;
+        throw new Error('Simulated finalize failure');
+      },
+    });
+
+    // Trigger one polling tick directly.
+    await (module as unknown as { processProofPollingQueue: () => Promise<void> }).processProofPollingQueue();
+
+    expect(callbackInvoked).toBe(true);
+    // Pre-FIX-B would be 'spent'; post-FIX-B remains 'pending' for retry.
+    expect(internals(module).tokens.get(GENESIS_TOKEN_ID)?.status).toBe('pending');
+    // Job stays in queue for retry (callbackOk=false → not added to completedJobs).
+    expect(internals(module).proofPollingJobs.has(GENESIS_TOKEN_ID)).toBe(true);
+  });
+
+  it('processProofPollingQueue marks pending tokens invalid on timeout (steelman FIX C)', async () => {
+    // Regression for the steelman finding: pre-FIX-C the timeout
+    // branch only marked status='submitted' tokens invalid. Recovery
+    // jobs target status='pending' tokens; pre-FIX-C they stayed
+    // 'pending' forever, creating a zombie loop on every restart.
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    // Register a job with attemptCount already at the max — the next
+    // tick should hit the timeout branch.
+    internals(module).proofPollingJobs.set(GENESIS_TOKEN_ID, {
+      tokenId: GENESIS_TOKEN_ID,
+      requestIdHex: '00deadbeef',
+      commitmentJson: '',
+      sourceTokenJson: sdkData,
+      startedAt: Date.now() - 60_000,
+      attemptCount: 29, // ← bumps to 30 on the tick → hits MAX_ATTEMPTS branch
+      lastAttemptAt: Date.now() - 2000,
+    });
+
+    await (module as unknown as { processProofPollingQueue: () => Promise<void> }).processProofPollingQueue();
+
+    // Post-FIX-C: pending → invalid on timeout.
+    expect(internals(module).tokens.get(GENESIS_TOKEN_ID)?.status).toBe('invalid');
+    // Operator alert emitted for visibility.
+    const alerts = setup.emittedEvents.filter((e) => e.type === 'transfer:operator-alert');
+    expect(alerts.length).toBeGreaterThan(0);
+  });
+
+  it('restoreProofPollingJobs honors cumulative-attempts cap (steelman FIX G)', async () => {
+    // Regression: if a token has burned through its cumulative budget
+    // across prior process lifetimes, restore must mark it invalid
+    // instead of granting another fresh 60s polling budget.
+    const sdkData = makeV6DirectReceiveSdkData();
+    setup.storageState.set(
+      STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS,
+      JSON.stringify([
+        {
+          genesisTokenId: GENESIS_TOKEN_ID,
+          stateHash: STATE_HASH,
+          requestIdHex: '00restored',
+          commitmentJson: '{}',
+          sourceTokenJson: sdkData,
+          startedAt: Date.now() - 600_000,
+          attemptCount: 30,
+          lastAttemptAt: Date.now() - 2000,
+          cumulativeAttempts: 200, // > MAX_CUMULATIVE (150)
+        },
+      ]),
+    );
+    const tokenAfterLoad: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(tokenAfterLoad.id, tokenAfterLoad);
+
+    await internals(module).restoreProofPollingJobs();
+
+    // Job NOT restored (skipped due to cap).
+    expect(internals(module).proofPollingJobs.has(GENESIS_TOKEN_ID)).toBe(false);
+    // Token marked invalid.
+    expect(internals(module).tokens.get(GENESIS_TOKEN_ID)?.status).toBe('invalid');
+    // Operator alert emitted.
+    const alerts = setup.emittedEvents.filter((e) => e.type === 'transfer:operator-alert');
+    expect(alerts.length).toBeGreaterThan(0);
   });
 
   it('recoverStrandedReceivedTokens skips tokens that are not V6-direct receives', async () => {

--- a/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
+++ b/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
@@ -1,0 +1,682 @@
+/**
+ * Tests for #144 — receiver finalize-on-restart fix.
+ *
+ * Three layers:
+ *  - L1: proof-polling jobs persist to KV on add/tick and restore on load.
+ *  - L2: `resolveUnconfirmed` accepts status='pending' and routes V6-direct
+ *        legacy receives through `resolveLegacyReceivedToken`.
+ *  - L3: `loadFromStorageData` moves tokens whose latest-state predicate
+ *        isn't ours AND have no plan to archive. `recoverStrandedReceivedTokens`
+ *        registers polling jobs for stranded V6-direct receives.
+ *
+ * Pre-fix behavior: on CLI usage every `sphere <cmd>` is a fresh Node.js
+ * process. `proofPollingJobs` Map dies between process invocations, so
+ * V6-direct receives whose proof arrives later never finalize. After
+ * save→load, status flips from 'submitted' to 'pending' (per `determineTokenStatus`
+ * in txf-serializer.ts) and `resolveUnconfirmed` silently skipped it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createPaymentsModule,
+  type PaymentsModuleDependencies,
+  type ProofPollingJob,
+} from '../../../modules/payments/PaymentsModule';
+import { STORAGE_KEYS_ADDRESS } from '../../../constants';
+import type { Token, FullIdentity } from '../../../types';
+import type {
+  StorageProvider,
+  TokenStorageProvider,
+  TxfStorageDataBase,
+} from '../../../storage';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+
+// ---------------------------------------------------------------------------
+// SDK static-import mocks (match existing PaymentsModule.* test pattern)
+// ---------------------------------------------------------------------------
+
+vi.mock('@unicitylabs/state-transition-sdk/lib/token/Token', () => ({
+  Token: { fromJSON: vi.fn().mockResolvedValue({ id: { toString: () => 'mock-id' }, coins: null, state: {} }) },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/token/fungible/CoinId', () => ({
+  CoinId: class { toJSON() { return 'UCT_HEX'; } },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/transaction/TransferCommitment', () => ({
+  TransferCommitment: {
+    fromJSON: vi.fn().mockResolvedValue({
+      requestId: new Uint8Array([1, 2, 3, 4]),
+      toJSON() { return { requestId: '01020304' }; },
+      toTransaction() { return {}; },
+    }),
+  },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/transaction/TransferTransaction', () => ({
+  TransferTransaction: { fromJSON: vi.fn().mockResolvedValue({}) },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/transaction/TransferTransactionData', () => ({
+  TransferTransactionData: {
+    fromJSON: vi.fn().mockImplementation(async () => ({
+      sourceState: {
+        predicate: 'mock-predicate-cbor',
+        async calculateHash() {
+          return new Uint8Array([0xaa, 0xbb]);
+        },
+      },
+      salt: new Uint8Array([0x33]),
+      async calculateHash() {
+        return { toJSON: () => '0000mocktxhash' };
+      },
+    })),
+  },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/sign/SigningService', () => ({
+  SigningService: {
+    createFromSecret: vi.fn().mockResolvedValue({ sign: vi.fn(), publicKey: new Uint8Array([0x02]) }),
+  },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/address/AddressScheme', () => ({
+  AddressScheme: class { static DIRECT = 'DIRECT'; static PROXY = 'PROXY'; },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/predicate/embedded/UnmaskedPredicate', () => ({
+  UnmaskedPredicate: { create: vi.fn().mockResolvedValue({}) },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/predicate/PredicateEngineService', () => ({
+  PredicateEngineService: {
+    createPredicate: vi.fn().mockResolvedValue({
+      publicKey: new Uint8Array([0x02, 0x99, 0x88, 0x77]),
+    }),
+  },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/api/RequestId', () => ({
+  RequestId: {
+    create: vi.fn().mockResolvedValue({ toJSON: () => '00deadbeef00recovery00requestid' }),
+  },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/token/TokenState', () => ({
+  TokenState: class {},
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/hash/HashAlgorithm', () => ({
+  HashAlgorithm: { SHA256: 'sha256' },
+}));
+vi.mock('../../../l1/network', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  isWebSocketConnected: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../../registry', () => ({
+  TokenRegistry: {
+    getInstance: () => ({
+      getDefinition: () => null,
+      getIconUrl: () => null,
+      getSymbol: (id: string) => id,
+      getName: (id: string) => id,
+      getDecimals: () => 8,
+    }),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const OUR_PUBKEY = '02' + 'a1'.repeat(32);
+const OUR_DIRECT = 'DIRECT://9999ABCDEF';
+const SENDER_PUBKEY = '03' + 'b2'.repeat(32);
+const GENESIS_TOKEN_ID = '892069aea482d543'.padEnd(64, '0');
+const STATE_HASH = '0000beef'.padEnd(64, '0');
+
+/**
+ * Build a V6-direct receive shape — a TXF with 2 transactions where the
+ * last one has `inclusionProof: null` and `data.recipient.address` is
+ * OUR_DIRECT. Mirrors what alice ships to bob in the issue reproduction.
+ */
+function makeV6DirectReceiveSdkData(opts?: {
+  lastTxRecipient?: string;
+  predicateContainsOurPubkey?: boolean;
+}): string {
+  const recipient = opts?.lastTxRecipient ?? OUR_DIRECT;
+  // For the state.predicate, encode CBOR-hex containing SENDER's pubkey
+  // unless explicitly overridden. The L3 invariant check looks for OUR
+  // pubkey as a substring; absence means "not ours".
+  const predicate = opts?.predicateContainsOurPubkey
+    ? `0000${OUR_PUBKEY.toLowerCase()}0000`
+    : `0000${SENDER_PUBKEY.toLowerCase()}0000`;
+
+  return JSON.stringify({
+    version: '2.0',
+    genesis: {
+      data: { tokenId: GENESIS_TOKEN_ID, tokenType: 'coinType', coinData: [['UCT_HEX', '100']] },
+      inclusionProof: { authenticator: { stateHash: 'genesisHash' } },
+    },
+    state: {
+      data: '',
+      predicate,
+    },
+    transactions: [
+      {
+        previousStateHash: 'h0',
+        newStateHash: STATE_HASH,
+        predicate: 'pred1',
+        inclusionProof: { authenticator: { stateHash: STATE_HASH } },
+        data: { recipient: { address: 'PROXY://senderProxy', scheme: 'PROXY' } },
+      },
+      {
+        previousStateHash: STATE_HASH,
+        predicate: 'pred2',
+        inclusionProof: null, // ← unproved alice→bob transition
+        data: { recipient: { address: recipient, scheme: 'DIRECT' }, salt: '0x33' },
+      },
+    ],
+    // _integrity.currentStateHash makes getCurrentStateHash deterministic
+    // — the last tx has no newStateHash/inclusionProof, so without this
+    // helper falls through to genesis.
+    _integrity: { genesisDataJSONHash: '0000' + '0'.repeat(60), currentStateHash: STATE_HASH },
+  });
+}
+
+function createDeps(getReturns?: Record<string, string | null>): {
+  deps: PaymentsModuleDependencies;
+  storageState: Map<string, string>;
+  emittedEvents: Array<{ type: string; payload: unknown }>;
+} {
+  const storageState = new Map<string, string>();
+  for (const [k, v] of Object.entries(getReturns ?? {})) {
+    if (v !== null) storageState.set(k, v);
+  }
+
+  const mockStorage: StorageProvider = {
+    id: 'mock-storage',
+    name: 'Mock Storage',
+    type: 'local',
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected'),
+    setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => storageState.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { storageState.set(k, v); }),
+    remove: vi.fn(async (k: string) => { storageState.delete(k); }),
+    has: vi.fn(async (k: string) => storageState.has(k)),
+    keys: vi.fn(async () => Array.from(storageState.keys())),
+    clear: vi.fn(async () => { storageState.clear(); }),
+  };
+
+  const emittedEvents: Array<{ type: string; payload: unknown }> = [];
+
+  const mockTransport = {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected'),
+    setIdentity: vi.fn(),
+    sendTokenTransfer: vi.fn(),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+  } as unknown as TransportProvider;
+
+  const mockOracle = {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'network' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected'),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getProof: vi.fn().mockResolvedValue(null),
+    waitForProofSdk: vi.fn().mockResolvedValue(null),
+    getStateTransitionClient: vi.fn().mockReturnValue({}),
+    getTrustBase: vi.fn().mockReturnValue({}),
+  } as unknown as OracleProvider;
+
+  const identity: FullIdentity = {
+    chainPubkey: OUR_PUBKEY,
+    l1Address: 'alpha1ourtestaddress',
+    directAddress: OUR_DIRECT,
+    // 64-hex (no 0x prefix) — `createSigningService` calls `hexToBytes`
+    // which rejects non-hex inputs.
+    privateKey: 'c'.repeat(64),
+  };
+
+  return {
+    deps: {
+      identity,
+      storage: mockStorage,
+      tokenStorageProviders: new Map<string, TokenStorageProvider<TxfStorageDataBase>>(),
+      transport: mockTransport,
+      oracle: mockOracle,
+      emitEvent: vi.fn((type: string, payload: unknown) => {
+        emittedEvents.push({ type, payload });
+      }) as unknown as PaymentsModuleDependencies['emitEvent'],
+    } as PaymentsModuleDependencies,
+    storageState,
+    emittedEvents,
+  };
+}
+
+/** Access PaymentsModule internals (Map + private methods) for assertions. */
+interface ModuleInternals {
+  tokens: Map<string, Token>;
+  archivedTokens: Map<string, unknown>;
+  proofPollingJobs: Map<string, ProofPollingJob>;
+  addProofPollingJob: (job: ProofPollingJob) => void;
+  saveProofPollingJobs: () => Promise<void>;
+  restoreProofPollingJobs: () => Promise<void>;
+  recoverStrandedReceivedTokens: () => Promise<number>;
+  loadFromStorageData: (data: TxfStorageDataBase) => void;
+  isReceivedLegacyPending: (token: Token) => boolean;
+  hasFinalizationPlan: (token: Token) => boolean;
+  latestStatePredicateMatchesWallet: (token: Token) => boolean;
+  resolveUnconfirmed: () => Promise<{ resolved: number; stillPending: number; failed: number; details: unknown[] }>;
+}
+function internals(m: ReturnType<typeof createPaymentsModule>): ModuleInternals {
+  return m as unknown as ModuleInternals;
+}
+
+// =============================================================================
+// L1 — Persistence of proof-polling jobs
+// =============================================================================
+
+describe('#144 L1 — proofPollingJobs persist across process restarts', () => {
+  let module: ReturnType<typeof createPaymentsModule>;
+  let setup: ReturnType<typeof createDeps>;
+
+  beforeEach(() => {
+    module = createPaymentsModule();
+    setup = createDeps();
+    module.initialize(setup.deps);
+  });
+
+  it('persists a job with sourceTokenJson to KV storage', async () => {
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: 'inmem-uuid-1',
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'submitted',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    internals(module).addProofPollingJob({
+      tokenId: token.id,
+      requestIdHex: '00deadbeef',
+      commitmentJson: '{"requestId":"01020304","transactionData":{},"authenticator":{}}',
+      sourceTokenJson: sdkData,
+      startedAt: Date.now(),
+      attemptCount: 0,
+      lastAttemptAt: 0,
+    });
+
+    // saveProofPollingJobs is fire-and-forget from addProofPollingJob;
+    // flush the queue.
+    await internals(module).saveProofPollingJobs();
+
+    const stored = setup.storageState.get(STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS);
+    expect(stored).toBeTruthy();
+    const persisted = JSON.parse(stored as string);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].genesisTokenId).toBe(GENESIS_TOKEN_ID);
+    expect(persisted[0].stateHash).toBe(STATE_HASH);
+    expect(persisted[0].requestIdHex).toBe('00deadbeef');
+    expect(persisted[0].sourceTokenJson).toBe(sdkData);
+  });
+
+  it('does NOT persist jobs that lack sourceTokenJson (legacy callsites)', async () => {
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: 'inmem-uuid-2',
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'submitted',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    internals(module).addProofPollingJob({
+      tokenId: token.id,
+      requestIdHex: '00deadbeef',
+      commitmentJson: '{}',
+      // ← intentionally no sourceTokenJson
+      startedAt: Date.now(),
+      attemptCount: 0,
+      lastAttemptAt: 0,
+    });
+
+    await internals(module).saveProofPollingJobs();
+
+    const stored = setup.storageState.get(STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS);
+    // saveProofPollingJobs clears the KV entry when no eligible jobs exist.
+    expect(stored ?? '').toBe('');
+  });
+
+  it('restoreProofPollingJobs rebuilds jobs keyed by current in-memory tokenId', async () => {
+    // Simulate a fresh process: persisted KV exists; in-memory tokens are
+    // loaded with the GENESIS tokenId as their Map key (per txfToToken).
+    const sdkData = makeV6DirectReceiveSdkData();
+    setup.storageState.set(
+      STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS,
+      JSON.stringify([
+        {
+          genesisTokenId: GENESIS_TOKEN_ID,
+          stateHash: STATE_HASH,
+          requestIdHex: '00restored',
+          commitmentJson: '{}',
+          sourceTokenJson: sdkData,
+          startedAt: Date.now() - 5000,
+          attemptCount: 17, // ignored on restore
+          lastAttemptAt: Date.now() - 2000,
+        },
+      ]),
+    );
+
+    // Populate in-memory token map as loadFromStorageData would.
+    const tokenAfterLoad: Token = {
+      id: GENESIS_TOKEN_ID, // ← post-load id is genesis tokenId
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(tokenAfterLoad.id, tokenAfterLoad);
+
+    await internals(module).restoreProofPollingJobs();
+
+    const job = internals(module).proofPollingJobs.get(GENESIS_TOKEN_ID);
+    expect(job).toBeDefined();
+    expect(job?.requestIdHex).toBe('00restored');
+    expect(job?.sourceTokenJson).toBe(sdkData);
+    // Attempt count is reset on restore (prior process's attempts don't count).
+    expect(job?.attemptCount).toBe(0);
+    expect(job?.onProofReceived).toBeTypeOf('function');
+  });
+
+  it('restoreProofPollingJobs skips jobs with no matching in-memory token', async () => {
+    setup.storageState.set(
+      STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS,
+      JSON.stringify([
+        {
+          genesisTokenId: 'nonexistent-token-id',
+          stateHash: 'nonexistent-state',
+          requestIdHex: '00orphan',
+          commitmentJson: '{}',
+          sourceTokenJson: makeV6DirectReceiveSdkData(),
+          startedAt: Date.now(),
+          attemptCount: 0,
+          lastAttemptAt: 0,
+        },
+      ]),
+    );
+
+    await internals(module).restoreProofPollingJobs();
+
+    expect(internals(module).proofPollingJobs.size).toBe(0);
+  });
+
+  it('gracefully handles malformed persisted-job JSON', async () => {
+    setup.storageState.set(STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS, '{not-an-array}');
+    await expect(internals(module).restoreProofPollingJobs()).resolves.toBeUndefined();
+    expect(internals(module).proofPollingJobs.size).toBe(0);
+  });
+});
+
+// =============================================================================
+// L2 — resolveUnconfirmed widened status filter
+// =============================================================================
+
+describe('#144 L2 — resolveUnconfirmed accepts status=pending', () => {
+  let module: ReturnType<typeof createPaymentsModule>;
+  let setup: ReturnType<typeof createDeps>;
+
+  beforeEach(() => {
+    module = createPaymentsModule();
+    setup = createDeps();
+    module.initialize(setup.deps);
+  });
+
+  it('routes a status=pending V6-direct receive through resolveLegacyReceivedToken', async () => {
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending', // ← key: was 'submitted' pre-save→load
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    // No persisted polling job → resolveLegacyReceivedToken returns
+    // 'stillPending' without contacting the oracle.
+    const result = await internals(module).resolveUnconfirmed();
+    expect(result.stillPending).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.resolved).toBe(0);
+    expect(result.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ tokenId: GENESIS_TOKEN_ID, stage: 'v6_direct', status: 'pending' }),
+      ]),
+    );
+  });
+
+  it('skips status=pending tokens whose last-tx recipient is NOT us', async () => {
+    const sdkData = makeV6DirectReceiveSdkData({ lastTxRecipient: 'DIRECT://someone-else' });
+    internals(module).tokens.set('foreign-token', {
+      id: 'foreign-token',
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    });
+
+    const result = await internals(module).resolveUnconfirmed();
+    // Foreign-recipient tokens are not eligible for V6-direct retry; count
+    // as still-pending but without a v6_direct detail entry.
+    expect(result.stillPending).toBe(1);
+    expect(result.details.find((d) => (d as { stage: string }).stage === 'v6_direct')).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// L3 — Load-time invariant + stranded-token migration
+// =============================================================================
+
+describe('#144 L3 — balance-model invariant + stranded recovery', () => {
+  let module: ReturnType<typeof createPaymentsModule>;
+  let setup: ReturnType<typeof createDeps>;
+
+  beforeEach(() => {
+    module = createPaymentsModule();
+    setup = createDeps();
+    module.initialize(setup.deps);
+  });
+
+  it('hasFinalizationPlan returns true for a V6-direct receive even without a polling job', () => {
+    const token: Token = {
+      id: 'plan-test',
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData: makeV6DirectReceiveSdkData(),
+    };
+    expect(internals(module).isReceivedLegacyPending(token)).toBe(true);
+    expect(internals(module).hasFinalizationPlan(token)).toBe(true);
+  });
+
+  it('latestStatePredicateMatchesWallet returns false when state.predicate lacks our pubkey', () => {
+    const token: Token = {
+      id: 'pred-test',
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      // state.predicate encodes sender's pubkey, not ours.
+      sdkData: makeV6DirectReceiveSdkData({ predicateContainsOurPubkey: false }),
+    };
+    expect(internals(module).latestStatePredicateMatchesWallet(token)).toBe(false);
+  });
+
+  it('latestStatePredicateMatchesWallet returns true when state.predicate contains our pubkey', () => {
+    const token: Token = {
+      id: 'ownership-test',
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'confirmed',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData: makeV6DirectReceiveSdkData({ predicateContainsOurPubkey: true }),
+    };
+    expect(internals(module).latestStatePredicateMatchesWallet(token)).toBe(true);
+  });
+
+  it('loadFromStorageData preserves a stranded V6-direct receive (hasFinalizationPlan=true)', () => {
+    // Build minimal TxfStorageData containing the stranded token.
+    const sdkData = makeV6DirectReceiveSdkData();
+    const data: TxfStorageDataBase = {
+      _meta: {
+        version: 1,
+        address: OUR_PUBKEY,
+        formatVersion: '1.0.0',
+        updatedAt: Date.now(),
+      },
+      // Token key is `token-<tokenId>` per `keyFromTokenId`.
+      [`_${GENESIS_TOKEN_ID}`]: JSON.parse(sdkData),
+    } as TxfStorageDataBase;
+
+    internals(module).loadFromStorageData(data);
+
+    // The stranded receive stays in active because isReceivedLegacyPending
+    // makes hasFinalizationPlan return true (bob's scenario).
+    expect(internals(module).tokens.has(GENESIS_TOKEN_ID)).toBe(true);
+    expect(internals(module).archivedTokens.has(GENESIS_TOKEN_ID)).toBe(false);
+  });
+
+  it('loadFromStorageData archive-moves tokens that fail BOTH ownership AND plan checks', () => {
+    // Foreign-recipient token with no plan — should be archived.
+    const sdkData = makeV6DirectReceiveSdkData({
+      lastTxRecipient: 'DIRECT://different-recipient',
+      predicateContainsOurPubkey: false,
+    });
+    const data: TxfStorageDataBase = {
+      _meta: {
+        version: 1,
+        address: OUR_PUBKEY,
+        formatVersion: '1.0.0',
+        updatedAt: Date.now(),
+      },
+      [`_${GENESIS_TOKEN_ID}`]: JSON.parse(sdkData),
+    } as TxfStorageDataBase;
+
+    internals(module).loadFromStorageData(data);
+
+    expect(internals(module).tokens.has(GENESIS_TOKEN_ID)).toBe(false);
+    expect(internals(module).archivedTokens.has(GENESIS_TOKEN_ID)).toBe(true);
+  });
+
+  it('recoverStrandedReceivedTokens registers a polling job for a stranded V6-direct receive', async () => {
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    expect(internals(module).proofPollingJobs.size).toBe(0);
+
+    const recovered = await internals(module).recoverStrandedReceivedTokens();
+    expect(recovered).toBe(1);
+    const job = internals(module).proofPollingJobs.get(GENESIS_TOKEN_ID);
+    expect(job).toBeDefined();
+    // Migration jobs have empty commitmentJson — proof fetched via
+    // getProof(requestIdHex) path in processProofPollingQueue.
+    expect(job?.commitmentJson).toBe('');
+    // requestIdHex comes from the mocked RequestId.create.
+    expect(job?.requestIdHex).toBe('00deadbeef00recovery00requestid');
+    // sourceTokenJson is the source-at-state-N-1 (last tx stripped).
+    const sourceParsed = JSON.parse(job?.sourceTokenJson ?? '{}');
+    expect(sourceParsed.transactions).toHaveLength(1);
+  });
+
+  it('recoverStrandedReceivedTokens skips tokens that already have a polling job', async () => {
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    internals(module).proofPollingJobs.set(GENESIS_TOKEN_ID, {
+      tokenId: GENESIS_TOKEN_ID,
+      requestIdHex: 'pre-existing',
+      commitmentJson: '{}',
+      startedAt: Date.now(),
+      attemptCount: 0,
+      lastAttemptAt: 0,
+    });
+
+    const recovered = await internals(module).recoverStrandedReceivedTokens();
+    expect(recovered).toBe(0);
+    expect(internals(module).proofPollingJobs.get(GENESIS_TOKEN_ID)?.requestIdHex).toBe('pre-existing');
+  });
+
+  it('recoverStrandedReceivedTokens skips tokens that are not V6-direct receives', async () => {
+    // Confirmed token with all proofs present.
+    const sdkData = JSON.stringify({
+      version: '2.0',
+      genesis: { data: { tokenId: 'X', coinData: [['UCT_HEX', '100']] }, inclusionProof: {} },
+      state: { predicate: `0000${OUR_PUBKEY.toLowerCase()}0000` },
+      transactions: [{ inclusionProof: { authenticator: { stateHash: 'h1' } }, data: {} }],
+    });
+    internals(module).tokens.set('confirmed-token', {
+      id: 'confirmed-token',
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'confirmed',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    });
+
+    const recovered = await internals(module).recoverStrandedReceivedTokens();
+    expect(recovered).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #144.

## Summary

In CLI usage every `sphere <cmd>` is a fresh Node.js process. The in-memory `proofPollingJobs` Map dies between invocations; combined with `txfToToken`'s `inclusionProof: null → status='pending'` flip on save→load, V6-direct receives whose proof arrives later never finalize. Bob's wallet shows the token as `status='pending'` forever; `payments.sync()` emits the drain warning every poll cycle.

The fix is implementation-ready per the spec on #144, organized in two commits:

1. **`fix(payments): #144 receiver finalize machinery survives process restart`** — three-layer implementation (L1 persistence, L2 retry expansion, L3 invariant + migration) and 15 unit tests.
2. **`fix(payments): #144 steelman pass — close 8 correctness/security gaps`** — adversarial-review fixes A through H, including a CI flake (test timer leak), status-semantics bug (receive jobs marked 'spent'), timeout zombie loop, PROXY DoS amplification, fork-detection bypass, and a pre-existing finalize catch that silently swallowed integrity failures. 3 additional regression tests.

## Architecture

**L1 — Persist `proofPollingJobs`**

- New `STORAGE_KEYS_ADDRESS.PROOF_POLLING_JOBS` KV entry.
- `addProofPollingJob` flushes on every add (fire-and-forget).
- `processProofPollingQueue` flushes on every tick (attempt counts survive a crash).
- `load()` calls `restoreProofPollingJobs` AFTER the token map is populated, re-keying persisted jobs by `(genesisTokenId, stateHash)` to the post-load `Token.id` (which `txfToToken` set to the genesis tokenId).
- Persisted shape carries `sourceTokenJson` + `commitmentJson` so the job can re-fire `finalizeReceivedToken` without the original closure capture.

**L2 — `resolveUnconfirmed` widened**

- Accepts `status === 'pending'` (not just `'submitted'`) so post-load V6-direct receives re-engage the periodic retry.
- New `isReceivedLegacyPending` predicate identifies V6-direct receives by TXF shape (last tx `inclusionProof: null` AND recipient is us).
- New `resolveLegacyReceivedToken` re-fires `finalizeReceivedToken` for status='pending' V6-direct tokens.
- `scheduleResolveUnconfirmed` includes `'pending'`.

**L3 — Balance-model invariant + stranded-token migration**

- `loadFromStorageData`: tokens whose latest state's predicate isn't ours AND have no finalization plan move to the archive map (per #143's mutual-exclusivity refinement). `hasFinalizationPlan` covers `_pendingFinalization`, live polling jobs, AND `isReceivedLegacyPending` so bob's stranded receive (the reproduction case) is preserved.
- `recoverStrandedReceivedTokens` walks `status='pending'` tokens whose last tx is unproved-and-addressed-to-us, derives `requestIdHex` from the source TXF's last-tx data using the same canonical recipe as the recipient UXF worker (`TransferTransactionData.fromJSON` → `PredicateEngineService.createPredicate` → `RequestId.create`), and registers a fresh proof-polling job with empty `commitmentJson`.
- New `finalizeStrandedReceivedToken` patches the proof into the source TXF's lastTxJson and calls `finalizeTransferToken` directly — distinct from `finalizeReceivedToken` because migration jobs lack the sender's `TransferCommitment`.
- `processProofPollingQueue` falls back to `getProof(requestIdHex)` when `commitmentJson` is empty (migration path).

## Steelman fixes (commit 2)

| Fix | Issue | Severity |
|---|---|---|
| A | Test file leaked setInterval timers → CI flake | Critical |
| B | RECEIVE jobs flipped to `status='spent'`; callback was fire-and-forget; throw → permanently stuck | Critical |
| C | Timeout branch only marked `'submitted'` invalid → `'pending'` zombie loop on every restart | Critical |
| D | `resolveLegacyReceivedToken` threw on empty `commitmentJson` → 10s retry was a silent no-op | Warning |
| E | Archive-move silently overwrote existing entries → fork records destroyed | Warning |
| F | `isReceivedLegacyPending` PROXY branch accepted any non-empty hash → DoS amplification | Warning |
| G | `attemptCount` reset on every restore → unbounded zombie polling across restarts | Warning |
| H | `finalizeReceivedToken` catch silently marked 'confirmed' on integrity failures | Warning (pre-existing) |

## Test plan

- [x] `tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts` — 18 unit tests covering L1 persist+restore, L2 resolveUnconfirmed routing, L3 archive-move + recovery, FIX B/C/G regression
- [x] Full PaymentsModule test suite: 366/366 pass
- [x] Full SDK test suite: 7025/7025 pass (was flaky before FIX A)
- [x] Typecheck clean
- [x] Lint: 2 pre-existing warnings, none introduced
- [ ] Manual repro from `manual-test-drain-fix.md` against testnet (next step)