### PR TITLE
fix(accounting)(#230): refresh invoiceTermsCache on sync:completed

### DIFF
--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -463,56 +463,11 @@ export class AccountingModule {
     // from TokenStorageProvider by PaymentsModule.load()). We filter by
     // INVOICE_TOKEN_TYPE_HEX, which is stored in genesis.data.tokenType.
     // ------------------------------------------------------------------
-    try {
-      const allTokens = deps.payments.getTokens();
-      for (const token of allTokens) {
-        if (!token.sdkData) continue;
-        try {
-          const txf = JSON.parse(token.sdkData) as TxfToken;
-          // Filter by invoice token type
-          const tokenType = txf.genesis?.data?.tokenType;
-          if (tokenType !== INVOICE_TOKEN_TYPE_HEX) continue;
-
-          const tokenData = txf.genesis?.data?.tokenData;
-          if (!tokenData) continue;
-
-          const rawTerms = this._parseInvoiceTerms(tokenData);
-          if (rawTerms) {
-            this.invoiceTermsCache.set(token.id, this._normalizeInvoiceTerms(rawTerms));
-          }
-        } catch (err) {
-          logger.warn(LOG_TAG, `Failed to parse invoice token ${token.id}:`, err);
-        }
-      }
-
-      // Also scan archived tokens (spec §5.4 Phase 2 step 5)
-      const archivedTokens = deps.payments.getArchivedTokens();
-      for (const [archivedId, txf] of archivedTokens) {
-        try {
-          const tokenType = txf.genesis?.data?.tokenType;
-          if (tokenType !== INVOICE_TOKEN_TYPE_HEX) continue;
-
-          const tokenData = txf.genesis?.data?.tokenData;
-          if (!tokenData) continue;
-
-          const rawTerms = this._parseInvoiceTerms(tokenData);
-          if (rawTerms) {
-            this.invoiceTermsCache.set(archivedId, this._normalizeInvoiceTerms(rawTerms));
-          }
-        } catch (err) {
-          logger.warn(LOG_TAG, `Failed to parse archived invoice token ${archivedId}:`, err);
-        }
-      }
-
-      // Build hash→ID index for privacy-preserving on-chain lookups
-      this._rebuildHashIndex();
-
-      if (this.config.debug) {
-        logger.debug(LOG_TAG, `Loaded ${this.invoiceTermsCache.size} invoice token(s), hash index: ${this.invoiceIdHashIndex.size}`);
-      }
-    } catch (err) {
-      logger.warn(LOG_TAG, 'Failed to enumerate tokens via PaymentsModule:', err);
-    }
+    // Initial scan: populate from scratch — every invoice token currently
+    // in the wallet's storage. No `invoice:created` is emitted here because
+    // this is post-restart cache rehydration, not new discovery (callers
+    // already saw those events when the invoices first arrived).
+    this._refreshInvoiceTermsCache({ emitForNew: false });
 
     // W16: destroyed check between major steps — prevents partial state population
     // if destroy() was called while _doLoad() is in progress.
@@ -4449,6 +4404,100 @@ export class AccountingModule {
   // ===========================================================================
 
   /**
+   * Scan PaymentsModule's live + archived token sets for INVOICE-typed
+   * tokens and populate `invoiceTermsCache` with any whose terms are
+   * parseable. Idempotent — existing entries are NOT overwritten (the
+   * cache is also a write-through surface for locally-minted /
+   * locally-imported invoices that may have additional state the
+   * on-disk genesis doesn't carry yet).
+   *
+   * Used by:
+   *   - `_doLoad()` to populate the cache at startup (`emitForNew: false`).
+   *   - The `sync:completed` subscriber to pick up invoice tokens that
+   *     a peer published to Profile/IPFS but never delivered via DM-TXF
+   *     (`emitForNew: true`). The §C.4 cross-device flow depends on this.
+   *
+   * Always rebuilds the hash→ID index at the end so the index stays in
+   * sync with the cache.
+   *
+   * @param opts.emitForNew  When true, fire `invoice:created` with
+   *                         `confirmed: false` for any invoiceId that
+   *                         was NOT already in the cache before this
+   *                         call (matches `importInvoice` semantics —
+   *                         externally-sourced invoices are
+   *                         "unconfirmed" until the caller validates).
+   * @returns The list of invoiceIds newly added by this call.
+   */
+  private _refreshInvoiceTermsCache(opts: { emitForNew: boolean }): string[] {
+    if (!this.deps) return [];
+    const deps = this.deps;
+    const newlyAdded: string[] = [];
+
+    const tryAdd = (id: string, tokenData: string): void => {
+      if (this.invoiceTermsCache.has(id)) return;
+      const rawTerms = this._parseInvoiceTerms(tokenData);
+      if (!rawTerms) return;
+      this.invoiceTermsCache.set(id, this._normalizeInvoiceTerms(rawTerms));
+      newlyAdded.push(id);
+    };
+
+    try {
+      const allTokens = deps.payments.getTokens();
+      for (const token of allTokens) {
+        if (!token.sdkData) continue;
+        try {
+          const txf = JSON.parse(token.sdkData) as TxfToken;
+          const tokenType = txf.genesis?.data?.tokenType;
+          if (tokenType !== INVOICE_TOKEN_TYPE_HEX) continue;
+          const tokenData = txf.genesis?.data?.tokenData;
+          if (!tokenData) continue;
+          tryAdd(token.id, tokenData);
+        } catch (err) {
+          logger.warn(LOG_TAG, `Failed to parse invoice token ${token.id}:`, err);
+        }
+      }
+
+      const archivedTokens = deps.payments.getArchivedTokens();
+      for (const [archivedId, txf] of archivedTokens) {
+        try {
+          const tokenType = txf.genesis?.data?.tokenType;
+          if (tokenType !== INVOICE_TOKEN_TYPE_HEX) continue;
+          const tokenData = txf.genesis?.data?.tokenData;
+          if (!tokenData) continue;
+          tryAdd(archivedId, tokenData);
+        } catch (err) {
+          logger.warn(LOG_TAG, `Failed to parse archived invoice token ${archivedId}:`, err);
+        }
+      }
+    } catch (err) {
+      logger.warn(LOG_TAG, 'Failed to enumerate tokens via PaymentsModule:', err);
+    }
+
+    // Always rebuild the hash index so it stays consistent with the cache.
+    this._rebuildHashIndex();
+
+    if (this.config.debug) {
+      logger.debug(
+        LOG_TAG,
+        `_refreshInvoiceTermsCache: cache=${this.invoiceTermsCache.size}, hashIndex=${this.invoiceIdHashIndex.size}, newlyAdded=${newlyAdded.length}`,
+      );
+    }
+
+    if (opts.emitForNew && newlyAdded.length > 0) {
+      for (const invoiceId of newlyAdded) {
+        // confirmed: false — matches `importInvoice` semantics for
+        // externally-sourced invoices. The sync provider's trust chain
+        // is stronger than DM-TXF in practice, but downstream
+        // consumers should still treat this as "needs payment-side
+        // attribution before any UI commits".
+        deps.emitEvent('invoice:created', { invoiceId, confirmed: false });
+      }
+    }
+
+    return newlyAdded;
+  }
+
+  /**
    * Rebuild the hash→invoiceId index from all known invoices.
    * Called after invoiceTermsCache is fully populated during load().
    */
@@ -5263,7 +5312,44 @@ export class AccountingModule {
       }
     });
 
-    this.unsubscribePayments = [unsubIncoming, unsubConfirmed, unsubHistory, unsubTokenChange];
+    // Refresh the invoice terms cache on every sync completion.
+    //
+    // `PaymentsModule.sync()` pulls new tokens from Profile/IPFS providers
+    // via `loadFromStorageData(result.merged)`, which intentionally
+    // BYPASSES `addToken()` — so the `onTokenChange` observer above
+    // never fires for sync-imported invoice tokens. Without this
+    // subscriber, an invoice that another peer minted + published to
+    // Profile (the §C.4 cross-device flow) never lands in
+    // `invoiceTermsCache`, and `getInvoiceStatus(invoiceId)` returns
+    // "No invoice found matching prefix" even though the token IS in
+    // the local store.
+    //
+    // The handler runs the same scan as `load()` but in idempotent
+    // mode: only new IDs are added, existing entries are preserved
+    // (they may carry write-through state from locally-minted invoices
+    // that the on-disk genesis doesn't reflect yet), and
+    // `invoice:created` fires once per newly-discovered ID with
+    // `confirmed: false`. See `_refreshInvoiceTermsCache` for details.
+    //
+    // Companion CLI fix: sphere-cli#24 routes `invoice-status` /
+    // `invoice-list` through `ensureSync(sphere, 'full')` so this
+    // listener actually has data to pick up.
+    const unsubSyncCompleted = deps.on('sync:completed', () => {
+      if (this.destroyed) return;
+      try {
+        this._refreshInvoiceTermsCache({ emitForNew: true });
+      } catch (err) {
+        logger.warn(LOG_TAG, 'Error refreshing invoice terms cache after sync:', err);
+      }
+    });
+
+    this.unsubscribePayments = [
+      unsubIncoming,
+      unsubConfirmed,
+      unsubHistory,
+      unsubTokenChange,
+      unsubSyncCompleted,
+    ];
   }
 
   // ===========================================================================

