### PR TITLE
feat(payments): flip features.orphanAutoRecovery default-OFF → default-ON

### DIFF
--- a/docs/uxf/OUTBOX-SEND-FOLLOWUPS.md
+++ b/docs/uxf/OUTBOX-SEND-FOLLOWUPS.md
@@ -151,7 +151,14 @@ The OUTBOX is a working queue that **drains** to SENT as deliveries complete. To
 
 ---
 
-### 5. Soak validation + default-ON flip for the new workers
+### 5. Soak validation + default-ON flip for the new workers — **PARTIAL**
+
+> **Status (2026-05-20)**:
+>
+>   - `features.spentStateRescan` — **FLIPPED default-ON** in PR #178 (Item #16). Default closure does archive + tombstone + map-delete via `removeToken`; durable `_audit` record via PR #179 when DispositionWriter is wired.
+>   - `features.orphanAutoRecovery` — **FLIPPED default-ON** in this PR. Item #1's aggregator cross-check prerequisite is satisfied (`PaymentsModule.defaultOrphanRecovery` queries `oracle.isSpent(sourceStateHash)` before flipping status and escalates to `'manual'` when the aggregator reports the source state spent). Without this flip a crashed send leaves the source token unspendable indefinitely; with it, the load-tail orphan sweep auto-recovers.
+>   - `features.tombstoneGcWorker` — **STILL default-OFF**. Storage-reclamation surface; not a correctness path. The 30-day default retention is conservative and the worker is fully tested (see Item #4). Defer flip until storage growth becomes operationally relevant or an organization-wide soak measurement confirms safety.
+>   - `features.nostrPersistenceVerifier` — **STILL default-OFF**. Adds relay query traffic proportional to SENT volume. Item #2's Item-#15 scope clarification eliminated most of the cross-device retention gap; the remaining surface is the inline-CAR retention case (covered by Item #6.a). Defer flip until relay-load measurement.
 
 **Why it matters**: two new workers landed in default-OFF state pending soak validation:
 - `features.nostrPersistenceVerifier` — adds relay query traffic

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1618,10 +1618,19 @@ export class PaymentsModule {
       // sweep is an optimisation, not a correctness path. Flip ON
       // explicitly when storage growth becomes operationally relevant.
       tombstoneGcWorker: config?.features?.tombstoneGcWorker ?? false,
-      // Issue #166 P2 #1 — orphan-spending auto-recovery. Default-OFF:
-      // the safe-restore-to-`confirmed` strategy assumes the spending
-      // commit never reached the aggregator. Flip ON after soak.
-      orphanAutoRecovery: config?.features?.orphanAutoRecovery ?? false,
+      // Issue #166 P2 #1 — orphan-spending auto-recovery. Default-ON
+      // after the OUTBOX-SEND-FOLLOWUPS item #1 prerequisite (aggregator
+      // cross-check before restore) landed. `defaultOrphanRecovery`
+      // queries `oracle.isSpent(sourceStateHash)` before flipping
+      // `'transferring'` → `'confirmed'` and escalates to `'manual'`
+      // when the aggregator reports the source state spent (i.e. the
+      // commit DID land before the crash; local restore would diverge).
+      // Without this flip a crashed send leaves the source token
+      // unspendable indefinitely and the operator must intervene by
+      // hand — with the flip, the cross-checked recovery hook runs
+      // automatically on the load-tail orphan sweep. Set `false`
+      // explicitly to suppress (e.g. timer-sensitive unit tests).
+      orphanAutoRecovery: config?.features?.orphanAutoRecovery ?? true,
       // Issue #174 — per-token spent-state rescan worker
       // (UXF-TRANSFER-PROTOCOL §12.3.2). Default-ON after soak: probes
       // oracle.isSpent for each `'confirmed'` token every ~5 min per

--- a/tests/unit/modules/payments/detect-orphan-spending-wrapper.test.ts
+++ b/tests/unit/modules/payments/detect-orphan-spending-wrapper.test.ts
@@ -243,12 +243,18 @@ describe('PaymentsModule.detectOrphanSpendingTokens — orphanAutoRecovery (Issu
     vi.clearAllMocks();
   });
 
-  it('default-OFF: features.orphanAutoRecovery omitted → no attemptRecovery wired (Phase-1 behavior preserved)', async () => {
+  it('explicit OFF: features.orphanAutoRecovery=false → no attemptRecovery wired (Phase-1 behavior preserved)', async () => {
     const emit = vi.fn();
     const payments = createPaymentsModule({
       debug: false,
       autoSync: false,
-      features: { recoveryWorker: false, finalizationWorker: false },
+      // OUTBOX-SEND-FOLLOWUPS item #5 flipped this flag default-ON
+      // (PR #N, branch `feat/orphan-auto-recovery-default-on`). To
+      // exercise the legacy Phase-1 detect-only behavior, explicit
+      // `false` is now required. The test name was updated from
+      // "default-OFF" to "explicit OFF" to reflect the post-flip
+      // semantics.
+      features: { recoveryWorker: false, finalizationWorker: false, orphanAutoRecovery: false },
     });
     payments.initialize({ ...createPaymentsDeps(), emitEvent: emit });
     const { outboxWriter, sentLedgerWriter } = createWriterPair();


### PR DESCRIPTION
## Summary

Production-blocking flip identified by the 2026-05-20 readiness assessment. One-line code change in `PaymentsModule.ts` (`?? false` → `?? true`) plus the matching status update in OUTBOX-SEND-FOLLOWUPS Item #5 plus one test that needed an explicit `false` instead of relying on the now-flipped default.

## Why this is production-blocking

Without the flip:
- A crashed send (process death between `commitSources` and OUTBOX entry persist) leaves the source token at `'transferring'` indefinitely.
- The load-tail orphan sweeper emits `transfer:orphan-spending-detected` but takes no action.
- Operator must intervene manually — for an end-user this is "token disappears from spendable balance with no automatic recovery."

With the flip (Item #1's aggregator cross-check, landed earlier):
- `defaultOrphanRecovery` queries `oracle.isSpent(sourceStateHash)` BEFORE flipping status.
- aggregator UNSPENT → restores to `'confirmed'`, fires `transfer:orphan-recovered`.
- aggregator SPENT → `'manual'` (correctly preserves the on-chain commit; operator triage needed).
- RPC throw or unparseable state → fail-closed to `'manual'`.

The safety contract Item #5 listed as the default-ON prerequisite is now satisfied; Item #1 LANDED status was confirmed by the audit.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `tests/unit/modules/payments/detect-orphan-spending-wrapper.test.ts` — 14 tests pass (one test renamed from "default-OFF" → "explicit OFF" and updated to set the flag explicitly).
- [x] `npx vitest run tests/unit/payments/transfer/ tests/integration/payments/ tests/unit/modules/payments/` — 80 files / 1,514 tests pass.

## Doc impact

OUTBOX-SEND-FOLLOWUPS Item #5 status flipped to PARTIAL with explicit per-flag breakdown:
- `spentStateRescan` — flipped (PR #178).
- `orphanAutoRecovery` — flipped (this PR).
- `tombstoneGcWorker` — still default-OFF (storage-reclamation surface; not a correctness path).
- `nostrPersistenceVerifier` — still default-OFF (relay query load; not a correctness path).

## Behavior change for end-users

The first wallet that ships from `integration/all-fixes` after this PR will, on each `load()`, auto-recover any orphan-spending tokens where the aggregator confirms the source state is UNSPENT. Wallets that prefer the legacy detect-only behavior can opt out via explicit `features.orphanAutoRecovery: false`.