### PR TITLE
fix(profile)(#268): unblock §C.2 — detach consolidation + fix monotonicity over-reporting

### DIFF
--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -489,11 +489,78 @@ export class FlushScheduler {
       const previousData = this.host.getLastLoadedData();
 
       // (i) Token-set check.
+      //
+      // Issue #268 follow-up — the raw set-difference of storage keys
+      // over-reports violations whenever PaymentsModule retires a
+      // token via the normal lifecycle. Two retirement paths exist:
+      //
+      //   (a) **Tombstone** (spent / burned / invalidated). The token
+      //       is removed from `this.tokens` AND a `{tokenId, stateHash,
+      //       timestamp}` row is appended to `_tombstones`. Storage key
+      //       `_<tokenId>` disappears in the new flush — legitimate.
+      //
+      //   (b) **Archive** (state transition: same genesis tokenId,
+      //       new stateHash). `addToken` archives the prior state
+      //       under the `archived-<tokenId>` key AND deletes the
+      //       wallet-level entry whose old `token.id` no longer
+      //       matches the new state. The active key `_<tokenId>` is
+      //       re-populated by the new state on the next
+      //       `createStorageData()` call — typically same key, no
+      //       set-difference. BUT during the invoice-pay /
+      //       receive-finalize race, the new state may not be in
+      //       `this.tokens` when the flush serializes (e.g., the
+      //       payment removed the source token before the next
+      //       receive replenished any state). In that case the
+      //       archive entry is the canonical record of the token.
+      //
+      // Without this allowance the at-least-once Nostr gate refuses
+      // every ack on every replayed event, the daemon spins at 200 %+
+      // CPU re-running `handleIncomingTransfer`, and the soak hang
+      // documented in issue #268 (receive --finalize → invoice pay
+      // cascade) presents as a 3-minute timeout on `invoice pay`.
+      //
+      // The legitimate-removal set is built from the operational state
+      // extracted alongside `tokens` above so we don't pay an extra
+      // OrbitDB read. Tombstone tokenIds map to `_<tokenId>` keys via
+      // the same `keyFromTokenId` rule the storage layer uses; archive
+      // keys are extracted directly from the current data via
+      // `extractTokensFromTxfData` (which includes `archived-*` keys).
       const tokenMissing: string[] = [];
       if (previousData && previousData !== data) {
         const previousTokens = this.host.extractTokensFromTxfData(previousData);
-        for (const tokenId of previousTokens.keys()) {
-          if (!tokens.has(tokenId)) tokenMissing.push(tokenId);
+        // Build the set of token IDs that have been legitimately
+        // retired in the current flush. Storage keys for active
+        // tokens are `_<id>`; archive keys are `archived-<id>`. We
+        // collapse both prefixes to the underlying id and compare
+        // against the previous-key id to detect a transition.
+        const stripKeyPrefix = (k: string): string => {
+          if (k.startsWith('archived-')) return k.substring('archived-'.length);
+          if (k.startsWith('_forked_')) {
+            const rest = k.substring('_forked_'.length);
+            const sep = rest.indexOf('_');
+            return sep === -1 ? rest : rest.substring(0, sep);
+          }
+          if (k.startsWith('_')) return k.substring(1);
+          return k;
+        };
+        const currentTokenIds = new Set<string>();
+        for (const k of tokens.keys()) currentTokenIds.add(stripKeyPrefix(k));
+        const tombstoneTokenIds = new Set<string>();
+        for (const t of opState.tombstones ?? []) {
+          if (t && typeof (t as { tokenId?: unknown }).tokenId === 'string') {
+            tombstoneTokenIds.add((t as { tokenId: string }).tokenId);
+          }
+        }
+        for (const key of previousTokens.keys()) {
+          if (tokens.has(key)) continue;
+          const id = stripKeyPrefix(key);
+          // (b) Archive transition — current data has the token under
+          // the active OR archive key for the same underlying id.
+          if (currentTokenIds.has(id)) continue;
+          // (a) Tombstoned — current operational state records a
+          // deliberate retirement of this tokenId.
+          if (tombstoneTokenIds.has(id)) continue;
+          tokenMissing.push(key);
         }
       }
 

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -91,6 +91,22 @@ export class FlushScheduler {
    */
   private noDataFlushPending = false;
 
+  /**
+   * Issue #268 — in-memory dedup for background consolidation tasks.
+   *
+   * `flushToIpfs` triggers consolidation when bundle count exceeds
+   * `CONSOLIDATION_THRESHOLD` (3). Without this flag a burst of N
+   * rapid flushes (e.g. faucet topup delivering 6 tokens in quick
+   * succession) would each spawn its own fire-and-forget consolidate
+   * coroutine. The engine's `isConsolidationInProgress` cross-device
+   * check would catch most of them, but only after each pays the
+   * cost of one OrbitDB read. This in-process flag short-circuits
+   * the spawn entirely, ensuring exactly one consolidation runs at a
+   * time per provider instance. Cleared in the `finally` of the
+   * fire-and-forget IIFE so the next eligible flush can spawn one.
+   */
+  private consolidationInFlight: Promise<void> | null = null;
+
   constructor(
     private readonly host: ProfileTokenStorageHost,
     private readonly bundleIndex: BundleIndex,
@@ -796,34 +812,98 @@ export class FlushScheduler {
       // (fetch + pin) which would block shutdown for minutes per N
       // bundles. Without this gate, F.43's shutdown-await-flushPromise
       // could hold up to (N × per-gateway timeout) before completing.
+      // Issue #268 — fire-and-forget consolidation.
+      //
+      // The consolidation engine carries a 30 s TOCTOU sleep
+      // (`consolidation.ts:199`) that fires once `shouldConsolidate()`
+      // is true and `isConsolidationInProgress()` returns false. The
+      // sleep is necessary to let `consolidation.pending` propagate
+      // across OrbitDB peers so a concurrent device can detect our
+      // attempt and abort theirs (the previous 3 s window let two
+      // devices both pin redundant CARs). Inline await of
+      // `engine.consolidate()` therefore blocks the surrounding
+      // `forceFlushSerialized` chain for ≥30 s, which:
+      //   - times out shutdown's `awaitNextFlush(30 s)` →
+      //     at-least-once Nostr replay loop (every CLI session that
+      //     received tokens exits with `pre-shutdown awaitNextFlush
+      //     failed: timeout awaiting serialized flush`);
+      //   - serializes incoming TOKEN_TRANSFER receives at ~30 s
+      //     each (`handleIncomingTransfer → awaitAllProvidersDurable
+      //     → awaitNextFlush`);
+      //   - manifests as the §C.2 soak hang in
+      //     `manual-test-full-recovery.sh` (sphere payments sync
+      //     spins for 14+ minutes at 200 %+ CPU because each of
+      //     the 6 replayed faucet events triggers a 30 s flush).
+      //
+      // Detaching consolidation from the inline path lets the
+      // durability-critical work (pin + bundle ref + publish) commit
+      // in the foreground and return immediately. Consolidation
+      // continues in the background; failure is non-fatal because
+      // every source bundle is already pinned + indexed before
+      // consolidation runs.
+      //
+      // Safety:
+      //   - the in-memory `consolidationInFlight` flag dedupes
+      //     concurrent flushes on this instance so a burst of N
+      //     flushes does not spawn N background tasks;
+      //   - the engine's `isConsolidationInProgress` check still
+      //     handles cross-device concurrency;
+      //   - the engine's 30 s TOCTOU sleep `.unref()`s its timer
+      //     so a process exit while consolidation is sleeping
+      //     simply cancels the sleep — no extra work needed to
+      //     keep the process from staying alive.
       if (this.host.getIsShuttingDown()) {
         this.host.log('Consolidation skipped: shutdown in progress');
+      } else if (this.consolidationInFlight !== null) {
+        this.host.log(
+          'Consolidation skipped: background task already running on this instance',
+        );
       } else if (await this.bundleIndex.shouldConsolidate()) {
-        try {
-          const { ConsolidationEngine } = await import('../consolidation.js');
-          const engine = new ConsolidationEngine(
-            this.host.db,
-            encryptionKey,
-            this.host.ipfsGateways,
-          );
-          if (!(await engine.isConsolidationInProgress())) {
+        // Spawn fire-and-forget consolidation. The IIFE captures the
+        // local `encryptionKey` so it remains valid even after the
+        // outer `flushToIpfs` returns.
+        this.consolidationInFlight = (async (): Promise<void> => {
+          try {
+            const { ConsolidationEngine } = await import('../consolidation.js');
+            const engine = new ConsolidationEngine(
+              this.host.db,
+              encryptionKey,
+              this.host.ipfsGateways,
+            );
+            if (await engine.isConsolidationInProgress()) {
+              this.host.log(
+                'Consolidation skipped: another device is in progress',
+              );
+              return;
+            }
+            // Bail out early if shutdown started between the
+            // outer-arm check and here. Avoids spawning a 30 s
+            // sleeper that the process is about to exit anyway.
+            if (this.host.getIsShuttingDown()) {
+              this.host.log(
+                'Consolidation skipped: shutdown started before background spawn',
+              );
+              return;
+            }
             const result = await engine.consolidate();
             if (result.consolidated) {
               this.host.log(
-                `Consolidation: merged ${result.sourceBundleCount} bundles → ${result.consolidatedCid ?? 'n/a'}`,
+                `Consolidation: merged ${result.sourceBundleCount} bundles → ${result.consolidatedCid ?? 'n/a'} (background)`,
               );
             } else {
               this.host.log('Consolidation skipped (engine no-op)');
             }
-          } else {
-            this.host.log('Consolidation skipped: another device is in progress');
+          } catch (err) {
+            this.host.log(
+              `Consolidation failed (non-fatal, background): ${err instanceof Error ? err.message : String(err)}`,
+            );
+          } finally {
+            this.consolidationInFlight = null;
           }
-        } catch (err) {
-          // Best-effort: do not fail the flush on consolidation error.
-          this.host.log(
-            `Consolidation failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
+        })();
+        // Detach from the active flush chain. The flush body must
+        // not await this promise (that defeats the fix); any failure
+        // is logged inside the IIFE.
       }
 
       // 9. Publish to the aggregator pointer layer for cold-start recovery.


### PR DESCRIPTION
## Summary

Closes the §C.2 hang in `manual-test-full-recovery.sh` (#268). Two complementary fixes inside `profile/profile-token-storage/flush-scheduler.ts`:

1. **Detach consolidation from the inline flush path** (commit 9bab39d). The engine's 30 s TOCTOU sleep (`profile/consolidation.ts:199`) was blocking every flush past 3 active bundles. Inline await stacked 30 s per flush, timed out shutdown's `awaitNextFlush(30 s)`, and drove the at-least-once Nostr replay loop that surfaces as `sphere payments sync` spinning 14+ minutes at 200 %+ CPU.
2. **Allow archived + tombstoned tokens in the monotonicity check** (commit 3f916b7). The token-set check was doing a raw set-difference of storage keys and over-reporting violations whenever PaymentsModule retired a token via the normal lifecycle (tombstone on spend, archive on state transition).

## Impact

| Operation | Before | After |
|---|---|---|
| sphere faucet (CLI exit) | 39 s | 14 s |
| sphere balance (subsequent) | 39 s | 7 s |
| **§C.2 payments sync** | **hang 14+ min** | **10.7 s** |
| **§C.2 receive --finalize** | **hang 8+ min** | **70 s** |
| **§C.2 invoice pay** | **timeout 180 s** | **26 s (submitted)** |

Full §C.2 sequence: ~107 s vs 22+ minute hang.

## Diagnosis path

- Built isolated reproducer `repro-c2.sh` (45 min full soak → 30 s micro-repro) so iteration could be fast.
- Disabled the `verifyFlushDurability` HEAD gate via `SPHERE_FLUSH_VERIFY_MS=0` — did NOT fix the hang → original 2026-05-25 memory diagnosis was wrong (gateway propagation was a red herring).
- Added per-phase warn() timing to `flushToIpfs` — revealed `consolidation=30418ms` while `pin+orbitdb+publish=~1300ms`.
- Traced to `consolidation.ts:199` 30 s TOCTOU sleep.
- After fix 1, observed cascading POINTER_MONOTONICITY_VIOLATION in the receive-finalize → invoice-pay flow. Token-set check at `flush-scheduler.ts:489` was the culprit.

## Validation

- 4 iterations of FAST micro-reproducer — all clean, no `awaitNextFlush failed` messages.
- Full §C.2 reproducer (sync + receive --finalize + invoice pay) — clean, payment submitted.
- 7,581 unit tests pass (`npx vitest run tests/unit`) — 0 regressions.
- Official `manual-test-full-recovery.sh` — passed §C entirely (originally the blocker). Stalls at §D.1 with a **separate, unrelated bug** filed as #269 (`drainPendingFinalizations` retries permanent verification failures).

## Safety

Both fixes are local to flush-scheduler. No public API surface, no behavior change for genuine violations:

- **Consolidation:** the engine's `isConsolidationInProgress` cross-device check still handles concurrency; the in-memory `consolidationInFlight` flag dedupes per-instance; the 30 s sleep `.unref()`s its timer so process exit cancels it cleanly. Failure during consolidation is non-fatal (source bundles were already pinned + indexed before consolidation ran).
- **Monotonicity check:** genuine violations (cross-device race, partial save() bug) still throw. Only the over-reported cases (tombstones + archive transitions) are now skipped via prefix-aware comparison.

## Test plan

- [x] Confirm `repro-c2.sh` FAST mode is clean × 4 iterations
- [x] Confirm full §C.2 reproducer completes (sync + receive --finalize + invoice pay)
- [x] `npx vitest run tests/unit/profile` (1910 tests)
- [x] `npx vitest run tests/unit/modules/payments` (515 tests)
- [x] `npx vitest run tests/unit` (7581 tests)
- [x] `manual-test-full-recovery.sh` — passes §C cleanly (#268 closed); §D.1 stalls due to #269 (unrelated)

## Follow-up

#269 — `drainPendingFinalizations` retries permanent verification failures indefinitely (V6-RECOVER drain loop). Surfaces in §D.1 of the soak; unrelated root cause; same pattern (distinguish transient vs permanent) as the monotonicity recovery fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)