### PR TITLE
test(e2e)(#199): apply PR #201 scaffolding pattern to 2 follow-up suites

### DIFF
--- a/tests/e2e/lib/profile-sync-worker.ts
+++ b/tests/e2e/lib/profile-sync-worker.ts
@@ -63,6 +63,18 @@ export type WorkerInitConfig = {
   readonly nametag?: string;
   /** When true, swap the real Nostr transport for a no-op stub. */
   readonly useNoopTransport: boolean;
+  /**
+   * Profile flush debounce override. Tests that need deterministic
+   * single-shot publishes pass a long debounce (e.g. 300_000) so all
+   * `save()` calls during a test phase coalesce into one pendingData;
+   * `handleSync()` then drives ONE explicit `awaitNextFlush()` to
+   * publish. Mirrors PR #201's pattern for `profile-multi-device-sync`.
+   * NOTE: scaffolding parity alone does NOT make this test pass — see
+   * the follow-up issues filed in the parent PR for the SDK-level
+   * defects (unconfirmed-token-flush regression, missing pointer-
+   * version walk-through, OrbitDB OpLog CBOR decode failures).
+   */
+  readonly flushDebounceMs?: number;
 };
 
 export type ParentRequest =
@@ -133,7 +145,12 @@ async function handleInit(
   const dirs = makeTempDirs(`profile-live1-${config.label}`);
   cleanupDir = dirs.base;
   await ensureTrustbase(dirs.dataDir);
-  const providers = makeProfileProviders(dirs);
+  const providers = makeProfileProviders(
+    dirs,
+    config.flushDebounceMs !== undefined
+      ? { flushDebounceMs: config.flushDebounceMs }
+      : {},
+  );
 
   if (config.mnemonic) {
     log('init: importing existing mnemonic with no-op transport=' +
@@ -206,7 +223,42 @@ async function handleReceive(requestId: string): Promise<void> {
 
 async function handleSync(requestId: string): Promise<void> {
   if (!sphere) throw new Error('sync: sphere not initialized');
-  const result = await sphere.payments.sync();
+
+  // Mirror PR #201's pattern: drive sphere.payments.sync() (which
+  // drains pending V5 finalizations) THEN call awaitNextFlush on
+  // every TokenStorageProvider that exposes it. The legacy flush
+  // path also drives the new lean-snapshot publish via
+  // `publishSnapshotIfWired` (flush-scheduler.ts), so awaitNextFlush
+  // is the single seam that publishes both the bundle CAR and the
+  // pointer.
+  //
+  // NOTE: with `flushDebounceMs: 300_000` the auto-flush is
+  // effectively disabled; the post-sync awaitNextFlush is the ONLY
+  // publish path. Under the SDK default 2 s debounce the auto-flush
+  // races aggregator-gateway propagation, which is the symptom
+  // called out in issue #199's follow-up.
+  //
+  // This scaffolding parity matches what PR #201 applied to
+  // `profile-multi-device-sync.test.ts`. It is NECESSARY but NOT
+  // SUFFICIENT to make the test pass — see the follow-up issues
+  // referenced in the parent PR.
+  const result = await sphere.payments.sync({ drainTimeoutMs: 60_000 });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const providers = (sphere.payments as any).getTokenStorageProviders?.()
+    ?? new Map<string, { awaitNextFlush?: (ms: number) => Promise<void> }>();
+  for (const [pid, provider] of providers as Map<string, { awaitNextFlush?: (ms: number) => Promise<void> }>) {
+    if (typeof provider.awaitNextFlush === 'function') {
+      try {
+        await provider.awaitNextFlush(120_000);
+      } catch (err) {
+        log(`sync: awaitNextFlush on provider ${pid} failed (best-effort): ${
+          err instanceof Error ? err.message : String(err)
+        }`);
+      }
+    }
+  }
+
   send({
     type: 'sync_ok',
     requestId,

--- a/tests/e2e/lib/two-device-mint-worker.ts
+++ b/tests/e2e/lib/two-device-mint-worker.ts
@@ -53,6 +53,15 @@ import { mintTestTokenToSelf } from './test-mint';
 export type MintWorkerInitConfig = {
   readonly label: string;
   readonly mnemonic?: string;
+  /**
+   * Profile flush debounce override. Tests pass a long debounce so
+   * all per-mint `save()` calls coalesce into one pendingData; the
+   * next `sync()` then drives ONE explicit `awaitNextFlush()` that
+   * publishes the merged state. Mirrors PR #201's pattern. NOTE:
+   * scaffolding parity alone does NOT make this test pass — see
+   * follow-up issues referenced in the parent PR.
+   */
+  readonly flushDebounceMs?: number;
 };
 
 export type MintWorkerRequest =
@@ -113,7 +122,11 @@ async function handleInit(
   const dirs = makeTempDirs(`two-dev-mint-${config.label}`);
   cleanupDir = dirs.base;
   await ensureTrustbase(dirs.dataDir);
-  const providers = makeProfileProviders(dirs);
+  const profileOptions =
+    config.flushDebounceMs !== undefined
+      ? { flushDebounceMs: config.flushDebounceMs }
+      : {};
+  const providers = makeProfileProviders(dirs, profileOptions);
 
   if (config.mnemonic) {
     log('init: importing existing mnemonic...');
@@ -143,7 +156,7 @@ async function handleInit(
     // Reimport with the no-op transport — same dirs, fresh providers
     // since the old ones had their connections torn down.
     log('init: reimporting with no-op transport to lock in noop...');
-    const reimportProviders = makeProfileProviders(dirs);
+    const reimportProviders = makeProfileProviders(dirs, profileOptions);
     sphere = await Sphere.import({
       storage: reimportProviders.storage,
       tokenStorage: reimportProviders.tokenStorage,
@@ -223,18 +236,27 @@ async function handleSync(requestId: string): Promise<void> {
 
   // Force any pending write-behind flushes to land durably BEFORE the
   // pointer-poll inside sync(). Without this, recent addToken() calls
-  // sit in the 2s debounce buffer and the actual IPFS pin +
+  // sit in the debounce buffer and the actual IPFS pin +
   // aggregator-pointer publish hasn't happened yet — so the pointer
   // poll returns the local cursor (no new CIDs) and convergence
   // never fires. awaitNextFlush is the public seam PaymentsModule's
   // own at-least-once gate uses for exactly this purpose.
+  //
+  // The 120 s budget accommodates the per-block dag/put pin path
+  // landed in PR #201 (issue #199): each CAR block is a separate
+  // HTTP round-trip against the gateway and a multi-mint CAR can
+  // contain ~10-20 blocks. The previous 60 s default was tight enough
+  // to deterministically time out under real-testnet gateway latency,
+  // which surfaced as the "awaitNextFlush: timeout awaiting serialized
+  // flush" log noise + the convergence failure called out in the
+  // issue #199 follow-up.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const providers = (sphere.payments as any).getTokenStorageProviders?.()
     ?? new Map<string, { awaitNextFlush?: (ms: number) => Promise<void> }>();
   for (const [pid, provider] of providers as Map<string, { awaitNextFlush?: (ms: number) => Promise<void> }>) {
     if (typeof provider.awaitNextFlush === 'function') {
       try {
-        await provider.awaitNextFlush(60_000);
+        await provider.awaitNextFlush(120_000);
       } catch (err) {
         log(`sync: awaitNextFlush on provider ${pid} failed (best-effort): ${
           err instanceof Error ? err.message : String(err)

--- a/tests/e2e/profile-live-concurrent-sync.test.ts
+++ b/tests/e2e/profile-live-concurrent-sync.test.ts
@@ -360,12 +360,22 @@ describe.skipIf(SKIP_INFRA)('Profile Live Concurrent Sync E2E', () => {
       const nametag = `e2e-live1-${rand()}`;
       console.log(`\n[Test 1] Setting up A and B as forked workers @${nametag}...`);
 
-      const REQUEST_TIMEOUT_MS = 120_000;
+      // IPC budget for `workerSync` — must exceed the inner
+      // `awaitNextFlush(120_000)` plus the aggregator-pointer poll
+      // round-trip. 180 s gives 60 s headroom after the flush
+      // completes for sphere.payments.sync() to run.
+      const REQUEST_TIMEOUT_MS = 180_000;
       // Init covers wallet creation + identity binding publish + first
       // OrbitDB connect — slow, especially from cold-start. Allow the
       // full propagation budget so the test doesn't false-alarm on
       // transient testnet relay slowdowns.
       const INIT_TIMEOUT_MS = PROPAGATION_TIMEOUT_MS;
+
+      // Long flush debounce: 5 min. All per-receive `save()` calls
+      // coalesce into ONE pendingData; `handleSync`'s post-sync
+      // `awaitNextFlush` is the explicit publish trigger. Mirrors
+      // PR #201's pattern applied to `profile-multi-device-sync`.
+      const FLUSH_DEBOUNCE_MS = 300_000;
 
       // Fork A first — autoGenerate, real Nostr transport, registers
       // the nametag. A is the source of truth for the shared mnemonic.
@@ -374,7 +384,12 @@ describe.skipIf(SKIP_INFRA)('Profile Live Concurrent Sync E2E', () => {
       console.log('  A: spawning worker (real Nostr, autoGenerate)...');
       const aInit = await workerInit(
         workerA,
-        { label: 'A', nametag, useNoopTransport: false },
+        {
+          label: 'A',
+          nametag,
+          useNoopTransport: false,
+          flushDebounceMs: FLUSH_DEBOUNCE_MS,
+        },
         INIT_TIMEOUT_MS,
       );
       console.log(`  A: identity=${aInit.l1Address}`);
@@ -388,7 +403,12 @@ describe.skipIf(SKIP_INFRA)('Profile Live Concurrent Sync E2E', () => {
       console.log('  B: spawning worker (no-op transport, importing A\'s mnemonic)...');
       const bInit = await workerInit(
         workerB,
-        { label: 'B', mnemonic: aInit.mnemonic, useNoopTransport: true },
+        {
+          label: 'B',
+          mnemonic: aInit.mnemonic,
+          useNoopTransport: true,
+          flushDebounceMs: FLUSH_DEBOUNCE_MS,
+        },
         INIT_TIMEOUT_MS,
       );
       console.log(`  B: identity=${bInit.l1Address}`);

--- a/tests/e2e/two-device-local-mint-convergence.test.ts
+++ b/tests/e2e/two-device-local-mint-convergence.test.ts
@@ -81,9 +81,19 @@ const CONVERGENCE_POLL_INTERVAL_MS = 5_000;
 // Per-IPC-call timeout buckets.
 const INIT_TIMEOUT_MS = 90_000;
 const MINT_TIMEOUT_MS = 60_000;
-const SYNC_TIMEOUT_MS = 90_000;
+// SYNC_TIMEOUT_MS must exceed the inner `awaitNextFlush(120_000)` so
+// the IPC wrapper doesn't fire before the flush completes. 180 s
+// gives 60 s headroom for sphere.payments.sync()'s pointer-poll
+// round-trip.
+const SYNC_TIMEOUT_MS = 180_000;
 const SHORT_TIMEOUT_MS = 15_000;
 const DESTROY_TIMEOUT_MS = 60_000;
+
+// Long flush debounce: 5 min. All per-mint `save()` calls coalesce
+// into ONE pendingData; the next `sync()` then drives ONE explicit
+// awaitNextFlush() to publish. Mirrors PR #201's pattern applied to
+// `profile-multi-device-sync`.
+const FLUSH_DEBOUNCE_MS = 300_000;
 
 // Test coin hex — distinct from real testnet coin IDs so faucet
 // balances on a shared wallet (if any) don't pollute the assertions.
@@ -296,7 +306,10 @@ describe.skipIf(SKIP_INFRA)('Two-Device Local-Mint Convergence E2E', () => {
       const workerA = new WorkerHandle('A');
       workers.push(workerA);
 
-      const initA = await workerInit(workerA, { label: 'A' });
+      const initA = await workerInit(workerA, {
+        label: 'A',
+        flushDebounceMs: FLUSH_DEBOUNCE_MS,
+      });
       console.log(`[A] initialized: ${initA.l1Address}`);
       const mnemonic = initA.mnemonic;
       expect(mnemonic).toBeTruthy();
@@ -306,7 +319,11 @@ describe.skipIf(SKIP_INFRA)('Two-Device Local-Mint Convergence E2E', () => {
       const workerB = new WorkerHandle('B');
       workers.push(workerB);
 
-      const initB = await workerInit(workerB, { label: 'B', mnemonic });
+      const initB = await workerInit(workerB, {
+        label: 'B',
+        mnemonic,
+        flushDebounceMs: FLUSH_DEBOUNCE_MS,
+      });
       console.log(`[B] initialized: ${initB.l1Address}`);
 
       // Sanity: both devices share identity.


### PR DESCRIPTION
## Summary

Mirrors PR #201's fix shape (long flush debounce + explicit `awaitNextFlush`) to the **two E2E suites called out in #199's follow-up comment** that PR #201 did NOT touch:

- `tests/e2e/profile-live-concurrent-sync.test.ts` (Test 1: cross-device sync via aggregator pointer + IPFS CAR)
- `tests/e2e/two-device-local-mint-convergence.test.ts` (concurrent §9.2 conflict path)

Both suites run each Sphere in a forked Node process (vs the in-process suites PR #201 fixed directly), so the scaffolding is plumbed through their respective worker IPC protocols:

- `profile-sync-worker.ts` / `two-device-mint-worker.ts`: new optional `flushDebounceMs` field on the init config, threaded into `makeProfileProviders`. `handleSync` now drives `sphere.payments.sync({ drainTimeoutMs: 60_000 })` THEN iterates every `TokenStorageProvider` and calls `awaitNextFlush(120_000)`.
- Test files pass `flushDebounceMs: 300_000` through `workerInit` and raise the per-IPC-call timeouts (`REQUEST_TIMEOUT_MS=180_000`, `SYNC_TIMEOUT_MS=180_000`) to sit above the inner flush budget.

## Status: NECESSARY but NOT SUFFICIENT

This PR makes the scaffolding consistent with PR #201's pattern but **does NOT make the tests pass**. Both suites still fail under `RUN_UXF_E2E=1` against the public testnet, because investigation surfaced three distinct SDK-level defects that PR #201's CID-mismatch fix doesn't reach:

| Follow-up | Issue | Summary |
| --------- | ----- | ------- |
| A         | #202  | Bundle CAR omits V5-pending tokens — `buildTxfStorageData` silently drops them via `tokenToTxf=null`. User flagged as a previously-fixed behaviour that has regressed. |
| B         | #203  | Pointer-version walk-through missing — receiver only fetches the latest pointer (`recoverLatest()`), losing intermediate version content. User-requested feature. |
| C         | #204  | OrbitDB OpLog CBOR decode failures on replicated bundle entries — silent token loss on cross-device replication. |

The branch can land as-is to lock in the scaffolding parity (no behaviour change relative to PR #201's pattern) and serves as the on-ramp for the three follow-up fixes. The two affected suites will start passing only once #202, #203, and #204 are addressed.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint <changed files>` clean.
- [x] `RUN_UXF_E2E=1 npx vitest run --config vitest.e2e.config.ts tests/e2e/profile-live-concurrent-sync.test.ts -t \"Cross-device sync\"` — STILL FAILS (expected, see #202/#203/#204).
- [x] `RUN_UXF_E2E=1 npx vitest run --config vitest.e2e.config.ts tests/e2e/two-device-local-mint-convergence.test.ts` — STILL FAILS (expected, see #202/#203/#204).
- [ ] After #202 lands, re-run both suites and confirm one of them flips to PASS (the live-concurrent test depends primarily on #202; the two-device test additionally needs #203 for §9.2 convergence and #204 for OpLog reliability).

## Refs

- Original regression: #199
- PR #201 (closes #199's named suites): `73f2fef`
- Follow-up issues: #202 (unconfirmed-flush regression), #203 (pointer walk-through), #204 (CBOR decode failures)