### PR TITLE
feat(core)(#255): sphere.destroy() flushes pending pointer publishes before exit

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -612,13 +612,47 @@ export interface AddressModuleSet {
  * exits where waiting for gateway propagation is not acceptable.
  */
 /**
- * Alias for `ShutdownOptions` re-exported under a wallet-layer name so
- * consumers don't have to import the storage-layer interface. Kept as
- * a distinct symbol so the wallet API can grow independently of the
- * storage signature without a breaking rename. See {@link ShutdownOptions}
- * for the field semantics.
+ * Wallet-layer destroy options. Extends `ShutdownOptions` with
+ * wallet-only knobs the storage layer doesn't see.
+ *
+ * Issue #255 (2026-05-25) — `skipFlush` + `flushTimeoutMs` added so
+ * `Sphere.destroy()` can drive a synchronous pre-shutdown
+ * `awaitNextFlush()` on every TokenStorageProvider. Without that,
+ * fire-and-exit CLI commands (`sphere init`, `sphere faucet`,
+ * `sphere invoice pay`, etc.) trigger `notifyProfileDirty()` but
+ * exit before the debounced flush timer fires — their state
+ * mutations never reach IPFS / the aggregator pointer, leaving
+ * sibling devices unable to discover what just happened. The
+ * default behavior is now "flush then shutdown" so CLI mutations
+ * are durably published before the process exits.
+ *
+ * Use `skipFlush: true` for ungraceful-shutdown simulation in tests
+ * or any caller that explicitly wants the legacy fast-exit
+ * semantics (state stamps `pendingPublishCid` and replays on next
+ * boot).
  */
-export type DestroyOptions = ShutdownOptions;
+export interface DestroyOptions extends ShutdownOptions {
+  /**
+   * If `true`, skip the pre-shutdown
+   * `provider.awaitNextFlush(flushTimeoutMs)` call. Default `false`
+   * — destroy waits for any pending debounced flush to complete
+   * (pin + OrbitDB ref + aggregator pointer publish) before
+   * shutting providers down. Set to `true` for fast-exit
+   * scenarios where the cold-start `pendingPublishCid` retry path
+   * is an acceptable recovery surface.
+   */
+  readonly skipFlush?: boolean;
+  /**
+   * Per-provider timeout for the pre-shutdown
+   * `awaitNextFlush(timeoutMs)` call. Default 30 000 ms (matches
+   * `awaitNextFlush`'s own default, and the `flushVerificationDeadlineMs`
+   * the factory wires by default). On TIMEOUT the provider's
+   * `pendingPublishCid` retry marker is left stamped — destroy()
+   * proceeds to shutdown anyway so the caller doesn't hang
+   * indefinitely on a misbehaving gateway.
+   */
+  readonly flushTimeoutMs?: number;
+}
 
 // =============================================================================
 // Sphere Class
@@ -4515,6 +4549,58 @@ export class Sphere {
   // Public Methods - Lifecycle
   // ===========================================================================
 
+  /**
+   * Issue #255 (2026-05-25) — synchronously drain every pending
+   * debounced flush across all per-address ProfileTokenStorage
+   * providers (pin + OrbitDB ref + aggregator pointer publish +
+   * per-flush remote-durability verification per #239).
+   *
+   * Use this when a CLI command wants to confirm its state mutation
+   * is durably published BEFORE returning a success exit, without
+   * actually tearing the wallet down. Equivalent to the implicit
+   * pre-shutdown sweep `destroy()` now does, but re-callable.
+   *
+   * Returns when all providers report no pending data OR the
+   * `timeoutMs` budget is exhausted (in which case the affected
+   * provider's `pendingPublishCid` retry marker remains stamped for
+   * cold-start recovery and this method resolves normally — never
+   * throws). Errors during individual provider flushes are logged
+   * and swallowed; the caller cannot distinguish per-provider
+   * failures via this API. For that, call
+   * `(provider as { awaitNextFlush?: ... }).awaitNextFlush(timeoutMs)`
+   * directly on the specific provider you care about.
+   *
+   * @param timeoutMs Per-provider deadline. Default 30 000 ms.
+   */
+  async flushPending(timeoutMs: number = 30_000): Promise<void> {
+    if (!this._initialized) return;
+    const allProviders: TokenStorageProvider<TxfStorageDataBase>[] = [];
+    for (const moduleSet of this._addressModules.values()) {
+      for (const provider of moduleSet.tokenStorageProviders.values()) {
+        allProviders.push(provider);
+      }
+    }
+    for (const provider of this._tokenStorageProviders.values()) {
+      if (!allProviders.includes(provider)) {
+        allProviders.push(provider);
+      }
+    }
+    for (const provider of allProviders) {
+      try {
+        await (provider as TokenStorageProvider<TxfStorageDataBase> & {
+          awaitNextFlush?: (timeoutMs?: number) => Promise<void>;
+        }).awaitNextFlush?.(timeoutMs);
+      } catch (err) {
+        logger.warn(
+          'Sphere',
+          `flushPending: provider ${provider.id ?? '<unknown>'} flush failed ` +
+          `(continuing; pendingPublishCid retry will handle): ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
   async destroy(options?: DestroyOptions): Promise<void> {
     // Issue #239 — the shutdown durability gate is OPT-IN at the
     // wallet layer. Rationale: the per-flush verification gate
@@ -4536,6 +4622,10 @@ export class Sphere {
     // (typical N = 30 000). E2E tests that want to simulate an
     // ungraceful crash continue to use `force: true`.
     const effectiveOptions = options;
+    // Issue #255 (2026-05-25) — opt-out flag for the new pre-shutdown
+    // flush sweep; default false ⇒ flush before shutting down.
+    const skipFlush = options?.skipFlush === true;
+    const flushTimeoutMs = options?.flushTimeoutMs ?? 30_000;
 
     this.cleanupProviderEventSubscriptions();
 
@@ -4552,6 +4642,71 @@ export class Sphere {
       await this._accounting?.destroy();
     } catch (err) {
       logger.warn('Sphere', 'Accounting module destroy failed:', err);
+    }
+
+    // Issue #255 (2026-05-25) — synchronous pre-shutdown flush sweep.
+    //
+    // Fire-and-exit CLI commands (`sphere init`, `sphere faucet`,
+    // `sphere invoice pay`, etc.) call into PaymentsModule which
+    // writes to the per-address ProfileTokenStorage. Those writes
+    // call `notifyProfileDirty()`, which arms a debounced flush
+    // timer (default `flushDebounceMs = 2000`). If the CLI process
+    // exits before the timer fires, the dirty data never gets
+    // pinned to IPFS and never gets a pointer publish — sibling
+    // devices have no way to discover the mutation until some
+    // long-running daemon happens to retry via the
+    // `pendingPublishCid` cold-start path.
+    //
+    // The fix: before shutting providers down, call each
+    // provider's `awaitNextFlush(timeoutMs)`. That cancels the
+    // debounce timer, forces a serialized flush, and waits for
+    // pin + OrbitDB ref + aggregator pointer publish + per-flush
+    // remote-durability verification (per #239) to complete. On
+    // TIMEOUT the `pendingPublishCid` retry marker is left
+    // stamped; destroy() proceeds with shutdown so the caller
+    // doesn't hang on a misbehaving gateway.
+    //
+    // `options.skipFlush = true` opts out for fast-exit / E2E
+    // crash-simulation paths. Swap + accounting destroy run
+    // BEFORE this sweep so their in-flight operations have
+    // already committed to token-storage by flush time.
+    //
+    // Providers that don't implement `awaitNextFlush` (File /
+    // IndexedDB / IPFS-legacy) silently skip via optional chaining
+    // — they don't have a debounced flush surface to drain.
+    if (!skipFlush) {
+      const allProviders: TokenStorageProvider<TxfStorageDataBase>[] = [];
+      for (const moduleSet of this._addressModules.values()) {
+        for (const provider of moduleSet.tokenStorageProviders.values()) {
+          allProviders.push(provider);
+        }
+      }
+      for (const provider of this._tokenStorageProviders.values()) {
+        // De-dupe: per-address modules' providers may also be in the
+        // top-level map (the active-address modules reference is a
+        // pointer to the same Map entry). Identity-compare to avoid
+        // double-flushing.
+        if (!allProviders.includes(provider)) {
+          allProviders.push(provider);
+        }
+      }
+      for (const provider of allProviders) {
+        try {
+          await (provider as TokenStorageProvider<TxfStorageDataBase> & {
+            awaitNextFlush?: (timeoutMs?: number) => Promise<void>;
+          }).awaitNextFlush?.(flushTimeoutMs);
+        } catch (err) {
+          // Don't hang destroy() on a flush failure. The provider's
+          // own `pendingPublishCid` retry marker covers the next-boot
+          // recovery path. Log so the operator sees it.
+          logger.warn(
+            'Sphere',
+            `pre-shutdown awaitNextFlush failed on provider ${provider.id ?? '<unknown>'} ` +
+            `(continuing with shutdown; pendingPublishCid retry will handle): ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
     }
 
     // Issue #97 (steelman C6) — null out per-address profile writers

--- a/tests/unit/core/Sphere.destroy-flush.test.ts
+++ b/tests/unit/core/Sphere.destroy-flush.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the Issue #255 (2026-05-25) pre-shutdown flush sweep in
+ * `Sphere.destroy()`.
+ *
+ * Default behavior: `destroy()` now calls `provider.awaitNextFlush(timeoutMs)`
+ * on every TokenStorageProvider BEFORE `provider.shutdown(opts)`. This
+ * makes fire-and-exit CLI commands publish their pending pointer +
+ * pin durably before the process returns, fixing the publish-lost
+ * race that left peer2 unable to discover what peer1 just did.
+ *
+ * Opt-out: `destroy({ skipFlush: true })` preserves the legacy
+ * fast-exit semantics for E2E crash-simulation paths.
+ *
+ * Same Object.create(Sphere.prototype) harness pattern as
+ * `Sphere.destroy-teardown.test.ts` — populates only the fields
+ * destroy() reads.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { Sphere } from '../../../core/Sphere';
+import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+
+// ---------------------------------------------------------------------------
+// Minimal spies
+// ---------------------------------------------------------------------------
+
+function makeSpyStorage(): StorageProvider {
+  return {
+    id: 'spy-storage',
+    name: 'Spy Storage',
+    type: 'local',
+    setIdentity: vi.fn(),
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+    has: vi.fn().mockResolvedValue(false),
+    keys: vi.fn().mockResolvedValue([]),
+    clear: vi.fn().mockResolvedValue(undefined),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected'),
+    saveTrackedAddresses: vi.fn().mockResolvedValue(undefined),
+    loadTrackedAddresses: vi.fn().mockResolvedValue([]),
+  } as unknown as StorageProvider;
+}
+
+function makeSpyTransport(): TransportProvider {
+  return {
+    id: 'spy-transport',
+    name: 'Spy Transport',
+    type: 'p2p',
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected'),
+    setIdentity: vi.fn(),
+  } as unknown as TransportProvider;
+}
+
+function makeSpyOracle(): OracleProvider {
+  return {
+    id: 'spy-oracle',
+    name: 'Spy Oracle',
+    type: 'network',
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected'),
+  } as unknown as OracleProvider;
+}
+
+interface SpyTokenProviderWithFlush {
+  id: string;
+  awaitNextFlush: ReturnType<typeof vi.fn>;
+  shutdown: ReturnType<typeof vi.fn>;
+  setIdentity: ReturnType<typeof vi.fn>;
+  initialize: ReturnType<typeof vi.fn>;
+  isConnected: ReturnType<typeof vi.fn>;
+  getStatus: ReturnType<typeof vi.fn>;
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+function makeSpyTokenProvider(
+  id: string,
+  opts?: { flushThrows?: boolean; flushImpl?: () => Promise<void> },
+): SpyTokenProviderWithFlush {
+  const flushImpl = opts?.flushImpl
+    ?? (opts?.flushThrows
+      ? async () => { throw new Error('simulated flush failure'); }
+      : async () => { /* succeed */ });
+  return {
+    id,
+    awaitNextFlush: vi.fn(flushImpl),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    setIdentity: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(true),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected'),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createHarness(opts?: { providersWithFlush?: SpyTokenProviderWithFlush[] }): {
+  sphere: Sphere;
+  providers: SpyTokenProviderWithFlush[];
+} {
+  const sphere = Object.create(Sphere.prototype) as Sphere;
+  const sphereAny = sphere as unknown as Record<string, unknown>;
+
+  const providers = opts?.providersWithFlush ?? [makeSpyTokenProvider('p1')];
+
+  sphereAny._providerEventCleanups = [];
+  sphereAny._lastProviderConnected = new Map();
+  sphereAny._swap = null;
+  sphereAny._accounting = null;
+  sphereAny._addressModules = new Map();
+  sphereAny._payments = { destroy: vi.fn(), installOutboxWriter: vi.fn(), installSentLedgerWriter: vi.fn() };
+  sphereAny._communications = { destroy: vi.fn() };
+  sphereAny._groupChat = null;
+  sphereAny._market = null;
+  sphereAny._transportMux = null;
+  sphereAny._transport = makeSpyTransport();
+  sphereAny._storage = makeSpyStorage();
+  sphereAny._oracle = makeSpyOracle();
+
+  const tokenStorageProviders = new Map<string, unknown>();
+  for (const p of providers) {
+    tokenStorageProviders.set(p.id, p);
+  }
+  sphereAny._tokenStorageProviders = tokenStorageProviders;
+
+  sphereAny._initialized = true;
+  sphereAny._trackedAddressesLoaded = true;
+  sphereAny._identity = null;
+  sphereAny._trackedAddresses = new Map();
+  sphereAny._addressIdToIndex = new Map();
+  sphereAny._addressNametags = new Map();
+  sphereAny._disabledProviders = new Set();
+  sphereAny.eventHandlers = new Map();
+
+  return { sphere, providers };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Sphere.destroy() — pre-shutdown awaitNextFlush sweep (#255 CLI flush fix)', () => {
+  it('calls awaitNextFlush on each TokenStorageProvider before shutdown', async () => {
+    const p1 = makeSpyTokenProvider('p1');
+    const p2 = makeSpyTokenProvider('p2');
+    const { sphere } = createHarness({ providersWithFlush: [p1, p2] });
+
+    await sphere.destroy();
+
+    expect(p1.awaitNextFlush).toHaveBeenCalledTimes(1);
+    expect(p2.awaitNextFlush).toHaveBeenCalledTimes(1);
+    // shutdown still runs after flush.
+    expect(p1.shutdown).toHaveBeenCalledTimes(1);
+    expect(p2.shutdown).toHaveBeenCalledTimes(1);
+    // Ordering: flush BEFORE shutdown for each provider.
+    const p1FlushOrder = p1.awaitNextFlush.mock.invocationCallOrder[0];
+    const p1ShutdownOrder = p1.shutdown.mock.invocationCallOrder[0];
+    expect(p1FlushOrder).toBeLessThan(p1ShutdownOrder);
+  });
+
+  it('honors the default 30 000 ms timeout when no flushTimeoutMs is supplied', async () => {
+    const p1 = makeSpyTokenProvider('p1');
+    const { sphere } = createHarness({ providersWithFlush: [p1] });
+
+    await sphere.destroy();
+
+    expect(p1.awaitNextFlush).toHaveBeenCalledWith(30_000);
+  });
+
+  it('passes flushTimeoutMs through when caller supplies it', async () => {
+    const p1 = makeSpyTokenProvider('p1');
+    const { sphere } = createHarness({ providersWithFlush: [p1] });
+
+    await sphere.destroy({ flushTimeoutMs: 5_000 });
+
+    expect(p1.awaitNextFlush).toHaveBeenCalledWith(5_000);
+  });
+
+  it('skipFlush: true bypasses awaitNextFlush entirely (fast-exit path)', async () => {
+    const p1 = makeSpyTokenProvider('p1');
+    const { sphere } = createHarness({ providersWithFlush: [p1] });
+
+    await sphere.destroy({ skipFlush: true });
+
+    expect(p1.awaitNextFlush).not.toHaveBeenCalled();
+    // Shutdown still runs — fast-exit only skips the flush gate.
+    expect(p1.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT hang destroy() if a provider flush throws — logs + continues', async () => {
+    const failing = makeSpyTokenProvider('failing', { flushThrows: true });
+    const ok = makeSpyTokenProvider('ok');
+    const { sphere } = createHarness({ providersWithFlush: [failing, ok] });
+
+    // Must resolve — destroy() catches per-provider flush errors.
+    await expect(sphere.destroy()).resolves.toBeUndefined();
+
+    // BOTH providers shut down even though one's flush threw.
+    expect(failing.shutdown).toHaveBeenCalledTimes(1);
+    expect(ok.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('tolerates providers without awaitNextFlush (e.g. file/IndexedDB providers)', async () => {
+    // A provider missing the optional awaitNextFlush method (typical of
+    // FileTokenStorageProvider, IndexedDBTokenStorageProvider).
+    const minimal = {
+      id: 'minimal',
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      setIdentity: vi.fn(),
+      initialize: vi.fn().mockResolvedValue(true),
+      isConnected: vi.fn().mockReturnValue(true),
+      getStatus: vi.fn().mockReturnValue('connected'),
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      // NO awaitNextFlush.
+    } as unknown as TokenStorageProvider<TxfStorageDataBase>;
+    const { sphere } = createHarness({
+      providersWithFlush: [minimal as unknown as SpyTokenProviderWithFlush],
+    });
+
+    await expect(sphere.destroy()).resolves.toBeUndefined();
+    expect(minimal.shutdown).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Sphere.flushPending() — explicit public API', () => {
+  it('calls awaitNextFlush on each provider with the supplied timeout', async () => {
+    const p1 = makeSpyTokenProvider('p1');
+    const p2 = makeSpyTokenProvider('p2');
+    const { sphere } = createHarness({ providersWithFlush: [p1, p2] });
+
+    await sphere.flushPending(15_000);
+
+    expect(p1.awaitNextFlush).toHaveBeenCalledWith(15_000);
+    expect(p2.awaitNextFlush).toHaveBeenCalledWith(15_000);
+  });
+
+  it('defaults to 30 000 ms', async () => {
+    const p1 = makeSpyTokenProvider('p1');
+    const { sphere } = createHarness({ providersWithFlush: [p1] });
+    await sphere.flushPending();
+    expect(p1.awaitNextFlush).toHaveBeenCalledWith(30_000);
+  });
+
+  it('returns normally even when one provider throws', async () => {
+    const failing = makeSpyTokenProvider('failing', { flushThrows: true });
+    const ok = makeSpyTokenProvider('ok');
+    const { sphere } = createHarness({ providersWithFlush: [failing, ok] });
+
+    await expect(sphere.flushPending()).resolves.toBeUndefined();
+    expect(ok.awaitNextFlush).toHaveBeenCalled();
+  });
+
+  it('no-ops when sphere is not initialized', async () => {
+    const p1 = makeSpyTokenProvider('p1');
+    const { sphere } = createHarness({ providersWithFlush: [p1] });
+    (sphere as unknown as { _initialized: boolean })._initialized = false;
+    await sphere.flushPending();
+    expect(p1.awaitNextFlush).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes the fire-and-exit CLI publish-loss bug surfaced by Stage B.1 v3 run-1: rc=1, 710s, §C.2 + §C.4 both FAIL, **zero** successful pointer publishes across the entire run because peer1's CLI commands exited inside the 2s flush debounce window.

## Root cause

Per-writer mutations call `notifyProfileDirty()` → arms `flushDebounceMs=2000` timer. Fire-and-exit CLI commands call `sphere.destroy()` BEFORE the timer fires. Old `destroy()` went straight to `provider.shutdown()`; the dirty data sat in `pendingData` when shutdown tore the provider down. The `pendingPublishCid` retry marker was stamped for cold-start, but until the next long-running daemon called `retryPendingPublishIfAny`, sibling devices had no path to discover the mutation.

`ProfileTokenStorageProvider.awaitNextFlush(timeoutMs)` already implements exactly the right "cancel debounce, force serialized flush, await durability" semantics (used by `PaymentsModule.handleIncomingTransfer` for the at-least-once gate). The bug was just that `Sphere.destroy()` never called it.

## Changes

1. **`Sphere.destroy()`** — adds a pre-shutdown flush sweep. For every `TokenStorageProvider` (per-address + top-level, de-duped), calls `awaitNextFlush(flushTimeoutMs)` BEFORE `shutdown(opts)`. Swap + accounting destroy still run first so their in-flight operations have committed to token-storage by flush time. Per-provider failures are caught, logged, don't hang destroy — `pendingPublishCid` is the cold-start safety net.

2. **`DestroyOptions`** — promoted from `type` alias to `interface extends ShutdownOptions`:
   - `skipFlush?: boolean` (default `false`) — opt-out for tests / explicit fast-exit.
   - `flushTimeoutMs?: number` (default `30_000`) — matches `awaitNextFlush`'s default and `flushVerificationDeadlineMs`.

3. **`Sphere.flushPending(timeoutMs?)`** — new public API for callers that want durability confirmation WITHOUT destroying the wallet. Same logic as the destroy sweep, re-callable. Useful for long-running processes gating user-visible \"operation complete\" on real durability.

## Why this is THE fix for Stage B.1

Without this, peer1's CLI mutations never become globally visible during the test → the cross-device race the win-broadcast (#257) was designed to mitigate doesn't even exist → peer2 daemons publish race only themselves (replica-lag-vs-own-localVersion). With this fix, both devices publish on every mutation → the actual cross-device race appears → Stage B.1 can characterize it properly.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint core/Sphere.ts tests/unit/core/Sphere.destroy-flush.test.ts\` — 0 warnings
- [x] **10 new tests** in \`tests/unit/core/Sphere.destroy-flush.test.ts\` covering pre-shutdown sweep semantics + flushPending API + skipFlush opt-out + per-provider failure isolation + legacy-provider tolerance (no \`awaitNextFlush\`)
- [x] **Full unit suite: 8155 pass, 13 skipped, 0 regressions**
- [ ] **Stage B.1 re-run** after merge + rebuild. Expected: pointer publishes actually fire from peer1; broadcasts from #257 fire and propagate to peer2; §C.4 either improves OR characterizes the real race.

Refs: #255 #257 #259 #260 (reverted, this PR is the actual right fix for the same symptom)