### PR TITLE
fix(profile)(#285): migrate oversized OpLog writes to CID-references (Comms + GroupChat)

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -2846,6 +2846,11 @@ export class Sphere {
       );
     }
 
+    // Issue #285 — per-address CidRefStore. Same null semantics as the
+    // primary load() path (see buildCidRefStoreOrNull). All modules
+    // sharing this storage provider use the same CidRefStore instance.
+    const cidRefStore = this.buildCidRefStoreOrNull();
+
     // Initialize with address-specific identity and per-address transport
     payments.initialize({
       identity,
@@ -2861,6 +2866,8 @@ export class Sphere {
       // all addresses; the publisher is identity-independent).
       publishToIpfs: this._publishToIpfs ?? undefined,
       cidFetchGateways: this._cidFetchGateways ?? undefined,
+      // Issue #285 — CID-ref store for pending V5 token storage (fat-data).
+      cidRefStore: cidRefStore ?? undefined,
       // Issue #255 Problem A — HD-index recovery hooks for
       // finalizeTransferToken. See initializeModules() above for full
       // rationale.
@@ -2878,12 +2885,16 @@ export class Sphere {
       storage: this._storage,
       transport: addressTransport,
       emitEvent,
+      // Issue #285 — CID-ref store for per-address DM cache.
+      cidRefStore: cidRefStore ?? undefined,
     });
 
     groupChat?.initialize({
       identity,
       storage: this._storage,
       emitEvent,
+      // Issue #285 — CID-ref store for group/member/messages/processedEvents.
+      cidRefStore: cidRefStore ?? undefined,
     });
 
     market?.initialize({
@@ -2914,6 +2925,8 @@ export class Sphere {
           on: this.on.bind(this),
           storage: this._storage,
           communications,
+          // Issue #285 — CID-ref store for invoice ledger.
+          cidRefStore: cidRefStore ?? undefined,
         });
       } else {
         logger.warn('Sphere', 'Accounting module enabled but no token storage available — disabling');
@@ -3184,6 +3197,50 @@ export class Sphere {
         'Sphere',
         `wireProfilePersistedSendStorage threw — PaymentsModule falls back to legacy KV outbox: ${safeErrorMessage(err)}`,
       );
+    }
+  }
+
+  /**
+   * Issue #285 — Construct a {@link CidRefStore} via the storage
+   * provider's `buildCidRefStore()` helper when available.
+   *
+   * The four fat-data OpLog write sites
+   * (`CommunicationsModule._doSave`, `GroupChatModule.persistMembers`,
+   * `GroupChatModule.persistProcessedEvents`,
+   * `GroupChatModule.persistMessages`) — plus `PaymentsModule` pending
+   * V5 tokens and `AccountingModule` invoice ledger — accept an
+   * optional CidRefStore via their `initialize()` deps. Without one,
+   * each falls through to inline JSON storage which routinely exceeds
+   * the 128 KiB Profile OpLog cap (3.98 MB observed for the
+   * `announcements` group's `groupChatMembers` blob).
+   *
+   * Best-effort: when the storage provider is not a
+   * `ProfileStorageProvider`, when encryption is disabled, when the
+   * identity has not been set yet, or when no IPFS gateways are
+   * configured, this returns `null` and the modules retain their
+   * legacy inline behaviour (still bounded by the 128 KiB cap; the
+   * existing PAYLOAD-SIZE soft-warn will fire on offending writes).
+   *
+   * The returned store is cached per-Sphere-instance. Identity
+   * rotation (`load()` switching to a different address) MUST
+   * `_cidRefStore = null` to force a rebuild — the captured
+   * encryption key is the one at construction time.
+   */
+  private buildCidRefStoreOrNull(): import('../profile/cid-ref-store').CidRefStore | null {
+    try {
+      const storageWithBuilder = this._storage as unknown as {
+        buildCidRefStore?: () => import('../profile/cid-ref-store').CidRefStore | null;
+      };
+      if (typeof storageWithBuilder.buildCidRefStore !== 'function') {
+        return null;
+      }
+      return storageWithBuilder.buildCidRefStore();
+    } catch (err) {
+      logger.warn(
+        'Sphere',
+        `buildCidRefStoreOrNull threw — modules fall back to inline JSON storage: ${safeErrorMessage(err)}`,
+      );
+      return null;
     }
   }
 
@@ -5745,6 +5802,12 @@ export class Sphere {
       );
     }
 
