### PR TITLE
fix(communications): #155 — onDirectMessage replay must skip self-sent

### DIFF
--- a/modules/communications/CommunicationsModule.ts
+++ b/modules/communications/CommunicationsModule.ts
@@ -444,23 +444,35 @@ export class CommunicationsModule {
   }
 
   /**
-   * Subscribe to incoming DMs
+   * Subscribe to incoming DMs.
+   *
+   * Replay contract: cached messages that haven't yet been delivered to
+   * `handler` are replayed SYNCHRONOUSLY inside this call, before the
+   * function returns. This is load-bearing for two callers:
+   *   - modules loaded after `Sphere.init` (SwapModule, AccountingModule)
+   *     rely on the replay completing before their `load()` returns so
+   *     they can recover state without losing DMs that arrived while the
+   *     module was being constructed;
+   *   - E2E test helpers distinguish replays from live deliveries by
+   *     ignoring handler invocations that occur before this function
+   *     returns. Changing replay to be asynchronous (deferred via
+   *     queueMicrotask, setImmediate, etc.) would silently break those
+   *     callers — keep it synchronous and update this comment + the
+   *     `synchronous replay` unit test in CommunicationsModule.selffilter
+   *     if the contract ever has to change.
+   *
+   * Self-filter (#155): handleIncomingMessage skips self-sent messages
+   * before calling handlers (`handlers` is the "incoming only" contract,
+   * see CommunicationsModule.selffilter.test.ts). The cache holds BOTH
+   * sent and received messages, so the replay loop must apply the same
+   * filter; otherwise newly registered handlers see their own outbound
+   * messages — exactly the bug that surfaced in #155 dm-nip17 tests.
    */
   onDirectMessage(handler: (message: DirectMessage) => void): () => void {
     this.dmHandlers.add(handler);
 
-    // Replay existing messages to new handler — ensures DMs that arrived
-    // before this handler was registered (e.g., swap proposals arriving
-    // during Sphere.init before SwapModule.load) are not lost.
     // Guard: only replay once per handler reference to prevent duplicate
     // processing when a handler is unsubscribed and re-registered.
-    //
-    // Self-filter (#155): handleIncomingMessage filters out self-sent
-    // messages before calling handlers. The cache (this.messages) holds
-    // BOTH sent and received messages, so a naive replay leaks self-sent
-    // ones to handlers — violating the "incoming only" contract that
-    // CommunicationsModule.selffilter.test.ts asserts. Skip self-sent
-    // here too, using the same key-normalization as getUnreadCount.
     if (!this.replayedHandlers.has(handler)) {
       this.replayedHandlers.add(handler);
       const ownKey = CommunicationsModule._normalizeKey(
@@ -468,9 +480,17 @@ export class CommunicationsModule {
       );
       const snapshot = Array.from(this.messages.values());
       for (const message of snapshot) {
+        // Defensive: malformed cache entries (legacy migration, corrupted
+        // storage) may have a non-string senderPubkey. _normalizeKey reads
+        // .length, so undefined/null would crash the entire replay loop
+        // and propagate out of onDirectMessage. Skip the self-filter for
+        // anything we can't normalize — those messages can't be self-sent
+        // by definition, so delivering them is the safe fallback.
+        const sender = message.senderPubkey;
         if (
           ownKey &&
-          CommunicationsModule._normalizeKey(message.senderPubkey) === ownKey
+          typeof sender === 'string' &&
+          CommunicationsModule._normalizeKey(sender) === ownKey
         ) {
           continue;
         }

--- a/modules/communications/CommunicationsModule.ts
+++ b/modules/communications/CommunicationsModule.ts
@@ -454,10 +454,26 @@ export class CommunicationsModule {
     // during Sphere.init before SwapModule.load) are not lost.
     // Guard: only replay once per handler reference to prevent duplicate
     // processing when a handler is unsubscribed and re-registered.
+    //
+    // Self-filter (#155): handleIncomingMessage filters out self-sent
+    // messages before calling handlers. The cache (this.messages) holds
+    // BOTH sent and received messages, so a naive replay leaks self-sent
+    // ones to handlers — violating the "incoming only" contract that
+    // CommunicationsModule.selffilter.test.ts asserts. Skip self-sent
+    // here too, using the same key-normalization as getUnreadCount.
     if (!this.replayedHandlers.has(handler)) {
       this.replayedHandlers.add(handler);
+      const ownKey = CommunicationsModule._normalizeKey(
+        this.deps?.identity.chainPubkey ?? ''
+      );
       const snapshot = Array.from(this.messages.values());
       for (const message of snapshot) {
+        if (
+          ownKey &&
+          CommunicationsModule._normalizeKey(message.senderPubkey) === ownKey
+        ) {
+          continue;
+        }
         try {
           handler(message);
         } catch (err) {

--- a/tests/e2e/dm-nip17.test.ts
+++ b/tests/e2e/dm-nip17.test.ts
@@ -45,10 +45,23 @@ async function ensureTrustbase(dataDir: string): Promise<void> {
 function waitForDM(sphere: Sphere, timeoutMs = 15000): Promise<DirectMessage> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(`Timeout: DM not received within ${timeoutMs}ms`)), timeoutMs);
-    sphere.communications.onDirectMessage((msg) => {
+    // onDirectMessage replays already-stored messages to new handlers
+    // (see CommunicationsModule.onDirectMessage). The replay loop runs
+    // synchronously inside onDirectMessage(), so any handler invocation
+    // that happens before onDirectMessage() returns is a replay — drop
+    // those and only accept live deliveries. Without this guard,
+    // waitForDM would resolve with a stale message on every iteration
+    // after the first.
+    let acceptLive = false;
+    let resolved = false;
+    const unsub: (() => void) = sphere.communications.onDirectMessage((msg) => {
+      if (!acceptLive || resolved) return;
+      resolved = true;
       clearTimeout(timer);
+      try { unsub(); } catch { /* ignore */ }
       resolve(msg);
     });
+    acceptLive = true;
   });
 }
 

--- a/tests/e2e/dm-nip17.test.ts
+++ b/tests/e2e/dm-nip17.test.ts
@@ -44,21 +44,32 @@ async function ensureTrustbase(dataDir: string): Promise<void> {
 
 function waitForDM(sphere: Sphere, timeoutMs = 15000): Promise<DirectMessage> {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`Timeout: DM not received within ${timeoutMs}ms`)), timeoutMs);
     // onDirectMessage replays already-stored messages to new handlers
-    // (see CommunicationsModule.onDirectMessage). The replay loop runs
-    // synchronously inside onDirectMessage(), so any handler invocation
-    // that happens before onDirectMessage() returns is a replay — drop
-    // those and only accept live deliveries. Without this guard,
-    // waitForDM would resolve with a stale message on every iteration
-    // after the first.
+    // (see CommunicationsModule.onDirectMessage JSDoc — replay is
+    // contractually synchronous). Any handler invocation that fires
+    // before onDirectMessage() returns is a replay; only accept live
+    // deliveries. Without this guard, waitForDM would resolve with a
+    // stale message whenever the cache already holds a prior peer-sent
+    // message — e.g. every iteration after the first in the
+    // multi-exchange test.
     let acceptLive = false;
     let resolved = false;
-    const unsub: (() => void) = sphere.communications.onDirectMessage((msg) => {
+    let unsub: (() => void) | null = null;
+    const cleanup = () => {
+      if (unsub) {
+        try { unsub(); } catch { /* ignore */ }
+        unsub = null;
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timeout: DM not received within ${timeoutMs}ms`));
+    }, timeoutMs);
+    unsub = sphere.communications.onDirectMessage((msg) => {
       if (!acceptLive || resolved) return;
       resolved = true;
       clearTimeout(timer);
-      try { unsub(); } catch { /* ignore */ }
+      cleanup();
       resolve(msg);
     });
     acceptLive = true;

--- a/tests/unit/modules/CommunicationsModule.selffilter.test.ts
+++ b/tests/unit/modules/CommunicationsModule.selffilter.test.ts
@@ -273,5 +273,144 @@ describe('CommunicationsModule — self-message filtering', () => {
         senderPubkey: PEER_PUBKEY,
       }));
     });
+
+    it('should NOT replay self-sent message stored in x-only form', async () => {
+      // Defensive coverage: legacy cache entries may store senderPubkey
+      // in x-only (64-char) form rather than compressed (66-char). The
+      // current chainPubkey is compressed, so _normalizeKey must canonicalise
+      // both sides to the same x-only lowercase form for the filter to
+      // catch this as self-sent.
+      const storage = createMockStorage();
+      const selfSentXOnly: DirectMessage = {
+        id: 'self-xonly',
+        senderPubkey: MY_XONLY, // 64-char, no 02/03 prefix
+        recipientPubkey: PEER_PUBKEY,
+        content: 'outgoing stored in x-only form',
+        timestamp: Date.now(),
+        isRead: false,
+      };
+      await storage.set('messages', JSON.stringify([selfSentXOnly]));
+
+      mod = new CommunicationsModule();
+      mod.initialize({
+        identity: createMockIdentity(MY_PUBKEY), // compressed form
+        storage,
+        transport: createMockTransport(),
+        emitEvent: vi.fn(),
+      });
+      await mod.load();
+
+      const handler = vi.fn();
+      mod.onDirectMessage(handler);
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should replay everything when identity has no chainPubkey', async () => {
+      // Degenerate case: identity present but chainPubkey is empty. The
+      // self-filter must short-circuit (`if (ownKey && ...)`) so legit
+      // messages still flow rather than being all dropped or crashing.
+      const storage = createMockStorage();
+      const incoming: DirectMessage = {
+        id: 'incoming-1',
+        senderPubkey: PEER_PUBKEY,
+        recipientPubkey: MY_XONLY,
+        content: 'incoming under blank identity',
+        timestamp: Date.now(),
+        isRead: false,
+      };
+      await storage.set('messages', JSON.stringify([incoming]));
+
+      mod = new CommunicationsModule();
+      mod.initialize({
+        identity: createMockIdentity(''), // empty chainPubkey
+        storage,
+        transport: createMockTransport(),
+        emitEvent: vi.fn(),
+      });
+      await mod.load();
+
+      const handler = vi.fn();
+      mod.onDirectMessage(handler);
+
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('should not crash when cached message has malformed senderPubkey', async () => {
+      // Storage corruption or pre-validation legacy data could produce a
+      // message where senderPubkey is undefined / wrong shape. The replay
+      // loop must not propagate an exception out of onDirectMessage, since
+      // that breaks every subsequent caller (test helpers, SwapModule.load,
+      // AccountingModule.load).
+      const storage = createMockStorage();
+      const malformed = {
+        id: 'malformed-1',
+        // senderPubkey intentionally missing
+        recipientPubkey: MY_PUBKEY,
+        content: 'corrupted entry',
+        timestamp: Date.now(),
+        isRead: false,
+      } as unknown as DirectMessage;
+      const ok: DirectMessage = {
+        id: 'ok-1',
+        senderPubkey: PEER_PUBKEY,
+        recipientPubkey: MY_PUBKEY,
+        content: 'still delivered',
+        timestamp: Date.now(),
+        isRead: false,
+      };
+      await storage.set('messages', JSON.stringify([malformed, ok]));
+
+      mod = new CommunicationsModule();
+      mod.initialize({
+        identity: createMockIdentity(MY_PUBKEY),
+        storage,
+        transport: createMockTransport(),
+        emitEvent: vi.fn(),
+      });
+      await mod.load();
+
+      const handler = vi.fn();
+      // Must not throw — replay must continue past the malformed entry.
+      expect(() => mod.onDirectMessage(handler)).not.toThrow();
+      // The well-formed peer-sent entry still gets delivered. (The
+      // malformed entry is delivered too — non-string senderPubkey can't
+      // be self-sent by definition, so the safe fallback is to surface it.)
+      const deliveredContents = handler.mock.calls.map(([m]) => m.content);
+      expect(deliveredContents).toContain('still delivered');
+    });
+
+    it('contract: onDirectMessage replays synchronously before returning', () => {
+      // The dm-nip17.test.ts waitForDM helper depends on this contract to
+      // distinguish replays from live deliveries. If a future change
+      // defers replay (queueMicrotask, setImmediate, …), this test fails
+      // fast — fix the contract in onDirectMessage and update both the
+      // test helper and the JSDoc above onDirectMessage.
+      const storage = createMockStorage();
+      mod = new CommunicationsModule();
+      let onMsgCallback: ((msg: IncomingMessage) => void) | null = null;
+      const transport = createMockTransport((handler) => {
+        onMsgCallback = handler;
+        return () => {};
+      });
+      mod.initialize({
+        identity: createMockIdentity(MY_PUBKEY),
+        storage,
+        transport,
+        emitEvent: vi.fn(),
+      });
+      // Seed an incoming message before any handler is registered.
+      onMsgCallback!(makeIncomingMessage({
+        senderTransportPubkey: PEER_PUBKEY,
+        content: 'must replay synchronously',
+      }));
+
+      const handler = vi.fn();
+      mod.onDirectMessage(handler);
+      // Critical: by the time onDirectMessage returns, the replay MUST
+      // already have called handler. Any deferred-replay refactor that
+      // schedules handler invocation for a later microtask breaks this.
+      expect(handler).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/tests/unit/modules/CommunicationsModule.selffilter.test.ts
+++ b/tests/unit/modules/CommunicationsModule.selffilter.test.ts
@@ -182,4 +182,96 @@ describe('CommunicationsModule — self-message filtering', () => {
       recipientPubkey: PEER_PUBKEY,
     }));
   });
+
+  // ===========================================================================
+  // Replay-on-register self-filter (#155)
+  //
+  // onDirectMessage() replays cached messages to newly registered handlers so
+  // modules loaded after a DM arrives (e.g. SwapModule.load during
+  // Sphere.init) don't miss them. The cache stores BOTH sent and received
+  // messages, so the replay loop must apply the same self-filter that
+  // handleIncomingMessage applies — otherwise registered handlers see their
+  // own sent messages, violating the "incoming only" contract asserted above.
+  // ===========================================================================
+
+  describe('onDirectMessage replay self-filter', () => {
+    it('should NOT replay self-sent messages to a newly registered handler', async () => {
+      // Pre-populate storage with one self-sent message and one peer-sent
+      // message, then load() into the cache and register a handler.
+      // Replay must fire only for the peer-sent message.
+      const storage = createMockStorage();
+      const selfSent: DirectMessage = {
+        id: 'self-sent-1',
+        senderPubkey: MY_PUBKEY,
+        recipientPubkey: PEER_PUBKEY,
+        content: 'outgoing from me',
+        timestamp: Date.now(),
+        isRead: false,
+      };
+      const peerSent: DirectMessage = {
+        id: 'peer-sent-1',
+        senderPubkey: PEER_PUBKEY,
+        recipientPubkey: MY_PUBKEY,
+        content: 'incoming from peer',
+        timestamp: Date.now(),
+        isRead: false,
+      };
+      // Seed per-address messages key (matches load() lookup path).
+      await storage.set('messages', JSON.stringify([selfSent, peerSent]));
+
+      mod = new CommunicationsModule();
+      const transport = createMockTransport();
+      const deps: CommunicationsModuleDependencies = {
+        identity: createMockIdentity(MY_PUBKEY),
+        storage,
+        transport,
+        emitEvent: vi.fn(),
+      };
+      mod.initialize(deps);
+      await mod.load();
+
+      const handler = vi.fn();
+      mod.onDirectMessage(handler);
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'peer-sent-1',
+        content: 'incoming from peer',
+      }));
+    });
+
+    it('should replay incoming messages to a newly registered handler', () => {
+      mod = new CommunicationsModule();
+      let onMsgCallback: ((msg: IncomingMessage) => void) | null = null;
+      const transport = createMockTransport((handler) => {
+        onMsgCallback = handler;
+        return () => {};
+      });
+      const deps: CommunicationsModuleDependencies = {
+        identity: createMockIdentity(MY_PUBKEY),
+        storage: createMockStorage(),
+        transport,
+        emitEvent: vi.fn(),
+      };
+      mod.initialize(deps);
+
+      // Simulate an incoming message arriving before any handler registers.
+      onMsgCallback!(makeIncomingMessage({
+        senderTransportPubkey: PEER_PUBKEY,
+        content: 'incoming before handler',
+      }));
+
+      // Now register a handler — the replay should fire it once with the
+      // incoming message (this is the documented "don't lose DMs that
+      // arrived during init" guarantee).
+      const handler = vi.fn();
+      mod.onDirectMessage(handler);
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+        content: 'incoming before handler',
+        senderPubkey: PEER_PUBKEY,
+      }));
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #155. The dm-nip17 E2E test failures ("70 seconds idle" + "sustains multiple DM exchanges") were misdiagnosed as a Nostr connection-stability regression. The relay holds up fine — the failure is in-process: `CommunicationsModule.onDirectMessage` replays cached messages to newly registered handlers (so modules loaded after a DM arrives don't miss it), but the cache contains **both** sent and received messages. The live path (`handleIncomingMessage`) filters self-sent before calling handlers; the replay path didn't. Handlers got their own outgoing messages replayed to them, which `CommunicationsModule.selffilter.test.ts` already asserts must not happen on the live path.

Manifestations:
- **70s idle test**: Bob sends a greeting first. `waitForDM(bob)` then registers a handler that resolves immediately with Bob's own outgoing greeting — never waits for Alice's reply.
- **Multiple exchanges**: From iteration 2 onward, each `waitForDM` is satisfied by a replayed historical message instead of the current iteration's send.

## Changes

1. **SDK fix** (`modules/communications/CommunicationsModule.ts`): apply the same `_normalizeKey` self-filter inside the replay loop. Sent messages stay in the cache (still visible via `getConversation`/history) but no longer leak to incoming handlers.
2. **Test fix** (`tests/e2e/dm-nip17.test.ts`): harden `waitForDM` so it ignores any handler invocation that happens synchronously inside `onDirectMessage()` — those are replays of pre-existing cached messages, not live deliveries. This makes the helper robust against future replays of old incoming messages too.
3. **Unit tests** (`tests/unit/modules/CommunicationsModule.selffilter.test.ts`): add two cases covering the new replay contract (replay skips self-sent, still delivers peer-sent that arrived before registration).

## Test plan

- [x] Unit suite — 2630 / 2630 passing
- [x] Integration suite — 179 / 179 passing
- [x] dm-nip17 E2E — 5 / 5 passing (was 2 / 5 before)
- [x] messaging-e2e — 14 / 14 passing (no regression)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on touched files clean

## Notes for reviewers

- The "Client disconnected" log during messaging-e2e teardown that #155 mentions as an adjacent signal is unrelated to this fix and was pre-existing. It's a destroy-order issue (sphere tries to send a read receipt as part of teardown after the transport has already started disconnecting) and warrants a separate follow-up, but it does not cause test failures.
- The internal users of `onDirectMessage` (SwapModule, AccountingModule, Sphere) only need INCOMING DMs replayed — they track their own outbound messages through other paths (storage, sent-tx index). Removing self-sent from the replay does not break any consumer.