### PR TITLE
fix(profile)(#234): destroy ordering — partial fix + diagnostic test

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -4519,10 +4519,22 @@ export class Sphere {
     }
 
     await this._transport.disconnect();
-    await this._storage.disconnect();
-    await this._oracle.disconnect();
 
-    // Shutdown original token storage providers (close IndexedDB connections etc.)
+    // Issue #234 (shutdown ordering): shutdown token storage providers
+    // BEFORE disconnecting the KV storage. ProfileTokenStorageProvider
+    // shares its OrbitDbAdapter instance with ProfileStorageProvider
+    // (see profile/factory.ts:427); the token provider's shutdown-time
+    // flush writes the bundle CID via bundleIndex.addBundle ->
+    // db.putEntry on that shared adapter. If _storage.disconnect()
+    // runs first, the put throws PROFILE_NOT_INITIALIZED, the flush
+    // throws, the aggregator pointer publish is skipped, and the
+    // just-pinned CAR is orphaned. Note: this races a SECOND failure
+    // mode tracked under #234 — IPFS gateway propagation lag, where
+    // even a successful flush leaves the next process's load() unable
+    // to fetch the CAR until the gateways catch up. This reorder is
+    // necessary but NOT sufficient to fix the manual-test failure;
+    // the IPFS propagation fix (e.g., persist CAR blocks to the local
+    // Helia blockstore) is recommended as a follow-up.
     for (const provider of this._tokenStorageProviders.values()) {
       try {
         await provider.shutdown();
@@ -4531,6 +4543,9 @@ export class Sphere {
       }
     }
     this._tokenStorageProviders.clear();
+
+    await this._storage.disconnect();
+    await this._oracle.disconnect();
 
     this._initialized = false;
     this._trackedAddressesLoaded = false;

--- a/tests/e2e/profile-invoice-durability-234.test.ts
+++ b/tests/e2e/profile-invoice-durability-234.test.ts
@@ -1,0 +1,168 @@
+/**
+ * E2E Test: Profile (OrbitDB) Invoice Token Durability — Issue #234
+ *
+ * Reproduces the failure mode from `manual-test-full-recovery.sh §C.1b`:
+ * an invoice token minted in one process is not visible to the next
+ * process started on the same wallet/dataDir.
+ *
+ * The test verifies that the invoice token survives a destroy()+recreate
+ * cycle on the same dataDir+tokensDir. The cross-process variant in the
+ * manual-test script exercises the same SDK durability surface — both
+ * paths share the same Profile flush/load semantics.
+ *
+ * Diagnostic findings while building this test (recorded inline as
+ * comments for future operators):
+ *
+ *   - The mint succeeds; PaymentsModule.addToken writes the invoice
+ *     into ProfileTokenStorageProvider.pendingData.
+ *   - The flush succeeds: the CAR is pinned via HTTP to the configured
+ *     IPFS gateways and the bundle CID is written to the shared
+ *     OrbitDbAdapter via bundleIndex.addBundle.
+ *   - The bundle CID PERSISTS in OrbitDB across destroy/restart.
+ *   - **But** the next process's load() resolves that CID through
+ *     IPFS HTTP gateways, and the gateways have not yet propagated the
+ *     just-pinned blocks — fetch returns "not found", the bundle merges
+ *     0 tokens, and the invoice is silently absent.
+ *
+ *   The 15-second wait below buffers gateway propagation. Without it
+ *   the test fails reliably (Phase 2 sees 0 tokens). With it the test
+ *   passes — proving the durability path works once propagation has
+ *   caught up.
+ *
+ * Required infra: aggregator (L3 mint) + ipfs (Profile CAR pin).
+ *
+ * Run with: `npm run test:e2e`.
+ */
+
+import { describe, it, expect, afterAll } from 'vitest';
+import { rmSync } from 'node:fs';
+import { Sphere } from '../../core/Sphere';
+import { makeTempDirs, ensureTrustbase } from './helpers';
+import { makeProfileProviders, unwrapProfileProviders } from './profile-helpers';
+import { preflightSkip } from './lib/preflight';
+
+const SKIP_INFRA = preflightSkip(
+  ['aggregator', 'ipfs'],
+  'profile-invoice-durability-234',
+);
+
+describe.skipIf(SKIP_INFRA)(
+  'Profile (OrbitDB) Invoice Token Durability — Issue #234',
+  () => {
+    const cleanupDirs: string[] = [];
+    const spheres: Sphere[] = [];
+
+    afterAll(async () => {
+      for (const s of spheres) {
+        try {
+          await s.destroy();
+        } catch {
+          /* cleanup */
+        }
+      }
+      spheres.length = 0;
+      for (const d of cleanupDirs) {
+        try {
+          rmSync(d, { recursive: true, force: true });
+        } catch {
+          /* cleanup */
+        }
+      }
+      cleanupDirs.length = 0;
+    });
+
+    it('invoice token minted then destroy()ed survives re-init on same dirs', async () => {
+      const dirs = makeTempDirs('issue-234-durability');
+      cleanupDirs.push(dirs.base);
+      await ensureTrustbase(dirs.dataDir);
+
+      // ---------------- Phase 1: mint invoice + destroy ----------------
+      // Suppress auto-flush so awaitNextFlush below drives the exact
+      // moment of CAR pin + OrbitDB ref-write.
+      const providersA = makeProfileProviders(dirs, { flushDebounceMs: 300_000 });
+      console.log('\n[Issue #234] Phase 1: init wallet with accounting...');
+      const initResult = await Sphere.init({
+        ...providersA,
+        autoGenerate: true,
+        accounting: true,
+      });
+      const sphereA = initResult.sphere;
+      spheres.push(sphereA);
+      expect(initResult.created).toBe(true);
+      expect(initResult.generatedMnemonic).toBeTruthy();
+      const mnemonic = initResult.generatedMnemonic!;
+      const directAddress = sphereA.identity!.directAddress!;
+      console.log(`  Wallet A: ${sphereA.identity!.l1Address}`);
+
+      console.log('  Minting invoice for 11000000 UCT to self...');
+      const invResult = await sphereA.accounting!.createInvoice({
+        targets: [
+          {
+            address: directAddress,
+            assets: [{ coin: ['UCT', '11000000'] }],
+          },
+        ],
+        memo: 'issue-234 cross-process durability repro',
+      });
+      expect(invResult.success).toBe(true);
+      expect(invResult.invoiceId).toBeTruthy();
+      const invoiceId = invResult.invoiceId!;
+      console.log(`  Minted invoice: ${invoiceId}`);
+
+      const tokensBeforeDestroy = sphereA.payments.getTokens();
+      expect(
+        tokensBeforeDestroy.some((t) => t.id === invoiceId),
+        `invoice token ${invoiceId} should be in payments storage right after mint`,
+      ).toBe(true);
+
+      // Force the in-flight write all the way through pin+ref-write.
+      const tokenStorageA = unwrapProfileProviders(providersA).tokenStorage;
+      await tokenStorageA.awaitNextFlush(60_000);
+
+      console.log('  Destroying sphereA...');
+      await sphereA.destroy();
+      spheres.splice(spheres.indexOf(sphereA), 1);
+
+      // IPFS propagation buffer. The CAR was just HTTP-pinned to the
+      // configured gateways but block availability lags acceptance —
+      // see header comment. The aggregator pointer publish (also fired
+      // during the flush) needs the same window to become observable.
+      // 15 s tracks the upper bound observed on testnet for both.
+      console.log('  Waiting 15s for IPFS + aggregator propagation...');
+      await new Promise((r) => setTimeout(r, 15_000));
+
+      // ---------------- Phase 2: re-init on the SAME dirs --------------
+      console.log('\n[Issue #234] Phase 2: re-init on SAME dirs...');
+      const providersB = makeProfileProviders(dirs);
+      const reInitResult = await Sphere.init({
+        ...providersB,
+        mnemonic,
+        accounting: true,
+      });
+      const sphereB = reInitResult.sphere;
+      spheres.push(sphereB);
+      expect(
+        reInitResult.created,
+        'second init should LOAD (wallet exists on disk), not CREATE',
+      ).toBe(false);
+      console.log(`  Wallet B (re-loaded): ${sphereB.identity!.l1Address}`);
+
+      const tokensAfterReload = sphereB.payments.getTokens();
+      const invoicesAfterReload = await sphereB.accounting!.getInvoices();
+      console.log(
+        `  Post-reload: ${tokensAfterReload.length} tokens, ${invoicesAfterReload.length} invoices`,
+      );
+
+      expect(
+        tokensAfterReload.some((t) => t.id === invoiceId),
+        `Issue #234: invoice token ${invoiceId} must survive destroy + re-init`,
+      ).toBe(true);
+      expect(
+        invoicesAfterReload.some((i) => i.invoiceId === invoiceId),
+        `Issue #234: invoice ref ${invoiceId} must survive destroy + re-init`,
+      ).toBe(true);
+
+      console.log('[Issue #234] PASSED');
+    }, 180_000);
+  },
+);


### PR DESCRIPTION
## Summary

Fixes a (secondary) cause of #234. The KV storage was disconnected before token storage shutdown, causing the shutdown-time flush to throw `PROFILE_NOT_INITIALIZED` on the shared `OrbitDbAdapter`, silently dropping the bundle CID write. Adds a regression test that documents the cross-process invoice durability path.

## What this fixes

- **Sphere.destroy() ordering**: token storage providers are now shut down BEFORE `_storage.disconnect()`. `ProfileTokenStorageProvider` shares its `OrbitDbAdapter` instance with `ProfileStorageProvider` (see `profile/factory.ts:427`), so the shutdown flush's `bundleIndex.addBundle → db.putEntry` call must run while the adapter is still connected. The flush failure was being swallowed by `lifecycleManager.shutdown()`'s try/catch.

## What this DOES NOT fix (recommended follow-up)

While building the regression test, I confirmed via direct OrbitDB probing that the bundle CID IS written to OrbitDB and the pin IS pushed to IPFS gateways, but the just-pinned CAR is not immediately retrievable from the gateways. The next process's `load()` reads the bundle CID, attempts to fetch the CAR via `ipfsGateways`, and gets nothing until the gateways propagate (~15 s on testnet).

The regression test buffers this with a 15-second wait. The CLI scenario from #234 has no such buffer, so this PR alone does not unblock `manual-test-full-recovery.sh §C.1b`.

**Recommended architectural fix** (separate PR): persist CAR blocks to the local Helia blockstore at pin time (the OrbitDbAdapter already runs a Helia node for the KV layer), and have `fetchCarFromIpfs` consult the local blockstore before HTTP gateways. This closes the gap deterministically — cross-process recovery becomes "open OrbitDB locally + read CAR from local Helia," no gateway dependency.

## Test plan

- [x] `npx vitest run tests/unit/core/` — 441 tests pass
- [x] `npx vitest run tests/unit/core/Sphere.clear.test.ts tests/unit/core/Sphere.destroy-teardown.test.ts` — pass
- [x] New e2e: `npx vitest run --config vitest.e2e.config.ts tests/e2e/profile-invoice-durability-234.test.ts` — passes with the documented propagation buffer
- [ ] Manual: `bash manual-test-full-recovery.sh §C.1b` — will still fail until the follow-up architectural fix lands

## Related

- #234 (this issue) — primary repro
- Memory note `project_c4_cross_device_sync_diagnosis.md` already flagged this as part of a stack of bugs
- #199 follow-up item 3 (CBOR decode failures) — related but distinct symptom of the same family