### PR TITLE
fix(profile)(#264): auto-merge monotonicity violations; gate broadcasts behind flag (default OFF)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ tests/e2e/local-infra/.aggregator-go/
 
 # Community / Discord report drafts (agent-authored, not source)
 community-reports/
+.tmp/

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -5324,6 +5324,42 @@ export class Sphere {
             // when the subscription is already in place.
             void this.maybeInstallPointerWinSubscription();
           }
+          // Issue #264 — bridge `storage:monotonicity-recovered` to a
+          // user-visible Sphere event so dashboards / telemetry
+          // pipelines subscribing via `sphere.on(...)` can observe
+          // auto-merge convergence work without dropping to provider-
+          // direct subscriptions. Pure informational forward — the
+          // provider's data payload rides through verbatim with
+          // `providerId` added for fan-out attribution.
+          if (event.type === 'storage:monotonicity-recovered') {
+            const d = (event.data ?? {}) as {
+              recoveredTokenIds?: string[];
+              recoveredTokenCount?: number;
+              mergedUnknownBundleCids?: string[];
+              mergedUnknownBundleCount?: number;
+              residualUnknownBundleCids?: string[];
+              residualUnknownBundleCount?: number;
+              residualTokenMissingIds?: string[];
+              residualTokenMissingCount?: number;
+              recoveredOutboxIdsDroppedAsSent?: string[];
+              recoveredOutboxIdsDroppedAsSentCount?: number;
+              truncated?: boolean;
+            };
+            this.emitEvent('storage:monotonicity-recovered', {
+              providerId,
+              recoveredTokenIds: d.recoveredTokenIds ?? [],
+              recoveredTokenCount: d.recoveredTokenCount ?? 0,
+              mergedUnknownBundleCids: d.mergedUnknownBundleCids ?? [],
+              mergedUnknownBundleCount: d.mergedUnknownBundleCount ?? 0,
+              residualUnknownBundleCids: d.residualUnknownBundleCids ?? [],
+              residualUnknownBundleCount: d.residualUnknownBundleCount ?? 0,
+              residualTokenMissingIds: d.residualTokenMissingIds ?? [],
+              residualTokenMissingCount: d.residualTokenMissingCount ?? 0,
+              recoveredOutboxIdsDroppedAsSent: d.recoveredOutboxIdsDroppedAsSent ?? [],
+              recoveredOutboxIdsDroppedAsSentCount: d.recoveredOutboxIdsDroppedAsSentCount ?? 0,
+              truncated: d.truncated === true,
+            });
+          }
         });
         if (unsub) this._providerEventCleanups.push(unsub);
       }
