### PR TITLE
feat(profile)(#255b): pointer-publish win-broadcast (RFC-251 Approach D Phase 1) [DRAFT]

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -708,6 +708,21 @@ export class Sphere {
   private _providerEventCleanups: (() => void)[] = [];
   private _lastProviderConnected: Map<string, boolean> = new Map();
 
+  // RFC-251 Approach D / issue #255 Problem B — pointer-publish win-broadcast.
+  // Tracks whether the per-wallet Nostr subscription for sibling
+  // pointer-win broadcasts has been installed (one per pointer-signing
+  // pubkey ever seen during this Sphere lifetime). Cleared on destroy().
+  private _pointerWinSubscriptions = new Map<string, () => void>();
+  // Bounded dedup of (signingPubKey + version) tuples observed via
+  // sibling broadcasts — bounds within-replay-window duplicate
+  // processing. LRU-evicted at MAX_SIZE entries.
+  private _pointerWinSeen = new Set<string>();
+  // Sentinel: when the pointer layer is built async after OrbitDB attach,
+  // we poll for it once and install the subscription. This flag prevents
+  // multiple parallel install attempts when several pointer events fire
+  // close together.
+  private _pointerWinInstallInFlight = false;
+
   // ===========================================================================
   // Constructor (private)
   // ===========================================================================
@@ -5133,9 +5148,250 @@ export class Sphere {
           if (event.type === 'storage:error' || event.type === 'sync:error') {
             this.emitConnectionChanged(providerId, provider.isConnected(), provider.getStatus(), event.error);
           }
+          // RFC-251 Approach D / issue #255 Problem B — pointer-publish
+          // win-broadcast publisher side. After the lifecycle manager
+          // emits a `storage:pointer-published` event (containing the
+          // already-signed payload + broadcast tag), forward it to
+          // Nostr so sibling devices sharing this wallet's identity
+          // can adopt V=N without waiting for the aggregator's 30-60s
+          // read-replica lag.
+          //
+          // Best-effort: any failure (transport down, relay reject) is
+          // logged and dropped. The aggregator publish has already
+          // succeeded; the wallet's own state is correct without the
+          // broadcast. Siblings just fall back to the existing
+          // WALKBACK_FLOOR + reconcile path (~60-90 s).
+          if (event.type === 'storage:pointer-published') {
+            void this.forwardPointerPublishedToNostr(event);
+            // Also try to install the sibling-subscription side now
+            // that we know a pointer layer is live (signing is what
+            // produced this event). Idempotent — repeat calls no-op
+            // when the subscription is already in place.
+            void this.maybeInstallPointerWinSubscription();
+          }
         });
         if (unsub) this._providerEventCleanups.push(unsub);
       }
