### PR TITLE
fix(profile,transport)(#272): decouple per-flush HEAD-verify from at-least-once gate

### DIFF
--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -1041,11 +1041,19 @@ export class ProfileTokenStorageProvider
       // Errors from the chain (POINTER_MONOTONICITY_VIOLATION, etc.)
       // propagate as a rejection — caller decides ack behavior.
       const chained = this.flushScheduler.forceFlushSerialized();
+      // Issue #272 — explicitly hold the timeout handle so we can
+      // clearTimeout in finally. Without this, when `chained` settles
+      // first, the setTimeout fires later (after the original deadline)
+      // with an unhandled rejection from `Promise.race` (already-
+      // settled, but the timer callback still allocates the
+      // SphereError). Over a replay storm of N iterations × M parallel
+      // awaitNextFlush callers, these timer handles accumulate.
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       try {
         await Promise.race([
           chained,
-          new Promise<never>((_, reject) =>
-            setTimeout(
+          new Promise<never>((_, reject) => {
+            timeoutHandle = setTimeout(
               () =>
                 reject(
                   new SphereError(
@@ -1054,8 +1062,8 @@ export class ProfileTokenStorageProvider
                   ),
                 ),
               remainingMs(),
-            ),
-          ),
+            );
+          }),
         ]);
       } catch (err) {
         if (err instanceof SphereError && err.code === 'TIMEOUT') throw err;
@@ -1090,6 +1098,13 @@ export class ProfileTokenStorageProvider
         // refuses to advance the Nostr ack — event re-replays on
         // next reconnect; addToken stateHash dedup is idempotent.
         throw err;
+      } finally {
+        // Issue #272 — always clear the race timeout, whether `chained`
+        // settled first (timer would fire late) or the timer fired
+        // first (already cleared by the throw path, but harmless).
+        if (timeoutHandle !== undefined) {
+          clearTimeout(timeoutHandle);
+        }
       }
 
       // After the flush, pendingData was cleared inside flushToIpfs

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -1528,7 +1528,42 @@ export class FlushScheduler {
         const snapshotCid = freshSnapshotPublished
           ? this.host.getLastDiscoveredPointerCid()
           : null;
-        await this.host.verifyFlushDurability(cid, snapshotCid, verifyDeadlineMs);
+
+        // Issue #272 — detach the HEAD-verify leg from the synchronous
+        // flush completion path. Local-durability is already guaranteed
+        // by the conditions satisfied above:
+        //   (1) bundle CAR pin POST returned 200 — operator Kubo holds
+        //       the bytes;
+        //   (2) OrbitDB bundle ref written — sibling replicas will sync
+        //       the new bundle in the next OrbitDB exchange;
+        //   (3) snapshot publish call returned ok (when `publishResult`
+        //       is set ok) — the aggregator pointer reflects the new
+        //       version for cold-import discovery.
+        //
+        // The HEAD-verify leg checks whether the operator gateway is
+        // serving the just-pinned CID YET. That is a property of the
+        // OPERATOR'S IPFS PROPAGATION LATENCY, not of the receiver's
+        // local crash-safety. Awaiting it inline coupled per-flush
+        // operations to gateway latency, which under contended testnet
+        // caused the at-least-once gate to refuse Nostr ack on every
+        // flush (`awaitNextFlush` rejects with `FLUSH_DURABILITY_TIMEOUT`
+        // → `awaitAllProvidersDurable` returns false → `since` cursor
+        // never advances → same TOKEN_TRANSFER event replays on every
+        // reconnect → each replay schedules another flush → busy-spin).
+        //
+        // The forensics at `.tmp/soak-postmerge-271/` captured 134
+        // `[AT-LEAST-ONCE] not durable` warnings across only 14 unique
+        // event IDs in 6 minutes with 3 node processes pegged at 90-175%
+        // CPU — purely from this coupling.
+        //
+        // We now run the verification as a background task with full
+        // budget. On failure we emit a typed `storage:durability-
+        // deferred` event for operator triage and update the last-
+        // verified watermarks (or leave them stale) so the shutdown
+        // gate, which has its own deadline and SHOULD still gate on
+        // remote durability before exit, gets the correct view.
+        // The flush itself completes synchronously regardless.
+        this.startBackgroundDurabilityVerify(cid, snapshotCid, verifyDeadlineMs);
       }
     } catch (err) {
       // On failure, re-queue the data so it is not lost
@@ -1545,6 +1580,57 @@ export class FlushScheduler {
    * `lastLoadedData`) bookkeeping happens on the facade so byte-
    * identical fields stay in their original location.
    */
+  /**
+   * Issue #272 — fire-and-forget background HEAD-verify of just-pinned
+   * CIDs against the operator IPFS gateway. Detached from the
+   * synchronous flush completion path so a gateway propagation lag
+   * does NOT close the at-least-once Nostr ack gate. See the long
+   * comment block at the {@link flushToIpfs} verification call site
+   * for the design rationale.
+   *
+   * On failure, emits `storage:durability-deferred` with structured
+   * detail. The shutdown gate's own remote-durability verification
+   * (`LifecycleManager.awaitRemoteDurability`) runs independently
+   * with its own deadline; if THIS background verify is still in
+   * flight at shutdown time, the shutdown gate may run a redundant
+   * HEAD-verify, which is bounded by its own configured deadline
+   * (acceptable cost — shutdown is rare and operator-triggered).
+   *
+   * Never throws; never rejects. The returned Promise is intentionally
+   * unawaited and any error is routed through `emitEvent` only.
+   */
+  private startBackgroundDurabilityVerify(
+    cid: string,
+    snapshotCid: string | null,
+    verifyDeadlineMs: number,
+  ): void {
+    // Use a void IIFE so the floating-promises lint rule sees an
+    // explicit fire-and-forget intent without `void`-prefixing the
+    // call site (which loses the `.catch()` ergonomics).
+    void (async (): Promise<void> => {
+      try {
+        await this.host.verifyFlushDurability(cid, snapshotCid, verifyDeadlineMs);
+      } catch (err) {
+        const code = (err as { code?: string }).code;
+        const details = (err as { details?: unknown }).details;
+        this.host.emitEvent({
+          type: 'storage:durability-deferred',
+          timestamp: Date.now(),
+          data: { cid, snapshotCid, code, details },
+          error: err instanceof Error ? err.message : String(err),
+          code,
+          cause: err,
+        });
+        this.host.log(
+          `Profile durability: background verify deferred for bundle=${cid}` +
+            (snapshotCid ? ` snapshot=${snapshotCid}` : '') +
+            ` — code=${code ?? 'unknown'}. Local state remains durable; ` +
+            `gateway propagation may still be in progress.`,
+        );
+      }
+    })();
+  }
+
   enqueueSave(data: TxfStorageDataBase): void {
     // Any new save() invalidates the lastPinnedCid retry cache
     // unconditionally. A reference-identity check is insufficient: a

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -898,6 +898,32 @@ export class LifecycleManager {
     snapshotCid: string | null,
     deadlineMs: number,
   ): Promise<void> {
+    // Issue #272 — short-circuit when both CIDs are already verified
+    // within this provider's lifetime. Under replay storms the same
+    // bundle CID can be presented many times (no save() in between);
+    // each previous call to verifyFlushDurability stamped the watermark
+    // (`setLastVerifiedBundleCid` below), so re-running ~80 HEAD probes
+    // (4 awaitNextFlush iterations × 2 legs × ~10 retries each) is
+    // pure wasted work that adds to the gateway contention this gate
+    // is supposed to recover FROM.
+    //
+    // The watermark is cleared implicitly by a fresh flush on different
+    // CIDs (the next per-flush gate either succeeds and updates it, or
+    // fails and leaves it stale — shutdown still runs the legs on the
+    // newer CIDs anyway). There is no TTL: the watermark is per-
+    // provider-lifetime and a process restart clears it naturally.
+    const verifiedBundle = this.host.getLastVerifiedBundleCid();
+    const verifiedSnapshot = this.host.getLastVerifiedSnapshotCid();
+    const bundleMatches = bundleCid === verifiedBundle;
+    const snapshotMatches =
+      snapshotCid === null || snapshotCid === verifiedSnapshot;
+    if (bundleMatches && snapshotMatches) {
+      this.host.log(
+        `Profile durability: ${bundleCid} HEAD-verify short-circuited (already verified this lifetime)`,
+      );
+      return;
+    }
+
     const deadline = Date.now() + Math.max(0, deadlineMs);
 
     // No shared abort signal — every leg honors `deadline` directly via

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -413,7 +413,45 @@ export type StorageEventType =
    * subsequent cross-device syncs detecting the same gap and
    * re-attempting the inline merge.
    */
-  | 'storage:monotonicity-recovered';
+  | 'storage:monotonicity-recovered'
+  /**
+   * Issue #272 — emitted when the per-flush remote-durability
+   * HEAD-verify leg (`verifyFlushDurability`), now run as a background
+   * task detached from the synchronous flush completion path, fails
+   * for a just-pinned bundle CID and/or snapshot CID.
+   *
+   * Local-durability is unaffected: the bundle CAR pin POST returned
+   * 200, the OrbitDB bundle ref is written, and (when wired) the
+   * snapshot publish call returned ok. What this event signals is that
+   * the operator's IPFS gateway has not yet served the just-pinned
+   * CID back via HEAD within the configured deadline (default 30s).
+   * This is a gateway propagation property — not a receiver crash-
+   * safety property — and does NOT close the at-least-once Nostr ack
+   * gate. Distinct from `storage:error` (terminal fatal class).
+   *
+   * `data` carries `{ cid, snapshotCid?, code?, details? }`:
+   *   - `cid`         the bundle CID whose HEAD-verify failed
+   *   - `snapshotCid` the snapshot CID (when also verified)
+   *   - `code`        the structured error code (e.g.,
+   *                   `FLUSH_DURABILITY_TIMEOUT`)
+   *   - `details`     the failed-leg detail array from
+   *                   `verifyFlushDurability`
+   *
+   * Operator action: investigate operator Kubo gateway propagation
+   * lag if this fires repeatedly for distinct CIDs. Single-shot fires
+   * (a CID that eventually does propagate) are expected under normal
+   * testnet contention and require no action.
+   *
+   * Before #272: this same failure threw inline and forced the
+   * at-least-once gate's `awaitNextFlush` to reject, causing the
+   * Nostr `since` cursor to refuse to advance and the inbound
+   * TOKEN_TRANSFER event to replay on every reconnect. Each replay
+   * triggered another flush, each flush re-hit the same HEAD-verify
+   * timeout, producing a sustained busy-spin (134 replays for 14
+   * unique event IDs in the §C.2 soak failure observed at
+   * `integration/all-fixes` HEAD `6102d59`).
+   */
+  | 'storage:durability-deferred';
 
 export interface StorageEvent {
   type: StorageEventType;

--- a/tests/unit/profile/lifecycle-manager-verify-shortcircuit-272.test.ts
+++ b/tests/unit/profile/lifecycle-manager-verify-shortcircuit-272.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Issue #272 — `verifyFlushDurability` short-circuits on already-verified CIDs.
+ *
+ * Background: pre-#272, each `awaitNextFlush` iteration (capped at 4)
+ * called `verifyFlushDurability` from scratch — including the HEAD-verify
+ * retry loop against the operator gateway. Under replay storms the same
+ * bundle CID was presented many times (no save() in between), each
+ * call running up to ~80 HEAD probes (4 iterations × 2 legs × ~10
+ * retries) before throwing TIMEOUT.
+ *
+ * Fix: when both `bundleCid === getLastVerifiedBundleCid()` AND
+ * `snapshotCid === null || === getLastVerifiedSnapshotCid()`, return
+ * immediately. The watermark is per-provider-lifetime; a fresh flush on
+ * different CIDs leaves the watermark stale (shutdown still verifies
+ * the new CIDs) — there is no TTL.
+ *
+ * Coverage:
+ *   1. First call with fresh CIDs hits the network (verifyCidAccessible
+ *      fetch is invoked) and stamps the watermark.
+ *   2. Second call with the SAME CIDs short-circuits (no network calls).
+ *   3. A second call with a DIFFERENT bundleCid hits the network again.
+ *   4. snapshotCid=null is accepted even when getLastVerifiedSnapshotCid
+ *      returns null (the bundle-only common case).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import type { ProfilePointerLayer } from '../../../profile/aggregator-pointer';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { create as createMultihash } from 'multiformats/hashes/digest';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+const GATEWAY_A = 'https://gateway-a.test';
+const GATEWAY_B = 'https://gateway-b.test';
+
+function makeCid(seed: string): string {
+  const bytes = new TextEncoder().encode(seed);
+  return CID.createV1(raw.code, createMultihash(0x12, sha256(bytes))).toString();
+}
+
+const BUNDLE_CID = makeCid('272-bundle-A');
+const BUNDLE_CID_B = makeCid('272-bundle-B');
+const SNAPSHOT_CID = makeCid('272-snapshot-A');
+
+function createMockDb(): ProfileDatabase & { _store: Map<string, Uint8Array> } {
+  const store = new Map<string, Uint8Array>();
+  return {
+    _store: store,
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as ProfileDatabase & { _store: Map<string, Uint8Array> };
+}
+
+function createMockLocalCache(): {
+  storage: {
+    get: (k: string) => Promise<string | null>;
+    set: (k: string, v: string) => Promise<void>;
+    remove: (k: string) => Promise<void>;
+    clear: () => Promise<void>;
+  };
+} {
+  const store = new Map<string, string>();
+  return {
+    storage: {
+      async get(k: string) { return store.get(k) ?? null; },
+      async set(k: string, v: string) { store.set(k, v); },
+      async remove(k: string) { store.delete(k); },
+      async clear() { store.clear(); },
+    },
+  };
+}
+
+function stubPointer(): ProfilePointerLayer {
+  return {
+    async recoverLatest() {
+      return null;
+    },
+    async publish() {
+      return { cid: new Uint8Array(0), version: 0, attemptsUsed: 1 } as never;
+    },
+  } as unknown as ProfilePointerLayer;
+}
+
+async function createHandle() {
+  const db = createMockDb();
+  const localCache = createMockLocalCache();
+  const pointer = stubPointer();
+  const provider = new ProfileTokenStorageProvider(
+    db,
+    new Uint8Array(32).fill(0x11),
+    [GATEWAY_A, GATEWAY_B],
+    {
+      config: { orbitDb: { privateKey: TEST_PRIVATE_KEY }, ipnsSnapshot: false },
+      addressId: 'test-272',
+      encrypt: true,
+      getPointerLayer: () => pointer,
+    },
+    localCache.storage as unknown as never,
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  await provider.initialize();
+
+  const lifecycle = (provider as unknown as {
+    lifecycleManager: {
+      verifyFlushDurability(b: string, s: string | null, dms: number): Promise<void>;
+    };
+  }).lifecycleManager;
+
+  return { provider, lifecycle };
+}
+
+function mockFetchCounter(): { calls: number; restore: () => void } {
+  const original = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls += 1;
+    return new Response(null, { status: 200 });
+  }) as typeof fetch;
+  return {
+    get calls() { return calls; },
+    restore: () => { globalThis.fetch = original; },
+  };
+}
+
+describe('LifecycleManager.verifyFlushDurability — short-circuit on already-verified CIDs (Issue #272)', () => {
+  let restore: (() => void) | null = null;
+
+  beforeEach(() => { vi.useRealTimers(); });
+  afterEach(async () => {
+    restore?.();
+    restore = null;
+  });
+
+  it('first verify call hits the network and stamps the watermark', async () => {
+    const counter = mockFetchCounter();
+    restore = counter.restore;
+    const handle = await createHandle();
+    try {
+      await expect(
+        handle.lifecycle.verifyFlushDurability(BUNDLE_CID, SNAPSHOT_CID, 5_000),
+      ).resolves.toBeUndefined();
+      expect(counter.calls).toBeGreaterThanOrEqual(1);
+    } finally {
+      await handle.provider.shutdown({ force: true });
+    }
+  });
+
+  it('second verify call with the SAME CIDs short-circuits (zero network calls)', async () => {
+    const counter = mockFetchCounter();
+    restore = counter.restore;
+    const handle = await createHandle();
+    try {
+      await handle.lifecycle.verifyFlushDurability(BUNDLE_CID, SNAPSHOT_CID, 5_000);
+      const callsAfterFirst = counter.calls;
+      expect(callsAfterFirst).toBeGreaterThanOrEqual(1);
+
+      // Second call — identical CIDs. Must short-circuit.
+      await handle.lifecycle.verifyFlushDurability(BUNDLE_CID, SNAPSHOT_CID, 5_000);
+      expect(counter.calls).toBe(callsAfterFirst); // no additional network calls
+    } finally {
+      await handle.provider.shutdown({ force: true });
+    }
+  });
+
+  it('second verify call with a DIFFERENT bundleCid re-hits the network', async () => {
+    const counter = mockFetchCounter();
+    restore = counter.restore;
+    const handle = await createHandle();
+    try {
+      await handle.lifecycle.verifyFlushDurability(BUNDLE_CID, SNAPSHOT_CID, 5_000);
+      const callsAfterFirst = counter.calls;
+
+      // Different bundle CID — must NOT short-circuit.
+      await handle.lifecycle.verifyFlushDurability(BUNDLE_CID_B, SNAPSHOT_CID, 5_000);
+      expect(counter.calls).toBeGreaterThan(callsAfterFirst);
+    } finally {
+      await handle.provider.shutdown({ force: true });
+    }
+  });
+
+  it('bundle-only verify (snapshotCid=null) short-circuits on repeat', async () => {
+    const counter = mockFetchCounter();
+    restore = counter.restore;
+    const handle = await createHandle();
+    try {
+      await handle.lifecycle.verifyFlushDurability(BUNDLE_CID, null, 5_000);
+      const callsAfterFirst = counter.calls;
+      expect(callsAfterFirst).toBeGreaterThanOrEqual(1);
+
+      await handle.lifecycle.verifyFlushDurability(BUNDLE_CID, null, 5_000);
+      expect(counter.calls).toBe(callsAfterFirst);
+    } finally {
+      await handle.provider.shutdown({ force: true });
+    }
+  });
+});

--- a/tests/unit/transport/NostrTransportProvider.durabilityCooldown272.test.ts
+++ b/tests/unit/transport/NostrTransportProvider.durabilityCooldown272.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Issue #272 — per-event durability-failure cooldown gate.
+ *
+ * Background: pre-#272, a `handleTokenTransfer` returning `false`
+ * (the at-least-once gate refused the Nostr ack) caused the
+ * `lastEventTs` cursor to not advance, so the same event re-replayed
+ * on every Nostr reconnect cycle. Under the soak conditions captured
+ * in `.tmp/soak-postmerge-271/`, this produced 134 replay warnings
+ * across only 14 unique event IDs — the receive pipeline (parse +
+ * crypto verify + flush + HEAD-verify) burned ~10x the work per
+ * unique event with all 3 node processes pegged at 90-175% CPU.
+ *
+ * Fix: add a per-event cooldown ledger so consecutive durability
+ * misses for the same event ID are subject to exponential backoff,
+ * and after `DURABILITY_MAX_REPLAY_ATTEMPTS` consecutive misses the
+ * cursor advances anyway (with an operator alert) so subsequent
+ * events do not back up behind one persistently-failing one.
+ *
+ * These tests exercise the cooldown methods directly via reflection
+ * because routing through the public `handleEvent → handleTokenTransfer`
+ * path requires functional NIP-04 decryption, which would couple the
+ * tests to crypto-mock plumbing without adding logic coverage. The
+ * methods being tested (`isInDurabilityCooldown`, `recordDurabilityMiss`)
+ * are the ONLY non-trivial code introduced by the patch; the call sites
+ * are simple branches that are covered by existing integration tests.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { WebSocketFactory } from '../../../transport/websocket';
+
+// =============================================================================
+// Mock NostrClient
+// =============================================================================
+
+const mockSubscribe = vi.fn().mockReturnValue('mock-sub-id');
+const mockUnsubscribe = vi.fn();
+const mockPublishEvent = vi.fn().mockResolvedValue('mock-event-id');
+const mockConnect = vi.fn().mockResolvedValue(undefined);
+const mockDisconnect = vi.fn();
+const mockIsConnected = vi.fn().mockReturnValue(true);
+const mockGetConnectedRelays = vi.fn().mockReturnValue(new Set(['wss://test.relay']));
+const mockAddConnectionListener = vi.fn();
+const mockRelaysMap = new Map<string, unknown>();
+const mockStopPingTimer = vi.fn();
+
+vi.mock('@unicitylabs/nostr-js-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/nostr-js-sdk')>();
+  return {
+    ...actual,
+    NostrClient: vi.fn().mockImplementation(() => ({
+      connect: mockConnect,
+      disconnect: mockDisconnect,
+      isConnected: mockIsConnected,
+      getConnectedRelays: mockGetConnectedRelays,
+      subscribe: mockSubscribe,
+      unsubscribe: mockUnsubscribe,
+      publishEvent: mockPublishEvent,
+      addConnectionListener: mockAddConnectionListener,
+      relays: mockRelaysMap,
+      stopPingTimer: mockStopPingTimer,
+    })),
+  };
+});
+
+const { NostrTransportProvider } = await import('../../../transport/NostrTransportProvider');
+
+function createProvider() {
+  return new NostrTransportProvider({
+    relays: ['wss://test.relay'],
+    createWebSocket: (() => {}) as unknown as WebSocketFactory,
+    timeout: 100,
+    autoReconnect: false,
+  });
+}
+
+interface CooldownEntry {
+  nextRetryAt: number;
+  attempts: number;
+}
+
+interface ProviderInternals {
+  failedEventCooldowns: Map<string, CooldownEntry>;
+  isInDurabilityCooldown(eventId: string): boolean;
+  recordDurabilityMiss(eventId: string): boolean;
+}
+
+function inspect(provider: unknown): ProviderInternals {
+  return provider as unknown as ProviderInternals;
+}
+
+describe('NostrTransportProvider — durability cooldown (Issue #272)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+    mockGetConnectedRelays.mockReturnValue(new Set(['wss://test.relay']));
+  });
+
+  describe('recordDurabilityMiss', () => {
+    it('first miss arms a ~30s cooldown, returns false (do NOT advance cursor)', () => {
+      const provider = createProvider();
+      const internals = inspect(provider);
+      const eventId = 'a'.repeat(64);
+
+      const shouldAdvance = internals.recordDurabilityMiss(eventId);
+      expect(shouldAdvance).toBe(false);
+
+      const entry = internals.failedEventCooldowns.get(eventId);
+      expect(entry).toBeDefined();
+      expect(entry!.attempts).toBe(1);
+
+      const cooldownMs = entry!.nextRetryAt - Date.now();
+      // 30s ± slack for jitter
+      expect(cooldownMs).toBeGreaterThan(20_000);
+      expect(cooldownMs).toBeLessThanOrEqual(30_000);
+    });
+
+    it('second miss exponentially backs off to ~60s', () => {
+      const provider = createProvider();
+      const internals = inspect(provider);
+      const eventId = 'b'.repeat(64);
+
+      internals.recordDurabilityMiss(eventId);
+      const shouldAdvance = internals.recordDurabilityMiss(eventId);
+      expect(shouldAdvance).toBe(false);
+
+      const entry = internals.failedEventCooldowns.get(eventId);
+      expect(entry!.attempts).toBe(2);
+
+      const cooldownMs = entry!.nextRetryAt - Date.now();
+      // 60s ± slack
+      expect(cooldownMs).toBeGreaterThan(50_000);
+      expect(cooldownMs).toBeLessThanOrEqual(60_000);
+    });
+
+    it('third miss exhausts the budget, returns true (advance cursor), clears ledger', () => {
+      const provider = createProvider();
+      const internals = inspect(provider);
+      const eventId = 'c'.repeat(64);
+
+      internals.recordDurabilityMiss(eventId); // 1
+      internals.recordDurabilityMiss(eventId); // 2
+      const shouldAdvance = internals.recordDurabilityMiss(eventId); // 3
+
+      expect(shouldAdvance).toBe(true);
+      // Ledger entry was cleared so a re-occurrence after advance gets
+      // a fresh budget (typically irrelevant — cursor moved past).
+      expect(internals.failedEventCooldowns.has(eventId)).toBe(false);
+    });
+  });
+
+  describe('isInDurabilityCooldown', () => {
+    it('returns false for an unknown event ID', () => {
+      const provider = createProvider();
+      const internals = inspect(provider);
+      expect(internals.isInDurabilityCooldown('unknown')).toBe(false);
+    });
+
+    it('returns true for an event ID with a live cooldown', () => {
+      const provider = createProvider();
+      const internals = inspect(provider);
+      const eventId = 'd'.repeat(64);
+      internals.recordDurabilityMiss(eventId);
+      expect(internals.isInDurabilityCooldown(eventId)).toBe(true);
+    });
+
+    it('returns false once the cooldown has expired (entry preserved for attempt counting)', () => {
+      const provider = createProvider();
+      const internals = inspect(provider);
+      const eventId = 'e'.repeat(64);
+      internals.recordDurabilityMiss(eventId);
+      // Force-expire by rewinding nextRetryAt into the past.
+      internals.failedEventCooldowns.get(eventId)!.nextRetryAt = Date.now() - 1;
+      expect(internals.isInDurabilityCooldown(eventId)).toBe(false);
+      // Attempts count survives so the next miss correctly increments to 2.
+      expect(internals.failedEventCooldowns.get(eventId)!.attempts).toBe(1);
+    });
+  });
+
+  describe('LRU eviction', () => {
+    it('caps the cooldown ledger at the configured size by evicting the oldest entry', () => {
+      const provider = createProvider();
+      const internals = inspect(provider);
+      // The cap is private (DURABILITY_COOLDOWN_MAP_CAP = 256). Insert
+      // enough entries to trigger one eviction.
+      for (let i = 0; i < 256; i++) {
+        internals.recordDurabilityMiss(`evict-${i.toString().padStart(4, '0')}`);
+      }
+      expect(internals.failedEventCooldowns.size).toBe(256);
+      const firstKey = 'evict-0000';
+      expect(internals.failedEventCooldowns.has(firstKey)).toBe(true);
+
+      // One more insert — pushes capacity, evicts oldest.
+      internals.recordDurabilityMiss('overflow');
+      expect(internals.failedEventCooldowns.size).toBe(256);
+      expect(internals.failedEventCooldowns.has(firstKey)).toBe(false);
+      expect(internals.failedEventCooldowns.has('overflow')).toBe(true);
+    });
+  });
+
+  describe('cooldown intervals are bounded by COOLDOWN_MAX_MS (~120s)', () => {
+    it('a 3-miss sequence does NOT exceed the configured max cooldown', () => {
+      const provider = createProvider();
+      const internals = inspect(provider);
+      const eventId = 'f'.repeat(64);
+      internals.recordDurabilityMiss(eventId);
+      internals.recordDurabilityMiss(eventId);
+      // Third miss returns true (budget exhausted) and clears the entry —
+      // so we never observe the third backoff. The max is exercised by
+      // the (attempts-1)=2 case clamping 30s*2^2=120s → COOLDOWN_MAX_MS.
+      // Verify the second-miss cooldown is exactly the max (60s here,
+      // since 30s*2^1=60s which is below the max).
+      const entry = internals.failedEventCooldowns.get(eventId);
+      if (entry) {
+        const cooldownMs = entry.nextRetryAt - Date.now();
+        expect(cooldownMs).toBeLessThanOrEqual(120_000);
+      }
+    });
+  });
+});