--- a/tests/unit/modules/AccountingModule.syncRefresh.test.ts
+++ b/tests/unit/modules/AccountingModule.syncRefresh.test.ts
@@ -1,0 +1,202 @@
+/**
+ * AccountingModule — invoiceTermsCache refresh on sync:completed (issue #230)
+ *
+ * `PaymentsModule.sync()` pulls new tokens from Profile/IPFS providers via
+ * `loadFromStorageData(result.merged)`, which intentionally bypasses
+ * `addToken()` — so the `onTokenChange` observer never fires for
+ * sync-imported invoice tokens. Without the `sync:completed` subscriber,
+ * cross-device invoice propagation (Alice mints on peer1, peer2 receives
+ * the invoice token via Profile sync) leaves `invoiceTermsCache` stale and
+ * `getInvoiceStatus(invoiceId)` returns "No invoice found".
+ *
+ * These tests pin:
+ *   1. New invoice tokens visible to PaymentsModule after sync ARE added
+ *      to the cache and fire `invoice:created` with `confirmed: false`.
+ *   2. Existing entries are NOT overwritten (the cache is also a
+ *      write-through surface for locally-minted invoices).
+ *   3. Already-cached IDs do NOT re-fire `invoice:created` on subsequent
+ *      sync events — idempotent refresh.
+ *   4. Non-invoice tokens (regular coin tokens) are ignored.
+ *
+ * @see https://github.com/unicity-sphere/sphere-sdk/issues/230
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createTestAccountingModule,
+  createTestToken,
+  INVOICE_TOKEN_TYPE_HEX,
+} from './accounting-test-helpers.js';
+import type { InvoiceTerms } from '../../../modules/accounting/types.js';
+import type { Token } from '../../../types/index.js';
+
+function makeTerms(suffix: string): InvoiceTerms {
+  return {
+    createdAt: Date.now(),
+    targets: [
+      {
+        address: `DIRECT://target_${suffix}`,
+        assets: [{ coin: ['UCT', '10000000'] }],
+      },
+    ],
+    memo: `invoice-${suffix}`,
+  };
+}
+
+function makeInvoiceUiToken(terms: InvoiceTerms): { id: string; uiToken: Token } {
+  const txf = createTestToken(terms);
+  const id = txf.genesis.data.tokenId;
+  return {
+    id,
+    uiToken: {
+      id,
+      coinId: INVOICE_TOKEN_TYPE_HEX,
+      symbol: 'INVOICE',
+      name: 'Invoice',
+      decimals: 0,
+      amount: '0',
+      status: 'confirmed',
+      createdAt: terms.createdAt!,
+      updatedAt: terms.createdAt!,
+      sdkData: JSON.stringify(txf),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+  };
+}
+
+describe('AccountingModule — sync:completed refreshes invoiceTermsCache (#230)', () => {
+  let module: ReturnType<typeof createTestAccountingModule>['module'];
+  let mocks: ReturnType<typeof createTestAccountingModule>['mocks'];
+  let emitEvent: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const built = createTestAccountingModule();
+    module = built.module;
+    mocks = built.mocks;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    await module.load();
+  });
+
+  afterEach(() => {
+    try {
+      module.destroy();
+    } catch {
+      /* ignore */
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('adds sync-discovered invoice tokens to the cache and fires invoice:created', async () => {
+    // Cache starts empty (no invoice tokens at load time).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = (module as any).invoiceTermsCache as Map<string, InvoiceTerms>;
+    expect(cache.size).toBe(0);
+
+    // Simulate sync pulling in a new invoice token from Profile/IPFS.
+    const { id, uiToken } = makeInvoiceUiToken(makeTerms('peer1'));
+    mocks.payments._tokens.push(uiToken);
+
+    emitEvent.mockClear();
+    mocks.payments._emit('sync:completed', { source: 'payments', count: 1 });
+
+    // The handler is synchronous w.r.t. its impact on the cache.
+    expect(cache.has(id)).toBe(true);
+    expect(cache.get(id)!.memo).toBe('invoice-peer1');
+    expect(emitEvent).toHaveBeenCalledWith(
+      'invoice:created',
+      { invoiceId: id, confirmed: false },
+    );
+  });
+
+  it('does not re-emit invoice:created for an already-cached invoice on a second sync', async () => {
+    const { uiToken } = makeInvoiceUiToken(makeTerms('peer1'));
+    mocks.payments._tokens.push(uiToken);
+
+    // First sync — discovery + emit.
+    mocks.payments._emit('sync:completed', { source: 'payments', count: 1 });
+
+    emitEvent.mockClear();
+
+    // Second sync — same token still present, no new event.
+    mocks.payments._emit('sync:completed', { source: 'payments', count: 1 });
+
+    const created = emitEvent.mock.calls.filter(([evt]) => evt === 'invoice:created');
+    expect(created).toHaveLength(0);
+  });
+
+  it('does not overwrite existing cache entries (locally-minted invoices keep their terms)', async () => {
+    // Pre-seed the cache as if createInvoice() had just minted it — the
+    // terms here are NOT what the on-disk token genesis would parse to,
+    // so an overwrite would be observable.
+    const localTerms = makeTerms('local');
+    localTerms.memo = 'LOCAL_WRITE_THROUGH';
+
+    const { id, uiToken } = makeInvoiceUiToken(makeTerms('peer1'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (module as any).invoiceTermsCache.set(id, localTerms);
+
+    // Now make PaymentsModule report the on-disk version (memo = invoice-peer1).
+    mocks.payments._tokens.push(uiToken);
+
+    emitEvent.mockClear();
+    mocks.payments._emit('sync:completed', { source: 'payments', count: 1 });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = (module as any).invoiceTermsCache as Map<string, InvoiceTerms>;
+    expect(cache.get(id)!.memo).toBe('LOCAL_WRITE_THROUGH');
+
+    // And no `invoice:created` fires because the ID was already in the cache.
+    const created = emitEvent.mock.calls.filter(([evt]) => evt === 'invoice:created');
+    expect(created).toHaveLength(0);
+  });
+
+  it('ignores non-invoice tokens during the post-sync refresh', async () => {
+    const coinToken: Token = {
+      id: 'a'.repeat(64),
+      coinId: 'UCT', // NOT INVOICE_TOKEN_TYPE_HEX
+      symbol: 'UCT',
+      name: 'Unicity Coin',
+      decimals: 8,
+      amount: '100000000',
+      status: 'confirmed',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData: JSON.stringify({
+        genesis: {
+          data: {
+            tokenId: 'a'.repeat(64),
+            tokenType: 'deadbeef', // arbitrary non-invoice type
+            tokenData: '',
+          },
+        },
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    mocks.payments._tokens.push(coinToken);
+
+    emitEvent.mockClear();
+    mocks.payments._emit('sync:completed', { source: 'payments', count: 1 });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = (module as any).invoiceTermsCache as Map<string, InvoiceTerms>;
+    expect(cache.size).toBe(0);
+
+    const created = emitEvent.mock.calls.filter(([evt]) => evt === 'invoice:created');
+    expect(created).toHaveLength(0);
+  });
+
+  it('rebuilds the hash index so resolveInvoiceRef can find the new invoice', async () => {
+    const { id, uiToken } = makeInvoiceUiToken(makeTerms('peer1'));
+    mocks.payments._tokens.push(uiToken);
+
+    mocks.payments._emit('sync:completed', { source: 'payments', count: 1 });
+
+    // Hash index should include the new ID. Look it up via resolveInvoiceRef
+    // by computing the SHA-256 of the invoice id ourselves.
+    const { hashInvoiceId } = await import('../../../modules/accounting/memo.js');
+    const hash = hashInvoiceId(id);
+
+    expect(module.resolveInvoiceRef(hash)).toBe(id);
+  });
+});


### PR DESCRIPTION
## Summary

After a peer publishes a paid invoice's terms to IPFS (via Profile pointer) and another device receives the payment via Nostr, the receiver's local `AccountingModule.invoiceTermsCache` is NOT refreshed. Calling `sphere.accounting.getInvoiceStatus(invoiceId)` returned the invoice as unknown — even though the payment landed and `transfer:incoming` fired.

The root cause: `PaymentsModule.sync()` calls `loadFromStorageData(result.merged)` which intentionally **bypasses** `addToken()`. So the `onTokenChange` observer that AccountingModule already uses for inline indexing never fires for sync-imported invoice tokens.

## What this PR does

- Extracts the load()-time invoice scan into a reusable `_refreshInvoiceTermsCache({ emitForNew })` helper.
- Wires `sync:completed` → `_refreshInvoiceTermsCache({ emitForNew: true })` in `_subscribeToPaymentsEvents()`. The handler:
  - Is **idempotent** — existing cache entries are preserved (the cache is also a write-through surface for locally-minted invoices that may carry state the on-disk genesis doesn't reflect yet).
  - Fires `invoice:created` with `confirmed: false` (matches `importInvoice` semantics — externally sourced) once per newly-discovered ID.
  - Always rebuilds the hash→ID index so `resolveInvoiceRef()` picks up sync-discovered invoices for privacy-preserving on-chain memo lookups.

## Tests

New file: `tests/unit/modules/AccountingModule.syncRefresh.test.ts` (5 tests, all passing):

1. Adds sync-discovered tokens and fires `invoice:created`
2. Does not re-emit on a second sync for already-cached invoices (idempotency)
3. Does not overwrite existing entries (locally-minted preserved)
4. Ignores non-invoice tokens
5. Rebuilds hash index so `resolveInvoiceRef` finds sync-discovered IDs

Full suite: **7966 passed | 13 skipped** — no regression.

## Companion CLI fix

sphere-cli#24 already routes `invoice-status` / `invoice-list` through `ensureSync(sphere, 'full')` (was incorrectly `'nostr'`). Both fixes are required for the full §C.4 cross-device flow to work end-to-end:

- Without the CLI fix: `invoice-status` skips the IPFS pull, so this SDK listener has nothing to pick up.
- Without this SDK fix: even when the CLI does pull IPFS data, the cache doesn't refresh.

## Adversarial self-review

- **Race: sync:completed during destroy()** → handler guards with `if (this.destroyed) return;` and `deps` is never nulled, so the call is safe.
- **Race: sync:completed during load()** → subscribe happens AFTER initial cache scan (load step 9). If sync fires before subscribe, no handler is registered. If it fires after, the cache is fully populated and the diff is correct.
- **Concurrent sync events** → handler is synchronous; Node's event loop serializes. No interleave.
- **Same invoice in live + archived tokens** → `tryAdd` short-circuits on the second occurrence (already in cache). Correct.
- **Performance** → O(N) per sync, but JSON.parse + tokenType filter is cheap and sync events aren't high-frequency. Acceptable.
- **Memory leak** → unsubscribe added to `this.unsubscribePayments`, cleaned up in destroy().

Closes #230.