### PR TITLE
fix(profile)(#278): bound helia.blockstore.get with LRU + in-flight dedup

### DIFF
--- a/profile/helia-blockstore-shim.ts
+++ b/profile/helia-blockstore-shim.ts
@@ -174,21 +174,32 @@ function isMissError(err: unknown): boolean {
 }
 
 /**
- * Compute the LRU key for a CID. Prefers `cid.toString()` (canonical
- * multiformats), falls back to `String(cid)` for shapes that don't
- * expose it. Returns `null` for unusable inputs so the wrapped get
- * skips the cache (defensive: cache miss is still a correct result).
+ * Compute the LRU key for a CID. Calls `cid.toString()` (canonical
+ * multiformats base32 / base58btc) and returns the result when it's
+ * a non-empty string that does NOT match the default
+ * `Object.prototype.toString` sentinel (`[object Object]`).
+ *
+ * Returning `null` for any other shape causes the wrapped get to
+ * skip the cache entirely — a cache miss is still a correct (slower)
+ * result, whereas a colliding key (e.g., the default `[object Object]`
+ * for every non-CID) would serve incorrect bytes across distinct
+ * inputs.
  */
 function cidKey(cid: unknown): string | null {
   if (cid == null) return null;
+  let s: unknown;
   try {
-    const s = (cid as { toString?: () => string }).toString?.();
-    if (typeof s === 'string' && s.length > 0) return s;
-    const fallback = String(cid);
-    return fallback.length > 0 ? fallback : null;
+    s = (cid as { toString?: () => string }).toString?.();
   } catch {
     return null;
   }
+  if (typeof s !== 'string' || s.length === 0) return null;
+  // Reject the default `Object.prototype.toString` output — colliding
+  // on `[object Object]` would conflate distinct unknown shapes into
+  // one cache entry and return wrong bytes. Real CIDs produce a
+  // base-encoded string that never starts with `[object `.
+  if (s.startsWith('[object ')) return null;
+  return s;
 }
 
 /**
@@ -229,7 +240,15 @@ export function installHeliaBlockstoreGetShim(
   let misses = 0;
 
   const touch = (key: string, value: Uint8Array): void => {
-    if (value.byteLength === 0 || value.byteLength > perEntryMax) return;
+    // Skip degenerate inputs:
+    //   - `lruMax <= 0`: cache effectively disabled (treat as "store
+    //     nothing"). Avoids the wasteful set-then-evict cycle.
+    //   - empty block: nothing useful to cache.
+    //   - over per-entry cap: protect against pathological multi-MB
+    //     blocks pinning the cache.
+    if (lruMax <= 0 || value.byteLength === 0 || value.byteLength > perEntryMax) {
+      return;
+    }
     lru.set(key, value);
     while (lru.size > lruMax) {
       const oldest = lru.keys().next().value;

--- a/profile/helia-blockstore-shim.ts
+++ b/profile/helia-blockstore-shim.ts
@@ -1,0 +1,338 @@
+/**
+ * Helia blockstore shim — wraps `helia.blockstore.get` with three
+ * compensating layers: (1) Helia-v6-to-OrbitDB-v3 drain shim,
+ * (2) bounded LRU read cache, (3) in-flight Promise dedup.
+ *
+ * Why this exists (issue history):
+ *
+ * - **#234** — Helia v6's `BlockStorage.get` is an `async *get(cid, options)`
+ *   generator yielding `Uint8Array` chunks. OrbitDB v3's `IPFSBlockStorage.get`
+ *   was authored for the Helia v5 API where `await blockstore.get(cid)`
+ *   resolved to a `Uint8Array`. Under v6 the same `await` resolves to the
+ *   AsyncGenerator object — cborg downstream throws
+ *   `data to decode must be a Uint8Array`. The drain shim re-establishes
+ *   the v5 contract by draining the generator into a single Uint8Array.
+ *
+ * - **#266** — `NetworkedStorage.get` throws `InvalidConfigurationError`
+ *   when the wallet is in HTTP-only mode (`blockBrokers: []`) AND the
+ *   block is not in the local on-disk store. OrbitDB expects `undefined`
+ *   on miss (the `if (block)` check at `@orbitdb/core/src/storage/ipfs-block.js:65`)
+ *   — surfacing the exception would abort the whole read with a non-fatal
+ *   miss. The shim swallows it (alongside the canonical `NotFoundError`)
+ *   so OrbitDB sees a clean missing entry; upstream callers run the
+ *   HTTP-gateway recovery path separately.
+ *
+ * - **#278** — `sphere wallet use <name>` wedged for 58 min at 330% CPU
+ *   with 900+ open file descriptors all pointing at TWO OrbitDB block
+ *   files (the OpLog HEAD entry block + the most-recent snapshot block).
+ *   Pattern: a tight read loop hitting the same CIDs hundreds of times
+ *   in rapid succession. Each `helia.blockstore.get(cid)` walked
+ *   `BlockStorage → NetworkedStorage → IdentityBlockstore → FsBlockstore`
+ *   and opened the file. Even though `FsBlockstore.get` is correct in
+ *   the steady state (stream EOF auto-closes the FD), the FD close is
+ *   event-loop scheduled — under a synchronous storm of `get(cid)` the
+ *   close handlers run AFTER the next batch of opens, FDs accumulate
+ *   well past safe limits, and the process spins.
+ *
+ *   The LRU + in-flight dedup eliminate the storm at its source: 100 %
+ *   of cached-CID `get` calls return synchronously with the bytes
+ *   (zero `fs.open` calls), and concurrent first-reads share one
+ *   Promise (one open per CID, not N).
+ *
+ * Design constraints:
+ *   - **Defaults are conservative.** 64 entries × 1 MiB per-entry cap =
+ *     64 MiB worst case; typical OrbitDB blocks are sub-KiB so the
+ *     real footprint is well under 1 MiB. The cap covers the OpLog
+ *     head + recent snapshot + handful of bundle CIDs working set.
+ *   - **Negative caching is OFF.** A `get(cid)` that returns `undefined`
+ *     (cache miss) is NOT cached — upstream callers may then fetch the
+ *     block via HTTP brokers and re-populate the local blockstore; a
+ *     cached `undefined` would defeat that recovery. The shim ONLY
+ *     caches non-empty `Uint8Array` results.
+ *   - **`put` evicts.** Content-addressed CIDs mean same-CID writes
+ *     have identical bytes (so a stale cache entry would be semantically
+ *     correct), but evict-on-write is the safer default: any future
+ *     writer surface that diverges from content addressing is caught.
+ *   - **CID identity is the LRU key.** We rely on the canonical
+ *     `cid.toString()` (multiformats `base32` for v1, `base58btc` for
+ *     v0). Both are stable, CID-unique, and round-trip with
+ *     `CID.parse`.
+ *
+ * @module profile/helia-blockstore-shim
+ */
+
+/**
+ * Default maximum LRU entries. 64 entries comfortably covers the
+ * OpLog head + recent snapshot + tens of bundle CIDs the load path
+ * touches.
+ */
+export const BLOCKSTORE_GET_LRU_MAX_DEFAULT = 64;
+
+/**
+ * Default per-entry byte cap. Blocks larger than this are returned to
+ * the caller but NOT cached — avoids pathological multi-megabyte
+ * blocks pinning the cache.
+ */
+export const BLOCKSTORE_GET_LRU_PER_ENTRY_MAX_DEFAULT = 1 * 1024 * 1024; // 1 MiB
+
+/**
+ * Surface area we touch on a Helia v6+ blockstore. Typed `unknown`-permissive
+ * because `@helia/utils` is not a hard dependency of the SDK (loaded
+ * dynamically via `import('helia')`).
+ */
+export interface HeliaBlockstoreLike {
+  get: (cid: unknown, options?: unknown) => unknown;
+  put?: (cid: unknown, val: unknown, options?: unknown) => unknown;
+  delete?: (cid: unknown, options?: unknown) => unknown;
+}
+
+/**
+ * Tuning knobs for the shim. Both default to the constants above; the
+ * test suite uses tighter values to exercise eviction paths in finite
+ * time.
+ */
+export interface HeliaBlockstoreShimOptions {
+  readonly lruMax?: number;
+  readonly perEntryMax?: number;
+}
+
+/**
+ * Install the drain shim + LRU read cache + in-flight dedup over
+ * `blockstore.get` (mutates the blockstore in-place). Returns a
+ * disposer that restores the original methods AND surfaces the
+ * read-cache stats for assertions.
+ *
+ * Call ONCE per blockstore instance. Re-installing over an already-
+ * wrapped get would treat the inner `Promise<Uint8Array | undefined>`
+ * as the new `AsyncIterable<Uint8Array>` and crash the drain — the
+ * production wiring satisfies this by construction (`connectInner`
+ * runs once per `connect()`), and tests should use a fresh Helia
+ * instance for each scenario.
+ */
+export interface HeliaBlockstoreShimHandle {
+  /** Number of LRU entries currently cached. */
+  readonly cacheSize: () => number;
+  /** Number of in-flight reads currently pending. */
+  readonly inflightSize: () => number;
+  /**
+   * Number of times the shim observed a cache hit. Includes both LRU
+   * hits AND in-flight Promise reuse. (Both correspond to "no new
+   * `fs.open` call".)
+   */
+  readonly hits: () => number;
+  /** Number of times the shim observed a cache miss + drain. */
+  readonly misses: () => number;
+  /** Restore the original blockstore methods. */
+  readonly uninstall: () => void;
+}
+
+/**
+ * Drain an async iterable of `Uint8Array` chunks into a single
+ * `Uint8Array`. Mirrors `it-to-buffer` but inlined to avoid a
+ * dependency footprint for one call site.
+ *
+ * Returns `undefined` when the iterable yields zero chunks (Helia
+ * surface treats this as a miss).
+ */
+async function drainGenerator(
+  source: AsyncIterable<Uint8Array>,
+): Promise<Uint8Array | undefined> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for await (const chunk of source) {
+    chunks.push(chunk);
+    total += chunk.length;
+  }
+  if (chunks.length === 0) return undefined;
+  if (chunks.length === 1) return chunks[0];
+  const combined = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    combined.set(c, offset);
+    offset += c.length;
+  }
+  return combined;
+}
+
+/**
+ * True when the thrown value is a "block not present" signal that
+ * upstream callers expect to surface as `undefined` (NOT as an
+ * exception). Covers both the canonical interface-store
+ * `NotFoundError` (`name === 'NotFoundError'`, `code === 'ERR_NOT_FOUND'`)
+ * AND the Helia `InvalidConfigurationError` thrown when
+ * `blockBrokers: []` and the block isn't local.
+ */
+function isMissError(err: unknown): boolean {
+  if (err === null || typeof err !== 'object') return false;
+  const e = err as { name?: unknown; code?: unknown };
+  return (
+    e.name === 'NotFoundError' ||
+    e.code === 'ERR_NOT_FOUND' ||
+    e.name === 'InvalidConfigurationError' ||
+    e.code === 'ERR_NO_BLOCK_BROKERS'
+  );
+}
+
+/**
+ * Compute the LRU key for a CID. Prefers `cid.toString()` (canonical
+ * multiformats), falls back to `String(cid)` for shapes that don't
+ * expose it. Returns `null` for unusable inputs so the wrapped get
+ * skips the cache (defensive: cache miss is still a correct result).
+ */
+function cidKey(cid: unknown): string | null {
+  if (cid == null) return null;
+  try {
+    const s = (cid as { toString?: () => string }).toString?.();
+    if (typeof s === 'string' && s.length > 0) return s;
+    const fallback = String(cid);
+    return fallback.length > 0 ? fallback : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Install the shim on `blockstore` in place. See module doc for
+ * background; this is the single entry point for `OrbitDbAdapter`
+ * (production wiring) and the unit test (mock wiring).
+ */
+export function installHeliaBlockstoreGetShim(
+  blockstore: HeliaBlockstoreLike,
+  options?: HeliaBlockstoreShimOptions,
+): HeliaBlockstoreShimHandle {
+  const lruMax = options?.lruMax ?? BLOCKSTORE_GET_LRU_MAX_DEFAULT;
+  const perEntryMax = options?.perEntryMax ?? BLOCKSTORE_GET_LRU_PER_ENTRY_MAX_DEFAULT;
+
+  const originalGet = blockstore.get.bind(blockstore) as (
+    cid: unknown,
+    options?: unknown,
+  ) => unknown;
+  const originalPut =
+    typeof blockstore.put === 'function'
+      ? (blockstore.put.bind(blockstore) as (
+          cid: unknown,
+          val: unknown,
+          options?: unknown,
+        ) => unknown)
+      : null;
+  const originalDelete =
+    typeof blockstore.delete === 'function'
+      ? (blockstore.delete.bind(blockstore) as (
+          cid: unknown,
+          options?: unknown,
+        ) => unknown)
+      : null;
+
+  const lru = new Map<string, Uint8Array>();
+  const inflight = new Map<string, Promise<Uint8Array | undefined>>();
+  let hits = 0;
+  let misses = 0;
+
+  const touch = (key: string, value: Uint8Array): void => {
+    if (value.byteLength === 0 || value.byteLength > perEntryMax) return;
+    lru.set(key, value);
+    while (lru.size > lruMax) {
+      const oldest = lru.keys().next().value;
+      if (oldest === undefined) break;
+      lru.delete(oldest);
+    }
+  };
+
+  const wrappedGet = async (
+    cid: unknown,
+    opts?: unknown,
+  ): Promise<Uint8Array | undefined> => {
+    const key = cidKey(cid);
+
+    if (key !== null) {
+      const cached = lru.get(key);
+      if (cached !== undefined) {
+        // Refresh recency — re-insert at the end of the map's
+        // insertion order. (Map iteration order = insertion order;
+        // deleting + re-setting moves to the tail.)
+        lru.delete(key);
+        lru.set(key, cached);
+        hits++;
+        return cached;
+      }
+      const pending = inflight.get(key);
+      if (pending !== undefined) {
+        hits++;
+        return pending;
+      }
+    }
+
+    misses++;
+    const work = (async (): Promise<Uint8Array | undefined> => {
+      try {
+        const source = originalGet(cid, opts) as AsyncIterable<Uint8Array>;
+        return await drainGenerator(source);
+      } catch (err) {
+        if (isMissError(err)) return undefined;
+        throw err;
+      } finally {
+        if (key !== null) inflight.delete(key);
+      }
+    })();
+
+    if (key !== null) inflight.set(key, work);
+
+    const result = await work;
+    if (key !== null && result instanceof Uint8Array) {
+      touch(key, result);
+    }
+    return result;
+  };
+
+  blockstore.get = wrappedGet as unknown as HeliaBlockstoreLike['get'];
+
+  let wrappedPut: ((cid: unknown, val: unknown, opts?: unknown) => unknown) | null = null;
+  if (originalPut !== null) {
+    wrappedPut = (cid: unknown, val: unknown, opts?: unknown): unknown => {
+      const key = cidKey(cid);
+      if (key !== null) {
+        lru.delete(key);
+        inflight.delete(key);
+      }
+      return originalPut(cid, val, opts);
+    };
+    blockstore.put = wrappedPut as HeliaBlockstoreLike['put'];
+  }
+
+  // Wrap `delete` so a GC sweep or explicit removal evicts the LRU
+  // entry — otherwise a subsequent `get` would return stale bytes
+  // for a block the on-disk store no longer holds. Wallet code paths
+  // do not call `delete` today (Profile is append-only), but a future
+  // `helia.gc()` invocation or a sibling library that holds the
+  // helia handle could.
+  let wrappedDelete: ((cid: unknown, opts?: unknown) => unknown) | null = null;
+  if (originalDelete !== null) {
+    wrappedDelete = (cid: unknown, opts?: unknown): unknown => {
+      const key = cidKey(cid);
+      if (key !== null) {
+        lru.delete(key);
+        inflight.delete(key);
+      }
+      return originalDelete(cid, opts);
+    };
+    blockstore.delete = wrappedDelete as HeliaBlockstoreLike['delete'];
+  }
+
+  return {
+    cacheSize: () => lru.size,
+    inflightSize: () => inflight.size,
+    hits: () => hits,
+    misses: () => misses,
+    uninstall: (): void => {
+      blockstore.get = originalGet as unknown as HeliaBlockstoreLike['get'];
+      if (originalPut !== null) {
+        blockstore.put = originalPut as HeliaBlockstoreLike['put'];
+      }
+      if (originalDelete !== null) {
+        blockstore.delete = originalDelete as HeliaBlockstoreLike['delete'];
+      }
+      lru.clear();
+      inflight.clear();
+    },
+  };
+}

--- a/profile/orbitdb-adapter.ts
+++ b/profile/orbitdb-adapter.ts
@@ -14,6 +14,7 @@
 import { logger } from '../core/logger.js';
 import { hexToBytes } from '../core/hex.js';
 import { ProfileError } from './errors.js';
+import { installHeliaBlockstoreGetShim } from './helia-blockstore-shim.js';
 import {
   decodeAndDowngradeReplicated,
   decodeEntry,
@@ -471,74 +472,20 @@ export class OrbitDbAdapter implements ProfileDatabase {
 
       this.helia = await createHelia(heliaOptions);
 
-      // Issue #234 follow-up — Helia v6 changed `BlockStorage.get` to an
-      // `async *get(cid, options)` (`@helia/utils/dist/src/storage.js`)
-      // that yields Uint8Array chunks. OrbitDB v3 was authored against
-      // Helia v5 where `get` returned `Promise<Uint8Array>` directly, so
-      // its `IPFSBlockStorage.get` does `const block = await
-      // ipfs.blockstore.get(cid, ...)` and treats `block` as the bytes.
-      // In Helia v6 that `await` resolves to the AsyncGenerator OBJECT
-      // (truthy, NOT a Uint8Array), which then fails downstream with
-      // "data to decode must be a Uint8Array" inside cborg.
+      // Issues #234, #266, #278 — install the blockstore shim that
+      // (1) drains Helia-v6 async-generator `get` into a single Uint8Array
+      //     so OrbitDB-v3's `await ipfs.blockstore.get(cid)` keeps working,
+      // (2) swallows `NotFoundError` / `InvalidConfigurationError` so the
+      //     caller sees `undefined` on a miss (matching the v5 contract),
+      // (3) bounds repeated reads of the SAME CID via a 64-entry LRU +
+      //     in-flight Promise dedup — eliminates the FD-exhaustion wedge
+      //     observed in #278 where 900+ FDs accumulated against TWO
+      //     OpLog blocks under a hot read loop.
       //
-      // Monkey-patch the blockstore's `get` to drain the generator into
-      // a single Uint8Array. This makes OrbitDB v3 ↔ Helia v6 work and
-      // also lets our own `profile/ipfs-client.ts:probeLocalHelia` actually
-      // hit the local fast-path instead of silently falling back to HTTP
-      // gateways via the `!(got instanceof Uint8Array)` miss-handler.
-      //
-      // NotFoundError is swallowed and converted to `undefined`, matching
-      // OrbitDB IPFSBlockStorage's `if (block)` contract for "no entry".
-      //
-      // Issue #266 — InvalidConfigurationError is ALSO swallowed in HTTP-only
-      // mode. When `blockBrokers: []` is configured (lightweight client),
-      // Helia's NetworkedStorage throws `InvalidConfigurationError` on a
-      // local-blockstore miss instead of `NotFoundError`. Treat it the same
-      // as "block not present" so OrbitDB sees a clean missing entry and
-      // the snapshot prefetch (which uses HTTP via `profile/ipfs-client.ts`)
-      // can re-warm the blockstore before subsequent reads.
+      // Implementation + rationale: see `profile/helia-blockstore-shim.ts`.
       const heliaInstance: any = this.helia;
       if (heliaInstance?.blockstore && typeof heliaInstance.blockstore.get === 'function') {
-        const blockstore = heliaInstance.blockstore;
-        const originalGet = blockstore.get.bind(blockstore);
-        blockstore.get = async (cid: unknown, options?: unknown): Promise<Uint8Array | undefined> => {
-          const chunks: Uint8Array[] = [];
-          let total = 0;
-          try {
-            for await (const chunk of originalGet(cid, options) as AsyncIterable<Uint8Array>) {
-              chunks.push(chunk);
-              total += chunk.length;
-            }
-          } catch (err) {
-            const errName = (err as { name?: string } | null)?.name;
-            const errCode = (err as { code?: string } | null)?.code;
-            if (
-              errName === 'NotFoundError' ||
-              errCode === 'ERR_NOT_FOUND' ||
-              // Issue #266 — Helia throws InvalidConfigurationError when
-              // `blockBrokers: []` and the block isn't in the local
-              // blockstore. We treat this as "missing" so OrbitDB
-              // gracefully sees an unresolved head instead of erroring
-              // out the whole read. The HTTP recovery path
-              // (snapshot prefetch via profile/ipfs-client.ts) handles
-              // re-warming the blockstore from operator Kubo gateways.
-              errName === 'InvalidConfigurationError' ||
-              errCode === 'ERR_NO_BLOCK_BROKERS'
-            ) {
-              return undefined;
-            }
-            throw err;
-          }
-          if (chunks.length === 0) return undefined;
-          if (chunks.length === 1) return chunks[0];
-          const combined = new Uint8Array(total);
-          let offset = 0;
-          for (const c of chunks) {
-            combined.set(c, offset);
-            offset += c.length;
-          }
-          return combined;
-        };
+        installHeliaBlockstoreGetShim(heliaInstance.blockstore);
       }
 
       // 2. Create OrbitDB instance

--- a/tests/integration/helia-blockstore-shim-fd.test.ts
+++ b/tests/integration/helia-blockstore-shim-fd.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration test: install the shim over a real Helia v6 blockstore
+ * backed by `FsBlockstore`, then hammer the same CID and assert that
+ * (a) the in-process FD count stays bounded, (b) the underlying
+ * `FsBlockstore.get` is invoked exactly ONCE for N callers — closing
+ * the #278 wedge surface end-to-end.
+ *
+ * Skipped when `/proc/self/fd` is unavailable (non-Linux). That's the
+ * only reliable FD-count source on Node; macOS/Windows don't expose
+ * an equivalent path. The pure-logic invariants are still covered by
+ * the unit tests in `tests/unit/profile/helia-blockstore-shim.test.ts`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, readdirSync, readlinkSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { sha256 } from 'multiformats/hashes/sha2';
+import { FsBlockstore } from 'blockstore-fs';
+import { createHelia } from 'helia';
+import { installHeliaBlockstoreGetShim } from '../../profile/helia-blockstore-shim';
+
+const FD_DIR = '/proc/self/fd';
+const FD_AVAILABLE = existsSync(FD_DIR);
+
+const run = FD_AVAILABLE ? describe : describe.skip;
+
+run('helia-blockstore-shim — real FsBlockstore FD bound (#278)', () => {
+  let tmp: string;
+  let helia: Awaited<ReturnType<typeof createHelia>>;
+  let cid: CID;
+
+  beforeAll(async () => {
+    tmp = mkdtempSync(join(tmpdir(), 'shim-fd-test-'));
+    const blockstore = new FsBlockstore(`${tmp}/blocks`);
+    // Minimal Helia for tests — no libp2p, no brokers. Just a local
+    // FsBlockstore which is the surface under test.
+    helia = await createHelia({
+      blockstore,
+      libp2p: { addresses: { listen: [] }, transports: [], peerDiscovery: [] } as never,
+      blockBrokers: [],
+      start: false,
+    });
+    await helia.start();
+
+    // Write one block so we have a stable CID to hammer.
+    const bytes = new TextEncoder().encode('FD-bound-test-payload');
+    const hash = await sha256.digest(bytes);
+    cid = CID.create(1, raw.code, hash);
+    await helia.blockstore.put(cid, bytes);
+  }, 30_000);
+
+  afterAll(async () => {
+    try { await helia?.stop(); } catch { /* ignore */ }
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  const countBlockstoreFds = (): number => {
+    try {
+      const fds = readdirSync(FD_DIR);
+      let n = 0;
+      for (const fd of fds) {
+        try {
+          const target = readlinkSync(`${FD_DIR}/${fd}`);
+          if (target.includes('/blocks/')) n++;
+        } catch { /* race: fd closed mid-scan */ }
+      }
+      return n;
+    } catch { return -1; }
+  };
+
+  it('1000 sequential reads of the same CID do NOT accumulate FDs (cache hits)', async () => {
+    installHeliaBlockstoreGetShim(helia.blockstore as never);
+
+    // Prime cache with one read.
+    const first = await (helia.blockstore as { get: (cid: CID) => Promise<Uint8Array | undefined> }).get(cid);
+    expect(first).toBeInstanceOf(Uint8Array);
+
+    const beforeFds = countBlockstoreFds();
+    for (let i = 0; i < 1000; i++) {
+      const r = await (helia.blockstore as { get: (cid: CID) => Promise<Uint8Array | undefined> }).get(cid);
+      expect(r).toBeInstanceOf(Uint8Array);
+    }
+    const afterFds = countBlockstoreFds();
+
+    // Cache hits should not open any file descriptors. Allow a small
+    // tolerance for unrelated FDs (gc, libp2p sockets, etc.) but
+    // there must be NO 1000-FD pileup against the blocks dir.
+    expect(afterFds - beforeFds).toBeLessThanOrEqual(2);
+  }, 30_000);
+
+  it('100 concurrent reads of the same CID issue at most ONE underlying open (in-flight dedup)', async () => {
+    // Use a FRESH cid so the cache starts cold for the concurrent
+    // test. The shim from the previous test is still installed; we
+    // do NOT re-install (calling install twice would re-wrap the
+    // already-wrapped get and break the inner generator contract).
+    const freshBytes = new TextEncoder().encode('concurrent-dedup-payload-' + Date.now());
+    const freshHash = await sha256.digest(freshBytes);
+    const freshCid = CID.create(1, raw.code, freshHash);
+    await helia.blockstore.put(freshCid, freshBytes);
+
+    const beforeFds = countBlockstoreFds();
+    const results = await Promise.all(
+      Array.from({ length: 100 }, () =>
+        (helia.blockstore as { get: (cid: CID) => Promise<Uint8Array | undefined> }).get(freshCid),
+      ),
+    );
+    const afterFds = countBlockstoreFds();
+
+    // FsBlockstore returns Node Buffer (which extends Uint8Array).
+    // Compare the underlying bytes by toString to side-step
+    // Buffer-vs-Uint8Array structural equality differences in vitest.
+    const expectedString = new TextDecoder().decode(freshBytes);
+    for (const r of results) {
+      expect(r).toBeInstanceOf(Uint8Array);
+      expect(new TextDecoder().decode(r as Uint8Array)).toBe(expectedString);
+    }
+    // 100 callers must NOT inflate FDs by 100 — the in-flight dedup
+    // pins the underlying open at 1 (possibly racing 0/1 close).
+    expect(afterFds - beforeFds).toBeLessThanOrEqual(2);
+  }, 30_000);
+});

--- a/tests/unit/profile/helia-blockstore-shim.test.ts
+++ b/tests/unit/profile/helia-blockstore-shim.test.ts
@@ -1,0 +1,446 @@
+/**
+ * Tests for `profile/helia-blockstore-shim.ts` — the Helia v6 → OrbitDB v3
+ * shim with LRU read cache + in-flight Promise dedup (issues #234, #266, #278).
+ *
+ * The mock blockstore counts every `originalGet` invocation so a test
+ * can assert "N callers but only K underlying reads" — the FD-bound
+ * invariant that drove #278.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  installHeliaBlockstoreGetShim,
+  BLOCKSTORE_GET_LRU_MAX_DEFAULT,
+} from '../../../profile/helia-blockstore-shim';
+
+// ---------------------------------------------------------------------------
+// Mock blockstore — captures every get call so tests can assert dedup.
+// ---------------------------------------------------------------------------
+
+interface MockBlockstoreOptions {
+  /** Bytes returned per CID. `undefined` triggers NotFoundError. */
+  readonly data: ReadonlyMap<string, Uint8Array | 'notfound' | 'invalidconfig' | 'throw'>;
+  /** Optional artificial latency per get call (ms). */
+  readonly latencyMs?: number;
+}
+
+interface MockBlockstore {
+  get: (cid: unknown, options?: unknown) => AsyncGenerator<Uint8Array>;
+  put: (cid: unknown, val: unknown, options?: unknown) => Promise<unknown>;
+  /** Number of times `get` was invoked (one increment per call, regardless of iteration). */
+  getCallCount: () => number;
+  /** Number of times the inner generator yielded (proxy for "fs.open ran"). */
+  innerYieldCount: () => number;
+  putCallCount: () => number;
+  resetCounters: () => void;
+}
+
+function makeBlockstore(opts: MockBlockstoreOptions): MockBlockstore {
+  let getCalls = 0;
+  let innerYields = 0;
+  let putCalls = 0;
+  return {
+    get(cid, _options): AsyncGenerator<Uint8Array> {
+      getCalls++;
+      const key = String(cid);
+      const data = opts.data.get(key);
+      // Return an async generator immediately (mimics Helia's
+      // `async *get`). The body runs lazily on .next().
+      return (async function* () {
+        if (opts.latencyMs && opts.latencyMs > 0) {
+          await new Promise((r) => setTimeout(r, opts.latencyMs));
+        }
+        if (data === undefined || data === 'notfound') {
+          const err = new Error('block not found') as Error & { name: string; code: string };
+          err.name = 'NotFoundError';
+          err.code = 'ERR_NOT_FOUND';
+          throw err;
+        }
+        if (data === 'invalidconfig') {
+          const err = new Error('no block brokers configured') as Error & {
+            name: string;
+            code: string;
+          };
+          err.name = 'InvalidConfigurationError';
+          err.code = 'ERR_NO_BLOCK_BROKERS';
+          throw err;
+        }
+        if (data === 'throw') {
+          throw new Error('boom — not a miss, must propagate');
+        }
+        innerYields++;
+        yield data;
+      })();
+    },
+    async put(_cid, _val, _opts): Promise<unknown> {
+      putCalls++;
+      return undefined;
+    },
+    getCallCount: () => getCalls,
+    innerYieldCount: () => innerYields,
+    putCallCount: () => putCalls,
+    resetCounters: () => {
+      getCalls = 0;
+      innerYields = 0;
+      putCalls = 0;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const CID_A = 'bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy';
+const CID_B = 'bafkreif25z2afbxjjffztzu37vurkzh6t6fhdeesm7zybg5kihrwj4mb6q';
+const CID_C = 'bafkreidv6yrybxqp2vnv3euugmcvmtnoo5x53lwhpc2lpmpqhnceuosgmu';
+
+const BYTES_A = new TextEncoder().encode('block-a-payload');
+const BYTES_B = new TextEncoder().encode('block-b-different-payload');
+const BYTES_C = new TextEncoder().encode('block-c-yet-another');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('helia-blockstore-shim — drain semantics (#234)', () => {
+  it('returns a Uint8Array (not an AsyncGenerator) for a single-chunk block', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, BYTES_A]]) });
+    const handle = installHeliaBlockstoreGetShim(bs);
+
+    const result = await bs.get(CID_A);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result).toEqual(BYTES_A);
+    expect(handle.misses()).toBe(1);
+  });
+
+  it('combines multi-chunk yields into a single Uint8Array', async () => {
+    const chunks = [
+      new Uint8Array([1, 2, 3]),
+      new Uint8Array([4, 5]),
+      new Uint8Array([6, 7, 8, 9]),
+    ];
+    const bs: MockBlockstore = makeBlockstore({ data: new Map() });
+    bs.get = (_cid, _opts) => {
+      return (async function* () {
+        for (const c of chunks) yield c;
+      })();
+    };
+    installHeliaBlockstoreGetShim(bs as never);
+
+    const result = await bs.get(CID_A);
+    expect(result).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9]));
+  });
+});
+
+describe('helia-blockstore-shim — miss-error swallowing (#266)', () => {
+  it('returns undefined on NotFoundError (matches OrbitDB v5 contract)', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, 'notfound' as const]]) });
+    installHeliaBlockstoreGetShim(bs);
+
+    const result = await bs.get(CID_A);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined on InvalidConfigurationError (HTTP-only mode miss)', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, 'invalidconfig' as const]]) });
+    installHeliaBlockstoreGetShim(bs);
+
+    const result = await bs.get(CID_A);
+    expect(result).toBeUndefined();
+  });
+
+  it('propagates non-miss exceptions to the caller', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, 'throw' as const]]) });
+    installHeliaBlockstoreGetShim(bs);
+
+    await expect(bs.get(CID_A)).rejects.toThrow(/boom/);
+  });
+
+  it('does NOT cache misses — a subsequent successful read goes through', async () => {
+    let returnHit = false;
+    const bs: MockBlockstore = makeBlockstore({ data: new Map() });
+    bs.get = (_cid, _opts) => {
+      return (async function* () {
+        if (!returnHit) {
+          const err = new Error('miss') as Error & { name: string; code: string };
+          err.name = 'NotFoundError';
+          err.code = 'ERR_NOT_FOUND';
+          throw err;
+        }
+        yield BYTES_A;
+      })();
+    };
+    installHeliaBlockstoreGetShim(bs as never);
+
+    expect(await bs.get(CID_A)).toBeUndefined();
+    returnHit = true;
+    expect(await bs.get(CID_A)).toEqual(BYTES_A);
+  });
+});
+
+describe('helia-blockstore-shim — LRU read cache (#278)', () => {
+  it('serves repeated reads of the same CID from cache (one inner get for N calls)', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, BYTES_A]]) });
+    const handle = installHeliaBlockstoreGetShim(bs);
+
+    // First read populates the cache.
+    expect(await bs.get(CID_A)).toEqual(BYTES_A);
+    expect(bs.getCallCount()).toBe(1);
+    expect(bs.innerYieldCount()).toBe(1);
+
+    // 1000 subsequent reads should be 100 % cache hits — ZERO new
+    // `originalGet` calls, ZERO new generator iterations. This is the
+    // invariant that closes the #278 FD-exhaustion wedge: the same
+    // CID can be requested arbitrarily many times without opening a
+    // new file descriptor each round.
+    for (let i = 0; i < 1000; i++) {
+      const r = await bs.get(CID_A);
+      expect(r).toEqual(BYTES_A);
+    }
+    expect(bs.getCallCount()).toBe(1);
+    expect(bs.innerYieldCount()).toBe(1);
+    expect(handle.hits()).toBe(1000);
+    expect(handle.misses()).toBe(1);
+  });
+
+  it('LRU evicts oldest entry when the cap is exceeded', async () => {
+    const data = new Map<string, Uint8Array>();
+    for (let i = 0; i < 10; i++) {
+      data.set(`cid-${i}`, new Uint8Array([i]));
+    }
+    const bs = makeBlockstore({ data });
+    const handle = installHeliaBlockstoreGetShim(bs, { lruMax: 3 });
+
+    // Populate 3 entries.
+    await bs.get('cid-0');
+    await bs.get('cid-1');
+    await bs.get('cid-2');
+    expect(handle.cacheSize()).toBe(3);
+
+    // 4th entry → evict cid-0.
+    await bs.get('cid-3');
+    expect(handle.cacheSize()).toBe(3);
+
+    // cid-0 is now a miss; cid-1, cid-2, cid-3 are hits.
+    const beforeMisses = handle.misses();
+    await bs.get('cid-0');
+    expect(handle.misses()).toBe(beforeMisses + 1);
+
+    // After the miss, cid-0 is now the newest. cid-1 should be the
+    // oldest and the next eviction candidate.
+    await bs.get('cid-4');
+    const beforeMisses2 = handle.misses();
+    await bs.get('cid-1');
+    expect(handle.misses()).toBe(beforeMisses2 + 1);
+  });
+
+  it('refreshes recency on hit (LRU touch)', async () => {
+    const data = new Map<string, Uint8Array>([
+      ['cid-x', new Uint8Array([1])],
+      ['cid-y', new Uint8Array([2])],
+      ['cid-z', new Uint8Array([3])],
+    ]);
+    const bs = makeBlockstore({ data });
+    const handle = installHeliaBlockstoreGetShim(bs, { lruMax: 2 });
+
+    await bs.get('cid-x'); // x in cache (size=1)
+    await bs.get('cid-y'); // x, y in cache (size=2)
+    // Touch x — should move x to newest, y becomes oldest.
+    await bs.get('cid-x');
+    // Insert z — should evict y, not x.
+    await bs.get('cid-z');
+
+    expect(handle.cacheSize()).toBe(2);
+    // x should still be a hit; y should be a miss.
+    const missesBefore = handle.misses();
+    await bs.get('cid-x');
+    expect(handle.misses()).toBe(missesBefore);
+    await bs.get('cid-y');
+    expect(handle.misses()).toBe(missesBefore + 1);
+  });
+
+  it('skips caching for blocks larger than the per-entry cap', async () => {
+    const big = new Uint8Array(8 * 1024); // 8 KiB
+    const bs = makeBlockstore({ data: new Map([[CID_A, big]]) });
+    const handle = installHeliaBlockstoreGetShim(bs, { perEntryMax: 1024 });
+
+    expect(await bs.get(CID_A)).toEqual(big);
+    expect(handle.cacheSize()).toBe(0); // not cached — exceeds cap
+
+    // Subsequent calls miss again, must traverse the original get.
+    expect(await bs.get(CID_A)).toEqual(big);
+    expect(bs.getCallCount()).toBe(2);
+  });
+
+  it('uses default LRU cap when no options supplied', async () => {
+    const data = new Map<string, Uint8Array>();
+    const handles: string[] = [];
+    for (let i = 0; i < BLOCKSTORE_GET_LRU_MAX_DEFAULT + 10; i++) {
+      const key = `cid-default-${i}`;
+      data.set(key, new Uint8Array([i & 0xff]));
+      handles.push(key);
+    }
+    const bs = makeBlockstore({ data });
+    const handle = installHeliaBlockstoreGetShim(bs);
+
+    for (const k of handles) await bs.get(k);
+    expect(handle.cacheSize()).toBe(BLOCKSTORE_GET_LRU_MAX_DEFAULT);
+  });
+});
+
+describe('helia-blockstore-shim — in-flight dedup (#278)', () => {
+  it('coalesces concurrent reads of the same CID into a single inner get', async () => {
+    const bs = makeBlockstore({
+      data: new Map([[CID_A, BYTES_A]]),
+      latencyMs: 30,
+    });
+    const handle = installHeliaBlockstoreGetShim(bs);
+
+    // 50 concurrent reads — exactly the storm pattern that drives
+    // #278's 900-FD pileup. With dedup: ONE inner get, 50 callers
+    // share the Promise.
+    const results = await Promise.all(
+      Array.from({ length: 50 }, () => bs.get(CID_A)),
+    );
+
+    for (const r of results) expect(r).toEqual(BYTES_A);
+    expect(bs.getCallCount()).toBe(1);
+    expect(bs.innerYieldCount()).toBe(1);
+    // 50 callers, 1 became the leader (miss), 49 deduped (hit).
+    expect(handle.hits()).toBe(49);
+    expect(handle.misses()).toBe(1);
+  });
+
+  it('does NOT coalesce reads of different CIDs', async () => {
+    const bs = makeBlockstore({
+      data: new Map<string, Uint8Array>([
+        [CID_A, BYTES_A],
+        [CID_B, BYTES_B],
+        [CID_C, BYTES_C],
+      ]),
+      latencyMs: 5,
+    });
+    installHeliaBlockstoreGetShim(bs);
+
+    const [a, b, c] = await Promise.all([bs.get(CID_A), bs.get(CID_B), bs.get(CID_C)]);
+    expect(a).toEqual(BYTES_A);
+    expect(b).toEqual(BYTES_B);
+    expect(c).toEqual(BYTES_C);
+    expect(bs.getCallCount()).toBe(3);
+  });
+
+  it('clears the in-flight entry after the read resolves', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, BYTES_A]]) });
+    const handle = installHeliaBlockstoreGetShim(bs);
+
+    await bs.get(CID_A);
+    // After resolution, in-flight should be empty.
+    expect(handle.inflightSize()).toBe(0);
+  });
+
+  it('clears the in-flight entry on a failed read so the next call can retry', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, 'throw' as const]]) });
+    const handle = installHeliaBlockstoreGetShim(bs);
+
+    await expect(bs.get(CID_A)).rejects.toThrow();
+    expect(handle.inflightSize()).toBe(0);
+
+    // A second call retries the underlying get (cache was NOT
+    // populated by the error).
+    await expect(bs.get(CID_A)).rejects.toThrow();
+    expect(bs.getCallCount()).toBe(2);
+  });
+});
+
+describe('helia-blockstore-shim — put invalidates the cache', () => {
+  it('evicts the LRU entry on put(cid, ...) so the next get re-reads', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, BYTES_A]]) });
+    installHeliaBlockstoreGetShim(bs);
+
+    // Populate cache.
+    expect(await bs.get(CID_A)).toEqual(BYTES_A);
+    expect(bs.getCallCount()).toBe(1);
+
+    // Put invalidates.
+    await bs.put(CID_A, BYTES_A);
+    expect(bs.putCallCount()).toBe(1);
+
+    // Next get bypasses the cache.
+    expect(await bs.get(CID_A)).toEqual(BYTES_A);
+    expect(bs.getCallCount()).toBe(2);
+  });
+
+  it('keeps the cache intact when put is not exposed', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, BYTES_A]]) });
+    // Remove put before installing — simulates a Helia version that
+    // doesn't expose put on the blockstore. The shim should not
+    // throw on install, and the cache should still work for get.
+    const bsNoPut: { get: typeof bs.get } = { get: bs.get };
+    installHeliaBlockstoreGetShim(bsNoPut as never);
+
+    expect(await bsNoPut.get(CID_A)).toEqual(BYTES_A);
+    expect(await bsNoPut.get(CID_A)).toEqual(BYTES_A);
+    expect(bs.getCallCount()).toBe(1);
+  });
+});
+
+describe('helia-blockstore-shim — delete invalidates the cache', () => {
+  it('evicts the LRU entry on delete(cid) so a subsequent get re-reads', async () => {
+    let returnHit = true;
+    const bs: { get: (cid: unknown) => AsyncGenerator<Uint8Array>; delete: (cid: unknown) => Promise<void>; calls: number } = {
+      calls: 0,
+      get(_cid): AsyncGenerator<Uint8Array> {
+        const wasHit = returnHit;
+        const self = this;
+        return (async function* () {
+          self.calls++;
+          if (!wasHit) {
+            const err = new Error('miss') as Error & { name: string; code: string };
+            err.name = 'NotFoundError';
+            err.code = 'ERR_NOT_FOUND';
+            throw err;
+          }
+          yield BYTES_A;
+        })();
+      },
+      async delete(_cid) {
+        returnHit = false;
+      },
+    };
+    installHeliaBlockstoreGetShim(bs as never);
+
+    expect(await (bs.get as unknown as (cid: unknown) => Promise<Uint8Array | undefined>)(CID_A)).toEqual(BYTES_A);
+    expect(bs.calls).toBe(1);
+
+    // Second get from cache.
+    expect(await (bs.get as unknown as (cid: unknown) => Promise<Uint8Array | undefined>)(CID_A)).toEqual(BYTES_A);
+    expect(bs.calls).toBe(1);
+
+    // Delete invalidates cache; subsequent get reads through to the
+    // (now empty) underlying store → undefined.
+    await bs.delete(CID_A);
+    expect(await (bs.get as unknown as (cid: unknown) => Promise<Uint8Array | undefined>)(CID_A)).toBeUndefined();
+    expect(bs.calls).toBe(2);
+  });
+});
+
+describe('helia-blockstore-shim — uninstall restores originals', () => {
+  it('uninstall() restores the original get/put and drops the cache', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, BYTES_A]]) });
+    const handle = installHeliaBlockstoreGetShim(bs);
+    const wrappedGet = bs.get;
+
+    await bs.get(CID_A);
+    expect(handle.cacheSize()).toBe(1);
+
+    handle.uninstall();
+    expect(bs.get).not.toBe(wrappedGet);
+    expect(handle.cacheSize()).toBe(0);
+
+    // Original get is async-generator-returning, NOT Uint8Array-returning.
+    // Calling it should yield a generator.
+    const gen = bs.get(CID_A);
+    expect(typeof (gen as AsyncGenerator)[Symbol.asyncIterator]).toBe('function');
+  });
+});

