### PR TITLE
test(flake)(#217): isolate three flakes surfaced by 10-run full-suite stress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,8 @@ tests/integration/.test-*/
 # E2e preflight infra-probe result (regenerated each run)
 tests/e2e/.preflight-result.json
 
+# Local clone of aggregator-go used by e2e local-infra (not tracked here)
+tests/e2e/local-infra/.aggregator-go/
+
 # Community / Discord report drafts (agent-authored, not source)
 community-reports/

--- a/tests/integration/wallet-password.test.ts
+++ b/tests/integration/wallet-password.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { Sphere } from '../../core/Sphere';
@@ -26,9 +27,24 @@ import type { ProviderStatus } from '../../types';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const TEST_DIR = path.join(__dirname, '.test-wallet-password');
-const DATA_DIR = path.join(TEST_DIR, 'data');
-const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+// Per-test unique directory (Date.now() + random suffix). The previous
+// shared `path.join(__dirname, '.test-wallet-password')` triggered
+// intermittent failures under full-suite worker contention (#217) —
+// five distinct tests in this file failed across 5/10 runs due to FS
+// race between cleanTestDir() and the next test's wallet write. Same
+// family of fix as commit `9bf3e90` on Sphere.test.ts.
+let TEST_DIR: string = path.join(__dirname, '.test-wallet-password');
+let DATA_DIR: string = path.join(TEST_DIR, 'data');
+let TOKENS_DIR: string = path.join(TEST_DIR, 'tokens');
+
+function freshTestDirs(): void {
+  TEST_DIR = path.join(
+    os.tmpdir(),
+    `sphere-wallet-password-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+  );
+  DATA_DIR = path.join(TEST_DIR, 'data');
+  TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+}
 
 const TEST_MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 const TEST_PASSWORD = 'my-secret-password';
@@ -140,6 +156,7 @@ describe('Wallet password encryption', () => {
     // (from a prior test that didn't await its own destroy) flush
     // before we delete the directory. cleanTestDir is sync rm.
     await new Promise((r) => setImmediate(r));
+    freshTestDirs();
     cleanTestDir();
   });
 

--- a/tests/unit/core/Sphere.init-nametag.test.ts
+++ b/tests/unit/core/Sphere.init-nametag.test.ts
@@ -25,6 +25,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { Sphere } from '../../../core/Sphere';
 import { FileStorageProvider } from '../../../impl/nodejs/storage/FileStorageProvider';
@@ -33,9 +34,24 @@ import type { TransportProvider, OracleProvider } from '../../../index';
 import type { ProviderStatus } from '../../../types';
 import { mockMintNametagSuccess } from '../../helpers/mockMintNametag';
 
-const TEST_DIR = path.join(__dirname, '.test-init-nametag');
-const DATA_DIR = path.join(TEST_DIR, 'data');
-const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+// Per-test unique directory (Date.now() + random suffix). The previous
+// shared `path.join(__dirname, '.test-init-nametag')` triggered
+// intermittent "Wallet already exists" failures under full-suite
+// worker contention (#217), same family as the flake fixed for
+// `Sphere.test.ts` in commit `9bf3e90`. Issuing each test its own
+// tmpdir eliminates FS-level interference between tests in this file.
+let TEST_DIR: string = '';
+let DATA_DIR: string = '';
+let TOKENS_DIR: string = '';
+
+function freshTestDirs(): void {
+  TEST_DIR = path.join(
+    os.tmpdir(),
+    `sphere-init-nametag-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+  );
+  DATA_DIR = path.join(TEST_DIR, 'data');
+  TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+}
 
 function createMockTransport(): TransportProvider {
   return {
@@ -96,7 +112,7 @@ describe('Sphere.init({ nametag }) on existing wallet (Bug A)', () => {
   let mintSpy: ReturnType<typeof vi.spyOn> | undefined;
 
   beforeEach(async () => {
-    cleanTestDir();
+    freshTestDirs();
     if (Sphere.getInstance()) {
       (Sphere as unknown as { instance: null }).instance = null;
     }

--- a/tests/unit/profile/pointer-monotonicity.test.ts
+++ b/tests/unit/profile/pointer-monotonicity.test.ts
@@ -411,18 +411,27 @@ describe('pointer monotonicity invariant', () => {
     // flush later bumped `tracker.pinCalls` while the NEXT test was
     // running (cascading into "race-stale flush" failing with
     // pinCalls=1 vs expected 0).
-    await vi.waitFor(() => {
-      expect(tracker.pinCalls).toBe(1);
-    }, { timeout: 5000, interval: 25 });
+    //
+    // Issue #217: bumping the `vi.waitFor(pinCalls === N)` budget
+    // alone was insufficient because the assertion still races with
+    // the OrbitDB bundle write that happens AFTER the pin (see
+    // `flush-scheduler.ts` step-6: `pinCarBlocksToIpfs` →
+    // `bundleIndex.addBundle`). `pinCalls === N` was observed mid-
+    // flush in run 6/10, then `bundleKeys.length === N` failed because
+    // the addBundle call hadn't landed yet. Switch to
+    // `waitForFlushSettled`, which waits for the whole flush body
+    // (pin + OrbitDB write + IPNS pointer + operational state) to
+    // resolve. The pinCalls equality is preserved as a sanity check.
+    await waitForFlushSettled(provider, 10000);
+    expect(tracker.pinCalls).toBe(1);
 
     // V2: save() with {T1, T2} — strict superset.
     const tokenT2 = { id: '_T2', genesis: { tokenId: 'T2' } };
     const v2 = buildTxfData({ _T1: tokenT1, _T2: tokenT2 });
     await provider.save(v2);
 
-    await vi.waitFor(() => {
-      expect(tracker.pinCalls).toBe(2);
-    }, { timeout: 5000, interval: 25 });
+    await waitForFlushSettled(provider, 10000);
+    expect(tracker.pinCalls).toBe(2);
 
     // Both bundles registered in OrbitDB.
     const bundleKeys = [...db._store.keys()].filter((k) =>


### PR DESCRIPTION
## Summary

Closes #217. Fixes three test-isolation flakes surfaced by a 10-run full-scope vitest stress on `integration/all-fixes` @ 17aec32 (after #215/PR #216 landed). All three are the same family — test-side timing / isolation issues under worker contention — and none indicate production bugs.

| File | Pre-fix | Post-fix |
|---|---|---|
| `tests/unit/core/Sphere.init-nametag.test.ts` | 4/10 fails | **0/10** |
| `tests/integration/wallet-password.test.ts` | 5/10 fails | **0/10** |
| `tests/unit/profile/pointer-monotonicity.test.ts` | 1/10 fails | **0/10** |

## Fixes

### Flake A & B — per-test unique TEST_DIR

Mirrors the 9bf3e90 pattern (`Sphere.test.ts`): replace shared `path.join(__dirname, '.test-X')` with a per-test fresh path under `os.tmpdir()` via a `freshTestDirs()` helper called in `beforeEach`. tmpfs gives no fsync and no real cross-process lock contention; the unique path guarantees zero FS interaction between tests.

### Flake C — `waitForFlushSettled` instead of `vi.waitFor(pinCalls === N)`

Initial attempt to bump the `vi.waitFor` timeout from 5 s → 10 s exposed a deeper race. `pinCalls` increments at flush step 5 (`pinCarBlocksToIpfs`, `flush-scheduler.ts:627`) BEFORE the OrbitDB bundle write at step 6 (`bundleIndex.addBundle`, line 642). So `vi.waitFor` can return mid-flush, and the next `expect(bundleKeys.length).toBe(N)` assertion (line 435) fails because `addBundle` hasn't landed.

Confirmed by stress v1 Run 6/10: 91 ms total test runtime — both `vi.waitFor` calls succeeded fast, then `bundleKeys.length` check failed.

The fix replaces `vi.waitFor(pinCalls === N)` with `await waitForFlushSettled(provider, 10000)`. The helper (already defined in the file at lines 343-375) waits for the whole flush body — pin + OrbitDB write + IPNS pointer + operational state — to resolve. The `pinCalls` equality is preserved as a post-settle sanity check.

## Verification

10-run full-scope vitest stress (`timeout 240 npx vitest run --no-coverage`, default threads pool, ~70 s wall-clock per run):

```
=== SUMMARY ===
Clean runs:    9 / 10
Failed runs:   1 / 10
  Sphere.init-nametag.test.ts:   0 / 10
  wallet-password.test.ts:        0 / 10
  pointer-monotonicity.test.ts:   0 / 10
```

The single non-target failure (Run 1) was an **unrelated** flake in `tests/integration/profile/no-token-loss-tombstones.test.ts` — same race family (a `setTimeout(r, 200)` budget for save() flush settle). Filed as #219 with a broader audit of `setTimeout(r, N)` flush-budget patterns across the profile test suite.

## Test plan

- [x] Three target files pass in isolation (`npx vitest run --no-coverage <path>`)
- [x] Typecheck + lint clean
- [x] 10-run full-scope stress: target files 0/10 fails
- [x] Follow-up filed for unrelated tombstones flake (#219)
- [x] Follow-up filed for extended manual-test doc (#218)

## Refs

- Closes #217
- Follow-ups: #218 (extend manual-test-drain-fix.md to full peer2 + daemon scenario), #219 (audit + fix setTimeout(r, N) flush-budget pattern across profile tests)
- Related: 9bf3e90 (Sphere.test.ts per-test TEST_DIR pattern), #215/PR #216 (initial pointer-monotonicity fix)