### PR TITLE
feat(#166): P1 #2 tombstone Lamport + P1 #3 DoS bounds-defense

### DIFF
--- a/core/errors.ts
+++ b/core/errors.ts
@@ -47,6 +47,12 @@ export type SphereErrorCode =
   // live OUTBOX entry OR in the SENT ledger. Override via
   // `TransferRequest.allowDuplicateBundleMembership = true`.
   | 'DUPLICATE_BUNDLE_MEMBERSHIP'
+  // Issue #166 P1 #2 — tombstone resurrection guard.
+  // `OutboxWriter.write()` and `SentLedgerWriter.write()` refuse to
+  // overwrite a slot that currently holds a tombstone marker. Pass
+  // `{ allowResurrection: true }` as the second argument for
+  // operator escape-hatch / test-fixture resurrections.
+  | 'OUTBOX_ENTRY_TOMBSTONED'
   | 'STORAGE_ERROR'
   | 'STORAGE_CORRUPTED'
   | 'TRANSPORT_ERROR'

--- a/profile/outbox-writer.ts
+++ b/profile/outbox-writer.ts
@@ -60,6 +60,7 @@ import { decryptProfileValue, encryptProfileValue } from './encryption.js';
 import { Lamport } from './lamport.js';
 import { assertTransition } from './outbox-state-machine.js';
 import type { ProfileDatabase } from './types.js';
+import { MAX_ENTRY_BYTES_RAW } from '../types/uxf-bounds.js';
 
 // =============================================================================
 // 1. Public option / classification types
@@ -103,6 +104,27 @@ export type OutboxWriteInput = Omit<
   /** Optional: explicit timestamp for the write. Defaults to `Date.now()`. */
   readonly updatedAt?: number;
 };
+
+/**
+ * Optional second argument to {@link OutboxWriter.write}. Issue #166
+ * P1 #2 adds the {@link WriteOptions.allowResurrection} escape hatch.
+ */
+export interface WriteOptions {
+  /**
+   * Issue #166 P1 #2 — by default, calling `write()` on an id whose
+   * slot is currently a tombstone is REFUSED with
+   * `OUTBOX_ENTRY_TOMBSTONED`. The tombstone represents a completed
+   * delivery (the matching SENT entry is the durable record); writing
+   * a new entry over it would silently resurrect a key that should
+   * stay dead, defeating the whole point of the OUTBOX drain.
+   *
+   * Pass `true` ONLY for legitimate escape-hatch resurrections —
+   * operator triage of a poisoned key, test fixtures, or explicit
+   * spec-defined "rewind" operations. The writer emits no log on
+   * `true` so the caller takes responsibility for the audit trail.
+   */
+  readonly allowResurrection?: boolean;
+}
 
 // =============================================================================
 // 2. OutboxWriter
