### PR TITLE
fix(payments)(#269): classify VerificationError(Recipient address mismatch) as permanent

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -297,6 +297,7 @@ import { MintTransactionData } from '@unicitylabs/state-transition-sdk/lib/trans
 import { waitInclusionProof } from '@unicitylabs/state-transition-sdk/lib/util/InclusionProofUtils';
 import { InclusionProof } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof';
 import { InvalidJsonStructureError } from '@unicitylabs/state-transition-sdk/lib/InvalidJsonStructureError';
+import { VerificationError } from '@unicitylabs/state-transition-sdk/lib/verification/VerificationError';
 import { TransferTransactionData } from '@unicitylabs/state-transition-sdk/lib/transaction/TransferTransactionData';
 import { RequestId } from '@unicitylabs/state-transition-sdk/lib/api/RequestId';
 import { Authenticator } from '@unicitylabs/state-transition-sdk/lib/api/Authenticator';
@@ -9364,39 +9365,83 @@ export class PaymentsModule {
 
       logger.debug('Payments', `[V6-RECOVER] Finalized stranded receive ${tokenId.slice(0, 12)} → confirmed`);
     } catch (err) {
-      // Classify the error: structural / parse-shape failures cannot be
-      // fixed by retry — the on-disk `lastTxJson` or the aggregator
-      // `proofJson` is malformed in a way that no amount of re-polling
-      // changes. Without classification, V6-RECOVER would re-register the
-      // job on every process restart (via `recoverStrandedReceivedTokens`)
-      // and spam the operator with a non-converging error every cycle.
+      // Classify the error: some failures cannot be fixed by retry. Without
+      // classification, V6-RECOVER would re-register the job on every process
+      // restart (via `recoverStrandedReceivedTokens`) and `drainPendingFinalizations`
+      // would burn its full timeout window every sync, spamming the operator
+      // and stalling §D.1 of the soak harness.
       //
-      // Permanent failure handling:
+      // Two permanent classes are recognised here:
+      //
+      //  (a) Structural / parse-shape failures — `InvalidJsonStructureError`
+      //      from SDK `TransferTransaction.fromJSON` / `InclusionProof.fromJSON`.
+      //      The on-disk `lastTxJson` or the aggregator `proofJson` is malformed;
+      //      no amount of re-polling changes the bytes. Issue: sphere-sdk#231.
+      //
+      //  (b) Recipient address mismatch — SDK `VerificationError` with inner
+      //      `verificationResult.message === 'Recipient address mismatch'` (from
+      //      `Token.verifyRecipient`, surfaced via `transaction.verify` →
+      //      `token.update`'s "Transaction verification failed" wrapper, OR
+      //      directly via "Recipient verification failed" in `token.update`).
+      //      By the time we reach this catch, `finalizeTransferToken` has
+      //      already invoked `tryRecoverSigningServiceForRecipient` and exhausted
+      //      every tracked HD address — none of our signers derive the predicate
+      //      the sender targeted. Retrying with the same inputs cannot succeed.
+      //      Issue: sphere-sdk#269. The reversibility hook (re-trying once a
+      //      previously untracked HD index gets activated) is deferred; for now
+      //      operators see the `not-our-state` alert and can re-scan after
+      //      activating the missing index manually.
+      //
+      // Permanent failure handling (both classes):
       //   1. Mark the token as 'invalid' so `recoverStrandedReceivedTokens`
       //      doesn't re-pick it up on next load.
       //   2. Remove any live proof-polling job for this token.
-      //   3. Emit `transfer:operator-alert` with code `structural`
-      //      (canonical disposition reason for parse-shape failures).
-      //   4. Log the shape of `lastTxJson` and `proofJson` at debug level
-      //      so SDK developers can diagnose the underlying SDK
-      //      `InclusionProof.fromJSON` / `TransferTransaction.fromJSON`
-      //      mismatch. Only top-level keys are logged — full payloads
-      //      may contain large authenticator bytes we don't need to dump.
-      //
-      // Issue: sphere-sdk#231.
-      const isPermanent = err instanceof InvalidJsonStructureError ||
+      //   3. Emit `transfer:operator-alert` with the appropriate canonical
+      //      disposition reason — `structural` for (a), `not-our-state` for (b).
+      //   4. (Structural only) Log the shape of `lastTxJson` / `proofJson` at
+      //      debug level so SDK developers can diagnose the underlying SDK
+      //      mismatch. Only top-level keys are logged — full payloads may
+      //      contain large authenticator bytes we don't need to dump.
+      const isStructural = err instanceof InvalidJsonStructureError ||
         (err as { name?: string } | null)?.name === 'InvalidJsonStructureError';
 
+      // (b) Recipient address mismatch. We accept either an `instanceof
+      // VerificationError` OR a duck-typed shape (`verificationResult.status`
+      // + recognisable message) so the classifier survives bundle-duplication
+      // edge cases where the SDK module loaded by the catch site differs from
+      // the one that constructed the thrown error (tsup multi-entry,
+      // hoisted-vs-nested dep resolution, ESM/CJS interop in tests).
+      const verificationResult = (err as { verificationResult?: { status?: number; message?: string } } | null)
+        ?.verificationResult;
+      const isMismatchMessage = (msg: string | undefined): boolean =>
+        typeof msg === 'string' && (
+          msg === 'Recipient address mismatch' ||
+          msg.includes('address mismatch')
+        );
+      const isPermanentMismatch =
+        (err instanceof VerificationError || (err as { name?: string } | null)?.name === 'VerificationError') &&
+        verificationResult?.status === 1 &&
+        isMismatchMessage(verificationResult.message);
+
+      const isPermanent = isStructural || isPermanentMismatch;
+
       if (isPermanent) {
+        const classLabel = isPermanentMismatch
+          ? 'permanent recipient-address mismatch (HD-index recovery exhausted)'
+          : 'permanent structural failure';
         logger.error(
           'Payments',
-          `[V6-RECOVER] Stranded receive ${tokenId.slice(0, 12)} hit permanent structural failure (no retry):`,
+          `[V6-RECOVER] Stranded receive ${tokenId.slice(0, 12)} hit ${classLabel} (no retry):`,
           err,
         );
 
         // One-shot diagnostic dump so the SDK-level shape can be inspected.
         // Top-level keys only — full bodies can carry large fields (proofs,
         // authenticators) that aren't necessary for SDK-error triage.
+        // Skipped for the not-our-state path — the bytes are well-formed; the
+        // useful diagnostic was already emitted by `tryRecoverSigningServiceForRecipient`
+        // as a `[FINALIZE-RECOVER]` warn line naming the divergent addresses.
+        if (isStructural) {
         try {
           const job = this.proofPollingJobs.get(tokenId);
           let proofShape: string[] | string = 'not-fetched';
@@ -9445,6 +9490,7 @@ export class PaymentsModule {
         } catch (diagErr) {
           logger.debug('Payments', `[V6-RECOVER] ${tokenId.slice(0, 12)} diagnostic dump itself threw:`, diagErr);
         }
+        }
 
         // 1. Mark the token as invalid so subsequent load() runs skip it.
         const token = this.tokens.get(tokenId);
@@ -9465,19 +9511,30 @@ export class PaymentsModule {
           logger.debug('Payments', `[V6-RECOVER] saveProofPollingJobs after permanent-fail mark failed:`, persistErr),
         );
 
-        // 3. Surface to operator/UI via the canonical `structural`
-        //    disposition reason — parse-shape failure that no retry fixes.
+        // 3. Surface to operator/UI via the canonical disposition reason.
+        //    - structural  → parse-shape failure that no retry fixes
+        //    - not-our-state → recipient predicate doesn't bind to any of
+        //      our tracked HD signers; structurally valid, just unspendable
+        //      by us with currently-tracked addresses.
         try {
-          this.deps!.emitEvent('transfer:operator-alert', {
-            code: 'structural',
-            tokenId,
-            message: sanitizeReasonString(
-              `Token ${tokenId.slice(0, 12)}... cannot be finalized: ` +
+          const innerMsg = verificationResult?.message;
+          const alertCode = isPermanentMismatch ? 'not-our-state' : 'structural';
+          const alertMessage = isPermanentMismatch
+            ? `Token ${tokenId.slice(0, 12)}... cannot be finalized: ` +
+              `${(err as Error)?.message ?? 'VerificationError'} (${innerMsg ?? 'recipient address mismatch'}). ` +
+              `The sender targeted a recipient predicate that none of this wallet's currently-tracked ` +
+              `HD addresses derive. Marked invalid; no further automatic recovery attempts will run for ` +
+              `this token. If the sender targeted an HD index you have not yet activated, activate it ` +
+              `and re-import the OrbitDB pointer to retry.`
+            : `Token ${tokenId.slice(0, 12)}... cannot be finalized: ` +
               `${(err as Error)?.message ?? 'InvalidJsonStructureError'}. ` +
               `The stored last-transaction JSON or the aggregator proof has an unexpected shape. ` +
               `Marked invalid; no further automatic recovery attempts will run for this token. ` +
-              `Manual diagnosis required — see debug logs for the shape dump.`,
-            ),
+              `Manual diagnosis required — see debug logs for the shape dump.`;
+          this.deps!.emitEvent('transfer:operator-alert', {
+            code: alertCode,
+            tokenId,
+            message: sanitizeReasonString(alertMessage),
           });
         } catch { /* event emitter not wired */ }
 

--- a/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
+++ b/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
@@ -994,6 +994,188 @@ describe('#144 L3 — balance-model invariant + stranded recovery', () => {
     }
   });
 
+  // Issue #269 — `finalizeStrandedReceivedToken` previously treated SDK
+  // `VerificationError` with `verificationResult.message === 'Recipient
+  // address mismatch'` as transient: the catch logged at error level and
+  // returned, leaving the token in 'pending'. Each `sync()` then ran
+  // `drainPendingFinalizations` for the full timeoutMs window because
+  // `hasUnconfirmedOrInflight()` kept seeing the unresolved token. With
+  // the at-least-once Nostr replay (PR #240) every replay re-triggered
+  // the same drain, stalling §D.1 of `manual-test-full-recovery.sh`.
+  //
+  // By the time this catch fires, `finalizeTransferToken` has already
+  // run `tryRecoverSigningServiceForRecipient` and exhausted every
+  // tracked HD address. The mismatch is therefore permanent w.r.t. the
+  // wallet's current key inventory — retrying with the same inputs
+  // cannot succeed.
+  it('finalizeStrandedReceivedToken classifies VerificationError(Recipient address mismatch) as permanent (issue #269)', async () => {
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    // Oracle returns a structurally-valid proof so the unwrap +
+    // `TransferTransaction.fromJSON` path succeeds. The failure must come
+    // from `finalizeTransferToken`'s SDK call, not from the proof shape.
+    (setup.deps.oracle as { getProof: ReturnType<typeof vi.fn> }).getProof =
+      vi.fn().mockResolvedValue({
+        merkleTreePath: { steps: [] },
+        unicityCertificate: { rootHash: '00' },
+        toJSON() { return { merkleTreePath: { steps: [] }, unicityCertificate: { rootHash: '00' } }; },
+      });
+
+    // Construct the SDK error shape the bug surfaces. Outer message
+    // mirrors the issue's stack trace (`token.update` wraps the
+    // `transaction.verify` result).
+    const sdkVerifMod = await import(
+      '@unicitylabs/state-transition-sdk/lib/verification/VerificationError'
+    );
+    const verificationError = new sdkVerifMod.VerificationError(
+      'Transaction verification failed',
+      // Cast: we only need shape fidelity (status + message), not the
+      // full SDK class instance for `instanceof` — the classifier also
+      // accepts the duck-typed shape.
+      { status: 1, message: 'Recipient address mismatch', results: [] } as never,
+    );
+
+    // Bypass `finalizeTransferToken`'s internal HD-index recovery and
+    // jump straight to the throw — that path is covered by other tests;
+    // here we are exercising the catch classifier in
+    // `finalizeStrandedReceivedToken`.
+    const internalsAny = module as unknown as {
+      finalizeTransferToken: (...args: unknown[]) => Promise<unknown>;
+    };
+    const priorFinalize = internalsAny.finalizeTransferToken;
+    internalsAny.finalizeTransferToken = vi
+      .fn()
+      .mockRejectedValue(verificationError);
+
+    try {
+      const lastTxJson = { previousStateHash: STATE_HASH, predicate: 'pred2', data: {} };
+      const sourceTokenJson = JSON.stringify({ genesis: { data: { tokenId: GENESIS_TOKEN_ID } } });
+      internals(module).proofPollingJobs.set(GENESIS_TOKEN_ID, {
+        tokenId: GENESIS_TOKEN_ID,
+        requestIdHex: '00deadbeef',
+        commitmentJson: '',
+        sourceTokenJson,
+        startedAt: Date.now(),
+        attemptCount: 0,
+        lastAttemptAt: 0,
+      });
+
+      await (module as unknown as {
+        finalizeStrandedReceivedToken: (
+          tokenId: string,
+          sourceTokenJson: string,
+          lastTxJson: Record<string, unknown>,
+        ) => Promise<void>;
+      }).finalizeStrandedReceivedToken(GENESIS_TOKEN_ID, sourceTokenJson, lastTxJson);
+
+      // 1. Token marked invalid so `hasUnconfirmedOrInflight()` no longer
+      //    sees it and the drain loop can return early.
+      expect(internals(module).tokens.get(GENESIS_TOKEN_ID)?.status).toBe('invalid');
+
+      // 2. Polling job removed.
+      expect(internals(module).proofPollingJobs.has(GENESIS_TOKEN_ID)).toBe(false);
+
+      // 3. Operator alert fired with `not-our-state` (NOT 'structural'
+      //    — bytes were well-formed; the address just doesn't bind).
+      const alerts = setup.emittedEvents.filter(
+        (e) => e.type === 'transfer:operator-alert',
+      );
+      expect(alerts.length).toBeGreaterThanOrEqual(1);
+      const alert = alerts[alerts.length - 1].payload as {
+        code: string;
+        tokenId: string;
+        message: string;
+      };
+      expect(alert.code).toBe('not-our-state');
+      expect(alert.tokenId).toBe(GENESIS_TOKEN_ID);
+      expect(alert.message).toContain('cannot be finalized');
+      expect(alert.message.toLowerCase()).toContain('mismatch');
+    } finally {
+      internalsAny.finalizeTransferToken = priorFinalize;
+    }
+  });
+
+  // Negative: a VerificationError whose inner message isn't a recipient/
+  // address mismatch (e.g., predicate-verify failure due to malformed
+  // signature bytes) must NOT trip the permanent-fail path — those can
+  // be transient (network blip yielding a bad proof, retried).
+  it('finalizeStrandedReceivedToken keeps non-mismatch VerificationError transient (issue #269 negative case)', async () => {
+    const sdkData = makeV6DirectReceiveSdkData();
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    (setup.deps.oracle as { getProof: ReturnType<typeof vi.fn> }).getProof =
+      vi.fn().mockResolvedValue({
+        toJSON() { return { merkleTreePath: { steps: [] }, unicityCertificate: { rootHash: '00' } }; },
+      });
+
+    const sdkVerifMod = await import(
+      '@unicitylabs/state-transition-sdk/lib/verification/VerificationError'
+    );
+    const verificationError = new sdkVerifMod.VerificationError(
+      'Predicate verification failed',
+      { status: 1, message: 'Predicate verification failed', results: [] } as never,
+    );
+
+    const internalsAny = module as unknown as {
+      finalizeTransferToken: (...args: unknown[]) => Promise<unknown>;
+    };
+    const priorFinalize = internalsAny.finalizeTransferToken;
+    internalsAny.finalizeTransferToken = vi.fn().mockRejectedValue(verificationError);
+
+    try {
+      const lastTxJson = { previousStateHash: STATE_HASH, predicate: 'pred2', data: {} };
+      const sourceTokenJson = JSON.stringify({ genesis: { data: { tokenId: GENESIS_TOKEN_ID } } });
+      internals(module).proofPollingJobs.set(GENESIS_TOKEN_ID, {
+        tokenId: GENESIS_TOKEN_ID,
+        requestIdHex: '00deadbeef',
+        commitmentJson: '',
+        sourceTokenJson,
+        startedAt: Date.now(),
+        attemptCount: 0,
+        lastAttemptAt: 0,
+      });
+
+      await (module as unknown as {
+        finalizeStrandedReceivedToken: (
+          tokenId: string,
+          sourceTokenJson: string,
+          lastTxJson: Record<string, unknown>,
+        ) => Promise<void>;
+      }).finalizeStrandedReceivedToken(GENESIS_TOKEN_ID, sourceTokenJson, lastTxJson);
+
+      // Stays pending, job retained, no operator alert.
+      expect(internals(module).tokens.get(GENESIS_TOKEN_ID)?.status).toBe('pending');
+      expect(internals(module).proofPollingJobs.has(GENESIS_TOKEN_ID)).toBe(true);
+      const alerts = setup.emittedEvents.filter(
+        (e) => e.type === 'transfer:operator-alert',
+      );
+      expect(alerts.length).toBe(0);
+    } finally {
+      internalsAny.finalizeTransferToken = priorFinalize;
+    }
+  });
+
   // Issue #251 — V6-RECOVER previously passed `oracle.getProof`'s wrapper
   // shape ({requestId, roundNumber, proof, timestamp}) directly as the
   // inclusionProof patched into the synthetic lastTxJson. The wrapper has


### PR DESCRIPTION
## Summary

Fixes #269 — `drainPendingFinalizations` was burning its full `timeoutMs` window every `sync()` on tokens whose `VerificationError(Recipient address mismatch)` was already permanent (HD-index recovery exhausted in `finalizeTransferToken`). Combined with the at-least-once Nostr replay (PR #240), this stalled §D.1 of `manual-test-full-recovery.sh`, discovered while validating PR #270 (#268) against the soak.

By the time `finalizeStrandedReceivedToken`'s catch fires, `tryRecoverSigningServiceForRecipient` (PR #251/#255) has already iterated every tracked HD address — none of our signers derive the predicate the sender targeted. Retry cannot succeed.

## Changes

`modules/payments/PaymentsModule.ts` — `finalizeStrandedReceivedToken` catch:

- Adds a second permanent-error class alongside the existing `InvalidJsonStructureError` path (PR for #231): `VerificationError` with `verificationResult.status === 1` and message containing `"address mismatch"` → permanent NOT-OUR-STATE.
- Defensive classifier: accepts `instanceof VerificationError` OR duck-typed shape (`name === 'VerificationError'` + `verificationResult` shape) to survive tsup multi-entry bundle duplication.
- Other `VerificationError` causes (`"Predicate verification failed"`, etc.) stay transient — those can be genuine bad-proof / signature blips that retry resolves.

Handling mirrors the structural path:
1. Token marked `'invalid'` so `recoverStrandedReceivedTokens` skips it.
2. Proof-polling job removed.
3. `transfer:operator-alert` emitted with `code: 'not-our-state'` (vs `'structural'`) and an actionable message naming the manual workaround (activate the missing HD index, re-import the OrbitDB pointer).
4. Structural diagnostic dump skipped on the mismatch path — bytes are well-formed; the useful diagnostic was already emitted by `tryRecoverSigningServiceForRecipient` as a `[FINALIZE-RECOVER]` warn line.

A reversibility hook (auto-retry on `address:activated`) is deferred to a follow-up.

## Tests

`tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts`:

- **Positive**: `VerificationError` with `'Recipient address mismatch'` → token becomes `'invalid'`, polling job removed, `transfer:operator-alert` with `code='not-our-state'` fired.
- **Negative**: `VerificationError` with `'Predicate verification failed'` → token stays `'pending'`, polling job retained, no alert emitted.

All 436 existing `PaymentsModule.*` tests remain green per local run before push.

## Test plan

- [x] Unit tests in `PaymentsModule.proof-polling-persistence.test.ts` cover both classifier paths
- [ ] Re-run §D.1 of `manual-test-full-recovery.sh` to confirm the §D.1 hang is resolved
- [ ] Verify `transfer:operator-alert` `not-our-state` is visible in the wallet UI when a misaddressed token arrives

## Funds safety

Funds are NOT lost. The aggregator-confirmed transfer is unchanged — the `invalid` mark is wallet-local. If the sender targeted an HD index this wallet hasn't activated yet, the value sits in the aggregator state addressed to a predicate we DO derive (just not iterated). Operators see the alert and can re-scan after activating the missing index.

Closes #269.