### PR TITLE
fix(test): #149 — production-shaped fixtures for transfer integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ tests/integration/.test-*/
 
 # E2e preflight infra-probe result (regenerated each run)
 tests/e2e/.preflight-result.json
+
+# Community / Discord report drafts (agent-authored, not source)
+community-reports/

--- a/tests/integration/transfer/_harness.ts
+++ b/tests/integration/transfer/_harness.ts
@@ -256,3 +256,39 @@ export function rewriteFixtureTokenId(
     },
   };
 }
+
+/**
+ * Produce a copy of a TOKEN fixture with the genesis `coinData` rewritten.
+ *
+ * Production `TokenSplitExecutor` mints recipient tokens whose `coinData`
+ * is `[[coinId, splitAmount]]` — only the requested slice, not the source's
+ * full balance. NFT-direct transfers preserve the source's empty/null
+ * `coinData`. The OVER_TRANSFER_GUARD (`over-transfer-guard.ts`) inspects
+ * the recipient JSON's `coinData` per source as defense-in-depth against
+ * a buggy commitSources callback silently over-sending.
+ *
+ * Tests that ingest a `TOKEN_A`-shaped placeholder as a recipient JSON
+ * must override `coinData` to match what the production planner would
+ * produce — otherwise the guard fires on `TOKEN_A`'s default
+ * `[['UCT', '1000000']]` against a smaller per-coin request budget.
+ *
+ * Pass `[]` or `null` for NFT-class recipients (empty/absent coinData →
+ * guard treats as NFT and skips the budget check).
+ */
+export function rewriteFixtureCoinData(
+  fixture: Record<string, unknown>,
+  coinData: ReadonlyArray<readonly [string, string]> | null,
+): Record<string, unknown> {
+  const genesis = (fixture as { genesis: Record<string, unknown> }).genesis;
+  const data = genesis.data as Record<string, unknown>;
+  return {
+    ...fixture,
+    genesis: {
+      ...genesis,
+      data: {
+        ...data,
+        coinData,
+      },
+    },
+  };
+}