@@ -5429,7 +5465,19 @@ export class Sphere {
       // reach `handleIncomingPointerWinBroadcast`. The aggregator
       // pointer + auto-merge convergence path covers correctness
       // without the broadcast optimization.
-      if (!pointer.winBroadcastsEnabled()) {
+      //
+      // Tolerant of pointer stubs that predate the
+      // `winBroadcastsEnabled` accessor (mirrors the symmetric guard
+      // in `lifecycle-manager.ts:publishAggregatorPointerBestEffort`):
+      // a missing method is treated as flag=false (fail-closed). The
+      // production code path always builds a real `ProfilePointerLayer`
+      // which implements the method; this defensive check keeps the
+      // contract robust for any future test stub or duck-typed
+      // consumer.
+      if (
+        typeof pointer.winBroadcastsEnabled !== 'function' ||
+        !pointer.winBroadcastsEnabled()
+      ) {
         return;
       }
       const signerHandle = pointer.getSignerForWinBroadcast();

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -5474,21 +5474,43 @@ export class Sphere {
       // which implements the method; this defensive check keeps the
       // contract robust for any future test stub or duck-typed
       // consumer.
-      if (
-        typeof pointer.winBroadcastsEnabled !== 'function' ||
-        // Strict `=== true` mirrors the production normalization in
-        // ProfilePointerLayer's frozen config snapshot. A test stub
-        // returning a truthy non-boolean (`1`, `'yes'`, `{}`) must
-        // be treated as flag=false — same fail-closed policy. Match
-        // the lifecycle-manager guard exactly for symmetry.
-        pointer.winBroadcastsEnabled() !== true ||
-        // Symmetric stub guard: a fake pointer that returns
-        // `winBroadcastsEnabled() === true` but lacks
-        // `getSignerForWinBroadcast` would TypeError at the call
-        // below, surface as a noisy "subscription install failed"
-        // warn, and re-arm on every event. Fail-closed instead.
-        typeof pointer.getSignerForWinBroadcast !== 'function'
-      ) {
+      // Defensive try/catch around the accessor: same rationale as
+      // lifecycle-manager. The accessor contract says
+      // `winBroadcastsEnabled()` MUST NOT throw, but a misbehaving
+      // stub could violate it. Without this catch, an accessor
+      // throw would escape to the outer `try { ... } catch (err)`
+      // and surface as a noisy "subscription install failed (will
+      // retry on next event)" warn — re-arming on every subsequent
+      // `storage:pointer-published` event indefinitely. Treat the
+      // throw as flag=false (fail-closed) so the early-return path
+      // fires cleanly with no noise.
+      let armed = false;
+      try {
+        armed =
+          typeof pointer.winBroadcastsEnabled === 'function' &&
+          // Strict `=== true` mirrors the production normalization
+          // in ProfilePointerLayer's frozen config snapshot. A test
+          // stub returning a truthy non-boolean (`1`, `'yes'`, `{}`)
+          // must be treated as flag=false — same fail-closed policy.
+          pointer.winBroadcastsEnabled() === true &&
+          // Symmetric stub guard: a fake pointer that returns
+          // `winBroadcastsEnabled() === true` but lacks
+          // `getSignerForWinBroadcast` would TypeError at the call
+          // below; fail-closed earlier.
+          typeof pointer.getSignerForWinBroadcast === 'function';
+      } catch (accessorErr) {
+        const msg =
+          accessorErr instanceof Error
+            ? accessorErr.message
+            : String(accessorErr);
+        logger.debug(
+          'Sphere',
+          `pointer-win subscription: winBroadcastsEnabled() threw ` +
+            `(accessor contract violation, treating as flag=false): ${msg}`,
+        );
+        armed = false;
+      }
+      if (!armed) {
         return;
       }
       const signerHandle = pointer.getSignerForWinBroadcast();

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -5476,7 +5476,13 @@ export class Sphere {
       // consumer.
       if (
         typeof pointer.winBroadcastsEnabled !== 'function' ||
-        !pointer.winBroadcastsEnabled()
+        !pointer.winBroadcastsEnabled() ||
+        // Symmetric stub guard: a fake pointer that returns
+        // `winBroadcastsEnabled() === true` but lacks
+        // `getSignerForWinBroadcast` would TypeError at the call
+        // below, surface as a noisy "subscription install failed"
+        // warn, and re-arm on every event. Fail-closed instead.
+        typeof pointer.getSignerForWinBroadcast !== 'function'
       ) {
         return;
       }

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -5422,6 +5422,16 @@ export class Sphere {
         // Pointer layer not yet built; try again on the next event.
         return;
       }
+      // Issue #264 — gated behind the pointer layer's
+      // `enablePointerWinBroadcasts` capability (default OFF). With
+      // the flag false this subscriber side is dormant: no per-wallet
+      // Nostr subscription is installed, so no sibling broadcasts can
+      // reach `handleIncomingPointerWinBroadcast`. The aggregator
+      // pointer + auto-merge convergence path covers correctness
+      // without the broadcast optimization.
+      if (!pointer.winBroadcastsEnabled()) {
+        return;
+      }
       const signerHandle = pointer.getSignerForWinBroadcast();
       const signingPubKeyHex = signerHandle.signingPubKeyHex;
       if (this._pointerWinSubscriptions.has(signingPubKeyHex)) {

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -5476,7 +5476,12 @@ export class Sphere {
       // consumer.
       if (
         typeof pointer.winBroadcastsEnabled !== 'function' ||
-        !pointer.winBroadcastsEnabled() ||
+        // Strict `=== true` mirrors the production normalization in
+        // ProfilePointerLayer's frozen config snapshot. A test stub
+        // returning a truthy non-boolean (`1`, `'yes'`, `{}`) must
+        // be treated as flag=false — same fail-closed policy. Match
+        // the lifecycle-manager guard exactly for symmetry.
+        pointer.winBroadcastsEnabled() !== true ||
         // Symmetric stub guard: a fake pointer that returns
         // `winBroadcastsEnabled() === true` but lacks
         // `getSignerForWinBroadcast` would TypeError at the call

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -191,6 +191,16 @@ export class ProfilePointerLayer {
    * treated as flag=false / fail-closed). Implementing only one
    * silently disables broadcasts with no error.
    *
+   * **Accessor contract.** `winBroadcastsEnabled()` MUST be a pure
+   * accessor and MUST NOT throw. The publisher's broad catch arm
+   * would otherwise classify the throw as a TRANSIENT publish
+   * failure and silently disable broadcasts while reporting
+   * `{ ok: true, transient: true }` to the caller; the subscriber
+   * side would log "subscription install failed" and indefinitely
+   * re-arm on every subsequent event. A real `ProfilePointerLayer`
+   * reads its frozen config snapshot and cannot throw; alternative
+   * implementations MUST honor the same contract.
+   *
    * **Init-time-only flag.** The flag is captured in the frozen
    * `#config` snapshot at construction time. Flipping
    * `enablePointerWinBroadcasts` at runtime (e.g., via a hot config
@@ -206,6 +216,18 @@ export class ProfilePointerLayer {
    * arms the subscription automatically. There is no third trigger
    * that would re-arm the subscriber on a flip from false→true
    * without a fresh publish.
+   *
+   * **Receive-only-wallet caveat.** A wallet that has the flag
+   * enabled but never PUBLISHES (e.g., a pure receive endpoint that
+   * only ingests sibling-device payments) will never emit a
+   * `storage:pointer-published` event of its own. Its
+   * `maybeInstallPointerWinSubscription` is therefore not triggered
+   * by its own publish path; the subscription only arms if some
+   * external code path calls `maybeInstallPointerWinSubscription()`
+   * directly. For receive-only wallets that want to consume sibling
+   * broadcasts, the wiring layer (Sphere) must arrange that
+   * trigger explicitly — e.g., on init when the flag is observed
+   * enabled.
    */
   winBroadcastsEnabled(): boolean {
     return this.#config.enablePointerWinBroadcasts === true;

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -192,14 +192,19 @@ export class ProfilePointerLayer {
    * silently disables broadcasts with no error.
    *
    * **Accessor contract.** `winBroadcastsEnabled()` MUST be a pure
-   * accessor and MUST NOT throw. The publisher's broad catch arm
-   * would otherwise classify the throw as a TRANSIENT publish
-   * failure and silently disable broadcasts while reporting
-   * `{ ok: true, transient: true }` to the caller; the subscriber
-   * side would log "subscription install failed" and indefinitely
-   * re-arm on every subsequent event. A real `ProfilePointerLayer`
-   * reads its frozen config snapshot and cannot throw; alternative
-   * implementations MUST honor the same contract.
+   * accessor and MUST NOT throw. Both the publisher (lifecycle-
+   * manager) and subscriber (Sphere) guards wrap the accessor call
+   * in a defensive try/catch that treats a throw as flag=false
+   * (fail-closed). The publish path still reports success; the
+   * subscriber early-returns without registering the per-wallet
+   * Nostr subscription. A single log line is emitted per accessor
+   * throw at debug-level (Sphere) and host-log level
+   * (lifecycle-manager) so operators can correlate. A real
+   * `ProfilePointerLayer` reads its frozen config snapshot and
+   * cannot throw; this defensive treatment exists so a misbehaving
+   * stub or alternative implementation cannot silently corrupt
+   * publish-success classification or trigger noisy
+   * subscription-install retries.
    *
    * **Init-time-only flag.** The flag is captured in the frozen
    * `#config` snapshot at construction time. Flipping
@@ -224,10 +229,14 @@ export class ProfilePointerLayer {
    * `maybeInstallPointerWinSubscription` is therefore not triggered
    * by its own publish path; the subscription only arms if some
    * external code path calls `maybeInstallPointerWinSubscription()`
-   * directly. For receive-only wallets that want to consume sibling
-   * broadcasts, the wiring layer (Sphere) must arrange that
-   * trigger explicitly — e.g., on init when the flag is observed
-   * enabled.
+   * directly. As of #264, `core/Sphere.ts` does NOT arrange an
+   * explicit init-time call — receive-only-wallet support for
+   * pointer-win broadcasts requires a follow-up wiring change (an
+   * init-time invocation gated on the flag's enabled state, OR a
+   * lazy first-incoming-event trigger). Acceptable today because
+   * the flag is default-OFF and the broadcast pipeline is an
+   * optimization layer (the aggregator pointer + auto-merge cover
+   * correctness without it).
    */
   winBroadcastsEnabled(): boolean {
     return this.#config.enablePointerWinBroadcasts === true;

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -183,6 +183,29 @@ export class ProfilePointerLayer {
    *
    * Default: `false`. See PointerLayerConfig.enablePointerWinBroadcasts
    * for the full rationale.
+   *
+   * **API pairing contract.** Test stubs / alternative pointer-layer
+   * implementations that expose `winBroadcastsEnabled()` MUST also
+   * expose `getSignerForWinBroadcast()` — the publisher and subscriber
+   * guards treat them as a coupled pair (a partial implementation is
+   * treated as flag=false / fail-closed). Implementing only one
+   * silently disables broadcasts with no error.
+   *
+   * **Init-time-only flag.** The flag is captured in the frozen
+   * `#config` snapshot at construction time. Flipping
+   * `enablePointerWinBroadcasts` at runtime (e.g., via a hot config
+   * reload that constructs a NEW `ProfilePointerLayer`) requires:
+   *   (1) Tearing down the old layer (calling `shutdown()`); AND
+   *   (2) Rebuilding the wiring so the new layer's
+   *       `winBroadcastsEnabled() === true` is observed by both
+   *       publisher and subscriber on next event.
+   * The publisher side picks up the new flag on its next successful
+   * publish. The subscriber side picks it up on the next emitted
+   * `storage:pointer-published` event — which only fires when the
+   * publisher is also enabled, so the first such event after the flip
+   * arms the subscription automatically. There is no third trigger
+   * that would re-arm the subscriber on a flip from false→true
+   * without a fresh publish.
    */
   winBroadcastsEnabled(): boolean {
     return this.#config.enablePointerWinBroadcasts === true;

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -158,9 +158,34 @@ export class ProfilePointerLayer {
     // a normalized frozen snapshot. This drops `allowUnverifiedOverride`
     // post-guard — defense-in-depth, since the field has no behavior
     // effect in v1 and won't be read by any code path.
+    //
+    // Issue #264: `enablePointerWinBroadcasts` is normalized via
+    // `=== true` so accidental truthy non-boolean values (`'true'`,
+    // `1`) fail closed. The flag's default is OFF — the broadcast
+    // pipeline is an optimization layer not load-bearing for
+    // convergence (see PointerLayerConfig.enablePointerWinBroadcasts
+    // for the full design rationale).
     this.#config = Object.freeze({
       allowOperatorOverrides: suppliedConfig.allowOperatorOverrides === true,
+      enablePointerWinBroadcasts:
+        suppliedConfig.enablePointerWinBroadcasts === true,
     });
+  }
+
+  /**
+   * Issue #264 — capability gate for the pointer-win broadcast
+   * pipeline. Consulted by:
+   *   - `LifecycleManager.publishAggregatorPointerBestEffort` before
+   *     signing the broadcast payload and emitting the
+   *     `storage:pointer-published` event (publisher).
+   *   - `Sphere.maybeInstallPointerWinSubscription` before installing
+   *     the per-wallet Nostr subscription (subscriber).
+   *
+   * Default: `false`. See PointerLayerConfig.enablePointerWinBroadcasts
+   * for the full rationale.
+   */
+  winBroadcastsEnabled(): boolean {
+    return this.#config.enablePointerWinBroadcasts === true;
   }
 
   /**

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -528,7 +528,18 @@ export class ProfilePointerLayer {
       walkbackLimit,
       abortSignal,
     });
-    this.#lastProbeVersions = result.probeVersions;
+    // Issue #264 steelman fix (symmetric with `publish`): only overwrite
+    // the probe-fingerprint history when discovery actually produced
+    // probes. A discoverLatestVersion that resolves on the first probe
+    // (no walkback needed) returns an empty `probeVersions` array;
+    // unconditionally assigning would clobber any fingerprint
+    // populated by a prior discovery / publish / probe call. Since
+    // `recoverLatest()` is implemented as
+    // `#recoverLatestInner → #discoverLatestVersionInner → here`, this
+    // fix also covers the recoverLatest path the steelman flagged.
+    if (result.probeVersions.length > 0) {
+      this.#lastProbeVersions = result.probeVersions;
+    }
     return result;
   }
 

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -372,7 +372,18 @@ export class ProfilePointerLayer {
       resolveRemoteCid: this.#init.resolveRemoteCid,
       abortSignal,
     });
-    this.#lastProbeVersions = result.probeHistory;
+    // Issue #264 steelman fix: only overwrite the probe history when
+    // the publish actually ran a discovery walkback. The fast-path
+    // (#263, attempts === 0) skips Step B and returns
+    // `probeHistory: []`. Unconditionally assigning would clobber any
+    // fingerprint populated by a prior discovery / recoverLatest /
+    // probe call — destroying the UI same-wallet-clustering signal
+    // surfaced by `getProbeFingerprint()`. The non-empty guard keeps
+    // the last meaningful probe sequence available across fast-path
+    // publishes.
+    if (result.probeHistory.length > 0) {
+      this.#lastProbeVersions = result.probeHistory;
+    }
     return { version: result.v, attemptsUsed: result.attemptsUsed };
   }
 

--- a/profile/aggregator-pointer/config.ts
+++ b/profile/aggregator-pointer/config.ts
@@ -42,6 +42,47 @@ export interface PointerLayerConfig {
    * outside NODE_ENV=development. See SPEC §13 W6.
    */
   readonly allowUnverifiedOverride?: boolean;
+
+  /**
+   * Issue #264 — enables the `pointer-win` Nostr broadcast publisher
+   * (in `LifecycleManager.publishAggregatorPointerBestEffort` after a
+   * successful publish) AND the per-wallet subscriber (in
+   * `Sphere.maybeInstallPointerWinSubscription`).
+   *
+   * OFF BY DEFAULT post-#264: broadcasts were originally introduced
+   * (PR #257, RFC-251 Approach D) as an optimization to short-circuit
+   * the aggregator's 30-60s read-replica lag for sibling devices that
+   * share an HD identity. Issue #264 reframes them as an OPTIONAL
+   * convergence-speed optimization, not a correctness requirement —
+   * convergence is now guaranteed by:
+   *   1. The aggregator pointer versions alone (the load-bearing
+   *      cross-device source of truth); AND
+   *   2. The flush-scheduler's monotonicity-violation auto-merge,
+   *      which reconstructs the missing state in-place rather than
+   *      throwing.
+   *
+   * With auto-merge in place, broadcasts add no correctness signal —
+   * a wrong/stale broadcast at best speeds convergence and at worst
+   * triggers an extra wasted publish cycle. We turn them off so the
+   * system's convergence properties can be tested without the
+   * optimization layer obscuring them.
+   *
+   * When `enablePointerWinBroadcasts !== true`:
+   *   - `LifecycleManager.publishAggregatorPointerBestEffort` skips
+   *     signing the broadcast payload and emitting the
+   *     `storage:pointer-published` event (publisher side OFF).
+   *   - `Sphere.maybeInstallPointerWinSubscription` returns early —
+   *     the per-wallet Nostr subscription is never installed
+   *     (subscriber side OFF).
+   *
+   * Strictly `=== true` to enable — defends against accidental
+   * truthy-but-not-boolean values (`'true'`, `1`) being interpreted
+   * as enabled.
+   *
+   * Flip to `true` to re-enable the optimization layer once auto-merge
+   * convergence is proven without it.
+   */
+  readonly enablePointerWinBroadcasts?: boolean;
 }
 
 // ── Capability gate ───────────────────────────────────────────────────────

--- a/profile/aggregator-pointer/reconcile-algorithm.ts
+++ b/profile/aggregator-pointer/reconcile-algorithm.ts
@@ -281,35 +281,54 @@ export async function reconcileAndPublish(input: ReconcileInput): Promise<Reconc
     // Step A: produce a fresh CID (may include state merged on prior conflict).
     const cidBytes = await input.cidProducer();
 
-    // Step B: discover V_true and target nextV = max(validV, includedV) + 1 (H4).
-    // Discovery errors propagate unchanged (DISCOVERY_OVERFLOW, CAR_UNAVAILABLE,
-    // CORRUPT_STREAK, TRUST_BASE_STALE, UNTRUSTED_PROOF). Reconcile cannot
-    // make progress without a valid V_true.
+    // Step B: determine nextV.
     //
-    // EXCEPTION (2026-05-16): `AGGREGATOR_POINTER_WALKBACK_FLOOR` is
-    // wrapped in a bounded retry loop. It fires when Phase 3 walkback
-    // would cross below `currentLocalVersion` — meaning the aggregator
-    // currently can't reach a version the wallet has already confirmed.
-    // This is replication lag (a successful publish at v=N becoming
-    // briefly invisible on a stale replica), not a real consistency
-    // fault. Retrying with backoff lets the lag settle before
-    // propagating up to the caller's retry-marker logic.
-    const discovery: DiscoverResult = await findLatestValidVersionWithWalkbackFloorRetry(
-      {
-        currentLocalVersion,
-        keyMaterial: input.keyMaterial,
-        signer: input.signer,
-        aggregatorClient: input.aggregatorClient,
-        trustBase: input.trustBase,
-        decodeCid: input.decodeCid,
-        fetchCar: input.fetchCar,
-        discoveryDeadlineMs: reconcileDeadlineMs,
-        abortSignal: input.abortSignal,
-      },
-      input.abortSignal,
-    );
-    probeHistory.push(...discovery.probeVersions);
-    const nextV = (Math.max(discovery.validV, discovery.includedV) + 1) as PointerVersion;
+    // Issue #263 fast-path: attempt 0 SKIPS the discovery walkback (which
+    // costs aggregator round-trip + IPFS CAR fetch per probed version)
+    // and targets `currentLocalVersion + 1` directly. For the common
+    // no-conflict case this saves ~30s of wall-clock per publish on a
+    // healthy testnet. If the fast-path submit returns `conflict`, we
+    // fall through to the same §9.2 rediscover + fetchAndJoin + retry
+    // loop the always-walkback flow used; attempts >= 1 run the full
+    // walkback discovery as before — preserving SPEC §8.2 conflict
+    // semantics.
+    //
+    // Issue #264 — the sibling-broadcast plumbing that issue #263
+    // originally added (`siblingHighestV` adoption into
+    // `currentLocalVersion`) is INTENTIONALLY OMITTED. The
+    // pointer-win broadcast pipeline is gated OFF by default and the
+    // aggregator alone is the load-bearing convergence mechanism;
+    // adopting a broadcast-derived version into `currentLocalVersion`
+    // would leak into `publishOnceAtVersion → resolvePublishVersion`
+    // and could silently clear legitimate crash-retry markers whose
+    // H8 v-burn accounting is still load-bearing (SPEC §7.1.4 Case 2).
+    //
+    // Attempts >= 1 (SLOW PATH) run the standard SPEC §8.2 three-phase
+    // walk. Discovery errors propagate unchanged (DISCOVERY_OVERFLOW,
+    // CAR_UNAVAILABLE, CORRUPT_STREAK, TRUST_BASE_STALE, UNTRUSTED_PROOF),
+    // except `AGGREGATOR_POINTER_WALKBACK_FLOOR` which is wrapped in a
+    // bounded retry loop to ride out replica-lag windows.
+    let nextV: PointerVersion;
+    if (attempts === 0) {
+      nextV = (currentLocalVersion + 1) as PointerVersion;
+    } else {
+      const discovery: DiscoverResult = await findLatestValidVersionWithWalkbackFloorRetry(
+        {
+          currentLocalVersion,
+          keyMaterial: input.keyMaterial,
+          signer: input.signer,
+          aggregatorClient: input.aggregatorClient,
+          trustBase: input.trustBase,
+          decodeCid: input.decodeCid,
+          fetchCar: input.fetchCar,
+          discoveryDeadlineMs: reconcileDeadlineMs,
+          abortSignal: input.abortSignal,
+        },
+        input.abortSignal,
+      );
+      probeHistory.push(...discovery.probeVersions);
+      nextV = (Math.max(discovery.validV, discovery.includedV) + 1) as PointerVersion;
+    }
 
     // Step C: run one publish attempt at nextV.
     const outcome = await publishOnceAtVersion(

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -123,6 +123,23 @@ export const POINTER_MONOTONICITY_VIOLATION = 'POINTER_MONOTONICITY_VIOLATION';
  */
 export const POINTER_MONOTONICITY_RECOVERED = 'POINTER_MONOTONICITY_RECOVERED';
 
+/**
+ * Issue #264 — cap on per-array entries surfaced in the
+ * `storage:monotonicity-recovered` and residual `storage:error`
+ * payloads. Log volume is bounded by truncating the listed
+ * `recoveredTokenIds`, `residualUnknownBundleCids`,
+ * `residualTokenMissingIds`, etc. to this many entries; the
+ * unbounded count is still emitted as a separate field, and a
+ * `truncated: true` flag is set whenever ANY of the arrays
+ * exceeded the cap.
+ *
+ * Exported so tests can pin the boundary atomically with the
+ * implementation — a deliberate cap change updates both sides
+ * together, and a regression flipping the `>` comparator becomes
+ * detectable via the boundary tests in `tests/unit/profile/`.
+ */
+export const MONOTONICITY_RECOVERY_PAYLOAD_CAP = 100;
+
 // ── Helpers ───────────────────────────────────────────────────────────────
 
 /**
@@ -150,38 +167,37 @@ export type OpStateArrays = {
  * tombstone live entries that exist in `previousOp` but were not
  * carried in this flush's in-memory `currentOp`.
  *
- * # Amplification-minimal contract (steelman fix)
+ * # Naive Map-based union — correctness > amplification claims
  *
- * The naive union — "current ∪ previous" — re-emits EVERY previous
- * entry through the per-entry-key writer. Because `writeProfileKey`
- * encrypts each value with a fresh random IV (see
- * `profile/encryption.ts:encryptProfileValue`), every re-emit lands a
- * NEW OrbitDB OpLog row even when the plaintext is byte-identical to
- * the on-disk record. Under sustained cross-device replication churn
- * this would inflate the OpLog by O(previous-size) per recovery cycle.
+ * Earlier remediation attempted an "amplification-minimal" variant
+ * that only added previous entries missing from current. On closer
+ * analysis the resulting set size is identical to the naive union
+ * `|current ∪ previous|` — both implementations dedup shared ids and
+ * preserve previous-only fill-in. The writer's per-entry diff
+ * (`writeOrbitOperationalStatePerEntry` → `applyPerEntryDiff` →
+ * `writeProfileKey`) writes EVERY live entry regardless of source,
+ * so amplification reduction is impossible at this layer.
  *
- * The amplification-minimal contract: `merged.outbox` (etc.) MUST
- * contain every entry from `currentOp` PLUS only those entries from
- * `previousOp` whose id is NOT in `currentOp`. The diff in
- * `writeOrbitOperationalStatePerEntry` writes every entry in
- * `merged`; by minimising the previous-only fill-in to the entries
- * that current is actually missing, we (a) preserve the original
- * "current wins on collision" semantic at zero extra cost, and
- * (b) bound the OpLog amplification to the smallest possible set —
- * the entries that current would otherwise have the writer tombstone
- * by omission.
+ * The amplification concern raised in the prior steelman is REAL but
+ * lives at the WRITER layer: `writeProfileKey` calls
+ * `encryptProfileValue` (`profile/encryption.ts:122`) with a fresh
+ * random IV per call, so re-writing identical plaintext lands a new
+ * OrbitDB OpLog row. Eliminating that requires plaintext-aware diff
+ * in the writer (read existing ciphertext, decrypt, compare, skip on
+ * equality) OR deterministic-IV encryption — both broader refactors
+ * out of scope for #264. Tracked as a writer-layer follow-up.
  *
- * Steelman-residual: writes for entries that ARE in `currentOp` still
- * produce fresh ciphertext because the writer does not plaintext-
- * compare existing values. That amplification exists pre-#264 and is
- * a writer-layer concern out of scope for this issue (tracked in
- * follow-ups to the per-entry diff).
+ * We therefore use the simpler naive union: dedupe by id via
+ * `Map.set` (current wins on collision), and collect no-id entries
+ * into a separate bucket that the consumer appends. This preserves
+ * correct semantics under intra-current duplicates (the variant
+ * silently kept duplicates) and empty-string ids (the variant routed
+ * `id: ''` to the no-id bucket and lost the dedup).
  *
  * Per-collection semantics:
  *   - `outbox`, `sent`, `audit`, `finalizationQueue`: union by
  *     `entry.id` (UxfTransferOutboxEntry / UxfSentLedgerEntry share the
- *     stable transferId as `.id`); current wins on id collision (i.e.
- *     entries from previous with the same id are dropped).
+ *     stable transferId as `.id`); current wins on id collision.
  *   - `outbox` then gets the SENT-wins filter applied: any outbox entry
  *     whose `id` matches a SENT entry's `id` is dropped — the
  *     transition outbox→sent is terminal and the OUTBOX residue should
@@ -205,100 +221,75 @@ export function unionOpStateWithSentWins(
   function readId(entry: unknown): string | undefined {
     if (!entry || typeof entry !== 'object') return undefined;
     const id = (entry as { id?: unknown }).id;
-    return typeof id === 'string' && id.length > 0 ? id : undefined;
+    // Accept any string (including empty) as a real id so the Map
+    // dedup collapses duplicates uniformly. Downstream writers
+    // (writeOrbitOperationalStatePerEntry) gate writes on
+    // `id.length > 0`, so empty-id entries are silently dropped at
+    // write time — but we still want intra-set dedup here.
+    return typeof id === 'string' ? id : undefined;
   }
   function readTokenId(entry: unknown): string | undefined {
     if (!entry || typeof entry !== 'object') return undefined;
     const id = (entry as { tokenId?: unknown }).tokenId;
-    return typeof id === 'string' && id.length > 0 ? id : undefined;
+    return typeof id === 'string' ? id : undefined;
   }
 
   function unionById(
     current: ReadonlyArray<unknown>,
     previous: ReadonlyArray<unknown>,
   ): unknown[] {
-    // Amplification-minimal: emit every current entry, then ONLY the
-    // previous entries whose id is not already in current. Entries
-    // shared by both are written once (from current), not twice. This
-    // keeps the per-entry-key write count at `|current| + |previous-only|`
-    // instead of `|current ∪ previous|` doubling for shared ids.
-    const currentIds = new Set<string>();
-    const result: unknown[] = [];
-    const previousNoId: unknown[] = [];
-    for (const e of current) {
-      result.push(e);
-      const id = readId(e);
-      if (id !== undefined) currentIds.add(id);
-    }
+    // Naive Map dedup: insert previous first so current's value wins
+    // on id collision. No-id entries collect in a separate bucket
+    // appended at the end. Intra-source duplicates with the same id
+    // collapse to one entry per id (the LAST one inserted wins —
+    // current's last for current-vs-current ties, current's
+    // overriding previous's for cross-source ties).
+    const byId = new Map<string, unknown>();
+    const noId: unknown[] = [];
     for (const e of previous) {
       const id = readId(e);
-      if (id === undefined) {
-        // No id → cannot dedup against current; treat as a separate
-        // record (the writer will JSON-stringify the full opState
-        // collection for non-per-entry stores like history).
-        previousNoId.push(e);
-        continue;
-      }
-      if (!currentIds.has(id)) {
-        // Fill-in: current is missing this id, so the per-entry diff
-        // would otherwise tombstone the on-disk record. Preserve it.
-        result.push(e);
-      }
-      // else: id is in current — current already wrote (or will write)
-      // a value for this id. Skip the previous version (would amplify
-      // OpLog with a redundant write).
+      if (id !== undefined) byId.set(id, e);
+      else noId.push(e);
     }
-    return [...result, ...previousNoId];
+    for (const e of current) {
+      const id = readId(e);
+      if (id !== undefined) byId.set(id, e);
+      else noId.push(e);
+    }
+    return [...byId.values(), ...noId];
   }
 
   function unionByTokenIdOrJson(
     current: ReadonlyArray<unknown>,
     previous: ReadonlyArray<unknown>,
   ): unknown[] {
-    // Amplification-minimal variant for collections persisted as a
-    // single JSON blob (tombstones, invalidatedNametags, history): we
-    // still want to dedup by `tokenId` when present, but only ADD
-    // previous's entries that current is missing. Same rationale as
-    // `unionById`: current's values are authoritative; previous is
-    // only used as a fill-in source.
-    const currentTokenIds = new Set<string>();
-    const currentJsonKeys = new Set<string>();
-    const result: unknown[] = [];
-    for (const e of current) {
-      result.push(e);
-      const tid = readTokenId(e);
-      if (tid !== undefined) {
-        currentTokenIds.add(tid);
-      } else {
+    // Dedup by `tokenId` when present (aligns with the writer's
+    // `tokenId`-keyed per-entry stores for `invalid` / `mintOutbox`).
+    // Fall back to JSON-key dedup for entries without tokenId
+    // (tombstones, history, invalidatedNametags). Non-serializable
+    // entries are force-appended (extremely rare in practice; these
+    // collections hold plain `{tokenId, deletedAt}`-shaped values).
+    const byTokenId = new Map<string, unknown>();
+    const byJson = new Map<string, unknown>();
+    const nonSerializable: unknown[] = [];
+    function ingest(arr: ReadonlyArray<unknown>): void {
+      for (const e of arr) {
+        const tid = readTokenId(e);
+        if (tid !== undefined) {
+          byTokenId.set(tid, e);
+          continue;
+        }
         try {
-          currentJsonKeys.add(JSON.stringify(e));
+          byJson.set(JSON.stringify(e), e);
         } catch {
-          // Non-serializable: cannot dedup, but it's already in result
-          // so the consumer sees it once.
+          nonSerializable.push(e);
         }
       }
     }
-    for (const e of previous) {
-      const tid = readTokenId(e);
-      if (tid !== undefined) {
-        if (!currentTokenIds.has(tid)) result.push(e);
-        continue;
-      }
-      // No tokenId in previous entry: dedup against current's JSON keys.
-      try {
-        const json = JSON.stringify(e);
-        if (!currentJsonKeys.has(json)) {
-          result.push(e);
-          currentJsonKeys.add(json);
-        }
-      } catch {
-        // Non-serializable previous entry: defensive append (can't
-        // dedup against current; better to over-include than to drop
-        // a tombstone or invalid record silently).
-        result.push(e);
-      }
-    }
-    return result;
+    // Insert previous first so current wins on key collision.
+    ingest(previous);
+    ingest(current);
+    return [...byTokenId.values(), ...byJson.values(), ...nonSerializable];
   }
 
   const mergedSent = unionById(currentOp.sent, previousOp.sent);
@@ -969,21 +960,21 @@ export class FlushScheduler {
           timestamp: Date.now(),
           code: POINTER_MONOTONICITY_RECOVERED,
           data: {
-            recoveredTokenIds: recoveredTokenIds.slice(0, 100),
+            recoveredTokenIds: recoveredTokenIds.slice(0, MONOTONICITY_RECOVERY_PAYLOAD_CAP),
             recoveredTokenCount: recoveredTokenIds.length,
-            mergedUnknownBundleCids: mergedUnknownBundleCids.slice(0, 100),
+            mergedUnknownBundleCids: mergedUnknownBundleCids.slice(0, MONOTONICITY_RECOVERY_PAYLOAD_CAP),
             mergedUnknownBundleCount: mergedUnknownBundleCids.length,
-            residualUnknownBundleCids: residualUnknownBundleCids.slice(0, 100),
+            residualUnknownBundleCids: residualUnknownBundleCids.slice(0, MONOTONICITY_RECOVERY_PAYLOAD_CAP),
             residualUnknownBundleCount: residualUnknownBundleCids.length,
-            residualTokenMissingIds: residualTokenMissing.slice(0, 100),
+            residualTokenMissingIds: residualTokenMissing.slice(0, MONOTONICITY_RECOVERY_PAYLOAD_CAP),
             residualTokenMissingCount: residualTokenMissing.length,
-            recoveredOutboxIdsDroppedAsSent: droppedOutboxIdsAsSent.slice(0, 100),
+            recoveredOutboxIdsDroppedAsSent: droppedOutboxIdsAsSent.slice(0, MONOTONICITY_RECOVERY_PAYLOAD_CAP),
             recoveredOutboxIdsDroppedAsSentCount: droppedOutboxIdsAsSent.length,
             truncated:
-              recoveredTokenIds.length > 100 ||
-              residualUnknownBundleCids.length > 100 ||
-              residualTokenMissing.length > 100 ||
-              droppedOutboxIdsAsSent.length > 100,
+              recoveredTokenIds.length > MONOTONICITY_RECOVERY_PAYLOAD_CAP ||
+              residualUnknownBundleCids.length > MONOTONICITY_RECOVERY_PAYLOAD_CAP ||
+              residualTokenMissing.length > MONOTONICITY_RECOVERY_PAYLOAD_CAP ||
+              droppedOutboxIdsAsSent.length > MONOTONICITY_RECOVERY_PAYLOAD_CAP,
           },
         });
       }
@@ -1071,14 +1062,14 @@ export class FlushScheduler {
           code: POINTER_MONOTONICITY_VIOLATION,
           error: violation.message,
           data: {
-            missingTokenIds: residualTokenMissing.slice(0, 100),
+            missingTokenIds: residualTokenMissing.slice(0, MONOTONICITY_RECOVERY_PAYLOAD_CAP),
             missingTokenCount: residualTokenMissing.length,
-            unknownBundleCids: residualUnknownBundleCids.slice(0, 100),
+            unknownBundleCids: residualUnknownBundleCids.slice(0, MONOTONICITY_RECOVERY_PAYLOAD_CAP),
             unknownBundleCount: residualUnknownBundleCids.length,
             autoMergeResidual: true,
             truncated:
-              residualTokenMissing.length > 100 ||
-              residualUnknownBundleCids.length > 100,
+              residualTokenMissing.length > MONOTONICITY_RECOVERY_PAYLOAD_CAP ||
+              residualUnknownBundleCids.length > MONOTONICITY_RECOVERY_PAYLOAD_CAP,
           },
         });
         // Intentionally NOT throwing — see comment block above.

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -131,7 +131,7 @@ export const POINTER_MONOTONICITY_RECOVERED = 'POINTER_MONOTONICITY_RECOVERED';
  * shape via the host facade; this shape is just the loose subset we need
  * to reason about during the merge.
  */
-type OpStateArrays = {
+export type OpStateArrays = {
   tombstones: unknown[];
   outbox: unknown[];
   sent: unknown[];
@@ -171,7 +171,7 @@ type OpStateArrays = {
  * forward-compatible with `T.1.E` composite-key tokenIds and any
  * future per-entry fields.
  */
-function unionOpStateWithSentWins(
+export function unionOpStateWithSentWins(
   currentOp: OpStateArrays,
   previousOp: OpStateArrays,
 ): { merged: OpStateArrays; droppedOutboxIds: string[] } {
@@ -964,20 +964,30 @@ export class FlushScheduler {
           `[POINTER_MONOTONICITY_VIOLATION] residual after auto-merge (continuing): ${reasonParts.join('; ')}`,
         );
 
-        // Gap 4 recovery (legacy): still kick off the baseline refresh
-        // as defense-in-depth. The auto-merge above already handles the
-        // happy path; this microtask covers the rare case where
-        // `previousData` was null and the bundle inline fetch also
-        // failed — a subsequent successful `load()` re-evaluates the
-        // baseline so the NEXT flush sees a clean state.
-        queueMicrotask(() => {
-          this.host.refreshBaselineForMonotonicity().catch((err) => {
-            this.host.log(
-              `Baseline-refresh recovery threw (best-effort): ` +
-                `${err instanceof Error ? err.message : String(err)}`,
-            );
-          });
-        });
+        // Issue #264 — intentionally NOT scheduling the legacy
+        // `refreshBaselineForMonotonicity` microtask anymore.
+        //
+        // Pre-#264 that helper rebuilt `lastLoadedFromBundleCids` from
+        // OrbitDB's `listActiveBundles()` so the throw-then-retry path
+        // could re-flush past a stale baseline. The retry path
+        // (awaitNextFlush) is the only legitimate consumer that still
+        // benefits.
+        //
+        // Post-#264, an unconditional refresh actively BREAKS the
+        // residual-retry contract: the residual CID (the unfetchable
+        // foreign bundle) IS present in `listActiveBundles()` because
+        // it landed in OrbitDB before our flush. A refresh would mark
+        // it as "in baseline", and the next flush's bundle-set check
+        // would no longer treat it as unknown — silently skipping the
+        // inline fetch retry. Subsequent saves would publish CARs
+        // missing the residual's tokens despite OrbitDB still showing
+        // the bundle as active. The auto-merge is precisely the
+        // mechanism that keeps eventual convergence working; the
+        // refresh would sabotage it.
+        //
+        // The `awaitNextFlush` Gap 4 path that DID rely on the throw
+        // continues to work for synthetic-violation tests; for real
+        // workloads it no longer triggers (no throw).
 
         // Surface to operators via the legacy `storage:error` code so
         // dashboards keyed on POINTER_MONOTONICITY_VIOLATION still

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -73,12 +73,221 @@ import type { ProfileTokenStorageHost } from './host.js';
 import type { TxfStorageDataBase } from '../../storage/storage-provider.js';
 
 /**
- * Error code emitted when the runtime pointer-monotonicity assertion
- * fires. The flush is aborted before pin + publish; the operator-alert
- * event is emitted with the missing token IDs so monitoring can surface
- * the regression. Exported so consumers/tests can reference the literal.
+ * Issue #264 — historical compatibility constant.
+ *
+ * The runtime pointer-monotonicity check originally aborted the flush
+ * and emitted this code on `storage:error` when either the token-set or
+ * bundle-set invariant failed. Post-#264 the same conditions are
+ * auto-recovered in place (see {@link POINTER_MONOTONICITY_RECOVERED}):
+ *   - `tokenMissing` is healed by re-merging the missing TXF entries
+ *     from the last-loaded baseline (`previousData`) back into the
+ *     in-flight UXF package and re-exporting the CAR. Operational state
+ *     is unioned with the SENT-wins-over-OUTBOX rule so the
+ *     per-entry-key OrbitDB write does not tombstone live entries that
+ *     are present in the baseline but absent from this flush's `data`.
+ *   - `unknownBundleCids` is healed inline by fetching each foreign
+ *     CAR and merging it into `pkg` (the #255 / PR #262 behavior). If
+ *     the fetch fails for some subset, this is now logged at warn-level
+ *     and the flush proceeds with whatever superset it managed to
+ *     assemble — eventual convergence happens via subsequent
+ *     cross-device syncs detecting the same residual.
+ *
+ * The constant is still exported so test suites and operator tooling
+ * that pattern-match on the literal continue to compile, but it is no
+ * longer emitted on the auto-merge path. The throw path is preserved
+ * only for the truly-unrecoverable case where `previousData === null`
+ * AND every unknown-bundle inline fetch failed AND the token-set check
+ * had no source to recover from — i.e., no signal at all. Even then the
+ * flush body does NOT throw; it logs warn-level and continues so the
+ * at-least-once gate isn't held closed by metadata-layer transients.
  */
 export const POINTER_MONOTONICITY_VIOLATION = 'POINTER_MONOTONICITY_VIOLATION';
+
+/**
+ * Issue #264 — emitted on `storage:monotonicity-recovered` when the
+ * flush body auto-merges a detected monotonicity gap in place. Distinct
+ * from `storage:error` so operators see auto-merges as routine
+ * convergence work, not alarms.
+ *
+ * Payload (see flush-scheduler emit site):
+ *   - `recoveredTokenIds`: token ids re-merged from `previousData` to
+ *     satisfy the token-set invariant (capped at 100 for log volume).
+ *   - `mergedUnknownBundleCids`: foreign bundle CIDs inline-fetched and
+ *     merged into `pkg` (capped at 100).
+ *   - `residualUnknownBundleCids`: foreign bundle CIDs that could not
+ *     be fetched (network down, malformed CAR, etc.) — the flush
+ *     continued without them; downstream convergence retries on the
+ *     next flush.
+ *   - `recoveredOutboxIdsDroppedAsSent`: outbox-entry ids that the
+ *     SENT-wins dedup removed during the opState union.
+ */
+export const POINTER_MONOTONICITY_RECOVERED = 'POINTER_MONOTONICITY_RECOVERED';
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Lightweight projection of `OperationalState` arrays for the SENT-wins
+ * union helper. The flush body reads/writes the actual OperationalState
+ * shape via the host facade; this shape is just the loose subset we need
+ * to reason about during the merge.
+ */
+type OpStateArrays = {
+  tombstones: unknown[];
+  outbox: unknown[];
+  sent: unknown[];
+  invalid: unknown[];
+  history: unknown[];
+  mintOutbox: unknown[];
+  invalidatedNametags: unknown[];
+  audit: unknown[];
+  finalizationQueue: unknown[];
+};
+
+/**
+ * Issue #264 — union two OperationalState array sets with the
+ * SENT-wins-over-OUTBOX dedup rule. Used by the flush-scheduler's
+ * tokenMissing auto-merge so the per-entry-key OrbitDB write does NOT
+ * tombstone live entries that exist in `previousOp` but were not
+ * carried in this flush's in-memory `currentOp`.
+ *
+ * Per-collection semantics:
+ *   - `outbox`, `sent`, `audit`, `finalizationQueue`: union by
+ *     `entry.id` (UxfTransferOutboxEntry / UxfSentLedgerEntry share the
+ *     stable transferId as `.id`); on collision the current value wins
+ *     because it is the more recent observation of that record.
+ *   - `outbox` then gets the SENT-wins filter applied: any outbox entry
+ *     whose `id` matches a SENT entry's `id` is dropped — the
+ *     transition outbox→sent is terminal and the OUTBOX residue should
+ *     not be resurrected when we union with the baseline. The dropped
+ *     outbox ids are returned so the flush body can surface them on
+ *     the `storage:monotonicity-recovered` event for operator audit.
+ *   - `tombstones`, `invalid`, `mintOutbox`, `invalidatedNametags`,
+ *     `history`: union by `entry.tokenId` when present, else dedup by
+ *     JSON serialization (best-effort; these collections are append-
+ *     only by construction so duplicates are rare and tolerable).
+ *
+ * The helper does not parse the inner entry shapes beyond reading
+ * `id` / `tokenId`; richer fields ride through opaquely. This keeps it
+ * forward-compatible with `T.1.E` composite-key tokenIds and any
+ * future per-entry fields.
+ */
+function unionOpStateWithSentWins(
+  currentOp: OpStateArrays,
+  previousOp: OpStateArrays,
+): { merged: OpStateArrays; droppedOutboxIds: string[] } {
+  function readId(entry: unknown): string | undefined {
+    if (!entry || typeof entry !== 'object') return undefined;
+    const id = (entry as { id?: unknown }).id;
+    return typeof id === 'string' && id.length > 0 ? id : undefined;
+  }
+  function readTokenId(entry: unknown): string | undefined {
+    if (!entry || typeof entry !== 'object') return undefined;
+    const id = (entry as { tokenId?: unknown }).tokenId;
+    return typeof id === 'string' && id.length > 0 ? id : undefined;
+  }
+
+  function unionById(
+    current: ReadonlyArray<unknown>,
+    previous: ReadonlyArray<unknown>,
+  ): unknown[] {
+    const byId = new Map<string, unknown>();
+    const noId: unknown[] = [];
+    // Insert previous first so current's value wins on collision.
+    for (const e of previous) {
+      const id = readId(e);
+      if (id !== undefined) byId.set(id, e);
+      else noId.push(e);
+    }
+    for (const e of current) {
+      const id = readId(e);
+      if (id !== undefined) byId.set(id, e);
+      else noId.push(e);
+    }
+    return [...byId.values(), ...noId];
+  }
+
+  function unionByTokenIdOrJson(
+    current: ReadonlyArray<unknown>,
+    previous: ReadonlyArray<unknown>,
+  ): unknown[] {
+    const byTokenId = new Map<string, unknown>();
+    const byJson = new Map<string, unknown>();
+    for (const e of previous) {
+      const tid = readTokenId(e);
+      if (tid !== undefined) {
+        byTokenId.set(tid, e);
+      } else {
+        try {
+          byJson.set(JSON.stringify(e), e);
+        } catch {
+          // Non-serializable entry — append once, dedup not possible.
+          byJson.set(String(byJson.size) + '_p', e);
+        }
+      }
+    }
+    for (const e of current) {
+      const tid = readTokenId(e);
+      if (tid !== undefined) {
+        byTokenId.set(tid, e);
+      } else {
+        try {
+          byJson.set(JSON.stringify(e), e);
+        } catch {
+          byJson.set(String(byJson.size) + '_c', e);
+        }
+      }
+    }
+    return [...byTokenId.values(), ...byJson.values()];
+  }
+
+  const mergedSent = unionById(currentOp.sent, previousOp.sent);
+  const mergedAudit = unionById(currentOp.audit, previousOp.audit);
+  const mergedFinalizationQueue = unionById(
+    currentOp.finalizationQueue,
+    previousOp.finalizationQueue,
+  );
+  let mergedOutbox = unionById(currentOp.outbox, previousOp.outbox);
+
+  // SENT-wins-over-OUTBOX dedup. The id space is shared between
+  // OutboxEntry and UxfSentLedgerEntry (the SENT entry reuses the
+  // outbox transferId as its primary key), so an outbox entry whose id
+  // matches a SENT entry's id is the residue of a transition that has
+  // already moved to terminal success — drop it.
+  const sentIds = new Set<string>();
+  for (const e of mergedSent) {
+    const id = readId(e);
+    if (id !== undefined) sentIds.add(id);
+  }
+  const droppedOutboxIds: string[] = [];
+  if (sentIds.size > 0) {
+    mergedOutbox = mergedOutbox.filter((e) => {
+      const id = readId(e);
+      if (id !== undefined && sentIds.has(id)) {
+        droppedOutboxIds.push(id);
+        return false;
+      }
+      return true;
+    });
+  }
+
+  return {
+    merged: {
+      tombstones: unionByTokenIdOrJson(currentOp.tombstones, previousOp.tombstones),
+      outbox: mergedOutbox,
+      sent: mergedSent,
+      invalid: unionByTokenIdOrJson(currentOp.invalid, previousOp.invalid),
+      history: unionByTokenIdOrJson(currentOp.history, previousOp.history),
+      mintOutbox: unionByTokenIdOrJson(currentOp.mintOutbox, previousOp.mintOutbox),
+      invalidatedNametags: unionByTokenIdOrJson(
+        currentOp.invalidatedNametags,
+        previousOp.invalidatedNametags,
+      ),
+      audit: mergedAudit,
+      finalizationQueue: mergedFinalizationQueue,
+    },
+    droppedOutboxIds,
+  };
+}
 
 export class FlushScheduler {
   /**
@@ -332,9 +541,15 @@ export class FlushScheduler {
     }
 
     try {
-      // 1. Extract tokens and operational state
+      // 1. Extract tokens and operational state.
+      //
+      // Issue #264: both are `let` (was `const opState`) because the
+      // monotonicity auto-merge below may union the in-memory `data`'s
+      // opState with `previousData`'s to satisfy the per-entry-key
+      // OrbitDB write contract — see `unionOpStateWithSentWins` for the
+      // SENT-wins dedup rule.
       let tokens = this.host.extractTokensFromTxfData(data);
-      const opState = this.host.extractOperationalState(data);
+      let opState = this.host.extractOperationalState(data);
 
       // 2. Build UXF package
       const { UxfPackage } = await import('../../uxf/UxfPackage.js');
@@ -539,10 +754,17 @@ export class FlushScheduler {
       }
 
       // In-place recovery for unknown bundles (#255). Try to fetch and
-      // merge each unknown bundle into `pkg`. On any failure, leave the
-      // CIDs in `unknownBundleCids` so the violation throw fires below.
+      // merge each unknown bundle into `pkg`. On any failure the CID
+      // stays in `unknownBundleCids` — issue #264 reframes the fallback
+      // from "throw POINTER_MONOTONICITY_VIOLATION" to "log + continue
+      // with the best-effort superset"; the auto-merge residual block
+      // below emits the operator event and proceeds with the publish.
+      //
+      // `bundlesMergedInline` is hoisted to the outer scope so the
+      // `storage:monotonicity-recovered` event emitted later can surface
+      // both the merged set AND the residual set in a single payload.
+      const bundlesMergedInline: string[] = [];
       if (unknownBundleCids.length > 0) {
-        const mergedCids: string[] = [];
         const stillUnknown: string[] = [];
         for (const cid of unknownBundleCids) {
           try {
@@ -555,7 +777,7 @@ export class FlushScheduler {
             );
             const foreignPkg = await UxfPackage.fromCar(foreignCarBytes);
             pkg.merge(foreignPkg);
-            mergedCids.push(cid);
+            bundlesMergedInline.push(cid);
             if (loadedBundleCids !== null) {
               loadedBundleCids.add(cid);
             }
@@ -563,7 +785,7 @@ export class FlushScheduler {
             stillUnknown.push(cid);
             this.host.log(
               `In-place merge failed for unknown bundle ${cid} ` +
-                `(falling back to violation throw): ` +
+                `(residual after auto-merge — flush continues): ` +
                 `${err instanceof Error ? err.message : String(err)}`,
             );
           }
@@ -572,63 +794,182 @@ export class FlushScheduler {
         // code (CAR export, bundle ref tokenCount) reflects the union.
         // Re-export carBytes from the merged pkg so the pin step uses
         // the superset CAR (the pre-merge carBytes above is now stale).
-        if (mergedCids.length > 0) {
+        if (bundlesMergedInline.length > 0) {
           tokens = pkg.assembleAll() as Map<string, unknown>;
           tokenValues = [...tokens.values()];
           carBytes = await pkg.toCar();
           this.host.log(
-            `In-place monotonicity recovery: merged ${mergedCids.length} foreign ` +
+            `In-place monotonicity recovery: merged ${bundlesMergedInline.length} foreign ` +
               `bundle(s) into in-flight CAR ` +
-              `(${mergedCids.slice(0, 5).join(', ')}${mergedCids.length > 5 ? ', ...' : ''}) — ` +
+              `(${bundlesMergedInline.slice(0, 5).join(', ')}` +
+              `${bundlesMergedInline.length > 5 ? ', ...' : ''}) — ` +
               `pkg now has ${tokens.size} token(s)`,
           );
         }
-        // Anything we couldn't fetch+merge falls through to the throw.
+        // Anything we couldn't fetch+merge stays as a residual; see
+        // the auto-merge residual block below.
         unknownBundleCids = stillUnknown;
       }
 
-      if (tokenMissing.length > 0 || unknownBundleCids.length > 0) {
-        const reasonParts: string[] = [];
-        if (tokenMissing.length > 0) {
-          reasonParts.push(
-            `would drop ${tokenMissing.length} token(s) from baseline ` +
-              `(${tokenMissing.slice(0, 10).join(', ')}${tokenMissing.length > 10 ? ', ...' : ''})`,
+      // Issue #264 — token-set auto-merge.
+      //
+      // When the token-set check found token IDs in `previousData` that
+      // are absent from this flush's `pkg`, the previous behavior threw
+      // POINTER_MONOTONICITY_VIOLATION and relied on a fire-and-forget
+      // baseline refresh + the at-least-once gate's `awaitNextFlush`
+      // one-shot retry to recover. That deferred path:
+      //   (a) was not reliable under cross-device replication churn
+      //       (every retry race-loses to a fresh peer write); and
+      //   (b) held the at-least-once Nostr gate closed for the entire
+      //       retry window, manifesting as inbound TOKEN_TRANSFER events
+      //       replaying forever without ever durably landing.
+      //
+      // Per #264 design principle: convergence MUST be guaranteed by
+      // the aggregator pointer versions alone; profile metadata
+      // convergence is eventually-consistent via auto-merge. So:
+      //
+      //   - For each missing tokenId, extract its TXF entry from
+      //     `previousData` (the last-loaded baseline) and ingest it
+      //     back into `pkg`. By construction `previousData` contains
+      //     every missing entry (that's the definition of tokenMissing
+      //     in the check above), so recovery is total.
+      //   - Union the in-memory `opState` arrays with `previousData`'s
+      //     opState via `unionOpStateWithSentWins` so the per-entry-key
+      //     OrbitDB write does NOT tombstone live OUTBOX / SENT / etc.
+      //     entries that exist in the baseline but were not carried in
+      //     this flush's `data`. SENT-wins dedup drops any OUTBOX entry
+      //     whose id matches a SENT entry's id — that transition is
+      //     terminal and the OUTBOX residue should not survive the
+      //     union.
+      //   - Re-export `carBytes` from the merged `pkg` so the pin step
+      //     writes the superset CAR.
+      const recoveredTokenIds: string[] = [];
+      let droppedOutboxIdsAsSent: string[] = [];
+      if (tokenMissing.length > 0 && previousData) {
+        const previousTokens = this.host.extractTokensFromTxfData(previousData);
+        const toReingest: unknown[] = [];
+        for (const tokenId of tokenMissing) {
+          const txfEntry = previousTokens.get(tokenId);
+          if (txfEntry !== undefined) {
+            toReingest.push(txfEntry);
+            recoveredTokenIds.push(tokenId);
+          }
+        }
+        if (toReingest.length > 0) {
+          pkg.ingestAll(toReingest);
+          tokens = pkg.assembleAll() as Map<string, unknown>;
+          tokenValues = [...tokens.values()];
+
+          const previousOpState = this.host.extractOperationalState(previousData);
+          const { merged: mergedOp, droppedOutboxIds } =
+            unionOpStateWithSentWins(
+              opState as unknown as OpStateArrays,
+              previousOpState as unknown as OpStateArrays,
+            );
+          opState = mergedOp as unknown as typeof opState;
+          droppedOutboxIdsAsSent = droppedOutboxIds;
+
+          carBytes = await pkg.toCar();
+          this.host.log(
+            `In-place monotonicity recovery: re-merged ${recoveredTokenIds.length} ` +
+              `missing token(s) from previous baseline ` +
+              `(${recoveredTokenIds.slice(0, 5).join(', ')}` +
+              `${recoveredTokenIds.length > 5 ? ', ...' : ''}); ` +
+              `opState union dropped ${droppedOutboxIdsAsSent.length} OUTBOX ` +
+              `id(s) superseded by SENT — pkg now has ${tokens.size} token(s)`,
           );
         }
-        if (unknownBundleCids.length > 0) {
+      }
+
+      // Compute residuals: tokens we wanted to recover but couldn't
+      // (e.g., `previousData` was null, or the entry was somehow
+      // missing from `previousTokens`). Unknown bundles that couldn't
+      // be fetched in the inline merge above also stay in
+      // `unknownBundleCids` and become residuals here.
+      const residualTokenMissing = tokenMissing.filter(
+        (id) => !recoveredTokenIds.includes(id),
+      );
+      const residualUnknownBundleCids = unknownBundleCids;
+      const mergedUnknownBundleCids = bundlesMergedInline;
+
+      // Emit the operator-visible recovery event whenever anything was
+      // recovered OR any residual exists. This is a routine convergence
+      // signal — distinct from `storage:error` — so monitoring
+      // dashboards can plot recovery rates without conflating them with
+      // alarms.
+      if (
+        recoveredTokenIds.length > 0 ||
+        droppedOutboxIdsAsSent.length > 0 ||
+        residualTokenMissing.length > 0 ||
+        residualUnknownBundleCids.length > 0
+      ) {
+        this.host.emitEvent({
+          type: 'storage:monotonicity-recovered',
+          timestamp: Date.now(),
+          code: POINTER_MONOTONICITY_RECOVERED,
+          data: {
+            recoveredTokenIds: recoveredTokenIds.slice(0, 100),
+            recoveredTokenCount: recoveredTokenIds.length,
+            mergedUnknownBundleCids: mergedUnknownBundleCids.slice(0, 100),
+            mergedUnknownBundleCount: mergedUnknownBundleCids.length,
+            residualUnknownBundleCids: residualUnknownBundleCids.slice(0, 100),
+            residualUnknownBundleCount: residualUnknownBundleCids.length,
+            residualTokenMissingIds: residualTokenMissing.slice(0, 100),
+            residualTokenMissingCount: residualTokenMissing.length,
+            recoveredOutboxIdsDroppedAsSent: droppedOutboxIdsAsSent.slice(0, 100),
+            recoveredOutboxIdsDroppedAsSentCount: droppedOutboxIdsAsSent.length,
+            truncated:
+              recoveredTokenIds.length > 100 ||
+              residualUnknownBundleCids.length > 100 ||
+              residualTokenMissing.length > 100 ||
+              droppedOutboxIdsAsSent.length > 100,
+          },
+        });
+      }
+
+      // Residuals: log at warn-level + emit `storage:error` with the
+      // legacy POINTER_MONOTONICITY_VIOLATION code (so existing
+      // monitoring dashboards keyed on that literal still fire), but
+      // DO NOT throw. The publish proceeds with the best-effort
+      // superset CAR we managed to assemble — the next cross-device
+      // sync from any peer will detect the same residual and re-attempt
+      // the inline merge, achieving eventual convergence per the
+      // aggregator-pointer-as-source-of-truth design principle in #264.
+      if (
+        residualTokenMissing.length > 0 ||
+        residualUnknownBundleCids.length > 0
+      ) {
+        const reasonParts: string[] = [];
+        if (residualTokenMissing.length > 0) {
           reasonParts.push(
-            `${unknownBundleCids.length} unknown bundle(s) in OrbitDB not in baseline ` +
-              `(${unknownBundleCids.slice(0, 5).join(', ')}${unknownBundleCids.length > 5 ? ', ...' : ''})`,
+            `could not recover ${residualTokenMissing.length} token(s) from baseline ` +
+              `(${residualTokenMissing.slice(0, 10).join(', ')}` +
+              `${residualTokenMissing.length > 10 ? ', ...' : ''})`,
+          );
+        }
+        if (residualUnknownBundleCids.length > 0) {
+          reasonParts.push(
+            `${residualUnknownBundleCids.length} unknown bundle(s) inline fetch failed ` +
+              `(${residualUnknownBundleCids.slice(0, 5).join(', ')}` +
+              `${residualUnknownBundleCids.length > 5 ? ', ...' : ''})`,
           );
         }
         const violation = new Error(
-          `Pointer monotonicity violation: ${reasonParts.join('; ')}. ` +
-            `Aborting publish to prevent silent token loss across cross-device sync.`,
+          `Pointer monotonicity auto-merge residuals: ${reasonParts.join('; ')}. ` +
+            `Publishing best-effort superset; subsequent cross-device syncs will retry.`,
         );
-        (violation as Error & { code?: string }).code = POINTER_MONOTONICITY_VIOLATION;
-        this.host.log(`[POINTER_MONOTONICITY_VIOLATION] aborting publish: ${reasonParts.join('; ')}`);
+        (violation as Error & { code?: string }).code =
+          POINTER_MONOTONICITY_VIOLATION;
+        this.host.log(
+          `[POINTER_MONOTONICITY_VIOLATION] residual after auto-merge (continuing): ${reasonParts.join('; ')}`,
+        );
 
-        // Gap 4 recovery: kick off a fire-and-forget baseline refresh
-        // so subsequent save-driven flushes (which DON'T retry via
-        // awaitNextFlush) get a fresh `lastLoadedFromBundleCids` and
-        // can pass the check. Called via a microtask schedule so the
-        // in-flight flush settles BEFORE load() tries to await
-        // `flushPromise` (otherwise the refresh would deadlock on
-        // ourselves).
-        //
-        // The at-least-once gate's `awaitNextFlush` loop does its own
-        // synchronous retry — that path bypasses this fire-and-forget
-        // since it has tighter latency requirements. This fire-and-
-        // forget covers the save-driven timer path, the periodic
-        // poll's no-data flush path, and any other call site that
-        // doesn't loop on violation.
-        //
-        // Post-#255: this path now only fires when (a) the token-set
-        // check fired (partial-save bug, no merge possible) or (b) the
-        // inline fetch+merge above failed for every unknown bundle
-        // (network down + no local Helia blockstore for those CIDs).
-        // The common cross-device-race case is handled by the inline
-        // recovery without reaching this throw.
+        // Gap 4 recovery (legacy): still kick off the baseline refresh
+        // as defense-in-depth. The auto-merge above already handles the
+        // happy path; this microtask covers the rare case where
+        // `previousData` was null and the bundle inline fetch also
+        // failed — a subsequent successful `load()` re-evaluates the
+        // baseline so the NEXT flush sees a clean state.
         queueMicrotask(() => {
           this.host.refreshBaselineForMonotonicity().catch((err) => {
             this.host.log(
@@ -638,18 +979,10 @@ export class FlushScheduler {
           });
         });
 
-        // The catch block at the bottom of flushToIpfs() re-queues
-        // `data` so the user's writes are not lost; subsequent
-        // flushes will re-evaluate once the refresh above completes.
-        // Surface to operators via storage:error AND a structured
-        // alert so monitoring dashboards can fire on the literal code.
-        this.host.emitEvent(
-          this.host.buildErrorEvent(
-            'storage:error',
-            violation,
-            POINTER_MONOTONICITY_VIOLATION,
-          ),
-        );
+        // Surface to operators via the legacy `storage:error` code so
+        // dashboards keyed on POINTER_MONOTONICITY_VIOLATION still
+        // fire. The richer per-recovery payload is on the separate
+        // `storage:monotonicity-recovered` event emitted above.
         this.host.emitEvent({
           type: 'storage:error',
           timestamp: Date.now(),
@@ -657,15 +990,17 @@ export class FlushScheduler {
           error: violation.message,
           data: {
             alert: 'transfer:operator-alert',
-            missingTokenIds: tokenMissing.slice(0, 100),
-            missingTokenCount: tokenMissing.length,
-            unknownBundleCids: unknownBundleCids.slice(0, 100),
-            unknownBundleCount: unknownBundleCids.length,
+            missingTokenIds: residualTokenMissing.slice(0, 100),
+            missingTokenCount: residualTokenMissing.length,
+            unknownBundleCids: residualUnknownBundleCids.slice(0, 100),
+            unknownBundleCount: residualUnknownBundleCids.length,
+            autoMergeResidual: true,
             truncated:
-              tokenMissing.length > 100 || unknownBundleCids.length > 100,
+              residualTokenMissing.length > 100 ||
+              residualUnknownBundleCids.length > 100,
           },
         });
-        throw violation;
+        // Intentionally NOT throwing — see comment block above.
       }
 
       // 4. Pin to IPFS (reuse last pinned CID on retry to avoid duplicate pins)

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -150,11 +150,38 @@ export type OpStateArrays = {
  * tombstone live entries that exist in `previousOp` but were not
  * carried in this flush's in-memory `currentOp`.
  *
+ * # Amplification-minimal contract (steelman fix)
+ *
+ * The naive union — "current ∪ previous" — re-emits EVERY previous
+ * entry through the per-entry-key writer. Because `writeProfileKey`
+ * encrypts each value with a fresh random IV (see
+ * `profile/encryption.ts:encryptProfileValue`), every re-emit lands a
+ * NEW OrbitDB OpLog row even when the plaintext is byte-identical to
+ * the on-disk record. Under sustained cross-device replication churn
+ * this would inflate the OpLog by O(previous-size) per recovery cycle.
+ *
+ * The amplification-minimal contract: `merged.outbox` (etc.) MUST
+ * contain every entry from `currentOp` PLUS only those entries from
+ * `previousOp` whose id is NOT in `currentOp`. The diff in
+ * `writeOrbitOperationalStatePerEntry` writes every entry in
+ * `merged`; by minimising the previous-only fill-in to the entries
+ * that current is actually missing, we (a) preserve the original
+ * "current wins on collision" semantic at zero extra cost, and
+ * (b) bound the OpLog amplification to the smallest possible set —
+ * the entries that current would otherwise have the writer tombstone
+ * by omission.
+ *
+ * Steelman-residual: writes for entries that ARE in `currentOp` still
+ * produce fresh ciphertext because the writer does not plaintext-
+ * compare existing values. That amplification exists pre-#264 and is
+ * a writer-layer concern out of scope for this issue (tracked in
+ * follow-ups to the per-entry diff).
+ *
  * Per-collection semantics:
  *   - `outbox`, `sent`, `audit`, `finalizationQueue`: union by
  *     `entry.id` (UxfTransferOutboxEntry / UxfSentLedgerEntry share the
- *     stable transferId as `.id`); on collision the current value wins
- *     because it is the more recent observation of that record.
+ *     stable transferId as `.id`); current wins on id collision (i.e.
+ *     entries from previous with the same id are dropped).
  *   - `outbox` then gets the SENT-wins filter applied: any outbox entry
  *     whose `id` matches a SENT entry's `id` is dropped — the
  *     transition outbox→sent is terminal and the OUTBOX residue should
@@ -190,54 +217,88 @@ export function unionOpStateWithSentWins(
     current: ReadonlyArray<unknown>,
     previous: ReadonlyArray<unknown>,
   ): unknown[] {
-    const byId = new Map<string, unknown>();
-    const noId: unknown[] = [];
-    // Insert previous first so current's value wins on collision.
+    // Amplification-minimal: emit every current entry, then ONLY the
+    // previous entries whose id is not already in current. Entries
+    // shared by both are written once (from current), not twice. This
+    // keeps the per-entry-key write count at `|current| + |previous-only|`
+    // instead of `|current ∪ previous|` doubling for shared ids.
+    const currentIds = new Set<string>();
+    const result: unknown[] = [];
+    const previousNoId: unknown[] = [];
+    for (const e of current) {
+      result.push(e);
+      const id = readId(e);
+      if (id !== undefined) currentIds.add(id);
+    }
     for (const e of previous) {
       const id = readId(e);
-      if (id !== undefined) byId.set(id, e);
-      else noId.push(e);
+      if (id === undefined) {
+        // No id → cannot dedup against current; treat as a separate
+        // record (the writer will JSON-stringify the full opState
+        // collection for non-per-entry stores like history).
+        previousNoId.push(e);
+        continue;
+      }
+      if (!currentIds.has(id)) {
+        // Fill-in: current is missing this id, so the per-entry diff
+        // would otherwise tombstone the on-disk record. Preserve it.
+        result.push(e);
+      }
+      // else: id is in current — current already wrote (or will write)
+      // a value for this id. Skip the previous version (would amplify
+      // OpLog with a redundant write).
     }
-    for (const e of current) {
-      const id = readId(e);
-      if (id !== undefined) byId.set(id, e);
-      else noId.push(e);
-    }
-    return [...byId.values(), ...noId];
+    return [...result, ...previousNoId];
   }
 
   function unionByTokenIdOrJson(
     current: ReadonlyArray<unknown>,
     previous: ReadonlyArray<unknown>,
   ): unknown[] {
-    const byTokenId = new Map<string, unknown>();
-    const byJson = new Map<string, unknown>();
+    // Amplification-minimal variant for collections persisted as a
+    // single JSON blob (tombstones, invalidatedNametags, history): we
+    // still want to dedup by `tokenId` when present, but only ADD
+    // previous's entries that current is missing. Same rationale as
+    // `unionById`: current's values are authoritative; previous is
+    // only used as a fill-in source.
+    const currentTokenIds = new Set<string>();
+    const currentJsonKeys = new Set<string>();
+    const result: unknown[] = [];
+    for (const e of current) {
+      result.push(e);
+      const tid = readTokenId(e);
+      if (tid !== undefined) {
+        currentTokenIds.add(tid);
+      } else {
+        try {
+          currentJsonKeys.add(JSON.stringify(e));
+        } catch {
+          // Non-serializable: cannot dedup, but it's already in result
+          // so the consumer sees it once.
+        }
+      }
+    }
     for (const e of previous) {
       const tid = readTokenId(e);
       if (tid !== undefined) {
-        byTokenId.set(tid, e);
-      } else {
-        try {
-          byJson.set(JSON.stringify(e), e);
-        } catch {
-          // Non-serializable entry — append once, dedup not possible.
-          byJson.set(String(byJson.size) + '_p', e);
+        if (!currentTokenIds.has(tid)) result.push(e);
+        continue;
+      }
+      // No tokenId in previous entry: dedup against current's JSON keys.
+      try {
+        const json = JSON.stringify(e);
+        if (!currentJsonKeys.has(json)) {
+          result.push(e);
+          currentJsonKeys.add(json);
         }
+      } catch {
+        // Non-serializable previous entry: defensive append (can't
+        // dedup against current; better to over-include than to drop
+        // a tombstone or invalid record silently).
+        result.push(e);
       }
     }
-    for (const e of current) {
-      const tid = readTokenId(e);
-      if (tid !== undefined) {
-        byTokenId.set(tid, e);
-      } else {
-        try {
-          byJson.set(JSON.stringify(e), e);
-        } catch {
-          byJson.set(String(byJson.size) + '_c', e);
-        }
-      }
-    }
-    return [...byTokenId.values(), ...byJson.values()];
+    return result;
   }
 
   const mergedSent = unionById(currentOp.sent, previousOp.sent);
@@ -993,13 +1054,23 @@ export class FlushScheduler {
         // dashboards keyed on POINTER_MONOTONICITY_VIOLATION still
         // fire. The richer per-recovery payload is on the separate
         // `storage:monotonicity-recovered` event emitted above.
+        //
+        // Issue #264 steelman fix: the `alert: 'transfer:operator-alert'`
+        // field is INTENTIONALLY NOT set on the residual emit anymore.
+        // Pre-#264 a monotonicity violation was a rare hard-throw and
+        // warranted paging. Post-#264 the residual fires whenever a
+        // foreign bundle's inline fetch fails — a routine network
+        // transient. Pagers keyed on `data.alert === 'transfer:operator-
+        // alert'` would burn out on-call within hours of a flaky IPFS
+        // gateway. Operators who DO want paging on residuals can opt in
+        // explicitly via the new `autoMergeResidual: true` discriminator
+        // (paired with the unchanged `code: POINTER_MONOTONICITY_VIOLATION`).
         this.host.emitEvent({
           type: 'storage:error',
           timestamp: Date.now(),
           code: POINTER_MONOTONICITY_VIOLATION,
           error: violation.message,
           data: {
-            alert: 'transfer:operator-alert',
             missingTokenIds: residualTokenMissing.slice(0, 100),
             missingTokenCount: residualTokenMissing.length,
             unknownBundleCids: residualUnknownBundleCids.slice(0, 100),

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -1271,24 +1271,49 @@ export class LifecycleManager {
         // missing method is treated as flag=false (fail-closed). The
         // production code path always builds a real `ProfilePointerLayer`
         // which implements the method.
-        const winBroadcastsOn =
-          typeof pointer.winBroadcastsEnabled === 'function' &&
-          // Strict `=== true` to mirror the production
-          // ProfilePointerLayer constructor's normalization (which
-          // freezes the snapshot as `=== true`). A test stub that
-          // returns a truthy non-boolean (`1`, `'yes'`, `{}`) MUST be
-          // treated as flag=false — same fail-closed policy as
-          // production config. Symmetric with the Sphere subscriber
-          // guard in `core/Sphere.ts:maybeInstallPointerWinSubscription`.
-          pointer.winBroadcastsEnabled() === true &&
-          // Symmetric with the new accessor: stubs lacking the signer
-          // helper fall through cleanly (fail-closed) rather than
-          // surfacing a TypeError caught only by the broad catch arm
-          // below. The two accessors are added together on real
-          // ProfilePointerLayer instances; a stub omitting one but
-          // not the other is a test-harness shape, not a production
-          // path.
-          typeof pointer.getSignerForWinBroadcast === 'function';
+        // Defensive try/catch around the accessor: the
+        // `winBroadcastsEnabled()` contract is "MUST be a pure
+        // accessor, MUST NOT throw" (see ProfilePointerLayer doc),
+        // but a misbehaving stub could violate it. Without this
+        // catch, an accessor throw would escape to the broad outer
+        // catch (~line 1326) and be misclassified as a TRANSIENT
+        // publish failure returning `{ ok: false, transient: true,
+        // code: 'UNCLASSIFIED' }` — making the entire publish
+        // appear to have failed even though it had already
+        // succeeded. Treat the throw as flag=false (fail-closed
+        // policy), which silently disables broadcasts for this
+        // publish but lets the publish itself report success.
+        let winBroadcastsOn = false;
+        try {
+          winBroadcastsOn =
+            typeof pointer.winBroadcastsEnabled === 'function' &&
+            // Strict `=== true` to mirror the production
+            // ProfilePointerLayer constructor's normalization (which
+            // freezes the snapshot as `=== true`). A test stub that
+            // returns a truthy non-boolean (`1`, `'yes'`, `{}`) MUST be
+            // treated as flag=false — same fail-closed policy as
+            // production config. Symmetric with the Sphere subscriber
+            // guard in `core/Sphere.ts:maybeInstallPointerWinSubscription`.
+            pointer.winBroadcastsEnabled() === true &&
+            // Symmetric with the new accessor: stubs lacking the signer
+            // helper fall through cleanly (fail-closed) rather than
+            // surfacing a TypeError caught only by the broad catch arm
+            // below. The two accessors are added together on real
+            // ProfilePointerLayer instances; a stub omitting one but
+            // not the other is a test-harness shape, not a production
+            // path.
+            typeof pointer.getSignerForWinBroadcast === 'function';
+        } catch (accessorErr) {
+          const msg =
+            accessorErr instanceof Error
+              ? accessorErr.message
+              : String(accessorErr);
+          this.host.log(
+            `Pointer publish: winBroadcastsEnabled() threw (accessor ` +
+              `contract violation, treating as flag=false): ${msg}`,
+          );
+          winBroadcastsOn = false;
+        }
         if (winBroadcastsOn) {
           try {
             const signerHandle = pointer.getSignerForWinBroadcast();

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -1273,7 +1273,15 @@ export class LifecycleManager {
         // which implements the method.
         const winBroadcastsOn =
           typeof pointer.winBroadcastsEnabled === 'function' &&
-          pointer.winBroadcastsEnabled();
+          pointer.winBroadcastsEnabled() &&
+          // Symmetric with the new accessor: stubs lacking the signer
+          // helper fall through cleanly (fail-closed) rather than
+          // surfacing a TypeError caught only by the broad catch arm
+          // below. The two accessors are added together on real
+          // ProfilePointerLayer instances; a stub omitting one but
+          // not the other is a test-harness shape, not a production
+          // path.
+          typeof pointer.getSignerForWinBroadcast === 'function';
         if (winBroadcastsOn) {
           try {
             const signerHandle = pointer.getSignerForWinBroadcast();

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -1273,7 +1273,14 @@ export class LifecycleManager {
         // which implements the method.
         const winBroadcastsOn =
           typeof pointer.winBroadcastsEnabled === 'function' &&
-          pointer.winBroadcastsEnabled() &&
+          // Strict `=== true` to mirror the production
+          // ProfilePointerLayer constructor's normalization (which
+          // freezes the snapshot as `=== true`). A test stub that
+          // returns a truthy non-boolean (`1`, `'yes'`, `{}`) MUST be
+          // treated as flag=false — same fail-closed policy as
+          // production config. Symmetric with the Sphere subscriber
+          // guard in `core/Sphere.ts:maybeInstallPointerWinSubscription`.
+          pointer.winBroadcastsEnabled() === true &&
           // Symmetric with the new accessor: stubs lacking the signer
           // helper fall through cleanly (fail-closed) rather than
           // surfacing a TypeError caught only by the broad catch arm

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -1265,7 +1265,16 @@ export class LifecycleManager {
         // to forward. Convergence still works via the aggregator pointer
         // alone — broadcasts are an optimization, not a correctness
         // requirement.
-        if (pointer.winBroadcastsEnabled()) {
+        //
+        // Tolerant of pointer stubs that predate the
+        // `winBroadcastsEnabled` accessor (e.g. unit-test fakes): a
+        // missing method is treated as flag=false (fail-closed). The
+        // production code path always builds a real `ProfilePointerLayer`
+        // which implements the method.
+        const winBroadcastsOn =
+          typeof pointer.winBroadcastsEnabled === 'function' &&
+          pointer.winBroadcastsEnabled();
+        if (winBroadcastsOn) {
           try {
             const signerHandle = pointer.getSignerForWinBroadcast();
             const signed = await signWinBroadcastPayload(signerHandle.signer, {

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -1257,36 +1257,46 @@ export class LifecycleManager {
         //
         // Best-effort: any failure during sign / emit is logged and
         // dropped — the publish-success return path is the contract.
-        try {
-          const signerHandle = pointer.getSignerForWinBroadcast();
-          const signed = await signWinBroadcastPayload(signerHandle.signer, {
-            _kind: WIN_BROADCAST_KIND_MARKER,
-            v: WIN_BROADCAST_SCHEMA_VERSION,
-            version: result.version,
-            cid: cidString,
-            signingPubKey: signerHandle.signingPubKeyHex,
-            ts: Date.now(),
-          });
-          this.host.emitEvent({
-            type: 'storage:pointer-published',
-            timestamp: Date.now(),
-            data: {
-              cid: cidString,
+        //
+        // Issue #264 — gated behind the `enablePointerWinBroadcasts`
+        // capability (default OFF). When the flag is false the entire
+        // sign + emit block is skipped: no payload built, no event
+        // emitted, nothing for Sphere's `forwardPointerPublishedToNostr`
+        // to forward. Convergence still works via the aggregator pointer
+        // alone — broadcasts are an optimization, not a correctness
+        // requirement.
+        if (pointer.winBroadcastsEnabled()) {
+          try {
+            const signerHandle = pointer.getSignerForWinBroadcast();
+            const signed = await signWinBroadcastPayload(signerHandle.signer, {
+              _kind: WIN_BROADCAST_KIND_MARKER,
+              v: WIN_BROADCAST_SCHEMA_VERSION,
               version: result.version,
-              attemptsUsed: result.attemptsUsed,
-              signedPayloadJson: JSON.stringify(signed),
-              broadcastTag: buildWinBroadcastTag(signerHandle.signingPubKeyHex),
-            },
-          });
-        } catch (broadcastErr) {
-          const errMsg =
-            broadcastErr instanceof Error
-              ? broadcastErr.message
-              : String(broadcastErr);
-          this.host.log(
-            `Pointer publish: win-broadcast build/sign failed (best-effort, ` +
-            `ignored): ${errMsg}`,
-          );
+              cid: cidString,
+              signingPubKey: signerHandle.signingPubKeyHex,
+              ts: Date.now(),
+            });
+            this.host.emitEvent({
+              type: 'storage:pointer-published',
+              timestamp: Date.now(),
+              data: {
+                cid: cidString,
+                version: result.version,
+                attemptsUsed: result.attemptsUsed,
+                signedPayloadJson: JSON.stringify(signed),
+                broadcastTag: buildWinBroadcastTag(signerHandle.signingPubKeyHex),
+              },
+            });
+          } catch (broadcastErr) {
+            const errMsg =
+              broadcastErr instanceof Error
+                ? broadcastErr.message
+                : String(broadcastErr);
+            this.host.log(
+              `Pointer publish: win-broadcast build/sign failed (best-effort, ` +
+              `ignored): ${errMsg}`,
+            );
+          }
         }
         return { ok: true, transient: false } as const;
       } catch (err) {

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -377,7 +377,43 @@ export type StorageEventType =
    * converge via the existing WALKBACK_FLOOR + reconcile path
    * (just slower, ~60-90 s vs ~1 s).
    */
-  | 'storage:pointer-published';
+  | 'storage:pointer-published'
+  /**
+   * Issue #264 — emitted by the flush scheduler when it auto-merges
+   * a detected monotonicity gap in place (previously this fired
+   * POINTER_MONOTONICITY_VIOLATION on `storage:error` and aborted
+   * the flush). Distinct from `storage:error` so operators see
+   * auto-merges as routine convergence work, not alarms.
+   *
+   * `data` payload (see flush-scheduler.ts for the canonical shape):
+   *   - `recoveredTokenIds: string[]`   token ids re-merged from
+   *     `previousData` to satisfy the token-set invariant.
+   *   - `recoveredTokenCount: number`
+   *   - `mergedUnknownBundleCids: string[]`   foreign bundle CIDs
+   *     inline-fetched and merged into the in-flight UXF package.
+   *   - `mergedUnknownBundleCount: number`
+   *   - `residualUnknownBundleCids: string[]`   foreign bundle CIDs
+   *     that could not be fetched (network down, malformed CAR,
+   *     etc.) — the flush continued without them; downstream
+   *     convergence retries on the next flush.
+   *   - `residualUnknownBundleCount: number`
+   *   - `residualTokenMissingIds: string[]`   token ids the token-set
+   *     check flagged but `previousData` could not provide (only
+   *     possible when `previousData === null`).
+   *   - `residualTokenMissingCount: number`
+   *   - `recoveredOutboxIdsDroppedAsSent: string[]`   outbox-entry
+   *     ids that the SENT-wins dedup removed during the
+   *     `OperationalState` union — surfaced for operator audit.
+   *   - `recoveredOutboxIdsDroppedAsSentCount: number`
+   *   - `truncated: boolean`   true when any of the listed arrays
+   *     were capped at 100 entries for log-volume control.
+   *
+   * Informational only. The flush continues to publish the
+   * best-effort superset CAR regardless; residuals are addressed by
+   * subsequent cross-device syncs detecting the same gap and
+   * re-attempting the inline merge.
+   */
+  | 'storage:monotonicity-recovered';
 
 export interface StorageEvent {
   type: StorageEventType;

--- a/tests/integration/pointer/category-C.test.ts
+++ b/tests/integration/pointer/category-C.test.ts
@@ -829,12 +829,19 @@ describe('Pointer Category-C — multi-device contention (SPEC §9)', () => {
         ipfs: ipfsB,
       });
 
-      // B publishes once. It starts at localVersion=0, discovery finds
-      // validV=3 includedV=3, target = max(3, 3) + 1 = 4.
+      // B publishes once. It starts at localVersion=0.
+      //
+      // Issue #263 fast-path-miss path (cold-start): attempt 0 targets
+      // v=1 (currentLocalVersion + 1) and gets REQUEST_ID_EXISTS from
+      // the shared aggregator (A already holds v=1). reconcile then
+      // falls back to its existing rediscover + slow-path discovery,
+      // finds validV=3 includedV=3, targets v=4 (H4), and lands —
+      // total 2 attempts. The final version is unchanged from the
+      // pre-fast-path behavior.
       const cidB = cidForBytes(new TextEncoder().encode('C9-vB'));
       const resB = await devB.layer.publish(async () => cidB.bytes);
       expect(resB.version).toBe(4);
-      expect(resB.attemptsUsed).toBe(1); // No conflict — v=4 was vacant.
+      expect(resB.attemptsUsed).toBe(2); // attempt 0 (v=1) conflict + attempt 1 (v=4) success.
       expect(devB.localVersion()).toBe(4);
     });
   });
@@ -868,20 +875,25 @@ describe('Pointer Category-C — multi-device contention (SPEC §9)', () => {
       const rA1 = await devA.layer.publish(async () => cidA1.bytes);
       expect(rA1.version).toBe(1);
 
-      // B publishes: B's localVersion=0 → discovery finds validV=1 → target
-      // v=2 vacant → B publishes at v=2 on the first attempt (no conflict
-      // because A hasn't advanced past v=1). NOTE: no fetchAndJoin fires
-      // here because there was no conflict — discovery just picked up A's
-      // state implicitly via findLatestValidVersion.
+      // B publishes: B's localVersion=0.
+      //
+      // Issue #263 fast-path-miss path: attempt 0 targets v=1 and
+      // conflicts (A already holds v=1). Fall-back rediscovers
+      // validV=1, attempt 1 targets v=2 → success.
+      // NOTE: B doesn't run fetchAndJoin for the file-store CIDs in
+      // this test (resolveRemoteCid stub), but the conflict + walkback
+      // still bumps to v=2 deterministically.
       const rB2 = await devB.layer.publish(async () => cidB2.bytes);
       expect(rB2.version).toBe(2);
-      expect(rB2.attemptsUsed).toBe(1);
+      expect(rB2.attemptsUsed).toBe(2); // attempt 0 (v=1) conflict + attempt 1 (v=2) success.
 
-      // A publishes again: A's localVersion is 1, discovery finds validV=2,
-      // target v=3. Again, no conflict (v=3 is vacant).
+      // A publishes again: A's localVersion is 1 (after own publish).
+      // Issue #263 fast-path-miss: attempt 0 targets v=2 and conflicts
+      // (B just landed v=2). Fall-back to walkback finds validV=2,
+      // attempt 1 targets v=3 → success.
       const rA3 = await devA.layer.publish(async () => cidA3.bytes);
       expect(rA3.version).toBe(3);
-      expect(rA3.attemptsUsed).toBe(1);
+      expect(rA3.attemptsUsed).toBe(2); // attempt 0 (v=2) conflict + attempt 1 (v=3) success.
 
       // Both devices now converge to validV=3 on discover (each discovers
       // independently — they share the aggregator).

--- a/tests/integration/pointer/category-M.test.ts
+++ b/tests/integration/pointer/category-M.test.ts
@@ -126,7 +126,17 @@ function makeFakeAggregator(): {
       transactionHash: { data: Uint8Array },
       _authenticator: unknown,
     ) {
-      commitments.set(requestId.toString(), new Uint8Array(transactionHash.data));
+      // Issue #263 — model the production aggregator's per-requestId
+      // idempotency. A second writer at the same requestId gets
+      // REQUEST_ID_EXISTS (matches the category-C shared aggregator's
+      // contract). Without this, the fast-path's attempt at v=1 would
+      // silently overwrite a prior commitment at the same v rather than
+      // surface a conflict, which is the behavior the SPEC requires.
+      const key = requestId.toString();
+      if (commitments.has(key)) {
+        return new SubmitCommitmentResponse(SubmitCommitmentStatus.REQUEST_ID_EXISTS);
+      }
+      commitments.set(key, new Uint8Array(transactionHash.data));
       return new SubmitCommitmentResponse(SubmitCommitmentStatus.SUCCESS);
     },
     async getInclusionProof(requestId: { toString(): string }) {
@@ -549,16 +559,21 @@ describe('Category-M: Token Conservation across pointer-layer ops', () => {
     await layerA.publish(async () => cidForBytes(remotePayload).bytes);
     expect(versionA).toBe(1);
 
-    // Device B runs with a *different* localVersion state — 0 —
-    // so reconcile will compute nextV=2 (max(validV=1, includedV=1)+1).
-    // Device B has NO conflict here because localVersion=0 means it
-    // will discover v=1 on the aggregator, see that as validV, and
-    // target v=2. No fetchAndJoin needed in this happy path.
+    // Device B runs with localVersion=1 so its first publish targets
+    // v=2 directly — exercising the H4 max(validV, includedV)+1
+    // arithmetic on the happy path (no conflict).
     //
-    // But we want to verify that after publish, the caller's pool is
-    // conserved and the remote tokens can be merged (the merge itself
-    // lives above the pointer layer — we simulate it here).
-    let versionB = 0;
+    // Issue #263 — under the eager-publish optimization, B's fast-path
+    // (attempt 0) targets `currentLocalVersion + 1 = 2`, which is
+    // vacant on the shared aggregator, so the publish lands without
+    // a conflict (and therefore without firing fetchAndJoin). If we
+    // started B at localVersion=0 instead, the fast path would try
+    // v=1, hit REQUEST_ID_EXISTS, and fall through to the slow path
+    // — which would invoke fetchAndJoin and break the "happy-path
+    // conservation" contract this test is asserting. The application
+    // level multi-device-sync test (which DOES drive the fetchAndJoin
+    // path) covers that case separately.
+    let versionB = 1;
     const localPool = new MockTokenPool([tok('local-1', 'USDU', 200n)]);
 
     const beforeJoin = localPool.snapshot('device-B pre-join');

--- a/tests/unit/profile/lifecycle-manager-pointer-win-broadcast.test.ts
+++ b/tests/unit/profile/lifecycle-manager-pointer-win-broadcast.test.ts
@@ -108,6 +108,15 @@ async function buildStubPointer(opts: {
         signingPubKeyHex: opts.signer.signingPubKeyHex,
       };
     },
+    // Issue #264 — these tests are pinned to the legacy
+    // broadcasts-enabled wiring (they exist precisely to verify the
+    // sign/emit path works end-to-end). Return true here so the
+    // lifecycle-manager gate doesn't trip and the broadcast event
+    // emits as before. ProfilePointerLayer enforces a default-OFF
+    // policy in production via `PointerLayerConfig.enablePointerWinBroadcasts`;
+    // suppression of the default-OFF path is covered by a separate
+    // test file.
+    winBroadcastsEnabled() { return true; },
   } as unknown as ProfilePointerLayer;
 }
 

--- a/tests/unit/profile/monotonicity-auto-merge.test.ts
+++ b/tests/unit/profile/monotonicity-auto-merge.test.ts
@@ -244,99 +244,82 @@ describe('unionOpStateWithSentWins — SENT-wins dedup (#264)', () => {
     expect(fqById.size).toBe(2);
   });
 
-  it('amplification-minimal: entries shared by both sides appear ONCE in merged output (steelman fix)', () => {
-    // Pre-fix the union re-emitted every `previous` entry through the
-    // per-entry writer, even for ids already present in `current`.
-    // Because `writeProfileKey` encrypts with a fresh random IV, a
-    // redundant re-emit lands a new OrbitDB OpLog row even when the
-    // plaintext is identical — O(previous-size) OpLog amplification
-    // per recovery cycle under sustained cross-device churn.
-    //
-    // The amplification-minimal contract: the merged array MUST
-    // include each shared id exactly ONCE (current's value wins),
-    // not twice.
-    const shared = { id: 'transfer-shared', status: 'submitted' };
-    const sharedPrev = { id: 'transfer-shared', status: 'pending' }; // older state
-    const prev: OpStateArrays = {
-      ...emptyOpState(),
-      outbox: [
-        sharedPrev,
-        { id: 'transfer-prev-only', status: 'pending' },
-      ],
-      audit: [
-        { id: 'audit-shared', op: 'old' },
-        { id: 'audit-prev-only', op: 'prev' },
-      ],
-    };
+  it('intra-current duplicate ids collapse to one entry per id (regression test for prior amplification-minimal variant)', () => {
+    // Steelman finding (round 2): a prior remediation variant lost the
+    // Map-based intra-source dedup, so `currentOp.outbox = [{id:A,v:1},
+    // {id:A,v:2}]` produced TWO entries in merged.outbox. This test
+    // pins the naive-Map contract: duplicate ids within a single
+    // source collapse, with later-inserted winning.
     const curr: OpStateArrays = {
       ...emptyOpState(),
-      outbox: [shared],
-      audit: [{ id: 'audit-shared', op: 'new' }],
+      outbox: [
+        { id: 'A', v: 1 },
+        { id: 'A', v: 2 }, // intra-current dup
+        { id: 'B', v: 1 },
+      ],
     };
+    const prev: OpStateArrays = emptyOpState();
     const { merged } = unionOpStateWithSentWins(curr, prev);
-    // OUTBOX: shared id appears ONCE; prev-only id appears.
+    // 2 ids → 2 entries (NOT 3).
     expect(merged.outbox).toHaveLength(2);
-    const outboxIds = merged.outbox.map((e) => (e as { id: string }).id).sort();
-    expect(outboxIds).toEqual(['transfer-prev-only', 'transfer-shared']);
-    // current wins for shared id (proves we kept current's value, not previous's).
-    const sharedEntry = merged.outbox.find(
-      (e) => (e as { id: string }).id === 'transfer-shared',
-    ) as { status: string };
-    expect(sharedEntry.status).toBe('submitted');
-    // AUDIT: same contract.
-    expect(merged.audit).toHaveLength(2);
-    const auditShared = merged.audit.find(
-      (e) => (e as { id: string }).id === 'audit-shared',
-    ) as { op: string };
-    expect(auditShared.op).toBe('new');
-  });
-
-  it('amplification-minimal: previous-ONLY entries fill in the gap (steelman fix)', () => {
-    // The fill-in case the auto-merge actually needs: previous has
-    // entries that current is missing. These MUST be added to merged
-    // (otherwise the per-entry diff would tombstone them by omission).
-    const prev: OpStateArrays = {
-      ...emptyOpState(),
-      outbox: [
-        { id: 'transfer-A', status: 'pending' },
-        { id: 'transfer-B', status: 'pending' },
-        { id: 'transfer-C', status: 'pending' },
-      ],
-    };
-    const curr: OpStateArrays = {
-      ...emptyOpState(),
-      // current is missing A and B — perhaps the partial-save bug
-      // that triggered the auto-merge in the first place.
-      outbox: [{ id: 'transfer-C', status: 'submitted' }],
-    };
-    const { merged } = unionOpStateWithSentWins(curr, prev);
-    expect(merged.outbox).toHaveLength(3);
     const byId = new Map<string, unknown>();
     for (const e of merged.outbox) byId.set((e as { id: string }).id, e);
-    // A and B filled in from previous; C stays from current (updated state).
-    expect((byId.get('transfer-A') as { status: string }).status).toBe('pending');
-    expect((byId.get('transfer-B') as { status: string }).status).toBe('pending');
-    expect((byId.get('transfer-C') as { status: string }).status).toBe('submitted');
+    expect(byId.size).toBe(2);
+    // Last-inserted wins for the duplicate id.
+    expect((byId.get('A') as { v: number }).v).toBe(2);
+    expect((byId.get('B') as { v: number }).v).toBe(1);
   });
 
-  it('SENT-wins triggers only on string id equality — null/undefined ids are ignored', () => {
+  it('empty-string id is dedup-able (regression test for prior amplification-minimal variant)', () => {
+    // Steelman finding (round 2): the prior variant routed `id: ''`
+    // through the no-id bucket, losing dedup. Naive Map treats empty
+    // strings as valid keys. Two entries with `id: ''` collapse.
+    const curr: OpStateArrays = {
+      ...emptyOpState(),
+      outbox: [{ id: '', x: 'curr' }],
+    };
+    const prev: OpStateArrays = {
+      ...emptyOpState(),
+      outbox: [{ id: '', x: 'prev' }],
+    };
+    const { merged } = unionOpStateWithSentWins(curr, prev);
+    // One entry with id '' (collapsed), current wins.
+    expect(merged.outbox).toHaveLength(1);
+    expect((merged.outbox[0] as { id: string; x: string }).id).toBe('');
+    expect((merged.outbox[0] as { x: string }).x).toBe('curr');
+  });
+
+  it('SENT-wins triggers only on string id equality — non-string ids are ignored', () => {
+    // `readId` accepts ANY string (including empty); SENT-wins fires
+    // for both. But non-string ids (null, undefined, numeric, object)
+    // are NOT treated as valid ids — they fall through to the no-id
+    // bucket and never match SENT entries.
     const prev: OpStateArrays = {
       ...emptyOpState(),
       outbox: [
-        { id: '', status: 'pending' }, // empty id — readId returns undefined
+        { id: null as unknown as string, status: 'pending' },
+        { id: undefined as unknown as string, status: 'pending' },
+        { id: 42 as unknown as string, status: 'pending' },
         { id: 'transfer-A', status: 'pending' },
       ],
     };
     const curr: OpStateArrays = {
       ...emptyOpState(),
       sent: [
-        { _schemaVersion: 'uxf-1', id: '', tokenIds: ['tk'], bundleCid: 'b' }, // empty id
+        { _schemaVersion: 'uxf-1', id: 'transfer-A', tokenIds: ['tk'], bundleCid: 'b' },
       ],
     };
     const { merged, droppedOutboxIds } = unionOpStateWithSentWins(curr, prev);
-    // Empty-id outbox entry stays (no SENT match by valid id).
-    expect(merged.outbox).toHaveLength(2);
-    expect(droppedOutboxIds).toEqual([]);
+    // SENT-wins drops transfer-A from outbox; the 3 non-string-id
+    // entries fall through to the no-id bucket and survive unchanged.
+    expect(merged.outbox).toHaveLength(3);
+    expect(droppedOutboxIds).toEqual(['transfer-A']);
+    // None of the 3 surviving outbox entries should be the dropped 'transfer-A'.
+    const survivingIds = merged.outbox.map((e) => (e as { id: unknown }).id);
+    expect(survivingIds).not.toContain('transfer-A');
+    expect(survivingIds).toContain(null);
+    expect(survivingIds).toContain(undefined);
+    expect(survivingIds).toContain(42);
   });
 });
 

--- a/tests/unit/profile/monotonicity-auto-merge.test.ts
+++ b/tests/unit/profile/monotonicity-auto-merge.test.ts
@@ -244,6 +244,81 @@ describe('unionOpStateWithSentWins — SENT-wins dedup (#264)', () => {
     expect(fqById.size).toBe(2);
   });
 
+  it('amplification-minimal: entries shared by both sides appear ONCE in merged output (steelman fix)', () => {
+    // Pre-fix the union re-emitted every `previous` entry through the
+    // per-entry writer, even for ids already present in `current`.
+    // Because `writeProfileKey` encrypts with a fresh random IV, a
+    // redundant re-emit lands a new OrbitDB OpLog row even when the
+    // plaintext is identical — O(previous-size) OpLog amplification
+    // per recovery cycle under sustained cross-device churn.
+    //
+    // The amplification-minimal contract: the merged array MUST
+    // include each shared id exactly ONCE (current's value wins),
+    // not twice.
+    const shared = { id: 'transfer-shared', status: 'submitted' };
+    const sharedPrev = { id: 'transfer-shared', status: 'pending' }; // older state
+    const prev: OpStateArrays = {
+      ...emptyOpState(),
+      outbox: [
+        sharedPrev,
+        { id: 'transfer-prev-only', status: 'pending' },
+      ],
+      audit: [
+        { id: 'audit-shared', op: 'old' },
+        { id: 'audit-prev-only', op: 'prev' },
+      ],
+    };
+    const curr: OpStateArrays = {
+      ...emptyOpState(),
+      outbox: [shared],
+      audit: [{ id: 'audit-shared', op: 'new' }],
+    };
+    const { merged } = unionOpStateWithSentWins(curr, prev);
+    // OUTBOX: shared id appears ONCE; prev-only id appears.
+    expect(merged.outbox).toHaveLength(2);
+    const outboxIds = merged.outbox.map((e) => (e as { id: string }).id).sort();
+    expect(outboxIds).toEqual(['transfer-prev-only', 'transfer-shared']);
+    // current wins for shared id (proves we kept current's value, not previous's).
+    const sharedEntry = merged.outbox.find(
+      (e) => (e as { id: string }).id === 'transfer-shared',
+    ) as { status: string };
+    expect(sharedEntry.status).toBe('submitted');
+    // AUDIT: same contract.
+    expect(merged.audit).toHaveLength(2);
+    const auditShared = merged.audit.find(
+      (e) => (e as { id: string }).id === 'audit-shared',
+    ) as { op: string };
+    expect(auditShared.op).toBe('new');
+  });
+
+  it('amplification-minimal: previous-ONLY entries fill in the gap (steelman fix)', () => {
+    // The fill-in case the auto-merge actually needs: previous has
+    // entries that current is missing. These MUST be added to merged
+    // (otherwise the per-entry diff would tombstone them by omission).
+    const prev: OpStateArrays = {
+      ...emptyOpState(),
+      outbox: [
+        { id: 'transfer-A', status: 'pending' },
+        { id: 'transfer-B', status: 'pending' },
+        { id: 'transfer-C', status: 'pending' },
+      ],
+    };
+    const curr: OpStateArrays = {
+      ...emptyOpState(),
+      // current is missing A and B — perhaps the partial-save bug
+      // that triggered the auto-merge in the first place.
+      outbox: [{ id: 'transfer-C', status: 'submitted' }],
+    };
+    const { merged } = unionOpStateWithSentWins(curr, prev);
+    expect(merged.outbox).toHaveLength(3);
+    const byId = new Map<string, unknown>();
+    for (const e of merged.outbox) byId.set((e as { id: string }).id, e);
+    // A and B filled in from previous; C stays from current (updated state).
+    expect((byId.get('transfer-A') as { status: string }).status).toBe('pending');
+    expect((byId.get('transfer-B') as { status: string }).status).toBe('pending');
+    expect((byId.get('transfer-C') as { status: string }).status).toBe('submitted');
+  });
+
   it('SENT-wins triggers only on string id equality — null/undefined ids are ignored', () => {
     const prev: OpStateArrays = {
       ...emptyOpState(),

--- a/tests/unit/profile/monotonicity-auto-merge.test.ts
+++ b/tests/unit/profile/monotonicity-auto-merge.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Issue #264 — focused unit tests for the auto-merge primitives
+ * introduced by `fix(profile)(#264): auto-merge monotonicity
+ * violations in flush-scheduler`.
+ *
+ * Two surfaces are pinned here:
+ *
+ *   1. `unionOpStateWithSentWins(current, previous)` — the helper
+ *      that constructs the merged `OperationalState` so the
+ *      per-entry-key OrbitDB write doesn't tombstone live entries.
+ *      Tests cover the SENT-wins-over-OUTBOX dedup rule (the spec's
+ *      explicit ask), id-based union behavior across all collections,
+ *      no-id fall-through, and the `droppedOutboxIds` audit output.
+ *
+ *   2. `enablePointerWinBroadcasts` default-OFF policy — verified at
+ *      the ProfilePointerLayer + lifecycle-manager seam. The publisher
+ *      side (`storage:pointer-published` emit) MUST stay silent when
+ *      the flag is unset or explicitly false, and MUST fire when the
+ *      flag is explicitly `true`. Strict `=== true` coercion is
+ *      asserted so accidental truthy non-boolean values (`'true'`,
+ *      `1`) fail closed.
+ *
+ * Sibling-adoption test cases from #263 were never landed on this
+ * branch (the `siblingHighestV` plumbing was intentionally omitted
+ * per #264 — see commit `perf(profile)(#264): fast-path skip Step B
+ * discovery on attempts === 0`). There is therefore no
+ * `reconcile-and-publish.test.ts` to drop sibling cases from on this
+ * branch; the issue's "drop the 2 sibling-adoption cases" instruction
+ * is satisfied by construction.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  type OpStateArrays,
+  unionOpStateWithSentWins,
+} from '../../../profile/profile-token-storage/flush-scheduler';
+import type { ProfileDatabase, OrbitDbConfig } from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import {
+  buildPointerSigner,
+  createMasterPrivateKey,
+  derivePointerKeyMaterial,
+  ProfilePointerLayer,
+  type PointerSigner,
+} from '../../../profile/aggregator-pointer';
+import type { StorageEvent } from '../../../storage/storage-provider';
+
+// ---------------------------------------------------------------------------
+// Test 1: unionOpStateWithSentWins
+// ---------------------------------------------------------------------------
+
+function emptyOpState(): OpStateArrays {
+  return {
+    tombstones: [],
+    outbox: [],
+    sent: [],
+    invalid: [],
+    history: [],
+    mintOutbox: [],
+    invalidatedNametags: [],
+    audit: [],
+    finalizationQueue: [],
+  };
+}
+
+describe('unionOpStateWithSentWins — SENT-wins dedup (#264)', () => {
+  it('returns empty arrays when both inputs are empty', () => {
+    const { merged, droppedOutboxIds } = unionOpStateWithSentWins(
+      emptyOpState(),
+      emptyOpState(),
+    );
+    expect(droppedOutboxIds).toEqual([]);
+    for (const key of Object.keys(merged) as (keyof OpStateArrays)[]) {
+      expect(merged[key]).toEqual([]);
+    }
+  });
+
+  it('unions OUTBOX entries by id; current value wins on collision', () => {
+    const prev: OpStateArrays = {
+      ...emptyOpState(),
+      outbox: [
+        { id: 'transfer-A', status: 'pending', oldField: 'old' },
+        { id: 'transfer-B', status: 'pending' },
+      ],
+    };
+    const curr: OpStateArrays = {
+      ...emptyOpState(),
+      outbox: [
+        { id: 'transfer-A', status: 'submitted', newField: 'new' },
+      ],
+    };
+    const { merged } = unionOpStateWithSentWins(curr, prev);
+    // Both ids present after the union.
+    const byId = new Map<string, unknown>();
+    for (const e of merged.outbox) {
+      const id = (e as { id: string }).id;
+      byId.set(id, e);
+    }
+    expect(byId.size).toBe(2);
+    // transfer-A from CURRENT (newer view wins on conflict).
+    expect(byId.get('transfer-A')).toEqual({
+      id: 'transfer-A',
+      status: 'submitted',
+      newField: 'new',
+    });
+    // transfer-B carried through from previous.
+    expect(byId.get('transfer-B')).toEqual({ id: 'transfer-B', status: 'pending' });
+  });
+
+  it('drops OUTBOX entries whose id matches a SENT entry (SENT wins)', () => {
+    const prev: OpStateArrays = {
+      ...emptyOpState(),
+      outbox: [
+        { id: 'transfer-A', status: 'pending' }, // stale — has moved to SENT
+        { id: 'transfer-C', status: 'pending' }, // still live in OUTBOX
+      ],
+    };
+    const curr: OpStateArrays = {
+      ...emptyOpState(),
+      sent: [
+        {
+          _schemaVersion: 'uxf-1',
+          id: 'transfer-A',
+          tokenIds: ['tk1'],
+          bundleCid: 'bafy-sent-A',
+        },
+      ],
+    };
+    const { merged, droppedOutboxIds } = unionOpStateWithSentWins(curr, prev);
+    // SENT entry is preserved.
+    expect(merged.sent).toHaveLength(1);
+    expect((merged.sent[0] as { id: string }).id).toBe('transfer-A');
+    // OUTBOX no longer has the SENT-shadowed id.
+    const outboxIds = merged.outbox.map((e) => (e as { id: string }).id);
+    expect(outboxIds).not.toContain('transfer-A');
+    expect(outboxIds).toContain('transfer-C');
+    // Dropped id is surfaced for operator audit.
+    expect(droppedOutboxIds).toContain('transfer-A');
+    expect(droppedOutboxIds).not.toContain('transfer-C');
+  });
+
+  it('drops MULTIPLE OUTBOX entries when several SENT entries shadow them', () => {
+    const prev: OpStateArrays = {
+      ...emptyOpState(),
+      outbox: [
+        { id: 'transfer-A', status: 'pending' },
+        { id: 'transfer-B', status: 'pending' },
+        { id: 'transfer-C', status: 'pending' },
+      ],
+    };
+    const curr: OpStateArrays = {
+      ...emptyOpState(),
+      sent: [
+        { _schemaVersion: 'uxf-1', id: 'transfer-A', tokenIds: ['tk1'], bundleCid: 'b1' },
+        { _schemaVersion: 'uxf-1', id: 'transfer-B', tokenIds: ['tk2'], bundleCid: 'b2' },
+      ],
+    };
+    const { merged, droppedOutboxIds } = unionOpStateWithSentWins(curr, prev);
+    expect(merged.outbox.map((e) => (e as { id: string }).id)).toEqual(['transfer-C']);
+    expect(droppedOutboxIds.sort()).toEqual(['transfer-A', 'transfer-B']);
+  });
+
+  it('unions SENT entries by id; current wins on collision', () => {
+    const prev: OpStateArrays = {
+      ...emptyOpState(),
+      sent: [
+        { _schemaVersion: 'uxf-1', id: 'transfer-A', tokenIds: ['tk-old'], bundleCid: 'b-old' },
+        { _schemaVersion: 'uxf-1', id: 'transfer-B', tokenIds: ['tk-B'], bundleCid: 'b-B' },
+      ],
+    };
+    const curr: OpStateArrays = {
+      ...emptyOpState(),
+      sent: [
+        { _schemaVersion: 'uxf-1', id: 'transfer-A', tokenIds: ['tk-new'], bundleCid: 'b-new' },
+      ],
+    };
+    const { merged } = unionOpStateWithSentWins(curr, prev);
+    const byId = new Map<string, unknown>();
+    for (const e of merged.sent) byId.set((e as { id: string }).id, e);
+    expect(byId.size).toBe(2);
+    // current wins for transfer-A
+    expect((byId.get('transfer-A') as { tokenIds: string[] }).tokenIds).toEqual(['tk-new']);
+    expect((byId.get('transfer-A') as { bundleCid: string }).bundleCid).toBe('b-new');
+    // previous carried for transfer-B
+    expect((byId.get('transfer-B') as { tokenIds: string[] }).tokenIds).toEqual(['tk-B']);
+  });
+
+  it('unions TOMBSTONES by tokenId; non-tokenId entries dedup by JSON', () => {
+    const prev: OpStateArrays = {
+      ...emptyOpState(),
+      tombstones: [
+        { tokenId: 'tk1', reason: 'old' },
+        { tokenId: 'tk2', reason: 'previous' },
+        { meta: 'no-tokenId-old' },
+      ],
+    };
+    const curr: OpStateArrays = {
+      ...emptyOpState(),
+      tombstones: [
+        { tokenId: 'tk1', reason: 'new' }, // collides — current wins
+        { meta: 'no-tokenId-new' },
+        { meta: 'no-tokenId-old' }, // same JSON as previous → deduped
+      ],
+    };
+    const { merged } = unionOpStateWithSentWins(curr, prev);
+    const byTokenId = new Map<string, unknown>();
+    const noId: unknown[] = [];
+    for (const e of merged.tombstones) {
+      const tid = (e as { tokenId?: string }).tokenId;
+      if (typeof tid === 'string') byTokenId.set(tid, e);
+      else noId.push(e);
+    }
+    expect(byTokenId.size).toBe(2);
+    expect(byTokenId.get('tk1')).toEqual({ tokenId: 'tk1', reason: 'new' });
+    expect(byTokenId.get('tk2')).toEqual({ tokenId: 'tk2', reason: 'previous' });
+    // Two distinct no-tokenId meta entries (old + new), dup of old removed.
+    expect(noId).toHaveLength(2);
+    const metaValues = noId.map((e) => (e as { meta: string }).meta).sort();
+    expect(metaValues).toEqual(['no-tokenId-new', 'no-tokenId-old']);
+  });
+
+  it('keeps audit and finalizationQueue entries with stable id semantics', () => {
+    const prev: OpStateArrays = {
+      ...emptyOpState(),
+      audit: [{ id: 'audit-1', op: 'prev' }],
+      finalizationQueue: [{ id: 'fq-1', payload: 'prev' }],
+    };
+    const curr: OpStateArrays = {
+      ...emptyOpState(),
+      audit: [{ id: 'audit-2', op: 'curr' }, { id: 'audit-1', op: 'curr-overwrite' }],
+      finalizationQueue: [{ id: 'fq-2', payload: 'curr' }],
+    };
+    const { merged } = unionOpStateWithSentWins(curr, prev);
+    const auditById = new Map<string, unknown>();
+    for (const e of merged.audit) auditById.set((e as { id: string }).id, e);
+    expect(auditById.size).toBe(2);
+    // current wins for audit-1
+    expect(auditById.get('audit-1')).toEqual({ id: 'audit-1', op: 'curr-overwrite' });
+    expect(auditById.get('audit-2')).toEqual({ id: 'audit-2', op: 'curr' });
+    const fqById = new Map<string, unknown>();
+    for (const e of merged.finalizationQueue) fqById.set((e as { id: string }).id, e);
+    expect(fqById.size).toBe(2);
+  });
+
+  it('SENT-wins triggers only on string id equality — null/undefined ids are ignored', () => {
+    const prev: OpStateArrays = {
+      ...emptyOpState(),
+      outbox: [
+        { id: '', status: 'pending' }, // empty id — readId returns undefined
+        { id: 'transfer-A', status: 'pending' },
+      ],
+    };
+    const curr: OpStateArrays = {
+      ...emptyOpState(),
+      sent: [
+        { _schemaVersion: 'uxf-1', id: '', tokenIds: ['tk'], bundleCid: 'b' }, // empty id
+      ],
+    };
+    const { merged, droppedOutboxIds } = unionOpStateWithSentWins(curr, prev);
+    // Empty-id outbox entry stays (no SENT match by valid id).
+    expect(merged.outbox).toHaveLength(2);
+    expect(droppedOutboxIds).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: enablePointerWinBroadcasts default-OFF policy
+// ---------------------------------------------------------------------------
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+const FAKE_CID = 'bafkreigh2akiscaildc6ovwc6m3fy5puxhxcw7qveyf2nbn7xmqwfajeuy';
+
+function createMockDb(): ProfileDatabase & { _store: Map<string, Uint8Array> } {
+  const store = new Map<string, Uint8Array>();
+  return {
+    _store: store,
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) { store.set(key, value); },
+    async get(key: string) { return store.get(key) ?? null; },
+    async del(key: string) { store.delete(key); },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() { return () => {}; },
+    isConnected() { return true; },
+  } as ProfileDatabase & { _store: Map<string, Uint8Array> };
+}
+
+async function buildRealSigner(): Promise<PointerSigner> {
+  const seed = new Uint8Array(32).fill(0x42);
+  const masterKey = createMasterPrivateKey(seed);
+  const keyMaterial = derivePointerKeyMaterial(masterKey);
+  return buildPointerSigner(keyMaterial.signingSeed);
+}
+
+/**
+ * Build a real `ProfilePointerLayer` with `publish` stubbed to a
+ * deterministic success. The flag plumbing IS tested via the real
+ * constructor's normalized-config snapshot.
+ */
+async function buildRealPointerWithFlag(
+  enablePointerWinBroadcasts: boolean | undefined,
+): Promise<ProfilePointerLayer> {
+  const signer = await buildRealSigner();
+  const layer = new ProfilePointerLayer({
+    keyMaterial: { signingSeed: new Uint8Array(32), xorSeed: new Uint8Array(32) } as never,
+    signer,
+    aggregatorClient: {} as never,
+    trustBase: {} as never,
+    flagStore: {} as never,
+    mutex: {} as never,
+    decodeCid: (() => ({ bytes: new Uint8Array(0) })) as never,
+    fetchCar: (async () => ({ bytes: new Uint8Array(0) })) as never,
+    fetchAndJoin: async () => {},
+    readLocalVersion: async () => 0 as never,
+    persistLocalVersion: async () => {},
+    resolveRemoteCid: async () => new Uint8Array(0),
+    config:
+      enablePointerWinBroadcasts === undefined
+        ? undefined
+        : { enablePointerWinBroadcasts },
+  });
+  // Stub publish to a deterministic success.
+  (layer as unknown as { publish: () => Promise<unknown> }).publish = async () => ({
+    version: 11,
+    attemptsUsed: 1,
+  });
+  return layer;
+}
+
+async function createHarness(pointer: ProfilePointerLayer): Promise<{
+  events: StorageEvent[];
+  publish: (cid: string) => Promise<{ ok: boolean; transient: boolean; code?: string }>;
+  shutdown: () => Promise<void>;
+}> {
+  const db = createMockDb();
+  const provider = new ProfileTokenStorageProvider(
+    db,
+    new Uint8Array(32).fill(0x11),
+    ['https://mock-ipfs.test'],
+    {
+      config: { orbitDb: { privateKey: TEST_PRIVATE_KEY }, ipnsSnapshot: false },
+      addressId: 'test',
+      encrypt: true,
+      getPointerLayer: () => pointer,
+    },
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  await provider.initialize();
+  const events: StorageEvent[] = [];
+  if (typeof provider.onEvent === 'function') {
+    provider.onEvent((event) => { events.push(event); });
+  }
+  const lifecycle = (provider as unknown as {
+    lifecycleManager: {
+      publishAggregatorPointerBestEffort(
+        cid: string,
+      ): Promise<{ ok: boolean; transient: boolean; code?: string }>;
+    };
+  }).lifecycleManager;
+  return {
+    events,
+    publish: (cid: string) => lifecycle.publishAggregatorPointerBestEffort(cid),
+    shutdown: () => provider.shutdown(),
+  };
+}
+
+describe('enablePointerWinBroadcasts — default-OFF policy (#264)', () => {
+  beforeEach(() => { vi.useRealTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('default (no config): winBroadcastsEnabled() returns false; lifecycle-manager skips storage:pointer-published emit', async () => {
+    const pointer = await buildRealPointerWithFlag(undefined);
+    expect(pointer.winBroadcastsEnabled()).toBe(false);
+
+    const h = await createHarness(pointer);
+    const result = await h.publish(FAKE_CID);
+    expect(result.ok).toBe(true);
+
+    // Gate trips → no storage:pointer-published event.
+    expect(h.events.find((e) => e.type === 'storage:pointer-published')).toBeUndefined();
+
+    await h.shutdown();
+  });
+
+  it('explicit false: same suppression as default', async () => {
+    const pointer = await buildRealPointerWithFlag(false);
+    expect(pointer.winBroadcastsEnabled()).toBe(false);
+
+    const h = await createHarness(pointer);
+    const result = await h.publish(FAKE_CID);
+    expect(result.ok).toBe(true);
+    expect(h.events.find((e) => e.type === 'storage:pointer-published')).toBeUndefined();
+
+    await h.shutdown();
+  });
+
+  it('explicit true: storage:pointer-published fires with signed payload + tag', async () => {
+    const pointer = await buildRealPointerWithFlag(true);
+    expect(pointer.winBroadcastsEnabled()).toBe(true);
+
+    const h = await createHarness(pointer);
+    const result = await h.publish(FAKE_CID);
+    expect(result.ok).toBe(true);
+
+    const published = h.events.find((e) => e.type === 'storage:pointer-published');
+    expect(published).toBeDefined();
+    const data = published!.data as {
+      cid?: string;
+      version?: number;
+      signedPayloadJson?: string;
+      broadcastTag?: string;
+    };
+    expect(data.cid).toBe(FAKE_CID);
+    expect(data.version).toBe(11);
+    expect(typeof data.signedPayloadJson).toBe('string');
+    expect(typeof data.broadcastTag).toBe('string');
+
+    await h.shutdown();
+  });
+
+  it('truthy non-boolean (string "true", number 1) is coerced to false — strict === true policy', async () => {
+    // Pass `'true'` as a string and `1` as a number — both are truthy
+    // but should fail closed per the normalization in ProfilePointerLayer's
+    // frozen config snapshot (defense against accidentally truthy values
+    // from env-var unmarshalling, JSON parsing, etc.).
+    for (const accidental of ['true' as unknown as boolean, 1 as unknown as boolean]) {
+      const pointer = await buildRealPointerWithFlag(accidental);
+      expect(pointer.winBroadcastsEnabled()).toBe(false);
+      const h = await createHarness(pointer);
+      const result = await h.publish(FAKE_CID);
+      expect(result.ok).toBe(true);
+      expect(h.events.find((e) => e.type === 'storage:pointer-published')).toBeUndefined();
+      await h.shutdown();
+    }
+  });
+});

--- a/tests/unit/profile/monotonicity-inline-merge.test.ts
+++ b/tests/unit/profile/monotonicity-inline-merge.test.ts
@@ -392,7 +392,13 @@ describe('FlushScheduler — in-place monotonicity recovery (#255)', () => {
     await provider.shutdown();
   });
 
-  it('on unknown bundle whose fetch FAILS, falls back to throwing the violation (legacy safety net)', async () => {
+  it('on unknown bundle whose fetch FAILS, auto-merge surfaces the residual via events but flush continues (#264)', async () => {
+    // Issue #264 — the legacy throw is replaced by an auto-merge that
+    // logs warn-level and proceeds. The unfetchable CID is reported on
+    // BOTH `storage:monotonicity-recovered` (as a residual) AND on
+    // legacy `storage:error` with POINTER_MONOTONICITY_VIOLATION (so
+    // dashboards keyed on the literal still fire), but NO throw escapes
+    // the flush body.
     const provider = createProvider(db);
     await provider.initialize();
 
@@ -412,7 +418,7 @@ describe('FlushScheduler — in-place monotonicity recovery (#255)', () => {
     }).lastLoadedFromBundleCids = new Set([localCid]);
 
     // The foreign bundle is in OrbitDB but its CAR is NOT in fetchByCid
-    // → the stub throws → inline merge fails → falls back to violation.
+    // → the stub throws → inline merge fails → residual after auto-merge.
     const tokenRemote = { id: '_TR', genesis: { tokenId: 'TR' } };
     const remoteCarBytes = await makeFakeUxfCar({ tokens: [tokenRemote] });
     const remoteCid = await extractCarRootCid(remoteCarBytes);
@@ -428,9 +434,12 @@ describe('FlushScheduler — in-place monotonicity recovery (#255)', () => {
       pendingData;
 
     const violationEvents: Array<{ code?: string; data?: unknown }> = [];
+    const recoveredEvents: Array<{ data?: unknown }> = [];
     provider.onEvent((evt) => {
       if (evt.type === 'storage:error' && evt.code === POINTER_MONOTONICITY_VIOLATION) {
         violationEvents.push({ code: evt.code, data: evt.data });
+      } else if (evt.type === 'storage:monotonicity-recovered') {
+        recoveredEvents.push({ data: evt.data });
       }
     });
 
@@ -447,13 +456,25 @@ describe('FlushScheduler — in-place monotonicity recovery (#255)', () => {
       thrown = err;
     }
 
-    expect(thrown).toBeDefined();
-    expect((thrown as { code?: string }).code).toBe(POINTER_MONOTONICITY_VIOLATION);
-    expect(fetchCalls).toBe(1); // we tried
-    expect(violationEvents.length).toBeGreaterThan(0);
+    // Issue #264 — no throw escapes the flush body.
+    expect(thrown).toBeNull();
+    expect(fetchCalls).toBe(1); // we tried the inline fetch
 
-    // The CID stays in the alert payload because the inline recovery
-    // failed for it.
+    // The recovered event surfaces the residual unknown bundle.
+    expect(recoveredEvents.length).toBe(1);
+    const recoveredData = recoveredEvents[0]!.data as {
+      mergedUnknownBundleCount: number;
+      residualUnknownBundleCids: string[];
+      residualUnknownBundleCount: number;
+      recoveredTokenCount: number;
+    };
+    expect(recoveredData.mergedUnknownBundleCount).toBe(0);
+    expect(recoveredData.residualUnknownBundleCount).toBe(1);
+    expect(recoveredData.residualUnknownBundleCids).toContain(remoteCid);
+    expect(recoveredData.recoveredTokenCount).toBe(0);
+
+    // The legacy storage:error event also fires for dashboards.
+    expect(violationEvents.length).toBeGreaterThan(0);
     const alert = violationEvents.find(
       (e) => (e.data as { alert?: string } | undefined)?.alert === 'transfer:operator-alert',
     );
@@ -461,14 +482,16 @@ describe('FlushScheduler — in-place monotonicity recovery (#255)', () => {
     const data = alert!.data as {
       unknownBundleCids: string[];
       unknownBundleCount: number;
+      autoMergeResidual?: boolean;
     };
     expect(data.unknownBundleCount).toBe(1);
     expect(data.unknownBundleCids).toContain(remoteCid);
+    expect(data.autoMergeResidual).toBe(true);
 
     await provider.shutdown();
   });
 
-  it('when multiple unknown bundles are present, all fetchable ones are merged; only fetch-failed ones surface in the violation', async () => {
+  it('when multiple unknown bundles are present, all fetchable ones are merged; only fetch-failed ones surface as residual (#264)', async () => {
     const provider = createProvider(db);
     await provider.initialize();
 
@@ -526,18 +549,24 @@ describe('FlushScheduler — in-place monotonicity recovery (#255)', () => {
 
     // Both fetches were attempted.
     expect(fetchCalls).toBe(2);
-    // The throw still fires because cidB couldn't be merged.
-    expect(thrown).toBeDefined();
-    expect((thrown as { code?: string }).code).toBe(POINTER_MONOTONICITY_VIOLATION);
+    // Issue #264 — no throw escapes; flush continues with the
+    // best-effort superset including cidA's tokens.
+    expect(thrown).toBeNull();
 
     // cidA WAS added to the baseline (the inline merge succeeded for it).
+    // cidB stays OUT of the baseline so the NEXT flush re-evaluates the
+    // bundle-set check and re-attempts the inline fetch (per #264 the
+    // legacy refreshBaselineForMonotonicity microtask was intentionally
+    // removed; a refresh would have marked cidB as "in baseline" and
+    // silently skipped the residual retry on subsequent flushes).
     const baseline = (provider as unknown as {
       lastLoadedFromBundleCids: Set<string>;
     }).lastLoadedFromBundleCids;
     expect(baseline.has(cidA)).toBe(true);
     expect(baseline.has(cidB)).toBe(false);
 
-    // The violation payload mentions ONLY cidB.
+    // The legacy storage:error payload (kept for dashboards keyed on
+    // the literal POINTER_MONOTONICITY_VIOLATION) mentions ONLY cidB.
     const alert = violationEvents.find(
       (e) => (e.data as { alert?: string } | undefined)?.alert === 'transfer:operator-alert',
     );
@@ -545,10 +574,12 @@ describe('FlushScheduler — in-place monotonicity recovery (#255)', () => {
     const data = alert!.data as {
       unknownBundleCids: string[];
       unknownBundleCount: number;
+      autoMergeResidual?: boolean;
     };
     expect(data.unknownBundleCount).toBe(1);
     expect(data.unknownBundleCids).toContain(cidB);
     expect(data.unknownBundleCids).not.toContain(cidA);
+    expect(data.autoMergeResidual).toBe(true);
 
     await provider.shutdown();
   });

--- a/tests/unit/profile/monotonicity-inline-merge.test.ts
+++ b/tests/unit/profile/monotonicity-inline-merge.test.ts
@@ -473,20 +473,26 @@ describe('FlushScheduler — in-place monotonicity recovery (#255)', () => {
     expect(recoveredData.residualUnknownBundleCids).toContain(remoteCid);
     expect(recoveredData.recoveredTokenCount).toBe(0);
 
-    // The legacy storage:error event also fires for dashboards.
+    // The legacy storage:error event also fires for dashboards,
+    // discriminated by `autoMergeResidual: true`. The pre-#264
+    // `alert: 'transfer:operator-alert'` field is INTENTIONALLY no
+    // longer emitted — see the residual-emit comment in
+    // flush-scheduler.ts for the on-call burnout rationale.
     expect(violationEvents.length).toBeGreaterThan(0);
     const alert = violationEvents.find(
-      (e) => (e.data as { alert?: string } | undefined)?.alert === 'transfer:operator-alert',
+      (e) => (e.data as { autoMergeResidual?: boolean } | undefined)?.autoMergeResidual === true,
     );
     expect(alert).toBeDefined();
     const data = alert!.data as {
       unknownBundleCids: string[];
       unknownBundleCount: number;
       autoMergeResidual?: boolean;
+      alert?: string;
     };
     expect(data.unknownBundleCount).toBe(1);
     expect(data.unknownBundleCids).toContain(remoteCid);
     expect(data.autoMergeResidual).toBe(true);
+    expect(data.alert).toBeUndefined();
 
     await provider.shutdown();
   });
@@ -567,19 +573,23 @@ describe('FlushScheduler — in-place monotonicity recovery (#255)', () => {
 
     // The legacy storage:error payload (kept for dashboards keyed on
     // the literal POINTER_MONOTONICITY_VIOLATION) mentions ONLY cidB.
+    // Discriminated by `autoMergeResidual: true`; the pre-#264
+    // `alert: 'transfer:operator-alert'` field is no longer set.
     const alert = violationEvents.find(
-      (e) => (e.data as { alert?: string } | undefined)?.alert === 'transfer:operator-alert',
+      (e) => (e.data as { autoMergeResidual?: boolean } | undefined)?.autoMergeResidual === true,
     );
     expect(alert).toBeDefined();
     const data = alert!.data as {
       unknownBundleCids: string[];
       unknownBundleCount: number;
       autoMergeResidual?: boolean;
+      alert?: string;
     };
     expect(data.unknownBundleCount).toBe(1);
     expect(data.unknownBundleCids).toContain(cidB);
     expect(data.unknownBundleCids).not.toContain(cidA);
     expect(data.autoMergeResidual).toBe(true);
+    expect(data.alert).toBeUndefined();
 
     await provider.shutdown();
   });

--- a/tests/unit/profile/pointer-monotonicity.test.ts
+++ b/tests/unit/profile/pointer-monotonicity.test.ts
@@ -494,19 +494,27 @@ describe('pointer monotonicity invariant', () => {
     expect(recoveredData.residualUnknownBundleCount).toBe(1);
     expect(recoveredData.residualUnknownBundleCids).toContain(remoteCid);
 
-    // The legacy storage:error event also fires for dashboards.
+    // The legacy storage:error event also fires for dashboards. The
+    // residual emit is discriminated by `autoMergeResidual: true` —
+    // pre-#264 the event also carried `alert: 'transfer:operator-alert'`
+    // which has been DROPPED to prevent on-call burnout on routine
+    // network transients (see the residual-emit comment in flush-
+    // scheduler.ts for the rationale).
     const alertEvent = errors.find(
-      (e) => (e.data as { alert?: string } | undefined)?.alert === 'transfer:operator-alert',
+      (e) => (e.data as { autoMergeResidual?: boolean } | undefined)?.autoMergeResidual === true,
     );
     expect(alertEvent).toBeDefined();
     const alertData = alertEvent!.data as {
       unknownBundleCids: string[];
       unknownBundleCount: number;
       autoMergeResidual?: boolean;
+      alert?: string;
     };
     expect(alertData.unknownBundleCount).toBe(1);
     expect(alertData.unknownBundleCids).toContain(remoteCid);
     expect(alertData.autoMergeResidual).toBe(true);
+    // The legacy paging field is no longer emitted.
+    expect(alertData.alert).toBeUndefined();
 
     await provider.shutdown();
   });
@@ -602,6 +610,85 @@ describe('pointer monotonicity invariant', () => {
 
     // No residual → no legacy `storage:error` should fire.
     expect(errors.length).toBe(0);
+
+    await provider.shutdown();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 3b: truncated=true boundary on the storage:monotonicity-recovered event
+  // ---------------------------------------------------------------------------
+  it('large-scale token-loss recovery (101+ tokens): recoveredTokenIds capped at 100 with truncated=true (#264)', async () => {
+    // Stresses the event-payload cap added in flush-scheduler.ts. The
+    // event surfaces up to 100 ids for log-volume control and sets a
+    // `truncated: true` flag when the full set exceeds the cap.
+    // Without this test, a regression flipping the cap or the flag
+    // would silently degrade operator visibility (e.g., a dashboard
+    // claiming "we recovered 100 tokens" when 5000 were actually
+    // re-merged).
+    installMockFetch(tracker, new Map());
+    const provider = createProvider(db, { flushDebounceMs: 20 });
+    await provider.initialize();
+
+    const TOKEN_COUNT = 150; // > 100 cap → triggers truncation.
+    const allTokens: Record<string, unknown> = {};
+    const allTokenIds: string[] = [];
+    for (let i = 0; i < TOKEN_COUNT; i++) {
+      const key = `_T${String(i).padStart(3, '0')}`;
+      allTokens[key] = { id: key, genesis: { tokenId: `T${i}` } };
+      allTokenIds.push(key);
+    }
+    const baseline = buildTxfData(allTokens);
+    (provider as unknown as {
+      lastLoadedData: TxfStorageDataBase;
+      lastLoadedFromBundleCids: Set<string>;
+    }).lastLoadedData = baseline;
+    (provider as unknown as {
+      lastLoadedFromBundleCids: Set<string>;
+    }).lastLoadedFromBundleCids = new Set();
+
+    // The about-to-flush data has only ONE token — all others would be
+    // dropped without the auto-merge.
+    const keptId = allTokenIds[0]!;
+    const partialData = buildTxfData({ [keptId]: allTokens[keptId] });
+
+    const flushScheduler = (
+      provider as unknown as {
+        flushScheduler: { flushToIpfs(): Promise<void> };
+      }
+    ).flushScheduler;
+    (provider as unknown as { pendingData: TxfStorageDataBase }).pendingData =
+      partialData;
+
+    const recovered: Array<{ data?: unknown }> = [];
+    provider.onEvent((evt) => {
+      if (evt.type === 'storage:monotonicity-recovered') {
+        recovered.push({ data: evt.data });
+      }
+    });
+
+    let thrown: unknown = null;
+    try {
+      await flushScheduler.flushToIpfs();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeNull();
+
+    expect(recovered.length).toBe(1);
+    const data = recovered[0]!.data as {
+      recoveredTokenIds: string[];
+      recoveredTokenCount: number;
+      truncated: boolean;
+    };
+    // Full count surfaced for monitoring totals (TOKEN_COUNT - 1
+    // re-merged; partialData kept 1).
+    expect(data.recoveredTokenCount).toBe(TOKEN_COUNT - 1);
+    // Array slice capped at 100 to bound log-line size.
+    expect(data.recoveredTokenIds.length).toBe(100);
+    // truncated flag MUST be set when count > slice length, otherwise
+    // operators reading "100 ids + count 149" would silently get a
+    // wrong picture.
+    expect(data.truncated).toBe(true);
 
     await provider.shutdown();
   });

--- a/tests/unit/profile/pointer-monotonicity.test.ts
+++ b/tests/unit/profile/pointer-monotonicity.test.ts
@@ -617,27 +617,26 @@ describe('pointer monotonicity invariant', () => {
   // ---------------------------------------------------------------------------
   // Test 3b: truncated=true boundary on the storage:monotonicity-recovered event
   // ---------------------------------------------------------------------------
-  it('large-scale token-loss recovery (101+ tokens): recoveredTokenIds capped at 100 with truncated=true (#264)', async () => {
-    // Stresses the event-payload cap added in flush-scheduler.ts. The
-    // event surfaces up to 100 ids for log-volume control and sets a
-    // `truncated: true` flag when the full set exceeds the cap.
-    // Without this test, a regression flipping the cap or the flag
-    // would silently degrade operator visibility (e.g., a dashboard
-    // claiming "we recovered 100 tokens" when 5000 were actually
-    // re-merged).
+  // Helper: drive the auto-merge with N tokens missing from current
+  // data, return the storage:monotonicity-recovered event payload.
+  async function runRecoveryWithMissingCount(
+    missingCount: number,
+  ): Promise<{
+    recoveredTokenIds: string[];
+    recoveredTokenCount: number;
+    truncated: boolean;
+  }> {
     installMockFetch(tracker, new Map());
     const provider = createProvider(db, { flushDebounceMs: 20 });
     await provider.initialize();
-
-    const TOKEN_COUNT = 150; // > 100 cap → triggers truncation.
-    const allTokens: Record<string, unknown> = {};
-    const allTokenIds: string[] = [];
-    for (let i = 0; i < TOKEN_COUNT; i++) {
-      const key = `_T${String(i).padStart(3, '0')}`;
-      allTokens[key] = { id: key, genesis: { tokenId: `T${i}` } };
-      allTokenIds.push(key);
+    // missingCount tokens in baseline that aren't in current data.
+    // Plus 1 token that IS in current to keep the data non-empty.
+    const baselineTokens: Record<string, unknown> = {};
+    for (let i = 0; i < missingCount + 1; i++) {
+      const key = `_T${String(i).padStart(4, '0')}`;
+      baselineTokens[key] = { id: key, genesis: { tokenId: `T${i}` } };
     }
-    const baseline = buildTxfData(allTokens);
+    const baseline = buildTxfData(baselineTokens);
     (provider as unknown as {
       lastLoadedData: TxfStorageDataBase;
       lastLoadedFromBundleCids: Set<string>;
@@ -645,52 +644,69 @@ describe('pointer monotonicity invariant', () => {
     (provider as unknown as {
       lastLoadedFromBundleCids: Set<string>;
     }).lastLoadedFromBundleCids = new Set();
-
-    // The about-to-flush data has only ONE token — all others would be
-    // dropped without the auto-merge.
-    const keptId = allTokenIds[0]!;
-    const partialData = buildTxfData({ [keptId]: allTokens[keptId] });
-
-    const flushScheduler = (
-      provider as unknown as {
-        flushScheduler: { flushToIpfs(): Promise<void> };
-      }
-    ).flushScheduler;
+    const partialKey = '_T0000';
+    const partialData = buildTxfData({
+      [partialKey]: baselineTokens[partialKey],
+    });
     (provider as unknown as { pendingData: TxfStorageDataBase }).pendingData =
       partialData;
-
     const recovered: Array<{ data?: unknown }> = [];
     provider.onEvent((evt) => {
       if (evt.type === 'storage:monotonicity-recovered') {
         recovered.push({ data: evt.data });
       }
     });
-
-    let thrown: unknown = null;
-    try {
-      await flushScheduler.flushToIpfs();
-    } catch (err) {
-      thrown = err;
-    }
-    expect(thrown).toBeNull();
-
+    const flushScheduler = (
+      provider as unknown as {
+        flushScheduler: { flushToIpfs(): Promise<void> };
+      }
+    ).flushScheduler;
+    await flushScheduler.flushToIpfs();
+    await provider.shutdown();
     expect(recovered.length).toBe(1);
-    const data = recovered[0]!.data as {
+    return recovered[0]!.data as {
       recoveredTokenIds: string[];
       recoveredTokenCount: number;
       truncated: boolean;
     };
-    // Full count surfaced for monitoring totals (TOKEN_COUNT - 1
-    // re-merged; partialData kept 1).
-    expect(data.recoveredTokenCount).toBe(TOKEN_COUNT - 1);
-    // Array slice capped at 100 to bound log-line size.
-    expect(data.recoveredTokenIds.length).toBe(100);
-    // truncated flag MUST be set when count > slice length, otherwise
-    // operators reading "100 ids + count 149" would silently get a
-    // wrong picture.
-    expect(data.truncated).toBe(true);
+  }
 
-    await provider.shutdown();
+  it('truncated boundary: recoveredCount === MONOTONICITY_RECOVERY_PAYLOAD_CAP (exactly 100) → truncated=false (#264)', async () => {
+    // Pins the `> CAP` comparator vs `>= CAP`. At exactly the cap, the
+    // payload's array length equals the count → no information lost →
+    // truncated MUST be false.
+    const { MONOTONICITY_RECOVERY_PAYLOAD_CAP } = await import(
+      '../../../profile/profile-token-storage/flush-scheduler'
+    );
+    const data = await runRecoveryWithMissingCount(MONOTONICITY_RECOVERY_PAYLOAD_CAP);
+    expect(data.recoveredTokenCount).toBe(MONOTONICITY_RECOVERY_PAYLOAD_CAP);
+    expect(data.recoveredTokenIds.length).toBe(MONOTONICITY_RECOVERY_PAYLOAD_CAP);
+    expect(data.truncated).toBe(false);
+  });
+
+  it('truncated boundary: recoveredCount === CAP + 1 (exactly 101) → truncated=true (#264)', async () => {
+    // The smallest count that exceeds the cap — one more than the
+    // array slice can carry. Operators see 100 ids + count 101 +
+    // truncated=true so they know to query the full set elsewhere.
+    const { MONOTONICITY_RECOVERY_PAYLOAD_CAP } = await import(
+      '../../../profile/profile-token-storage/flush-scheduler'
+    );
+    const data = await runRecoveryWithMissingCount(MONOTONICITY_RECOVERY_PAYLOAD_CAP + 1);
+    expect(data.recoveredTokenCount).toBe(MONOTONICITY_RECOVERY_PAYLOAD_CAP + 1);
+    expect(data.recoveredTokenIds.length).toBe(MONOTONICITY_RECOVERY_PAYLOAD_CAP);
+    expect(data.truncated).toBe(true);
+  });
+
+  it('truncated boundary: recoveredCount > CAP (150 vs 100) → truncated=true with full count surfaced (#264)', async () => {
+    // Original test: stresses well above the cap to verify the count
+    // field surfaces the FULL total even when the array is truncated.
+    const { MONOTONICITY_RECOVERY_PAYLOAD_CAP } = await import(
+      '../../../profile/profile-token-storage/flush-scheduler'
+    );
+    const data = await runRecoveryWithMissingCount(150);
+    expect(data.recoveredTokenCount).toBe(150);
+    expect(data.recoveredTokenIds.length).toBe(MONOTONICITY_RECOVERY_PAYLOAD_CAP);
+    expect(data.truncated).toBe(true);
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/profile/pointer-monotonicity.test.ts
+++ b/tests/unit/profile/pointer-monotonicity.test.ts
@@ -397,14 +397,25 @@ describe('pointer monotonicity invariant', () => {
   // ---------------------------------------------------------------------------
   // Test 2: Race-stale flush (Mode A scenario) — assertion fires
   // ---------------------------------------------------------------------------
-  it('race-stale flush: lastLoadedData missing tokens that are in active OrbitDB bundles → assertion fires, no publish', async () => {
+  it('race-stale flush: unfetchable unknown bundle → auto-merge residual, flush continues + emits both recovered and residual events (#264)', async () => {
     // Simulate the Mode A race: an active bundle B_remote (containing
     // T_remote) lives in OrbitDB but lastLoadedData was captured BEFORE
     // it replicated. A no-data flush built from stale lastLoadedData
-    // would produce a CAR missing T_remote — silent token loss.
+    // would produce a CAR missing T_remote.
     //
     // The bundle-set check fires: B_remote's CID is in the active
-    // bundle index but NOT in lastLoadedFromBundleCids.
+    // bundle index but NOT in lastLoadedFromBundleCids. The inline
+    // fetch fails (empty mock map → 404), so the bundle stays as a
+    // residual after auto-merge.
+    //
+    // Issue #264 behavior change: the flush no longer throws on
+    // residual. It logs warn-level, emits BOTH `storage:monotonicity-
+    // recovered` (with the residual surfaced) AND legacy
+    // `storage:error` with POINTER_MONOTONICITY_VIOLATION (for
+    // dashboards keyed on the literal), and PROCEEDS to pin + publish
+    // the best-effort superset. Subsequent cross-device syncs will
+    // detect the same residual and re-attempt the inline merge,
+    // achieving eventual convergence.
     installMockFetch(tracker, new Map());
     const provider = createProvider(db, { flushDebounceMs: 20 });
     await provider.initialize();
@@ -440,11 +451,15 @@ describe('pointer monotonicity invariant', () => {
       createdAt: 1000,
     });
 
-    // Listen for storage:error events to verify the assertion fires.
+    // Listen for BOTH the residual `storage:error` (for dashboards)
+    // AND the new `storage:monotonicity-recovered` event.
     const errors: Array<{ code?: string; data?: unknown }> = [];
+    const recovered: Array<{ data?: unknown }> = [];
     provider.onEvent((evt) => {
       if (evt.type === 'storage:error' && evt.code === POINTER_MONOTONICITY_VIOLATION) {
         errors.push({ code: evt.code, data: evt.data });
+      } else if (evt.type === 'storage:monotonicity-recovered') {
+        recovered.push({ data: evt.data });
       }
     });
 
@@ -459,15 +474,27 @@ describe('pointer monotonicity invariant', () => {
     flushScheduler.scheduleFlushNoData();
 
     // Issue #215: wait for the debounced flush to actually run
-    // (timer → flush body → catch arm) before asserting that no pin
-    // was issued. The original 100 ms fixed wait was insufficient
-    // under full-suite contention.
+    // (timer → flush body → recovery path) before asserting.
     await waitForFlushSettled(provider);
 
-    // Assertion fired: no pin, error event emitted with the violation
-    // code and the unknown bundle CID listed.
-    expect(tracker.pinCalls).toBe(0);
+    // Issue #264 — the flush now PROCEEDS to pin after the auto-merge
+    // residual emit; pinCalls is non-zero (the no-data flush builds a
+    // CAR from lastLoadedData and pins it best-effort).
+    expect(tracker.pinCalls).toBeGreaterThan(0);
+
+    // Both event surfaces fire.
+    expect(recovered.length).toBeGreaterThan(0);
     expect(errors.length).toBeGreaterThan(0);
+
+    // The recovered event surfaces the residual unknown bundle.
+    const recoveredData = recovered[0]!.data as {
+      residualUnknownBundleCids: string[];
+      residualUnknownBundleCount: number;
+    };
+    expect(recoveredData.residualUnknownBundleCount).toBe(1);
+    expect(recoveredData.residualUnknownBundleCids).toContain(remoteCid);
+
+    // The legacy storage:error event also fires for dashboards.
     const alertEvent = errors.find(
       (e) => (e.data as { alert?: string } | undefined)?.alert === 'transfer:operator-alert',
     );
@@ -475,9 +502,11 @@ describe('pointer monotonicity invariant', () => {
     const alertData = alertEvent!.data as {
       unknownBundleCids: string[];
       unknownBundleCount: number;
+      autoMergeResidual?: boolean;
     };
     expect(alertData.unknownBundleCount).toBe(1);
     expect(alertData.unknownBundleCids).toContain(remoteCid);
+    expect(alertData.autoMergeResidual).toBe(true);
 
     await provider.shutdown();
   });
@@ -485,9 +514,19 @@ describe('pointer monotonicity invariant', () => {
   // ---------------------------------------------------------------------------
   // Test 3: Direct token-loss attempt — assertion fires
   // ---------------------------------------------------------------------------
-  it('token-loss: flush data missing a token from lastLoadedData baseline → assertion fires, no publish', async () => {
+  it('token-loss: flush data missing a token from lastLoadedData baseline → auto-merges in-place + publishes superset, no throw (#264)', async () => {
     // Construct a flush where `data` (set via save()) is missing a
     // token present in lastLoadedData. The token-set check fires.
+    //
+    // Issue #264 behavior change: the flush no longer throws on
+    // monotonicity violation. Instead it extracts the missing TXF
+    // entry from `previousData` and re-merges into the in-flight
+    // `pkg`. Because `previousData` contains every missing entry by
+    // construction (that's the definition of `tokenMissing` in the
+    // check), recovery is total. The flush proceeds to pin + publish
+    // the superset CAR and emits `storage:monotonicity-recovered`
+    // with the recovered token id. NO `storage:error` is emitted
+    // because the residual count is zero.
     installMockFetch(tracker, new Map());
     const provider = createProvider(db, { flushDebounceMs: 20 });
     await provider.initialize();
@@ -501,7 +540,7 @@ describe('pointer monotonicity invariant', () => {
     // check trivially passes (bundle-set check requires a non-null
     // lastLoadedFromBundleCids; we set it to an empty set so the
     // bundle-set check does fire BUT correctly observes "no unknown
-    // bundles" — only the token-set check should produce the violation).
+    // bundles" — only the token-set check produces the recovery).
     const baseline = buildTxfData({ _TA: tokenA, _TB: tokenB });
     (provider as unknown as {
       lastLoadedData: TxfStorageDataBase;
@@ -511,7 +550,8 @@ describe('pointer monotonicity invariant', () => {
       lastLoadedFromBundleCids: Set<string>;
     }).lastLoadedFromBundleCids = new Set();
 
-    // The about-to-flush data has only A — B is being dropped.
+    // The about-to-flush data has only A — B would be dropped without
+    // the auto-merge.
     const partialData = buildTxfData({ _TA: tokenA });
 
     // Drive the flush directly via the internal scheduler (avoids
@@ -525,15 +565,15 @@ describe('pointer monotonicity invariant', () => {
       partialData;
 
     const errors: Array<{ code?: string; data?: unknown }> = [];
+    const recovered: Array<{ data?: unknown }> = [];
     provider.onEvent((evt) => {
       if (evt.type === 'storage:error' && evt.code === POINTER_MONOTONICITY_VIOLATION) {
         errors.push({ code: evt.code, data: evt.data });
+      } else if (evt.type === 'storage:monotonicity-recovered') {
+        recovered.push({ data: evt.data });
       }
     });
 
-    // The flush body throws on violation. The catch in scheduleFlush
-    // would normally swallow it, but we invoke flushToIpfs() directly
-    // to assert the throw, then verify the events.
     let thrown: unknown = null;
     try {
       await flushScheduler.flushToIpfs();
@@ -541,21 +581,27 @@ describe('pointer monotonicity invariant', () => {
       thrown = err;
     }
 
-    expect(thrown).toBeDefined();
-    expect((thrown as { code?: string }).code).toBe(POINTER_MONOTONICITY_VIOLATION);
-    expect(tracker.pinCalls).toBe(0);
+    // No throw — the auto-merge resolves the violation in-place.
+    expect(thrown).toBeNull();
 
-    expect(errors.length).toBeGreaterThan(0);
-    const alertEvent = errors.find(
-      (e) => (e.data as { alert?: string } | undefined)?.alert === 'transfer:operator-alert',
-    );
-    expect(alertEvent).toBeDefined();
-    const alertData = alertEvent!.data as {
-      missingTokenIds: string[];
-      missingTokenCount: number;
+    // The flush proceeded to pin the superset CAR.
+    expect(tracker.pinCalls).toBeGreaterThan(0);
+
+    // The recovered event surfaces the re-merged token id.
+    expect(recovered.length).toBe(1);
+    const recoveredData = recovered[0]!.data as {
+      recoveredTokenIds: string[];
+      recoveredTokenCount: number;
+      residualTokenMissingCount: number;
+      residualUnknownBundleCount: number;
     };
-    expect(alertData.missingTokenCount).toBe(1);
-    expect(alertData.missingTokenIds).toContain('_TB');
+    expect(recoveredData.recoveredTokenCount).toBe(1);
+    expect(recoveredData.recoveredTokenIds).toContain('_TB');
+    expect(recoveredData.residualTokenMissingCount).toBe(0);
+    expect(recoveredData.residualUnknownBundleCount).toBe(0);
+
+    // No residual → no legacy `storage:error` should fire.
+    expect(errors.length).toBe(0);
 
     await provider.shutdown();
   });

--- a/tests/unit/profile/steelman-remediation-264.test.ts
+++ b/tests/unit/profile/steelman-remediation-264.test.ts
@@ -147,15 +147,26 @@ describe('ProfilePointerLayer — probeHistory preservation (#264)', () => {
     expect(fp2).not.toBe(fp1);
   });
 
-  it('cold-start fingerprint is empty until first non-empty discovery', async () => {
+  it('cold-start fingerprint is empty; survives an empty-probe discovery; flips to non-empty on first real probe (#264)', async () => {
     const layer = await buildLayer();
     const fp0 = await layer.getProbeFingerprint();
     expect(fp0).toBe('');
-    // First discovery with empty probeVersions stays empty.
+    // Empty-probe discovery preserves the empty fingerprint.
     discoverMockState.nextResult = { validV: 0, includedV: 0, probeVersions: [] };
     await layer.discoverLatestVersion();
     const fp1 = await layer.getProbeFingerprint();
     expect(fp1).toBe('');
+    // Tightening (round-4 steelman): a follow-on non-empty discovery
+    // MUST actually flip the fingerprint to non-empty. Without this
+    // assertion the "empty stays empty" test passes under a buggy
+    // variant `if (length === 0) assign` because in that variant
+    // empty preserves empty too — but a real probe-set wouldn't
+    // produce a fingerprint.
+    discoverMockState.nextResult = { validV: 7, includedV: 5, probeVersions: [3, 4, 5] };
+    await layer.discoverLatestVersion();
+    const fp2 = await layer.getProbeFingerprint();
+    expect(fp2.length).toBeGreaterThan(0);
+    expect(fp2).not.toBe(fp0);
   });
 });
 

--- a/tests/unit/profile/steelman-remediation-264.test.ts
+++ b/tests/unit/profile/steelman-remediation-264.test.ts
@@ -1,31 +1,66 @@
 /**
  * Issue #264 — steelman remediation tests.
  *
- * Pins the three observability fixes from the second steelman round:
+ * Pins the observability fixes from the remediation rounds. EVERY
+ * test in this file MUST exercise production code, not re-implement
+ * the predicate it claims to pin (the round-3 steelman caught the
+ * prior version doing exactly that).
  *
- *   1. `ProfilePointerLayer.publish/discoverLatestVersion` — only
- *      overwrite the probe-fingerprint history when the discovery
- *      actually ran probes. The fast-path (#263) returns
- *      `probeHistory: []`; unconditionally assigning would clobber
- *      any fingerprint populated by a prior discovery / probe call.
+ *   1. `ProfilePointerLayer.#discoverLatestVersionInner` — only
+ *      overwrite `#lastProbeVersions` when `result.probeVersions`
+ *      is non-empty. Drives the real `discoverLatestVersion` public
+ *      method with a mocked `findLatestValidVersion` so the
+ *      production conditional at ProfilePointerLayer.ts:541 is on
+ *      the call stack.
  *
- *   2. `core/Sphere.maybeInstallPointerWinSubscription` — symmetric
- *      stub guard. A pointer stub lacking `winBroadcastsEnabled`
- *      OR `getSignerForWinBroadcast` early-returns cleanly without
- *      throwing or installing a subscription.
- *
- *   3. `core/Sphere.bridgeProviderEvents` — the
+ *   2. `core/Sphere.bridgeProviderEvents` — the
  *      `storage:monotonicity-recovered` event from the provider is
- *      forwarded to a Sphere-level event with `providerId` attached,
- *      so consumers subscribing via `sphere.on(...)` see the auto-
- *      merge convergence signal.
+ *      forwarded to a Sphere-level event with `providerId` attached.
+ *      Drives the real `subscribeToProviderEvents` bridge code by
+ *      registering a provider on a real Sphere instance and emitting
+ *      the synthetic provider event.
+ *
+ *   3. `core/Sphere.maybeInstallPointerWinSubscription` — symmetric
+ *      stub guards. Invokes the REAL private method (via cast) with
+ *      stub pointers and asserts no throw + no subscription installed.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import type { ProfileDatabase, OrbitDbConfig } from '../../../profile/types';
-import type { FullIdentity } from '../../../types';
-import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+// vi.mock MUST be hoisted above the import that uses the module —
+// vitest hoists vi.mock automatically, but the mocked module's exports
+// must be accessible to the test (we capture the mock instance via the
+// factory's closure variable).
+const discoverMockState: {
+  nextResult: {
+    validV: number;
+    includedV: number;
+    probeVersions: ReadonlyArray<number>;
+  };
+} = {
+  nextResult: { validV: 0, includedV: 0, probeVersions: [] },
+};
+
+vi.mock('../../../profile/aggregator-pointer/discover-algorithm.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../profile/aggregator-pointer/discover-algorithm.js')
+  >('../../../profile/aggregator-pointer/discover-algorithm.js');
+  return {
+    ...actual,
+    findLatestValidVersion: vi.fn(async () => {
+      const r = discoverMockState.nextResult;
+      return {
+        validV: r.validV as unknown as never,
+        includedV: r.includedV as unknown as never,
+        probeVersions: r.probeVersions as unknown as never,
+      };
+    }),
+    // Keep computeProbeFingerprint real so the test can assert
+    // fingerprint-equality semantics end-to-end.
+    computeProbeFingerprint: actual.computeProbeFingerprint,
+  };
+});
+
 import {
   ProfilePointerLayer,
   buildPointerSigner,
@@ -33,35 +68,10 @@ import {
   derivePointerKeyMaterial,
   type PointerSigner,
 } from '../../../profile/aggregator-pointer';
-
-const TEST_PRIVATE_KEY =
-  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
-
-const TEST_IDENTITY: FullIdentity = {
-  chainPubkey: '02' + 'aa'.repeat(32),
-  l1Address: 'alpha1testaddress',
-  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
-  privateKey: TEST_PRIVATE_KEY,
-};
-
-function createMockDb(): ProfileDatabase & { _store: Map<string, Uint8Array> } {
-  const store = new Map<string, Uint8Array>();
-  return {
-    _store: store,
-    async connect(_config: OrbitDbConfig) {},
-    async put(key: string, value: Uint8Array) { store.set(key, value); },
-    async get(key: string) { return store.get(key) ?? null; },
-    async del(key: string) { store.delete(key); },
-    async all(prefix?: string) {
-      const out = new Map<string, Uint8Array>();
-      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
-      return out;
-    },
-    async close() {},
-    onReplication() { return () => {}; },
-    isConnected() { return true; },
-  } as ProfileDatabase & { _store: Map<string, Uint8Array> };
-}
+import { Sphere } from '../../../core/Sphere';
+import type { ProfileDatabase, OrbitDbConfig } from '../../../profile/types';
+import type { StorageProvider, TokenStorageProvider } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
 
 async function buildRealSigner(): Promise<PointerSigner> {
   const seed = new Uint8Array(32).fill(0x42);
@@ -70,214 +80,368 @@ async function buildRealSigner(): Promise<PointerSigner> {
   return buildPointerSigner(keyMaterial.signingSeed);
 }
 
+async function buildLayer(): Promise<ProfilePointerLayer> {
+  const signer = await buildRealSigner();
+  return new ProfilePointerLayer({
+    keyMaterial: { signingSeed: new Uint8Array(32), xorSeed: new Uint8Array(32) } as never,
+    signer,
+    aggregatorClient: {} as never,
+    trustBase: {} as never,
+    flagStore: {} as never,
+    mutex: {} as never,
+    decodeCid: (() => ({ bytes: new Uint8Array(0) })) as never,
+    fetchCar: (async () => ({ bytes: new Uint8Array(0) })) as never,
+    fetchAndJoin: async () => {},
+    readLocalVersion: async () => 0 as never,
+    persistLocalVersion: async () => {},
+    resolveRemoteCid: async () => new Uint8Array(0),
+  });
+}
+
 // ---------------------------------------------------------------------------
-// Fix #4: probeHistory preservation across fast-path publish
+// Fix #4: probeHistory preservation across empty-probe discovery
 // ---------------------------------------------------------------------------
+//
+// Drives the REAL `ProfilePointerLayer.discoverLatestVersion()` public
+// method, which calls into `#discoverLatestVersionInner` (where the
+// production guard lives at ProfilePointerLayer.ts:541). The mock for
+// `findLatestValidVersion` controls what `result.probeVersions` looks
+// like; the production conditional decides whether to overwrite
+// `#lastProbeVersions`. We observe via the public `getProbeFingerprint()`.
+// If the production guard were reverted to an unconditional assignment,
+// fp2 would change to the empty-fingerprint output → test fails.
 
 describe('ProfilePointerLayer — probeHistory preservation (#264)', () => {
-  beforeEach(() => { vi.useRealTimers(); });
+  beforeEach(() => {
+    discoverMockState.nextResult = { validV: 0, includedV: 0, probeVersions: [] };
+  });
   afterEach(() => { vi.useRealTimers(); });
 
-  it('publish() with empty probeHistory does NOT clobber a prior fingerprint', async () => {
-    const signer = await buildRealSigner();
-    const layer = new ProfilePointerLayer({
-      keyMaterial: { signingSeed: new Uint8Array(32), xorSeed: new Uint8Array(32) } as never,
-      signer,
-      aggregatorClient: {} as never,
-      trustBase: {} as never,
-      flagStore: {} as never,
-      mutex: {} as never,
-      decodeCid: (() => ({ bytes: new Uint8Array(0) })) as never,
-      fetchCar: (async () => ({ bytes: new Uint8Array(0) })) as never,
-      fetchAndJoin: async () => {},
-      readLocalVersion: async () => 0 as never,
-      persistLocalVersion: async () => {},
-      resolveRemoteCid: async () => new Uint8Array(0),
-    });
+  it('discoverLatestVersion with empty probeVersions does NOT clobber a prior fingerprint', async () => {
+    const layer = await buildLayer();
+    // Round 1: drive discovery with a non-empty probe set → seeds
+    // the real #lastProbeVersions through the production code path.
+    discoverMockState.nextResult = { validV: 7, includedV: 5, probeVersions: [3, 4, 5] };
+    await layer.discoverLatestVersion();
+    const fp1 = await layer.getProbeFingerprint();
+    expect(fp1.length).toBeGreaterThan(0); // sanity: real fingerprint computed
 
-    // Stub the internal #publishInner to return a result with empty
-    // probeHistory — simulating the #263 fast-path success.
-    //
-    // We seed `#lastProbeVersions` by accessing the private field via
-    // a cast; then publish() with empty probeHistory must NOT clear it.
-    const priorVersions = [3, 4, 5];
-    (layer as unknown as { ['#lastProbeVersions']: readonly number[] })['#lastProbeVersions'] = priorVersions;
-    // Access the actual private field by name via Object.assign on the
-    // prototype-bound symbol — JS private fields aren't accessible by
-    // string, so we shadow via the public getter instead:
-    // populate via `discoverLatestVersion` which writes the field.
-    // Replace publish's reconcile call with a stub returning empty.
-    const layerPriv = layer as unknown as {
-      publish: (cidProducer: () => Promise<Uint8Array>) => Promise<unknown>;
-      getProbeFingerprint: () => Promise<string>;
-    };
-
-    // Force a non-empty seed by replacing the internal publishInner
-    // with a controllable double:
-    const stubLayer = Object.create(layer) as ProfilePointerLayer & {
-      __seedFingerprint: () => Promise<void>;
-    };
-    // Use a stub publish that returns empty probeHistory:
-    let returnEmpty = false;
-    (stubLayer as unknown as { publish: (cp: unknown) => Promise<unknown> }).publish = async () => {
-      // First call returns non-empty (seed fingerprint), second returns
-      // empty (fast-path simulation).
-      const result = returnEmpty
-        ? { version: 11, attemptsUsed: 1, probeHistory: [] as number[] }
-        : { version: 10, attemptsUsed: 1, probeHistory: [3, 4, 5] };
-      returnEmpty = true;
-      // Apply the same conditional logic our fix added to publish:
-      if (result.probeHistory.length > 0) {
-        (layer as unknown as { '#lastProbeVersions': readonly number[] })['#lastProbeVersions'] = result.probeHistory;
-      }
-      return result;
-    };
-
-    // Round 1: seed with probeHistory = [3,4,5].
-    await (stubLayer as unknown as { publish: (cp: unknown) => Promise<unknown> }).publish(async () => new Uint8Array(0));
-    const fp1 = await layerPriv.getProbeFingerprint();
-
-    // Round 2: fast-path publish returns empty.
-    await (stubLayer as unknown as { publish: (cp: unknown) => Promise<unknown> }).publish(async () => new Uint8Array(0));
-    const fp2 = await layerPriv.getProbeFingerprint();
-
-    // Fingerprint MUST be unchanged across the empty-probeHistory publish.
-    // (The exact value is implementation-defined; what matters is fp2 === fp1.)
+    // Round 2: drive discovery with EMPTY probeVersions (fast-path /
+    // single-probe scenario). Production conditional MUST skip the
+    // assignment → fingerprint unchanged.
+    discoverMockState.nextResult = { validV: 7, includedV: 5, probeVersions: [] };
+    await layer.discoverLatestVersion();
+    const fp2 = await layer.getProbeFingerprint();
     expect(fp2).toBe(fp1);
+  });
+
+  it('discoverLatestVersion with a non-empty probeVersions OVERWRITES the prior fingerprint (sanity for the conditional)', async () => {
+    const layer = await buildLayer();
+    discoverMockState.nextResult = { validV: 7, includedV: 5, probeVersions: [3, 4, 5] };
+    await layer.discoverLatestVersion();
+    const fp1 = await layer.getProbeFingerprint();
+
+    discoverMockState.nextResult = { validV: 11, includedV: 9, probeVersions: [8, 9, 10, 11] };
+    await layer.discoverLatestVersion();
+    const fp2 = await layer.getProbeFingerprint();
+    expect(fp2).not.toBe(fp1);
+  });
+
+  it('cold-start fingerprint is empty until first non-empty discovery', async () => {
+    const layer = await buildLayer();
+    const fp0 = await layer.getProbeFingerprint();
+    expect(fp0).toBe('');
+    // First discovery with empty probeVersions stays empty.
+    discoverMockState.nextResult = { validV: 0, includedV: 0, probeVersions: [] };
+    await layer.discoverLatestVersion();
+    const fp1 = await layer.getProbeFingerprint();
+    expect(fp1).toBe('');
   });
 });
 
 // ---------------------------------------------------------------------------
-// Fix #6: Sphere event bridge for storage:monotonicity-recovered
+// Fix #3: symmetric subscriber guard
+// (Sphere.maybeInstallPointerWinSubscription)
 // ---------------------------------------------------------------------------
+//
+// Drives the REAL private method via cast. The test stub pointer is
+// returned from a mocked storage provider's `getPointerLayer()`; the
+// method's guard must early-return cleanly without throwing and
+// without registering a transport subscription.
 
-describe('Sphere — storage:monotonicity-recovered event bridge (#264)', () => {
-  it('forwards the provider event to a Sphere-level event with providerId attached', async () => {
-    // Direct provider-level test: instantiate a ProfileTokenStorageProvider,
-    // attach a listener to its onEvent, emit the storage:monotonicity-
-    // recovered event, verify the bridge wiring SHAPE. Full Sphere init
-    // requires more infrastructure than this isolated unit test needs;
-    // bridge behavior is exercised end-to-end via the existing
-    // pointer-monotonicity.test.ts auto-merge tests (which emit the
-    // provider event), and the type contract in types/index.ts pins the
-    // payload shape at compile time.
-    //
-    // Here we verify the PROVIDER side of the bridge: the provider IS
-    // the source of the event, and the payload shape matches what the
-    // Sphere bridge consumes.
-    const db = createMockDb();
-    const provider = new ProfileTokenStorageProvider(
-      db,
-      new Uint8Array(32).fill(0x11),
-      ['https://mock-ipfs.test'],
-      {
-        config: { orbitDb: { privateKey: TEST_PRIVATE_KEY }, ipnsSnapshot: false },
-        addressId: 'test',
-        encrypt: true,
+function createMinimalSphereForGuardTest(opts: {
+  pointer: unknown;
+  subscribeToBroadcast?: (
+    tags: string[],
+    cb: (msg: { content: string }) => void,
+  ) => () => void;
+}): Sphere {
+  // Build the most minimal Sphere we can inject our stub into, by
+  // constructing via prototype and assigning only the fields the
+  // private method touches:
+  //   - this._storage.getPointerLayer()
+  //   - this._transport.subscribeToBroadcast
+  //   - this._pointerWinInstallInFlight
+  //   - this._pointerWinSubscriptions
+  //   - this._pointerWinSeen
+  //
+  // Object.create on the Sphere prototype is the canonical pattern used
+  // elsewhere in this repo's test suite (search for `Object.create(Sphere`
+  // — see Sphere.destroy-flush.test.ts) to test private methods without
+  // running the full init pipeline.
+  const sphere = Object.create(Sphere.prototype) as Sphere;
+  const subscribeStub = opts.subscribeToBroadcast ?? (() => () => {});
+  Object.assign(sphere, {
+    _storage: { getPointerLayer: () => opts.pointer },
+    _transport: { subscribeToBroadcast: subscribeStub },
+    _pointerWinInstallInFlight: false,
+    _pointerWinSubscriptions: new Map<string, () => void>(),
+    _pointerWinSeen: new Set<string>(),
+  });
+  return sphere;
+}
+
+describe('Sphere.maybeInstallPointerWinSubscription — symmetric guard (#264)', () => {
+  it('pointer stub WITHOUT winBroadcastsEnabled → early-return, no subscription, no throw', async () => {
+    let subscribeCalls = 0;
+    const sphere = createMinimalSphereForGuardTest({
+      pointer: {
+        getSignerForWinBroadcast: () => ({ signer: {}, signingPubKeyHex: 'abc' }),
       },
-    );
-    provider.setIdentity(TEST_IDENTITY);
-    await provider.initialize();
-
-    const observed: Array<{ type: string; data?: unknown }> = [];
-    provider.onEvent((evt) => {
-      if (evt.type === 'storage:monotonicity-recovered') {
-        observed.push({ type: evt.type, data: evt.data });
-      }
+      subscribeToBroadcast: () => {
+        subscribeCalls++;
+        return () => {};
+      },
     });
+    // Invoke the REAL private method via cast.
+    await expect(
+      (sphere as unknown as {
+        maybeInstallPointerWinSubscription: () => Promise<void>;
+      }).maybeInstallPointerWinSubscription(),
+    ).resolves.toBeUndefined();
+    expect(subscribeCalls).toBe(0);
+    const subs = (sphere as unknown as { _pointerWinSubscriptions: Map<string, unknown> })._pointerWinSubscriptions;
+    expect(subs.size).toBe(0);
+  });
 
-    // Emit a synthetic recovery event with the canonical payload
-    // shape (matches what flush-scheduler produces).
-    (provider as unknown as { emitEvent: (e: unknown) => void }).emitEvent({
+  it('pointer with winBroadcastsEnabled() === false → early-return, no subscription, no throw', async () => {
+    let subscribeCalls = 0;
+    const sphere = createMinimalSphereForGuardTest({
+      pointer: {
+        winBroadcastsEnabled: () => false,
+        getSignerForWinBroadcast: () => ({ signer: {}, signingPubKeyHex: 'abc' }),
+      },
+      subscribeToBroadcast: () => {
+        subscribeCalls++;
+        return () => {};
+      },
+    });
+    await (sphere as unknown as {
+      maybeInstallPointerWinSubscription: () => Promise<void>;
+    }).maybeInstallPointerWinSubscription();
+    expect(subscribeCalls).toBe(0);
+  });
+
+  it('pointer with winBroadcastsEnabled() returning truthy non-boolean (1) → fail-closed, no subscription (strict === true)', async () => {
+    let subscribeCalls = 0;
+    const sphere = createMinimalSphereForGuardTest({
+      pointer: {
+        winBroadcastsEnabled: () => 1 as unknown as boolean,
+        getSignerForWinBroadcast: () => ({ signer: {}, signingPubKeyHex: 'abc' }),
+      },
+      subscribeToBroadcast: () => {
+        subscribeCalls++;
+        return () => {};
+      },
+    });
+    await (sphere as unknown as {
+      maybeInstallPointerWinSubscription: () => Promise<void>;
+    }).maybeInstallPointerWinSubscription();
+    // Strict-`=== true` policy: truthy non-boolean treated as flag=false.
+    expect(subscribeCalls).toBe(0);
+  });
+
+  it('pointer with winBroadcastsEnabled() === true BUT missing getSignerForWinBroadcast → fail-closed, no subscription, no throw', async () => {
+    let subscribeCalls = 0;
+    const sphere = createMinimalSphereForGuardTest({
+      pointer: {
+        winBroadcastsEnabled: () => true,
+        // No getSignerForWinBroadcast.
+      },
+      subscribeToBroadcast: () => {
+        subscribeCalls++;
+        return () => {};
+      },
+    });
+    await (sphere as unknown as {
+      maybeInstallPointerWinSubscription: () => Promise<void>;
+    }).maybeInstallPointerWinSubscription();
+    expect(subscribeCalls).toBe(0);
+    // _pointerWinInstallInFlight reset in finally.
+    const inFlight = (sphere as unknown as { _pointerWinInstallInFlight: boolean })._pointerWinInstallInFlight;
+    expect(inFlight).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #6: Sphere bridge for storage:monotonicity-recovered
+// ---------------------------------------------------------------------------
+//
+// Drives the REAL bridge code in core/Sphere.ts:subscribeToProviderEvents.
+// We construct a minimal Sphere whose `_tokenStorageProviders` contains
+// one provider with `onEvent`, then directly invoke
+// `subscribeToProviderEvents` (via cast), emit a provider event, and
+// assert the bridged Sphere event fires with the providerId-augmented
+// payload.
+
+interface FakeProvider {
+  id: string;
+  listeners: Array<(event: { type: string; timestamp: number; data?: unknown }) => void>;
+  onEvent(cb: (event: { type: string; timestamp: number; data?: unknown }) => void): () => void;
+  emit(event: { type: string; timestamp: number; data?: unknown }): void;
+  isConnected(): boolean;
+  getStatus(): 'connected' | 'disconnected' | 'error';
+}
+
+function createFakeProvider(id: string): FakeProvider {
+  const listeners: FakeProvider['listeners'] = [];
+  return {
+    id,
+    listeners,
+    onEvent(cb) {
+      listeners.push(cb);
+      return () => {
+        const i = listeners.indexOf(cb);
+        if (i >= 0) listeners.splice(i, 1);
+      };
+    },
+    emit(event) {
+      for (const cb of [...listeners]) cb(event);
+    },
+    isConnected() { return true; },
+    getStatus() { return 'connected'; },
+  };
+}
+
+describe('Sphere — storage:monotonicity-recovered bridge (#264)', () => {
+  it('forwards the provider event to a Sphere-level event with providerId attached, applying defaults for missing fields', async () => {
+    const sphere = Object.create(Sphere.prototype) as Sphere;
+    const fake = createFakeProvider('fake-provider-A');
+    Object.assign(sphere, {
+      _oracle: {},
+      _transport: { /* no onEvent method → bridge skips the transport branch */ },
+      _tokenStorageProviders: new Map([[fake.id, fake]]),
+      _providerEventCleanups: [] as Array<() => void>,
+      _lastProviderConnected: new Map<string, boolean>(),
+      _disabledProviders: new Set<string>(),
+      // Sphere routes emitEvent through this.eventHandlers (Map of
+      // event type → Set<handler>). Initialize the Map so the real
+      // emitEvent path can dispatch.
+      eventHandlers: new Map<string, Set<(payload: unknown) => void>>(),
+    });
+    // Drive the REAL private bridge wiring.
+    (sphere as unknown as {
+      subscribeToProviderEvents: () => void;
+    }).subscribeToProviderEvents();
+
+    // Register a real handler via this.eventHandlers (the same Map
+    // Sphere's public `on()` method uses). The bridge will call
+    // `this.emitEvent(...)` which dispatches through this Map.
+    const observed: unknown[] = [];
+    const handlers = (sphere as unknown as {
+      eventHandlers: Map<string, Set<(payload: unknown) => void>>;
+    }).eventHandlers;
+    handlers.set(
+      'storage:monotonicity-recovered',
+      new Set([(payload: unknown) => observed.push(payload)]),
+    );
+
+    // Provider emits the storage:monotonicity-recovered event.
+    fake.emit({
       type: 'storage:monotonicity-recovered',
       timestamp: Date.now(),
       data: {
         recoveredTokenIds: ['_TA'],
         recoveredTokenCount: 1,
-        mergedUnknownBundleCids: [],
-        mergedUnknownBundleCount: 0,
-        residualUnknownBundleCids: [],
-        residualUnknownBundleCount: 0,
-        residualTokenMissingIds: [],
-        residualTokenMissingCount: 0,
-        recoveredOutboxIdsDroppedAsSent: [],
-        recoveredOutboxIdsDroppedAsSentCount: 0,
+        // mergedUnknownBundleCids intentionally omitted → defaults to [].
+        residualUnknownBundleCids: ['cidB'],
+        residualUnknownBundleCount: 1,
+        // residualTokenMissingIds / Count omitted → defaults.
+        recoveredOutboxIdsDroppedAsSent: ['transfer-1'],
+        recoveredOutboxIdsDroppedAsSentCount: 1,
         truncated: false,
       },
     });
 
     expect(observed).toHaveLength(1);
-    expect(observed[0]!.type).toBe('storage:monotonicity-recovered');
-    const data = observed[0]!.data as {
+    const payload = observed[0] as {
+      providerId: string;
       recoveredTokenIds: string[];
       recoveredTokenCount: number;
       mergedUnknownBundleCids: string[];
+      mergedUnknownBundleCount: number;
+      residualUnknownBundleCids: string[];
       residualUnknownBundleCount: number;
+      residualTokenMissingIds: string[];
+      residualTokenMissingCount: number;
+      recoveredOutboxIdsDroppedAsSent: string[];
+      recoveredOutboxIdsDroppedAsSentCount: number;
       truncated: boolean;
     };
-    // Pin every field the Sphere bridge consumes (defaults against
-    // schema drift between provider emit and Sphere forward).
-    expect(data.recoveredTokenIds).toEqual(['_TA']);
-    expect(data.recoveredTokenCount).toBe(1);
-    expect(data.mergedUnknownBundleCids).toEqual([]);
-    expect(data.residualUnknownBundleCount).toBe(0);
-    expect(data.truncated).toBe(false);
 
-    await provider.shutdown();
+    // providerId attached for fan-out attribution.
+    expect(payload.providerId).toBe('fake-provider-A');
+    // Passed-through fields.
+    expect(payload.recoveredTokenIds).toEqual(['_TA']);
+    expect(payload.recoveredTokenCount).toBe(1);
+    expect(payload.residualUnknownBundleCids).toEqual(['cidB']);
+    expect(payload.residualUnknownBundleCount).toBe(1);
+    expect(payload.recoveredOutboxIdsDroppedAsSent).toEqual(['transfer-1']);
+    expect(payload.truncated).toBe(false);
+    // Defaults applied for missing fields.
+    expect(payload.mergedUnknownBundleCids).toEqual([]);
+    expect(payload.mergedUnknownBundleCount).toBe(0);
+    expect(payload.residualTokenMissingIds).toEqual([]);
+    expect(payload.residualTokenMissingCount).toBe(0);
+  });
+
+  it('does NOT forward unrelated storage events as storage:monotonicity-recovered', async () => {
+    const sphere = Object.create(Sphere.prototype) as Sphere;
+    const fake = createFakeProvider('fake-provider-B');
+    Object.assign(sphere, {
+      _oracle: {},
+      _transport: { /* no onEvent method → bridge skips the transport branch */ },
+      _tokenStorageProviders: new Map([[fake.id, fake]]),
+      _providerEventCleanups: [] as Array<() => void>,
+      _lastProviderConnected: new Map<string, boolean>(),
+      _disabledProviders: new Set<string>(),
+      // Sphere routes emitEvent through this.eventHandlers (Map of
+      // event type → Set<handler>). Initialize the Map so the real
+      // emitEvent path can dispatch.
+      eventHandlers: new Map<string, Set<(payload: unknown) => void>>(),
+    });
+    (sphere as unknown as { subscribeToProviderEvents: () => void }).subscribeToProviderEvents();
+    const observed: unknown[] = [];
+    const handlers = (sphere as unknown as {
+      eventHandlers: Map<string, Set<(payload: unknown) => void>>;
+    }).eventHandlers;
+    handlers.set(
+      'storage:monotonicity-recovered',
+      new Set([(payload: unknown) => observed.push(payload)]),
+    );
+    // Emit a different storage event — bridge MUST ignore.
+    fake.emit({
+      type: 'storage:saved',
+      timestamp: Date.now(),
+      data: { cid: 'bafy', tokenCount: 1 },
+    });
+    expect(observed).toHaveLength(0);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Fix #3: symmetric subscriber guard (Sphere.maybeInstallPointerWinSubscription)
+// Defensive: silence unused-import warnings if TS complains.
 // ---------------------------------------------------------------------------
-
-describe('Sphere — pointer-win subscriber symmetric guard (#264)', () => {
-  it('pointer stub without `winBroadcastsEnabled` is treated as flag=false (no subscription, no throw)', () => {
-    // The guard is `typeof pointer.winBroadcastsEnabled !== 'function'`.
-    // A stub lacking the method short-circuits to the early-return.
-    // We test the predicate directly: any object without the method
-    // satisfies the "fail-closed" condition.
-    const stub = {} as unknown as { winBroadcastsEnabled?: () => boolean };
-    const enabled =
-      typeof stub.winBroadcastsEnabled === 'function' &&
-      stub.winBroadcastsEnabled();
-    expect(enabled).toBe(false);
-  });
-
-  it('pointer stub with `winBroadcastsEnabled` returning false also short-circuits', () => {
-    const stub = { winBroadcastsEnabled: () => false } as unknown as {
-      winBroadcastsEnabled: () => boolean;
-    };
-    const enabled =
-      typeof stub.winBroadcastsEnabled === 'function' &&
-      stub.winBroadcastsEnabled();
-    expect(enabled).toBe(false);
-  });
-
-  it('pointer stub with `winBroadcastsEnabled` true BUT no `getSignerForWinBroadcast` is treated as flag=false (symmetric guard)', () => {
-    // Even when winBroadcastsEnabled is true, missing the signer
-    // helper means we'd TypeError mid-install. The symmetric guard
-    // prevents that by failing closed earlier.
-    const stub = { winBroadcastsEnabled: () => true } as unknown as {
-      winBroadcastsEnabled: () => boolean;
-      getSignerForWinBroadcast?: () => unknown;
-    };
-    const fullyArmed =
-      typeof stub.winBroadcastsEnabled === 'function' &&
-      stub.winBroadcastsEnabled() &&
-      typeof stub.getSignerForWinBroadcast === 'function';
-    expect(fullyArmed).toBe(false);
-  });
-
-  it('pointer with BOTH accessors implementing correctly is fully armed', () => {
-    const stub = {
-      winBroadcastsEnabled: () => true,
-      getSignerForWinBroadcast: () => ({ signer: {}, signingPubKeyHex: 'abc' }),
-    };
-    const fullyArmed =
-      typeof stub.winBroadcastsEnabled === 'function' &&
-      stub.winBroadcastsEnabled() &&
-      typeof stub.getSignerForWinBroadcast === 'function';
-    expect(fullyArmed).toBe(true);
-  });
-});
+void ProfileTokenStorageProvider;
+type _t = StorageProvider | TokenStorageProvider | OrbitDbConfig | ProfileDatabase;
+void (null as unknown as _t);

--- a/tests/unit/profile/steelman-remediation-264.test.ts
+++ b/tests/unit/profile/steelman-remediation-264.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Issue #264 — steelman remediation tests.
+ *
+ * Pins the three observability fixes from the second steelman round:
+ *
+ *   1. `ProfilePointerLayer.publish/discoverLatestVersion` — only
+ *      overwrite the probe-fingerprint history when the discovery
+ *      actually ran probes. The fast-path (#263) returns
+ *      `probeHistory: []`; unconditionally assigning would clobber
+ *      any fingerprint populated by a prior discovery / probe call.
+ *
+ *   2. `core/Sphere.maybeInstallPointerWinSubscription` — symmetric
+ *      stub guard. A pointer stub lacking `winBroadcastsEnabled`
+ *      OR `getSignerForWinBroadcast` early-returns cleanly without
+ *      throwing or installing a subscription.
+ *
+ *   3. `core/Sphere.bridgeProviderEvents` — the
+ *      `storage:monotonicity-recovered` event from the provider is
+ *      forwarded to a Sphere-level event with `providerId` attached,
+ *      so consumers subscribing via `sphere.on(...)` see the auto-
+ *      merge convergence signal.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { ProfileDatabase, OrbitDbConfig } from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import {
+  ProfilePointerLayer,
+  buildPointerSigner,
+  createMasterPrivateKey,
+  derivePointerKeyMaterial,
+  type PointerSigner,
+} from '../../../profile/aggregator-pointer';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+function createMockDb(): ProfileDatabase & { _store: Map<string, Uint8Array> } {
+  const store = new Map<string, Uint8Array>();
+  return {
+    _store: store,
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) { store.set(key, value); },
+    async get(key: string) { return store.get(key) ?? null; },
+    async del(key: string) { store.delete(key); },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() { return () => {}; },
+    isConnected() { return true; },
+  } as ProfileDatabase & { _store: Map<string, Uint8Array> };
+}
+
+async function buildRealSigner(): Promise<PointerSigner> {
+  const seed = new Uint8Array(32).fill(0x42);
+  const masterKey = createMasterPrivateKey(seed);
+  const keyMaterial = derivePointerKeyMaterial(masterKey);
+  return buildPointerSigner(keyMaterial.signingSeed);
+}
+
+// ---------------------------------------------------------------------------
+// Fix #4: probeHistory preservation across fast-path publish
+// ---------------------------------------------------------------------------
+
+describe('ProfilePointerLayer — probeHistory preservation (#264)', () => {
+  beforeEach(() => { vi.useRealTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('publish() with empty probeHistory does NOT clobber a prior fingerprint', async () => {
+    const signer = await buildRealSigner();
+    const layer = new ProfilePointerLayer({
+      keyMaterial: { signingSeed: new Uint8Array(32), xorSeed: new Uint8Array(32) } as never,
+      signer,
+      aggregatorClient: {} as never,
+      trustBase: {} as never,
+      flagStore: {} as never,
+      mutex: {} as never,
+      decodeCid: (() => ({ bytes: new Uint8Array(0) })) as never,
+      fetchCar: (async () => ({ bytes: new Uint8Array(0) })) as never,
+      fetchAndJoin: async () => {},
+      readLocalVersion: async () => 0 as never,
+      persistLocalVersion: async () => {},
+      resolveRemoteCid: async () => new Uint8Array(0),
+    });
+
+    // Stub the internal #publishInner to return a result with empty
+    // probeHistory — simulating the #263 fast-path success.
+    //
+    // We seed `#lastProbeVersions` by accessing the private field via
+    // a cast; then publish() with empty probeHistory must NOT clear it.
+    const priorVersions = [3, 4, 5];
+    (layer as unknown as { ['#lastProbeVersions']: readonly number[] })['#lastProbeVersions'] = priorVersions;
+    // Access the actual private field by name via Object.assign on the
+    // prototype-bound symbol — JS private fields aren't accessible by
+    // string, so we shadow via the public getter instead:
+    // populate via `discoverLatestVersion` which writes the field.
+    // Replace publish's reconcile call with a stub returning empty.
+    const layerPriv = layer as unknown as {
+      publish: (cidProducer: () => Promise<Uint8Array>) => Promise<unknown>;
+      getProbeFingerprint: () => Promise<string>;
+    };
+
+    // Force a non-empty seed by replacing the internal publishInner
+    // with a controllable double:
+    const stubLayer = Object.create(layer) as ProfilePointerLayer & {
+      __seedFingerprint: () => Promise<void>;
+    };
+    // Use a stub publish that returns empty probeHistory:
+    let returnEmpty = false;
+    (stubLayer as unknown as { publish: (cp: unknown) => Promise<unknown> }).publish = async () => {
+      // First call returns non-empty (seed fingerprint), second returns
+      // empty (fast-path simulation).
+      const result = returnEmpty
+        ? { version: 11, attemptsUsed: 1, probeHistory: [] as number[] }
+        : { version: 10, attemptsUsed: 1, probeHistory: [3, 4, 5] };
+      returnEmpty = true;
+      // Apply the same conditional logic our fix added to publish:
+      if (result.probeHistory.length > 0) {
+        (layer as unknown as { '#lastProbeVersions': readonly number[] })['#lastProbeVersions'] = result.probeHistory;
+      }
+      return result;
+    };
+
+    // Round 1: seed with probeHistory = [3,4,5].
+    await (stubLayer as unknown as { publish: (cp: unknown) => Promise<unknown> }).publish(async () => new Uint8Array(0));
+    const fp1 = await layerPriv.getProbeFingerprint();
+
+    // Round 2: fast-path publish returns empty.
+    await (stubLayer as unknown as { publish: (cp: unknown) => Promise<unknown> }).publish(async () => new Uint8Array(0));
+    const fp2 = await layerPriv.getProbeFingerprint();
+
+    // Fingerprint MUST be unchanged across the empty-probeHistory publish.
+    // (The exact value is implementation-defined; what matters is fp2 === fp1.)
+    expect(fp2).toBe(fp1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #6: Sphere event bridge for storage:monotonicity-recovered
+// ---------------------------------------------------------------------------
+
+describe('Sphere — storage:monotonicity-recovered event bridge (#264)', () => {
+  it('forwards the provider event to a Sphere-level event with providerId attached', async () => {
+    // Direct provider-level test: instantiate a ProfileTokenStorageProvider,
+    // attach a listener to its onEvent, emit the storage:monotonicity-
+    // recovered event, verify the bridge wiring SHAPE. Full Sphere init
+    // requires more infrastructure than this isolated unit test needs;
+    // bridge behavior is exercised end-to-end via the existing
+    // pointer-monotonicity.test.ts auto-merge tests (which emit the
+    // provider event), and the type contract in types/index.ts pins the
+    // payload shape at compile time.
+    //
+    // Here we verify the PROVIDER side of the bridge: the provider IS
+    // the source of the event, and the payload shape matches what the
+    // Sphere bridge consumes.
+    const db = createMockDb();
+    const provider = new ProfileTokenStorageProvider(
+      db,
+      new Uint8Array(32).fill(0x11),
+      ['https://mock-ipfs.test'],
+      {
+        config: { orbitDb: { privateKey: TEST_PRIVATE_KEY }, ipnsSnapshot: false },
+        addressId: 'test',
+        encrypt: true,
+      },
+    );
+    provider.setIdentity(TEST_IDENTITY);
+    await provider.initialize();
+
+    const observed: Array<{ type: string; data?: unknown }> = [];
+    provider.onEvent((evt) => {
+      if (evt.type === 'storage:monotonicity-recovered') {
+        observed.push({ type: evt.type, data: evt.data });
+      }
+    });
+
+    // Emit a synthetic recovery event with the canonical payload
+    // shape (matches what flush-scheduler produces).
+    (provider as unknown as { emitEvent: (e: unknown) => void }).emitEvent({
+      type: 'storage:monotonicity-recovered',
+      timestamp: Date.now(),
+      data: {
+        recoveredTokenIds: ['_TA'],
+        recoveredTokenCount: 1,
+        mergedUnknownBundleCids: [],
+        mergedUnknownBundleCount: 0,
+        residualUnknownBundleCids: [],
+        residualUnknownBundleCount: 0,
+        residualTokenMissingIds: [],
+        residualTokenMissingCount: 0,
+        recoveredOutboxIdsDroppedAsSent: [],
+        recoveredOutboxIdsDroppedAsSentCount: 0,
+        truncated: false,
+      },
+    });
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]!.type).toBe('storage:monotonicity-recovered');
+    const data = observed[0]!.data as {
+      recoveredTokenIds: string[];
+      recoveredTokenCount: number;
+      mergedUnknownBundleCids: string[];
+      residualUnknownBundleCount: number;
+      truncated: boolean;
+    };
+    // Pin every field the Sphere bridge consumes (defaults against
+    // schema drift between provider emit and Sphere forward).
+    expect(data.recoveredTokenIds).toEqual(['_TA']);
+    expect(data.recoveredTokenCount).toBe(1);
+    expect(data.mergedUnknownBundleCids).toEqual([]);
+    expect(data.residualUnknownBundleCount).toBe(0);
+    expect(data.truncated).toBe(false);
+
+    await provider.shutdown();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix #3: symmetric subscriber guard (Sphere.maybeInstallPointerWinSubscription)
+// ---------------------------------------------------------------------------
+
+describe('Sphere — pointer-win subscriber symmetric guard (#264)', () => {
+  it('pointer stub without `winBroadcastsEnabled` is treated as flag=false (no subscription, no throw)', () => {
+    // The guard is `typeof pointer.winBroadcastsEnabled !== 'function'`.
+    // A stub lacking the method short-circuits to the early-return.
+    // We test the predicate directly: any object without the method
+    // satisfies the "fail-closed" condition.
+    const stub = {} as unknown as { winBroadcastsEnabled?: () => boolean };
+    const enabled =
+      typeof stub.winBroadcastsEnabled === 'function' &&
+      stub.winBroadcastsEnabled();
+    expect(enabled).toBe(false);
+  });
+
+  it('pointer stub with `winBroadcastsEnabled` returning false also short-circuits', () => {
+    const stub = { winBroadcastsEnabled: () => false } as unknown as {
+      winBroadcastsEnabled: () => boolean;
+    };
+    const enabled =
+      typeof stub.winBroadcastsEnabled === 'function' &&
+      stub.winBroadcastsEnabled();
+    expect(enabled).toBe(false);
+  });
+
+  it('pointer stub with `winBroadcastsEnabled` true BUT no `getSignerForWinBroadcast` is treated as flag=false (symmetric guard)', () => {
+    // Even when winBroadcastsEnabled is true, missing the signer
+    // helper means we'd TypeError mid-install. The symmetric guard
+    // prevents that by failing closed earlier.
+    const stub = { winBroadcastsEnabled: () => true } as unknown as {
+      winBroadcastsEnabled: () => boolean;
+      getSignerForWinBroadcast?: () => unknown;
+    };
+    const fullyArmed =
+      typeof stub.winBroadcastsEnabled === 'function' &&
+      stub.winBroadcastsEnabled() &&
+      typeof stub.getSignerForWinBroadcast === 'function';
+    expect(fullyArmed).toBe(false);
+  });
+
+  it('pointer with BOTH accessors implementing correctly is fully armed', () => {
+    const stub = {
+      winBroadcastsEnabled: () => true,
+      getSignerForWinBroadcast: () => ({ signer: {}, signingPubKeyHex: 'abc' }),
+    };
+    const fullyArmed =
+      typeof stub.winBroadcastsEnabled === 'function' &&
+      stub.winBroadcastsEnabled() &&
+      typeof stub.getSignerForWinBroadcast === 'function';
+    expect(fullyArmed).toBe(true);
+  });
+});

--- a/tests/unit/profile/steelman-remediation-264.test.ts
+++ b/tests/unit/profile/steelman-remediation-264.test.ts
@@ -273,36 +273,73 @@ describe('Sphere.maybeInstallPointerWinSubscription — symmetric guard (#264)',
     expect(subscribeCalls).toBe(0);
   });
 
-  it('pointer with winBroadcastsEnabled() that THROWS → fail-closed, no subscription, no throw escapes (R5 defensive try/catch)', async () => {
-    // Steelman R5: a misbehaving stub that violates the "MUST NOT
-    // throw" accessor contract must NOT cause the subscriber-install
-    // path to surface a confusing "subscription install failed
-    // (will retry on next event)" log line + arm a permanent retry
-    // loop. The defensive try/catch around the guard expression
-    // treats the throw as flag=false and early-returns cleanly.
-    let subscribeCalls = 0;
-    const sphere = createMinimalSphereForGuardTest({
-      pointer: {
-        winBroadcastsEnabled: () => {
-          throw new Error('synthetic accessor failure');
+  it('pointer with winBroadcastsEnabled() that THROWS → fail-closed via defensive try/catch (NOT outer broad catch) (R5)', async () => {
+    // Steelman R5/R6: a misbehaving stub that violates the
+    // "MUST NOT throw" accessor contract must be handled by the
+    // INNER defensive try/catch, NOT the outer broad catch.
+    // Distinguish the two paths by spying on the logger:
+    //   - INNER (R5) path → `logger.debug('Sphere', 'pointer-win
+    //     subscription: winBroadcastsEnabled() threw (accessor
+    //     contract violation, treating as flag=false): ...')`
+    //   - OUTER (R4) path → `logger.warn('Sphere', 'pointer-win
+    //     subscription install failed (will retry on next event)
+    //     ...')`
+    //
+    // Assert the SPECIFIC debug line + assert no warn was emitted,
+    // so a regression that removes the inner try/catch would route
+    // the throw to the outer catch and trip both assertions.
+    const { logger } = await import('../../../core/logger');
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      let subscribeCalls = 0;
+      const sphere = createMinimalSphereForGuardTest({
+        pointer: {
+          winBroadcastsEnabled: () => {
+            throw new Error('synthetic accessor failure');
+          },
+          getSignerForWinBroadcast: () => ({ signer: {}, signingPubKeyHex: 'abc' }),
         },
-        getSignerForWinBroadcast: () => ({ signer: {}, signingPubKeyHex: 'abc' }),
-      },
-      subscribeToBroadcast: () => {
-        subscribeCalls++;
-        return () => {};
-      },
-    });
-    await expect(
-      (sphere as unknown as {
-        maybeInstallPointerWinSubscription: () => Promise<void>;
-      }).maybeInstallPointerWinSubscription(),
-    ).resolves.toBeUndefined();
-    expect(subscribeCalls).toBe(0);
-    const inFlight = (sphere as unknown as {
-      _pointerWinInstallInFlight: boolean;
-    })._pointerWinInstallInFlight;
-    expect(inFlight).toBe(false);
+        subscribeToBroadcast: () => {
+          subscribeCalls++;
+          return () => {};
+        },
+      });
+      await expect(
+        (sphere as unknown as {
+          maybeInstallPointerWinSubscription: () => Promise<void>;
+        }).maybeInstallPointerWinSubscription(),
+      ).resolves.toBeUndefined();
+      expect(subscribeCalls).toBe(0);
+      const inFlight = (sphere as unknown as {
+        _pointerWinInstallInFlight: boolean;
+      })._pointerWinInstallInFlight;
+      expect(inFlight).toBe(false);
+
+      // INNER defensive path fired: specific debug line emitted.
+      const debugCalls = debugSpy.mock.calls;
+      const accessorViolationLog = debugCalls.find(
+        (call) =>
+          call[0] === 'Sphere' &&
+          typeof call[1] === 'string' &&
+          call[1].includes('accessor contract violation'),
+      );
+      expect(accessorViolationLog).toBeDefined();
+
+      // OUTER broad catch did NOT fire: no "subscription install
+      // failed" warn. A regression that removes the inner try/catch
+      // would route the throw to the outer catch → this would fail.
+      const installFailedWarn = warnSpy.mock.calls.find(
+        (call) =>
+          call[0] === 'Sphere' &&
+          typeof call[1] === 'string' &&
+          call[1].includes('subscription install failed'),
+      );
+      expect(installFailedWarn).toBeUndefined();
+    } finally {
+      debugSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 
   it('pointer with winBroadcastsEnabled() === true BUT missing getSignerForWinBroadcast → fail-closed, no subscription, no throw', async () => {

--- a/tests/unit/profile/steelman-remediation-264.test.ts
+++ b/tests/unit/profile/steelman-remediation-264.test.ts
@@ -165,8 +165,9 @@ describe('ProfilePointerLayer — probeHistory preservation (#264)', () => {
     discoverMockState.nextResult = { validV: 7, includedV: 5, probeVersions: [3, 4, 5] };
     await layer.discoverLatestVersion();
     const fp2 = await layer.getProbeFingerprint();
+    // `fp2.length > 0` is equivalent to `fp2 !== fp0` here (fp0 ===
+    // ''), so we only assert the stronger condition.
     expect(fp2.length).toBeGreaterThan(0);
-    expect(fp2).not.toBe(fp0);
   });
 });
 
@@ -270,6 +271,38 @@ describe('Sphere.maybeInstallPointerWinSubscription — symmetric guard (#264)',
     }).maybeInstallPointerWinSubscription();
     // Strict-`=== true` policy: truthy non-boolean treated as flag=false.
     expect(subscribeCalls).toBe(0);
+  });
+
+  it('pointer with winBroadcastsEnabled() that THROWS → fail-closed, no subscription, no throw escapes (R5 defensive try/catch)', async () => {
+    // Steelman R5: a misbehaving stub that violates the "MUST NOT
+    // throw" accessor contract must NOT cause the subscriber-install
+    // path to surface a confusing "subscription install failed
+    // (will retry on next event)" log line + arm a permanent retry
+    // loop. The defensive try/catch around the guard expression
+    // treats the throw as flag=false and early-returns cleanly.
+    let subscribeCalls = 0;
+    const sphere = createMinimalSphereForGuardTest({
+      pointer: {
+        winBroadcastsEnabled: () => {
+          throw new Error('synthetic accessor failure');
+        },
+        getSignerForWinBroadcast: () => ({ signer: {}, signingPubKeyHex: 'abc' }),
+      },
+      subscribeToBroadcast: () => {
+        subscribeCalls++;
+        return () => {};
+      },
+    });
+    await expect(
+      (sphere as unknown as {
+        maybeInstallPointerWinSubscription: () => Promise<void>;
+      }).maybeInstallPointerWinSubscription(),
+    ).resolves.toBeUndefined();
+    expect(subscribeCalls).toBe(0);
+    const inFlight = (sphere as unknown as {
+      _pointerWinInstallInFlight: boolean;
+    })._pointerWinInstallInFlight;
+    expect(inFlight).toBe(false);
   });
 
   it('pointer with winBroadcastsEnabled() === true BUT missing getSignerForWinBroadcast → fail-closed, no subscription, no throw', async () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -603,6 +603,23 @@ export type SphereEventType =
   | 'address:hidden'
   | 'address:unhidden'
   | 'sync:remote-update'
+  /**
+   * Issue #264 — Sphere bridge of the provider-level
+   * `storage:monotonicity-recovered` event. Fires when the
+   * flush-scheduler auto-merges a detected monotonicity gap in
+   * place: tokens re-merged from the previously-loaded baseline,
+   * unknown bundle CIDs inline-fetched + merged, OUTBOX entries
+   * dropped by SENT-wins dedup, or residuals surfaced for
+   * subsequent retries. See `StorageEventType` for the full payload
+   * shape — Sphere forwards the provider event's `data` verbatim
+   * with an added `providerId` field.
+   *
+   * Informational. Distinct from `transfer:operator-alert` /
+   * `storage:error`: auto-merges are routine convergence work, not
+   * alarms. Observability hook for dashboards plotting recovery rates,
+   * not a paging signal.
+   */
+  | 'storage:monotonicity-recovered'
   | 'groupchat:message'
   | 'groupchat:joined'
   | 'groupchat:left'
@@ -1378,6 +1395,20 @@ export interface SphereEventMap {
   'address:hidden': { index: number; addressId: string };
   'address:unhidden': { index: number; addressId: string };
   'sync:remote-update': { providerId: string; name: string; sequence: number; cid: string; added: number; removed: number };
+  'storage:monotonicity-recovered': {
+    providerId: string;
+    recoveredTokenIds: string[];
+    recoveredTokenCount: number;
+    mergedUnknownBundleCids: string[];
+    mergedUnknownBundleCount: number;
+    residualUnknownBundleCids: string[];
+    residualUnknownBundleCount: number;
+    residualTokenMissingIds: string[];
+    residualTokenMissingCount: number;
+    recoveredOutboxIdsDroppedAsSent: string[];
+    recoveredOutboxIdsDroppedAsSentCount: number;
+    truncated: boolean;
+  };
   'groupchat:message': import('../modules/groupchat/types').GroupMessageData;
   'groupchat:joined': { groupId: string; groupName: string };
   'groupchat:left': { groupId: string };


### PR DESCRIPTION
Closes #264.

## Summary

Implements the four scope items from #264 across 5 commits:

1. **Fast-path port from #263** (`perf(profile)(#264): fast-path skip Step B discovery on attempts === 0`) — `attempts === 0` targets `currentLocalVersion + 1` directly, saving ~30s of wall-clock per publish in the common no-conflict case. The `siblingHighestV` plumbing that #263 introduced is **intentionally omitted** per #264's option (b): adopting a broadcast-derived version into `currentLocalVersion` would leak into `publishOnceAtVersion → resolvePublishVersion` and could silently clear legitimate crash-retry markers whose H8 v-burn accounting is still load-bearing (SPEC §7.1.4 Case 2 — the steelman-critical finding from #263 review).

2. **Feature flag for broadcasts** (`feat(profile)(#264): gate pointer-win broadcasts behind feature flag (default OFF)`) — adds `PointerLayerConfig.enablePointerWinBroadcasts` (strict `=== true` to enable). Gates both the lifecycle-manager publisher (skips sign + `storage:pointer-published` emit) and the Sphere subscriber (`maybeInstallPointerWinSubscription` returns early). ABI-stable: the broadcast wire format and `getSignerForWinBroadcast()` stay in place for eventual re-enablement.

3. **Auto-merge in flush-scheduler** (`fix(profile)(#264): auto-merge monotonicity violations in flush-scheduler`):
   - `tokenMissing` — re-merge missing TXF entries from `previousData` into `pkg`. Union opState with the **SENT-wins-over-OUTBOX** dedup rule via `unionOpStateWithSentWins` so the per-entry-key OrbitDB write doesn't tombstone live entries.
   - `unknownBundleCids` fetch-fail — log warn-level and continue with the best-effort superset (no throw). The existing #255 / PR #262 inline fetch + merge stays for the happy path.
   - New `storage:monotonicity-recovered` event surfaces routine convergence work (distinct from `storage:error`). The legacy `storage:error` with `POINTER_MONOTONICITY_VIOLATION` still fires for residuals so existing dashboards keyed on the literal continue to work.
   - The legacy `queueMicrotask(refreshBaselineForMonotonicity)` is **removed** — under the new contract it would mark the residual CID as in-baseline and silently skip the next flush's inline-fetch retry.

4. **Test updates + new tests** (last two commits):
   - Updated 4 existing tests that asserted the throw behavior (`pointer-monotonicity.test.ts` × 2, `monotonicity-inline-merge.test.ts` × 2) to assert the new auto-merge contract.
   - Cherry-picked #263's fast-path test updates for category-C (C9, C10) and category-M (M5).
   - Updated `lifecycle-manager-pointer-win-broadcast.test.ts` stub to set `winBroadcastsEnabled() { return true; }` so the legacy emission contract still runs end-to-end.
   - New `tests/unit/profile/monotonicity-auto-merge.test.ts` (12 cases) covering: SENT-wins dedup edge cases, OUTBOX/SENT union-by-id semantics, tombstone union by tokenId + JSON dedup, and the `enablePointerWinBroadcasts` default-OFF policy including strict `=== true` coercion against accidentally-truthy values.
   - Lifecycle-manager gate is **tolerant** of pointer stubs without `winBroadcastsEnabled` (fail-closed): treats a missing method as `false` so legacy test harnesses don't need boilerplate.

## Design principle (per #264)

> Convergence MUST be guaranteed by the aggregator pointer versions alone. DM/broadcast coordination is an OPTIMIZATION layer — it can speed convergence but is never load-bearing for correctness. Each device best-effort tries not to violate monotonicity locally; if a violation is detected, the violator MERGES the conflicting state and continues publishing.

With auto-merge in place, the broadcast pipeline is no longer a CORRECTNESS dependency. It's turned off so the system's convergence properties can be tested without the optimization layer obscuring them.

## Acceptance criteria checklist

- [x] `flush-scheduler` no longer throws on monotonicity violation; both `tokenMissing` and `unknownBundleCids`-fetch-fail are recovered in-place with documented merge semantics.
- [x] SENT-vs-OUTBOX dedup rule (SENT wins) is implemented and tested.
- [x] `pointer-win` broadcast pipeline gated by `enablePointerWinBroadcasts` (default OFF). No-op in both publisher (lifecycle-manager) and subscriber (Sphere) paths.
- [x] `siblingHighestV` plumbing from #263 reverted (never landed on this branch — option (b)). Steelman-critical finding from #263 review closed.
- [x] Fast-path optimization from #263 preserved (no discovery on attempt 0).
- [x] All unit + integration tests pass. Lint + typecheck clean.
- [ ] Stage B.1 `manual-test-full-recovery.sh` 5-iteration soak: §C.2 + §C.4 PASS, zero `POINTER_MONOTONICITY_VIOLATION` log lines — **awaiting reviewer run**.
- [ ] `/steelman` review on the resulting branch returns `SHIP IT` — **awaiting reviewer run**.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` on changed files — clean (one pre-existing warning in cherry-picked category-C test)
- [x] `npx vitest run` — 483 files / 8170 tests pass, 13 skipped
- [ ] Manual `manual-test-full-recovery.sh` × 5 iterations — verify §C.2 + §C.4 pass without `bcast_pub > 0`, zero `POINTER_MONOTONICITY_VIOLATION` log lines
- [ ] `/steelman` review on the branch