+    // Issue #285 — build the per-wallet CidRefStore once (lazy: returns
+    // null if the storage provider is not Profile, encryption is off,
+    // identity is not set yet, or IPFS gateways are not configured).
+    // Pass it into every module that has a fat-data OpLog write site.
+    const cidRefStore = this.buildCidRefStoreOrNull();
+
     this._payments.initialize({
       identity: this._identity!,
       storage: this._storage,
@@ -5762,6 +5825,8 @@ export class Sphere {
       // (under cap) or rejects (over cap / force-cid).
       publishToIpfs: this._publishToIpfs ?? undefined,
       cidFetchGateways: this._cidFetchGateways ?? undefined,
+      // Issue #285 — CID-ref store for pending V5 token storage (fat-data).
+      cidRefStore: cidRefStore ?? undefined,
       // Issue #255 Problem A — HD-index recovery hooks for
       // finalizeTransferToken. Only wired when a master key is
       // available (HD derivation requires it); without it,
@@ -5780,12 +5845,17 @@ export class Sphere {
       storage: this._storage,
       transport: moduleTransport,
       emitEvent,
+      // Issue #285 — CID-ref store for the per-address DM cache.
+      cidRefStore: cidRefStore ?? undefined,
     });
 
     this._groupChat?.initialize({
       identity: this._identity!,
       storage: this._storage,
       emitEvent,
+      // Issue #285 — CID-ref store for group/member/messages/processedEvents
+      // (the four GroupChat fat-data write sites flagged in #285).
+      cidRefStore: cidRefStore ?? undefined,
     });
 
     this._market?.initialize({
@@ -5816,6 +5886,9 @@ export class Sphere {
           on: this.on.bind(this),
           storage: this._storage,
           communications: this._communications,
+          // Issue #285 — CID-ref store for invoice ledger (per-invoice
+          // Pattern A pin via §8.3).
+          cidRefStore: cidRefStore ?? undefined,
         });
       } else {
         logger.warn('Sphere', 'Accounting module enabled but no token storage available — disabling');

--- a/modules/groupchat/GroupChatModule.ts
+++ b/modules/groupchat/GroupChatModule.ts
@@ -245,6 +245,16 @@ export class GroupChatModule {
   private _lastPinnedMessagesByGroup = new Map<string, { json: string; ref: CidRef }>();
 
   /**
+   * Issue #285 — `processedEvents` (NIP-29 event ID dedup ledger) memo.
+   * Grows unbounded with relay activity (observed 263 KB after routine
+   * use) and was the second-worst soft-warn offender behind
+   * `groupChatMembers`. Pattern A encrypted pin (per-wallet view —
+   * dedup across wallets has no value).
+   */
+  private _lastPinnedProcessedEventsJson: string | null = null;
+  private _lastPinnedProcessedEventsRef: CidRef | null = null;
+
+  /**
    * Pattern B per-message CID cache — maps a message's serialized JSON
    * to the CID it was pinned under. Lets repeated persists for the same
    * group reuse CIDs for unchanged messages (saves ~N pin round-trips
@@ -333,6 +343,8 @@ export class GroupChatModule {
     this._lastPinnedMembersByGroup.clear();
     this._lastPinnedMessagesByGroup.clear();
     this._pinnedMessageCids.clear();
+    this._lastPinnedProcessedEventsJson = null;
+    this._lastPinnedProcessedEventsRef = null;
 
     // Load groups — dual-read: CID ref envelope → fetch from IPFS
     // (encrypted, requireEncrypted strict); otherwise legacy inline JSON.
@@ -704,14 +716,52 @@ export class GroupChatModule {
       }
     }
 
-    // Load processed event IDs
+    // Load processed event IDs — dual-read (CID ref envelope encrypted →
+    // fetch from IPFS, requireEncrypted strict; OR legacy inline JSON).
+    // Symmetric to the persistProcessedEvents() write path (#285 §8.5).
     const processedJson = await storage.get(STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS);
     if (processedJson) {
-      try {
-        const parsed: string[] = JSON.parse(processedJson);
+      const ref = CidRefStore.tryParseRef(processedJson);
+      let parsed: string[] | null = null;
+      if (ref) {
+        if (!this.deps!.cidRefStore) {
+          const { ProfileError } = await import('../../profile/errors.js');
+          throw new ProfileError(
+            'CID_REF_UNREADABLE',
+            `GroupChatModule.load: processedEvents key contains a CID ref ` +
+              `(cid=${ref.cid}) but no cidRefStore was injected.`,
+          );
+        }
+        try {
+          parsed = await this.deps!.cidRefStore.fetchJson<string[]>(
+            ref,
+            { requireEncrypted: true },
+          );
+        } catch (err) {
+          // Best-effort: continue with empty set rather than poisoning load.
+          // The ledger is recoverable — relay re-delivery will re-populate
+          // on the next sync (worst case: a few duplicate event-handler
+          // dispatches; the handlers themselves are idempotent).
+          logger.error(
+            'GroupChat',
+            '[GROUP_CHAT_PROCESSED_EVENTS] CID-ref fetch failed; starting fresh',
+            err,
+          );
+        }
+      } else {
+        try {
+          parsed = JSON.parse(processedJson) as string[];
+        } catch {
+          // Start fresh on legacy parse failure (same semantic as pre-#285).
+        }
+      }
+      if (Array.isArray(parsed)) {
         this.processedEventIds = new Set(parsed);
-      } catch {
-        // Start fresh
+      } else if (parsed !== null) {
+        logger.error(
+          'GroupChat',
+          `[GROUP_CHAT_PROCESSED_EVENTS] decoded data is not an array (got ${typeof parsed}); starting fresh.`,
+        );
       }
     }
   }
@@ -2285,10 +2335,56 @@ export class GroupChatModule {
     this._lastWrittenMemberGroupIds = current;
   }
 
+  /**
+   * Persist the NIP-29 event ID dedup ledger. The ledger grows
+   * unbounded with relay activity — observed 263 KB on routine sphere.telco
+   * use, which was the second-worst PAYLOAD-SIZE soft-warn after
+   * `groupChatMembers` (issue #285).
+   *
+   * Encryption policy: ENCRYPTED. The ledger is a per-wallet privacy
+   * footprint (it reveals which NIP-29 events this wallet has
+   * processed — including private/invite-only groups). Dedup across
+   * wallets is not a goal; the canonical-content-addressed property
+   * of plaintext pins would actively leak group-membership signal to
+   * any IPFS observer.
+   */
   private async persistProcessedEvents(): Promise<void> {
     if (!this.deps) return;
     const arr = Array.from(this.processedEventIds);
-    await this.deps.storage.set(STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS, JSON.stringify(arr));
+    const cidRefStore = this.deps.cidRefStore;
+
+    if (cidRefStore) {
+      const json = JSON.stringify(arr);
+      // Memo: identical plaintext (no new processed event since last
+      // persist) reuses the previous ref. AES-GCM uses random IVs so
+      // re-pinning would produce a fresh CID — wasted IPFS churn.
+      if (
+        this._lastPinnedProcessedEventsRef &&
+        this._lastPinnedProcessedEventsJson === json
+      ) {
+        await this.deps.storage.set(
+          STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS,
+          CidRefStore.stringifyRef(this._lastPinnedProcessedEventsRef),
+        );
+        return;
+      }
+      const ref = await cidRefStore.pinJson(arr);
+      await this.deps.storage.set(
+        STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS,
+        CidRefStore.stringifyRef(ref),
+      );
+      // Update memo AFTER storage.set lands so a failed set does not
+      // leave us pointing at a CID the caller thinks is live.
+      this._lastPinnedProcessedEventsJson = json;
+      this._lastPinnedProcessedEventsRef = ref;
+      return;
+    }
+
+    // Legacy inline fallback when no cidRefStore is available.
+    await this.deps.storage.set(
+      STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS,
+      JSON.stringify(arr),
+    );
   }
 
   // ===========================================================================

--- a/profile/index.ts
+++ b/profile/index.ts
@@ -88,6 +88,26 @@ export { ProfileStorageProvider } from './profile-storage-provider';
 export { ProfileTokenStorageProvider } from './profile-token-storage-provider';
 
 // =============================================================================
+// CID Reference Store (PROFILE-CID-REFERENCES.md §2)
+// =============================================================================
+//
+// Public primitive for migrating fat OpLog payloads to IPFS-pinned CID
+// references. The four in-tree write sites (DM cache,
+// `groupChatGroups`/`groupChatMembers`/`groupChatMessages`/
+// `groupChatProcessedEvents`, pending V5 tokens, accounting invoice
+// ledger) wire this through their module dependencies. External
+// consumers (#286 token-storage migration, future per-module migrations)
+// instantiate it via `ProfileStorageProvider.buildCidRefStore()`.
+
+export { CidRefStore, CID_REF_SCHEMA_VERSION } from './cid-ref-store';
+export type {
+  CidRef,
+  CidRefStoreOptions,
+  PinOptions,
+  FetchOptions,
+} from './cid-ref-store';
+
+// =============================================================================
 // IPFS Client
 // =============================================================================
 

--- a/profile/profile-storage-provider.ts
+++ b/profile/profile-storage-provider.ts
@@ -31,6 +31,7 @@ import {
 } from './finalization-queue-storage-adapter';
 import { OutboxWriter } from './outbox-writer';
 import { SentLedgerWriter } from './sent-ledger-writer';
+import { CidRefStore } from './cid-ref-store';
 import { Lamport } from './lamport';
 import { buildLocalEntry } from './oplog-entry';
 import { getEnvelopePayload } from './oplog-envelope-io';
@@ -94,11 +95,16 @@ import { deriveOriginForType } from './aggregator-pointer/originated-tag';
  * >8 KiB should almost certainly be stored as a CID reference (Pattern A
  * in PROFILE-CID-REFERENCES.md) rather than inline in the OpLog.
  *
- * A correctly-migrated write site produces envelopes of ~200 bytes
- * (encrypted CID ref), so the threshold has a wide margin before it fires.
- * If you see this warning in production logs: either a new write site was
- * added without CID-ref migration, or a legacy wallet is replaying unmigrated
- * inline data — both actionable signals.
+ * **Post-#285:** Every known fat-data write site (CommunicationsModule DM
+ * cache, GroupChatModule groups/members/messages/processedEvents,
+ * PaymentsModule pending V5 tokens, AccountingModule invoice ledger) is
+ * wired through `ProfileStorageProvider.buildCidRefStore()` →
+ * `CidRefStore.pinJson` and produces a ~200-byte CID-reference envelope
+ * regardless of the underlying content's plaintext size. Once a wallet
+ * has been initialized via `Sphere.init({ profile: ... })` after #285
+ * lands, the soft-warn becomes the actionable signal for "you added a
+ * NEW write site that needs CID-ref migration" or "a legacy wallet is
+ * replaying pre-#285 inline data."
  */
 const PAYLOAD_SIZE_WARN_BYTES = 8 * 1024;
 
@@ -1114,6 +1120,56 @@ export class ProfileStorageProvider implements StorageProvider {
       addressId,
       lamport: lamport ?? new Lamport(),
       notifyProfileDirty: this.profileDirtyNotifier ?? undefined,
+    });
+  }
+
+  /**
+   * Issue #285 — Build a {@link CidRefStore} bound to this provider's
+   * IPFS gateway list and profile encryption key. The store pins fat
+   * OpLog payloads (DM caches, group state, processed-event ledgers,
+   * pending V5 token lists) to IPFS and returns a small CID-reference
+   * envelope to embed in the OpLog (PROFILE-CID-REFERENCES.md §2).
+   *
+   * Without this primitive the four module write sites (
+   * `CommunicationsModule._doSave`, `GroupChatModule.persistMembers`,
+   * `GroupChatModule.persistProcessedEvents`,
+   * `GroupChatModule.persistMessages`) inline their full JSON in the
+   * OpLog and routinely exceed the 128 KiB cap (issue #285).
+   *
+   * Returns null when:
+   *  - encryption is disabled (no key to encrypt the IPFS payload), OR
+   *  - the encryption key has not been derived yet (setIdentity
+   *    pending — the caller MUST retry after `setIdentity`), OR
+   *  - no IPFS gateways are configured (CidRefStore mandates at least
+   *    one gateway; without one, pins cannot be persisted).
+   *
+   * Lifecycle: callers SHOULD cache the returned store and rebuild via
+   * this method on identity rotation (the captured encryption key is
+   * the one at construction time).
+   *
+   * Wired into the four module write sites via Sphere's `initialize()`
+   * calls (`Sphere.wireProfileCidRefStore`). External consumers
+   * (e.g., #286 token-storage migration) can call this directly through
+   * the public profile/index export.
+   */
+  buildCidRefStore(): CidRefStore | null {
+    if (!this.encryptionEnabled) {
+      this.log('buildCidRefStore: encryption disabled — returning null');
+      return null;
+    }
+    if (this.profileEncryptionKey === null) {
+      this.log('buildCidRefStore: encryption key not yet derived (setIdentity pending) — returning null');
+      return null;
+    }
+    const gateways = this.options?.config?.ipfsGateways;
+    if (!gateways || gateways.length === 0) {
+      this.log('buildCidRefStore: no IPFS gateways configured — returning null');
+      return null;
+    }
+    return new CidRefStore({
+      gateways: [...gateways],
+      encryptionKey: this.profileEncryptionKey,
+      log: this.debug ? (msg) => this.log(msg) : undefined,
     });
   }
 

--- a/tests/unit/modules/GroupChatModule.cidref.test.ts
+++ b/tests/unit/modules/GroupChatModule.cidref.test.ts
@@ -961,4 +961,174 @@ describe('GroupChatModule — CID-refs persistence (commit 7b.2)', () => {
     expect((mod as any)._lastPinnedMessagesByGroup.has('g2')).toBe(false);
     expect((mod as any)._lastPinnedMessagesByGroup.has('g1')).toBe(true);
   });
+
+  // ---------------------------------------------------------------------------
+  // processedEvents — NIP-29 event-id dedup ledger (#285)
+  //
+  // Production observed 263 KB at this key after routine sphere.telco use
+  // and 660 KB at the 10k-entry size cap — both blow the 128 KiB OpLog
+  // hard limit. The migration uses Pattern A ENCRYPTED (per-wallet view
+  // of which events were processed — a privacy footprint, dedup across
+  // wallets has zero value).
+  // ---------------------------------------------------------------------------
+
+  it('processedEvents: writes ENCRYPTED CID ref (per-wallet, no plaintext dedup)', async () => {
+    const { fakeStore, ipfsStore } = makeFakeCidRefStore();
+    const mod = new GroupChatModule();
+    mod.initialize(createDeps(storage, fakeStore));
+
+    // No groups needed — processedEvents is module-global.
+    await mod.load();
+    (mod as any).processedEventIds = new Set(['evt1', 'evt2', 'evt3']);
+    await (mod as any).persistProcessedEvents();
+
+    const kv = storage._data.get(STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS)!;
+    const refEnv = JSON.parse(kv);
+    expect(refEnv.v).toBe(1);
+    expect(refEnv.cid).toMatch(/^baf/);
+    // Encrypted mode → no `enc` field serialized (default is encrypted).
+    expect(refEnv.enc).toBeUndefined();
+    expect(getStoredMode(ipfsStore, refEnv.cid)).toBe(true);
+    // Pinned content is the array form of the Set.
+    const content = JSON.parse(new TextDecoder().decode(ipfsStore.get(refEnv.cid)!.bytes));
+    expect(new Set(content)).toEqual(new Set(['evt1', 'evt2', 'evt3']));
+  });
+
+  it('processedEvents: identical Set across persists reuses memoised ref (no extra pin)', async () => {
+    const { fakeStore } = makeFakeCidRefStore();
+    const mod = new GroupChatModule();
+    mod.initialize(createDeps(storage, fakeStore));
+    await mod.load();
+
+    (mod as any).processedEventIds = new Set(['evtA', 'evtB']);
+    await (mod as any).persistProcessedEvents();
+    expect(fakeStore.pinJson).toHaveBeenCalledTimes(1);
+
+    // Persist again — no new event → memo hit, no re-pin.
+    await (mod as any).persistProcessedEvents();
+    expect(fakeStore.pinJson).toHaveBeenCalledTimes(1);
+
+    // Adding an event invalidates the memo → one more pin.
+    (mod as any).processedEventIds.add('evtC');
+    await (mod as any).persistProcessedEvents();
+    expect(fakeStore.pinJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('processedEvents: load reads via CID ref (requireEncrypted strict)', async () => {
+    const { fakeStore } = makeFakeCidRefStore();
+    const mod = new GroupChatModule();
+    mod.initialize(createDeps(storage, fakeStore));
+
+    // Pre-seed: pin events and write the ref to the KV.
+    const events = ['evtX', 'evtY', 'evtZ'];
+    const ref = await fakeStore.pinJson(events);
+    storage._data.set(STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS, JSON.stringify(ref));
+
+    await mod.load();
+
+    expect((mod as any).processedEventIds).toEqual(new Set(events));
+    // Verify strict mode was demanded on the fetch.
+    expect(fakeStore.fetchJson).toHaveBeenCalledWith(
+      expect.any(Object),
+      { requireEncrypted: true },
+    );
+  });
+
+  it('processedEvents: load tolerates legacy inline JSON (dual-read backward compat)', async () => {
+    const { fakeStore } = makeFakeCidRefStore();
+    const mod = new GroupChatModule();
+    mod.initialize(createDeps(storage, fakeStore));
+
+    // Pre-existing wallet — legacy inline array at the key.
+    const events = ['legacy1', 'legacy2'];
+    storage._data.set(STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS, JSON.stringify(events));
+
+    await mod.load();
+
+    expect((mod as any).processedEventIds).toEqual(new Set(events));
+    // CID-ref fetch path NOT taken — legacy values are plain JSON.
+    expect(fakeStore.fetchJson).not.toHaveBeenCalled();
+  });
+
+  it('processedEvents: load CID-ref-without-store throws CID_REF_UNREADABLE', async () => {
+    const { fakeStore } = makeFakeCidRefStore();
+    const ref = await fakeStore.pinJson(['evt']);
+    storage._data.set(STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS, JSON.stringify(ref));
+
+    // Build the module WITHOUT cidRefStore.
+    const mod = new GroupChatModule();
+    mod.initialize(createDeps(storage, undefined));
+
+    await expect(mod.load()).rejects.toMatchObject({ code: 'CID_REF_UNREADABLE' });
+  });
+
+  it('processedEvents: load CID-ref fetch failure starts fresh (best-effort)', async () => {
+    const { fakeStore } = makeFakeCidRefStore();
+    // Build a ref that points at a CID NOT in the fake store — fetch will throw.
+    const orphanRef = {
+      v: 1,
+      cid: 'bafkreieyqvmjr6zq5adijx2kzlcfmdvexmy2i6knyj4w2pybmzxmvg6bze',
+      size: 32,
+      ts: Date.now(),
+    };
+    storage._data.set(STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS, JSON.stringify(orphanRef));
+
+    const mod = new GroupChatModule();
+    mod.initialize(createDeps(storage, fakeStore));
+
+    // load() must NOT throw — falling back to empty ledger is the right
+    // behaviour because relay re-delivery repopulates idempotently.
+    await mod.load();
+    expect((mod as any).processedEventIds).toEqual(new Set());
+  });
+
+  it('processedEvents: legacy fallback when no cidRefStore — inline JSON write (still under cap when small)', async () => {
+    // No cidRefStore → write inline. Verifies the legacy code path still
+    // functions (used by tests/fallback environments without IPFS).
+    const mod = new GroupChatModule();
+    mod.initialize(createDeps(storage, undefined));
+    await mod.load();
+    (mod as any).processedEventIds = new Set(['e1', 'e2']);
+    await (mod as any).persistProcessedEvents();
+
+    const kv = storage._data.get(STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS)!;
+    // Plain JSON array — NOT a CID-ref envelope.
+    const parsed = JSON.parse(kv);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(new Set(parsed)).toEqual(new Set(['e1', 'e2']));
+  });
+
+  it('processedEvents: large 10k-entry ledger (~660 KB) round-trips via CID ref under the 128 KiB cap', async () => {
+    // Stress-test the #285 BLOCKING case: at 10k entries the legacy inline
+    // payload was ~660 KB (5× over the 128 KiB OpLog cap). Through the
+    // CID-ref path the OpLog entry shrinks to the ~150-byte ref envelope
+    // while the full payload lives at IPFS. This is the production-realistic
+    // size we needed to migrate.
+    const { fakeStore, ipfsStore } = makeFakeCidRefStore();
+    const mod = new GroupChatModule();
+    mod.initialize(createDeps(storage, fakeStore));
+    await mod.load();
+
+    // 10000 entries × 64-char IDs ≈ 660 KB plaintext.
+    const big = new Set<string>();
+    for (let i = 0; i < 10_000; i++) {
+      big.add(`evt_${i.toString(16).padStart(60, '0')}`);
+    }
+    (mod as any).processedEventIds = big;
+    await (mod as any).persistProcessedEvents();
+
+    const kvRaw = storage._data.get(STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS)!;
+    // The OpLog entry itself is now a small CID-ref envelope — under 1 KiB.
+    expect(kvRaw.length).toBeLessThan(1024);
+    const refEnv = JSON.parse(kvRaw);
+    expect(refEnv.v).toBe(1);
+    // The big payload now lives at IPFS. Verify size is multiple-MB-scale.
+    const stored = ipfsStore.get(refEnv.cid)!;
+    expect(stored.bytes.byteLength).toBeGreaterThan(500_000);
+
+    // Round-trip — wipe in-memory state and reload from the seeded KV.
+    (mod as any).processedEventIds = new Set();
+    await mod.load();
+    expect((mod as any).processedEventIds.size).toBe(10_000);
+  });
 });

--- a/tests/unit/profile/build-cid-ref-store.test.ts
+++ b/tests/unit/profile/build-cid-ref-store.test.ts
@@ -1,0 +1,175 @@
+/**
+ * `ProfileStorageProvider.buildCidRefStore()` tests (Issue #285).
+ *
+ * The accessor mirrors the existing build* family (`buildOutboxWriter`,
+ * `buildSentLedgerWriter`, `buildDispositionStorageAdapter`, …) and
+ * returns null when:
+ *   - encryption is disabled (`encrypt: false`), OR
+ *   - the encryption key has not been derived yet (setIdentity pending),
+ *     OR
+ *   - no IPFS gateways are configured.
+ *
+ * Otherwise it returns a fully wired CidRefStore using the provider's
+ * profile encryption key and configured gateway list. The returned
+ * store's pinJson/fetchJson round-trip is covered separately in
+ * `cid-ref-store.test.ts`; here we only assert the construction path
+ * + null-handling.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ProfileStorageProvider } from '../../../profile/profile-storage-provider';
+import { CidRefStore } from '../../../profile/cid-ref-store';
+import type { ProfileDatabase } from '../../../profile/types';
+import type { StorageProvider } from '../../../storage';
+import type { FullIdentity } from '../../../types';
+
+// ── Test fixtures ─────────────────────────────────────────────────────────
+
+const TEST_PRIVKEY = 'aa'.repeat(32);
+const TEST_PUBKEY = '02' + 'bb'.repeat(32);
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: TEST_PUBKEY,
+  privateKey: TEST_PRIVKEY,
+  l1Address: 'alpha1test',
+  directAddress: 'DIRECT://testaddr',
+};
+
+/** Minimal local-cache stub satisfying `StorageProvider` shape. */
+function createStubLocalCache(): StorageProvider {
+  const store = new Map<string, string>();
+  return {
+    id: 'stub-local-cache',
+    name: 'Stub Local Cache',
+    type: 'local',
+    description: '',
+    connect: async () => undefined,
+    disconnect: async () => undefined,
+    isConnected: () => true,
+    getStatus: () => 'connected',
+    setIdentity: () => undefined,
+    get: async (k) => store.get(k) ?? null,
+    set: async (k, v) => {
+      store.set(k, v);
+    },
+    remove: async (k) => {
+      store.delete(k);
+    },
+    has: async (k) => store.has(k),
+    keys: async (prefix) => {
+      const all = Array.from(store.keys());
+      return prefix == null ? all : all.filter((k) => k.startsWith(prefix));
+    },
+    clear: async () => undefined,
+    saveTrackedAddresses: async () => undefined,
+    loadTrackedAddresses: async () => [],
+  } as StorageProvider;
+}
+
+/** Minimal ProfileDatabase stub — never actually accessed in build* paths. */
+function createStubProfileDb(): ProfileDatabase {
+  return {
+    connect: async () => undefined,
+    disconnect: async () => undefined,
+    put: async () => undefined,
+    get: async () => null,
+    del: async () => undefined,
+    all: async () => [],
+    keys: async () => [],
+  } as unknown as ProfileDatabase;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('ProfileStorageProvider.buildCidRefStore (Issue #285)', () => {
+  let cache: StorageProvider;
+  let db: ProfileDatabase;
+
+  beforeEach(() => {
+    cache = createStubLocalCache();
+    db = createStubProfileDb();
+  });
+
+  it('returns a wired CidRefStore when encryption + identity + gateways are configured', () => {
+    const provider = new ProfileStorageProvider(cache, db, {
+      encrypt: true,
+      config: {
+        ipfsGateways: ['https://ipfs.example.com'],
+        orbitDb: { name: 'test-db' },
+      },
+    });
+    provider.setIdentity(TEST_IDENTITY);
+
+    const store = provider.buildCidRefStore();
+    expect(store).not.toBeNull();
+    expect(store).toBeInstanceOf(CidRefStore);
+  });
+
+  it('returns null when encryption is disabled', () => {
+    const provider = new ProfileStorageProvider(cache, db, {
+      encrypt: false,
+      config: {
+        ipfsGateways: ['https://ipfs.example.com'],
+        orbitDb: { name: 'test-db' },
+      },
+    });
+    provider.setIdentity(TEST_IDENTITY);
+
+    expect(provider.buildCidRefStore()).toBeNull();
+  });
+
+  it('returns null when setIdentity has not been called yet (encryption key undefined)', () => {
+    const provider = new ProfileStorageProvider(cache, db, {
+      encrypt: true,
+      config: {
+        ipfsGateways: ['https://ipfs.example.com'],
+        orbitDb: { name: 'test-db' },
+      },
+    });
+    // setIdentity intentionally NOT called.
+    expect(provider.buildCidRefStore()).toBeNull();
+  });
+
+  it('returns null when no IPFS gateways are configured', () => {
+    const provider = new ProfileStorageProvider(cache, db, {
+      encrypt: true,
+      config: {
+        // ipfsGateways omitted
+        orbitDb: { name: 'test-db' },
+      },
+    });
+    provider.setIdentity(TEST_IDENTITY);
+
+    expect(provider.buildCidRefStore()).toBeNull();
+  });
+
+  it('returns null when IPFS gateways array is empty', () => {
+    const provider = new ProfileStorageProvider(cache, db, {
+      encrypt: true,
+      config: {
+        ipfsGateways: [],
+        orbitDb: { name: 'test-db' },
+      },
+    });
+    provider.setIdentity(TEST_IDENTITY);
+
+    expect(provider.buildCidRefStore()).toBeNull();
+  });
+
+  it('each call returns a FRESH CidRefStore instance (callers cache externally)', () => {
+    const provider = new ProfileStorageProvider(cache, db, {
+      encrypt: true,
+      config: {
+        ipfsGateways: ['https://ipfs.example.com'],
+        orbitDb: { name: 'test-db' },
+      },
+    });
+    provider.setIdentity(TEST_IDENTITY);
+
+    const a = provider.buildCidRefStore();
+    const b = provider.buildCidRefStore();
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the production-blocking `[PROFILE:ORBITDB_WRITE_FAILED]` error from #285 by migrating the four fat-data OpLog write sites onto the existing `CidRefStore` primitive (PROFILE-CID-REFERENCES.md §8). After this PR every OpLog entry stays under ~150 bytes while the payload lives at IPFS — the 128 KiB cap is no longer a ticking clock.

## Per-site before/after payload sizes

| Site | Key shape | Observed before | After (OpLog entry) | Status before |
|---|---|---:|---:|---|
| `CommunicationsModule._doSave` -> `writeMessagesKey` | `<addr>.messages` (`dm_send`) | **685 KB** | ~150 B CID-ref | soft warn |
| `GroupChatModule.persistMembers` | `group_chat_members:<gid>` (`cache_index`) | **3.98 MB** | ~150 B CID-ref | **HARD ERROR (#285 repro)** |
| `GroupChatModule.persistProcessedEvents` | `<addr>.groupchat.processedEvents` (`cache_index`) | **263 KB** | ~150 B CID-ref | soft warn |
| `GroupChatModule.persistMessages` | `group_chat_messages:<gid>` (`cache_index`) | **30 KB** | ~150 B CID-ref + per-message dedup | soft warn |

(Plus `PaymentsModule` pending V5 tokens and `AccountingModule` invoice ledger, which were already migrated in earlier waves — this PR's contribution to those is the wiring change so they actually receive a `CidRefStore` instance.)

## Wire format

Uses the existing on-disk envelope already specified in `docs/uxf/PROFILE-CID-REFERENCES.md` §2:

```json
{"v":1,"cid":"bafy...","size":N,"ts":1700000000000,"enc"?:false,"contentV"?:N}
```

* `v` — schema version, currently `1`. Strictly validated on read (unknown versions fail-closed).
* `cid` — sha2-256 multihash, parsed via `multiformats/cid` (rejects arbitrary strings that happen to look like CIDs).
* `size` — declared encrypted byte size at IPFS. Read-side caps fetch at `size + 128` and rejects on mismatch, preventing both `(50 MiB × N-items)` bandwidth DoS and the "small size declared, huge blob served" attack via LWW replication.
* `ts` — wall-clock creation time (ms epoch). Must be `> 0` to discriminate from legacy values where `ts:0` could appear.
* `enc` — self-describing encryption flag. Absent or `true` -> AES-GCM ciphertext (default); `false` -> plaintext pin (used ONLY for NIP-29 group-chat messages where transit privacy is already public on the relay, so plaintext enables cross-wallet content-dedup).
* `contentV` — optional caller-supplied content-version tag for layered schema changes.

The discriminator is `CidRefStore.tryParseRef(jsonString)` — null means legacy inline content; a valid `CidRef` means CID-ref path.

## Encryption policy per key

Per PROFILE-CID-REFERENCES.md §8.5, calibrated per privacy threat model:

  - `groups`               -> ENCRYPTED (per-wallet membership view)
  - `members:<gid>`        -> ENCRYPTED (per-wallet view of group) + `requireEncrypted: true` on fetch
  - `messages:<gid>`       -> PLAINTEXT (NIP-29 messages already public on the relay; plaintext pins enable cross-wallet IPFS content-dedup; per-message CID cache in `_pinnedMessageCids`)
  - `processedEvents`      -> ENCRYPTED (NIP-29 event-id ledger reveals which groups this wallet has processed events for — a privacy footprint) + `requireEncrypted: true` on fetch
  - `messages` (DM cache)  -> ENCRYPTED (NIP-17 private envelopes — encryption already implicit in the protocol)

## Migration story for existing wallets

Every load path uses the **dual-read** pattern documented in §6:

1. `CidRefStore.tryParseRef(value)` -> ref -> `cidRefStore.fetchJson(ref)` -> hydrate.
2. tryParseRef returns null -> `JSON.parse(value)` -> hydrate (legacy inline).

For wallets that already wrote a >128 KiB inline value before the OpLog hard-cap landed: the inline blob is technically larger than the per-entry envelope cap on write, but read-side tolerance is unchanged — the legacy value rides through `db.get(key)` and `JSON.parse` exactly as before. The first write after upgrade replaces it with a CID-ref envelope.

Downgrade after upgrade is a known one-way migration (PROFILE-CID-REFERENCES.md §6 caveat): an older SDK reading a CID-ref envelope would try `JSON.parse(...)` and get a small `{v:1,cid:...}` object instead of the expected array. Matches the existing OpLog-schema migration discipline (PROFILE-OPLOG-SCHEMA.md §7.4).

## Implementation

* **`ProfileStorageProvider.buildCidRefStore()`** — public factory. Returns null when encryption is off, identity not yet set, or no IPFS gateways configured. Each call returns a fresh `CidRefStore` instance (callers cache externally).
* **`Sphere.buildCidRefStoreOrNull()`** — duck-typed bridge. Pulls a `CidRefStore` from any storage provider exposing the builder; falls back to null silently for non-Profile providers. Logs (not throws) on unexpected build failure.
* **`Sphere.initializeModules` + `Sphere.initializeAddressModules`** — both paths now build a `CidRefStore` after `setIdentity` and thread it through `Payments`, `Communications`, `GroupChat`, and `Accounting` module deps. Identity rotation rebuilds the store implicitly via the re-initialization path.
* **`GroupChatModule.persistProcessedEvents`** — migrated to Pattern A encrypted with memo guard. Symmetric dual-read in `load()` with best-effort fetch-failure recovery (relay re-delivery is idempotent; starting from an empty ledger is safe).
* **`profile/index.ts`** — re-exports `CidRefStore`, `CidRef`, `CidRefStoreOptions`, `PinOptions`, `FetchOptions` so the upcoming #286 bidirectional storage migration helper can consume the primitive directly.

## PAYLOAD-SIZE soft-warn

The 8 KiB warn at `ProfileStorageProvider.writeEnvelope` is unchanged. After this PR the four migrated sites no longer emit OpLog entries that exceed 8 KiB (refs are ~150 B), so the warn becomes the actionable signal for "a NEW write site that should be migrated" — the steelman against gradual fat-data regression.

## Adversarial review highlights

1. **Hostile CID-ref via OrbitDB LWW**: `tryParseRef` strict-validates `v=1`, real CID parse, finite size+ts. `members`/`groups`/`processedEvents` demand `requireEncrypted: true` -> attacker without the wallet key can't produce valid ciphertext, fetch decryption fails gracefully. `messages` (plaintext) is capped via `MAX_INDEX_ITEMS=10000` and `MAX_GROUP_MESSAGE_SIZE=65536`.
2. **Bandwidth DoS via undersized `size` field**: per-ref cap is `ref.size + 128B tolerance`, NOT the instance `maxFetchBytes` (50 MiB). Fetch aborts before the attacker's huge blob streams in.
3. **Memo poisoning on write failure**: every site updates the memo (`_lastPinnedXJson`/`Ref`) **after** the `storage.set` lands. A pin-success/set-failure leaves the memo untouched so the next persist re-pins.
4. **Identity rotation**: `Sphere.buildCidRefStoreOrNull()` is called once per `initializeModules` invocation, and both the `load()` path and the per-address `initializeAddressModules` path call it. The nametag-only re-init path at `switchToAddress` does NOT re-pass the store, which is intentional: only nametag changes, the underlying secp256k1 key (and thus the derived encryption key) stays the same.
5. **`publishToIpfs === undefined`** (no IPFS gateway): `buildCidRefStore()` returns null, modules fall through to inline JSON. PAYLOAD-SIZE warn still fires as the actionable signal.

## Test plan

  - [x] `npx tsc --noEmit` -> exit 0
  - [x] `npx vitest run tests/unit/` -> **7751 passed | 2 skipped** (no regressions)
  - [x] `npx tsup` -> all 14 bundle entry points build clean
  - [x] **New tests** (14 new):
    - `tests/unit/profile/build-cid-ref-store.test.ts` (6) — every null-return branch + fresh-instance semantics
    - `tests/unit/modules/GroupChatModule.cidref.test.ts` (+8) — `persistProcessedEvents` write/read round-trip + legacy fallback + fetch-failure recovery + CID_REF_UNREADABLE on missing store + memo-hit assertion + 10k-entry stress (660 KB plaintext that used to blow the 128 KiB cap now rides a ~150-byte CID-ref)
  - [x] Acceptance: replay of the #285 `announcements` scenario — `GroupChatModule.persistMembers` with a 3.98 MB member list no longer raises `[PROFILE:ORBITDB_WRITE_FAILED]`; the OpLog entry is ~150 B and IPFS holds the full payload.

## Coordination with #286

Issue #286 (bidirectional legacy<->Profile token storage migration) depends on the `CidRefStore` being reachable from external consumers. `profile/index.ts` now re-exports the full surface (`CidRefStore`, `CidRef`, `CidRefStoreOptions`, `PinOptions`, `FetchOptions`) so the future migration helper can call `ProfileStorageProvider.buildCidRefStore()` directly.