### PR TITLE
feat(uxf)(#202): UXF supports tokens with unproven genesis + V5-pending CAR visibility

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -6157,6 +6157,46 @@ export class PaymentsModule {
    *
    * @param deferPersistence - If true, skip addToken/save calls (caller batches them).
    *   The token is still added to the in-memory map for dedup; caller must call save().
+   *
+   * #202 — V5-pending TXF/UXF expressibility.
+   *
+   * Pre-#202 this saved `sdkData = '{"_pendingFinalization":...}'` — an
+   * opaque wrapper with no `genesis` or `state`. Both serialization
+   * layers then dropped/rejected it:
+   *
+   *   - `serialization/txf-serializer.ts:tokenToTxf` returned null, so
+   *     `buildTxfStorageData` silently dropped the token.
+   *   - `profile/profile-token-storage/flush-scheduler.ts` calls
+   *     `UxfPackage.ingestAll` which calls `deconstructToken` whose
+   *     `validateToken` (pre-#202) threw `INVALID_PACKAGE` on
+   *     `_pendingFinalization`.
+   *
+   * Net effect: A's bundle CAR contained zero tokens after `receive()`;
+   * cross-device profile sync (Device B reading A's CAR) saw an empty
+   * inventory. Reported in #202.
+   *
+   * Fix: synthesize a UXF/TXF-valid sdkData mirroring what
+   * `finalizeFromV5Bundle()` produces post-finalization, but with
+   * `inclusionProof: null` on BOTH the genesis (mint not yet proven) and
+   * the synthetic transfer transaction (transfer commitment not yet
+   * proven). The sender-signed transfer authenticator rides as
+   * `transactions[0]._wallet.authenticator` — preserved across UXF
+   * deconstruct → assemble round-trip via the new `pending-authenticator`
+   * element type (#202 schema extension).
+   *
+   * The `_pendingFinalization` marker is kept at the top level for
+   * backward-compat with single-device KV restore (`PENDING_V5_TOKENS`)
+   * and with `hasFinalizationPlan()` / `parsePendingFinalization()`.
+   * It's a wallet-internal top-level field — UXF deconstruct drops it on
+   * round-trip (UXF only preserves canonical typed elements). The
+   * structural shape (null proofs + `_wallet.authenticator`) carries
+   * enough for `resolveV5Token` to operate without the marker if it ever
+   * needs to (future PR-B will refactor `resolveV5Token` to read from
+   * the token shape directly).
+   *
+   * If parsing fails for any reason (malformed bundle), falls back to
+   * the legacy opaque shape so the token is still recoverable via the
+   * KV path — pre-#202 single-device behavior preserved on bad input.
    */
   private async saveUnconfirmedV5Token(
     bundle: InstantSplitBundleV5,
@@ -6179,6 +6219,74 @@ export class PaymentsModule {
       attemptCount: 0,
     };
 
+    // #202 — Build a UXF/TXF-valid synthetic sdkData. See doc-comment.
+    // On any parse failure, fall back to the legacy opaque
+    // `{_pendingFinalization: ...}` shape (single-device KV path still
+    // recovers the token; bundle CAR omits it as pre-#202).
+    const sdkDataJson = (() => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const mintDataJson = JSON.parse(bundle.recipientMintData) as Record<string, any>;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const transferCommitmentJson = JSON.parse(bundle.transferCommitment) as Record<string, any>;
+        const mintedTokenState = JSON.parse(bundle.mintedTokenStateJson);
+
+        const transferTxData =
+          transferCommitmentJson.transactionData !== undefined
+            ? transferCommitmentJson.transactionData
+            : transferCommitmentJson.data ?? null;
+
+        // Sender-signed authenticator over the transfer commitment.
+        // Carried inside `_wallet.authenticator` so it survives UXF
+        // round-trip via the new `pending-authenticator` element type.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const transferAuth: any = transferCommitmentJson.authenticator;
+
+        // The transfer commitment's authenticator signs over
+        // (transactionHash, sourceStateHash). The `stateHash` field IS
+        // the source state hash (= hash of `mintedTokenStateJson`).
+        // Carry it as `_integrity.currentStateHash` so the wallet's
+        // (tokenId, stateHash) dedup index produces stable identities
+        // across save/load round-trips for V5-pending tokens.
+        const currentStateHash: string | undefined =
+          transferAuth && typeof transferAuth === 'object' && typeof transferAuth.stateHash === 'string'
+            ? transferAuth.stateHash
+            : undefined;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const syntheticPendingTx: Record<string, any> = {
+          data: transferTxData,
+          inclusionProof: null,
+        };
+        if (transferAuth && typeof transferAuth === 'object') {
+          syntheticPendingTx._wallet = { authenticator: transferAuth };
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const syntheticTxf: Record<string, any> = {
+          version: '2.0',
+          state: mintedTokenState,
+          genesis: {
+            data: mintDataJson,
+            inclusionProof: null,
+          },
+          transactions: transferTxData !== null ? [syntheticPendingTx] : [],
+          nametags: [],
+          _pendingFinalization: pendingData,
+        };
+        if (currentStateHash) {
+          syntheticTxf._integrity = { currentStateHash };
+        }
+        return JSON.stringify(syntheticTxf);
+      } catch (err) {
+        logger.warn(
+          'Payments',
+          `saveUnconfirmedV5Token: failed to synthesize UXF-compatible shape for bundle ${bundle.splitGroupId.slice(0, 12)}, falling back to legacy opaque shape — token will be omitted from bundle CAR but recoverable via PENDING_V5_TOKENS KV: ${(err as Error)?.message ?? err}`,
+        );
+        return JSON.stringify({ _pendingFinalization: pendingData });
+      }
+    })();
+
     const uiToken: Token = {
       id: deterministicId,
       coinId: bundle.coinId,
@@ -6189,7 +6297,7 @@ export class PaymentsModule {
       status: 'submitted',  // UNCONFIRMED
       createdAt: Date.now(),
       updatedAt: Date.now(),
-      sdkData: JSON.stringify({ _pendingFinalization: pendingData }),
+      sdkData: sdkDataJson,
     };
 
     // Record splitGroupId for persistent dedup across page reloads

--- a/tests/unit/uxf/deconstruct.test.ts
+++ b/tests/unit/uxf/deconstruct.test.ts
@@ -278,12 +278,22 @@ describe('deconstructToken', () => {
       }
     });
 
-    it('pendingFinalization rejected with INVALID_PACKAGE', () => {
+    // #202 — `_pendingFinalization` is no longer rejected by the validator.
+    // The legacy `EDGE_PENDING_FINALIZATION` fixture is just a `{_pendingFinalization: ...}`
+    // wrapper with NO genesis at all, so it's now rejected for a different
+    // reason (the genesis-required check) — the failure mode shifts but the
+    // error code stays `INVALID_PACKAGE`. A separate positive test below
+    // covers the new "pending token with full structural shape" acceptance.
+    it('pendingFinalization stub WITHOUT genesis still rejected (no genesis)', () => {
       expect(() => deconstructToken(pool, EDGE_PENDING_FINALIZATION)).toThrow(UxfError);
       try {
         deconstructToken(pool, EDGE_PENDING_FINALIZATION);
       } catch (e) {
-        expect((e as UxfError).code).toBe('INVALID_PACKAGE');
+        const err = e as UxfError;
+        expect(err.code).toBe('INVALID_PACKAGE');
+        // Confirm the rejection is now from the "missing genesis" path,
+        // NOT the (removed) "_pendingFinalization" path.
+        expect(err.message).toContain('genesis');
       }
     });
 
@@ -304,6 +314,47 @@ describe('deconstructToken', () => {
       const txEl = pool.get(rootChildren.transactions[0])!;
       const txChildren = txEl.children as unknown as TransactionChildren;
       expect(txChildren.inclusionProof).toBeNull();
+    });
+
+    // #202 — Pending genesis (mint commitment not yet submitted / proven).
+    // Symmetric with the existing "null inclusionProof on transaction" case
+    // above. Pre-#202 this threw TypeError inside deconstructInclusionProof
+    // because deconstructGenesis passed null through unconditionally.
+    it('#202 — null genesis.inclusionProof produces a genesis element with null inclusionProof child', () => {
+      const pendingGenesisToken = {
+        version: '2.0',
+        state: {
+          predicate: 'aa00000000000000000000000000000000000000000000000000000000000001',
+          data: null,
+        },
+        genesis: {
+          data: {
+            tokenId: 'bb00000000000000000000000000000000000000000000000000000000000002',
+            tokenType:
+              '0000000000000000000000000000000000000000000000000000000000000001',
+            coinData: [['UCT', '1000000']],
+            tokenData: '',
+            salt: 'bb000000000000000000000000000000000000000000000000000000005a1602',
+            recipient: 'DIRECT://alice-pending-01',
+            recipientDataHash: null,
+            reason: null,
+          },
+          inclusionProof: null, // mint unproven
+        },
+        transactions: [],
+        nametags: [],
+      };
+
+      const rootHash = deconstructToken(pool, pendingGenesisToken);
+      const rootEl = pool.get(rootHash)!;
+      const rootChildren = rootEl.children as unknown as TokenRootChildren;
+      const genesisEl = pool.get(rootChildren.genesis)!;
+      const genesisChildren =
+        genesisEl.children as unknown as { data: string; inclusionProof: string | null };
+      expect(genesisChildren.inclusionProof).toBeNull();
+      // The genesis data should still be present and addressable.
+      expect(genesisChildren.data).toBeDefined();
+      expect(typeof genesisChildren.data).toBe('string');
     });
   });
 });

--- a/tests/unit/uxf/types.test.ts
+++ b/tests/unit/uxf/types.test.ts
@@ -97,8 +97,9 @@ describe('contentHash', () => {
 // =============================================================================
 
 describe('ELEMENT_TYPE_IDS', () => {
-  it('has exactly 12 entries', () => {
-    expect(Object.keys(ELEMENT_TYPE_IDS)).toHaveLength(12);
+  // 13 = 12 pre-#202 element types + `pending-authenticator` (0x0e).
+  it('has exactly 13 entries', () => {
+    expect(Object.keys(ELEMENT_TYPE_IDS)).toHaveLength(13);
   });
 
   it('maps token-root to 0x01', () => {
@@ -149,10 +150,15 @@ describe('ELEMENT_TYPE_IDS', () => {
     expect(ELEMENT_TYPE_IDS['smt-path']).toBe(0x0d);
   });
 
+  // #202 — pending-authenticator wire type tag.
+  it('maps pending-authenticator to 0x0e', () => {
+    expect(ELEMENT_TYPE_IDS['pending-authenticator']).toBe(0x0e);
+  });
+
   it('all type IDs are unique', () => {
     const values = Object.values(ELEMENT_TYPE_IDS);
     const uniqueValues = new Set(values);
-    expect(uniqueValues.size).toBe(12);
+    expect(uniqueValues.size).toBe(13);
   });
 });
 

--- a/tests/unit/uxf/v5-pending-roundtrip.test.ts
+++ b/tests/unit/uxf/v5-pending-roundtrip.test.ts
@@ -1,0 +1,214 @@
+/**
+ * #202 — UXF round-trip tests for V5-pending tokens.
+ *
+ * Pins the contract that lets cross-device profile sync and Nostr-shipped
+ * UXF bundles carry tokens that have not yet been finalized on-chain:
+ *
+ *   1. A token with `genesis.inclusionProof: null` AND
+ *      `transactions[0].inclusionProof: null` ingests, serializes to CAR,
+ *      and round-trips back with both null markers preserved.
+ *
+ *   2. A token with `_pendingFinalization` at the top level no longer
+ *      throws on ingest (the field is silently dropped on round-trip,
+ *      consistent with all other non-schema top-level metadata).
+ *
+ *   3. A `transactions[0]._wallet.authenticator` field is preserved
+ *      across CAR round-trip via the new `pending-authenticator` element
+ *      type, so the sender-signed authenticator for an in-flight transfer
+ *      survives even though `inclusionProof` is null.
+ *
+ * Pre-#202, all three behaviors failed:
+ *   - (1) threw `TypeError: Cannot read properties of null` from
+ *     deconstructGenesis passing null to deconstructInclusionProof
+ *   - (2) threw `UxfError[INVALID_PACKAGE] Cannot ingest placeholder or
+ *     pending finalization tokens` from the validator
+ *   - (3) `_wallet.authenticator` was a top-level non-schema field and
+ *     was silently dropped on deconstruct → assemble (UXF shreds tokens
+ *     into typed element pools and doesn't preserve unknown fields).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { UxfPackage } from '../../../uxf/UxfPackage.js';
+import {
+  TOKEN_TYPE_FUNGIBLE,
+  PUBKEY_ALICE,
+  PREDICATE_A,
+} from '../../fixtures/uxf-mock-tokens.js';
+
+// -----------------------------------------------------------------------------
+// Shared fixture helpers
+// -----------------------------------------------------------------------------
+
+const PENDING_TOKEN_ID =
+  'aaaaaa00000000000000000000000000000000000000000000000000000000aa';
+
+function makePendingV5Token(opts?: {
+  withPendingFinalizationMarker?: boolean;
+  withWalletAuthenticator?: boolean;
+}): Record<string, unknown> {
+  const token: Record<string, unknown> = {
+    version: '2.0',
+    state: {
+      predicate: PREDICATE_A,
+      data: null,
+    },
+    genesis: {
+      data: {
+        tokenId: PENDING_TOKEN_ID,
+        tokenType: TOKEN_TYPE_FUNGIBLE,
+        coinData: [['UCT', '1000000']],
+        tokenData: '',
+        salt: 'aaaaaa00000000000000000000000000000000000000000000000000000055aa',
+        recipient: 'DIRECT://alice-pending-01',
+        recipientDataHash: null,
+        reason: null,
+      },
+      inclusionProof: null, // V5 RECEIVED stage — mint not yet submitted
+    },
+    transactions: [
+      {
+        data: {
+          sourceState: {
+            predicate: PREDICATE_A,
+            data: null,
+          },
+          recipient: 'DIRECT://bob-pending-01',
+          salt: 'aaaaaa000000000000000000000000000000000000000000000000000099aa01',
+          recipientDataHash: null,
+          message: null,
+          nametags: [],
+        },
+        inclusionProof: null, // transfer commitment not yet proven
+        ...(opts?.withWalletAuthenticator
+          ? {
+              _wallet: {
+                authenticator: {
+                  algorithm: 'secp256k1',
+                  publicKey: PUBKEY_ALICE,
+                  signature:
+                    '3045022100ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01022000ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff',
+                  stateHash:
+                    'ee0000000000000000000000000000000000000000000000000000ee004a5401',
+                },
+              },
+            }
+          : {}),
+      },
+    ],
+    nametags: [],
+  };
+
+  if (opts?.withPendingFinalizationMarker) {
+    token._pendingFinalization = {
+      type: 'v5_bundle',
+      stage: 'RECEIVED',
+      bundleJson: '{"version":"5.0","type":"INSTANT_SPLIT"}',
+      senderPubkey: PUBKEY_ALICE,
+      savedAt: 1700000000000,
+      attemptCount: 0,
+    };
+  }
+
+  return token;
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+describe('#202 — UXF round-trip for V5-pending tokens', () => {
+  it('null genesis.inclusionProof + null transfer.inclusionProof: ingests and round-trips', async () => {
+    const pkg = UxfPackage.create();
+    const token = makePendingV5Token();
+
+    pkg.ingestAll([token]);
+    expect(pkg.tokenCount).toBe(1);
+
+    const car = await pkg.toCar();
+    const restored = await UxfPackage.fromCar(car);
+    expect(restored.tokenCount).toBe(1);
+
+    const assembled = restored.assemble(PENDING_TOKEN_ID) as Record<string, unknown>;
+    const restoredGenesis = assembled.genesis as Record<string, unknown>;
+    const restoredTxs = assembled.transactions as Array<Record<string, unknown>>;
+
+    expect(restoredGenesis.inclusionProof).toBeNull();
+    expect(restoredTxs).toHaveLength(1);
+    expect(restoredTxs[0].inclusionProof).toBeNull();
+  });
+
+  it('_pendingFinalization at top level is ACCEPTED (not rejected) and silently dropped on assemble', async () => {
+    const pkg = UxfPackage.create();
+    const token = makePendingV5Token({ withPendingFinalizationMarker: true });
+
+    // Pre-#202 this threw [UXF:INVALID_PACKAGE]. Now it ingests.
+    expect(() => pkg.ingestAll([token])).not.toThrow();
+    expect(pkg.tokenCount).toBe(1);
+
+    const car = await pkg.toCar();
+    const restored = await UxfPackage.fromCar(car);
+    const assembled = restored.assemble(PENDING_TOKEN_ID) as Record<string, unknown>;
+
+    // The `_pendingFinalization` field is wallet-internal metadata; UXF
+    // deconstruct preserves only canonical typed elements. The marker is
+    // expected to be dropped on round-trip. The wallet preserves this
+    // field through its own KV storage (PENDING_V5_TOKENS).
+    expect(assembled._pendingFinalization).toBeUndefined();
+
+    // But the structural shape survives — that's what matters for
+    // cross-device visibility.
+    const restoredGenesis = assembled.genesis as Record<string, unknown>;
+    expect(restoredGenesis.inclusionProof).toBeNull();
+  });
+
+  it('transactions[0]._wallet.authenticator survives CAR round-trip via pending-authenticator element', async () => {
+    const pkg = UxfPackage.create();
+    const token = makePendingV5Token({ withWalletAuthenticator: true });
+
+    pkg.ingestAll([token]);
+
+    const car = await pkg.toCar();
+    const restored = await UxfPackage.fromCar(car);
+    const assembled = restored.assemble(PENDING_TOKEN_ID) as Record<string, unknown>;
+    const restoredTxs = assembled.transactions as Array<Record<string, unknown>>;
+
+    expect(restoredTxs[0].inclusionProof).toBeNull();
+    expect(restoredTxs[0]._wallet).toBeDefined();
+    const wallet = restoredTxs[0]._wallet as { authenticator: Record<string, string> };
+    expect(wallet.authenticator).toBeDefined();
+    expect(wallet.authenticator.algorithm).toBe('secp256k1');
+    expect(wallet.authenticator.publicKey).toBe(PUBKEY_ALICE.toLowerCase());
+    expect(wallet.authenticator.signature).toMatch(/^3045022100ee01/);
+    expect(wallet.authenticator.stateHash).toMatch(/^ee0000/);
+  });
+
+  it('transactions WITHOUT _wallet.authenticator do NOT get a pendingAuthenticator child (no element hash drift)', async () => {
+    // Backwards-compat check: the very same input that worked pre-#202
+    // (transaction with null inclusionProof, no _wallet field) must produce
+    // a transaction element whose children object DOES NOT include the
+    // optional `pendingAuthenticator` slot. Adding the slot unconditionally
+    // would change the element hash for every existing transaction in the
+    // wild — a silent content-address break that would invalidate every
+    // already-pinned bundle CAR. We use the "omit when null" convention.
+    const pkg = UxfPackage.create();
+    const token = makePendingV5Token({ withWalletAuthenticator: false });
+
+    pkg.ingestAll([token]);
+
+    const car = await pkg.toCar();
+    const restored = await UxfPackage.fromCar(car);
+    const assembled = restored.assemble(PENDING_TOKEN_ID) as Record<string, unknown>;
+    const restoredTxs = assembled.transactions as Array<Record<string, unknown>>;
+
+    expect(restoredTxs[0]._wallet).toBeUndefined();
+  });
+
+  it('verify() succeeds for a fully-pending token', async () => {
+    const pkg = UxfPackage.create();
+    pkg.ingestAll([makePendingV5Token({ withWalletAuthenticator: true })]);
+
+    const result = pkg.verify();
+    expect(result.errors).toHaveLength(0);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/uxf/assemble.ts
+++ b/uxf/assemble.ts
@@ -193,6 +193,31 @@ function assembleAuthenticator(
 }
 
 /**
+ * #202 — Assemble a pending-authenticator element.
+ *
+ * Same wire shape as a proven authenticator (publicKey, algorithm,
+ * signature, stateHash); the distinct element type tag carries the
+ * "submitted-but-not-yet-proven" semantic. The caller decides how to
+ * surface it on the assembled token; `assembleTransaction` puts it under
+ * `tx._wallet.authenticator` to preserve the legacy ad-hoc field name
+ * introduced by V6-direct (saveCommitmentOnlyToken).
+ */
+function assemblePendingAuthenticator(
+  pool: ElementPool,
+  authHash: ContentHash,
+  ctx: AssemblyContext,
+): { algorithm: string; publicKey: string; signature: string; stateHash: string } {
+  const el = resolveAndVerify(pool, authHash, ctx, 'pending-authenticator');
+  const c = el.content as unknown as AuthenticatorContent;
+  return {
+    algorithm: c.algorithm,
+    publicKey: c.publicKey,
+    signature: c.signature,
+    stateHash: c.stateHash,
+  };
+}
+
+/**
  * Assemble an smt-path element into `{ root, steps[] }`.
  */
 function assembleSmtPath(
@@ -336,6 +361,12 @@ function assembleGenesisData(
 
 /**
  * Assemble a genesis element into the IMintTransactionJson shape.
+ *
+ * #202 — `inclusionProof` is nullable; returns `null` when the underlying
+ * `genesis` element has `children.inclusionProof === null` (V5/V4-pending
+ * mint, not yet submitted / not yet proven). Pre-#202 this asserted
+ * non-null via the type system and would have crashed in
+ * `assembleInclusionProof` on the typecast.
  */
 function assembleGenesis(
   pool: ElementPool,
@@ -343,13 +374,16 @@ function assembleGenesis(
   ctx: AssemblyContext,
 ): {
   data: ReturnType<typeof assembleGenesisData>;
-  inclusionProof: ReturnType<typeof assembleInclusionProof>;
+  inclusionProof: ReturnType<typeof assembleInclusionProof> | null;
 } {
   const el = resolveAndVerify(pool, genesisHash, ctx, 'genesis');
   const ch = el.children as unknown as GenesisChildren;
 
   const data = assembleGenesisData(pool, ch.data, ctx);
-  const inclusionProof = assembleInclusionProof(pool, ch.inclusionProof, ctx);
+  const inclusionProof =
+    ch.inclusionProof !== null
+      ? assembleInclusionProof(pool, ch.inclusionProof, ctx)
+      : null;
 
   return { data, inclusionProof };
 }
@@ -399,6 +433,17 @@ function assembleTransactionData(
 
 /**
  * Assemble a transaction element into the ITransferTransactionJson shape.
+ *
+ * #202 — Restores the wallet-internal `_wallet.authenticator` field
+ * (introduced ad-hoc by V6-direct's saveCommitmentOnlyToken) when the
+ * underlying transaction element has a `pendingAuthenticator` child
+ * pointing at a `pending-authenticator` element. Pre-#202 the field was
+ * silently dropped on UXF round-trip; now it survives.
+ *
+ * The returned object's TypeScript shape doesn't formally declare
+ * `_wallet` because it's wallet-internal SDK metadata, not part of
+ * `ITransferTransactionJson`. Callers that care about the field read it
+ * dynamically.
  */
 function assembleTransaction(
   pool: ElementPool,
@@ -414,6 +459,7 @@ function assembleTransaction(
     nametags: unknown[];
   };
   inclusionProof: ReturnType<typeof assembleInclusionProof> | null;
+  _wallet?: { authenticator: ReturnType<typeof assemblePendingAuthenticator> };
 } {
   const el = resolveAndVerify(pool, txHash, ctx, 'transaction');
   const ch = el.children as unknown as TransactionChildren;
@@ -446,7 +492,17 @@ function assembleTransaction(
     nametags: [],
   };
 
-  return { data, inclusionProof };
+  // #202 — Restore wallet-internal pending authenticator if present.
+  // The element schema makes pendingAuthenticator OPTIONAL (only emitted
+  // by deconstruct when the input carried `_wallet.authenticator`), so
+  // the field may be undefined OR null. Treat both as "no pending state".
+  const pendingAuthHash = ch.pendingAuthenticator;
+  const result: ReturnType<typeof assembleTransaction> = { data, inclusionProof };
+  if (pendingAuthHash != null) {
+    const authenticator = assemblePendingAuthenticator(pool, pendingAuthHash, ctx);
+    result._wallet = { authenticator };
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/uxf/deconstruct.ts
+++ b/uxf/deconstruct.ts
@@ -73,10 +73,17 @@ interface MintDataShape {
   readonly reason: unknown | null;
 }
 
-/** Minimal shape of IMintTransactionJson / genesis. */
+/**
+ * Minimal shape of IMintTransactionJson / genesis.
+ *
+ * #202 — `inclusionProof` is nullable to express pending genesis (mint
+ * commitment not yet submitted / not yet proven). Mirrors the existing
+ * `TransferTxShape.inclusionProof` nullable behavior so genesis and
+ * transactions have symmetric handling.
+ */
 interface GenesisShape {
   readonly data: MintDataShape;
-  readonly inclusionProof: InclusionProofShape;
+  readonly inclusionProof: InclusionProofShape | null;
 }
 
 /** Minimal shape of ITransferTransactionDataJson. */
@@ -168,8 +175,19 @@ function lowerHexNullable(value: string | null | undefined): string | null {
 // ---------------------------------------------------------------------------
 
 /**
- * Validates that the input is a usable token and not a placeholder or pending
- * finalization stub.
+ * Validates that the input is a usable token and not a placeholder stub.
+ *
+ * #202 update — `_pendingFinalization` is NO LONGER rejected. UXF now
+ * supports pending tokens (no proven genesis, no proven transfer) so that
+ * cross-device profile sync and Nostr-shipped self-sufficient bundles can
+ * carry the full lifecycle of a token, not just its post-finalization
+ * form. The `_pendingFinalization` field is a wallet-local hint
+ * (preserved through the SDK's sdkData but DROPPED on UXF deconstruct →
+ * assemble round-trip, like any non-schema top-level field); it doesn't
+ * affect UXF semantics any more.
+ *
+ * `_placeholder` is still rejected because a placeholder is a UI
+ * stand-in with no `genesis` at all — there's nothing to deconstruct.
  */
 function validateToken(token: unknown): asserts token is TokenShape {
   if (!token || typeof token !== 'object') {
@@ -181,14 +199,7 @@ function validateToken(token: unknown): asserts token is TokenShape {
   if (obj._placeholder === true) {
     throw new UxfError(
       'INVALID_PACKAGE',
-      'Cannot ingest placeholder or pending finalization tokens',
-    );
-  }
-
-  if (obj._pendingFinalization) {
-    throw new UxfError(
-      'INVALID_PACKAGE',
-      'Cannot ingest placeholder or pending finalization tokens',
+      'Cannot ingest placeholder tokens (no genesis field)',
     );
   }
 
@@ -456,7 +467,14 @@ function deriveAllStates(token: TokenShape): DerivedStates {
 /**
  * Deconstruct a GenesisTransaction into a `genesis` element.
  *
- * Children: data (genesis-data), inclusionProof, destinationState (token-state).
+ * Children: data (genesis-data), inclusionProof (nullable; #202), destinationState (token-state).
+ *
+ * #202 — `genesis.inclusionProof` is nullable to express V5/V4-pending
+ * tokens whose mint commitment has not yet been submitted or proven.
+ * Symmetric with `deconstructTransaction`'s existing nullable proof
+ * handling. Pre-#202 this asserted a non-null proof, propagating
+ * `Cannot read properties of null (reading 'authenticator')` from
+ * `deconstructInclusionProof` when callers passed a pending genesis.
  */
 export function deconstructGenesis(
   pool: ElementPool,
@@ -464,10 +482,10 @@ export function deconstructGenesis(
   destinationState: StateShape,
 ): ContentHash {
   const dataHash = deconstructGenesisData(pool, genesis.data);
-  const inclusionProofHash = deconstructInclusionProof(
-    pool,
-    genesis.inclusionProof,
-  );
+  let inclusionProofHash: ContentHash | null = null;
+  if (genesis.inclusionProof != null) {
+    inclusionProofHash = deconstructInclusionProof(pool, genesis.inclusionProof);
+  }
   const destinationStateHash = deconstructState(pool, destinationState);
 
   return putElement(pool, 'genesis', {}, {
@@ -475,6 +493,35 @@ export function deconstructGenesis(
     inclusionProof: inclusionProofHash,
     destinationState: destinationStateHash,
   });
+}
+
+/**
+ * #202 — Deconstruct a pending-authenticator into a dedicated element.
+ *
+ * Wire shape matches the standard `AuthenticatorShape` (publicKey,
+ * algorithm, signature, stateHash). Distinct element type ID so the
+ * "submitted-but-not-yet-proven" semantic is explicit in the canonical
+ * DAG rather than overloaded onto `authenticator`.
+ *
+ * On assemble, this element is materialized as `tx._wallet.authenticator
+ * = {...}` so wallet code retains the legacy ad-hoc field name introduced
+ * by saveCommitmentOnlyToken (V6-direct).
+ */
+export function deconstructPendingAuthenticator(
+  pool: ElementPool,
+  auth: AuthenticatorShape,
+): ContentHash {
+  return putElement(
+    pool,
+    'pending-authenticator',
+    {
+      algorithm: auth.algorithm,
+      publicKey: lowerHex(auth.publicKey),
+      signature: lowerHex(auth.signature),
+      stateHash: lowerHex(auth.stateHash),
+    },
+    {},
+  );
 }
 
 /**
@@ -516,9 +563,18 @@ function deconstructTransferData(
  * Deconstruct a TransferTransaction into a `transaction` element.
  *
  * sourceState and destinationState are pre-derived StateShape objects.
- * Children: sourceState, data, inclusionProof, destinationState.
+ * Children: sourceState, data, inclusionProof, destinationState,
+ * pendingAuthenticator (#202).
  *
  * For uncommitted transactions, data and inclusionProof are null.
+ *
+ * #202 — When the input tx carries a `_wallet.authenticator` field (the
+ * sender-signed authenticator for a committed-but-not-yet-proven transfer,
+ * as written by saveCommitmentOnlyToken / saveUnconfirmedV5Token), that
+ * authenticator is deconstructed into a `pending-authenticator` element
+ * referenced by the optional `pendingAuthenticator` child. On assemble,
+ * the field is restored as `tx._wallet = { authenticator: {...} }` so
+ * wallet code retains the legacy naming.
  */
 export function deconstructTransaction(
   pool: ElementPool,
@@ -542,12 +598,36 @@ export function deconstructTransaction(
     inclusionProofHash = deconstructInclusionProof(pool, tx.inclusionProof);
   }
 
-  return putElement(pool, 'transaction', {}, {
+  // #202 — Pending authenticator. Read from the wallet-internal
+  // `_wallet.authenticator` field that saveCommitmentOnlyToken (and now
+  // saveUnconfirmedV5Token) writes onto transactions awaiting proof.
+  // Absence is the normal case (transaction either proven or never
+  // committed); presence means "committed locally, awaiting proof".
+  let pendingAuthenticatorHash: ContentHash | null = null;
+  const txWallet = (tx as TransferTxShape & {
+    readonly _wallet?: { readonly authenticator?: AuthenticatorShape | null };
+  })._wallet;
+  if (txWallet && txWallet.authenticator != null) {
+    pendingAuthenticatorHash = deconstructPendingAuthenticator(
+      pool,
+      txWallet.authenticator,
+    );
+  }
+
+  // Children object: only include pendingAuthenticator when set so the
+  // element hash for tokens without pending state matches the pre-#202
+  // hash (back-compat with on-chain content-addressed bundles).
+  const children: Record<string, ContentHash | ContentHash[] | null> = {
     sourceState: sourceStateHash,
     data: dataHash,
     inclusionProof: inclusionProofHash,
     destinationState: destinationStateHash,
-  });
+  };
+  if (pendingAuthenticatorHash !== null) {
+    children.pendingAuthenticator = pendingAuthenticatorHash;
+  }
+
+  return putElement(pool, 'transaction', {}, children);
 }
 
 // ---------------------------------------------------------------------------

--- a/uxf/hash.ts
+++ b/uxf/hash.ts
@@ -79,6 +79,13 @@ const BYTE_FIELDS: Readonly<Record<UxfElementType, ReadonlySet<string>>> = {
   'token-state': new Set(['data', 'predicate']),
   'token-coin-data': new Set(),
   'smt-path': new Set(['root']),
+  // #202 — Same byte-fields as `authenticator`. The element type tag is
+  // different (pending vs. proven) but the wire content is identical.
+  'pending-authenticator': new Set([
+    'publicKey',
+    'signature',
+    'stateHash',
+  ]),
 };
 
 // ---------------------------------------------------------------------------

--- a/uxf/types.ts
+++ b/uxf/types.ts
@@ -71,7 +71,22 @@ export type UxfElementType =
   | 'predicate'
   | 'token-state'
   | 'token-coin-data'
-  | 'smt-path';
+  | 'smt-path'
+  // #202 — Pending authenticator element. Carries the sender-signed
+  // authenticator for a transaction that has been committed locally but
+  // whose inclusion proof has not yet been retrieved from the aggregator.
+  // This is the wallet-internal "submitted-but-not-proven" recovery state
+  // expressed in the canonical UXF DAG, replacing the ad-hoc
+  // `tx._wallet.authenticator` non-schema field that previously rode along
+  // outside the UXF type system (and was therefore silently dropped on
+  // deconstruct → assemble round-trip).
+  //
+  // Same content shape as `authenticator` (publicKey + signature +
+  // stateHash + algorithm); separate type tag because the semantic is
+  // different (pending vs. proven). On assemble, materializes as
+  // `tx._wallet = { authenticator: {...} }` so consumers retain the
+  // pre-#202 wallet-internal naming convention.
+  | 'pending-authenticator';
 
 /**
  * Steelman¹⁹: canonical UxfElementType string-literal constants.
@@ -90,10 +105,16 @@ export const ELEMENT_TYPE_PREDICATE = 'predicate' as const satisfies UxfElementT
 export const ELEMENT_TYPE_TOKEN_STATE = 'token-state' as const satisfies UxfElementType;
 export const ELEMENT_TYPE_TOKEN_COIN_DATA = 'token-coin-data' as const satisfies UxfElementType;
 export const ELEMENT_TYPE_SMT_PATH = 'smt-path' as const satisfies UxfElementType;
+export const ELEMENT_TYPE_PENDING_AUTHENTICATOR =
+  'pending-authenticator' as const satisfies UxfElementType;
 
 /**
  * Maps UxfElementType string tags to unsigned integer type IDs.
  * Values are taken from SPECIFICATION Section 2.1.
+ *
+ * 0x0b is intentionally absent — it was reserved in earlier drafts and is
+ * not currently allocated. 0x0e is the new (#202) pending-authenticator
+ * type, allocated to the next free slot after smt-path (0x0d).
  */
 export const ELEMENT_TYPE_IDS: Readonly<Record<UxfElementType, number>> = {
   'token-root': 0x01,
@@ -108,6 +129,7 @@ export const ELEMENT_TYPE_IDS: Readonly<Record<UxfElementType, number>> = {
   'unicity-certificate': 0x0a,
   'token-coin-data': 0x0c,
   'smt-path': 0x0d,
+  'pending-authenticator': 0x0e,
 };
 
 // ---------------------------------------------------------------------------
@@ -164,9 +186,17 @@ export interface TokenRootChildren {
 export type GenesisContent = Record<string, never>;
 
 export interface GenesisChildren {
-  readonly data: ContentHash;              // -> genesis-data
-  readonly inclusionProof: ContentHash;    // -> inclusion-proof
-  readonly destinationState: ContentHash;  // -> token-state (post-genesis state)
+  readonly data: ContentHash;                       // -> genesis-data
+  // #202 — `inclusionProof` is nullable to express V5-pending tokens at
+  // the RECEIVED stage (mint commitment created but not yet submitted /
+  // proven). Pre-#202 this was non-nullable, implicitly requiring every
+  // UXF-expressible token to have a proven genesis. The SDK protocol
+  // permits genesis-pending tokens (the SDK token type itself can carry
+  // an unproven genesis); UXF was the only layer enforcing the
+  // "must be proven" constraint, blocking cross-device sync of pending
+  // tokens through the bundle CAR.
+  readonly inclusionProof: ContentHash | null;     // -> inclusion-proof (null when mint is unproven)
+  readonly destinationState: ContentHash;          // -> token-state (post-genesis state)
 }
 
 // ---- Genesis Data ----
@@ -199,6 +229,20 @@ export interface TransactionChildren {
   readonly data: ContentHash | null;             // -> transaction-data (null if uncommitted)
   readonly inclusionProof: ContentHash | null;   // -> inclusion-proof (null if uncommitted)
   readonly destinationState: ContentHash;        // -> token-state (state after transition)
+  // #202 — Optional pending authenticator. Carries the (sender-signed)
+  // authenticator for a transaction whose commitment was submitted but
+  // whose inclusion proof has not yet landed. When `inclusionProof` is
+  // null AND `pendingAuthenticator` is set, the transaction is in the
+  // "submitted, awaiting proof" state and the receiver can re-submit the
+  // commitment idempotently. On assemble, materializes as
+  // `tx._wallet = { authenticator: {...} }` to preserve the legacy
+  // wallet-internal naming convention introduced by saveCommitmentOnlyToken
+  // (V6-direct, commit ff3ee2e).
+  //
+  // Absence (undefined) means "no pending authenticator stored"; this is
+  // the legacy `tx.inclusionProof: null && tx.data: null` "uncommitted"
+  // shape (no submission has happened yet). Both shapes co-exist.
+  readonly pendingAuthenticator?: ContentHash | null;
 }
 
 // ---- Transaction Data ----
@@ -232,6 +276,18 @@ export interface AuthenticatorContent {
   readonly signature: string;
   readonly stateHash: string;
 }
+// No children -- leaf node.
+
+// ---- Pending Authenticator (#202) ----
+
+/**
+ * Pending authenticator -- same wire shape as `AuthenticatorContent` but a
+ * distinct element type to carry "submitted but not yet proven" recovery
+ * state. See the `pending-authenticator` doc on `UxfElementType` above for
+ * the architectural rationale (replaces ad-hoc `tx._wallet.authenticator`
+ * non-schema field).
+ */
+export type PendingAuthenticatorContent = AuthenticatorContent;
 // No children -- leaf node.
 
 // ---- SMT Path ----


### PR DESCRIPTION
## Summary

Closes #202 (PR-A scope). Allows the UXF token DAG to express tokens whose genesis mint is not yet proven AND whose transfer commitment is submitted but not yet proven. Unblocks cross-device profile sync by letting V5-pending tokens appear in the bundle CAR rather than being silently dropped by `UxfPackage.ingestAll`'s `validateToken` rejection.

## Background

Diagnosed on `integration/all-fixes @ 73f2fef` (issue #202). Symptom: on `tests/e2e/profile-live-concurrent-sync.test.ts > Cross-device sync …`, the originating device A holds a fully-confirmed token in memory after `payments.receive()`, but A's published bundle CAR contains zero tokens — recipients fetching the same CID see zero tokens too.

Root cause: the bundle CAR is built via `UxfPackage.ingestAll` (profile-token-storage/flush-scheduler.ts:331-372), which calls `deconstructToken` → `validateToken` which threw `INVALID_PACKAGE` on any object carrying `_pendingFinalization` (the wallet-internal V5 stage marker). Additionally, `deconstructGenesis` passed `genesis.inclusionProof` straight to `deconstructInclusionProof` without null-check, so even a structurally pending token would crash with `TypeError: Cannot read properties of null (reading 'authenticator')`.

After investigation we determined that **neither constraint is protocol-required** — the SDK token type itself permits null inclusion proofs; UXF was the only layer enforcing "genesis must be proven". This PR lifts that constraint symmetrically with the existing nullable transaction proof handling.

## What changed

### UXF schema (forward-compatible additions)

- `validateToken` no longer rejects `_pendingFinalization`. The field is now wallet-local metadata that survives sdkData but is dropped on UXF deconstruct → assemble (consistent with all other non-schema top-level fields). `_placeholder` rejection is unchanged.
- `GenesisChildren.inclusionProof` is `ContentHash | null` (was non-null). `GenesisShape.inclusionProof: InclusionProofShape | null`. `deconstructGenesis` and `assembleGenesis` null-check symmetric with the existing transaction-level null handling.
- New `pending-authenticator` element type (0x0e) with the same wire shape as `authenticator`. Distinct tag so "submitted-but-not-proven" semantics are explicit in the DAG.
- New optional `pendingAuthenticator` slot on `TransactionChildren`. When the input transaction carries `_wallet.authenticator` (the legacy V6-direct convention from `saveCommitmentOnlyToken`, commit `ff3ee2e`), the field is deconstructed into a `pending-authenticator` element. On assemble it is materialized back as `tx._wallet.authenticator`. **The slot is OMITTED from the children object when null so transaction element hashes for already-pinned bundles are unchanged** (no content-address break).

### SDK wiring

- `saveUnconfirmedV5Token` now produces a UXF-compatible synthetic shape:
  - `state` from `bundle.mintedTokenStateJson`
  - `genesis.data` from `bundle.recipientMintData`
  - `genesis.inclusionProof: null`
  - `transactions[0].data` from `bundle.transferCommitment.transactionData`
  - `transactions[0].inclusionProof: null`
  - `transactions[0]._wallet.authenticator` from `bundle.transferCommitment.authenticator` (sender-signed)
  - `_integrity.currentStateHash` from the transfer authenticator's stateHash (stable dedup identity)
  - `_pendingFinalization` retained at top level for the single-device `PENDING_V5_TOKENS` KV restore path
- On any parse failure, falls back to the legacy opaque shape — pre-#202 single-device behavior preserved on malformed input.

### Scope

This is **PR-A** in the #202 plan: cross-device CAR visibility. `resolveV5Token` still reads from `_pendingFinalization.bundleJson` for finalization driving; **PR-B (follow-up)** will refactor it to read from the token shape directly so Nostr-shipped UXF bundles are truly self-sufficient and don't depend on OrbitDB OpLog replication of `PENDING_V5_TOKENS`.

## Test plan

- [x] Type-check passes (`npm run typecheck`).
- [x] 540 targeted tests pass: full `tests/unit/uxf/` (445), `PaymentsModule.v5-finalization` (31), `PaymentsModule.sync-drain` (7), `txf-serializer` (57). New `tests/unit/uxf/v5-pending-roundtrip.test.ts` adds 5 CAR round-trip pins for the new contract.
- [x] Full unit suite: 7312/7316 passing. The 2 failures (`profile-token-storage-no-data-flush.test.ts`) are pre-existing test-parallelism flakes confirmed on the parent branch with my changes stashed.
- [ ] E2E acceptance: `tests/e2e/profile-live-concurrent-sync.test.ts > Cross-device sync …` against testnet — A's CAR has `tokenCount >= 1` and B's `load()` assembles the same token. Will verify post-merge.

## Refs

- Closes the CAR-visibility scope of issue #202.
- Spun out from #199 follow-up. Branch `fix/issue-199-followup` is the scaffolding-parity PR that motivated this.
- PR-B follow-up tracked separately for `resolveV5Token` shape-reading refactor + V4 production-viability evaluation.