### PR TITLE
fix(e2e): #157 swap-continuous skip missing escrow instead of ENOENT

### DIFF
--- a/tests/e2e/swap-continuous.test.ts
+++ b/tests/e2e/swap-continuous.test.ts
@@ -38,9 +38,15 @@ import {
   rand,
 } from './helpers';
 
-const SKIP = !process.env.RUN_CONTINUOUS_TESTS;
 const ESCROW_SRC = process.env.ESCROW_DIR || join(__dirname, '../../../../escrow-service');
 const SDK_ROOT = join(__dirname, '../..');
+const ESCROW_AVAILABLE = existsSync(ESCROW_SRC);
+if (process.env.RUN_CONTINUOUS_TESTS && !ESCROW_AVAILABLE) {
+  console.warn(
+    `[preflight] skipping swap-continuous: escrow source not present at ${ESCROW_SRC}`,
+  );
+}
+const SKIP = !process.env.RUN_CONTINUOUS_TESTS || !ESCROW_AVAILABLE;
 
 // Timeouts
 const ESCROW_STARTUP_TIMEOUT = 60_000;


### PR DESCRIPTION
## Summary

- `swap-continuous.test.ts` previously hard-failed with ENOENT when `ESCROW_SRC` (default `/home/escrow-service`, overridable via `ESCROW_DIR`) was not present — turning a missing-dev-infra condition into a test FAIL during PR #153's comprehensive run.
- Probe the escrow source at module load via `existsSync()` and fold the result into the existing `SKIP` gate so the suite cleanly skips when the source is missing.
- When opted in via `RUN_CONTINUOUS_TESTS=1` but the source is missing, emit a single `[preflight] skipping swap-continuous: …` warning matching the pattern used by `tests/e2e/lib/preflight.ts`. Silent otherwise.

Closes #157.

## Test plan

- [x] `RUN_CONTINUOUS_TESTS` unset → 2 tests skipped, no log, no ENOENT.
- [x] `RUN_CONTINUOUS_TESTS=1 ESCROW_DIR=/nonexistent/escrow-foo` → 2 tests skipped, `[preflight] skipping swap-continuous: escrow source not present at /nonexistent/escrow-foo` printed.
- [x] `npx eslint tests/e2e/swap-continuous.test.ts` — no new errors/warnings (pre-existing `require()` import errors unchanged).
- [x] `npx tsc --noEmit` — clean.