### PR TITLE
fix(payments)(#231): classify V6-RECOVER InvalidJsonStructureError as permanent

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -294,6 +294,7 @@ import { MintCommitment } from '@unicitylabs/state-transition-sdk/lib/transactio
 import { MintTransactionData } from '@unicitylabs/state-transition-sdk/lib/transaction/MintTransactionData';
 import { waitInclusionProof } from '@unicitylabs/state-transition-sdk/lib/util/InclusionProofUtils';
 import { InclusionProof } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof';
+import { InvalidJsonStructureError } from '@unicitylabs/state-transition-sdk/lib/InvalidJsonStructureError';
 import { TransferTransactionData } from '@unicitylabs/state-transition-sdk/lib/transaction/TransferTransactionData';
 import { RequestId } from '@unicitylabs/state-transition-sdk/lib/api/RequestId';
 import { Authenticator } from '@unicitylabs/state-transition-sdk/lib/api/Authenticator';
@@ -9191,6 +9192,113 @@ export class PaymentsModule {
 
       logger.debug('Payments', `[V6-RECOVER] Finalized stranded receive ${tokenId.slice(0, 12)} → confirmed`);
     } catch (err) {
+      // Classify the error: structural / parse-shape failures cannot be
+      // fixed by retry — the on-disk `lastTxJson` or the aggregator
+      // `proofJson` is malformed in a way that no amount of re-polling
+      // changes. Without classification, V6-RECOVER would re-register the
+      // job on every process restart (via `recoverStrandedReceivedTokens`)
+      // and spam the operator with a non-converging error every cycle.
+      //
+      // Permanent failure handling:
+      //   1. Mark the token as 'invalid' so `recoverStrandedReceivedTokens`
+      //      doesn't re-pick it up on next load.
+      //   2. Remove any live proof-polling job for this token.
+      //   3. Emit `transfer:operator-alert` with code `structural`
+      //      (canonical disposition reason for parse-shape failures).
+      //   4. Log the shape of `lastTxJson` and `proofJson` at debug level
+      //      so SDK developers can diagnose the underlying SDK
+      //      `InclusionProof.fromJSON` / `TransferTransaction.fromJSON`
+      //      mismatch. Only top-level keys are logged — full payloads
+      //      may contain large authenticator bytes we don't need to dump.
+      //
+      // Issue: sphere-sdk#231.
+      const isPermanent = err instanceof InvalidJsonStructureError ||
+        (err as { name?: string } | null)?.name === 'InvalidJsonStructureError';
+
+      if (isPermanent) {
+        logger.error(
+          'Payments',
+          `[V6-RECOVER] Stranded receive ${tokenId.slice(0, 12)} hit permanent structural failure (no retry):`,
+          err,
+        );
+
+        // One-shot diagnostic dump so the SDK-level shape can be inspected.
+        // Top-level keys only — full bodies can carry large fields (proofs,
+        // authenticators) that aren't necessary for SDK-error triage.
+        try {
+          const job = this.proofPollingJobs.get(tokenId);
+          let proofShape: string[] | string = 'not-fetched';
+          if (job) {
+            try {
+              const proof = await this.deps!.oracle.getProof(job.requestIdHex);
+              if (proof) {
+                const proofWithToJson = proof as { toJSON?: () => unknown };
+                const pj = typeof proofWithToJson.toJSON === 'function'
+                  ? proofWithToJson.toJSON()
+                  : proof;
+                proofShape = pj && typeof pj === 'object'
+                  ? Object.keys(pj as Record<string, unknown>)
+                  : `non-object:${typeof pj}`;
+              } else {
+                proofShape = 'null';
+              }
+            } catch (fetchErr) {
+              proofShape = `fetch-threw:${(fetchErr as Error)?.message ?? fetchErr}`;
+            }
+          }
+          const lastTxKeys = lastTxJson && typeof lastTxJson === 'object'
+            ? Object.keys(lastTxJson)
+            : `non-object:${typeof lastTxJson}`;
+          logger.debug(
+            'Payments',
+            `[V6-RECOVER] ${tokenId.slice(0, 12)} diagnostic shapes: lastTxJsonKeys=${JSON.stringify(lastTxKeys)} proofKeys=${JSON.stringify(proofShape)}`,
+          );
+        } catch (diagErr) {
+          logger.debug('Payments', `[V6-RECOVER] ${tokenId.slice(0, 12)} diagnostic dump itself threw:`, diagErr);
+        }
+
+        // 1. Mark the token as invalid so subsequent load() runs skip it.
+        const token = this.tokens.get(tokenId);
+        if (token && (token.status === 'pending' || token.status === 'submitted')) {
+          token.status = 'invalid';
+          token.updatedAt = Date.now();
+          this.tokens.set(tokenId, token);
+          try {
+            await this.save();
+          } catch (saveErr) {
+            logger.warn('Payments', `[V6-RECOVER] Failed to persist invalid status for ${tokenId.slice(0, 12)}:`, saveErr);
+          }
+        }
+
+        // 2. Remove the proof-polling job and persist the change.
+        this.proofPollingJobs.delete(tokenId);
+        this.saveProofPollingJobs().catch((persistErr) =>
+          logger.debug('Payments', `[V6-RECOVER] saveProofPollingJobs after permanent-fail mark failed:`, persistErr),
+        );
+
+        // 3. Surface to operator/UI via the canonical `structural`
+        //    disposition reason — parse-shape failure that no retry fixes.
+        try {
+          this.deps!.emitEvent('transfer:operator-alert', {
+            code: 'structural',
+            tokenId,
+            message: sanitizeReasonString(
+              `Token ${tokenId.slice(0, 12)}... cannot be finalized: ` +
+              `${(err as Error)?.message ?? 'InvalidJsonStructureError'}. ` +
+              `The stored last-transaction JSON or the aggregator proof has an unexpected shape. ` +
+              `Marked invalid; no further automatic recovery attempts will run for this token. ` +
+              `Manual diagnosis required — see debug logs for the shape dump.`,
+            ),
+          });
+        } catch { /* event emitter not wired */ }
+
+        return;
+      }
+
+      // Non-structural error — keep current behaviour (log, return,
+      // let the next polling tick retry). The polling tick's
+      // PROOF_POLLING_MAX_ATTEMPTS cap eventually marks the token
+      // invalid if the transient never resolves.
       logger.error('Payments', `[V6-RECOVER] Failed to finalize stranded receive ${tokenId.slice(0, 12)}:`, err);
     }
   }

