### PR TITLE
test(flake)(#219): deterministic flush-settle waits across profile tests

### DIFF
--- a/tests/helpers/profile/waitForFlushSettled.ts
+++ b/tests/helpers/profile/waitForFlushSettled.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared test helper: deterministically wait for the
+ * `ProfileTokenStorageProvider` debounced flush pipeline to settle.
+ *
+ * Why this exists
+ * ----------------
+ * `provider.save(data)` and the various `scheduleFlush*` paths arm a
+ * `setTimeout(flushDebounceMs)` and only later kick off the IPFS pin +
+ * OrbitDB write body in `flush-scheduler.ts`. Tests that assert anything
+ * dependent on that body completing (the bundle write, the pin call,
+ * the operational state at `${addr}.tombstones` / `.invalidatedNametags`,
+ * the pointer publish, etc.) MUST wait for the in-flight flush to fully
+ * settle — not just for the debounce to elapse.
+ *
+ * The naive `await new Promise(r => setTimeout(r, flushDebounceMs + 100))`
+ * is racy under full-suite worker contention: the debounce timer may not
+ * have fired yet at wake-up, and the flush body's awaits (mocked `fetch`,
+ * dynamic `import('UxfPackage.js')`) take real time. Originally surfaced
+ * by issue #215 (`pointer-monotonicity.test.ts`) and again by #219
+ * (`no-token-loss-tombstones.test.ts`).
+ *
+ * Strategy
+ * --------
+ * Poll the host's private `flushPromise` / `flushTimer` fields:
+ *   - If a flush is in flight (`flushPromise != null`), `await` it.
+ *   - If the timer is armed (`flushTimer != null`), wait briefly and re-check.
+ *   - If both are null AND remain null across a short stability window,
+ *     return — no scheduled work is pending.
+ *
+ * A timeout returns silently so callers can still proceed to assert
+ * "nothing happened" without throwing. If the flush actually rejects
+ * (`POINTER_MONOTONICITY_VIOLATION`, etc.), the rejection is swallowed
+ * here — that's a normal completion path for some tests.
+ *
+ * Generic over the provider type so unit tests using mocked OrbitDB
+ * implementations don't need to expose the full provider class.
+ */
+
+interface FlushPipelineHost {
+  flushPromise: Promise<void> | null;
+  flushTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export async function waitForFlushSettled(
+  provider: unknown,
+  deadlineMs = 2000,
+): Promise<void> {
+  const host = provider as FlushPipelineHost;
+  const start = Date.now();
+  while (Date.now() - start < deadlineMs) {
+    if (host.flushPromise) {
+      try {
+        await host.flushPromise;
+      } catch {
+        // Flush body may reject (POINTER_MONOTONICITY_VIOLATION etc.);
+        // that's a normal completion path for some tests.
+      }
+      if (!host.flushTimer && !host.flushPromise) return;
+      continue;
+    }
+    if (!host.flushTimer) {
+      // Stability window — give a late-arming timer a moment to land.
+      await new Promise((r) => setTimeout(r, 5));
+      if (!host.flushTimer && !host.flushPromise) return;
+      continue;
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}

--- a/tests/integration/profile/no-token-loss-tombstones.test.ts
+++ b/tests/integration/profile/no-token-loss-tombstones.test.ts
@@ -37,6 +37,7 @@ import {
   deriveProfileEncryptionKey,
   encryptProfileValue,
 } from '../../../profile/encryption.js';
+import { waitForFlushSettled } from '../../helpers/profile/waitForFlushSettled.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { CID } from 'multiformats/cid';
 import * as raw from 'multiformats/codecs/raw';
@@ -275,10 +276,12 @@ describe('G4 — tombstones survive cold-start (security boundary)', () => {
     const data = buildTxfData();
     data._tombstones = tombstones;
     await provider.save(data);
-    // Give the debounce + flush + IPFS pin + OrbitDB write the time
-    // to settle. Higher timeout is fine — this test has no realtime
-    // constraint.
-    await new Promise((r) => setTimeout(r, 200));
+    // Issue #219: wait deterministically for the flush body (pin → bundle
+    // write → operational state at `${addr}.tombstones`) to fully settle
+    // instead of polling on a fixed timer. Under full-suite worker
+    // contention the bundle write can land before the tombstone write,
+    // making any fixed budget racy.
+    await waitForFlushSettled(provider, 10000);
 
     // Dump keys for diagnostic clarity if the assertion fails — without
     // this, a flush-scheduler regression here is opaque to triage.
@@ -304,7 +307,7 @@ describe('G4 — tombstones survive cold-start (security boundary)', () => {
     const data1 = buildTxfData();
     data1._tombstones = tombstones;
     await provider1.save(data1);
-    await new Promise((r) => setTimeout(r, 80));
+    await waitForFlushSettled(provider1, 10000);
 
     // Plant a dummy bundle so load() goes through the merge path
     // (zero bundles short-circuits load). Must be done BEFORE wiping

--- a/tests/unit/profile/per-entry-key-writers.test.ts
+++ b/tests/unit/profile/per-entry-key-writers.test.ts
@@ -38,6 +38,7 @@ import type {
 } from '../../../storage/storage-provider';
 import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
 import { decryptProfileValue } from '../../../profile/encryption';
+import { waitForFlushSettled } from '../../helpers/profile/waitForFlushSettled';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -221,7 +222,7 @@ describe('Per-entry-key writers — audit + finalizationQueue (T.0.G7-fill-gaps)
       ];
       data._audit = audit;
       await provider.save(data);
-      await new Promise((r) => setTimeout(r, 100));
+      await waitForFlushSettled(provider, 10000);
 
       const keys = [...db._store.keys()].filter((k) => k.startsWith(`${ADDR}.audit.`));
       expect(keys.length).toBe(2);
@@ -259,7 +260,7 @@ describe('Per-entry-key writers — audit + finalizationQueue (T.0.G7-fill-gaps)
         },
       ];
       await provider.save(data);
-      await new Promise((r) => setTimeout(r, 100));
+      await waitForFlushSettled(provider, 10000);
 
       const expectedKey = `${ADDR}.audit.${compositeId}`;
       expect(db._store.has(expectedKey)).toBe(true);
@@ -279,7 +280,7 @@ describe('Per-entry-key writers — audit + finalizationQueue (T.0.G7-fill-gaps)
         { id: 'idDropped', tokenId: 'tD', disposition: 'UNSPENDABLE_BY_US', detectedAt: 2 },
       ];
       await provider.save(data1);
-      await new Promise((r) => setTimeout(r, 100));
+      await waitForFlushSettled(provider, 10000);
       expect(db._store.has(`${ADDR}.audit.idKept`)).toBe(true);
       expect(db._store.has(`${ADDR}.audit.idDropped`)).toBe(true);
 
@@ -289,7 +290,7 @@ describe('Per-entry-key writers — audit + finalizationQueue (T.0.G7-fill-gaps)
         { id: 'idKept', tokenId: 'tK', disposition: 'NOT_OUR_CURRENT_STATE', detectedAt: 1 },
       ];
       await provider.save(data2);
-      await new Promise((r) => setTimeout(r, 100));
+      await waitForFlushSettled(provider, 10000);
 
       // Kept entry: still live (parses as audit entry).
       const kept = (await readEntry(db, `${ADDR}.audit.idKept`)) as TxfAuditEntry;
@@ -327,7 +328,7 @@ describe('Per-entry-key writers — audit + finalizationQueue (T.0.G7-fill-gaps)
       ];
       data._finalizationQueue = queue;
       await provider.save(data);
-      await new Promise((r) => setTimeout(r, 100));
+      await waitForFlushSettled(provider, 10000);
 
       const keys = [...db._store.keys()].filter((k) =>
         k.startsWith(`${ADDR}.finalizationQueue.`),
@@ -362,14 +363,14 @@ describe('Per-entry-key writers — audit + finalizationQueue (T.0.G7-fill-gaps)
         { id: 'reqB', status: 'pending', enqueuedAt: 2 },
       ];
       await provider.save(data1);
-      await new Promise((r) => setTimeout(r, 100));
+      await waitForFlushSettled(provider, 10000);
 
       const data2 = buildEmptyTxfData();
       data2._finalizationQueue = [
         { id: 'reqA', status: 'pending', enqueuedAt: 1 },
       ];
       await provider.save(data2);
-      await new Promise((r) => setTimeout(r, 100));
+      await waitForFlushSettled(provider, 10000);
 
       const tomb = (await readEntry(db, `${ADDR}.finalizationQueue.reqB`)) as {
         tombstoned: true;
@@ -399,7 +400,7 @@ describe('Per-entry-key writers — audit + finalizationQueue (T.0.G7-fill-gaps)
       { id: 'shared-id', status: 'pending', enqueuedAt: 4 },
     ];
     await provider.save(data);
-    await new Promise((r) => setTimeout(r, 100));
+    await waitForFlushSettled(provider, 10000);
 
     // All four collections have a key with the same trailing id but
     // distinct prefixes — they must not overwrite each other.

--- a/tests/unit/profile/pointer-monotonicity.test.ts
+++ b/tests/unit/profile/pointer-monotonicity.test.ts
@@ -48,6 +48,7 @@ import {
   encryptProfileValue,
 } from '../../../profile/encryption';
 import { POINTER_MONOTONICITY_VIOLATION } from '../../../profile/profile-token-storage/flush-scheduler';
+import { waitForFlushSettled } from '../../helpers/profile/waitForFlushSettled';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { CID } from 'multiformats/cid';
 import * as raw from 'multiformats/codecs/raw';
@@ -322,57 +323,8 @@ async function plantBundleInOrbit(
   );
 }
 
-/**
- * Issue #215: wait for any debounced flush armed via `scheduleFlush*`
- * to actually fire AND its in-flight promise to settle.
- *
- * The bare `setTimeout(r, flushDebounceMs + epsilon)` pattern is racy
- * under full-suite worker contention: the debounce timer may not have
- * fired yet at the wake-up, and the flush body's awaits (mocked
- * `fetch`, dynamic `import('UxfPackage.js')`) take real time. If the
- * test asserts before the flush settles, leaked in-flight work bumps
- * the shared `tracker.pinCalls` counter mid-way through the NEXT test
- * (which has already swapped in its own tracker via `installMockFetch`),
- * making that test fail with `pinCalls = 1` when it expected 0.
- *
- * Strategy: poll until the host exposes a non-null `flushPromise` (the
- * timer fired and a flush is now in flight), then `await` it. If no
- * flush starts within the deadline, return — the caller is then free
- * to assert "nothing happened" without worrying about a deferred pin.
- */
-async function waitForFlushSettled(
-  provider: ProfileTokenStorageProvider,
-  deadlineMs = 2000,
-): Promise<void> {
-  const host = provider as unknown as {
-    flushPromise: Promise<void> | null;
-    flushTimer: ReturnType<typeof setTimeout> | null;
-  };
-  const start = Date.now();
-  // Wait for the debounce timer to fire (flushPromise becomes non-null)
-  // OR for both the timer and the promise to be null AND stay null for
-  // a short stability window (= no flush was actually scheduled).
-  while (Date.now() - start < deadlineMs) {
-    if (host.flushPromise) {
-      try {
-        await host.flushPromise;
-      } catch {
-        // Flush body throws on POINTER_MONOTONICITY_VIOLATION etc.;
-        // that's a normal completion path for the tests below.
-      }
-      // After settle, check whether a chained flush re-armed.
-      if (!host.flushTimer && !host.flushPromise) return;
-      continue;
-    }
-    if (!host.flushTimer) {
-      // Stability window — give a late-arming timer a moment to land.
-      await new Promise((r) => setTimeout(r, 5));
-      if (!host.flushTimer && !host.flushPromise) return;
-      continue;
-    }
-    await new Promise((r) => setTimeout(r, 5));
-  }
-}
+// `waitForFlushSettled` lives in `tests/helpers/profile/` and is shared
+// across the profile test suite — see issue #219 for the broader audit.
 
 // =============================================================================
 // Tests

--- a/tests/unit/profile/profile-token-storage-flush-serialization.test.ts
+++ b/tests/unit/profile/profile-token-storage-flush-serialization.test.ts
@@ -49,6 +49,7 @@ import { ProfileTokenStorageProvider } from '../../../profile/profile-token-stor
 import {
   deriveProfileEncryptionKey,
 } from '../../../profile/encryption';
+import { waitForFlushSettled } from '../../helpers/profile/waitForFlushSettled';
 
 // =============================================================================
 // Test fixtures (mirrors profile-token-storage-no-data-flush.test.ts setup)
@@ -355,7 +356,7 @@ describe('ProfileTokenStorageProvider — flush serialization (PR #127 partial-C
     flushScheduler.scheduleFlush();
 
     // Wait for both flushes to settle.
-    await new Promise((r) => setTimeout(r, 200));
+    await waitForFlushSettled(provider, 10000);
 
     // Critical assertion: serialization held — never two flushes in
     // flight at the same time.
@@ -389,7 +390,7 @@ describe('ProfileTokenStorageProvider — flush serialization (PR #127 partial-C
     // existing one.
     flushScheduler.scheduleFlushNoData();
 
-    await new Promise((r) => setTimeout(r, 200));
+    await waitForFlushSettled(provider, 10000);
 
     expect(tracker.maxInFlight).toBe(1);
     expect(tracker.startCount).toBe(2);
@@ -425,7 +426,7 @@ describe('ProfileTokenStorageProvider — flush serialization (PR #127 partial-C
     (provider as unknown as { pendingData: TxfStorageDataBase | null }).pendingData = data3;
     flushScheduler.scheduleFlush();
 
-    await new Promise((r) => setTimeout(r, 300));
+    await waitForFlushSettled(provider, 10000);
 
     expect(tracker.maxInFlight).toBe(1);
     expect(tracker.startCount).toBe(3);

--- a/tests/unit/profile/profile-token-storage-no-data-flush.test.ts
+++ b/tests/unit/profile/profile-token-storage-no-data-flush.test.ts
@@ -45,6 +45,7 @@ import {
   deriveProfileEncryptionKey,
   encryptProfileValue,
 } from '../../../profile/encryption';
+import { waitForFlushSettled } from '../../helpers/profile/waitForFlushSettled';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { CID } from 'multiformats/cid';
 import * as raw from 'multiformats/codecs/raw';
@@ -365,7 +366,7 @@ describe('ProfileTokenStorageProvider — no-data flush on remote update', () =>
     const spy = vi.spyOn(flushScheduler, 'scheduleFlushNoData');
 
     db._triggerReplication();
-    await new Promise((r) => setTimeout(r, 50));
+    await waitForFlushSettled(provider, 10000);
 
     expect(spy).not.toHaveBeenCalled();
 
@@ -418,7 +419,7 @@ describe('ProfileTokenStorageProvider — no-data flush on remote update', () =>
     flushScheduler.scheduleFlushNoData();
 
     // Wait for debounce + flush to complete.
-    await new Promise((r) => setTimeout(r, 100));
+    await waitForFlushSettled(provider, 10000);
 
     // No pin should have been issued — short-circuit fired.
     expect(pinCallCount).toBe(0);
@@ -478,7 +479,7 @@ describe('ProfileTokenStorageProvider — no-data flush on remote update', () =>
     ).flushScheduler;
     flushScheduler.scheduleFlushNoData();
 
-    await new Promise((r) => setTimeout(r, 100));
+    await waitForFlushSettled(provider, 10000);
 
     expect(pinCallCount).toBe(0);
 
@@ -525,7 +526,7 @@ describe('ProfileTokenStorageProvider — no-data flush on remote update', () =>
     ).flushScheduler;
     flushScheduler.scheduleFlushNoData();
 
-    await new Promise((r) => setTimeout(r, 100));
+    await waitForFlushSettled(provider, 10000);
 
     // The flush proceeded — pin was issued.
     expect(pinCallCount).toBe(1);
@@ -568,7 +569,7 @@ describe('ProfileTokenStorageProvider — no-data flush on remote update', () =>
     ).flushScheduler;
     flushScheduler.scheduleFlushNoData();
 
-    await new Promise((r) => setTimeout(r, 100));
+    await waitForFlushSettled(provider, 10000);
 
     expect(pinCallCount).toBe(0);
 

--- a/tests/unit/profile/profile-token-storage-provider.test.ts
+++ b/tests/unit/profile/profile-token-storage-provider.test.ts
@@ -23,6 +23,7 @@ import {
   encryptString,
   decryptString,
 } from '../../../profile/encryption';
+import { waitForFlushSettled } from '../../helpers/profile/waitForFlushSettled';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { CID } from 'multiformats/cid';
 import * as raw from 'multiformats/codecs/raw';
@@ -538,7 +539,7 @@ describe('ProfileTokenStorageProvider', () => {
       await provider.save(data3);
 
       // Wait for debounce + flush to complete
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
 
       // Only one pin call should have been made
       expect(pinCallCount).toBe(1);
@@ -755,7 +756,7 @@ describe('ProfileTokenStorageProvider', () => {
       await provider.save(txfData);
 
       // Wait for debounce + flush
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
 
       // Check that a bundle ref was written
       const bundleKeys = Array.from(db._store.keys()).filter((k) =>
@@ -869,7 +870,7 @@ describe('ProfileTokenStorageProvider', () => {
       txfData._sent = [{ tokenId: 't1', recipient: 'bob', txHash: 'hash1', sentAt: 2000 }];
 
       await provider.save(txfData);
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
 
       // Synced (OrbitDB): outbox entry exists under per-entry key
       // (Wave G.7 layout — `${addr}.outbox.${id}` instead of single-
@@ -972,7 +973,7 @@ describe('ProfileTokenStorageProvider', () => {
       ];
       txfData._invalid = [{ tokenId: 'tBad', reason: 'r', detectedAt: 999 }];
       await provider.save(txfData);
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
 
       // Each outbox entry stored under its own key.
       expect(db._store.has(`${EXPECTED_ADDRESS_ID}.outbox.oA`)).toBe(true);
@@ -1003,14 +1004,14 @@ describe('ProfileTokenStorageProvider', () => {
         { id: 'oA', status: 'pending', tokenId: 't1', recipient: 'alice', createdAt: 1000, data: {} },
       ];
       await provider.save(txfData);
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
       expect(db._store.has(`${EXPECTED_ADDRESS_ID}.outbox.oA`)).toBe(true);
 
       // Second save with empty outbox — oA should be tombstoned.
       const txfData2 = buildTxfData({ _token1: { id: '_token1' } });
       txfData2._outbox = [];
       await provider.save(txfData2);
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
 
       // The key still exists but its content is a tombstone marker.
       expect(db._store.has(`${EXPECTED_ADDRESS_ID}.outbox.oA`)).toBe(true);
@@ -1341,7 +1342,7 @@ describe('ProfileTokenStorageProvider', () => {
 
       const txfData = buildTxfData({ _token1: { id: '_token1' } });
       await provider.save(txfData);
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
 
       // The pinned blocks must be the raw CAR content (unencrypted) so
       // that identical token pools across wallets produce the same CIDs.
@@ -1404,7 +1405,7 @@ describe('ProfileTokenStorageProvider', () => {
 
       const txfData = buildTxfData({ _t1: { id: '_t1' } });
       await provider.save(txfData);
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
 
       // Find bundle ref key
       const bundleKeys = Array.from(db._store.keys()).filter((k) =>
@@ -1460,7 +1461,7 @@ describe('ProfileTokenStorageProvider', () => {
       txfData._history = history;
 
       await provider.save(txfData);
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
 
       // G4 — tombstones ARE now also persisted to OrbitDB (security
       // boundary). The local derived cache still mirrors them.
@@ -1596,13 +1597,13 @@ describe('ProfileTokenStorageProvider', () => {
 
       const txfData = buildTxfData({ _t1: { id: '_t1' } });
       await provider.save(txfData);
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
 
       // User-initiated retry: second save with same data reference.
       // Under the new invariant, save() clears lastPinnedCid, so this
       // triggers a fresh pin — not a reuse.
       await provider.save(txfData);
-      await new Promise((r) => setTimeout(r, 200));
+      await waitForFlushSettled(provider, 10000);
 
       // Two saves → two pins (fresh-pin invariant).
       expect(pinCallCount).toBe(2);

--- a/tests/unit/profile/wave-g7-prereq.test.ts
+++ b/tests/unit/profile/wave-g7-prereq.test.ts
@@ -29,6 +29,7 @@ import type { FullIdentity } from '../../../types';
 import type { TxfStorageDataBase } from '../../../storage/storage-provider';
 import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
 import { PROFILE_KEY_MAPPING } from '../../../profile/types';
+import { waitForFlushSettled } from '../../helpers/profile/waitForFlushSettled';
 
 // ---------------------------------------------------------------------------
 // Fixtures (mirrors profile-token-storage-provider.test.ts conventions)
@@ -170,7 +171,7 @@ describe('Wave G.7 prerequisite verification (T.0.G7-verify)', () => {
       { id: 'oB', status: 'pending', tokenId: 't2', recipient: '@bob', createdAt: 2, data: {} },
     ];
     await provider.save(data);
-    await new Promise((r) => setTimeout(r, 100));
+    await waitForFlushSettled(provider, 10000);
 
     const perEntryKeys = [...db._store.keys()].filter((k) => k.startsWith(`${ADDR}.outbox.`));
     expect(
@@ -201,7 +202,7 @@ describe('Wave G.7 prerequisite verification (T.0.G7-verify)', () => {
       { tokenId: 'tBad2', reason: 'continuity-broken', detectedAt: 2 },
     ];
     await provider.save(data);
-    await new Promise((r) => setTimeout(r, 100));
+    await waitForFlushSettled(provider, 10000);
 
     const perEntryKeys = [...db._store.keys()].filter((k) => k.startsWith(`${ADDR}.invalid.`));
     expect(


### PR DESCRIPTION
## Summary

Closes #219.

Surfaced by the 10-run full-suite stress that validated #217 (Run 1/10 failed on `tests/integration/profile/no-token-loss-tombstones.test.ts > G4 — tombstones survive cold-start`). Same race family as #215: a fixed-time `setTimeout(r, 200)` budget after `provider.save()` is not always enough for the flush body (pin → bundle write → operational state at `${addr}.tombstones`) to complete under full-suite worker contention.

The deterministic fix already existed as a local helper in `pointer-monotonicity.test.ts`. This PR promotes it to a shared helper and applies it to every flush-dependent fixed-time wait in the profile test suite (per the audit list called out in the issue).

## Changes

- **New shared helper** `tests/helpers/profile/waitForFlushSettled.ts` — polls the provider's private `flushPromise` / `flushTimer` fields and returns only when both are null across a 5ms stability window, or when the in-flight flush settles (including normal rejections like `POINTER_MONOTONICITY_VIOLATION`).
- **Target file** `tests/integration/profile/no-token-loss-tombstones.test.ts` — two `setTimeout` budgets (lines 281, 307) replaced with `waitForFlushSettled(provider, 10000)`.
- **Audited files** (7 profile test files): `pointer-monotonicity.test.ts`, `wave-g7-prereq.test.ts`, `per-entry-key-writers.test.ts`, `profile-token-storage-flush-serialization.test.ts`, `profile-token-storage-no-data-flush.test.ts`, `profile-token-storage-provider.test.ts` — every flush-dependent `setTimeout` replaced.

## What was intentionally NOT changed

- **20ms mid-flight waits in `flush-serialization.test.ts`** — they probe in-flight state (`expect(tracker.inFlight).toBe(1)`); replacing them with `waitForFlushSettled` would settle the flush and defeat the assertion.
- **Post-`_triggerReplication` event-handler wait in `profile-token-storage-provider.test.ts:1178`** — waits for a synchronous event push, not a flush body.
- **30ms artificial `toCar()` delay in the UxfPackage mock** — fixture, not a test wait.

## Verification

- **Full-suite 10-run stress: 10/10 clean.** Each run: 461 test files, 7915 tests passed (13 skipped). Median runtime 72s.
- **Touched-files 5-run stress: 5/5 clean.**
- `npx tsc --noEmit` clean.
- `npx eslint <touched-files>` clean (only pre-existing warnings; no new ones).

## Test plan

- [x] Unit tests for all 7 touched files pass
- [x] Full unit suite passes
- [x] 10-run full-suite stress passes 10/10
- [x] Typecheck clean
- [x] Lint clean

## Refs

- Closes #219
- #217 (stress run that surfaced this flake — already merged as PR #220)
- #215 / PR #216 (original `waitForFlushSettled` pattern)
- `profile/profile-token-storage/flush-scheduler.ts:627-664` (pin → bundle → operational state ordering — production code unchanged)