### PR TITLE
fix(payments)(#251): unwrap OracleProvider wrapper in V6-RECOVER finalize

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -9252,6 +9252,20 @@ export class PaymentsModule {
         const wrapper = proof as { proof?: unknown; toJSON?: () => unknown };
         if (wrapper.proof !== undefined && wrapper.proof !== null) {
           proofJson = wrapper.proof;
+        } else if (
+          // Steelman finding (PR #252 review): the OracleProvider
+          // interface declares `proof: unknown`, so a wrapper whose
+          // inner proof is null/undefined is structurally valid even
+          // though `UnicityAggregatorProvider` short-circuits this case
+          // to `null` today. If we reached this branch via the wrapper
+          // shape (i.e., the object carries the wrapper's signature
+          // fields) treat it as "proof not yet available" rather than
+          // falling through to pass the wrapper itself — which would
+          // crash `TransferTransaction.fromJSON` exactly the way this
+          // PR fixes for the non-null case.
+          'proof' in wrapper && typeof (wrapper as { roundNumber?: unknown }).roundNumber === 'number'
+        ) {
+          proofJson = null;
         } else if (typeof wrapper.toJSON === 'function') {
           proofJson = wrapper.toJSON();
         } else {
@@ -9358,14 +9372,22 @@ export class PaymentsModule {
                 let pj: unknown;
                 if (wrapper.proof !== undefined && wrapper.proof !== null) {
                   pj = wrapper.proof;
+                } else if (
+                  'proof' in wrapper && typeof (wrapper as { roundNumber?: unknown }).roundNumber === 'number'
+                ) {
+                  // Wrapper-shape but proof payload absent — diagnostic
+                  // logs this as 'null' rather than dumping wrapper keys.
+                  pj = null;
                 } else if (typeof wrapper.toJSON === 'function') {
                   pj = wrapper.toJSON();
                 } else {
                   pj = proof;
                 }
-                proofShape = pj && typeof pj === 'object'
-                  ? Object.keys(pj as Record<string, unknown>)
-                  : `non-object:${typeof pj}`;
+                proofShape = pj === null
+                  ? 'null'
+                  : pj && typeof pj === 'object'
+                    ? Object.keys(pj as Record<string, unknown>)
+                    : `non-object:${typeof pj}`;
               } else {
                 proofShape = 'null';
               }

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -9227,16 +9227,36 @@ export class PaymentsModule {
 
       // Fetch the proof one more time (the queue already saw it, but it
       // doesn't pass the proof through to the callback).
+      //
+      // Issue #251 — `OracleProvider.getProof` returns the local wrapper
+      // shape `{ requestId, roundNumber, proof, timestamp }` where the
+      // SDK-shaped `IInclusionProofJson` (carrying `merkleTreePath`,
+      // `authenticator`, `transactionHash`, `unicityCertificate`) lives
+      // under `.proof`. `TransferTransaction.fromJSON` ultimately calls
+      // `InclusionProof.isJSON` which requires `merkleTreePath` AND
+      // `unicityCertificate` at the top level of the patched
+      // `inclusionProof` value. Pre-fix this code passed the wrapper
+      // through (the wrapper has no `toJSON()` method), and every
+      // cross-device finalize tripped `InvalidJsonStructureError` —
+      // surfacing as the §C.4 "Stranded receive hit permanent structural
+      // failure" loop on peer2-alice.
+      //
+      // Order matters:
+      //   1. Wrapper with `.proof` (canonical OracleProvider return).
+      //   2. SDK `InclusionProof` instance carrying `.toJSON()` — kept
+      //      for callers that mock/return an instance directly.
+      //   3. Already-JSON shape — defensive pass-through.
       let proofJson: unknown = null;
       const proof = await this.deps!.oracle.getProof(job.requestIdHex);
       if (proof) {
-        // proof may be an InclusionProof instance or a plain JSON object —
-        // `TransferTransaction.fromJSON` expects the JSON shape, so
-        // normalize via `toJSON()` when available.
-        const proofWithToJson = proof as { toJSON?: () => unknown };
-        proofJson = typeof proofWithToJson.toJSON === 'function'
-          ? proofWithToJson.toJSON()
-          : proof;
+        const wrapper = proof as { proof?: unknown; toJSON?: () => unknown };
+        if (wrapper.proof !== undefined && wrapper.proof !== null) {
+          proofJson = wrapper.proof;
+        } else if (typeof wrapper.toJSON === 'function') {
+          proofJson = wrapper.toJSON();
+        } else {
+          proofJson = proof;
+        }
       }
       if (!proofJson) {
         logger.debug('Payments', `[V6-RECOVER] Proof for ${tokenId.slice(0, 12)} unavailable on re-fetch — leaving for next tick`);
@@ -9330,10 +9350,19 @@ export class PaymentsModule {
             try {
               const proof = await this.deps!.oracle.getProof(job.requestIdHex);
               if (proof) {
-                const proofWithToJson = proof as { toJSON?: () => unknown };
-                const pj = typeof proofWithToJson.toJSON === 'function'
-                  ? proofWithToJson.toJSON()
-                  : proof;
+                // Issue #251 — mirror the unwrap order used in the
+                // finalize path (above) so the diagnostic logs the
+                // canonical SDK keys, not the OracleProvider wrapper
+                // keys. Misleading-but-noisy → useful triage signal.
+                const wrapper = proof as { proof?: unknown; toJSON?: () => unknown };
+                let pj: unknown;
+                if (wrapper.proof !== undefined && wrapper.proof !== null) {
+                  pj = wrapper.proof;
+                } else if (typeof wrapper.toJSON === 'function') {
+                  pj = wrapper.toJSON();
+                } else {
+                  pj = proof;
+                }
                 proofShape = pj && typeof pj === 'object'
                   ? Object.keys(pj as Record<string, unknown>)
                   : `non-object:${typeof pj}`;

--- a/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
+++ b/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
@@ -1122,6 +1122,85 @@ describe('#144 L3 — balance-model invariant + stranded recovery', () => {
       (ttMod.TransferTransaction.fromJSON as unknown as ReturnType<typeof vi.fn>) = prior as never;
     }
   });
+
+  // Steelman finding (PR #252 review): the OracleProvider interface
+  // declares `proof: unknown`, so a wrapper whose inner proof is null
+  // is structurally permitted even though `UnicityAggregatorProvider`
+  // currently short-circuits the null case at the source. Pre-fix the
+  // null-wrapper would fall through to `proofJson = proof` (the whole
+  // wrapper, a truthy object) and crash `TransferTransaction.fromJSON`
+  // exactly the way Issue #251's primary bug fired. The post-fix wrapper
+  // branch detects the wrapper shape (roundNumber:number + 'proof' in
+  // wrapper) and routes a null proof through the early-return path.
+  it('finalizeStrandedReceivedToken treats wrapper with null proof as not-yet-available (PR #252 review)', async () => {
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    // Wrapper with proof:null — what a future provider implementation
+    // might emit if it forgets to filter at the boundary.
+    (setup.deps.oracle as { getProof: ReturnType<typeof vi.fn> }).getProof =
+      vi.fn().mockResolvedValue({
+        requestId: '00deadbeef',
+        roundNumber: 42,
+        proof: null,
+        timestamp: Date.now(),
+      });
+
+    const ttMod = await import(
+      '@unicitylabs/state-transition-sdk/lib/transaction/TransferTransaction'
+    );
+    const fromJsonMock = vi.fn();
+    const prior = ttMod.TransferTransaction.fromJSON;
+    (ttMod.TransferTransaction.fromJSON as unknown as ReturnType<typeof vi.fn>) = fromJsonMock;
+
+    try {
+      const lastTxJson = {
+        previousStateHash: STATE_HASH,
+        predicate: 'pred2',
+        data: { sourceState: {}, recipient: 'DIRECT://x', salt: '00', recipientDataHash: null, message: null, nametags: [] },
+      };
+      const sourceTokenJson = JSON.stringify({ genesis: { data: { tokenId: GENESIS_TOKEN_ID } } });
+      internals(module).proofPollingJobs.set(GENESIS_TOKEN_ID, {
+        tokenId: GENESIS_TOKEN_ID,
+        requestIdHex: '00deadbeef',
+        commitmentJson: '',
+        sourceTokenJson,
+        startedAt: Date.now(),
+        attemptCount: 0,
+        lastAttemptAt: 0,
+      });
+
+      await (module as unknown as {
+        finalizeStrandedReceivedToken: (
+          tokenId: string,
+          sourceTokenJson: string,
+          lastTxJson: Record<string, unknown>,
+        ) => Promise<void>;
+      }).finalizeStrandedReceivedToken(GENESIS_TOKEN_ID, sourceTokenJson, lastTxJson);
+
+      // The early-return must fire — fromJSON should NOT have been called.
+      expect(fromJsonMock).not.toHaveBeenCalled();
+      // Token stays pending — next polling tick may have a real proof.
+      expect(internals(module).tokens.get(GENESIS_TOKEN_ID)?.status).toBe('pending');
+      // No operator alert (this is a transient "wait for next tick").
+      const alerts = setup.emittedEvents.filter(
+        (e) => e.type === 'transfer:operator-alert',
+      );
+      expect(alerts.length).toBe(0);
+    } finally {
+      (ttMod.TransferTransaction.fromJSON as unknown as ReturnType<typeof vi.fn>) = prior as never;
+    }
+  });
 });
 
 // =============================================================================

--- a/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
+++ b/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
@@ -993,6 +993,135 @@ describe('#144 L3 — balance-model invariant + stranded recovery', () => {
       (ttMod.TransferTransaction.fromJSON as unknown as ReturnType<typeof vi.fn>) = prior as never;
     }
   });
+
+  // Issue #251 — V6-RECOVER previously passed `oracle.getProof`'s wrapper
+  // shape ({requestId, roundNumber, proof, timestamp}) directly as the
+  // inclusionProof patched into the synthetic lastTxJson. The wrapper has
+  // no top-level `merkleTreePath` / `unicityCertificate`, so the SDK's
+  // `InclusionProof.isJSON` rejected it with `InvalidJsonStructureError`
+  // — surfacing as the cross-device finalize loop on peer2-alice in
+  // manual-test-full-recovery.sh §C.4.
+  //
+  // The bug never fired for live receives (in-memory job has
+  // `commitmentJson` → `finalizeReceivedToken` uses `waitForProofSdk`
+  // which returns an SDK instance directly) or same-device restarts
+  // (`restoreProofPollingJobs` rehydrates with `commitmentJson`). It is
+  // gated to the cross-device-sync scenario where peer2 learns the
+  // token via OrbitDB profile-sync without ever holding the commitment
+  // — V6-RECOVER is the only path forward and the inner `getProof`
+  // call is the only proof source.
+  //
+  // This regression asserts the fix unwraps `.proof` from the
+  // OracleProvider's canonical return shape so the SDK accepts the
+  // patched transaction.
+  it('finalizeStrandedReceivedToken unwraps OracleProvider wrapper to canonical SDK proof shape (issue #251)', async () => {
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    // Canonical SDK shape buried under the wrapper's `.proof` field —
+    // mirrors UnicityAggregatorProvider.getProof's real return.
+    const innerSdkProof = {
+      merkleTreePath: { steps: [], rootHash: '00' },
+      authenticator: { publicKey: '02', signature: '00', stateHash: '00' },
+      transactionHash: '00deadbeef',
+      unicityCertificate: { certHash: '00', signers: [] },
+    };
+    (setup.deps.oracle as { getProof: ReturnType<typeof vi.fn> }).getProof =
+      vi.fn().mockResolvedValue({
+        requestId: '00deadbeef',
+        roundNumber: 42,
+        proof: innerSdkProof,
+        timestamp: Date.now(),
+      });
+
+    // Capture what TransferTransaction.fromJSON sees so we can assert
+    // the unwrap happened before the SDK boundary.
+    const ttMod = await import(
+      '@unicitylabs/state-transition-sdk/lib/transaction/TransferTransaction'
+    );
+    const captured: Array<unknown> = [];
+    const prior = ttMod.TransferTransaction.fromJSON;
+    (ttMod.TransferTransaction.fromJSON as unknown as ReturnType<typeof vi.fn>) = vi
+      .fn()
+      .mockImplementation(async (input: unknown) => {
+        captured.push(input);
+        // Returning {} is enough — finalizeStrandedReceivedToken only
+        // needs the value to pass through to finalizeTransferToken,
+        // which is mocked higher up.
+        return {};
+      });
+
+    // Stub the rest of the finalize path so the test isolates the
+    // proof-unwrap behavior. `finalizeTransferToken` is the next call
+    // after fromJSON succeeds; mocking it to return a minimal SDK
+    // token-shaped object lets the code reach the save() boundary.
+    (module as unknown as {
+      finalizeTransferToken: (...args: unknown[]) => Promise<unknown>;
+    }).finalizeTransferToken = vi.fn().mockResolvedValue({
+      toJSON: () => ({ genesis: { data: { tokenId: GENESIS_TOKEN_ID } } }),
+    });
+    // Source-token parse — SdkToken.fromJSON is module-mocked at the top
+    // to return a minimal shape, so we don't need to override it.
+
+    try {
+      const lastTxJson = {
+        previousStateHash: STATE_HASH,
+        predicate: 'pred2',
+        data: { sourceState: {}, recipient: 'DIRECT://x', salt: '00', recipientDataHash: null, message: null, nametags: [] },
+      };
+      const sourceTokenJson = JSON.stringify({ genesis: { data: { tokenId: GENESIS_TOKEN_ID } } });
+      internals(module).proofPollingJobs.set(GENESIS_TOKEN_ID, {
+        tokenId: GENESIS_TOKEN_ID,
+        requestIdHex: '00deadbeef',
+        commitmentJson: '',
+        sourceTokenJson,
+        startedAt: Date.now(),
+        attemptCount: 0,
+        lastAttemptAt: 0,
+      });
+
+      await (module as unknown as {
+        finalizeStrandedReceivedToken: (
+          tokenId: string,
+          sourceTokenJson: string,
+          lastTxJson: Record<string, unknown>,
+        ) => Promise<void>;
+      }).finalizeStrandedReceivedToken(GENESIS_TOKEN_ID, sourceTokenJson, lastTxJson);
+
+      // The SDK call must have received the UNWRAPPED canonical shape
+      // patched into the lastTxJson's inclusionProof slot — NOT the
+      // OracleProvider wrapper.
+      expect(captured.length).toBe(1);
+      const patched = captured[0] as { inclusionProof?: Record<string, unknown> };
+      expect(patched.inclusionProof).toBeDefined();
+      expect(patched.inclusionProof).toEqual(innerSdkProof);
+      // Pre-fix this would have been the wrapper:
+      expect(patched.inclusionProof).not.toHaveProperty('roundNumber');
+      expect(patched.inclusionProof).not.toHaveProperty('requestId');
+      expect(patched.inclusionProof).toHaveProperty('merkleTreePath');
+      expect(patched.inclusionProof).toHaveProperty('unicityCertificate');
+
+      // No structural failure means no operator alert and the token
+      // does NOT get marked invalid on the first try.
+      const alerts = setup.emittedEvents.filter(
+        (e) => e.type === 'transfer:operator-alert',
+      );
+      expect(alerts.length).toBe(0);
+      expect(internals(module).tokens.get(GENESIS_TOKEN_ID)?.status).toBe('confirmed');
+    } finally {
+      (ttMod.TransferTransaction.fromJSON as unknown as ReturnType<typeof vi.fn>) = prior as never;
+    }
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Closes the §C.4 cross-device `InvalidJsonStructureError` loop seen in `manual-test-full-recovery.sh`. `oracle.getProof()` returns the local wrapper `{requestId, roundNumber, proof, timestamp}` where the canonical SDK `IInclusionProofJson` (`merkleTreePath`, `authenticator`, `transactionHash`, `unicityCertificate`) lives under `.proof`. Pre-fix, `finalizeStrandedReceivedToken` passed the wrapper through to `TransferTransaction.fromJSON` via a `toJSON()`-or-self fallback; the wrapper has no `toJSON` method, so the wrapper itself landed in `lastTxJson.inclusionProof`, and the SDK's `InclusionProof.isJSON` rejected it. The PR #231 classifier then correctly marked it as permanent, freezing the token.
- New regression test asserts the patched `inclusionProof` carries the canonical SDK fields (`merkleTreePath`, `unicityCertificate`) and not the wrapper fields (`requestId`, `roundNumber`).
- Diagnostic dump in the same function harmonised so the logged `proofShape` reflects SDK keys instead of wrapper keys.

## Why only §C.4 fired this bug

V6-RECOVER's `finalizeStrandedReceivedToken` only runs when `recoverStrandedReceivedTokens` reconstructs a proof-polling job WITHOUT a `commitmentJson` — the cross-device-sync scenario where peer2-alice learns the token via OrbitDB profile-sync at status=`pending` with no in-memory job. Three live-receive paths bypass it entirely:

| Path | Where it fires | Finalize path |
|---|---|---|
| Live Nostr receive (§B, §C.1–§C.3) | `processCombinedTransferBundle` saves token + job with full `commitmentJson` | `finalizeReceivedToken` → uses `waitForProofSdk` (SDK instance, no wrapper) |
| Same-device restart | `restoreProofPollingJobs` rehydrates the persisted job | `finalizeReceivedToken` again |
| Cross-device sync (§C.4) | peer2-alice never processed the Nostr DM | `finalizeStrandedReceivedToken` → calls `oracle.getProof()` directly → **hit the bug** |

The existing #231 regression test mocked `getProof` returning `{toJSON: () => (...)}`, exercising the `toJSON()` branch — therefore missing the realistic wrapper-without-`toJSON` shape returned by the real provider.

## Test plan

- [x] New regression test in `tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts` ("unwraps OracleProvider wrapper to canonical SDK proof shape") asserts the patched inclusionProof carries `merkleTreePath` + `unicityCertificate` and does NOT carry `roundNumber` + `requestId`.
- [x] All 25 tests in the proof-polling-persistence suite still pass.
- [x] Wave-4 regressions (37 tests) + never-wipe tests pass.
- [x] Full unit suite (7505 tests) passes.
- [x] Type check + lint clean.

## Cross-refs

- Issue #251 — Problem 2 (this PR addresses)
- Issue #251 — Problem 3 (separate PR: `fix/issue-251-coerce-fail-loud`)
- Issue #251 — Problem 1 (separate PR: design RFC, `docs/issue-251-pointer-coordination-rfc`)
- PR #231 — V6-RECOVER permanent-failure classifier
- PR #146 — receiver finalize-on-restart fix (#144)