### PR TITLE
fix(payments)(#195): unblock recipient finalization for inbound deposits

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -16125,7 +16125,6 @@ export function buildDefaultFinalizationWorkerRecipient(opts: {
     },
   };
   const manifestCas = new ManifestCas(manifestStorage);
-  const placeholderRootHash = contentHash('00'.repeat(32));
 
   const tombstoneSet = new Set<string>();
   const tombstones = {
@@ -16192,12 +16191,26 @@ export function buildDefaultFinalizationWorkerRecipient(opts: {
           proof: proof.proof,
         };
         poolProofs.set(`${input.tokenId}:${input.requestId}`, descriptor);
-        if (!manifestEntries.has(`${addressId}:${input.tokenId}`)) {
-          manifestEntries.set(`${addressId}:${input.tokenId}`, {
-            rootHash: placeholderRootHash,
-            status: 'pending',
-          });
-        }
+        // Issue #195: do NOT synthesize a placeholder manifest entry here.
+        // The §5.5 step 5 4-step write order assigns ownership of the
+        // manifest entry to step 2 (`step2ManifestCidRewrite`). The
+        // recipient enqueue path populates `RequestContext` with
+        // `previousCid: undefined` (genesis), which step 2 translates to
+        // `prev = null` (assert "no entry exists"). Writing a placeholder
+        // here before step 2 runs breaks that contract — `manifestCas.update`
+        // observes the placeholder, returns `cas-mismatch` (placeholder
+        // ≠ undefined), and step 2 throws `ManifestCidRewriteCasError`.
+        //
+        // The escrow swap deposit flow surfaces this most visibly: the
+        // CAS error blocks the deposit token from flipping to
+        // `'confirmed'`, leaving the swap stuck at `PARTIAL_DEPOSIT`
+        // with no progression to payout. Real receives are also broken;
+        // they only "work" because the local Token still appears in the
+        // UI and casual flows tolerate the silently stuck pending state.
+        //
+        // Removing this write lets step 2's CAS execute cleanly: it
+        // observes `undefined`, accepts the `prev = null` assertion,
+        // and inserts the canonical first entry via `writeEntry`.
         const newCid = contentHash(
           input.requestId.replace(/[^0-9a-f]/gi, '').padStart(64, '0').slice(0, 64),
         );

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -16389,6 +16389,20 @@ export function buildDefaultFinalizationWorkerRecipient(opts: {
               // forever. Now mirrors the main success path below.
               recipientFinalizationContext.delete(tokenId);
               saveFailureStreak.delete(ctx.localTokenId);
+              // Issue #195 (follow-up): emit `transfer:confirmed` so
+              // listeners (notably AccountingModule) learn the inbound
+              // deposit token is now aggregator-confirmed. Without this
+              // emission an `invoice:covered` event never re-fires with
+              // `confirmed: true`, leaving downstream consumers
+              // (e.g. escrow swap orchestrator) stuck at PARTIAL_DEPOSIT
+              // even after my CAS-mismatch fix unblocks the dispositionWriter.
+              // Payload shape mirrors the NOSTR-FIRST and V5 emit sites.
+              emit('transfer:confirmed', {
+                id: crypto.randomUUID(),
+                status: 'completed',
+                tokens: [updatedFallback],
+                tokenTransfers: [],
+              });
             } catch (saveErr) {
               // Wave 6 critical fix — roll back the in-memory mutation
               // so retries can re-enter the `status === 'pending'`
@@ -16470,6 +16484,20 @@ export function buildDefaultFinalizationWorkerRecipient(opts: {
             'Payments',
             `Task #151: token ${ctx.localTokenId.slice(0, 16)} finalized via recipient worker`,
           );
+          // Issue #195 (follow-up): emit `transfer:confirmed` so
+          // listeners (notably AccountingModule) learn the inbound
+          // deposit token is now aggregator-confirmed. Without this
+          // emission an `invoice:covered` event never re-fires with
+          // `confirmed: true`, leaving downstream consumers (e.g. the
+          // escrow swap orchestrator) stuck at PARTIAL_DEPOSIT even
+          // after the CAS-mismatch fix unblocks the dispositionWriter.
+          // Payload shape mirrors the NOSTR-FIRST and V5 emit sites.
+          emit('transfer:confirmed', {
+            id: crypto.randomUUID(),
+            status: 'completed',
+            tokens: [updated],
+            tokenTransfers: [],
+          });
         } catch (saveErr) {
           const saveMsg = `Task #151: save() after finalization threw: ${saveErr instanceof Error ? saveErr.message : String(saveErr)}`;
           logger.warn('Payments', saveMsg);

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -16397,6 +16397,23 @@ export function buildDefaultFinalizationWorkerRecipient(opts: {
               // (e.g. escrow swap orchestrator) stuck at PARTIAL_DEPOSIT
               // even after my CAS-mismatch fix unblocks the dispositionWriter.
               // Payload shape mirrors the NOSTR-FIRST and V5 emit sites.
+              //
+              // CAVEAT (steelman finding): `updatedFallback.sdkData` is in
+              // SENDER-PREDICATE form — the recipient never ran
+              // `finalizeTransferToken` on this path (it requires stClient
+              // + trustBase, both missing here). The token is correctly
+              // marked 'confirmed' for accounting purposes (the aggregator
+              // anchored the commitment) but is NOT yet spendable: any
+              // subsequent spend would build the commitment with the
+              // sender's sourceState predicate while the authenticator
+              // carries this wallet's pubkey, and `submitTransferCommitment`
+              // would reject with "Authenticator does not match source
+              // state predicate." The NOSTR-FIRST finalization path
+              // (`handleCommitmentOnlyTransfer` → line ~13900) overwrites
+              // `sdkData` with the properly finalized form once stClient
+              // + trustBase become available. Listeners that read
+              // `sdkData` for spend operations MUST guard against this
+              // intermediate state.
               emit('transfer:confirmed', {
                 id: crypto.randomUUID(),
                 status: 'completed',

--- a/profile/per-token-mutex.ts
+++ b/profile/per-token-mutex.ts
@@ -148,9 +148,19 @@ export class PerTokenMutex {
       }
 
       let timer: ReturnType<typeof setTimeout> | undefined;
+      // Issue #195: track whether the bounded-hold timer has fired. The
+      // detached-fn `.catch` below originally logged EVERY rejection as
+      // "detached fn rejected after timeout" — including ordinary
+      // pre-timeout rejections that the awaiter is about to surface.
+      // That wording sent operators chasing imaginary hold-time blowups
+      // when the real failure was a synchronous error inside `fn` (e.g.
+      // a `ManifestCidRewriteCasError` returned in microseconds). Gate
+      // the warn-log on the timer actually having fired.
+      let timedOut = false;
       try {
         const timeoutPromise = new Promise<never>((_, reject) => {
           timer = setTimeout(() => {
+            timedOut = true;
             reject(
               new SphereError(
                 `PerTokenMutex 'bounded-hold' fired: tokenId=${tokenId} exceeded ${timeoutMs}ms (W35)`,
@@ -169,8 +179,24 @@ export class PerTokenMutex {
         // / corrupted-state failures that fire on the detached fn after
         // the timeout has already returned. Without this, catastrophic
         // post-timeout failures vanish silently.
+        //
+        // Issue #195 fix: only warn when the rejection genuinely arrives
+        // AFTER the bounded-hold timeout has already fired. If the
+        // rejection arrives FIRST, `Promise.race` propagates it to the
+        // awaiter (the surrounding `await` throws), and the caller
+        // handles it through normal error flow — the `.catch` here is
+        // only needed to prevent post-timeout unhandled-rejection noise.
         const fnPromise = fn();
         fnPromise.catch((err) => {
+          if (!timedOut) {
+            // Pre-timeout rejection — the awaiter surfaces this through
+            // `Promise.race`'s rejection. The `.catch` is here solely
+            // to keep the post-timeout case observable; silence the
+            // pre-timeout case to avoid double-reporting + misleading
+            // "after timeout" wording for failures that arrived in
+            // microseconds.
+            return;
+          }
           logger.warn(
             'PerTokenMutex',
             `bounded-hold tokenId=${tokenId} detached fn rejected after timeout: ${

--- a/tests/unit/modules/PaymentsModule.wave4-regressions.test.ts
+++ b/tests/unit/modules/PaymentsModule.wave4-regressions.test.ts
@@ -1540,3 +1540,246 @@ describe('Wave 6 — REAL UXF round-trip: pkg.ingestAll → toCar → fromCar �
     expect(graftCalled).toBe(false);
   });
 });
+
+// =============================================================================
+// I. Issue #195 follow-up — dispositionWriter emits `transfer:confirmed`
+// =============================================================================
+//
+// Pins the contract added by commit 360ed22 (`fix(payments)(#195): emit
+// transfer:confirmed from recipient dispositionWriter`): both the main
+// success path AND the stClient/trustBase-missing fallback path MUST emit
+// `transfer:confirmed` after `await save()` succeeds, so listeners
+// (notably AccountingModule) learn the inbound deposit token is now
+// aggregator-confirmed and `invoice:covered` can re-fire with
+// `confirmed: true`.
+//
+// Without this emit, the escrow swap orchestrator hangs at
+// PARTIAL_DEPOSIT even after the CAS-mismatch fix unblocks step 5 —
+// see sphere-sdk issue #195 and sphere-cli PR #16 / issue #163.
+//
+// Reuses the module-level mocks declared at the top of section F.
+
+describe('Issue #195 — dispositionWriter emits transfer:confirmed', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let buildDefaultFinalizationWorkerRecipient: any;
+
+  beforeAll(async () => {
+    const mod = await import('../../../modules/payments/PaymentsModule');
+    buildDefaultFinalizationWorkerRecipient = (
+      mod as unknown as { buildDefaultFinalizationWorkerRecipient: unknown }
+    ).buildDefaultFinalizationWorkerRecipient;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Build a builder configured for the issue #195 follow-up tests.
+   * Mirrors the section-F `makeBuilder` shape but parameterises whether
+   * `getStateTransitionClient` returns a stub (main path) or undefined
+   * (fallback path).
+   */
+  function makeBuilder(opts: {
+    saveImpl: () => Promise<void>;
+    emit: ReturnType<typeof vi.fn>;
+    tokenId: string;
+    localTokenId: string;
+    stClientAvailable: boolean;
+  }) {
+    const tokens = new Map<string, import('../../../types').Token>();
+    tokens.set(opts.localTokenId, {
+      id: opts.localTokenId,
+      coinId: 'UCT',
+      symbol: 'UCT',
+      name: 'Unicity',
+      decimals: 8,
+      amount: '100',
+      sdkData: '{}',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const recipientFinalizationContext = new Map<string, unknown>();
+    recipientFinalizationContext.set(opts.tokenId, {
+      localTokenId: opts.localTokenId,
+      sourceTokenJson: { stub: 'src' },
+      lastTxJson: { stub: 'lastTx' },
+      requestIdHex: '00'.repeat(34),
+    });
+
+    const oracle = {
+      getProof: vi.fn().mockResolvedValue({ proof: { stub: 'proof' } }),
+      validateToken: vi.fn().mockResolvedValue({ valid: true }),
+      getStateTransitionClient: vi.fn().mockReturnValue({}),
+      getAggregatorClient: vi.fn().mockReturnValue({}),
+      waitForProofSdk: vi.fn(),
+    };
+
+    const built = buildDefaultFinalizationWorkerRecipient({
+      addressId: 'addr-test',
+      oracle,
+      recipientRequestContextMap: new Map(),
+      recipientFinalizationContext,
+      tokens,
+      finalizeTransferToken: vi.fn().mockResolvedValue({
+        toJSON: () => ({ stub: 'finalized-token' }),
+      }),
+      // Returning undefined here forces the fallback path; returning a
+      // stub object exercises the main success path. The trustBase
+      // companion getter follows the same toggle.
+      getStateTransitionClient: () => (opts.stClientAvailable ? ({} as unknown) : undefined),
+      getTrustBase: () => (opts.stClientAvailable ? ({}) : undefined),
+      save: opts.saveImpl,
+      emit: opts.emit,
+    });
+
+    return { built, tokens };
+  }
+
+  it('main success path → emits transfer:confirmed with the updated token', async () => {
+    const tokenId = 'tok-issue195-main';
+    const localTokenId = 'local-issue195-main';
+    const emit = vi.fn();
+
+    const { built, tokens } = makeBuilder({
+      saveImpl: vi.fn().mockResolvedValue(undefined),
+      emit,
+      tokenId,
+      localTokenId,
+      stClientAvailable: true,
+    });
+
+    await built.dispositionWriter.write('addr-test', {
+      tokenId,
+      disposition: 'VALID',
+    } as never);
+
+    const confirmedCalls = emit.mock.calls.filter(
+      (call) => call[0] === 'transfer:confirmed',
+    );
+    expect(confirmedCalls).toHaveLength(1);
+
+    const payload = confirmedCalls[0][1];
+    expect(payload).toMatchObject({
+      status: 'completed',
+    });
+    expect(typeof payload.id).toBe('string');
+    expect(payload.id.length).toBeGreaterThan(0);
+    expect(payload.tokens).toHaveLength(1);
+    expect(payload.tokens[0]).toMatchObject({
+      id: localTokenId,
+      status: 'confirmed',
+    });
+    // The main path overwrites sdkData with the finalized form before
+    // emitting — distinct from the fallback path which preserves the
+    // sender-predicate sdkData.
+    expect(payload.tokens[0].sdkData).toBe(
+      JSON.stringify({ stub: 'finalized-token' }),
+    );
+    expect(payload.tokenTransfers).toEqual([]);
+
+    // Local token also reflects the confirmed state.
+    expect(tokens.get(localTokenId)?.status).toBe('confirmed');
+  });
+
+  it('stClient-fallback path (stClient/trustBase missing) → emits transfer:confirmed with sender-predicate sdkData', async () => {
+    const tokenId = 'tok-issue195-fallback';
+    const localTokenId = 'local-issue195-fallback';
+    const emit = vi.fn();
+
+    const { built, tokens } = makeBuilder({
+      saveImpl: vi.fn().mockResolvedValue(undefined),
+      emit,
+      tokenId,
+      localTokenId,
+      stClientAvailable: false,
+    });
+
+    await built.dispositionWriter.write('addr-test', {
+      tokenId,
+      disposition: 'VALID',
+    } as never);
+
+    const confirmedCalls = emit.mock.calls.filter(
+      (call) => call[0] === 'transfer:confirmed',
+    );
+    expect(confirmedCalls).toHaveLength(1);
+
+    const payload = confirmedCalls[0][1];
+    expect(payload.tokens[0]).toMatchObject({
+      id: localTokenId,
+      status: 'confirmed',
+    });
+    // CAVEAT (pinned by the in-source comment): the fallback path does
+    // NOT re-finalize sdkData — it stays in sender-predicate form. The
+    // emit is for accounting attribution only; subsequent spend MUST
+    // wait until the NOSTR-FIRST finalization path overwrites sdkData.
+    expect(payload.tokens[0].sdkData).toBe('{}');
+
+    expect(tokens.get(localTokenId)?.status).toBe('confirmed');
+  });
+
+  it('main path save() throws → no transfer:confirmed emit (emit is INSIDE try, after save)', async () => {
+    const tokenId = 'tok-issue195-save-throws-main';
+    const localTokenId = 'local-issue195-save-throws-main';
+    const emit = vi.fn();
+
+    const { built } = makeBuilder({
+      saveImpl: vi.fn().mockRejectedValue(new Error('disk full')),
+      emit,
+      tokenId,
+      localTokenId,
+      stClientAvailable: true,
+    });
+
+    await built.dispositionWriter.write('addr-test', {
+      tokenId,
+      disposition: 'VALID',
+    } as never);
+
+    // The emit lives inside `try { await save(); ... emit(...); }` so a
+    // save throw skips the emit entirely. Pinning this prevents future
+    // regressions that move the emit before save() or out of the try.
+    const confirmedCalls = emit.mock.calls.filter(
+      (call) => call[0] === 'transfer:confirmed',
+    );
+    expect(confirmedCalls).toHaveLength(0);
+
+    // operator-alert MUST still fire so persistence failures are visible.
+    const alertCalls = emit.mock.calls.filter(
+      (call) => call[0] === 'transfer:operator-alert',
+    );
+    expect(alertCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('fallback path save() throws → no transfer:confirmed emit', async () => {
+    const tokenId = 'tok-issue195-save-throws-fallback';
+    const localTokenId = 'local-issue195-save-throws-fallback';
+    const emit = vi.fn();
+
+    const { built } = makeBuilder({
+      saveImpl: vi.fn().mockRejectedValue(new Error('disk full')),
+      emit,
+      tokenId,
+      localTokenId,
+      stClientAvailable: false,
+    });
+
+    await built.dispositionWriter.write('addr-test', {
+      tokenId,
+      disposition: 'VALID',
+    } as never);
+
+    const confirmedCalls = emit.mock.calls.filter(
+      (call) => call[0] === 'transfer:confirmed',
+    );
+    expect(confirmedCalls).toHaveLength(0);
+
+    const alertCalls = emit.mock.calls.filter(
+      (call) => call[0] === 'transfer:operator-alert',
+    );
+    expect(alertCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/unit/modules/PaymentsModule.wave4-regressions.test.ts
+++ b/tests/unit/modules/PaymentsModule.wave4-regressions.test.ts
@@ -519,8 +519,14 @@ describe('Wave 5 — dispositionWriter save-failure ctx retention coherence', ()
   it('deletes recipientFinalizationContext only AFTER save() succeeds — the Wave 5 fix', () => {
     // The Wave 5 fix moves the delete INSIDE the try block, immediately
     // after `await save()`. We pin that structural shape.
+    //
+    // Issue #195 follow-up: the post-delete window inside the try was
+    // widened from 400 to 1200 chars to accommodate the new
+    // `transfer:confirmed` emit (plus its comment block) that fires AFTER
+    // the delete inside the try. The structural invariant — delete is
+    // AFTER save(), INSIDE the try — is unchanged.
     const fixPattern =
-      /try\s*\{\s*await\s+save\(\)\s*;[\s\S]{0,600}recipientFinalizationContext\.delete\(tokenId\)\s*;[\s\S]{0,400}\}\s*catch\s*\(\s*saveErr\s*\)/;
+      /try\s*\{\s*await\s+save\(\)\s*;[\s\S]{0,600}recipientFinalizationContext\.delete\(tokenId\)\s*;[\s\S]{0,1200}\}\s*catch\s*\(\s*saveErr\s*\)/;
     expect(src.match(fixPattern)).not.toBeNull();
   });
 

--- a/tests/unit/payments/transfer/issue-195-recipient-manifest-placeholder.test.ts
+++ b/tests/unit/payments/transfer/issue-195-recipient-manifest-placeholder.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Issue #195 — recipient default builder must NOT pre-seed the manifest
+ * store with a placeholder entry; pre-timeout PerTokenMutex rejections
+ * must NOT log "after timeout".
+ *
+ * Background.
+ * The recipient finalization worker (T.5.C) auto-installed by
+ * `buildDefaultFinalizationWorkerRecipient` previously wrote a
+ * placeholder manifest entry (rootHash = 32 zero bytes, status =
+ * 'pending') inside its `aggregatorClient.poll` callback whenever a
+ * proof was returned for the first time on a tokenId. The §5.5 step 5
+ * 4-step write order assigns ownership of the manifest entry to
+ * `step2ManifestCidRewrite`, which uses the `RequestContext.previousCid`
+ * as the CAS precondition. The recipient enqueue path populates
+ * `RequestContext` with `previousCid: undefined` (genesis case), which
+ * step 2 translates to `prev = null` — asserting "no entry exists" in
+ * the manifest store.
+ *
+ * The placeholder write in the poll callback contradicted that contract:
+ * by the time step 2 ran, `manifestCas.update(addr, tokenId, null, next)`
+ * read the placeholder, saw `prev === null && observed !== undefined`,
+ * returned `{ ok: false, reason: 'cas-mismatch', observed }`, and
+ * step 2 threw `ManifestCidRewriteCasError` because the observed
+ * `rootHash` (the placeholder) did not equal `newCid` (the requestId-
+ * derived target).
+ *
+ * Symptom in the wild: escrow swap deposit invoices never flipped to
+ * `'confirmed'`, leaving the swap stuck at `PARTIAL_DEPOSIT`.
+ *
+ * The fix removes the placeholder write. This file pins:
+ *
+ *  (1) Contract — with an empty manifest store, step 2 must accept
+ *      `previousCid = undefined` and insert the first entry cleanly.
+ *  (2) Contract — with a placeholder pre-seeded (the old bug shape),
+ *      step 2 must throw `ManifestCidRewriteCasError`. Documents the
+ *      reason removing the placeholder is correct, not gratuitous.
+ *  (3) Source guard — `buildDefaultFinalizationWorkerRecipient` must
+ *      not reintroduce the `placeholderRootHash` pattern.
+ *  (4) PerTokenMutex log gating — a pre-timeout rejection must NOT
+ *      emit a warning that claims the detached fn rejected "after
+ *      timeout". A post-timeout rejection MUST still surface.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  performManifestCidRewrite,
+  ManifestCidRewriteCasError,
+  type ManifestCidRewriteContext,
+  type PoolWriteAdapter,
+  type TombstoneWriteAdapter,
+  type FinalizationQueueAdapter,
+} from '../../../../modules/payments/transfer/manifest-cid-rewrite';
+import {
+  ManifestCas,
+  type MinimalManifestStorage,
+} from '../../../../profile/manifest-cas';
+import type { TokenManifestEntry } from '../../../../profile/token-manifest';
+import type { InclusionProof } from '../../../../oracle/oracle-provider';
+import { PerTokenMutex } from '../../../../profile/per-token-mutex';
+import { logger } from '../../../../core/logger';
+
+// =============================================================================
+// Shared helpers — minimal adapter set matching the recipient builder shape
+// =============================================================================
+
+const ADDR = 'DIRECT://addr-issue-195';
+const TOKEN_ID = 'token-issue-195';
+const NEW_CID = 'cid-new-issue-195';
+const PLACEHOLDER_ROOT_HASH = '00'.repeat(32);
+const QUEUE_REQ_ID = 'req-issue-195';
+
+function buildAdapters(seedPlaceholder: boolean): {
+  ctx: ManifestCidRewriteContext;
+  manifestEntries: Map<string, TokenManifestEntry>;
+} {
+  const manifestEntries = new Map<string, TokenManifestEntry>();
+  if (seedPlaceholder) {
+    // Reproduce the pre-fix poll-callback side-effect verbatim.
+    manifestEntries.set(`${ADDR}:${TOKEN_ID}`, {
+      rootHash: PLACEHOLDER_ROOT_HASH,
+      status: 'pending',
+    });
+  }
+  const manifestStorage: MinimalManifestStorage = {
+    async readEntry(addr, tokenId) {
+      return manifestEntries.get(`${addr}:${tokenId}`);
+    },
+    async writeEntry(addr, tokenId, entry) {
+      manifestEntries.set(`${addr}:${tokenId}`, entry);
+    },
+  };
+
+  const poolAttached = new Set<string>();
+  const pool: PoolWriteAdapter = {
+    async isProofAttached(tokenId, reqId) {
+      return poolAttached.has(`${tokenId}:${reqId}`);
+    },
+    async attachProof(tokenId, reqId) {
+      poolAttached.add(`${tokenId}:${reqId}`);
+    },
+  };
+
+  const tombstoneSet = new Set<string>();
+  const tombstones: TombstoneWriteAdapter = {
+    async hasTombstone(tokenId, cid) {
+      return tombstoneSet.has(`${tokenId}:${cid}`);
+    },
+    async insertTombstone(tokenId, cid) {
+      tombstoneSet.add(`${tokenId}:${cid}`);
+    },
+  };
+
+  const queueEntries = new Set<string>();
+  queueEntries.add(`${ADDR}:${QUEUE_REQ_ID}`);
+  const queue: FinalizationQueueAdapter = {
+    async hasEntry(addr, reqId) {
+      return queueEntries.has(`${addr}:${reqId}`);
+    },
+    async removeEntry(addr, reqId) {
+      queueEntries.delete(`${addr}:${reqId}`);
+    },
+  };
+
+  const proof: InclusionProof = {
+    requestId: QUEUE_REQ_ID,
+    roundNumber: 1,
+    proof: { ok: true },
+    timestamp: 1700000000000,
+  };
+
+  const ctx: ManifestCidRewriteContext = {
+    addr: ADDR,
+    tokenId: TOKEN_ID,
+    proofToAttach: proof,
+    newCid: NEW_CID,
+    // Recipient genesis case — RequestContext.previousCid is undefined,
+    // step2 translates to `prev = null`.
+    previousCid: undefined,
+    nextEntryRest: { status: 'valid' },
+    queueEntryRequestId: QUEUE_REQ_ID,
+    pool,
+    manifestCas: new ManifestCas(manifestStorage),
+    tombstones,
+    queue,
+  };
+
+  return { ctx, manifestEntries };
+}
+
+// =============================================================================
+// 1. Contract — empty manifest store + previousCid=undefined → success
+// =============================================================================
+
+describe('Issue #195 — manifest-cid-rewrite genesis contract', () => {
+  it('with EMPTY manifest store, recipient genesis context (previousCid=undefined) succeeds and inserts the first entry', async () => {
+    const { ctx, manifestEntries } = buildAdapters(/* seedPlaceholder */ false);
+
+    const result = await performManifestCidRewrite(ctx);
+
+    expect(result.result).toBe('ok');
+    // Step 2 inserted the canonical first entry — rootHash = newCid (not
+    // any placeholder).
+    expect(manifestEntries.get(`${ADDR}:${TOKEN_ID}`)).toEqual({
+      rootHash: NEW_CID,
+      status: 'valid',
+    });
+  });
+
+  it('with PLACEHOLDER pre-seeded (the pre-fix poll-callback bug shape), the same context throws ManifestCidRewriteCasError', async () => {
+    // This is the buggy state the recipient builder used to produce
+    // BEFORE the issue #195 fix: the poll callback wrote a zero-hash
+    // placeholder into `manifestEntries` before step 2 ran. step 2 then
+    // observed `prev=null` but `observed !== undefined`, failing CAS.
+    // The observed.rootHash (placeholder) does not match newCid, so
+    // step 2's "already-applied" idempotency branch does not fire — the
+    // error propagates to the worker as a real CAS conflict.
+    const { ctx } = buildAdapters(/* seedPlaceholder */ true);
+
+    let caught: unknown;
+    try {
+      await performManifestCidRewrite(ctx);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ManifestCidRewriteCasError);
+    const err = caught as ManifestCidRewriteCasError;
+    expect(err.casReason).toBe('cas-mismatch');
+    expect(err.observedCid).toBe(PLACEHOLDER_ROOT_HASH);
+  });
+});
+
+// =============================================================================
+// 2. Source guard — recipient default builder must not reintroduce the
+//                    placeholder write pattern
+// =============================================================================
+
+describe('Issue #195 — buildDefaultFinalizationWorkerRecipient source guard', () => {
+  const SRC_PATH = resolve(__dirname, '../../../../modules/payments/PaymentsModule.ts');
+  const src = readFileSync(SRC_PATH, 'utf8');
+
+  function extractRecipientBuilderBody(): string {
+    const start = src.indexOf(
+      'export function buildDefaultFinalizationWorkerRecipient',
+    );
+    expect(start).toBeGreaterThan(-1);
+    // The builder ends with its sibling `export function ...` or the
+    // file's terminal sender helpers; bound the search at the next
+    // top-level `export function` declaration after the start.
+    const nextExport = src.indexOf('\nexport function ', start + 1);
+    const end = nextExport === -1 ? src.length : nextExport;
+    return src.slice(start, end);
+  }
+
+  it('does NOT declare a `placeholderRootHash` symbol in the recipient builder', () => {
+    const body = extractRecipientBuilderBody();
+    expect(body).not.toMatch(/placeholderRootHash/);
+  });
+
+  it('does NOT pre-populate `manifestEntries` from the aggregator poll callback', () => {
+    const body = extractRecipientBuilderBody();
+    // The pre-fix pattern was: `if (!manifestEntries.has(...)) { manifestEntries.set(...) }`
+    // inside the poll callback. After the fix, the only writes to
+    // `manifestEntries` should come from `manifestStorage.writeEntry`
+    // (called by ManifestCas) — not from a fall-through `.set` in the
+    // poll producer.
+    expect(body).not.toMatch(/manifestEntries\.set\(\s*`\$\{addressId\}:/);
+  });
+});
+
+// =============================================================================
+// 3. PerTokenMutex bounded-hold log gating
+// =============================================================================
+
+describe('Issue #195 — PerTokenMutex bounded-hold log gating', () => {
+  it('pre-timeout rejection does NOT log "after timeout"', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    try {
+      const mutex = new PerTokenMutex();
+      const err = new Error('synchronous-cas-mismatch');
+      await expect(
+        mutex.acquire(
+          'token-pre-timeout',
+          // fn rejects in microseconds — far below any sensible bounded-hold.
+          async () => {
+            throw err;
+          },
+          { strategy: 'bounded-hold', timeoutMs: 500 },
+        ),
+      ).rejects.toBe(err);
+
+      // Yield a few ticks to ensure no late .catch fires (defensive).
+      await new Promise<void>((r) => setTimeout(r, 50));
+
+      // The fix: the pre-timeout `.catch` must not emit the misleading
+      // "after timeout" warn. Operator dashboards previously logged
+      // EVERY synchronous fn rejection as a bounded-hold blowup; this
+      // assertion locks the new behavior.
+      const matchedCalls = warnSpy.mock.calls.filter((call) => {
+        const message = call.find((arg) =>
+          typeof arg === 'string' && arg.includes('detached fn rejected after timeout'),
+        );
+        return message !== undefined;
+      });
+      expect(matchedCalls).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('post-timeout rejection STILL logs "after timeout" (observability preserved)', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    try {
+      const mutex = new PerTokenMutex();
+      const lateErr = new Error('disk-full-arriving-late');
+
+      // The acquire itself should reject with LOCK_BOUNDED_HOLD_FIRED;
+      // we discard the awaiter's error so the test focuses on the
+      // detached-fn .catch behavior.
+      await expect(
+        mutex.acquire(
+          'token-post-timeout',
+          async () => {
+            // Hang past the timeout, then reject. The detached fn .catch
+            // must surface this so disk-full / quota-exceeded failures
+            // are visible to operators.
+            await new Promise<void>((r) => setTimeout(r, 150));
+            throw lateErr;
+          },
+          { strategy: 'bounded-hold', timeoutMs: 50 },
+        ),
+      ).rejects.toHaveProperty('code', 'LOCK_BOUNDED_HOLD_FIRED');
+
+      // Yield long enough for the detached fn to reject (set to 150 ms
+      // above; allow extra slack for CI).
+      await new Promise<void>((r) => setTimeout(r, 250));
+
+      const matchedCalls = warnSpy.mock.calls.filter((call) => {
+        const matchedAfterTimeout = call.some((arg) =>
+          typeof arg === 'string' &&
+          arg.includes('detached fn rejected after timeout') &&
+          arg.includes('disk-full-arriving-late'),
+        );
+        return matchedAfterTimeout;
+      });
+      expect(matchedCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Closes #195.

## Summary

Two bugs in the recipient finalization worker (T.5.C) prevented escrow swap deposits from ever being confirmed:

1. **CAS-mismatch on every inbound finalization.** `buildDefaultFinalizationWorkerRecipient`'s `aggregatorClient.poll` callback pre-seeded a placeholder manifest entry (rootHash = 32 zero bytes) before step 5's `step2ManifestCidRewrite` could run. The recipient enqueue path populates `RequestContext.previousCid = undefined` (genesis case), which step 2 translates to `prev = null` ("assert no entry exists"). The placeholder violated that assertion → `cas-mismatch` → `ManifestCidRewriteCasError` thrown on every received token.

2. **Missing `transfer:confirmed` emit.** Even after the CAS-mismatch was fixed and the dispositionWriter could actually run, neither its main success path nor its stClient/trustBase-missing fallback path emitted `transfer:confirmed`. The `AccountingModule` listens for that event to mark invoice ledger entries as confirmed and re-fire `invoice:covered` with `confirmed: true`. Without it, downstream consumers gating on confirmation (escrow swap orchestrator, payment-request flow) stall indefinitely.

Both bugs surface together: under run-time, the CAS-mismatch is the first symptom an operator sees (`[PerTokenMutex] bounded-hold ... manifest CID rewrite CAS failure`). Fixing only the CAS leaves a second-order hang at `PARTIAL_DEPOSIT` with `invoice:covered with unconfirmed deposits — waiting for aggregator confirmation`.

## Symptom (verbatim from #195)

> After both parties deposit (sequential or parallel — both orderings reproduce):
>
> ```
> {\"swap_id\":\"...\",\"partySide\":\"B\",\"msg\":\"First valid deposit received, timeout timer started\"}
> [PerTokenMutex] bounded-hold tokenId=DIRECT_<escrow-wallet-tokenid>
> <requestId-hash> detached fn rejected after timeout: manifest CID rewrite CAS failure: cas-mismatch
> {\"swap_id\":\"...\",\"partySide\":\"A\",\"state\":\"PARTIAL_DEPOSIT\",\"msg\":\"Valid deposit received (not first)\"}
> {\"invoiceId\":\"...\",\"msg\":\"invoice:covered with unconfirmed deposits — waiting for aggregator confirmation\"}
> ```

## Commits

| Commit | What |
|---|---|
| `961c528` | Drop the placeholder manifest entry write from `aggregatorClient.poll`. Adds `timedOut`-flag gating to `profile/per-token-mutex.ts` so pre-timeout detached-fn rejections stop logging as \"after timeout\". 6 new regression tests pin the genesis contract + source guard + log gating. |
| `360ed22` | Emit `transfer:confirmed` from both success paths of the recipient dispositionWriter VALID branch. Widen the Wave 5 source-inspection regex from 400→1200 chars to accommodate the new emit block. |
| `8ea1ef5` | (Review follow-up.) Add 4 runtime tests pinning the `transfer:confirmed` emit contract — including the contract that save() throwing skips the emit. Document the `sdkData` caveat on the fallback path (the emitted token is in sender-predicate form, not spendable until NOSTR-FIRST finalization runs). |

## Verification

**Unit tests**: 4942 transfer + profile + module unit tests pass. typecheck clean. lint clean on touched files (5 pre-existing warnings unrelated to this PR).

**E2E**: sphere-cli PR #16 `E2E_RUN_SWAP_FULL=1` against a locally-built escrow image bundling this branch:
- All 3 tests passed.
- Full settlement test completed in **147s** (well under the 600s budget).
- Timeline from escrow logs:
  - 23:02:08 — Swap announced
  - 23:02:14 — Party B deposit received
  - 23:02:42 — Party A deposit received → `invoice:covered with unconfirmed deposits — waiting for aggregator confirmation`
  - 23:03:15 — `Deposit invoice already closed, proceeding to payouts` *(this is the moment the confirmed=true re-fire works)*
  - 23:03:21 — `Swap concluding — paying payout invoices`
  - 23:03:25 — `Swap completed successfully`
- No `cas-mismatch` or `PerTokenMutex` bounded-hold timeout fired during the run.

Previously (3 separate runs against escrow:v0.2): all hung at PARTIAL_DEPOSIT, never reached `completed`.

## Steelman review

A code-reviewer agent attacked the branch against the §5.5 step 5 contract, AccountingModule listener semantics, double-emit hazards, persistence ordering, idempotency on replay, and stClient-fallback correctness. Findings:

- **Confirmed safe**: concurrency closed by the existing module-scoped mutex on `(addr, tokenId)`. Payload shape compatible with all existing `transfer:confirmed` consumers. Idempotency replay safe — second-pass returns early via the `ctx === undefined` guard. Persistence ordering correct (`save` → `delete` → `emit` is the same shape as the NOSTR-FIRST and V5 emit sites).
- **Action items addressed in 8ea1ef5**:
  - Test gap → added 4 runtime tests pinning the emit contract.
  - Documentation gap → added in-source CAVEAT block explaining that the fallback-path emit fires with a token whose `sdkData` is in sender-predicate form.
- **Deferred (out of scope)**: there is a pre-existing concurrent-completion hazard between the V5/V6 recovery interval and the recipient worker on the same token. AccountingModule's `_markTokenEntriesConfirmed` is idempotent (only mutates `!entry.confirmed`), and the escrow swap orchestrator's `_onInvoiceCovered` is idempotent against second-fire (state-guard at `swap-orchestrator.ts:866-877`). The race exists before this PR and is not made worse by it; closing it is a separate refactor.

## Closing the loop

After merge into `integration/all-fixes`:
1. Bump `SPHERE_SDK_SHA` in `escrow-service/.github/workflows/docker-publish.yml` to the merge commit.
2. Cut escrow release `v0.3` (the workflow publishes to `ghcr.io/vrogojin/agentic-hosting/escrow:v0.3`).
3. Sphere-cli PR #16's `E2E_RUN_SWAP_FULL=1` tier will then pass automatically once the new image is the default.

## Test plan

- [x] Unit tests: 4942 pass (full transfer + profile + module sweep)
- [x] typecheck clean
- [x] lint clean on touched files
- [x] End-to-end: sphere-cli `E2E_RUN_SWAP_FULL=1` swap reaches `completed` in 147s
- [x] Steelman review — actionable findings addressed in 8ea1ef5