### PR TITLE
feat(payments)(#5): flip features.nostrPersistenceVerifier default-ON

### DIFF
--- a/docs/uxf/OUTBOX-SEND-FOLLOWUPS.md
+++ b/docs/uxf/OUTBOX-SEND-FOLLOWUPS.md
@@ -151,14 +151,14 @@ The OUTBOX is a working queue that **drains** to SENT as deliveries complete. To
 
 ---
 
-### 5. Soak validation + default-ON flip for the new workers — **PARTIAL**
+### 5. Soak validation + default-ON flip for the new workers — **SHIPPED**
 
-> **Status (2026-05-20)**:
+> **Status (2026-05-20)**: All four soak-gated flags have flipped to default-ON. Wallets can still opt out explicitly per flag.
 >
 >   - `features.spentStateRescan` — **FLIPPED default-ON** in PR #178 (Item #16). Default closure does archive + tombstone + map-delete via `removeToken`; durable `_audit` record via PR #179 when DispositionWriter is wired.
 >   - `features.orphanAutoRecovery` — **FLIPPED default-ON** in PR #181. Item #1's aggregator cross-check prerequisite is satisfied (`PaymentsModule.defaultOrphanRecovery` queries `oracle.isSpent(sourceStateHash)` before flipping status and escalates to `'manual'` when the aggregator reports the source state spent). Without this flip a crashed send leaves the source token unspendable indefinitely; with it, the load-tail orphan sweep auto-recovers.
->   - `features.tombstoneGcWorker` — **FLIPPED default-ON** in this PR. The 30-day default retention is conservative — longer than any realistic concurrent-replica pre-sync window per Issue #166 P1 #2 safety contract — so swept slots cannot be resurrected by a stale replica. The worker self-skips when no OUTBOX or SENT writer is installed, so the flip is a safe no-op for legacy-only wallets. Tests can opt out with `features.tombstoneGcWorker: false` (timer-sensitive paths).
->   - `features.nostrPersistenceVerifier` — **STILL default-OFF**. Adds relay query traffic proportional to SENT volume. Item #2's Item-#15 scope clarification eliminated most of the cross-device retention gap; the remaining surface is the inline-CAR retention case (covered by Item #6.a). Defer flip until relay-load measurement.
+>   - `features.tombstoneGcWorker` — **FLIPPED default-ON** in PR #184. The 30-day default retention is conservative — longer than any realistic concurrent-replica pre-sync window per Issue #166 P1 #2 safety contract — so swept slots cannot be resurrected by a stale replica. The worker self-skips when no OUTBOX or SENT writer is installed, so the flip is a safe no-op for legacy-only wallets. Tests can opt out with `features.tombstoneGcWorker: false` (timer-sensitive paths).
+>   - `features.nostrPersistenceVerifier` — **FLIPPED default-ON** in this PR. Query traffic is proportional to eligible SENT volume with an LRU-bounded cap and per-entry cooldown (default 5 minutes); the worker self-skips wallets with no `nostrEventId`-tagged SENT entries (legacy pre-#166 P2 #3). On `'missing'` outcome the verifier re-arms the OUTBOX entry to `'sending'` so the recovery worker republishes via Item #2's path. Deployments on restrictive relay sets that cannot absorb the steady load should set `features.nostrPersistenceVerifier: false` explicitly.
 
 **Why it matters**: two new workers landed in default-OFF state pending soak validation:
 - `features.nostrPersistenceVerifier` — adds relay query traffic
@@ -843,7 +843,7 @@ This unblocks the `'entry-tombstoned-or-missing'` skip reason on `transfer:reten
 - Don't open another PR against `main`; the integration branch is `integration/all-fixes`.
 - Don't re-litigate the tombstone vs vector debate (item #10) without first getting a maintainer call. We had this conversation; it's documented but not decided.
 - Don't try to start P1 #1 (AAD) — explicitly deferred. If you think it should be revisited, ping the maintainer first.
-- Don't flip `features.orphanAutoRecovery` or `features.nostrPersistenceVerifier` to default-ON without first landing items #1 and #5 respectively. They're default-OFF for documented reasons.
+- Don't roll back the default-ON flips for `features.orphanAutoRecovery`, `features.tombstoneGcWorker`, `features.nostrPersistenceVerifier`, or `features.spentStateRescan` without first weighing the protocol consequences. Each was flipped under documented soak gates (PRs #178, #181, #184, and the current PR) — the regressions they prevent are listed under item #5.
 
 ## See also
 

--- a/docs/uxf/RUNBOOK-SEND-PIPELINE.md
+++ b/docs/uxf/RUNBOOK-SEND-PIPELINE.md
@@ -62,9 +62,9 @@ The aggregator's view may or may not include the commit. Locally the token is un
 
 **Actions.**
 
-1. **If `features.orphanAutoRecovery` is OFF (the default):** the wallet emits this event but takes no action. You can:
+1. **If `features.orphanAutoRecovery` is explicitly set to `false` (default-ON since PR #181):** the wallet emits this event but takes no action. You can:
    - Manually flip the token's status back to `'confirmed'` via direct profile edit (test environments only).
-   - Or: enable `features.orphanAutoRecovery` and restart the wallet — the recovery hook runs aggregator cross-check before restoring (see `transfer:orphan-recovered`).
+   - Or: remove the explicit `false` so `features.orphanAutoRecovery` reverts to its default-ON state and restart the wallet — the recovery hook runs aggregator cross-check before restoring (see `transfer:orphan-recovered`).
 2. **If aggregator reports the source state SPENT:** the commit landed on-chain. Local restore would diverge from the aggregator's view. You must either re-package the bundle from the post-spend state (out of scope for the auto-recovery hook today) or accept the value as already-sent.
 3. **If aggregator reports the source state UNSPENT:** safe to restore. Enabling `features.orphanAutoRecovery` performs this restore automatically; `transfer:orphan-recovered` then fires.
 
@@ -76,7 +76,7 @@ The aggregator's view may or may not include the commit. Locally the token is un
 
 **Payload**: `{ tokenId, coinId, amount, fromStatus, toStatus, strategy, recoveredAt }`
 
-**What it means.** The auto-recovery hook (gated on `features.orphanAutoRecovery`, default-OFF) cross-checked the aggregator and confirmed the source state was UNSPENT, then flipped the token from `'transferring'` back to `toStatus` (today: `'confirmed'`). The value is spendable again.
+**What it means.** The auto-recovery hook (gated on `features.orphanAutoRecovery`, default-ON since PR #181) cross-checked the aggregator and confirmed the source state was UNSPENT, then flipped the token from `'transferring'` back to `toStatus` (today: `'confirmed'`). The value is spendable again.
 
 **State of the system.** Token is back in normal circulation. No OUTBOX or SENT entry is created — the recovery is purely local (the send that originally moved the token to `'transferring'` is treated as if it never happened).
 
@@ -268,11 +268,11 @@ Likely cause: the tombstones are within the retention window (default 30 days fr
 features: {
   recoveryWorker:                true,   // default-ON
   sentReconciliationWorker:      true,   // default-ON
-  nostrPersistenceVerifier:      false,  // default-OFF (soak gated)
+  nostrPersistenceVerifier:      true,   // default-ON (item #5 — LRU + cooldown bound the load)
   orphanAutoRecovery:            true,   // default-ON (PR #181 — item #1 aggregator cross-check landed)
   tombstoneGcWorker:             true,   // default-ON (item #5 — 30-day retention is safe)
   spentStateRescan:              true,   // default-ON (Issue #174 — soak gate cleared)
 }
 ```
 
-Per OUTBOX-SEND-FOLLOWUPS item #5, the remaining default-OFF flag (`nostrPersistenceVerifier`) will flip to default-ON after the relay-load measurement clears. `orphanAutoRecovery` flipped to default-ON in PR #181 once item #1's aggregator cross-check landed (`PaymentsModule.defaultOrphanRecovery` queries `oracle.isSpent(sourceStateHash)` before flipping `'transferring'` → `'confirmed'` and escalates to `'manual'` on conflict). `tombstoneGcWorker` flipped to default-ON under item #5 — the 30-day retention default is conservative enough that no concurrent-replica pre-sync state can resurrect a swept slot. `spentStateRescan` (Issue #174) flipped to default-ON after its soak gate cleared — the worker probes `oracle.isSpent` for each `'confirmed'` token and routes detection through the default `removeToken()` cleanup. Wallets that prefer the reactive-only surface (`transfer:double-spend-detected` at next `send()`) can explicitly set `features.spentStateRescan: false`. Set any flag to `false` explicitly to opt out (e.g. timer-sensitive unit tests).
+All soak-gated workers have now flipped to default-ON under OUTBOX-SEND-FOLLOWUPS item #5. `orphanAutoRecovery` flipped in PR #181 once item #1's aggregator cross-check landed (`PaymentsModule.defaultOrphanRecovery` queries `oracle.isSpent(sourceStateHash)` before flipping `'transferring'` → `'confirmed'` and escalates to `'manual'` on conflict). `tombstoneGcWorker` flipped under item #5 — the 30-day retention default is conservative enough that no concurrent-replica pre-sync state can resurrect a swept slot. `nostrPersistenceVerifier` flipped under item #5 — query traffic is proportional to eligible SENT volume with an LRU-bounded cap and per-entry cooldown (default 5 minutes), and the worker self-skips wallets with no `nostrEventId`-tagged SENT entries. `spentStateRescan` (Issue #174) flipped after its soak gate cleared — the worker probes `oracle.isSpent` for each `'confirmed'` token and routes detection through the default `removeToken()` cleanup. Wallets that prefer the reactive-only surface (`transfer:double-spend-detected` at next `send()`) can explicitly set `features.spentStateRescan: false`. Deployments on restrictive relay sets that cannot absorb the verifier's steady load should set `features.nostrPersistenceVerifier: false`. Set any flag to `false` explicitly to opt out (e.g. timer-sensitive unit tests).

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1049,21 +1049,26 @@ export interface UxfTransferFeatures {
   /**
    * Issue #166 P2 #3 — Nostr persistence verification worker.
    *
-   * Default `false` (opt-in). When `true`, auto-installs and starts a
-   * {@link NostrPersistenceVerifier} in {@link PaymentsModule.initialize}
-   * that periodically re-queries the relay set for SENT-ledger entries'
-   * Nostr event ids to detect retention drops (events accepted at
-   * publish but later evicted by relay retention policy / restart /
-   * segregation).
+   * Default `true` (default-ON after soak; flipped under item #5).
+   * Auto-installs and starts a {@link NostrPersistenceVerifier} in
+   * {@link PaymentsModule.initialize} that periodically re-queries
+   * the relay set for SENT-ledger entries' Nostr event ids to detect
+   * retention drops (events accepted at publish but later evicted by
+   * relay retention policy / restart / segregation). On `'missing'`
+   * outcome the verifier re-arms the OUTBOX entry to `'sending'` so
+   * the recovery worker republishes via Item #2's path.
    *
-   * Default-OFF because the worker adds relay query traffic
-   * proportional to SENT volume. Production deployments that want
-   * retention monitoring should flip the flag explicitly after
-   * confirming their relay set tolerates the extra query load.
+   * The worker adds relay query traffic proportional to SENT volume
+   * with an LRU-bounded eligibility cap; the per-entry cooldown
+   * (default 5 minutes) and the verifier's own backoff prevent
+   * runaway probing. Deployments on restrictive relay sets that
+   * cannot absorb the steady load should set the flag explicitly to
+   * `false` to opt out.
    *
    * The worker self-skips when no SENT entries have `nostrEventId`
-   * set (legacy entries pre-#166 P2 #3 wiring) — so flipping the flag
-   * is safe even on wallets with no eligible entries; it just no-ops.
+   * set (legacy entries pre-#166 P2 #3 wiring) — so the default-ON
+   * flip is a safe no-op for wallets with no eligible entries; it
+   * just no-ops every cycle.
    */
   readonly nostrPersistenceVerifier?: boolean;
   /**
@@ -1607,13 +1612,18 @@ export class PaymentsModule {
       sentReconciliationWorker:
         config?.features?.sentReconciliationWorker ?? true,
       // Issue #166 P2 #3 — Nostr persistence verification worker.
-      // Default-OFF (opt-in): the worker periodically re-queries the
-      // relay set for SENT-ledger entries' Nostr event ids to detect
-      // retention drops. Adds relay query traffic proportional to
-      // eligible SENT volume; flip ON after confirming the relay set
-      // tolerates the load.
+      // Default-ON after item #5 soak: the worker periodically re-
+      // queries the relay set for SENT-ledger entries' Nostr event
+      // ids to detect retention drops, then re-arms the OUTBOX entry
+      // so the recovery worker republishes (Item #2). Query traffic
+      // is proportional to eligible SENT volume with an LRU-bounded
+      // cap and per-entry cooldown. The worker self-skips when no
+      // SENT entries have `nostrEventId` set, so the flip is a safe
+      // no-op for legacy-only wallets. Set `false` explicitly to
+      // suppress (e.g. restrictive relay sets, timer-sensitive unit
+      // tests).
       nostrPersistenceVerifier:
-        config?.features?.nostrPersistenceVerifier ?? false,
+        config?.features?.nostrPersistenceVerifier ?? true,
       // OUTBOX-SEND-FOLLOWUPS item #4 — tombstone GC. Default-ON after
       // soak: the sweeper reclaims OrbitDB log bytes by replacing
       // tombstone markers older than `retentionMs` (default 30 days)
@@ -2067,7 +2077,7 @@ export class PaymentsModule {
 
     // Issue #166 P2 #3 — auto-install the Nostr persistence
     // verification worker. Mirrors the recovery / reconciliation
-    // worker patterns above. Default-OFF feature gate; when ON the
+    // worker patterns above. Default-ON after item #5 soak; the
     // worker self-skips entries that lack `nostrEventId` (legacy
     // SENT entries from before the dispatcher capture wiring), and
     // routes verify() through transport.verifyTokenTransferRetained

--- a/tests/unit/modules/payments/detect-orphan-spending-wrapper.test.ts
+++ b/tests/unit/modules/payments/detect-orphan-spending-wrapper.test.ts
@@ -135,7 +135,12 @@ describe('PaymentsModule.detectOrphanSpendingTokens (Issue #166 — P3 #8)', () 
     payments = createPaymentsModule({
       debug: false,
       autoSync: false,
-      features: { recoveryWorker: false, finalizationWorker: false },
+      features: {
+        recoveryWorker: false,
+        finalizationWorker: false,
+        nostrPersistenceVerifier: false,
+        tombstoneGcWorker: false,
+      },
     });
     payments.initialize(createPaymentsDeps());
   });
@@ -254,7 +259,13 @@ describe('PaymentsModule.detectOrphanSpendingTokens — orphanAutoRecovery (Issu
       // `false` is now required. The test name was updated from
       // "default-OFF" to "explicit OFF" to reflect the post-flip
       // semantics.
-      features: { recoveryWorker: false, finalizationWorker: false, orphanAutoRecovery: false },
+      features: {
+        recoveryWorker: false,
+        finalizationWorker: false,
+        orphanAutoRecovery: false,
+        nostrPersistenceVerifier: false,
+        tombstoneGcWorker: false,
+      },
     });
     payments.initialize({ ...createPaymentsDeps(), emitEvent: emit });
     const { outboxWriter, sentLedgerWriter } = createWriterPair();
@@ -288,6 +299,8 @@ describe('PaymentsModule.detectOrphanSpendingTokens — orphanAutoRecovery (Issu
       features: {
         recoveryWorker: false,
         finalizationWorker: false,
+        nostrPersistenceVerifier: false,
+        tombstoneGcWorker: false,
         orphanAutoRecovery: true,
       },
     });
@@ -356,6 +369,8 @@ describe('PaymentsModule.detectOrphanSpendingTokens — orphanAutoRecovery (Issu
       features: {
         recoveryWorker: false,
         finalizationWorker: false,
+        nostrPersistenceVerifier: false,
+        tombstoneGcWorker: false,
         orphanAutoRecovery: true,
       },
     });
@@ -399,6 +414,8 @@ describe('PaymentsModule.detectOrphanSpendingTokens — orphanAutoRecovery (Issu
       features: {
         recoveryWorker: false,
         finalizationWorker: false,
+        nostrPersistenceVerifier: false,
+        tombstoneGcWorker: false,
         orphanAutoRecovery: true,
       },
     });
@@ -485,6 +502,8 @@ describe('defaultOrphanRecovery — aggregator cross-check (OUTBOX-SEND-FOLLOWUP
       features: {
         recoveryWorker: false,
         finalizationWorker: false,
+        nostrPersistenceVerifier: false,
+        tombstoneGcWorker: false,
         orphanAutoRecovery: true,
       },
     });
@@ -534,6 +553,8 @@ describe('defaultOrphanRecovery — aggregator cross-check (OUTBOX-SEND-FOLLOWUP
       features: {
         recoveryWorker: false,
         finalizationWorker: false,
+        nostrPersistenceVerifier: false,
+        tombstoneGcWorker: false,
         orphanAutoRecovery: true,
       },
     });
@@ -578,6 +599,8 @@ describe('defaultOrphanRecovery — aggregator cross-check (OUTBOX-SEND-FOLLOWUP
       features: {
         recoveryWorker: false,
         finalizationWorker: false,
+        nostrPersistenceVerifier: false,
+        tombstoneGcWorker: false,
         orphanAutoRecovery: true,
       },
     });
@@ -623,6 +646,8 @@ describe('defaultOrphanRecovery — aggregator cross-check (OUTBOX-SEND-FOLLOWUP
       features: {
         recoveryWorker: false,
         finalizationWorker: false,
+        nostrPersistenceVerifier: false,
+        tombstoneGcWorker: false,
         orphanAutoRecovery: true,
       },
     });


### PR DESCRIPTION
## Summary

OUTBOX-SEND-FOLLOWUPS [item #5](https://github.com/unicity-sphere/sphere-sdk/blob/integration/all-fixes/docs/uxf/OUTBOX-SEND-FOLLOWUPS.md) — fourth and final soak-gated flag to flip default-ON, completing the wave (after PR #178 `spentStateRescan`, PR #181 `orphanAutoRecovery`, PR #184 `tombstoneGcWorker`).

The `NostrPersistenceVerifier` periodically re-queries the relay set for SENT-ledger entries' `nostrEventId` to detect retention drops (events accepted at publish but later evicted by retention policy, relay restart, or segregation). On `'missing'` outcome the verifier re-arms the OUTBOX entry to `'sending'` so the recovery worker republishes via Item #2's path.

Query traffic is proportional to eligible SENT volume with an LRU-bounded cap and per-entry cooldown (default 5 minutes); the worker self-skips wallets with no `nostrEventId`-tagged SENT entries.

## Base branch

This PR stacks on top of `feat/item5-pr1-tombstone-gc-default-on` (PR #184). Merge order: #184 first, then this one.

## Changes

- `modules/payments/PaymentsModule.ts` — flip `?? false` → `?? true` at line 1626; update inline comment + type JSDoc to reflect default-ON.
- `docs/uxf/RUNBOOK-SEND-PIPELINE.md` — config-reference table now reads `nostrPersistenceVerifier: true`. Also fixes adversarial-review H1: two stale `default-OFF` mentions of `orphanAutoRecovery` in the `transfer:orphan-spending-detected` and `transfer:orphan-recovered` operator sections (PR #181 flipped the code default but missed these in the same RUNBOOK file).
- `docs/uxf/OUTBOX-SEND-FOLLOWUPS.md` — Item #5 banner now **SHIPPED** (all four flags flipped); "How to NOT resume" rewritten to capture the post-flip protocol consequences.
- `tests/unit/modules/payments/detect-orphan-spending-wrapper.test.ts` — add `nostrPersistenceVerifier: false, tombstoneGcWorker: false` to every features block (10 callsites). H2 follow-up from adversarial review.

## Adversarial review pre-merge

Ran `code-reviewer` against the branch. Findings:
- **No critical findings.** One-line flip is correct; guard logic unchanged.
- **H1 (fixed in this PR):** two stale `default-OFF` RUNBOOK lines for `orphanAutoRecovery` in the operator-event sections.
- **H2 (fixed in this PR):** verifier's 5-min `setTimeout` would leak as an open handle in `detect-orphan-spending-wrapper.test.ts` under CI `--detectOpenHandles`. Added explicit `nostrPersistenceVerifier: false, tombstoneGcWorker: false` to every test's features block.
- Reviewer confirmed: `verifyTokenTransferRetained` is implemented on `NostrTransportProvider`; transports without it return `'unverifiable'` (no false warnings, no traffic). No republish loop. Tombstone GC interaction safe (verifier's `checkedIds` set just holds harmless stale IDs).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/unit/payments/transfer/ tests/unit/modules/` — 3103 / 3103 pass
- [x] `npx vitest run tests/unit/payments/transfer/nostr-persistence-verifier.test.ts` — 23 / 23 pass
- [x] `npx vitest run tests/unit/modules/payments/detect-orphan-spending-wrapper.test.ts` — 14 / 14 pass

## Follow-ups

- The `orphanAutoRecovery` JSDoc in `PaymentsModule.ts:1093-1122` is still stale from PR #181 (says `Default 'false' (opt-in)`). Out of scope here; track as a separate doc-hygiene rider.