--- a/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
+++ b/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
@@ -841,6 +841,158 @@ describe('#144 L3 — balance-model invariant + stranded recovery', () => {
     const recovered = await internals(module).recoverStrandedReceivedTokens();
     expect(recovered).toBe(0);
   });
+
+  // Issue #231 — finalizeStrandedReceivedToken hit InvalidJsonStructureError
+  // from TransferTransaction.fromJSON every sync cycle without ever
+  // converging or marking the token invalid. Pre-fix the error was caught
+  // and swallowed (returned normally), so the resolveUnconfirmed path
+  // deleted the job, but the token stayed 'pending' — letting the next
+  // load's `recoverStrandedReceivedTokens` re-register the job and produce
+  // the same error indefinitely.
+  it('finalizeStrandedReceivedToken classifies InvalidJsonStructureError as permanent and stops retrying (issue #231)', async () => {
+    // Set up a stranded V6-direct receive in 'pending' status.
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    // Oracle returns a (malformed-looking) proof — the value itself
+    // doesn't matter because the SDK mock throws.
+    (setup.deps.oracle as { getProof: ReturnType<typeof vi.fn> }).getProof =
+      vi.fn().mockResolvedValue({ toJSON: () => ({ malformed: 'shape' }) });
+
+    // Make TransferTransaction.fromJSON throw the exact SDK error class
+    // the bug surfaces. The mock is reset after the test.
+    const sdkErrMod = await import(
+      '@unicitylabs/state-transition-sdk/lib/InvalidJsonStructureError'
+    );
+    const InvalidJsonStructureError = sdkErrMod.InvalidJsonStructureError;
+    const ttMod = await import(
+      '@unicitylabs/state-transition-sdk/lib/transaction/TransferTransaction'
+    );
+    const prior = ttMod.TransferTransaction.fromJSON;
+    (ttMod.TransferTransaction.fromJSON as unknown as ReturnType<typeof vi.fn>) = vi
+      .fn()
+      .mockRejectedValue(new InvalidJsonStructureError());
+
+    try {
+      // Register a recovery job and invoke the private finalize directly.
+      const lastTxJson = { previousStateHash: STATE_HASH, predicate: 'pred2', data: {} };
+      const sourceTokenJson = JSON.stringify({ genesis: { data: { tokenId: GENESIS_TOKEN_ID } } });
+      internals(module).proofPollingJobs.set(GENESIS_TOKEN_ID, {
+        tokenId: GENESIS_TOKEN_ID,
+        requestIdHex: '00deadbeef',
+        commitmentJson: '',
+        sourceTokenJson,
+        startedAt: Date.now(),
+        attemptCount: 0,
+        lastAttemptAt: 0,
+      });
+
+      await (module as unknown as {
+        finalizeStrandedReceivedToken: (
+          tokenId: string,
+          sourceTokenJson: string,
+          lastTxJson: Record<string, unknown>,
+        ) => Promise<void>;
+      }).finalizeStrandedReceivedToken(GENESIS_TOKEN_ID, sourceTokenJson, lastTxJson);
+
+      // 1. Token marked invalid — recoverStrandedReceivedTokens (which
+      //    only re-picks tokens at status='pending') will now skip it.
+      expect(internals(module).tokens.get(GENESIS_TOKEN_ID)?.status).toBe('invalid');
+
+      // 2. Job removed — no further polling-tick retries.
+      expect(internals(module).proofPollingJobs.has(GENESIS_TOKEN_ID)).toBe(false);
+
+      // 3. Operator alert fired with the structural disposition reason.
+      const alerts = setup.emittedEvents.filter(
+        (e) => e.type === 'transfer:operator-alert',
+      );
+      expect(alerts.length).toBeGreaterThanOrEqual(1);
+      const alert = alerts[alerts.length - 1].payload as {
+        code: string;
+        tokenId: string;
+        message: string;
+      };
+      expect(alert.code).toBe('structural');
+      expect(alert.tokenId).toBe(GENESIS_TOKEN_ID);
+      expect(alert.message).toContain('cannot be finalized');
+    } finally {
+      (ttMod.TransferTransaction.fromJSON as unknown as ReturnType<typeof vi.fn>) = prior as never;
+    }
+  });
+
+  it('finalizeStrandedReceivedToken keeps non-structural errors transient (existing behaviour)', async () => {
+    // A garden-variety throw (network blip, oracle reject) should NOT
+    // trip the permanent-fail path: the token must remain at 'pending'
+    // and the job stays in the queue for the next poll tick.
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    (setup.deps.oracle as { getProof: ReturnType<typeof vi.fn> }).getProof =
+      vi.fn().mockResolvedValue({ toJSON: () => ({ ok: 'shape' }) });
+
+    const ttMod = await import(
+      '@unicitylabs/state-transition-sdk/lib/transaction/TransferTransaction'
+    );
+    const prior = ttMod.TransferTransaction.fromJSON;
+    (ttMod.TransferTransaction.fromJSON as unknown as ReturnType<typeof vi.fn>) = vi
+      .fn()
+      .mockRejectedValue(new Error('Transient network blip'));
+
+    try {
+      const lastTxJson = { previousStateHash: STATE_HASH, predicate: 'pred2', data: {} };
+      const sourceTokenJson = JSON.stringify({ genesis: { data: { tokenId: GENESIS_TOKEN_ID } } });
+      internals(module).proofPollingJobs.set(GENESIS_TOKEN_ID, {
+        tokenId: GENESIS_TOKEN_ID,
+        requestIdHex: '00deadbeef',
+        commitmentJson: '',
+        sourceTokenJson,
+        startedAt: Date.now(),
+        attemptCount: 0,
+        lastAttemptAt: 0,
+      });
+
+      await (module as unknown as {
+        finalizeStrandedReceivedToken: (
+          tokenId: string,
+          sourceTokenJson: string,
+          lastTxJson: Record<string, unknown>,
+        ) => Promise<void>;
+      }).finalizeStrandedReceivedToken(GENESIS_TOKEN_ID, sourceTokenJson, lastTxJson);
+
+      // Status stays pending — caller's polling tick / cumulative-cap
+      // mechanism eventually marks it invalid.
+      expect(internals(module).tokens.get(GENESIS_TOKEN_ID)?.status).toBe('pending');
+      // Job stays for retry — this code path does NOT delete the job.
+      expect(internals(module).proofPollingJobs.has(GENESIS_TOKEN_ID)).toBe(true);
+      // No operator alert from the transient path.
+      const alerts = setup.emittedEvents.filter(
+        (e) => e.type === 'transfer:operator-alert',
+      );
+      expect(alerts.length).toBe(0);
+    } finally {
+      (ttMod.TransferTransaction.fromJSON as unknown as ReturnType<typeof vi.fn>) = prior as never;
+    }
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

`PaymentsModule.finalizeStrandedReceivedToken` threw `InvalidJsonStructureError` from `TransferTransaction.fromJSON` when the on-disk `lastTxJson` or the aggregator proof shape was malformed. The catch block swallowed the error and returned normally — so the polling tick / resolveUnconfirmed paths cleaned up the live job, but the token stayed at `status='pending'`.

On every subsequent process restart, `recoverStrandedReceivedTokens` re-registered the job and the same error fired again — a non-converging zombie loop that spammed operator dashboards on every sync cycle.

## What this PR does

In the catch block of `finalizeStrandedReceivedToken`:

- **Classify** the error: `err instanceof InvalidJsonStructureError` (plus a defensive `err.name === 'InvalidJsonStructureError'` fallback for wrapped instances).
- **On permanent failure**:
  1. Mark the token `'invalid'` so subsequent `recoverStrandedReceivedTokens` loads skip it (the scan only picks `'pending'`).
  2. Remove the proof-polling job from in-memory and persisted maps so the polling tick stops re-firing.
  3. Emit `transfer:operator-alert` with `code='structural'` — the canonical disposition reason for parse-shape failures. Operators get a single surfaced signal instead of a flood of duplicate error logs.
  4. Dump the top-level keys of `lastTxJson` and the re-fetched `proofJson` at debug level so SDK developers can diagnose the underlying `InclusionProof.fromJSON` / `TransferTransaction.fromJSON` mismatch. Top-level keys only — full payloads carry large authenticator bytes that aren't useful for triage.
- **On non-structural errors**: keep current behaviour (log, return, let the next polling tick retry; `PROOF_POLLING_MAX_ATTEMPTS` cap eventually marks invalid if the transient never resolves).

## Tests (2 new in `PaymentsModule.proof-polling-persistence.test.ts`)

1. `InvalidJsonStructureError` → token marked `invalid`, job removed from `proofPollingJobs`, `transfer:operator-alert` fires with `code='structural'`, `tokenId` attached, message contains \"cannot be finalized\".
2. Generic `Error` → token stays `pending`, job stays in the queue for retry, no operator alert (existing behaviour preserved).

Full suite: **7963 passed | 13 skipped**. (`tests/integration/nametag-overwrite-guard.test.ts` showed 2 transient failures on first run, all passed on isolated re-run — known flake unrelated to this change.)

## Adversarial self-review

- **Race: status already 'confirmed' or 'spent'** — guarded by `if (token && (token.status === 'pending' || token.status === 'submitted'))`. No downgrade.
- **Race: token removed** — same guard short-circuits cleanly.
- **Diagnostic dump re-fetches proof** — could differ from the original; acceptable since we're not making decisions on it, just dumping shape for triage.
- **Diagnostic dump throws** — wrapped in try/catch, falls through to status update.
- **save() throws** — wrapped in try/catch with warn. Token stays invalid in-memory; next load may re-pick. Acceptable degradation.
- **Iterator mutation** — `proofPollingJobs.delete(tokenId)` inside `for (const [tokenId, job] of this.proofPollingJobs)` of the polling tick is safe per spec (deleting current entry doesn't break advance).
- **Double-delete** — polling tick's post-loop tries to delete the same tokenId; `Map.delete` of a missing key returns `false` silently.
- **Wrapped InvalidJsonStructureError** — `instanceof` won't catch wrapped instances; the `name` fallback covers the common subclass case. Acceptable; can be extended if needed.

## Companion fixes already in flight

- sphere-cli #24 (PR #26) — routes `invoice-status`/`invoice-list` through `ensureSync(sphere, 'full')`.
- sphere-sdk #230 (PR #232) — refreshes `invoiceTermsCache` on `sync:completed`.

This PR closes out the §C.4 manual-test triage triplet from issue #223.

Closes #231.