### PR TITLE
fix(#245): isSpent + pointer-publish + OrbitDB connect follow-ups to #243

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -248,7 +248,7 @@ function isUxfV1Payload(value: unknown): value is UxfV1Payload {
 }
 import { parseInvoiceMemoForOnChain } from '../accounting/memo.js';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { hexToBytes as fromHex } from '../../core/hex';
+import { hexToBytes as fromHex, bytesToHex } from '../../core/hex';
 // `profile/types` is a pure types + constants module with zero runtime
 // dependencies — safe to import statically in every build. The previous
 // dynamic import was motivated by a bundle-size concern that didn't apply
@@ -768,6 +768,68 @@ function extractTokenIdFromSdkData(sdkData: string | undefined): string | null {
 function extractStateHashFromSdkData(sdkData: string | undefined): string {
   if (!sdkData) return '';
   return parseSdkDataCached(sdkData).stateHash;
+}
+
+/**
+ * Issue #245 #1 — extract the hex-encoded publicKey of the CURRENT
+ * state's predicate from a token's TXF sdkData.
+ *
+ * Why: the canonical aggregator indexes commitments by
+ * `requestId = SHA256(publicKey || stateHash)` where publicKey is
+ * the OWNER of the source state being consumed. Callers that probe
+ * `oracle.isSpent(publicKey, stateHash)` MUST pass the predicate's
+ * actual publicKey — not the wallet's `chainPubkey` — otherwise the
+ * derived requestId misses for tokens whose state.predicate was
+ * constructed under a foreign or non-current key (sync race,
+ * migration data, multi-address wallets where the worker runs
+ * against address A while the token's predicate was constructed
+ * under address B).
+ *
+ * Returns the hex-encoded publicKey, or `null` if the predicate
+ * cannot be parsed. Callers SHOULD fall back to `chainPubkey` on
+ * `null` so the probe still happens (preserves legacy behaviour for
+ * wallet-owned tokens with non-parseable predicates).
+ *
+ * Best-effort and async — does one SDK Token parse + one
+ * PredicateEngineService.createPredicate. Safe to call on the hot
+ * path: each parse is bounded by a small cache (the SDK's internal
+ * fromJSON caching) and the wrapper falls back to `chainPubkey` on
+ * any throw.
+ */
+async function extractCurrentStatePublicKeyHexFromSdkData(
+  sdkData: string | undefined,
+): Promise<string | null> {
+  if (!sdkData) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(sdkData);
+  } catch {
+    return null;
+  }
+  let sdkTokenInstance;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sdkTokenInstance = await SdkToken.fromJSON(parsed as any);
+  } catch {
+    return null;
+  }
+  if (!sdkTokenInstance?.state?.predicate) return null;
+  let predicate;
+  try {
+    predicate = await PredicateEngineService.createPredicate(
+      sdkTokenInstance.state.predicate,
+    );
+  } catch {
+    return null;
+  }
+  // DefaultPredicate / MaskedPredicate / UnmaskedPredicate all expose
+  // `publicKey: Uint8Array`. The IPredicate interface doesn't declare
+  // it, so narrow via runtime check + cast (matches the recipe at
+  // `recoverStrandedReceivedTokens`, line ~8979).
+  const pubkey = (predicate as unknown as { publicKey?: Uint8Array })
+    .publicKey;
+  if (!(pubkey instanceof Uint8Array) || pubkey.length === 0) return null;
+  return bytesToHex(pubkey);
 }
 
 /**
@@ -2211,26 +2273,35 @@ export class PaymentsModule {
       const rescanDeps: SpentStateRescanWorkerDeps = {
         tokensProvider: (): Iterable<Token> => this.tokens.values(),
         oracleProvider: (): {
-          readonly isSpent: (stateHash: string) => Promise<boolean>;
+          readonly isSpent: (token: Token, stateHash: string) => Promise<boolean>;
         } | null => {
-          // Issue #243 — wallet-scoped wrapper around oracle.isSpent.
-          // The underlying OracleProvider.isSpent now requires
-          // `(publicKey, stateHash)` (the canonical aggregator API
-          // indexes commitments by `RequestId.create(pubkey, hash)`).
-          // The worker only knows the stateHash, so we bind the
-          // active wallet's `chainPubkey` here — correct for any
-          // token in `this.tokens` because the worker scans the
-          // current address's holdings and our predicate's pubkey
-          // gates spending the current state.
+          // Issue #243 / #245 #1 — wallet-scoped wrapper around
+          // oracle.isSpent. The underlying OracleProvider.isSpent
+          // requires `(publicKey, stateHash)` because the canonical
+          // aggregator indexes commitments by
+          // `RequestId.create(pubkey, hash)`.
+          //
+          // Per-token publicKey extraction: parse the token's CURRENT
+          // state predicate from `sdkData` and use ITS publicKey,
+          // falling back to `chainPubkey` on parse failure. Binding
+          // `chainPubkey` for every token misses spent states whose
+          // predicate was constructed under a different key (sync
+          // race / migration data / multi-address wallets where the
+          // worker scans address A's pool but a token's predicate
+          // was built under address B).
           const oracle = this.deps?.oracle;
           if (oracle === undefined || typeof oracle.isSpent !== 'function') {
             return null;
           }
-          const ownerPubkey = this.deps?.identity?.chainPubkey;
-          if (!ownerPubkey) return null;
+          const fallbackPubkey = this.deps?.identity?.chainPubkey;
+          if (!fallbackPubkey) return null;
           return {
-            isSpent: (stateHash: string): Promise<boolean> =>
-              oracle.isSpent(ownerPubkey, stateHash),
+            isSpent: async (token: Token, stateHash: string): Promise<boolean> => {
+              const ownerPubkey =
+                (await extractCurrentStatePublicKeyHexFromSdkData(token.sdkData)) ??
+                fallbackPubkey;
+              return oracle.isSpent(ownerPubkey, stateHash);
+            },
           };
         },
         extractCurrentStateHash: (token: Token): string =>
@@ -3970,12 +4041,17 @@ export class PaymentsModule {
     }
     let aggregatorRecordsSpent: boolean;
     try {
-      // Issue #243 — pass owner pubkey alongside stateHash. The token
-      // is in this wallet's active set (orphan recovery only fires
-      // for our own locally-stranded tokens), so `chainPubkey` is the
-      // correct predicate owner for the requestId derivation.
+      // Issue #243 / #245 #1 — pass owner pubkey alongside stateHash.
+      // Prefer the publicKey embedded in the token's CURRENT state
+      // predicate (canonical aggregator requestId basis). Fall back
+      // to `chainPubkey` when the predicate cannot be parsed —
+      // matches the legacy assumption that orphan recovery only fires
+      // for our own locally-stranded tokens.
+      const ownerPubkey =
+        (await extractCurrentStatePublicKeyHexFromSdkData(token.sdkData)) ??
+        this.deps!.identity.chainPubkey;
       aggregatorRecordsSpent = await this.deps!.oracle.isSpent(
-        this.deps!.identity.chainPubkey,
+        ownerPubkey,
         sourceStateHash,
       );
     } catch (oracleErr) {
@@ -14119,20 +14195,35 @@ export class PaymentsModule {
     // commit" from generic failures via an authoritative oracle
     // re-query against the source state hash.
     //
-    // Issue #243 — pass owner pubkey alongside stateHash. The source
-    // state we just tried to consume was guarded by OUR predicate
-    // (we constructed the commitment), so the requestId the aggregator
-    // indexed under is derived from `chainPubkey` + the source state.
+    // Issue #243 / #245 #1 — pass owner pubkey alongside stateHash.
+    // Derive the publicKey from the commitment's actual source-state
+    // predicate (the canonical aggregator requestId basis). The
+    // commitment we constructed carries the source-state predicate
+    // directly, so this is more precise than wrapping `chainPubkey`
+    // (which is wrong for multi-address wallets where the source
+    // predicate was built under a different address).
     let isSpent = false;
     let sourceStateHashHex: string | null = null;
     if (oracle !== undefined && typeof oracle.isSpent === 'function') {
       try {
         const sourceStateHashObj = await commitment.transactionData.sourceState.calculateHash();
         sourceStateHashHex = sourceStateHashObj.toJSON();
-        isSpent = await oracle.isSpent(
-          this.deps!.identity.chainPubkey,
-          sourceStateHashHex,
-        );
+        // Best-effort predicate-publicKey extraction. The fallback to
+        // `chainPubkey` preserves the legacy assumption for wallet-
+        // owned source states; a partial / mocked commitment without
+        // a `.predicate` field must NOT skip the isSpent probe.
+        let ownerPubkey: string = this.deps!.identity.chainPubkey;
+        const sourceState = commitment.transactionData.sourceState as
+          | { predicate?: unknown }
+          | undefined;
+        const sourcePredicate = sourceState?.predicate;
+        if (sourcePredicate !== undefined && sourcePredicate !== null) {
+          const pubkeyBytes = (sourcePredicate as { publicKey?: unknown }).publicKey;
+          if (pubkeyBytes instanceof Uint8Array && pubkeyBytes.length > 0) {
+            ownerPubkey = bytesToHex(pubkeyBytes);
+          }
+        }
+        isSpent = await oracle.isSpent(ownerPubkey, sourceStateHashHex);
       } catch (probeErr) {
         // The probe is best-effort. If it throws (e.g. aggregator
         // offline), we fall through to the generic

--- a/modules/payments/transfer/spent-state-rescan-worker.ts
+++ b/modules/payments/transfer/spent-state-rescan-worker.ts
@@ -101,9 +101,16 @@ import { redactCause } from '../../../core/errors';
  * `isSpent`. Threaded as a provider closure (mirrors the verifier's
  * pattern) so the worker observes hot-swaps and uninstalls without
  * holding a dangling reference past `Sphere.destroy()`.
+ *
+ * Issue #245 #1 — the callback receives the full `Token` so the
+ * wrapper at the PaymentsModule boundary can derive the predicate's
+ * actual publicKey from `token.sdkData` (the canonical aggregator
+ * indexes commitments by `RequestId.create(predicatePublicKey, hash)`).
+ * Wrapping the wallet's `chainPubkey` for every token misses spent
+ * states whose predicate was constructed under a different key.
  */
 export type SpentStateOracleProvider = () => {
-  readonly isSpent: (stateHash: string) => Promise<boolean>;
+  readonly isSpent: (token: Token, stateHash: string) => Promise<boolean>;
 } | null;
 
 /**
@@ -474,7 +481,10 @@ export class SpentStateRescanWorker {
   ): Promise<'spent' | 'unspent' | 'threw'> {
     let isSpent: boolean;
     try {
-      isSpent = await oracle.isSpent(stateHash);
+      // Issue #245 #1 — pass the token so the wrapper can derive the
+      // current state's predicate publicKey (canonical aggregator
+      // requestId basis). See SpentStateOracleProvider for rationale.
+      isSpent = await oracle.isSpent(token, stateHash);
     } catch (err) {
       this.recordThrow(token.id);
       this.warn('oracle.isSpent threw; bumping per-token throw counter', {

--- a/oracle/UnicityAggregatorProvider.ts
+++ b/oracle/UnicityAggregatorProvider.ts
@@ -34,6 +34,7 @@ import { StateTransitionClient } from '@unicitylabs/state-transition-sdk/lib/Sta
 import { AggregatorClient } from '@unicitylabs/state-transition-sdk/lib/api/AggregatorClient';
 import { RootTrustBase } from '@unicitylabs/state-transition-sdk/lib/bft/RootTrustBase';
 import { Token as SdkToken } from '@unicitylabs/state-transition-sdk/lib/token/Token';
+import { PredicateEngineService } from '@unicitylabs/state-transition-sdk/lib/predicate/PredicateEngineService';
 import { waitInclusionProof } from '@unicitylabs/state-transition-sdk/lib/util/InclusionProofUtils';
 import type { TransferCommitment as SdkTransferCommitment } from '@unicitylabs/state-transition-sdk/lib/transaction/TransferCommitment';
 import {
@@ -42,7 +43,7 @@ import {
 } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof';
 import { RequestId } from '@unicitylabs/state-transition-sdk/lib/api/RequestId';
 import { DataHash } from '@unicitylabs/state-transition-sdk/lib/hash/DataHash';
-import { hexToBytes } from '../core/hex';
+import { hexToBytes, bytesToHex } from '../core/hex';
 
 // SDK MintCommitment type - using interface to avoid generic complexity
 interface SdkMintCommitment {
@@ -521,11 +522,28 @@ export class UnicityAggregatorProvider implements OracleProvider {
   async validateToken(tokenData: unknown): Promise<ValidationResult> {
     this.ensureConnected();
 
+    // Issue #245 #5 — parse the SDK token ONCE so we can reuse it for
+    // (a) SDK-path verification AND (b) deriving the predicate
+    // publicKey for the spent-cache key. Aligning the cache key with
+    // `isSpent`'s `${publicKey}:${stateHash}` format lets a
+    // validateToken-driven spent decision short-circuit a subsequent
+    // `isSpent(pubkey, sameHash)` call (and vice versa). Pre-parsing
+    // is cheap relative to the RPC fallback and is best-effort —
+    // failure here only prevents the spent-cache key from including
+    // the publicKey (cached under bare stateHash as legacy fallback).
+    let sdkToken: Awaited<ReturnType<typeof SdkToken.fromJSON>> | null = null;
+    try {
+      sdkToken = await SdkToken.fromJSON(tokenData);
+    } catch {
+      // Pre-parse failed; SDK path will detect the same failure and
+      // fall through to RPC. Cache key falls back to legacy bare-
+      // stateHash form below.
+    }
+
     try {
       // Try SDK validation first if we have trust base
-      if (this.trustBase && !this.config.skipVerification) {
+      if (this.trustBase && !this.config.skipVerification && sdkToken !== null) {
         try {
-          const sdkToken = await SdkToken.fromJSON(tokenData);
           const verifyResult = await sdkToken.verify(this.trustBase);
 
           // Calculate state hash
@@ -563,9 +581,17 @@ export class UnicityAggregatorProvider implements OracleProvider {
         data: { valid },
       });
 
-      // Cache spent state if spent (Wave L: bounded with LRU eviction)
+      // Cache spent state if spent (Wave L: bounded with LRU eviction).
+      // Issue #245 #5 — key under `${publicKey}:${stateHash}` when the
+      // predicate publicKey can be derived, matching `isSpent`'s key
+      // namespace so cache hits transfer between the two paths.
       if (response.stateHash && spent) {
-        this.cacheSpent(response.stateHash);
+        const pubkeyHex = await this.derivePredicatePublicKeyHex(sdkToken);
+        const cacheKey =
+          pubkeyHex !== null
+            ? `${pubkeyHex}:${response.stateHash}`
+            : response.stateHash;
+        this.cacheSpent(cacheKey);
       }
 
       return {
@@ -581,6 +607,33 @@ export class UnicityAggregatorProvider implements OracleProvider {
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  /**
+   * Issue #245 #5 — derive the hex-encoded publicKey from a parsed
+   * SDK Token's current state predicate. Best-effort; returns `null`
+   * when the predicate is missing or cannot be materialized.
+   *
+   * Same recipe as PaymentsModule's
+   * `extractCurrentStatePublicKeyHexFromSdkData` but operates on an
+   * already-parsed `SdkToken` (validateToken parses once and shares).
+   */
+  private async derivePredicatePublicKeyHex(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sdkToken: any,
+  ): Promise<string | null> {
+    if (sdkToken === null || sdkToken === undefined) return null;
+    const statePredicate = sdkToken?.state?.predicate;
+    if (statePredicate === undefined || statePredicate === null) return null;
+    let predicate;
+    try {
+      predicate = await PredicateEngineService.createPredicate(statePredicate);
+    } catch {
+      return null;
+    }
+    const pubkey = (predicate as unknown as { publicKey?: Uint8Array }).publicKey;
+    if (!(pubkey instanceof Uint8Array) || pubkey.length === 0) return null;
+    return bytesToHex(pubkey);
   }
 
   /**
@@ -844,15 +897,23 @@ export class UnicityAggregatorProvider implements OracleProvider {
     // ambiguous — treat as "no proof yet" (unspent) rather than
     // throwing, matching the legacy isSpent's tolerant default but
     // KEEPING the fail-closed throw contract for transport errors.
+    //
+    // Issue #245 #4 — tighten the spent decision. Per the canonical
+    // aggregator contract, `transactionHash` is either a non-empty
+    // string hex (path-inclusion proof → spent) or null/undefined
+    // (path-non-inclusion → unspent). A misbehaving aggregator that
+    // returns `transactionHash: { unexpected: 'shape' }` would slip
+    // past a bare `!== null && !== undefined` check and be classified
+    // as spent. Require the canonical shape: non-empty string.
     const proof = (response.inclusionProof ?? response.proof) as
-      | { transactionHash?: string | null }
+      | { transactionHash?: unknown }
+      | null
       | undefined;
-    const spent =
-      proof !== undefined &&
-      proof !== null &&
-      typeof proof === 'object' &&
-      proof.transactionHash !== null &&
-      proof.transactionHash !== undefined;
+    let spent = false;
+    if (proof !== undefined && proof !== null && typeof proof === 'object') {
+      const txHash = (proof as { transactionHash?: unknown }).transactionHash;
+      spent = typeof txHash === 'string' && txHash.length > 0;
+    }
 
     // Cache result (Wave L: bounded with LRU eviction)
     if (spent) {

--- a/profile/orbitdb-adapter.ts
+++ b/profile/orbitdb-adapter.ts
@@ -112,10 +112,92 @@ export class OrbitDbAdapter implements ProfileDatabase {
     if (this.connectInFlight) {
       return this.connectInFlight;
     }
-    this.connectInFlight = this.connectInner(config).finally(() => {
+    this.connectInFlight = this.connectWithRetry(config).finally(() => {
       this.connectInFlight = null;
     });
     return this.connectInFlight;
+  }
+
+  /**
+   * Issue #245 #2 — bounded retry wrapper around `connectInner`.
+   *
+   * **Why:** the manual-test-full-recovery.sh §C.4 step reliably
+   * surfaced
+   *   `Failed to attach OrbitDB: ORBITDB_CONNECTION_FAILED: ...
+   *    Failed to connect to OrbitDB: Database is not open`
+   * on the FIRST CLI invocation following a daemon-driven sync
+   * (where the daemon's prior `closeInner()` had hit the
+   * `helia.stop exceeded 10000ms — dropping reference and continuing`
+   * budget timeout, leaving on-disk state in a transient
+   * lock/teardown limbo). The next process couldn't open the same
+   * directory cleanly until ~seconds had passed.
+   *
+   * `cleanupOnError()` (run inside `connectInner` on throw) wipes
+   * adapter-local helia/orbitdb/db handles before re-throwing — so
+   * a retry creates a fresh helia + orbitdb pair from scratch. That
+   * makes the retry both safe (no stale state carry-over) and
+   * meaningful (we get a fresh attempt at acquiring the on-disk
+   * locks / pubsub init / DB open).
+   *
+   * **Retry budget:** 2 attempts × 1.5s linear backoff = ~3-4.5s
+   * worst-case extra latency. Acceptable given the failure mode
+   * (test-script reliability + UX after a daemon restart). We do
+   * NOT retry `ORBITDB_NOT_INSTALLED` — that's a sticky dep error.
+   *
+   * **Multi-process diagnosis:** if all retries exhaust and the
+   * final message matches a lock-contention pattern, we augment the
+   * error with an actionable hint pointing at the most likely cause
+   * (a sphere daemon holding the lock). The base ProfileErrorCode
+   * is preserved so callers' code-based routing keeps working.
+   */
+  private async connectWithRetry(config: OrbitDbConfig): Promise<void> {
+    const RETRY_ATTEMPTS = 2; // 1 initial + 2 retries = 3 total
+    const RETRY_BACKOFF_MS = 1500;
+    let lastErr: unknown;
+    for (let attempt = 0; attempt <= RETRY_ATTEMPTS; attempt++) {
+      try {
+        await this.connectInner(config);
+        return;
+      } catch (err) {
+        lastErr = err;
+        // Sticky errors: no retry. ORBITDB_NOT_INSTALLED is a dep
+        // problem that won't fix itself; retrying just delays the
+        // operator-visible failure.
+        if (
+          err instanceof ProfileError &&
+          err.code === 'ORBITDB_NOT_INSTALLED'
+        ) {
+          throw err;
+        }
+        if (attempt >= RETRY_ATTEMPTS) break;
+        // Linear backoff (≥1s) — absorbs a few seconds of teardown
+        // / file-lock release without overshooting.
+        await new Promise((resolve) => setTimeout(resolve, RETRY_BACKOFF_MS));
+      }
+    }
+    // Augment the final error with multi-process diagnostic hint
+    // when the message matches a likely lock-contention or
+    // teardown-race pattern. Keep the original code so any caller
+    // that branches on `err.code === 'ORBITDB_CONNECTION_FAILED'`
+    // keeps working.
+    if (
+      lastErr instanceof ProfileError &&
+      lastErr.code === 'ORBITDB_CONNECTION_FAILED' &&
+      /Database is not open|LOCK|Resource temporarily unavailable|lockfile|EBUSY/i.test(
+        lastErr.message,
+      )
+    ) {
+      throw new ProfileError(
+        'ORBITDB_CONNECTION_FAILED',
+        `${lastErr.message} (after ${RETRY_ATTEMPTS + 1} attempts). ` +
+          `This is typically caused by another process (e.g. a ` +
+          `\`sphere daemon\`) still holding the OrbitDB / Helia ` +
+          `directory lock. Stop the daemon (\`sphere daemon stop\`) ` +
+          `or wait for its teardown to complete, then retry.`,
+        lastErr,
+      );
+    }
+    throw lastErr;
   }
 
   private async connectInner(config: OrbitDbConfig): Promise<void> {

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -109,6 +109,41 @@ const POINTER_POLL_MIN_MS = 30_000;
 const POINTER_POLL_RANGE_MS = 60_000; // → [30s, 90s)
 const POINTER_POLL_BACKOFF_MULTIPLIER = 5;
 
+/**
+ * Issue #245 #3 — outer throttle window applied AFTER a
+ * `AGGREGATOR_POINTER_WALKBACK_FLOOR` transient failure. While this
+ * window is active, subsequent `publishAggregatorPointerBestEffort`
+ * calls short-circuit (returning the same transient outcome) rather
+ * than burning another ~9-15s of inner reconcile-retry budget.
+ *
+ * Rationale: WALKBACK_FLOOR fires when the aggregator's current
+ * highest-visible version is BELOW a version this wallet has already
+ * confirmed (replication lag). It is DETERMINISTIC for a given
+ * `(currentLocalVersion, aggregator state)` — retrying within
+ * milliseconds returns the same answer. The existing inner retry
+ * (5 attempts with exponential backoff up to ~15s total) already
+ * absorbs short lag windows; this outer throttle absorbs the
+ * longer-lag case where lag persists past the inner budget and we'd
+ * otherwise re-burn it on every save-driven flush (debounce ~2s)
+ * and every periodic pointer poll. A 25-min manual-test run with
+ * this scenario emitted hundreds of identical WARN lines per #245.
+ *
+ * The `pendingPublishCid` marker is preserved across throttled
+ * skips — the at-least-once gate (PaymentsModule.handleIncomingTransfer)
+ * stays closed for the entire throttle window, exactly as if the
+ * inner retries kept failing. The user observes a slightly longer
+ * delay before durable publish, in exchange for orders-of-magnitude
+ * less log noise and CPU spent in pointless retries.
+ *
+ * 60s is chosen so a routine ~30s replication lag clears within one
+ * throttle window; at the typical 2s save debounce that reduces WARN
+ * volume by ~30x. Other transient codes (NETWORK_ERROR,
+ * UNCLASSIFIED) are NOT throttled — those are not deterministic given
+ * local state and benefit from prompt retry.
+ */
+const WALKBACK_FLOOR_RETRY_THROTTLE_MS = 60_000;
+const WALKBACK_FLOOR_CODE = 'AGGREGATOR_POINTER_WALKBACK_FLOOR';
+
 export class LifecycleManager {
   /**
    * Periodic-poll timer for Path 2 (aggregator pointer recovery).
@@ -117,6 +152,25 @@ export class LifecycleManager {
    * it). Set by `schedulePointerPoll()`, cleared by `shutdown()`.
    */
   private pointerPollTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Issue #245 #3 — wall-clock deadline (ms epoch) until which a
+   * publish attempt should short-circuit because a recent attempt
+   * hit `AGGREGATOR_POINTER_WALKBACK_FLOOR`. Zero when no throttle is
+   * active. Cleared on:
+   *   - any successful publish (lag has cleared)
+   *   - a transient failure with a DIFFERENT code (the prior
+   *     WALKBACK_FLOOR diagnosis no longer applies — different fault
+   *     class, the inner retry budget is the right tool)
+   * See `WALKBACK_FLOOR_RETRY_THROTTLE_MS` for rationale.
+   */
+  private walkbackFloorThrottleUntilMs = 0;
+  /**
+   * Issue #245 #3 — number of throttled-skip events accumulated
+   * during the active throttle window. Logged at the END (next
+   * non-throttled outcome) so a single summary replaces the storm.
+   */
+  private walkbackFloorThrottleSkipCount = 0;
 
   /**
    * Poll-discovery handler captured from `initialize()`. Invoked by
@@ -380,6 +434,23 @@ export class LifecycleManager {
       return { ok: false, transient: false };
     }
 
+    // Issue #245 #3 — short-circuit while a WALKBACK_FLOOR throttle is
+    // active. Returns the same shape as the transient-failure arm so
+    // callers (flushToIpfs / retryPendingPublishIfAny) keep the
+    // `pendingPublishCid` marker live and hold the at-least-once gate
+    // closed. No log line per skip — only a summary when the throttle
+    // clears (in the catch arm or the success arm).
+    const nowMs = Date.now();
+    if (nowMs < this.walkbackFloorThrottleUntilMs) {
+      this.walkbackFloorThrottleSkipCount += 1;
+      // Mark the pending CID — caller may have invoked with a fresh
+      // CID (save-driven flush) that we couldn't publish yet. Set
+      // unconditionally so a wakeup retry uses the most recent CID
+      // rather than a stale one.
+      this.host.setPendingPublishCid(cidString);
+      return { ok: false, transient: true, code: WALKBACK_FLOOR_CODE };
+    }
+
     try {
       const cidBytes = CID.parse(cidString).bytes;
       const result = await pointer.publish(async () => cidBytes);
@@ -387,6 +458,17 @@ export class LifecycleManager {
       // Clear any previously-pending marker — this publish succeeded,
       // so the cross-device recovery path can now reach the bundle.
       this.host.setPendingPublishCid(null);
+      // Issue #245 #3 — successful publish clears the throttle and
+      // logs the prior skip count (operator visibility on how much
+      // noise was suppressed).
+      if (this.walkbackFloorThrottleSkipCount > 0) {
+        this.host.log(
+          `Pointer publish recovered after ${this.walkbackFloorThrottleSkipCount} ` +
+            `WALKBACK_FLOOR-throttled skip(s).`,
+        );
+      }
+      this.walkbackFloorThrottleUntilMs = 0;
+      this.walkbackFloorThrottleSkipCount = 0;
       this.host.log(
         `Pointer publish ok: cid=${cidString} version=${result.version} attempts=${result.attemptsUsed}`,
       );
@@ -401,6 +483,11 @@ export class LifecycleManager {
         // alert event is the call to action; auto-retry would just
         // hammer a wallet that needs human intervention.
         this.host.setPendingPublishCid(null);
+        // Issue #245 #3 — permanent failure also clears the WALKBACK
+        // throttle (it no longer applies — we've decided to stop
+        // retrying entirely).
+        this.walkbackFloorThrottleUntilMs = 0;
+        this.walkbackFloorThrottleSkipCount = 0;
         return { ok: false, transient: false, code };
       }
       // Elevate the transient publish failure to warn-level so the
@@ -417,11 +504,33 @@ export class LifecycleManager {
         'Profile-TokenStorage',
         `Pointer publish failed (transient, code=${transientCode}, cid=${cidString}): ${msg}`,
       );
+      // Issue #245 #3 — arm / disarm the WALKBACK_FLOOR throttle.
+      // Only WALKBACK_FLOOR is throttled (it's deterministic for a
+      // given currentLocalVersion / aggregator state); other transient
+      // codes (NETWORK_ERROR, UNCLASSIFIED, …) are NOT throttled —
+      // they're not deterministic and benefit from prompt retry. A
+      // non-WALKBACK transient AFTER a WALKBACK clears the throttle
+      // because the fault class changed (the prior diagnosis no longer
+      // applies).
+      if (transientCode === WALKBACK_FLOOR_CODE) {
+        this.walkbackFloorThrottleUntilMs =
+          Date.now() + WALKBACK_FLOOR_RETRY_THROTTLE_MS;
+        this.walkbackFloorThrottleSkipCount = 0;
+      } else {
+        if (this.walkbackFloorThrottleSkipCount > 0) {
+          this.host.log(
+            `Pointer publish: ${this.walkbackFloorThrottleSkipCount} ` +
+              `WALKBACK_FLOOR-throttled skip(s) cleared by new transient code=${transientCode}.`,
+          );
+        }
+        this.walkbackFloorThrottleUntilMs = 0;
+        this.walkbackFloorThrottleSkipCount = 0;
+      }
       // Transient: stamp the retry marker (with localCache persistence
       // for crash safety) so subsequent flushes / polls re-attempt
       // before any new save-driven work.
       this.host.setPendingPublishCid(cidString);
-      return { ok: false, transient: true };
+      return { ok: false, transient: true, code: transientCode };
     }
   }
 

--- a/tests/integration/payments/spent-state-rescan.test.ts
+++ b/tests/integration/payments/spent-state-rescan.test.ts
@@ -187,7 +187,10 @@ function makeAuditRecorder(): AuditRecorder {
 function buildWorker(args: {
   readonly peer: Peer;
   readonly tokens: ReadonlyArray<Token>;
-  readonly isSpent: (stateHash: string) => Promise<boolean>;
+  // Issue #245 #1 — isSpent now receives the token (so the
+  // PaymentsModule wrapper can derive per-token publicKey). Tests
+  // ignore the token and key on stateHash only.
+  readonly isSpent: (token: Token, stateHash: string) => Promise<boolean>;
   readonly audit: AuditRecorder;
   readonly emit: SpentStateRescanWorkerDeps['emit'];
 }): SpentStateRescanWorker {
@@ -362,7 +365,7 @@ describe('SpentStateRescanWorker — integration with real OUTBOX/SENT writers (
     const worker = buildWorker({
       peer,
       tokens,
-      isSpent: async (stateHash: string): Promise<boolean> => {
+      isSpent: async (_token: Token, stateHash: string): Promise<boolean> => {
         if (stateHash === 'state-tok-spent') return true;
         if (stateHash === 'state-tok-unspent') return false;
         throw new Error(`unexpected stateHash: ${stateHash}`);

--- a/tests/unit/payments/transfer/spent-state-rescan-worker.test.ts
+++ b/tests/unit/payments/transfer/spent-state-rescan-worker.test.ts
@@ -79,7 +79,10 @@ function makeToken(overrides: Partial<Token> = {}): Token {
 }
 
 interface FakeOracle {
-  readonly isSpent: (stateHash: string) => Promise<boolean>;
+  // Issue #245 #1 — isSpent receives the token so callers can derive
+  // per-token publicKey from token.sdkData (the PaymentsModule wrapper
+  // does this). Test fakes ignore the token and key on stateHash only.
+  readonly isSpent: (token: Token, stateHash: string) => Promise<boolean>;
   readonly calls: () => ReadonlyArray<string>;
 }
 
@@ -98,7 +101,7 @@ function makeOracle(
       };
   return {
     calls: () => calls,
-    async isSpent(stateHash: string): Promise<boolean> {
+    async isSpent(_token: Token, stateHash: string): Promise<boolean> {
       calls.push(stateHash);
       const o = resolve(stateHash);
       if (o instanceof Error) throw o;
@@ -471,7 +474,7 @@ describe('SpentStateRescanWorker — outcomes (Issue #174)', () => {
     const tokens = [makeToken({ id: 't1' })];
     let throwNext = true;
     const oracle = {
-      isSpent: vi.fn(async (_sh: string) => {
+      isSpent: vi.fn(async (_token: Token, _sh: string) => {
         if (throwNext) throw new Error('flake');
         return false;
       }),
@@ -517,7 +520,7 @@ describe('SpentStateRescanWorker — concurrency cap (Issue #174)', () => {
     let inFlight = 0;
     let peak = 0;
     const oracle = {
-      isSpent: async (_sh: string): Promise<boolean> => {
+      isSpent: async (_token: Token, _sh: string): Promise<boolean> => {
         inFlight += 1;
         if (inFlight > peak) peak = inFlight;
         // Yield so we can observe concurrent in-flights.
@@ -620,7 +623,7 @@ describe('SpentStateRescanWorker — lifecycle (Issue #174)', () => {
   it('stop() awaits in-flight scan cycle', async () => {
     let resolveProbe: ((v: boolean) => void) | null = null;
     const oracle = {
-      isSpent: (_sh: string): Promise<boolean> =>
+      isSpent: (_token: Token, _sh: string): Promise<boolean> =>
         new Promise<boolean>((r) => {
           resolveProbe = r;
         }),

--- a/tests/unit/profile/lifecycle-manager-publish-retry.test.ts
+++ b/tests/unit/profile/lifecycle-manager-publish-retry.test.ts
@@ -308,3 +308,147 @@ describe('LifecycleManager.publishAggregatorPointerBestEffort — Gap 2', () => 
     }
   });
 });
+
+/**
+ * Issue #245 #3 — WALKBACK_FLOOR retry throttle.
+ *
+ * After a `AGGREGATOR_POINTER_WALKBACK_FLOOR` transient failure,
+ * subsequent calls to `publishAggregatorPointerBestEffort` within
+ * the throttle window short-circuit (returning the same transient
+ * code) WITHOUT invoking `pointer.publish` — which prevents burning
+ * the ~9-15s inner retry budget on a deterministic-given-state
+ * failure mode and reduces log noise from "hundreds" to ~one per
+ * minute (per the issue's observed manual-test storm).
+ *
+ * Coverage:
+ *   - First WALKBACK_FLOOR arms the throttle and stamps the CID.
+ *   - Second call within the window short-circuits (publish NOT
+ *     invoked) but still returns transient + keeps the CID stamped.
+ *   - A different transient code (NETWORK_ERROR) CLEARS the
+ *     throttle — fault class change re-enables prompt retry.
+ *   - A successful publish CLEARS the throttle and re-enables
+ *     normal retry on future failures.
+ */
+describe('LifecycleManager.publishAggregatorPointerBestEffort — WALKBACK_FLOOR throttle (#245 #3)', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function walkbackError(): AggregatorPointerError {
+    return new AggregatorPointerError(
+      AggregatorPointerErrorCode.WALKBACK_FLOOR,
+      'simulated replication lag — Phase 3 walkback below localVersion',
+    );
+  }
+
+  it('first WALKBACK_FLOOR arms the throttle; second call within window short-circuits', async () => {
+    const publish = vi.fn(async () => {
+      throw walkbackError();
+    });
+    const pointer = stubPointer({ publish });
+    const handle = await createTestProvider(pointer);
+    try {
+      // First call — invokes publish, hits WALKBACK_FLOOR, arms throttle.
+      const r1 = await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(r1.ok).toBe(false);
+      expect(r1.transient).toBe(true);
+      expect(r1.code).toBe('AGGREGATOR_POINTER_WALKBACK_FLOOR');
+      expect(publish).toHaveBeenCalledOnce();
+      expect(handle.getPendingPublishCid()).toBe(FAKE_CID);
+
+      // Second call within the throttle window — short-circuits.
+      const r2 = await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(r2.ok).toBe(false);
+      expect(r2.transient).toBe(true);
+      expect(r2.code).toBe('AGGREGATOR_POINTER_WALKBACK_FLOOR');
+      // publish was NOT called again — throttle short-circuited.
+      expect(publish).toHaveBeenCalledOnce();
+      // pendingPublishCid still stamped (caller's flush body needs it).
+      expect(handle.getPendingPublishCid()).toBe(FAKE_CID);
+    } finally {
+      await handle.provider.shutdown();
+    }
+  });
+
+  it('a different transient code (NETWORK_ERROR) clears the throttle', async () => {
+    let nextThrow: 'walkback' | 'network' = 'walkback';
+    const publish = vi.fn(async () => {
+      if (nextThrow === 'walkback') throw walkbackError();
+      throw new AggregatorPointerError(
+        AggregatorPointerErrorCode.NETWORK_ERROR,
+        'simulated network blip',
+      );
+    });
+    const pointer = stubPointer({ publish });
+    const handle = await createTestProvider(pointer);
+    try {
+      // Arm the throttle with WALKBACK_FLOOR.
+      await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(publish).toHaveBeenCalledOnce();
+
+      // Throttled — publish NOT invoked.
+      await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(publish).toHaveBeenCalledOnce();
+
+      // Manually clear the throttle by simulating the WALKBACK lag
+      // expiring (test-only knob via internals — avoids waiting 60s).
+      (handle.provider as unknown as {
+        lifecycleManager: { walkbackFloorThrottleUntilMs: number };
+      }).lifecycleManager.walkbackFloorThrottleUntilMs = 0;
+
+      // Next call hits the NETWORK_ERROR arm — publish invoked,
+      // and the throttle should NOT re-arm (different code class).
+      nextThrow = 'network';
+      const r = await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(r.transient).toBe(true);
+      expect(r.code).toBe('AGGREGATOR_POINTER_NETWORK_ERROR');
+      expect(publish).toHaveBeenCalledTimes(2);
+
+      // Subsequent call after NETWORK_ERROR is NOT throttled.
+      await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(publish).toHaveBeenCalledTimes(3);
+    } finally {
+      await handle.provider.shutdown();
+    }
+  });
+
+  it('successful publish clears the throttle', async () => {
+    let succeedNext = false;
+    const publish = vi.fn(async () => {
+      if (!succeedNext) throw walkbackError();
+      return { cid: new Uint8Array(0), version: 99, attemptsUsed: 1 } as never;
+    });
+    const pointer = stubPointer({ publish });
+    const handle = await createTestProvider(pointer);
+    try {
+      // Arm the throttle.
+      await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(publish).toHaveBeenCalledOnce();
+      // Throttled.
+      await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(publish).toHaveBeenCalledOnce();
+
+      // Clear throttle (simulate window expiry), then succeed.
+      (handle.provider as unknown as {
+        lifecycleManager: { walkbackFloorThrottleUntilMs: number };
+      }).lifecycleManager.walkbackFloorThrottleUntilMs = 0;
+      succeedNext = true;
+      const r = await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(r.ok).toBe(true);
+      expect(publish).toHaveBeenCalledTimes(2);
+      expect(handle.getPendingPublishCid()).toBeNull();
+
+      // Throttle was cleared on success; a future WALKBACK_FLOOR
+      // would re-arm fresh (no carry-over from prior session).
+      succeedNext = false;
+      await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(publish).toHaveBeenCalledTimes(3);
+    } finally {
+      await handle.provider.shutdown();
+    }
+  });
+});

--- a/tests/unit/profile/orbitdb-adapter.test.ts
+++ b/tests/unit/profile/orbitdb-adapter.test.ts
@@ -297,3 +297,126 @@ describe('OrbitDbAdapter.close() teardown budget', () => {
     expect(adapter.isConnected()).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #245 #2 — connect() retry wrapper for transient init failures.
+//
+// `connectInner` can throw `ORBITDB_CONNECTION_FAILED` with messages
+// matching "Database is not open" / "LOCK" / "EBUSY" patterns when a
+// prior teardown's on-disk lock release hasn't fully landed. The retry
+// wrapper gives 2 extra attempts with 1.5s linear backoff before
+// surfacing the failure (augmented with a multi-process diagnostic
+// hint when the pattern matches).
+// ---------------------------------------------------------------------------
+
+describe('OrbitDbAdapter.connect() — Issue #245 #2 retry on transient init failure', () => {
+  beforeEach(() => {
+    // Real timers — we want the actual backoff sleeps to elapse.
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // Helper: wrap an OrbitDbAdapter so we can stub `connectInner` (private).
+  function withStubbedConnectInner(
+    impl: (config: OrbitDbConfig) => Promise<void>,
+  ): { adapter: OrbitDbAdapter; spy: ReturnType<typeof vi.fn> } {
+    const adapter = new OrbitDbAdapter();
+    const spy = vi.fn(impl);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (adapter as any).connectInner = spy;
+    return { adapter, spy };
+  }
+
+  it('retries up to 2 times on transient ORBITDB_CONNECTION_FAILED, then succeeds', async () => {
+    const { ProfileError } = await import('../../../profile/errors.js');
+    let attempt = 0;
+    const { adapter, spy } = withStubbedConnectInner(async () => {
+      attempt += 1;
+      if (attempt < 3) {
+        throw new ProfileError(
+          'ORBITDB_CONNECTION_FAILED',
+          'Failed to connect to OrbitDB: Database is not open',
+        );
+      }
+      // Mark connected on the 3rd attempt so isConnected() reports true.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (adapter as any).connected = true;
+    });
+
+    await adapter.connect({ privateKey: 'aa'.repeat(32) });
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(adapter.isConnected()).toBe(true);
+  });
+
+  it('does NOT retry ORBITDB_NOT_INSTALLED (sticky dep error)', async () => {
+    const { ProfileError } = await import('../../../profile/errors.js');
+    const { adapter, spy } = withStubbedConnectInner(async () => {
+      throw new ProfileError(
+        'ORBITDB_NOT_INSTALLED',
+        '@orbitdb/core is not installed.',
+      );
+    });
+
+    let thrown: unknown = null;
+    try {
+      await adapter.connect({ privateKey: 'aa'.repeat(32) });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ProfileError);
+    expect((thrown as InstanceType<typeof ProfileError>).code).toBe(
+      'ORBITDB_NOT_INSTALLED',
+    );
+    // No retry — exactly one attempt.
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('augments the error with multi-process diagnostic hint when retries exhaust', async () => {
+    const { ProfileError } = await import('../../../profile/errors.js');
+    const { adapter, spy } = withStubbedConnectInner(async () => {
+      throw new ProfileError(
+        'ORBITDB_CONNECTION_FAILED',
+        'Failed to connect to OrbitDB: Database is not open',
+      );
+    });
+
+    let thrown: unknown = null;
+    try {
+      await adapter.connect({ privateKey: 'aa'.repeat(32) });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ProfileError);
+    expect((thrown as InstanceType<typeof ProfileError>).code).toBe(
+      'ORBITDB_CONNECTION_FAILED',
+    );
+    // 1 initial + 2 retries = 3 attempts.
+    expect(spy).toHaveBeenCalledTimes(3);
+    // Augmented message mentions the daemon-lock diagnosis.
+    expect((thrown as Error).message).toMatch(/sphere daemon/i);
+    expect((thrown as Error).message).toMatch(/holding the OrbitDB/i);
+  });
+
+  it('non-matching error message is NOT augmented (preserves original text)', async () => {
+    const { ProfileError } = await import('../../../profile/errors.js');
+    const ORIGINAL = 'Failed to connect to OrbitDB: peer dependency missing';
+    const { adapter, spy } = withStubbedConnectInner(async () => {
+      throw new ProfileError('ORBITDB_CONNECTION_FAILED', ORIGINAL);
+    });
+
+    let thrown: unknown = null;
+    try {
+      await adapter.connect({ privateKey: 'aa'.repeat(32) });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(spy).toHaveBeenCalledTimes(3);
+    // No "sphere daemon" hint — message pattern didn't match.
+    expect((thrown as Error).message).not.toMatch(/sphere daemon/i);
+    expect((thrown as Error).message).toContain('peer dependency missing');
+  });
+});


### PR DESCRIPTION
## Summary

Addresses all 5 items in #245 (follow-ups to #243 / PR #244):

| # | Priority | What |
|---|---|---|
| **#1** | P1 | `isSpent` callers derive predicate publicKey from the token's CURRENT state instead of hard-binding `chainPubkey`. New helper + widened `SpentStateOracleProvider` signature. Closes the blind spot for tokens whose `state.predicate` was constructed under a different key. |
| **#4** | P3 | `UnicityAggregatorProvider.isSpent` tightens the spent decision to `typeof transactionHash === 'string'` with non-zero length. |
| **#5** | P3 | `validateToken` pre-parses the `SdkToken` once and reuses it for verify + publicKey derivation, so the RPC-fallback cache writes use the same `${publicKey}:${stateHash}` key namespace as `isSpent`. Cache hits transfer between paths. |
| **#3** | P2 | New 60s WALKBACK_FLOOR-specific outer throttle in `LifecycleManager.publishAggregatorPointerBestEffort`. Short-circuits subsequent calls within the window without invoking `pointer.publish`. Other transient codes (NETWORK_ERROR) unchanged. |
| **#2** | P1 | `OrbitDbAdapter.connect()` wraps `connectInner` in 2-retry / 1.5s-linear-backoff. Final error augmented with multi-process diagnostic hint when the message matches lock-contention / teardown-race patterns. |

3 commits, one per logical fix group:
- `63b8dc0` — items #1, #4, #5 (`oracle.isSpent` cleanup)
- `697af83` — item #3 (pointer-publish WALKBACK_FLOOR throttle)
- `d087797` — item #2 (OrbitDB connect retry + diagnostic)

## Branch base

Off `integration/all-fixes` (201820a, post-PR-#244 merge). Targets `integration/all-fixes` for the same reason — keeps the in-flight fixes stacked.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all touched files — clean (only pre-existing `any` warnings; no new warnings)
- [x] `npx vitest run tests/unit/ tests/integration/` — **7865 pass / 11 skip / 0 fail**
- [x] `npx vitest run tests/unit/oracle/` — 27/27 pass (isSpent / verifyInclusionProof / rpc-methods)
- [x] `npx vitest run tests/unit/profile/orbitdb-adapter.test.ts` — 22/22 pass (incl. 4 new connect-retry tests)
- [x] `npx vitest run tests/unit/profile/lifecycle-manager-publish-retry.test.ts` — 8/8 pass (incl. 3 new WALKBACK_FLOOR throttle tests)
- [x] `npx vitest run tests/unit/payments/transfer/spent-state-rescan-worker.test.ts tests/integration/payments/spent-state-rescan.test.ts tests/unit/modules/payments/detect-orphan-spending-wrapper.test.ts tests/unit/modules/PaymentsModule.double-spend-detection.test.ts` — 48/48 pass
- [ ] ~~Manual: re-run `manual-test-full-recovery.sh`~~ → **deferred to #247**. A validation run hit a different flake at §C.1b (invoice missing across CLI exit/restart) before reaching §C.4. The 5 #246 code paths never activated in that run — verified by grep against the run log. The shifting failure mode across runs (#243 → §C.2 hang, #245 #2 → §C.4 NOT_INITIALIZED, this run → §C.1b invoice-loss) points at a deeper race in the Profile persistence / shutdown-flush layer that's out of scope for this PR. Tracked in #247.

## Out of scope (filed as follow-ups)

- **#247** — End-to-end flow flake: same script fails at different sections per run. Captures the persistent `consolidation.pending` OpLog CBOR-corruption + `AT-LEAST-ONCE … not durable` storm patterns observed during PR #246 validation. The §C.4 PROFILE_NOT_INITIALIZED scenario this PR targets is one symptom of that broader race; this PR's item #2 fix is defensive (bounded retry + clearer error) and remains correct on its own merits, but end-to-end validation needs #247 resolved first.

## Diff stat

```
 modules/payments/PaymentsModule.ts                          | 147 ++++++++++++++++----
 modules/payments/transfer/spent-state-rescan-worker.ts      |  14 +-
 oracle/UnicityAggregatorProvider.ts                         |  85 ++++++++++--
 profile/orbitdb-adapter.ts                                  |  84 +++++++++++-
 profile/profile-token-storage/lifecycle-manager.ts          | 111 +++++++++++++++-
 tests/integration/payments/spent-state-rescan.test.ts       |   7 +-
 tests/unit/payments/transfer/spent-state-rescan-worker.test.ts | 13 +-
 tests/unit/profile/lifecycle-manager-publish-retry.test.ts  | 144 ++++++++++++++++++++
 tests/unit/profile/orbitdb-adapter.test.ts                  | 123 +++++++++++++++++
 9 files changed, 677 insertions(+), 51 deletions(-)
```

Closes #245.
Related: #247 (end-to-end flake follow-up surfaced during validation of this PR).

