### PR TITLE
fix(uxf)(#226): accept 64- or 68-char tokenId so invoice tokens ride UXF

### DIFF
--- a/tests/unit/uxf/ipld.test.ts
+++ b/tests/unit/uxf/ipld.test.ts
@@ -756,9 +756,13 @@ describe('importFromCar — manifest tokenId validation (FIX 6)', () => {
     expect(err.code).toBe('SERIALIZATION_ERROR');
   });
 
-  it('manifest with 65-char hex key is rejected', async () => {
+  it('manifest with wrong-length hex key is rejected', async () => {
+    // #226: the regex was relaxed from `{64}` to `{64,68}` so invoice
+    // tokenIds (imprint form, 68 chars) survive a round-trip through
+    // the CAR import. A length outside the [64, 68] range still gets
+    // rejected — 70 chars is the smallest unambiguous over-cap value.
     const fakeCid = CID.createV1(DAG_CBOR_CODE_TEST, makeSha256Digest(new Uint8Array(32)));
-    const car = await buildCarWithManifest({ ['ab'.repeat(32) + 'cd']: fakeCid });
+    const car = await buildCarWithManifest({ ['ab'.repeat(35)]: fakeCid }); // 70 chars
     let err: any;
     try {
       await importFromCar(car);

--- a/tests/unit/uxf/json.test.ts
+++ b/tests/unit/uxf/json.test.ts
@@ -475,8 +475,11 @@ describe('packageFromJson — manifest tokenId validation (FIX 6)', () => {
     expect(err.code).toBe('SERIALIZATION_ERROR');
   });
 
-  it('rejects 65-char hex tokenId', () => {
-    const json = makeMinimalJson({ ['ab'.repeat(32) + 'cd']: 'a'.repeat(64) });
+  it('rejects 69-char hex tokenId (above the 64-68 valid range, #226)', () => {
+    // #226 relaxed the regex from `{64}` to `{64,68}` so invoice
+    // tokenIds (imprint form, 68 chars) survive round-trip. Anything
+    // strictly outside [64, 68] is still rejected.
+    const json = makeMinimalJson({ ['ab'.repeat(34) + 'a']: 'a'.repeat(64) }); // 69 chars
     let err: any;
     try {
       packageFromJson(json);

--- a/uxf/deconstruct.ts
+++ b/uxf/deconstruct.ts
@@ -211,20 +211,29 @@ function validateToken(token: unknown): asserts token is TokenShape {
     throw new UxfError('INVALID_PACKAGE', 'Token must have a state field');
   }
 
-  // Steelman²⁸ note: assert genesis.data.tokenId is a non-empty 64-char
-  // lowercase hex string. Without this, malformed tokens silently coerce
-  // tokenId='' via lowerHex(null), producing manifest entries keyed by
-  // an empty string — hard to remove and prone to collision.
+  // Steelman²⁸ note: assert genesis.data.tokenId is a non-empty hex
+  // string. Without this, malformed tokens silently coerce tokenId=''
+  // via lowerHex(null), producing manifest entries keyed by an empty
+  // string — hard to remove and prone to collision.
+  //
+  // #226: accept BOTH 64-char (plain hash bytes — the historical coin
+  // token form, e.g. `new TokenId(await sha256(...))`) and 68-char
+  // (imprint form — algo marker prefix + hash bytes, e.g. `new TokenId(
+  // hash.imprint)` which the AccountingModule uses for invoice tokens).
+  // The receiver's importInvoice already accepts `/^[0-9a-f]{64,68}$/`;
+  // mirror that here so invoice tokens can ride UXF bundles without a
+  // sender-side normalization step. Coin tokens are unchanged (still
+  // 64-char).
   const genesis = obj.genesis as Record<string, unknown>;
   const data = genesis.data as Record<string, unknown> | undefined;
   if (!data || typeof data !== 'object') {
     throw new UxfError('INVALID_PACKAGE', 'Token genesis must have a data field');
   }
   const tokenId = data.tokenId;
-  if (typeof tokenId !== 'string' || !/^[0-9a-fA-F]{64}$/.test(tokenId)) {
+  if (typeof tokenId !== 'string' || !/^[0-9a-fA-F]{64,68}$/.test(tokenId)) {
     throw new UxfError(
       'INVALID_PACKAGE',
-      `Token genesis.data.tokenId must be 64-char hex, got ${typeof tokenId === 'string' ? `"${tokenId}"` : String(tokenId)}`,
+      `Token genesis.data.tokenId must be 64- or 68-char hex, got ${typeof tokenId === 'string' ? `"${tokenId}"` : String(tokenId)}`,
     );
   }
 }

--- a/uxf/ipld.ts
+++ b/uxf/ipld.ts
@@ -548,7 +548,10 @@ export async function importFromCar(car: Uint8Array): Promise<UxfPackageData> {
   }
   const tokens = new Map<string, ContentHash>();
   for (const [tokenId, cid] of manifestEntries) {
-    if (!/^[0-9a-f]{64}$/.test(tokenId)) {
+    // #226: accept 64-char (coin tokens) and 68-char (invoice tokens —
+    // imprint form). Mirrors deconstruct.ts:226 and json.ts manifest
+    // reader.
+    if (!/^[0-9a-f]{64,68}$/.test(tokenId)) {
       throw new UxfError(
         'SERIALIZATION_ERROR',
         `Invalid manifest tokenId: ${tokenId.slice(0, 32)}…`,

--- a/uxf/json.ts
+++ b/uxf/json.ts
@@ -424,7 +424,10 @@ export function packageFromJson(json: string): UxfPackageData {
     // ingest gate). The regex naturally rejects `__proto__`,
     // `constructor`, `prototype`, empty strings, non-hex unicode,
     // wrong-length keys.
-    if (!/^[0-9a-f]{64}$/.test(tokenId)) {
+    // #226: accept 64-char (coin tokens) and 68-char (invoice tokens —
+    // imprint form). Mirrors deconstruct.ts:226 and ipld.ts manifest
+    // reader. Lowercase-hex preserved.
+    if (!/^[0-9a-f]{64,68}$/.test(tokenId)) {
       throw new UxfError(
         'SERIALIZATION_ERROR',
         `Invalid manifest tokenId: ${tokenId.slice(0, 32)}…`,

--- a/uxf/types.ts
+++ b/uxf/types.ts
@@ -169,7 +169,7 @@ export interface UxfElement {
 // ---- Token Root ----
 
 export interface TokenRootContent {
-  readonly tokenId: string;   // 64-char hex
+  readonly tokenId: string;   // 64-char hex (coin tokens) or 68-char hex (invoice tokens — imprint form, #226)
   readonly version: string;   // e.g. "2.0"
 }
 
@@ -338,7 +338,7 @@ export interface TokenCoinDataContent {
  * The manifest is the entry point for reassembly.
  */
 export interface UxfManifest {
-  /** tokenId (64-char hex) -> ContentHash of the token-root element */
+  /** tokenId (64- or 68-char hex; see TokenRootContent.tokenId) -> ContentHash of the token-root element */
   readonly tokens: ReadonlyMap<string, ContentHash>;
 }
 


### PR DESCRIPTION
## Summary

- Invoice tokens mint with `new TokenId(hash.imprint)` (algo prefix + hash → 68-char hex); coin tokens use `new TokenId(sha256(...))` → 64-char hex. UXF rejected the 68-char form, so `accounting.deliverInvoice` (PR #226 SDK API) crashed on both sender ingest and receiver `fromCar`.
- Relax three UXF tokenId checks from `/^[0-9a-fA-F]{64}$/` → `/^[0-9a-fA-F]{64,68}$/` — same range `importInvoice` already trusts:
  - `uxf/deconstruct.ts` sender-side ingest gate
  - `uxf/json.ts` `packageFromJson` manifest reader
  - `uxf/ipld.ts` `importFromCar` manifest reader
- Tokens of either length now round-trip through `pkg.ingest → toCar → fromCar → pkg.assemble`. Coin tokens are unchanged (still 64-char).

## Test plan

- [x] All 7384 unit tests pass (`npx vitest run tests/unit`)
- [x] Updated `tests/unit/uxf/ipld.test.ts` and `tests/unit/uxf/json.test.ts` rejection cases to use lengths outside the new `[64, 68]` inclusive range (69 and 70 chars)
- [x] Live testnet manual test (`manual-test-full-recovery.sh` §C round-trip):
  - §C.1 Alice mints invoice (68-char `tokenId`)
  - §C.1b `sphere invoice deliver` ships inline `uxf-car` DM → `{ sent: 1, failed: 0 }`
  - §C.2 Bob's wallet finds the invoice in the local ledger and submits payment

## Why this is safe

- The empty-string / null-coercion / wrong-type guard rails the original `/^[0-9a-fA-F]{64}$/` was added for (steelman²⁸) are still in force — the new regex still rejects empty strings, non-hex characters, oversize keys, and `__proto__` / `constructor` / `prototype` strings.
- Receiver's `importInvoice` already accepts `[0-9a-f]{64,68}`, so this PR brings UXF in line with the established invoice contract rather than introducing a new one.
- Companion to `accounting.deliverInvoice` on `integration/all-fixes` (commit 90a5cc3). Cannot land without this PR.