### PR TITLE
docs: §12.3.1 SHIPPED + §12.3.2 → Issue #174 (per-token spent-state rescan)

### DIFF
--- a/docs/uxf/OUTBOX-SEND-FOLLOWUPS.md
+++ b/docs/uxf/OUTBOX-SEND-FOLLOWUPS.md
@@ -715,6 +715,44 @@ Migration consideration: existing wallets that have published only UXF-bundle po
 
 ---
 
+### 16. Per-token spent-state rescan — proactive off-record-spend detection (NEW 2026-05-19)
+
+> **Tracked as [Issue #174](https://github.com/unicity-sphere/sphere-sdk/issues/174)**. Surfaces the §12.3.2 piece of `UXF-TRANSFER-PROTOCOL.md` that the aggregator-pointer wave (which shipped §12.3.1) did NOT cover.
+
+**Why it matters**: when two instances of the SAME wallet (same mnemonic / chain pubkey) coexist — desktop + mobile, primary + recovered backup, etc. — and one spends a token without the other having seen the spend, the second instance keeps the token in `manifest.status === 'valid'` until either (a) the spending device's snapshot propagates via §12.3.1 profile-pointer rescan (typically 30–90s, but indefinite if the spender is offline), OR (b) the local UI triggers a `send()` and `submitTransferCommitment` fails (which since PR #173 / commit `9b4fae7` surfaces as the reactive `STATE_ALREADY_SPENT_BY_OTHER` throw + `transfer:double-spend-detected` event from Item #14 Phase 1).
+
+Item #14 Phase 1 closes the reactive surface. Item #16 closes the proactive surface — a low-rate background sweep over the active pool calling `oracle.isSpent(currentDestinationStateHash)` per token (default `TOKEN_SPENT_RESCAN_INTERVAL = 5 min/token`, capped concurrent ≤ 4) so the UI doesn't continue showing the token as spendable until the user attempts to spend it.
+
+**Acceptance criteria**: see Issue #174 for the full breakdown. Summary:
+1. New background worker `modules/payments/transfer/spent-state-rescan-worker.ts`.
+2. On `isSpent === true` → transition to `_audit` with reason `'off-record-spend'` via the existing disposition writer; emit new `transfer:off-record-spent` event.
+3. `suspectedSiblingInstance` flag: `true` when local OUTBOX + SENT have no record of having spent this state (signals another instance with the same keys is the spender).
+4. Feature flag `features.spentStateRescan` (default-OFF for soak, flip to default-ON after 7-day testnet observation).
+5. Runbook entry in `docs/uxf/RUNBOOK-SEND-PIPELINE.md`.
+
+**Relationship to other items**:
+  - **Item #14 Phase 1** (PR #173): reactive surface — catches the off-record spend WHEN you try to send.
+  - **Item #15 (profile-pointer rescan)**: catches the spend IF the spender device's snapshot has propagated.
+  - **Item #16 (this item)**: catches it independently of either, via the L3 aggregator's authoritative spent-state view.
+
+**Files** (proposed):
+  - New: `modules/payments/transfer/spent-state-rescan-worker.ts`
+  - New: `tests/unit/payments/transfer/spent-state-rescan-worker.test.ts`
+  - New: `tests/integration/payments/spent-state-rescan.test.ts`
+  - Modified: `types/index.ts` — new `'transfer:off-record-spent'` event type + payload
+  - Modified: `modules/payments/PaymentsModule.ts` — worker lifecycle + feature flag
+  - Modified: `docs/uxf/RUNBOOK-SEND-PIPELINE.md` — operator section
+
+**Complexity**: Small to Medium. The disposition engine + writer + LRU cache infrastructure already exist; this is mostly the new worker module (mirroring `nostr-persistence-verifier.ts`'s low-rate background scanner shape), the new event type, and the `suspectedSiblingInstance` detection logic.
+
+**Blast radius**: Low. Gated behind a default-OFF feature flag until soak proves no false-positive surface. Transition to `_audit` uses the disposition engine's existing UNSPENDABLE_BY_US classification — no new disposition machinery needed.
+
+**Doc references**:
+  - `docs/uxf/UXF-TRANSFER-PROTOCOL.md §12.3.2` (now updated 2026-05-19 to flip §12.3.1 to SHIPPED and link this item).
+  - `docs/uxf/UXF-TRANSFER-IMPL-PLAN.md` "Out-of-scope for T.1–T.8 (deferred)" (now updated to flip §12.3.1 to SHIPPED and link this item).
+
+---
+
 ## Cross-cutting concerns
 
 ### Pointer-layer vs OrbitDB-log layering (architectural clarification — superseded by Item #15)

--- a/docs/uxf/UXF-TRANSFER-IMPL-PLAN.md
+++ b/docs/uxf/UXF-TRANSFER-IMPL-PLAN.md
@@ -1417,7 +1417,14 @@ T.8 ships the informational `wireProtocols` field on the identity binding event,
 
 ### Out-of-scope for T.1–T.8 (deferred)
 
-Per canonical §12.3, periodic rescans (profile-pointer + per-token spent-state) are deferred. T.1–T.8 wire up the storage, events, and audit-promotion plumbing so future-wave rescan code can drop in cleanly — but no rescan loop ships in this implementation plan. Coordination point only.
+Per canonical §12.3, periodic rescans (profile-pointer + per-token spent-state) were both deferred at T.1–T.8 plan-time. T.1–T.8 wire up the storage, events, and audit-promotion plumbing so future-wave rescan code can drop in cleanly — but no rescan loop ships in this implementation plan. Coordination point only.
+
+> **Status update (2026-05-19)** — the deferral status has since split:
+>
+>   - **§12.3.1 (profile-pointer rescan) is SHIPPED** outside this plan's T.1–T.8 scope, landed as the core of the **aggregator-pointer wave** (`PROFILE-AGGREGATOR-POINTER-IMPL-PLAN.md` Phases A–E) and consolidated by **Item #15** (Full Profile State Snapshot Sync; PR #173). Implementation: `profile/profile-token-storage/lifecycle-manager.ts:schedulePointerPoll`/`runPointerPollOnce` — randomized [30s, 90s) interval, calls `pointer.recoverLatest()`, dispatches the new CID via `applySnapshotIfWired()`.
+>   - **§12.3.2 (per-token spent-state rescan) is STILL OPEN** as **[Issue #174](https://github.com/unicity-sphere/sphere-sdk/issues/174)**.
+>
+> The original "deferred as a unit" framing is preserved here for historical accuracy of what T.1–T.8 specifically didn't ship; the actual current state is split per the above.
 
 ---
 

--- a/docs/uxf/UXF-TRANSFER-PROTOCOL.md
+++ b/docs/uxf/UXF-TRANSFER-PROTOCOL.md
@@ -1709,33 +1709,52 @@ The implementation MUST include:
 - **Conflict-resolution UI/API**: `CONFLICTING` tokens (genuinely-divergent chains) need an explicit `resolveConflict(tokenId, chosenHead)` API and UI surface. Lex-min `bundleCid` provides an automatic primary, but operator override is a planned future addition.
 - **Peer-reputation framework**: §11.4 mentions a 1-hour cooldown on bandwidth-burning peers. The reputation interface itself is out of scope here. Note: peer-reputation rises in operational importance once NFTs are in scope — a peer who delivers a forged or cascade-prone NFT chain can corrupt the recipient's collection in a way coin damage cannot (NFTs are non-fungible / non-replaceable). Reserve a future protocol revision for per-peer trust scores or signed NFT-receipt acknowledgements.
 
-### 12.3 Periodic rescans (two orthogonal scanner types — in-scope; design summary here, implementation deferred)
+### 12.3 Periodic rescans (two orthogonal scanner types — split status)
+
+> **Status update (2026-05-19)**: the original §12.3 framed BOTH rescans as deferred at the time T.1–T.8 were planned. That framing is now out of date:
+>
+>   - **§12.3.1 (profile-pointer rescan) is SHIPPED** — landed as the core of the **aggregator-pointer wave** (`PROFILE-AGGREGATOR-POINTER-IMPL-PLAN.md` Phases A–E, 75 tasks) and consolidated by **Item #15** (Full Profile State Snapshot Sync; merged via PR #173). The implementation is in `profile/profile-token-storage/lifecycle-manager.ts` (`schedulePointerPoll` / `runPointerPollOnce`).
+>   - **§12.3.2 (per-token spent-state rescan) is STILL OPEN** — tracked as **Issue #174**.
+>
+> The "two rescans deferred as a unit" language in `UXF-TRANSFER-IMPL-PLAN.md`'s "Out-of-scope for T.1–T.8 (deferred)" section is similarly stale (kept for historical accuracy of what shipped in T.1–T.8 specifically; the aggregator-pointer wave landed §12.3.1 outside that wave bucket).
 
 The protocol relies on two periodic rescan loops to maintain consistency between local state and the canonical aggregator/profile views. Both are operator-configurable and run independently:
 
-#### 12.3.1 Profile-pointer rescan
+#### 12.3.1 Profile-pointer rescan — **SHIPPED**
 
-**Purpose**: detect updates to the wallet's UXF profile that landed via another instance of the same wallet (different device, recovered backup, etc.). The profile pointer is registered with the aggregator; periodically, the local instance MUST query the next pointer position to discover whether a remote update has bumped it.
+**Purpose**: detect updates to the wallet's UXF profile that landed via another instance of the same wallet (different device, recovered backup, etc.). The profile pointer is registered with the aggregator; periodically, the local instance queries the latest pointer position to discover whether a remote update has bumped it.
 
-**Mechanism**:
-- Schedule: every `PROFILE_POINTER_RESCAN_INTERVAL` (default 30s).
-- Query: `aggregator.getNextProfilePointer(currentLocalPointerId)` — returns the next pointer in the chain, or `null` if local is the head.
-- On bump: sync the new profile CID locally, run §5.3 disposition matrix on any new tokens, merge per Wave G.3 rules into local pool/manifest. New `_invalid` / `_audit` entries are added per §5.4 keying.
-- Backoff on aggregator unavailability: exponential up to 5 min.
+**Mechanism (as implemented in `profile/profile-token-storage/lifecycle-manager.ts`)**:
+- **Schedule**: randomized in **[30s, 90s)** (`POINTER_POLL_MIN_MS = 30_000`; `POINTER_POLL_RANGE_MS = 60_000`). Jitter avoids synchronized polling across devices booting simultaneously, which would otherwise create thundering-herd load on the aggregator. (The original spec wording "every 30s" is preserved in this section as the design intent; the as-implemented jitter is a refinement of that intent, not a departure.)
+- **Query**: `pointer.recoverLatest()` — returns the latest pointer version anchored to the wallet's chain pubkey, content-verified end-to-end (inclusion proof + trust base + CAR content-address verify). Internally implemented via `aggregatorClient.submitCommitment(healthCheckRid)` discovery probes scanning the version range.
+- **On new CID detected**: fetches the CAR via IPFS gateways (with content-address verify), parses as a `LeanProfileSnapshot` per Item #15, dispatches via the host-wired `applySnapshotIfWired(cid)` for per-writer JOIN (OUTBOX / SENT / disposition / finalization-queue / recipient-context / bundle-refs). Disposition matrix runs implicitly through the disposition writer's existing path for any newly-arrived bundle refs.
+- **Hint channel**: `OrbitDbAdapter.onReplication` calls `triggerPointerPollNow()` so a pubsub event collapses worst-case cross-device sync latency from ~90s to ~1-2s on healthy infra. Pubsub is explicitly DEMOTED to a hint channel per Item #15; the aggregator pointer is the authoritative source.
+- **Backoff on transient errors**: standard interval continues. Permanent classifier (e.g. `AGGREGATOR_POINTER_TRUST_BASE_STALE`) triggers a **5× back-off** ([150s, 450s)) AND emits `storage:error` for operator visibility.
+- **Cold-start path** (`recoverFromAggregatorPointerBestEffort`): the same pointer/applier path runs once at `initialize()` BEFORE the periodic poll arms, so a fresh wallet re-imported from mnemonic on a new device bootstraps from the aggregator-anchored snapshot rather than waiting for the first 30s tick.
 
 This rescan is the primary mechanism by which the audit-collection promotion scanner (formerly listed in §12.2 as deferred) actually fires — when a remote update brings in a new transfer that makes a previously `audit-not-our-state` token ours, the rescan-driven §5.3 pass detects the new ownership and promotes per §5.4.
 
-#### 12.3.2 Per-token spent-state rescan
+**Operator override**: omitting the `getPointerLayer` accessor / not wiring an oracle disables the polling entirely (the lifecycle manager silently skips when no pointer closure is wired). There is no `{ disableProfilePointerRescan: true }` SDK init flag — the wiring presence IS the on-switch. Disabling leaves the wallet dependent on OrbitDB pubsub alone (unreliable across NAT/firewalls) plus event-driven incoming-bundle paths.
 
-**Purpose**: detect off-record spends. If another instance of the same wallet (sharing the private keys but not yet synced to us) has spent one of our tokens, the aggregator's SMT will show that token's current state as having a committed transition — but our local manifest still believes the token is `valid`. Without rescan, we'd attempt to spend an already-spent token and learn the truth only at next `send()`.
+#### 12.3.2 Per-token spent-state rescan — **OPEN** (Issue #174)
+
+> **Status**: tracked as [Issue #174](https://github.com/unicity-sphere/sphere-sdk/issues/174). The reactive surface — surfacing the off-record-spend at next `send()` attempt — is in place (Item #14 Phase 1 / commit `9b4fae7`: `STATE_ALREADY_SPENT_BY_OTHER` typed throw + `transfer:double-spend-detected` event). The proactive surface (background sweep) remains to be implemented per the spec below.
+
+**Purpose**: detect off-record spends. If another instance of the same wallet (sharing the private keys but not yet synced to us) has spent one of our tokens, the aggregator's SMT will show that token's current state as having a committed transition — but our local manifest still believes the token is `valid`. **Without rescan, we'd attempt to spend an already-spent token and learn the truth only at next `send()`** (which today surfaces as the typed `STATE_ALREADY_SPENT_BY_OTHER` throw + `transfer:double-spend-detected` event — the reactive surface). The proactive surface catches it earlier so the local UI doesn't continue showing the token as spendable until the user tries to spend it.
 
 **Mechanism**:
 - Schedule: for each token in active pool with `manifest.status === 'valid'`, query `oracle.isSpent(currentDestinationStateHash)` periodically. Default interval `TOKEN_SPENT_RESCAN_INTERVAL = 5 min` per token; cap concurrent in-flight queries at `MAX_CONCURRENT_SPENT_RESCANS` (default 4).
-- On `isSpent === true`: transition the token from active pool to `_audit` with reason='off-record-spend' (UNSPENDABLE_BY_US disposition per §5.3 [E]). Emit `token:off-record-spent` event with `{tokenId, detectedAt, suspectedSiblingInstance: boolean}` — suspected-sibling-instance is set if local outbox has no record of having spent this state, suggesting another instance with the same keys is the spender.
+- On `isSpent === true`: transition the token from active pool to `_audit` with reason='off-record-spend' (UNSPENDABLE_BY_US disposition per §5.3 [E]). Emit `transfer:off-record-spent` event with `{tokenId, detectedAt, suspectedSiblingInstance: boolean}` — `suspectedSiblingInstance` is set if local outbox (OUTBOX + SENT) has no record of having spent this state, suggesting another instance with the same keys is the spender. (Spec wording was `token:off-record-spent`; renamed to `transfer:*` for consistency with the existing `transfer:*` event family.)
 - On transient errors (aggregator unavailable): backoff; retry.
 - Cache: §8 already references the Wave L LRU cache for `isSpent`. The rescan respects the cache TTL — a recently-cached `isSpent === false` doesn't force a fresh query.
+- Feature flag: `features.spentStateRescan` (default-OFF during soak; flip to default-ON after 7-day testnet observation).
 
-These two rescans are CONFIGURABLE: operators can disable either via SDK init (`{ disableProfilePointerRescan: true }` or `{ disableSpentRescan: true }`) for cost-sensitive deployments. Disabling both leaves the wallet purely event-driven (responsive to incoming bundles only).
+**Relationship to other surfaces**:
+- **Complementary to §12.3.1**: the profile-pointer rescan catches the spend IF the spending device publishes a snapshot to the aggregator before our local poll fires. §12.3.2 catches it independently of whether the spender device's snapshot has propagated.
+- **Complementary to Item #14 Phase 1**: Phase 1's `transfer:double-spend-detected` is REACTIVE (fires at our next `send()` attempt). §12.3.2 is PROACTIVE (fires from the background sweep before any send attempt).
+- **Distinct from orphan-spending sweeper** (Item #166 P2 #1): that sweeper looks at tokens stuck `'transferring'` with no matching OUTBOX/SENT entry. §12.3.2 looks at tokens at `'confirmed'` AND in the active manifest.
+
+**Operator override**: when Issue #174 lands, an `{ features: { spentStateRescan: false } }` SDK init flag will disable the worker. Disabling leaves the wallet dependent on the reactive surface (Item #14 Phase 1) for off-record-spend detection.
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation refresh after the architectural shift Item #15 delivered.

The transfer protocol doc had \`§12.3 Periodic rescans\` framed as "two rescans deferred as a unit" at T.1–T.8 plan-time. That framing is stale:

- **§12.3.1 (profile-pointer rescan) is SHIPPED** — landed via the aggregator-pointer wave (`PROFILE-AGGREGATOR-POINTER-IMPL-PLAN.md` Phases A–E, 75 tasks) and consolidated by Item #15 (PR #173). Implementation: `profile/profile-token-storage/lifecycle-manager.ts:schedulePointerPoll` / `runPointerPollOnce`, randomized [30s, 90s) interval.
- **§12.3.2 (per-token spent-state rescan) is STILL OPEN** as **[Issue #174](https://github.com/unicity-sphere/sphere-sdk/issues/174)**.

## Changes

- \`docs/uxf/UXF-TRANSFER-PROTOCOL.md §12.3\`: banner status block + §12.3.1 body rewritten as as-implemented mechanism; §12.3.2 body flagged with Issue #174 status. Event name aligned to project convention (\`token:off-record-spent\` → \`transfer:off-record-spent\`).
- \`docs/uxf/UXF-TRANSFER-IMPL-PLAN.md\` "Out-of-scope for T.1–T.8 (deferred)": same status banner; original wording preserved as historical record.
- \`docs/uxf/OUTBOX-SEND-FOLLOWUPS.md\`: new Item #16 row covering §12.3.2 acceptance criteria + relationships to Items #14 / #15.

## Caught by

A user question after PR #173 landed: "we do not have periodic polling for the profile pointer update from the unicity aggregator???" — I had carelessly described \`§12.3 periodic rescans (DEFERRED as a unit)\` in a status summary, conflating §12.3.1 (shipped) with §12.3.2 (open). This PR fixes the doc drift that misled me.

## Test plan

Documentation only — no code changes. Verified the §12.3.1 description matches the actual code in \`lifecycle-manager.ts\` (interval bounds, mechanism, hint-channel wiring, back-off semantics, cold-start path).

## Refs

- Issue #174 (the spent-state rescan tracker filed alongside this PR)
- Issue #97 (UXF umbrella)
- PR #173 (Item #15 + Item #14 Phase 1 — the architectural shift behind this status flip)