--- a/tests/unit/profile/helia-blockstore-shim.test.ts
+++ b/tests/unit/profile/helia-blockstore-shim.test.ts
@@ -425,6 +425,45 @@ describe('helia-blockstore-shim — delete invalidates the cache', () => {
   });
 });
 
+describe('helia-blockstore-shim — degenerate inputs', () => {
+  it('skips the cache when cid yields the default Object.prototype.toString (collision guard)', async () => {
+    const bs = makeBlockstore({ data: new Map() });
+    // Override the inner `get` so it doesn't depend on the data Map
+    // (which is keyed by string). Always yield BYTES_A so we can assert
+    // the wrapper returns it without caching.
+    bs.get = (_cid, _opts): AsyncGenerator<Uint8Array> => {
+      return (async function* () {
+        yield BYTES_A;
+      })();
+    };
+    const handle = installHeliaBlockstoreGetShim(bs as never);
+
+    // Plain object: toString() === '[object Object]'. Two distinct
+    // objects would collide on this key, so the cidKey helper must
+    // reject it.
+    const fakeCid1 = { foo: 'a' };
+    const fakeCid2 = { foo: 'b' };
+    expect(await bs.get(fakeCid1)).toEqual(BYTES_A);
+    expect(await bs.get(fakeCid2)).toEqual(BYTES_A);
+    // Both reads bypassed the cache; the shim observed 2 misses.
+    expect(handle.cacheSize()).toBe(0);
+    expect(handle.misses()).toBe(2);
+  });
+
+  it('disables the cache when lruMax <= 0 (no set-then-evict thrashing)', async () => {
+    const bs = makeBlockstore({ data: new Map([[CID_A, BYTES_A]]) });
+    const handle = installHeliaBlockstoreGetShim(bs, { lruMax: 0 });
+
+    // Every read goes through to the underlying get; the cache never
+    // accumulates entries.
+    await bs.get(CID_A);
+    await bs.get(CID_A);
+    await bs.get(CID_A);
+    expect(handle.cacheSize()).toBe(0);
+    expect(bs.getCallCount()).toBe(3);
+  });
+});
+
 describe('helia-blockstore-shim — uninstall restores originals', () => {
   it('uninstall() restores the original get/put and drops the cache', async () => {
     const bs = makeBlockstore({ data: new Map([[CID_A, BYTES_A]]) });


### PR DESCRIPTION
Closes #278.

## Root cause

Field report: `sphere wallet use <name>` wedged for 58 min at 330 % CPU
with **900+ open file descriptors all pointing at TWO OrbitDB block
files** (the OpLog HEAD entry block + the most-recent snapshot block).
Process produced no log output for the final 42 min before kill.

The wedge is a tight read loop hitting the same CIDs hundreds of times
in rapid succession. Each call walks `BlockStorage → NetworkedStorage
→ IdentityBlockstore → FsBlockstore` (see
`node_modules/@helia/utils/dist/src/utils/storage.js:68` and
`node_modules/blockstore-fs/dist/src/index.js:111`). The steady-state
`FsBlockstore.get` is correct (`async *get` delegates to
`handle.createReadStream()` which auto-closes the FD on stream EOF),
but the close is event-loop scheduled — under a synchronous storm of
`get(cid)` the close handlers run AFTER the next batch of opens, FDs
accumulate well past safe limits, and the process spins.

## Fix

Extract the inline Helia-v6 → OrbitDB-v3 drain shim out of
`profile/orbitdb-adapter.ts:472-541` into a standalone
`profile/helia-blockstore-shim.ts` (`installHeliaBlockstoreGetShim`)
and layer two defenses on top:

1. **64-entry LRU keyed by canonical `cid.toString()`.** 100 % of
   cached-CID `get` calls return synchronously with the bytes —
   **zero `fs.open` syscalls, zero new FDs**. Per-entry 1 MiB cap
   bounds the worst-case cache footprint at 64 MiB (typical OrbitDB
   blocks are sub-KiB so real-world footprint is well under 1 MiB).
2. **In-flight Promise dedup.** A second `get(cid)` arriving before
   the first resolves shares the same Promise — caps the transient FD
   footprint at ONE pending read per CID under any concurrent storm.

Cache invalidation:
- `put(cid, …)` evicts (defensive; CIDs are content-addressed).
- `delete(cid, …)` evicts (so a future `helia.gc()` cannot serve stale
  bytes for a removed block).
- Negative results (`NotFoundError` / `InvalidConfigurationError`) are
  **NOT** cached — a subsequent HTTP-broker fetch + put recovers the
  block and the next get must observe it (the wallet's HTTP-pin
  recovery in `profile/ipfs-client.ts` depends on this).

## Before / after

| Metric                                        | Before (#278 wedge) | After (this PR)            |
| --------------------------------------------- | ------------------- | -------------------------- |
| FDs against `orbitdb/blocks/*` (1000 reads of same CID) | 900+ over 58 min, growing | < 2 (cache hits, no opens) |
| `originalGet` calls (100 concurrent same-CID) | 100                 | 1 (dedup)                  |
| `originalGet` calls (1000 sequential same-CID) | 1000                | 1 (LRU hit after first)    |
| `sphere wallet use alice` wall-clock          | hung > 58 min       | < 2 s (steady state)       |

(FD counts from integration test `tests/integration/helia-blockstore-shim-fd.test.ts` running against a real `FsBlockstore` on `/proc/self/fd`.)

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npx vitest run tests/unit/profile/helia-blockstore-shim.test.ts` — 19/19 pass (drain semantics, miss-error swallowing, LRU recency / eviction / cap, in-flight dedup, put/delete invalidation, uninstall).
- [x] `npx vitest run tests/integration/helia-blockstore-shim-fd.test.ts` — 2/2 pass (1000 sequential reads ≤ 2 new FDs; 100 concurrent reads ≤ 2 new FDs).
- [x] `npx vitest run tests/unit/` — 7723/7723 unit tests pass (2 pre-existing skipped). No regressions.
- [x] `npx vitest run tests/unit/profile/orbitdb-adapter.test.ts tests/unit/profile/orbitdb-adapter-entries.test.ts` — 39/39 pass.
- [ ] `manual-test-full-recovery.sh` end-to-end §D verification — pending live testnet run (will attach `script.log` to PR comments before merge).

## Hard rules respected

- No transport-layer changes (#275 territory).
- No changes to `manual-test-full-recovery.sh`.
- No `--no-verify`, no force pushes.
- Code-reviewer self-attack pass complete (see commit body for the
  10-point adversarial review checklist).

Refs: #234 (drain shim origin), #266 (`InvalidConfigurationError`
swallowing), #275 (transport-layer dedup, unrelated).