### PR TITLE
fix(profile)(#210): bundle pinning — revert to monolithic raw-codec single-block pin

### DIFF
--- a/profile/profile-token-storage/bundle-index.ts
+++ b/profile/profile-token-storage/bundle-index.ts
@@ -291,7 +291,38 @@ export class BundleIndex implements ProfileSyncWriter {
         return this.classifyBundleBytes(entry.encryptedValue, /* remote = */ true);
       },
       writeRemote: async (key, bytes) => {
-        await this.host.db.put(key, bytes);
+        // #207 E2E fix — wrap the remote encrypted payload in a fresh
+        // OpLog envelope before writing. Pre-fix this used `db.put(key,
+        // bytes)` which stored the encrypted bytes RAW (no envelope
+        // wrapper), causing subsequent `db.getEntry(key)` →
+        // `decodeEntry(bytes)` to throw "tag not supported (X)" on the
+        // ciphertext bytes. The lean-snapshot publisher (which reads
+        // via `getEncryptedRaw` → `readEnvelopePayload` → `db.getEntry`)
+        // then silently skipped the bundle entry, producing an empty
+        // bundle slice in the published snapshot — so any peer (or our
+        // own next pointer-poll cycle) saw no bundles. That's the
+        // proximate cause of the `profile-live-concurrent-sync` failure
+        // (A's published bundle CAR contained zero tokens; B saw
+        // nothing).
+        //
+        // Falling back to raw `db.put` when `putEntry` is unavailable
+        // matches `addBundle()`'s pattern — the adapter's read-time
+        // legacy wrap (v=0 synthetic envelope) handles those bytes.
+        const db = this.host.db;
+        if (typeof db.putEntry === 'function') {
+          const envelope = buildLocalEntry({
+            type: 'cache_index',
+            originated: 'system',
+            payload: bytes,
+          });
+          await db.putEntry(key, envelope);
+        } else {
+          await db.put(key, bytes);
+          const markHook = (db as { markLocallyAuthored?: (k: string) => void }).markLocallyAuthored;
+          if (typeof markHook === 'function') {
+            markHook.call(db, key);
+          }
+        }
         const cid = key.slice(BUNDLE_KEY_PREFIX.length);
         if (cid.length > 0) {
           this.host.getKnownBundleCids().add(cid);

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -53,8 +53,29 @@
  * @module profile/profile-token-storage/flush-scheduler
  */
 
-import { pinCarBlocksToIpfs } from '../ipfs-client.js';
+// #207 E2E fix — bundle pinning currently uses `pinToIpfs` (legacy
+// monolithic raw-codec single-block pin) instead of `pinCarBlocksToIpfs`
+// (#200 hierarchical per-block pin). The latter is structurally broken
+// for UXF bundles because element CIDs are computed over the hash
+// canonical form (children = raw hash bytes) while the emitted block
+// bytes are in IPLD form (children = Tag 42 CID links). Kubo re-derives
+// the CID from the bytes and pins under THAT, leaving the manifest's
+// content-hash-derived links unreachable. See uxf/ipld.ts:144 and
+// docs/uxf/V4-INSTANT-SPLIT-VIABILITY.md sibling follow-up for the
+// proper architectural fix (decouple bytes-derived CIDs from
+// content-hash identity, refactor exportToCar to bottom-up).
+//
+// Both functions are imported so this file shows the contrast and the
+// switch-back point. Currently only `pinToIpfs` is on the hot path;
+// `pinCarBlocksToIpfs` stays imported for the imminent revert when
+// the architectural fix lands.
+import { pinCarBlocksToIpfs, pinToIpfs } from '../ipfs-client.js';
+// `extractCarRootCid` is retained for type-flow continuity with the
+// hierarchical path even though the current bundle pin doesn't call it.
 import { extractCarRootCid } from '../../uxf/transfer-payload.js';
+// Mark the retained imports as intentionally unused on the hot path.
+void pinCarBlocksToIpfs;
+void extractCarRootCid;
 import type {
   ProfileSnapshotPublishResult,
   UxfBundleRef,
@@ -70,6 +91,21 @@ import type { TxfStorageDataBase } from '../../storage/storage-provider.js';
  * the regression. Exported so consumers/tests can reference the literal.
  */
 export const POINTER_MONOTONICITY_VIOLATION = 'POINTER_MONOTONICITY_VIOLATION';
+
+/**
+ * #207 E2E fix — compute the CID that `pinToIpfs` will publish for a
+ * given CAR's bytes. Matches `pinToIpfs`'s convention:
+ * `CID.createV1(raw, sha256(carBytes))`. Used by the no-data
+ * short-circuit so it can compare against the eventual pin CID without
+ * actually performing the pin.
+ */
+async function computeRawPinCid(carBytes: Uint8Array): Promise<string> {
+  const { CID } = await import('multiformats/cid');
+  const { sha256 } = await import('@noble/hashes/sha2.js');
+  const raw = await import('multiformats/codecs/raw');
+  const { create: createMultihash } = await import('multiformats/hashes/digest');
+  return CID.createV1(raw.code, createMultihash(0x12, sha256(carBytes))).toString();
+}
 
 export class FlushScheduler {
   /**
@@ -389,14 +425,15 @@ export class FlushScheduler {
       //     only fires when the merged-state CAR happens to be byte-
       //     identical to a known anchor.
       if (noDataMode) {
-        // Issue #200 Phase 2: bundle CIDs are now the dag-cbor envelope
-        // root of the CAR (matches what `pinCarBlocksToIpfs` publishes
-        // below). The legacy raw-pinning convention computed
-        // `CID.createV1(raw, sha256(carBytes))` here, but every newly
-        // pinned bundle is published under its envelope CID — the
-        // short-circuit comparison must use the same convention or it
-        // would never fire.
-        const projectedCid = await extractCarRootCid(carBytes);
+        // #207 E2E fix: bundle pinning reverted to legacy monolithic
+        // raw-codec single-block pin via `pinToIpfs(carBytes)`. The
+        // projected CID for the no-data short-circuit MUST match the
+        // CID that `pinToIpfs` will publish — `CID.createV1(raw,
+        // sha256(carBytes))`. Computing via `extractCarRootCid`
+        // (dag-cbor envelope CID) would produce a different value, so
+        // the short-circuit would never fire and every no-data flush
+        // would gratuitously republish.
+        const projectedCid = await computeRawPinCid(carBytes);
         const knownDiscovered = this.host.getLastDiscoveredPointerCid();
         if (knownDiscovered === projectedCid) {
           this.host.log(
@@ -599,19 +636,37 @@ export class FlushScheduler {
       if (useCachedCid && cachedCidNow) {
         cid = cachedCidNow;
       } else {
-        // Issue #200 Phase 2: pin each block in the bundle CAR under
-        // its canonical CID (envelope + manifest + per-token elements)
-        // and publish the dag-cbor envelope CID as the bundle ref.
-        // Individual tokens / sub-token components are now directly
-        // addressable on IPFS, and bundles that share blocks dedup at
-        // the storage layer (paying off most in the hierarchical model
-        // from Phase 3 onward).
-        const expectedRootCid = await extractCarRootCid(carBytes);
-        cid = await pinCarBlocksToIpfs(
-          this.host.ipfsGateways,
-          carBytes,
-          expectedRootCid,
-        );
+        // #207 E2E ROOT CAUSE FIX — UXF bundle CARs use content-hash-
+        // derived CIDs for sub-block elements (children encoded as raw
+        // hash bytes in canonical form per uxf/hash.ts:308). But the
+        // ACTUAL bytes emitted to the CAR are in IPLD form (children
+        // as Tag 42 CID links per uxf/ipld.ts:144). The two encodings
+        // produce DIFFERENT bytes, so `sha256(block.bytes) !=
+        // block.cid.multihash.digest` for non-envelope sub-blocks.
+        //
+        // Issue #200 Phase 2 (pinCarBlocksToIpfs / block-by-block
+        // dag/put) recomputes CIDs from the bytes on Kubo's side and
+        // pins under those bytes-derived CIDs. The bundle's manifest
+        // then links to content-hash-derived CIDs that DON'T match
+        // anything pinned → receivers see "BUNDLE_NOT_FOUND" walking
+        // the DAG from envelope → manifest → token roots.
+        //
+        // Until uxf/ipld.ts's CID computation is reworked to match
+        // the bytes (substantial refactor — content hashes are also
+        // the UXF integrity-verification primitive), restore the
+        // pre-#200 single-block raw pin for bundles. The receiver's
+        // `fetchCarFromIpfs` short-circuits raw-codec roots to fetch
+        // the entire CAR in one shot — the internal content-hash-
+        // derived CIDs never need to round-trip through Kubo's
+        // re-encoding. Bundle CARs become opaque blobs again (loses
+        // hierarchical per-block dedup, gains correctness).
+        //
+        // The lean-snapshot publish path (factory.ts:496) keeps using
+        // pinCarBlocksToIpfs — snapshots are constructed with
+        // bytes-derived CIDs throughout (see profile-lean-snapshot.ts
+        // `dagCborCid(rootBytes)`) so their per-block pinning works
+        // correctly.
+        cid = await pinToIpfs(this.host.ipfsGateways, carBytes);
         this.host.setLastPinnedCid(cid);
       }
 

--- a/tests/integration/oplog-bundle-roundtrip.test.ts
+++ b/tests/integration/oplog-bundle-roundtrip.test.ts
@@ -1,0 +1,146 @@
+/**
+ * #207 E2E acceptance — diagnostic for the OrbitDB CBOR decode failure
+ * observed in `tests/e2e/profile-live-concurrent-sync.test.ts`.
+ *
+ * Reproduces the exact write/read flow that `addBundle` exercises:
+ *   1. Build a typed OpLog envelope (`buildLocalEntry`) wrapping an
+ *      encrypted-style Uint8Array payload.
+ *   2. Encode it via `@ipld/dag-cbor` (`encodeEntry`).
+ *   3. Write the bytes to OrbitDB via `db.putEntry`.
+ *   4. Read back via `db.getEntry` (which calls `decodeEntry`).
+ *
+ * Pin: the round-trip MUST be lossless. A decode failure here proves the
+ * regression is in the put/get layer (OrbitDB's internal encoding) rather
+ * than in our caller-side handling.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { OrbitDbAdapter } from '../../profile/orbitdb-adapter.js';
+import { buildLocalEntry, decodeEntry, encodeEntry } from '../../profile/oplog-entry.js';
+import { randomBytes } from 'crypto';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const nodeVersion = parseInt(process.versions.node.split('.')[0], 10);
+const describeOrSkip = nodeVersion >= 22 ? describe : describe.skip;
+
+function randomKey(): string {
+  return randomBytes(32).toString('hex');
+}
+
+function makeTempDir(label: string): string {
+  const dir = path.join(os.tmpdir(), `oplog-roundtrip-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanupDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch { /* best-effort */ }
+}
+
+describeOrSkip('OpLog bundle envelope round-trip (#207 diagnostic)', { timeout: 60_000 }, () => {
+  let adapter: OrbitDbAdapter;
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = makeTempDir('main');
+    adapter = new OrbitDbAdapter();
+    await adapter.connect({
+      privateKey: randomKey(),
+      directory: testDir,
+      enablePubSub: false,
+      bootstrapPeers: [],
+    });
+  });
+
+  afterAll(async () => {
+    await adapter.close();
+    cleanupDir(testDir);
+  });
+
+  it('putEntry → getEntry round-trips a bundle envelope (the actual addBundle path)', async () => {
+    const key = 'tokens.bundle.bafyreitestkey';
+    const fakeEncryptedPayload = new Uint8Array([0xfa, 0x11, 0xff, 0xee, 0x00, 0xc0, 0xff, 0xee]);
+
+    const envelope = buildLocalEntry({
+      type: 'cache_index',
+      originated: 'system',
+      payload: fakeEncryptedPayload,
+    });
+
+    // Write via the structured-entry API (the path addBundle takes).
+    await adapter.putEntry(key, envelope);
+
+    // Diagnostic: also verify the encoded bytes round-trip locally
+    // (sanity check that our own encode/decode is consistent).
+    const localBytes = encodeEntry(envelope);
+    const localRoundTrip = decodeEntry(localBytes);
+    expect(localRoundTrip.v).toBe(1);
+    expect(Array.from(localRoundTrip.payload)).toEqual(Array.from(fakeEncryptedPayload));
+
+    // Now read back via OrbitDB → decodeEntry (the path lean-snapshot
+    // takes via getEncryptedRaw).
+    const recovered = await adapter.getEntry(key, { trustLocalClaim: true });
+    expect(recovered).not.toBeNull();
+    expect(recovered!.v).toBe(1);
+    expect(recovered!.type).toBe('cache_index');
+    expect(Array.from(recovered!.payload)).toEqual(Array.from(fakeEncryptedPayload));
+  });
+
+  it('raw db.get returns the same bytes we put (byte-identity check)', async () => {
+    const key = 'tokens.bundle.raw-byte-check';
+    const envelope = buildLocalEntry({
+      type: 'cache_index',
+      originated: 'system',
+      payload: new Uint8Array([1, 2, 3, 4, 5]),
+    });
+    const cborBytes = encodeEntry(envelope);
+    await adapter.put(key, cborBytes);
+
+    // Read raw bytes back. This bypasses decodeEntry.
+    const raw = await adapter.get(key);
+    expect(raw).not.toBeNull();
+
+    // Compare byte-for-byte. If OrbitDB transforms the bytes (e.g.,
+    // re-encodes Uint8Array via a different CBOR encoder that emits a
+    // tag), the comparison fails and we have proof of the encoding
+    // round-trip defect.
+    expect(Array.from(raw!)).toEqual(Array.from(cborBytes));
+  });
+
+  // The #207 E2E acceptance root cause: BundleIndex.joinSnapshot.writeRemote
+  // uses `db.put(key, encryptedPayloadBytes)` — RAW encrypted bytes, no envelope.
+  // When the wallet later reads this key via `db.getEntry` → `decodeEntry`,
+  // the encrypted payload is not valid `@ipld/dag-cbor` and decode throws
+  // "tag not supported (X)" — surfacing as the ProfileLeanSnapshot warning
+  // observed in the E2E test logs.
+  it('REPRO: raw db.put of non-envelope bytes makes getEntry fail with CBOR decode error', async () => {
+    const key = 'tokens.bundle.repro-snapshot-write';
+    // Mimic what joinSnapshot.writeRemote does: write the RAW encrypted
+    // payload directly (no envelope wrapper). Use bytes that look like
+    // an AES-GCM ciphertext — random-looking — to trigger the same
+    // decode failure observed in the failing E2E test.
+    const encryptedPayloadBytes = new Uint8Array([
+      // Header byte that looks like CBOR major type 6 (tagged value)
+      // with an unsupported tag — triggers `@ipld/dag-cbor`'s "tag not
+      // supported" branch the same way as real ciphertext.
+      0xca, // major 6, minor 10 → tag 10
+      0x01,
+      0x02,
+      0x03,
+    ]);
+    await adapter.put(key, encryptedPayloadBytes);
+
+    let caught: unknown = null;
+    try {
+      await adapter.getEntry(key, { trustLocalClaim: true });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).not.toBeNull();
+    expect(String(caught)).toMatch(/CBOR decode|tag not supported/);
+  });
+});

--- a/tests/unit/profile/pointer-monotonicity.test.ts
+++ b/tests/unit/profile/pointer-monotonicity.test.ts
@@ -546,16 +546,20 @@ describe('pointer monotonicity invariant', () => {
 
     const tokenA = { id: '_TA', genesis: { tokenId: 'TA' } };
     const merged = buildTxfData({ _TA: tokenA });
-    // Issue #200 Phase 2: the flush scheduler computes `projectedCid`
-    // via `extractCarRootCid` (dag-cbor envelope CID), not the legacy
-    // raw-CID convention. Mirror the same shape so the short-circuit
-    // comparison fires.
+    // #207 E2E fix: the flush scheduler reverted to legacy monolithic
+    // raw-codec single-block pin via `pinToIpfs(carBytes)`. The
+    // `projectedCid` shape is now `CID.createV1(raw, sha256(carBytes))`
+    // — mirror that here so the short-circuit comparison fires.
     const { makeFakeUxfCar } = await import('./_helpers/fake-uxf-car.js');
-    const { extractCarRootCid } = await import(
-      '../../../uxf/transfer-payload.js'
-    );
+    const { CID } = await import('multiformats/cid');
+    const { sha256 } = await import('@noble/hashes/sha2.js');
+    const raw = await import('multiformats/codecs/raw');
+    const { create: createMultihash } = await import('multiformats/hashes/digest');
     const projectedCarBytes = await makeFakeUxfCar({ tokens: [tokenA] });
-    const projectedCid = await extractCarRootCid(projectedCarBytes);
+    const projectedCid = CID.createV1(
+      raw.code,
+      createMultihash(0x12, sha256(projectedCarBytes)),
+    ).toString();
 
     // Plant the merged state AND the matching authoritative pointer CID.
     (provider as unknown as {

--- a/tests/unit/profile/profile-token-storage-no-data-flush.test.ts
+++ b/tests/unit/profile/profile-token-storage-no-data-flush.test.ts
@@ -86,12 +86,14 @@ function getEncryptionKey(): Uint8Array {
  * that produced raw-codec CIDs incompatible with the new pin path.
  */
 async function projectedFlushCid(tokens: unknown[]): Promise<string> {
+  // #207 E2E fix — bundle CIDs are now raw-codec single-block pins
+  // (see `pinToIpfs` and `computeRawPinCid` in flush-scheduler). The
+  // legacy dag-cbor envelope CID via `extractCarRootCid` no longer
+  // matches what gets pinned. Mirror the actual pin CID computation
+  // here so test assertions see the same identity.
   const { makeFakeUxfCar } = await import('./_helpers/fake-uxf-car.js');
-  const { extractCarRootCid } = await import(
-    '../../../uxf/transfer-payload.js'
-  );
   const carBytes = await makeFakeUxfCar({ tokens });
-  return extractCarRootCid(carBytes);
+  return cidForBytes(carBytes);
 }
 
 function cidForBytes(bytes: Uint8Array): string {

--- a/tests/unit/profile/profile-token-storage-provider.test.ts
+++ b/tests/unit/profile/profile-token-storage-provider.test.ts
@@ -1347,13 +1347,17 @@ describe('ProfileTokenStorageProvider', () => {
       // that identical token pools across wallets produce the same CIDs.
       expect(pinnedBlocks.length).toBeGreaterThan(0);
 
-      // At least one block must dag-cbor decode and carry the `payload`
-      // shape the fake-CAR helper wraps the token list inside. If the
-      // flush had encrypted the CAR before pinning, dag-cbor decode of
-      // ciphertext would fail across every block.
+      // At least one block must carry the unencrypted payload — either
+      // as a dag-cbor envelope (legacy block-by-block pin produces one
+      // such block per CAR element) OR as a CAR wrapper containing the
+      // envelope (monolithic raw-pin per #207 E2E fix). If the flush
+      // had encrypted the CAR before pinning, neither shape would
+      // surface the `payload.tokens` marker.
       const { decode: dagCborDecode } = await import('@ipld/dag-cbor');
+      const { CarReader } = await import('@ipld/car');
       let foundEnvelope = false;
       for (const blk of pinnedBlocks) {
+        // Try direct dag-cbor decode (block-by-block pin shape).
         try {
           const decoded = dagCborDecode(blk) as { payload?: { tokens?: unknown } };
           if (decoded && decoded.payload && 'tokens' in decoded.payload) {
@@ -1361,7 +1365,23 @@ describe('ProfileTokenStorageProvider', () => {
             break;
           }
         } catch {
-          // not the envelope block — continue
+          // not a dag-cbor block — try CAR-wrapper decode below
+        }
+        // Try CAR-wrapper decode (monolithic raw-pin shape).
+        try {
+          const reader = await CarReader.fromBytes(blk);
+          for await (const inner of reader.blocks()) {
+            try {
+              const decoded = dagCborDecode(inner.bytes) as { payload?: { tokens?: unknown } };
+              if (decoded && decoded.payload && 'tokens' in decoded.payload) {
+                foundEnvelope = true;
+                break;
+              }
+            } catch { /* try next inner block */ }
+          }
+          if (foundEnvelope) break;
+        } catch {
+          // not a CAR either — continue to next pinned block
         }
       }
       expect(foundEnvelope).toBe(true);


### PR DESCRIPTION
## Summary

Closes #210. Unblocks the E2E acceptance criterion for #207 by switching bundle CAR pinning from the (broken) #200 hierarchical per-block path back to the legacy `pinToIpfs(carBytes)` monolithic raw-codec pin. Cross-device sync now delivers tokens within 28s (was hard-failing at the 100s polling budget).

Architectural follow-up tracking the proper fix: **#211**.

## Root cause

UXF bundle CARs ship sub-blocks where **`block.cid != sha256(block.bytes)`**:

- The CID is computed over the *hash canonical form* (`uxf/ipld.ts:121`'s `computeCid` — children encoded as raw 32-byte hash bytes).
- The emitted bytes are in *IPLD form* (`uxf/ipld.ts:144`'s `elementToIpldBlock` — children encoded as Tag-42 CID links).

Tag-42 prefix vs raw-bstr — the two encodings produce byte-different blocks. When Kubo's `dag/put` receives the bytes, it computes the CID from what it received and pins under THAT bytes-derived CID. The bundle's internal manifest still references the original content-hash-derived CIDs which never get pinned. Receivers walking from envelope → manifest → token-element CIDs hit 404 on every sub-block.

Diagnostic ran in `tests/e2e/profile-live-concurrent-sync.test.ts`:
```
[A] sync.after: bundle bafyreicsscwqd5l fetch failed: BUNDLE_NOT_FOUND
    Failed to fetch CAR bafyreibwsldr6sdffa7i6wheqimtcic4r64jksbk7v6pq44mzuldqkr26m
    from all gateways: The operation was aborted due to timeout
```
Note: even device A could not fetch its own bundle. Confirms the CID stored in the manifest doesn't match anything pinned to any gateway.

PR-A (#206) and PR-B (#207) did NOT cause this — it's a pre-existing defect from #201 / Issue #200 Phase 2.

## What the fix does

**Primary:** `profile/profile-token-storage/flush-scheduler.ts:flushToIpfs` calls `pinToIpfs(carBytes)` instead of `pinCarBlocksToIpfs(...)`. The bundle CID becomes `CID.createV1(raw, sha256(carBytes))` — bytes-derived by construction. The receiver's `fetchCarFromIpfs` already short-circuits raw-codec roots to single-block fetch (`profile/ipfs-client.ts:592-601`). One round trip per CAR; no DAG walking; sub-block CIDs inside the CAR never round-trip through Kubo.

**Secondary:** `profile/profile-token-storage/bundle-index.ts:joinSnapshot.writeRemote` now wraps the encrypted payload in a fresh OpLog envelope via `db.putEntry` instead of writing raw bytes via `db.put`. Pre-fix this caused subsequent `getEntry → decodeEntry` reads to throw `OpLog entry CBOR decode failed: tag not supported (X)` on the ciphertext bytes. Surfaced as the `[ProfileLeanSnapshot] failed to read encrypted KV entry` warnings in the in-process test logs.

## Trade-offs

| | Before fix | After fix |
|---|---|---|
| Cross-device bundle CAR fetch | broken (404 walking DAG) | works (single-shot raw fetch) |
| Bundle CID codec | dag-cbor (mismatch with bytes) | raw (bytes-derived) |
| Per-block IPFS dedup | intended but broken (sub-blocks never pinned correctly) | gone — each bundle is a fully-independent blob |
| Bandwidth per token-update | (broken anyway) | full CAR re-download per mutation |
| Lean profile snapshot pinning | hierarchical, works | unchanged — `profile-lean-snapshot.ts:606` already uses bytes-derived `dagCborCid(rootBytes)` |
| Receiver backward compat | dual-codec walker | dual-codec walker (unchanged) |

**On bandwidth efficiency:** yes, every token mutation now produces a fresh bundle CAR that receivers re-download in full. Consolidation (threshold = 3 bundles) caps unbounded accumulation, but per-mutation bandwidth grows with token-set size. This is a real regression vs. the *intended* (but broken) #200 design; not a regression vs. the actual *previous* behavior (#200 produced unreachable bundles).

**On backward compat:** the receiver's `fetchCarFromIpfs` already accepts BOTH raw and dag-cbor root CIDs (lines 592-601). When #211 lands and bundles flip back to hierarchical, raw-codec bundles from this interim period continue to be readable. No migration needed at flip-over time.

## Updated tests

- `tests/unit/profile/pointer-monotonicity.test.ts` — no-data short-circuit projected CID matches the actual raw-pin CID.
- `tests/unit/profile/profile-token-storage-no-data-flush.test.ts` — `projectedFlushCid` helper switches to raw-codec computation.
- `tests/unit/profile/profile-token-storage-provider.test.ts` — `CAR files are pinned unencrypted` test accepts both pin shapes (forward-compat once #211 lands).
- `tests/integration/oplog-bundle-roundtrip.test.ts` — NEW: 3 regression tests pinning the OpLog envelope round-trip and reproducing the raw-bytes write defect that was in `BundleIndex.joinSnapshot.writeRemote`.

## Test plan

- [x] Typecheck passes.
- [x] All 49 targeted unit tests pass (profile-token-storage + no-data-flush + pointer-monotonicity + oplog-bundle-roundtrip).
- [x] `tests/e2e/profile-live-concurrent-sync.test.ts > Cross-device sync …` passes in 28s against testnet.
- [x] `tests/e2e/profile-sync.test.ts > ProfileTokenStorageProvider pins real tokens to a CAR and recovers them on a fresh load` still passes (in-process CAR round-trip preserved).
- [x] Full unit suite: same 2 pre-existing test-parallelism flakes (`profile-token-storage-no-data-flush.test.ts`) as parent commit d5f309e. No new regressions.

## Refs

- Closes: #210 (E2E acceptance blocker for #207).
- Follow-up: #211 (proper architectural fix for UXF bundle CID/bytes alignment to restore hierarchical pinning).
- Pre-existing parallelism flakes: documented in project memory note `project_issue_199_followup_findings.md`.
- Reverted-from: Issue #200 Phase 2 (`pinCarBlocksToIpfs`) introduced by PR #201.