@@ -175,12 +197,37 @@ export class OutboxWriter {
    * produces two distinct Lamport stamps but the same `id` slot is
    * overwritten — second write wins.
    */
-  async write(input: OutboxWriteInput): Promise<UxfTransferOutboxEntry> {
+  async write(
+    input: OutboxWriteInput,
+    options?: WriteOptions,
+  ): Promise<UxfTransferOutboxEntry> {
     if (typeof input.id !== 'string' || input.id.length === 0) {
       throw new SphereError(
         'OutboxWriter.write: input.id must be a non-empty string',
         'VALIDATION_ERROR',
       );
+    }
+
+    // Issue #166 P1 #2 — refuse-write guard against tombstone
+    // resurrection. After sync, the slot at `input.id` may be a
+    // tombstone from another replica that completed delivery + SENT
+    // write. Resurrecting it would erase that completion signal.
+    // Callers that genuinely need to resurrect (e.g. test fixtures,
+    // operator escape-hatch) pass `{ allowResurrection: true }`.
+    //
+    // Legacy tombstones (pre-#166, no `lamport` field) are still
+    // refused — the resurrection risk is the same regardless of
+    // whether the tombstone carries a Lamport stamp.
+    if (options?.allowResurrection !== true) {
+      const existing = await this.readTombstoneAt(input.id);
+      if (existing !== null) {
+        throw new SphereError(
+          `OutboxWriter.write: refusing to resurrect tombstoned slot "${input.id}" ` +
+            `(tombstone lamport=${existing.lamport}, deletedAt=${existing.deletedAt}). ` +
+            `If this is intentional (operator escape-hatch / test fixture), pass { allowResurrection: true }.`,
+          'OUTBOX_ENTRY_TOMBSTONED',
+        );
+      }
     }
 
     // Read all observed Lamports for the bump rule. Includes the
@@ -304,7 +351,22 @@ export class OutboxWriter {
         'VALIDATION_ERROR',
       );
     }
-    const tombstone = JSON.stringify({ tombstoned: true, deletedAt: Date.now() });
+    // Issue #166 P1 #2 — stamp the tombstone with a Lamport via the
+    // same §7.1 bump rule used by live writes. The Lamport lets the
+    // refuse-write guard in write() identify "previously deleted"
+    // slots after sync and lets collectObservedLamports() count
+    // tombstones toward the clock so subsequent writes don't reuse a
+    // stale Lamport. Cold-restart rehydrate happens for the same
+    // reason as in write() — observations come from our durable
+    // store so the W39 bounds defense must not fire.
+    const observedLamports = await this.collectObservedLamports();
+    this.lamport.rehydrate(observedLamports);
+    const lamport = this.lamport.bumpFor([]);
+    const tombstone = JSON.stringify({
+      tombstoned: true,
+      deletedAt: Date.now(),
+      lamport,
+    });
     await this.writeRaw(id, tombstone);
   }
 
@@ -394,11 +456,97 @@ export class OutboxWriter {
     const out: number[] = [];
     for (const key of entries.keys()) {
       if (!key.startsWith(this.keyPrefix)) continue;
-      const decoded = await this.readDecoded(key);
-      if (decoded === null) continue;
-      if (isUxfTransferOutboxEntry(decoded)) out.push(decoded.lamport);
+      // Issue #166 P1 #2 — observe live AND tombstone Lamports.
+      // Without including tombstones, a fresh write after deletion
+      // could stamp a Lamport equal to or below the tombstone's,
+      // violating the §7.1 monotonic invariant.
+      const shape = await this.readSlotShape(key);
+      if (shape === null) continue;
+      if (shape.kind === 'value') {
+        if (isUxfTransferOutboxEntry(shape.value)) out.push(shape.value.lamport);
+      } else if (shape.kind === 'tombstone') {
+        out.push(shape.lamport);
+      }
     }
     return out;
+  }
+
+  /**
+   * Issue #166 P1 #2 — check whether the slot at `id` is currently a
+   * tombstone, and if so return its Lamport + deletedAt for the
+   * refuse-write guard. Returns `null` for absent slots, live values,
+   * and any decode/decrypt failures.
+   *
+   * Legacy tombstones (pre-#166, no `lamport` field) report
+   * `lamport: 0` so the refusal still fires. The lamport field is
+   * forensic for the error message; the refusal itself is unconditional
+   * on the presence of the tombstone marker.
+   */
+  private async readTombstoneAt(
+    id: string,
+  ): Promise<{ readonly lamport: number; readonly deletedAt: number } | null> {
+    const shape = await this.readSlotShape(this.keyFor(id));
+    if (shape === null) return null;
+    if (shape.kind !== 'tombstone') return null;
+    return { lamport: shape.lamport, deletedAt: shape.deletedAt };
+  }
+
+  /**
+   * Issue #166 P1 #2 — read raw bytes at `key`, decrypt + parse, and
+   * classify the slot. Returns a discriminated union so callers can
+   * distinguish absent / tombstone / live value without re-decoding.
+   *
+   * `readDecoded()` remains the backward-compat surface (returns
+   * `null` for absent + tombstone, the parsed value otherwise) — most
+   * consumers want that semantics.
+   */
+  private async readSlotShape(
+    key: string,
+  ): Promise<
+    | null
+    | { readonly kind: 'tombstone'; readonly lamport: number; readonly deletedAt: number }
+    | { readonly kind: 'value'; readonly value: unknown }
+  > {
+    let raw: Uint8Array | null;
+    try {
+      raw = await this.db.get(key);
+    } catch {
+      return null;
+    }
+    if (!raw) return null;
+    // Issue #166 P1 #3 — pre-decrypt size cap; see readDecoded().
+    if (raw.byteLength > MAX_ENTRY_BYTES_RAW) return null;
+    let plaintextBytes: Uint8Array;
+    try {
+      plaintextBytes = this.encryptionKey
+        ? await decryptProfileValue(this.encryptionKey, raw)
+        : raw;
+    } catch {
+      return null;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(new TextDecoder().decode(plaintextBytes));
+    } catch {
+      return null;
+    }
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'tombstoned' in (parsed as Record<string, unknown>) &&
+      (parsed as Record<string, unknown>).tombstoned === true
+    ) {
+      const p = parsed as Record<string, unknown>;
+      // Legacy tombstones lack `lamport`; coerce to 0 so callers can
+      // still identify the slot as tombstoned. Same for missing
+      // `deletedAt` — purely forensic.
+      const lamport = typeof p.lamport === 'number' && Number.isInteger(p.lamport) && p.lamport >= 0
+        ? p.lamport
+        : 0;
+      const deletedAt = typeof p.deletedAt === 'number' ? p.deletedAt : 0;
+      return { kind: 'tombstone', lamport, deletedAt };
+    }
+    return { kind: 'value', value: parsed };
   }
 
   /**
@@ -425,6 +573,11 @@ export class OutboxWriter {
       return null;
     }
     if (!raw) return null;
+    // Issue #166 P1 #3 — pre-decrypt size cap. A hostile peer
+    // replicating a 100MB blob would otherwise cost RAM + CPU at the
+    // decrypt step before we could reject. Cap BEFORE decrypt so the
+    // cost stays bounded.
+    if (raw.byteLength > MAX_ENTRY_BYTES_RAW) return null;
     let plaintextBytes: Uint8Array;
     try {
       plaintextBytes = this.encryptionKey

--- a/profile/sent-ledger-writer.ts
+++ b/profile/sent-ledger-writer.ts
@@ -49,6 +49,7 @@ import {
 import { decryptProfileValue, encryptProfileValue } from './encryption.js';
 import { Lamport } from './lamport.js';
 import type { ProfileDatabase } from './types.js';
+import { MAX_ENTRY_BYTES_RAW } from '../types/uxf-bounds.js';
 
 // =============================================================================
 // 1. Public option / input types
@@ -79,6 +80,20 @@ export type SentLedgerWriteInput = Omit<
   UxfSentLedgerEntry,
   '_schemaVersion' | 'lamport'
 >;
+
+/**
+ * Optional second argument to {@link SentLedgerWriter.write}. Mirrors
+ * the OutboxWriter shape — see {@link OutboxWriter.WriteOptions}.
+ * Issue #166 P1 #2.
+ */
+export interface SentWriteOptions {
+  /**
+   * By default, calling `write()` on an id whose slot is currently a
+   * tombstone is REFUSED with `OUTBOX_ENTRY_TOMBSTONED`. Pass `true`
+   * ONLY for operator escape-hatch resurrections / test fixtures.
+   */
+  readonly allowResurrection?: boolean;
+}
 
 // =============================================================================
 // 2. SentLedgerWriter
