### PR TITLE
docs(manual-test)(#218): full two-peer + daemon + IPFS-only recovery walkthrough

### DIFF
--- a/manual-test-full-recovery.md
+++ b/manual-test-full-recovery.md
@@ -233,10 +233,27 @@ sphere invoice create --target @$BOB_TAG --asset "11000000 UCT" --memo "Full-rec
 INV=<paste invoiceId>
 ```
 
+### C.1b Alice delivers the invoice to Bob (#226)
+
+`sphere invoice create` does not auto-deliver. Delivery is a separate,
+explicit step that packages the invoice into a UXF bundle and ships it
+to every non-self target via NIP-17 DM. Without this step, Bob's wallet
+has no path to discover the invoice — `payments sync` / `payments
+receive` don't pull invoices addressed to him.
+
+```bash
+sphere invoice deliver $INV
+# Per-recipient outcome is printed as JSON. Successful delivery shows
+# { sent: 1, failed: 0, recipients: [{ ..., success: true, shape: "inline" }] }.
+```
+
 ### C.2 Bob pays (on peer1)
 
 ```bash
 sphere wallet use bob
+# Give Bob's relay subscription a beat to ingest the invoice_delivery: DM.
+sleep 5
+sphere payments sync
 sphere invoice pay $INV
 sphere payments sync
 ```

--- a/manual-test-full-recovery.md
+++ b/manual-test-full-recovery.md
@@ -1,0 +1,468 @@
+# Manual CLI test — full two-peer + daemon + bidirectional invoice + IPFS-only recovery
+
+End-to-end smoke test for the multi-instance scenarios that the existing
+`manual-test-drain-fix.md` does not exercise: a **second profile instance
+per wallet** with the same mnemonic but a distinct `DATA_DIR`, long-running
+**daemons** picking up live updates, **bidirectional invoices** verified
+without manual sync, and **IPFS-only recovery** of both wallets on both
+peers from mnemonics alone.
+
+This is the companion to `manual-test-drain-fix.md`. Re-read §0 of that
+document first — the CLI prerequisites, profile-mode defaults, and "save
+the mnemonic" gates apply unchanged here.
+
+> **Companion docs:**
+> - `manual-test-drain-fix.md` — single-peer sync + IPFS recovery (drain fix)
+> - This doc                   — two peers + daemon + invoices + IPFS-only recovery
+
+---
+
+## 0. Layout: three CWDs
+
+This test uses three working directories under `~/sphere-full-test/`:
+
+```
+~/sphere-full-test/
+├── peer1/         ← primary instance; both alice + bob via profile switching
+│   ├── .sphere-cli/                ← profile registry (CWD-relative)
+│   ├── .sphere-cli-alice/          ← alice's OrbitDB + tokens (peer1 view)
+│   └── .sphere-cli-bob/            ← bob's   OrbitDB + tokens (peer1 view)
+├── peer2-alice/   ← secondary instance of alice (own daemon)
+│   ├── .sphere-cli/
+│   └── .sphere-cli-alice/          ← alice's OrbitDB + tokens (peer2 view)
+└── peer2-bob/     ← secondary instance of bob   (own daemon)
+    ├── .sphere-cli/
+    └── .sphere-cli-bob/            ← bob's   OrbitDB + tokens (peer2 view)
+```
+
+**Why three dirs?** The CLI reads `./.sphere-cli/config.json` from the
+current working directory, and the daemon writes its PID/log to
+`./.sphere-cli/daemon.{pid,log}` — also CWD-relative, not profile-scoped.
+Running two daemons (one per identity) from the same CWD collides on PID
+and config. Per-peer-wallet CWDs sidesteps the collision without needing
+`--pid` / `--log` overrides.
+
+Peer1 keeps the drain-fix layout (both profiles in one CWD via
+`sphere wallet use`) because peer1 doesn't run daemons.
+
+---
+
+## 1. Peer1 setup — two wallets + faucet (same as drain-fix §1–§2)
+
+```bash
+mkdir -p ~/sphere-full-test/peer1 && cd ~/sphere-full-test/peer1
+
+# Unique suffixes — testnet keeps minted nametags forever.
+SUFFIX=$(date +%s)
+ALICE_TAG=alice-full-$SUFFIX
+BOB_TAG=bob-full-$SUFFIX
+
+sphere wallet create alice
+sphere wallet use alice
+sphere init --network testnet --nametag $ALICE_TAG
+# ⚠️  Save the mnemonic — needed for peer2 init and §D recovery.
+ALICE_MNEMONIC="<paste alice's mnemonic here>"
+sphere status                              # Nametag: line MUST appear
+
+sphere wallet create bob
+sphere wallet use bob
+sphere init --network testnet --nametag $BOB_TAG
+BOB_MNEMONIC="<paste bob's mnemonic here>"
+sphere status                              # Nametag: line MUST appear
+
+# Top up alice (faucet drops several coins)
+sphere wallet use alice
+sphere faucet
+sphere payments sync                       # drains pending v5 + publishes CAR
+sphere balance                             # should reflect faucet
+```
+
+If either `sphere status` doesn't show a `Nametag:` line, the on-chain mint
+failed silently — fix per drain-fix §1's gotcha block before proceeding.
+
+---
+
+## §A. Peer2 setup — same identity, separate `DATA_DIR`
+
+**Goal:** verify per-instance OrbitDB / IPFS sync works across distinct
+`DATA_DIR`s for the same identity (same mnemonic). Peer2 must reconstruct
+peer1's token set from IPFS only, with no faucet input.
+
+### A.1 Alice on peer2-alice
+
+```bash
+mkdir -p ~/sphere-full-test/peer2-alice && cd ~/sphere-full-test/peer2-alice
+
+sphere wallet create alice
+sphere wallet use alice
+
+# Same mnemonic → same secp256k1 identity → same L1/L3/transport addresses.
+# A fresh DATA_DIR (./.sphere-cli-alice/) means peer2 starts with an empty
+# OrbitDB; sync() must pull peer1's state from IPFS.
+sphere init --network testnet --mnemonic "$ALICE_MNEMONIC"
+sphere status                              # L1 address MUST match peer1
+
+# Pull peer1's published state. Auto-sync runs at init; force one more
+# and finalize any unconfirmed v5 tokens delivered via Nostr.
+sphere payments sync
+sphere payments receive --finalize
+sphere balance > /tmp/alice-peer2-initial.txt
+
+# What you're looking for: balance matches peer1's alice balance from §1.
+sphere wallet use alice                    # (stay on alice for §B)
+```
+
+**Assertion gate.** Compare:
+
+```bash
+( cd ~/sphere-full-test/peer1 && sphere wallet use alice && sphere balance ) \
+  > /tmp/alice-peer1-initial.txt
+diff /tmp/alice-peer1-initial.txt /tmp/alice-peer2-initial.txt
+# Empty diff = per-instance IPFS sync works for the same identity.
+```
+
+### A.2 Bob on peer2-bob
+
+```bash
+mkdir -p ~/sphere-full-test/peer2-bob && cd ~/sphere-full-test/peer2-bob
+
+sphere wallet create bob
+sphere wallet use bob
+sphere init --network testnet --mnemonic "$BOB_MNEMONIC"
+sphere status                              # L1 address MUST match peer1's bob
+
+sphere payments sync
+sphere payments receive --finalize
+sphere balance > /tmp/bob-peer2-initial.txt
+
+# Peer1 bob received nothing yet (faucet only hit alice), so this is
+# typically empty — that's fine. The point is the sync didn't error.
+```
+
+---
+
+## §B. Long-running daemons on peer2
+
+**Goal:** start a foreground listener for each peer2 wallet that picks up
+live updates (`transfer:incoming`, profile sync) while peer1 is active.
+
+The daemon's quick-mode syntax is:
+
+```
+sphere daemon start --event <event> --action <spec> [--event ... --action ...] [--verbose]
+```
+
+Each `--event` subscribes to a Sphere event type; `--action auto-receive`
+auto-finalizes incoming transfers; `log:<path>` appends a JSON line per
+event. Multiple `--action` flags on a single rule all fire for every
+subscribed event.
+
+### B.1 Start alice's peer2 daemon (terminal 1, leave running)
+
+```bash
+cd ~/sphere-full-test/peer2-alice
+sphere wallet use alice
+
+# Foreground daemon. Ctrl-C to stop after §C/§D.
+# - auto-receive finalizes incoming v5 tokens automatically
+# - log:./events.log records every event as a JSON line for inspection
+sphere daemon start \
+  --event 'transfer:incoming' --action auto-receive \
+  --event 'transfer:incoming' --action 'log:./events.log' \
+  --event 'transfer:confirmed' --action 'log:./events.log' \
+  --event 'invoice:payment'    --action 'log:./events.log' \
+  --event 'invoice:covered'    --action 'log:./events.log' \
+  --verbose
+```
+
+You should see:
+```
+Starting Sphere daemon...
+Active rules: 1
+Subscribed events: transfer:incoming, transfer:confirmed, invoice:payment, invoice:covered
+Wallet: @alice-full-...
+Daemon running. Waiting for events...
+```
+
+### B.2 Start bob's peer2 daemon (terminal 2, leave running)
+
+```bash
+cd ~/sphere-full-test/peer2-bob
+sphere wallet use bob
+
+sphere daemon start \
+  --event 'transfer:incoming' --action auto-receive \
+  --event 'transfer:incoming' --action 'log:./events.log' \
+  --event 'transfer:confirmed' --action 'log:./events.log' \
+  --event 'invoice:payment'    --action 'log:./events.log' \
+  --event 'invoice:covered'    --action 'log:./events.log' \
+  --verbose
+```
+
+> **Gotcha — two daemons in one CWD will collide.** Both default to
+> `./.sphere-cli/daemon.pid`. The per-wallet CWD layout above avoids the
+> collision. If you must share a CWD, pass `--pid ./alice.pid --log
+> ./alice.log` to one and matching paths to the other.
+
+### B.3 Detach mode (optional)
+
+Add `--detach` to fork into the background. Logs go to
+`./.sphere-cli/daemon.log` (or your `--log`). Stop with:
+
+```bash
+sphere daemon stop
+sphere daemon status        # → "Daemon not running" once stopped
+```
+
+This walkthrough uses foreground daemons so you can watch events arrive.
+
+---
+
+## §C. Bidirectional invoice flow — verify peer2 sees state without manual sync
+
+**Goal:** with peer2 daemons running, drive an invoice round-trip on peer1
+and confirm peer2 reflects the new state with no manual `sync` call.
+
+### C.1 Alice creates a 11 UCT invoice for Bob (on peer1)
+
+```bash
+cd ~/sphere-full-test/peer1
+sphere wallet use alice
+sphere invoice create --target @$BOB_TAG --asset "11000000 UCT" --memo "Full-recovery test invoice"
+# Capture the invoiceId from the JSON output.
+INV=<paste invoiceId>
+```
+
+### C.2 Bob pays (on peer1)
+
+```bash
+sphere wallet use bob
+sphere invoice pay $INV
+sphere payments sync
+```
+
+### C.3 Watch the peer2 daemons (terminals 1 & 2)
+
+Within a few seconds you should see lines like the following appear in
+each daemon's terminal:
+
+```
+[<ISO timestamp>] EVENT transfer:incoming data={"senderPubkey":"...","tokens":[...],...}
+[<ISO timestamp>] EVENT invoice:payment   data={"invoiceId":"<id>",...}
+[<ISO timestamp>] EVENT invoice:covered   data={"invoiceId":"<id>"}
+```
+
+`./events.log` in each peer2 CWD records the same events as one JSON line
+per dispatch.
+
+### C.4 Assert peer2 sees the payment without manual `sphere payments sync`
+
+```bash
+# Alice's peer2 view — invoice should be COVERED, balance reflects payment
+cd ~/sphere-full-test/peer2-alice
+sphere invoice status $INV                 # State: COVERED
+sphere balance                             # +11 UCT vs §A.1's initial snapshot
+
+# Bob's peer2 view — balance reflects the 11 UCT he sent (decreased)
+cd ~/sphere-full-test/peer2-bob
+sphere balance                             # tokens consumed by invoice-pay
+```
+
+If peer2's `sphere balance` reflects the payment **before** you've run
+`sphere payments sync` on peer2, the daemon's auto-receive worked.
+
+### C.5 (Optional) Send a small L3 transfer in the other direction
+
+```bash
+cd ~/sphere-full-test/peer1
+sphere wallet use bob
+sphere payments send @$ALICE_TAG 1 UCT     # 1 UCT bob → alice
+sphere payments sync
+# Peer2 daemons should log a fresh transfer:incoming / transfer:confirmed pair.
+```
+
+---
+
+## §D. Wipe-and-recover BOTH profiles from IPFS only
+
+**Goal:** clear both wallets on both peers, re-init from mnemonics alone
+(no faucet, no live Nostr — `--no-nostr` disables the transport so IPFS is
+the only data source), and prove the published state survived.
+
+### D.1 Snapshot pre-clear state on peer1
+
+```bash
+cd ~/sphere-full-test/peer1
+
+sphere wallet use alice
+sphere payments sync                       # ensure latest CAR is on IPFS
+sphere balance        > /tmp/alice-before.txt
+sphere payments tokens > /tmp/alice-tokens-before.txt
+sphere invoice list --state COVERED > /tmp/alice-invoices-before.txt
+
+sphere wallet use bob
+sphere payments sync
+sphere balance        > /tmp/bob-before.txt
+sphere payments tokens > /tmp/bob-tokens-before.txt
+sphere invoice list --state COVERED > /tmp/bob-invoices-before.txt
+```
+
+### D.2 Stop the peer2 daemons
+
+In terminals 1 and 2 (where the daemons are running), press Ctrl-C. You
+should see:
+```
+Shutting down daemon...
+Daemon stopped.
+```
+
+### D.3 Wipe every wallet on every peer
+
+```bash
+# Peer1 — both wallets
+cd ~/sphere-full-test/peer1
+sphere wallet use alice && sphere clear    # respond at the prompt
+sphere wallet use bob   && sphere clear
+
+# Peer2-alice
+cd ~/sphere-full-test/peer2-alice
+sphere wallet use alice && sphere clear
+
+# Peer2-bob
+cd ~/sphere-full-test/peer2-bob
+sphere wallet use bob   && sphere clear
+```
+
+Verify each:
+```bash
+sphere status                              # should refuse — no wallet
+```
+
+### D.4 Recover with mnemonics, IPFS only (no Nostr, no faucet)
+
+`--no-nostr` installs a no-op transport. The wallet loads identity from
+mnemonic, then `sphere payments sync` pulls token state from IPFS. If a
+peer's balance comes back complete after this, the published CAR was
+complete and IPFS-only recovery works.
+
+```bash
+# Peer1 alice
+cd ~/sphere-full-test/peer1
+sphere wallet use alice
+sphere init --network testnet --no-nostr --mnemonic "$ALICE_MNEMONIC"
+sphere payments sync
+sphere payments receive --finalize         # safe even with no-op transport
+sphere balance        > /tmp/alice-after.txt
+sphere payments tokens > /tmp/alice-tokens-after.txt
+sphere invoice list --state COVERED > /tmp/alice-invoices-after.txt
+
+# Peer1 bob
+sphere wallet use bob
+sphere init --network testnet --no-nostr --mnemonic "$BOB_MNEMONIC"
+sphere payments sync
+sphere payments receive --finalize
+sphere balance        > /tmp/bob-after.txt
+sphere payments tokens > /tmp/bob-tokens-after.txt
+sphere invoice list --state COVERED > /tmp/bob-invoices-after.txt
+
+# Peer2-alice
+cd ~/sphere-full-test/peer2-alice
+sphere wallet use alice
+sphere init --network testnet --no-nostr --mnemonic "$ALICE_MNEMONIC"
+sphere payments sync
+sphere balance        > /tmp/alice-peer2-after.txt
+
+# Peer2-bob
+cd ~/sphere-full-test/peer2-bob
+sphere wallet use bob
+sphere init --network testnet --no-nostr --mnemonic "$BOB_MNEMONIC"
+sphere payments sync
+sphere balance        > /tmp/bob-peer2-after.txt
+```
+
+### D.5 ASSERT — pre-clear vs post-recovery diffs must all be empty
+
+```bash
+# Peer1
+diff /tmp/alice-before.txt        /tmp/alice-after.txt
+diff /tmp/alice-tokens-before.txt /tmp/alice-tokens-after.txt
+diff /tmp/bob-before.txt          /tmp/bob-after.txt
+diff /tmp/bob-tokens-before.txt   /tmp/bob-tokens-after.txt
+
+# Peer2 — recovered from IPFS alone, no Nostr, no faucet
+diff /tmp/alice-before.txt /tmp/alice-peer2-after.txt
+diff /tmp/bob-before.txt   /tmp/bob-peer2-after.txt
+```
+
+**All four diffs empty = the CAR published in §C.2 (and the §C.5 sync, if
+you ran it) was complete on IPFS.** Any missing UCT/USDC/USDU = a partial
+CAR shipped at some sync step.
+
+---
+
+## §E. Recovery preserves the invoice ledger
+
+**Goal:** verify the COVERED §C invoice round-trips through the wipe.
+`invoice list` reads from the recovered profile's local OrbitDB store,
+which was rebuilt from IPFS in §D.4.
+
+```bash
+# Each diff should be empty.
+diff /tmp/alice-invoices-before.txt \
+     <(cd ~/sphere-full-test/peer1 && sphere wallet use alice && sphere invoice list --state COVERED)
+diff /tmp/bob-invoices-before.txt \
+     <(cd ~/sphere-full-test/peer1 && sphere wallet use bob   && sphere invoice list --state COVERED)
+
+# Spot-check the §C invoice on the recovered alice profile:
+cd ~/sphere-full-test/peer1
+sphere wallet use alice
+sphere invoice status $INV                 # State: COVERED, same target + memo
+```
+
+If both diffs are empty and `invoice status $INV` reports `COVERED` with
+the same target and "Full-recovery test invoice" memo, the invoice ledger
+survived a full wipe + IPFS-only recovery.
+
+---
+
+## What you're looking for (summary)
+
+| Section | Assertion |
+|---|---|
+| §A.1 | Peer2-alice's initial balance matches peer1 alice's balance after `init --mnemonic + sync` (no faucet on peer2) |
+| §B   | `Daemon running. Waiting for events...` line for each peer2 wallet, with no PID-collision error |
+| §C.4 | Peer2 balance reflects the §C payment **without** a manual `sphere payments sync` (auto-receive did it) |
+| §D.5 | All four `diff` outputs empty: pre-clear ≡ post-recovery, on both peers |
+| §E   | Pre-clear invoice list ≡ post-recovery invoice list, `--no-nostr` recovery preserved the §C COVERED invoice |
+
+---
+
+## Three gotchas
+
+1. **Two daemons in one CWD collide on `./.sphere-cli/daemon.pid`.** Per
+   §0's layout, alice's and bob's peer2 daemons run from separate CWDs to
+   sidestep this. If you must share a CWD, pass distinct `--pid` and
+   `--log` to each invocation.
+2. **`sphere wallet use <name>` mutates `./.sphere-cli/config.json`
+   globally.** A running daemon already loaded its config; switching
+   profile in another terminal does NOT redirect the live daemon, but it
+   DOES change which wallet a subsequent `sphere balance` (etc.) targets.
+   Be deliberate about profile switching while daemons are alive.
+3. **`--no-nostr` means no incoming transfers at all.** Use it for the §D
+   IPFS-only recovery proof, but don't try to receive new transfers
+   while it's active — the no-op transport drops them. Re-init without
+   `--no-nostr` to resume live operations.
+
+---
+
+## Command cheat sheet (delta vs drain-fix doc)
+
+| Want to... | Command |
+|---|---|
+| Start foreground listener daemon | `sphere daemon start --event 'transfer:incoming' --action auto-receive --verbose` |
+| Append events to a file | add `--event '<ev>' --action 'log:./events.log'` to the daemon invocation |
+| Stop daemon (detach mode) | `sphere daemon stop` |
+| Check daemon status | `sphere daemon status` |
+| Init wallet with IPFS-only recovery | `sphere init --network testnet --no-nostr --mnemonic "<phrase>"` |
+| List COVERED invoices | `sphere invoice list --state COVERED` |
+| Show one invoice | `sphere invoice status <id>` |

--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+#
+# manual-test-full-recovery.sh — automated re-run of manual-test-full-recovery.md
+#
+# Mirrors the exact CLI commands from the markdown walkthrough so an
+# operator can re-validate end-to-end without retyping. The script creates
+# a clean workspace and tears it down on exit.
+#
+# Env knobs:
+#   SPHERE_FULL_TEST_DIR   workspace path (default: ~/sphere-full-test-manual)
+#   KEEP=1                 skip teardown — keep workspace + daemons for debugging
+#   SUFFIX                 override nametag suffix (default: epoch seconds + $$)
+#
+# Exit code:
+#   0 on success, non-zero on any failed step or assertion.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+ROOT="${SPHERE_FULL_TEST_DIR:-$HOME/sphere-full-test-manual}"
+PEER1="$ROOT/peer1"
+PEER2_ALICE="$ROOT/peer2-alice"
+PEER2_BOB="$ROOT/peer2-bob"
+SNAP="$ROOT/snapshots"
+
+# CWDs that have started a daemon; cleaned up in teardown.
+DAEMON_DIRS=()
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
+teardown() {
+  local rc=$?
+  set +e
+
+  if [[ "${KEEP:-}" == "1" ]]; then
+    echo
+    echo "=== KEEP=1 — leaving $ROOT in place (rc=$rc) ==="
+    echo "Remember to: pkill -f 'sphere daemon' ; rm -rf $ROOT"
+    return $rc
+  fi
+
+  echo
+  echo "=== Teardown (rc=$rc) ==="
+
+  # Stop each daemon via its CWD (uses ./.sphere-cli/daemon.pid by default).
+  local d
+  for d in "${DAEMON_DIRS[@]:-}"; do
+    if [[ -n "$d" && -d "$d" ]]; then
+      ( cd "$d" && sphere daemon stop >/dev/null 2>&1 ) || true
+    fi
+  done
+
+  # Belt-and-braces: kill any leftover sphere daemons (foreground variants
+  # or daemons whose PID file vanished).
+  pkill -f "sphere-daemon" 2>/dev/null || true
+  pkill -f "sphere daemon" 2>/dev/null || true
+
+  # Give the daemons a moment to flush their PID files.
+  sleep 1
+
+  if [[ -d "$ROOT" ]]; then
+    rm -rf "$ROOT"
+  fi
+
+  echo "=== Teardown done ==="
+  return $rc
+}
+trap teardown EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Extract a 12- or 24-word lowercase mnemonic from a log file. Relies
+# on SPHERE_ALLOW_MNEMONIC_NON_TTY=1 emitting the phrase on stdout when
+# init generates a fresh wallet from a non-TTY shell.
+#
+# CLI's `sphere init` default emits a 12-word BIP-39 mnemonic. The
+# 24-word path is exposed via a flag (not used by this script). We
+# accept either word count so the script works with both defaults.
+#
+# IMPORTANT: anchor to FULL LINES (^...$). The CLI's deprecation-
+# warning text contains spans of 12+ consecutive lowercase words
+# (e.g. "provider remains functional for backward compatibility but
+# is no longer the recommended") that a non-anchored `\b...\b` regex
+# would match BEFORE the real mnemonic — producing a "valid"-looking
+# but actually-wrong string that the next `sphere init --mnemonic`
+# rejects with "Invalid mnemonic". The real mnemonic always appears
+# on a line by itself, so `^...$` is the correct discriminator.
+#
+# Tries 24-word first (longer match), then 12-word — `head -n 1`
+# returns the first whole-line match in the file.
+extract_mnemonic() {
+  local m
+  m="$(grep -E '^([a-z]+ ){23}[a-z]+$' "$1" | head -n 1)"
+  if [[ -z "$m" ]]; then
+    m="$(grep -E '^([a-z]+ ){11}[a-z]+$' "$1" | head -n 1)"
+  fi
+  printf '%s' "$m"
+}
+
+# Sleep up to NSEC seconds while polling CMD for a non-empty match against
+# GREP_PATTERN. Used to wait for daemon log lines.
+wait_for_log() {
+  local file="$1" pattern="$2" timeout="${3:-30}"
+  local elapsed=0
+  while (( elapsed < timeout )); do
+    if [[ -f "$file" ]] && grep -q -- "$pattern" "$file" 2>/dev/null; then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  echo "TIMEOUT waiting ${timeout}s for '$pattern' in $file" >&2
+  return 1
+}
+
+assert_diff_empty() {
+  local label="$1" a="$2" b="$3"
+  if diff -u "$a" "$b" > "$SNAP/${label}.diff"; then
+    echo "ASSERT OK ($label): $(basename "$a") == $(basename "$b")"
+  else
+    echo "ASSERT FAIL ($label): see $SNAP/${label}.diff" >&2
+    cat "$SNAP/${label}.diff" >&2 || true
+    return 1
+  fi
+}
+
+banner() {
+  echo
+  echo "================================================================"
+  echo "$*"
+  echo "================================================================"
+}
+
+# ---------------------------------------------------------------------------
+# Prereqs
+# ---------------------------------------------------------------------------
+
+banner "§0 Prereqs"
+
+sphere --version
+which sphere
+
+# Drain fix sentinel (must be 2 in the linked SDK build).
+SDK_LINK="$HOME/sphere-cli-work/sphere-cli/node_modules/@unicitylabs/sphere-sdk/dist/index.cjs"
+if [[ -f "$SDK_LINK" ]]; then
+  DRAIN_COUNT="$(grep -c "drain timed out" "$SDK_LINK" || true)"
+  echo "drain-fix sentinel count in linked SDK: $DRAIN_COUNT (expected 2)"
+fi
+
+# Allow non-TTY mnemonic capture from `sphere init`.
+export SPHERE_ALLOW_MNEMONIC_NON_TTY=1
+
+# ---------------------------------------------------------------------------
+# Workspace
+# ---------------------------------------------------------------------------
+
+banner "Setup workspace at $ROOT"
+
+rm -rf "$ROOT"
+mkdir -p "$PEER1" "$PEER2_ALICE" "$PEER2_BOB" "$SNAP"
+
+# Nametags must satisfy the SDK's Unicity ID regex: lowercase
+# alphanumeric / underscore / hyphen, 3-20 chars total. The default
+# epoch+pid suffix used to produce a 18+-char suffix (e.g.
+# "1779456738-1932107") which pushed "alice-full-${SUFFIX}" past 20 chars
+# and the init step failed with "Invalid Unicity ID format" before we
+# could exercise anything. Trim to last 4 epoch digits + 4 hex chars
+# (8 chars total) so "alice-${SUFFIX}" stays comfortably under the cap.
+SUFFIX="${SUFFIX:-$(date +%s | tail -c 5)$(printf '%04x' $((RANDOM % 65536)))}"
+ALICE_TAG="alice-${SUFFIX}"
+BOB_TAG="bob-${SUFFIX}"
+echo "ALICE_TAG=$ALICE_TAG"
+echo "BOB_TAG=$BOB_TAG"
+
+# ---------------------------------------------------------------------------
+# §1 — Peer1 setup (drain-fix doc §1–§2)
+# ---------------------------------------------------------------------------
+
+banner "§1 Peer1 setup (wallets + faucet)"
+
+cd "$PEER1"
+
+# Alice
+sphere wallet create alice
+sphere wallet use alice
+sphere init --network testnet --nametag "$ALICE_TAG" 2>&1 | tee "$SNAP/peer1-alice-init.log"
+ALICE_MNEMONIC="$(extract_mnemonic "$SNAP/peer1-alice-init.log")"
+[[ -n "$ALICE_MNEMONIC" ]] || { echo "FAIL: couldn't extract alice mnemonic" >&2; exit 1; }
+sphere status | tee "$SNAP/peer1-alice-status.log"
+grep -qi "nametag" "$SNAP/peer1-alice-status.log" \
+  || { echo "FAIL: alice nametag mint failed silently" >&2; exit 1; }
+
+# Bob
+sphere wallet create bob
+sphere wallet use bob
+sphere init --network testnet --nametag "$BOB_TAG" 2>&1 | tee "$SNAP/peer1-bob-init.log"
+BOB_MNEMONIC="$(extract_mnemonic "$SNAP/peer1-bob-init.log")"
+[[ -n "$BOB_MNEMONIC" ]] || { echo "FAIL: couldn't extract bob mnemonic" >&2; exit 1; }
+sphere status | tee "$SNAP/peer1-bob-status.log"
+grep -qi "nametag" "$SNAP/peer1-bob-status.log" \
+  || { echo "FAIL: bob nametag mint failed silently" >&2; exit 1; }
+
+# Stash for debug (in-workspace, gets wiped on teardown)
+printf '%s\n' "$ALICE_MNEMONIC" > "$SNAP/alice.mnemonic"
+printf '%s\n' "$BOB_MNEMONIC"   > "$SNAP/bob.mnemonic"
+
+# Top up alice
+sphere wallet use alice
+sphere faucet            2>&1 | tee "$SNAP/peer1-alice-faucet.log"
+sphere payments sync     2>&1 | tee "$SNAP/peer1-alice-sync.log"
+sphere balance           | tee "$SNAP/peer1-alice-balance.txt"
+
+# ---------------------------------------------------------------------------
+# §A — Peer2 setup (same identity, separate DATA_DIR)
+# ---------------------------------------------------------------------------
+
+banner "§A.1 Peer2-alice setup"
+
+cd "$PEER2_ALICE"
+sphere wallet create alice
+sphere wallet use alice
+sphere init --network testnet --mnemonic "$ALICE_MNEMONIC" 2>&1 | tee "$SNAP/peer2-alice-init.log"
+sphere status                              | tee "$SNAP/peer2-alice-status.log"
+sphere payments sync                       2>&1 | tee "$SNAP/peer2-alice-sync.log"
+sphere payments receive --finalize         2>&1 | tee "$SNAP/peer2-alice-receive.log"
+sphere balance                             > "$SNAP/peer2-alice-initial.txt"
+cat "$SNAP/peer2-alice-initial.txt"
+
+# Peer1 snapshot for diffing
+( cd "$PEER1" && sphere wallet use alice && sphere balance ) > "$SNAP/peer1-alice-initial.txt"
+
+assert_diff_empty "alice-peer1-vs-peer2-initial" \
+  "$SNAP/peer1-alice-initial.txt" \
+  "$SNAP/peer2-alice-initial.txt" \
+  || { echo "WARN: peer1/peer2 alice balance mismatch — IPFS may need more sync time" >&2; }
+
+banner "§A.2 Peer2-bob setup"
+
+cd "$PEER2_BOB"
+sphere wallet create bob
+sphere wallet use bob
+sphere init --network testnet --mnemonic "$BOB_MNEMONIC" 2>&1 | tee "$SNAP/peer2-bob-init.log"
+sphere status                              | tee "$SNAP/peer2-bob-status.log"
+sphere payments sync                       2>&1 | tee "$SNAP/peer2-bob-sync.log"
+sphere payments receive --finalize         2>&1 | tee "$SNAP/peer2-bob-receive.log"
+sphere balance                             > "$SNAP/peer2-bob-initial.txt"
+cat "$SNAP/peer2-bob-initial.txt"
+
+# ---------------------------------------------------------------------------
+# §B — Daemons on peer2
+# ---------------------------------------------------------------------------
+
+banner "§B Start peer2 daemons (--detach)"
+
+cd "$PEER2_ALICE"
+sphere wallet use alice
+sphere daemon start \
+  --detach \
+  --event 'transfer:incoming' --action auto-receive \
+  --event 'transfer:incoming' --action 'log:./events.log' \
+  --event 'transfer:confirmed' --action 'log:./events.log' \
+  --event 'invoice:payment'    --action 'log:./events.log' \
+  --event 'invoice:covered'    --action 'log:./events.log' \
+  --verbose
+DAEMON_DIRS+=("$PEER2_ALICE")
+sleep 3
+sphere daemon status
+
+cd "$PEER2_BOB"
+sphere wallet use bob
+sphere daemon start \
+  --detach \
+  --event 'transfer:incoming' --action auto-receive \
+  --event 'transfer:incoming' --action 'log:./events.log' \
+  --event 'transfer:confirmed' --action 'log:./events.log' \
+  --event 'invoice:payment'    --action 'log:./events.log' \
+  --event 'invoice:covered'    --action 'log:./events.log' \
+  --verbose
+DAEMON_DIRS+=("$PEER2_BOB")
+sleep 3
+sphere daemon status
+
+# ---------------------------------------------------------------------------
+# §C — Bidirectional invoice flow on peer1
+# ---------------------------------------------------------------------------
+
+banner "§C.1 Alice creates 11 UCT invoice for Bob"
+
+cd "$PEER1"
+sphere wallet use alice
+sphere invoice create --target "@$BOB_TAG" --asset "11000000 UCT" --memo "Full-recovery test invoice" \
+  2>&1 | tee "$SNAP/peer1-invoice-create.log"
+
+INV="$(grep -Eo '"invoiceId":[[:space:]]*"[^"]+"' "$SNAP/peer1-invoice-create.log" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+[[ -n "$INV" ]] || { echo "FAIL: couldn't extract invoiceId" >&2; exit 1; }
+echo "INV=$INV"
+
+banner "§C.2 Bob pays"
+
+sphere wallet use bob
+# Bob must pull alice's just-minted invoice token from the relay /
+# IPFS before he can resolve the invoice id. The script's §B daemons
+# are currently unreliable on testnet (stale PID after detach), so
+# we drive the pull explicitly with `payments sync` here. Without
+# this the next `invoice pay $INV` errors with
+# "No invoice found matching prefix: ..." because bob's local
+# invoice ledger is empty.
+sphere payments sync       2>&1 | tee "$SNAP/peer1-bob-pre-pay-sync.log"
+# Some implementations route the invoice token through `payments
+# receive` rather than `payments sync` (Nostr-delivered vs IPFS-
+# discovered). Drive both with --finalize so any pending V5 tokens
+# also get finalized before bob looks up the invoice.
+sphere payments receive --finalize 2>&1 | tee "$SNAP/peer1-bob-pre-pay-receive.log"
+sphere invoice pay "$INV"  2>&1 | tee "$SNAP/peer1-invoice-pay.log"
+sphere payments sync       2>&1 | tee "$SNAP/peer1-invoice-pay-sync.log"
+
+banner "§C.3 Verify peer2 daemons saw events"
+
+# Alice's peer2 daemon should have logged invoice:payment or invoice:covered.
+wait_for_log "$PEER2_ALICE/events.log" "invoice:" 60 \
+  || { echo "WARN: no invoice event hit alice peer2 events.log in 60s" >&2; }
+
+# Bob's peer2 daemon should have seen transfer:incoming or transfer:confirmed.
+wait_for_log "$PEER2_BOB/events.log" "transfer:" 60 \
+  || { echo "WARN: no transfer event hit bob peer2 events.log in 60s" >&2; }
+
+echo "--- peer2-alice events.log (tail) ---"
+tail -n 20 "$PEER2_ALICE/events.log" 2>/dev/null || true
+echo "--- peer2-bob events.log (tail) ---"
+tail -n 20 "$PEER2_BOB/events.log"   2>/dev/null || true
+
+banner "§C.4 Peer2 view (NO manual sync)"
+
+cd "$PEER2_ALICE"
+sphere invoice status "$INV" 2>&1 | tee "$SNAP/peer2-alice-invoice-status.log"
+sphere balance               | tee "$SNAP/peer2-alice-postC-balance.txt"
+
+cd "$PEER2_BOB"
+sphere balance               | tee "$SNAP/peer2-bob-postC-balance.txt"
+
+# ---------------------------------------------------------------------------
+# §D — Pre-clear snapshots + wipe + IPFS-only recovery
+# ---------------------------------------------------------------------------
+
+banner "§D.1 Pre-clear snapshots on peer1"
+
+cd "$PEER1"
+sphere wallet use alice
+sphere payments sync
+sphere balance                      > "$SNAP/alice-before.txt"
+sphere payments tokens              > "$SNAP/alice-tokens-before.txt"
+sphere invoice list --state COVERED > "$SNAP/alice-invoices-before.txt"
+
+sphere wallet use bob
+sphere payments sync
+sphere balance                      > "$SNAP/bob-before.txt"
+sphere payments tokens              > "$SNAP/bob-tokens-before.txt"
+sphere invoice list --state COVERED > "$SNAP/bob-invoices-before.txt"
+
+banner "§D.2 Stop peer2 daemons"
+
+cd "$PEER2_ALICE" && sphere daemon stop  || true
+cd "$PEER2_BOB"   && sphere daemon stop  || true
+sleep 2
+
+banner "§D.3 sphere clear on all wallets"
+
+cd "$PEER1"      && sphere wallet use alice && sphere clear --yes
+cd "$PEER1"      && sphere wallet use bob   && sphere clear --yes
+cd "$PEER2_ALICE" && sphere wallet use alice && sphere clear --yes
+cd "$PEER2_BOB"   && sphere wallet use bob   && sphere clear --yes
+
+banner "§D.4 Recover with mnemonics + --no-nostr (IPFS only)"
+
+# Peer1 alice
+cd "$PEER1"
+sphere wallet use alice
+sphere init --network testnet --no-nostr --mnemonic "$ALICE_MNEMONIC"
+sphere payments sync
+sphere payments receive --finalize
+sphere balance                      > "$SNAP/alice-after.txt"
+sphere payments tokens              > "$SNAP/alice-tokens-after.txt"
+sphere invoice list --state COVERED > "$SNAP/alice-invoices-after.txt"
+
+# Peer1 bob
+sphere wallet use bob
+sphere init --network testnet --no-nostr --mnemonic "$BOB_MNEMONIC"
+sphere payments sync
+sphere payments receive --finalize
+sphere balance                      > "$SNAP/bob-after.txt"
+sphere payments tokens              > "$SNAP/bob-tokens-after.txt"
+sphere invoice list --state COVERED > "$SNAP/bob-invoices-after.txt"
+
+# Peer2-alice
+cd "$PEER2_ALICE"
+sphere wallet use alice
+sphere init --network testnet --no-nostr --mnemonic "$ALICE_MNEMONIC"
+sphere payments sync
+sphere balance                      > "$SNAP/alice-peer2-after.txt"
+
+# Peer2-bob
+cd "$PEER2_BOB"
+sphere wallet use bob
+sphere init --network testnet --no-nostr --mnemonic "$BOB_MNEMONIC"
+sphere payments sync
+sphere balance                      > "$SNAP/bob-peer2-after.txt"
+
+banner "§D.5 Assertions"
+
+assert_diff_empty "alice-peer1-before-vs-after"   "$SNAP/alice-before.txt"        "$SNAP/alice-after.txt"
+assert_diff_empty "alice-peer1-tokens"            "$SNAP/alice-tokens-before.txt" "$SNAP/alice-tokens-after.txt"
+assert_diff_empty "bob-peer1-before-vs-after"     "$SNAP/bob-before.txt"          "$SNAP/bob-after.txt"
+assert_diff_empty "bob-peer1-tokens"              "$SNAP/bob-tokens-before.txt"   "$SNAP/bob-tokens-after.txt"
+assert_diff_empty "alice-peer1-vs-peer2-after"    "$SNAP/alice-before.txt"        "$SNAP/alice-peer2-after.txt"
+assert_diff_empty "bob-peer1-vs-peer2-after"      "$SNAP/bob-before.txt"          "$SNAP/bob-peer2-after.txt"
+
+# ---------------------------------------------------------------------------
+# §E — Invoice ledger preserved
+# ---------------------------------------------------------------------------
+
+banner "§E Recovery preserves invoice ledger"
+
+assert_diff_empty "alice-invoices" "$SNAP/alice-invoices-before.txt" "$SNAP/alice-invoices-after.txt"
+assert_diff_empty "bob-invoices"   "$SNAP/bob-invoices-before.txt"   "$SNAP/bob-invoices-after.txt"
+
+cd "$PEER1"
+sphere wallet use alice
+sphere invoice status "$INV" | tee "$SNAP/alice-invoice-status-after.log"
+grep -qi "COVERED" "$SNAP/alice-invoice-status-after.log" \
+  || { echo "FAIL: invoice $INV not COVERED after recovery" >&2; exit 1; }
+
+banner "ALL GREEN"
+echo "Workspace: $ROOT  (will be removed by teardown unless KEEP=1)"

--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -217,6 +217,15 @@ sphere faucet            2>&1 | tee "$SNAP/peer1-alice-faucet.log"
 sphere payments sync     2>&1 | tee "$SNAP/peer1-alice-sync.log"
 sphere balance           | tee "$SNAP/peer1-alice-balance.txt"
 
+# Top up bob — needed for §C.2 invoice pay (11 UCT). Without this,
+# bob's balance is 0 and `sphere invoice pay $INV` errors with
+# "Insufficient balance" even though the invoice was successfully
+# discovered via §C.1b deliver (#226).
+sphere wallet use bob
+sphere faucet            2>&1 | tee "$SNAP/peer1-bob-faucet.log"
+sphere payments sync     2>&1 | tee "$SNAP/peer1-bob-sync.log"
+sphere balance           | tee "$SNAP/peer1-bob-balance.txt"
+
 # ---------------------------------------------------------------------------
 # §A — Peer2 setup (same identity, separate DATA_DIR)
 # ---------------------------------------------------------------------------

--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -302,21 +302,28 @@ INV="$(grep -Eo '"invoiceId":[[:space:]]*"[^"]+"' "$SNAP/peer1-invoice-create.lo
 [[ -n "$INV" ]] || { echo "FAIL: couldn't extract invoiceId" >&2; exit 1; }
 echo "INV=$INV"
 
+banner "§C.1b Alice delivers the invoice to Bob (#226 — UXF bundle over DM)"
+
+# `sphere invoice create` no longer auto-delivers (#226). Delivery is a
+# separate, explicit step: package the invoice into a UXF bundle and
+# ship it to every non-self target via NIP-17 DM. Without this step,
+# Bob's wallet has no path to discover the invoice — payment-time
+# sync/receive don't pull invoices addressed to him, and `invoice pay`
+# would error with "No invoice found matching prefix: ...".
+sphere invoice deliver "$INV" 2>&1 | tee "$SNAP/peer1-invoice-deliver.log"
+
 banner "§C.2 Bob pays"
 
 sphere wallet use bob
-# Bob must pull alice's just-minted invoice token from the relay /
-# IPFS before he can resolve the invoice id. The script's §B daemons
-# are currently unreliable on testnet (stale PID after detach), so
-# we drive the pull explicitly with `payments sync` here. Without
-# this the next `invoice pay $INV` errors with
-# "No invoice found matching prefix: ..." because bob's local
-# invoice ledger is empty.
+# Give Bob's relay subscription a beat to ingest the just-published
+# `invoice_delivery:` DM. The receive pipeline imports the bundled
+# invoice synchronously on DM arrival, so a short settle suffices.
+sleep 5
 sphere payments sync       2>&1 | tee "$SNAP/peer1-bob-pre-pay-sync.log"
-# Some implementations route the invoice token through `payments
-# receive` rather than `payments sync` (Nostr-delivered vs IPFS-
-# discovered). Drive both with --finalize so any pending V5 tokens
-# also get finalized before bob looks up the invoice.
+# `payments receive --finalize` drains any pending V5 tokens before
+# Bob looks up the invoice. The invoice itself rides through the
+# `invoice_delivery:` DM channel (handled by AccountingModule, not
+# the payments pipeline) — included here purely for hygiene.
 sphere payments receive --finalize 2>&1 | tee "$SNAP/peer1-bob-pre-pay-receive.log"
 sphere invoice pay "$INV"  2>&1 | tee "$SNAP/peer1-invoice-pay.log"
 sphere payments sync       2>&1 | tee "$SNAP/peer1-invoice-pay-sync.log"


### PR DESCRIPTION
## Summary

Closes #218. Adds `manual-test-full-recovery.md` as a companion to
`manual-test-drain-fix.md`, covering the §A–§E scenarios called out in
the issue:

- **§A** Second profile instance per wallet (peer2-alice, peer2-bob in separate CWDs) — verifies per-instance OrbitDB / IPFS sync for the same identity.
- **§B** Long-running foreground `sphere daemon` listeners on peer2 — documents the exact `--event / --action` quick-mode flags and the per-CWD daemon PID collision gotcha.
- **§C** Bidirectional invoice flow (11 UCT) with daemons running — asserts peer2 sees the new state **without** a manual `sphere payments sync`.
- **§D** Wipe-and-recover BOTH profiles on BOTH peers using `sphere init --no-nostr --mnemonic` — proves the published CARs survive without faucet or live Nostr input.
- **§E** Recovery preserves the invoice ledger — `sphere invoice list --state COVERED` diffed pre/post wipe must be empty.

## Why a sibling doc (vs. extending in-place)

The issue's acceptance section explicitly allows both. The existing
243-line drain-fix doc is tightly focused on the PR #127 follow-up
(`sync()` drain). Extending it would balloon it to ~700 lines and dilute
its narrative. The sibling cross-references §0 of the drain-fix doc for
prereqs and matches its style (numbered sections, "what you're looking
for" assertions, gotchas, command cheat sheet).

## Layout decision

Three CWDs under `~/sphere-full-test/`:

```
peer1/         ← primary; both alice + bob via `sphere wallet use`
peer2-alice/   ← secondary instance of alice (own daemon)
peer2-bob/     ← secondary instance of bob   (own daemon)
```

Rationale: `./.sphere-cli/{config.json,daemon.pid,daemon.log}` are
CWD-relative and not profile-scoped. Two daemons in one CWD collide on
PID without explicit `--pid/--log` overrides. Per-peer-wallet CWDs
sidestep the collision and keep the daemon commands simple.

## Test plan

- [ ] Operator follows §0–§E on a fresh testnet checkout, all five
      assertions pass.
- [ ] §A's peer1↔peer2 balance diff is empty after `init --mnemonic + sync`.
- [ ] §B daemons report `Daemon running. Waiting for events...` with no
      PID-collision error.
- [ ] §C.4 peer2 balance reflects the 11 UCT invoice payment **without** a
      manual `sphere payments sync` (auto-receive worked).
- [ ] §D.5 — all four `diff` outputs empty after `--no-nostr` recovery on
      both peers.
- [ ] §E — `invoice list --state COVERED` diff pre/post wipe is empty;
      the §C invoice spot-check shows `COVERED` with the same memo.

## Out of scope

Per the issue: scripted automation lives separately in `tests/e2e/*.test.ts`
(`profile-multi-device-sync.test.ts`, `ipfs-multi-device-sync.test.ts`,
`two-device-local-mint-convergence.test.ts`). This walkthrough is meant
to be **human-runnable on testnet**.

## Refs

- Issue: #218
- Companion: `manual-test-drain-fix.md`
- Related automated tests: `tests/e2e/profile-multi-device-sync.test.ts`,
  `tests/e2e/ipfs-multi-device-sync.test.ts`,
  `tests/e2e/two-device-local-mint-convergence.test.ts`