### PR TITLE
feat(payments)(#174): default transitionToAudit closure for spent-state rescan

### DIFF
--- a/docs/uxf/OUTBOX-SEND-FOLLOWUPS.md
+++ b/docs/uxf/OUTBOX-SEND-FOLLOWUPS.md
@@ -733,6 +733,8 @@ Migration consideration: existing wallets that have published only UXF-bundle po
 
 **Soak-gate follow-up**: flip `features.spentStateRescan` to default-ON after the 7-day testnet observation. The flip is a one-line change in `PaymentsModule.ts` (`config?.features?.spentStateRescan ?? true`) plus a status update on this item.
 
+**Bootstrap-layer follow-up (LANDED in PR #N, branch `feat/spent-state-rescan-bootstrap-wiring`)**: `PaymentsModule.defaultSpentStateTransition` is now wired as the default `transitionToAudit` closure. When the worker detects `oracle.isSpent === true`, the closure calls `removeToken()` — archive + tombstone + active-map deletion + persist — so the spent token leaves the spendable pool and the tombstone prevents re-sync resurrection. The token's value is correctly off the wallet's books even without the durable `_audit` record. The setter `payments.setSpentStateRescanTransitionToAudit(...)` remains available for callers that want to ALSO write a `_audit` disposition record (future work — `DispositionWriter` is constructed only in tests today; production bootstrap wiring of `DispositionWriter` is a separate cross-cutting concern).
+
 ---
 
 ## Cross-cutting concerns

--- a/docs/uxf/RUNBOOK-SEND-PIPELINE.md
+++ b/docs/uxf/RUNBOOK-SEND-PIPELINE.md
@@ -206,7 +206,7 @@ The most common cause is **a sibling instance of the same wallet** — desktop +
 - **`true`**  → neither the local OUTBOX nor the SENT ledger holds any record referencing `tokenId`, so the spend cannot have been initiated on THIS device. Almost certainly a sibling-device spend.
 - **`false`** → either OUTBOX or SENT has a record. The local instance is (or was) the spender; the manifest just hasn't been GC'd to reflect the spend yet. Rare edge case — typically only happens if the SENT-write path raced the next rescan cycle.
 
-**Wallet-side state after the event.** If a `transitionToAudit` route is wired (the default for the production `Sphere` wiring), the token is also moved out of the active pool to `_audit` with `reason='off-record-spend'` (§5.3 [E]). Without that route, the worker stays in detect-only mode — the event fires, but the local manifest still shows the token as `'confirmed'`.
+**Wallet-side state after the event.** Out of the box, the auto-installed default closure (`PaymentsModule.defaultSpentStateTransition`) calls `removeToken()` on the off-record-spent token — archive + tombstone + active-map deletion + persist. The token leaves the spendable pool; the tombstone prevents re-sync resurrection. (When `DispositionWriter` becomes wired in production, callers can ALSO synthesize a durable `_audit` record per §5.3 [E] by passing a custom closure to `payments.setSpentStateRescanTransitionToAudit(...)`; the local Token.status flip and the durable `_audit` record are orthogonal.) If you've explicitly overridden the closure with a no-op, the worker stays in detect-only mode — the event fires, but the local manifest still shows the token as `'confirmed'`.
 
 **Diagnostic data to collect.**
 
@@ -231,7 +231,7 @@ The most common cause is **a sibling instance of the same wallet** — desktop +
 **Forward direction.**
 
 - Repeated `transfer:off-record-spent` events firing for many `tokenId`s in a short window typically mean a sibling device recently sent multiple tokens. After the sibling's profile snapshot syncs (§12.3.1), the local view should converge naturally; the audit transitions are correct.
-- If the event fires every cycle for the SAME `tokenId` (5 min cadence by default), check whether the disposition writer is wired. Without the audit route, the worker re-emits the event on every cycle past the per-token interval. Wire `setSpentStateRescanTransitionToAudit(...)` on `PaymentsModule` (or call `Sphere`'s bootstrap setter) to suppress the repeat fires.
+- If the event fires every cycle for the SAME `tokenId` (5 min cadence by default), the local Token.status flip path is NOT firing — either an explicit `setSpentStateRescanTransitionToAudit(...)` override is in place and not removing the token, OR `removeToken()` is throwing internally (check WARN-level `[Payments] defaultSpentStateTransition: removeToken failed` log lines). Out of the box the auto-installed default closure (`defaultSpentStateTransition`) calls `removeToken()` so the spent token is archived + tombstoned + dropped from the active map after the first detection.
 
 **Companion events.** Distinct from `transfer:double-spend-detected` (reactive — fires only when YOU attempt a send) and from `transfer:orphan-spending-detected` (covers `'transferring'` tokens stuck mid-send). All three can fire for related tokens during a sibling-device race; the `tokenId` is the join key.
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -4493,11 +4493,24 @@ export class PaymentsModule {
 
   /**
    * Issue #174 — set the closure invoked when the spent-state rescan
-   * worker detects an off-record spend. The bootstrap layer (Sphere)
-   * wires this to a route that calls `dispositionWriter.write()` with
-   * a synthesized AUDIT record (`reason: 'off-record-spend'`). When
-   * unset, the auto-installed worker stays in detect-only mode
-   * (event emission only — no `_audit` transition).
+   * worker detects an off-record spend. When unset (or reset via
+   * `null`), the auto-installed worker uses
+   * {@link defaultSpentStateTransition} — `removeToken()` so the spent
+   * token is archived, tombstoned, and removed from the active map.
+   *
+   * Override use cases:
+   *   - Future bootstrap-layer wiring of `DispositionWriter` (today
+   *     constructed only in tests) — the override can ALSO synthesize
+   *     a durable `_audit` record per §5.3 [E] / §5.4 in addition to
+   *     calling `removeToken()` for the local-state cleanup. The two
+   *     paths are orthogonal.
+   *   - Tests / operator escape-hatch — the override can be an
+   *     explicit no-op (`async () => undefined`) to FORCE detect-only
+   *     mode (event emission only, no local Token.status flip).
+   *
+   * **Important:** passing `null` does NOT give you detect-only mode
+   * — it RESTORES the default closure (`removeToken`). To force
+   * detect-only behavior, pass an explicit no-op closure.
    *
    * The closure takes effect on the NEXT `initialize()` call when the
    * worker is auto-constructed. To replace the route on a running

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -2110,12 +2110,15 @@ export class PaymentsModule {
     // (UXF-TRANSFER-PROTOCOL §12.3.2). Default-OFF; when ON the worker
     // probes oracle.isSpent for each `'confirmed'` token to detect
     // off-record spends from sibling instances of the same wallet.
-    // `transitionToAudit` routes detection through the disposition
-    // writer when one is wired; otherwise the worker stays in
-    // detect-only mode (event-only). The `oracleProvider` closure
-    // reads `this.deps?.oracle` lazily so a future `deps` re-init
-    // (e.g. oracle swap on reconnect) is observed; same closure
-    // pattern as `sentProvider` / `outboxProvider` for consistency.
+    // `transitionToAudit` defaults to {@link defaultSpentStateTransition}
+    // (local Token.status flip + archive + tombstone via removeToken);
+    // callers that need to route through a production-wired
+    // `DispositionWriter.write()` (future, once that wiring lands in
+    // production) override via {@link setSpentStateRescanTransitionToAudit}.
+    // The `oracleProvider` closure reads `this.deps?.oracle` lazily so
+    // a future `deps` re-init (e.g. oracle swap on reconnect) is
+    // observed; same closure pattern as `sentProvider` / `outboxProvider`
+    // for consistency.
     if (
       this.features.spentStateRescan &&
       this.spentStateRescanWorker === null
@@ -2138,7 +2141,8 @@ export class PaymentsModule {
         outboxProvider: (): Pick<OutboxWriter, 'readAll'> | null =>
           this._outboxWriter,
         transitionToAudit:
-          this._spentStateRescanTransitionToAudit ?? undefined,
+          this._spentStateRescanTransitionToAudit ??
+          this.defaultSpentStateTransition.bind(this),
         emit: sphereEmit,
         logger: {
           warn: (message: string, context?: Record<string, unknown>): void => {
@@ -3796,6 +3800,106 @@ export class PaymentsModule {
     return 'recovered';
   }
 
+  /**
+   * Issue #174 — default `transitionToAudit` route for the spent-state
+   * rescan worker (UXF-TRANSFER-PROTOCOL §12.3.2).
+   *
+   * Strategy: the off-record spend is FINAL (the L3 aggregator confirmed
+   * the source state is spent), so the local token's value is gone from
+   * THIS wallet's perspective regardless of who spent it. Apply the same
+   * local-side cleanup that a successful local send applies:
+   *
+   *   1. Archive the token to history.
+   *   2. Write a tombstone for `(tokenId, stateHash)` so a subsequent
+   *      sync (Item #15 profile-pointer rescan, manual restore, etc.)
+   *      cannot resurrect the token.
+   *   3. Remove from the active in-memory map.
+   *   4. Persist via `save()`.
+   *
+   * This is `removeToken()`'s exact contract — we delegate to it. The
+   * archived record + tombstone preserves forensic context (the event
+   * already fired with `tokenId / coinId / amount / suspectedSibling
+   * Instance`, so operators can correlate after the fact).
+   *
+   * **Why not write `_audit` durable record here**: the
+   * `DispositionWriter` route (§5.4 `_audit` collection) is the
+   * canonical durable-record surface. Today `DispositionWriter` is
+   * constructed only in tests — no production bootstrap wires it. When
+   * that wiring lands, callers can override this default via
+   * {@link setSpentStateRescanTransitionToAudit} to additionally
+   * synthesize an AUDIT record. The local Token.status flip is
+   * orthogonal: it removes the spent value from the UI regardless of
+   * the durable-record path.
+   *
+   * **Defensive guards**:
+   *  - Token concurrent-removal: `this.tokens.get(token.id)` may return
+   *    `undefined` if a concurrent path (legitimate send, manual triage,
+   *    another worker cycle) already removed the token. No-op in that
+   *    case — the desired terminal state was reached.
+   *  - Status drift: if the token's status is no longer `'confirmed'`
+   *    (e.g. concurrent send moved it to `'transferring'`), defer to the
+   *    other path — the send pipeline owns the transition.
+   *  - `removeToken` throw: surface in a warn-log; the worker's caller
+   *    contract already swallows throws from `transitionToAudit`. The
+   *    `transfer:off-record-spent` event already fired so operator
+   *    visibility is preserved.
+   *
+   * Never throws — defense-in-depth converts every error path to a
+   * warn-log so the worker's outer `try/catch` in `probeOne` sees the
+   * call as a "best-effort completion" rather than a failure.
+   *
+   * @param params - injected by the SpentStateRescanWorker. Carries the
+   *   snapshot Token reference (NOT a live re-fetch), the derived
+   *   `currentStateHash`, the heuristic `suspectedSiblingInstance` flag,
+   *   and the wall-clock `detectedAt`. The flag is forensic only — both
+   *   true and false produce the same local cleanup.
+   */
+  private async defaultSpentStateTransition(params: {
+    readonly token: Token;
+    readonly currentStateHash: string;
+    readonly suspectedSiblingInstance: boolean;
+    readonly detectedAt: number;
+  }): Promise<void> {
+    const live = this.tokens.get(params.token.id);
+    if (live === undefined) {
+      logger.debug(
+        'Payments',
+        `defaultSpentStateTransition: token ${params.token.id.slice(0, 12)}… already removed; no-op`,
+      );
+      return;
+    }
+    if (live.status !== 'confirmed') {
+      logger.debug(
+        'Payments',
+        `defaultSpentStateTransition: token ${params.token.id.slice(0, 12)}… is now ${live.status} (not 'confirmed'); ` +
+          `deferring to whatever path owns that transition`,
+      );
+      return;
+    }
+    try {
+      // `removeToken` archives, tombstones, removes from the active map,
+      // and persists via `save()`. All four are required for a clean
+      // off-record-spend cleanup — partial application would either
+      // leak forensic context (no archive) or risk re-sync resurrection
+      // (no tombstone) or leave the in-memory map inconsistent.
+      await this.removeToken(params.token.id);
+      logger.debug(
+        'Payments',
+        `defaultSpentStateTransition: token ${params.token.id.slice(0, 12)}… ` +
+          `(coin=${params.token.coinId.slice(0, 12)}, amount=${params.token.amount}, ` +
+          `suspectedSibling=${params.suspectedSiblingInstance}) removed after off-record-spend ` +
+          `(stateHash=${params.currentStateHash.slice(0, 16)}…, detectedAt=${params.detectedAt})`,
+      );
+    } catch (removeErr) {
+      logger.warn(
+        'Payments',
+        `defaultSpentStateTransition: removeToken failed for ${params.token.id.slice(0, 12)}… ` +
+          `(transfer:off-record-spent event already fired; operator triage recommended): ` +
+          `${removeErr instanceof Error ? removeErr.message : String(removeErr)}`,
+      );
+    }
+  }
+
   installOutboxWriter(writer: OutboxWriter | null): void {
     this._outboxWriter = writer;
     if (writer !== null) {
@@ -3895,11 +3999,22 @@ export class PaymentsModule {
   private spentStateRescanWorker: SpentStateRescanWorker | null = null;
   /**
    * @internal — optional override for the spent-state rescan worker's
-   * `transitionToAudit` closure. The bootstrap layer (Sphere) installs
-   * a production wiring (disposition writer route) via
-   * {@link setSpentStateRescanTransitionToAudit}; tests may override.
-   * When unset, the auto-installed worker stays in detect-only mode
-   * (event emission only). Issue #174.
+   * `transitionToAudit` closure. When set via
+   * {@link setSpentStateRescanTransitionToAudit}, the override REPLACES
+   * the default {@link defaultSpentStateTransition} closure that the
+   * auto-install wires in {@link initialize}. The override exists so
+   * future bootstrap-layer work can route detection through a
+   * production-wired `DispositionWriter.write()` (synthesized AUDIT
+   * record per §5.3 [E] / §5.4 — once `DispositionWriter` is
+   * constructed in production; today it lives only in tests).
+   *
+   * Pass `null` (or never call the setter) → the default closure
+   * runs: archive + tombstone + remove from active map via
+   * {@link removeToken}, mirroring `defaultOrphanRecovery`'s pattern.
+   * The token's value leaves the spendable pool and the tombstone
+   * prevents re-sync resurrection.
+   *
+   * Issue #174.
    */
   private _spentStateRescanTransitionToAudit: TransitionToAuditFn | null = null;
   /** @internal — auto-installed when `features.tombstoneGcWorker` is on.

--- a/tests/integration/payments/spent-state-rescan-default-closure.test.ts
+++ b/tests/integration/payments/spent-state-rescan-default-closure.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Integration test for the default `transitionToAudit` closure that
+ * `PaymentsModule` wires into the spent-state rescan worker by default
+ * (Issue #174 bootstrap follow-up).
+ *
+ * Covers the two layers:
+ *
+ *  1. **Direct invocation of `defaultSpentStateTransition`** — exercises
+ *     the closure in isolation against a `PaymentsModule` whose private
+ *     `tokens` map has been seeded. Happy path: token at `'confirmed'`
+ *     gets removed (archived + tombstoned + map-deleted via
+ *     `removeToken`). Edge cases: token already removed (no-op), token
+ *     no longer at `'confirmed'` (no-op), `removeToken` throw is
+ *     swallowed (worker contract requires `transitionToAudit` never to
+ *     throw).
+ *
+ *  2. **Auto-install end-to-end** — calls `module.initialize()` with
+ *     `features.spentStateRescan: true`, asserts the auto-installed
+ *     worker is wired to the default closure (no setter override), then
+ *     runs a scan cycle against a mocked `oracle.isSpent` returning
+ *     `true` for the seeded token. After the cycle, the token MUST be
+ *     gone from `module.tokens` (the default closure called
+ *     `removeToken`), and the `transfer:off-record-spent` event MUST
+ *     have fired.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PaymentsModule } from '../../../modules/payments/PaymentsModule';
+import { SpentStateRescanWorker } from '../../../modules/payments/transfer/spent-state-rescan-worker';
+import type { FullIdentity, SphereEventMap, SphereEventType, Token } from '../../../types';
+import type { OracleProvider } from '../../../oracle';
+import type { StorageProvider } from '../../../storage';
+import type { TransportProvider } from '../../../transport';
+
+// =============================================================================
+// SDK / registry mocks — keep tests deterministic, avoid network/crypto.
+// =============================================================================
+
+vi.mock('../../../registry', () => ({
+  TokenRegistry: {
+    getInstance: () => ({
+      getDefinition: () => null,
+      getIconUrl: () => null,
+    }),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../../l1/network', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  isWebSocketConnected: vi.fn().mockReturnValue(false),
+}));
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeIdentity(): FullIdentity {
+  return {
+    chainPubkey: '02' + 'a'.repeat(64),
+    l1Address: 'alpha1test',
+    directAddress: 'DIRECT://test',
+    privateKey: 'a'.repeat(64),
+  };
+}
+
+function makeStorage(): StorageProvider {
+  const store = new Map<string, string>();
+  return {
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => {
+      store.set(k, v);
+    }),
+    delete: vi.fn(async (k: string) => {
+      store.delete(k);
+    }),
+    clear: vi.fn(async () => store.clear()),
+    has: vi.fn(async (k: string) => store.has(k)),
+    keys: vi.fn(async () => [...store.keys()]),
+  } as unknown as StorageProvider;
+}
+
+function makeTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => undefined),
+    onPaymentRequest: vi.fn().mockReturnValue(() => undefined),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => undefined),
+    resolve: vi.fn().mockResolvedValue(null),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    publishNametag: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TransportProvider;
+}
+
+interface MockOracle {
+  readonly provider: OracleProvider;
+  readonly isSpent: ReturnType<typeof vi.fn>;
+}
+
+function makeOracle(): MockOracle {
+  const isSpent = vi.fn();
+  return {
+    isSpent,
+    provider: {
+      validateToken: vi.fn().mockResolvedValue({ valid: true }),
+      getStateTransitionClient: vi.fn().mockReturnValue(null),
+      waitForProofSdk: vi.fn(),
+      isSpent,
+    } as unknown as OracleProvider,
+  };
+}
+
+function makeToken(overrides: Partial<Token> = {}): Token {
+  return {
+    id: overrides.id ?? 'tok-1',
+    coinId: overrides.coinId ?? 'UCT-coin',
+    symbol: overrides.symbol ?? 'UCT',
+    name: overrides.name ?? 'Unicity',
+    decimals: overrides.decimals ?? 8,
+    amount: overrides.amount ?? '1000',
+    status: overrides.status ?? 'confirmed',
+    createdAt: overrides.createdAt ?? 1_700_000_000_000,
+    updatedAt: overrides.updatedAt ?? 1_700_000_000_000,
+    sdkData: overrides.sdkData ?? JSON.stringify({
+      genesis: {
+        data: { tokenId: 'tok-genesis-id' },
+        inclusionProof: { authenticator: { stateHash: 'deadbeef' } },
+      },
+      transactions: [],
+    }),
+    ...overrides,
+  };
+}
+
+interface RecordedEvent {
+  readonly type: SphereEventType;
+  readonly data: unknown;
+}
+
+function makeEventRecorder(): {
+  readonly emit: <T extends SphereEventType>(
+    type: T,
+    data: SphereEventMap[T],
+  ) => void;
+  readonly events: ReadonlyArray<RecordedEvent>;
+} {
+  const events: RecordedEvent[] = [];
+  return {
+    events,
+    emit: <T extends SphereEventType>(type: T, data: SphereEventMap[T]): void => {
+      events.push({ type, data });
+    },
+  };
+}
+
+// =============================================================================
+// Helper — invoke the private defaultSpentStateTransition method on the
+// module. Casts through `unknown` so the call site has no leaking `any`.
+// =============================================================================
+
+type PrivateDefaultSpentStateTransitionFn = (params: {
+  readonly token: Token;
+  readonly currentStateHash: string;
+  readonly suspectedSiblingInstance: boolean;
+  readonly detectedAt: number;
+}) => Promise<void>;
+
+function invokeDefaultClosure(
+  module: PaymentsModule,
+  params: Parameters<PrivateDefaultSpentStateTransitionFn>[0],
+): Promise<void> {
+  const fn = (
+    module as unknown as {
+      defaultSpentStateTransition: PrivateDefaultSpentStateTransitionFn;
+    }
+  ).defaultSpentStateTransition.bind(module);
+  return fn(params);
+}
+
+function getTokensMap(module: PaymentsModule): Map<string, Token> {
+  return (module as unknown as { tokens: Map<string, Token> }).tokens;
+}
+
+function getInstalledWorker(module: PaymentsModule): SpentStateRescanWorker | null {
+  return (module as unknown as { spentStateRescanWorker: SpentStateRescanWorker | null })
+    .spentStateRescanWorker;
+}
+
+// =============================================================================
+// Tests — direct invocation of the default closure
+// =============================================================================
+
+describe('PaymentsModule.defaultSpentStateTransition (Issue #174 bootstrap follow-up)', () => {
+  let module: PaymentsModule;
+
+  beforeEach(() => {
+    module = new PaymentsModule({
+      features: { spentStateRescan: false }, // we test the method, not auto-install
+    });
+    // Inject minimal deps so `ensureInitialized` (called by removeToken)
+    // passes without standing up the full dependency graph.
+    (module as unknown as { deps: unknown }).deps = {
+      transport: makeTransport(),
+      emitEvent: vi.fn(),
+      identity: makeIdentity(),
+    };
+    // `save()` is private and writes to storage; stub it to a no-op so
+    // we don't need a real storage provider. The closure's contract is
+    // that `removeToken` returns successfully; `save()`-throw paths are
+    // exercised in PaymentsModule's own removeToken tests.
+    (module as unknown as { save: () => Promise<void> }).save = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    // archiveToken is private + invoked by removeToken; stub for the
+    // same reason (we don't want to depend on the archive store wiring).
+    (module as unknown as { archiveToken: (t: Token) => Promise<void> }).archiveToken = vi
+      .fn()
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('removes a confirmed token via removeToken (archive + tombstone + map delete)', async () => {
+    const token = makeToken({ id: 'tok-spent', status: 'confirmed' });
+    getTokensMap(module).set(token.id, token);
+
+    expect(getTokensMap(module).has(token.id)).toBe(true);
+
+    await invokeDefaultClosure(module, {
+      token,
+      currentStateHash: 'state-tok-spent',
+      suspectedSiblingInstance: true,
+      detectedAt: 1_700_000_000_000,
+    });
+
+    // Token is gone from the active map.
+    expect(getTokensMap(module).has(token.id)).toBe(false);
+
+    // Tombstone was created (the (tokenId, stateHash) pair).
+    const tombstones = module.getTombstones();
+    expect(tombstones.length).toBeGreaterThan(0);
+  });
+
+  it('no-ops when the token is already gone from the active map (concurrent removal)', async () => {
+    const token = makeToken({ id: 'tok-gone' });
+    // Token NOT seeded into module.tokens — simulates the case where a
+    // concurrent send / removeToken already cleared it.
+
+    await expect(
+      invokeDefaultClosure(module, {
+        token,
+        currentStateHash: 'state-tok-gone',
+        suspectedSiblingInstance: false,
+        detectedAt: 1_700_000_000_000,
+      }),
+    ).resolves.toBeUndefined();
+
+    // archiveToken should NOT have been invoked — the no-op path
+    // returns before calling removeToken.
+    const archiveToken = (
+      module as unknown as { archiveToken: ReturnType<typeof vi.fn> }
+    ).archiveToken;
+    expect(archiveToken).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the token status drifted from confirmed (race with send pipeline)', async () => {
+    const token = makeToken({ id: 'tok-transferring' });
+    const live = { ...token, status: 'transferring' as const };
+    getTokensMap(module).set(live.id, live);
+
+    await invokeDefaultClosure(module, {
+      token,
+      currentStateHash: 'state-tok-transferring',
+      suspectedSiblingInstance: false,
+      detectedAt: 1_700_000_000_000,
+    });
+
+    // Token stays in the map (the send pipeline owns this state).
+    expect(getTokensMap(module).has(live.id)).toBe(true);
+    expect(getTokensMap(module).get(live.id)!.status).toBe('transferring');
+  });
+
+  it('swallows a removeToken throw (worker contract requires no rethrow)', async () => {
+    const token = makeToken({ id: 'tok-throw' });
+    getTokensMap(module).set(token.id, token);
+
+    // Replace the prototype `removeToken` so the unbound default closure
+    // (bound at instance construction by the closure factory) hits a
+    // throwing implementation.
+    const moduleWithRemove = module as unknown as {
+      removeToken: (id: string) => Promise<void>;
+    };
+    moduleWithRemove.removeToken = vi
+      .fn()
+      .mockRejectedValue(new Error('save failed'));
+
+    await expect(
+      invokeDefaultClosure(module, {
+        token,
+        currentStateHash: 'state-tok-throw',
+        suspectedSiblingInstance: true,
+        detectedAt: 1_700_000_000_000,
+      }),
+    ).resolves.toBeUndefined(); // critical: no rethrow
+  });
+});
+
+// =============================================================================
+// Tests — end-to-end auto-install via initialize() + scan cycle
+// =============================================================================
+
+describe('PaymentsModule auto-install wires the default closure (Issue #174 bootstrap follow-up)', () => {
+  let module: PaymentsModule;
+  let oracle: MockOracle;
+  let recorder: ReturnType<typeof makeEventRecorder>;
+
+  beforeEach(() => {
+    oracle = makeOracle();
+    recorder = makeEventRecorder();
+    module = new PaymentsModule({
+      features: { spentStateRescan: true, recipientUxf: false },
+    });
+    // `save()` and `archiveToken` are private and would otherwise need
+    // a real storage backend to succeed. The auto-install path itself
+    // does not invoke them; they fire only when the worker's
+    // default closure calls `removeToken`, which we DO want to exercise
+    // end-to-end. Stub both to no-ops so the integration runs
+    // deterministically without standing up storage.
+    (module as unknown as { save: () => Promise<void> }).save = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    (module as unknown as { archiveToken: (t: Token) => Promise<void> }).archiveToken = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    module.initialize({
+      identity: makeIdentity(),
+      storage: makeStorage(),
+      transport: makeTransport(),
+      oracle: oracle.provider,
+      emitEvent: recorder.emit,
+    });
+  });
+
+  afterEach(async () => {
+    await module.destroy();
+    vi.clearAllMocks();
+  });
+
+  it('initialize() auto-installs a SpentStateRescanWorker when the flag is ON', () => {
+    const worker = getInstalledWorker(module);
+    expect(worker).not.toBeNull();
+    expect(worker).toBeInstanceOf(SpentStateRescanWorker);
+    expect(worker!.isRunning()).toBe(true);
+  });
+
+  it('runScanCycle with isSpent=true triggers the default closure → token leaves the active map', async () => {
+    const token = makeToken({ id: 'tok-e2e', amount: '5000' });
+    getTokensMap(module).set(token.id, token);
+    oracle.isSpent.mockResolvedValue(true);
+
+    expect(getTokensMap(module).has(token.id)).toBe(true);
+
+    const worker = getInstalledWorker(module)!;
+    const result = await worker.runScanCycle();
+
+    expect(result.spent).toBe(1);
+    expect(result.unspent).toBe(0);
+    // Token removed via the default closure.
+    expect(getTokensMap(module).has(token.id)).toBe(false);
+    // Tombstone was created.
+    expect(module.getTombstones().length).toBeGreaterThan(0);
+
+    // Event fired with the expected payload shape.
+    const fired = recorder.events.filter(
+      (e) => e.type === 'transfer:off-record-spent',
+    );
+    expect(fired).toHaveLength(1);
+    const data = fired[0].data as {
+      tokenId: string;
+      coinId: string;
+      amount: string;
+      suspectedSiblingInstance: boolean;
+    };
+    expect(data.tokenId).toBe('tok-e2e');
+    expect(data.coinId).toBe('UCT-coin');
+    expect(data.amount).toBe('5000');
+    // Neither OUTBOX nor SENT seeded → conservative true.
+    expect(data.suspectedSiblingInstance).toBe(true);
+  });
+
+  it('runScanCycle with isSpent=false leaves the token untouched', async () => {
+    const token = makeToken({ id: 'tok-unspent' });
+    getTokensMap(module).set(token.id, token);
+    oracle.isSpent.mockResolvedValue(false);
+
+    const worker = getInstalledWorker(module)!;
+    const result = await worker.runScanCycle();
+
+    expect(result.spent).toBe(0);
+    expect(result.unspent).toBe(1);
+    // Token survives.
+    expect(getTokensMap(module).has(token.id)).toBe(true);
+    expect(
+      recorder.events.filter((e) => e.type === 'transfer:off-record-spent'),
+    ).toHaveLength(0);
+  });
+
+  it('setSpentStateRescanTransitionToAudit override replaces the default', async () => {
+    // Override BEFORE initialize would be the usual pattern, but the
+    // setter also works post-initialize when an explicit
+    // installSpentStateRescanWorker call re-installs a worker. For this
+    // test we stop the existing worker, set the override, and reinstall
+    // a fresh worker that picks up the override.
+    await module.destroy();
+
+    const overrideCalls: Array<{ tokenId: string }> = [];
+    module = new PaymentsModule({
+      features: { spentStateRescan: true, recipientUxf: false },
+    });
+    (module as unknown as { save: () => Promise<void> }).save = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    (module as unknown as { archiveToken: (t: Token) => Promise<void> }).archiveToken = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    module.setSpentStateRescanTransitionToAudit(async (params) => {
+      overrideCalls.push({ tokenId: params.token.id });
+      // Override deliberately does NOT call removeToken — the token
+      // should remain in the active map.
+    });
+    module.initialize({
+      identity: makeIdentity(),
+      storage: makeStorage(),
+      transport: makeTransport(),
+      oracle: oracle.provider,
+      emitEvent: recorder.emit,
+    });
+
+    const token = makeToken({ id: 'tok-override' });
+    getTokensMap(module).set(token.id, token);
+    oracle.isSpent.mockResolvedValue(true);
+
+    const worker = getInstalledWorker(module)!;
+    await worker.runScanCycle();
+
+    // Override fired; default did NOT (token still in map).
+    expect(overrideCalls).toHaveLength(1);
+    expect(overrideCalls[0].tokenId).toBe('tok-override');
+    expect(getTokensMap(module).has(token.id)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Bootstrap-layer follow-up to PR #176 (Issue #174 — per-token spent-state rescan worker). Wires `PaymentsModule.defaultSpentStateTransition` as the worker's auto-installed default `transitionToAudit` route so an off-record-spent token leaves the spendable pool on first detection — not only after the user attempts a `send()`.

## What's changed

- **New `PaymentsModule.defaultSpentStateTransition` private method** (next to `defaultOrphanRecovery`). On `isSpent === true`, calls `removeToken()` for the off-record-spent token (archive + tombstone + active-map delete + persist via `save()`). Defensive guards: no-op when token absent (concurrent removal) or no longer at `'confirmed'` (concurrent send owns the transition). Never throws.
- **Auto-install wires the default by default**: `transitionToAudit: this._spentStateRescanTransitionToAudit ?? this.defaultSpentStateTransition.bind(this)`. The setter `setSpentStateRescanTransitionToAudit(...)` still overrides for callers that want a different route (e.g. ALSO synthesize a durable `_audit` record when `DispositionWriter` becomes wired in production — separate cross-cutting work).
- **Tests**: 8 new tests in `tests/integration/payments/spent-state-rescan-default-closure.test.ts`. Covers direct invocation (happy + 3 edge cases) + auto-install end-to-end (worker installed + running + cycle removes token + override-replaces-default).
- **Runbook**: updated `transfer:off-record-spent` operator section to reflect that the default closure ships with PaymentsModule; repeat-fires triage refined accordingly.
- **Item #16 in OUTBOX-SEND-FOLLOWUPS.md**: new "Bootstrap-layer follow-up LANDED" entry.

## Why this approach (not a DispositionWriter route)

PR #176's closing summary said the bootstrap-layer wiring would route through `DispositionWriter.write()` with a synthesized AUDIT record. A scan of the codebase confirmed `DispositionWriter` is constructed only in tests today — no production bootstrap wires it. Routing the rescan worker through a non-existent production writer would leave the token visible in the spendable pool indefinitely, defeating the proactive-surface purpose of §12.3.2.

The Token.status flip via `removeToken()` is orthogonal to the durable-record path: it achieves the user-visible goal today (off-record-spent tokens disappear from the spendable pool, tombstone prevents re-sync resurrection) without depending on `DispositionWriter` wiring. When that wiring lands, callers can override `transitionToAudit` to ALSO write the durable `_audit` record — the local Token.status flip and the `_audit` record are not mutually exclusive.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — 0 errors (pre-existing warnings only).
- [x] `npx vitest run tests/unit/payments/transfer/ tests/integration/payments/ tests/unit/payments/PaymentsModule.test.ts` — 73 files / 1,435 tests pass (8 new).

## Behavior change

When `features.spentStateRescan` is opt-in flipped to `true` (still default-OFF during soak), the default behaviour changes from "detect-only" to "auto-cleanup" (archive + tombstone + remove). This is the desired behaviour per §12.3.2 — the proactive surface only delivers value when the off-record-spent token actually leaves the spendable pool. Callers that want the legacy detect-only behaviour can pass an explicit no-op closure to `setSpentStateRescanTransitionToAudit(...)`.

## Future direction

When production bootstrap wires `DispositionWriter` (separate cross-cutting work), the override path becomes useful: a Sphere-level closure can additionally synthesize a `disposition: 'AUDIT', reason: 'off-record-spend'` record and call `dispositionWriter.write(addr, record)` for the durable forensic trail. The local `removeToken()` cleanup stays correct regardless — it's orthogonal to the `_audit` durable-record path.