### PR TITLE
test(profile)(#215): fix flake — vi.waitFor + flush-settle in no-data-flush & pointer-monotonicity

### DIFF
--- a/tests/unit/profile/pointer-monotonicity.test.ts
+++ b/tests/unit/profile/pointer-monotonicity.test.ts
@@ -322,6 +322,58 @@ async function plantBundleInOrbit(
   );
 }
 
+/**
+ * Issue #215: wait for any debounced flush armed via `scheduleFlush*`
+ * to actually fire AND its in-flight promise to settle.
+ *
+ * The bare `setTimeout(r, flushDebounceMs + epsilon)` pattern is racy
+ * under full-suite worker contention: the debounce timer may not have
+ * fired yet at the wake-up, and the flush body's awaits (mocked
+ * `fetch`, dynamic `import('UxfPackage.js')`) take real time. If the
+ * test asserts before the flush settles, leaked in-flight work bumps
+ * the shared `tracker.pinCalls` counter mid-way through the NEXT test
+ * (which has already swapped in its own tracker via `installMockFetch`),
+ * making that test fail with `pinCalls = 1` when it expected 0.
+ *
+ * Strategy: poll until the host exposes a non-null `flushPromise` (the
+ * timer fired and a flush is now in flight), then `await` it. If no
+ * flush starts within the deadline, return — the caller is then free
+ * to assert "nothing happened" without worrying about a deferred pin.
+ */
+async function waitForFlushSettled(
+  provider: ProfileTokenStorageProvider,
+  deadlineMs = 2000,
+): Promise<void> {
+  const host = provider as unknown as {
+    flushPromise: Promise<void> | null;
+    flushTimer: ReturnType<typeof setTimeout> | null;
+  };
+  const start = Date.now();
+  // Wait for the debounce timer to fire (flushPromise becomes non-null)
+  // OR for both the timer and the promise to be null AND stay null for
+  // a short stability window (= no flush was actually scheduled).
+  while (Date.now() - start < deadlineMs) {
+    if (host.flushPromise) {
+      try {
+        await host.flushPromise;
+      } catch {
+        // Flush body throws on POINTER_MONOTONICITY_VIOLATION etc.;
+        // that's a normal completion path for the tests below.
+      }
+      // After settle, check whether a chained flush re-armed.
+      if (!host.flushTimer && !host.flushPromise) return;
+      continue;
+    }
+    if (!host.flushTimer) {
+      // Stability window — give a late-arming timer a moment to land.
+      await new Promise((r) => setTimeout(r, 5));
+      if (!host.flushTimer && !host.flushPromise) return;
+      continue;
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -352,18 +404,25 @@ describe('pointer monotonicity invariant', () => {
     const v1 = buildTxfData({ _T1: tokenT1 });
     await provider.save(v1);
 
-    // Wait for V1 flush to complete.
-    await new Promise((r) => setTimeout(r, 80));
-    expect(tracker.pinCalls).toBe(1);
+    // Issue #215: wait for the debounced V1 flush to actually finish
+    // pinning. The original `setTimeout(r, 80)` expired before the
+    // pin under full-suite contention (load() + import('UxfPackage.js')
+    // round-trip), the assertion failed mid-test, AND the in-flight
+    // flush later bumped `tracker.pinCalls` while the NEXT test was
+    // running (cascading into "race-stale flush" failing with
+    // pinCalls=1 vs expected 0).
+    await vi.waitFor(() => {
+      expect(tracker.pinCalls).toBe(1);
+    }, { timeout: 5000, interval: 25 });
 
     // V2: save() with {T1, T2} — strict superset.
     const tokenT2 = { id: '_T2', genesis: { tokenId: 'T2' } };
     const v2 = buildTxfData({ _T1: tokenT1, _T2: tokenT2 });
     await provider.save(v2);
 
-    await new Promise((r) => setTimeout(r, 80));
-    // V2 flush succeeded — assertion did NOT fire.
-    expect(tracker.pinCalls).toBe(2);
+    await vi.waitFor(() => {
+      expect(tracker.pinCalls).toBe(2);
+    }, { timeout: 5000, interval: 25 });
 
     // Both bundles registered in OrbitDB.
     const bundleKeys = [...db._store.keys()].filter((k) =>
@@ -438,7 +497,11 @@ describe('pointer monotonicity invariant', () => {
     ).flushScheduler;
     flushScheduler.scheduleFlushNoData();
 
-    await new Promise((r) => setTimeout(r, 100));
+    // Issue #215: wait for the debounced flush to actually run
+    // (timer → flush body → catch arm) before asserting that no pin
+    // was issued. The original 100 ms fixed wait was insufficient
+    // under full-suite contention.
+    await waitForFlushSettled(provider);
 
     // Assertion fired: no pin, error event emitted with the violation
     // code and the unknown bundle CID listed.
@@ -590,7 +653,12 @@ describe('pointer monotonicity invariant', () => {
     ).flushScheduler;
     flushScheduler.scheduleFlushNoData();
 
-    await new Promise((r) => setTimeout(r, 100));
+    // Issue #215: wait for the flush body to actually run + short-
+    // circuit before asserting nothing happened. Without this the
+    // assertion could pass simply because the debounce timer hadn't
+    // fired yet — and the deferred flush would then leak into the
+    // next test.
+    await waitForFlushSettled(provider);
 
     // Short-circuit fired: no pin, no assertion violation.
     expect(tracker.pinCalls).toBe(0);

--- a/tests/unit/profile/profile-token-storage-no-data-flush.test.ts
+++ b/tests/unit/profile/profile-token-storage-no-data-flush.test.ts
@@ -339,10 +339,18 @@ describe('ProfileTokenStorageProvider — no-data flush on remote update', () =>
     );
 
     db._triggerReplication();
-    // handleReplication is async and detached — wait for microtasks.
-    await new Promise((r) => setTimeout(r, 50));
-
-    expect(spy).toHaveBeenCalledTimes(1);
+    // Issue #215: `handleReplication` is async + detached and awaits
+    // `this.load()` inside, which iterates `fetchCarFromIpfs` calls per
+    // active bundle. Under full-suite contention the chain can take
+    // 150+ ms before `scheduleFlushNoData` is reached — the original
+    // 50 ms fixed wait expired before the call landed, the assertion
+    // failed, and the still-in-flight `handleReplication` leaked async
+    // work into the next test. Poll via `vi.waitFor` so the test
+    // tolerates contention without burning real wall time when the
+    // call lands quickly (the normal case).
+    await vi.waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    }, { timeout: 5000, interval: 25 });
 
     await provider.shutdown();
   });


### PR DESCRIPTION
## Summary

Closes #215.

Two test files in `tests/unit/profile/` failed in full-suite runs but passed in isolation — same flake family: fixed `setTimeout` waits that expired before debounced async work completed under full-suite worker contention. When the first assertion fired prematurely, the still-in-flight `handleReplication` / flush body leaked work into the next test, cascading the failure into a sibling test that also expected a 0-state counter.

This PR replaces the fixed waits with `vi.waitFor` for positive assertions and a new `waitForFlushSettled` helper for negative assertions that polls the host's private `flushPromise` until the debounced flush actually fires AND settles.

## Changes

- **`tests/unit/profile/profile-token-storage-no-data-flush.test.ts`** (commit fb1b86d): replace `setTimeout(r, 50)` in test 1 with `vi.waitFor` (5 s timeout, 25 ms interval). Test 3 was failing as a secondary effect of test 1's leaked async work — fixing test 1 fixes test 3.
- **`tests/unit/profile/pointer-monotonicity.test.ts`** (commit 4bc7f20): apply the same pattern to test 1 (positive `pinCalls` assertions) and tests 2 + 4 (negative `pinCalls` assertions via new `waitForFlushSettled` helper that awaits the host's `flushPromise`).

## Production semantics — verified, not a real bug

Per a follow-up review with the issue author, the flakes did **not** surface a production token-loss bug:

- `handleReplication` runs to completion in production regardless of any test wait budget; `scheduleFlushNoData` is always invoked.
- `FlushScheduler.startSerializedFlushInternal` chains every flush through `host.flushPromise` — V_n+1 cannot publish before V_n settles. High-frequency saves remain ordered.
- Each `save()` is a full `TxfStorageDataBase` snapshot, not a delta; the latest save in a debounce window covers everything before it.
- The `POINTER_MONOTONICITY_VIOLATION` defense (bundle-set + token-set checks in `flush-scheduler.ts:432-578`) refuses to publish lossy CARs even when `load()` fails to merge a remote bundle.
- The no-data-flush short-circuit (test 3 + test 4) is an **optimization** — its absence wastes a pin + publish but does not lose tokens (Kubo `dag/put` is content-addressed and idempotent; the pointer would just advance V_n→V_n+1 pointing to the same CID).

## Verification

- **Isolation:** both files pass cleanly (6/6 and 4/4 tests).
- **Stress test, 10 full-profile-dir runs:** 10/10 clean for both files (was 0/10 and 4/10 respectively before this PR).
- **Full unit suite (7341 tests):** clean, no regressions.

## Test plan

- [x] `npx vitest run tests/unit/profile/profile-token-storage-no-data-flush.test.ts` — passes in isolation
- [x] `npx vitest run tests/unit/profile/pointer-monotonicity.test.ts` — passes in isolation
- [x] `npx vitest run tests/unit/profile/` — 10/10 stress runs clean
- [x] `npx vitest run tests/unit/` — full unit suite clean
- [x] `npx eslint tests/unit/profile/profile-token-storage-no-data-flush.test.ts tests/unit/profile/pointer-monotonicity.test.ts` — clean