### PR TITLE
fix(oracle)(#243): use canonical get_inclusion_proof for isSpent

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -2213,10 +2213,25 @@ export class PaymentsModule {
         oracleProvider: (): {
           readonly isSpent: (stateHash: string) => Promise<boolean>;
         } | null => {
+          // Issue #243 — wallet-scoped wrapper around oracle.isSpent.
+          // The underlying OracleProvider.isSpent now requires
+          // `(publicKey, stateHash)` (the canonical aggregator API
+          // indexes commitments by `RequestId.create(pubkey, hash)`).
+          // The worker only knows the stateHash, so we bind the
+          // active wallet's `chainPubkey` here — correct for any
+          // token in `this.tokens` because the worker scans the
+          // current address's holdings and our predicate's pubkey
+          // gates spending the current state.
           const oracle = this.deps?.oracle;
-          return oracle !== undefined && typeof oracle.isSpent === 'function'
-            ? oracle
-            : null;
+          if (oracle === undefined || typeof oracle.isSpent !== 'function') {
+            return null;
+          }
+          const ownerPubkey = this.deps?.identity?.chainPubkey;
+          if (!ownerPubkey) return null;
+          return {
+            isSpent: (stateHash: string): Promise<boolean> =>
+              oracle.isSpent(ownerPubkey, stateHash),
+          };
         },
         extractCurrentStateHash: (token: Token): string =>
           extractStateHashFromSdkData(token.sdkData),
@@ -3955,7 +3970,14 @@ export class PaymentsModule {
     }
     let aggregatorRecordsSpent: boolean;
     try {
-      aggregatorRecordsSpent = await this.deps!.oracle.isSpent(sourceStateHash);
+      // Issue #243 — pass owner pubkey alongside stateHash. The token
+      // is in this wallet's active set (orphan recovery only fires
+      // for our own locally-stranded tokens), so `chainPubkey` is the
+      // correct predicate owner for the requestId derivation.
+      aggregatorRecordsSpent = await this.deps!.oracle.isSpent(
+        this.deps!.identity.chainPubkey,
+        sourceStateHash,
+      );
     } catch (oracleErr) {
       // Per OracleProvider.isSpent contract, an RPC failure throws
       // (never fail-open). Treat the throw as ambiguous: we cannot
@@ -14096,13 +14118,21 @@ export class PaymentsModule {
     // Non-success arc — disambiguate "state already spent by another
     // commit" from generic failures via an authoritative oracle
     // re-query against the source state hash.
+    //
+    // Issue #243 — pass owner pubkey alongside stateHash. The source
+    // state we just tried to consume was guarded by OUR predicate
+    // (we constructed the commitment), so the requestId the aggregator
+    // indexed under is derived from `chainPubkey` + the source state.
     let isSpent = false;
     let sourceStateHashHex: string | null = null;
     if (oracle !== undefined && typeof oracle.isSpent === 'function') {
       try {
         const sourceStateHashObj = await commitment.transactionData.sourceState.calculateHash();
         sourceStateHashHex = sourceStateHashObj.toJSON();
-        isSpent = await oracle.isSpent(sourceStateHashHex);
+        isSpent = await oracle.isSpent(
+          this.deps!.identity.chainPubkey,
+          sourceStateHashHex,
+        );
       } catch (probeErr) {
         // The probe is best-effort. If it throws (e.g. aggregator
         // offline), we fall through to the generic

--- a/oracle/UnicityAggregatorProvider.ts
+++ b/oracle/UnicityAggregatorProvider.ts
@@ -41,6 +41,8 @@ import {
   InclusionProofVerificationStatus,
 } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof';
 import { RequestId } from '@unicitylabs/state-transition-sdk/lib/api/RequestId';
+import { DataHash } from '@unicitylabs/state-transition-sdk/lib/hash/DataHash';
+import { hexToBytes } from '../core/hex';
 
 // SDK MintCommitment type - using interface to avoid generic complexity
 interface SdkMintCommitment {
@@ -750,27 +752,49 @@ export class UnicityAggregatorProvider implements OracleProvider {
     return result;
   }
 
-  async isSpent(stateHash: string): Promise<boolean> {
-    // Check cache first (spent is immutable). Wave L: LRU touch on
-    // hit so frequently-accessed stateHashes survive eviction longer.
-    if (this.spentCache.has(stateHash)) {
-      const cached = this.spentCache.get(stateHash)!;
-      this.spentCache.delete(stateHash);
-      this.spentCache.set(stateHash, cached);
+  async isSpent(publicKey: string, stateHash: string): Promise<boolean> {
+    // Cache key binds publicKey + stateHash. A given stateHash may
+    // be commit-checked under multiple pubkeys in a multi-address
+    // wallet; we MUST NOT cross-pollinate cache hits between keys.
+    const cacheKey = `${publicKey}:${stateHash}`;
+    if (this.spentCache.has(cacheKey)) {
+      const cached = this.spentCache.get(cacheKey)!;
+      this.spentCache.delete(cacheKey);
+      this.spentCache.set(cacheKey, cached);
       return cached;
     }
 
     this.ensureConnected();
 
-    // Wave 3 / steelman: do NOT fail-open on RPC failure. The previous
-    // behaviour (`return false`) opened a double-spend window when the
-    // aggregator was network-partitioned or a relay-MitM dropped the
-    // isSpent request: the recipient would treat an unverifiable state
-    // as "confirmed unspent" and accept the proof. We now PROPAGATE the
-    // failure as a typed `AGGREGATOR_ERROR` so callers can distinguish
-    // "verified unspent (aggregator said no)" from "couldn't check".
+    // Issue #243 fix — the canonical aggregator (aggregator-go) has no
+    // `isSpent` JSON-RPC method. It indexes commitments by `requestId
+    // = SHA256(publicKey || stateHash)` and exposes only
+    // `submit_commitment`, `get_inclusion_proof`,
+    // `get_no_deletion_proof`, `get_block_height`. The previous
+    // implementation hand-rolled a `{method: 'isSpent', params:
+    // {stateHash}}` JSON-RPC request which the server rejected with
+    // HTTP 400 ("JSON-RPC requests must include either requestId or
+    // shardId") at the request-validation layer — every call failed,
+    // and the spent-state rescan worker bumped per-token throw
+    // counters until per-token backoff kicked in. The noise blocked
+    // `manual-test-full-recovery.sh` at §C.2.
     //
-    // Important caching contract: we still cache only `spent: true`
+    // The canonical check: derive `requestId` from `publicKey` (the
+    // owner of the state) and the `stateHash`, then call
+    // `get_inclusion_proof(requestId)`. The aggregator returns either:
+    //   - A path-inclusion proof (transactionHash !== null) → the
+    //     owner submitted a commit consuming this state → spent.
+    //   - A path-non-inclusion proof (transactionHash === null) → no
+    //     commit exists for this (pubkey, stateHash) pair → unspent.
+    //
+    // Wave 3 / steelman: do NOT fail-open on RPC failure (preserved).
+    // The previous behaviour (`return false`) opened a double-spend
+    // window when the aggregator was network-partitioned or a relay-
+    // MitM dropped the request: the recipient would treat an
+    // unverifiable state as "confirmed unspent" and accept the proof.
+    // We PROPAGATE the failure as a typed `AGGREGATOR_ERROR`.
+    //
+    // Caching contract (unchanged): cache only `spent: true`
     // (immutable). Confirmed `false` is NOT cached because the answer
     // can change at any moment when the owner spends the state. A
     // throw here is NEVER cached — the next call retries the RPC.
@@ -781,9 +805,30 @@ export class UnicityAggregatorProvider implements OracleProvider {
     // and :1020), so this change is non-breaking for the production
     // path and turns a silent fail-open into a deterministic
     // structural rejection that a later bundle can recover from.
-    let response: RpcSpentResponse;
+    let requestIdHex: string;
     try {
-      response = await this.rpcCall<RpcSpentResponse>('isSpent', { stateHash });
+      const pubkeyBytes = hexToBytes(publicKey);
+      const stateHashDataHash = DataHash.fromJSON(stateHash);
+      const requestId = await RequestId.create(pubkeyBytes, stateHashDataHash);
+      requestIdHex = requestId.toJSON();
+    } catch (error) {
+      const cause = error instanceof Error ? error.message : String(error);
+      // Structural failure to build requestId is a caller bug
+      // (bad hex, wrong-length pubkey, malformed stateHash imprint),
+      // not a transient RPC failure. Surface it as AGGREGATOR_ERROR
+      // so the disposition-engine's catch routes it consistently.
+      throw new SphereError(
+        `isSpent: failed to derive requestId from publicKey/stateHash (${cause})`,
+        'AGGREGATOR_ERROR',
+        error,
+      );
+    }
+
+    let response: RpcProofResponse;
+    try {
+      response = await this.rpcCall<RpcProofResponse>('get_inclusion_proof', {
+        requestId: requestIdHex,
+      });
     } catch (error) {
       const cause = error instanceof Error ? error.message : String(error);
       logger.warn('Aggregator', 'isSpent RPC failed; refusing to fail-open', error);
@@ -793,11 +838,25 @@ export class UnicityAggregatorProvider implements OracleProvider {
         error,
       );
     }
-    const spent = response.spent ?? false;
+
+    // Accept canonical (`inclusionProof`) or legacy (`proof`) shape.
+    // Defense in depth: an aggregator that returns neither field is
+    // ambiguous — treat as "no proof yet" (unspent) rather than
+    // throwing, matching the legacy isSpent's tolerant default but
+    // KEEPING the fail-closed throw contract for transport errors.
+    const proof = (response.inclusionProof ?? response.proof) as
+      | { transactionHash?: string | null }
+      | undefined;
+    const spent =
+      proof !== undefined &&
+      proof !== null &&
+      typeof proof === 'object' &&
+      proof.transactionHash !== null &&
+      proof.transactionHash !== undefined;
 
     // Cache result (Wave L: bounded with LRU eviction)
     if (spent) {
-      this.cacheSpent(stateHash);
+      this.cacheSpent(cacheKey);
     }
 
     return spent;

--- a/oracle/oracle-provider.ts
+++ b/oracle/oracle-provider.ts
@@ -49,7 +49,29 @@ export interface OracleProvider extends BaseProvider {
   validateToken(tokenData: unknown): Promise<ValidationResult>;
 
   /**
-   * Check if token state is spent.
+   * Check if a state has been spent by the owner identified by `publicKey`.
+   *
+   * Implemented via `get_inclusion_proof(requestId)` where
+   * `requestId = RequestId.create(publicKey, stateHash)`. The aggregator
+   * indexes commitments by requestId (= hash of pubkey+stateHash), so we
+   * cannot ask "has anyone spent this state" without knowing whose
+   * predicate guards it — for normal flows this is the wallet's own
+   * `chainPubkey` because the wallet owns the state it's probing.
+   *
+   * Spent iff the returned inclusion proof carries a non-null
+   * `transactionHash` (path-included). A path-non-inclusion proof
+   * (`transactionHash: null`) means no commitment exists → unspent.
+   *
+   * **Issue #243 — historical broken contract**: the prior implementation
+   * called a non-existent `isSpent` JSON-RPC method with a single
+   * `stateHash` parameter. The canonical aggregator (`aggregator-go`)
+   * never exposed that method; it returns HTTP 400 ("requests must
+   * include either requestId or shardId") at the validation layer.
+   * Callers (the spent-state rescan worker, orphan recovery) saw a
+   * cascade of failures, bumped their per-token backoff counters, and
+   * the noise blocked `manual-test-full-recovery.sh` at §C.2. The fix
+   * threads `publicKey` through and uses the canonical inclusion-proof
+   * RPC.
    *
    * **Throws on RPC failure** — implementations MUST NOT fail-open
    * (returning `false` on a network/transport error opens a double-
@@ -57,14 +79,21 @@ export interface OracleProvider extends BaseProvider {
    * (typically a `SphereError` with code `'AGGREGATOR_ERROR'`). The
    * boolean return value carries cryptographically-verified state
    * only:
-   *   - `true`  — aggregator confirmed the state has been spent.
-   *   - `false` — aggregator confirmed the state is unspent.
+   *   - `true`  — aggregator returned a path-inclusion proof.
+   *   - `false` — aggregator returned a path-non-inclusion proof.
    *
    * Callers (notably the disposition-engine `[E]` hook) treat a
    * throw as STRUCTURAL_INVALID per §5.3 [A] and re-evaluate when a
    * later bundle arrives.
+   *
+   * @param publicKey Hex-encoded compressed secp256k1 owner pubkey
+   *                  (66 chars, "02"/"03" prefix). For wallet-local
+   *                  scans this is `Identity.chainPubkey`.
+   * @param stateHash Hex-encoded state hash imprint (typically 68 chars
+   *                  including the algorithm prefix; the SDK accepts the
+   *                  canonical imprint form).
    */
-  isSpent(stateHash: string): Promise<boolean>;
+  isSpent(publicKey: string, stateHash: string): Promise<boolean>;
 
   /**
    * Get token state

--- a/tests/unit/modules/payments/detect-orphan-spending-wrapper.test.ts
+++ b/tests/unit/modules/payments/detect-orphan-spending-wrapper.test.ts
@@ -537,7 +537,13 @@ describe('defaultOrphanRecovery — aggregator cross-check (OUTBOX-SEND-FOLLOWUP
     });
 
     expect(outcome).toBe('manual');
-    expect(internals.deps.oracle.isSpent).toHaveBeenCalledWith('aabbccdd');
+    // Issue #243 — isSpent now takes (publicKey, stateHash). The
+    // pubkey comes from the wallet's identity.chainPubkey because
+    // the orphan's source state was guarded by our predicate.
+    expect(internals.deps.oracle.isSpent).toHaveBeenCalledWith(
+      '02' + 'aa'.repeat(32),
+      'aabbccdd',
+    );
     expect(saveSpy).not.toHaveBeenCalled();
     // Token status untouched.
     expect(
@@ -584,7 +590,11 @@ describe('defaultOrphanRecovery — aggregator cross-check (OUTBOX-SEND-FOLLOWUP
     });
 
     expect(outcome).toBe('manual');
-    expect(internals.deps.oracle.isSpent).toHaveBeenCalledWith('99887766');
+    // Issue #243 — (publicKey, stateHash) signature.
+    expect(internals.deps.oracle.isSpent).toHaveBeenCalledWith(
+      '02' + 'aa'.repeat(32),
+      '99887766',
+    );
     expect(saveSpy).not.toHaveBeenCalled();
     expect(asInternals(payments).tokens.get('orphan-rpc-error')?.status).toBe(
       'transferring',
@@ -679,7 +689,11 @@ describe('defaultOrphanRecovery — aggregator cross-check (OUTBOX-SEND-FOLLOWUP
     });
 
     expect(outcome).toBe('recovered');
-    expect(internals.deps.oracle.isSpent).toHaveBeenCalledWith('11223344');
+    // Issue #243 — (publicKey, stateHash) signature.
+    expect(internals.deps.oracle.isSpent).toHaveBeenCalledWith(
+      '02' + 'aa'.repeat(32),
+      '11223344',
+    );
     expect(saveSpy).toHaveBeenCalledTimes(1);
     expect(asInternals(payments).tokens.get('orphan-safe')?.status).toBe(
       'confirmed',

--- a/tests/unit/oracle/UnicityAggregatorProvider.isSpent.test.ts
+++ b/tests/unit/oracle/UnicityAggregatorProvider.isSpent.test.ts
@@ -1,19 +1,31 @@
 /**
- * Wave 3 / steelman regression: `UnicityAggregatorProvider.isSpent` must
- * NOT fail-open on RPC failure.
+ * `UnicityAggregatorProvider.isSpent` contract (Issue #243 + Wave 3).
  *
- * The previous implementation logged a warning and returned `false`
- * ("assuming unspent") when the JSON-RPC call to the aggregator failed.
- * That opened a double-spend window: a network-partitioned aggregator
- * or a relay-MitM dropping the `isSpent` request would cause the
- * recipient to treat an unverifiable state as confirmed-unspent, accept
- * the proof, and credit the (potentially already-spent) token.
+ * The canonical aggregator (`aggregator-go`) has no `isSpent` JSON-RPC
+ * method. It indexes commitments by `requestId = SHA256(publicKey ||
+ * stateHash)` and exposes only `submit_commitment`,
+ * `get_inclusion_proof`, `get_no_deletion_proof`, `get_block_height`.
+ *
+ * The historical implementation hand-rolled a `{method: 'isSpent',
+ * params: {stateHash}}` JSON-RPC request which the server rejected with
+ * HTTP 400 at request-validation time ("must include either requestId
+ * or shardId"). The `SpentStateRescanWorker` saw every probe throw,
+ * bumped per-token throw counters, and produced log spam that blocked
+ * `manual-test-full-recovery.sh` at §C.2 (Issue #243).
  *
  * The fixed contract:
- *   - `isSpent` returns `true`  IFF the aggregator confirmed spent.
- *   - `isSpent` returns `false` IFF the aggregator confirmed unspent.
- *   - `isSpent` THROWS a `SphereError` (`AGGREGATOR_ERROR`) on any
- *     RPC / network failure. It NEVER returns `false` on failure.
+ *   - Signature is `isSpent(publicKey, stateHash)` — both hex strings.
+ *   - Implementation derives `requestId` from those two inputs and
+ *     calls `get_inclusion_proof(requestId)`.
+ *   - Returns `true`  IFF the proof has `transactionHash !== null`
+ *     (path-included → a commit for this requestId landed → spent).
+ *   - Returns `false` IFF the proof has `transactionHash === null`
+ *     (path-non-inclusion proof → no commit exists → unspent).
+ *   - THROWS a `SphereError` (`AGGREGATOR_ERROR`) on any RPC / network
+ *     failure. NEVER returns `false` on failure — that would re-open
+ *     the Wave 3 double-spend window (a network-partitioned aggregator
+ *     or relay-MitM dropping the request would let the recipient
+ *     accept an already-spent state as confirmed-unspent).
  *
  * Callers in the disposition-engine wrap the call in try/catch and
  * route throws to STRUCTURAL_INVALID per §5.3 [A], so the retry loop
@@ -24,10 +36,29 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { UnicityAggregatorProvider } from '../../../oracle/UnicityAggregatorProvider';
 import { SphereError } from '../../../core/errors';
 
-function makeOkFetch(spent: boolean): typeof fetch {
+// Valid hex inputs for the new (publicKey, stateHash) signature. The
+// pubkey is a 33-byte compressed secp256k1 key (66 hex chars). The
+// stateHash is a 34-byte imprint — algorithm prefix (2 bytes) plus
+// the 32-byte digest — encoded as 68 hex chars, matching the SDK's
+// `DataHash.fromJSON` expectation.
+const TEST_PUBKEY = '02' + 'a'.repeat(64);
+const TEST_STATEHASH_A = '0000' + 'a'.repeat(64);
+const TEST_STATEHASH_B = '0000' + 'b'.repeat(64);
+
+function makeProofFetch(spent: boolean): typeof fetch {
   return vi.fn(async () => ({
     ok: true,
-    json: async () => ({ result: { spent } }),
+    json: async () => ({
+      result: {
+        inclusionProof: {
+          transactionHash: spent ? 'aa'.repeat(32) : null,
+          authenticator: {},
+          merkleTreePath: { root: '', steps: [] },
+          unicityCertificate: '',
+        },
+        roundNumber: 1,
+      },
+    }),
   })) as unknown as typeof fetch;
 }
 
@@ -48,6 +79,17 @@ function makeNetworkErrorFetch(): typeof fetch {
   }) as unknown as typeof fetch;
 }
 
+function makeHttp400Fetch(): typeof fetch {
+  return vi.fn(async () => ({
+    ok: false,
+    status: 400,
+    statusText: 'Bad Request',
+    json: async () => ({
+      error: 'JSON-RPC requests must include either requestId or shardId',
+    }),
+  })) as unknown as typeof fetch;
+}
+
 function makeProvider(): UnicityAggregatorProvider {
   const provider = new UnicityAggregatorProvider({
     url: 'https://test.example/',
@@ -59,7 +101,7 @@ function makeProvider(): UnicityAggregatorProvider {
   return provider;
 }
 
-describe('UnicityAggregatorProvider.isSpent — Wave 3 fail-CLOSED contract', () => {
+describe('UnicityAggregatorProvider.isSpent — Issue #243 + Wave 3 fail-CLOSED contract', () => {
   let originalFetch: typeof fetch;
 
   beforeEach(() => {
@@ -71,16 +113,20 @@ describe('UnicityAggregatorProvider.isSpent — Wave 3 fail-CLOSED contract', ()
     vi.restoreAllMocks();
   });
 
-  it('returns true when aggregator confirms spent', async () => {
-    global.fetch = makeOkFetch(true);
+  it('returns true when inclusion proof carries a non-null transactionHash', async () => {
+    global.fetch = makeProofFetch(true);
     const provider = makeProvider();
-    await expect(provider.isSpent('state-hash-spent')).resolves.toBe(true);
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).resolves.toBe(true);
   });
 
-  it('returns false when aggregator confirms unspent', async () => {
-    global.fetch = makeOkFetch(false);
+  it('returns false when inclusion proof carries transactionHash:null (path-non-inclusion)', async () => {
+    global.fetch = makeProofFetch(false);
     const provider = makeProvider();
-    await expect(provider.isSpent('state-hash-unspent')).resolves.toBe(false);
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).resolves.toBe(false);
   });
 
   it('throws (NOT returns false) on JSON-RPC error envelope', async () => {
@@ -90,27 +136,59 @@ describe('UnicityAggregatorProvider.isSpent — Wave 3 fail-CLOSED contract', ()
     global.fetch = makeRpcErrorFetch();
     const provider = makeProvider();
 
-    await expect(provider.isSpent('state-hash-rpc-err')).rejects.toThrow(
-      /isSpent.*RPC failed/i,
-    );
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).rejects.toThrow(/isSpent.*RPC failed/i);
   });
 
   it('throws (NOT returns false) on network-layer failure', async () => {
     global.fetch = makeNetworkErrorFetch();
     const provider = makeProvider();
 
-    await expect(provider.isSpent('state-hash-net-err')).rejects.toThrow(
-      /isSpent.*RPC failed/i,
-    );
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).rejects.toThrow(/isSpent.*RPC failed/i);
   });
 
-  it('throws a SphereError with code AGGREGATOR_ERROR on failure', async () => {
+  it('throws (NOT returns false) on HTTP 400 — the Issue #243 baseline failure mode', async () => {
+    // The exact failure mode that motivated this fix: the canonical
+    // aggregator rejects unknown methods / missing requestId with an
+    // HTTP 400 at the request-validation layer. The new
+    // implementation no longer triggers this (it sends a valid
+    // requestId), but a misbehaving custom aggregator could still
+    // return 400 — we MUST throw, never silently return false.
+    global.fetch = makeHttp400Fetch();
+    const provider = makeProvider();
+
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).rejects.toThrow(/isSpent.*RPC failed/i);
+  });
+
+  it('throws a SphereError with code AGGREGATOR_ERROR on RPC failure', async () => {
     global.fetch = makeNetworkErrorFetch();
     const provider = makeProvider();
 
     let caught: unknown;
     try {
-      await provider.isSpent('state-hash');
+      await provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SphereError);
+    expect((caught as SphereError).code).toBe('AGGREGATOR_ERROR');
+  });
+
+  it('throws AGGREGATOR_ERROR when publicKey is malformed (caller-bug surface)', async () => {
+    // Bad-hex pubkey can never produce a valid requestId. Surface
+    // structurally so the disposition-engine's catch routes it
+    // through the same fail-closed path.
+    global.fetch = makeProofFetch(false);
+    const provider = makeProvider();
+
+    let caught: unknown;
+    try {
+      await provider.isSpent('not-hex!', TEST_STATEHASH_A);
     } catch (err) {
       caught = err;
     }
@@ -128,14 +206,27 @@ describe('UnicityAggregatorProvider.isSpent — Wave 3 fail-CLOSED contract', ()
       if (callCount === 1) throw new TypeError('Failed to fetch');
       return {
         ok: true,
-        json: async () => ({ result: { spent: true } }),
+        json: async () => ({
+          result: {
+            inclusionProof: {
+              transactionHash: 'aa'.repeat(32),
+              authenticator: {},
+              merkleTreePath: { root: '', steps: [] },
+              unicityCertificate: '',
+            },
+          },
+        }),
       };
     }) as unknown as typeof fetch;
 
     const provider = makeProvider();
-    await expect(provider.isSpent('state-hash-recovers')).rejects.toThrow();
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).rejects.toThrow();
     // Recovery: the cache did NOT pin the prior failure.
-    await expect(provider.isSpent('state-hash-recovers')).resolves.toBe(true);
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).resolves.toBe(true);
   });
 
   it('still caches confirmed-spent results (immutable answer)', async () => {
@@ -145,13 +236,26 @@ describe('UnicityAggregatorProvider.isSpent — Wave 3 fail-CLOSED contract', ()
       callCount++;
       return {
         ok: true,
-        json: async () => ({ result: { spent: true } }),
+        json: async () => ({
+          result: {
+            inclusionProof: {
+              transactionHash: 'aa'.repeat(32),
+              authenticator: {},
+              merkleTreePath: { root: '', steps: [] },
+              unicityCertificate: '',
+            },
+          },
+        }),
       };
     }) as unknown as typeof fetch;
 
     const provider = makeProvider();
-    await expect(provider.isSpent('state-hash-cached')).resolves.toBe(true);
-    await expect(provider.isSpent('state-hash-cached')).resolves.toBe(true);
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).resolves.toBe(true);
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).resolves.toBe(true);
     expect(callCount).toBe(1); // second call hit the cache
   });
 
@@ -163,13 +267,112 @@ describe('UnicityAggregatorProvider.isSpent — Wave 3 fail-CLOSED contract', ()
       callCount++;
       return {
         ok: true,
-        json: async () => ({ result: { spent: false } }),
+        json: async () => ({
+          result: {
+            inclusionProof: {
+              transactionHash: null,
+              authenticator: {},
+              merkleTreePath: { root: '', steps: [] },
+              unicityCertificate: '',
+            },
+          },
+        }),
       };
     }) as unknown as typeof fetch;
 
     const provider = makeProvider();
-    await expect(provider.isSpent('state-hash-unspent')).resolves.toBe(false);
-    await expect(provider.isSpent('state-hash-unspent')).resolves.toBe(false);
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).resolves.toBe(false);
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).resolves.toBe(false);
     expect(callCount).toBe(2); // both calls hit RPC
+  });
+
+  it('cache key binds (publicKey, stateHash) — different pubkeys do not collide', async () => {
+    // Multi-address wallets may probe the same stateHash under
+    // different pubkeys. A naive cache keyed only on stateHash
+    // would cross-pollinate results (a "spent" answer for one
+    // pubkey would silently apply to another, hiding genuine
+    // unspent state). Verify the new cache key prevents this.
+    let callCount = 0;
+    global.fetch = vi.fn(async () => {
+      callCount++;
+      return {
+        ok: true,
+        json: async () => ({
+          result: {
+            inclusionProof: {
+              transactionHash: 'aa'.repeat(32),
+              authenticator: {},
+              merkleTreePath: { root: '', steps: [] },
+              unicityCertificate: '',
+            },
+          },
+        }),
+      };
+    }) as unknown as typeof fetch;
+
+    const provider = makeProvider();
+    const otherPubkey = '03' + 'c'.repeat(64);
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).resolves.toBe(true);
+    await expect(
+      provider.isSpent(otherPubkey, TEST_STATEHASH_A),
+    ).resolves.toBe(true);
+    expect(callCount).toBe(2); // separate cache keys, both hit RPC
+  });
+
+  it('returns false when the aggregator response omits both inclusionProof and proof', async () => {
+    // Defense in depth: an ambiguous response (no proof field at all)
+    // is treated as "no proof yet" / unspent rather than throwing.
+    // This matches the legacy isSpent's tolerant default but
+    // preserves the fail-closed throw contract for transport errors.
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ result: {} }),
+    })) as unknown as typeof fetch;
+
+    const provider = makeProvider();
+    await expect(
+      provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_A),
+    ).resolves.toBe(false);
+  });
+
+  it('uses the canonical get_inclusion_proof method, not the broken isSpent RPC', async () => {
+    // Issue #243 regression: ensure the wire request targets
+    // `get_inclusion_proof` with a `requestId` param, not the
+    // non-existent `isSpent` method with a bare `stateHash`.
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        result: {
+          inclusionProof: {
+            transactionHash: null,
+            authenticator: {},
+            merkleTreePath: { root: '', steps: [] },
+            unicityCertificate: '',
+          },
+        },
+      }),
+    })) as unknown as typeof fetch;
+    global.fetch = fetchMock;
+
+    const provider = makeProvider();
+    await provider.isSpent(TEST_PUBKEY, TEST_STATEHASH_B);
+
+    const [, init] = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body)) as {
+      method: string;
+      params: { requestId?: string; stateHash?: string };
+    };
+    expect(body.method).toBe('get_inclusion_proof');
+    expect(body.params.requestId).toBeDefined();
+    expect(body.params.stateHash).toBeUndefined();
+    // Sanity: the requestId is a hex string (typically 68 chars for sha2-256).
+    expect(body.params.requestId).toMatch(/^[0-9a-f]+$/);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #243 — `sphere payments sync` hangs on testnet because the `SpentStateRescanWorker` hammers a non-existent `isSpent` JSON-RPC method that the canonical aggregator (aggregator-go) rejects with HTTP 400.

The aggregator indexes commitments by `requestId = SHA256(publicKey || stateHash)` and exposes only `submit_commitment`, `get_inclusion_proof`, `get_no_deletion_proof`, `get_block_height`. The hand-rolled `{method: 'isSpent', params: {stateHash}}` request was rejected at the request-validation layer ("must include either requestId or shardId"), causing every probe to throw, bump per-token throw counters, and produce log spam that wedged `manual-test-full-recovery.sh` at §C.2.

## Fix

- **`OracleProvider.isSpent(publicKey, stateHash)`** — signature widened to carry the owner pubkey needed for requestId derivation.
- **`UnicityAggregatorProvider.isSpent`** — derives `requestId` via the canonical SDK (`RequestId.create(pubkeyBytes, DataHash.fromJSON(stateHash))`), calls `get_inclusion_proof`, returns `true` iff `transactionHash !== null`. Spent-cache key bound to `(pubkey, stateHash)` so multi-address wallets don't cross-pollinate. Wave 3 fail-CLOSED throw contract preserved (RPC failure still throws `AGGREGATOR_ERROR`).
- **`PaymentsModule` callers** thread `identity.chainPubkey`:
  - `SpentStateRescanWorker.rescanDeps` wrapper (worker still sees the narrow `isSpent(stateHash)` interface — the wallet-scoped wrapper binds the pubkey).
  - `defaultOrphanRecovery` (orphan source state was OUR predicate).
  - `submitCommitmentClassified` (our commitment, our source state).

## Verification

| Check | Result |
|---|---|
| Build (`npm run build`) | clean |
| Type-check (`npx tsc --noEmit`) | clean |
| Focused live testnet repro (random pubkey + stateHash) | returns `false` — pre-fix returned HTTP 400 |
| Full unit suite | 7990 pass / 13 skipped / 0 fail |
| `manual-test-full-recovery.sh` §C.2 (the original 21-min hang) | completes cleanly (4 `Ready.` markers, ~3 min total) |
| Total `isSpent.*RPC failed` / `HTTP 400` in 25-min manual run | **0** |

### Tests

- Rewrote `UnicityAggregatorProvider.isSpent.test.ts` for the new contract (13 tests covering spent/unspent shapes, fail-closed on RPC error / HTTP 400 / network failure / bad-hex pubkey, cache-key binding, ambiguous-response handling, and a wire-format assertion that we call `get_inclusion_proof` not the broken `isSpent` method).
- Updated 3 call-arg assertions in `detect-orphan-spending-wrapper.test.ts` to include the pubkey first-arg.

## Out of scope / known limitations

- **Theoretical blind spot**: a `confirmed` token whose predicate publicKey isn't `chainPubkey` (e.g., from a sync race or pre-existing bug). The requestId derived from our pubkey wouldn't match what the aggregator stored, so isSpent would return false. Same blind spot existed in the old broken impl. Could be tightened by parsing the predicate CBOR for its real publicKey — left for a follow-up.
- **`manual-test-full-recovery.sh` §C.4** still fails with `[PROFILE:PROFILE_NOT_INITIALIZED]` — an unrelated OrbitDB-area issue in the peer2-view path, not the §C.2 hang from #243.

## Test plan

- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` (7990 pass / 13 skipped / 0 fail)
- [x] Focused live testnet repro via Node REPL
- [x] `manual-test-full-recovery.sh` §C.2 completes