--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -145,6 +145,47 @@ export class NostrTransportProvider implements TransportProvider {
 
   // Event handlers
   private processedEventIds = new Set<string>();
+
+  /**
+   * Issue #272 — per-event failure cooldown ledger for TOKEN_TRANSFER
+   * replays. When `handleIncomingTransfer` returns `false` (the at-
+   * least-once gate refused the ack), we record an exponential cool-
+   * down so the relay-paced replay storm cannot busy-spin the
+   * receive pipeline (parse → crypto verify → flush → HEAD-verify)
+   * for the same event on every reconnect cycle.
+   *
+   * Semantics:
+   *   - `attempts` counts consecutive durability misses. Cleared on
+   *     success (advance happens) or when the bounded budget exhausts.
+   *   - `nextRetryAt` is `Date.now() + min(COOLDOWN_BASE_MS * 2^(n-1),
+   *     COOLDOWN_MAX_MS)`. Events arriving inside the cooldown window
+   *     are skipped without entering the gate.
+   *   - After `MAX_REPLAY_ATTEMPTS` consecutive misses, we ADVANCE the
+   *     cursor anyway and emit an operator alert. This matches the
+   *     acceptance criterion in issue #272: "`[AT-LEAST-ONCE] not
+   *     durable` count per token bounded by a small constant (≤3)
+   *     rather than unbounded replay." Local-durability is intact
+   *     (issue #272 also decoupled the per-flush HEAD-verify from
+   *     the gate, so persistent durability=false now strictly
+   *     indicates an underlying OrbitDB/pin POST/publish failure that
+   *     replay alone won't fix — operator intervention is the right
+   *     escalation).
+   *   - The map is LRU-capped to bound memory under pathological
+   *     replay floods. Eviction is single-victim per insert when at
+   *     capacity (cheap; no full sort).
+   *
+   * Not persisted across process restarts (intentional — a fresh
+   * process gets a fresh chance, and the `processedEventIds` dedup
+   * still prevents double-processing of an already-acked event).
+   */
+  private failedEventCooldowns = new Map<
+    string,
+    { nextRetryAt: number; attempts: number }
+  >();
+  private static readonly DURABILITY_COOLDOWN_BASE_MS = 30_000;
+  private static readonly DURABILITY_COOLDOWN_MAX_MS = 120_000;
+  private static readonly DURABILITY_MAX_REPLAY_ATTEMPTS = 3;
+  private static readonly DURABILITY_COOLDOWN_MAP_CAP = 256;
   private messageHandlers: Set<MessageHandler> = new Set();
   private transferHandlers: Set<TokenTransferHandler> = new Set();
   private paymentRequestHandlers: Set<PaymentRequestHandler> = new Set();
@@ -1548,6 +1589,20 @@ export class NostrTransportProvider implements TransportProvider {
           await this.handleGiftWrap(event);
           break;
         case EVENT_KINDS.TOKEN_TRANSFER:
+          // Issue #272: cooldown gate. Skip processing entirely when a
+          // recent durability miss for this event ID is still within
+          // its cooldown window. Without this, relay reconnect immediately
+          // re-fires the failing event and the receive pipeline (parse +
+          // crypto verify + flush + HEAD-verify) burns CPU on every retry
+          // before refusing the ack again. The cooldown is a memory-only
+          // map (see field doc); a process restart gets a fresh budget.
+          if (event.id && this.isInDurabilityCooldown(event.id)) {
+            logger.debug(
+              'Nostr',
+              `[AT-LEAST-ONCE] TOKEN_TRANSFER ${event.id.slice(0, 12)} in durability cooldown — skipping replay`,
+            );
+            return;
+          }
           tokenTransferDurable = await this.handleTokenTransfer(event);
           break;
         case EVENT_KINDS.PAYMENT_REQUEST:
@@ -1576,11 +1631,39 @@ export class NostrTransportProvider implements TransportProvider {
           this.updateLastEventTimestamp(event.created_at);
         } else if (kind === EVENT_KINDS.TOKEN_TRANSFER) {
           if (tokenTransferDurable) {
+            // Issue #272: success — drop any prior cooldown tracking
+            // so a future event with the same ID (which shouldn't
+            // normally happen, but happens during cold-start replay
+            // floods on Nostr reconnect) gets a fresh budget.
+            if (event.id) this.failedEventCooldowns.delete(event.id);
             this.updateLastEventTimestamp(event.created_at);
+          } else if (event.id) {
+            // Issue #272: bounded replay budget. `recordDurabilityMiss`
+            // increments the per-event attempt counter, arms an
+            // exponential cooldown, and returns `true` once the budget
+            // is exhausted — at which point we advance the cursor to
+            // unstick subsequent events behind this one.
+            const shouldAdvance = this.recordDurabilityMiss(event.id);
+            if (shouldAdvance) {
+              logger.warn(
+                'Nostr',
+                `[AT-LEAST-ONCE] TOKEN_TRANSFER ${event.id.slice(0, 12)} exhausted ${NostrTransportProvider.DURABILITY_MAX_REPLAY_ATTEMPTS} durability replay attempts — advancing cursor; operator should investigate local OrbitDB/IPFS-pin/publish failures.`,
+              );
+              this.updateLastEventTimestamp(event.created_at);
+            } else {
+              const entry = this.failedEventCooldowns.get(event.id);
+              const cooldownMs = entry ? Math.max(0, entry.nextRetryAt - Date.now()) : 0;
+              logger.warn(
+                'Nostr',
+                `[AT-LEAST-ONCE] TOKEN_TRANSFER ${event.id.slice(0, 12)} not durable — leaving 'since' at ${this.lastEventTs}; cooldown ${cooldownMs}ms (attempt ${entry?.attempts ?? '?'}/${NostrTransportProvider.DURABILITY_MAX_REPLAY_ATTEMPTS}).`,
+              );
+            }
           } else {
+            // Defensive: no event.id means we can't track cooldown or
+            // advance idempotently. Preserve legacy behavior.
             logger.warn(
               'Nostr',
-              `[AT-LEAST-ONCE] TOKEN_TRANSFER ${event.id?.slice(0, 12)} not durable — leaving 'since' at ${this.lastEventTs}; event will replay on next reconnect`,
+              `[AT-LEAST-ONCE] TOKEN_TRANSFER (no id) not durable — leaving 'since' at ${this.lastEventTs}; event will replay on next reconnect`,
             );
           }
         }
@@ -1606,6 +1689,69 @@ export class NostrTransportProvider implements TransportProvider {
     this.storage.set(storageKey, createdAt.toString()).catch(err => {
       logger.debug('Nostr', 'Failed to save last event timestamp:', err);
     });
+  }
+
+  /**
+   * Issue #272 — return true iff this event ID has a live durability
+   * cooldown. Cleans up the entry when the cooldown has expired so the
+   * map doesn't accumulate stale entries on the read path.
+   */
+  private isInDurabilityCooldown(eventId: string): boolean {
+    const entry = this.failedEventCooldowns.get(eventId);
+    if (!entry) return false;
+    if (Date.now() >= entry.nextRetryAt) {
+      // Cooldown expired — leave the attempts count INTACT (we still
+      // need it so the next failure increments correctly toward the
+      // MAX_REPLAY_ATTEMPTS budget). The entry will be replaced on
+      // the next miss or deleted on the next success.
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Issue #272 — record a durability miss for this event ID and arm
+   * an exponential cooldown. Returns `true` when the per-event replay
+   * budget (`DURABILITY_MAX_REPLAY_ATTEMPTS`) is exhausted — in that
+   * case the caller should advance the `since` cursor (the entry is
+   * deleted by this method to free the slot) so subsequent events
+   * are not blocked indefinitely behind one persistently-failing one.
+   * Local-durability is decoupled from this gate (issue #272 background-
+   * verify patch in `flush-scheduler.ts`), so a persistent miss after
+   * the budget exhausts indicates a genuine local persistence failure
+   * (OrbitDB write timeout / pin POST != 200 / monotonicity violation)
+   * that re-replay alone cannot resolve.
+   */
+  private recordDurabilityMiss(eventId: string): boolean {
+    const prior = this.failedEventCooldowns.get(eventId);
+    const attempts = (prior?.attempts ?? 0) + 1;
+
+    if (attempts >= NostrTransportProvider.DURABILITY_MAX_REPLAY_ATTEMPTS) {
+      this.failedEventCooldowns.delete(eventId);
+      return true;
+    }
+
+    // LRU-style cap: when at capacity, evict the oldest insertion
+    // (Map preserves insertion order, so the first key IS the oldest).
+    // Single-victim eviction per insert is sufficient under typical
+    // replay-flood pressure (14 unique IDs in the §C.2 forensics; cap
+    // of 256 covers >18x that headroom).
+    if (this.failedEventCooldowns.size >= NostrTransportProvider.DURABILITY_COOLDOWN_MAP_CAP) {
+      const oldestKey = this.failedEventCooldowns.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.failedEventCooldowns.delete(oldestKey);
+      }
+    }
+
+    const delayMs = Math.min(
+      NostrTransportProvider.DURABILITY_COOLDOWN_BASE_MS * Math.pow(2, attempts - 1),
+      NostrTransportProvider.DURABILITY_COOLDOWN_MAX_MS,
+    );
+    this.failedEventCooldowns.set(eventId, {
+      nextRetryAt: Date.now() + delayMs,
+      attempts,
+    });
+    return false;
   }
 
   /** Persist the max DM (gift-wrap) event timestamp for the since filter on next connect. */


### PR DESCRIPTION
## Summary

Closes #272. Fixes the fourth surface of the §C.2 failure family
(#266, #268, #269, #272) by **decoupling the per-flush IPFS HEAD-verify
leg from the synchronous at-least-once Nostr ack path** and **bounding
the per-event replay budget**.

## Why this keeps coming back

Each prior §C.2 fix closed ONE arm of the same coupling defect:

| Issue | Symptom | Fix shape |
|---|---|---|
| **#266** | Full libp2p stack pulled into client startup | HTTP-only IPFS default (#267) |
| **#268** | Consolidation 30s TOCTOU + monotonicity over-reporting | Detached consolidation from inline flush (#270) |
| **#269** | `Recipient address mismatch` retried as transient | Classified as permanent (#271) |
| **#272** (this) | Operator gateway propagation jitter exceeds 30s leg | This PR |

The architect-level review of the UXF/OrbitDB/Profile design concluded
the underlying defect is **narrow and surgical, not foundational**: a
single conditional in `flush-scheduler.ts` was conflating two unrelated
invariants — LOCAL crash-safety (already satisfied by CAR pin POST 200 +
OrbitDB ref written + publish call ok) and REMOTE gateway propagation
observability (a property of the operator's IPFS infrastructure, not of
the receiver's correctness). Awaiting the remote-observability leg
inline made every gateway hiccup amplify into a sustained replay storm.

Both the architect review and the code-quality review independently
arrived at the same primary recommendation: **make the HEAD-verify
leg background; bound replay attempts per event**.

## Forensics

`/home/vrogojin/uxf/.tmp/soak-postmerge-271/` (preserved):
- `script.log` (38 KB) — full output, ends mid-§C.2 sync
- `processes_at_kill.txt` — 175%/93%/93% CPU at kill
- `proc_state_at_kill.txt` — 810 MB / 709 MB / 855 MB RSS, growing
- 134 \`[AT-LEAST-ONCE] not durable\` warnings for **only 14 unique event IDs** (~10x replay each)
- \`since\` cursor stuck at \`1779789068\` / \`1779789101\` for 6+ minutes

## The four patches

### Patch 1 (root cause) — `flush-scheduler.ts`
\`verifyFlushDurability\` is now launched as a fire-and-forget
background task. The synchronous flush completes as soon as
local-durability is achieved. On HEAD-verify failure, a new typed
\`storage:durability-deferred\` event is emitted for operator triage.

### Patch 2 (defense-in-depth) — `NostrTransportProvider.ts`
Per-event failure cooldown ledger:
- After a durability miss, the same event ID is skipped during an
  exponential backoff window (30s → 60s → 120s cap).
- After 3 consecutive misses the cursor advances anyway, with an
  operator-alert warn log — matching the issue's acceptance criterion
  (\"≤3 replays per token\").
- LRU-capped at 256 entries to bound memory under pathological replay floods.

### Patch 3 (perf) — `lifecycle-manager.ts`
\`verifyFlushDurability\` short-circuits when both CIDs match the
last-verified watermarks. Prevents repeated ~80 HEAD probes against
unchanged CIDs across replay cycles.

### Patch 4 (timer leak) — `profile-token-storage-provider.ts`
Clear the \`setTimeout\` in \`awaitNextFlush\`'s \`Promise.race\` via
\`finally\` (code-reviewer's confirmed bug — under replay storms these
timers accumulated as unhandled handles).

## What this PR does NOT do (deferred)

- **\`MultiAddressTransportMux.dispatchWalletEvent\` gate bypass**
  (code-reviewer's confirmed bug #1): \`dispatchTokenTransfer\` returns
  \`void\` and \`updateLastEventTimestamp\` runs unconditionally. The
  Mux path silently breaks the at-least-once invariant for token
  transfers. The §C.2 failure does NOT originate here (the warnings
  in the soak logs come from the bare \`NostrTransportProvider\`
  path), so this is **a separate latent bug** that needs its own
  issue and fix. Plugging the Mux gate WITHOUT this PR's cooldown
  would turn the Mux path INTO the same spin we're fixing — order
  matters.
- **Persistent per-event retry ledger** (architect's structural
  follow-up). The cooldown map is in-memory; a process restart loses
  the budget. A persistent ledger would harden CLI tools that exit
  and re-enter, but is a larger surgery than #272 needs.
- **Tuning the production \`flushVerificationDeadlineMs\`**. With
  Patch 1 making the call background, the deadline now only governs
  how long the background task runs — it never blocks the gate.
  Tuning it further is a no-op for #272's bug and a follow-up only
  if operators want to reduce background HEAD load.

## Test plan

### Unit (mandatory)
- [x] \`tests/unit/transport/NostrTransportProvider.durabilityCooldown272.test.ts\` — 8 tests covering \`recordDurabilityMiss\` exponential backoff, \`isInDurabilityCooldown\` lifecycle, LRU eviction, \`MAX_REPLAY_ATTEMPTS\` budget exhaustion.
- [x] \`tests/unit/profile/lifecycle-manager-verify-shortcircuit-272.test.ts\` — 4 tests covering the CID-change short-circuit via mocked \`fetch\` HEAD call count.
- [x] Full suite: **8177 passed | 13 skipped** (unchanged from baseline; no regressions).
- [x] \`npm run typecheck\` — clean.

### Soak (acceptance criteria from #272)
- [ ] \`manual-test-full-recovery.sh\` §C.2 clears in reasonable window (running in background; will update once complete).
- [ ] No node process pegging >50% CPU sustained.
- [ ] \`[AT-LEAST-ONCE] not durable\` count per token bounded by ≤3.
- [ ] §C.3 / §C.4 / §D / §E continue to pass.

## Steelman / risk notes

**Risk: by making HEAD-verify background, do we lose any guarantee?**
No. The synchronous flush path still guarantees:
1. CAR pin POST returned 200 — operator Kubo HOLDS the bytes.
2. OrbitDB bundle ref written — sibling replicas will sync on next OrbitDB exchange.
3. Publish call returned ok (when wired) — aggregator pointer reflects the new version.

These three conditions ARE the cross-device recoverability invariant. HEAD-verify was checking whether the gateway is SERVING the CID YET — a property of operator infrastructure propagation latency, distinct from the receiver's local crash-safety.

**Risk: the shutdown gate's last-verified watermark.**
Patch 3's short-circuit reads the watermark; Patch 1's background task still writes it. If shutdown fires while a background verify is in flight, the shutdown gate runs its OWN verification (independent deadline) — bounded by the configured shutdown deadline. Acceptable cost; shutdown is rare and operator-triggered.

**Risk: cooldown ledger memory.**
LRU-capped at 256 entries; with 14 unique event IDs in the worst observed flood that's 18x headroom. Eviction is single-victim per insert (O(1) using Map insertion-order). Each entry is ~80 bytes — total bound is ~20 KB.

**Risk: budget exhaustion advances the cursor on a real persistent failure.**
After Patch 1, persistent durability=false strictly indicates a genuine LOCAL persistence failure (OrbitDB write timeout / pin POST != 200 / monotonicity violation) that re-replay alone cannot resolve. Advancing the cursor with an operator alert is the right escalation; sitting in a replay storm forever is worse.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)