@@ -135,12 +150,31 @@ export class SentLedgerWriter {
    * second-write-wins behaviour gives the recovery sweeper room to
    * safely re-stamp without checking existence first.
    */
-  async write(input: SentLedgerWriteInput): Promise<UxfSentLedgerEntry> {
+  async write(
+    input: SentLedgerWriteInput,
+    options?: SentWriteOptions,
+  ): Promise<UxfSentLedgerEntry> {
     if (typeof input.id !== 'string' || input.id.length === 0) {
       throw new SphereError(
         'SentLedgerWriter.write: input.id must be a non-empty string',
         'VALIDATION_ERROR',
       );
+    }
+
+    // Issue #166 P1 #2 — refuse-write guard against tombstone
+    // resurrection. SENT tombstones are rare (the ledger is meant to
+    // be permanent), but the operator escape-hatch path exists; once
+    // tombstoned a SENT entry must not silently come back.
+    if (options?.allowResurrection !== true) {
+      const existing = await this.readTombstoneAt(input.id);
+      if (existing !== null) {
+        throw new SphereError(
+          `SentLedgerWriter.write: refusing to resurrect tombstoned slot "${input.id}" ` +
+            `(tombstone lamport=${existing.lamport}, deletedAt=${existing.deletedAt}). ` +
+            `If this is intentional (operator escape-hatch / test fixture), pass { allowResurrection: true }.`,
+          'OUTBOX_ENTRY_TOMBSTONED',
+        );
+      }
     }
 
     // Cold-restart correctness: same rationale as OutboxWriter — see
@@ -177,7 +211,16 @@ export class SentLedgerWriter {
         'VALIDATION_ERROR',
       );
     }
-    const tombstone = JSON.stringify({ tombstoned: true, deletedAt: Date.now() });
+    // Issue #166 P1 #2 — Lamport-stamp the tombstone. Same rationale
+    // as OutboxWriter.delete.
+    const observedLamports = await this.collectObservedLamports();
+    this.lamport.rehydrate(observedLamports);
+    const lamport = this.lamport.bumpFor([]);
+    const tombstone = JSON.stringify({
+      tombstoned: true,
+      deletedAt: Date.now(),
+      lamport,
+    });
     await this.writeRaw(id, tombstone);
   }
 
@@ -294,11 +337,81 @@ export class SentLedgerWriter {
     const out: number[] = [];
     for (const key of entries.keys()) {
       if (!key.startsWith(this.keyPrefix)) continue;
-      const decoded = await this.readDecoded(key);
-      if (decoded === null) continue;
-      if (isUxfSentLedgerEntry(decoded)) out.push(decoded.lamport);
+      // Issue #166 P1 #2 — observe live AND tombstone Lamports.
+      const shape = await this.readSlotShape(key);
+      if (shape === null) continue;
+      if (shape.kind === 'value') {
+        if (isUxfSentLedgerEntry(shape.value)) out.push(shape.value.lamport);
+      } else if (shape.kind === 'tombstone') {
+        out.push(shape.lamport);
+      }
     }
     return out;
+  }
+
+  /**
+   * Issue #166 P1 #2 — check whether the slot at `id` is currently a
+   * tombstone. Returns the tombstone metadata (lamport, deletedAt) or
+   * null. Mirrors OutboxWriter.readTombstoneAt.
+   */
+  private async readTombstoneAt(
+    id: string,
+  ): Promise<{ readonly lamport: number; readonly deletedAt: number } | null> {
+    const shape = await this.readSlotShape(this.keyFor(id));
+    if (shape === null) return null;
+    if (shape.kind !== 'tombstone') return null;
+    return { lamport: shape.lamport, deletedAt: shape.deletedAt };
+  }
+
+  /**
+   * Issue #166 P1 #2 — discriminated-union slot reader. Mirrors
+   * OutboxWriter.readSlotShape.
+   */
+  private async readSlotShape(
+    key: string,
+  ): Promise<
+    | null
+    | { readonly kind: 'tombstone'; readonly lamport: number; readonly deletedAt: number }
+    | { readonly kind: 'value'; readonly value: unknown }
+  > {
+    let raw: Uint8Array | null;
+    try {
+      raw = await this.db.get(key);
+    } catch {
+      return null;
+    }
+    if (!raw) return null;
+    // Issue #166 P1 #3 — pre-decrypt size cap; see readDecoded().
+    if (raw.byteLength > MAX_ENTRY_BYTES_RAW) return null;
+    let plaintextBytes: Uint8Array;
+    try {
+      plaintextBytes = this.encryptionKey
+        ? await decryptProfileValue(this.encryptionKey, raw)
+        : raw;
+    } catch {
+      return null;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(new TextDecoder().decode(plaintextBytes));
+    } catch {
+      return null;
+    }
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'tombstoned' in (parsed as Record<string, unknown>) &&
+      (parsed as Record<string, unknown>).tombstoned === true
+    ) {
+      const p = parsed as Record<string, unknown>;
+      const lamport =
+        typeof p.lamport === 'number' && Number.isInteger(p.lamport) && p.lamport >= 0
+          ? p.lamport
+          : 0;
+      const deletedAt = typeof p.deletedAt === 'number' ? p.deletedAt : 0;
+      return { kind: 'tombstone', lamport, deletedAt };
+    }
+    return { kind: 'value', value: parsed };
   }
 
   private async writeRaw(id: string, value: string): Promise<void> {
@@ -317,6 +430,8 @@ export class SentLedgerWriter {
       return null;
     }
     if (!raw) return null;
+    // Issue #166 P1 #3 — pre-decrypt size cap.
+    if (raw.byteLength > MAX_ENTRY_BYTES_RAW) return null;
     let plaintextBytes: Uint8Array;
     try {
       plaintextBytes = this.encryptionKey

--- a/tests/unit/profile/outbox-writer.test.ts
+++ b/tests/unit/profile/outbox-writer.test.ts
@@ -814,4 +814,218 @@ describe('isUxfTransferOutboxEntry / isLegacyOutboxEntry', () => {
       ).toBe(false);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Issue #166 P1 #3 — DoS bounds-defense at the type-guard gate.
+  // -------------------------------------------------------------------------
+  describe('isUxfTransferOutboxEntry — P1 #3 size caps', () => {
+    function makeValid(): UxfTransferOutboxEntry {
+      return {
+        _schemaVersion: 'uxf-1',
+        id: 'x',
+        bundleCid: 'b',
+        tokenIds: ['t1'],
+        deliveryMethod: 'car-over-nostr',
+        recipient: '@a',
+        recipientTransportPubkey: 'a'.repeat(64),
+        mode: 'instant',
+        status: 'packaging',
+        submitRetryCount: 0,
+        proofErrorCount: 0,
+        createdAt: 1,
+        updatedAt: 1,
+        lamport: 1,
+      };
+    }
+
+    it('accepts tokenIds.length at the cap (4096) — boundary', () => {
+      const tokenIds = Array.from({ length: 4096 }, (_, i) => `t${i}`);
+      expect(isUxfTransferOutboxEntry({ ...makeValid(), tokenIds })).toBe(true);
+    });
+
+    it('rejects tokenIds.length > MAX_TOKEN_IDS_PER_ENTRY (4097)', () => {
+      const tokenIds = Array.from({ length: 4097 }, (_, i) => `t${i}`);
+      expect(isUxfTransferOutboxEntry({ ...makeValid(), tokenIds })).toBe(false);
+    });
+
+    it('rejects a single tokenId longer than MAX_TOKEN_ID_LENGTH (256+1)', () => {
+      const longId = 'a'.repeat(257);
+      expect(
+        isUxfTransferOutboxEntry({ ...makeValid(), tokenIds: [longId] }),
+      ).toBe(false);
+    });
+
+    it('accepts tokenId at the cap (256 chars) — boundary', () => {
+      const id = 'a'.repeat(256);
+      expect(
+        isUxfTransferOutboxEntry({ ...makeValid(), tokenIds: [id] }),
+      ).toBe(true);
+    });
+
+    it('rejects empty-string tokenId', () => {
+      expect(
+        isUxfTransferOutboxEntry({ ...makeValid(), tokenIds: [''] }),
+      ).toBe(false);
+    });
+
+    it('rejects recipient longer than MAX_RECIPIENT_LENGTH (1024+1)', () => {
+      const recipient = 'a'.repeat(1025);
+      expect(isUxfTransferOutboxEntry({ ...makeValid(), recipient })).toBe(false);
+    });
+
+    it('rejects bundleCid longer than MAX_BUNDLE_CID_LENGTH (256+1)', () => {
+      const bundleCid = 'a'.repeat(257);
+      expect(isUxfTransferOutboxEntry({ ...makeValid(), bundleCid })).toBe(false);
+    });
+
+    it('rejects recipientNametag longer than MAX_NAMETAG_LENGTH (256+1) when present', () => {
+      const recipientNametag = 'a'.repeat(257);
+      expect(
+        isUxfTransferOutboxEntry({ ...makeValid(), recipientNametag }),
+      ).toBe(false);
+    });
+
+    it('rejects memo longer than MAX_MEMO_LENGTH (8192+1) when present', () => {
+      const memo = 'a'.repeat(8193);
+      expect(isUxfTransferOutboxEntry({ ...makeValid(), memo })).toBe(false);
+    });
+
+    it('rejects error longer than MAX_ERROR_LENGTH (4096+1) when present', () => {
+      const error = 'a'.repeat(4097);
+      expect(isUxfTransferOutboxEntry({ ...makeValid(), error })).toBe(false);
+    });
+
+    it('rejects nostrEventId longer than MAX_NOSTR_EVENT_ID_LENGTH (128+1)', () => {
+      const nostrEventId = 'a'.repeat(129);
+      expect(
+        isUxfTransferOutboxEntry({ ...makeValid(), nostrEventId }),
+      ).toBe(false);
+    });
+
+    it('rejects recipientTransportPubkey longer than MAX_TRANSPORT_PUBKEY_LENGTH (128+1)', () => {
+      const recipientTransportPubkey = 'a'.repeat(129);
+      expect(
+        isUxfTransferOutboxEntry({ ...makeValid(), recipientTransportPubkey }),
+      ).toBe(false);
+    });
+
+    it('rejects outstandingRequestIds.length over cap', () => {
+      const outstandingRequestIds = Array.from({ length: 4097 }, (_, i) => `r${i}`);
+      expect(
+        isUxfTransferOutboxEntry({ ...makeValid(), outstandingRequestIds }),
+      ).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #166 P1 #2 — tombstone Lamport + write-refuse guard.
+  // -------------------------------------------------------------------------
+  describe('OutboxWriter — P1 #2 tombstone Lamport + refuse-write', () => {
+    let db: MockProfileDb;
+
+    beforeEach(() => {
+      db = createMockDb();
+    });
+
+    it('delete() writes a tombstone carrying a Lamport stamp', async () => {
+      const writer = buildWriter(db);
+      const written = await writer.write(buildBaseInput('a'));
+      await writer.delete('a');
+
+      // Inspect the raw stored value: should be a tombstone with lamport > written.lamport
+      const raw = db._store.get(`${KEY_PREFIX}a`);
+      expect(raw).toBeDefined();
+      const parsed = JSON.parse(new TextDecoder().decode(raw!)) as {
+        tombstoned: boolean;
+        deletedAt: number;
+        lamport: number;
+      };
+      expect(parsed.tombstoned).toBe(true);
+      expect(typeof parsed.deletedAt).toBe('number');
+      expect(typeof parsed.lamport).toBe('number');
+      expect(parsed.lamport).toBeGreaterThan(written.lamport);
+    });
+
+    it('write() refuses to resurrect a tombstoned slot by default', async () => {
+      const writer = buildWriter(db);
+      await writer.write(buildBaseInput('rip'));
+      await writer.delete('rip');
+
+      await expect(writer.write(buildBaseInput('rip'))).rejects.toMatchObject({
+        code: 'OUTBOX_ENTRY_TOMBSTONED',
+      });
+      // Slot remains tombstoned (read returns null).
+      expect(await writer.readOne('rip')).toBeNull();
+    });
+
+    it('write({ allowResurrection: true }) permits explicit resurrection', async () => {
+      const writer = buildWriter(db);
+      await writer.write(buildBaseInput('phoenix'));
+      await writer.delete('phoenix');
+
+      const restored = await writer.write(buildBaseInput('phoenix'), {
+        allowResurrection: true,
+      });
+      expect(restored.id).toBe('phoenix');
+      const readBack = await writer.readOne('phoenix');
+      expect(readBack).not.toBeNull();
+      expect(readBack?.shape).toBe('uxf-1');
+    });
+
+    it('resurrected entry has a Lamport > tombstone Lamport (clock observed tombstone)', async () => {
+      const writer = buildWriter(db);
+      const v1 = await writer.write(buildBaseInput('p'));
+      await writer.delete('p');
+      // Read tombstone lamport from raw store
+      const tombstoneRaw = db._store.get(`${KEY_PREFIX}p`)!;
+      const tombstone = JSON.parse(new TextDecoder().decode(tombstoneRaw));
+      const tombLamport = tombstone.lamport;
+
+      const v2 = await writer.write(buildBaseInput('p'), { allowResurrection: true });
+      expect(v2.lamport).toBeGreaterThan(tombLamport);
+      expect(v2.lamport).toBeGreaterThan(v1.lamport);
+    });
+
+    it('legacy tombstones (no lamport field) are also refused (backward-compat)', async () => {
+      const writer = buildWriter(db);
+      // Plant a legacy tombstone directly bypassing delete().
+      const legacy = JSON.stringify({ tombstoned: true, deletedAt: 1 });
+      db._store.set(`${KEY_PREFIX}old`, new TextEncoder().encode(legacy));
+
+      await expect(writer.write(buildBaseInput('old'))).rejects.toMatchObject({
+        code: 'OUTBOX_ENTRY_TOMBSTONED',
+      });
+    });
+
+    it('subsequent writes after delete advance the clock past the tombstone (write to a DIFFERENT id)', async () => {
+      const writer = buildWriter(db);
+      const v1 = await writer.write(buildBaseInput('alpha'));
+      await writer.delete('alpha');
+      // Read the tombstone Lamport.
+      const tombstoneRaw = db._store.get(`${KEY_PREFIX}alpha`)!;
+      const tombstone = JSON.parse(new TextDecoder().decode(tombstoneRaw));
+
+      // Now write a DIFFERENT id. collectObservedLamports must include
+      // the tombstone's Lamport so the new write's Lamport is strictly
+      // greater than the tombstone's.
+      const v2 = await writer.write(buildBaseInput('beta'));
+      expect(v2.lamport).toBeGreaterThan(tombstone.lamport);
+      expect(v2.lamport).toBeGreaterThan(v1.lamport);
+    });
+
+    it('pre-decrypt size cap rejects oversized blobs without decryption', async () => {
+      const writer = buildWriter(db);
+      // Inject a 2MB blob at a key (encrypted or plaintext — irrelevant
+      // since the cap kicks in before decrypt).
+      const big = new Uint8Array(2 * 1024 * 1024);
+      big.fill(0xff);
+      db._store.set(`${KEY_PREFIX}toobig`, big);
+
+      // Reader returns null without throwing — the blob is dropped at
+      // the size-cap gate.
+      expect(await writer.readOne('toobig')).toBeNull();
+      // readAll() also skips the oversized blob silently.
+      expect(await writer.readAll()).toHaveLength(0);
+    });
+  });
 });

--- a/tests/unit/profile/sent-ledger-writer.test.ts
+++ b/tests/unit/profile/sent-ledger-writer.test.ts
@@ -158,9 +158,29 @@ describe('SentLedgerWriter (Issue #97)', () => {
 
     await writer.delete('xfer-1');
     expect(await writer.readOne('xfer-1')).toBeNull();
+  });
 
-    // Re-writing after tombstone restores the entry.
-    const restored = await writer.write(buildBaseInput('xfer-1'));
+  it('Issue #166 P1 #2 — re-writing a tombstoned slot is REFUSED by default', async () => {
+    await writer.write(buildBaseInput('xfer-1'));
+    await writer.delete('xfer-1');
+
+    // Default behavior: tombstone resurrection rejected with
+    // OUTBOX_ENTRY_TOMBSTONED. Prevents silent loss of the deletion
+    // signal under concurrent-replica sync races.
+    await expect(writer.write(buildBaseInput('xfer-1'))).rejects.toMatchObject({
+      code: 'OUTBOX_ENTRY_TOMBSTONED',
+    });
+    // Slot still reads as absent.
+    expect(await writer.readOne('xfer-1')).toBeNull();
+  });
+
+  it('Issue #166 P1 #2 — allowResurrection:true permits explicit resurrection (operator escape-hatch)', async () => {
+    await writer.write(buildBaseInput('xfer-1'));
+    await writer.delete('xfer-1');
+
+    const restored = await writer.write(buildBaseInput('xfer-1'), {
+      allowResurrection: true,
+    });
     expect(restored.id).toBe('xfer-1');
     expect(await writer.readOne('xfer-1')).toEqual(restored);
   });
@@ -484,6 +504,171 @@ describe('SentLedgerWriter (Issue #97)', () => {
       expect(
         isUxfSentLedgerEntry({ ...(makeValid() as object), sentAt: Infinity }),
       ).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #166 P1 #3 — DoS bounds-defense at the type-guard gate.
+  // -------------------------------------------------------------------------
+  describe('isUxfSentLedgerEntry — P1 #3 size caps', () => {
+    function makeValid(): unknown {
+      return {
+        _schemaVersion: 'uxf-1',
+        id: 'x',
+        tokenIds: ['t'],
+        bundleCid: 'b',
+        recipientTransportPubkey: 'r'.repeat(64),
+        deliveryMethod: 'car-over-nostr',
+        mode: 'conservative',
+        sentAt: 1_700_000_000_000,
+        lamport: 1,
+      };
+    }
+
+    let isUxfSentLedgerEntry: (v: unknown) => boolean;
+    beforeEach(async () => {
+      const mod = await import('../../../types/uxf-sent.js');
+      isUxfSentLedgerEntry = mod.isUxfSentLedgerEntry;
+    });
+
+    it('accepts tokenIds.length at the cap (4096) — boundary', () => {
+      const tokenIds = Array.from({ length: 4096 }, (_, i) => `t${i}`);
+      expect(
+        isUxfSentLedgerEntry({ ...(makeValid() as object), tokenIds }),
+      ).toBe(true);
+    });
+
+    it('rejects tokenIds.length > MAX_TOKEN_IDS_PER_ENTRY (4097)', () => {
+      const tokenIds = Array.from({ length: 4097 }, (_, i) => `t${i}`);
+      expect(
+        isUxfSentLedgerEntry({ ...(makeValid() as object), tokenIds }),
+      ).toBe(false);
+    });
+
+    it('rejects a single tokenId longer than MAX_TOKEN_ID_LENGTH (256+1)', () => {
+      const longId = 'a'.repeat(257);
+      expect(
+        isUxfSentLedgerEntry({ ...(makeValid() as object), tokenIds: [longId] }),
+      ).toBe(false);
+    });
+
+    it('rejects empty-string tokenId', () => {
+      expect(
+        isUxfSentLedgerEntry({ ...(makeValid() as object), tokenIds: [''] }),
+      ).toBe(false);
+    });
+
+    it('rejects bundleCid longer than MAX_BUNDLE_CID_LENGTH (256+1)', () => {
+      const bundleCid = 'a'.repeat(257);
+      expect(
+        isUxfSentLedgerEntry({ ...(makeValid() as object), bundleCid }),
+      ).toBe(false);
+    });
+
+    it('rejects recipient longer than MAX_RECIPIENT_LENGTH (1024+1) when present', () => {
+      const recipient = 'a'.repeat(1025);
+      expect(
+        isUxfSentLedgerEntry({ ...(makeValid() as object), recipient }),
+      ).toBe(false);
+    });
+
+    it('rejects recipientNametag longer than MAX_NAMETAG_LENGTH (256+1) when present', () => {
+      const recipientNametag = 'a'.repeat(257);
+      expect(
+        isUxfSentLedgerEntry({ ...(makeValid() as object), recipientNametag }),
+      ).toBe(false);
+    });
+
+    it('rejects recipientTransportPubkey longer than MAX_TRANSPORT_PUBKEY_LENGTH (128+1)', () => {
+      const recipientTransportPubkey = 'a'.repeat(129);
+      expect(
+        isUxfSentLedgerEntry({
+          ...(makeValid() as object),
+          recipientTransportPubkey,
+        }),
+      ).toBe(false);
+    });
+
+    it('rejects nostrEventId longer than MAX_NOSTR_EVENT_ID_LENGTH (128+1)', () => {
+      const nostrEventId = 'a'.repeat(129);
+      expect(
+        isUxfSentLedgerEntry({ ...(makeValid() as object), nostrEventId }),
+      ).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #166 P1 #2 — tombstone Lamport + refuse-write guard.
+  // -------------------------------------------------------------------------
+  describe('SentLedgerWriter — P1 #2 tombstone Lamport + refuse-write', () => {
+    let db: MockProfileDb;
+    let writer: SentLedgerWriter;
+
+    beforeEach(() => {
+      db = createMockDb();
+      writer = new SentLedgerWriter({
+        db,
+        encryptionKey: null,
+        addressId: 'DIRECT_aabbcc_ddeeff',
+        lamport: new Lamport(),
+      });
+    });
+
+    it('delete() stamps tombstone with Lamport > prior write Lamport', async () => {
+      const written = await writer.write(buildBaseInput('a'));
+      await writer.delete('a');
+
+      const raw = db._store.get(`DIRECT_aabbcc_ddeeff.sent.a`);
+      expect(raw).toBeDefined();
+      const parsed = JSON.parse(new TextDecoder().decode(raw!)) as {
+        tombstoned: boolean;
+        deletedAt: number;
+        lamport: number;
+      };
+      expect(parsed.tombstoned).toBe(true);
+      expect(parsed.lamport).toBeGreaterThan(written.lamport);
+    });
+
+    it('write() refuses to resurrect tombstoned slot by default', async () => {
+      await writer.write(buildBaseInput('zombie'));
+      await writer.delete('zombie');
+
+      await expect(writer.write(buildBaseInput('zombie'))).rejects.toMatchObject(
+        { code: 'OUTBOX_ENTRY_TOMBSTONED' },
+      );
+    });
+
+    it('write({ allowResurrection: true }) permits explicit resurrection', async () => {
+      await writer.write(buildBaseInput('zombie'));
+      await writer.delete('zombie');
+
+      const restored = await writer.write(buildBaseInput('zombie'), {
+        allowResurrection: true,
+      });
+      expect(restored.id).toBe('zombie');
+      expect(await writer.readOne('zombie')).not.toBeNull();
+    });
+
+    it('legacy tombstone (no lamport field) is still refused', async () => {
+      // Plant a legacy tombstone directly.
+      const legacy = JSON.stringify({ tombstoned: true, deletedAt: 1 });
+      db._store.set(
+        `DIRECT_aabbcc_ddeeff.sent.old`,
+        new TextEncoder().encode(legacy),
+      );
+
+      await expect(writer.write(buildBaseInput('old'))).rejects.toMatchObject({
+        code: 'OUTBOX_ENTRY_TOMBSTONED',
+      });
+    });
+
+    it('pre-decrypt size cap (1MB) rejects oversized blobs', async () => {
+      const big = new Uint8Array(2 * 1024 * 1024);
+      big.fill(0xff);
+      db._store.set(`DIRECT_aabbcc_ddeeff.sent.toobig`, big);
+
+      expect(await writer.readOne('toobig')).toBeNull();
+      expect(await writer.readAll()).toHaveLength(0);
     });
   });
 });

--- a/types/uxf-bounds.ts
+++ b/types/uxf-bounds.ts
@@ -1,0 +1,131 @@
+/**
+ * Issue #166 P1 #3 — DoS bounds-defense constants.
+ *
+ * Profile-resident OUTBOX and SENT entries are encrypted blobs
+ * replicated via OrbitDB across peers. Without bounds at the type-guard
+ * gate, a hostile peer could replicate a 100MB entry that
+ * `readAll`/`contains` materializes into memory before the guard could
+ * reject it. The cost of decryption + JSON.parse + scan would land
+ * BEFORE any application-level rejection — DoS by replication.
+ *
+ * **Why these specific numbers.** Each cap is sized to be:
+ *  - Comfortably above the largest legitimate entry we expect today
+ *    (typical OUTBOX entry is 1-4 tokenIds, short bundleCid, short
+ *    nametag — well under every cap below).
+ *  - Small enough that a malicious entry hitting the cap is rejected
+ *    BEFORE any expensive operation.
+ *  - Easy to revise upward without breaking on-disk data (caps are
+ *    enforced at READ time via type guards; existing entries that
+ *    were valid under a higher cap still validate).
+ *
+ * **Pre-decrypt cap** ({@link MAX_ENTRY_BYTES_RAW}). Enforced by
+ * `readDecoded()` BEFORE the decrypt step. A hostile 100MB blob is
+ * rejected at the network/storage boundary without consuming RAM for
+ * decryption. Sized at 1 MiB — comfortably above any legitimate UXF
+ * outbox entry (including future fields and conservative-mode
+ * outstanding requestId arrays).
+ *
+ * @module types/uxf-bounds
+ */
+
+/**
+ * Maximum number of tokenIds in a single OUTBOX or SENT entry.
+ *
+ * 4096 is well above any legitimate single-bundle delivery (typical
+ * bundles ship 1-10 tokens; the max sane manual bundle is ~100). A
+ * hostile entry with 1M tokenIds would have caused a `for` loop to
+ * spend seconds in a security-critical code path.
+ */
+export const MAX_TOKEN_IDS_PER_ENTRY = 4096;
+
+/**
+ * Maximum byte length of a single tokenId string. Token ids are hex
+ * digests (SDK-defined), typically 64-128 chars. 256 covers any
+ * conceivable future hash widening without permitting a single
+ * tokenId to grow into a denial-of-service payload.
+ */
+export const MAX_TOKEN_ID_LENGTH = 256;
+
+/**
+ * Maximum byte length of the `recipient` field on OUTBOX/SENT
+ * entries. Recipients are `@nametag`, `DIRECT://...`, or chain
+ * pubkeys — all well under 1024 chars in legitimate use.
+ */
+export const MAX_RECIPIENT_LENGTH = 1024;
+
+/**
+ * Maximum byte length of an optional `recipientNametag` field.
+ * Nametags are short human-readable handles; 256 is generous.
+ */
+export const MAX_NAMETAG_LENGTH = 256;
+
+/**
+ * Maximum byte length of a `bundleCid` field. IPFS CIDs are
+ * fixed-width (~50-100 chars depending on hash function); 256
+ * accommodates v0, v1, and future hash-function changes.
+ */
+export const MAX_BUNDLE_CID_LENGTH = 256;
+
+/**
+ * Maximum byte length of an optional `memo` field. Memos are
+ * sender-supplied free text shipped on the wire. 8 KiB matches the
+ * order-of-magnitude limit a Nostr relay would accept for a TOKEN_TRANSFER
+ * event's content before fragmenting; values much above this would
+ * not survive transport anyway.
+ */
+export const MAX_MEMO_LENGTH = 8192;
+
+/**
+ * Maximum byte length of a `nostrEventId` field. Nostr event ids are
+ * 64-char hex sha256 digests; 128 leaves room for any future format
+ * change without permitting unbounded strings.
+ */
+export const MAX_NOSTR_EVENT_ID_LENGTH = 128;
+
+/**
+ * Maximum byte length of the `recipientTransportPubkey` field.
+ * Transport pubkeys are 64-char hex secp256k1 keys; 128 is generous.
+ */
+export const MAX_TRANSPORT_PUBKEY_LENGTH = 128;
+
+/**
+ * Maximum byte length of the `error` field on OUTBOX entries. Stores
+ * truncated forensic strings (W40 redactCause output); large blobs
+ * could be a vector for log-injection / storage exhaustion.
+ */
+export const MAX_ERROR_LENGTH = 4096;
+
+/**
+ * Maximum raw (encrypted) entry size, in bytes, accepted by
+ * `readDecoded()` BEFORE the decrypt step. A hostile entry exceeding
+ * this is rejected without consuming RAM for decryption.
+ *
+ * 1 MiB is well above any legitimate UXF outbox entry. The largest
+ * legitimate entry today is a conservative-mode delivered entry with
+ * a few hundred outstandingRequestIds (each ~64-char hex). At
+ * ~4096 tokenIds × 256 bytes = 1 MiB worst-case legitimate; the
+ * encrypted blob's AES-GCM overhead (IV + tag = 28 bytes) is
+ * negligible at that scale.
+ */
+export const MAX_ENTRY_BYTES_RAW = 1024 * 1024;
+
+// =============================================================================
+// Helper: validate string bounds at the type-guard gate
+// =============================================================================
+
+/**
+ * Helper used by type guards to verify an optional string field's
+ * length when present. Treats absent / undefined as valid (the field
+ * is optional). Returns `false` for any string longer than `max` so
+ * the guard can reject the entry.
+ *
+ * @internal
+ */
+export function isWithinOptionalStringLength(
+  v: unknown,
+  max: number,
+): boolean {
+  if (v === undefined) return true;
+  if (typeof v !== 'string') return false;
+  return v.length <= max;
+}

--- a/types/uxf-outbox.ts
+++ b/types/uxf-outbox.ts
@@ -39,6 +39,18 @@
  */
 
 import type { OutboxEntry } from './txf.js';
+import {
+  MAX_TOKEN_IDS_PER_ENTRY,
+  MAX_TOKEN_ID_LENGTH,
+  MAX_RECIPIENT_LENGTH,
+  MAX_NAMETAG_LENGTH,
+  MAX_BUNDLE_CID_LENGTH,
+  MAX_MEMO_LENGTH,
+  MAX_NOSTR_EVENT_ID_LENGTH,
+  MAX_TRANSPORT_PUBKEY_LENGTH,
+  MAX_ERROR_LENGTH,
+  isWithinOptionalStringLength,
+} from './uxf-bounds.js';
 
 // =============================================================================
 // 1. Status enumeration — §7 lifecycle states
@@ -394,6 +406,48 @@ export function isUxfTransferOutboxEntry(
   if (obj.nostrEventId !== undefined) {
     if (typeof obj.nostrEventId !== 'string' || obj.nostrEventId.length === 0) {
       return false;
+    }
+  }
+  // Issue #166 P1 #3 — DoS bounds. A hostile peer replicating an
+  // entry with 1M tokenIds (or a single 100MB tokenId) would cost
+  // seconds of CPU + GB of RAM inside readAll()/contains() before
+  // the application could reject it. Cap at the type-guard gate so
+  // oversized entries are skipped silently — they never enter the
+  // result set returned to callers.
+  if (obj.tokenIds.length > MAX_TOKEN_IDS_PER_ENTRY) return false;
+  for (const t of obj.tokenIds) {
+    if (typeof t !== 'string') return false;
+    if (t.length === 0 || t.length > MAX_TOKEN_ID_LENGTH) return false;
+  }
+  if (obj.bundleCid.length > MAX_BUNDLE_CID_LENGTH) return false;
+  if (obj.recipient.length > MAX_RECIPIENT_LENGTH) return false;
+  if (obj.recipientTransportPubkey.length > MAX_TRANSPORT_PUBKEY_LENGTH) return false;
+  if (!isWithinOptionalStringLength(obj.recipientNametag, MAX_NAMETAG_LENGTH)) return false;
+  if (!isWithinOptionalStringLength(obj.memo, MAX_MEMO_LENGTH)) return false;
+  if (!isWithinOptionalStringLength(obj.error, MAX_ERROR_LENGTH)) return false;
+  if (
+    obj.nostrEventId !== undefined &&
+    typeof obj.nostrEventId === 'string' &&
+    obj.nostrEventId.length > MAX_NOSTR_EVENT_ID_LENGTH
+  ) {
+    return false;
+  }
+  // outstandingRequestIds / completedRequestIds are also tokenId-shaped
+  // hex digests; bound them with the same MAX_TOKEN_ID_LENGTH cap.
+  if (obj.outstandingRequestIds !== undefined) {
+    if (!Array.isArray(obj.outstandingRequestIds)) return false;
+    if (obj.outstandingRequestIds.length > MAX_TOKEN_IDS_PER_ENTRY) return false;
+    for (const r of obj.outstandingRequestIds) {
+      if (typeof r !== 'string') return false;
+      if (r.length === 0 || r.length > MAX_TOKEN_ID_LENGTH) return false;
+    }
+  }
+  if (obj.completedRequestIds !== undefined) {
+    if (!Array.isArray(obj.completedRequestIds)) return false;
+    if (obj.completedRequestIds.length > MAX_TOKEN_IDS_PER_ENTRY) return false;
+    for (const r of obj.completedRequestIds) {
+      if (typeof r !== 'string') return false;
+      if (r.length === 0 || r.length > MAX_TOKEN_ID_LENGTH) return false;
     }
   }
   return true;

--- a/types/uxf-sent.ts
+++ b/types/uxf-sent.ts
@@ -1,3 +1,14 @@
+import {
+  MAX_TOKEN_IDS_PER_ENTRY,
+  MAX_TOKEN_ID_LENGTH,
+  MAX_RECIPIENT_LENGTH,
+  MAX_NAMETAG_LENGTH,
+  MAX_BUNDLE_CID_LENGTH,
+  MAX_NOSTR_EVENT_ID_LENGTH,
+  MAX_TRANSPORT_PUBKEY_LENGTH,
+  isWithinOptionalStringLength,
+} from './uxf-bounds.js';
+
 /**
  * UXF Inter-Wallet Transfer — SENT ledger type (Issue #97)
  *
@@ -174,6 +185,23 @@ export function isUxfSentLedgerEntry(value: unknown): value is UxfSentLedgerEntr
     if (typeof v.nostrEventId !== 'string' || (v.nostrEventId as string).length === 0) {
       return false;
     }
+  }
+  // Issue #166 P1 #3 — DoS bounds (mirror OUTBOX guard's caps).
+  if (v.tokenIds.length > MAX_TOKEN_IDS_PER_ENTRY) return false;
+  for (const t of v.tokenIds) {
+    // Already typeof-checked above; bounds-check the length too.
+    if ((t as string).length === 0 || (t as string).length > MAX_TOKEN_ID_LENGTH) return false;
+  }
+  if (v.bundleCid.length > MAX_BUNDLE_CID_LENGTH) return false;
+  if (v.recipientTransportPubkey.length > MAX_TRANSPORT_PUBKEY_LENGTH) return false;
+  if (!isWithinOptionalStringLength(v.recipient, MAX_RECIPIENT_LENGTH)) return false;
+  if (!isWithinOptionalStringLength(v.recipientNametag, MAX_NAMETAG_LENGTH)) return false;
+  if (
+    v.nostrEventId !== undefined &&
+    typeof v.nostrEventId === 'string' &&
+    v.nostrEventId.length > MAX_NOSTR_EVENT_ID_LENGTH
+  ) {
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
## Summary

Closes the two remaining defensive-hardening items from issue #166's P1 bucket. **P1 #1 (AAD per-record encryption) deliberately deferred** — not on the near-term roadmap per maintainer call.

Targets \`integration/all-fixes\` (where the P2/P3/P4 work landed) rather than \`main\`.

## P1 #2 — Tombstone Lamport + refuse-write guard

**The bug**: tombstones (`{ tombstoned: true, deletedAt }`) lacked a Lamport stamp. When two replicas concurrently wrote to the same OUTBOX/SENT key (one tombstoning, one with stale state attempting a regular write), the resurrection scenario silently lost the deletion signal.

**The fix**:

- `OutboxWriter.delete()` and `SentLedgerWriter.delete()` now stamp the tombstone with a Lamport via the same §7.1 bump rule used by live writes. New shape: `{ tombstoned: true, deletedAt, lamport }`.
- `OutboxWriter.write()` and `SentLedgerWriter.write()` **REFUSE by default** to write over a tombstoned slot — throws new error code `OUTBOX_ENTRY_TOMBSTONED`.
- New escape hatch: `write(input, { allowResurrection: true })` for operator triage / test fixtures.
- `collectObservedLamports()` now includes tombstone Lamports so any subsequent write (even at a different id) bumps past the tombstone — preserves the §7.1 monotonic invariant across delete→write sequences.
- Backward-compat: legacy tombstones (no `lamport` field) are still refused — the resurrection risk is the same regardless of whether the marker carries a Lamport.
- New private helper `readSlotShape()` returns a discriminated union `null | tombstone | value` so writers can distinguish a tombstoned slot from an absent one without double-decoding.

## P1 #3 — DoS bounds-defense at the type-guard gate

**The risk**: a hostile peer replicating a 100MB entry would cost seconds of CPU + GB of RAM inside `readAll()` / `contains()` before the application could reject it. The encrypted blob also had to be decrypted first — DoS by replication.

**The fix**: new module `types/uxf-bounds.ts` with documented caps:

| Constant | Value |
|----------|-------|
| `MAX_TOKEN_IDS_PER_ENTRY` | 4096 |
| `MAX_TOKEN_ID_LENGTH` | 256 |
| `MAX_RECIPIENT_LENGTH` | 1024 |
| `MAX_NAMETAG_LENGTH` | 256 |
| `MAX_BUNDLE_CID_LENGTH` | 256 |
| `MAX_MEMO_LENGTH` | 8192 |
| `MAX_NOSTR_EVENT_ID_LENGTH` | 128 |
| `MAX_TRANSPORT_PUBKEY_LENGTH` | 128 |
| `MAX_ERROR_LENGTH` | 4096 |
| `MAX_ENTRY_BYTES_RAW` | 1 MiB (pre-decrypt) |

- `isUxfTransferOutboxEntry` / `isUxfSentLedgerEntry` enforce each cap — oversized fields fail the guard, entries are dropped from result sets.
- `readDecoded()` and `readSlotShape()` reject blobs over `MAX_ENTRY_BYTES_RAW` **BEFORE the decrypt step** — keeps the cost bounded at the storage/network boundary.

## Coverage

- `tests/unit/profile/outbox-writer.test.ts` — +20 cases:
  - Tombstone Lamport stamping
  - Refuse-write guard with/without `allowResurrection`
  - Legacy-tombstone (no lamport) refusal
  - Clock advancement past tombstone Lamport
  - Pre-decrypt size cap rejection
  - 11 size-cap boundary tests on type guards
- `tests/unit/profile/sent-ledger-writer.test.ts` — +14 cases:
  - Mirrors the outbox tests
  - **Modified the pre-existing test that documented resurrection as a feature** ("Re-writing after tombstone restores the entry") — replaced with two new tests pinning the refuse-by-default + `allowResurrection`-override contract.

## Test plan

- [x] New writer tests pass (outbox 80/80, sent 48/48)
- [x] Full vitest suite: 7388 passing (+36), 13 skipped
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] Default-OFF resurrection refusal preserves production behavior (no production code path does write-after-delete on the same id; legacy KV outbox path is unaffected — that's a separate storage layer).

## Out of scope

- **P1 #1 (AAD per-record encryption)** — deferred indefinitely per maintainer call. The keyspace-lift attack documented in `profile/encryption.ts:85-94` remains theoretically exploitable but is not on the near-term roadmap.
- Real storage GC (true `db.del()` after long retention window) — tombstones still occupy bytes; freeing storage is a separate retention concern at a much lower urgency.

This PR completes issue #166's remaining hardening work that's currently in scope.

cc: #166, #97