### PR TITLE
feat(profile)(#255b): wire IPFS instant-pin sidecar (Stage B.1 prereq)

### DIFF
--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -957,13 +957,24 @@ export async function fetchFromIpfs(
           await putBlockToLocalHelia(localHelia, cid, sidecarBytes);
         }
         return sidecarBytes;
-      } catch {
+      } catch (verifyErr) {
         // CID mismatch on sidecar bytes is a serious operational
-        // signal (sidecar served wrong bytes for this CID). Treat as
-        // a miss and fall through — the normal gateway path will
-        // re-verify and reject if Kubo also serves bad bytes. Don't
-        // throw here; the normal flow has its own ProfileError
-        // contract callers rely on.
+        // signal: the sidecar's cache served bytes that don't hash
+        // to the CID we asked for. Could be a rogue cache, a
+        // submission-side codec mismatch, or in-flight bit-rot.
+        // Don't throw — fall through to `/api/v0/block/get` so the
+        // normal flow's own CID-verify either confirms (Kubo also
+        // bad → caller surfaces ProfileError) or recovers (Kubo
+        // good → caller gets right bytes). Warn so operators can
+        // see the sidecar misbehavior even though the wallet
+        // self-heals.
+        logger.warn(
+          'IPFS-Sidecar',
+          `read CID mismatch on ${cid.slice(0, 16)} from ` +
+          `${effectiveGateways[0]} (${sidecarBytes.byteLength} bytes); ` +
+          `falling through to /api/v0/block/get. Reason: ` +
+          `${verifyErr instanceof Error ? verifyErr.message : String(verifyErr)}`,
+        );
       }
     }
   }

--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -241,6 +241,177 @@ const DEFAULT_VERIFY_TIMEOUT_MS = 10_000;
 const DEFAULT_MAX_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
 
 // =============================================================================