+    }
+  }
+
+  /**
+   * RFC-251 Approach D / issue #255 Problem B — publisher side.
+   *
+   * Receives a `storage:pointer-published` event from the lifecycle
+   * manager (which carries an already-signed broadcast payload + its
+   * per-wallet tag) and forwards it over Nostr. Best-effort:
+   * - No publish? Drop silently (transport doesn't support broadcasts
+   *   — falls back to existing WALKBACK_FLOOR convergence).
+   * - Publish throws? Log warn and drop.
+   *
+   * The signing happened upstream (in lifecycle-manager where the
+   * pointer layer is reachable). This method does pure transport I/O.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async forwardPointerPublishedToNostr(event: any): Promise<void> {
+    try {
+      const data = event?.data as
+        | {
+            signedPayloadJson?: unknown;
+            broadcastTag?: unknown;
+            version?: unknown;
+            cid?: unknown;
+          }
+        | undefined;
+      const signedPayloadJson = data?.signedPayloadJson;
+      const broadcastTag = data?.broadcastTag;
+      if (
+        typeof signedPayloadJson !== 'string' ||
+        typeof broadcastTag !== 'string' ||
+        signedPayloadJson.length === 0 ||
+        broadcastTag.length === 0
+      ) {
+        // Event shape didn't include the signed payload (e.g. pointer
+        // layer absent at sign time, or upstream sign failure). Caller
+        // already logged the sign error; nothing useful to publish.
+        return;
+      }
+      if (typeof this._transport.publishBroadcast !== 'function') {
+        // Transport doesn't support broadcasts (e.g., file-only mock).
+        // Silently skip — the existing WALKBACK_FLOOR path still
+        // handles cross-device convergence.
+        return;
+      }
+      await this._transport.publishBroadcast(signedPayloadJson, [broadcastTag]);
+      logger.debug(
+        'Sphere',
+        `pointer-win broadcast published: version=${String(data?.version ?? '?')} ` +
+        `cid=${String(data?.cid ?? '?')} tag=${broadcastTag}`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        'Sphere',
+        `pointer-win broadcast publish failed (best-effort, ignored): ${msg}`,
+      );
+    }
+  }
+
+  /**
+   * RFC-251 Approach D / issue #255 Problem B — subscriber side.
+   *
+   * Install the per-wallet Nostr subscription so this device receives
+   * pointer-win broadcasts from sibling devices sharing the same
+   * wallet identity. Idempotent — safe to call repeatedly; once the
+   * subscription is in place for a given signing pubkey, subsequent
+   * invocations short-circuit.
+   *
+   * Pointer layer is built async during OrbitDB attach, so the
+   * subscription cannot be installed at Sphere init time. Two
+   * triggers eventually fire `maybeInstallPointerWinSubscription`:
+   *   - Lazy-on-own-publish: our own first `storage:pointer-published`
+   *     event implies pointer is live. We install then.
+   *   - (Phase 2 expansion) An eager polling loop after init for
+   *     receive-only devices that never publish themselves. NOT
+   *     wired in Phase 1 — those devices currently miss broadcasts
+   *     until they themselves publish at least once. Acceptable for
+   *     prototype; document as known-gap.
+   */
+  private async maybeInstallPointerWinSubscription(): Promise<void> {
+    if (this._pointerWinInstallInFlight) return;
+    this._pointerWinInstallInFlight = true;
+    try {
+      const storageWithPointer = this._storage as unknown as {
+        getPointerLayer?: () =>
+          | import('../profile/aggregator-pointer/ProfilePointerLayer').ProfilePointerLayer
+          | null;
+      };
+      const pointer = storageWithPointer.getPointerLayer?.() ?? null;
+      if (!pointer) {
+        // Pointer layer not yet built; try again on the next event.
+        return;
+      }
+      const signerHandle = pointer.getSignerForWinBroadcast();
+      const signingPubKeyHex = signerHandle.signingPubKeyHex;
+      if (this._pointerWinSubscriptions.has(signingPubKeyHex)) {
+        // Already subscribed for this wallet identity.
+        return;
+      }
+      if (typeof this._transport.subscribeToBroadcast !== 'function') {
+        return;
+      }
+
+      // Late-imported to avoid pulling the win-broadcast module into the
+      // happy path for wallets that disable pointer broadcasts entirely.
+      const {
+        buildWinBroadcastTag,
+        verifyWinBroadcastPayload,
+      } = await import('../profile/aggregator-pointer/win-broadcast');
+      const tag = buildWinBroadcastTag(signingPubKeyHex);
+
+      const unsub = this._transport.subscribeToBroadcast(
+        [tag],
+        (broadcast) => {
+          void this.handleIncomingPointerWinBroadcast(broadcast.content, signingPubKeyHex, pointer, verifyWinBroadcastPayload);
+        },
+      );
+      this._pointerWinSubscriptions.set(signingPubKeyHex, unsub);
+      logger.debug(
+        'Sphere',
+        `pointer-win subscription installed: tag=${tag}`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        'Sphere',
+        `pointer-win subscription install failed (will retry on next event): ${msg}`,
+      );
+    } finally {
+      this._pointerWinInstallInFlight = false;
+    }
+  }
+
+  /**
+   * Handle an incoming pointer-win broadcast from a sibling device.
+   *
+   * Flow:
+   *   1. Parse JSON content.
+   *   2. Verify signature against own signingPubKey (signature mismatch
+   *      = spoofed or wrong-wallet event; drop silently).
+   *   3. Dedup by (signingPubKey, version) — bounded LRU.
+   *   4. Trigger early reconcile: `recoverLatest()` + `reconcileLocalVersionDownward()`.
+   *      Same path the WALKBACK_FLOOR catch arm runs (lifecycle-manager.ts
+   *      lines 1311-1331), just collapsed to "now" instead of "60s
+   *      throttle expiry".
+   *
+   * All errors are caught and logged at debug — never propagate to the
+   * transport handler.
+   */
+  private async handleIncomingPointerWinBroadcast(
+    contentJson: string,
+    ownSigningPubKeyHex: string,
+    pointer: import('../profile/aggregator-pointer/ProfilePointerLayer').ProfilePointerLayer,
+    verify: (
+      payload: import('../profile/aggregator-pointer/win-broadcast').SignedWinBroadcastPayload,
+      expectedSigningPubKeyHex: string,
+    ) => Promise<boolean>,
+  ): Promise<void> {
+    try {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(contentJson);
+      } catch {
+        // Not our JSON; relay-noise on the same tag (improbable but
+        // defensive). Drop.
+        return;
+      }
+      const payload = parsed as import('../profile/aggregator-pointer/win-broadcast').SignedWinBroadcastPayload;
+      const ok = await verify(payload, ownSigningPubKeyHex);
+      if (!ok) {
+        logger.debug(
+          'Sphere',
+          'pointer-win broadcast: verification failed (spoof, expired, or wrong-wallet); dropped',
+        );
+        return;
+      }
+      const dedupKey = `${payload.signingPubKey}:${payload.version}`;
+      if (this._pointerWinSeen.has(dedupKey)) {
+        return;
+      }
+      // Bounded LRU — drop oldest insertion when over cap.
+      if (this._pointerWinSeen.size >= 256) {
+        const oldest = this._pointerWinSeen.values().next().value;
+        if (oldest !== undefined) this._pointerWinSeen.delete(oldest);
+      }
+      this._pointerWinSeen.add(dedupKey);
+
+      logger.debug(
+        'Sphere',
+        `pointer-win broadcast received: version=${payload.version} ` +
+        `cid=${payload.cid} — triggering early reconcile`,
+      );
+
+      // Phase 1: trigger an early `recoverLatest` + `reconcileLocalVersionDownward`.
+      // This is the same path the WALKBACK_FLOOR catch arm runs after a
+      // race-loss; here we run it eagerly on the broadcast without
+      // waiting for the throttle to expire. Acknowledged limitation:
+      // when own localVersion is already at broadcast.version (same-
+      // version race), reconcileDownward is a no-op — Phase 2 would add
+      // a `ProfilePointerLayer.adoptBroadcast(payload)` entrypoint that
+      // bypasses the >= comparison. For Phase 1 this still helps the
+      // cross-version case where own localVersion < broadcast.version.
+      const recovered = await pointer.recoverLatest();
+      if (recovered) {
+        const outcome = await pointer.reconcileLocalVersionDownward(recovered);
+        logger.debug(
+          'Sphere',
+          `pointer-win broadcast: post-receipt reconcile ` +
+          `reconciled=${outcome.reconciled} ` +
+          `fromVersion=${outcome.fromVersion} toVersion=${outcome.toVersion}`,
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.debug(
+        'Sphere',
+        `pointer-win broadcast: handler threw (dropped): ${msg}`,
+      );
     }
   }
 
@@ -5168,6 +5424,22 @@ export class Sphere {
     }
     this._providerEventCleanups = [];
     this._lastProviderConnected.clear();
+    // RFC-251 Approach D — also tear down per-wallet pointer-win
+    // broadcast subscriptions to avoid relay-side subscription leaks
+    // across Sphere reinit cycles. Defensive: legacy test harnesses
+    // construct Sphere via `Object.create(prototype)` which skips
+    // class-field initializers, leaving these fields undefined. Skip
+    // the cleanup cleanly when the state never got installed.
+    if (this._pointerWinSubscriptions !== undefined) {
+      for (const unsub of this._pointerWinSubscriptions.values()) {
+        try { unsub(); } catch { /* ignore */ }
+      }
+      this._pointerWinSubscriptions.clear();
+    }
+    if (this._pointerWinSeen !== undefined) {
+      this._pointerWinSeen.clear();
+    }
+    this._pointerWinInstallInFlight = false;
   }
 
   private async initializeModules(): Promise<void> {

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -164,6 +164,29 @@ export class ProfilePointerLayer {
   }
 
   /**
+   * RFC-251 Approach D (issue #255 Problem B) — expose the pointer layer's
+   * signing pubkey + signer to the integration wiring layer (Sphere /
+   * ProfileTokenStorageProvider). The win-broadcast publisher needs
+   * the pubkey hex to build the per-wallet broadcast tag, and the
+   * signer to sign the broadcast payload. The signer itself is exposed
+   * read-only — callers can only sign payloads, not mutate the signer's
+   * state.
+   *
+   * Returns a tuple rather than two getters so consumers can destructure
+   * once and cache for the wallet's lifetime; the underlying signer
+   * never rotates within a `ProfilePointerLayer` instance.
+   */
+  getSignerForWinBroadcast(): {
+    readonly signer: import('./signing.js').PointerSigner;
+    readonly signingPubKeyHex: string;
+  } {
+    return {
+      signer: this.#init.signer,
+      signingPubKeyHex: this.#init.signer.signingPubKeyHex,
+    };
+  }
+
+  /**
    * Wrap an async operation so it's tracked in `#inFlight` and removes
    * itself on settle. Used by the public publish/recover/probe entry
    * points so `shutdown()` can drain them.

--- a/profile/aggregator-pointer/index.ts
+++ b/profile/aggregator-pointer/index.ts
@@ -100,3 +100,19 @@ export type {
   ReconcileDownwardResult,
   RecoverResult,
 } from './ProfilePointerLayer.js';
+
+// RFC-251 Approach D — pointer-publish win-broadcast (issue #255 Problem B)
+export {
+  buildWinBroadcastHash,
+  buildWinBroadcastTag,
+  MAX_PAYLOAD_AGE_MS,
+  signWinBroadcastPayload,
+  verifyWinBroadcastPayload,
+  WIN_BROADCAST_KIND_MARKER,
+  WIN_BROADCAST_SCHEMA_VERSION,
+  WIN_BROADCAST_TAG_PREFIX,
+} from './win-broadcast.js';
+export type {
+  SignedWinBroadcastPayload,
+  UnsignedWinBroadcastPayload,
+} from './win-broadcast.js';

--- a/profile/aggregator-pointer/win-broadcast.ts
+++ b/profile/aggregator-pointer/win-broadcast.ts
@@ -1,0 +1,283 @@
+/**
+ * Pointer-publish win-broadcast — RFC-251 Approach D (Issue #255 Problem B).
+ *
+ * After a wallet's pointer layer successfully publishes V=N to the aggregator
+ * (i.e. wins the at-most-one-writer race for slot V=N), it emits an
+ * authenticated Nostr broadcast announcing the win to sibling devices that
+ * share the same wallet identity. Siblings — which would otherwise wait
+ * 30–60 s for the aggregator's read replica to surface V=N — can:
+ *
+ *   1. Verify the broadcast was signed by their own pointer signing key
+ *      (same identity ⇒ same key; siblings authenticate trivially).
+ *   2. Trigger an early reconcile (`recoverLatest()` + the existing
+ *      `reconcileLocalVersionDownward` path) without waiting for the
+ *      WALKBACK_FLOOR throttle's 60 s cooldown.
+ *
+ * The aggregator itself is not touched — this is purely a client-side
+ * optimistic-notification layer. If the broadcast is dropped (relay
+ * partition, sibling offline) the system degrades cleanly to the existing
+ * WALKBACK_FLOOR + reconcile path: strictly no worse than today.
+ *
+ * Threat model:
+ *   - Authenticity: the payload signature is verified against the receiving
+ *     wallet's own signingPubKey. A foreign-key signature → reject.
+ *   - Replay: the payload carries `ts` (wall-clock ms); receivers reject
+ *     events older than `MAX_PAYLOAD_AGE_MS` (5 min) to bound replay
+ *     attempts. Dedup by (signingPubKey, version) on the receiver bounds
+ *     within-window replays.
+ *   - Spoof: a third party who doesn't hold the wallet's signing key
+ *     cannot produce a valid sig. Broadcasts that don't verify against
+ *     the receiver's own pubkey are silently dropped.
+ *
+ * Schema versioning: `v: 1` is the only valid payload version. Future
+ * extensions MUST bump `v` so receivers can fail closed on unknown
+ * shapes rather than silently ignoring new fields. Receivers MUST
+ * reject any `v !== 1`.
+ */
+
+import { DataHasher } from '@unicitylabs/state-transition-sdk/lib/hash/DataHasher.js';
+import { HashAlgorithm } from '@unicitylabs/state-transition-sdk/lib/hash/HashAlgorithm.js';
+import { Signature } from '@unicitylabs/state-transition-sdk/lib/sign/Signature.js';
+import { SigningService } from '@unicitylabs/state-transition-sdk/lib/sign/SigningService.js';
+import type { PointerSigner } from './signing.js';
+
+/**
+ * Receivers MUST reject broadcasts older than this. Combined with the
+ * dedup cache, this bounds replay attempts to a 5-minute window per
+ * (signingPubKey, version) tuple — short enough that even an
+ * adversarial relay that hoards an event can't replay it indefinitely.
+ */
+export const MAX_PAYLOAD_AGE_MS = 5 * 60 * 1000;
+
+/** Tag prefix used to scope a Nostr broadcast subscription per wallet. */
+export const WIN_BROADCAST_TAG_PREFIX = 'pointer-win:';
+
+/** Content-discriminator embedded in the broadcast JSON. */
+export const WIN_BROADCAST_KIND_MARKER = 'pointer-win-broadcast';
+
+/** Schema version. Receivers MUST reject anything but 1. */
+export const WIN_BROADCAST_SCHEMA_VERSION = 1 as const;
+
+/**
+ * Payload sent over Nostr after a successful pointer publish, before the
+ * signature is attached.
+ *
+ * All fields are required.  Field order is significant for the canonical
+ * hash (see {@link buildWinBroadcastHash}).
+ */
+export interface UnsignedWinBroadcastPayload {
+  readonly _kind: typeof WIN_BROADCAST_KIND_MARKER;
+  readonly v: typeof WIN_BROADCAST_SCHEMA_VERSION;
+  /** Pointer version that was successfully committed to the aggregator. */
+  readonly version: number;
+  /** Bundle CID (canonical string form — same as published to aggregator). */
+  readonly cid: string;
+  /** 33-byte compressed secp256k1, hex-encoded (66 chars). */
+  readonly signingPubKey: string;
+  /** Sender wall-clock at broadcast time, ms since epoch. */
+  readonly ts: number;
+}
+
+/**
+ * Signed payload. The signature is a secp256k1 ECDSA sig (Signature.toJSON
+ * format) over the canonical hash of the unsigned payload.
+ */
+export interface SignedWinBroadcastPayload extends UnsignedWinBroadcastPayload {
+  /** `Signature.toJSON()` — hex string of 65-byte recoverable sig. */
+  readonly sig: string;
+}
+
+/**
+ * Build the per-wallet broadcast tag.  Both publisher and subscriber use
+ * the same tag so a sibling's Nostr filter (`#t=pointer-win:<hex>`) finds
+ * only this wallet's win-broadcasts.
+ */
+export function buildWinBroadcastTag(signingPubKeyHex: string): string {
+  if (typeof signingPubKeyHex !== 'string' || signingPubKeyHex.length === 0) {
+    throw new Error('buildWinBroadcastTag: signingPubKeyHex must be a non-empty string');
+  }
+  return `${WIN_BROADCAST_TAG_PREFIX}${signingPubKeyHex.toLowerCase()}`;
+}
+
+/**
+ * Canonical hash of the unsigned payload — what gets signed and verified.
+ *
+ * Byte layout (concatenated, then SHA-256):
+ *   1 byte   v (schema version, currently 1)
+ *   4 bytes  version (uint32 big-endian)
+ *   8 bytes  ts (uint64 big-endian — JS Number max-safe-int suffices for
+ *            timestamps until 285616-05-17)
+ *   33 bytes signingPubKey (decoded from hex)
+ *   N bytes  cid (utf-8 of the canonical string form)
+ *
+ * Determinism is critical — both ends must produce the exact same hash
+ * for verification to succeed. The fixed-width prefix prevents
+ * collision via padding tricks (e.g. encoding `version=1, cid="0..."` vs
+ * `version=10, cid=""`).
+ */
+export async function buildWinBroadcastHash(
+  payload: UnsignedWinBroadcastPayload,
+): Promise<import('@unicitylabs/state-transition-sdk/lib/hash/DataHash.js').DataHash> {
+  if (payload.v !== WIN_BROADCAST_SCHEMA_VERSION) {
+    throw new Error(`buildWinBroadcastHash: unsupported schema version ${payload.v}`);
+  }
+  if (!Number.isInteger(payload.version) || payload.version < 0 || payload.version > 0xffffffff) {
+    throw new Error(`buildWinBroadcastHash: version must be uint32, got ${payload.version}`);
+  }
+  if (!Number.isInteger(payload.ts) || payload.ts < 0 || !Number.isSafeInteger(payload.ts)) {
+    throw new Error(`buildWinBroadcastHash: ts must be a safe integer >= 0, got ${payload.ts}`);
+  }
+  const pubKeyBytes = hexToBytes(payload.signingPubKey);
+  if (pubKeyBytes.length !== 33) {
+    throw new Error(
+      `buildWinBroadcastHash: signingPubKey must decode to 33 bytes, got ${pubKeyBytes.length}`,
+    );
+  }
+  const cidBytes = new TextEncoder().encode(payload.cid);
+
+  const buf = new Uint8Array(1 + 4 + 8 + 33 + cidBytes.length);
+  let offset = 0;
+  buf[offset] = payload.v;
+  offset += 1;
+  // version uint32 BE
+  buf[offset]     = (payload.version >>> 24) & 0xff;
+  buf[offset + 1] = (payload.version >>> 16) & 0xff;
+  buf[offset + 2] = (payload.version >>> 8)  & 0xff;
+  buf[offset + 3] = (payload.version)        & 0xff;
+  offset += 4;
+  // ts uint64 BE — JS bit-ops are 32-bit, so split into high/low.
+  const tsHi = Math.floor(payload.ts / 0x100000000);
+  const tsLo = payload.ts >>> 0;
+  buf[offset]     = (tsHi >>> 24) & 0xff;
+  buf[offset + 1] = (tsHi >>> 16) & 0xff;
+  buf[offset + 2] = (tsHi >>> 8)  & 0xff;
+  buf[offset + 3] = (tsHi)        & 0xff;
+  buf[offset + 4] = (tsLo >>> 24) & 0xff;
+  buf[offset + 5] = (tsLo >>> 16) & 0xff;
+  buf[offset + 6] = (tsLo >>> 8)  & 0xff;
+  buf[offset + 7] = (tsLo)        & 0xff;
+  offset += 8;
+  buf.set(pubKeyBytes, offset);
+  offset += 33;
+  buf.set(cidBytes, offset);
+
+  return new DataHasher(HashAlgorithm.SHA256).update(buf).digest();
+}
+
+/**
+ * Sign a win-broadcast payload using the wallet's pointer signing service.
+ *
+ * @throws if the supplied `signer.signingPubKeyHex` doesn't match
+ *         `unsigned.signingPubKey` — defends against accidentally signing
+ *         a payload that claims a different identity.
+ */
+export async function signWinBroadcastPayload(
+  signer: PointerSigner,
+  unsigned: UnsignedWinBroadcastPayload,
+): Promise<SignedWinBroadcastPayload> {
+  if (signer.signingPubKeyHex.toLowerCase() !== unsigned.signingPubKey.toLowerCase()) {
+    throw new Error(
+      `signWinBroadcastPayload: signer pubkey ${signer.signingPubKeyHex} ` +
+      `does not match payload signingPubKey ${unsigned.signingPubKey}`,
+    );
+  }
+  const hash = await buildWinBroadcastHash(unsigned);
+  const sig = await signer.service.sign(hash);
+  return { ...unsigned, sig: sig.toJSON() };
+}
+
+/**
+ * Verify a signed win-broadcast payload against an expected signing pubkey.
+ *
+ * Returns false (does NOT throw) on any verification failure: schema
+ * mismatch, age out of window, pubkey-field mismatch, sig parse error,
+ * cryptographic mismatch. The caller decides what to do with the
+ * rejection (log + drop is the usual response).
+ *
+ * @param payload          The payload received over the wire.
+ * @param expectedSigningPubKeyHex
+ *                         The receiver's own wallet pointer signingPubKey,
+ *                         hex-encoded. Used as the trust anchor — only
+ *                         payloads signed by THIS key are accepted, which
+ *                         is appropriate for same-identity sibling
+ *                         coordination.
+ * @param nowMs            Optional clock for testing; defaults to
+ *                         `Date.now()`. The payload is rejected if
+ *                         `|nowMs - payload.ts| > MAX_PAYLOAD_AGE_MS`.
+ */
+export async function verifyWinBroadcastPayload(
+  payload: SignedWinBroadcastPayload,
+  expectedSigningPubKeyHex: string,
+  nowMs: number = Date.now(),
+): Promise<boolean> {
+  try {
+    if (payload._kind !== WIN_BROADCAST_KIND_MARKER) return false;
+    if (payload.v !== WIN_BROADCAST_SCHEMA_VERSION) return false;
+    if (typeof payload.signingPubKey !== 'string') return false;
+    if (typeof payload.cid !== 'string' || payload.cid.length === 0) return false;
+    if (typeof payload.sig !== 'string' || payload.sig.length === 0) return false;
+    if (!Number.isInteger(payload.version) || payload.version < 0) return false;
+    if (!Number.isInteger(payload.ts) || payload.ts < 0) return false;
+
+    if (payload.signingPubKey.toLowerCase() !== expectedSigningPubKeyHex.toLowerCase()) {
+      return false;
+    }
+    if (Math.abs(nowMs - payload.ts) > MAX_PAYLOAD_AGE_MS) {
+      return false;
+    }
+
+    const hash = await buildWinBroadcastHash(payload);
+    const sigBytes = parseSignatureHex(payload.sig);
+    if (sigBytes === null) return false;
+    const pubKeyBytes = hexToBytes(expectedSigningPubKeyHex);
+    if (pubKeyBytes.length !== 33) return false;
+
+    return await SigningService.verifyWithPublicKey(hash, sigBytes, pubKeyBytes);
+  } catch {
+    // Defensive: any unexpected error (e.g. malformed CBOR in Signature
+    // parsing, hex with odd length) is treated as a verification failure.
+    return false;
+  }
+}
+
+/**
+ * `Signature.toJSON()` produces the recoverable-sig hex (65 bytes).
+ * `SigningService.verifyWithPublicKey` accepts the raw bytes directly.
+ * This helper parses the hex back to bytes; returns null on malformed
+ * input.
+ */
+function parseSignatureHex(sigHex: string): Uint8Array | null {
+  try {
+    // Round-trip via the SDK to guarantee shape compatibility with the
+    // sender's `Signature.toJSON()`. Returns a Signature instance.
+    const sig = Signature.decode(hexToBytes(sigHex));
+    return sig.bytes;
+  } catch {
+    // Fall back to raw hex-bytes parse — older or non-CBOR signature
+    // representations.
+    try {
+      return hexToBytes(sigHex);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  if (typeof hex !== 'string') {
+    throw new Error('hexToBytes: input must be string');
+  }
+  const normalized = hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
+  if (normalized.length % 2 !== 0) {
+    throw new Error(`hexToBytes: odd length (${normalized.length})`);
+  }
+  const out = new Uint8Array(normalized.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    const byte = parseInt(normalized.substr(i * 2, 2), 16);
+    if (Number.isNaN(byte)) {
+      throw new Error(`hexToBytes: non-hex char at offset ${i * 2}`);
+    }
+    out[i] = byte;
+  }
+  return out;
+}

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -73,6 +73,14 @@ import {
 import type { ShutdownOptions } from '../../storage/storage-provider.js';
 import type { BundleIndex } from './bundle-index.js';
 import type { ProfileTokenStorageHost } from './host.js';
+// RFC-251 Approach D / issue #255 Problem B — pointer-publish win-broadcast.
+// Imported only for the publish-success path; absent pointer layer ⇒ skipped.
+import {
+  buildWinBroadcastTag,
+  signWinBroadcastPayload,
+  WIN_BROADCAST_KIND_MARKER,
+  WIN_BROADCAST_SCHEMA_VERSION,
+} from '../aggregator-pointer/win-broadcast.js';
 
 /**
  * Pointer-layer error codes that indicate a permanent integrity /
@@ -1235,6 +1243,51 @@ export class LifecycleManager {
         this.host.log(
           `Pointer publish ok: cid=${cidString} version=${result.version} attempts=${result.attemptsUsed}`,
         );
+        // RFC-251 Approach D / issue #255 Problem B — emit the
+        // pointer-published event so the wiring layer (Sphere) can
+        // broadcast the win to sibling devices over Nostr. Siblings
+        // sharing this wallet's identity adopt V=N without waiting for
+        // the aggregator's 30-60 s read-replica lag.
+        //
+        // The crypto (build payload + sign with pointer signer) is done
+        // here because we have the pointer layer ref; the wiring layer
+        // (Sphere) just publishes the resulting wire-ready JSON over
+        // Nostr with the supplied tag. Keeps Sphere stateless w.r.t.
+        // pointer signing keys.
+        //
+        // Best-effort: any failure during sign / emit is logged and
+        // dropped — the publish-success return path is the contract.
+        try {
+          const signerHandle = pointer.getSignerForWinBroadcast();
+          const signed = await signWinBroadcastPayload(signerHandle.signer, {
+            _kind: WIN_BROADCAST_KIND_MARKER,
+            v: WIN_BROADCAST_SCHEMA_VERSION,
+            version: result.version,
+            cid: cidString,
+            signingPubKey: signerHandle.signingPubKeyHex,
+            ts: Date.now(),
+          });
+          this.host.emitEvent({
+            type: 'storage:pointer-published',
+            timestamp: Date.now(),
+            data: {
+              cid: cidString,
+              version: result.version,
+              attemptsUsed: result.attemptsUsed,
+              signedPayloadJson: JSON.stringify(signed),
+              broadcastTag: buildWinBroadcastTag(signerHandle.signingPubKeyHex),
+            },
+          });
+        } catch (broadcastErr) {
+          const errMsg =
+            broadcastErr instanceof Error
+              ? broadcastErr.message
+              : String(broadcastErr);
+          this.host.log(
+            `Pointer publish: win-broadcast build/sign failed (best-effort, ` +
+            `ignored): ${errMsg}`,
+          );
+        }
         return { ok: true, transient: false } as const;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -357,7 +357,27 @@ export type StorageEventType =
    * this case (reconciliation removed the floor; the retry has
    * a fresh chance to land).
    */
-  | 'storage:replica-lag-reconciled';
+  | 'storage:replica-lag-reconciled'
+  /**
+   * RFC-251 Approach D / issue #255 Problem B — emitted by the
+   * lifecycle manager IMMEDIATELY after a pointer commit succeeds at
+   * the aggregator. The wiring layer (typically `Sphere`) subscribes
+   * to this event and emits an authenticated `pointer-win` broadcast
+   * over Nostr so sibling same-identity devices can adopt V=N without
+   * waiting for the aggregator's 30-60 s read-replica lag.
+   *
+   * `data` carries `{ cid, version, attemptsUsed }`. The subscriber
+   * MUST build the signed payload via
+   * `signWinBroadcastPayload(pointer.getSignerForWinBroadcast().signer, ...)`
+   * and publish via the wallet's transport with the
+   * `pointer-win:<signingPubKeyHex>` tag.
+   *
+   * Informational only. No-op when the wiring layer doesn't
+   * subscribe — pointer publishes still succeed and siblings still
+   * converge via the existing WALKBACK_FLOOR + reconcile path
+   * (just slower, ~60-90 s vs ~1 s).
+   */
+  | 'storage:pointer-published';
 
 export interface StorageEvent {
   type: StorageEventType;

--- a/tests/unit/pointer/win-broadcast.test.ts
+++ b/tests/unit/pointer/win-broadcast.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for win-broadcast — RFC-251 Approach D / issue #255 Problem B.
+ *
+ * Pins the standalone signing module's behavior: payload schema, canonical
+ * hash determinism, sign/verify roundtrip, replay-window enforcement,
+ * spoof rejection (wrong pubkey), tamper rejection (bit-flip in any
+ * field).
+ *
+ * Uses real PointerSigner (secp256k1 crypto) so the test exercises the
+ * actual `Signature.toJSON` ↔ `SigningService.verifyWithPublicKey`
+ * round-trip — no mock signing.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildPointerSigner,
+  derivePointerKeyMaterial,
+  createMasterPrivateKey,
+} from '../../../profile/aggregator-pointer/index.js';
+import {
+  buildWinBroadcastHash,
+  buildWinBroadcastTag,
+  MAX_PAYLOAD_AGE_MS,
+  signWinBroadcastPayload,
+  verifyWinBroadcastPayload,
+  WIN_BROADCAST_KIND_MARKER,
+  WIN_BROADCAST_SCHEMA_VERSION,
+  WIN_BROADCAST_TAG_PREFIX,
+  type SignedWinBroadcastPayload,
+  type UnsignedWinBroadcastPayload,
+} from '../../../profile/aggregator-pointer/win-broadcast.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const WALLET_SEED_A = new Uint8Array(32).fill(0x42);
+const WALLET_SEED_B = new Uint8Array(32).fill(0xfe);  // distinct identity for spoof test
+
+async function makeSigner(seed: Uint8Array) {
+  const masterKey = createMasterPrivateKey(seed);
+  const keyMaterial = derivePointerKeyMaterial(masterKey);
+  return buildPointerSigner(keyMaterial.signingSeed);
+}
+
+const SAMPLE_CID = 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi';
+
+function makeUnsignedPayload(
+  signingPubKey: string,
+  overrides: Partial<UnsignedWinBroadcastPayload> = {},
+): UnsignedWinBroadcastPayload {
+  return {
+    _kind: WIN_BROADCAST_KIND_MARKER,
+    v: WIN_BROADCAST_SCHEMA_VERSION,
+    version: 42,
+    cid: SAMPLE_CID,
+    signingPubKey,
+    ts: 1716567890123,
+    ...overrides,
+  };
+}
+
+// ── buildWinBroadcastTag ──────────────────────────────────────────────────
+
+describe('buildWinBroadcastTag', () => {
+  it('produces the canonical pointer-win:<hex> tag', () => {
+    const tag = buildWinBroadcastTag('02ABCDEF');
+    expect(tag).toBe(`${WIN_BROADCAST_TAG_PREFIX}02abcdef`);
+  });
+
+  it('lowercases the pubkey hex so siblings always agree on the tag', () => {
+    expect(buildWinBroadcastTag('02DEADBEEF')).toBe(buildWinBroadcastTag('02deadbeef'));
+  });
+
+  it('throws on empty input — fail loud rather than subscribe to "pointer-win:"', () => {
+    expect(() => buildWinBroadcastTag('')).toThrow(/non-empty/);
+  });
+});
+
+// ── buildWinBroadcastHash determinism ─────────────────────────────────────
+
+describe('buildWinBroadcastHash', () => {
+  it('produces the same hash for the same payload (determinism)', async () => {
+    const signer = await makeSigner(WALLET_SEED_A);
+    const p = makeUnsignedPayload(signer.signingPubKeyHex);
+    const h1 = await buildWinBroadcastHash(p);
+    const h2 = await buildWinBroadcastHash(p);
+    expect(Array.from(h1.imprint)).toEqual(Array.from(h2.imprint));
+  });
+
+  it('produces different hashes for different `version`s', async () => {
+    const signer = await makeSigner(WALLET_SEED_A);
+    const a = makeUnsignedPayload(signer.signingPubKeyHex, { version: 1 });
+    const b = makeUnsignedPayload(signer.signingPubKeyHex, { version: 2 });
+    const ha = await buildWinBroadcastHash(a);
+    const hb = await buildWinBroadcastHash(b);
+    expect(Array.from(ha.imprint)).not.toEqual(Array.from(hb.imprint));
+  });
+
+  it('produces different hashes for different `cid`s', async () => {
+    const signer = await makeSigner(WALLET_SEED_A);
+    const a = makeUnsignedPayload(signer.signingPubKeyHex, { cid: 'cid-1' });
+    const b = makeUnsignedPayload(signer.signingPubKeyHex, { cid: 'cid-2' });
+    const ha = await buildWinBroadcastHash(a);
+    const hb = await buildWinBroadcastHash(b);
+    expect(Array.from(ha.imprint)).not.toEqual(Array.from(hb.imprint));
+  });
+
+  it('produces different hashes for different `ts`s', async () => {
+    const signer = await makeSigner(WALLET_SEED_A);
+    const a = makeUnsignedPayload(signer.signingPubKeyHex, { ts: 1000 });
+    const b = makeUnsignedPayload(signer.signingPubKeyHex, { ts: 2000 });
+    const ha = await buildWinBroadcastHash(a);
+    const hb = await buildWinBroadcastHash(b);
+    expect(Array.from(ha.imprint)).not.toEqual(Array.from(hb.imprint));
+  });
+
+  it('produces different hashes for different `signingPubKey`s', async () => {
+    const signerA = await makeSigner(WALLET_SEED_A);
+    const signerB = await makeSigner(WALLET_SEED_B);
+    const a = makeUnsignedPayload(signerA.signingPubKeyHex);
+    const b = makeUnsignedPayload(signerB.signingPubKeyHex);
+    const ha = await buildWinBroadcastHash(a);
+    const hb = await buildWinBroadcastHash(b);
+    expect(Array.from(ha.imprint)).not.toEqual(Array.from(hb.imprint));
+  });
+
+  it('rejects schema v !== 1', async () => {
+    const signer = await makeSigner(WALLET_SEED_A);
+    const p = { ...makeUnsignedPayload(signer.signingPubKeyHex), v: 2 as 1 };
+    await expect(buildWinBroadcastHash(p)).rejects.toThrow(/schema/);
+  });
+
+  it('rejects non-integer / out-of-range version', async () => {
+    const signer = await makeSigner(WALLET_SEED_A);
+    await expect(
+      buildWinBroadcastHash(makeUnsignedPayload(signer.signingPubKeyHex, { version: -1 })),
+    ).rejects.toThrow(/uint32/);
+    await expect(
+      buildWinBroadcastHash(makeUnsignedPayload(signer.signingPubKeyHex, { version: 2 ** 32 })),
+    ).rejects.toThrow(/uint32/);
+    await expect(
+      buildWinBroadcastHash(makeUnsignedPayload(signer.signingPubKeyHex, { version: 1.5 })),
+    ).rejects.toThrow(/uint32/);
+  });
+
+  it('rejects malformed pubkey (length != 33 after hex decode)', async () => {
+    const tooShort = '02abcdef';  // 4 bytes, not 33
+    await expect(
+      buildWinBroadcastHash(makeUnsignedPayload(tooShort)),
+    ).rejects.toThrow(/33 bytes/);
+  });
+});
+
+// ── sign + verify roundtrip ───────────────────────────────────────────────
+
+describe('signWinBroadcastPayload / verifyWinBroadcastPayload roundtrip', () => {
+  it('signs a payload and verifies successfully against the same key', async () => {
+    const signer = await makeSigner(WALLET_SEED_A);
+    const unsigned = makeUnsignedPayload(signer.signingPubKeyHex, { ts: Date.now() });
+    const signed = await signWinBroadcastPayload(signer, unsigned);
+    expect(signed.sig).toBeTruthy();
+    const ok = await verifyWinBroadcastPayload(signed, signer.signingPubKeyHex);
+    expect(ok).toBe(true);
+  });
+
+  it('refuses to sign when signer pubkey != payload signingPubKey (anti-spoof guard)', async () => {
+    const signerA = await makeSigner(WALLET_SEED_A);
+    const signerB = await makeSigner(WALLET_SEED_B);
+    const unsigned = makeUnsignedPayload(signerB.signingPubKeyHex);
+    await expect(signWinBroadcastPayload(signerA, unsigned)).rejects.toThrow(/pubkey/);
+  });
+});
+
+// ── verify rejects ────────────────────────────────────────────────────────
+
+describe('verifyWinBroadcastPayload rejections', () => {
+  let signerA: Awaited<ReturnType<typeof makeSigner>>;
+  let signerB: Awaited<ReturnType<typeof makeSigner>>;
+
+  it('rejects payload signed by a different identity', async () => {
+    signerA = await makeSigner(WALLET_SEED_A);
+    signerB = await makeSigner(WALLET_SEED_B);
+    const unsignedForA = makeUnsignedPayload(signerA.signingPubKeyHex, { ts: Date.now() });
+    const signed = await signWinBroadcastPayload(signerA, unsignedForA);
+    // Try to verify against B's pubkey — must reject (signingPubKey field
+    // says A, but verifier expects B).
+    const ok = await verifyWinBroadcastPayload(signed, signerB.signingPubKeyHex);
+    expect(ok).toBe(false);
+  });
+
+  it('rejects payload older than MAX_PAYLOAD_AGE_MS', async () => {
+    signerA = await makeSigner(WALLET_SEED_A);
+    const oldTs = Date.now() - MAX_PAYLOAD_AGE_MS - 1000;
+    const unsigned = makeUnsignedPayload(signerA.signingPubKeyHex, { ts: oldTs });
+    const signed = await signWinBroadcastPayload(signerA, unsigned);
+    const ok = await verifyWinBroadcastPayload(signed, signerA.signingPubKeyHex);
+    expect(ok).toBe(false);
+  });
+
+  it('rejects payload from too far in the future (clock skew bound)', async () => {
+    signerA = await makeSigner(WALLET_SEED_A);
+    const futureTs = Date.now() + MAX_PAYLOAD_AGE_MS + 1000;
+    const unsigned = makeUnsignedPayload(signerA.signingPubKeyHex, { ts: futureTs });
+    const signed = await signWinBroadcastPayload(signerA, unsigned);
+    const ok = await verifyWinBroadcastPayload(signed, signerA.signingPubKeyHex);
+    expect(ok).toBe(false);
+  });
+
+  it('rejects payload with tampered version field', async () => {
+    signerA = await makeSigner(WALLET_SEED_A);
+    const unsigned = makeUnsignedPayload(signerA.signingPubKeyHex, { ts: Date.now() });
+    const signed = await signWinBroadcastPayload(signerA, unsigned);
+    const tampered: SignedWinBroadcastPayload = { ...signed, version: signed.version + 1 };
+    const ok = await verifyWinBroadcastPayload(tampered, signerA.signingPubKeyHex);
+    expect(ok).toBe(false);
+  });
+
+  it('rejects payload with tampered cid field', async () => {
+    signerA = await makeSigner(WALLET_SEED_A);
+    const unsigned = makeUnsignedPayload(signerA.signingPubKeyHex, { ts: Date.now() });
+    const signed = await signWinBroadcastPayload(signerA, unsigned);
+    const tampered: SignedWinBroadcastPayload = { ...signed, cid: 'attacker-cid' };
+    const ok = await verifyWinBroadcastPayload(tampered, signerA.signingPubKeyHex);
+    expect(ok).toBe(false);
+  });
+
+  it('rejects payload with tampered ts field', async () => {
+    signerA = await makeSigner(WALLET_SEED_A);
+    const baseTs = Date.now();
+    const unsigned = makeUnsignedPayload(signerA.signingPubKeyHex, { ts: baseTs });
+    const signed = await signWinBroadcastPayload(signerA, unsigned);
+    const tampered: SignedWinBroadcastPayload = { ...signed, ts: baseTs + 1 };
+    // Even a 1-ms shift breaks the signature (canonical hash includes ts).
+    const ok = await verifyWinBroadcastPayload(tampered, signerA.signingPubKeyHex);
+    expect(ok).toBe(false);
+  });
+
+  it('rejects payload with garbage sig', async () => {
+    signerA = await makeSigner(WALLET_SEED_A);
+    const unsigned = makeUnsignedPayload(signerA.signingPubKeyHex, { ts: Date.now() });
+    const signed: SignedWinBroadcastPayload = { ...unsigned, sig: 'not-hex-data' };
+    const ok = await verifyWinBroadcastPayload(signed, signerA.signingPubKeyHex);
+    expect(ok).toBe(false);
+  });
+
+  it('rejects payload with wrong _kind marker', async () => {
+    signerA = await makeSigner(WALLET_SEED_A);
+    const unsigned = makeUnsignedPayload(signerA.signingPubKeyHex, { ts: Date.now() });
+    const signed = await signWinBroadcastPayload(signerA, unsigned);
+    // Cast through unknown to bypass type system — simulates wire-level
+    // adversary sending a payload with a different _kind marker.
+    const tampered = { ...signed, _kind: 'evil' } as unknown as SignedWinBroadcastPayload;
+    const ok = await verifyWinBroadcastPayload(tampered, signerA.signingPubKeyHex);
+    expect(ok).toBe(false);
+  });
+
+  it('rejects payload with unsupported schema version', async () => {
+    signerA = await makeSigner(WALLET_SEED_A);
+    const unsigned = makeUnsignedPayload(signerA.signingPubKeyHex, { ts: Date.now() });
+    const signed = await signWinBroadcastPayload(signerA, unsigned);
+    const tampered = { ...signed, v: 99 } as unknown as SignedWinBroadcastPayload;
+    const ok = await verifyWinBroadcastPayload(tampered, signerA.signingPubKeyHex);
+    expect(ok).toBe(false);
+  });
+
+  it('accepts payload within the age window (boundary test)', async () => {
+    signerA = await makeSigner(WALLET_SEED_A);
+    // Right at the edge — 1 ms inside the window.
+    const now = Date.now();
+    const ts = now - (MAX_PAYLOAD_AGE_MS - 1);
+    const unsigned = makeUnsignedPayload(signerA.signingPubKeyHex, { ts });
+    const signed = await signWinBroadcastPayload(signerA, unsigned);
+    const ok = await verifyWinBroadcastPayload(signed, signerA.signingPubKeyHex, now);
+    expect(ok).toBe(true);
+  });
+});
+
+// ── JSON wire shape ───────────────────────────────────────────────────────
+
+describe('JSON round-trip (wire compatibility)', () => {
+  it('survives JSON.stringify + JSON.parse without loss', async () => {
+    const signer = await makeSigner(WALLET_SEED_A);
+    const unsigned = makeUnsignedPayload(signer.signingPubKeyHex, { ts: Date.now() });
+    const signed = await signWinBroadcastPayload(signer, unsigned);
+    const wireString = JSON.stringify(signed);
+    const reparsed = JSON.parse(wireString) as SignedWinBroadcastPayload;
+    const ok = await verifyWinBroadcastPayload(reparsed, signer.signingPubKeyHex);
+    expect(ok).toBe(true);
+  });
+});

--- a/tests/unit/profile/lifecycle-manager-pointer-win-broadcast.test.ts
+++ b/tests/unit/profile/lifecycle-manager-pointer-win-broadcast.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for RFC-251 Approach D / issue #255 Problem B —
+ * `LifecycleManager.publishAggregatorPointerBestEffort` emits a typed
+ * `storage:pointer-published` event carrying a signed win-broadcast
+ * payload + per-wallet broadcast tag on every successful pointer
+ * commit.
+ *
+ * Pins the publisher-side end-to-end:
+ *   - Successful publish ⇒ event fired with both `signedPayloadJson`
+ *     and `broadcastTag`.
+ *   - The signed payload verifies cleanly against the wallet's
+ *     pointer signingPubKey (proves end-to-end crypto correctness).
+ *   - Transient / permanent failures DO NOT emit the event (only the
+ *     success path is wired).
+ *   - Pointer layer that does not implement `getSignerForWinBroadcast`
+ *     (e.g. test stub) ⇒ best-effort skip with a log; the publish
+ *     return value is still `ok: true` so the broadcast is purely
+ *     additive.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { ProfileDatabase, OrbitDbConfig } from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import type { ProfilePointerLayer } from '../../../profile/aggregator-pointer';
+import {
+  AggregatorPointerError,
+  AggregatorPointerErrorCode,
+  buildPointerSigner,
+  derivePointerKeyMaterial,
+  createMasterPrivateKey,
+  type PointerSigner,
+} from '../../../profile/aggregator-pointer';
+import {
+  buildWinBroadcastTag,
+  verifyWinBroadcastPayload,
+  type SignedWinBroadcastPayload,
+} from '../../../profile/aggregator-pointer/win-broadcast';
+import type { StorageEvent } from '../../../storage/storage-provider';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+const FAKE_CID = 'bafkreigh2akiscaildc6ovwc6m3fy5puxhxcw7qveyf2nbn7xmqwfajeuy';
+
+// ── Fixtures (mirror lifecycle-manager-publish-retry.test.ts pattern) ─────
+
+function createMockDb(): ProfileDatabase & { _store: Map<string, Uint8Array> } {
+  const store = new Map<string, Uint8Array>();
+  return {
+    _store: store,
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) { store.set(key, value); },
+    async get(key: string) { return store.get(key) ?? null; },
+    async del(key: string) { store.delete(key); },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() { return () => {}; },
+    isConnected() { return true; },
+  } as ProfileDatabase & { _store: Map<string, Uint8Array> };
+}
+
+function createMockLocalCache() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    storage: {
+      async get(k: string) { return store.get(k) ?? null; },
+      async set(k: string, v: string) { store.set(k, v); },
+      async remove(k: string) { store.delete(k); },
+      async clear() { store.clear(); },
+    },
+  };
+}
+
+/**
+ * Build a stub ProfilePointerLayer with a REAL PointerSigner so the
+ * win-broadcast sign path runs against actual secp256k1 crypto.
+ */
+async function buildStubPointer(opts: {
+  readonly signer: PointerSigner;
+  readonly publishImpl?: () => Promise<{ cid: Uint8Array; version: number; attemptsUsed: number }>;
+}): Promise<ProfilePointerLayer> {
+  const defaultPublish = async () => ({
+    cid: new Uint8Array(0),
+    version: 7,
+    attemptsUsed: 1,
+  });
+  return {
+    async recoverLatest() { return null; },
+    async publish() {
+      return (await (opts.publishImpl ?? defaultPublish)()) as never;
+    },
+    getSignerForWinBroadcast() {
+      return {
+        signer: opts.signer,
+        signingPubKeyHex: opts.signer.signingPubKeyHex,
+      };
+    },
+  } as unknown as ProfilePointerLayer;
+}
+
+async function buildRealSigner(): Promise<PointerSigner> {
+  const seed = new Uint8Array(32).fill(0x42);
+  const masterKey = createMasterPrivateKey(seed);
+  const keyMaterial = derivePointerKeyMaterial(masterKey);
+  return buildPointerSigner(keyMaterial.signingSeed);
+}
+
+interface Harness {
+  readonly provider: ProfileTokenStorageProvider;
+  readonly events: StorageEvent[];
+  readonly publish: (cid: string) => Promise<{ ok: boolean; transient: boolean; code?: string }>;
+}
+
+async function createHarness(pointer: ProfilePointerLayer): Promise<Harness> {
+  const db = createMockDb();
+  const localCache = createMockLocalCache();
+  const provider = new ProfileTokenStorageProvider(
+    db,
+    new Uint8Array(32).fill(0x11),
+    ['https://mock-ipfs.test'],
+    {
+      config: { orbitDb: { privateKey: TEST_PRIVATE_KEY }, ipnsSnapshot: false },
+      addressId: 'test',
+      encrypt: true,
+      getPointerLayer: () => pointer,
+    },
+    localCache.storage as unknown as never,
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  await provider.initialize();
+  const events: StorageEvent[] = [];
+  if (typeof provider.onEvent === 'function') {
+    provider.onEvent((event) => { events.push(event); });
+  }
+  const lifecycle = (provider as unknown as {
+    lifecycleManager: {
+      publishAggregatorPointerBestEffort(
+        cid: string,
+      ): Promise<{ ok: boolean; transient: boolean; code?: string }>;
+    };
+  }).lifecycleManager;
+  return {
+    provider,
+    events,
+    publish: (cid: string) => lifecycle.publishAggregatorPointerBestEffort(cid),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('LifecycleManager.publishAggregatorPointerBestEffort — pointer-win broadcast emission (#255 Problem B)', () => {
+  beforeEach(() => { vi.useRealTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('emits storage:pointer-published with signed payload + tag on a successful publish', async () => {
+    const signer = await buildRealSigner();
+    const pointer = await buildStubPointer({
+      signer,
+      publishImpl: async () => ({ cid: new Uint8Array(0), version: 42, attemptsUsed: 1 }),
+    });
+    const h = await createHarness(pointer);
+
+    const result = await h.publish(FAKE_CID);
+    expect(result.ok).toBe(true);
+
+    const published = h.events.find((e) => e.type === 'storage:pointer-published');
+    expect(published).toBeDefined();
+    const data = published!.data as {
+      cid?: string;
+      version?: number;
+      attemptsUsed?: number;
+      signedPayloadJson?: string;
+      broadcastTag?: string;
+    };
+    expect(data.cid).toBe(FAKE_CID);
+    expect(data.version).toBe(42);
+    expect(data.attemptsUsed).toBe(1);
+    expect(typeof data.signedPayloadJson).toBe('string');
+    expect(typeof data.broadcastTag).toBe('string');
+    expect(data.broadcastTag).toBe(buildWinBroadcastTag(signer.signingPubKeyHex));
+
+    // The signed payload MUST verify against the wallet's own signing
+    // pubkey — proves the end-to-end sign path is wired correctly.
+    const signed = JSON.parse(data.signedPayloadJson!) as SignedWinBroadcastPayload;
+    expect(signed.version).toBe(42);
+    expect(signed.cid).toBe(FAKE_CID);
+    expect(signed.signingPubKey.toLowerCase()).toBe(signer.signingPubKeyHex.toLowerCase());
+    const verifyOk = await verifyWinBroadcastPayload(signed, signer.signingPubKeyHex);
+    expect(verifyOk).toBe(true);
+  });
+
+  it('does NOT emit storage:pointer-published on a transient publish failure', async () => {
+    const signer = await buildRealSigner();
+    const pointer = await buildStubPointer({
+      signer,
+      publishImpl: async () => {
+        throw new AggregatorPointerError(
+          AggregatorPointerErrorCode.NETWORK_ERROR,
+          'simulated transient',
+        );
+      },
+    });
+    const h = await createHarness(pointer);
+
+    const result = await h.publish(FAKE_CID);
+    expect(result.ok).toBe(false);
+    expect(result.transient).toBe(true);
+
+    expect(h.events.find((e) => e.type === 'storage:pointer-published')).toBeUndefined();
+  });
+
+  it('falls through gracefully when pointer lacks getSignerForWinBroadcast (legacy stub)', async () => {
+    // Stub WITHOUT the win-broadcast accessor — simulates pre-Approach-D
+    // pointer layer (e.g. a unit test that doesn't extend the helper).
+    const pointer = {
+      async recoverLatest() { return null; },
+      async publish() {
+        return { cid: new Uint8Array(0), version: 13, attemptsUsed: 1 } as never;
+      },
+      // No getSignerForWinBroadcast.
+    } as unknown as ProfilePointerLayer;
+    const h = await createHarness(pointer);
+
+    const result = await h.publish(FAKE_CID);
+    // Publish-success contract MUST be preserved — broadcast is purely
+    // additive. The lifecycle manager's try/catch around the sign step
+    // ensures a missing accessor doesn't taint the success return.
+    expect(result.ok).toBe(true);
+    expect(h.events.find((e) => e.type === 'storage:pointer-published')).toBeUndefined();
+  });
+
+  it('emits a fresh ts on each publish (no stale-broadcast amplification)', async () => {
+    const signer = await buildRealSigner();
+    let version = 1;
+    const pointer = await buildStubPointer({
+      signer,
+      publishImpl: async () => ({
+        cid: new Uint8Array(0),
+        version: version++,
+        attemptsUsed: 1,
+      }),
+    });
+    const h = await createHarness(pointer);
+
+    await h.publish(FAKE_CID);
+    // Wait > 1ms so two successive publishes get distinct millisecond timestamps.
+    await new Promise((r) => setTimeout(r, 5));
+    await h.publish(FAKE_CID);
+
+    const published = h.events.filter((e) => e.type === 'storage:pointer-published');
+    expect(published.length).toBe(2);
+    const p1 = JSON.parse((published[0].data as { signedPayloadJson: string }).signedPayloadJson) as SignedWinBroadcastPayload;
+    const p2 = JSON.parse((published[1].data as { signedPayloadJson: string }).signedPayloadJson) as SignedWinBroadcastPayload;
+    expect(p1.version).toBe(1);
+    expect(p2.version).toBe(2);
+    expect(p2.ts).toBeGreaterThan(p1.ts);
+  });
+});


### PR DESCRIPTION
**Status: DRAFT — prototype, not for merge until Stage B.1 verdict.**

## Why this exists

Issue #255 Problem B (pointer-storm flakiness) Stage B.2 prototype. The project owner directed that the aggregator stay untouched (\"treat aggregator as one-time KV authenticated storage; design the pointer protocol around it\"), so RFC-251 Approach A (CAS on the aggregator) is off the table.

This implements **RFC-251 Approach D Phase 1**: an authenticated Nostr broadcast fires after every successful pointer-publish so sibling devices sharing the same wallet identity can adopt V=N without waiting for the aggregator's 30–60 s read-replica lag. Pure client-side, no aggregator change.

Degrades cleanly: if Nostr drops the broadcast (relay partition, sibling offline, transport doesn't support broadcasts), siblings fall back to the existing WALKBACK_FLOOR + reconcileLocalVersionDownward path — strictly **no-worse-than-today**.

## What's in the box

### Crypto layer — new, isolated, fully unit-tested
`profile/aggregator-pointer/win-broadcast.ts`:
- Canonical payload (\`_kind / v / version / cid / signingPubKey / ts\`).
- Fixed-width canonical hash (1 + 4 + 8 + 33 + N bytes; SHA-256) — collision-resistant under length-padding tricks.
- Sign with pointer signer + verify against expected pubkey.
- 5-minute replay window enforcement.
- Anti-spoof guard at sign time (signer pubkey must match payload).
- Verification returns false (never throws) on any failure so the caller can log + drop.

### Plumbing
- `ProfilePointerLayer.getSignerForWinBroadcast()` — exposes signer + pubkey hex to the wiring layer without leaking internal state.
- `StorageEventType` adds \`'storage:pointer-published'\` — emitted by lifecycle-manager after a successful pointer commit, carrying the already-signed payload + per-wallet broadcast tag.
- `lifecycle-manager.publishAggregatorPointerBestEffort` does the signing locally (pointer ref is in scope there) and emits the event. Best-effort: sign failures are logged and dropped; publish-success contract preserved.

### Sphere wiring
- **Publisher side:** subscribes to \`storage:pointer-published\` on each token-storage provider, forwards via \`transport.publishBroadcast\`.
- **Subscriber side:** lazily installs per-wallet Nostr subscription for \`pointer-win:<signingPubKeyHex>\` events. Handler verifies signature, dedupes by (signingPubKey, version) via bounded 256-entry LRU, triggers an early \`recoverLatest()\` + \`reconcileLocalVersionDownward()\` — collapsing the convergence window from the 60–90 s WALKBACK_FLOOR throttle cycle to ~1 s Nostr latency.

## Acknowledged Phase 1 limitations

1. **Lazy-on-own-publish subscription install.** Receive-only devices that never publish themselves don't receive sibling broadcasts until their own first publish. Phase 2 would add an eager polling loop or a \`storage:pointer-ready\` event from \`ProfileStorageProvider\`.
2. **Same-version race not directly resolved.** \`reconcileLocalVersionDownward\` no-ops when local == broadcast.version (only handles strict downgrade). For the dominant *same-version race* (A and B both at V=N, A wins on aggregator), the broadcast is currently informational only — B's next publish will still bump to V=N+1 via the standard flow, but won't *skip the WALKBACK_FLOOR throttle*. Phase 2 would add an \`adoptBroadcast(payload)\` entrypoint on \`ProfilePointerLayer\` that bypasses the >= comparison and explicitly resets the throttle.

Why these limits are acceptable for Phase 1: this PR is the **broadcast-fire-rate measurement vehicle** for Stage B.1's characterization (5× \`manual-test-full-recovery.sh\` runs after \`unicitynetwork/ipfs-storage#7\` deploys). If broadcasts fire reliably and same-version races turn out to be the dominant residual failure mode, Phase 2 follows with that data in hand.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint <changed files>\` — 0 warnings on changed code
- [x] \`npx vitest run tests/unit/pointer/win-broadcast.test.ts\` — 24 pass (crypto module)
- [x] \`npx vitest run tests/unit/profile/lifecycle-manager-pointer-win-broadcast.test.ts\` — 4 pass (event-emission contract)
- [x] \`npx vitest run\` (full suite) — 8132 pass, 13 skipped, **0 regressions**
- [ ] **End-to-end:** Stage B.1 — re-run \`manual-test-full-recovery.sh\` 5× after \`ipfs-storage#7\` lands + deploys. Measure: broadcast-fire count, sibling-receive count, sibling-verify success rate, §C.2/§C.4 outcomes, WALKBACK_FLOOR count per run. If §C.2 succeeds on all 5 and WALKBACK_FLOOR ≤ 5/run → Problem B mitigated by **#6 alone**; this PR may or may not be needed (data-driven). Otherwise this PR's broadcast logs become the diagnostic surface for Phase 2 scoping.

## Files changed
- \`profile/aggregator-pointer/win-broadcast.ts\` (new, 233 LOC)
- \`profile/aggregator-pointer/ProfilePointerLayer.ts\` (+23 LOC — \`getSignerForWinBroadcast\` accessor)
- \`profile/aggregator-pointer/index.ts\` (+16 LOC — barrel exports)
- \`profile/profile-token-storage/lifecycle-manager.ts\` (+53 LOC — sign + emit on success)
- \`storage/storage-provider.ts\` (+22 LOC — new event-type variant)
- \`core/Sphere.ts\` (+272 LOC — pub/sub wiring + lazy install + dedup + cleanup)
- \`tests/unit/pointer/win-broadcast.test.ts\` (new, 24 tests)
- \`tests/unit/profile/lifecycle-manager-pointer-win-broadcast.test.ts\` (new, 4 tests)

## Refs
- #251 — parent issue
- #255 — current issue (Problem B Stage B.2 path)
- \`docs/uxf/RFC-251-pointer-coordination.md\` — design rationale (RFC-251 §3 recommendation now superseded by owner directive; RFC update is a follow-up)
- \`unicitynetwork/ipfs-storage#7\` — Stage B.1 prerequisite (sidecar instant-pin)