### PR TITLE
feat(profile)(#255b): pin path — sidecar primary, /api/v0/dag/put fallback

### DIFF
--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -271,26 +271,98 @@ const SIDECAR_SUBMIT_TIMEOUT_MS = 5_000;
 const SIDECAR_READ_TIMEOUT_MS = 500;
 
 /**
+ * Synchronously submit `bytes` to the gateway's instant-pin sidecar.
+ * Returns `true` on a 2xx response, `false` on any non-2xx / network
+ * error / timeout. Never throws.
+ *
+ * **This is the primary pin write path** (issue #255 Problem B). It
+ * sits in front of the legacy `/api/v0/dag/put` flow:
+ *   - On success (return true) the bytes are durable on the sidecar's
+ *     blobstore within milliseconds. The sidecar's reconciler will
+ *     promote to Kubo via internal `block/put` + `pin/add` within
+ *     `SIDECAR_CACHE_RECONCILE_INTERVAL` (default 5 s). Caller may
+ *     return immediately; readers via `/ipfs/<cid>` will hit the
+ *     sidecar's read path or Kubo (whichever's ready first).
+ *   - On failure (return false) the caller falls back to the legacy
+ *     `/api/v0/dag/put` write path — defense-in-depth for transient
+ *     sidecar outages.
+ *
+ * The bytes MUST hash to `cid` under the codec the sidecar reconciler
+ * will infer from the CID prefix (raw / dag-cbor / dag-pb). For the
+ * two call sites in this module (`pinToIpfs`, `pinSingleBlock`) this
+ * holds by construction; the sidecar's `_infer_block_put_params`
+ * handles the codec choice server-side.
+ *
+ * Status-code handling:
+ *   - 200 (`accepted` / `already_present` / `already_confirmed`) → true.
+ *   - 400 (bad input) → false. dag/put would also reject; fallback noop.
+ *   - 413 (over 32 MiB) → false. dag/put may have a higher limit.
+ *   - 503 (cache_full back-pressure) → false. Try dag/put.
+ *   - 5xx (other server error) / network error / timeout → false.
+ *     Try dag/put.
+ *   - 404 (gateway without sidecar — non-Unicity gateway) → false.
+ *     Falls through to dag/put. Per project policy (2026-05-25) only
+ *     Unicity-specialized gateways are configured for sphere-sdk, so
+ *     this branch should not fire in production.
+ */
+async function submitToSidecar(
+  gateway: string,
+  cid: string,
+  bytes: Uint8Array,
+): Promise<boolean> {
+  if (typeof gateway !== 'string' || gateway.length === 0) return false;
+  if (typeof cid !== 'string' || cid.length === 0) return false;
+  if (!(bytes instanceof Uint8Array) || bytes.length === 0) return false;
+  if (bytes.length > SIDECAR_SUBMIT_MAX_BYTES) return false;
+  try {
+    const url =
+      `${gateway.replace(/\/$/, '')}/sidecar/submit?cid=${encodeURIComponent(cid)}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      body: bytes as BlobPart,
+      headers: { 'Content-Type': 'application/octet-stream' },
+      signal: AbortSignal.timeout(SIDECAR_SUBMIT_TIMEOUT_MS),
+    });
+    // Drain the body so the connection releases promptly (we don't need
+    // the JSON envelope — outcome is just diagnostic).
+    response.body?.cancel?.().catch(() => { /* ignore */ });
+    if (response.ok) {
+      logger.debug(
+        'IPFS-Sidecar',
+        `submit ${cid.slice(0, 16)} → 200 on ${gateway}`,
+      );
+      return true;
+    }
+    logger.debug(
+      'IPFS-Sidecar',
+      `submit ${cid.slice(0, 16)} → HTTP ${response.status} on ${gateway} ` +
+      `(falling back to /api/v0/dag/put)`,
+    );
+    return false;
+  } catch (err) {
+    logger.debug(
+      'IPFS-Sidecar',
+      `submit ${cid.slice(0, 16)} threw on ${gateway} ` +
+      `(falling back to /api/v0/dag/put): ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+}
+
+/**
  * Fire-and-forget POST the raw bytes that hash to `cid` to the
- * gateway's instant-pin sidecar (`/sidecar/submit?cid=<cid>`). Lets
- * cross-device readers fetch `cid` immediately after pin, before
- * Kubo's bitswap registration window closes (the dominant cross-
- * device race amplifier — see issue #255 Problem B, RFC-251).
+ * gateway's instant-pin sidecar (`/sidecar/submit?cid=<cid>`). Used
+ * ONLY by the dag/put fallback path to populate the sidecar's cache
+ * after a successful dag/put — so subsequent cross-device readers via
+ * `/sidecar/blob` still benefit from the instant-pin window even
+ * when the sidecar was temporarily down at primary-submit time.
  *
  * Contract:
  *   - Never throws. Never blocks the caller. Errors are swallowed
  *     via the trailing `.catch(() => {})`.
- *   - The bytes MUST hash to `cid` under the codec the sidecar
- *     reconciler will infer from the CID prefix (raw / dag-cbor /
- *     dag-pb). For the two call sites in this module (`pinToIpfs`,
- *     `pinSingleBlock`) this holds by construction; the sidecar's
- *     `_infer_block_put_params` handles the codec choice server-side.
- *   - If the gateway doesn't run the sidecar (e.g. `ipfs.io`), the
- *     POST 404s and is silently dropped — the primary pin already
- *     succeeded, so the bytes are durable in Kubo regardless.
- *   - 503 (cache_full back-pressure) and 413 (over 32 MiB) are
- *     handled identically: drop on the floor. The primary pin is
- *     the source of truth.
+ *   - 200 / 4xx / 5xx all treated identically — primary pin already
+ *     succeeded via dag/put, this is pure optimization.
  */
 function submitToSidecarBestEffort(
   gateway: string,
@@ -437,6 +509,26 @@ export async function pinToIpfs(
 
   for (const gateway of effectiveGateways) {
     try {
+      // Compute the canonical CID locally up-front — both the
+      // primary sidecar path and the legacy dag/put fallback agree
+      // on `CID.createV1(raw.code, sha256(data))` for raw-codec.
+      // Computing here means we can submit to the sidecar with the
+      // CID in the query param without a server round-trip.
+      const expectedCid = CID.createV1(raw.code, createMultihash(0x12, sha256(data))).toString();
+
+      // Issue #255 Problem B — try the instant-pin sidecar first.
+      // On success the bytes are durable on the sidecar within
+      // milliseconds; the reconciler promotes to Kubo within ~5 s.
+      // On failure (gateway-without-sidecar, transient outage,
+      // 4xx/5xx, network error) we fall through to the legacy
+      // `/api/v0/dag/put` path below — defense-in-depth.
+      const sidecarOk = await submitToSidecar(gateway, expectedCid, data);
+      if (sidecarOk) {
+        return expectedCid;
+      }
+
+      // Sidecar miss — legacy /api/v0/dag/put path.
+      //
       // Kubo `/api/v0/dag/put` REQUIRES multipart/form-data with a
       // `data` field name — the raw-body-with-application/octet-stream
       // shape this code used previously returns HTTP 400
@@ -495,15 +587,12 @@ export async function pinToIpfs(
       // DIFFERENT CID reduces to a pin-failure from our perspective
       // (404 on next lookup); attacker cannot redirect the wallet's
       // anchor to attacker-chosen content.
-      const expectedCid = CID.createV1(raw.code, createMultihash(0x12, sha256(data))).toString();
-      // Issue #255 Problem B / ipfs-storage#7 — fire-and-forget submit
-      // to the sidecar so cross-device readers can fetch the CID
-      // immediately, before Kubo's bitswap registration window closes.
-      // Always eligible here: `pinToIpfs` forces input-codec=raw, so
-      // `expectedCid` is always a raw-leaf v1 (`bafkrei...`) and the
-      // bytes that hash to it are exactly `data`. Gateway-targeted at
-      // the SAME gateway that just succeeded the pin — if that gateway
-      // doesn't run the sidecar, the POST 404s and is dropped silently.
+      //
+      // Cache-population: dag/put succeeded but the sidecar was the
+      // one that just failed at the top of this iteration. Try a
+      // fire-and-forget submit anyway so subsequent cross-device
+      // readers via `/sidecar/blob` get the fast-path. Often the
+      // sidecar's transient outage clears by the time this runs.
       submitToSidecarBestEffort(gateway, expectedCid, data);
       return expectedCid;
     } catch (err) {
@@ -566,6 +655,18 @@ async function pinSingleBlock(
   let lastError: Error | null = null;
   for (const gateway of effectiveGateways) {
     try {
+      // Issue #255 Problem B — sidecar primary path. Bytes hash to
+      // `expectedCid` by construction (Issue #213 / Option C ensures
+      // `sha256(block.bytes) === block.cid.multihash.digest` for
+      // every legitimate bundle CAR block). The sidecar's
+      // `_infer_block_put_params` handles raw / dag-cbor / dag-pb
+      // codecs server-side. Fall through to dag/put on miss.
+      const sidecarOk = await submitToSidecar(gateway, expectedCid, blockBytes);
+      if (sidecarOk) {
+        return;
+      }
+
+      // Sidecar miss — legacy /api/v0/dag/put fallback.
       const url =
         `${gateway.replace(/\/$/, '')}/api/v0/dag/put` +
         `?input-codec=${codecName}&store-codec=${codecName}&pin=true&hash=sha2-256`;
@@ -590,13 +691,11 @@ async function pinSingleBlock(
       } catch {
         // ignore — body parse failure on a 200 doesn't change durability
       }
-      // Issue #255 Problem B / ipfs-storage#7 — fire-and-forget submit
-      // to the sidecar (same gateway). The bytes hash to `expectedCid`
-      // by construction here (each block in a CAR satisfies
-      // `sha256(block.bytes) === block.cid.multihash.digest` per Issue
-      // #213 / Option C). The sidecar's `_infer_block_put_params`
-      // handles raw / dag-cbor / dag-pb codecs by CID prefix — no
-      // codec-specific gating needed on this side.
+      // Cache-population: dag/put succeeded but the sidecar failed
+      // moments ago. Fire-and-forget submit so subsequent
+      // cross-device readers via `/sidecar/blob` still get the
+      // instant-pin fast-path when the sidecar's transient outage
+      // clears.
       submitToSidecarBestEffort(gateway, expectedCid, blockBytes);
       return;
     } catch (err) {

--- a/tests/unit/payments/transfer/ipfs-publisher.test.ts
+++ b/tests/unit/payments/transfer/ipfs-publisher.test.ts
@@ -63,6 +63,12 @@ interface FetchCall {
  * "<cid>" } }`). The stub does NOT verify the CIDs returned — the
  * canonical publisher ignores the gateway-supplied CID and uses its own
  * locally-computed `bundleCid` (defense against malicious gateways).
+ *
+ * Issue #255 Problem B — the new `pinSingleBlock` tries
+ * `/sidecar/submit` first and falls back to `/api/v0/dag/put` on
+ * non-2xx. To exercise the dag/put codec-inference path these tests
+ * were written for, the stub returns 503 on `/sidecar/submit` so the
+ * fallback fires.
  */
 function installFetchStub(): { calls: FetchCall[] } {
   const calls: FetchCall[] = [];
@@ -78,6 +84,11 @@ function installFetchStub(): { calls: FetchCall[] } {
       method: init?.method,
       body: init?.body instanceof FormData ? init.body : undefined,
     });
+    if (url.includes('/sidecar/submit')) {
+      // Force the dag/put fallback path so these tests can keep
+      // asserting on dag/put behavior.
+      return new Response('sidecar disabled for this test', { status: 503 });
+    }
     return new Response(
       JSON.stringify({ Cid: { '/': 'bafkreigatewaysuppliedwhatever' } }),
       {

--- a/tests/unit/profile/ipfs-client-sidecar-submit.test.ts
+++ b/tests/unit/profile/ipfs-client-sidecar-submit.test.ts
@@ -135,7 +135,7 @@ const SAMPLE_BYTES = new TextEncoder().encode('hello sidecar — test payload');
 // pinToIpfs sidecar submit
 // ---------------------------------------------------------------------------
 
-describe('pinToIpfs → /sidecar/submit fire-and-forget', () => {
+describe('pinToIpfs — sidecar primary + dag/put fallback', () => {
   let mock: ReturnType<typeof installFetchMock>;
 
   afterEach(() => {
@@ -236,30 +236,97 @@ describe('pinToIpfs → /sidecar/submit fire-and-forget', () => {
     expect(sidecarCalled).toBe(false);
   });
 
-  it('uses the SAME gateway that won the pin race (not the first in the list)', async () => {
-    // First gateway 5xx on pin, second succeeds. Sidecar must hit the second.
+  it('sidecar succeeds on first gateway → dag/put never called', async () => {
     const gw1 = 'https://gw1.test';
     const gw2 = 'https://gw2.test';
+    let pinCalled = false;
     mock = installFetchMock({
-      pinHandler: (req) => {
-        if (req.url.startsWith(gw1)) {
-          return new Response('boom', { status: 503 });
-        }
-        return new Response(
-          JSON.stringify({ Cid: { '/': 'ignored' } }),
-          { status: 200 },
-        );
+      pinHandler: () => {
+        pinCalled = true;
+        return new Response('should not be called', { status: 500 });
       },
-      sidecarHandler: () => new Response('', { status: 200 }),
+      sidecarHandler: () => new Response(
+        JSON.stringify({ ok: true, outcome: 'accepted' }),
+        { status: 200 },
+      ),
+    });
+
+    await pinToIpfs([gw1, gw2], SAMPLE_BYTES);
+
+    // Sidecar primary: succeeded on gw1 → loop exits → gw2 not visited,
+    // dag/put never called.
+    expect(pinCalled).toBe(false);
+    const sidecarCalls = mock.recorded.filter((r) => r.url.includes('/sidecar/submit'));
+    expect(sidecarCalls).toHaveLength(1);
+    expect(sidecarCalls[0].url.startsWith(gw1)).toBe(true);
+  });
+
+  it('sidecar 5xx on gw1 → falls back to dag/put on gw1 (NOT to gw2 sidecar)', async () => {
+    // Per-gateway iteration: sidecar 5xx triggers fallback to dag/put on
+    // the SAME gateway before continuing to the next gateway. This
+    // preserves locality (dag/put has access to the same Kubo as the
+    // sidecar that was supposed to be in front of it).
+    const gw1 = 'https://gw1.test';
+    const gw2 = 'https://gw2.test';
+    const sidecarSeen: string[] = [];
+    const pinSeen: string[] = [];
+    mock = installFetchMock({
+      sidecarHandler: (req) => {
+        sidecarSeen.push(req.url);
+        return new Response('boom', { status: 503 });
+      },
+      pinHandler: (req) => {
+        pinSeen.push(req.url);
+        return new Response(JSON.stringify({ Cid: { '/': 'ignored' } }), { status: 200 });
+      },
     });
 
     await pinToIpfs([gw1, gw2], SAMPLE_BYTES);
     await waitForDetachedFetch();
 
-    const sidecarCalls = mock.recorded.filter((r) => r.url.includes('/sidecar/submit'));
-    expect(sidecarCalls).toHaveLength(1);
-    expect(sidecarCalls[0].url.startsWith(gw2)).toBe(true);
-    expect(sidecarCalls[0].url.startsWith(gw1)).toBe(false);
+    // gw1 sidecar 503 → gw1 dag/put 200 → success.
+    expect(sidecarSeen.length).toBeGreaterThanOrEqual(1);
+    expect(sidecarSeen[0]).toContain('gw1.test');
+    expect(pinSeen.length).toBeGreaterThanOrEqual(1);
+    expect(pinSeen[0]).toContain('gw1.test');
+    // gw2 never visited (gw1 succeeded via fallback).
+    expect(pinSeen.find((u) => u.includes('gw2.test'))).toBeUndefined();
+    // Post-success cache-populator fired on gw1 (best-effort).
+    const submitCalls = mock.recorded.filter((r) => r.url.includes('/sidecar/submit'));
+    expect(submitCalls.length).toBeGreaterThanOrEqual(2); // primary attempt + post-success
+  });
+
+  it('sidecar fails AND dag/put fails on gw1 → continues to gw2', async () => {
+    const gw1 = 'https://gw1.test';
+    const gw2 = 'https://gw2.test';
+    mock = installFetchMock({
+      sidecarHandler: () => new Response('boom', { status: 503 }),
+      pinHandler: (req) => {
+        if (req.url.startsWith(gw1)) {
+          return new Response('upstream blip', { status: 503 });
+        }
+        return new Response(JSON.stringify({ Cid: { '/': 'ignored' } }), { status: 200 });
+      },
+    });
+
+    const cid = await pinToIpfs([gw1, gw2], SAMPLE_BYTES);
+    expect(cid).toBe(cidForBytes(SAMPLE_BYTES));
+
+    // Both gateways visited.
+    const pinCalls = mock.recorded.filter((r) => r.url.includes('/api/v0/dag/put'));
+    expect(pinCalls.some((c) => c.url.startsWith(gw1))).toBe(true);
+    expect(pinCalls.some((c) => c.url.startsWith(gw2))).toBe(true);
+  });
+
+  it('all gateways fail on BOTH sidecar and dag/put → throws ORBITDB_WRITE_FAILED', async () => {
+    mock = installFetchMock({
+      sidecarHandler: () => new Response('boom', { status: 503 }),
+      pinHandler: () => new Response('boom', { status: 503 }),
+    });
+
+    await expect(
+      pinToIpfs([TEST_GATEWAY], SAMPLE_BYTES),
+    ).rejects.toThrow(/IPFS pin failed on all gateways/);
   });
 });
 


### PR DESCRIPTION
Reworks sphere-sdk's pin path to use the IPFS instant-pin sidecar as the **primary** write transport, with `/api/v0/dag/put` as a **defense-in-depth fallback** for transient sidecar outages.

## Why now

Stage B.1 kickoff (after #257/#258/#259 merged) surfaced an operational issue: the production gateway returns **HTTP 404 on `/api/v0/dag/put`** (confirmed both `unicity-ipfs1.dyndns.org` and `ipfs.unicity.network`), causing every sphere-sdk pin to fail with `ORBITDB_WRITE_FAILED`. Manual-test run-1 died at §C.1b after 147s, well before the §C.4 race scenario.

Sidecar-engineer pinged about the nginx regression; in parallel, this PR removes the dependency entirely on sphere-sdk's side. With sidecar-primary, sphere-sdk no longer cares whether `/api/v0/dag/put` is exposed.

## Architecture

| Layer | What it does | Status |
|---|---|---|
| **Discovery** — Nostr `pointer-win` broadcast | Tells siblings about V=N within ~1 s | #257 ✓ |
| **Data availability — write** | Bytes durable on Unicity gateway within ms | **This PR** |
| **Data availability — read** | Cross-device reader gets bytes within ms | #259 ✓ (sidecar read fast-path) |
| **Long-term durability** | Sidecar reconciler promotes to Kubo via internal `block/put + pin/add` | sidecar's job |

Kubo durability is unchanged — only the **write transport** shifts. The sidecar's reconciler (already in production) handles the Kubo promotion via the internal IPFS API (works inside the container regardless of external `/api/v0/dag/put` HTTP exposure).

## Changes

**`profile/ipfs-client.ts`** (+135 LOC):

1. **`submitToSidecar(gateway, cid, bytes): Promise<boolean>`** — new synchronous primary-path helper. Returns true on 2xx, false on 4xx/5xx/network-error/timeout. Never throws.
2. **`submitToSidecarBestEffort` repurposed** — now ONLY fires on the dag/put fallback path to populate the sidecar's cache post-success, so subsequent cross-device readers via `/sidecar/blob` benefit even when the sidecar was down at primary-submit time.
3. **`pinToIpfs` rework** — compute `expectedCid` locally → try sidecar → on success return → on failure fall through to existing `/api/v0/dag/put` multipart code → fire cache-populator.
4. **`pinSingleBlock` rework** — same primary/fallback pattern. Sidecar's `_infer_block_put_params` handles raw/dag-cbor/dag-pb codecs server-side, matching the codec the dag/put fallback would emit.

**Tests** (+88 LOC):

- `tests/unit/profile/ipfs-client-sidecar-submit.test.ts` — replaced the "uses the SAME gateway that won the pin race" test (was asserting post-pin sidecar firing) with **3 new tests** for the new precedence:
  1. Sidecar succeeds on first gateway → dag/put never called.
  2. Sidecar 5xx on gw1 → falls back to dag/put on gw1 (NOT to gw2 sidecar) — per-gateway iteration preserved.
  3. Sidecar fails AND dag/put fails on gw1 → continues to gw2.
  4. Both gateways fail on both paths → throws ORBITDB_WRITE_FAILED.

- `tests/unit/payments/transfer/ipfs-publisher.test.ts` — updated the fetch stub to return 503 on `/sidecar/submit` so the existing dag/put codec-inference assertions exercise the fallback path (preserves original test intent).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint profile/ipfs-client.ts tests/unit/profile/ipfs-client-sidecar-submit.test.ts tests/unit/payments/transfer/ipfs-publisher.test.ts` — 0 warnings
- [x] Full unit suite: **8148 pass, 13 skipped, 0 regressions**
- [x] End-to-end smoke against `https://ipfs.unicity.network` already confirmed (per #259): `/sidecar/submit` accepts → reconciler promotes within ~10s → `promotions_succeeded` increments
- [ ] **Stage B.1** — once merged + dist built, kick off `manual-test-full-recovery.sh` 5×. The dag/put 404 regression no longer blocks it.

## Operational note

After this lands, the sidecar-engineer's nginx fix to restore `/api/v0/dag/put` becomes a non-blocker for sphere-sdk. It remains valuable for non-sphere-sdk clients (other tooling that uses Kubo's HTTP API directly) but the wallet itself no longer cares.

## Refs

- #251 — parent issue
- #255 — current issue (Problem B)
- #257 — Approach D Phase 1 (Nostr win-broadcast)
- #259 — sidecar submit + read fast-path (this PR completes the design by making sidecar the primary)
- \`unicitynetwork/ipfs-storage#7\` — sidecar deploy
- \`docs/uxf/RFC-251-pointer-coordination.md\` — design rationale