### PR TITLE
fix(profile)(#241): decouple at-least-once gate from aggregator publish + extend walkback retry

### DIFF
--- a/profile/aggregator-pointer/reconcile-algorithm.ts
+++ b/profile/aggregator-pointer/reconcile-algorithm.ts
@@ -162,15 +162,28 @@ function sleep(ms: number): Promise<void> {
  * discovery sees v=N again.
  *
  * Retry with exponential backoff (reuses the existing PUBLISH_BACKOFF_*
- * schedule for consistency with the rest of the publish flow). Five
- * attempts with the default schedule sum to ~9–15s of total backoff
- * before we propagate the error to the caller — enough to ride out
- * routine replication-lag windows on testnet without holding the
- * publish mutex indefinitely. Past this budget the error propagates,
- * the caller's retry-marker logic stamps `pendingPublishCid`, and the
- * outer flush cadence (or periodic pointer poll) re-attempts later.
+ * schedule for consistency with the rest of the publish flow). With
+ * BASE=250ms, MAX=4000ms, the schedule per attempt is
+ *   250, 500, 1000, 2000, 4000, 4000, 4000ms
+ * (jittered by [0.5, 1.5]×). Seven attempts sum to ~15.75s of total
+ * backoff — chosen to ride out the routine testnet replication-lag
+ * window (issue #241 reports stalls of several seconds at sustained
+ * write rate; 5 attempts at ~7.75s proved insufficient under load).
+ * Past this budget the error propagates as a typed WALKBACK_FLOOR; the
+ * lifecycle layer catches the transient and emits a typed
+ * `storage:replica-lag` event so operators can distinguish it from
+ * generic transients in monitoring, then stamps `pendingPublishCid`
+ * for the next flush / pointer poll to re-attempt.
+ *
+ * Issue #241 (B): even when this budget is exhausted, the at-least-
+ * once Nostr gate is no longer held closed — pin durability is the
+ * cross-device recoverability invariant; the aggregator publish is a
+ * liveness optimization that retries asynchronously. This budget thus
+ * bounds the latency cost of attempting to ride out lag in-band; the
+ * old correctness pressure that required holding the publish mutex
+ * "as long as it takes" is gone.
  */
-const WALKBACK_FLOOR_RETRY_BUDGET = 5;
+const WALKBACK_FLOOR_RETRY_BUDGET = 7;
 
 /**
  * Wrap `findLatestValidVersion` with a bounded retry loop specifically

--- a/profile/factory.ts
+++ b/profile/factory.ts
@@ -298,16 +298,15 @@ export async function runProfileDirtyFlush(
   await deps.pin(snapshot.carBytes, snapshot.rootCid);
 
   const result = await deps.publishCid(snapshot.rootCid);
-  if (!result.ok && result.transient) {
-    // Surface transient publish failures to the upstream debouncer so
-    // `storage:error` fires with PROFILE_DIRTY_FLUSH_FAILED. The
-    // pending-publish marker is already stamped by the lifecycle layer
-    // — subsequent flushes / pointer-polls will retry.
-    throw new Error(
-      `dirty-flush publish transient failure (cid=${snapshot.rootCid})` +
-        (result.code ? `; code=${result.code}` : ''),
-    );
-  }
+  // Issue #241: transient publish failures (replica lag, network blip)
+  // are no longer surfaced as throws. The lifecycle layer has already
+  // stamped `pendingPublishCid` and emitted `storage:replica-lag` when
+  // applicable; the upstream FlushScheduler emits the soft
+  // `storage:pending-publish` event and lets the flush complete on the
+  // strength of the IPFS pin durability gate (the actual cross-device
+  // recoverability invariant). Throwing here previously closed the
+  // at-least-once Nostr gate, which amplified replica-lag transients
+  // into a sustained retry storm.
   return result;
 }
 

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -233,9 +233,15 @@ export class ProfileTokenStorageProvider
    * CID whose CAR is durably pinned + OrbitDB bundle ref written but
    * whose aggregator pointer publish is outstanding due to a transient
    * failure. The next `flushToIpfs` and the periodic pointer poll
-   * retry the publish at start. While non-null, downstream callers
-   * that await durability via `awaitNextFlush` MUST see the chain
-   * reject so the at-least-once gate keeps the Nostr ack held.
+   * retry the publish at start.
+   *
+   * Issue #241: while non-null, `awaitNextFlush` (and therefore the
+   * at-least-once Nostr gate) NO LONGER rejects on transient publish
+   * failure — pin durability is the cross-device recoverability
+   * invariant, and the aggregator publish is a liveness optimization
+   * for cold-import discovery. A `storage:pending-publish` event is
+   * emitted so operators can monitor the outstanding state without
+   * conflating it with the terminal `storage:error` class.
    *
    * Persisted to `localCache` under
    * `<STORAGE_KEYS_GLOBAL.PROFILE_PENDING_PUBLISH_CID>_<addressId>`
@@ -664,13 +670,17 @@ export class ProfileTokenStorageProvider
    *     `ProfileSnapshotPublishResult`. A `void` return from the
    *     callback (legacy `() => Promise<void>` shape) is normalised
    *     to `{ ok: true, transient: false }`.
-   *   - On throw (programmer error OR
-   *     `runProfileDirtyFlush`'s transient-failure throw): emits
-   *     `storage:error` with code `PROFILE_DIRTY_FLUSH_FAILED`
+   *   - On throw (programmer error, snapshot-build failure, etc.):
+   *     emits `storage:error` with code `PROFILE_DIRTY_FLUSH_FAILED`
    *     (matching the debouncer's surfacing contract) and re-throws
    *     so FlushScheduler can propagate to `forceFlushSerialized`'s
-   *     rejection arm — holding the at-least-once gate closed until
-   *     the publish lands.
+   *     rejection arm. Issue #241: transient publish failures
+   *     (e.g., aggregator replica lag) are NOT surfaced as throws —
+   *     `publishAggregatorPointerBestEffort` returns a structured
+   *     `{ ok: false, transient: true }` result. FlushScheduler emits
+   *     `storage:pending-publish` and lets the flush succeed. Only
+   *     non-publish exceptions (e.g., snapshot construction errors)
+   *     reach this catch arm.
    *
    * The shutdown gate (`isShuttingDown` / `hasShutdown`) returns
    * `null` so a flush mid-shutdown skips the snapshot publish

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -755,14 +755,42 @@ export class FlushScheduler {
       //    construct the provider directly without lean-snapshot wiring.
       //
       //    On a TRANSIENT publish failure the snapshot publisher's
-      //    internal `runProfileDirtyFlush` throws — caught below — and
-      //    we propagate so the chained `forceFlushSerialized` rejection
-      //    reaches `awaitNextFlush` and the at-least-once gate refuses
-      //    the Nostr ack (event replays on next reconnect; addToken
-      //    stateHash dedup is idempotent). On PERMANENT failure the
-      //    publisher returns `{ ok: false, transient: false }` and we
-      //    still emit `storage:saved` — local state is durable, only
-      //    the cross-device anchor is missing and no retry would help.
+      //    internal `runProfileDirtyFlush` throws — caught below.
+      //
+      //    Issue #241 — the at-least-once Nostr gate is decoupled from
+      //    aggregator-publish transient failures. The cross-device
+      //    recoverability invariant is satisfied by:
+      //      (1) The UXF bundle CAR being pinned + HEAD-verifiable on
+      //          IPFS (step 4 above + the verifyFlushDurability leg
+      //          below); AND
+      //      (2) The OrbitDB bundle ref being written (step 6).
+      //    Together (1)+(2) guarantee that any device sharing this
+      //    wallet's OrbitDB log will see the new bundle on the next
+      //    sync — no aggregator pointer is needed for replica-to-
+      //    replica propagation. The aggregator publish is a LIVENESS
+      //    optimization for COLD-IMPORT discovery (a brand-new device
+      //    with only the master key). A transient publish failure
+      //    (replica lag, network blip) is handled by the existing
+      //    `pendingPublishCid` retry marker — the next flush or
+      //    pointer poll re-attempts before the wallet does any new
+      //    save-driven work.
+      //
+      //    Before #241 a transient publish would throw here, which
+      //    closed the at-least-once gate and forced the inbound
+      //    TOKEN_TRANSFER event to replay on every Nostr reconnect.
+      //    Each replay fired another flush; each flush re-hit the
+      //    same `AGGREGATOR_POINTER_WALKBACK_FLOOR` (read-replica
+      //    lagging behind the wallet's confirmed `localVersion`),
+      //    converting an invisible transient into a sustained retry
+      //    storm. Decoupling the gate from publish durability breaks
+      //    that amplification while preserving the actual recover-
+      //    ability invariant.
+      //
+      //    On PERMANENT failure the publisher returns `{ ok: false,
+      //    transient: false }`, has already emitted `storage:error`
+      //    upstream, and we continue — local state is durable, the
+      //    cross-device anchor is missing, and no auto-retry would
+      //    help (operator intervention required).
       let publishResult: ProfileSnapshotPublishResult | null = null;
       let publishThrew: unknown = undefined;
       try {
@@ -781,11 +809,16 @@ export class FlushScheduler {
         throw publishThrew;
       }
       if (publishResult && !publishResult.ok && publishResult.transient) {
-        throw new Error(
-          `Aggregator pointer snapshot publish transient failure (bundle cid=${cid}` +
-            (publishResult.code ? `, code=${publishResult.code}` : '') +
-            `); retry marker stored. Refusing to advance the at-least-once ack.`,
-        );
+        // Issue #241 — see policy comment above. Emit a soft event so
+        // operators can observe pending publishes without conflating
+        // them with terminal `storage:error` signals. The flush still
+        // proceeds to verifyFlushDurability for the bundle CAR — pin
+        // durability is the gate the at-least-once invariant rides on.
+        this.host.emitEvent({
+          type: 'storage:pending-publish',
+          timestamp: Date.now(),
+          data: { cid, code: publishResult.code },
+        });
       }
 
       // Issue #239 — per-profile-update remote-durability verification.
@@ -836,14 +869,20 @@ export class FlushScheduler {
       if (shouldVerify) {
         // Snapshot CID is set on host by the successful publish path
         // (`LifecycleManager.publishAggregatorPointerBestEffort` →
-        // `setLastDiscoveredPointerCid`). Null when no snapshot was
-        // published in this flush (transient publish failure handled
-        // above already threw before we got here, so a null here means
-        // the publisher wasn't wired — defensive fallback).
-        const snapshotCid =
-          publishResult !== null
-            ? this.host.getLastDiscoveredPointerCid()
-            : null;
+        // `setLastDiscoveredPointerCid`). Issue #241: a transient
+        // publish failure does NOT update this CID — the host still
+        // holds the PREVIOUS successful publish's snapshot CID (or
+        // null if no publish has ever succeeded). Verifying that
+        // stale CID would be both pointless (it's already-pinned
+        // from a prior flush) and misleading (a pass here doesn't
+        // mean THIS flush's state reached the aggregator). Skip the
+        // snapshot leg unless we're sure a fresh snapshot was just
+        // anchored.
+        const freshSnapshotPublished =
+          publishResult !== null && publishResult.ok;
+        const snapshotCid = freshSnapshotPublished
+          ? this.host.getLastDiscoveredPointerCid()
+          : null;
         await this.host.verifyFlushDurability(cid, snapshotCid, verifyDeadlineMs);
       }
     } catch (err) {

--- a/profile/profile-token-storage/host.ts
+++ b/profile/profile-token-storage/host.ts
@@ -167,9 +167,15 @@ export interface ProfileTokenStorageHost {
    * written, but whose pointer publish (aggregator anchor) is still
    * outstanding due to a transient failure. The next flush AND the
    * periodic pointer-poll re-attempt the publish at start; on success
-   * the field is cleared. While non-null, the at-least-once gate in
-   * `PaymentsModule.handleIncomingTransfer` is held closed because the
-   * cross-device recovery path cannot reach this bundle yet.
+   * the field is cleared.
+   *
+   * Issue #241: while non-null, the at-least-once Nostr gate
+   * (`PaymentsModule.handleIncomingTransfer`) is NO LONGER held
+   * closed — pin durability is the cross-device recoverability
+   * invariant; the aggregator publish is a liveness optimization
+   * for cold-import discovery and is retried in background.
+   * Operators see the outstanding state via `storage:pending-publish`
+   * (and `storage:replica-lag` for the WALKBACK_FLOOR case).
    *
    * Persisted to `localCache` under the key
    * `STORAGE_KEYS_GLOBAL.PROFILE_PENDING_PUBLISH_CID_PREFIX + addressId`

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -751,7 +751,10 @@ export class LifecycleManager {
    *   2. **Snapshot CID HEAD-accessible** on ≥1 IPFS gateway — needed
    *      because cross-device recovery fetches the snapshot CAR first,
    *      then walks to bundle refs. Skipped when no snapshot was
-   *      published (`snapshotCid === null`, e.g. no pointer wiring).
+   *      published (`snapshotCid === null`) — either because no pointer
+   *      layer is wired OR because the publish returned a transient
+   *      result (issue #241: a stale snapshot CID would be a no-op
+   *      verify; only the bundle leg is checked in that case).
    *
    * NOT verified here:
    *   - **Aggregator `recoverLatest()` read-back of the snapshot CID.**
@@ -775,6 +778,12 @@ export class LifecycleManager {
    * then refuses to advance the Nostr `since` filter, the inbound event
    * replays on next reconnect, and the addToken stateHash dedup ensures
    * idempotency.
+   *
+   * Issue #241: only the IPFS pin legs gate the Nostr ack here. The
+   * aggregator-publish durability (pointer read-back) is intentionally
+   * NOT a per-flush leg — it's a liveness optimization for cold-import
+   * discovery and is retried in background via `pendingPublishCid`.
+   * Pin durability is the cross-device recoverability invariant.
    *
    * @param bundleCid    The UXF bundle CID just pinned via flushToIpfs.
    * @param snapshotCid  The lean-snapshot CID just published via
@@ -1021,20 +1030,29 @@ export class LifecycleManager {
    * Publish the just-flushed CID to the aggregator pointer layer.
    *
    * Returns a structured result instead of swallowing failures so the
-   * caller (FlushScheduler) can propagate transient errors up to the
-   * at-least-once gate. The persistence of the retry marker
-   * (`pendingPublishCid`) is handled here:
+   * caller (FlushScheduler) can route transient failures via a soft
+   * event without closing the at-least-once gate. The persistence of
+   * the retry marker (`pendingPublishCid`) is handled here:
    *
    *   - SUCCESS — clears `pendingPublishCid`, anchors
    *     `lastDiscoveredPointerCid`, returns `{ ok: true }`.
    *   - TRANSIENT failure — sets `pendingPublishCid = cidString` (with
    *     localCache persistence for crash safety), returns
-   *     `{ ok: false, transient: true }`. Caller MUST treat this as
-   *     "not durable" — the at-least-once gate refuses the Nostr ack
-   *     so the inbound event replays on next reconnect (idempotent
-   *     via addToken stateHash dedup and processedCombinedTransferIds).
-   *     The pending marker is retried at start of every subsequent
-   *     `flushToIpfs` and `runPointerPollOnce`.
+   *     `{ ok: false, transient: true, code? }`. Issue #241: callers
+   *     route this to a `storage:pending-publish` event instead of
+   *     throwing — the at-least-once Nostr gate is decoupled from
+   *     aggregator-publish durability and rides on IPFS pin
+   *     durability alone (which is the actual cross-device
+   *     recoverability invariant). The pending marker is retried
+   *     at start of every subsequent `flushToIpfs` and
+   *     `runPointerPollOnce`.
+   *
+   *     A WALKBACK_FLOOR transient (aggregator read-replica lagging
+   *     behind a version this wallet has already confirmed locally)
+   *     additionally emits a typed `storage:replica-lag` event so
+   *     operators can distinguish it from generic network
+   *     transients in monitoring.
+   *
    *   - PERMANENT failure (UNREACHABLE_RECOVERY_BLOCKED, REJECTED,
    *     UNTRUSTED_PROOF, TRUST_BASE_STALE, MARKER_CORRUPT, CORRUPT_STREAK,
    *     SECURITY_ORIGIN_MISMATCH, CAPABILITY_DENIED, UNSUPPORTED_RUNTIME,
@@ -1084,11 +1102,11 @@ export class LifecycleManager {
         return { ok: false, transient: false, code };
       }
       // Elevate the transient publish failure to warn-level so the
-      // operator sees the underlying cause without enabling debug —
-      // pointer publish failures hold the at-least-once gate closed
-      // and the user cannot diagnose the stall otherwise. Includes
-      // any typed AggregatorPointerError code so monitoring can
-      // filter on transient classes (NETWORK_ERROR vs unclassified).
+      // operator sees the underlying cause without enabling debug.
+      // Issue #241: this no longer holds the at-least-once gate
+      // closed (the flush proceeds and stamps a pending-publish
+      // marker), but the underlying cause is still useful for
+      // diagnosis when a wallet stays in pending-publish for long.
       const transientCode =
         typeof (err as { code?: unknown }).code === 'string'
           ? (err as { code: string }).code
@@ -1097,11 +1115,26 @@ export class LifecycleManager {
         'Profile-TokenStorage',
         `Pointer publish failed (transient, code=${transientCode}, cid=${cidString}): ${msg}`,
       );
+      // Issue #241 — a WALKBACK_FLOOR transient is specifically the
+      // aggregator's read replica lagging behind the wallet's locally-
+      // confirmed `localVersion`. Surface this as a typed
+      // `storage:replica-lag` event so monitoring can distinguish
+      // replica-lag stalls from generic transients (network blips,
+      // gateway hiccups). All other transients flow through the
+      // generic `storage:pending-publish` event emitted by the
+      // caller (FlushScheduler).
+      if (transientCode === 'AGGREGATOR_POINTER_WALKBACK_FLOOR') {
+        this.host.emitEvent({
+          type: 'storage:replica-lag',
+          timestamp: Date.now(),
+          data: { cid: cidString, code: transientCode, message: msg },
+        });
+      }
       // Transient: stamp the retry marker (with localCache persistence
       // for crash safety) so subsequent flushes / polls re-attempt
       // before any new save-driven work.
       this.host.setPendingPublishCid(cidString);
-      return { ok: false, transient: true };
+      return { ok: false, transient: true, code: transientCode };
     }
   }
 

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -297,7 +297,42 @@ export type StorageEventType =
    * informational so operators can investigate cross-process recovery
    * gaps. Skipped when `Sphere.destroy({ force: true })` is used.
    */
-  | 'shutdown:verification-timeout';
+  | 'shutdown:verification-timeout'
+  /**
+   * Issue #241 — emitted when the aggregator pointer publish path
+   * returns a TRANSIENT failure for a just-flushed bundle. The flush
+   * itself succeeded (CAR pinned + bundle ref written + pin verified
+   * fetchable), but the aggregator publish stamped `pendingPublishCid`
+   * for retry. `data` carries `{ cid, code? }` — `cid` is the bundle
+   * CID and `code` is the pointer-layer error code when classifiable
+   * (e.g., `AGGREGATOR_POINTER_WALKBACK_FLOOR`, `NETWORK_ERROR`).
+   *
+   * Distinct from `storage:error` (which is a fatal-class signal). A
+   * pending-publish event tells the operator that the local state is
+   * durable AND cross-device readers via OrbitDB sync will see the new
+   * state, but COLD-IMPORT discovery (a fresh device with only the
+   * master key) will read the previous pointer version until the
+   * retry succeeds. The retry happens automatically on the next flush
+   * or pointer poll.
+   */
+  | 'storage:pending-publish'
+  /**
+   * Issue #241 — emitted when discovery / publish observes the
+   * aggregator's read replica lagging behind a version the wallet has
+   * already locally confirmed. Concretely: Phase 3 walkback returns
+   * `AGGREGATOR_POINTER_WALKBACK_FLOOR` after the
+   * `WALKBACK_FLOOR_RETRY_BUDGET` exponential-backoff window
+   * (~15s) without the replica catching up. `data` carries
+   * `{ localVersion, cid? }` so operators can correlate with
+   * aggregator-side replication metrics.
+   *
+   * Informational only — the publish path's `pendingPublishCid`
+   * marker is already stamped (treated as transient), and the
+   * next flush / pointer poll continues to retry. This event lets
+   * operators distinguish "publish stuck on replica lag" from
+   * other transient classes (network errors, etc.).
+   */
+  | 'storage:replica-lag';
 
 export interface StorageEvent {
   type: StorageEventType;

--- a/tests/unit/profile/factory-dirty-flush.test.ts
+++ b/tests/unit/profile/factory-dirty-flush.test.ts
@@ -16,8 +16,10 @@
  *   6. Build failure → propagates (caller surfaces via storage:error).
  *   7. Pin failure → propagates.
  *   8. publishCid throw → propagates.
- *   9. publishCid transient → throws so the dispatcher emits the
- *      `storage:error` event.
+ *   9. publishCid transient (issue #241) → returns intact (no throw)
+ *      so the upstream FlushScheduler emits `storage:pending-publish`
+ *      and the at-least-once Nostr gate advances on IPFS pin
+ *      durability alone.
  *  10. publishCid permanent (ok:false, transient:false) → swallows
  *      (the lifecycle layer already emitted its own storage:error).
  *
@@ -262,15 +264,18 @@ describe('runProfileDirtyFlush — error propagation', () => {
     ).rejects.toThrow('publish failed');
   });
 
-  it('throws on transient publishCid failure so the dispatcher surfaces it', async () => {
+  it('returns transient publishCid result intact (issue #241 — no throw, gate advances on pin durability)', async () => {
     const publishCid = vi.fn(async () => ({
       ok: false,
       transient: true,
       code: 'NETWORK_ERROR',
     }));
-    await expect(
-      runProfileDirtyFlush(makeDeps({ publishCid })),
-    ).rejects.toThrow(/transient failure.*NETWORK_ERROR/);
+    const result = await runProfileDirtyFlush(makeDeps({ publishCid }));
+    expect(result).toEqual({
+      ok: false,
+      transient: true,
+      code: 'NETWORK_ERROR',
+    });
   });
 
   it('returns permanent publishCid failure without throwing (lifecycle already alerted)', async () => {

--- a/tests/unit/profile/flush-scheduler-d1b.test.ts
+++ b/tests/unit/profile/flush-scheduler-d1b.test.ts
@@ -172,6 +172,32 @@ describe('ProfileTokenStorageProvider.publishSnapshotIfWired — happy path', ()
     // Callers (FlushScheduler) treat this as "publish failed but no
     // retry would help" — storage:saved still fires, no throw.
   });
+
+  it('returns a transient failure result intact without throwing (issue #241 — gate rides on pin durability)', async () => {
+    // Issue #241: prior to the decoupling, runProfileDirtyFlush threw on
+    // transient results so the at-least-once gate stayed closed. Now the
+    // factory returns the structured result; the upstream FlushScheduler
+    // emits `storage:pending-publish` and the gate advances based on the
+    // bundle CAR's IPFS pin durability (verifyFlushDurability) — which
+    // IS the cross-device recoverability invariant.
+    const result: ProfileSnapshotPublishResult = {
+      ok: false,
+      transient: true,
+      code: 'AGGREGATOR_POINTER_WALKBACK_FLOOR',
+    };
+    const onProfileDirtyFlush = vi.fn(async () => result);
+    const provider = buildProvider({ onProfileDirtyFlush });
+    const errors: StorageEvent[] = [];
+    provider.onEvent((event) => {
+      if (event.type === 'storage:error') errors.push(event);
+    });
+    const got = await provider.publishSnapshotIfWired();
+    expect(got).toEqual(result);
+    // No terminal error event for a transient publish — the soft
+    // `storage:pending-publish` is emitted at the FlushScheduler layer
+    // (see profile/profile-token-storage/flush-scheduler.ts).
+    expect(errors).toHaveLength(0);
+  });
 });
 
 describe('ProfileTokenStorageProvider.publishSnapshotIfWired — error propagation', () => {
@@ -198,19 +224,22 @@ describe('ProfileTokenStorageProvider.publishSnapshotIfWired — error propagati
     expect(errors[0]?.code).toBe('PROFILE_DIRTY_FLUSH_FAILED');
   });
 
-  it('re-throws a transient publish failure (runProfileDirtyFlush-style throw) intact', async () => {
-    // Mirrors `runProfileDirtyFlush` behaviour when the underlying
-    // `publishCid` returns `{ ok: false, transient: true }` — the
-    // factory closure throws with a "transient failure" message that
-    // FlushScheduler propagates to forceFlushSerialized.
+  it('re-throws when the callback itself throws (programmer error / snapshot build failure)', async () => {
+    // Issue #241: `runProfileDirtyFlush` no longer throws on a
+    // transient publishCid result — it returns the structured result
+    // intact (so FlushScheduler can emit `storage:pending-publish`
+    // instead of closing the at-least-once gate). This test stays as
+    // a contract guard for OTHER throw classes: a callback that
+    // throws (programmer error, snapshot build failure, etc.) MUST
+    // still propagate through `publishSnapshotIfWired` unchanged.
     const onProfileDirtyFlush = vi.fn(async () => {
       throw new Error(
-        'dirty-flush publish transient failure (cid=...); code=NETWORK_ERROR',
+        'snapshot build failed: simulated programmer error',
       );
     });
     const provider = buildProvider({ onProfileDirtyFlush });
     await expect(provider.publishSnapshotIfWired()).rejects.toThrow(
-      /transient failure.*NETWORK_ERROR/,
+      /snapshot build failed/,
     );
   });
 });

--- a/tests/unit/profile/lifecycle-manager-publish-retry.test.ts
+++ b/tests/unit/profile/lifecycle-manager-publish-retry.test.ts
@@ -308,3 +308,80 @@ describe('LifecycleManager.publishAggregatorPointerBestEffort — Gap 2', () => 
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #241 — typed transient event surfaces (replica-lag vs generic)
+// ---------------------------------------------------------------------------
+
+describe('LifecycleManager.publishAggregatorPointerBestEffort — issue #241 events', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits storage:replica-lag with code AGGREGATOR_POINTER_WALKBACK_FLOOR on the walkback-floor transient', async () => {
+    const pointer = stubPointer({
+      publish: vi.fn(async () => {
+        throw new AggregatorPointerError(
+          AggregatorPointerErrorCode.WALKBACK_FLOOR,
+          'Phase 3 walkback reached candidate=10 below localVersion=11',
+        );
+      }),
+    });
+    const handle = await createTestProvider(pointer);
+    const events: { type: string; data?: unknown }[] = [];
+    handle.provider.onEvent((ev) => {
+      if (ev.type === 'storage:replica-lag' || ev.type === 'storage:error') {
+        events.push({ type: ev.type, data: ev.data });
+      }
+    });
+    try {
+      const result = await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      // Pin durability is the gate; lifecycle stamps marker + returns transient.
+      expect(result.ok).toBe(false);
+      expect(result.transient).toBe(true);
+      expect(result.code).toBe('AGGREGATOR_POINTER_WALKBACK_FLOOR');
+      // Soft `storage:replica-lag` event is emitted (distinct from
+      // terminal `storage:error`) so monitoring can route on it.
+      const replicaLag = events.find((e) => e.type === 'storage:replica-lag');
+      expect(replicaLag).toBeDefined();
+      expect((replicaLag?.data as { code?: string })?.code).toBe(
+        'AGGREGATOR_POINTER_WALKBACK_FLOOR',
+      );
+      // The retry marker is stamped for the next flush / pointer poll.
+      expect(handle.getPendingPublishCid()).toBe(FAKE_CID);
+    } finally {
+      await handle.provider.shutdown();
+    }
+  });
+
+  it('does NOT emit storage:replica-lag for a generic transient (network blip)', async () => {
+    const pointer = stubPointer({
+      publish: vi.fn(async () => {
+        throw new AggregatorPointerError(
+          AggregatorPointerErrorCode.NETWORK_ERROR,
+          'simulated transient network blip',
+        );
+      }),
+    });
+    const handle = await createTestProvider(pointer);
+    const events: { type: string }[] = [];
+    handle.provider.onEvent((ev) => {
+      if (ev.type === 'storage:replica-lag') events.push({ type: ev.type });
+    });
+    try {
+      const result = await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(result.transient).toBe(true);
+      expect(result.code).toBe('AGGREGATOR_POINTER_NETWORK_ERROR');
+      // Generic transients route through the upstream FlushScheduler's
+      // `storage:pending-publish` event — `storage:replica-lag` is reserved
+      // for the walkback-floor case so operators can distinguish them.
+      expect(events).toHaveLength(0);
+      expect(handle.getPendingPublishCid()).toBe(FAKE_CID);
+    } finally {
+      await handle.provider.shutdown();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #241 (slow-retry storm under aggregator replica lag).

- Decouple PR #240's at-least-once Nostr gate from aggregator-publish transient failures so a stuck pointer publish no longer amplifies into a replay storm. Pin durability is the cross-device recoverability invariant; the publish is a liveness optimization for cold-import discovery.
- Extend `WALKBACK_FLOOR_RETRY_BUDGET` from 5 → 7 (~15.75s of backoff) and emit a typed `storage:replica-lag` event when the budget exhausts so monitoring can distinguish replica-lag from generic transients.
- New `storage:pending-publish` and `storage:replica-lag` event types in `StorageEventType`.

## Why this is needed

Issue #241 traced the symptom: at sustained write rate the aggregator's read replica lags behind the wallet's locally-confirmed `localVersion`. `Phase 3 walkback` correctly refuses to cross below `localVersion` (SPEC W7 confused-deputy protection) and throws `AGGREGATOR_POINTER_WALKBACK_FLOOR`. PR #240's per-flush gate previously treated this as a flush failure → `awaitNextFlush` rejected → at-least-once gate kept `since` pinned → TOKEN_TRANSFER replayed on every reconnect → each replay triggered another flush → loop only breaks when the replica eventually catches up (which under load apparently never does).

This change applies mitigation **C** (A + B) from the issue, recommended option.

## What changed

### B — decouple the gate from publish durability

- `profile/profile-token-storage/flush-scheduler.ts`: a transient `publishResult` no longer throws. The flush emits `storage:pending-publish` and proceeds to `verifyFlushDurability` (pin-only). The snapshot leg of `verifyFlushDurability` is now gated on `publishResult.ok` to avoid verifying a stale snapshot CID from a prior successful publish.
- `profile/factory.ts` (`runProfileDirtyFlush`): mirror the policy at the lower layer — transient `publishCid` results are returned intact rather than thrown.
- `profile/profile-token-storage/lifecycle-manager.ts` (`publishAggregatorPointerBestEffort`): now returns `{ ok: false, transient: true, code }` (added `code`) so callers can route on the underlying error class; the WALKBACK_FLOOR case additionally emits `storage:replica-lag`.

### A — extend walkback retry budget

- `profile/aggregator-pointer/reconcile-algorithm.ts`: `WALKBACK_FLOOR_RETRY_BUDGET = 5 → 7`. With BASE=250ms / MAX=4000ms / jitter [0.5,1.5]× this expands the in-band wait from ~7.75s to ~15.75s — enough to ride out routine testnet replication-lag windows without holding the publish mutex indefinitely. With B in place, the budget is no longer a correctness gate; it just trades latency for fewer pending-publish events on the happy path.

### Event surfaces

- `storage:pending-publish`: bundle pinned + readable + OrbitDB ref written, aggregator publish stamped `pendingPublishCid` for retry. Distinct from terminal `storage:error`.
- `storage:replica-lag`: specifically the WALKBACK_FLOOR case, with the locally-confirmed CID + message in `data`. Lets operators distinguish replica-lag stalls from generic network transients.

### Docs / contracts updated

- `host.ts` and `profile-token-storage-provider.ts` jsdoc updated to reflect the new "gate rides on pin durability" contract.
- `verifyFlushDurability` jsdoc clarifies that the snapshot leg is now gated on a successful fresh publish.

## Stacking

This PR targets `fix/issue-239-shutdown-durability-contract` (PR #240's branch). PR #240 introduced the at-least-once gate; this PR fixes the amplification-loop follow-up. When #240 merges, rebase to `main`.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — no new errors in modified files (pre-existing repo-wide warnings/errors unchanged).
- [x] `npx vitest run tests/unit/profile/` — 1809 tests pass.
- [x] `npx vitest run tests/unit/` — 7423 tests pass, 2 pre-existing skips.
- [x] New tests:
  - `lifecycle-manager-publish-retry.test.ts` — verifies `storage:replica-lag` is emitted for WALKBACK_FLOOR and NOT for generic transients.
  - `factory-dirty-flush.test.ts` — verifies `runProfileDirtyFlush` returns transient intact (was: throws).
  - `flush-scheduler-d1b.test.ts` — adds "transient result returned without throwing" + retains "callback-throws still propagates" contract guard.
- [ ] Manual `manual-test-full-recovery.sh` re-run against testnet — verify §C.2 no longer enters the slow-retry storm (recommended before merge).