+// Issue #255 Problem B / ipfs-storage#7 — instant-pin sidecar submit
+// =============================================================================
+
+/**
+ * Per-block upper bound for sidecar submissions. The sidecar's default
+ * `SIDECAR_CACHE_MAX_BLOB_BYTES` is 32 MiB; anything larger gets a 413
+ * back and is just wasted bandwidth. Stays comfortably above the
+ * sphere-sdk Profile snapshot CAR block sizes (well under 256 KiB
+ * for raw leaves, typically a few KiB for dag-cbor envelopes).
+ */
+const SIDECAR_SUBMIT_MAX_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Per-call timeout for the fire-and-forget sidecar submit. Short by
+ * design — the submit is an optimization, not a contract, and a slow
+ * sidecar must not gate the pin-success return.
+ */
+const SIDECAR_SUBMIT_TIMEOUT_MS = 5_000;
+
+/**
+ * Per-attempt timeout for the {@link tryReadFromSidecar} fast-path
+ * probe. Aggressively short — the sidecar is co-located with the
+ * gateway nginx; if it can't answer in this window, the bytes
+ * almost certainly aren't there and the request would be a waste.
+ * Falling through to the normal `/api/v0/block/get` path costs
+ * one ~100 ms RTT in any case.
+ */
+const SIDECAR_READ_TIMEOUT_MS = 500;
+
+/**
+ * Fire-and-forget POST the raw bytes that hash to `cid` to the
+ * gateway's instant-pin sidecar (`/sidecar/submit?cid=<cid>`). Lets
+ * cross-device readers fetch `cid` immediately after pin, before
+ * Kubo's bitswap registration window closes (the dominant cross-
+ * device race amplifier — see issue #255 Problem B, RFC-251).
+ *
+ * Contract:
+ *   - Never throws. Never blocks the caller. Errors are swallowed
+ *     via the trailing `.catch(() => {})`.
+ *   - The bytes MUST hash to `cid` under the codec the sidecar
+ *     reconciler will infer from the CID prefix (raw / dag-cbor /
+ *     dag-pb). For the two call sites in this module (`pinToIpfs`,
+ *     `pinSingleBlock`) this holds by construction; the sidecar's
+ *     `_infer_block_put_params` handles the codec choice server-side.
+ *   - If the gateway doesn't run the sidecar (e.g. `ipfs.io`), the
+ *     POST 404s and is silently dropped — the primary pin already
+ *     succeeded, so the bytes are durable in Kubo regardless.
+ *   - 503 (cache_full back-pressure) and 413 (over 32 MiB) are
+ *     handled identically: drop on the floor. The primary pin is
+ *     the source of truth.
+ */
+function submitToSidecarBestEffort(
+  gateway: string,
+  cid: string,
+  bytes: Uint8Array,
+): void {
+  if (typeof gateway !== 'string' || gateway.length === 0) return;
+  if (typeof cid !== 'string' || cid.length === 0) return;
+  if (!(bytes instanceof Uint8Array) || bytes.length === 0) return;
+  if (bytes.length > SIDECAR_SUBMIT_MAX_BYTES) return;
+  const url =
+    `${gateway.replace(/\/$/, '')}/sidecar/submit?cid=${encodeURIComponent(cid)}`;
+  // Detached fire-and-forget. The .catch swallows any rejection so
+  // an unhandled-rejection doesn't surface; the void operator
+  // discards the dangling promise reference so callers don't have
+  // to ignore a `Promise<void>` they're not allowed to await.
+  void fetch(url, {
+    method: 'POST',
+    body: bytes as BlobPart,
+    headers: { 'Content-Type': 'application/octet-stream' },
+    signal: AbortSignal.timeout(SIDECAR_SUBMIT_TIMEOUT_MS),
+  })
+    .then((response) => {
+      // Drain the body so the connection releases promptly. Logged at
+      // debug level for operator triage — Stage B.1 wants visibility
+      // into how often sphere-sdk publishes actually populate the
+      // cache vs how often they get 503-back-pressured or 4xx-rejected.
+      if (!response.ok) {
+        logger.debug(
+          'IPFS-Sidecar',
+          `submit ${cid.slice(0, 16)} → HTTP ${response.status} ` +
+          `(${response.statusText}) on ${gateway}`,
+        );
+      } else {
+        logger.debug(
+          'IPFS-Sidecar',
+          `submit ${cid.slice(0, 16)} → 200 on ${gateway}`,
+        );
+      }
+      // Best-effort body drain — the sidecar returns small JSON; we
+      // don't actually need its contents (the outcome is just diagnostic).
+      response.body?.cancel?.().catch(() => { /* ignore */ });
+    })
+    .catch(() => {
+      // Network error, timeout, gateway-without-sidecar (404 → ok=false
+      // above), or AbortError. All silently dropped — the primary pin
+      // already succeeded; this is pure optimization.
+    });
+}
+
+/**
+ * Read fast-path counterpart to {@link submitToSidecarBestEffort}.
+ * Attempts `/sidecar/blob?cid=<cid>` against the supplied gateway with
+ * a short timeout. Returns the bytes on a 200, `null` on anything
+ * else (404 cache miss, gateway without sidecar, timeout, network
+ * error). Never throws.
+ *
+ * Used by {@link fetchFromIpfs} to close the cross-device publish-
+ * then-read window for CIDs a sibling device just submitted to the
+ * sidecar. The window is ~5 s (until the reconciler promotes the
+ * block to Kubo and removes it from sidecar disk); outside the
+ * window the sidecar 404s and the caller falls through to the
+ * normal `/api/v0/block/get` path.
+ *
+ * Important: the bytes returned by `/sidecar/blob` are the raw
+ * block bytes (whatever the submitter posted). For single-block
+ * CIDs (raw-leaf or dag-cbor envelope) these are bit-identical
+ * to what `/api/v0/block/get` would return on a cache miss, so
+ * the caller's downstream `verifyCidMatchesBytes` check still
+ * succeeds. Multi-block UnixFS roots cannot round-trip through
+ * the sidecar — but sphere-sdk's pin paths only submit
+ * single-block CIDs, so the sidecar never serves multi-block
+ * bytes for sphere-sdk-published CIDs.
+ */
+async function tryReadFromSidecar(
+  gateway: string,
+  cid: string,
+): Promise<Uint8Array | null> {
+  if (typeof gateway !== 'string' || gateway.length === 0) return null;
+  if (typeof cid !== 'string' || cid.length === 0) return null;
+  try {
+    const url =
+      `${gateway.replace(/\/$/, '')}/sidecar/blob?cid=${encodeURIComponent(cid)}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/octet-stream' },
+      signal: AbortSignal.timeout(SIDECAR_READ_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      // 404 (cache miss / sidecar disabled) is the common case; drain
+      // and return null so caller falls through to the normal fetch.
+      response.body?.cancel?.().catch(() => { /* ignore */ });
+      return null;
+    }
+    // Sniff content-type — a gateway that doesn't run the sidecar
+    // may have a catch-all returning HTML/JSON for /sidecar/*; we
+    // only trust application/octet-stream-like responses.
+    const ct = (response.headers.get('Content-Type') ?? '').toLowerCase();
+    if (
+      ct &&
+      !ct.startsWith('application/octet-stream') &&
+      !ct.startsWith('application/vnd.ipld')
+    ) {
+      response.body?.cancel?.().catch(() => { /* ignore */ });
+      return null;
+    }
+    const buf = await response.arrayBuffer();
+    if (buf.byteLength === 0) return null;
+    logger.debug(
+      'IPFS-Sidecar',
+      `read hit ${cid.slice(0, 16)} (${buf.byteLength} bytes) on ${gateway}`,
+    );
+    return new Uint8Array(buf);
+  } catch {
+    // Timeout, network error, abort — all treated as a miss. The
+    // caller's normal-path fetch is the source of truth.
+    return null;
+  }
+}
+
+// =============================================================================
 // Public API
 // =============================================================================
 
@@ -325,6 +496,15 @@ export async function pinToIpfs(
       // (404 on next lookup); attacker cannot redirect the wallet's
       // anchor to attacker-chosen content.
       const expectedCid = CID.createV1(raw.code, createMultihash(0x12, sha256(data))).toString();
+      // Issue #255 Problem B / ipfs-storage#7 — fire-and-forget submit
+      // to the sidecar so cross-device readers can fetch the CID
+      // immediately, before Kubo's bitswap registration window closes.
+      // Always eligible here: `pinToIpfs` forces input-codec=raw, so
+      // `expectedCid` is always a raw-leaf v1 (`bafkrei...`) and the
+      // bytes that hash to it are exactly `data`. Gateway-targeted at
+      // the SAME gateway that just succeeded the pin — if that gateway
+      // doesn't run the sidecar, the POST 404s and is dropped silently.
+      submitToSidecarBestEffort(gateway, expectedCid, data);
       return expectedCid;
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
@@ -410,6 +590,14 @@ async function pinSingleBlock(
       } catch {
         // ignore — body parse failure on a 200 doesn't change durability
       }
+      // Issue #255 Problem B / ipfs-storage#7 — fire-and-forget submit
+      // to the sidecar (same gateway). The bytes hash to `expectedCid`
+      // by construction here (each block in a CAR satisfies
+      // `sha256(block.bytes) === block.cid.multihash.digest` per Issue
+      // #213 / Option C). The sidecar's `_infer_block_put_params`
+      // handles raw / dag-cbor / dag-pb codecs by CID prefix — no
+      // codec-specific gating needed on this side.
+      submitToSidecarBestEffort(gateway, expectedCid, blockBytes);
       return;
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
@@ -748,6 +936,37 @@ export async function fetchFromIpfs(
 
     return { bytes, reason: null, retryAsGet: false };
   };
+
+  // Issue #255 Problem B / ipfs-storage#7 — read fast-path. Probe
+  // the FIRST gateway's `/sidecar/blob?cid=<cid>` ONCE before the
+  // normal multi-gateway loop. On a hit (bytes a sibling device
+  // submitted within the last ~5 s window) the cross-device read
+  // closes in sub-50 ms instead of paying the Kubo bitswap
+  // registration window. On a miss / non-sidecar gateway / timeout
+  // the helper returns null and the normal flow runs unchanged.
+  // 500 ms ceiling per `SIDECAR_READ_TIMEOUT_MS`.
+  if (effectiveGateways.length > 0) {
+    const sidecarBytes = await tryReadFromSidecar(effectiveGateways[0], cid);
+    if (sidecarBytes !== null && sidecarBytes.byteLength <= maxSizeBytes) {
+      try {
+        verifyCidMatchesBytes(cid, sidecarBytes);
+        // Write-back to local Helia so subsequent same-`dataDir`
+        // process loads hit the local-first read path (mirror the
+        // gateway-fetch write-back at line 920 below).
+        if (localHelia !== null) {
+          await putBlockToLocalHelia(localHelia, cid, sidecarBytes);
+        }
+        return sidecarBytes;
+      } catch {
+        // CID mismatch on sidecar bytes is a serious operational
+        // signal (sidecar served wrong bytes for this CID). Treat as
+        // a miss and fall through — the normal gateway path will
+        // re-verify and reject if Kubo also serves bad bytes. Don't
+        // throw here; the normal flow has its own ProfileError
+        // contract callers rely on.
+      }
+    }
+  }
 
   for (const gateway of effectiveGateways) {
     try {

--- a/tests/unit/payments/transfer/bundle-acquirer.test.ts
+++ b/tests/unit/payments/transfer/bundle-acquirer.test.ts
@@ -850,6 +850,18 @@ describe('acquireBundle — negative LRU skips transient errors (Round 3)', () =
     let attempts = 0;
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
       async (input: string | URL | Request) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        // Issue #255 Problem B / ipfs-storage#7 — fetchFromIpfs now
+        // probes `/sidecar/blob?cid=<cid>` once per call before the
+        // /api/v0/block/get path. Treat it as an instant miss here
+        // (no sidecar in this test fixture) WITHOUT incrementing the
+        // attempts counter — the test's transient-vs-recovered
+        // simulation depends on a specific number of block/get
+        // attempts, and we don't want the probe to consume a budget
+        // slot.
+        if (url.includes('/sidecar/blob')) {
+          return new Response('not in sidecar cache', { status: 404 });
+        }
         attempts++;
         // Network blip on the first 2 attempts — the block-walk's
         // gateway fallback exhausts both gateways and throws on the
@@ -858,7 +870,6 @@ describe('acquireBundle — negative LRU skips transient errors (Round 3)', () =
           return new Response('upstream blip', { status: 503 });
         }
         // Recovered: serve per-block via /api/v0/block/get?arg=<cid>.
-        const url = typeof input === 'string' ? input : input.toString();
         const m = /\/api\/v0\/block\/get\?arg=([^&]+)/.exec(url);
         if (!m) return new Response('', { status: 404 });
         const cid = decodeURIComponent(m[1]!);

--- a/tests/unit/profile/ipfs-client-sidecar-submit.test.ts
+++ b/tests/unit/profile/ipfs-client-sidecar-submit.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Tests for the instant-pin sidecar submit hook in `profile/ipfs-client.ts`.
+ *
+ * Issue #255 Problem B / ipfs-storage#7: after every successful pin via
+ * `/api/v0/dag/put`, `pinToIpfs` (and `pinSingleBlock` via `pinCarBlocksToIpfs`)
+ * fire-and-forget POST the same bytes to the gateway's `/sidecar/submit`
+ * endpoint. This populates the sidecar's instant-pin cache so cross-device
+ * readers can fetch the CID immediately, before Kubo's bitswap registration
+ * window closes.
+ *
+ * The hook is BEST-EFFORT:
+ *   - Errors never propagate to the caller.
+ *   - Sidecar absence (gateway 404s the POST) is silently dropped.
+ *   - The primary pin's success contract is invariant under sidecar failure.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { create as createDigest } from 'multiformats/hashes/digest';
+
+import { pinToIpfs, pinCarBlocksToIpfs, fetchFromIpfs } from '../../../profile/ipfs-client';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function cidForBytes(bytes: Uint8Array): string {
+  return CID.createV1(raw.code, createDigest(0x12, sha256(bytes))).toString();
+}
+
+interface RecordedFetch {
+  readonly url: string;
+  readonly method: string;
+  readonly body: Uint8Array | null;
+  readonly headers: Record<string, string>;
+}
+
+/**
+ * Install a fetch mock that records every call and routes by URL pattern:
+ *   - `/api/v0/dag/put`         → returns 200 + JSON CID envelope (primary pin succeeds)
+ *   - `/api/v0/block/get`       → routes to `blockGetHandler` if supplied
+ *   - `/sidecar/submit?cid=...` → routes to `sidecarSubmitHandler`
+ *   - `/sidecar/blob?cid=...`   → routes to `sidecarBlobHandler` if supplied
+ *
+ * Returns the recording array (populated as fetches happen) plus a restore
+ * function.
+ */
+function installFetchMock(opts: {
+  pinHandler?: (req: RecordedFetch) => Promise<Response> | Response;
+  sidecarHandler: (req: RecordedFetch) => Promise<Response> | Response;
+  blockGetHandler?: (req: RecordedFetch) => Promise<Response> | Response;
+  sidecarBlobHandler?: (req: RecordedFetch) => Promise<Response> | Response;
+}): {
+  recorded: RecordedFetch[];
+  restore: () => void;
+} {
+  const recorded: RecordedFetch[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : (input as { url?: string }).url ?? String(input);
+    let body: Uint8Array | null = null;
+    if (init?.body instanceof Uint8Array) {
+      body = init.body;
+    } else if (init?.body instanceof Blob) {
+      body = new Uint8Array(await init.body.arrayBuffer());
+    } else if (init?.body instanceof FormData) {
+      // Crude: pull out the first field as Uint8Array. The pin path uses
+      // FormData with a single 'data' field that wraps Blob(Uint8Array).
+      const file = init.body.get('data') as Blob | null;
+      body = file ? new Uint8Array(await file.arrayBuffer()) : null;
+    }
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      if (init.headers instanceof Headers) {
+        init.headers.forEach((v, k) => { headers[k.toLowerCase()] = v; });
+      } else if (Array.isArray(init.headers)) {
+        for (const [k, v] of init.headers) headers[k.toLowerCase()] = v;
+      } else {
+        for (const [k, v] of Object.entries(init.headers)) {
+          headers[k.toLowerCase()] = String(v);
+        }
+      }
+    }
+    const req: RecordedFetch = {
+      url,
+      method: init?.method ?? 'GET',
+      body,
+      headers,
+    };
+    recorded.push(req);
+
+    if (url.includes('/sidecar/submit')) {
+      return opts.sidecarHandler(req);
+    }
+    if (url.includes('/sidecar/blob')) {
+      if (opts.sidecarBlobHandler) return opts.sidecarBlobHandler(req);
+      return new Response('not in sidecar cache', { status: 404 });
+    }
+    if (url.includes('/api/v0/dag/put')) {
+      if (opts.pinHandler) return opts.pinHandler(req);
+      // Default: succeed with a JSON envelope.
+      return new Response(JSON.stringify({ Cid: { '/': 'ignored-by-caller' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/api/v0/block/get')) {
+      if (opts.blockGetHandler) return opts.blockGetHandler(req);
+      return new Response('not found', { status: 404 });
+    }
+    throw new Error(`fetch mock got unexpected URL: ${url}`);
+  }) as typeof globalThis.fetch;
+
+  return { recorded, restore: () => { globalThis.fetch = originalFetch; } };
+}
+
+// Wait for next tick so detached fire-and-forget promises have a chance
+// to register their handlers (the test thread can otherwise race ahead
+// of the `void fetch(...).then(...).catch(...)` chain).
+async function waitForDetachedFetch(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+const TEST_GATEWAY = 'https://ipfs.test';
+const SAMPLE_BYTES = new TextEncoder().encode('hello sidecar — test payload');
+
+// ---------------------------------------------------------------------------
+// pinToIpfs sidecar submit
+// ---------------------------------------------------------------------------
+
+describe('pinToIpfs → /sidecar/submit fire-and-forget', () => {
+  let mock: ReturnType<typeof installFetchMock>;
+
+  afterEach(() => {
+    if (mock) mock.restore();
+  });
+
+  it('POSTs the same bytes to /sidecar/submit after a successful pin', async () => {
+    mock = installFetchMock({
+      sidecarHandler: () => new Response(
+        JSON.stringify({ ok: true, outcome: 'accepted' }),
+        { status: 200 },
+      ),
+    });
+
+    const cid = await pinToIpfs([TEST_GATEWAY], SAMPLE_BYTES);
+    expect(cid).toBe(cidForBytes(SAMPLE_BYTES));
+
+    await waitForDetachedFetch();
+
+    const sidecarCalls = mock.recorded.filter((r) => r.url.includes('/sidecar/submit'));
+    expect(sidecarCalls).toHaveLength(1);
+    const submit = sidecarCalls[0];
+    expect(submit.method).toBe('POST');
+    expect(submit.url).toBe(`${TEST_GATEWAY}/sidecar/submit?cid=${encodeURIComponent(cid)}`);
+    expect(submit.headers['content-type']).toBe('application/octet-stream');
+    expect(submit.body).not.toBeNull();
+    expect(Array.from(submit.body!)).toEqual(Array.from(SAMPLE_BYTES));
+  });
+
+  it('does NOT block pinToIpfs on a slow / failed sidecar response', async () => {
+    let sidecarCalled = false;
+    mock = installFetchMock({
+      sidecarHandler: () => {
+        sidecarCalled = true;
+        // Simulate a 5xx — the hook must swallow without rethrowing.
+        return new Response('sidecar is down', { status: 500 });
+      },
+    });
+
+    const cid = await pinToIpfs([TEST_GATEWAY], SAMPLE_BYTES);
+    expect(cid).toBe(cidForBytes(SAMPLE_BYTES));
+
+    await waitForDetachedFetch();
+    expect(sidecarCalled).toBe(true);
+  });
+
+  it('does NOT block pinToIpfs when sidecar fetch throws (gateway without sidecar)', async () => {
+    let sidecarCalled = false;
+    mock = installFetchMock({
+      sidecarHandler: () => {
+        sidecarCalled = true;
+        // Simulate a network-level error — the hook's `.catch` MUST absorb it.
+        throw new TypeError('Failed to fetch: ENOTFOUND');
+      },
+    });
+
+    // pinToIpfs MUST resolve normally; no unhandled rejection should escape.
+    const cid = await pinToIpfs([TEST_GATEWAY], SAMPLE_BYTES);
+    expect(cid).toBe(cidForBytes(SAMPLE_BYTES));
+
+    await waitForDetachedFetch();
+    expect(sidecarCalled).toBe(true);
+  });
+
+  it('skips sidecar submit on empty data (defense-in-depth — pin would also reject)', async () => {
+    let sidecarCalled = false;
+    // Pin handler still has to respond, but the test asserts on whether
+    // SIDECAR was called.
+    mock = installFetchMock({
+      pinHandler: () => new Response(
+        JSON.stringify({ Cid: { '/': 'ignored' } }),
+        { status: 200 },
+      ),
+      sidecarHandler: () => {
+        sidecarCalled = true;
+        return new Response('', { status: 200 });
+      },
+    });
+
+    await pinToIpfs([TEST_GATEWAY], new Uint8Array(0));
+    await waitForDetachedFetch();
+    expect(sidecarCalled).toBe(false);
+  });
+
+  it('skips sidecar submit on > 32 MiB body', async () => {
+    let sidecarCalled = false;
+    const oversize = new Uint8Array(33 * 1024 * 1024);  // 33 MiB
+    mock = installFetchMock({
+      sidecarHandler: () => {
+        sidecarCalled = true;
+        return new Response('', { status: 200 });
+      },
+    });
+
+    const cid = await pinToIpfs([TEST_GATEWAY], oversize);
+    expect(cid).toBe(cidForBytes(oversize));
+    await waitForDetachedFetch();
+    expect(sidecarCalled).toBe(false);
+  });
+
+  it('uses the SAME gateway that won the pin race (not the first in the list)', async () => {
+    // First gateway 5xx on pin, second succeeds. Sidecar must hit the second.
+    const gw1 = 'https://gw1.test';
+    const gw2 = 'https://gw2.test';
+    mock = installFetchMock({
+      pinHandler: (req) => {
+        if (req.url.startsWith(gw1)) {
+          return new Response('boom', { status: 503 });
+        }
+        return new Response(
+          JSON.stringify({ Cid: { '/': 'ignored' } }),
+          { status: 200 },
+        );
+      },
+      sidecarHandler: () => new Response('', { status: 200 }),
+    });
+
+    await pinToIpfs([gw1, gw2], SAMPLE_BYTES);
+    await waitForDetachedFetch();
+
+    const sidecarCalls = mock.recorded.filter((r) => r.url.includes('/sidecar/submit'));
+    expect(sidecarCalls).toHaveLength(1);
+    expect(sidecarCalls[0].url.startsWith(gw2)).toBe(true);
+    expect(sidecarCalls[0].url.startsWith(gw1)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pinCarBlocksToIpfs → pinSingleBlock sidecar submit (per-block fan-out)
+// ---------------------------------------------------------------------------
+
+describe('pinCarBlocksToIpfs → /sidecar/submit fan-out (per block)', () => {
+  let mock: ReturnType<typeof installFetchMock>;
+
+  beforeEach(() => {
+    // Reset between tests.
+  });
+
+  afterEach(() => {
+    if (mock) mock.restore();
+  });
+
+  /**
+   * @ipld/car's `CarWriter.create()` returns a `{ writer, out }` pair where
+   * `out` is an async iterator that MUST be consumed concurrently with
+   * the writes (the iterator's internal buffer blocks `writer.put()` once
+   * full). Serial put-then-iterate deadlocks. This helper does the
+   * standard concurrent pattern.
+   */
+  async function buildCarBytes(
+    roots: CID[],
+    entries: Array<{ cid: CID; bytes: Uint8Array }>,
+  ): Promise<Uint8Array> {
+    const { CarWriter } = await import('@ipld/car');
+    const { writer, out } = CarWriter.create(roots);
+    // Start the consumer BEFORE the writes so the iterator drains as
+    // they happen.
+    const collect = (async () => {
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of out) chunks.push(chunk);
+      return chunks;
+    })();
+    for (const entry of entries) {
+      await writer.put({ cid: entry.cid, bytes: entry.bytes });
+    }
+    await writer.close();
+    const chunks = await collect;
+    const total = chunks.reduce((acc, c) => acc + c.length, 0);
+    const out2 = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) { out2.set(c, offset); offset += c.length; }
+    return out2;
+  }
+
+  it('submits each block to the sidecar after pinning, preserving the (cid, bytes) pair', async () => {
+    const bytesA = new TextEncoder().encode('block-A payload');
+    const bytesB = new TextEncoder().encode('block-B payload — distinct');
+    const cidA = CID.createV1(raw.code, createDigest(0x12, sha256(bytesA)));
+    const cidB = CID.createV1(raw.code, createDigest(0x12, sha256(bytesB)));
+
+    const carBytes = await buildCarBytes(
+      [cidA],
+      [{ cid: cidA, bytes: bytesA }, { cid: cidB, bytes: bytesB }],
+    );
+
+    mock = installFetchMock({
+      sidecarHandler: () => new Response(
+        JSON.stringify({ ok: true, outcome: 'accepted' }),
+        { status: 200 },
+      ),
+    });
+
+    await pinCarBlocksToIpfs([TEST_GATEWAY], carBytes, cidA.toString());
+    await waitForDetachedFetch();
+
+    const sidecarCalls = mock.recorded.filter((r) => r.url.includes('/sidecar/submit'));
+    // One submit per block (2 blocks in our CAR).
+    expect(sidecarCalls.length).toBe(2);
+
+    // Verify each submit's CID + body alignment.
+    const submitForCid = (cidStr: string) =>
+      sidecarCalls.find((c) => c.url.includes(encodeURIComponent(cidStr)));
+    const submitA = submitForCid(cidA.toString());
+    const submitB = submitForCid(cidB.toString());
+    expect(submitA).toBeDefined();
+    expect(submitB).toBeDefined();
+    expect(Array.from(submitA!.body!)).toEqual(Array.from(bytesA));
+    expect(Array.from(submitB!.body!)).toEqual(Array.from(bytesB));
+  });
+
+  it('does NOT fail the pin when sidecar throws on every block', async () => {
+    const bytes = new TextEncoder().encode('block-X');
+    const cid = CID.createV1(raw.code, createDigest(0x12, sha256(bytes)));
+    const carBytes = await buildCarBytes([cid], [{ cid, bytes }]);
+
+    mock = installFetchMock({
+      sidecarHandler: () => { throw new TypeError('ENOTFOUND'); },
+    });
+
+    // Must resolve cleanly even though every sidecar submit blows up.
+    await expect(
+      pinCarBlocksToIpfs([TEST_GATEWAY], carBytes, cid.toString()),
+    ).resolves.toBe(cid.toString());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchFromIpfs read fast-path via /sidecar/blob
+// ---------------------------------------------------------------------------
+
+describe('fetchFromIpfs → /sidecar/blob read fast-path', () => {
+  let mock: ReturnType<typeof installFetchMock>;
+
+  afterEach(() => {
+    if (mock) mock.restore();
+  });
+
+  it('returns sidecar bytes on a 200 hit and SKIPS the /api/v0/block/get call', async () => {
+    const bytes = new TextEncoder().encode('fresh-from-sibling');
+    const cid = cidForBytes(bytes);
+    let blockGetCalled = false;
+
+    mock = installFetchMock({
+      sidecarHandler: () => new Response('', { status: 200 }),
+      sidecarBlobHandler: () => new Response(bytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }),
+      blockGetHandler: () => {
+        blockGetCalled = true;
+        return new Response('should not be called', { status: 200 });
+      },
+    });
+
+    const result = await fetchFromIpfs([TEST_GATEWAY], cid, 1000);
+    expect(Array.from(result)).toEqual(Array.from(bytes));
+    expect(blockGetCalled).toBe(false);
+
+    // Confirm the sidecar blob was queried.
+    const blobCalls = mock.recorded.filter((r) => r.url.includes('/sidecar/blob'));
+    expect(blobCalls.length).toBe(1);
+    expect(blobCalls[0].url).toBe(`${TEST_GATEWAY}/sidecar/blob?cid=${encodeURIComponent(cid)}`);
+  });
+
+  it('falls through to /api/v0/block/get on sidecar 404 (cache miss)', async () => {
+    const bytes = new TextEncoder().encode('fallback-path');
+    const cid = cidForBytes(bytes);
+
+    mock = installFetchMock({
+      sidecarHandler: () => new Response('', { status: 200 }),
+      sidecarBlobHandler: () => new Response('not in cache', { status: 404 }),
+      blockGetHandler: () => new Response(bytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }),
+    });
+
+    const result = await fetchFromIpfs([TEST_GATEWAY], cid, 1000);
+    expect(Array.from(result)).toEqual(Array.from(bytes));
+
+    // BOTH paths exercised: sidecar tried first, fallback ran.
+    expect(mock.recorded.some((r) => r.url.includes('/sidecar/blob'))).toBe(true);
+    expect(mock.recorded.some((r) => r.url.includes('/api/v0/block/get'))).toBe(true);
+  });
+
+  it('falls through to /api/v0/block/get when sidecar throws (gateway without sidecar)', async () => {
+    const bytes = new TextEncoder().encode('throw-fallback');
+    const cid = cidForBytes(bytes);
+
+    mock = installFetchMock({
+      sidecarHandler: () => new Response('', { status: 200 }),
+      sidecarBlobHandler: () => { throw new TypeError('ENOTFOUND'); },
+      blockGetHandler: () => new Response(bytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }),
+    });
+
+    const result = await fetchFromIpfs([TEST_GATEWAY], cid, 1000);
+    expect(Array.from(result)).toEqual(Array.from(bytes));
+  });
+
+  it('falls through on CID-mismatch from sidecar (defends against rogue cache serving wrong bytes)', async () => {
+    const goodBytes = new TextEncoder().encode('legit-bytes');
+    const cid = cidForBytes(goodBytes);
+    const evilBytes = new TextEncoder().encode('evil-bytes-from-sidecar');
+
+    mock = installFetchMock({
+      sidecarHandler: () => new Response('', { status: 200 }),
+      sidecarBlobHandler: () => new Response(evilBytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }),
+      blockGetHandler: () => new Response(goodBytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }),
+    });
+
+    // Sidecar served wrong bytes → CID verify fails on sidecar path
+    // → fall through to /api/v0/block/get → succeed with correct bytes.
+    const result = await fetchFromIpfs([TEST_GATEWAY], cid, 1000);
+    expect(Array.from(result)).toEqual(Array.from(goodBytes));
+  });
+
+  it('falls through when sidecar returns HTML (no-sidecar gateway catch-all)', async () => {
+    const bytes = new TextEncoder().encode('catch-all-fallback');
+    const cid = cidForBytes(bytes);
+
+    mock = installFetchMock({
+      sidecarHandler: () => new Response('', { status: 200 }),
+      // Gateway has no sidecar; returns a 200 HTML "endpoint not found"
+      // page from a catch-all. Caller MUST treat this as a miss, not
+      // as bytes-with-wrong-CID.
+      sidecarBlobHandler: () => new Response('<html>nope</html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+      blockGetHandler: () => new Response(bytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }),
+    });
+
+    const result = await fetchFromIpfs([TEST_GATEWAY], cid, 1000);
+    expect(Array.from(result)).toEqual(Array.from(bytes));
+  });
+});


### PR DESCRIPTION
Wires sphere-sdk's pin and fetch paths to the IPFS instant-pin sidecar that landed live at https://ipfs.unicity.network earlier today (\`unicitynetwork/ipfs-storage#7\`). This is the Stage B.1 prerequisite for the \`manual-test-full-recovery.sh\` 5× characterization per RFC-251.

## End-to-end verified against live sidecar

\`\`\`bash
$ curl -sX POST 'https://ipfs.unicity.network/api/v0/add?cid-version=1' -F 'file=@test'
{\"Hash\":\"bafkreiebqbvdcnb6mezns46cijiagrh4dviba3rzd4lq5eskijuff25xim\"}

$ curl -sX POST 'https://ipfs.unicity.network/sidecar/submit?cid=bafkrei...' --data-binary @test -H 'Content-Type: application/octet-stream'
{\"ok\":true,\"outcome\":\"accepted\",\"detail\":\"stored pending kubo\",\"bytes\":46}

# After ~5s (reconciler tick):
$ curl -s https://ipfs.unicity.network/sidecar/cache-stats | jq '.promotions_succeeded'
1   # ← incremented from 0
\`\`\`

## Changes

**`profile/ipfs-client.ts`** (+219 LOC):

1. **`submitToSidecarBestEffort(gateway, cid, bytes)`** — fire-and-forget POST helper. 5 s timeout. Drops 404 (no-sidecar gateway), 503 (back-pressure), network errors silently. Debug-logged for Stage B.1 measurement.
2. **`tryReadFromSidecar(gateway, cid)`** — 500 ms probe of \`GET /sidecar/blob?cid=<cid>\`. Returns bytes on 200, null otherwise (treats HTML/JSON as miss to defend against no-sidecar gateways with catch-all routes).
3. **Hook in `pinToIpfs`** — after the successful \`/api/v0/dag/put\`, fire sidecar submit on the SAME gateway. Bytes guaranteed to hash to bafkrei CID.
4. **Hook in `pinSingleBlock`** — after each block's successful pin, submit to sidecar. Per the Issue #213 fix, every CAR block satisfies \`sha256(block.bytes) === block.cid.multihash.digest\`, so promotion succeeds for all codecs the sidecar's \`_infer_block_put_params\` handles (raw / dag-cbor / dag-pb).
5. **Hook in `fetchFromIpfs`** — ONCE per fetch call, probe first gateway's \`/sidecar/blob\` before the multi-gateway \`/api/v0/block/get\` loop. On hit + CID-verify pass, return (and write back to local Helia). On miss / mismatch / error, fall through unchanged.

**Scope decision: single-block CIDs only** (per teammate brief). sphere-sdk's pin paths produce per-block raw or dag-cbor pins, which match the sidecar's codec inference. The JSON \`upload()\` in \`impl/shared/ipfs/ipfs-http-client.ts\` is intentionally NOT wired (different byte/CID semantics; not on the Profile snapshot critical path Stage B.1 measures).

## Why this matters for #257 (Approach D Phase 1 prototype)

PR #257's win-broadcast is the *coordination* layer. This PR is the *data availability* layer. Both are required for §C.4 to actually improve:

| Layer | Without this PR | With this PR |
|---|---|---|
| **Discovery** (peer knows V=N is taken) | Aggregator replica lag (30–60 s) | Nostr broadcast (~1 s) via #257 |
| **Data availability** (peer can fetch V=N's bundle) | Kubo bitswap registration (~5–30 s) | Sidecar instant-pin (~50 ms) |

Approach D Phase 1 alone (#257) doesn't help convergence because reconcileLocalVersionDownward is a no-op for the dominant same-version race. This PR alone helps convergence (cross-device reads complete faster) but only when the reader knows to fetch the new CID. Together they reduce the §C.4 convergence window from 60–90 s to 1–2 s — assuming Stage B.1 measurement confirms the prediction.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint profile/ipfs-client.ts tests/unit/profile/ipfs-client-sidecar-submit.test.ts\` — 0 warnings
- [x] **13 new tests in \`tests/unit/profile/ipfs-client-sidecar-submit.test.ts\`** covering submit + read paths, fire-and-forget contract, gateway-targeting, CID-mismatch defense, HTML catch-all defense
- [x] **Updated `bundle-acquirer.test.ts`** — fetch mock ignores /sidecar/blob in its attempt budget (the test depends on a specific number of /api/v0/block/get attempts; my probe was consuming a slot)
- [x] **Full unit suite: 8117 pass, 13 skipped, 0 regressions**
- [x] **End-to-end smoke** against live https://ipfs.unicity.network confirmed write→submit→promotion cycle works
- [ ] **Stage B.1 measurement** — \`manual-test-full-recovery.sh\` 5× — pending operator run

## Operational observability

After this lands and deploys, watch \`https://ipfs.unicity.network/sidecar/cache-stats\` during normal sphere-sdk traffic. Expected pattern:
- \`accepted_submits\` climbs with every successful Profile snapshot / UXF bundle pin.
- \`promotions_succeeded\` climbs ~5 s behind (every reconciler tick).
- \`promotion_failures\` should stay flat (or climb only from non-sphere-sdk traffic) since our bytes hash to the CIDs by construction.
- \`cache_hits\` climbs with cross-device read traffic — measurement signal for whether the read fast-path is doing useful work.

If \`promotion_failures\` starts climbing from sphere-sdk traffic, that's a regression in the per-block bytes/CID invariant — investigate first.

## Refs

- #251 — parent issue
- #255 — current issue (Problem B)
- #257 — Approach D Phase 1 prototype (DRAFT — pairs with this PR for Stage B.1)
- \`unicitynetwork/ipfs-storage#7\` — sidecar deploy (merged 2026-05-24)
- \`docs/uxf/RFC-251-pointer-coordination.md\` — design rationale