### PR TITLE
perf(#275): persist Nostr event dedup across process restarts (#275)

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -69,6 +69,19 @@ export const STORAGE_KEYS_GLOBAL = {
    * invocations rather than resetting per-process.
    */
   FAILED_EVENT_COOLDOWNS: 'failed_event_cooldowns',
+  /**
+   * Issue #275 — persistent dedup set for the MultiAddressTransportMux
+   * level. The Mux maintains its own `processedEventIds` (independent
+   * of NostrTransportProvider's set) and dispatches to per-address
+   * adapters. Without persistence, every fresh CLI invocation
+   * re-walked the relay backlog through the Mux path as well as the
+   * outer-provider path. Bounded by `LIMITS.PROCESSED_EVENT_IDS_CAP`.
+   * Per-wallet storage scope: each Sphere instance has its own
+   * `storage` provider, so a bare global key is sufficient (no
+   * per-pubkey suffix needed because the Mux spans all per-wallet
+   * addresses).
+   */
+  MUX_PROCESSED_EVENT_IDS: 'mux_processed_event_ids',
   /** Group chat: last used relay URL (stale data detection) — global, same relay for all addresses */
   GROUP_CHAT_RELAY_URL: 'group_chat_relay_url',
   /** Cached token registry JSON (fetched from remote) */

--- a/constants.ts
+++ b/constants.ts
@@ -48,6 +48,27 @@ export const STORAGE_KEYS_GLOBAL = {
   LAST_WALLET_EVENT_TS: 'last_wallet_event_ts',
   /** Last processed Nostr DM (gift-wrap) event timestamp (unix seconds), keyed per pubkey */
   LAST_DM_EVENT_TS: 'last_dm_event_ts',
+  /**
+   * Issue #275 — persistent dedup for Nostr wallet event IDs that have
+   * been SUCCESSFULLY processed (cursor advanced). Keyed per pubkey;
+   * stored as a JSON string array bounded by
+   * `LIMITS.PROCESSED_EVENT_IDS_CAP` (FIFO eviction).
+   *
+   * Distinct from in-memory `inFlightEventIds`: this set persists across
+   * process restarts so cross-process CLI invocations don't re-walk the
+   * full relay backlog. At-least-once is preserved because we ONLY add
+   * to this set after the event's cursor was advanced (durability ok
+   * or replay budget exhausted), never after a transient failure.
+   */
+  PROCESSED_WALLET_EVENT_IDS: 'processed_wallet_event_ids',
+  /**
+   * Issue #275 — persistent durability-cooldown ledger for
+   * TOKEN_TRANSFER events. Tracks `attempts` and `nextRetryAt` across
+   * process restarts so the bounded replay budget
+   * (`DURABILITY_MAX_REPLAY_ATTEMPTS = 3`) accumulates across CLI
+   * invocations rather than resetting per-process.
+   */
+  FAILED_EVENT_COOLDOWNS: 'failed_event_cooldowns',
   /** Group chat: last used relay URL (stale data detection) — global, same relay for all addresses */
   GROUP_CHAT_RELAY_URL: 'group_chat_relay_url',
   /** Cached token registry JSON (fetched from remote) */
@@ -495,4 +516,19 @@ export const LIMITS = {
   MEMO_MAX_LENGTH: 500,
   /** Max message length */
   MESSAGE_MAX_LENGTH: 10000,
+  /**
+   * Issue #275 — FIFO cap for persisted dedup IDs in
+   * `STORAGE_KEYS_GLOBAL.PROCESSED_WALLET_EVENT_IDS`. Sized for several
+   * days of Nostr relay retention (typical relay holds 1-7 days). A
+   * 10k cap at ~70 bytes per id is ~700KB serialized — well under
+   * IndexedDB / file storage budgets.
+   */
+  PROCESSED_EVENT_IDS_CAP: 10_000,
+  /**
+   * Issue #275 — debounce interval for persisted dedup-set flushes.
+   * Coalesces rapid arrivals (e.g., EOSE replay burst of N events) into
+   * a single storage write rather than N writes. 200ms matches the
+   * proven pattern in `GroupChatModule.persistProcessedEvents`.
+   */
+  PROCESSED_EVENT_IDS_FLUSH_MS: 200,
 } as const;

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -15348,6 +15348,30 @@ export class PaymentsModule {
       }
 
       if (combinedBundle) {
+        // Issue #275 P2 — hoisted dedup. When the V6 bundle was already
+        // processed in a prior session (its `transferId` is in the
+        // persisted `processedCombinedTransferIds` set, hydrated in
+        // PaymentsModule.initialize), short-circuit BEFORE entering
+        // `processCombinedTransferBundle` AND skip the trailing
+        // `awaitAllProvidersDurable()`. The bundle's tokens are
+        // already durable on disk from the original processing —
+        // calling `awaitAllProvidersDurable()` for a no-op bundle was
+        // costing 2-3 s per duplicate dispatch in the §C soak (per
+        // OPTIMIZATION-FINDINGS.md in issue #275). The inner dedup
+        // check inside `processCombinedTransferBundle` is retained as
+        // defense-in-depth (e.g., when an upstream caller routes a
+        // bundle directly without going through `handleIncomingTransfer`).
+        if (this.processedCombinedTransferIds.has(combinedBundle.transferId)) {
+          logger.debug(
+            'Payments',
+            `[#275] V6 combined transfer ${combinedBundle.transferId.slice(0, 12)}... already processed — skipping (no awaitAllProvidersDurable)`,
+          );
+          // Return `true` so the Nostr transport advances `lastEventTs`
+          // past this event. Local state is already durable; further
+          // replays would be wasted work.
+          return true;
+        }
+
         logger.debug('Payments', 'Processing COMBINED_TRANSFER V6 bundle...');
         let v6Success = true;
         try {
@@ -15379,6 +15403,27 @@ export class PaymentsModule {
       }
 
       if (instantBundle) {
+        // Issue #275 P2 — symmetric hoist for V5 INSTANT_SPLIT bundles.
+        // V5 bundles carry a `splitGroupId` (persisted in
+        // `processedSplitGroupIds` after first processing). When the
+        // bundle was already processed in a prior session, skip BEFORE
+        // the call into `processInstantSplitBundle` AND BEFORE the
+        // trailing `awaitAllProvidersDurable()`. V4 dev bundles don't
+        // have a splitGroupId; they fall through to the normal sync
+        // path which is unaffected by this change.
+        const v5SplitGroupId = (instantBundle as { splitGroupId?: unknown }).splitGroupId;
+        if (
+          typeof v5SplitGroupId === 'string' &&
+          v5SplitGroupId.length > 0 &&
+          this.processedSplitGroupIds.has(v5SplitGroupId)
+        ) {
+          logger.debug(
+            'Payments',
+            `[#275] V5 instant split ${v5SplitGroupId.slice(0, 12)}... already processed — skipping (no awaitAllProvidersDurable)`,
+          );
+          return true;
+        }
+
         logger.debug('Payments', 'Processing INSTANT_SPLIT bundle...');
         try {
           let instantOk = false;

--- a/tests/unit/modules/PaymentsModule.dedup-hoist.test.ts
+++ b/tests/unit/modules/PaymentsModule.dedup-hoist.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Issue #275 P2 — tests for the V6/V5 bundle dedup hoist in
+ * handleIncomingTransfer.
+ *
+ * The hoist short-circuits BEFORE calling
+ * `processCombinedTransferBundle` / `processInstantSplitBundle` AND
+ * BEFORE the trailing `awaitAllProvidersDurable()` when the bundle's
+ * transferId / splitGroupId is already in the persistent dedup set.
+ *
+ * Without the hoist (pre-#275 behavior), every duplicate dispatch
+ * paid 2-3s on `awaitAllProvidersDurable()` even when the inner
+ * `processCombinedTransferBundle` immediately deduped at line 6783.
+ * The OPTIMIZATION-FINDINGS report attributed 71.5% of §C wall-clock
+ * to this cost.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPaymentsModule } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity } from '../../../types';
+import type { StorageProvider } from '../../../storage';
+import type { TransportProvider, IncomingTokenTransfer } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type {
+  CombinedTransferBundleV6,
+  InstantSplitBundleV5,
+} from '../../../types/instant-split';
+
+// =============================================================================
+// SDK mocks — prevent network/crypto. We never actually parse a real bundle in
+// these tests; the hoist short-circuits before any SDK call happens.
+// =============================================================================
+
+vi.mock('@unicitylabs/state-transition-sdk/lib/token/Token', () => ({
+  Token: { fromJSON: vi.fn() },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/token/fungible/CoinId', () => ({
+  CoinId: class MockCoinId { toJSON() { return 'aa'.repeat(32); } },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/transaction/TransferCommitment', () => ({
+  TransferCommitment: { fromJSON: vi.fn() },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/transaction/MintCommitment', () => ({
+  MintCommitment: { create: vi.fn() },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/transaction/MintTransactionData', () => ({
+  MintTransactionData: { fromJSON: vi.fn() },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/transaction/TransferTransaction', () => ({
+  TransferTransaction: class {},
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/sign/SigningService', () => ({
+  SigningService: { fromKeyPair: vi.fn(), createFromSecret: vi.fn() },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/address/AddressScheme', () => ({
+  AddressScheme: class {},
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/predicate/embedded/UnmaskedPredicate', () => ({
+  UnmaskedPredicate: class {},
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/token/TokenState', () => ({
+  TokenState: class {},
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/hash/HashAlgorithm', () => ({
+  HashAlgorithm: { SHA256: 'SHA256' },
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/token/TokenType', () => ({
+  TokenType: class {},
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/util/InclusionProofUtils', () => ({
+  waitInclusionProof: vi.fn(),
+}));
+vi.mock('@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof', () => ({
+  InclusionProof: {},
+}));
+vi.mock('../../../l1/network', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  isWebSocketConnected: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../../registry', () => ({
+  TokenRegistry: {
+    getInstance: () => ({ getDefinition: () => null, getIconUrl: () => null }),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+vi.mock('../../../serialization/txf-serializer', () => ({
+  tokenToTxf: vi.fn().mockReturnValue(null),
+  txfToToken: vi.fn(),
+  getCurrentStateHash: vi.fn().mockReturnValue(''),
+  buildTxfStorageData: vi.fn().mockResolvedValue({}),
+  parseTxfStorageData: vi.fn().mockReturnValue({ tokens: [], tombstones: [], sent: [] }),
+}));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const SENDER_PUBKEY = 'b'.repeat(64);
+
+function makeIdentity(): FullIdentity {
+  return {
+    chainPubkey: '02' + 'a'.repeat(64),
+    l1Address: 'alpha1test',
+    directAddress: 'DIRECT://test',
+    privateKey: 'a'.repeat(64),
+  };
+}
+
+function makeStorage(): StorageProvider {
+  const store = new Map<string, string>();
+  return {
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { store.set(k, v); }),
+    delete: vi.fn(async (k: string) => { store.delete(k); }),
+    clear: vi.fn(async () => store.clear()),
+    has: vi.fn(async (k: string) => store.has(k)),
+    keys: vi.fn(async () => [...store.keys()]),
+  } as unknown as StorageProvider;
+}
+
+function makeTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn(),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue(null),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    publishNametag: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TransportProvider;
+}
+
+function makeOracle(): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    getStateTransitionClient: vi.fn().mockReturnValue(null),
+    waitForProofSdk: vi.fn(),
+  } as unknown as OracleProvider;
+}
+
+function buildV6Bundle(transferId: string): CombinedTransferBundleV6 {
+  return {
+    version: '6.0',
+    type: 'COMBINED_TRANSFER',
+    transferId,
+    splitBundle: null,
+    directTokens: [],
+    totalAmount: '0',
+    coinId: 'aa'.repeat(32),
+    senderPubkey: SENDER_PUBKEY,
+  };
+}
+
+function buildV5Bundle(splitGroupId: string): InstantSplitBundleV5 {
+  // Shape that passes `isInstantSplitBundle` (V5 branch). All required
+  // fields are present as strings — the hoist only reads splitGroupId,
+  // but the type guard demands the full set.
+  return {
+    version: '5.0',
+    type: 'INSTANT_SPLIT',
+    splitGroupId,
+    coinId: 'aa'.repeat(32),
+    amount: '0',
+    senderPubkey: SENDER_PUBKEY,
+    recipientMintData: '{}',
+    transferCommitment: '{}',
+    recipientSaltHex: '00',
+    transferSaltHex: '00',
+    burnTransaction: '{}',
+    mintedTokenStateJson: '{}',
+    finalRecipientStateJson: '{}',
+    recipientAddressJson: '{}',
+  } as unknown as InstantSplitBundleV5;
+}
+
+function buildIncomingTransfer(payload: unknown): IncomingTokenTransfer {
+  return {
+    id: 'synthetic-transfer-id',
+    payload: payload as IncomingTokenTransfer['payload'],
+    senderTransportPubkey: SENDER_PUBKEY,
+    timestamp: Date.now(),
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Issue #275 P2 — V6/V5 bundle dedup hoist', () => {
+  let module: ReturnType<typeof createPaymentsModule>;
+  let processV6Spy: ReturnType<typeof vi.fn>;
+  let processV5Spy: ReturnType<typeof vi.fn>;
+  let awaitDurableSpy: ReturnType<typeof vi.fn>;
+  let callHandle: (transfer: IncomingTokenTransfer) => Promise<boolean>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Disable UXF / legacy adapter routing so the test exercises only
+    // the V6/V5 code path.
+    module = createPaymentsModule({
+      features: {
+        recipientUxf: false,
+        recipientLegacyAdapter: false,
+      },
+    });
+
+    module.initialize({
+      identity: makeIdentity(),
+      storage: makeStorage(),
+      transport: makeTransport(),
+      oracle: makeOracle(),
+      emitEvent: vi.fn(),
+    });
+
+    // Bypass load() so handleIncomingTransfer doesn't block on the
+    // loaded promise (tests directly populate the dedup set).
+    (module as unknown as { loaded: boolean }).loaded = true;
+    (module as unknown as { loadedPromise: Promise<void> | null }).loadedPromise = null;
+
+    // Spy on the bundle-processing entrypoints. Replace with stubs so
+    // they don't actually run (would fail because we haven't loaded a
+    // real token state).
+    processV6Spy = vi.fn().mockResolvedValue(undefined);
+    processV5Spy = vi.fn().mockResolvedValue({ success: true, token: null });
+    awaitDurableSpy = vi.fn().mockResolvedValue(true);
+
+    const m = module as unknown as {
+      processCombinedTransferBundle: typeof processV6Spy;
+      processInstantSplitBundle: typeof processV5Spy;
+      awaitAllProvidersDurable: typeof awaitDurableSpy;
+      handleIncomingTransfer: (t: IncomingTokenTransfer) => Promise<boolean>;
+    };
+    m.processCombinedTransferBundle = processV6Spy;
+    m.processInstantSplitBundle = processV5Spy;
+    m.awaitAllProvidersDurable = awaitDurableSpy;
+    callHandle = (t) => m.handleIncomingTransfer(t);
+  });
+
+  afterEach(() => {
+    module.destroy();
+  });
+
+  describe('V6 (COMBINED_TRANSFER) hoist', () => {
+    it('short-circuits when transferId is already in processedCombinedTransferIds', async () => {
+      const transferId = 'v6-dup-' + 'a'.repeat(56);
+      const bundle = buildV6Bundle(transferId);
+
+      // Pre-populate the persistent dedup set as if a prior session
+      // already finalized this bundle.
+      (module as unknown as { processedCombinedTransferIds: Set<string> }).processedCombinedTransferIds.add(transferId);
+
+      const result = await callHandle(buildIncomingTransfer(bundle));
+
+      // Hoist returns true so transport advances lastEventTs past the dup.
+      expect(result).toBe(true);
+      // Critical: neither the bundle processor NOR the durability wait ran.
+      expect(processV6Spy).not.toHaveBeenCalled();
+      expect(awaitDurableSpy).not.toHaveBeenCalled();
+    });
+
+    it('runs the full V6 pipeline for an unseen transferId', async () => {
+      const transferId = 'v6-fresh-' + 'b'.repeat(54);
+      const bundle = buildV6Bundle(transferId);
+
+      // dedup set is empty — fresh bundle.
+      expect(
+        (module as unknown as { processedCombinedTransferIds: Set<string> }).processedCombinedTransferIds.has(transferId),
+      ).toBe(false);
+
+      await callHandle(buildIncomingTransfer(bundle));
+
+      // Hoist did NOT short-circuit — both the processor and the
+      // durability wait were called.
+      expect(processV6Spy).toHaveBeenCalledTimes(1);
+      expect(processV6Spy.mock.calls[0][0]).toEqual(bundle);
+      expect(awaitDurableSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT short-circuit when the dedup set contains a different transferId', async () => {
+      const bundle = buildV6Bundle('v6-target-' + 'c'.repeat(53));
+
+      (module as unknown as { processedCombinedTransferIds: Set<string> }).processedCombinedTransferIds.add(
+        'v6-unrelated-' + 'd'.repeat(51),
+      );
+
+      await callHandle(buildIncomingTransfer(bundle));
+
+      expect(processV6Spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('V5 (INSTANT_SPLIT) hoist', () => {
+    it('short-circuits when splitGroupId is already in processedSplitGroupIds', async () => {
+      const splitGroupId = 'v5-dup-' + 'a'.repeat(56);
+      const bundle = buildV5Bundle(splitGroupId);
+
+      (module as unknown as { processedSplitGroupIds: Set<string> }).processedSplitGroupIds.add(splitGroupId);
+
+      const result = await callHandle(buildIncomingTransfer(bundle));
+
+      expect(result).toBe(true);
+      expect(processV5Spy).not.toHaveBeenCalled();
+      expect(awaitDurableSpy).not.toHaveBeenCalled();
+    });
+
+    it('runs the full V5 pipeline for an unseen splitGroupId', async () => {
+      const splitGroupId = 'v5-fresh-' + 'b'.repeat(54);
+      const bundle = buildV5Bundle(splitGroupId);
+
+      await callHandle(buildIncomingTransfer(bundle));
+
+      expect(processV5Spy).toHaveBeenCalledTimes(1);
+      expect(awaitDurableSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT short-circuit when splitGroupId is an empty string', async () => {
+      // Hoist guard is: `typeof v5SplitGroupId === 'string' && length > 0`.
+      // Empty-string splitGroupId should bypass the short-circuit and
+      // forward to the processor.
+      const bundle = buildV5Bundle('') as unknown as InstantSplitBundleV5;
+
+      // Don't add anything to processedSplitGroupIds — empty string in
+      // the set would also be unusual. We're testing the early guard.
+      await callHandle(buildIncomingTransfer(bundle));
+
+      expect(processV5Spy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/transport/NostrTransportProvider.test.ts
+++ b/tests/unit/transport/NostrTransportProvider.test.ts
@@ -717,12 +717,18 @@ describe('Last event timestamp persistence', () => {
       await provider.connect();
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Two reads: wallet event ts + DM event ts
-      expect(mockStorage.get).toHaveBeenCalledTimes(2);
-      const walletKeyArg = mockStorage.get.mock.calls[0][0];
-      const dmKeyArg = mockStorage.get.mock.calls[1][0];
-      expect(walletKeyArg).toMatch(/^last_wallet_event_ts_[0-9a-f]{16}$/);
-      expect(dmKeyArg).toMatch(/^last_dm_event_ts_[0-9a-f]{16}$/);
+      // Four reads: persistent dedup events (#275) + persistent cooldowns (#275)
+      // + wallet event ts + DM event ts. All four use the same pubkey prefix.
+      expect(mockStorage.get).toHaveBeenCalledTimes(4);
+      const calledKeys = mockStorage.get.mock.calls.map((c) => c[0] as string);
+      expect(calledKeys).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^processed_wallet_event_ids_[0-9a-f]{16}$/),
+          expect.stringMatching(/^failed_event_cooldowns_[0-9a-f]{16}$/),
+          expect.stringMatching(/^last_wallet_event_ts_[0-9a-f]{16}$/),
+          expect.stringMatching(/^last_dm_event_ts_[0-9a-f]{16}$/),
+        ]),
+      );
     });
 
     it('should use fallback since when no stored timestamp and fallback is set', async () => {
@@ -1001,6 +1007,363 @@ describe('Last event timestamp persistence', () => {
       await new Promise(resolve => setTimeout(resolve, 100));
       // Verify set was attempted (and failed gracefully)
       expect(mockStorage.set).toHaveBeenCalled();
+    });
+  });
+});
+
+// =============================================================================
+// Issue #275 — Persistent dedup of Nostr event IDs
+// =============================================================================
+
+describe('Issue #275 — persistent dedup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+    mockGetConnectedRelays.mockReturnValue(new Set(['wss://test.relay']));
+  });
+
+  function createProviderWithStorage(storage: { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> }) {
+    return new NostrTransportProvider({
+      relays: ['wss://test.relay'],
+      createWebSocket: (() => {}) as unknown as WebSocketFactory,
+      timeout: 100,
+      autoReconnect: false,
+      storage,
+    });
+  }
+
+  function setIdentity(provider: InstanceType<typeof NostrTransportProvider>) {
+    provider.setIdentity({
+      privateKey: 'b'.repeat(64),
+      chainPubkey: '02' + 'a'.repeat(64),
+      l1Address: 'alpha1test',
+    });
+  }
+
+  describe('hydration on connect', () => {
+    it('should hydrate persisted event IDs and dedupe subsequent dispatch', async () => {
+      const persistedIds = JSON.stringify(['evt-a', 'evt-b']);
+      const mockStorage = {
+        get: vi.fn().mockImplementation((key: string) => {
+          if (key.startsWith('processed_wallet_event_ids_')) {
+            return Promise.resolve(persistedIds);
+          }
+          return Promise.resolve(null);
+        }),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      await provider.connect();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Fire one of the hydrated event IDs through the handler
+      const callbacks = mockSubscribe.mock.calls[0][1];
+      const before = mockStorage.set.mock.calls.length;
+      callbacks.onEvent({
+        id: 'evt-a',
+        kind: 4, // DIRECT_MESSAGE
+        content: '{}',
+        tags: [],
+        pubkey: 'a'.repeat(64),
+        created_at: 1700000500,
+        sig: 'sig',
+      });
+
+      // Wait beyond the 200ms debounce window so any pending write
+      // would have landed by now.
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      // No new write should land for a hydrated/already-processed event —
+      // the dedup short-circuits BEFORE updateLastEventTimestamp.
+      const after = mockStorage.set.mock.calls.length;
+      const tsWrites = mockStorage.set.mock.calls
+        .slice(before, after)
+        .filter((c) => typeof c[0] === 'string' && (c[0] as string).startsWith('last_wallet_event_ts_'));
+      expect(tsWrites.length).toBe(0);
+    });
+
+    it('should tolerate malformed persisted JSON gracefully', async () => {
+      const mockStorage = {
+        get: vi.fn().mockImplementation((key: string) => {
+          if (key.startsWith('processed_wallet_event_ids_')) {
+            return Promise.resolve('{not valid json');
+          }
+          return Promise.resolve(null);
+        }),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      // Should not throw — corrupt data degrades to "start fresh".
+      await expect(provider.connect()).resolves.toBeUndefined();
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(mockSubscribe).toHaveBeenCalled();
+    });
+
+    it('should ignore non-array persisted JSON', async () => {
+      const mockStorage = {
+        get: vi.fn().mockImplementation((key: string) => {
+          if (key.startsWith('processed_wallet_event_ids_')) {
+            return Promise.resolve(JSON.stringify({ not: 'an array' }));
+          }
+          return Promise.resolve(null);
+        }),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      await expect(provider.connect()).resolves.toBeUndefined();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Subsequent event with same id should be processed (not deduped).
+      const callbacks = mockSubscribe.mock.calls[0][1];
+      mockStorage.set.mockClear();
+      callbacks.onEvent({
+        id: 'evt-after-malformed',
+        kind: 4,
+        content: '{}',
+        tags: [],
+        pubkey: 'a'.repeat(64),
+        created_at: 1700000900,
+        sig: 'sig',
+      });
+      await new Promise(resolve => setTimeout(resolve, 50));
+      // ts write should occur (event processed)
+      const tsWrites = mockStorage.set.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).startsWith('last_wallet_event_ts_'),
+      );
+      expect(tsWrites.length).toBe(1);
+    });
+
+    it('should hydrate persisted cooldowns and respect remaining window', async () => {
+      const nextRetryAt = Date.now() + 60_000;
+      const cooldowns = JSON.stringify([['stuck-evt', { nextRetryAt, attempts: 2 }]]);
+      const mockStorage = {
+        get: vi.fn().mockImplementation((key: string) => {
+          if (key.startsWith('failed_event_cooldowns_')) {
+            return Promise.resolve(cooldowns);
+          }
+          return Promise.resolve(null);
+        }),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      await provider.connect();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // The TOKEN_TRANSFER cooldown gate should now skip the stuck event
+      // without entering handleTokenTransfer. We don't have an easy way
+      // to spy on handleTokenTransfer from outside, but observing that
+      // no `last_wallet_event_ts_` write happens for this event is a
+      // proxy: cooldown skip returns early, no cursor advance.
+      const callbacks = mockSubscribe.mock.calls[0][1];
+      mockStorage.set.mockClear();
+      callbacks.onEvent({
+        id: 'stuck-evt',
+        kind: 31113, // TOKEN_TRANSFER
+        content: '{}',
+        tags: [],
+        pubkey: 'a'.repeat(64),
+        created_at: 1700000700,
+        sig: 'sig',
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      const tsWrites = mockStorage.set.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).startsWith('last_wallet_event_ts_'),
+      );
+      expect(tsWrites.length).toBe(0);
+    });
+
+    it('should drop stale cooldown entries on hydrate', async () => {
+      // nextRetryAt far in the past (> 2x COOLDOWN_MAX_MS) — should be dropped.
+      const veryStale = Date.now() - 600_000; // 10 minutes ago
+      const cooldowns = JSON.stringify([['stale-evt', { nextRetryAt: veryStale, attempts: 1 }]]);
+      const mockStorage = {
+        get: vi.fn().mockImplementation((key: string) => {
+          if (key.startsWith('failed_event_cooldowns_')) {
+            return Promise.resolve(cooldowns);
+          }
+          return Promise.resolve(null);
+        }),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      await provider.connect();
+      await new Promise(resolve => setTimeout(resolve, 50));
+      // No assertion on the count itself — the post-condition is that
+      // a future event with id "stale-evt" is NOT skipped because of a
+      // dropped cooldown. We'd need to send the event and watch for the
+      // cursor advance, but that path requires handleTokenTransfer to
+      // be wired to a real handler. Instead, assert hydrate didn't
+      // throw — coverage of the drop branch.
+      expect(true).toBe(true);
+    });
+  });
+
+  describe('persist on event processed', () => {
+    it('should write processed_wallet_event_ids after debounce window', async () => {
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      await provider.connect();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      mockStorage.set.mockClear();
+
+      const callbacks = mockSubscribe.mock.calls[0][1];
+      callbacks.onEvent({
+        id: 'evt-persist-1',
+        kind: 4,
+        content: '{}',
+        tags: [],
+        pubkey: 'a'.repeat(64),
+        created_at: 1700000123,
+        sig: 'sig',
+      });
+
+      // Wait longer than 200ms debounce window
+      await new Promise(resolve => setTimeout(resolve, 350));
+
+      const dedupWrites = mockStorage.set.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).startsWith('processed_wallet_event_ids_'),
+      );
+      expect(dedupWrites.length).toBe(1);
+      const payload = JSON.parse(dedupWrites[0][1] as string);
+      expect(Array.isArray(payload)).toBe(true);
+      expect(payload).toContain('evt-persist-1');
+    });
+
+    it('should coalesce rapid arrivals into a single debounced write', async () => {
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      await provider.connect();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      mockStorage.set.mockClear();
+      const callbacks = mockSubscribe.mock.calls[0][1];
+
+      // Fire 5 events well within the 200ms debounce window
+      for (let i = 0; i < 5; i++) {
+        callbacks.onEvent({
+          id: `burst-${i}`,
+          kind: 4,
+          content: '{}',
+          tags: [],
+          pubkey: 'a'.repeat(64),
+          created_at: 1700000200 + i,
+          sig: 'sig',
+        });
+      }
+
+      // Wait beyond debounce
+      await new Promise(resolve => setTimeout(resolve, 350));
+
+      const dedupWrites = mockStorage.set.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).startsWith('processed_wallet_event_ids_'),
+      );
+      // Coalesced: at most one write for the whole burst.
+      expect(dedupWrites.length).toBe(1);
+      const payload = JSON.parse(dedupWrites[0][1] as string);
+      expect(payload.length).toBe(5);
+    });
+  });
+
+  describe('cross-process semantics', () => {
+    it('should NOT add to processed set when event has no id', async () => {
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      await provider.connect();
+      await new Promise(resolve => setTimeout(resolve, 50));
+      mockStorage.set.mockClear();
+
+      const callbacks = mockSubscribe.mock.calls[0][1];
+      callbacks.onEvent({
+        // no id
+        kind: 4,
+        content: '{}',
+        tags: [],
+        pubkey: 'a'.repeat(64),
+        created_at: 1700001000,
+        sig: 'sig',
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+      const dedupWrites = mockStorage.set.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).startsWith('processed_wallet_event_ids_'),
+      );
+      expect(dedupWrites.length).toBe(0);
+    });
+
+    it('should cancel the armed debounce timer on setIdentity', async () => {
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      await provider.connect();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const callbacks = mockSubscribe.mock.calls[0][1];
+      callbacks.onEvent({
+        id: 'pre-switch',
+        kind: 4,
+        content: '{}',
+        tags: [],
+        pubkey: 'a'.repeat(64),
+        created_at: 1700001500,
+        sig: 'sig',
+      });
+
+      // Let handleEvent finish its synchronous work (markEventProcessed
+      // schedules the 200ms debounce timer). Wait 50ms — well under
+      // the 200ms debounce — so the timer is armed but has not fired.
+      await new Promise(resolve => setTimeout(resolve, 50));
+      mockStorage.set.mockClear();
+
+      // setIdentity must clear the armed timer.
+      await provider.setIdentity({
+        privateKey: 'c'.repeat(64),
+        chainPubkey: '02' + 'd'.repeat(64),
+        l1Address: 'alpha1other',
+      });
+
+      // Wait past the original 200ms debounce window. If the timer was
+      // properly cancelled, no write should carry 'pre-switch'.
+      await new Promise(resolve => setTimeout(resolve, 350));
+
+      const dedupWrites = mockStorage.set.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).startsWith('processed_wallet_event_ids_'),
+      );
+      // Either no write happened OR the writes carry only events from
+      // the NEW identity (which is empty in this test).
+      for (const w of dedupWrites) {
+        const payload = JSON.parse(w[1] as string);
+        expect(payload).not.toContain('pre-switch');
+      }
     });
   });
 });

--- a/tests/unit/transport/NostrTransportProvider.test.ts
+++ b/tests/unit/transport/NostrTransportProvider.test.ts
@@ -1157,35 +1157,28 @@ describe('Issue #275 — persistent dedup', () => {
       await provider.connect();
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // The TOKEN_TRANSFER cooldown gate should now skip the stuck event
-      // without entering handleTokenTransfer. We don't have an easy way
-      // to spy on handleTokenTransfer from outside, but observing that
-      // no `last_wallet_event_ts_` write happens for this event is a
-      // proxy: cooldown skip returns early, no cursor advance.
-      const callbacks = mockSubscribe.mock.calls[0][1];
-      mockStorage.set.mockClear();
-      callbacks.onEvent({
-        id: 'stuck-evt',
-        kind: 31113, // TOKEN_TRANSFER
-        content: '{}',
-        tags: [],
-        pubkey: 'a'.repeat(64),
-        created_at: 1700000700,
-        sig: 'sig',
-      });
-
-      await new Promise(resolve => setTimeout(resolve, 300));
-
-      const tsWrites = mockStorage.set.mock.calls.filter(
-        (c) => typeof c[0] === 'string' && (c[0] as string).startsWith('last_wallet_event_ts_'),
-      );
-      expect(tsWrites.length).toBe(0);
+      // Direct map inspection — the cooldown should have been hydrated
+      // into the in-memory ledger so the next TOKEN_TRANSFER dispatch
+      // for this id short-circuits at the gate. We assert on map state
+      // rather than on side-effects to disambiguate from kind-31113's
+      // handler-throw path (GAP 5 in steelman review).
+      const cooldownsMap = (provider as unknown as {
+        failedEventCooldowns: Map<string, { nextRetryAt: number; attempts: number }>;
+      }).failedEventCooldowns;
+      expect(cooldownsMap.has('stuck-evt')).toBe(true);
+      expect(cooldownsMap.get('stuck-evt')?.attempts).toBe(2);
     });
 
     it('should drop stale cooldown entries on hydrate', async () => {
-      // nextRetryAt far in the past (> 2x COOLDOWN_MAX_MS) — should be dropped.
-      const veryStale = Date.now() - 600_000; // 10 minutes ago
-      const cooldowns = JSON.stringify([['stale-evt', { nextRetryAt: veryStale, attempts: 1 }]]);
+      // Mix a stale entry (drop) and a fresh entry (kept). Inspect the
+      // in-memory map size after hydrate.
+      const now = Date.now();
+      const veryStale = now - 600_000; // 10 minutes ago — should drop
+      const fresh = now + 30_000;       // 30s in future — should keep
+      const cooldowns = JSON.stringify([
+        ['stale-evt', { nextRetryAt: veryStale, attempts: 1 }],
+        ['fresh-evt', { nextRetryAt: fresh, attempts: 2 }],
+      ]);
       const mockStorage = {
         get: vi.fn().mockImplementation((key: string) => {
           if (key.startsWith('failed_event_cooldowns_')) {
@@ -1200,13 +1193,14 @@ describe('Issue #275 — persistent dedup', () => {
       setIdentity(provider);
       await provider.connect();
       await new Promise(resolve => setTimeout(resolve, 50));
-      // No assertion on the count itself — the post-condition is that
-      // a future event with id "stale-evt" is NOT skipped because of a
-      // dropped cooldown. We'd need to send the event and watch for the
-      // cursor advance, but that path requires handleTokenTransfer to
-      // be wired to a real handler. Instead, assert hydrate didn't
-      // throw — coverage of the drop branch.
-      expect(true).toBe(true);
+
+      // Inspect the private field to verify the drop happened.
+      const cooldownsMap = (provider as unknown as {
+        failedEventCooldowns: Map<string, { nextRetryAt: number; attempts: number }>;
+      }).failedEventCooldowns;
+      expect(cooldownsMap.has('stale-evt')).toBe(false);
+      expect(cooldownsMap.has('fresh-evt')).toBe(true);
+      expect(cooldownsMap.size).toBe(1);
     });
   });
 
@@ -1315,6 +1309,76 @@ describe('Issue #275 — persistent dedup', () => {
         (c) => typeof c[0] === 'string' && (c[0] as string).startsWith('processed_wallet_event_ids_'),
       );
       expect(dedupWrites.length).toBe(0);
+    });
+
+    it('should evict oldest entry when exceeding PROCESSED_EVENT_IDS_CAP', async () => {
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      await provider.connect();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Pre-populate the set to exactly the cap by reaching into the
+      // private field. FIFO eviction must keep the set bounded.
+      const internal = provider as unknown as {
+        processedEventIds: Set<string>;
+        markEventProcessed: (id: string) => void;
+      };
+      const { LIMITS } = await import('../../../constants');
+      const cap = LIMITS.PROCESSED_EVENT_IDS_CAP;
+      for (let i = 0; i < cap; i++) {
+        internal.processedEventIds.add(`pre-${i}`);
+      }
+      expect(internal.processedEventIds.size).toBe(cap);
+
+      // Add ONE more via markEventProcessed — should evict the oldest
+      // ('pre-0') and stay at exactly cap.
+      internal.markEventProcessed('overflow-id');
+      expect(internal.processedEventIds.size).toBe(cap);
+      expect(internal.processedEventIds.has('pre-0')).toBe(false); // evicted
+      expect(internal.processedEventIds.has('pre-1')).toBe(true);
+      expect(internal.processedEventIds.has('overflow-id')).toBe(true);
+    });
+
+    it('should flush pending dedup write on disconnect()', async () => {
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined),
+      };
+      const provider = createProviderWithStorage(mockStorage);
+      setIdentity(provider);
+      await provider.connect();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const callbacks = mockSubscribe.mock.calls[0][1];
+      callbacks.onEvent({
+        id: 'evt-flush-on-disconnect',
+        kind: 4, // DIRECT_MESSAGE
+        content: '{}',
+        tags: [],
+        pubkey: 'a'.repeat(64),
+        created_at: 1700002000,
+        sig: 'sig',
+      });
+
+      // Let handleEvent finish its synchronous portion so the timer is
+      // armed. We do NOT wait the full 200ms debounce window.
+      await new Promise(resolve => setTimeout(resolve, 50));
+      mockStorage.set.mockClear();
+
+      // Disconnect must flush the pending write — without this, the
+      // pending dedup add would be lost on process exit.
+      await provider.disconnect();
+
+      const dedupWrites = mockStorage.set.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).startsWith('processed_wallet_event_ids_'),
+      );
+      expect(dedupWrites.length).toBe(1);
+      const payload = JSON.parse(dedupWrites[0][1] as string);
+      expect(payload).toContain('evt-flush-on-disconnect');
     });
 
     it('should cancel the armed debounce timer on setIdentity', async () => {

--- a/transport/MultiAddressTransportMux.ts
+++ b/transport/MultiAddressTransportMux.ts
@@ -1645,11 +1645,19 @@ export class MultiAddressTransportMux {
   // ===========================================================================
 
   /**
-   * Clear processed event IDs (e.g., on address change or periodic cleanup).
+   * Clear processed event IDs.
    *
-   * Issue #275: also cancels any pending persist timer and clears the
-   * `dedupHydrated` flag so the next subscribe round re-hydrates from
-   * storage (e.g., after a swap-in of address set).
+   * Currently unused — kept as part of the public surface for future
+   * forced-reset scenarios (e.g., a hypothetical "wipe dedup but keep
+   * connection" path). The Mux's dedup set is shared across all
+   * addresses, so address add/remove does NOT need to clear it — they
+   * legitimately share the same relay event stream. `Sphere.clear()`
+   * handles the full-wipe case via `storage.clear()`, which
+   * implicitly removes the persisted `MUX_PROCESSED_EVENT_IDS` key.
+   *
+   * Issue #275: when called, also cancels any pending persist timer
+   * and resets `dedupHydrated` so a follow-up `updateSubscriptions`
+   * re-hydrates from storage.
    */
   clearProcessedEvents(): void {
     this.processedEventIds.clear();

--- a/transport/MultiAddressTransportMux.ts
+++ b/transport/MultiAddressTransportMux.ts
@@ -62,6 +62,7 @@ import { NostrTransportProvider } from './NostrTransportProvider';
 import type { TransportStorageAdapter, NostrTransportProviderConfig } from './NostrTransportProvider';
 import {
   DEFAULT_NOSTR_RELAYS,
+  LIMITS,
   NOSTR_EVENT_KINDS,
   STORAGE_KEYS_GLOBAL,
   TIMEOUTS,
@@ -167,8 +168,21 @@ export class MultiAddressTransportMux {
 
   // Dedup — bounded to prevent memory leak in long-running sessions.
   // Set preserves insertion order; evict oldest entries when cap is reached.
+  //
+  // Issue #275: This set is PERSISTED via `storage` so cross-process CLI
+  // invocations don't re-walk the relay backlog through the Mux path.
+  // Without persistence, every `sphere <cmd>` paid the legacy SDK-format
+  // path's 4-8s per-event cost for events the prior process already
+  // finalized. See `hydrateProcessedDedup` / `schedulePersistDedup` below.
+  // FIFO eviction is at `LIMITS.PROCESSED_EVENT_IDS_CAP`.
   private processedEventIds = new Set<string>();
-  private static readonly MAX_PROCESSED_IDS = 10_000;
+  private static readonly MAX_PROCESSED_IDS = LIMITS.PROCESSED_EVENT_IDS_CAP;
+  /** Debounce timer for persisted dedup writes (#275). */
+  private persistDedupTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Serialize concurrent persistDedupNow calls (#275). */
+  private persistDedupInFlight: Promise<void> | null = null;
+  /** Gates re-hydration; true after the first successful load (#275). */
+  private dedupHydrated = false;
 
   // Event callbacks (mux-level, forwarded to all adapters)
   private eventCallbacks: Set<TransportEventCallback> = new Set();
@@ -421,6 +435,22 @@ export class MultiAddressTransportMux {
   }
 
   async disconnect(): Promise<void> {
+    // Issue #275 — flush any pending dedup write BEFORE tearing down
+    // the connection. A process exit that catches the tail of a
+    // 200ms debounce window would otherwise lose the latest adds
+    // and force the next process to re-walk the same relay backlog.
+    if (this.persistDedupTimer) {
+      clearTimeout(this.persistDedupTimer);
+      this.persistDedupTimer = null;
+    }
+    if (this.storage) {
+      try {
+        await this.persistDedupNow();
+      } catch (err) {
+        logger.debug('Mux', '[#275] disconnect: flush of persisted dedup failed:', err);
+      }
+    }
+
     if (this.resubscribeTimer) {
       clearTimeout(this.resubscribeTimer);
       this.resubscribeTimer = null;
@@ -746,6 +776,12 @@ export class MultiAddressTransportMux {
   private async updateSubscriptions(): Promise<void> {
     if (!this.nostrClient) return;
 
+    // Issue #275 — hydrate persistent dedup BEFORE EOSE replay arrives.
+    // The first CLI command of a new process otherwise re-walks the
+    // entire backlog through the Mux's `handleEvent`, paying the legacy
+    // SDK-format path's 4-8s addToken probe per event.
+    await this.hydrateProcessedDedup();
+
     // Always unsubscribe stale IDs first — the relay drops server-side
     // subscriptions on disconnect, so these IDs are dead after reconnect.
     if (this.walletSubscriptionId) {
@@ -920,12 +956,14 @@ export class MultiAddressTransportMux {
    * Route an incoming Nostr event to the correct address adapter.
    */
   private async handleEvent(event: NostrEvent): Promise<void> {
-    // Dedup — bounded set with LRU eviction
+    // Dedup — bounded set with FIFO eviction. Issue #275 persists this
+    // set so cross-process CLI invocations short-circuit at this gate.
     if (event.id && this.processedEventIds.has(event.id)) return;
     if (event.id) {
       this.processedEventIds.add(event.id);
+      // FIFO half-flush — preserves the legacy "evict half on overflow"
+      // behavior to avoid thrashing at the cap boundary under bursts.
       if (this.processedEventIds.size > MultiAddressTransportMux.MAX_PROCESSED_IDS) {
-        // Evict oldest entries (Set preserves insertion order)
         const it = this.processedEventIds.values();
         for (let i = 0; i < MultiAddressTransportMux.MAX_PROCESSED_IDS / 2; i++) {
           const entry = it.next();
@@ -933,6 +971,12 @@ export class MultiAddressTransportMux {
           this.processedEventIds.delete(entry.value);
         }
       }
+      // Persist asynchronously (#275). The Mux's dispatch model
+      // unconditionally advances `lastEventTs` per-address, so we
+      // don't need the two-tier "successfully processed vs. in-flight"
+      // split that NostrTransportProvider uses. Every add is a
+      // commitment to advance.
+      this.schedulePersistDedup();
     }
     try {
       if (event.kind === EventKinds.GIFT_WRAP) {
@@ -1602,9 +1646,101 @@ export class MultiAddressTransportMux {
 
   /**
    * Clear processed event IDs (e.g., on address change or periodic cleanup).
+   *
+   * Issue #275: also cancels any pending persist timer and clears the
+   * `dedupHydrated` flag so the next subscribe round re-hydrates from
+   * storage (e.g., after a swap-in of address set).
    */
   clearProcessedEvents(): void {
     this.processedEventIds.clear();
+    if (this.persistDedupTimer) {
+      clearTimeout(this.persistDedupTimer);
+      this.persistDedupTimer = null;
+    }
+    this.dedupHydrated = false;
+  }
+
+  /**
+   * Issue #275 — hydrate `processedEventIds` from storage. Idempotent;
+   * subsequent calls are no-ops once `dedupHydrated` is true. Failure
+   * modes (storage throw, JSON parse error, non-array) degrade to
+   * "start fresh" — the Mux still functions, just pays the legacy
+   * re-dispatch cost once until the next debounce flush repopulates.
+   */
+  private async hydrateProcessedDedup(): Promise<void> {
+    if (this.dedupHydrated) return;
+    if (!this.storage) {
+      this.dedupHydrated = true;
+      return;
+    }
+    try {
+      const raw = await this.storage.get(STORAGE_KEYS_GLOBAL.MUX_PROCESSED_EVENT_IDS);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          for (const id of parsed) {
+            if (typeof id === 'string' && id.length > 0) {
+              this.processedEventIds.add(id);
+            }
+          }
+        }
+      }
+    } catch (err) {
+      logger.debug('Mux', '[#275] hydrateProcessedDedup parse/read failed:', err);
+    }
+    this.dedupHydrated = true;
+    logger.debug(
+      'Mux',
+      `[#275] Mux dedup hydrated: ${this.processedEventIds.size} event IDs`,
+    );
+  }
+
+  /**
+   * Issue #275 — schedule a debounced write of `processedEventIds`.
+   * Coalesces a burst of EOSE-replay arrivals into a single storage
+   * transaction. Subsequent calls within the debounce window are
+   * no-ops (timer already armed).
+   */
+  private schedulePersistDedup(): void {
+    if (!this.storage) return;
+    if (this.persistDedupTimer) return;
+    this.persistDedupTimer = setTimeout(() => {
+      this.persistDedupTimer = null;
+      this.persistDedupNow().catch((err) => {
+        logger.debug('Mux', '[#275] Persisted dedup write failed (will retry on next mark):', err);
+      });
+    }, LIMITS.PROCESSED_EVENT_IDS_FLUSH_MS);
+  }
+
+  /**
+   * Issue #275 — write the persistent dedup set to storage. Serialized
+   * via `persistDedupInFlight` so concurrent timer fires and the
+   * disconnect-flush don't race on the underlying KV write.
+   */
+  private async persistDedupNow(): Promise<void> {
+    if (!this.storage) return;
+    if (this.persistDedupInFlight) {
+      await this.persistDedupInFlight.catch(() => undefined);
+    }
+    const inFlight = this.doPersistDedup();
+    this.persistDedupInFlight = inFlight;
+    try {
+      await inFlight;
+    } finally {
+      if (this.persistDedupInFlight === inFlight) {
+        this.persistDedupInFlight = null;
+      }
+    }
+  }
+
+  private async doPersistDedup(): Promise<void> {
+    if (!this.storage) return;
+    const ids = Array.from(this.processedEventIds);
+    try {
+      await this.storage.set(STORAGE_KEYS_GLOBAL.MUX_PROCESSED_EVENT_IDS, JSON.stringify(ids));
+    } catch (err) {
+      logger.debug('Mux', '[#275] doPersistDedup write failed:', err);
+    }
   }
 
   /**

--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -64,6 +64,7 @@ import type { WebSocketFactory, UUIDGenerator } from './websocket';
 import { defaultUUIDGenerator } from './websocket';
 import {
   DEFAULT_NOSTR_RELAYS,
+  LIMITS,
   NOSTR_EVENT_KINDS,
   STORAGE_KEYS_GLOBAL,
   TIMEOUTS,
@@ -143,11 +144,43 @@ export class NostrTransportProvider implements TransportProvider {
   private nostrClient: NostrClient | null = null;
   private mainSubscriptionId: string | null = null;
 
-  // Event handlers
+  // Event handlers — two-tier dedup (issue #275).
+  //
+  // `processedEventIds` is the PERSISTED set of event IDs that we have
+  // successfully processed (i.e., the wallet cursor advanced past them).
+  // It is hydrated from KV storage on connect/fetchPendingEvents so
+  // cross-process CLI invocations do not re-walk the relay backlog. The
+  // §C soak forensics in issue #275 showed 169 dispatches across 15
+  // unique event IDs because this set previously lived in-process only
+  // — 71.5% of §C wall-clock was wasted on duplicate dispatch.
+  //
+  // We MUST NOT add to this set before the event handler completes
+  // successfully: doing so would mask the at-least-once retry that
+  // TOKEN_TRANSFER's durability gate depends on (a failed event would
+  // be persisted as "processed" and never re-tried across restarts).
+  //
+  // `inFlightEventIds` is the IN-MEMORY set used for concurrent-arrival
+  // dedup: the same relay event may be delivered via multiple
+  // subscriptions (wallet sub + chat sub) within the same process. It
+  // is never persisted; entries are removed in the `finally` block of
+  // `handleEvent` so the second arrival short-circuits while the first
+  // is still in flight.
   private processedEventIds = new Set<string>();
+  private inFlightEventIds = new Set<string>();
 
   /**
-   * Issue #272 — per-event failure cooldown ledger for TOKEN_TRANSFER
+   * Issue #275 — debounce timer for persisting `processedEventIds` and
+   * `failedEventCooldowns`. Coalesces a burst of EOSE-replay arrivals
+   * into a single storage write. Set to `LIMITS.PROCESSED_EVENT_IDS_FLUSH_MS`.
+   */
+  private persistDedupTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Reentrancy guard so concurrent schedules don't race the in-flight write. */
+  private persistDedupInFlight: Promise<void> | null = null;
+  /** True once dedup state has been hydrated from storage; gates re-hydration. */
+  private dedupHydrated = false;
+
+  /**
+   * Issue #272 + #275 — per-event failure cooldown ledger for TOKEN_TRANSFER
    * replays. When `handleIncomingTransfer` returns `false` (the at-
    * least-once gate refused the ack), we record an exponential cool-
    * down so the relay-paced replay storm cannot busy-spin the
@@ -174,9 +207,12 @@ export class NostrTransportProvider implements TransportProvider {
    *     replay floods. Eviction is single-victim per insert when at
    *     capacity (cheap; no full sort).
    *
-   * Not persisted across process restarts (intentional — a fresh
-   * process gets a fresh chance, and the `processedEventIds` dedup
-   * still prevents double-processing of an already-acked event).
+   * Issue #275: this map is now PERSISTED across process restarts so
+   * the bounded replay budget accumulates across CLI invocations
+   * instead of resetting to zero per-process. Without persistence, a
+   * persistently-failing TOKEN_TRANSFER could replay across CLI
+   * sessions indefinitely because every fresh process saw `attempts=1`
+   * and never reached the budget exhaustion threshold.
    */
   private failedEventCooldowns = new Map<
     string,
@@ -433,6 +469,24 @@ export class NostrTransportProvider implements TransportProvider {
   }
 
   async disconnect(): Promise<void> {
+    // Issue #275 — flush any pending dedup writes before tearing down
+    // the connection. Without this, a process exit that catches the
+    // tail of a 200ms debounce window would lose the latest
+    // `processedEventIds` adds and force the next process to re-walk
+    // the same relay backlog. The flush is best-effort; we swallow
+    // errors so disconnect remains robust.
+    if (this.persistDedupTimer) {
+      clearTimeout(this.persistDedupTimer);
+      this.persistDedupTimer = null;
+    }
+    if (this.storage && this.keyManager) {
+      try {
+        await this.persistDedupNow();
+      } catch (err) {
+        logger.debug('Nostr', 'disconnect: flush of persisted dedup failed:', err);
+      }
+    }
+
     if (this.nostrClient) {
       this.nostrClient.disconnect();
       this.nostrClient = null;
@@ -578,9 +632,18 @@ export class NostrTransportProvider implements TransportProvider {
     // Clear per-address state so stale dedup entries from previous address
     // don't block legitimate events for the new address.
     this.processedEventIds.clear();
+    this.inFlightEventIds.clear();
+    this.failedEventCooldowns.clear();
+    this.dedupHydrated = false;
     this.lastEventTs = 0;
     this.lastDmEventTs = 0;
     this.fallbackDmSince = null;
+    // Cancel any pending debounced persist — the previous identity's
+    // state must not leak into the new identity's storage namespace.
+    if (this.persistDedupTimer) {
+      clearTimeout(this.persistDedupTimer);
+      this.persistDedupTimer = null;
+    }
 
     // Create NostrKeyManager from private key.
     // Steelman³³ warning: strict hex decode — Buffer.from(_, 'hex')
@@ -1556,12 +1619,20 @@ export class NostrTransportProvider implements TransportProvider {
   // ===========================================================================
 
   private async handleEvent(event: NostrEvent): Promise<void> {
-    // Dedup: skip events already processed by another subscription
+    // Issue #275 — two-tier dedup. The persistent set blocks events that
+    // were already FULLY processed in a prior session (cross-process
+    // dedup). The in-flight set blocks concurrent arrivals via multiple
+    // subscriptions within the same process. Neither set is added to
+    // until we've confirmed processing — at-least-once depends on
+    // failed TOKEN_TRANSFER events being replayable on next reconnect.
     if (event.id && this.processedEventIds.has(event.id)) {
       return;
     }
+    if (event.id && this.inFlightEventIds.has(event.id)) {
+      return;
+    }
     if (event.id) {
-      this.processedEventIds.add(event.id);
+      this.inFlightEventIds.add(event.id);
     }
 
     logger.debug('Nostr', 'Processing event kind:', event.kind, 'id:', event.id?.slice(0, 12));
@@ -1571,8 +1642,9 @@ export class NostrTransportProvider implements TransportProvider {
       // every registered handler reported the inbound token(s)
       // durably persisted (IPFS pin + OrbitDB ref + aggregator
       // pointer for the Profile provider). When `false`, we do NOT
-      // advance `lastEventTs`, so the event is re-replayed on the
-      // next reconnect (idempotent via addToken stateHash dedup).
+      // advance `lastEventTs` AND we do NOT add to `processedEventIds`,
+      // so the event is re-replayed on the next reconnect (idempotent
+      // via addToken stateHash dedup).
       //
       // Other wallet kinds (DM, payment-request, payment-request-
       // response) retain the legacy "advance on completion"
@@ -1594,8 +1666,10 @@ export class NostrTransportProvider implements TransportProvider {
           // its cooldown window. Without this, relay reconnect immediately
           // re-fires the failing event and the receive pipeline (parse +
           // crypto verify + flush + HEAD-verify) burns CPU on every retry
-          // before refusing the ack again. The cooldown is a memory-only
-          // map (see field doc); a process restart gets a fresh budget.
+          // before refusing the ack again. The cooldown map is now
+          // persisted (issue #275) so the bounded replay budget
+          // (`DURABILITY_MAX_REPLAY_ATTEMPTS = 3`) accumulates across
+          // process restarts rather than resetting per-process.
           if (event.id && this.isInDurabilityCooldown(event.id)) {
             logger.debug(
               'Nostr',
@@ -1621,6 +1695,14 @@ export class NostrTransportProvider implements TransportProvider {
       // Skip for TOKEN_TRANSFER when the handler reported non-durable —
       // re-replay on next reconnect protects against silent loss when
       // IPFS pin / OrbitDB write / aggregator publish fails.
+      //
+      // Issue #275: cursor advance and `processedEventIds` add MUST move
+      // together — they're the two halves of "this event is done." If
+      // we mark processed without advancing the cursor, the relay will
+      // re-deliver the event and we'll spin forever in dedup-skip. If
+      // we advance the cursor without marking processed, a process
+      // restart will refetch and reprocess the event (wasteful but
+      // safe). The lockstep below is the at-least-once invariant.
       if (event.created_at && this.storage && this.keyManager) {
         const kind = event.kind;
         if (
@@ -1629,6 +1711,7 @@ export class NostrTransportProvider implements TransportProvider {
           kind === EVENT_KINDS.PAYMENT_REQUEST_RESPONSE
         ) {
           this.updateLastEventTimestamp(event.created_at);
+          this.markEventProcessed(event.id);
         } else if (kind === EVENT_KINDS.TOKEN_TRANSFER) {
           if (tokenTransferDurable) {
             // Issue #272: success — drop any prior cooldown tracking
@@ -1637,6 +1720,7 @@ export class NostrTransportProvider implements TransportProvider {
             // floods on Nostr reconnect) gets a fresh budget.
             if (event.id) this.failedEventCooldowns.delete(event.id);
             this.updateLastEventTimestamp(event.created_at);
+            this.markEventProcessed(event.id);
           } else if (event.id) {
             // Issue #272: bounded replay budget. `recordDurabilityMiss`
             // increments the per-event attempt counter, arms an
@@ -1650,6 +1734,12 @@ export class NostrTransportProvider implements TransportProvider {
                 `[AT-LEAST-ONCE] TOKEN_TRANSFER ${event.id.slice(0, 12)} exhausted ${NostrTransportProvider.DURABILITY_MAX_REPLAY_ATTEMPTS} durability replay attempts — advancing cursor; operator should investigate local OrbitDB/IPFS-pin/publish failures.`,
               );
               this.updateLastEventTimestamp(event.created_at);
+              // Mark processed so subsequent cross-process replays
+              // short-circuit at the top of handleEvent. Without this,
+              // a budget-exhausted event would replay forever after
+              // process restart (its event ID isn't in `processedEventIds`
+              // and the persisted cooldowns may have expired).
+              this.markEventProcessed(event.id);
             } else {
               const entry = this.failedEventCooldowns.get(event.id);
               const cooldownMs = entry ? Math.max(0, entry.nextRetryAt - Date.now()) : 0;
@@ -1657,6 +1747,9 @@ export class NostrTransportProvider implements TransportProvider {
                 'Nostr',
                 `[AT-LEAST-ONCE] TOKEN_TRANSFER ${event.id.slice(0, 12)} not durable — leaving 'since' at ${this.lastEventTs}; cooldown ${cooldownMs}ms (attempt ${entry?.attempts ?? '?'}/${NostrTransportProvider.DURABILITY_MAX_REPLAY_ATTEMPTS}).`,
               );
+              // Persist the cooldown bump so a process restart sees
+              // the accumulated attempt count.
+              this.schedulePersistDedup();
             }
           } else {
             // Defensive: no event.id means we can't track cooldown or
@@ -1666,11 +1759,211 @@ export class NostrTransportProvider implements TransportProvider {
               `[AT-LEAST-ONCE] TOKEN_TRANSFER (no id) not durable — leaving 'since' at ${this.lastEventTs}; event will replay on next reconnect`,
             );
           }
+        } else {
+          // BROADCAST / GIFT_WRAP: no cursor tracking on the wallet
+          // since-filter (GIFT_WRAP uses lastDmEventTs which the DM
+          // handler advances; BROADCAST has no since-resume). Still
+          // mark processed so multi-subscription concurrent arrivals
+          // don't double-emit to handlers.
+          this.markEventProcessed(event.id);
         }
+      } else {
+        // No created_at or no storage — best-effort mark to dedup
+        // within session. Without storage we can't persist anyway.
+        this.markEventProcessed(event.id);
       }
     } catch (error) {
       logger.debug('Nostr', 'Failed to handle event:', error);
+    } finally {
+      // Always release in-flight slot so a retry (next reconnect) can
+      // re-enter handleEvent. Persistent dedup at the top will block
+      // duplicates of fully-processed events.
+      if (event.id) {
+        this.inFlightEventIds.delete(event.id);
+      }
     }
+  }
+
+  /**
+   * Issue #275 — add an event ID to the persistent dedup set and
+   * schedule a debounced write. FIFO-eviction keeps the set bounded
+   * at `LIMITS.PROCESSED_EVENT_IDS_CAP`.
+   */
+  private markEventProcessed(eventId: string | undefined): void {
+    if (!eventId) return;
+    if (this.processedEventIds.has(eventId)) return;
+    this.processedEventIds.add(eventId);
+    // FIFO eviction: Set preserves insertion order, so keys().next().value
+    // is the oldest entry. Evict in a single step (cheap) per insert at
+    // capacity; no full re-sort needed.
+    while (this.processedEventIds.size > LIMITS.PROCESSED_EVENT_IDS_CAP) {
+      const oldest = this.processedEventIds.keys().next().value;
+      if (oldest === undefined) break;
+      this.processedEventIds.delete(oldest);
+    }
+    this.schedulePersistDedup();
+  }
+
+  /**
+   * Issue #275 — schedule a debounced write of the persistent dedup
+   * sets to storage. Coalesces a burst of EOSE-replay arrivals into a
+   * single storage transaction. Subsequent calls within the debounce
+   * window are no-ops (timer already armed).
+   */
+  private schedulePersistDedup(): void {
+    if (!this.storage || !this.keyManager) return;
+    if (this.persistDedupTimer) return;
+    this.persistDedupTimer = setTimeout(() => {
+      this.persistDedupTimer = null;
+      this.persistDedupNow().catch((err) => {
+        logger.debug('Nostr', 'Persisted dedup write failed (will retry on next mark):', err);
+      });
+    }, LIMITS.PROCESSED_EVENT_IDS_FLUSH_MS);
+  }
+
+  /**
+   * Issue #275 — write the persistent dedup sets to storage. Serialized
+   * via `persistDedupInFlight` so concurrent timer fires (debounce + a
+   * forced flush) don't race on the underlying KV write.
+   */
+  private async persistDedupNow(): Promise<void> {
+    if (!this.storage || !this.keyManager) return;
+    // Serialize against any in-flight write — proper-lockfile in
+    // FileStorageProvider would block anyway, but IndexedDB doesn't,
+    // and overlapping writes risk last-writer-wins of a stale snapshot.
+    if (this.persistDedupInFlight) {
+      await this.persistDedupInFlight.catch(() => undefined);
+    }
+    const inFlight = this.doPersistDedup();
+    this.persistDedupInFlight = inFlight;
+    try {
+      await inFlight;
+    } finally {
+      if (this.persistDedupInFlight === inFlight) {
+        this.persistDedupInFlight = null;
+      }
+    }
+  }
+
+  private async doPersistDedup(): Promise<void> {
+    if (!this.storage || !this.keyManager) return;
+    const pubkey = this.keyManager.getPublicKeyHex();
+    const prefix = pubkey.slice(0, 16);
+    const eventsKey = `${STORAGE_KEYS_GLOBAL.PROCESSED_WALLET_EVENT_IDS}_${prefix}`;
+    const cooldownsKey = `${STORAGE_KEYS_GLOBAL.FAILED_EVENT_COOLDOWNS}_${prefix}`;
+
+    // Snapshot under sync — Set/Map iteration is stable but a concurrent
+    // markEventProcessed can mutate the underlying collection. Array.from
+    // captures a stable view for serialization.
+    const ids = Array.from(this.processedEventIds);
+    const cooldownsArr: Array<[string, { nextRetryAt: number; attempts: number }]> = Array.from(
+      this.failedEventCooldowns.entries(),
+    );
+
+    // Write events + cooldowns independently — they target distinct
+    // KV keys so a partial failure on one shouldn't block the other.
+    try {
+      await this.storage.set(eventsKey, JSON.stringify(ids));
+    } catch (err) {
+      logger.debug('Nostr', 'Persisted dedup: events write failed:', err);
+    }
+    try {
+      await this.storage.set(cooldownsKey, JSON.stringify(cooldownsArr));
+    } catch (err) {
+      logger.debug('Nostr', 'Persisted dedup: cooldowns write failed:', err);
+    }
+  }
+
+  /**
+   * Issue #275 — hydrate the persistent dedup sets from storage on the
+   * first connect/fetchPendingEvents per identity. Idempotent: subsequent
+   * calls are no-ops once `dedupHydrated` is true.
+   *
+   * Failure modes (storage read throw, JSON parse error, malformed
+   * data) all degrade to "start fresh" — the wallet still works, just
+   * pays the cross-process re-dispatch tax once until the next write
+   * cycle repopulates the disk.
+   */
+  private async hydrateProcessedDedup(): Promise<void> {
+    if (this.dedupHydrated) return;
+    if (!this.storage || !this.keyManager) {
+      this.dedupHydrated = true;
+      return;
+    }
+    const pubkey = this.keyManager.getPublicKeyHex();
+    const prefix = pubkey.slice(0, 16);
+    const eventsKey = `${STORAGE_KEYS_GLOBAL.PROCESSED_WALLET_EVENT_IDS}_${prefix}`;
+    const cooldownsKey = `${STORAGE_KEYS_GLOBAL.FAILED_EVENT_COOLDOWNS}_${prefix}`;
+
+    try {
+      const raw = await this.storage.get(eventsKey);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          for (const id of parsed) {
+            if (typeof id === 'string' && id.length > 0) {
+              this.processedEventIds.add(id);
+            }
+          }
+        }
+      }
+    } catch (err) {
+      logger.debug('Nostr', 'hydrateProcessedDedup events parse/read failed:', err);
+    }
+
+    try {
+      const raw = await this.storage.get(cooldownsKey);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          const now = Date.now();
+          let dropped = 0;
+          for (const entry of parsed) {
+            if (
+              Array.isArray(entry) &&
+              entry.length === 2 &&
+              typeof entry[0] === 'string' &&
+              entry[1] !== null &&
+              typeof entry[1] === 'object'
+            ) {
+              const [eventId, meta] = entry as [string, unknown];
+              const m = meta as { nextRetryAt?: unknown; attempts?: unknown };
+              const nextRetryAt = typeof m.nextRetryAt === 'number' ? m.nextRetryAt : NaN;
+              const attempts = typeof m.attempts === 'number' ? m.attempts : NaN;
+              if (
+                Number.isFinite(nextRetryAt) &&
+                Number.isFinite(attempts) &&
+                attempts >= 1 &&
+                attempts < NostrTransportProvider.DURABILITY_MAX_REPLAY_ATTEMPTS
+              ) {
+                // Drop entries whose cooldown elapsed more than one
+                // COOLDOWN_MAX_MS ago — the cooldown is meaningless and
+                // we'd just keep stale clutter. Keep recently-expired
+                // ones because the attempt counter still matters for
+                // budget accumulation.
+                const elapsed = now - nextRetryAt;
+                if (elapsed > NostrTransportProvider.DURABILITY_COOLDOWN_MAX_MS * 2) {
+                  dropped++;
+                  continue;
+                }
+                this.failedEventCooldowns.set(eventId, { nextRetryAt, attempts });
+              }
+            }
+          }
+          if (dropped > 0) {
+            logger.debug('Nostr', `hydrateProcessedDedup: dropped ${dropped} stale cooldown entries`);
+          }
+        }
+      }
+    } catch (err) {
+      logger.debug('Nostr', 'hydrateProcessedDedup cooldowns parse/read failed:', err);
+    }
+
+    this.dedupHydrated = true;
+    logger.debug(
+      'Nostr',
+      `[#275] Persisted dedup hydrated: ${this.processedEventIds.size} event IDs, ${this.failedEventCooldowns.size} cooldown entries`,
+    );
   }
 
   /**
@@ -2356,6 +2649,15 @@ export class NostrTransportProvider implements TransportProvider {
       throw new SphereError('Transport not connected', 'TRANSPORT_ERROR');
     }
 
+    // Issue #275 — hydrate persistent dedup BEFORE pulling EOSE backlog.
+    // Without this, the first CLI command of a new process would walk
+    // the full relay backlog once (pre-fix #275 §C soak: 169 dispatches
+    // across 15 unique ids). This is the same hook installed in
+    // `subscribeToEvents` for the long-lived subscription path; CLIs
+    // that only call `fetchPendingEvents` (no persistent subscription)
+    // also need the hydrate to take effect.
+    await this.hydrateProcessedDedup();
+
     // Issue #274 — perf instrumentation. Called once per `sphere.payments.receive()`
     // and once per `ensureSync(sphere, 'full')`. Per perf-engineer, the CLI runs
     // ensureSync at the start of every command — making this span the cheapest
@@ -2552,6 +2854,13 @@ export class NostrTransportProvider implements TransportProvider {
     // Use 32-byte Nostr pubkey (x-coordinate only), not 33-byte compressed key
     const nostrPubkey = this.keyManager.getPublicKeyHex();
     logger.debug('Nostr', 'Subscribing with Nostr pubkey:', nostrPubkey);
+
+    // Issue #275 — hydrate persistent dedup BEFORE the relay since-filter
+    // re-delivers backlog events. Without this, the relay's EOSE burst
+    // would hit the empty in-memory set, re-dispatch every event, and
+    // pay the parse/adapter/addToken cost for events the previous
+    // process already finalized.
+    await this.hydrateProcessedDedup();
 
     // Determine 'since' filter from persisted last event timestamp.
     // - Existing wallet: resume from last processed event (inclusive >=, dedup handles replays)

--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -889,6 +889,12 @@ export class NostrTransportProvider implements TransportProvider {
             // `undefined` is the legacy "no opinion" contract → durable.
             if (result !== false) {
               this.updateLastEventTimestamp(createdAtSec);
+              // Issue #275 — mark the buffered event as processed so
+              // cross-process replays short-circuit. Without this, the
+              // pre-Mux buffered events (which never enter handleEvent's
+              // success branches) would not be persisted in the dedup
+              // set, and every fresh CLI invocation would re-walk them.
+              this.markEventProcessed(transfer.id);
             } else {
               logger.debug(
                 'Nostr',


### PR DESCRIPTION
## Summary

Fixes #275. Issue forensics quantified **71.5% of §C wall-clock (381s of 533s) wasted on duplicate dispatches** — 169 dispatches across 15 unique event IDs because \`processedEventIds: Set<string>\` lived only in \`NostrTransportProvider\` (and \`MultiAddressTransportMux\`) memory. Every fresh CLI invocation re-walked the relay backlog.

This PR lands the issue's recommended P1 + P2 fixes.

## Soak results (\`soak-c-only.sh\`, testnet)

| Section | Pre-fix baseline | Post-fix | Δ |
|---|---|---|---|
| §C.2 (Bob pays) | 277s | **45s** | **-84%** |
| §C.4 (Peer2 view) | 256s | **93s** | **-64%** |
| §C total (C.2+C.4) | 533s | **138s** | **-74%** |
| Dispatches across 15 unique IDs | 169 (11.3× dup) | 28 (1.87× dup) | **-83%** |

Acceptance: §C.2 < 60s ✅. §C total < 120s ❌ (138s, 18s over — closing the remaining gap requires P3 \`receive().load()\` skip, deferred as out-of-scope per issue's "land P1+P2 as a single PR" recommendation).

## What changed

### P1 — Persist \`processedEventIds\` + \`failedEventCooldowns\` (both transports)

\`transport/NostrTransportProvider.ts\` (~370 lines)
- **Two-tier dedup:** in-flight set (in-memory, concurrent-arrival dedup) + processed set (persisted, cross-process dedup).
- \`markEventProcessed\` moves the persistent add from line 1564 (pre-dispatch) to AFTER cursor advance. Preserves at-least-once for failed TOKEN_TRANSFER events.
- FIFO cap at \`LIMITS.PROCESSED_EVENT_IDS_CAP\` (10k), debounced 200ms write.
- \`failedEventCooldowns\` also persists so \`DURABILITY_MAX_REPLAY_ATTEMPTS=3\` accumulates across process restarts.
- Hydrated in \`subscribeToEvents\` AND \`fetchPendingEvents\` before EOSE.
- \`disconnect()\` flushes pending write.
- \`onTokenTransfer\` buffered-drain (Issue #247 path) now also calls \`markEventProcessed\`.

\`transport/MultiAddressTransportMux.ts\` (~140 lines)
- Same persistence pattern applied to the Mux's own \`processedEventIds\`.
- Single-tier (no in-flight set) since Mux dispatch unconditionally advances per-address \`lastEventTs\`.
- \`STORAGE_KEYS_GLOBAL.MUX_PROCESSED_EVENT_IDS\` — global key (no pubkey suffix; Mux is per-Sphere-instance).
- Hydrate in \`updateSubscriptions\` before EOSE, flush on \`disconnect\`.

### P2 — Hoist V6/V5 bundle dedup in \`handleIncomingTransfer\`

\`modules/payments/PaymentsModule.ts\` (~45 lines)
- Pre-check \`processedCombinedTransferIds.has(transferId)\` BEFORE calling \`processCombinedTransferBundle\` AND BEFORE the trailing \`awaitAllProvidersDurable()\`.
- Symmetric hoist for V5 \`INSTANT_SPLIT\` via \`processedSplitGroupIds\`.
- Returns \`true\` so transport advances cursor past the duplicate.
- Inner dedup retained as defense-in-depth.

### Tests (+15 new tests across 2 files)

\`tests/unit/transport/NostrTransportProvider.test.ts\` (+9 tests)
- Hydrate persisted event IDs + dedup subsequent dispatch
- Tolerate malformed/non-array persisted JSON
- Hydrate cooldowns and respect remaining window
- **Drop stale cooldowns** (now asserts on map state, not a no-op)
- Persist after debounce window
- Coalesce rapid arrivals into a single write
- No add when event has no id
- Cancel armed debounce timer on \`setIdentity\`
- **FIFO eviction boundary** (verifies \`> cap\` not \`>= cap\`)
- **Disconnect flush** (verifies pending write persists on shutdown)

\`tests/unit/modules/PaymentsModule.dedup-hoist.test.ts\` (+6 tests, new file)
- V6 short-circuit (hit + miss + unrelated id in set)
- V5 short-circuit (hit + miss + empty splitGroupId)
- Confirms \`processCombinedTransferBundle\` and \`awaitAllProvidersDurable\` are NOT called on hoist hit.

\`constants.ts\` — added \`PROCESSED_WALLET_EVENT_IDS\`, \`FAILED_EVENT_COOLDOWNS\`, \`MUX_PROCESSED_EVENT_IDS\` keys + \`LIMITS.PROCESSED_EVENT_IDS_CAP\` (10_000) + \`PROCESSED_EVENT_IDS_FLUSH_MS\` (200).

## Reviewer attention

- **At-least-once preservation** — \`markEventProcessed\` is called ONLY when the cursor advances (durable=true OR replay budget exhausted). Failed TOKEN_TRANSFER events with budget remaining are NEITHER cursor-advanced NOR marked processed → replay on next reconnect.
- **Bounds** — both sets capped at 10k FIFO. Cooldowns retain their existing 256 LRU. Worst-case serialized size: ~700KB processed IDs + ~30KB cooldowns. Per-process disk hits: at most 1 write per 200ms.
- **Cross-process race** — multi-process concurrent access serialized by \`proper-lockfile\` in \`FileStorageProvider\`. IndexedDB has its own transaction serialization. The \`persistDedupInFlight\` guard handles in-process timer+disconnect overlap (last-writer-wins; both snapshots taken from same live collection so result is correct).

## Steelman review trail

3 parallel adversarial reviews ran on commit \`bb9dedf\`:
1. **At-least-once + invariants** (\`code-reviewer\`): SHIP IT — one doc gap, non-blocking.
2. **Storage + serialization** (\`code-reviewer\`): SHIP IT — one low-severity 3-caller race (last-writer-wins still correct).
3. **Test coverage + perf** (\`code-reviewer\`): GAPS BLOCKING — 3 test gaps (V6/V5 hoist coverage, no-op stale-drop, missing disconnect-flush test) + 2 advisory (FIFO boundary, cooldown gate test ambiguity).

All 5 blocking + advisory items addressed in follow-up commit \`5fa50cc\`.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npx eslint\` — clean (pre-existing warnings only)
- [x] \`npx vitest run\` — 8287 tests pass / 13 skipped
- [x] §C soak (testnet) — completes in 162s (down from 533s)
- [ ] PR-time CI green
- [ ] Steady-state soak (2nd run on warm workspace) — expected sub-100s for §C total

## Follow-ups (out of scope)

- **P3 — skip \`load()\` in \`receive()\` on zero-delta** (issue #275). Expected to close the remaining 18s gap to the 120s acceptance threshold. Medium-risk: requires audit of every \`addToken\` side-effect path.
- **P4 — broaden V6-RECOVER permanent verdict classifier** (issue #275). PR #271 already persists the verdict for the \`Recipient address mismatch\` class; broaden to cover the other classes flagged in #275's soak.
- Two findings from steelman review #2:
  - 3-caller race on \`persistDedupInFlight\` (low-severity; last-writer-wins remains correct)
  - Hydration doesn't enforce \`PROCESSED_EVENT_IDS_CAP\` cap on load (only on insert)

Refs #275, #274.