--- a/tests/integration/transfer/crash-recovery.test.ts
+++ b/tests/integration/transfer/crash-recovery.test.ts
@@ -420,11 +420,18 @@ describe('T.6.E — conservative crash between outbox commit and Nostr publish',
     expect(events.filter((e) => e.type === 'transfer:failed')).toHaveLength(1);
 
     // Acceptance — the outbox commit IS durable (status='sending').
+    // Persisted `tokenIds` is the per-commit recipient genesis tokenId
+    // (commit 718ab12 / #142 Loop4 — orchestrator advertises the
+    // recipient's mint, not the source). For a direct (whole-token)
+    // transfer of TOKEN_A the recipient preserves the source's tokenId
+    // → TOKEN_A.genesis.data.tokenId.
+    const tokenAGenesisId =
+      'aa00000000000000000000000000000000000000000000000000000000000001';
     const persisted = readPersistedEntry(store, addressId, transferId);
     expect(persisted).not.toBeNull();
     expect(persisted!.status).toBe<UxfOutboxStatus>('sending');
     expect(persisted!.bundleCid.length).toBeGreaterThan(0);
-    expect(persisted!.tokenIds).toEqual(['tok-1']);
+    expect(persisted!.tokenIds).toEqual([tokenAGenesisId]);
 
     // Acceptance — transport recorded ZERO publish attempts.
     expect(transport._calls).toHaveLength(0);

--- a/tests/integration/transfer/mixed-coin-nft.test.ts
+++ b/tests/integration/transfer/mixed-coin-nft.test.ts
@@ -47,6 +47,7 @@ import {
   makePeerInfo,
   makeRecordingTransport,
   makeToken,
+  rewriteFixtureCoinData,
   rewriteFixtureTokenId,
 } from './_harness';
 
@@ -76,11 +77,20 @@ describe('§11.2 — mixed coin + NFT send (separate sources)', () => {
       return { id: token.id, coins: null };
     };
 
-    // Coin commit: split → fresh recipient-token id.
-    // NFT commit: direct → preserved tokenId.
-    const coinChild = rewriteFixtureTokenId(
-      TOKEN_A,
-      `cc${'1'.padStart(2, '0')}${'0'.repeat(60)}`,
+    // Coin commit: split → fresh recipient-token id, coinData = the
+    // requested slice (UCT, 30). NFT commit: direct → preserved tokenId,
+    // empty coinData (NFT-shape per §4.1 class-disjointness rule).
+    // OVER_TRANSFER_GUARD inspects each commit's recipient coinData; the
+    // default TOKEN_A placeholder (`[['UCT', '1000000']]`) would trip
+    // the per-coin budget check.
+    const coinChildIdHex = `cc${'1'.padStart(2, '0')}${'0'.repeat(60)}`;
+    const coinChild = rewriteFixtureCoinData(
+      rewriteFixtureTokenId(TOKEN_A, coinChildIdHex),
+      [['UCT', '30']],
+    );
+    const nftChild = rewriteFixtureCoinData(
+      rewriteFixtureTokenId(TOKEN_A, nftIdHex),
+      [],
     );
     const commitResults: ConservativeCommitResult[] = [
       {
@@ -94,7 +104,7 @@ describe('§11.2 — mixed coin + NFT send (separate sources)', () => {
         sourceTokenId: nftIdHex,
         method: 'direct',
         requestIdHex: `req-${nftIdHex}`,
-        recipientTokenJson: rewriteFixtureTokenId(TOKEN_A, nftIdHex),
+        recipientTokenJson: nftChild,
       },
     ];
 
@@ -130,9 +140,12 @@ describe('§11.2 — mixed coin + NFT send (separate sources)', () => {
     const result = await sendConservativeUxf(request, makePeerInfo(), deps);
     expect(result.status).toBe('completed');
 
-    // Bundle carries both source ids on the wire.
+    // Bundle carries the RECIPIENT genesis tokenIds on the wire
+    // (commit 718ab12 / #142 Loop4). Coin source = split → child has
+    // a fresh tokenId. NFT source = direct → child preserves source
+    // tokenId.
     const payload = transport._calls[0].payload as UxfTransferPayloadCar;
-    expect([...payload.tokenIds].sort()).toEqual([coinIdHex, nftIdHex].sort());
+    expect([...payload.tokenIds].sort()).toEqual([coinChildIdHex, nftIdHex].sort());
 
     // Per-token detail: coin = split + splitGroupId; NFT = direct (no
     // splitGroupId).

--- a/tests/integration/transfer/multi-coin-additional-assets.test.ts
+++ b/tests/integration/transfer/multi-coin-additional-assets.test.ts
@@ -45,6 +45,7 @@ import {
   makePeerInfo,
   makeRecordingTransport,
   makeToken,
+  rewriteFixtureCoinData,
   rewriteFixtureTokenId,
 } from './_harness';
 
@@ -71,10 +72,18 @@ describe('§11.2 — additionalAssets happy path (single multi-coin source)', ()
     });
 
     // Recipient child: one fresh token with the requested slice
-    // {UCT:30, USDU:20}. The orchestrator does NOT inspect the JSON;
-    // we use the fixture's shape as a placeholder.
+    // {UCT:30, USDU:20}. The OVER_TRANSFER_GUARD inspects
+    // `genesis.data.coinData` per source — defense-in-depth against a
+    // buggy commitSources callback that silently over-sends. The
+    // placeholder fixture's default `coinData: [['UCT', '1000000']]`
+    // would trip the guard against the {UCT:30, USDU:20} budget, so
+    // we rewrite coinData to match what production's TokenSplitExecutor
+    // would mint for this slice.
     const childIdHex = `bb${'1'.padStart(2, '0')}${'0'.repeat(60)}`;
-    const childFixture = rewriteFixtureTokenId(TOKEN_A, childIdHex);
+    const childFixture = rewriteFixtureCoinData(
+      rewriteFixtureTokenId(TOKEN_A, childIdHex),
+      [['UCT', '30'], ['USDU', '20']],
+    );
 
     const commitResult: ConservativeCommitResult = {
       sourceTokenId: srcIdHex,
@@ -116,8 +125,12 @@ describe('§11.2 — additionalAssets happy path (single multi-coin source)', ()
     const result = await sendConservativeUxf(request, makePeerInfo(), deps);
     expect(result.status).toBe('completed');
 
+    // Wire `payload.tokenIds` is the RECIPIENT's genesis tokenId
+    // (commit 718ab12 / #142 Loop4 — without this, the recipient's
+    // bundle-verifier falls to advisoryUnclaimedRoots and silently
+    // drops the transfer). For a split the child's tokenId is fresh.
     const payload = transport._calls[0].payload as UxfTransferPayloadCar;
-    expect(payload.tokenIds).toEqual([srcIdHex]);
+    expect(payload.tokenIds).toEqual([childIdHex]);
     expect(events.count('transfer:confirmed')).toBe(1);
     expect(result.tokenTransfers).toHaveLength(1);
     expect(result.tokenTransfers[0].method).toBe('split');
@@ -152,14 +165,20 @@ describe('§11.2 — additionalAssets happy path (single multi-coin source)', ()
       return { id: token.id, coins: [{ coinId: 'USDU', amount: 50n }] };
     };
 
-    // Two children, one per source.
-    const childA = rewriteFixtureTokenId(
-      TOKEN_A,
-      `cc${'1'.padStart(2, '0')}${'0'.repeat(60)}`,
+    // Two children, one per source. Each child's `coinData` reflects
+    // ONLY the slice that source contributes (TokenSplitExecutor mints
+    // recipient coinData = `[[coinId, splitAmount]]`). The
+    // OVER_TRANSFER_GUARD enforces this per-source — sticking with the
+    // default TOKEN_A placeholder coinData would trip it.
+    const childAIdHex = `cc${'1'.padStart(2, '0')}${'0'.repeat(60)}`;
+    const childBIdHex = `cc${'2'.padStart(2, '0')}${'0'.repeat(60)}`;
+    const childA = rewriteFixtureCoinData(
+      rewriteFixtureTokenId(TOKEN_A, childAIdHex),
+      [['UCT', '30']],
     );
-    const childB = rewriteFixtureTokenId(
-      TOKEN_A,
-      `cc${'2'.padStart(2, '0')}${'0'.repeat(60)}`,
+    const childB = rewriteFixtureCoinData(
+      rewriteFixtureTokenId(TOKEN_A, childBIdHex),
+      [['USDU', '20']],
     );
     const commitResults: ConservativeCommitResult[] = [
       {
@@ -209,8 +228,10 @@ describe('§11.2 — additionalAssets happy path (single multi-coin source)', ()
     expect(result.status).toBe('completed');
 
     const payload = transport._calls[0].payload as UxfTransferPayloadCar;
-    // Both source ids surface in tokenIds, lex-sorted.
-    expect([...payload.tokenIds].sort()).toEqual([srcA.id, srcB.id].sort());
+    // `payload.tokenIds` is the per-commit recipient genesis tokenId,
+    // lex-sorted (commit 718ab12 / #142 Loop4). Splits produce fresh
+    // child tokenIds, distinct from each source's id.
+    expect([...payload.tokenIds].sort()).toEqual([childAIdHex, childBIdHex].sort());
     expect(result.tokenTransfers).toHaveLength(2);
     expect(events.count('transfer:confirmed')).toBe(1);
   });

--- a/tests/integration/transfer/multi-coin-token.test.ts
+++ b/tests/integration/transfer/multi-coin-token.test.ts
@@ -46,6 +46,7 @@ import {
   makePeerInfo,
   makeRecordingTransport,
   makeToken,
+  rewriteFixtureCoinData,
   rewriteFixtureTokenId,
 } from './_harness';
 
@@ -81,9 +82,16 @@ describe('§11.2 — multi-coin source, single-coin send (UCT slice)', () => {
     const source = makeToken({ id: srcIdHex, fixture: sourceFixture });
 
     // Recipient child: a fresh tokenId carrying only UCT(30). The
-    // orchestrator gets exactly this JSON ingested into the bundle.
+    // orchestrator ingests this JSON into the bundle and the
+    // OVER_TRANSFER_GUARD inspects `coinData` per source — overriding
+    // the placeholder's default `[['UCT', '1000000']]` so the per-coin
+    // ship-vs-budget sum lands at the exact requested slice (matches
+    // what production's TokenSplitExecutor would mint).
     const childIdHex = `bb${'1'.padStart(2, '0')}${'0'.repeat(60)}`;
-    const childFixture = rewriteFixtureTokenId(TOKEN_A, childIdHex);
+    const childFixture = rewriteFixtureCoinData(
+      rewriteFixtureTokenId(TOKEN_A, childIdHex),
+      [['UCT', '30']],
+    );
 
     const commitResult: ConservativeCommitResult = {
       sourceTokenId: srcIdHex,
@@ -125,11 +133,14 @@ describe('§11.2 — multi-coin source, single-coin send (UCT slice)', () => {
     const result = await sendConservativeUxf(request, makePeerInfo(), deps);
     expect(result.status).toBe('completed');
 
-    // Wire payload carries exactly ONE tokenId — the source's id.
-    // (The orchestrator surfaces sourceTokenId on the wire, not the
-    // freshly-minted child's tokenId; that's an SDK-side mapping.)
+    // Wire payload carries exactly ONE tokenId — the recipient mint's
+    // freshly-minted child tokenId. Commit 718ab12 (#142 Loop4) fixed
+    // a recipient-side silent loss: advertising sourceTokenId caused
+    // the receiver's bundle-verifier to fall to advisoryUnclaimedRoots
+    // because the source token isn't in the CAR (it was burned). The
+    // child mint IS in the CAR, so it must surface in tokenIds.
     const payload = transport._calls[0].payload as UxfTransferPayloadCar;
-    expect(payload.tokenIds).toEqual([srcIdHex]);
+    expect(payload.tokenIds).toEqual([childIdHex]);
     expect(payload.mode).toBe('conservative');
 
     // method='split' on the per-source TokenTransferDetail (the SDK

--- a/tests/integration/transfer/nft-only-send.test.ts
+++ b/tests/integration/transfer/nft-only-send.test.ts
@@ -41,6 +41,7 @@ import {
   makePeerInfo,
   makeRecordingTransport,
   makeToken,
+  rewriteFixtureCoinData,
   rewriteFixtureTokenId,
 } from './_harness';
 
@@ -62,7 +63,14 @@ function nftProjection(token: Token): TokenLike {
 describe('§11.2 — NFT-only send (single NFT, no primary slot)', () => {
   it('omits primary coinId/amount; additionalAssets carries one NFT entry; whole-token transfer', async () => {
     const nftIdHex = `aa${'1'.padStart(2, '0')}${'0'.repeat(60)}`;
-    const nftFixture = rewriteFixtureTokenId(TOKEN_A, nftIdHex);
+    // NFTs carry empty `coinData` per §4.1 (class-disjoint with coin
+    // tokens). The default TOKEN_A placeholder has UCT in coinData
+    // which would trip OVER_TRANSFER_GUARD on a request with no
+    // primary coin slot (budget = 0 for any coin).
+    const nftFixture = rewriteFixtureCoinData(
+      rewriteFixtureTokenId(TOKEN_A, nftIdHex),
+      [],
+    );
     const nftToken = makeToken({
       id: nftIdHex,
       fixture: nftFixture,
@@ -125,27 +133,32 @@ describe('§11.2 — NFT-only send (single NFT, no primary slot)', () => {
   it('multi-NFT send: two distinct NFTs in one bundle — both surface on the wire', async () => {
     const nft1Hex = `aa${'1'.padStart(2, '0')}${'0'.repeat(60)}`;
     const nft2Hex = `aa${'2'.padStart(2, '0')}${'0'.repeat(60)}`;
-    const nft1 = makeToken({
-      id: nft1Hex,
-      fixture: rewriteFixtureTokenId(TOKEN_A, nft1Hex),
-    });
-    const nft2 = makeToken({
-      id: nft2Hex,
-      fixture: rewriteFixtureTokenId(TOKEN_A, nft2Hex),
-    });
+    // Both NFT fixtures carry empty coinData (§4.1 class-disjoint).
+    // OVER_TRANSFER_GUARD treats empty/absent coinData as NFT-shape
+    // and skips the per-coin budget check.
+    const nft1Fixture = rewriteFixtureCoinData(
+      rewriteFixtureTokenId(TOKEN_A, nft1Hex),
+      [],
+    );
+    const nft2Fixture = rewriteFixtureCoinData(
+      rewriteFixtureTokenId(TOKEN_A, nft2Hex),
+      [],
+    );
+    const nft1 = makeToken({ id: nft1Hex, fixture: nft1Fixture });
+    const nft2 = makeToken({ id: nft2Hex, fixture: nft2Fixture });
 
     const commitResults: ConservativeCommitResult[] = [
       {
         sourceTokenId: nft1Hex,
         method: 'direct',
         requestIdHex: `req-${nft1Hex}`,
-        recipientTokenJson: rewriteFixtureTokenId(TOKEN_A, nft1Hex),
+        recipientTokenJson: nft1Fixture,
       },
       {
         sourceTokenId: nft2Hex,
         method: 'direct',
         requestIdHex: `req-${nft2Hex}`,
-        recipientTokenJson: rewriteFixtureTokenId(TOKEN_A, nft2Hex),
+        recipientTokenJson: nft2Fixture,
       },
     ];
 


### PR DESCRIPTION
## Summary

Resolves the 7 stable transfer/* failures on `integration/all-fixes` flagged in issue #149's latest comment (2026-05-15).

Investigation showed these were **test-side artifacts**, not production code bugs:

- The `OVER_TRANSFER_GUARD` (`modules/payments/transfer/over-transfer-guard.ts`) already correctly aggregates per-coin budgets from `request.coinId` + `additionalAssets[]`. The issue comment's hypothesis that `additionalAssets` were missing from the budget map was based on a stale read.
- 5 of 7 failures used `TOKEN_A` as a placeholder for `recipientTokenJson`. `TOKEN_A` has `coinData: [['UCT', '1000000']]`. The guard correctly inspects per-commit coinData against the request budget; the stale UCT entry exceeded budgets like `{UCT:30, USDU:20}` or NFT-only (no primary coin slot), so the guard fired as designed.
- 2 of 7 stale `payload.tokenIds` assertions expected source ids; commit 718ab12 (#142 Loop4) intentionally changed the orchestrator to advertise recipient genesis tokenIds (required so the receiver's bundle-verifier can claim tokens from the CAR pool — otherwise transfers silently dropped to `advisoryUnclaimedRoots`).
- 1 of 7 stale `persisted.tokenIds` assertion in `crash-recovery` T.6.E (same root cause as above — outbox persistence mirrors the wire payload's tokenIds).

## Changes

- **`tests/integration/transfer/_harness.ts`** — Add `rewriteFixtureCoinData` helper (mirrors the existing `rewriteFixtureTokenId`).
- **5 test files** — Update recipient fixtures to match what production's planner mints:
  - Coin splits → `coinData: [[coinId, splitAmount]]` (per `TokenSplitExecutor` line 134).
  - NFT-direct → `coinData: []` (empty → guard's NFT-skip branch).
- **3 assertions** — Update expected tokenIds to the recipient's genesis tokenId. Orchestrator-level invariants (status, `tokenTransfers.length`, `method`, `splitGroupId`, transport call count) unchanged — only the specific tokenId values are corrected to mirror the 718ab12 behavior change.
- **`.gitignore`** — Add `community-reports/` entry (agent-authored drafts, picked up while staging).

## Test plan

- [x] 7 previously-failing tests now pass.
- [x] Full transfer integration suite: **74/74 pass**.
- [x] All unit tests: **6621 pass** (6 skipped, unchanged baseline).
- [x] All integration tests: **390 pass** (13 skipped, unchanged baseline).
- [x] `npm run typecheck` — clean.
- [x] `npx eslint` on changed files — clean.

## Closes

Closes #149.