### PR TITLE
docs: rewrite README for outside developers; split into focused guides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Sphere SDK — Architecture
 
-This document explains how Sphere works underneath the friendly API. The [README](README.md) deliberately avoids this depth; if you are integrating, extending, or debugging the SDK, start here.
+This document explains how the Sphere SDK works underneath the friendly API. The [README](README.md) deliberately avoids this depth; if you are integrating, extending, or debugging the SDK, start here.
 
 The whole system rests on one idea, repeated at every layer: **a single key per user, and cryptographic proofs carried peer‑to‑peer instead of stored on a chain.**
 
@@ -8,7 +8,7 @@ The whole system rests on one idea, repeated at every layer: **a single key per 
 
 ## 1. One key, many identities
 
-A wallet is created from a BIP‑39 recovery phrase. That phrase derives a single secp256k1 private key (BIP‑32, path `m/44'/0'/0'/0/{index}`), and from that one key Sphere derives every address a user needs:
+A wallet is created from a BIP‑39 recovery phrase. That phrase derives a single secp256k1 private key (BIP‑32, path `m/44'/0'/0'/0/{index}`), and from that one key the SDK derives every address a user needs:
 
 ```
 recovery phrase
@@ -50,11 +50,11 @@ interface Identity {
 
 ## 2. The two networks
 
-Sphere spans two independent networks. The README calls them "tokens" and "the ALPHA coin"; here are their real names and mechanics. (Historically these are referred to as **L3** and **L1**.)
+The Sphere SDK spans two independent networks. The README calls them "tokens" and "the ALPHA coin"; here are their real names and mechanics. (Historically these are referred to as **L3** and **L1**.)
 
 ### 2a. The Unicity token network ("L3") — the core
 
-This is what Sphere is fundamentally for. A **token** is a self‑contained cryptographic object: a genesis (mint) record plus a chain of transfers, each anchored by a Merkle **inclusion proof** signed by a Byzantine‑fault‑tolerant validator set (the *trust base*).
+This is what the Sphere SDK is fundamentally for. A **token** is a self‑contained cryptographic object: a genesis (mint) record plus a chain of transfers, each anchored by a Merkle **inclusion proof** signed by a Byzantine‑fault‑tolerant validator set (the *trust base*).
 
 The defining property: **only a commitment (a hash) is ever published on the network.** The token itself — its full history and proofs — lives off‑chain and travels directly between users (over the messaging transport). This buys three things:
 
@@ -191,7 +191,7 @@ A few notes that explain the design:
 
 ## 7. Providers and storage
 
-Sphere is platform‑agnostic through five injectable interfaces:
+The Sphere SDK is platform‑agnostic through five injectable interfaces:
 
 | Provider | Role | Browser default | Node default |
 |---|---|---|---|
@@ -209,7 +209,7 @@ See [docs/PROVIDERS-AND-CONFIG.md](docs/PROVIDERS-AND-CONFIG.md) for configurati
 
 ## 8. Dependency stack
 
-Sphere is composition on top of Unicity's protocol packages:
+The Sphere SDK is composition on top of Unicity's protocol packages:
 
 ```
 @unicitylabs/sphere-sdk

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,233 @@
+# Sphere SDK — Architecture
+
+This document explains how Sphere works underneath the friendly API. The [README](README.new.md) deliberately avoids this depth; if you are integrating, extending, or debugging the SDK, start here.
+
+The whole system rests on one idea, repeated at every layer: **a single key per user, and cryptographic proofs carried peer‑to‑peer instead of stored on a chain.**
+
+---
+
+## 1. One key, many identities
+
+A wallet is created from a BIP‑39 recovery phrase. That phrase derives a single secp256k1 private key (BIP‑32, path `m/44'/0'/0'/0/{index}`), and from that one key Sphere derives every address a user needs:
+
+```
+recovery phrase
+   └─ BIP-39 seed
+        └─ BIP-32 master key  (HMAC-SHA512 "Bitcoin seed")
+             └─ child private key d at m/44'/0'/0'/0/{index}
+                  │
+                  ├─ used DIRECTLY (key = d):
+                  │    ├─ chain public key — 33-byte compressed secp256k1
+                  │    │      → messaging/transport identity (x-only: pubkey.slice(2))
+                  │    │      → nametag binding, signMessage / verifySignedMessage
+                  │    └─ ALPHA address — alpha1… (hash160 of the chain public key)
+                  │
+                  └─ HASHED FIRST (key = SHA-256(d), via SigningService.createFromSecret):
+                       └─ token signing key
+                              → wallet token address (DIRECT://…)
+                              → owns and signs tokens on the main network
+```
+
+> **There are actually two secp256k1 keypairs per address — this trips people up.** The **raw** child key `d` drives the messaging identity (the transport key is the chain public key with its parity prefix stripped, `pubkey.slice(2)`), the nametag binding, message signing, and the ALPHA address. The **token** key is `SHA-256(d)`: `SigningService.createFromSecret(secret)` hashes the secret *before* using it, so the `DIRECT://` token address and all token signatures are a **different elliptic‑curve point** from the chain/messaging key. Code that needs the token key must go through `SigningService.createFromSecret(privKey)` (as `deriveL3PredicateAddress` does). Using `new SigningService(privKey)` (the raw constructor) gives the messaging key instead — it will *not* match the token address. See [docs/IDENTITY-CRYPTO.md](docs/IDENTITY-CRYPTO.md).
+
+**One recovery phrase still fully reconstructs everything** — both keypairs derive deterministically from the same child key, and (with help from the relay) so does the user's `@nametag`.
+
+A second key system appears in exactly one place: the optional IPFS/IPNS token backup derives an **Ed25519** key from the wallet secret via HKDF (`info = "ipfs-storage-ed25519-v1"`). Nothing else uses a second curve.
+
+### Identity shape
+
+```typescript
+interface Identity {
+  chainPubkey: string;     // 33-byte compressed secp256k1 (token network)
+  directAddress?: string;  // DIRECT://…  — primary wallet address
+  l1Address: string;       // alpha1…     — ALPHA base-chain coin only
+  ipnsName?: string;       // identifier for IPFS token backup
+  nametag?: string;        // human-readable handle
+}
+```
+
+---
+
+## 2. The two networks
+
+Sphere spans two independent networks. The README calls them "tokens" and "the ALPHA coin"; here are their real names and mechanics. (Historically these are referred to as **L3** and **L1**.)
+
+### 2a. The Unicity token network ("L3") — the core
+
+This is what Sphere is fundamentally for. A **token** is a self‑contained cryptographic object: a genesis (mint) record plus a chain of transfers, each anchored by a Merkle **inclusion proof** signed by a Byzantine‑fault‑tolerant validator set (the *trust base*).
+
+The defining property: **only a commitment (a hash) is ever published on the network.** The token itself — its full history and proofs — lives off‑chain and travels directly between users (over the messaging transport). This buys three things:
+
+- **Privacy** — the network reveals nothing about amounts, token types, or parties.
+- **Scale** — a consensus round absorbs an enormous number of commitments; it is effectively one global sparse Merkle tree of spent states.
+- **Offline creation** — commitments can be built without connectivity and submitted later.
+
+The service that batches commitments into rounds and issues the signed proofs is the **aggregator** (the SDK calls it the *Oracle*).
+
+### 2b. The ALPHA blockchain ("L1")
+
+A conventional UTXO chain, Bitcoin‑style (SegWit / P2WPKH, bech32 `alpha1…` addresses). The SDK builds and signs transactions by hand (BIP‑143 signature hashing, low‑S canonical signatures, a fixed fee, 546‑sat dust threshold) and talks to a **Fulcrum** Electrum server over a WebSocket. The connection is *lazy* — it isn't opened until the first ALPHA operation.
+
+It also includes a **vesting classifier**: it traces each coin back to the coinbase that created it to label it vested or unvested, caching results in IndexedDB (browser) or memory (Node).
+
+### Network presets
+
+`createBrowserProviders({ network })` / `createNodeProviders({ network })` wire every service from one name. Endpoint values come from `constants.ts`:
+
+| Service | mainnet | testnet | dev |
+|---|---|---|---|
+| Aggregator | `aggregator.unicity.network/rpc` | `goggregator-test.unicity.network` | `dev-aggregator.dyndns.org/rpc` |
+| Messaging relay | `relay.unicity.network` | `nostr-relay.testnet.unicity.network` | `nostr-relay.testnet.unicity.network` |
+| Fulcrum (ALPHA) | `fulcrum.unicity.network:50004` | `fulcrum.unicity.network:50004` | `fulcrum.unicity.network:50004` |
+| Group‑chat relay | `sphere-relay.unicity.network` | `sphere-relay.unicity.network` | `sphere-relay.unicity.network` |
+
+Token metadata (symbols, decimals, icons) is fetched from a remote registry and cached; prices are optional via a CoinGecko provider.
+
+---
+
+## 3. How a token transfer works
+
+Sending a token reduces to: commit, prove, deliver.
+
+```
+1. Resolve recipient (@nametag / DIRECT:// / pubkey) → an address object
+2. Build a TransferCommitment over the token, recipient, a random 32-byte salt,
+   an optional on-chain message, signed with the sender's key
+3. Submit the commitment to the aggregator
+4. Wait for the inclusion proof (proof the commitment landed in a round)
+5. Turn commitment + proof into a finalized transfer transaction
+6. Deliver { sourceToken, transferTx } to the recipient over the messaging transport
+7. Recipient verifies the proof locally against the trust base — the sender is never trusted
+```
+
+When the amount is smaller than a single token's value, the SDK performs an **atomic split**: it burns the original and mints two new tokens (one for the recipient, one as change), each proof‑verified. Split salts are *deterministic* (derived from the token id and amounts), so a split is replayable and idempotent rather than duplicating value.
+
+### Two transfer modes
+
+- **Instant** (default) — all tokens are bundled into one message and shipped immediately; proofs are resolved in the background. Fast; failure can leave a partial delivery.
+- **Conservative** — each token is fully proven before it is sent. Slower; all‑or‑nothing per token.
+
+### Verification (the trust anchor)
+
+A recipient (or any holder) confirms a token by recomputing its state, deriving a `RequestId`, fetching the inclusion proof from the aggregator, and checking the Merkle path against the **trust base**:
+
+```
+spent  ⟺  merkleTreePath.verify(requestId) is valid AND included AND authenticator ≠ null
+```
+
+This is the single mechanism behind double‑spend detection, receive‑side validation, and swap payout verification.
+
+---
+
+## 4. TXF — the token storage/wire format
+
+Tokens are stored and transmitted as **TXF (Token eXchange Format)**, a version‑stable JSON that mirrors the on‑chain proof structure:
+
+```
+TxfToken {
+  version: "2.0",
+  genesis,                 // mint record + inclusion proof
+  state,                   // current ownership predicate
+  transactions[],          // history; inclusionProof == null means "pending"
+  nametags?, _integrity?
+}
+   inclusionProof {
+     authenticator { algorithm, publicKey, signature, stateHash },
+     merkleTreePath { root, steps[] },
+     unicityCertificate     // CBOR, signed by the BFT validator set
+   }
+```
+
+Everything is normalized to hex for cross‑version stability. Storage layers it into a document with reserved keys (`_meta`, `_tombstones`, `_outbox`, …) and `_{tokenId}` entries; spent states get tombstones, and divergent histories are kept under `_forked_…` keys.
+
+Helpers: `tokenToTxf`, `txfToToken`, `buildTxfStorageData`, `parseTxfStorageData`, `getCurrentStateHash`, `hasUncommittedTransactions`.
+
+### Validating tokens directly
+
+```typescript
+import { createTokenValidator } from '@unicitylabs/sphere-sdk';
+
+const validator = createTokenValidator({ aggregatorClient, trustBase });
+const { validTokens, issues } = await validator.validateAllTokens(tokens);
+const isSpent = await validator.isTokenStateSpent(tokenId, stateHash, publicKey);
+```
+
+---
+
+## 5. Messaging transport
+
+All peer‑to‑peer delivery — token transfers, payment requests, direct messages — rides on Nostr relays.
+
+- **Direct messages** use NIP‑17 gift wrap: a three‑layer envelope (rumor → seal → gift wrap) encrypted with NIP‑44 under an ephemeral key, with timestamps randomized ±2 days for privacy.
+- **Token transfers** are a custom event kind, NIP‑04 encrypted, tagged to the recipient.
+- **Identity binding** uses a replaceable event (kind 30078) that maps a `@nametag` ↔ transport key ↔ wallet addresses, with first‑seen‑wins anti‑hijacking and an encrypted nametag that can be recovered after import.
+- **Group chat** uses NIP‑29 on a dedicated relay with its own connection, separate from the wallet transport.
+
+The transport persists a per‑wallet "last seen" timestamp so reconnects resume rather than replay history, and verifies publishes by querying the relay back for the event.
+
+---
+
+## 6. Module map
+
+```
+Sphere (entry point: init / create / load / import / clear)
+├── payments          — token transfers, balances, history
+│   └── l1            — ALPHA blockchain operations (lazy Fulcrum connection)
+├── accounting        — invoices (an invoice IS a token), payment attribution, auto-return
+├── swap              — peer-to-peer token swaps via an escrow service
+├── communications    — direct messages and broadcasts
+├── groupChat         — NIP-29 group messaging (its own relay connection)
+├── market            — signed intent board (post/search listings)
+└── connect (host)    — dApp ↔ wallet RPC
+```
+
+A few notes that explain the design:
+
+- **An invoice is a token.** Accounting mints invoices as tokens with a dedicated token type; payment matching uses an on‑chain memo carrying a *hash* of the invoice id (so third parties can't correlate), with the refund address and contact riding on‑chain but never in cleartext.
+- **Swap rides on accounting rides on payments.** Deposits happen by paying escrow‑issued invoices; the SDK is a *client* of the escrow service and never custodies funds. Manifests are signed and content‑hashed (`swap_id = SHA‑256` of the canonical manifest, byte‑identical to the escrow's computation).
+- **Modules reuse the layer below** rather than reimplementing it — no module re‑invents transfers or transport.
+
+---
+
+## 7. Providers and storage
+
+Sphere is platform‑agnostic through five injectable interfaces:
+
+| Provider | Role | Browser default | Node default |
+|---|---|---|---|
+| `StorageProvider` | wallet keys, per‑address data | IndexedDB | files (atomic write) |
+| `TokenStorageProvider` | token data (TXF) | IndexedDB per address | files per address |
+| `TransportProvider` | peer‑to‑peer messaging | Nostr (native WS) | Nostr (`ws`) |
+| `OracleProvider` | aggregator / proofs | included | included |
+| `PriceProvider` | fiat prices | optional (CoinGecko) | optional (CoinGecko) |
+
+Wallet data is namespaced: global keys (recovery phrase, master key, tracked addresses, caches) and per‑address keys scoped by an `addressId` derived from the wallet address. `Sphere.clear()` deletes them in a strict order (vesting cache → token databases → key store) to avoid leaving partial state.
+
+See [docs/PROVIDERS-AND-CONFIG.md](docs/PROVIDERS-AND-CONFIG.md) for configuration, custom providers, and runtime management.
+
+---
+
+## 8. Dependency stack
+
+Sphere is composition on top of Unicity's protocol packages:
+
+```
+@unicitylabs/sphere-sdk
+├─ @unicitylabs/state-transition-sdk     ← the token engine (mint/transfer/split, commitments, proofs)
+│    ├─ @unicitylabs/commons             ← signing, hashing, sparse Merkle tree, CBOR, RequestId, InclusionProof
+│    └─ @unicitylabs/bft-js-sdk          ← RootTrustBase, UnicityCertificate (BFT consensus anchor)
+├─ @unicitylabs/nostr-js-sdk             ← messaging crypto (NIP-04/17/44, identity binding)
+├─ @noble/curves, @noble/hashes          ← modern curve/hash primitives
+├─ elliptic, crypto-js                   ← secp256k1 + SHA/RIPEMD/HMAC/AES (core + ALPHA chain)
+├─ bip39                                 ← recovery phrases
+├─ canonicalize                          ← RFC-8785 JSON canonicalization (swap manifests, invoice ids)
+└─ optional: @libp2p/crypto, @libp2p/peer-id, ipns, multiformats (IPFS backup), ws (Node)
+```
+
+The irreducible bottom is `@unicitylabs/commons` (Merkle + CBOR + hashing) and `@unicitylabs/bft-js-sdk` (the trust base), plus secp256k1. Everything above is built from those.
+
+---
+
+## In one sentence
+
+*One wallet key derives a base‑chain address and a messaging identity directly, plus a token‑custody key one SHA‑256 step further; tokens live as self‑verifying off‑chain proof bundles passed directly between users, while the network only ever sees opaque commitments validated against a BFT trust base.*

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ recovery phrase
                   ├─ used DIRECTLY (key = d):
                   │    ├─ chain public key — 33-byte compressed secp256k1
                   │    │      → messaging/transport identity (x-only: pubkey.slice(2))
-                  │    │      → nametag binding, signMessage / verifySignedMessage
+                  │    │      → Unicity-ID binding, signMessage / verifySignedMessage
                   │    └─ ALPHA address — alpha1… (hash160 of the chain public key)
                   │
                   └─ HASHED FIRST (key = SHA-256(d), via SigningService.createFromSecret):
@@ -28,9 +28,9 @@ recovery phrase
                               → owns and signs tokens on the main network
 ```
 
-> **There are actually two secp256k1 keypairs per address — this trips people up.** The **raw** child key `d` drives the messaging identity (the transport key is the chain public key with its parity prefix stripped, `pubkey.slice(2)`), the nametag binding, message signing, and the ALPHA address. The **token** key is `SHA-256(d)`: `SigningService.createFromSecret(secret)` hashes the secret *before* using it, so the `DIRECT://` token address and all token signatures are a **different elliptic‑curve point** from the chain/messaging key. Code that needs the token key must go through `SigningService.createFromSecret(privKey)` (as `deriveL3PredicateAddress` does). Using `new SigningService(privKey)` (the raw constructor) gives the messaging key instead — it will *not* match the token address. See [docs/IDENTITY-CRYPTO.md](docs/IDENTITY-CRYPTO.md).
+> **There are actually two secp256k1 keypairs per address — this trips people up.** The **raw** child key `d` drives the messaging identity (the transport key is the chain public key with its parity prefix stripped, `pubkey.slice(2)`), the Unicity-ID binding, message signing, and the ALPHA address. The **token** key is `SHA-256(d)`: `SigningService.createFromSecret(secret)` hashes the secret *before* using it, so the `DIRECT://` token address and all token signatures are a **different elliptic‑curve point** from the chain/messaging key. Code that needs the token key must go through `SigningService.createFromSecret(privKey)` (as `deriveL3PredicateAddress` does). Using `new SigningService(privKey)` (the raw constructor) gives the messaging key instead — it will *not* match the token address. See [docs/IDENTITY-CRYPTO.md](docs/IDENTITY-CRYPTO.md).
 
-**One recovery phrase still fully reconstructs everything** — both keypairs derive deterministically from the same child key, and (with help from the relay) so does the user's `@nametag`.
+**One recovery phrase still fully reconstructs everything** — both keypairs derive deterministically from the same child key, and (with help from the relay) so does the user's Unicity ID.
 
 A second key system appears in exactly one place: the optional IPFS/IPNS token backup derives an **Ed25519** key from the wallet secret via HKDF (`info = "ipfs-storage-ed25519-v1"`). Nothing else uses a second curve.
 
@@ -42,7 +42,7 @@ interface Identity {
   directAddress?: string;  // DIRECT://…  — primary wallet address
   l1Address: string;       // alpha1…     — ALPHA base-chain coin only
   ipnsName?: string;       // identifier for IPFS token backup
-  nametag?: string;        // human-readable handle
+  nametag?: string;        // the Unicity ID (human-readable handle, e.g. @alice)
 }
 ```
 
@@ -90,7 +90,7 @@ Token metadata (symbols, decimals, icons) is fetched from a remote registry and 
 Sending a token reduces to: commit, prove, deliver.
 
 ```
-1. Resolve recipient (@nametag / DIRECT:// / pubkey) → an address object
+1. Resolve recipient (Unicity ID / DIRECT:// / pubkey) → an address object
 2. Build a TransferCommitment over the token, recipient, a random 32-byte salt,
    an optional on-chain message, signed with the sender's key
 3. Submit the commitment to the aggregator
@@ -160,7 +160,7 @@ All peer‑to‑peer delivery — token transfers, payment requests, direct mess
 
 - **Direct messages** use NIP‑17 gift wrap: a three‑layer envelope (rumor → seal → gift wrap) encrypted with NIP‑44 under an ephemeral key, with timestamps randomized ±2 days for privacy.
 - **Token transfers** are a custom event kind, NIP‑04 encrypted, tagged to the recipient.
-- **Identity binding** uses a replaceable event (kind 30078) that maps a `@nametag` ↔ transport key ↔ wallet addresses, with first‑seen‑wins anti‑hijacking and an encrypted nametag that can be recovered after import.
+- **Identity binding** uses a replaceable event (kind 30078) that maps a Unicity ID ↔ transport key ↔ wallet addresses, with first‑seen‑wins anti‑hijacking and an encrypted Unicity ID that can be recovered after import. (In the API/transport this is the `nametag`.)
 - **Group chat** uses NIP‑29 on a dedicated relay with its own connection, separate from the wallet transport.
 
 The transport persists a per‑wallet "last seen" timestamp so reconnects resume rather than replay history, and verifies publishes by querying the relay back for the event.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Sphere SDK — Architecture
 
-This document explains how Sphere works underneath the friendly API. The [README](README.new.md) deliberately avoids this depth; if you are integrating, extending, or debugging the SDK, start here.
+This document explains how Sphere works underneath the friendly API. The [README](README.md) deliberately avoids this depth; if you are integrating, extending, or debugging the SDK, start here.
 
 The whole system rests on one idea, repeated at every layer: **a single key per user, and cryptographic proofs carried peer‑to‑peer instead of stored on a chain.**
 

--- a/README.md
+++ b/README.md
@@ -1,1424 +1,177 @@
-# Sphere SDK
+# Sphere
 
-A modular TypeScript SDK for Unicity wallet operations supporting both Layer 1 (ALPHA blockchain) and Layer 3 (Unicity state transition network).
+**A TypeScript SDK for apps where users hold their own tokens and pay each other by name — no payment backend to build, no custody of anyone's funds.**
 
-## Features
+[![npm](https://img.shields.io/npm/v/@unicitylabs/sphere-sdk.svg)](https://www.npmjs.com/package/@unicitylabs/sphere-sdk)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![node](https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg)](https://nodejs.org)
 
-- **Wallet Management** - BIP39/BIP32 key derivation, AES-256 encryption
-- **L1 Payments** - ALPHA blockchain transactions via Fulcrum WebSocket
-- **L3 Payments** - Token transfers with state transition proofs, concurrent-send safety (SpendQueue)
-- **Invoicing / Accounting** - On-chain invoice lifecycle with payment attribution, auto-return, privacy-preserving hashed invoice IDs
-- **Token Swaps** - P2P atomic swaps via escrow with DM-based negotiation protocol
-- **Payment Requests** - Request payments with async response tracking
-- **Group Chat** - NIP-29 relay-based group messaging with moderation
-- **Nostr Transport** - Resilient P2P messaging with verified publish, health checks, NIP-17 gift-wrap
-- **IPFS Storage** - Decentralized token backup via HTTP API (browser + Node.js)
-- **Multi-Address** - HD address derivation (BIP32/BIP44)
-- **Token Validation** - Aggregator-based token verification
-- **Connect Protocol** - dApp ↔ wallet communication via `ConnectClient` / `ConnectHost` (browser extension + popup)
-- **CLI** - Comprehensive command-line interface with shell auto-completion
+---
 
-## Installation
+Sphere gives your app a self‑custody wallet: each user holds their own keys, pays others by `@name`, and every transfer is settled on Unicity's network and backed by cryptographic proof. You get the wallet, transfers, encrypted messaging, and invoicing out of the box — without building or operating a payment backend, and without ever holding users' funds. It runs in the browser and in Node.js.
+
+## Why Sphere
+
+Most apps that move money put a custodial server in the middle: it holds everyone's balances, clears the payments, and can freeze or lose them — and it's yours to build, secure, and keep online.
+
+Sphere splits those jobs apart:
+
+- **Custody moves to the user.** Their wallet holds its own keys; your app never touches their funds.
+- **Settlement moves to Unicity's network** — a shared ledger run across many validator nodes — which records every transfer and lets the recipient verify it cryptographically.
+
+There is still infrastructure doing the clearing (a settlement network, messaging relays, and the base chain), but **you don't run it**, and no single company sits on top of users' balances. Your app just creates a wallet and asks it to do things.
+
+## What you can build
+
+**Send and receive tokens.** Move value between users by `@name` — no account numbers, and no backend of your own to operate.
+
+**Invoices and payment requests.** Ask another user to pay, and track whether they did, automatically.
+
+**Encrypted messaging.** One‑to‑one direct messages and group chat, end‑to‑end encrypted, built in.
+
+**Peer‑to‑peer swaps.** Two users trade one token for another, with an escrow service handling the exchange safely.
+
+**Wallet connections.** Let a web app ask a user's wallet to pay or sign something — without the app ever touching their keys.
+
+> The user holds the keys. The app just asks.
+
+## Install
 
 ```bash
 npm install @unicitylabs/sphere-sdk
+# Node.js also needs a WebSocket library:
+npm install @unicitylabs/sphere-sdk ws
 ```
 
-## Quick Start Guides
-
-Choose your platform:
-
-| Platform | Guide | Required | Optional |
-|----------|-------|----------|----------|
-| **Browser** | [QUICKSTART-BROWSER.md](docs/QUICKSTART-BROWSER.md) | SDK only | IPFS sync (built-in) |
-| **Node.js** | [QUICKSTART-NODEJS.md](docs/QUICKSTART-NODEJS.md) | SDK + `ws` | IPFS sync (built-in) |
-| **CLI** | [@unicity-sphere/cli](https://github.com/unicity-sphere/sphere-cli) | Separate package | - |
-| **dApp integration** | [CONNECT.md](docs/CONNECT.md) | SDK only | Sphere extension |
-
-## CLI (Command Line Interface)
-
-The CLI has moved to a dedicated package: [`@unicity-sphere/cli`](https://github.com/unicity-sphere/sphere-cli).
-
-```bash
-npm install -g @unicity-sphere/cli
-sphere --help
-```
-
-See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md) for the full command reference.
-
-## Quick Start
+## Quick start
 
 ```typescript
 import { Sphere } from '@unicitylabs/sphere-sdk';
 import { createBrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
+// Node.js: import { createNodeProviders } from '@unicitylabs/sphere-sdk/impl/nodejs';
 
-// Create providers (browser) - defaults to mainnet
-const providers = createBrowserProviders();
-
-// Or use testnet for development
-const testnetProviders = createBrowserProviders({ network: 'testnet' });
-
-// Initialize (auto-creates wallet if needed)
+// 1. Create a wallet (testnet is for experimenting)
 const { sphere, created, generatedMnemonic } = await Sphere.init({
-  ...providers,
-  autoGenerate: true,  // Generate mnemonic if wallet doesn't exist
-});
-
-if (created && generatedMnemonic) {
-  console.log('Save this mnemonic:', generatedMnemonic);
-}
-
-// Get identity (L3 DIRECT address is primary)
-console.log('Address:', sphere.identity?.directAddress);
-
-// Get assets with price data
-const assets = await sphere.payments.getAssets();
-console.log('Assets:', assets);
-
-// Get total portfolio value in USD (requires PriceProvider)
-const balance = await sphere.payments.getBalance();
-console.log('Total USD:', balance); // number | null
-
-// Send tokens
-const result = await sphere.payments.send({
-  recipient: '@alice',
-  amount: '1000000',
-  coinId: 'UCT',
-});
-
-// Derive additional addresses
-const addr1 = sphere.deriveAddress(1);
-console.log('Address 1:', addr1.address);
-```
-
-## Network Configuration
-
-The SDK supports three network presets that configure all services automatically:
-
-| Network | Aggregator | Nostr Relay | Electrum (L1) |
-|---------|------------|-------------|---------------|
-| `mainnet` | aggregator.unicity.network | relay.unicity.network | fulcrum.alpha.unicity.network |
-| `testnet` | goggregator-test.unicity.network | nostr-relay.testnet.unicity.network | fulcrum.alpha.testnet.unicity.network |
-| `dev` | dev-aggregator.dyndns.org | nostr-relay.testnet.unicity.network | fulcrum.alpha.testnet.unicity.network |
-
-```typescript
-// Use testnet for all services
-const providers = createBrowserProviders({ network: 'testnet' });
-
-// Override specific services while using network preset
-const providers = createBrowserProviders({
-  network: 'testnet',
-  oracle: { url: 'https://custom-aggregator.example.com' }, // custom oracle
-});
-
-// L1 is enabled by default — customize if needed
-const providers = createBrowserProviders({
-  network: 'testnet',
-  l1: { enableVesting: true },  // uses testnet electrum URL automatically
-});
-```
-
-## Price Provider (Optional)
-
-Enable fiat price display by adding a `price` config. Currently supports CoinGecko API (free and pro tiers).
-
-```typescript
-// With CoinGecko (free tier, no API key)
-const providers = createBrowserProviders({
-  network: 'testnet',
-  price: { platform: 'coingecko' },
-});
-
-// With CoinGecko Pro
-const providers = createBrowserProviders({
-  network: 'testnet',
-  price: { platform: 'coingecko', apiKey: 'CG-xxx' },
-});
-
-const { sphere } = await Sphere.init({ ...providers, autoGenerate: true });
-
-// Total portfolio value in USD
-const totalUsd = await sphere.payments.getBalance();
-// 1523.45
-
-// Assets with price data
-const assets = await sphere.payments.getAssets();
-// [{ coinId, symbol, totalAmount, priceUsd: 97500, fiatValueUsd: 975.00, change24h: 2.3, ... }]
-```
-
-Without `price` config, `getBalance()` returns `null` and price fields in `getAssets()` are `null`. All other functionality works normally.
-
-You can also set the price provider after initialization:
-
-```typescript
-import { createPriceProvider } from '@unicitylabs/sphere-sdk';
-
-sphere.setPriceProvider(createPriceProvider({
-  platform: 'coingecko',
-  apiKey: 'CG-xxx',
-}));
-```
-
-## Testnet Faucet
-
-To get test tokens on testnet, you **must first register a nametag**:
-
-```typescript
-// 1. Create wallet and register nametag
-const { sphere } = await Sphere.init({
   ...createBrowserProviders({ network: 'testnet' }),
-  autoGenerate: true,
-  nametag: 'myname',  // Register @myname
+  autoGenerate: true,   // make a new wallet if one doesn't exist yet
+  nametag: 'alice',     // claim @alice so people can pay you by name
 });
 
-// 2. Request tokens from faucet using nametag
-const response = await fetch('https://faucet.unicity.network/api/v1/faucet/request', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ unicityId: 'myname', coin: 'unicity', amount: 100 }),
-});
-```
-
-> **Note:** The faucet requires a registered nametag. Requests without a valid nametag will fail.
-
-## Multi-Address Support
-
-The SDK supports HD (Hierarchical Deterministic) wallets with multiple addresses:
-
-```typescript
-// Get current address index
-const currentIndex = sphere.getCurrentAddressIndex(); // 0
-
-// Switch to a different address
-await sphere.switchToAddress(1);
-console.log(sphere.identity?.l1Address); // alpha1... (address at index 1)
-
-// Register nametag for this address (independent per address)
-await sphere.registerNametag('bob');
-
-// Switch back to first address
-await sphere.switchToAddress(0);
-
-// Get nametag for specific address
-const bobNametag = sphere.getNametagForAddress(1); // 'bob'
-
-// Get all address nametags
-const allNametags = sphere.getAllAddressNametags();
-// Map { 0 => 'alice', 1 => 'bob' }
-
-// Derive address without switching (for display/receiving)
-const addr2 = sphere.deriveAddress(2);
-console.log(addr2.address, addr2.publicKey);
-```
-
-### Identity Properties
-
-**Important:** L3 (DIRECT address) is the primary address for the Unicity network. L1 address is only used for ALPHA blockchain operations.
-
-```typescript
-interface Identity {
-  chainPubkey: string;         // 33-byte compressed secp256k1 public key (for L3 chain)
-  directAddress?: string;      // L3 DIRECT address (DIRECT://...) - PRIMARY ADDRESS
-  l1Address: string;           // L1 address (alpha1...) - for ALPHA blockchain only
-  ipnsName?: string;           // IPNS name for token sync
-  nametag?: string;            // Registered nametag (@username)
+// 2. First run? Show the user their recovery phrase to back up.
+if (created && generatedMnemonic) {
+  console.log('Save this recovery phrase:', generatedMnemonic);
 }
 
-// Access identity - use directAddress as primary
-console.log(sphere.identity?.directAddress);    // DIRECT://0000be36... (PRIMARY)
-console.log(sphere.identity?.nametag);          // alice (human-readable)
-console.log(sphere.identity?.l1Address);        // alpha1qw3e... (L1 only)
-console.log(sphere.identity?.chainPubkey);      // 02abc123... (33-byte compressed)
-```
+// 3. Who am I?
+console.log('My handle: @' + sphere.identity?.nametag);
 
-### Address Change Event
-
-```typescript
-// Listen for address switches
-sphere.on('identity:changed', (event) => {
-  console.log('Switched to address index:', event.data.addressIndex);
-  console.log('L1 address:', event.data.l1Address);
-  console.log('L3 address:', event.data.directAddress);
-  console.log('Chain pubkey:', event.data.chainPubkey);
-  console.log('Nametag:', event.data.nametag);
-});
-
-// Listen for nametag recovery (when importing wallet)
-sphere.on('nametag:recovered', (event) => {
-  console.log('Recovered nametag from Nostr:', event.data.nametag);
+// 4. Send 1 token to @bob
+await sphere.payments.send({
+  recipient: '@bob',
+  coinId: 'UCT',       // which token to send
+  amount: '1000000',   // amount in the token's smallest unit, written as a string
 });
 ```
 
-## Payment Requests
+That is a real transfer between two users — settled on Unicity's network, with no backend of your own required.
 
-Request payments from others with response tracking:
+> **Getting test tokens.** On testnet you must claim a `@nametag` first, then request from the faucet. See the [Node.js](docs/QUICKSTART-NODEJS.md) and [Browser](docs/QUICKSTART-BROWSER.md) quick‑start guides.
 
+## Core concepts
+
+You only need four ideas to use Sphere.
+
+- **Token** — a unit of digital value (like `UCT`). A user's wallet can hold many tokens of different kinds.
+- **Wallet** — created from a 12‑word *recovery phrase*. The phrase is the only thing a user needs to back up; lose it and the wallet is gone.
+- **`@nametag`** — a human‑friendly handle (like `@alice`) that people use to pay or message you. Each wallet can claim one.
+- **Network** — `testnet` for building and experimenting, `mainnet` for real value. Pick one when you create the wallet; everything else is configured for you.
+
+That's enough to send and receive. Everything below is built on top of these.
+
+## Common tasks
+
+**Send tokens**
 ```typescript
-// Send payment request
-const result = await sphere.payments.sendPaymentRequest('@bob', {
-  amount: '1000000',
-  coinId: 'UCT',
-  message: 'Payment for order #1234',
-});
-
-// Wait for response (with 2 minute timeout)
-if (result.success) {
-  const response = await sphere.payments.waitForPaymentResponse(result.requestId!, 120000);
-  if (response.responseType === 'paid') {
-    console.log('Payment received! Transfer:', response.transferId);
-  }
-}
-
-// Or subscribe to responses
-sphere.payments.onPaymentRequestResponse((response) => {
-  console.log(`Response: ${response.responseType}`);
-});
-
-// Handle incoming payment requests
-sphere.payments.onPaymentRequest((request) => {
-  console.log(`${request.senderNametag} requests ${request.amount} ${request.symbol}`);
-
-  // Accept and pay
-  await sphere.payments.payPaymentRequest(request.id);
-
-  // Or reject
-  await sphere.payments.rejectPaymentRequest(request.id);
-});
+await sphere.payments.send({ recipient: '@bob', coinId: 'UCT', amount: '1000000' });
 ```
 
-## Group Chat (NIP-29)
-
-Relay-based group messaging using the NIP-29 protocol. The module embeds its own Nostr connection separate from the wallet transport.
-
-### Enabling Group Chat
-
+**Check balances and holdings**
 ```typescript
-// Enable with network defaults (wss://sphere-relay.unicity.network)
-const { sphere } = await Sphere.init({
-  ...providers,
-  autoGenerate: true,
-  groupChat: true,
-});
-
-// Enable with custom relay
-const { sphere } = await Sphere.init({
-  ...providers,
-  autoGenerate: true,
-  groupChat: { relays: ['wss://my-nip29-relay.com'] },
-});
-
-// Access the module
-const gc = sphere.groupChat!;
+const assets = await sphere.payments.getAssets();   // grouped by token, with prices if enabled
+const tokens = sphere.payments.getTokens();          // individual tokens
+const usd    = await sphere.payments.getBalance();   // total in USD, or null if prices are off
 ```
 
-### Connection
-
+**Receive tokens**
 ```typescript
-// Connect to the NIP-29 relay
-await gc.connect();
-console.log('Connected:', gc.getConnectionStatus());
+await sphere.payments.receive();                     // pull anything sent to you
 
-// Check if current user is a relay admin
-const isRelayAdmin = await gc.isCurrentUserRelayAdmin();
-```
-
-### Groups
-
-```typescript
-import { GroupVisibility } from '@unicitylabs/sphere-sdk';
-
-// Create a public group
-const group = await gc.createGroup({
-  name: 'General',
-  description: 'Public discussion',
-});
-
-// Create a private group
-const privateGroup = await gc.createGroup({
-  name: 'Team',
-  visibility: GroupVisibility.PRIVATE,
-});
-
-// Create a write-restricted group (only admins/writers can post)
-const announcements = await gc.createGroup({
-  name: 'Announcements',
-  writeRestricted: true,
-});
-
-// Discover and join
-const available = await gc.fetchAvailableGroups(); // public groups on relay
-await gc.joinGroup(group.id);
-
-// Join private group with invite
-await gc.joinGroup(privateGroup.id, inviteCode);
-
-// List joined groups
-const groups = gc.getGroups();
-
-// Leave or delete
-await gc.leaveGroup(group.id);
-await gc.deleteGroup(group.id); // admin only
-```
-
-### Messaging
-
-```typescript
-// Send a message
-const msg = await gc.sendMessage(group.id, 'Hello!');
-
-// Reply to a message
-await gc.sendMessage(group.id, 'Agreed', { replyToId: msg.id });
-
-// Fetch messages from relay
-const messages = await gc.fetchMessages(group.id, { limit: 50 });
-
-// Get locally cached messages
-const cached = gc.getMessages(group.id);
-
-// Listen for new messages in real-time
-const unsubscribe = gc.onMessage((message) => {
-  console.log(`[${message.groupId}] ${message.senderPubkey}: ${message.content}`);
+sphere.on('transfer:incoming', (t) => {
+  console.log(`Got ${t.tokens.length} token(s) from ${t.senderNametag ?? t.senderPubkey}`);
 });
 ```
 
-### Members & Moderation
-
+**Request a payment from someone**
 ```typescript
-// Get members
-const members = gc.getMembers(group.id);
-
-// Check roles
-gc.isCurrentUserAdmin(group.id);     // boolean
-gc.isCurrentUserModerator(group.id); // boolean
-await gc.canModerateGroup(group.id); // includes relay admin check
-gc.canWriteToGroup(group.id);       // false if write-restricted and not admin/moderator
-
-// Moderate (requires admin/moderator role)
-await gc.kickUser(group.id, userPubkey, 'reason');
-await gc.deleteMessage(group.id, messageId);
+const req = await sphere.payments.sendPaymentRequest('@bob', {
+  amount: '1000000', coinId: 'UCT', message: 'Invoice #1234',
+});
+const res = await sphere.payments.waitForPaymentResponse(req.requestId!, 120000);
 ```
 
-### Invites (Private Groups)
-
+**Send a direct message**
 ```typescript
-// Create invite code (admin only)
-const invite = await gc.createInvite(group.id);
-
-// Share invite code, recipient joins with:
-await gc.joinGroup(group.id, invite);
-```
-
-### Unread Counts
-
-```typescript
-const total = gc.getTotalUnreadCount();
-gc.markGroupAsRead(group.id);
-```
-
-### Key Types
-
-```typescript
-interface GroupData {
-  id: string;
-  relayUrl: string;
-  name: string;
-  description?: string;
-  visibility: GroupVisibility;  // 'PUBLIC' | 'PRIVATE'
-  writeRestricted?: boolean;   // Only admins and moderators can post
-  memberCount?: number;
-  unreadCount?: number;
-  lastMessageTime?: number;
-  lastMessageText?: string;
-}
-
-interface GroupMessageData {
-  id?: string;
-  groupId: string;
-  content: string;
-  timestamp: number;
-  senderPubkey: string;
-  senderNametag?: string;
-  replyToId?: string;
-}
-
-interface GroupMemberData {
-  pubkey: string;
-  groupId: string;
-  role: GroupRole;  // 'ADMIN' | 'MODERATOR' | 'MEMBER'
-  nametag?: string;
-  joinedAt: number;
-}
-```
-
-## Direct Messages (NIP-17)
-
-End-to-end encrypted DMs via NIP-17 gift wrap, accessed through `sphere.communications`:
-
-```typescript
-// Send a DM (by nametag or pubkey)
 await sphere.communications.sendDM('@alice', 'Hello!');
-
-// Listen for incoming DMs
-sphere.communications.onDirectMessage((msg) => {
-  console.log(`From ${msg.senderNametag ?? msg.senderPubkey}: ${msg.content}`);
-});
+sphere.communications.onDirectMessage((m) => console.log(m.senderNametag, m.content));
 ```
 
-### DM History on Connect
-
-By default, the SDK resumes from the last processed DM timestamp (persisted in storage). On first connect, it starts from "now" — no historical replay.
-
-Use `dmSince` to control how far back to fetch DMs on first connect:
-
+**Send the ALPHA coin** (Unicity's base‑chain coin)
 ```typescript
-const { sphere } = await Sphere.init({
-  ...providers,
-  autoGenerate: true,
-  dmSince: Math.floor(Date.now() / 1000) - 86400,  // last 24 hours
-});
+const r = await sphere.payments.l1!.send({ to: 'alpha1...', amount: '100000' /* in satoshis */ });
 ```
 
-Once the SDK processes DMs, the timestamp is persisted and `dmSince` is ignored on subsequent connects.
-
-### Ephemeral Mode (No Caching)
-
-For anonymous agents or LLM bots that don't need message history, disable DM caching:
-
-```typescript
-const { sphere } = await Sphere.init({
-  ...providers,
-  communications: { cacheMessages: false },
-});
-
-// Stream-only: receive, process, forget
-sphere.communications.onDirectMessage((msg) => {
-  processAndReply(msg);
-});
-
-// sendDM still works — message is sent but not stored locally
-await sphere.communications.sendDM('@alice', 'response');
-```
-
-When `cacheMessages` is `false`:
-- `onDirectMessage()` handlers and `message:dm` events fire normally
-- Messages are never stored in memory or persisted to storage
-- `getConversation()` / `getConversations()` return empty results
-- Deduplication is skipped (duplicate relay deliveries may trigger duplicate events)
-
-## L1 (ALPHA Blockchain) Operations
-
-Access L1 payments through `sphere.payments.l1`:
-
-```typescript
-// L1 is enabled by default with lazy Fulcrum connection.
-// Connection to Fulcrum is deferred until first L1 operation.
-const { sphere } = await Sphere.init({
-  ...providers,
-  autoGenerate: true,
-  // L1 config is optional — defaults are applied automatically:
-  // electrumUrl: network-specific (mainnet: fulcrum.alpha.unicity.network)
-  // defaultFeeRate: 10 sat/byte
-  // enableVesting: true
-});
-
-// To explicitly disable L1:
-// const { sphere } = await Sphere.init({ ...providers, l1: null });
-
-// Get L1 balance
-const balance = await sphere.payments.l1.getBalance();
-console.log('L1 Balance:', balance.total);
-console.log('Vested:', balance.vested);
-console.log('Unvested:', balance.unvested);
-
-// Get UTXOs
-const utxos = await sphere.payments.l1.getUtxos();
-console.log('UTXOs:', utxos.length);
-
-// Send L1 transaction
-const result = await sphere.payments.l1.send({
-  to: 'alpha1qxyz...',
-  amount: '100000',  // in satoshis
-  feeRate: 5,        // optional, sat/byte
-});
-
-if (result.success) {
-  console.log('TX Hash:', result.txHash);
-}
-
-// Get transaction history
-const history = await sphere.payments.l1.getHistory(10);
-
-// Estimate fee
-const { fee, feeRate } = await sphere.payments.l1.estimateFee('alpha1...', '50000');
-```
-
-## Alternative: Manual Create/Load
-
-```typescript
-import { Sphere } from '@unicitylabs/sphere-sdk';
-import {
-  createLocalStorageProvider,
-  createNostrTransportProvider,
-  createUnicityAggregatorProvider,
-} from '@unicitylabs/sphere-sdk/impl/browser';
-
-const storage = createLocalStorageProvider();
-const transport = createNostrTransportProvider();
-const oracle = createUnicityAggregatorProvider({ url: '/rpc' });
-
-// Check if wallet exists
-if (await Sphere.exists(storage)) {
-  // Load existing wallet
-  const sphere = await Sphere.load({ storage, transport, oracle });
-} else {
-  // Create new wallet with mnemonic
-  const mnemonic = Sphere.generateMnemonic();
-  const sphere = await Sphere.create({
-    mnemonic,
-    storage,
-    transport,
-    oracle,
-  });
-  console.log('Save this mnemonic:', mnemonic);
-}
-```
-
-## Import from Master Key (Legacy Wallets)
-
-For compatibility with legacy wallet files (.dat, .txt):
-
-```typescript
-// Import from master key + chain code (BIP32 mode)
-const sphere = await Sphere.import({
-  masterKey: '64-hex-chars-master-private-key',
-  chainCode: '64-hex-chars-chain-code',
-  basePath: "m/84'/1'/0'",  // from wallet.dat descriptor
-  derivationMode: 'bip32',
-  storage, transport, oracle,
-});
-
-// Import from master key only (WIF HMAC mode)
-const sphere = await Sphere.import({
-  masterKey: '64-hex-chars-master-private-key',
-  derivationMode: 'wif_hmac',
-  storage, transport, oracle,
-});
-```
-
-## Wallet Export/Import (JSON)
-
-```typescript
-// Export to JSON (for backup)
-const json = sphere.exportToJSON();
-console.log(JSON.stringify(json));
-
-// Export with encryption
-const encryptedJson = sphere.exportToJSON({ password: 'user-password' });
-
-// Export with multiple addresses
-const multiJson = sphere.exportToJSON({ addressCount: 5 });
-
-// Import from JSON
-const { success, mnemonic, error } = await Sphere.importFromJSON({
-  jsonContent: JSON.stringify(json),
-  password: 'user-password',  // if encrypted
-  storage, transport, oracle,
-});
-
-if (success && mnemonic) {
-  console.log('Recovered mnemonic:', mnemonic);
-}
-```
-
-## Wallet Info & Backup
-
-```typescript
-// Get wallet info
-const info = sphere.getWalletInfo();
-console.log('Source:', info.source);        // 'mnemonic' | 'file'
-console.log('Has mnemonic:', info.hasMnemonic);
-console.log('Derivation mode:', info.derivationMode);
-console.log('Base path:', info.basePath);
-
-// Get mnemonic for backup (if available)
-const mnemonic = sphere.getMnemonic();
-if (mnemonic) {
-  console.log('Backup this:', mnemonic);
-}
-```
-
-## Import from Legacy Files (.dat, .txt)
-
-```typescript
-// Import from wallet.dat file
-const fileBuffer = await file.arrayBuffer();
-const result = await Sphere.importFromLegacyFile({
-  fileContent: new Uint8Array(fileBuffer),
-  fileName: 'wallet.dat',
-  password: 'wallet-password',  // if encrypted
-  onDecryptProgress: (i, total) => console.log(`Decrypting: ${i}/${total}`),
-  storage, transport, oracle,
-});
-
-if (result.needsPassword) {
-  // Re-prompt user for password
-}
-
-if (result.success) {
-  const sphere = result.sphere;
-  console.log('Imported wallet:', sphere.identity?.l1Address);
-}
-
-// Import from text backup file
-const textContent = await file.text();
-const result = await Sphere.importFromLegacyFile({
-  fileContent: textContent,
-  fileName: 'backup.txt',
-  storage, transport, oracle,
-});
-
-// Detect file type and encryption status
-const fileType = Sphere.detectLegacyFileType(fileName, content);
-// Returns: 'dat' | 'txt' | 'json' | 'mnemonic' | 'unknown'
-
-const isEncrypted = Sphere.isLegacyFileEncrypted(fileName, content);
-```
-
-## Core Utilities
-
-The SDK exports commonly needed utility functions:
-
-```typescript
-import {
-  // Crypto
-  bytesToHex, hexToBytes,
-  generateMnemonic, validateMnemonic,
-  sha256, ripemd160, hash160,
-  getPublicKey, createKeyPair,
-  deriveAddressInfo,
-
-  // Currency conversion
-  toSmallestUnit,    // "1.5" → 1500000000000000000n
-  toHumanReadable,   // 1500000000000000000n → "1.5"
-  formatAmount,      // Format with decimals and symbol
-
-  // Address encoding
-  encodeBech32, decodeBech32,
-  createAddress, isValidBech32,
-
-  // Base58 (Bitcoin-style)
-  base58Encode, base58Decode,
-  isValidPrivateKey,
-
-  // General utilities
-  sleep, randomHex, randomUUID,
-  findPattern, extractFromText,
-} from '@unicitylabs/sphere-sdk';
-```
-
-## TXF Serialization
-
-Token eXchange Format for storage and transfer:
-
-```typescript
-import {
-  tokenToTxf,           // Token → TXF format
-  txfToToken,           // TXF → Token
-  buildTxfStorageData,  // Build IPFS storage data
-  parseTxfStorageData,  // Parse storage data
-  getCurrentStateHash,  // Get token's current state hash
-  hasUncommittedTransactions,
-} from '@unicitylabs/sphere-sdk';
-
-// Convert token to TXF
-const txf = tokenToTxf(token);
-console.log(txf.genesis.data.tokenId);
-
-// Build storage data for IPFS
-const storageData = await buildTxfStorageData(tokens, {
-  version: 1,
-  address: 'alpha1...',
-  ipnsName: 'k51...',
-});
-```
-
-## Token Validation
-
-Validate tokens against the aggregator:
-
-```typescript
-import { createTokenValidator } from '@unicitylabs/sphere-sdk';
-
-const validator = createTokenValidator({
-  aggregatorClient: oracleProvider,
-  trustBase: trustBaseData,
-  skipVerification: false,
-});
-
-// Validate all tokens
-const { validTokens, issues } = await validator.validateAllTokens(tokens);
-
-// Check if token state is spent
-const isSpent = await validator.isTokenStateSpent(tokenId, stateHash, publicKey);
-
-// Check spent tokens in batch
-const { spentTokens, errors } = await validator.checkSpentTokens(tokens, publicKey);
-```
-
-## Architecture
-
-**Single Identity Model**: L1 and L3 share the same secp256k1 key pair. One mnemonic = one wallet for both layers.
-
-```
-mnemonic → master key → BIP32 derivation → identity
-                                              ↓
-                        ┌─────────────────────┴─────────────────────┐
-                        │              shared keys                  │
-                        │  privateKey:   "abc..."  (hex secp256k1)  │
-                        │  chainPubkey:  "02def..." (33-byte comp.) │
-                        │  l1Address:    "alpha1..." (bech32)       │
-                        │  directAddress: "DIRECT://..." (L3)       │
-                        └─────────────────────┬─────────────────────┘
-                                              ↓
-              ┌──────────────────┬──────────────────┬──────────────────┐
-              ↓                  ↓                  ↓                  ↓
-         L1 (ALPHA)        L3 (Unicity)        Group Chat           Nostr
-     sphere.payments.l1  sphere.payments    sphere.groupChat  sphere.communications
-      UTXOs, blockchain  Tokens, aggregator  NIP-29 messaging    P2P messaging
-```
-
-```
-Sphere (main entry point)
-├── identity       - Wallet identity (address, publicKey, nametag)
-├── payments       - L3 token operations
-│   └── l1         - L1 ALPHA transactions (via sphere.payments.l1)
-├── groupChat      - NIP-29 group messaging (via sphere.groupChat)
-└── communications - Direct messages & broadcasts
-
-Providers (injectable dependencies)
-├── StorageProvider      - Key-value persistence
-├── TransportProvider    - P2P messaging (Nostr)
-├── OracleProvider       - State validation (Aggregator)
-└── TokenStorageProvider - Token backup (IPFS)
-
-Implementation (platform-specific)
-├── impl/shared/         - Common interfaces & resolvers
-│   ├── config.ts        - Base configuration types
-│   └── resolvers.ts     - Extend/override pattern utilities
-├── impl/browser/        - Browser implementations
-│   ├── LocalStorageProvider
-│   ├── IndexedDBTokenStorageProvider
-│   └── createBrowserProviders()
-└── impl/nodejs/         - Node.js implementations
-    ├── FileStorageProvider
-    ├── FileTokenStorageProvider
-    └── createNodeProviders()
-
-Core Utilities
-├── crypto     - Key derivation, hashing, signatures
-├── currency   - Amount formatting and conversion
-├── bech32     - Address encoding (BIP-173)
-└── utils      - Base58, patterns, sleep, random
-```
-
-## Shared Configuration Pattern
-
-Both browser and Node.js implementations share common configuration interfaces and resolution logic:
-
-```typescript
-// Base interfaces (impl/shared/config.ts)
-import type {
-  BaseTransportConfig,  // Common transport options
-  BaseOracleConfig,     // Common oracle options
-  L1Config,             // L1 configuration (same for all platforms)
-  BaseProviders,        // Common result structure
-} from '@unicitylabs/sphere-sdk/impl/shared';
-
-// Resolver utilities (impl/shared/resolvers.ts)
-import {
-  getNetworkConfig,        // Get mainnet/testnet/dev config
-  resolveTransportConfig,  // Apply extend/override pattern for relays
-  resolveOracleConfig,     // Resolve oracle URL with fallback
-  resolveL1Config,         // Resolve L1 with network defaults
-  resolveArrayConfig,      // Generic array merge helper
-} from '@unicitylabs/sphere-sdk/impl/shared';
-```
-
-### Extend/Override Pattern
-
-The configuration resolution follows a consistent pattern across platforms:
-
-```typescript
-// Priority for arrays: replace > extend > defaults
-const result = resolveArrayConfig(
-  networkDefaults,    // ['a', 'b']
-  config.relays,      // If set, replaces entirely
-  config.additionalRelays  // If set, extends defaults
-);
-
-// Examples:
-// No config → ['a', 'b'] (defaults)
-// { relays: ['x'] } → ['x'] (replace)
-// { additionalRelays: ['c'] } → ['a', 'b', 'c'] (extend)
-```
-
-### Platform-Specific Extensions
-
-Each platform extends the base interfaces with platform-specific options:
-
-```typescript
-// Browser: adds reconnectDelay, maxReconnectAttempts
-type TransportConfig = BaseTransportConfig & BrowserTransportExtensions;
-
-// Node.js: adds trustBasePath for file-based trust base
-type NodeOracleConfig = BaseOracleConfig & NodeOracleExtensions;
-```
-
-## Documentation
-
-- [Integration Guide](./docs/INTEGRATION.md)
-- [API Reference](./docs/API.md)
-
-## Browser Providers
-
-The SDK includes browser-ready provider implementations:
-
-| Provider | Description |
-|----------|-------------|
-| `LocalStorageProvider` | Browser localStorage with SSR fallback |
-| `NostrTransportProvider` | Nostr relay messaging with NIP-04 |
-| `UnicityAggregatorProvider` | Unicity aggregator for state proofs |
-| `IpfsStorageProvider` | HTTP-based IPFS/IPNS storage (cross-platform) |
-
-## Node.js Providers
-
-For CLI and server applications:
-
-```typescript
-import { Sphere } from '@unicitylabs/sphere-sdk';
-import { createNodeProviders } from '@unicitylabs/sphere-sdk/impl/nodejs';
-
-// Quick start with testnet
-const providers = createNodeProviders({
-  network: 'testnet',
-  dataDir: './wallet-data',
-  tokensDir: './tokens',
-});
-
-const { sphere } = await Sphere.init({
-  ...providers,
-  autoGenerate: true,
-});
-
-// Full configuration
-const providers = createNodeProviders({
-  network: 'testnet',
-  dataDir: './wallet-data',
-  tokensDir: './tokens',
-  transport: {
-    additionalRelays: ['wss://my-relay.com'],
-    timeout: 10000,
-    debug: true,
-  },
-  oracle: {
-    apiKey: 'my-api-key',
-    trustBasePath: './trustbase.json',  // Node.js specific
-  },
-  l1: {
-    enableVesting: true,
-  },
-});
-```
-
-### Manual Provider Creation
-
-```typescript
-import {
-  FileStorageProvider,
-  FileTokenStorageProvider,
-  createNostrTransportProvider,
-  createNodeTrustBaseLoader,
-} from '@unicitylabs/sphere-sdk/impl/nodejs';
-
-// File-based wallet storage
-const storage = new FileStorageProvider('./wallet-data');
-
-// File-based token storage (TXF format)
-const tokenStorage = new FileTokenStorageProvider('./tokens');
-
-// Nostr with Node.js WebSocket
-const transport = createNostrTransportProvider({
-  relays: ['wss://relay.unicity.network'],
-});
-
-// Load trust base from local file
-const trustBaseLoader = createNodeTrustBaseLoader('./trustbase-testnet.json');
-const trustBase = await trustBaseLoader.load();
-```
-
-## Custom Providers Configuration
-
-The SDK uses an **extend/override pattern** for flexible configuration:
-
-| Option | Behavior |
-|--------|----------|
-| `relays` | **Replaces** default relays entirely |
-| `additionalRelays` | **Adds** to default relays |
-| `gateways` | **Replaces** default IPFS gateways |
-| `additionalGateways` | **Adds** to default gateways |
-| `url`, `electrumUrl` | **Replaces** default URL (uses network default if not set) |
-
-```typescript
-// Simple: use network preset
-const providers = createBrowserProviders({ network: 'testnet' });
-
-// Add extra relays to testnet defaults
-const providers = createBrowserProviders({
-  network: 'testnet',
-  transport: {
-    additionalRelays: ['wss://my-relay.com', 'wss://backup-relay.com'],
-    // Result: testnet relay + my-relay + backup-relay
-  },
-});
-
-// Replace relays entirely (ignores network defaults)
-const providers = createBrowserProviders({
-  network: 'testnet',
-  transport: {
-    relays: ['wss://only-this-relay.com'],
-    // Result: only-this-relay (testnet default ignored)
-  },
-});
-
-// Override aggregator, keep other testnet defaults
-const providers = createBrowserProviders({
-  network: 'testnet',
-  oracle: {
-    url: 'https://my-aggregator.com',  // replaces testnet aggregator
-    apiKey: 'my-api-key',
-  },
-});
-
-// Full custom configuration
-const providers = createBrowserProviders({
-  network: 'testnet',
-  storage: {
-    prefix: 'myapp_',
-  },
-  transport: {
-    additionalRelays: ['wss://extra-relay.com'],
-    timeout: 15000,
-    autoReconnect: true,
-    debug: true,
-  },
-  oracle: {
-    url: 'https://custom-aggregator.com',
-    apiKey: 'secret',
-    timeout: 60000,
-  },
-  l1: {
-    electrumUrl: 'wss://custom-fulcrum.com:50004',
-    defaultFeeRate: 5,
-    enableVesting: true,
-  },
-  tokenSync: {
-    ipfs: {
-      enabled: true,
-      additionalGateways: ['https://my-ipfs-gateway.com'],
-    },
-  },
-});
-
-```
-
-## Token Sync Backends
-
-The SDK supports multiple token sync backends that can be enabled independently:
-
-| Backend | Status | Description |
-|---------|--------|-------------|
-| `ipfs` | ✅ Ready | HTTP-based IPFS/IPNS storage (browser + Node.js) |
-| `mongodb` | 🚧 Planned | MongoDB for centralized token storage |
-| `file` | 🚧 Planned | Local file system (Node.js) |
-| `cloud` | 🚧 Planned | Cloud storage (AWS S3, GCP, Azure) |
-
-```typescript
-// Browser: enable IPFS sync
-const providers = createBrowserProviders({
-  network: 'testnet',
-  tokenSync: {
-    ipfs: {
-      enabled: true,
-      additionalGateways: ['https://my-gateway.com'],
-    },
-  },
-});
-
-// Node.js: enable IPFS sync
-const providers = createNodeProviders({
-  network: 'testnet',
-  dataDir: './wallet-data',
-  tokensDir: './tokens-data',
-  tokenSync: {
-    ipfs: {
-      enabled: true,
-    },
-  },
-});
-```
-
-## Custom Token Storage Provider
-
-You can implement your own `TokenStorageProvider` for custom storage backends:
-
-```typescript
-import type { TokenStorageProvider, TxfStorageDataBase, SaveResult, LoadResult, SyncResult } from '@unicitylabs/sphere-sdk/storage';
-import type { FullIdentity, ProviderStatus } from '@unicitylabs/sphere-sdk/types';
-
-class MyCustomStorageProvider implements TokenStorageProvider<TxfStorageDataBase> {
-  readonly id = 'my-storage';
-  readonly name = 'My Custom Storage';
-  readonly type = 'remote' as const;
-
-  private status: ProviderStatus = 'disconnected';
-  private identity: FullIdentity | null = null;
-
-  setIdentity(identity: FullIdentity): void {
-    this.identity = identity;
-  }
-
-  async initialize(): Promise<boolean> {
-    // Connect to your storage backend
-    this.status = 'connected';
-    return true;
-  }
-
-  async shutdown(): Promise<void> {
-    this.status = 'disconnected';
-  }
-
-  async connect(): Promise<void> {
-    await this.initialize();
-  }
-
-  async disconnect(): Promise<void> {
-    await this.shutdown();
-  }
-
-  isConnected(): boolean {
-    return this.status === 'connected';
-  }
-
-  getStatus(): ProviderStatus {
-    return this.status;
-  }
-
-  async load(): Promise<LoadResult<TxfStorageDataBase>> {
-    // Load tokens from your storage
-    return {
-      success: true,
-      data: { _meta: { version: 1, address: this.identity?.l1Address ?? '', formatVersion: '2.0', updatedAt: Date.now() } },
-      source: 'remote',
-      timestamp: Date.now(),
-    };
-  }
-
-  async save(data: TxfStorageDataBase): Promise<SaveResult> {
-    // Save tokens to your storage
-    return { success: true, timestamp: Date.now() };
-  }
-
-  async sync(localData: TxfStorageDataBase): Promise<SyncResult<TxfStorageDataBase>> {
-    // Merge local and remote data
-    await this.save(localData);
-    return { success: true, merged: localData, added: 0, removed: 0, conflicts: 0 };
-  }
-}
-
-// Use your custom provider
-const myProvider = new MyCustomStorageProvider();
-
-const { sphere } = await Sphere.init({
-  ...providers,
-  tokenStorage: myProvider,
-  autoGenerate: true,
-});
-```
-
-## Dynamic Provider Management (Runtime)
-
-After `Sphere.init()` is called, you can add/remove token storage providers dynamically:
-
-```typescript
-import { createBrowserIpfsStorageProvider } from '@unicitylabs/sphere-sdk/impl/browser/ipfs';
-// For Node.js: import { createNodeIpfsStorageProvider } from '@unicitylabs/sphere-sdk/impl/nodejs/ipfs';
-
-// Add a new provider at runtime (e.g., user enables IPFS sync in settings)
-const ipfsProvider = createBrowserIpfsStorageProvider({
-  gateways: ['https://my-ipfs-node.com'],
-});
-
-await sphere.addTokenStorageProvider(ipfsProvider);
-
-// Provider is now active and will be used in sync operations
-
-// Check if provider exists
-if (sphere.hasTokenStorageProvider('ipfs-token-storage')) {
-  console.log('IPFS sync is enabled');
-}
-
-// Get all active providers
-const providers = sphere.getTokenStorageProviders();
-console.log('Active providers:', Array.from(providers.keys()));
-
-// Remove a provider (e.g., user disables IPFS sync)
-await sphere.removeTokenStorageProvider('ipfs-token-storage');
-
-// Listen for per-provider sync events
-sphere.on('sync:provider', (event) => {
-  console.log(`Provider ${event.providerId}: ${event.success ? 'synced' : 'failed'}`);
-  if (event.success) {
-    console.log(`  Added: ${event.added}, Removed: ${event.removed}`);
-  } else {
-    console.log(`  Error: ${event.error}`);
-  }
-});
-
-// Trigger sync (syncs with all active providers)
-await sphere.payments.sync();
-```
-
-## Dynamic Relay Management
-
-Nostr relays can be added or removed at runtime through the transport provider:
-
-```typescript
-const transport = sphere.getTransport();
-
-// Get current relays
-const configuredRelays = transport.getRelays();       // All configured
-const connectedRelays = transport.getConnectedRelays(); // Currently connected
-
-// Add a new relay (connects immediately if provider is connected)
-await transport.addRelay('wss://new-relay.com');
-
-// Remove a relay (disconnects if connected)
-await transport.removeRelay('wss://old-relay.com');
-
-// Check relay status
-transport.hasRelay('wss://relay.com');         // Is configured?
-transport.isRelayConnected('wss://relay.com'); // Is connected?
-```
-
-### Relay Events
-
-```typescript
-// Listen for relay changes
-sphere.on('transport:relay_added', (event) => {
-  console.log(`Relay added: ${event.data.relay}`);
-  console.log(`Connected: ${event.data.connected}`);
-});
-
-sphere.on('transport:relay_removed', (event) => {
-  console.log(`Relay removed: ${event.data.relay}`);
-});
-
-sphere.on('transport:error', (event) => {
-  console.log(`Transport error: ${event.data.error}`);
-});
-```
-
-### UI Integration Example
-
-```typescript
-// User adds relay via settings UI
-async function handleAddRelay(relayUrl: string) {
-  const transport = sphere.getTransport();
-
-  if (transport.hasRelay(relayUrl)) {
-    showError('Relay already configured');
-    return;
-  }
-
-  const success = await transport.addRelay(relayUrl);
-  if (success) {
-    showSuccess(`Added ${relayUrl}`);
-  } else {
-    showWarning(`Added but failed to connect to ${relayUrl}`);
-  }
-}
-
-// User removes relay via settings UI
-async function handleRemoveRelay(relayUrl: string) {
-  const transport = sphere.getTransport();
-  await transport.removeRelay(relayUrl);
-  showSuccess(`Removed ${relayUrl}`);
-}
-
-// Display relay status in UI
-function getRelayStatuses() {
-  const transport = sphere.getTransport();
-  return transport.getRelays().map(relay => ({
-    url: relay,
-    connected: transport.isRelayConnected(relay),
-  }));
-}
-```
-
-## Nametags
-
-Nametags provide human-readable addresses (e.g., `@alice`) for receiving payments. Valid formats: lowercase alphanumeric with `_` or `-` (3–20 chars), or E.164 phone numbers (e.g., `+14155552671`). Input is normalized to lowercase automatically.
-
-> **Important:** Nametags are required to use the testnet faucet. Register a nametag before requesting test tokens.
-
-> **Note:** Nametag minting requires an aggregator API key for proof verification. Configure it via the `oracle.apiKey` option when creating providers. Contact Unicity to obtain an API key.
-
-### Registering a Nametag
-
-```typescript
-// During wallet creation
-const { sphere } = await Sphere.init({
-  ...providers,
-  mnemonic: 'your twelve words...',
-  nametag: 'alice',  // Will register @alice
-});
-
-// Or after creation
-await sphere.registerNametag('alice');
-
-// Mint on-chain nametag token (required for receiving via PROXY addresses)
-const result = await sphere.mintNametag('alice');
-if (result.success) {
-  console.log('Nametag minted:', result.nametagData?.name);
-}
-```
-
-### Common Pitfall: Nametag Already Taken
-
-If you see this error:
-```
-Failed to register nametag. It may already be taken.
-[NostrTransportProvider] Nametag already taken: myname - owner: f124f93ae6946ffd...
-```
-
-This means the nametag is registered to a **different public key**. Common causes:
-
-1. **Storage cleared or not persisting**:
-   - `Sphere.exists()` returns `false` because storage is empty/inaccessible
-   - SDK creates a new wallet with new keypair
-   - Nametag registration fails because old pubkey owns it on Nostr
-
-2. **Different mnemonic provided**:
-   ```typescript
-   // ❌ WRONG: Random mnemonic each time
-   const mnemonic = Sphere.generateMnemonic();
-   const { sphere } = await Sphere.init({
-     mnemonic,
-     nametag: 'myservice',  // Fails after first run
-   });
-   ```
-
-**Note:** `autoGenerate: true` does NOT generate a new mnemonic on every restart. It only generates one if `Sphere.exists()` returns `false` (wallet not found in storage).
-
-### Solution: Persistent Storage or Fixed Mnemonic
-
-**Option 1: Persistent file storage** (recommended for backend):
-
-```typescript
-import { FileStorageProvider } from '@unicitylabs/sphere-sdk/impl/nodejs';
-
-const storage = new FileStorageProvider('./wallet-data');  // Persists to disk
-
-const { sphere } = await Sphere.init({
-  storage,
-  autoGenerate: true,  // OK: mnemonic saved to disk, reused on restart
-  nametag: 'myservice',
-});
-```
-
-**Option 2: Fixed mnemonic from environment**:
-
-```typescript
-const { sphere } = await Sphere.init({
-  ...providers,
-  mnemonic: process.env.WALLET_MNEMONIC,  // Same mnemonic every time
-  nametag: 'myservice',
-});
-```
-
-### Debugging Storage Issues
-
-If nametag fails unexpectedly, check if wallet exists:
-
-```typescript
-const exists = await Sphere.exists(storage);
-console.log('Wallet exists:', exists);  // Should be true after first run
-
-// If false - storage is not persisting properly
-```
-
-### Nametag Recovery on Import
-
-When importing a wallet (from mnemonic or file), the SDK automatically attempts to recover the nametag from Nostr:
-
-```typescript
-// Import wallet - nametag will be recovered automatically if found on Nostr
-const { sphere } = await Sphere.init({
-  ...providers,
-  mnemonic: 'your twelve words...',
-  // No nametag specified - will try to recover from Nostr
-});
-
-// Listen for recovery event
-sphere.on('nametag:recovered', (event) => {
-  console.log('Recovered nametag:', event.data.nametag);  // e.g., 'alice'
-});
-
-// After init, check if nametag was recovered
-console.log(sphere.identity?.nametag);  // 'alice' (if found on Nostr)
-```
-
-### Multi-Address Nametags
-
-Each derived address can have its own independent nametag:
-
-```typescript
-// Address 0: @alice
-await sphere.registerNametag('alice');
-
-// Switch to address 1 and register different nametag
-await sphere.switchToAddress(1);
-await sphere.registerNametag('bob');
-
-// Now:
-// - Address 0 → @alice
-// - Address 1 → @bob
-
-// Get nametag for specific address
-const aliceTag = sphere.getNametagForAddress(0);  // 'alice'
-const bobTag = sphere.getNametagForAddress(1);    // 'bob'
-```
-
----
-
-See [IPFS Storage Guide](docs/IPFS-STORAGE.md) for complete IPFS/IPNS documentation including configuration, caching, merge rules, and troubleshooting.
-
----
-
-## Known Limitations / TODO
-
-### Wallet Encryption
-
-Currently, wallet mnemonics are encrypted using a default key (`DEFAULT_ENCRYPTION_KEY` in constants.ts). This provides basic protection but is not secure for production use.
-
-**Future implementation needed:**
-- Add user password parameter to `Sphere.create()`, `Sphere.load()`, and `Sphere.init()`
-- Derive encryption key from user password using PBKDF2/Argon2
-- Migration strategy for existing wallets:
-  1. Try decrypting with user-provided password first
-  2. If decryption fails, fallback to `DEFAULT_ENCRYPTION_KEY`
-  3. If fallback succeeds, re-encrypt with new user password
-  4. This ensures backwards compatibility with wallets created before password support
+## Going further
+
+The root README stays short on purpose. Deeper guides live alongside it:
+
+| You want to… | Read |
+|---|---|
+| Get running in the browser | [docs/QUICKSTART-BROWSER.md](docs/QUICKSTART-BROWSER.md) |
+| Get running in Node.js | [docs/QUICKSTART-NODEJS.md](docs/QUICKSTART-NODEJS.md) |
+| Use `@nametags` (register, recover, troubleshoot) | [docs/NAMETAGS.md](docs/NAMETAGS.md) |
+| Request payments from others | [docs/PAYMENT-REQUESTS.md](docs/PAYMENT-REQUESTS.md) |
+| Send encrypted direct messages | [docs/DIRECT-MESSAGES.md](docs/DIRECT-MESSAGES.md) |
+| Run group chat | [docs/GROUP-CHAT.md](docs/GROUP-CHAT.md) |
+| Send the ALPHA coin | [docs/L1-ALPHA.md](docs/L1-ALPHA.md) |
+| Use multiple addresses per wallet | [docs/MULTI-ADDRESS.md](docs/MULTI-ADDRESS.md) |
+| Configure providers, networks, prices, relays | [docs/PROVIDERS-AND-CONFIG.md](docs/PROVIDERS-AND-CONFIG.md) |
+| Import/export wallets and recover legacy files | [docs/WALLET-IMPORT-EXPORT.md](docs/WALLET-IMPORT-EXPORT.md) |
+| Derive keys / sign messages directly (low‑level) | [docs/IDENTITY-CRYPTO.md](docs/IDENTITY-CRYPTO.md) |
+| Let a dApp connect to a wallet | [docs/CONNECT.md](docs/CONNECT.md) |
+| Invoicing and token swaps | [docs/API.md](docs/API.md) |
+| Full API reference | [docs/API.md](docs/API.md) |
+| Understand how it actually works under the hood | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| Back up tokens to IPFS | [docs/IPFS-STORAGE.md](docs/IPFS-STORAGE.md) |
+
+There is also a command‑line tool in a separate package, [`@unicity-sphere/cli`](https://github.com/unicity-sphere/sphere-cli).
+
+## Glossary
+
+- **Recovery phrase (mnemonic)** — 12 words that *are* the wallet. Back them up; never share them.
+- **Token** — a unit of digital value held in a wallet (e.g. `UCT`).
+- **`@nametag`** — a human‑readable handle for a wallet. Lowercase letters/digits with `-` or `_`, 3–20 characters.
+- **Wallet address** — the machine‑readable address behind a `@nametag`. People rarely type it; they use the `@name`.
+- **ALPHA coin** — the coin of Unicity's base blockchain. Sent through `sphere.payments.l1`.
+- **Smallest unit** — token amounts are integers in the token's smallest denomination, passed as strings (so `"1000000"`, not `1.0`).
+- **Provider** — a pluggable backend (storage, messaging, etc.). `createBrowserProviders()` / `createNodeProviders()` set these up for you.
+- **Network** — `testnet` (free, for building) or `mainnet` (real value).
+
+## Platforms
+
+| Platform | Storage | Notes |
+|---|---|---|
+| Browser | IndexedDB | Native WebSocket; may need `Buffer`/`process` polyfills — see [bundling notes](docs/PROVIDERS-AND-CONFIG.md#browser-bundling) |
+| Node.js | Files | Requires the `ws` package |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sphere
+# Sphere SDK
 
 **A TypeScript SDK for apps where users hold their own tokens and pay each other by name — no payment backend to build, no custody of anyone's funds.**
 
@@ -8,13 +8,13 @@
 
 ---
 
-Sphere gives your app a self‑custody wallet: each user holds their own keys, pays others by `@name`, and every transfer is settled on Unicity's network and backed by cryptographic proof. You get the wallet, transfers, encrypted messaging, and invoicing out of the box — without building or operating a payment backend, and without ever holding users' funds. It runs in the browser and in Node.js.
+The Sphere SDK gives your app a self‑custody wallet: each user holds their own keys, pays others by `@name`, and every transfer is settled on Unicity's network and backed by cryptographic proof. You get the wallet, transfers, encrypted messaging, and invoicing out of the box — without building or operating a payment backend, and without ever holding users' funds. It runs in the browser and in Node.js.
 
-## Why Sphere
+## Why Sphere SDK
 
 Most apps that move money put a custodial server in the middle: it holds everyone's balances, clears the payments, and can freeze or lose them — and it's yours to build, secure, and keep online.
 
-Sphere splits those jobs apart:
+The Sphere SDK splits those jobs apart:
 
 - **Custody moves to the user.** Their wallet holds its own keys; your app never touches their funds.
 - **Settlement moves to Unicity's network** — a shared ledger run across many validator nodes — which records every transfer and lets the recipient verify it cryptographically.
@@ -79,7 +79,7 @@ That is a real transfer between two users — settled on Unicity's network, with
 
 ## Core concepts
 
-You only need four ideas to use Sphere.
+You only need four ideas to use the Sphere SDK.
 
 - **Token** — a unit of digital value (like `UCT`). A user's wallet can hold many tokens of different kinds.
 - **Wallet** — created from a 12‑word *recovery phrase*. The phrase is the only thing a user needs to back up; lose it and the wallet is gone.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ---
 
-The Sphere SDK gives your app a self‑custody wallet: each user holds their own keys, pays others by `@name`, and every transfer is settled on Unicity's network and backed by cryptographic proof. You get the wallet, transfers, encrypted messaging, and invoicing out of the box — without building or operating a payment backend, and without ever holding users' funds. It runs in the browser and in Node.js.
+The Sphere SDK gives your app a self‑custody wallet: each user holds their own keys, pays others by name (like `@alice`), and every transfer is a self‑contained cryptographic object the recipient verifies on its own — no shared ledger in the middle. You get the wallet, transfers, encrypted messaging, and invoicing out of the box — without building or operating a payment backend, and without ever holding users' funds. It runs in the browser and in Node.js.
 
 ## Why Sphere SDK
 
@@ -17,13 +17,13 @@ Most apps that move money put a custodial server in the middle: it holds everyon
 The Sphere SDK splits those jobs apart:
 
 - **Custody moves to the user.** Their wallet holds its own keys; your app never touches their funds.
-- **Settlement moves to Unicity's network** — a shared ledger run across many validator nodes — which records every transfer and lets the recipient verify it cryptographically.
+- **Settlement is cryptographic, not custodial.** Each transfer is a self‑contained cryptographic object the recipient verifies on its own. There is **no shared ledger** of balances or transfer history — Unicity's network only registers an opaque commitment (a hash) so a token can't be spent twice.
 
-There is still infrastructure doing the clearing (a settlement network, messaging relays, and the base chain), but **you don't run it**, and no single company sits on top of users' balances. Your app just creates a wallet and asks it to do things.
+There is still shared infrastructure (the network that registers those commitments, messaging relays, and the base chain), but **you don't run it**, and no company sits on top of users' balances. Your app just creates a wallet and asks it to do things.
 
 ## What you can build
 
-**Send and receive tokens.** Move value between users by `@name` — no account numbers, and no backend of your own to operate.
+**Send and receive tokens.** Move value between users by name — `@alice` pays `@bob` — no account numbers, and no backend of your own to operate.
 
 **Invoices and payment requests.** Ask another user to pay, and track whether they did, automatically.
 
@@ -54,7 +54,7 @@ import { createBrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
 const { sphere, created, generatedMnemonic } = await Sphere.init({
   ...createBrowserProviders({ network: 'testnet' }),
   autoGenerate: true,   // make a new wallet if one doesn't exist yet
-  nametag: 'alice',     // claim @alice (receiving via @name also needs an on-chain mint — see docs/NAMETAGS.md)
+  nametag: 'alice',     // claim the Unicity ID @alice (receiving via @alice also needs an on-chain mint — see docs/UNICITY-ID.md)
 });
 
 // 2. First run? Show the user their recovery phrase to back up.
@@ -73,9 +73,9 @@ await sphere.payments.send({
 });
 ```
 
-That is a real transfer between two users — settled on Unicity's network, with no backend of your own required.
+That is a real transfer between two users — verified cryptographically, with no backend of your own required.
 
-> **Getting test tokens.** On testnet you must claim a `@nametag` first, then request from the faucet. See the [Node.js](docs/QUICKSTART-NODEJS.md) and [Browser](docs/QUICKSTART-BROWSER.md) quick‑start guides.
+> **Getting test tokens.** On testnet you must claim a Unicity ID first, then request from the faucet. See the [Node.js](docs/QUICKSTART-NODEJS.md) and [Browser](docs/QUICKSTART-BROWSER.md) quick‑start guides.
 
 ## Core concepts
 
@@ -83,7 +83,7 @@ You only need four ideas to use the Sphere SDK.
 
 - **Token** — a unit of digital value (like `UCT`). A user's wallet can hold many tokens of different kinds.
 - **Wallet** — created from a 12‑word *recovery phrase*. The phrase is the only thing a user needs to back up; lose it and the wallet is gone.
-- **`@nametag`** — a human‑friendly handle (like `@alice`) that people use to pay or message you. Each wallet can claim one.
+- **Unicity ID** — a human‑friendly handle (like `@alice`) that people use to pay or message you. Each wallet can claim one. (In the SDK's API this is the `nametag`.)
 - **Network** — `testnet` for building and experimenting, `mainnet` for real value. Pick one when you create the wallet; everything else is configured for you.
 
 That's enough to send and receive. Everything below is built on top of these.
@@ -139,7 +139,7 @@ The root README stays short on purpose. Deeper guides live alongside it:
 |---|---|
 | Get running in the browser | [docs/QUICKSTART-BROWSER.md](docs/QUICKSTART-BROWSER.md) |
 | Get running in Node.js | [docs/QUICKSTART-NODEJS.md](docs/QUICKSTART-NODEJS.md) |
-| Use `@nametags` (register, recover, troubleshoot) | [docs/NAMETAGS.md](docs/NAMETAGS.md) |
+| Use Unicity IDs (register, recover, troubleshoot) | [docs/UNICITY-ID.md](docs/UNICITY-ID.md) |
 | Request payments from others | [docs/PAYMENT-REQUESTS.md](docs/PAYMENT-REQUESTS.md) |
 | Send encrypted direct messages | [docs/DIRECT-MESSAGES.md](docs/DIRECT-MESSAGES.md) |
 | Run group chat | [docs/GROUP-CHAT.md](docs/GROUP-CHAT.md) |
@@ -160,8 +160,8 @@ There is also a command‑line tool in a separate package, [`@unicity-sphere/cli
 
 - **Recovery phrase (mnemonic)** — 12 words that *are* the wallet. Back them up; never share them.
 - **Token** — a unit of digital value held in a wallet (e.g. `UCT`).
-- **`@nametag`** — a human‑readable handle for a wallet. Lowercase letters/digits with `-` or `_`, 3–20 characters.
-- **Wallet address** — the machine‑readable address behind a `@nametag`. People rarely type it; they use the `@name`.
+- **Unicity ID** — a human‑readable handle for a wallet (e.g. `@alice`). Lowercase letters/digits with `-` or `_`, 3–20 characters. Called `nametag` in the SDK's API.
+- **Wallet address** — the machine‑readable address behind a Unicity ID. People rarely type it; they use the handle (e.g. `@alice`).
 - **ALPHA coin** — the coin of Unicity's base blockchain. Sent through `sphere.payments.l1`.
 - **Smallest unit** — token amounts are integers in the token's smallest denomination, passed as strings (so `"1000000"`, not `1.0`).
 - **Provider** — a pluggable backend (storage, messaging, etc.). `createBrowserProviders()` / `createNodeProviders()` set these up for you.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ import { createBrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
 const { sphere, created, generatedMnemonic } = await Sphere.init({
   ...createBrowserProviders({ network: 'testnet' }),
   autoGenerate: true,   // make a new wallet if one doesn't exist yet
-  nametag: 'alice',     // claim @alice so people can pay you by name
+  nametag: 'alice',     // claim @alice (receiving via @name also needs an on-chain mint — see docs/NAMETAGS.md)
 });
 
 // 2. First run? Show the user their recovery phrase to back up.
@@ -65,7 +65,7 @@ if (created && generatedMnemonic) {
 // 3. Who am I?
 console.log('My handle: @' + sphere.identity?.nametag);
 
-// 4. Send 1 token to @bob
+// 4. Send 1,000,000 base units to @bob (= 1 UCT when the token has 6 decimals)
 await sphere.payments.send({
   recipient: '@bob',
   coinId: 'UCT',       // which token to send

--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ await sphere.payments.send({ recipient: '@bob', coinId: 'UCT', amount: '1000000'
 
 **Check balances and holdings**
 ```typescript
-const assets = await sphere.payments.getAssets();   // grouped by token, with prices if enabled
-const tokens = sphere.payments.getTokens();          // individual tokens
-const usd    = await sphere.payments.getBalance();   // total in USD, or null if prices are off
+const assets  = await sphere.payments.getAssets();      // grouped by token, with prices if enabled
+const tokens  = sphere.payments.getTokens();            // individual tokens
+const balance = sphere.payments.getBalance();           // Asset[] breakdown (synchronous)
+const usd     = await sphere.payments.getFiatBalance(); // total in USD, or null if prices are off
 ```
 
 **Receive tokens**

--- a/docs/API.md
+++ b/docs/API.md
@@ -222,7 +222,7 @@ interface PeerInfo {
 
 Access via `sphere.payments`.
 
-Handles all L3 (Unicity state transition network) token operations including transfers, balance queries, token lifecycle management, nametag minting, and multi-provider sync.
+Handles all L3 (Unicity state transition network) token operations including transfers, balance queries, token lifecycle management, Unicity ID minting, and multi-provider sync.
 
 ### Transfer Modes
 
@@ -591,7 +591,7 @@ Remove a token. Archives it first, creates a tombstone `(tokenId, stateHash)`, a
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `tokenId` | `string` | — | Local UUID of the token |
-| `recipientNametag` | `string?` | — | Recipient nametag for history |
+| `recipientNametag` | `string?` | — | Recipient Unicity ID for history |
 | `skipHistory` | `boolean` | `false` | Skip creating a SENT history entry |
 
 ---
@@ -696,11 +696,11 @@ Append a history entry (UUID auto-generated). Persisted immediately.
 
 ---
 
-### Methods: Nametag Management
+### Methods: Unicity ID Management
 
 #### `mintNametag(nametag: string): Promise<MintNametagResult>`
 
-Mint a nametag token on-chain. Required for receiving tokens via PROXY addresses.
+Mint a Unicity ID token on-chain. Required for receiving tokens via PROXY addresses.
 
 ```typescript
 interface MintNametagResult {
@@ -727,23 +727,23 @@ type TransferStatus = 'pending' | 'submitted' | 'confirmed' | 'delivered' | 'com
 
 #### `isNametagAvailable(nametag: string): Promise<boolean>`
 
-Check if a nametag is available for minting.
+Check if a Unicity ID is available for minting.
 
 #### `setNametag(nametag: NametagData): Promise<void>`
 
-Set nametag data (persists to storage and file).
+Set Unicity ID data (persists to storage and file).
 
 #### `getNametag(): NametagData | null`
 
-Get current nametag data.
+Get current Unicity ID data.
 
 #### `hasNametag(): boolean`
 
-Check if a nametag is set.
+Check if a Unicity ID is set.
 
 #### `clearNametag(): Promise<void>`
 
-Remove nametag data from memory and storage.
+Remove Unicity ID data from memory and storage.
 
 ---
 
@@ -1092,11 +1092,11 @@ interface DirectMessage {
 
 #### `resolvePeerNametag(peerPubkey: string): Promise<string | undefined>`
 
-Resolve a peer's nametag by their transport pubkey via live lookup from Nostr relay binding events. Returns `undefined` if the transport doesn't support resolution, the peer has no registered nametag, or the lookup fails. Useful as a fallback when no nametag is available in stored messages.
+Resolve a peer's Unicity ID by their transport pubkey via live lookup from Nostr relay binding events. Returns `undefined` if the transport doesn't support resolution, the peer has no registered Unicity ID, or the lookup fails. Useful as a fallback when no Unicity ID is available in stored messages.
 
 #### `onDirectMessage(handler: (msg: DirectMessage) => void): () => void`
 
-Subscribe to incoming direct messages. Supports both NIP-17 gift-wrapped messages (kind 1059, used by Sphere app) and NIP-04 encrypted DMs (kind 4, legacy). For NIP-17 messages, the sender's nametag is extracted from the Sphere messaging format if present.
+Subscribe to incoming direct messages. Supports both NIP-17 gift-wrapped messages (kind 1059, used by Sphere app) and NIP-04 encrypted DMs (kind 4, legacy). For NIP-17 messages, the sender's Unicity ID is extracted from the Sphere messaging format if present.
 
 **DM history on connect:** The SDK persists the timestamp of the last processed DM event. On reconnect, only DMs newer than that timestamp are fetched from the relay. On first connect (no persisted timestamp), the SDK starts from "now" unless `dmSince` is set in `Sphere.init()` options — a unix timestamp (seconds) controlling how far back to fetch. This is a fallback: once the SDK processes a DM, the persisted timestamp takes priority on subsequent connects.
 
@@ -1411,9 +1411,9 @@ interface PaymentsModuleDependencies {
 
 ---
 
-## Nametag Minting
+## Unicity ID Minting
 
-Mint nametag tokens on-chain for PROXY address support (required for receiving tokens via @nametag).
+Mint Unicity ID tokens on-chain for PROXY address support (required for receiving tokens via @Unicity ID).
 
 ### Sphere Methods
 
@@ -1486,7 +1486,7 @@ interface NametagMinterConfig {
 
 ### Auto-mint on Registration
 
-The SDK automatically mints the nametag token on-chain whenever `registerNametag()` is called:
+The SDK automatically mints the Unicity ID token on-chain whenever `registerNametag()` is called:
 
 ```typescript
 // Option 1: During init (new wallet)
@@ -1506,12 +1506,12 @@ const { sphere } = await Sphere.init({ ...providers });
 ```
 
 **When minting happens:**
-- `Sphere.create()` with nametag → mints via `registerNametag()`
-- `Sphere.load()` → mints if nametag exists but token is missing
-- `Sphere.import()` with nametag → mints via `registerNametag()`
+- `Sphere.create()` with Unicity ID → mints via `registerNametag()`
+- `Sphere.load()` → mints if Unicity ID exists but token is missing
+- `Sphere.import()` with Unicity ID → mints via `registerNametag()`
 - `registerNametag()` → always mints if token not present
 
-Nametag token is required for receiving tokens via PROXY addresses (`finalizeTransaction` requires nametag token for PROXY scheme).
+Unicity ID token is required for receiving tokens via PROXY addresses (`finalizeTransaction` requires Unicity ID token for PROXY scheme).
 
 ---
 
@@ -3159,7 +3159,7 @@ try {
 | `INVALID_CONFIG` | Invalid configuration parameters |
 | `INVALID_IDENTITY` | Invalid mnemonic or key |
 | `INSUFFICIENT_BALANCE` | Not enough funds for transfer |
-| `INVALID_RECIPIENT` | Recipient nametag not found or invalid |
+| `INVALID_RECIPIENT` | Recipient Unicity ID not found or invalid |
 | `TRANSFER_FAILED` | Token transfer/mint/burn failed |
 | `STORAGE_ERROR` | Storage read/write failed |
 | `TRANSPORT_ERROR` | Relay/network transport error |

--- a/docs/API.md
+++ b/docs/API.md
@@ -206,7 +206,7 @@ Returns `PeerInfo`:
 
 ```typescript
 interface PeerInfo {
-  nametag?: string;        // @name if registered
+  nametag?: string;        // Unicity ID (e.g. @alice) if registered
   transportPubkey: string; // 32-byte transport key
   chainPubkey: string;     // 33-byte compressed secp256k1
   l1Address: string;       // alpha1... L1 address
@@ -1235,7 +1235,7 @@ interface Identity {
   directAddress?: string;
   /** IPNS identifier for storage */
   ipnsName?: string;
-  /** Registered @name alias */
+  /** Registered Unicity ID (e.g. @alice) */
   nametag?: string;
 }
 

--- a/docs/CONNECT.md
+++ b/docs/CONNECT.md
@@ -365,7 +365,7 @@ const isValid = verifySignedMessage(originalMessage, signature, expectedPubkey);
 | `transfer:confirmed` | transfer confirmed on chain |
 | `transfer:failed` | transfer failed |
 | `balance:updated` | balance changed |
-| `identity:updated` | identity info changed |
+| `identity:changed` | identity info changed |
 | `session:expired` | session TTL reached |
 
 ### Wallet Lock Handling
@@ -388,14 +388,14 @@ client.on('wallet:locked', async () => {
 
 #### Extension / iframe mode (P1, P2)
 
-The wallet's background service worker or parent frame stays alive. Instead of disconnecting, set a `isWalletLocked` flag and wait for the user to unlock. When the wallet is unlocked, the host calls `updateSphere(newSphere)` and fires an `identity:updated` event, which signals the dApp to resume:
+The wallet's background service worker or parent frame stays alive. Instead of disconnecting, set a `isWalletLocked` flag and wait for the user to unlock. When the wallet is unlocked, the host calls `updateSphere(newSphere)` and fires an `identity:changed` event, which signals the dApp to resume:
 
 ```typescript
 client.on('wallet:locked', () => {
   setIsWalletLocked(true);
 });
 
-client.on('identity:updated', (identity) => {
+client.on('identity:changed', (identity) => {
   setIsWalletLocked(false);
   // Refresh UI with new identity if it changed
 });

--- a/docs/CONNECT.md
+++ b/docs/CONNECT.md
@@ -154,6 +154,10 @@ const result = await autoConnect({
   dapp: { name: 'My App', url: location.origin },
   walletUrl: 'https://sphere.unicity.network',
   silent: true, // auto-reconnect without UI if already approved
+  // Request only the scopes you need. If `permissions` is OMITTED, autoConnect
+  // requests ALL scopes (including intent scopes like transfer:request) —
+  // prefer least privilege:
+  permissions: ['identity:read', 'balance:read', 'events:subscribe'],
 });
 
 // Use the client
@@ -294,11 +298,11 @@ The wallet's `onConnectionRequest` receives `silent=true` and must return `{ app
 | Method | Params | Returns |
 |--------|--------|---------|
 | `sphere_getIdentity` | — | `PublicIdentity` |
-| `sphere_getBalance` | `coinId?` | balance array |
-| `sphere_getAssets` | `coinId?` | asset array |
-| `sphere_getFiatBalance` | — | `{ fiatBalance }` |
-| `sphere_getTokens` | `coinId?` | token array |
-| `sphere_getHistory` | — | transaction history |
+| `sphere_getBalance` | `coinId?` | `Asset[]` (per-coin breakdown; **not** a USD total) |
+| `sphere_getAssets` | `coinId?` | `Asset[]` (adds `priceUsd` / `fiatValueUsd` when prices are enabled) |
+| `sphere_getFiatBalance` | — | `{ fiatBalance }` (USD total, or `null`) |
+| `sphere_getTokens` | `coinId?` | `Token[]` |
+| `sphere_getHistory` | — | `TransactionHistoryEntry[]` (full history — see note) |
 | `sphere_l1GetBalance` | — | L1 balance |
 | `sphere_l1GetHistory` | `limit?` | L1 history |
 | `sphere_resolve` | `identifier` | resolved address info |
@@ -307,6 +311,19 @@ The wallet's `onConnectionRequest` receives `silent=true` and must return `{ app
 | `sphere_subscribe` | `event` | `{ subscribed, event }` |
 | `sphere_unsubscribe` | `event` | `{ unsubscribed, event }` |
 | `sphere_disconnect` | — | `{ disconnected }` |
+
+> **`sphere_getHistory` takes no params and returns the full history.** Unlike `sphere_l1GetHistory` (which accepts `limit?`), incremental sync / pagination is the dApp's responsibility — filter client-side (e.g. by timestamp).
+
+**Return shapes** (forwarded from the wallet SDK):
+
+```typescript
+interface Asset { coinId; symbol; totalAmount; confirmedAmount?; tokenCount;
+                  priceUsd?; fiatValueUsd?; change24h?; }
+interface TransactionHistoryEntry { type: 'SENT'|'RECEIVED'|'SPLIT'|'MINT';
+                  amount; coinId; symbol; timestamp;
+                  recipientNametag?; senderPubkey?; }
+interface PublicIdentity { chainPubkey; directAddress?; l1Address; nametag?; }
+```
 
 ## Intent Actions (require user confirmation)
 
@@ -359,14 +376,24 @@ const isValid = verifySignedMessage(originalMessage, signature, expectedPubkey);
 
 ## Events (wallet → dApp push)
 
+There are **two delivery mechanisms** — don't conflate them.
+
+**Auto‑pushed** by the host with no subscription needed (these are the only two; see `WALLET_EVENTS` in `connect/protocol.ts`):
+
+| Event | Constant | Payload |
+|-------|----------|---------|
+| `wallet:locked` | `WALLET_EVENTS.LOCKED` | wallet locked / user logged out |
+| `identity:changed` | `WALLET_EVENTS.IDENTITY_CHANGED` | active address changed |
+
+**Subscribable** — require the `events:subscribe` permission and a `client.on(...)` (which issues `sphere_subscribe`):
+
 | Event | Payload |
 |-------|---------|
-| `transfer:incoming` | token transfer received |
-| `transfer:confirmed` | transfer confirmed on chain |
-| `transfer:failed` | transfer failed |
-| `balance:updated` | balance changed |
-| `identity:changed` | identity info changed |
-| `session:expired` | session TTL reached |
+| `transfer:incoming` | token transfer received (`{ tokens, senderNametag?, … }`) |
+| `transfer:confirmed` | outgoing transfer confirmed |
+| `transfer:failed` | outgoing transfer failed |
+
+> Use the exported constants (`WALLET_EVENTS.IDENTITY_CHANGED`) in code rather than the literal string, so it can't drift.
 
 ### Wallet Lock Handling
 
@@ -407,23 +434,24 @@ client.on('identity:changed', (identity) => {
 
 Permissions are requested during handshake and checked on every request:
 
+These are the exact scope strings from `connect/permissions.ts` (`PERMISSION_SCOPES`). Only `identity:read` is granted by default.
+
 | Scope | Grants access to |
 |-------|-----------------|
-| `identity:read` | `sphere_getIdentity` |
-| `balance:read` | `sphere_getBalance`, `sphere_getFiatBalance` |
-| `assets:read` | `sphere_getAssets` |
+| `identity:read` | `sphere_getIdentity` (+ the `receive` intent) |
+| `balance:read` | `sphere_getBalance`, `sphere_getAssets`, `sphere_getFiatBalance` |
 | `tokens:read` | `sphere_getTokens` |
 | `history:read` | `sphere_getHistory` |
 | `l1:read` | `sphere_l1GetBalance`, `sphere_l1GetHistory` |
-| `events:subscribe` | `sphere_subscribe/unsubscribe` |
-| `intent:send` | `send` intent |
-| `intent:l1_send` | `l1_send` intent |
-| `intent:dm` | `dm` intent |
-| `intent:payment_request` | `payment_request` intent |
-| `intent:receive` | `receive` intent |
-| `intent:sign_message` | `sign_message` intent |
-| `comms:read` | DM conversations |
-| `comms:write` | send DMs |
+| `resolve:peer` | `sphere_resolve` |
+| `events:subscribe` | `sphere_subscribe` / `sphere_unsubscribe` |
+| `transfer:request` | `send`, `pay_invoice`, `return_invoice_payment` intents |
+| `l1:transfer` | `l1_send` intent |
+| `dm:request` | `dm` intent |
+| `dm:read` | `sphere_getConversations`, `sphere_getMessages`, `sphere_getDMUnreadCount` |
+| `dm:manage` | `sphere_markAsRead` |
+| `payment:request` | `payment_request` intent |
+| `sign:request` | `sign_message` intent |
 | `invoice:read` | `sphere_getInvoices`, `sphere_getInvoiceStatus` |
 | `invoice:write` | `create_invoice`, `close_invoice`, `cancel_invoice`, `import_invoice`, `send_invoice_receipts`, `send_cancellation_notices`, `set_auto_return` intents |
 

--- a/docs/DIRECT-MESSAGES.md
+++ b/docs/DIRECT-MESSAGES.md
@@ -1,0 +1,64 @@
+# Direct Messages
+
+End‑to‑end encrypted one‑to‑one messages (NIP‑17 gift wrap), reached through `sphere.communications`.
+
+```typescript
+// Send a DM (by @nametag or public key)
+await sphere.communications.sendDM('@alice', 'Hello!');
+
+// Listen for incoming DMs
+sphere.communications.onDirectMessage((msg) => {
+  console.log(`From ${msg.senderNametag ?? msg.senderPubkey}: ${msg.content}`);
+});
+```
+
+## History on connect
+
+By default the SDK resumes from the last DM it processed (the timestamp is persisted in storage). On the very first connect it starts from "now" — no historical replay.
+
+Use `dmSince` to control how far back to fetch on first connect:
+
+```typescript
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  dmSince: Math.floor(Date.now() / 1000) - 86400,  // last 24 hours
+});
+```
+
+Once the SDK has processed DMs, the timestamp is persisted and `dmSince` is ignored on later connects.
+
+## Ephemeral mode (no caching)
+
+For anonymous agents or bots that don't need history, disable DM caching:
+
+```typescript
+const { sphere } = await Sphere.init({
+  ...providers,
+  communications: { cacheMessages: false },
+});
+
+// Stream-only: receive, process, forget
+sphere.communications.onDirectMessage((msg) => {
+  processAndReply(msg);
+});
+
+// sendDM still works — the message is sent but not stored locally
+await sphere.communications.sendDM('@alice', 'response');
+```
+
+When `cacheMessages` is `false`:
+
+- `onDirectMessage()` handlers and `message:dm` events fire normally.
+- Messages are never stored in memory or persisted to storage.
+- `getConversation()` / `getConversations()` return empty results.
+- Deduplication is skipped (duplicate relay deliveries may trigger duplicate events).
+
+## Reading conversations
+
+```typescript
+const conversation  = sphere.communications.getConversation('@alice'); // chronological
+const conversations = sphere.communications.getConversations();         // Map keyed by peer
+```
+
+(These return empty when `cacheMessages` is `false`.)

--- a/docs/DIRECT-MESSAGES.md
+++ b/docs/DIRECT-MESSAGES.md
@@ -3,7 +3,7 @@
 End‑to‑end encrypted one‑to‑one messages (NIP‑17 gift wrap), reached through `sphere.communications`.
 
 ```typescript
-// Send a DM (by @nametag or public key)
+// Send a DM (by @alice or public key)
 await sphere.communications.sendDM('@alice', 'Hello!');
 
 // Listen for incoming DMs

--- a/docs/GROUP-CHAT.md
+++ b/docs/GROUP-CHAT.md
@@ -1,0 +1,139 @@
+# Group Chat
+
+Relay‑based group messaging using the NIP‑29 protocol. The group‑chat module runs its own messaging connection, separate from the wallet's, and is reached through `sphere.groupChat`.
+
+## Enabling group chat
+
+```typescript
+// Enable with network defaults (wss://sphere-relay.unicity.network)
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  groupChat: true,
+});
+
+// Enable with a custom relay
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  groupChat: { relays: ['wss://my-nip29-relay.com'] },
+});
+
+// Access the module
+const gc = sphere.groupChat!;
+```
+
+## Connection
+
+```typescript
+await gc.connect();
+console.log('Connected:', gc.getConnectionStatus());
+
+// Is the current user a relay admin?
+const isRelayAdmin = await gc.isCurrentUserRelayAdmin();
+```
+
+## Groups
+
+```typescript
+import { GroupVisibility } from '@unicitylabs/sphere-sdk';
+
+// Public group
+const group = await gc.createGroup({ name: 'General', description: 'Public discussion' });
+
+// Private group
+const privateGroup = await gc.createGroup({ name: 'Team', visibility: GroupVisibility.PRIVATE });
+
+// Write-restricted group (only admins/writers can post)
+const announcements = await gc.createGroup({ name: 'Announcements', writeRestricted: true });
+
+// Discover and join
+const available = await gc.fetchAvailableGroups();    // public groups on the relay
+await gc.joinGroup(group.id);
+await gc.joinGroup(privateGroup.id, inviteCode);       // private group with invite
+
+// List, leave, delete
+const groups = gc.getGroups();
+await gc.leaveGroup(group.id);
+await gc.deleteGroup(group.id);                        // admin only
+```
+
+## Messaging
+
+```typescript
+const msg = await gc.sendMessage(group.id, 'Hello!');
+await gc.sendMessage(group.id, 'Agreed', { replyToId: msg.id });   // reply
+
+const messages = await gc.fetchMessages(group.id, { limit: 50 });   // from relay
+const cached   = gc.getMessages(group.id);                          // local cache
+
+// Real-time
+const unsubscribe = gc.onMessage((message) => {
+  console.log(`[${message.groupId}] ${message.senderPubkey}: ${message.content}`);
+});
+```
+
+## Members & moderation
+
+```typescript
+const members = gc.getMembers(group.id);
+
+gc.isCurrentUserAdmin(group.id);      // boolean
+gc.isCurrentUserModerator(group.id);  // boolean
+await gc.canModerateGroup(group.id);  // includes relay-admin check
+gc.canWriteToGroup(group.id);         // false if write-restricted and not admin/moderator
+
+// Requires admin/moderator role
+await gc.kickUser(group.id, userPubkey, 'reason');
+await gc.deleteMessage(group.id, messageId);
+```
+
+## Invites (private groups)
+
+```typescript
+const invite = await gc.createInvite(group.id);  // admin only
+// share the code; recipient joins with:
+await gc.joinGroup(group.id, invite);
+```
+
+## Unread counts
+
+```typescript
+const total = gc.getTotalUnreadCount();
+gc.markGroupAsRead(group.id);
+```
+
+## Key types
+
+```typescript
+interface GroupData {
+  id: string;
+  relayUrl: string;
+  name: string;
+  description?: string;
+  visibility: GroupVisibility;  // 'PUBLIC' | 'PRIVATE'
+  writeRestricted?: boolean;    // only admins and moderators can post
+  memberCount?: number;
+  unreadCount?: number;
+  lastMessageTime?: number;
+  lastMessageText?: string;
+}
+
+interface GroupMessageData {
+  id?: string;
+  groupId: string;
+  content: string;
+  timestamp: number;
+  senderPubkey: string;
+  senderNametag?: string;
+  replyToId?: string;
+}
+
+interface GroupMemberData {
+  pubkey: string;
+  groupId: string;
+  role: GroupRole;  // 'ADMIN' | 'MODERATOR' | 'MEMBER'
+  nametag?: string;
+  joinedAt: number;
+}
+```

--- a/docs/IDENTITY-CRYPTO.md
+++ b/docs/IDENTITY-CRYPTO.md
@@ -1,0 +1,81 @@
+# Identity & Crypto (low‑level)
+
+> **Audience:** developers working *below* the `Sphere` facade — deriving keys directly, signing messages for backend auth, or minting custom tokens. If you only call `sphere.payments` / `sphere.communications`, you don't need this.
+
+These helpers are exported from the package root (`@unicitylabs/sphere-sdk`).
+
+## ⚠️ Two keypairs: raw vs. hashed
+
+This is the single most important thing to know, and the easiest to get wrong.
+
+The token engine's `SigningService.createFromSecret(secret)` **SHA‑256‑hashes the secret before using it.** So a wallet's private key produces *two different* secp256k1 keypairs depending on how you use it:
+
+| Use the key… | How | Public key | Used for |
+|---|---|---|---|
+| **Raw** | `getPublicKey(privKey)` / `new SigningService(privKey)` | `chainPubkey` | messaging/transport identity, nametag binding, `signMessage`, ALPHA address |
+| **Hashed** | `SigningService.createFromSecret(privKey)` | different point | the `DIRECT://` token address, token ownership, token signatures |
+
+```typescript
+import { getPublicKey } from '@unicitylabs/sphere-sdk';
+
+const raw  = getPublicKey(privKeyHex);                          // == identity.chainPubkey
+// token key = SigningService.createFromSecret(privKeyBytes).publicKey  // ≠ raw
+
+// The wallet's DIRECT:// address is derived from the HASHED key (createFromSecret),
+// NOT from chainPubkey. Using `new SigningService(privKey)` (raw) will NOT match it.
+```
+
+If you mint or transfer tokens by hand, build the signer with `createFromSecret`. If you verify a `signMessage` signature or resolve a peer, use the raw `chainPubkey`.
+
+## Mnemonic → keys
+
+```typescript
+import {
+  generateMnemonic, validateMnemonic,
+  identityFromMnemonicSync,   // async variant: identityFromMnemonic
+  generateMasterKey, deriveKeyAtPath,
+  getPublicKey, createKeyPair,
+} from '@unicitylabs/sphere-sdk';
+
+const mnemonic = generateMnemonic();                 // 12 words (or generateMnemonic(256) for 24)
+validateMnemonic(mnemonic);                          // boolean
+
+const master = identityFromMnemonicSync(mnemonic);   // { privateKey, chainCode } (BIP-32 root)
+
+// Derive a key at a path (BIP-32; default base m/44'/0'/0')
+const child = deriveKeyAtPath(master.privateKey, master.chainCode, "m/44'/0'/0'/0/0");
+
+const pub = getPublicKey(child.privateKey);          // 33-byte compressed (chainPubkey form)
+const kp  = createKeyPair(child.privateKey);         // { privateKey, publicKey }
+```
+
+### Legacy (non‑BIP32) derivation
+
+For wallets imported from older formats that derive addresses by HMAC rather than BIP‑32:
+
+```typescript
+import { generateAddressFromMasterKey } from '@unicitylabs/sphere-sdk';
+const addr0 = generateAddressFromMasterKey(masterPrivateKeyHex, 0);
+```
+
+This corresponds to `derivationMode: 'wif_hmac' | 'legacy_hmac'` in `Sphere.import` (see [WALLET-IMPORT-EXPORT.md](WALLET-IMPORT-EXPORT.md)).
+
+## Message signing (backend auth)
+
+Bitcoin‑style signed messages over the **raw** key, useful for proving "this request came from the holder of `@alice`" without trusting a client‑supplied identifier.
+
+```typescript
+import { signMessage, verifySignedMessage, recoverPubkeyFromSignature } from '@unicitylabs/sphere-sdk';
+
+const sig = signMessage(privKeyHex, 'login: 2026-05-22');     // 130-hex string: v(2) + r(64) + s(64)
+
+verifySignedMessage('login: 2026-05-22', sig, expectedChainPubkey);   // boolean
+
+// Identify the signer without knowing them up front, then resolve who they are:
+const pubkey = recoverPubkeyFromSignature('login: 2026-05-22', sig);   // 66-hex compressed
+const peer   = await sphere.resolve(pubkey);                            // → @nametag, addresses
+```
+
+- The hash is `SHA-256(SHA-256(varint(prefix) + "Sphere Signed Message:\n" + varint(msg) + msg))`.
+- The recovery byte `v = 31 + recoveryParam`.
+- The recovered/expected public key is the **raw** `chainPubkey` (not the hashed token key).

--- a/docs/IDENTITY-CRYPTO.md
+++ b/docs/IDENTITY-CRYPTO.md
@@ -12,7 +12,7 @@ The token engine's `SigningService.createFromSecret(secret)` **SHA‑256‑hashe
 
 | Use the key… | How | Public key | Used for |
 |---|---|---|---|
-| **Raw** | `getPublicKey(privKey)` / `new SigningService(privKey)` | `chainPubkey` | messaging/transport identity, nametag binding, `signMessage`, ALPHA address |
+| **Raw** | `getPublicKey(privKey)` / `new SigningService(privKey)` | `chainPubkey` | messaging/transport identity, Unicity-ID binding, `signMessage`, ALPHA address |
 | **Hashed** | `SigningService.createFromSecret(privKey)` | different point | the `DIRECT://` token address, token ownership, token signatures |
 
 ```typescript
@@ -73,7 +73,7 @@ verifySignedMessage('login: 2026-05-22', sig, expectedChainPubkey);   // boolean
 
 // Identify the signer without knowing them up front, then resolve who they are:
 const pubkey = recoverPubkeyFromSignature('login: 2026-05-22', sig);   // 66-hex compressed
-const peer   = await sphere.resolve(pubkey);                            // → @nametag, addresses
+const peer   = await sphere.resolve(pubkey);                            // → @alice (Unicity ID), addresses
 ```
 
 - The hash is `SHA-256(SHA-256(varint(prefix) + "Sphere Signed Message:\n" + varint(msg) + msg))`.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1505,9 +1505,9 @@ unsubscribe();
 
 ---
 
-## Nametags
+## Unicity IDs
 
-Nametags provide human-readable addresses (e.g., `@alice`) for receiving tokens.
+Unicity IDs provide human-readable addresses (e.g., `@alice`) for receiving tokens.
 
 ### Registration Flow
 
@@ -1526,9 +1526,9 @@ await sphere.registerNametag('alice');
 const result = await sphere.mintNametag('alice');
 ```
 
-### Multi-Address Nametags
+### Multi-Address Unicity IDs
 
-Each derived address can have its own nametag:
+Each derived address can have its own Unicity ID:
 
 ```typescript
 // Register @alice for address 0
@@ -1544,7 +1544,7 @@ sphere.getNametagForAddress(1);  // 'bob'
 sphere.getAllAddressNametags();  // Map { 0 => 'alice', 1 => 'bob' }
 ```
 
-### Troubleshooting: "Nametag already taken"
+### Troubleshooting: "Unicity ID already taken"
 
 **Error:**
 ```
@@ -1552,7 +1552,7 @@ Failed to register nametag. It may already be taken.
 [NostrTransportProvider] Nametag already taken: myname - owner: f124f93ae6...
 ```
 
-**Cause:** The nametag is registered to a different public key. This happens when:
+**Cause:** The Unicity ID is registered to a different public key. This happens when:
 
 1. **Storage cleared or inaccessible** → `Sphere.exists()` returns `false` → new wallet created
 2. **Different mnemonic provided** on subsequent runs
@@ -1591,9 +1591,9 @@ logger.setTagDebug('IndexedDB', true);
 logger.setTagDebug('IPFS-Storage', true);
 ```
 
-### Nametag Sync on Load
+### Unicity ID Sync on Load
 
-When loading an existing wallet, the SDK automatically syncs the nametag with Nostr:
+When loading an existing wallet, the SDK automatically syncs the Unicity ID with Nostr:
 
 ```typescript
 // On Sphere.load(), if local nametag exists:
@@ -1602,9 +1602,9 @@ When loading an existing wallet, the SDK automatically syncs the nametag with No
 // 3. Logs warning if owned by different pubkey
 ```
 
-### Nametag Recovery on Import
+### Unicity ID Recovery on Import
 
-When importing a wallet without specifying a nametag, the SDK automatically attempts to recover it from Nostr:
+When importing a wallet without specifying a Unicity ID, the SDK automatically attempts to recover it from Nostr:
 
 ```typescript
 // Import wallet - nametag will be recovered if found on Nostr
@@ -1627,8 +1627,8 @@ if (sphere.identity?.nametag) {
 
 The recovery process:
 1. Derives transport pubkey from wallet keys
-2. Queries Nostr for nametag events owned by this pubkey
-3. If found, sets the nametag locally and emits `nametag:recovered` event
+2. Queries Nostr for Unicity ID events owned by this pubkey
+3. If found, sets the Unicity ID locally and emits `nametag:recovered` event
 
 ---
 
@@ -1835,14 +1835,14 @@ npm test -- --coverage
 | `serialization/wallet-dat` | 18 | SQLite wallet.dat parsing |
 | `modules/TokenSplitCalculator` | 23 | Token split optimization |
 | `modules/TokenSplitExecutor` | 16 | Token split execution |
-| `modules/PaymentsModule` | 36 | Payments, nametag, PROXY |
-| `modules/NametagMinter` | 22 | On-chain nametag minting |
+| `modules/PaymentsModule` | 36 | Payments, Unicity ID, PROXY |
+| `modules/NametagMinter` | 22 | On-chain Unicity ID minting |
 | `modules/CommunicationsModule.storage` | 16 | DM per-address storage, migration, pagination |
 | `price/CoinGeckoPriceProvider` | 29 | Price provider, cache, negative cache |
 | `transport/NostrTransportProvider` | 43 | Nostr P2P messaging, event timestamp persistence |
 | `impl/browser/IndexedDBStorageProvider` | 17 | IndexedDB kv storage, per-address key scoping |
 | `integration/wallet-import-export` | 20 | Wallet import/export |
-| `integration/nametag-roundtrip` | 9 | Nametag serialization |
+| `integration/nametag-roundtrip` | 9 | Unicity ID serialization |
 | `impl/shared/resolvers` | 41 | Config resolution utilities |
 | **Total** | **1613** | All passing (63 test files) |
 

--- a/docs/L1-ALPHA.md
+++ b/docs/L1-ALPHA.md
@@ -1,0 +1,51 @@
+# Sending the ALPHA coin
+
+ALPHA is the coin of Unicity's base blockchain. It is separate from the tokens on the main network and is reached through `sphere.payments.l1`. The connection to the blockchain server (Fulcrum) is **lazy** — it isn't opened until the first ALPHA operation.
+
+```typescript
+// ALPHA is enabled by default; no extra setup needed.
+const { sphere } = await Sphere.init({
+  ...providers,
+  autoGenerate: true,
+  // Optional defaults applied automatically:
+  //   electrumUrl:    network-specific
+  //   defaultFeeRate: 10 sat/byte
+  //   enableVesting:  true
+});
+
+// To disable ALPHA entirely:
+// const { sphere } = await Sphere.init({ ...providers, l1: null });
+```
+
+## Balance
+
+```typescript
+const balance = await sphere.payments.l1!.getBalance();
+console.log('Total:',    balance.total);
+console.log('Vested:',   balance.vested);
+console.log('Unvested:', balance.unvested);
+```
+
+All amounts are strings, in satoshis. "Vested" vs "unvested" reflects how the coins were originally created (see [ARCHITECTURE.md](../ARCHITECTURE.md#2b-the-alpha-blockchain-l1)).
+
+## Send
+
+```typescript
+const result = await sphere.payments.l1!.send({
+  to: 'alpha1qxyz...',
+  amount: '100000',   // in satoshis
+  feeRate: 5,         // optional, sat/byte
+});
+
+if (result.success) {
+  console.log('TX Hash:', result.txHash);
+}
+```
+
+## UTXOs, history, fee estimate
+
+```typescript
+const utxos   = await sphere.payments.l1!.getUtxos();
+const history = await sphere.payments.l1!.getHistory(10);
+const { fee, feeRate } = await sphere.payments.l1!.estimateFee('alpha1...', '50000');
+```

--- a/docs/L1-ALPHA.md
+++ b/docs/L1-ALPHA.md
@@ -35,6 +35,7 @@ const result = await sphere.payments.l1!.send({
   to: 'alpha1qxyz...',
   amount: '100000',   // in satoshis
   feeRate: 5,         // optional, sat/byte
+  useVested: true,    // optional — spend vested coins (default behavior depends on config)
 });
 
 if (result.success) {

--- a/docs/MULTI-ADDRESS.md
+++ b/docs/MULTI-ADDRESS.md
@@ -1,0 +1,69 @@
+# Multiple addresses
+
+One recovery phrase can produce many independent addresses (a hierarchical‑deterministic, or "HD", wallet). Each address has its own balance, its own `@nametag`, and its own message history.
+
+```typescript
+// Current address index
+const currentIndex = sphere.getCurrentAddressIndex(); // 0
+
+// Switch to a different address
+await sphere.switchToAddress(1);
+console.log(sphere.identity?.l1Address); // the address at index 1
+
+// Register a nametag for this address (independent per address)
+await sphere.registerNametag('bob');
+
+// Switch back
+await sphere.switchToAddress(0);
+
+// Look up a nametag for a specific address
+const bobNametag = sphere.getNametagForAddress(1); // 'bob'
+
+// All nametags across addresses
+const allNametags = sphere.getAllAddressNametags();
+// Map { 0 => 'alice', 1 => 'bob' }
+
+// Derive an address without switching to it (e.g. just to display or receive)
+const addr2 = sphere.deriveAddress(2);
+console.log(addr2.address, addr2.publicKey);
+```
+
+## Identity properties
+
+A wallet exposes several addresses. People normally use your `@nametag`; the rest are machine addresses.
+
+```typescript
+interface Identity {
+  directAddress?: string;   // your primary wallet address (DIRECT://…)
+  nametag?: string;         // human-readable handle (@username)
+  l1Address: string;        // your ALPHA coin address (alpha1…)
+  chainPubkey: string;      // 33-byte compressed public key
+  ipnsName?: string;        // identifier used for IPFS token backup
+}
+
+console.log(sphere.identity?.directAddress);  // DIRECT://0000be36…  (primary)
+console.log(sphere.identity?.nametag);        // alice               (human-readable)
+console.log(sphere.identity?.l1Address);      // alpha1qw3e…         (ALPHA coin only)
+console.log(sphere.identity?.chainPubkey);    // 02abc123…
+```
+
+For how these addresses are all derived from one key, see [ARCHITECTURE.md](../ARCHITECTURE.md#1-one-key-many-identities).
+
+## Address‑change event
+
+```typescript
+sphere.on('identity:changed', (event) => {
+  console.log('Switched to address index:', event.data.addressIndex);
+  console.log('Primary address:',           event.data.directAddress);
+  console.log('ALPHA address:',             event.data.l1Address);
+  console.log('Public key:',                event.data.chainPubkey);
+  console.log('Nametag:',                   event.data.nametag);
+});
+
+// Fired when a nametag is recovered while importing a wallet
+sphere.on('nametag:recovered', (event) => {
+  console.log('Recovered nametag:', event.data.nametag);
+});
+```
+
+See also [NAMETAGS.md → Multi-address nametags](NAMETAGS.md#multi-address-nametags).

--- a/docs/MULTI-ADDRESS.md
+++ b/docs/MULTI-ADDRESS.md
@@ -16,12 +16,12 @@ await sphere.registerNametag('bob');
 // Switch back
 await sphere.switchToAddress(0);
 
-// Look up a nametag for a specific address
-const bobNametag = sphere.getNametagForAddress(1); // 'bob'
+// Look up a nametag for a specific address — by its addressId (a string), not its index
+const addresses = sphere.getActiveAddresses();            // TrackedAddress[] (index, addressId, nametag, …)
+const bobNametag = sphere.getNametagForAddress(addresses[1].addressId); // 'bob'
 
-// All nametags across addresses
-const allNametags = sphere.getAllAddressNametags();
-// Map { 0 => 'alice', 1 => 'bob' }
+// (sphere.getAllAddressNametags() also exists but is @deprecated and returns a
+//  nested Map<addressId, Map<index, nametag>>; prefer getActiveAddresses().)
 
 // Derive an address without switching to it (e.g. just to display or receive)
 const addr2 = sphere.deriveAddress(2);

--- a/docs/MULTI-ADDRESS.md
+++ b/docs/MULTI-ADDRESS.md
@@ -1,6 +1,6 @@
 # Multiple addresses
 
-One recovery phrase can produce many independent addresses (a hierarchical‑deterministic, or "HD", wallet). Each address has its own balance, its own `@nametag`, and its own message history.
+One recovery phrase can produce many independent addresses (a hierarchical‑deterministic, or "HD", wallet). Each address has its own balance, its own Unicity ID, and its own message history.
 
 ```typescript
 // Current address index
@@ -10,39 +10,41 @@ const currentIndex = sphere.getCurrentAddressIndex(); // 0
 await sphere.switchToAddress(1);
 console.log(sphere.identity?.l1Address); // the address at index 1
 
-// Register a nametag for this address (independent per address)
+// Register a Unicity ID for this address (independent per address)
 await sphere.registerNametag('bob');
 
 // Switch back
 await sphere.switchToAddress(0);
 
-// Look up a nametag for a specific address — by its addressId (a string), not its index
+// Look up a Unicity ID for a specific address — by its addressId (a string), not its index
 const addresses = sphere.getActiveAddresses();            // TrackedAddress[] (index, addressId, nametag, …)
-const bobNametag = sphere.getNametagForAddress(addresses[1].addressId); // 'bob'
+const bobName = sphere.getNametagForAddress(addresses[1].addressId); // 'bob'
 
 // (sphere.getAllAddressNametags() also exists but is @deprecated and returns a
-//  nested Map<addressId, Map<index, nametag>>; prefer getActiveAddresses().)
+//  nested Map<addressId, Map<index, name>>; prefer getActiveAddresses().)
 
 // Derive an address without switching to it (e.g. just to display or receive)
 const addr2 = sphere.deriveAddress(2);
 console.log(addr2.address, addr2.publicKey);
 ```
 
+> The API uses the name `nametag` for a Unicity ID (`registerNametag`, `getNametagForAddress`, the `nametag` field). See [docs/UNICITY-ID.md](UNICITY-ID.md).
+
 ## Identity properties
 
-A wallet exposes several addresses. People normally use your `@nametag`; the rest are machine addresses.
+A wallet exposes several addresses. People normally use your Unicity ID; the rest are machine addresses.
 
 ```typescript
 interface Identity {
   directAddress?: string;   // your primary wallet address (DIRECT://…)
-  nametag?: string;         // human-readable handle (@username)
+  nametag?: string;         // your Unicity ID (human-readable handle, e.g. @alice)
   l1Address: string;        // your ALPHA coin address (alpha1…)
   chainPubkey: string;      // 33-byte compressed public key
   ipnsName?: string;        // identifier used for IPFS token backup
 }
 
 console.log(sphere.identity?.directAddress);  // DIRECT://0000be36…  (primary)
-console.log(sphere.identity?.nametag);        // alice               (human-readable)
+console.log(sphere.identity?.nametag);        // alice               (Unicity ID)
 console.log(sphere.identity?.l1Address);      // alpha1qw3e…         (ALPHA coin only)
 console.log(sphere.identity?.chainPubkey);    // 02abc123…
 ```
@@ -57,13 +59,13 @@ sphere.on('identity:changed', (event) => {
   console.log('Primary address:',           event.data.directAddress);
   console.log('ALPHA address:',             event.data.l1Address);
   console.log('Public key:',                event.data.chainPubkey);
-  console.log('Nametag:',                   event.data.nametag);
+  console.log('Unicity ID:',                event.data.nametag);
 });
 
-// Fired when a nametag is recovered while importing a wallet
+// Fired when a Unicity ID is recovered while importing a wallet
 sphere.on('nametag:recovered', (event) => {
-  console.log('Recovered nametag:', event.data.nametag);
+  console.log('Recovered Unicity ID:', event.data.nametag);
 });
 ```
 
-See also [NAMETAGS.md → Multi-address nametags](NAMETAGS.md#multi-address-nametags).
+See also [UNICITY-ID.md → Multiple Unicity IDs](UNICITY-ID.md#multiple-unicity-ids-per-address).

--- a/docs/NAMETAG-BINDINGS.md
+++ b/docs/NAMETAG-BINDINGS.md
@@ -1,18 +1,18 @@
-# Nametag Bindings
+# Unicity ID Bindings
 
 How the Sphere SDK publishes and resolves identity binding events on Nostr relays.
 
 ## Overview
 
-Nametag bindings are Nostr events (kind 30078, NIP-78 parameterized replaceable) that associate a human-readable nametag (`@alice`) with on-chain identity addresses. They enable:
+Unicity ID bindings are Nostr events (kind 30078, NIP-78 parameterized replaceable) that associate a human-readable Unicity ID (`@alice`) with on-chain identity addresses. They enable:
 
-- **Forward lookup**: nametag → pubkey/addresses (e.g., sending tokens to `@alice`)
-- **Reverse lookup**: address → nametag/identity (e.g., showing sender info in DMs)
-- **Recovery**: encrypted nametag in the event allows private key owner to recover their nametag on wallet import
+- **Forward lookup**: Unicity ID → pubkey/addresses (e.g., sending tokens to `@alice`)
+- **Reverse lookup**: address → Unicity ID/identity (e.g., showing sender info in DMs)
+- **Recovery**: encrypted Unicity ID in the event allows private key owner to recover their Unicity ID on wallet import
 
 ## Wallet Creation Flow
 
-### Path A: With nametag (`Sphere.init({ nametag: 'alice', ... })`)
+### Path A: With Unicity ID (`Sphere.init({ nametag: 'alice', ... })`)
 
 ```
 Sphere.init()
@@ -31,11 +31,11 @@ Sphere.init()
             └─ 3. update local state
 ```
 
-**Events published: 1** — a nametag binding event with full identity fields.
+**Events published: 1** — a Unicity ID binding event with full identity fields.
 
-Mint-before-publish ordering ensures no unbacked nametag claims exist on the relay. If minting fails, nothing is published.
+Mint-before-publish ordering ensures no unbacked Unicity ID claims exist on the relay. If minting fails, nothing is published.
 
-### Path B: Without nametag (`Sphere.init({ autoGenerate: true })`)
+### Path B: Without Unicity ID (`Sphere.init({ autoGenerate: true })`)
 
 ```
 Sphere.init()
@@ -51,9 +51,9 @@ Sphere.init()
                  └─ publishEvent(baseBindingEvent)  ← kind 30078, no nametag
 ```
 
-**Events published: 1** — a base identity binding with addresses only (no nametag).
+**Events published: 1** — a base identity binding with addresses only (no Unicity ID).
 
-### Path C: Without nametag initially, register later
+### Path C: Without Unicity ID initially, register later
 
 ```
 // Initial creation (Path B above)
@@ -67,13 +67,13 @@ await sphere.registerNametag('alice');
 
 **Events published: 2 total** (different d-tags, both coexist on relay):
 1. Base identity binding: `d = SHA256('unicity:identity:' + nostrPubkey)`
-2. Nametag binding: `d = SHA256('unicity:nametag:alice')`
+2. Unicity ID binding: `d = SHA256('unicity:nametag:alice')`
 
 Both events share address `#t` tags (hashed chainPubkey, l1Address, directAddress), so address-based reverse lookups find both.
 
 ## Event Formats
 
-### Nametag Binding Event (with identity)
+### Unicity ID Binding Event (with identity)
 
 Published by `registerNametag()` via nostr-js-sdk's `publishNametagBinding()`.
 
@@ -108,9 +108,9 @@ Published by `registerNametag()` via nostr-js-sdk's `publishNametagBinding()`.
 }
 ```
 
-### Base Identity Binding Event (without nametag)
+### Base Identity Binding Event (without Unicity ID)
 
-Published by `syncIdentityWithTransport()` when no nametag is set.
+Published by `syncIdentityWithTransport()` when no Unicity ID is set.
 
 ```json
 {
@@ -137,43 +137,43 @@ The `d` tag determines which event gets replaced (NIP-78: same kind + pubkey + d
 
 | Scenario | d-tag | Purpose |
 |----------|-------|---------|
-| Nametag binding | `SHA256('unicity:nametag:' + nametag)` | One event per nametag per author |
-| Base identity binding | `SHA256('unicity:identity:' + nostrPubkey)` | One event per identity (no nametag) |
+| Unicity ID binding | `SHA256('unicity:nametag:' + nametag)` | One event per Unicity ID per author |
+| Base identity binding | `SHA256('unicity:identity:' + nostrPubkey)` | One event per identity (no Unicity ID) |
 
-These are different d-tags, so they create **separate** replaceable events. A wallet that first publishes a base binding and later registers a nametag will have both events on the relay. Only the original author (same Nostr pubkey) can replace their own events.
+These are different d-tags, so they create **separate** replaceable events. A wallet that first publishes a base binding and later registers a Unicity ID will have both events on the relay. Only the original author (same Nostr pubkey) can replace their own events.
 
 ## Anti-Hijacking
 
 ### Conflict Detection (publish-time)
 
-`publishNametagBinding()` queries the relay before publishing. If the nametag is already claimed by a different pubkey, it throws `"already claimed"`. Same pubkey re-publishing (update) is allowed.
+`publishNametagBinding()` queries the relay before publishing. If the Unicity ID is already claimed by a different pubkey, it throws `"already claimed"`. Same pubkey re-publishing (update) is allowed.
 
-**TOCTOU caveat:** There is a race window between the conflict check and the publish. Another user can claim the same nametag in between. This is inherent to Nostr's eventually-consistent relay model — there is no atomic check-and-publish. The mint-before-publish ordering (see below) provides the real enforcement via on-chain state.
+**TOCTOU caveat:** There is a race window between the conflict check and the publish. Another user can claim the same Unicity ID in between. This is inherent to Nostr's eventually-consistent relay model — there is no atomic check-and-publish. The mint-before-publish ordering (see below) provides the real enforcement via on-chain state.
 
 ### Resolution Strategy (query-time)
 
 All query methods (`queryPubkeyByNametag`, `queryBindingByNametag`, `queryBindingByAddress`) use a two-level strategy:
 
-1. **First-seen-wins across authors** — if multiple pubkeys claim the same nametag or address tag, the author who published the earliest `created_at` event wins. Prevents hijacking. Ties are broken deterministically by lexicographic pubkey comparison (lowest wins).
+1. **First-seen-wins across authors** — if multiple pubkeys claim the same Unicity ID or address tag, the author who published the earliest `created_at` event wins. Prevents hijacking. Ties are broken deterministically by lexicographic pubkey comparison (lowest wins).
 
-2. **Latest-wins for same author** — if the rightful owner has multiple events (e.g., initial bare binding + later nametag binding), the most recent event is returned. Ensures the most complete data is returned.
+2. **Latest-wins for same author** — if the rightful owner has multiple events (e.g., initial bare binding + later Unicity ID binding), the most recent event is returned. Ensures the most complete data is returned.
 
-3. **Signature verification** — events with invalid signatures are silently skipped. This prevents malicious relays from injecting forged events to hijack nametag resolution.
+3. **Signature verification** — events with invalid signatures are silently skipped. This prevents malicious relays from injecting forged events to hijack Unicity ID resolution.
 
-This is critical for Path C (register nametag after creation). Address-based lookups find both the old bare binding and the newer nametag binding. Without latest-wins-for-same-author, the stale bare binding (without nametag) would be returned.
+This is critical for Path C (register Unicity ID after creation). Address-based lookups find both the old bare binding and the newer Unicity ID binding. Without latest-wins-for-same-author, the stale bare binding (without Unicity ID) would be returned.
 
 ### Mint-Before-Publish
 
-`registerNametag()` mints the nametag token on-chain **before** publishing to Nostr. This ensures:
+`registerNametag()` mints the Unicity ID token on-chain **before** publishing to Nostr. This ensures:
 - If minting fails → nothing published (no unbacked claims)
 - If minting succeeds but publishing fails → error is surfaced to the user
-- No relay-only nametag claims without blockchain backing
+- No relay-only Unicity ID claims without blockchain backing
 
 ## Privacy
 
-- Nametag is **hashed** in all indexed tags: `SHA256('unicity:nametag:' + name)` — relay operators see hashes, not plaintext
+- Unicity ID is **hashed** in all indexed tags: `SHA256('unicity:nametag:' + name)` — relay operators see hashes, not plaintext
 - Addresses are **hashed** in `t` tags: `SHA256('unicity:address:' + address)` — same relay-level privacy
-- **Plaintext nametag is stored in event content** (`content.nametag`). This is intentional: nametags must be publicly resolvable for the system to work (sending tokens to `@alice` requires resolving her addresses). The tag hashing provides relay-level indexing privacy, while content is publicly readable for kind 30078 events.
+- **Plaintext Unicity ID is stored in event content** (`content.nametag`). This is intentional: Unicity IDs must be publicly resolvable for the system to work (sending tokens to `@alice` requires resolving her addresses). The tag hashing provides relay-level indexing privacy, while content is publicly readable for kind 30078 events.
 - `encrypted_nametag` (AES-GCM) is a separate copy encrypted with the author's private key, enabling wallet recovery on import without relying on the plaintext field
 - `pubkey` and `l1` tags contain unhashed values for backward-compatible lookups
 

--- a/docs/NAMETAGS.md
+++ b/docs/NAMETAGS.md
@@ -1,0 +1,113 @@
+# Nametags
+
+A **nametag** is a human‑readable handle (e.g. `@alice`) that people use to pay or message a wallet, instead of a long machine address. Each wallet can claim one per address.
+
+Valid formats: lowercase alphanumeric with `_` or `-` (3–20 characters), or an E.164 phone number (e.g. `+14155552671`). Input is normalized to lowercase automatically.
+
+> **Testnet faucet requires a nametag.** Register one before requesting test tokens.
+
+> **Minting requires an aggregator API key** for proof verification. Configure it via the `oracle.apiKey` option when creating providers. Contact Unicity to obtain a key.
+
+## Registering a nametag
+
+```typescript
+// During wallet creation
+const { sphere } = await Sphere.init({
+  ...providers,
+  mnemonic: 'your twelve words...',
+  nametag: 'alice',  // registers @alice
+});
+
+// Or after creation
+await sphere.registerNametag('alice');
+
+// Mint the on-chain nametag token (required to receive via PROXY addresses)
+const result = await sphere.mintNametag('alice');
+if (result.success) {
+  console.log('Nametag minted:', result.nametagData?.name);
+}
+```
+
+## Common pitfall: "nametag already taken"
+
+If you see:
+
+```
+Failed to register nametag. It may already be taken.
+[NostrTransportProvider] Nametag already taken: myname - owner: f124f93ae6946ffd...
+```
+
+…the nametag is registered to a **different public key**. The usual causes:
+
+1. **Storage was cleared or isn't persisting.** `Sphere.exists()` returns `false`, so the SDK creates a *new* wallet with a new key — and the old key still owns the nametag on the relay.
+2. **A different recovery phrase each run:**
+   ```typescript
+   // WRONG: a new random phrase every start
+   const mnemonic = Sphere.generateMnemonic();
+   const { sphere } = await Sphere.init({ mnemonic, nametag: 'myservice' }); // fails after first run
+   ```
+
+> `autoGenerate: true` does **not** generate a new phrase on every restart — only when `Sphere.exists()` is `false` (no wallet found in storage).
+
+## Solution: persistent storage or a fixed phrase
+
+**Option 1 — persistent file storage (recommended for backends):**
+```typescript
+import { FileStorageProvider } from '@unicitylabs/sphere-sdk/impl/nodejs';
+
+const storage = new FileStorageProvider('./wallet-data'); // persists to disk
+const { sphere } = await Sphere.init({
+  storage,
+  autoGenerate: true,   // OK: phrase saved to disk, reused on restart
+  nametag: 'myservice',
+});
+```
+
+**Option 2 — fixed phrase from the environment:**
+```typescript
+const { sphere } = await Sphere.init({
+  ...providers,
+  mnemonic: process.env.WALLET_MNEMONIC, // same phrase every time
+  nametag: 'myservice',
+});
+```
+
+## Debugging storage
+
+```typescript
+const exists = await Sphere.exists(storage);
+console.log('Wallet exists:', exists); // should be true after the first run
+// If false, storage is not persisting.
+```
+
+## Recovery on import
+
+When importing a wallet (from a phrase or file), the SDK automatically tries to recover the nametag from the relay:
+
+```typescript
+const { sphere } = await Sphere.init({
+  ...providers,
+  mnemonic: 'your twelve words...',
+  // no nametag specified — recovered from the relay if found
+});
+
+sphere.on('nametag:recovered', (event) => {
+  console.log('Recovered nametag:', event.data.nametag);
+});
+
+console.log(sphere.identity?.nametag); // set if recovered
+```
+
+## Multi-address nametags
+
+Each derived address can have its own independent nametag:
+
+```typescript
+await sphere.registerNametag('alice');      // address 0 → @alice
+
+await sphere.switchToAddress(1);
+await sphere.registerNametag('bob');         // address 1 → @bob
+
+sphere.getNametagForAddress(0); // 'alice'
+sphere.getNametagForAddress(1); // 'bob'
+```

--- a/docs/NAMETAGS.md
+++ b/docs/NAMETAGS.md
@@ -108,6 +108,8 @@ await sphere.registerNametag('alice');      // address 0 → @alice
 await sphere.switchToAddress(1);
 await sphere.registerNametag('bob');         // address 1 → @bob
 
-sphere.getNametagForAddress(0); // 'alice'
-sphere.getNametagForAddress(1); // 'bob'
+// getNametagForAddress takes an addressId (string), not an index:
+const addresses = sphere.getActiveAddresses();             // TrackedAddress[] with addressId + nametag
+sphere.getNametagForAddress(addresses[0].addressId); // 'alice'
+sphere.getNametagForAddress(addresses[1].addressId); // 'bob'
 ```

--- a/docs/PAYMENT-REQUESTS.md
+++ b/docs/PAYMENT-REQUESTS.md
@@ -2,6 +2,8 @@
 
 Ask another user to pay you, and track whether they did. A payment request is a message, not a charge — the other side chooses to accept, pay, or reject it.
 
+> This page documents the high‑level `sphere.payments.*` API. A lower‑level path also exists on the transport (`sphere.getTransport().onPaymentRequest()` / `sendPaymentRequestResponse()`) — some integrations use it directly for finer control over sender plumbing and custom response types.
+
 ## Sending a request
 
 ```typescript

--- a/docs/PAYMENT-REQUESTS.md
+++ b/docs/PAYMENT-REQUESTS.md
@@ -1,0 +1,42 @@
+# Payment requests
+
+Ask another user to pay you, and track whether they did. A payment request is a message, not a charge — the other side chooses to accept, pay, or reject it.
+
+## Sending a request
+
+```typescript
+const result = await sphere.payments.sendPaymentRequest('@bob', {
+  amount: '1000000',
+  coinId: 'UCT',
+  message: 'Payment for order #1234',
+});
+
+// Wait for a response (2-minute timeout here)
+if (result.success) {
+  const response = await sphere.payments.waitForPaymentResponse(result.requestId!, 120000);
+  if (response.responseType === 'paid') {
+    console.log('Payment received! Transfer:', response.transferId);
+  }
+}
+
+// Or subscribe to responses instead of waiting
+sphere.payments.onPaymentRequestResponse((response) => {
+  console.log(`Response: ${response.responseType}`);
+});
+```
+
+## Handling incoming requests
+
+```typescript
+sphere.payments.onPaymentRequest(async (request) => {
+  console.log(`${request.senderNametag} requests ${request.amount} ${request.symbol}`);
+
+  // Accept and pay
+  await sphere.payments.payPaymentRequest(request.id);
+
+  // …or reject
+  await sphere.payments.rejectPaymentRequest(request.id);
+});
+```
+
+A response's `responseType` is one of `accepted`, `paid`, or `rejected`. When paid, `transferId` links to the resulting transfer.

--- a/docs/PROVIDERS-AND-CONFIG.md
+++ b/docs/PROVIDERS-AND-CONFIG.md
@@ -1,6 +1,6 @@
 # Providers & Configuration
 
-Sphere is configured by **providers** — pluggable backends for storage, messaging, proofs, and prices. The factory functions `createBrowserProviders()` and `createNodeProviders()` assemble a complete set from a single network name; everything below is for customizing that.
+The Sphere SDK is configured by **providers** — pluggable backends for storage, messaging, proofs, and prices. The factory functions `createBrowserProviders()` and `createNodeProviders()` assemble a complete set from a single network name; everything below is for customizing that.
 
 ## Network presets
 

--- a/docs/PROVIDERS-AND-CONFIG.md
+++ b/docs/PROVIDERS-AND-CONFIG.md
@@ -6,11 +6,13 @@ Sphere is configured by **providers** — pluggable backends for storage, messag
 
 A network name configures every service at once.
 
-| Network | Aggregator | Messaging relay | Fulcrum (ALPHA) |
-|---|---|---|---|
-| `mainnet` | aggregator.unicity.network | relay.unicity.network | fulcrum.unicity.network:50004 |
-| `testnet` | goggregator-test.unicity.network | nostr-relay.testnet.unicity.network | fulcrum.unicity.network:50004 |
-| `dev` | dev-aggregator.dyndns.org | nostr-relay.testnet.unicity.network | fulcrum.unicity.network:50004 |
+Values below are from `constants.ts` (the source of truth). Note the `/rpc` suffix on mainnet/dev aggregators but **not** testnet.
+
+| Network | Aggregator | Messaging relay | Fulcrum (ALPHA) | Group‑chat relay |
+|---|---|---|---|---|
+| `mainnet` | aggregator.unicity.network/rpc | relay.unicity.network | fulcrum.unicity.network:50004 | sphere-relay.unicity.network |
+| `testnet` | goggregator-test.unicity.network | nostr-relay.testnet.unicity.network | fulcrum.unicity.network:50004 | sphere-relay.unicity.network |
+| `dev` | dev-aggregator.dyndns.org/rpc | nostr-relay.testnet.unicity.network | fulcrum.unicity.network:50004 | sphere-relay.unicity.network |
 
 ```typescript
 // Use a preset

--- a/docs/PROVIDERS-AND-CONFIG.md
+++ b/docs/PROVIDERS-AND-CONFIG.md
@@ -100,8 +100,8 @@ const providers = createBrowserProviders({
   // price: { platform: 'coingecko', apiKey: 'CG-xxx' }, // pro
 });
 
-const usd    = await sphere.payments.getBalance(); // total in USD, or null without prices
-const assets = await sphere.payments.getAssets();  // includes priceUsd / fiatValueUsd / change24h
+const usd    = await sphere.payments.getFiatBalance(); // total in USD, or null without prices
+const assets = await sphere.payments.getAssets();      // includes priceUsd / fiatValueUsd / change24h
 ```
 
 You can also set it after init:
@@ -111,7 +111,7 @@ import { createPriceProvider } from '@unicitylabs/sphere-sdk';
 sphere.setPriceProvider(createPriceProvider({ platform: 'coingecko', apiKey: 'CG-xxx' }));
 ```
 
-Without a price provider, `getBalance()` returns `null` and price fields are `null`; everything else works.
+Without a price provider, `getFiatBalance()` returns `null` and the price fields on `getAssets()` are `null`; everything else works. (`getBalance()` always returns the `Asset[]` breakdown — it's price‑independent.)
 
 ## The extend / override pattern
 

--- a/docs/PROVIDERS-AND-CONFIG.md
+++ b/docs/PROVIDERS-AND-CONFIG.md
@@ -1,0 +1,263 @@
+# Providers & Configuration
+
+Sphere is configured by **providers** — pluggable backends for storage, messaging, proofs, and prices. The factory functions `createBrowserProviders()` and `createNodeProviders()` assemble a complete set from a single network name; everything below is for customizing that.
+
+## Network presets
+
+A network name configures every service at once.
+
+| Network | Aggregator | Messaging relay | Fulcrum (ALPHA) |
+|---|---|---|---|
+| `mainnet` | aggregator.unicity.network | relay.unicity.network | fulcrum.unicity.network:50004 |
+| `testnet` | goggregator-test.unicity.network | nostr-relay.testnet.unicity.network | fulcrum.unicity.network:50004 |
+| `dev` | dev-aggregator.dyndns.org | nostr-relay.testnet.unicity.network | fulcrum.unicity.network:50004 |
+
+```typescript
+// Use a preset
+const providers = createBrowserProviders({ network: 'testnet' });
+
+// Override one service, keep the rest
+const providers = createBrowserProviders({
+  network: 'testnet',
+  oracle: { url: 'https://custom-aggregator.example.com' },
+});
+```
+
+## Browser providers
+
+| Provider | Description |
+|---|---|
+| `LocalStorageProvider` | Browser localStorage with SSR fallback |
+| `IndexedDBStorageProvider` | Default key‑value store |
+| `NostrTransportProvider` | Relay messaging |
+| `UnicityAggregatorProvider` | Aggregator for proofs |
+| `IpfsStorageProvider` | HTTP‑based IPFS/IPNS token backup |
+
+## Node.js providers
+
+```typescript
+import { Sphere } from '@unicitylabs/sphere-sdk';
+import { createNodeProviders } from '@unicitylabs/sphere-sdk/impl/nodejs';
+
+const providers = createNodeProviders({
+  network: 'testnet',
+  dataDir: './wallet-data',
+  tokensDir: './tokens',
+});
+
+const { sphere } = await Sphere.init({ ...providers, autoGenerate: true });
+```
+
+Full configuration:
+
+```typescript
+const providers = createNodeProviders({
+  network: 'testnet',
+  dataDir: './wallet-data',
+  tokensDir: './tokens',
+  walletFileName: 'mnemonic.txt', // optional: custom filename; .txt is read as a raw mnemonic
+  transport: { additionalRelays: ['wss://my-relay.com'], timeout: 10000, debug: true },
+  oracle:    { apiKey: 'my-api-key', trustBasePath: './trustbase.json' },
+  l1:        { enableVesting: true },
+});
+```
+
+### Manual provider creation (Node.js)
+
+```typescript
+import {
+  FileStorageProvider,
+  FileTokenStorageProvider,
+  createNostrTransportProvider,
+  createNodeTrustBaseLoader,
+} from '@unicitylabs/sphere-sdk/impl/nodejs';
+
+const storage      = new FileStorageProvider('./wallet-data');
+const tokenStorage = new FileTokenStorageProvider('./tokens');
+const transport    = createNostrTransportProvider({ relays: ['wss://relay.unicity.network'] });
+
+const trustBase = await createNodeTrustBaseLoader('./trustbase-testnet.json').load();
+```
+
+## Wallet password (encryption at rest)
+
+The recovery phrase is stored as plaintext by default, or AES‑encrypted if you pass a password:
+
+```typescript
+const { sphere } = await Sphere.init({ ...providers, password: 'my-secret' });
+```
+
+Wallets written without a password (or by an external app as a plaintext `wallet.json` / `.txt`) still load without one; previously encrypted wallets remain compatible.
+
+## Prices (optional)
+
+Enable fiat values with a `price` config (CoinGecko, free or pro):
+
+```typescript
+const providers = createBrowserProviders({
+  network: 'testnet',
+  price: { platform: 'coingecko' },               // free tier
+  // price: { platform: 'coingecko', apiKey: 'CG-xxx' }, // pro
+});
+
+const usd    = await sphere.payments.getBalance(); // total in USD, or null without prices
+const assets = await sphere.payments.getAssets();  // includes priceUsd / fiatValueUsd / change24h
+```
+
+You can also set it after init:
+
+```typescript
+import { createPriceProvider } from '@unicitylabs/sphere-sdk';
+sphere.setPriceProvider(createPriceProvider({ platform: 'coingecko', apiKey: 'CG-xxx' }));
+```
+
+Without a price provider, `getBalance()` returns `null` and price fields are `null`; everything else works.
+
+## The extend / override pattern
+
+Configuration uses a consistent rule across platforms:
+
+| Option | Behavior |
+|---|---|
+| `relays` | **Replaces** the default relays |
+| `additionalRelays` | **Adds** to the defaults |
+| `gateways` | **Replaces** default IPFS gateways |
+| `additionalGateways` | **Adds** to the defaults |
+| `url`, `electrumUrl` | **Replaces** the default URL (network default otherwise) |
+
+```typescript
+// Add to defaults
+createBrowserProviders({ network: 'testnet', transport: { additionalRelays: ['wss://extra.com'] } });
+
+// Replace defaults entirely
+createBrowserProviders({ network: 'testnet', transport: { relays: ['wss://only-this.com'] } });
+```
+
+Shared interfaces and resolver helpers live under `@unicitylabs/sphere-sdk/impl/shared` (`BaseTransportConfig`, `BaseOracleConfig`, `L1Config`, `getNetworkConfig`, `resolveTransportConfig`, `resolveArrayConfig`, …). Each platform extends the base with its own options (browser adds `reconnectDelay`/`maxReconnectAttempts`; Node adds `trustBasePath`).
+
+## Token sync backends
+
+Token backup can be enabled independently of the rest.
+
+| Backend | Status | Description |
+|---|---|---|
+| `ipfs` | Ready | HTTP‑based IPFS/IPNS (browser + Node) |
+| `mongodb` | Planned | Centralized storage |
+| `file` | Planned | Local file system (Node) |
+| `cloud` | Planned | S3 / GCP / Azure |
+
+```typescript
+const providers = createBrowserProviders({
+  network: 'testnet',
+  tokenSync: { ipfs: { enabled: true, additionalGateways: ['https://my-gateway.com'] } },
+});
+```
+
+See [IPFS-STORAGE.md](IPFS-STORAGE.md) for caching, merge rules, and troubleshooting.
+
+## Custom token storage provider
+
+Implement `TokenStorageProvider` for your own backend:
+
+```typescript
+import type {
+  TokenStorageProvider, TxfStorageDataBase, SaveResult, LoadResult, SyncResult,
+} from '@unicitylabs/sphere-sdk/storage';
+import type { FullIdentity, ProviderStatus } from '@unicitylabs/sphere-sdk/types';
+
+class MyStorageProvider implements TokenStorageProvider<TxfStorageDataBase> {
+  readonly id = 'my-storage';
+  readonly name = 'My Custom Storage';
+  readonly type = 'remote' as const;
+
+  private status: ProviderStatus = 'disconnected';
+  private identity: FullIdentity | null = null;
+
+  setIdentity(identity: FullIdentity) { this.identity = identity; }
+  async initialize() { this.status = 'connected'; return true; }
+  async shutdown()   { this.status = 'disconnected'; }
+  async connect()    { await this.initialize(); }
+  async disconnect() { await this.shutdown(); }
+  isConnected()      { return this.status === 'connected'; }
+  getStatus()        { return this.status; }
+
+  async load(): Promise<LoadResult<TxfStorageDataBase>> {
+    return {
+      success: true,
+      data: { _meta: { version: 1, address: this.identity?.l1Address ?? '', formatVersion: '2.0', updatedAt: Date.now() } },
+      source: 'remote', timestamp: Date.now(),
+    };
+  }
+  async save(data: TxfStorageDataBase): Promise<SaveResult> {
+    return { success: true, timestamp: Date.now() };
+  }
+  async sync(localData: TxfStorageDataBase): Promise<SyncResult<TxfStorageDataBase>> {
+    await this.save(localData);
+    return { success: true, merged: localData, added: 0, removed: 0, conflicts: 0 };
+  }
+}
+
+const { sphere } = await Sphere.init({ ...providers, tokenStorage: new MyStorageProvider(), autoGenerate: true });
+```
+
+## Dynamic provider management (runtime)
+
+After `Sphere.init()`, token storage providers can be added or removed live:
+
+```typescript
+import { createBrowserIpfsStorageProvider } from '@unicitylabs/sphere-sdk/impl/browser/ipfs';
+
+const ipfs = createBrowserIpfsStorageProvider({ gateways: ['https://my-ipfs-node.com'] });
+await sphere.addTokenStorageProvider(ipfs);
+
+sphere.hasTokenStorageProvider('ipfs-token-storage'); // true
+await sphere.removeTokenStorageProvider('ipfs-token-storage');
+
+sphere.on('sync:provider', (e) => {
+  console.log(`${e.providerId}: ${e.success ? `+${e.added}/-${e.removed}` : e.error}`);
+});
+await sphere.payments.sync();
+```
+
+## Dynamic relay management
+
+```typescript
+const transport = sphere.getTransport();
+
+transport.getRelays();           // configured
+transport.getConnectedRelays();  // currently connected
+
+await transport.addRelay('wss://new-relay.com');
+await transport.removeRelay('wss://old-relay.com');
+
+transport.hasRelay('wss://relay.com');
+transport.isRelayConnected('wss://relay.com');
+
+sphere.on('transport:relay_added',   (e) => console.log('added', e.data.relay, e.data.connected));
+sphere.on('transport:relay_removed', (e) => console.log('removed', e.data.relay));
+sphere.on('transport:error',         (e) => console.log('error', e.data.error));
+```
+
+## Browser bundling
+
+The SDK runs in the browser, but it (and its `@unicitylabs/nostr-js-sdk` dependency) reference Node built‑ins (`crypto`, `zlib`) and globals (`Buffer`, `process`). Most modern bundlers don't polyfill these automatically, so a bare import can fail with `Buffer is not defined` or unresolved `node:` built‑ins. Provide polyfills/shims.
+
+**Vite**
+```ts
+// vite.config.ts
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+
+export default {
+  plugins: [nodePolyfills({ globals: { Buffer: true, process: true } })],
+};
+```
+
+**Webpack 5** — add `resolve.fallback` for `crypto`/`zlib`/`stream` (or stub the ones you don't use) and provide `Buffer`/`process` via `ProvidePlugin`.
+
+If a bundler still trips on an unused Node built‑in pulled in transitively, alias it to an empty stub. (This affects bundling only — at runtime the SDK uses Web Crypto and native WebSocket in the browser.)
+
+## Protocol / version compatibility
+
+This SDK **bundles `@unicitylabs/state-transition-sdk` `1.6.1`**, and the public testnet aggregator speaks that **v1** request shape. Use the state‑transition client the SDK already bundles (everything under `sphere.payments` does).
+
+If you also import `@unicitylabs/state-transition-sdk` directly in your app, **pin the same version the SDK bundles.** A separately installed v2 line uses a different request shape (e.g. `certification_request` + an `X-State-ID` header) that the v1 aggregator rejects with `HTTP 400` on fields like `requestId` / `shardId`. Mixing major lines against the same endpoint is the usual cause of unexplained 400s.

--- a/docs/QUICKSTART-BROWSER.md
+++ b/docs/QUICKSTART-BROWSER.md
@@ -193,7 +193,7 @@ Browser SDK uses two storage mechanisms automatically:
 
 | Data | Storage | Persistence |
 |------|---------|-------------|
-| Wallet (mnemonic, nametag) | `localStorage` | Per-domain, survives refresh |
+| Wallet (mnemonic, Unicity ID) | `localStorage` | Per-domain, survives refresh |
 | Tokens | `IndexedDB` | Per-domain, larger capacity |
 
 **SSR Note:** If `localStorage` is unavailable (SSR), an in-memory fallback is used.
@@ -339,7 +339,7 @@ const { transfers } = await sphere.payments.receive();
 console.log(`Received ${transfers.length} new transfers`);
 ```
 
-### Register Nametag
+### Register Unicity ID
 
 > **Note:** `registerNametag()` mints a token on-chain. This uses the Oracle (Aggregator) provider which is included by default with `createBrowserProviders()`.
 

--- a/docs/QUICKSTART-NODEJS.md
+++ b/docs/QUICKSTART-NODEJS.md
@@ -148,7 +148,7 @@ Node.js implementation uses **file-based storage**:
 
 | Data | Location | Format |
 |------|----------|--------|
-| Wallet (keys, nametag) | `dataDir/wallet.json` (or custom file name) | JSON (plaintext or password-encrypted mnemonic) |
+| Wallet (keys, Unicity ID) | `dataDir/wallet.json` (or custom file name) | JSON (plaintext or password-encrypted mnemonic) |
 | Tokens | `tokensDir/_<tokenId>.json` | One JSON file per token |
 
 > **Note:** IPFS sync is available for both browser and Node.js. See [IPFS Token Sync](#ipfs-token-sync-optional) below.
@@ -359,7 +359,7 @@ await sphere.payments.receive(undefined, (transfer) => {
 });
 ```
 
-### Register Nametag
+### Register Unicity ID
 
 > **Note:** `registerNametag()` mints a token on-chain. This uses the Oracle (Aggregator) provider which is included by default with `createNodeProviders()`.
 

--- a/docs/UNICITY-ID.md
+++ b/docs/UNICITY-ID.md
@@ -1,14 +1,16 @@
-# Nametags
+# Unicity IDs
 
-A **nametag** is a human‑readable handle (e.g. `@alice`) that people use to pay or message a wallet, instead of a long machine address. Each wallet can claim one per address.
+A **Unicity ID** is a human‑readable handle (e.g. `@alice`) that people use to pay or message a wallet, instead of a long machine address. Each wallet can claim one per address.
+
+> **In the SDK's API, a Unicity ID is called a `nametag`.** The method names, options, and events keep that word — `registerNametag()`, the `nametag` option, the `nametag:recovered` event, the `senderNametag` field. "Unicity ID" and `nametag` mean the same thing.
 
 Valid formats: lowercase alphanumeric with `_` or `-` (3–20 characters), or an E.164 phone number (e.g. `+14155552671`). Input is normalized to lowercase automatically.
 
-> **Testnet faucet requires a nametag.** Register one before requesting test tokens.
+> **Testnet faucet requires a Unicity ID.** Register one before requesting test tokens.
 
 > **Minting requires an aggregator API key** for proof verification. Configure it via the `oracle.apiKey` option when creating providers. Contact Unicity to obtain a key.
 
-## Registering a nametag
+## Registering a Unicity ID
 
 ```typescript
 // During wallet creation
@@ -21,14 +23,14 @@ const { sphere } = await Sphere.init({
 // Or after creation
 await sphere.registerNametag('alice');
 
-// Mint the on-chain nametag token (required to receive via PROXY addresses)
+// Mint the on-chain Unicity ID token (required to receive via PROXY addresses)
 const result = await sphere.mintNametag('alice');
 if (result.success) {
-  console.log('Nametag minted:', result.nametagData?.name);
+  console.log('Unicity ID minted:', result.nametagData?.name);
 }
 ```
 
-## Common pitfall: "nametag already taken"
+## Common pitfall: "Unicity ID already taken"
 
 If you see:
 
@@ -37,9 +39,9 @@ Failed to register nametag. It may already be taken.
 [NostrTransportProvider] Nametag already taken: myname - owner: f124f93ae6946ffd...
 ```
 
-…the nametag is registered to a **different public key**. The usual causes:
+…the Unicity ID is registered to a **different public key**. The usual causes:
 
-1. **Storage was cleared or isn't persisting.** `Sphere.exists()` returns `false`, so the SDK creates a *new* wallet with a new key — and the old key still owns the nametag on the relay.
+1. **Storage was cleared or isn't persisting.** `Sphere.exists()` returns `false`, so the SDK creates a *new* wallet with a new key — and the old key still owns the ID on the relay.
 2. **A different recovery phrase each run:**
    ```typescript
    // WRONG: a new random phrase every start
@@ -82,7 +84,7 @@ console.log('Wallet exists:', exists); // should be true after the first run
 
 ## Recovery on import
 
-When importing a wallet (from a phrase or file), the SDK automatically tries to recover the nametag from the relay:
+When importing a wallet (from a phrase or file), the SDK automatically tries to recover the Unicity ID from the relay:
 
 ```typescript
 const { sphere } = await Sphere.init({
@@ -92,15 +94,15 @@ const { sphere } = await Sphere.init({
 });
 
 sphere.on('nametag:recovered', (event) => {
-  console.log('Recovered nametag:', event.data.nametag);
+  console.log('Recovered Unicity ID:', event.data.nametag);
 });
 
 console.log(sphere.identity?.nametag); // set if recovered
 ```
 
-## Multi-address nametags
+## Multiple Unicity IDs (per address)
 
-Each derived address can have its own independent nametag:
+Each derived address can have its own independent Unicity ID:
 
 ```typescript
 await sphere.registerNametag('alice');      // address 0 → @alice
@@ -109,7 +111,7 @@ await sphere.switchToAddress(1);
 await sphere.registerNametag('bob');         // address 1 → @bob
 
 // getNametagForAddress takes an addressId (string), not an index:
-const addresses = sphere.getActiveAddresses();             // TrackedAddress[] with addressId + nametag
-sphere.getNametagForAddress(addresses[0].addressId); // 'alice'
-sphere.getNametagForAddress(addresses[1].addressId); // 'bob'
+const addresses = sphere.getActiveAddresses();        // TrackedAddress[] with addressId + Unicity ID
+sphere.getNametagForAddress(addresses[0].addressId);  // 'alice'
+sphere.getNametagForAddress(addresses[1].addressId);  // 'bob'
 ```

--- a/docs/WALLET-IMPORT-EXPORT.md
+++ b/docs/WALLET-IMPORT-EXPORT.md
@@ -1,0 +1,127 @@
+# Wallets: Create, Import, Export, Backup
+
+**`Sphere.init()` is the recommended entry point** — it creates a wallet if none exists, or loads the existing one, in a single call. `Sphere.create()`, `Sphere.load()`, and `Sphere.import()` are the lower‑level building blocks it calls; reach for them only when you need explicit control (you'll see `create`/`load` in some source docstrings, but prefer `init` in app code). This guide covers those lower‑level paths: manual create/load, importing from a recovery phrase or master key, JSON export/import, legacy wallet files, and backups.
+
+## Manual create / load
+
+```typescript
+import { Sphere } from '@unicitylabs/sphere-sdk';
+import {
+  createLocalStorageProvider,
+  createNostrTransportProvider,
+  createUnicityAggregatorProvider,
+} from '@unicitylabs/sphere-sdk/impl/browser';
+
+const storage   = createLocalStorageProvider();
+const transport = createNostrTransportProvider();
+const oracle    = createUnicityAggregatorProvider({ url: '/rpc' });
+
+if (await Sphere.exists(storage)) {
+  const sphere = await Sphere.load({ storage, transport, oracle });
+} else {
+  const mnemonic = Sphere.generateMnemonic();
+  const sphere = await Sphere.create({ mnemonic, storage, transport, oracle });
+  console.log('Save this recovery phrase:', mnemonic);
+}
+```
+
+## Import from a master key (legacy wallets)
+
+For compatibility with older wallet files:
+
+```typescript
+// BIP32 mode: master key + chain code
+const sphere = await Sphere.import({
+  masterKey: '64-hex-chars-master-private-key',
+  chainCode: '64-hex-chars-chain-code',
+  basePath: "m/84'/1'/0'",   // from a wallet.dat descriptor
+  derivationMode: 'bip32',
+  storage, transport, oracle,
+});
+
+// WIF HMAC mode: master key only
+const sphere = await Sphere.import({
+  masterKey: '64-hex-chars-master-private-key',
+  derivationMode: 'wif_hmac',
+  storage, transport, oracle,
+});
+```
+
+## Export / import as JSON
+
+```typescript
+// Export (optionally encrypted, optionally with multiple addresses)
+const json          = sphere.exportToJSON();
+const encryptedJson = sphere.exportToJSON({ password: 'user-password' });
+const multiJson     = sphere.exportToJSON({ addressCount: 5 });
+
+// Import
+const { success, mnemonic, error } = await Sphere.importFromJSON({
+  jsonContent: JSON.stringify(json),
+  password: 'user-password',  // if encrypted
+  storage, transport, oracle,
+});
+if (success && mnemonic) console.log('Recovered phrase:', mnemonic);
+```
+
+## Wallet info & backup
+
+```typescript
+const info = sphere.getWalletInfo();
+console.log(info.source);          // 'mnemonic' | 'file'
+console.log(info.hasMnemonic);
+console.log(info.derivationMode);
+console.log(info.basePath);
+
+const mnemonic = sphere.getMnemonic();   // for the user to back up, if available
+```
+
+## Import from legacy files (.dat, .txt)
+
+```typescript
+// wallet.dat (binary, possibly encrypted)
+const fileBuffer = await file.arrayBuffer();
+const result = await Sphere.importFromLegacyFile({
+  fileContent: new Uint8Array(fileBuffer),
+  fileName: 'wallet.dat',
+  password: 'wallet-password',  // if encrypted
+  onDecryptProgress: (i, total) => console.log(`Decrypting: ${i}/${total}`),
+  storage, transport, oracle,
+});
+
+if (result.needsPassword) {
+  // re-prompt the user for a password
+}
+if (result.success) {
+  console.log('Imported:', result.sphere.identity?.l1Address);
+}
+
+// text backup
+const textContent = await file.text();
+const r = await Sphere.importFromLegacyFile({
+  fileContent: textContent,
+  fileName: 'backup.txt',
+  storage, transport, oracle,
+});
+
+// detect type & encryption before importing
+Sphere.detectLegacyFileType(fileName, content);    // 'dat' | 'txt' | 'json' | 'mnemonic' | 'unknown'
+Sphere.isLegacyFileEncrypted(fileName, content);   // boolean
+```
+
+## Core utilities
+
+The SDK also exports common helpers:
+
+```typescript
+import {
+  bytesToHex, hexToBytes,
+  generateMnemonic, validateMnemonic,
+  sha256, ripemd160, hash160,
+  getPublicKey, createKeyPair, deriveAddressInfo,
+  toSmallestUnit, toHumanReadable, formatAmount,   // amount conversion
+  encodeBech32, decodeBech32, createAddress, isValidBech32,
+  base58Encode, base58Decode, isValidPrivateKey,
+  sleep, randomHex, randomUUID, findPattern, extractFromText,
+} from '@unicitylabs/sphere-sdk';
+```


### PR DESCRIPTION
Refactor the documentation so it leads with what the SDK *does* (a self-custody wallet: send tokens, message, request payments) instead of internal architecture terms. The root README drops from ~1450 to ~180 lines; everything else moves into focused, dedicated guides.

README.md
- New intro modeled on a clear, high-level "what you can build" style.
- Honest framing: non-custodial + no backend of your own to build. Removed the inaccurate "no server in the middle" claim — settlement runs on Unicity's network (acknowledged explicitly).
- Removed the L1/L3 jargon from the front door; it now lives in ARCHITECTURE.md. Added a 4-concept primer, common-task snippets, a glossary, and a "Going further" links table.
- Dropped the stale "Known Limitations / Wallet Encryption = future work" section (password encryption has shipped; now documented).

New ARCHITECTURE.md
- The technical home: identity model, the two networks (incl. L1/L3), transfer mechanics, TXF, transport, module map, dependency stack.
- Corrects a real error: the token (DIRECT://) address is NOT the same EC point as the chain/messaging key. SigningService.createFromSecret SHA-256-hashes the secret first, so there are two keypairs per address.

New docs/ guides (content relocated from README, nothing dropped):
- NAMETAGS, PAYMENT-REQUESTS, DIRECT-MESSAGES, GROUP-CHAT, L1-ALPHA, MULTI-ADDRESS, PROVIDERS-AND-CONFIG, WALLET-IMPORT-EXPORT.
- New IDENTITY-CRYPTO.md documents the low-level exports (key derivation, signMessage/verify/recover) and the raw-vs-hashed key footgun.
- PROVIDERS-AND-CONFIG adds browser-bundling caveats (Buffer/process polyfills) and a state-transition-sdk v1.6.1 version-compatibility note.

No secrets or internal infrastructure are disclosed (public service endpoints only).