### PR TITLE
feat(payments)(#207): self-sufficient UXF V5-pending bundles + resolveV5Token shape-reading (PR-B)

### DIFF
--- a/docs/uxf/V4-INSTANT-SPLIT-VIABILITY.md
+++ b/docs/uxf/V4-INSTANT-SPLIT-VIABILITY.md
@@ -1,0 +1,79 @@
+# V4 InstantSplit — Production Viability Analysis (#207)
+
+**Status**: V4 (`InstantSplitBundleV4`, `types/instant-split.ts:136`) is **NOT** production-viable as-is. The 2s burn-proof wait that V5 sustains is fundamental to the protocol-level `SplitMintReason` validation; V4's "skip burn proof, ship mint commitments immediately" model is incompatible with the SDK's split semantics. Recommended action: keep V4 dev-mode only, document the constraint, and revisit only if the SDK adopts a redesigned split-proof model.
+
+## Background
+
+PR #207 raised the question of whether V4 could be flipped from dev-mode to production. The hope: ~0.3s sender critical path (vs. ~2.3s in V5) by deferring the burn-proof wait to the receiver's chain-walker.
+
+Prerequisite asserted by the user: the SDK's token-digest computation must be **proof-independent**. We verified this — `Token.toJSON()` (`@unicitylabs/state-transition-sdk/lib/token/Token.d.ts`) and the underlying `MintTransaction` / `TransferTransaction` shapes nest `inclusionProof` as a separate sibling of `data`, and the deterministic identity of a transition is `RequestId.create(publicKey, sourceStateHash)` — neither depends on a proof being present. ✓
+
+But the second constraint, which makes V4 fail in production: **`SplitMintReason` requires a proven burn**.
+
+## SDK constraint — `SplitMintReason` requires a `burnedToken`
+
+`TokenSplitBuilder.createSplitMintCommitments(trustBase, burnTransaction)`
+(`node_modules/@unicitylabs/state-transition-sdk/lib/transaction/split/TokenSplitBuilder.js:71-74`):
+
+```js
+async createSplitMintCommitments(trustBase, burnTransaction) {
+    const burnedToken = await this.token.update(trustBase,
+        new TokenState(new BurnPredicate(...), null),
+        burnTransaction);
+    return Promise.all(this.tokens.map((request) =>
+        MintTransactionData.create(..., new SplitMintReason(burnedToken, ...))
+            .then((data) => MintCommitment.create(data))));
+}
+```
+
+Two things make V4 incompatible:
+
+1. **`token.update(trustBase, ..., burnTransaction)`** — verifies the burn transaction's inclusion proof. With only a burn *commitment* (V4's shape), this verification fails. The SDK is the gate; the aggregator is downstream.
+
+2. **`SplitMintReason` carries the burned token state** — a `Token` instance reflecting the post-burn state. That instance cannot be constructed without a proven burn (`token.update()` returns the new `Token`).
+
+Even if we could route around (1) by injecting a synthetic "unverified burned token", the aggregator's mint-commitment validation re-derives the `SplitMintReason` proof chain and would reject mints whose burn isn't anchored. V4's only way around this is "dev mode" — which is exactly the regime where this validation is skipped.
+
+## Failure model if V4 ships in production
+
+Hypothetical V4-production sender flow:
+1. Create burn commitment (no proof).
+2. Construct mint commitments referencing the unproven burn.
+3. Submit mint commitments first → **aggregator rejects** because `SplitMintReason` doesn't validate.
+
+If the aggregator's rejection were silent or asynchronous, the failure model gets worse:
+- Sender's UI marks the transfer as "succeeded" after Nostr delivery.
+- Receiver runs the chain-walker, sees burn → unprovable, mint → rejected, and has a permanently un-finalizable mint commitment.
+- No mechanism on the receiver to undo or detect — the source token state, meanwhile, is in `committedOnChainTokenIds`.
+
+This is the same "stranded receive" pathology #144 / #199 fought to eliminate. V5's 2s burn-proof wait is what prevents the sender from advertising a transfer that can't complete.
+
+## What would V4-production actually require?
+
+Hypothetical redesign that would let V4 work:
+- A new aggregator commitment shape that accepts a mint without `SplitMintReason`, then anchors the mint to the eventual burn proof in a later validation round.
+- Equivalent SDK support (a `MintTransactionData` variant without `SplitMintReason`, plus a "post-anchor" step that links mint → burn after the burn proves).
+- Receiver-side detection + cleanup for the "burn never proved" failure mode (e.g., the sender's burn request collided with another spend of the same source token).
+
+This is a substantial protocol change spanning aggregator, state-transition SDK, and wallet. It is not the kind of change that can be done as a follow-up to #207. If it is desirable, it warrants its own design doc + multi-quarter rollout, independent of UXF self-sufficiency work.
+
+## V4-pending in UXF — orthogonal capability
+
+PR-A's `pending-authenticator` element type (#202) and the null-inclusionProof tolerances in `uxf/assemble.ts` + `uxf/deconstruct.ts` make V4-pending tokens *expressible* in UXF: the synthetic shape with null genesis proof + sender-signed authenticator is the same regardless of whether the burn has proof yet.
+
+So if a V4 redesign ever lands, UXF will already accept its tokens. The current blocker is the SDK / aggregator layer, not the serialization layer.
+
+## Recommendation
+
+- V4 stays dev-mode only (`devMode: true` in `InstantSplitOptions`).
+- The dev-mode comment in `types/instant-split.ts:134` already calls this out: "V4 only works in dev mode. Production requires V5 with proper SplitMintReason."
+- No PR #207 work changes this. The viability question raised in #207 is **answered: not feasible** at the current protocol level.
+- If/when the protocol redesign happens, revisit this doc.
+
+## References
+
+- `types/instant-split.ts:136` — `InstantSplitBundleV4`
+- `node_modules/@unicitylabs/state-transition-sdk/lib/transaction/split/TokenSplitBuilder.js:71-74` — `createSplitMintCommitments` (the SDK constraint)
+- `node_modules/@unicitylabs/state-transition-sdk/lib/token/fungible/SplitMintReason.d.ts` — proof-bound mint reason
+- `modules/payments/InstantSplitExecutor.ts:240-256` — V5 sender's burn-proof wait
+- Issue #207 — original scope question

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -6233,15 +6233,20 @@ export class PaymentsModule {
     //
     // #207 PR-B — helper extracted to `v5-pending-shape.ts` for unit
     // testability + clear separation of pure shape-construction from
-    // wallet-side bookkeeping.
-    const sdkDataJson = buildSyntheticV5PendingSdkData(bundle, pendingData)
-      ?? (() => {
-        logger.warn(
-          'Payments',
-          `saveUnconfirmedV5Token: failed to synthesize UXF-compatible shape for bundle ${bundle.splitGroupId.slice(0, 12)}, falling back to legacy opaque shape — token will be omitted from bundle CAR but recoverable via PENDING_V5_TOKENS KV`,
-        );
-        return JSON.stringify({ _pendingFinalization: pendingData });
-      })();
+    // wallet-side bookkeeping. The helper returns a discriminated result
+    // so the fallback log carries the underlying error message — silent
+    // regressions in bundle shape are otherwise undiagnosable.
+    let sdkDataJson: string;
+    const syntheticResult = buildSyntheticV5PendingSdkData(bundle, pendingData);
+    if (syntheticResult.ok) {
+      sdkDataJson = syntheticResult.sdkData;
+    } else {
+      logger.warn(
+        'Payments',
+        `saveUnconfirmedV5Token: failed to synthesize UXF-compatible shape for bundle ${bundle.splitGroupId.slice(0, 12)} (${syntheticResult.error}), falling back to legacy opaque shape — token will be omitted from bundle CAR but recoverable via PENDING_V5_TOKENS KV`,
+      );
+      sdkDataJson = JSON.stringify({ _pendingFinalization: pendingData });
+    }
 
     const uiToken: Token = {
       id: deterministicId,
@@ -8270,8 +8275,11 @@ export class PaymentsModule {
 
     // Prefer shape-derived inputs; fall back to bundleJson for legacy
     // entries (pre-#207 opaque shape, or any case where the synthetic
-    // shape is malformed).
-    const inputs = readV5FinalizationInputsFromToken(token.sdkData);
+    // shape is malformed). `inputs` is `let` (not const) so the
+    // SDK-throws-on-shape-derived-input fallback can downgrade to
+    // bundleJson within the same resolve attempt without burning a
+    // full attemptCount cycle.
+    let inputs = readV5FinalizationInputsFromToken(token.sdkData);
     let cachedBundle: InstantSplitBundleV5 | null = null;
     const getBundle = (): InstantSplitBundleV5 => {
       if (cachedBundle === null) {
@@ -8285,15 +8293,28 @@ export class PaymentsModule {
     // from the authenticator's `publicKey` + `stateHash`
     // (deterministic — same as `RequestId.create(publicKey, stateHash)`
     // at commitment-construction time).
+    //
+    // #207 PR-B steelman — if Authenticator.fromJSON or RequestId.create
+    // throw (shape passed our pre-validation but the SDK still rejects),
+    // we MUST NOT burn an attemptCount for the structural failure.
+    // Downgrade to the legacy bundleJson path inside the same attempt.
     const getTransferCommitmentJson = async (): Promise<ITransferCommitmentJson> => {
       if (inputs) {
-        const auth = Authenticator.fromJSON(inputs.transferAuthenticatorJson);
-        const requestId = await RequestId.create(auth.publicKey, auth.stateHash);
-        return {
-          requestId: requestId.toJSON(),
-          transactionData: inputs.transferTransactionDataJson,
-          authenticator: inputs.transferAuthenticatorJson,
-        };
+        try {
+          const auth = Authenticator.fromJSON(inputs.transferAuthenticatorJson);
+          const requestId = await RequestId.create(auth.publicKey, auth.stateHash);
+          return {
+            requestId: requestId.toJSON(),
+            transactionData: inputs.transferTransactionDataJson,
+            authenticator: inputs.transferAuthenticatorJson,
+          };
+        } catch (err) {
+          logger.warn(
+            'Payments',
+            `[V5-RESOLVE] ${tokenId.slice(0, 12)}: shape-derived transferCommitment construction failed (${(err as Error)?.message ?? err}); downgrading to bundleJson fallback`,
+          );
+          inputs = null;
+        }
       }
       return JSON.parse(getBundle().transferCommitment) as ITransferCommitmentJson;
     };
@@ -8493,16 +8514,27 @@ export class PaymentsModule {
 
     // Create transfer transaction. Same lazy-shape-vs-bundle preference
     // as in resolveV5Token: derive requestId from the authenticator if
-    // we have shape inputs.
+    // we have shape inputs. SDK-throw → fall back to bundleJson rather
+    // than failing the whole finalize.
     let transferCommitment: TransferCommitment;
     if (inputs) {
-      const auth = Authenticator.fromJSON(inputs.transferAuthenticatorJson);
-      const requestId = await RequestId.create(auth.publicKey, auth.stateHash);
-      transferCommitment = await TransferCommitment.fromJSON({
-        requestId: requestId.toJSON(),
-        transactionData: inputs.transferTransactionDataJson,
-        authenticator: inputs.transferAuthenticatorJson,
-      });
+      try {
+        const auth = Authenticator.fromJSON(inputs.transferAuthenticatorJson);
+        const requestId = await RequestId.create(auth.publicKey, auth.stateHash);
+        transferCommitment = await TransferCommitment.fromJSON({
+          requestId: requestId.toJSON(),
+          transactionData: inputs.transferTransactionDataJson,
+          authenticator: inputs.transferAuthenticatorJson,
+        });
+      } catch (err) {
+        logger.warn(
+          'Payments',
+          `[V5-RESOLVE] finalize: shape-derived transferCommitment failed (${(err as Error)?.message ?? err}); using bundleJson fallback`,
+        );
+        transferCommitment = await TransferCommitment.fromJSON(
+          JSON.parse(getBundle().transferCommitment),
+        );
+      }
     } else {
       transferCommitment = await TransferCommitment.fromJSON(
         JSON.parse(getBundle().transferCommitment),
@@ -8583,6 +8615,14 @@ export class PaymentsModule {
    * token uses the synthetic `v5split_<groupId>` id. After successful
    * finalize the archived copy is stale and would otherwise linger
    * until the next archive sweep.
+   *
+   * Steelman: the archive map's keys come from
+   * `txf.genesis.data.tokenId` (raw string from the persisted JSON;
+   * UXF doesn't normalize hex casing), while `finalized.id.toJSON()`
+   * returns canonical SDK-formatted hex. To survive a case-mismatch
+   * we look up the entry by scanning the map's keys with normalized
+   * comparison — strictly bounded to a single archived entry per
+   * resolve, so the cost is O(archive size) once per finalize.
    */
   private gcArchivedV5PendingForFinalized(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -8593,13 +8633,34 @@ export class PaymentsModule {
         id?: { toJSON?: () => string };
       }).id?.toJSON?.();
       if (!tokenIdHex) return;
-      const archived = this.archivedTokens.get(tokenIdHex);
-      if (archived === undefined) return;
-      this.archivedTokens.delete(tokenIdHex);
-      logger.debug(
-        'Payments',
-        `[V5-RESOLVE] GC archived V5-pending entry for finalized token ${tokenIdHex.slice(0, 16)}...`,
-      );
+
+      // Fast path: exact match.
+      if (this.archivedTokens.delete(tokenIdHex)) {
+        logger.debug(
+          'Payments',
+          `[V5-RESOLVE] GC archived V5-pending entry for finalized token ${tokenIdHex.slice(0, 16)}...`,
+        );
+        return;
+      }
+
+      // Slow path: case/prefix-tolerant match. Strip `0x` prefix and
+      // lowercase both sides. Only matches the FIRST entry to avoid
+      // accidentally deleting more than one if the archive somehow
+      // contains case-variant duplicates (defensive — shouldn't happen
+      // since `archiveToken` writes whatever the JSON carried, so any
+      // duplicates are themselves a bug worth surfacing).
+      const norm = (s: string): string => s.replace(/^0x/i, '').toLowerCase();
+      const target = norm(tokenIdHex);
+      for (const key of this.archivedTokens.keys()) {
+        if (norm(key) === target) {
+          this.archivedTokens.delete(key);
+          logger.debug(
+            'Payments',
+            `[V5-RESOLVE] GC archived V5-pending entry (case-tolerant match) for finalized token ${tokenIdHex.slice(0, 16)}...`,
+          );
+          return;
+        }
+      }
     } catch {
       // Best-effort — never let GC failure block finalize.
     }
@@ -9423,8 +9484,36 @@ export class PaymentsModule {
   /**
    * Update pending finalization metadata in token's sdkData.
    * Creates a new token object since sdkData is readonly.
+   *
+   * #207 PR-B steelman — Preserve the synthetic V5-pending shape
+   * (genesis.data, state, transactions[0]._wallet.authenticator etc.)
+   * across stage transitions. Pre-fix this method overwrote sdkData
+   * with `{_pendingFinalization: pending}` — wiping the shape after the
+   * RECEIVED → MINT_SUBMITTED transition. Subsequent stages then had to
+   * parse `pending.bundleJson` which fundamentally defeats PR-B's
+   * self-sufficient-UXF goal for CAR-loaded tokens.
+   *
+   * Merge strategy: if existing sdkData is a parseable object, replace
+   * only the `_pendingFinalization` slot. Otherwise emit the legacy
+   * opaque shape (back-compat for any caller that pre-creates the
+   * pending entry without a synthetic shape).
    */
   private updatePendingFinalization(token: Token, pending: PendingV5Finalization): void {
+    let sdkDataJson: string;
+    try {
+      const existing = token.sdkData ? JSON.parse(token.sdkData) : null;
+      if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+        sdkDataJson = JSON.stringify({ ...existing, _pendingFinalization: pending });
+      } else {
+        sdkDataJson = JSON.stringify({ _pendingFinalization: pending });
+      }
+    } catch {
+      // Corrupted sdkData — fall back to legacy opaque shape (avoids
+      // a hard failure mid-resolve; the bundleJson legacy path can
+      // still finalize the token).
+      sdkDataJson = JSON.stringify({ _pendingFinalization: pending });
+    }
+
     const updated: Token = {
       id: token.id,
       coinId: token.coinId,
@@ -9436,7 +9525,7 @@ export class PaymentsModule {
       status: token.status,
       createdAt: token.createdAt,
       updatedAt: Date.now(),
-      sdkData: JSON.stringify({ _pendingFinalization: pending }),
+      sdkData: sdkDataJson,
     };
     this.tokens.set(token.id, updated);
   }

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -270,6 +270,12 @@ import type {
   DirectTokenEntry,
 } from '../../types/instant-split';
 import { isInstantSplitBundle, isInstantSplitBundleV5, isCombinedTransferBundleV6 } from '../../types/instant-split';
+import {
+  buildSyntheticV5PendingSdkData,
+  readV5FinalizationInputsFromToken,
+  type V5FinalizationInputs,
+  type ITransferCommitmentJson,
+} from './v5-pending-shape';
 
 // SDK imports for token parsing and transfers
 import { PredicateEngineService } from '@unicitylabs/state-transition-sdk/lib/predicate/PredicateEngineService';
@@ -289,6 +295,7 @@ import { waitInclusionProof } from '@unicitylabs/state-transition-sdk/lib/util/I
 import { InclusionProof } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof';
 import { TransferTransactionData } from '@unicitylabs/state-transition-sdk/lib/transaction/TransferTransactionData';
 import { RequestId } from '@unicitylabs/state-transition-sdk/lib/api/RequestId';
+import { Authenticator } from '@unicitylabs/state-transition-sdk/lib/api/Authenticator';
 import type { IAddress } from '@unicitylabs/state-transition-sdk/lib/address/IAddress';
 import type { StateTransitionClient } from '@unicitylabs/state-transition-sdk/lib/StateTransitionClient';
 import type { RootTrustBase } from '@unicitylabs/state-transition-sdk/lib/bft/RootTrustBase';
@@ -6223,69 +6230,18 @@ export class PaymentsModule {
     // On any parse failure, fall back to the legacy opaque
     // `{_pendingFinalization: ...}` shape (single-device KV path still
     // recovers the token; bundle CAR omits it as pre-#202).
-    const sdkDataJson = (() => {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const mintDataJson = JSON.parse(bundle.recipientMintData) as Record<string, any>;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const transferCommitmentJson = JSON.parse(bundle.transferCommitment) as Record<string, any>;
-        const mintedTokenState = JSON.parse(bundle.mintedTokenStateJson);
-
-        const transferTxData =
-          transferCommitmentJson.transactionData !== undefined
-            ? transferCommitmentJson.transactionData
-            : transferCommitmentJson.data ?? null;
-
-        // Sender-signed authenticator over the transfer commitment.
-        // Carried inside `_wallet.authenticator` so it survives UXF
-        // round-trip via the new `pending-authenticator` element type.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const transferAuth: any = transferCommitmentJson.authenticator;
-
-        // The transfer commitment's authenticator signs over
-        // (transactionHash, sourceStateHash). The `stateHash` field IS
-        // the source state hash (= hash of `mintedTokenStateJson`).
-        // Carry it as `_integrity.currentStateHash` so the wallet's
-        // (tokenId, stateHash) dedup index produces stable identities
-        // across save/load round-trips for V5-pending tokens.
-        const currentStateHash: string | undefined =
-          transferAuth && typeof transferAuth === 'object' && typeof transferAuth.stateHash === 'string'
-            ? transferAuth.stateHash
-            : undefined;
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const syntheticPendingTx: Record<string, any> = {
-          data: transferTxData,
-          inclusionProof: null,
-        };
-        if (transferAuth && typeof transferAuth === 'object') {
-          syntheticPendingTx._wallet = { authenticator: transferAuth };
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const syntheticTxf: Record<string, any> = {
-          version: '2.0',
-          state: mintedTokenState,
-          genesis: {
-            data: mintDataJson,
-            inclusionProof: null,
-          },
-          transactions: transferTxData !== null ? [syntheticPendingTx] : [],
-          nametags: [],
-          _pendingFinalization: pendingData,
-        };
-        if (currentStateHash) {
-          syntheticTxf._integrity = { currentStateHash };
-        }
-        return JSON.stringify(syntheticTxf);
-      } catch (err) {
+    //
+    // #207 PR-B — helper extracted to `v5-pending-shape.ts` for unit
+    // testability + clear separation of pure shape-construction from
+    // wallet-side bookkeeping.
+    const sdkDataJson = buildSyntheticV5PendingSdkData(bundle, pendingData)
+      ?? (() => {
         logger.warn(
           'Payments',
-          `saveUnconfirmedV5Token: failed to synthesize UXF-compatible shape for bundle ${bundle.splitGroupId.slice(0, 12)}, falling back to legacy opaque shape — token will be omitted from bundle CAR but recoverable via PENDING_V5_TOKENS KV: ${(err as Error)?.message ?? err}`,
+          `saveUnconfirmedV5Token: failed to synthesize UXF-compatible shape for bundle ${bundle.splitGroupId.slice(0, 12)}, falling back to legacy opaque shape — token will be omitted from bundle CAR but recoverable via PENDING_V5_TOKENS KV`,
         );
         return JSON.stringify({ _pendingFinalization: pendingData });
-      }
-    })();
+      })();
 
     const uiToken: Token = {
       id: deterministicId,
@@ -8289,6 +8245,17 @@ export class PaymentsModule {
 
   /**
    * Process a single V5 token through its finalization stages with quick-timeout proof checks.
+   *
+   * #207 PR-B — Reads finalization inputs directly from the synthetic
+   * token shape (mint data from `genesis.data`, transfer commitment
+   * fields from `transactions[0].data` + `transactions[0]._wallet.authenticator`)
+   * so a Nostr-shipped UXF bundle is self-sufficient and can drive
+   * cross-device V5 finalization without depending on OrbitDB OpLog
+   * replication of `PENDING_V5_TOKENS`.
+   *
+   * The legacy `pending.bundleJson` is parsed lazily — only if the
+   * synthetic shape is missing fields (e.g. tokens persisted before #207
+   * with the legacy opaque shape `{_pendingFinalization: ...}`).
    */
   private async resolveV5Token(
     tokenId: string,
@@ -8298,15 +8265,44 @@ export class PaymentsModule {
     trustBase: RootTrustBase,
     signingService: SigningService
   ): Promise<'resolved' | 'pending' | 'failed'> {
-    const bundle: InstantSplitBundleV5 = JSON.parse(pending.bundleJson);
     pending.attemptCount++;
     pending.lastAttemptAt = Date.now();
+
+    // Prefer shape-derived inputs; fall back to bundleJson for legacy
+    // entries (pre-#207 opaque shape, or any case where the synthetic
+    // shape is malformed).
+    const inputs = readV5FinalizationInputsFromToken(token.sdkData);
+    let cachedBundle: InstantSplitBundleV5 | null = null;
+    const getBundle = (): InstantSplitBundleV5 => {
+      if (cachedBundle === null) {
+        cachedBundle = JSON.parse(pending.bundleJson) as InstantSplitBundleV5;
+      }
+      return cachedBundle;
+    };
+
+    // Helper: produce a canonical `ITransferCommitmentJson` for
+    // `TransferCommitment.fromJSON`. The shape-path derives `requestId`
+    // from the authenticator's `publicKey` + `stateHash`
+    // (deterministic — same as `RequestId.create(publicKey, stateHash)`
+    // at commitment-construction time).
+    const getTransferCommitmentJson = async (): Promise<ITransferCommitmentJson> => {
+      if (inputs) {
+        const auth = Authenticator.fromJSON(inputs.transferAuthenticatorJson);
+        const requestId = await RequestId.create(auth.publicKey, auth.stateHash);
+        return {
+          requestId: requestId.toJSON(),
+          transactionData: inputs.transferTransactionDataJson,
+          authenticator: inputs.transferAuthenticatorJson,
+        };
+      }
+      return JSON.parse(getBundle().transferCommitment) as ITransferCommitmentJson;
+    };
 
     try {
       // Stage: RECEIVED → MINT_SUBMITTED
       if (pending.stage === 'RECEIVED') {
         logger.debug('Payments', `[V5-RESOLVE] ${tokenId.slice(0, 12)}: RECEIVED → submitting mint commitment...`);
-        const mintDataJson = JSON.parse(bundle.recipientMintData);
+        const mintDataJson = inputs?.mintDataJson ?? JSON.parse(getBundle().recipientMintData);
         const mintData = await MintTransactionData.fromJSON(mintDataJson);
         const mintCommitment = await MintCommitment.create(mintData);
         const mintResponse = await stClient.submitMintCommitment(mintCommitment);
@@ -8321,7 +8317,7 @@ export class PaymentsModule {
       // Stage: MINT_SUBMITTED → MINT_PROVEN
       if (pending.stage === 'MINT_SUBMITTED') {
         logger.debug('Payments', `[V5-RESOLVE] ${tokenId.slice(0, 12)}: MINT_SUBMITTED → checking mint proof...`);
-        const mintDataJson = JSON.parse(bundle.recipientMintData);
+        const mintDataJson = inputs?.mintDataJson ?? JSON.parse(getBundle().recipientMintData);
         const mintData = await MintTransactionData.fromJSON(mintDataJson);
         const mintCommitment = await MintCommitment.create(mintData);
         const proof = await this.quickProofCheck(stClient, trustBase, mintCommitment);
@@ -8339,7 +8335,7 @@ export class PaymentsModule {
       // Stage: MINT_PROVEN → TRANSFER_SUBMITTED
       if (pending.stage === 'MINT_PROVEN') {
         logger.debug('Payments', `[V5-RESOLVE] ${tokenId.slice(0, 12)}: MINT_PROVEN → submitting transfer commitment...`);
-        const transferCommitmentJson = JSON.parse(bundle.transferCommitment);
+        const transferCommitmentJson = await getTransferCommitmentJson();
         const transferCommitment = await TransferCommitment.fromJSON(transferCommitmentJson);
         const transferResponse = await stClient.submitTransferCommitment(transferCommitment);
         logger.debug('Payments', `[V5-RESOLVE] ${tokenId.slice(0, 12)}: transfer response status=${transferResponse.status}`);
@@ -8353,7 +8349,7 @@ export class PaymentsModule {
       // Stage: TRANSFER_SUBMITTED → FINALIZED
       if (pending.stage === 'TRANSFER_SUBMITTED') {
         logger.debug('Payments', `[V5-RESOLVE] ${tokenId.slice(0, 12)}: TRANSFER_SUBMITTED → checking transfer proof...`);
-        const transferCommitmentJson = JSON.parse(bundle.transferCommitment);
+        const transferCommitmentJson = await getTransferCommitmentJson();
         const transferCommitment = await TransferCommitment.fromJSON(transferCommitmentJson);
         const proof = await this.quickProofCheck(stClient, trustBase, transferCommitment);
         if (!proof) {
@@ -8364,7 +8360,14 @@ export class PaymentsModule {
         logger.debug('Payments', `[V5-RESOLVE] ${tokenId.slice(0, 12)}: transfer proof obtained! Finalizing...`);
 
         // Finalize: reconstruct minted token, create recipient state, finalize
-        const finalizedToken = await this.finalizeFromV5Bundle(bundle, pending, signingService, stClient, trustBase);
+        const finalizedToken = await this.finalizeFromV5Inputs(
+          inputs,
+          getBundle,
+          pending,
+          signingService,
+          stClient,
+          trustBase,
+        );
 
         // Replace token with confirmed version containing real SDK data
         const confirmedToken: Token = {
@@ -8381,6 +8384,14 @@ export class PaymentsModule {
           sdkData: JSON.stringify(finalizedToken.toJSON()),
         };
         this.tokens.set(tokenId, confirmedToken);
+
+        // #207 PR-B — Archive GC. If the CAR-loaded archived copy at
+        // archivedTokens[actualTokenId] is still present (cross-device
+        // sync produced a separate token entry under the real on-chain
+        // tokenId, distinct from this resolution token's `v5split_*`
+        // id), drop it: the active in-memory token is now the
+        // confirmed authority.
+        this.gcArchivedV5PendingForFinalized(finalizedToken);
 
         // Spend Queue: cache newly confirmed token and wake queued entries
         const resolvedAmount = this.extractCoinAmountForCache(finalizedToken, confirmedToken.coinId);
@@ -8440,11 +8451,17 @@ export class PaymentsModule {
   }
 
   /**
-   * Perform V5 bundle finalization from stored bundle data and proofs.
-   * Extracted from InstantSplitProcessor.processV5Bundle() steps 4-10.
+   * Perform V5 bundle finalization. Extracted from
+   * InstantSplitProcessor.processV5Bundle() steps 4-10.
+   *
+   * #207 PR-B — Reads inputs from the synthetic token shape (preferred)
+   * with lazy fallback to `pending.bundleJson` for legacy entries OR for
+   * fields not yet carried in the synthetic shape (currently the PROXY
+   * recipient's nametag token JSON).
    */
-  private async finalizeFromV5Bundle(
-    bundle: InstantSplitBundleV5,
+  private async finalizeFromV5Inputs(
+    inputs: V5FinalizationInputs | null,
+    getBundle: () => InstantSplitBundleV5,
     pending: PendingV5Finalization,
     signingService: SigningService,
     stClient: StateTransitionClient,
@@ -8452,15 +8469,17 @@ export class PaymentsModule {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<SdkToken<any>> {
     // Reconstruct minted token from bundle data
-    const mintDataJson = JSON.parse(bundle.recipientMintData);
+    const mintDataJson = inputs?.mintDataJson ?? JSON.parse(getBundle().recipientMintData);
     const mintData = await MintTransactionData.fromJSON(mintDataJson);
     const mintCommitment = await MintCommitment.create(mintData);
     const mintProofJson = JSON.parse(pending.mintProofJson!);
     const mintProof = InclusionProof.fromJSON(mintProofJson);
     const mintTransaction = mintCommitment.toTransaction(mintProof);
 
-    const tokenType = new TokenType(fromHex(bundle.tokenTypeHex));
-    const senderMintedStateJson = JSON.parse(bundle.mintedTokenStateJson);
+    const tokenTypeHex = inputs?.tokenTypeHex ?? getBundle().tokenTypeHex;
+    const tokenType = new TokenType(fromHex(tokenTypeHex));
+    const senderMintedStateJson = inputs?.mintedTokenStateJson
+      ?? JSON.parse(getBundle().mintedTokenStateJson);
 
     const tokenJson = {
       version: '2.0',
@@ -8472,14 +8491,29 @@ export class PaymentsModule {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mintedToken = await SdkToken.fromJSON(tokenJson) as SdkToken<any>;
 
-    // Create transfer transaction
-    const transferCommitmentJson = JSON.parse(bundle.transferCommitment);
-    const transferCommitment = await TransferCommitment.fromJSON(transferCommitmentJson);
+    // Create transfer transaction. Same lazy-shape-vs-bundle preference
+    // as in resolveV5Token: derive requestId from the authenticator if
+    // we have shape inputs.
+    let transferCommitment: TransferCommitment;
+    if (inputs) {
+      const auth = Authenticator.fromJSON(inputs.transferAuthenticatorJson);
+      const requestId = await RequestId.create(auth.publicKey, auth.stateHash);
+      transferCommitment = await TransferCommitment.fromJSON({
+        requestId: requestId.toJSON(),
+        transactionData: inputs.transferTransactionDataJson,
+        authenticator: inputs.transferAuthenticatorJson,
+      });
+    } else {
+      transferCommitment = await TransferCommitment.fromJSON(
+        JSON.parse(getBundle().transferCommitment),
+      );
+    }
     const transferProof = await waitInclusionProof(trustBase, stClient, transferCommitment);
     const transferTransaction = transferCommitment.toTransaction(transferProof);
 
     // Create recipient state
-    const transferSalt = fromHex(bundle.transferSaltHex);
+    const transferSaltHex = inputs?.transferSaltHex ?? getBundle().transferSaltHex;
+    const transferSalt = fromHex(transferSaltHex);
     const recipientPredicate = await UnmaskedPredicate.create(
       mintData.tokenId,
       tokenType,
@@ -8492,14 +8526,24 @@ export class PaymentsModule {
     // Handle nametag tokens for PROXY addresses
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let nametagTokens: SdkToken<any>[] = [];
-    const recipientAddressStr = bundle.recipientAddressJson;
+    const recipientAddressStr = inputs?.recipientAddress ?? getBundle().recipientAddressJson;
 
     if (recipientAddressStr.startsWith('PROXY://')) {
-      // Try to get nametag token from bundle first
-      if (bundle.nametagTokenJson) {
+      // Try to get nametag token from bundle first. (#207 PR-B follow-up:
+      // the nametag token isn't yet carried in the synthetic token shape
+      // because UXF doesn't preserve nested wallet-internal Token JSON.
+      // For PROXY recipients we still need the bundleJson — graceful
+      // fallback below to a local nametag covers most real-world cases.)
+      let nametagTokenJson: string | undefined;
+      try {
+        nametagTokenJson = getBundle().nametagTokenJson;
+      } catch {
+        nametagTokenJson = undefined;
+      }
+      if (nametagTokenJson) {
         try {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const nametagToken = await SdkToken.fromJSON(JSON.parse(bundle.nametagTokenJson)) as SdkToken<any>;
+          const nametagToken = await SdkToken.fromJSON(JSON.parse(nametagTokenJson)) as SdkToken<any>;
           const { ProxyAddress } = await import('@unicitylabs/state-transition-sdk/lib/address/ProxyAddress');
           const proxy = await ProxyAddress.fromTokenId(nametagToken.id);
           if (proxy.address === recipientAddressStr) {
@@ -8532,15 +8576,53 @@ export class PaymentsModule {
   }
 
   /**
+   * #207 PR-B — Garbage-collect the CAR-loaded archived V5-pending entry
+   * once the active resolution token finalizes. Cross-device sync
+   * produces a token entry under the real on-chain tokenId (extracted
+   * by `extractTokenIdFromSdkData`), while the in-process resolution
+   * token uses the synthetic `v5split_<groupId>` id. After successful
+   * finalize the archived copy is stale and would otherwise linger
+   * until the next archive sweep.
+   */
+  private gcArchivedV5PendingForFinalized(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    finalized: SdkToken<any>,
+  ): void {
+    try {
+      const tokenIdHex: string | undefined = (finalized as unknown as {
+        id?: { toJSON?: () => string };
+      }).id?.toJSON?.();
+      if (!tokenIdHex) return;
+      const archived = this.archivedTokens.get(tokenIdHex);
+      if (archived === undefined) return;
+      this.archivedTokens.delete(tokenIdHex);
+      logger.debug(
+        'Payments',
+        `[V5-RESOLVE] GC archived V5-pending entry for finalized token ${tokenIdHex.slice(0, 16)}...`,
+      );
+    } catch {
+      // Best-effort — never let GC failure block finalize.
+    }
+  }
+
+  /**
    * #144 L2/L3 — does this token look like a V6-direct received-but-
    * not-finalized token? Conditions:
    *   1. sdkData parses as TXF with transactions
    *   2. last tx has `inclusionProof === null`
-   *   3. last tx's `data.recipient.address` resolves to our wallet
+   *   3. last tx's `data.recipient` resolves to our wallet
    *      (DIRECT://<our> or PROXY://<our-nametag>)
    *
    * Used by `resolveUnconfirmed` and `recoverStrandedReceivedTokens` to
    * distinguish stranded receives from sends and from other shapes.
+   *
+   * #207 PR-B — `data.recipient` is canonically a string in the SDK
+   * (`ITransferTransactionDataJson.recipient: string`), but legacy
+   * wallet-local serializations sometimes wrapped it as `{address:
+   * string}`. Accept both shapes. Without the string-form branch the
+   * check returned false for every CAR-loaded V5-pending token (the
+   * canonical SDK shape) and the balance-model invariant in
+   * `loadFromStorageData` archived them.
    */
   private isReceivedLegacyPending(token: Token): boolean {
     if (!token.sdkData) return false;
@@ -8555,7 +8637,7 @@ export class PaymentsModule {
     if (!Array.isArray(txs) || txs.length === 0) return false;
     const lastTx = txs[txs.length - 1] as {
       inclusionProof?: unknown;
-      data?: { recipient?: { address?: string } };
+      data?: { recipient?: string | { address?: string } };
     };
     // Canonical default: missing inclusionProof === null (the V5/V6 protocol
     // treats both `inclusionProof: null` and the absence of the field as
@@ -8566,7 +8648,13 @@ export class PaymentsModule {
     // invariant in `loadFromStorageData`.
     const proof = lastTx.inclusionProof === undefined ? null : lastTx.inclusionProof;
     if (proof !== null) return false;
-    const recipientAddr = lastTx.data?.recipient?.address;
+    const recipientField = lastTx.data?.recipient;
+    const recipientAddr =
+      typeof recipientField === 'string'
+        ? recipientField
+        : (recipientField && typeof recipientField === 'object'
+            ? recipientField.address
+            : undefined);
     if (typeof recipientAddr !== 'string') return false;
 
     // DIRECT match — `identity.directAddress` is normalized to
@@ -9075,13 +9163,22 @@ export class PaymentsModule {
     //   (b) meant for someone else (in which case applying our predicate
     //       would corrupt the chain and the SDK would reject it
     //       downstream, but only after on-chain side-effects).
-    // Distinguish by inspecting the transfer transaction's
-    // `data.recipient.address` — only proceed when it matches one of
-    // OUR destination addresses:
+    // Distinguish by inspecting the transfer transaction's `data.recipient`
+    // — only proceed when it matches one of OUR destination addresses:
     //   - identity.directAddress (DIRECT:// scheme), OR
     //   - any PROXY:// derived from a nametag we hold (handled via
     //     `proxyAddressCache`, primed at load time from `this.nametags`).
-    const recipientAddr: unknown = lastTxJson.data?.recipient?.address;
+    //
+    // #207 PR-B — `recipient` is canonically a string in the SDK shape;
+    // legacy wallet-local serializations sometimes wrap it as
+    // `{address: string}`. Accept both.
+    const recipientField: unknown = lastTxJson.data?.recipient;
+    const recipientAddr: unknown =
+      typeof recipientField === 'string'
+        ? recipientField
+        : (recipientField && typeof recipientField === 'object'
+            ? (recipientField as { address?: unknown }).address
+            : undefined);
     if (typeof recipientAddr !== 'string' || recipientAddr.length === 0) {
       return 'skipped';
     }

--- a/modules/payments/v5-pending-shape.ts
+++ b/modules/payments/v5-pending-shape.ts
@@ -1,0 +1,265 @@
+/**
+ * #207 PR-B — V5-pending synthetic token-shape helpers.
+ *
+ * Two pure functions:
+ *
+ *   - `buildSyntheticV5PendingSdkData(bundle, pendingData)` — produces the
+ *     UXF/TXF-valid sdkData JSON string for a V5-pending token. Mirrors the
+ *     shape that `finalizeFromV5Bundle()` produces post-finalization but
+ *     with `inclusionProof: null` on both genesis (mint not yet proven)
+ *     and the synthetic transfer transaction (transfer commitment not yet
+ *     proven). Returns `null` on parse failure — caller falls back to the
+ *     legacy opaque `{ _pendingFinalization: ... }` shape.
+ *
+ *   - `readV5FinalizationInputsFromToken(sdkData)` — extracts the fields
+ *     needed by `resolveV5Token` from a token's sdkData (the synthetic
+ *     shape). Returns `null` if the token doesn't have the synthetic
+ *     shape; caller falls back to parsing `pending.bundleJson`.
+ *
+ * Extracted from PaymentsModule.ts:6226-6288 (IIFE) for unit testability.
+ */
+import type { IAuthenticatorJson } from '@unicitylabs/state-transition-sdk/lib/api/Authenticator';
+import type { IMintTransactionDataJson } from '@unicitylabs/state-transition-sdk/lib/transaction/MintTransactionData';
+import type { ITransferTransactionDataJson } from '@unicitylabs/state-transition-sdk/lib/transaction/TransferTransactionData';
+import type { ITokenStateJson } from '@unicitylabs/state-transition-sdk/lib/token/TokenState';
+import type { InstantSplitBundleV5, PendingV5Finalization } from '../../types/instant-split';
+
+/**
+ * Canonical JSON shape of `TransferCommitment.toJSON()`. Re-declared here
+ * because the SDK does not export the interface (only the class).
+ */
+export interface ITransferCommitmentJson {
+  readonly requestId: string;
+  readonly transactionData: ITransferTransactionDataJson;
+  readonly authenticator: IAuthenticatorJson;
+}
+
+/**
+ * Inputs `resolveV5Token` needs to drive finalization. Sourced from the
+ * synthetic token shape directly (preferred) or by parsing the legacy
+ * `pending.bundleJson` (back-compat for entries persisted pre-#207).
+ */
+export interface V5FinalizationInputs {
+  /** Recipient mint transaction data — `MintTransactionData.fromJSON(this)` */
+  readonly mintDataJson: IMintTransactionDataJson;
+  /**
+   * Transfer commitment JSON suitable for
+   * `TransferCommitment.fromJSON({ requestId, transactionData, authenticator })`.
+   * When sourced from the token shape, `requestId` is derived at submit
+   * time from `authenticator.publicKey` + `authenticator.stateHash` and
+   * is NOT carried here. Callers use the helper
+   * {@link buildTransferCommitmentJson} to construct the canonical JSON.
+   */
+  readonly transferTransactionDataJson: ITransferTransactionDataJson;
+  readonly transferAuthenticatorJson: IAuthenticatorJson;
+  /** Minted token state JSON — used to reconstruct the intermediate sender-owned token. */
+  readonly mintedTokenStateJson: ITokenStateJson;
+  /** Token type hex — derivable from mintDataJson.tokenType. */
+  readonly tokenTypeHex: string;
+  /** Transfer salt hex — derivable from transferTransactionDataJson.salt. */
+  readonly transferSaltHex: string;
+  /** Recipient address (DIRECT://... or PROXY://...). */
+  readonly recipientAddress: string;
+}
+
+/**
+ * Synthetic token shape produced by {@link buildSyntheticV5PendingSdkData}.
+ * Exported for the shape-reader and unit tests.
+ */
+export interface SyntheticV5PendingTxf {
+  readonly version: '2.0';
+  readonly state: ITokenStateJson;
+  readonly genesis: {
+    readonly data: IMintTransactionDataJson;
+    readonly inclusionProof: null;
+  };
+  readonly transactions: ReadonlyArray<{
+    readonly data: ITransferTransactionDataJson;
+    readonly inclusionProof: null;
+    readonly _wallet?: { readonly authenticator: IAuthenticatorJson };
+  }>;
+  readonly nametags: ReadonlyArray<unknown>;
+  readonly _pendingFinalization?: PendingV5Finalization;
+  readonly _integrity?: { readonly currentStateHash: string };
+}
+
+/**
+ * Construct the UXF/TXF-valid sdkData for a V5-pending token from a V5
+ * bundle. Returns the JSON string, or `null` if the bundle is malformed
+ * (caller logs + falls back to the legacy opaque shape).
+ *
+ * The transfer commitment's authenticator rides as
+ * `transactions[0]._wallet.authenticator` so it survives UXF round-trip
+ * via the new `pending-authenticator` element type (#202 schema).
+ *
+ * `_integrity.currentStateHash` is set from the transfer authenticator's
+ * `stateHash` (= the source state hash of the transfer = hash of the
+ * minted token state). The wallet's (tokenId, stateHash) dedup index
+ * uses this for stable identity across save/load.
+ */
+export function buildSyntheticV5PendingSdkData(
+  bundle: InstantSplitBundleV5,
+  pendingData: PendingV5Finalization,
+): string | null {
+  try {
+    const mintDataJson = JSON.parse(bundle.recipientMintData) as IMintTransactionDataJson;
+    const transferCommitmentJson = JSON.parse(bundle.transferCommitment) as ITransferCommitmentJson;
+    const mintedTokenState = JSON.parse(bundle.mintedTokenStateJson) as ITokenStateJson;
+
+    // The on-chain transactionData lives under either `transactionData`
+    // (canonical) or `data` (legacy). Tolerate both for safety.
+    const transferTxData =
+      transferCommitmentJson.transactionData !== undefined
+        ? transferCommitmentJson.transactionData
+        : ((transferCommitmentJson as unknown as { data?: ITransferTransactionDataJson }).data
+            ?? null);
+
+    if (transferTxData === null) {
+      return null;
+    }
+
+    const transferAuth: IAuthenticatorJson | undefined =
+      transferCommitmentJson.authenticator
+        && typeof transferCommitmentJson.authenticator === 'object'
+        ? transferCommitmentJson.authenticator
+        : undefined;
+
+    const currentStateHash: string | undefined =
+      transferAuth && typeof transferAuth.stateHash === 'string'
+        ? transferAuth.stateHash
+        : undefined;
+
+    const syntheticPendingTx: {
+      data: ITransferTransactionDataJson;
+      inclusionProof: null;
+      _wallet?: { authenticator: IAuthenticatorJson };
+    } = {
+      data: transferTxData,
+      inclusionProof: null,
+    };
+    if (transferAuth !== undefined) {
+      syntheticPendingTx._wallet = { authenticator: transferAuth };
+    }
+
+    const syntheticTxf: SyntheticV5PendingTxf & {
+      _pendingFinalization: PendingV5Finalization;
+      _integrity?: { currentStateHash: string };
+    } = {
+      version: '2.0',
+      state: mintedTokenState,
+      genesis: {
+        data: mintDataJson,
+        inclusionProof: null,
+      },
+      transactions: [syntheticPendingTx],
+      nametags: [],
+      _pendingFinalization: pendingData,
+    };
+    if (currentStateHash !== undefined) {
+      syntheticTxf._integrity = { currentStateHash };
+    }
+
+    return JSON.stringify(syntheticTxf);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reconstruct the canonical `TransferCommitment.toJSON()` shape from the
+ * synthetic token's transfer transaction data + authenticator.
+ *
+ * `TransferCommitment.fromJSON` requires `{requestId, transactionData,
+ * authenticator}`. The `requestId` is deterministically derivable from
+ * `authenticator.publicKey` + `authenticator.stateHash` via
+ * `RequestId.create(publicKey, stateHash)`. We pass the empty-string
+ * sentinel here and let the caller derive it via RequestId.create —
+ * inlining requires SDK side-effects we don't want in a pure helper.
+ *
+ * In practice callers don't need this helper because the synthetic
+ * shape's authenticator carries the same fields. Kept as a placeholder
+ * for the documentation of the shape mapping.
+ */
+export function buildTransferCommitmentJson(
+  transactionData: ITransferTransactionDataJson,
+  authenticator: IAuthenticatorJson,
+  requestId: string,
+): ITransferCommitmentJson {
+  return { requestId, transactionData, authenticator };
+}
+
+/**
+ * Read V5 finalization inputs from the synthetic token shape.
+ *
+ * Returns `null` if:
+ *   - sdkData is not parseable as JSON
+ *   - genesis / state / transactions[0] are absent or malformed
+ *   - transactions[0]._wallet.authenticator is missing (no sender-signed
+ *     authenticator means we can't re-submit the transfer commitment)
+ *
+ * Callers fall back to parsing `pending.bundleJson` on null.
+ */
+export function readV5FinalizationInputsFromToken(
+  sdkData: string | null | undefined,
+): V5FinalizationInputs | null {
+  if (!sdkData || typeof sdkData !== 'string') return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(sdkData);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const root = parsed as {
+    state?: unknown;
+    genesis?: { data?: unknown; inclusionProof?: unknown };
+    transactions?: unknown[];
+  };
+
+  const mintDataJson = root.genesis?.data as IMintTransactionDataJson | undefined;
+  if (!mintDataJson || typeof mintDataJson !== 'object') return null;
+  if (typeof mintDataJson.tokenType !== 'string') return null;
+
+  const mintedTokenStateJson = root.state as ITokenStateJson | undefined;
+  if (!mintedTokenStateJson || typeof mintedTokenStateJson !== 'object') return null;
+
+  if (!Array.isArray(root.transactions) || root.transactions.length === 0) return null;
+  const tx0 = root.transactions[0] as {
+    data?: ITransferTransactionDataJson;
+    _wallet?: { authenticator?: IAuthenticatorJson };
+  } | undefined;
+  if (!tx0 || typeof tx0 !== 'object') return null;
+
+  const transferTransactionDataJson = tx0.data;
+  if (!transferTransactionDataJson || typeof transferTransactionDataJson !== 'object') {
+    return null;
+  }
+  if (
+    typeof transferTransactionDataJson.recipient !== 'string'
+    || typeof transferTransactionDataJson.salt !== 'string'
+  ) {
+    return null;
+  }
+
+  const transferAuthenticatorJson = tx0._wallet?.authenticator;
+  if (
+    !transferAuthenticatorJson
+    || typeof transferAuthenticatorJson !== 'object'
+    || typeof transferAuthenticatorJson.publicKey !== 'string'
+    || typeof transferAuthenticatorJson.stateHash !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    mintDataJson,
+    transferTransactionDataJson,
+    transferAuthenticatorJson,
+    mintedTokenStateJson,
+    tokenTypeHex: mintDataJson.tokenType,
+    transferSaltHex: transferTransactionDataJson.salt,
+    recipientAddress: transferTransactionDataJson.recipient,
+  };
+}

--- a/modules/payments/v5-pending-shape.ts
+++ b/modules/payments/v5-pending-shape.ts
@@ -84,9 +84,20 @@ export interface SyntheticV5PendingTxf {
 }
 
 /**
+ * Result of {@link buildSyntheticV5PendingSdkData}. Discriminated by `ok`.
+ * On failure the `error` field carries a short reason for the log line —
+ * the caller's fallback warning embeds it so post-hoc diagnosis of
+ * silent regressions is possible.
+ */
+export type BuildSyntheticResult =
+  | { readonly ok: true; readonly sdkData: string }
+  | { readonly ok: false; readonly error: string };
+
+/**
  * Construct the UXF/TXF-valid sdkData for a V5-pending token from a V5
- * bundle. Returns the JSON string, or `null` if the bundle is malformed
- * (caller logs + falls back to the legacy opaque shape).
+ * bundle. Returns `{ok: true, sdkData}` on success, `{ok: false,
+ * error}` if the bundle is malformed (caller logs + falls back to the
+ * legacy opaque shape).
  *
  * The transfer commitment's authenticator rides as
  * `transactions[0]._wallet.authenticator` so it survives UXF round-trip
@@ -100,7 +111,7 @@ export interface SyntheticV5PendingTxf {
 export function buildSyntheticV5PendingSdkData(
   bundle: InstantSplitBundleV5,
   pendingData: PendingV5Finalization,
-): string | null {
+): BuildSyntheticResult {
   try {
     const mintDataJson = JSON.parse(bundle.recipientMintData) as IMintTransactionDataJson;
     const transferCommitmentJson = JSON.parse(bundle.transferCommitment) as ITransferCommitmentJson;
@@ -115,7 +126,7 @@ export function buildSyntheticV5PendingSdkData(
             ?? null);
 
     if (transferTxData === null) {
-      return null;
+      return { ok: false, error: 'transferCommitment missing transactionData (and legacy data)' };
     }
 
     const transferAuth: IAuthenticatorJson | undefined =
@@ -159,9 +170,9 @@ export function buildSyntheticV5PendingSdkData(
       syntheticTxf._integrity = { currentStateHash };
     }
 
-    return JSON.stringify(syntheticTxf);
-  } catch {
-    return null;
+    return { ok: true, sdkData: JSON.stringify(syntheticTxf) };
+  } catch (err) {
+    return { ok: false, error: (err as Error)?.message ?? String(err) };
   }
 }
 
@@ -188,16 +199,37 @@ export function buildTransferCommitmentJson(
   return { requestId, transactionData, authenticator };
 }
 
+/** Length of a compressed secp256k1 pubkey in hex characters (33 bytes × 2). */
+const SECP256K1_PUBKEY_HEX_LEN = 66;
+/** Hex regex (any case, any length ≥ 1). */
+const HEX_RE = /^[0-9a-fA-F]+$/;
+
 /**
  * Read V5 finalization inputs from the synthetic token shape.
  *
- * Returns `null` if:
- *   - sdkData is not parseable as JSON
- *   - genesis / state / transactions[0] are absent or malformed
- *   - transactions[0]._wallet.authenticator is missing (no sender-signed
- *     authenticator means we can't re-submit the transfer commitment)
+ * Returns `null` if any of the following hold:
+ *   - sdkData is not parseable as JSON or is not an object
+ *   - `genesis` is absent OR `genesis.inclusionProof` is non-null
+ *     (defense: if the mint is already proven, the shape-driven
+ *     re-submission path is unsafe — the legacy bundleJson path or a
+ *     normal load-time finalize should handle the token)
+ *   - `genesis.data` is missing or doesn't carry well-formed hex
+ *     `tokenId` / `tokenType`
+ *   - `transactions[0]` is absent OR its inclusionProof is non-null
+ *   - `transactions[0].data` is missing recipient (non-empty string)
+ *     or salt (hex string)
+ *   - `transactions[0]._wallet.authenticator` is missing OR has a
+ *     malformed shape (wrong types, non-hex fields, wrong publicKey
+ *     byte-length for secp256k1)
  *
  * Callers fall back to parsing `pending.bundleJson` on null.
+ *
+ * #207 PR-B steelman — Pre-validation here means the downstream
+ * `Authenticator.fromJSON` / `MintTransactionData.fromJSON` calls in
+ * `resolveV5Token` only ever see well-formed input. A structural
+ * defect (wrong key length, missing field, etc.) returns null here so
+ * the caller falls back to bundleJson instead of crashing inside the
+ * SDK and burning attemptCount budget.
  */
 export function readV5FinalizationInputsFromToken(
   sdkData: string | null | undefined,
@@ -218,9 +250,21 @@ export function readV5FinalizationInputsFromToken(
     transactions?: unknown[];
   };
 
-  const mintDataJson = root.genesis?.data as IMintTransactionDataJson | undefined;
+  // Both inclusion proofs MUST be null. Anything else means the
+  // transition is past the pending stage and resubmission is unsafe.
+  if (root.genesis === undefined || root.genesis === null || typeof root.genesis !== 'object') {
+    return null;
+  }
+  if (root.genesis.inclusionProof !== null) return null;
+
+  const mintDataJson = root.genesis.data as IMintTransactionDataJson | undefined;
   if (!mintDataJson || typeof mintDataJson !== 'object') return null;
-  if (typeof mintDataJson.tokenType !== 'string') return null;
+  if (typeof mintDataJson.tokenType !== 'string' || !HEX_RE.test(mintDataJson.tokenType)) {
+    return null;
+  }
+  if (typeof mintDataJson.tokenId !== 'string' || !HEX_RE.test(mintDataJson.tokenId)) {
+    return null;
+  }
 
   const mintedTokenStateJson = root.state as ITokenStateJson | undefined;
   if (!mintedTokenStateJson || typeof mintedTokenStateJson !== 'object') return null;
@@ -228,9 +272,11 @@ export function readV5FinalizationInputsFromToken(
   if (!Array.isArray(root.transactions) || root.transactions.length === 0) return null;
   const tx0 = root.transactions[0] as {
     data?: ITransferTransactionDataJson;
+    inclusionProof?: unknown;
     _wallet?: { authenticator?: IAuthenticatorJson };
   } | undefined;
   if (!tx0 || typeof tx0 !== 'object') return null;
+  if (tx0.inclusionProof !== null) return null;
 
   const transferTransactionDataJson = tx0.data;
   if (!transferTransactionDataJson || typeof transferTransactionDataJson !== 'object') {
@@ -238,7 +284,9 @@ export function readV5FinalizationInputsFromToken(
   }
   if (
     typeof transferTransactionDataJson.recipient !== 'string'
+    || transferTransactionDataJson.recipient.length === 0
     || typeof transferTransactionDataJson.salt !== 'string'
+    || !HEX_RE.test(transferTransactionDataJson.salt)
   ) {
     return null;
   }
@@ -247,8 +295,14 @@ export function readV5FinalizationInputsFromToken(
   if (
     !transferAuthenticatorJson
     || typeof transferAuthenticatorJson !== 'object'
+    || typeof transferAuthenticatorJson.algorithm !== 'string'
+    || typeof transferAuthenticatorJson.signature !== 'string'
     || typeof transferAuthenticatorJson.publicKey !== 'string'
     || typeof transferAuthenticatorJson.stateHash !== 'string'
+    || !HEX_RE.test(transferAuthenticatorJson.publicKey)
+    || transferAuthenticatorJson.publicKey.length !== SECP256K1_PUBKEY_HEX_LEN
+    || !HEX_RE.test(transferAuthenticatorJson.signature)
+    || !HEX_RE.test(transferAuthenticatorJson.stateHash)
   ) {
     return null;
   }

--- a/tests/unit/modules/v5-pending-shape.test.ts
+++ b/tests/unit/modules/v5-pending-shape.test.ts
@@ -11,8 +11,10 @@
  *     single-device KV restore path.
  *   - `_integrity.currentStateHash` is set from the authenticator's
  *     `stateHash` (= source state hash).
- *   - The helper returns `null` on malformed bundles (caller falls
- *     back to the legacy opaque shape — pin #207 review nit #5).
+ *   - The helper returns `{ok: false, error}` on malformed bundles —
+ *     caller logs the error context + falls back to the legacy opaque
+ *     shape (pin #207 review nit #5 + steelman diagnostic-visibility
+ *     fix).
  *   - `readV5FinalizationInputsFromToken` round-trips the synthetic
  *     shape back into structured inputs, including derivable fields
  *     (`tokenTypeHex` from `genesis.data.tokenType`, `transferSaltHex`
@@ -20,6 +22,9 @@
  *     `transactions[0].data.recipient`).
  *   - The reader returns `null` for legacy opaque shapes
  *     (`{_pendingFinalization: ...}`) → caller falls back to bundleJson.
+ *   - Steelman strictening: reader rejects non-null inclusionProofs,
+ *     non-hex tokenId/tokenType/salt, malformed authenticator,
+ *     wrong-length publicKey.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -115,18 +120,21 @@ function makePending(): PendingV5Finalization {
   };
 }
 
+function buildOk(bundle: InstantSplitBundleV5, pending: PendingV5Finalization): string {
+  const r = buildSyntheticV5PendingSdkData(bundle, pending);
+  if (!r.ok) {
+    throw new Error(`buildSyntheticV5PendingSdkData unexpectedly failed: ${r.error}`);
+  }
+  return r.sdkData;
+}
+
 // -----------------------------------------------------------------------------
 // buildSyntheticV5PendingSdkData
 // -----------------------------------------------------------------------------
 
 describe('#207 PR-B — buildSyntheticV5PendingSdkData', () => {
   it('produces a UXF/TXF-valid shape with null inclusionProofs', () => {
-    const bundle = makeBundle();
-    const pending = makePending();
-    const sdkDataJson = buildSyntheticV5PendingSdkData(bundle, pending);
-    expect(sdkDataJson).not.toBeNull();
-    const parsed = JSON.parse(sdkDataJson!);
-
+    const parsed = JSON.parse(buildOk(makeBundle(), makePending()));
     expect(parsed.version).toBe('2.0');
     expect(parsed.genesis.inclusionProof).toBeNull();
     expect(parsed.transactions).toHaveLength(1);
@@ -135,70 +143,53 @@ describe('#207 PR-B — buildSyntheticV5PendingSdkData', () => {
   });
 
   it('places mint data in genesis.data and minted state in state', () => {
-    const bundle = makeBundle();
-    const pending = makePending();
-    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    const parsed = JSON.parse(buildOk(makeBundle(), makePending()));
     expect(parsed.genesis.data.tokenId).toBe(TOKEN_ID);
     expect(parsed.genesis.data.tokenType).toBe(TOKEN_TYPE);
     expect(parsed.state.predicate).toBe('bb');
   });
 
   it('carries transfer authenticator at transactions[0]._wallet.authenticator', () => {
-    const bundle = makeBundle();
-    const pending = makePending();
-    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    const parsed = JSON.parse(buildOk(makeBundle(), makePending()));
     expect(parsed.transactions[0]._wallet.authenticator.publicKey).toBe(PUBKEY);
     expect(parsed.transactions[0]._wallet.authenticator.stateHash).toBe(STATE_HASH);
   });
 
   it('places transfer transactionData at transactions[0].data', () => {
-    const bundle = makeBundle();
-    const pending = makePending();
-    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    const parsed = JSON.parse(buildOk(makeBundle(), makePending()));
     expect(parsed.transactions[0].data.recipient).toBe('DIRECT://bob-pending-01');
     expect(parsed.transactions[0].data.salt).toBe(SALT);
   });
 
   it('retains _pendingFinalization at top level for KV restore path', () => {
-    const bundle = makeBundle();
-    const pending = makePending();
-    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    const parsed = JSON.parse(buildOk(makeBundle(), makePending()));
     expect(parsed._pendingFinalization).toBeDefined();
     expect(parsed._pendingFinalization.type).toBe('v5_bundle');
     expect(parsed._pendingFinalization.stage).toBe('RECEIVED');
   });
 
   it('sets _integrity.currentStateHash from authenticator.stateHash', () => {
-    const bundle = makeBundle();
-    const pending = makePending();
-    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    const parsed = JSON.parse(buildOk(makeBundle(), makePending()));
     expect(parsed._integrity.currentStateHash).toBe(STATE_HASH);
   });
 
-  it('returns null when recipientMintData JSON is malformed (fallback path)', () => {
-    const bundle = makeBundle({ recipientMintData: '{not-json' });
-    const pending = makePending();
-    const result = buildSyntheticV5PendingSdkData(bundle, pending);
-    expect(result).toBeNull();
+  it('returns {ok:false, error} when recipientMintData JSON is malformed', () => {
+    const r = buildSyntheticV5PendingSdkData(makeBundle({ recipientMintData: '{not-json' }), makePending());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/JSON|Unexpected/);
   });
 
-  it('returns null when transferCommitment JSON is malformed', () => {
-    const bundle = makeBundle({ transferCommitment: '{also-not-json' });
-    const pending = makePending();
-    const result = buildSyntheticV5PendingSdkData(bundle, pending);
-    expect(result).toBeNull();
+  it('returns {ok:false, error} when transferCommitment JSON is malformed', () => {
+    const r = buildSyntheticV5PendingSdkData(makeBundle({ transferCommitment: '{also-not-json' }), makePending());
+    expect(r.ok).toBe(false);
   });
 
-  it('returns null when mintedTokenStateJson is malformed', () => {
-    const bundle = makeBundle({ mintedTokenStateJson: 'definitely-not-json' });
-    const pending = makePending();
-    const result = buildSyntheticV5PendingSdkData(bundle, pending);
-    expect(result).toBeNull();
+  it('returns {ok:false, error} when mintedTokenStateJson is malformed', () => {
+    const r = buildSyntheticV5PendingSdkData(makeBundle({ mintedTokenStateJson: 'definitely-not-json' }), makePending());
+    expect(r.ok).toBe(false);
   });
 
   it('tolerates legacy transferCommitment with `data` instead of `transactionData`', () => {
-    // Pre-canonical TransferCommitment.toJSON shape used `data` not
-    // `transactionData`. The helper still extracts the tx data.
     const auth = makeTransferAuthJson();
     const txData = makeTransferTxData();
     const bundle = makeBundle({
@@ -208,8 +199,7 @@ describe('#207 PR-B — buildSyntheticV5PendingSdkData', () => {
         authenticator: auth,
       }),
     });
-    const pending = makePending();
-    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    const parsed = JSON.parse(buildOk(bundle, makePending()));
     expect(parsed.transactions[0].data.recipient).toBe('DIRECT://bob-pending-01');
   });
 });
@@ -220,9 +210,7 @@ describe('#207 PR-B — buildSyntheticV5PendingSdkData', () => {
 
 describe('#207 PR-B — readV5FinalizationInputsFromToken', () => {
   it('round-trips through buildSyntheticV5PendingSdkData', () => {
-    const bundle = makeBundle();
-    const pending = makePending();
-    const sdkDataJson = buildSyntheticV5PendingSdkData(bundle, pending)!;
+    const sdkDataJson = buildOk(makeBundle(), makePending());
     const inputs = readV5FinalizationInputsFromToken(sdkDataJson);
     expect(inputs).not.toBeNull();
     expect(inputs!.tokenTypeHex).toBe(TOKEN_TYPE);
@@ -235,11 +223,8 @@ describe('#207 PR-B — readV5FinalizationInputsFromToken', () => {
   });
 
   it('returns null on legacy opaque shape ({_pendingFinalization: ...})', () => {
-    // Pin: legacy entries must fall back to bundleJson parsing.
-    const pending = makePending();
-    const legacy = JSON.stringify({ _pendingFinalization: pending });
-    const inputs = readV5FinalizationInputsFromToken(legacy);
-    expect(inputs).toBeNull();
+    const legacy = JSON.stringify({ _pendingFinalization: makePending() });
+    expect(readV5FinalizationInputsFromToken(legacy)).toBeNull();
   });
 
   it('returns null when sdkData is empty/undefined', () => {
@@ -253,19 +238,11 @@ describe('#207 PR-B — readV5FinalizationInputsFromToken', () => {
   });
 
   it('returns null when transactions[0]._wallet.authenticator is missing', () => {
-    // Without the sender-signed authenticator we cannot reconstruct the
-    // transfer commitment for re-submission.
     const shape = {
       version: '2.0',
       state: { predicate: 'bb', data: null },
       genesis: { data: makeMintDataJson(), inclusionProof: null },
-      transactions: [
-        {
-          data: makeTransferTxData(),
-          inclusionProof: null,
-          // _wallet is intentionally absent
-        },
-      ],
+      transactions: [{ data: makeTransferTxData(), inclusionProof: null }],
       nametags: [],
     };
     expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
@@ -288,6 +265,124 @@ describe('#207 PR-B — readV5FinalizationInputsFromToken', () => {
       state: { predicate: 'bb', data: null },
       genesis: { data: makeMintDataJson(), inclusionProof: null },
       transactions: [],
+      nametags: [],
+    };
+    expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
+  });
+
+  // -- steelman strictening --
+
+  it('returns null when genesis.inclusionProof is non-null (post-mint-proven)', () => {
+    const shape = {
+      version: '2.0',
+      state: { predicate: 'bb', data: null },
+      genesis: { data: makeMintDataJson(), inclusionProof: { some: 'proof' } },
+      transactions: [
+        {
+          data: makeTransferTxData(),
+          inclusionProof: null,
+          _wallet: { authenticator: makeTransferAuthJson() },
+        },
+      ],
+      nametags: [],
+    };
+    expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
+  });
+
+  it('returns null when transactions[0].inclusionProof is non-null (post-transfer-proven)', () => {
+    const shape = {
+      version: '2.0',
+      state: { predicate: 'bb', data: null },
+      genesis: { data: makeMintDataJson(), inclusionProof: null },
+      transactions: [
+        {
+          data: makeTransferTxData(),
+          inclusionProof: { some: 'proof' },
+          _wallet: { authenticator: makeTransferAuthJson() },
+        },
+      ],
+      nametags: [],
+    };
+    expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
+  });
+
+  it('returns null when tokenType is non-hex', () => {
+    const bad = { ...makeMintDataJson(), tokenType: 'not-hex-zzz' };
+    const shape = {
+      version: '2.0',
+      state: { predicate: 'bb', data: null },
+      genesis: { data: bad, inclusionProof: null },
+      transactions: [
+        {
+          data: makeTransferTxData(),
+          inclusionProof: null,
+          _wallet: { authenticator: makeTransferAuthJson() },
+        },
+      ],
+      nametags: [],
+    };
+    expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
+  });
+
+  it('returns null when authenticator.publicKey has wrong length', () => {
+    const badAuth = { ...makeTransferAuthJson(), publicKey: 'aabb' };
+    const shape = {
+      version: '2.0',
+      state: { predicate: 'bb', data: null },
+      genesis: { data: makeMintDataJson(), inclusionProof: null },
+      transactions: [
+        {
+          data: makeTransferTxData(),
+          inclusionProof: null,
+          _wallet: { authenticator: badAuth },
+        },
+      ],
+      nametags: [],
+    };
+    expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
+  });
+
+  it('returns null when authenticator missing algorithm/signature', () => {
+    const badAuth: Record<string, unknown> = { publicKey: PUBKEY, stateHash: STATE_HASH };
+    const shape = {
+      version: '2.0',
+      state: { predicate: 'bb', data: null },
+      genesis: { data: makeMintDataJson(), inclusionProof: null },
+      transactions: [
+        {
+          data: makeTransferTxData(),
+          inclusionProof: null,
+          _wallet: { authenticator: badAuth },
+        },
+      ],
+      nametags: [],
+    };
+    expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
+  });
+
+  it('returns null when transfer recipient is empty string', () => {
+    const badTx = { ...makeTransferTxData(), recipient: '' };
+    const shape = {
+      version: '2.0',
+      state: { predicate: 'bb', data: null },
+      genesis: { data: makeMintDataJson(), inclusionProof: null },
+      transactions: [
+        { data: badTx, inclusionProof: null, _wallet: { authenticator: makeTransferAuthJson() } },
+      ],
+      nametags: [],
+    };
+    expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
+  });
+
+  it('returns null when transfer salt is non-hex', () => {
+    const badTx = { ...makeTransferTxData(), salt: 'not-hex' };
+    const shape = {
+      version: '2.0',
+      state: { predicate: 'bb', data: null },
+      genesis: { data: makeMintDataJson(), inclusionProof: null },
+      transactions: [
+        { data: badTx, inclusionProof: null, _wallet: { authenticator: makeTransferAuthJson() } },
+      ],
       nametags: [],
     };
     expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();

--- a/tests/unit/modules/v5-pending-shape.test.ts
+++ b/tests/unit/modules/v5-pending-shape.test.ts
@@ -1,0 +1,295 @@
+/**
+ * #207 PR-B — Unit tests for the V5-pending synthetic shape helpers.
+ *
+ * Pins:
+ *   - `buildSyntheticV5PendingSdkData` produces the canonical
+ *     UXF/TXF-valid shape with `inclusionProof: null` on both genesis
+ *     and the synthetic transfer transaction.
+ *   - The sender-signed transfer authenticator rides as
+ *     `transactions[0]._wallet.authenticator`.
+ *   - `_pendingFinalization` is retained at the top level for the
+ *     single-device KV restore path.
+ *   - `_integrity.currentStateHash` is set from the authenticator's
+ *     `stateHash` (= source state hash).
+ *   - The helper returns `null` on malformed bundles (caller falls
+ *     back to the legacy opaque shape — pin #207 review nit #5).
+ *   - `readV5FinalizationInputsFromToken` round-trips the synthetic
+ *     shape back into structured inputs, including derivable fields
+ *     (`tokenTypeHex` from `genesis.data.tokenType`, `transferSaltHex`
+ *     from `transactions[0].data.salt`, `recipientAddress` from
+ *     `transactions[0].data.recipient`).
+ *   - The reader returns `null` for legacy opaque shapes
+ *     (`{_pendingFinalization: ...}`) → caller falls back to bundleJson.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildSyntheticV5PendingSdkData,
+  readV5FinalizationInputsFromToken,
+} from '../../../modules/payments/v5-pending-shape';
+import type {
+  InstantSplitBundleV5,
+  PendingV5Finalization,
+} from '../../../types/instant-split';
+
+// -----------------------------------------------------------------------------
+// Fixtures
+// -----------------------------------------------------------------------------
+
+const PUBKEY = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+const STATE_HASH = '0000ee0000000000000000000000000000000000000000000000000000000000';
+const TOKEN_TYPE = 'aa00000000000000000000000000000000000000000000000000000000000001';
+const TOKEN_ID = 'aa00000000000000000000000000000000000000000000000000000000000099';
+const SALT = '00aa000000000000000000000000000000000000000000000000000000000033';
+
+function makeMintDataJson(): Record<string, unknown> {
+  return {
+    tokenId: TOKEN_ID,
+    tokenType: TOKEN_TYPE,
+    tokenData: null,
+    coinData: [['UCT', '1000']],
+    recipient: 'DIRECT://bob-pending-01',
+    salt: '00bb000000000000000000000000000000000000000000000000000000000001',
+    recipientDataHash: null,
+    reason: null,
+  };
+}
+
+function makeTransferAuthJson(): Record<string, unknown> {
+  return {
+    algorithm: 'secp256k1',
+    publicKey: PUBKEY,
+    signature:
+      '3045022100ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01ee01022000ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff',
+    stateHash: STATE_HASH,
+  };
+}
+
+function makeTransferTxData(): Record<string, unknown> {
+  return {
+    sourceState: { predicate: 'aa', data: null },
+    recipient: 'DIRECT://bob-pending-01',
+    salt: SALT,
+    recipientDataHash: null,
+    message: null,
+    nametags: [],
+  };
+}
+
+function makeBundle(overrides: Partial<InstantSplitBundleV5> = {}): InstantSplitBundleV5 {
+  const mintData = makeMintDataJson();
+  const txData = makeTransferTxData();
+  const auth = makeTransferAuthJson();
+  return {
+    version: '5.0',
+    type: 'INSTANT_SPLIT',
+    burnTransaction: '{}',
+    recipientMintData: JSON.stringify(mintData),
+    transferCommitment: JSON.stringify({
+      requestId: 'aa00bb',
+      transactionData: txData,
+      authenticator: auth,
+    }),
+    amount: '1000',
+    coinId: 'UCT',
+    tokenTypeHex: TOKEN_TYPE,
+    splitGroupId: 'group-aaaaaa',
+    senderPubkey: PUBKEY,
+    recipientSaltHex: '00cc',
+    transferSaltHex: SALT,
+    mintedTokenStateJson: JSON.stringify({ predicate: 'bb', data: null }),
+    finalRecipientStateJson: '',
+    recipientAddressJson: 'DIRECT://bob-pending-01',
+    ...overrides,
+  };
+}
+
+function makePending(): PendingV5Finalization {
+  return {
+    type: 'v5_bundle',
+    stage: 'RECEIVED',
+    bundleJson: '',
+    senderPubkey: PUBKEY,
+    savedAt: Date.now(),
+    attemptCount: 0,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// buildSyntheticV5PendingSdkData
+// -----------------------------------------------------------------------------
+
+describe('#207 PR-B — buildSyntheticV5PendingSdkData', () => {
+  it('produces a UXF/TXF-valid shape with null inclusionProofs', () => {
+    const bundle = makeBundle();
+    const pending = makePending();
+    const sdkDataJson = buildSyntheticV5PendingSdkData(bundle, pending);
+    expect(sdkDataJson).not.toBeNull();
+    const parsed = JSON.parse(sdkDataJson!);
+
+    expect(parsed.version).toBe('2.0');
+    expect(parsed.genesis.inclusionProof).toBeNull();
+    expect(parsed.transactions).toHaveLength(1);
+    expect(parsed.transactions[0].inclusionProof).toBeNull();
+    expect(Array.isArray(parsed.nametags)).toBe(true);
+  });
+
+  it('places mint data in genesis.data and minted state in state', () => {
+    const bundle = makeBundle();
+    const pending = makePending();
+    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    expect(parsed.genesis.data.tokenId).toBe(TOKEN_ID);
+    expect(parsed.genesis.data.tokenType).toBe(TOKEN_TYPE);
+    expect(parsed.state.predicate).toBe('bb');
+  });
+
+  it('carries transfer authenticator at transactions[0]._wallet.authenticator', () => {
+    const bundle = makeBundle();
+    const pending = makePending();
+    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    expect(parsed.transactions[0]._wallet.authenticator.publicKey).toBe(PUBKEY);
+    expect(parsed.transactions[0]._wallet.authenticator.stateHash).toBe(STATE_HASH);
+  });
+
+  it('places transfer transactionData at transactions[0].data', () => {
+    const bundle = makeBundle();
+    const pending = makePending();
+    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    expect(parsed.transactions[0].data.recipient).toBe('DIRECT://bob-pending-01');
+    expect(parsed.transactions[0].data.salt).toBe(SALT);
+  });
+
+  it('retains _pendingFinalization at top level for KV restore path', () => {
+    const bundle = makeBundle();
+    const pending = makePending();
+    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    expect(parsed._pendingFinalization).toBeDefined();
+    expect(parsed._pendingFinalization.type).toBe('v5_bundle');
+    expect(parsed._pendingFinalization.stage).toBe('RECEIVED');
+  });
+
+  it('sets _integrity.currentStateHash from authenticator.stateHash', () => {
+    const bundle = makeBundle();
+    const pending = makePending();
+    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    expect(parsed._integrity.currentStateHash).toBe(STATE_HASH);
+  });
+
+  it('returns null when recipientMintData JSON is malformed (fallback path)', () => {
+    const bundle = makeBundle({ recipientMintData: '{not-json' });
+    const pending = makePending();
+    const result = buildSyntheticV5PendingSdkData(bundle, pending);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when transferCommitment JSON is malformed', () => {
+    const bundle = makeBundle({ transferCommitment: '{also-not-json' });
+    const pending = makePending();
+    const result = buildSyntheticV5PendingSdkData(bundle, pending);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when mintedTokenStateJson is malformed', () => {
+    const bundle = makeBundle({ mintedTokenStateJson: 'definitely-not-json' });
+    const pending = makePending();
+    const result = buildSyntheticV5PendingSdkData(bundle, pending);
+    expect(result).toBeNull();
+  });
+
+  it('tolerates legacy transferCommitment with `data` instead of `transactionData`', () => {
+    // Pre-canonical TransferCommitment.toJSON shape used `data` not
+    // `transactionData`. The helper still extracts the tx data.
+    const auth = makeTransferAuthJson();
+    const txData = makeTransferTxData();
+    const bundle = makeBundle({
+      transferCommitment: JSON.stringify({
+        requestId: 'aa00bb',
+        data: txData,
+        authenticator: auth,
+      }),
+    });
+    const pending = makePending();
+    const parsed = JSON.parse(buildSyntheticV5PendingSdkData(bundle, pending)!);
+    expect(parsed.transactions[0].data.recipient).toBe('DIRECT://bob-pending-01');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// readV5FinalizationInputsFromToken
+// -----------------------------------------------------------------------------
+
+describe('#207 PR-B — readV5FinalizationInputsFromToken', () => {
+  it('round-trips through buildSyntheticV5PendingSdkData', () => {
+    const bundle = makeBundle();
+    const pending = makePending();
+    const sdkDataJson = buildSyntheticV5PendingSdkData(bundle, pending)!;
+    const inputs = readV5FinalizationInputsFromToken(sdkDataJson);
+    expect(inputs).not.toBeNull();
+    expect(inputs!.tokenTypeHex).toBe(TOKEN_TYPE);
+    expect(inputs!.transferSaltHex).toBe(SALT);
+    expect(inputs!.recipientAddress).toBe('DIRECT://bob-pending-01');
+    expect(inputs!.transferAuthenticatorJson.publicKey).toBe(PUBKEY);
+    expect(inputs!.transferAuthenticatorJson.stateHash).toBe(STATE_HASH);
+    expect(inputs!.mintedTokenStateJson).toBeDefined();
+    expect(inputs!.mintDataJson.tokenId).toBe(TOKEN_ID);
+  });
+
+  it('returns null on legacy opaque shape ({_pendingFinalization: ...})', () => {
+    // Pin: legacy entries must fall back to bundleJson parsing.
+    const pending = makePending();
+    const legacy = JSON.stringify({ _pendingFinalization: pending });
+    const inputs = readV5FinalizationInputsFromToken(legacy);
+    expect(inputs).toBeNull();
+  });
+
+  it('returns null when sdkData is empty/undefined', () => {
+    expect(readV5FinalizationInputsFromToken(undefined)).toBeNull();
+    expect(readV5FinalizationInputsFromToken('')).toBeNull();
+    expect(readV5FinalizationInputsFromToken(null)).toBeNull();
+  });
+
+  it('returns null when sdkData is not parseable JSON', () => {
+    expect(readV5FinalizationInputsFromToken('{not-json')).toBeNull();
+  });
+
+  it('returns null when transactions[0]._wallet.authenticator is missing', () => {
+    // Without the sender-signed authenticator we cannot reconstruct the
+    // transfer commitment for re-submission.
+    const shape = {
+      version: '2.0',
+      state: { predicate: 'bb', data: null },
+      genesis: { data: makeMintDataJson(), inclusionProof: null },
+      transactions: [
+        {
+          data: makeTransferTxData(),
+          inclusionProof: null,
+          // _wallet is intentionally absent
+        },
+      ],
+      nametags: [],
+    };
+    expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
+  });
+
+  it('returns null when genesis.data is missing or malformed', () => {
+    const shape = {
+      version: '2.0',
+      state: { predicate: 'bb', data: null },
+      genesis: { data: null, inclusionProof: null },
+      transactions: [],
+      nametags: [],
+    };
+    expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
+  });
+
+  it('returns null when transactions array is empty', () => {
+    const shape = {
+      version: '2.0',
+      state: { predicate: 'bb', data: null },
+      genesis: { data: makeMintDataJson(), inclusionProof: null },
+      transactions: [],
+      nametags: [],
+    };
+    expect(readV5FinalizationInputsFromToken(JSON.stringify(shape))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the PR-B scope of #207. After PR #206 put V5-pending tokens into the bundle CAR with a UXF-compatible synthetic shape, the finalization driver still parsed `pending.bundleJson` for every input. PR-B makes Nostr-shipped UXF bundles self-sufficient for cross-device V5 finalization (the DIRECT recipient case); PROXY recipients still need bundleJson fallback for the nametag-token until UXF round-trips nested wallet-internal Token JSON — tracked as #208.

## Scope

### Refactor: shape-driven finalization
- New `modules/payments/v5-pending-shape.ts` with two pure helpers:
  - `buildSyntheticV5PendingSdkData(bundle, pending)` — extracted from the IIFE in `saveUnconfirmedV5Token`. Returns `{ok, sdkData}` or `{ok: false, error}` (steelman: diagnostic visibility on fallback path).
  - `readV5FinalizationInputsFromToken(sdkData)` — extracts mint data, transfer transaction data, authenticator, and minted state from the synthetic shape. Strict validation (hex regex, secp256k1 publicKey length, null inclusionProofs).
- `resolveV5Token` + `finalizeFromV5Bundle` (renamed `finalizeFromV5Inputs`) read primary fields from the synthetic shape; `pending.bundleJson` is parsed lazily via `getBundle()`, only for legacy entries or the PROXY-only `nametagTokenJson` field.
- The transfer commitment's requestId is deterministically derived at submit time via `RequestId.create(authenticator.publicKey, authenticator.stateHash)` — same derivation the original sender used in `TransferCommitment.create`.

### Review nit fixes from PR #206
- `isReceivedLegacyPending` (PaymentsModule.ts:8569) and `tryLocalFinalizeUnconfirmed` (PaymentsModule.ts:9180) now accept both the canonical SDK string-recipient AND the legacy `{address: string}` shape. Pre-fix CAR-loaded V5-pending tokens always failed the check and were silently archived by the balance-model invariant.
- `gcArchivedV5PendingForFinalized()` deletes the CAR-loaded archived entry at `archivedTokens[realTokenId]` once the active resolution token finalizes (with case-/0x-prefix-tolerant lookup since UXF doesn't normalize hex casing).
- Helper extraction (above) for unit-testability.
- `Record<string, any>` replaced with `IMintTransactionDataJson`, `ITransferTransactionDataJson`, `IAuthenticatorJson` from the SDK.
- Direct test for the fallback path: 4 malformed-input branches return `{ok: false, error}`.

### Steelman remediation (commit 44441ea)
The first commit (621f356) passed a parallel adversarial review with two critical findings that are now fixed:
1. **`updatePendingFinalization` wiped the synthetic shape on every stage transition** — would have defeated PR-B's entire goal for CAR-loaded tokens without bundleJson. Now merges `_pendingFinalization` into the existing parsed sdkData.
2. **Authenticator.fromJSON throw burned attemptCount budget** — now wrapped in try/catch with explicit bundleJson fallback inside the same attempt.

Plus three warnings (shape-reader strictening, diagnostic restoration, GC case-mismatch).

### V4 viability
`docs/uxf/V4-INSTANT-SPLIT-VIABILITY.md` documents the SDK-level constraint: `TokenSplitBuilder.createSplitMintCommitments` requires a proven burn (`token.update(trustBase, ..., burnTransaction)` verifies inclusion proof; `SplitMintReason` carries the burned token state). V4 stays dev-mode only; revisiting requires a protocol redesign that spans aggregator + state-transition SDK.

## Follow-up tracked separately

- #208 — Nested nametag tokens via UXF-bundle CID refs. Closes the PROXY self-sufficiency gap: a token's transactions reference UXF bundles by CID, allowing recursive resolution of all PROXY addresses without a local nametag and without parsing `pending.bundleJson`.

## Test plan

- [x] Typecheck passes (`npm run typecheck`).
- [x] Lint clean on new code (only pre-existing `no-explicit-any` warnings in unrelated areas).
- [x] All 24 `v5-pending-shape` unit tests pass (17 functional + 7 steelman strictening pins).
- [x] All 31 `PaymentsModule.v5-finalization` tests pass.
- [x] All 5 `v5-pending-roundtrip` (UXF) tests pass.
- [x] Full unit suite: same 2-3 pre-existing test-parallelism flakes as parent commit d5f309e (confirmed by stashing my changes and re-running). No regressions from this PR.
- [ ] E2E acceptance per #207 acceptance criteria: `tests/e2e/profile-live-concurrent-sync.test.ts > Cross-device sync …` against testnet. Will verify post-merge.

## Refs

- Parent: #207
- PR-A: #206 (merged)
- Originating regression: #199
- V4 dev-mode types: `types/instant-split.ts:136`
- PROXY-self-sufficiency follow-up: #208