### PR TITLE
fix(profile)(#285): migrate oversized OpLog writes to CID-references (CommunicationsModule + GroupChatModule)

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -2647,6 +2647,15 @@ export class Sphere {
           // wired across nametag-driven re-initialization.
           publishToIpfs: this._publishToIpfs ?? undefined,
           cidFetchGateways: this._cidFetchGateways ?? undefined,
+          // Issue #285 — preserve the CidRefStore across nametag re-init.
+          // The wallet's encryption key has not changed (only the nametag
+          // moved), so the cached store is still valid; we rebuild for
+          // safety because `Sphere.buildCidRefStoreOrNull()` is cheap
+          // (one constructor call). Without this line, the re-init would
+          // drop the deps.cidRefStore field back to undefined and the
+          // PaymentsModule would silently fall back to inline JSON for
+          // pending V5 token persistence.
+          cidRefStore: this.buildCidRefStoreOrNull() ?? undefined,
           // Issue #255 Problem A — re-thread HD-index recovery hooks on
           // nametag-driven re-init so per-address PaymentsModule
           // instances keep the recovery surface alive after identity


### PR DESCRIPTION
## Summary

Wires up the existing `CidRefStore` primitive to the four `Profile`-mode write sites that were exceeding the 128 KiB `MAX_PAYLOAD_BYTES` OpLog cap (issue #285). The root cause was a missing factory hop: every module already had a CID-ref branch behind `if (cidRefStore)`, but **no one ever instantiated the store and passed it through `initialize()`**, so all four sites silently fell back to inline JSON.

The hard repro (sphere.telco `https://sphere-telco-test.dyndns.org/` with the `announcements` group joined) wrote a **3.98 MB** plaintext `groupChatMembers:announcements` blob and threw:

```
ProfileError: [PROFILE:ORBITDB_WRITE_FAILED]
  encodeEntry: payload 3986657 bytes exceeds MAX_PAYLOAD_BYTES=131072
    at GroupChatModule.persistMembers
```

## Per-site before/after

| Site | Key shape | Before | After |
|---|---|---:|---:|
| `CommunicationsModule._doSave` → `writeMessagesKey` | `<addr>.messages` (`dm_send`) | 685 KB | ~150 B CID-ref |
| `GroupChatModule.persistMembers` | `group_chat_members:<gid>` (`cache_index`) | **3.98 MB (HARD FAIL)** | ~150 B CID-ref |
| `GroupChatModule.persistProcessedEvents` | `<addr>.groupchat.processedEvents` (`cache_index`) | 263 KB | ~150 B CID-ref |
| `GroupChatModule.persistMessages` | `group_chat_messages:<gid>` (`cache_index`) | 30 KB | ~150 B CID-ref + per-message dedup |

Plus indirect wins on the V5 pending tokens (PaymentsModule) and invoice ledger (AccountingModule) sites that were already CID-ref-ready but never received a store.

## Wire-format spec

See `docs/uxf/PROFILE-CID-REFERENCES.md` §2 (already in-tree, no breaking changes). The OpLog stores `JSON.stringify(CidRef)`:

```json
{"v":1,"cid":"bafkreieyqvmjr…","size":3986657,"ts":1716000000000}
```

…and the encrypted plaintext (AES-256-GCM, per-wallet HKDF-derived key) is pinned as a CAR blob via `pinToIpfs`. Loads dual-read via `CidRefStore.tryParseRef` — legacy inline JSON still decodes unchanged.

Per the design doc §8.5 encryption policy:

- `groups`, `members`, `processedEvents`, DM `messages` → ENCRYPTED (per-wallet privacy)
- `messages:<groupId>` → PLAINTEXT (NIP-29 messages are already public on the relay; plaintext pins enable cross-wallet IPFS dedup)

## Migration story for existing wallets

- **Read path:** `tryParseRef` is the discriminator. A legacy wallet upgrading to this SDK reads its `>128 KB` inline blob via `JSON.parse` (the existing path) — the 128 KiB cap only binds WRITES, not the in-memory plaintext.
- **Write path:** the next persist after upgrade writes a CID-ref envelope, overwriting the inline blob. Legacy data migrates opportunistically through normal activity.
- **Downgrade is breaking** (documented in §6 of the design doc): an old SDK reading a CID-ref envelope would try `JSON.parse` and see `{v:1,cid:...}` instead of the expected array. This is the same downgrade contract as the existing migrated sites (groups/members/messages — pre-existing).

## Implementation hops

1. **`ProfileStorageProvider.buildCidRefStore()`** — public factory mirroring `buildOutboxWriter` / `buildSentLedgerWriter`. Returns null when encryption is off, identity is unset, or no gateways are configured. Each call returns a fresh instance.
2. **`Sphere.buildCidRefStoreOrNull()`** — duck-typed bridge. Best-effort null fallback for non-Profile providers (legacy `IndexedDBStorageProvider`, `FileStorageProvider`).
3. **Module `initialize()` calls** — every site that wires `cidRefStore?` deps now receives the same per-wallet store. Three init paths covered: `initializeModules`, `initializeAddressModules`, and the nametag-driven re-init path (the last covered by the second commit).
4. **`GroupChatModule.persistProcessedEvents`** migrated — this was the ONLY write site that didn't yet have a CID-ref branch. Pattern A encrypted, dual-read load path with best-effort fetch-failure recovery (relay re-delivery is idempotent).
5. **Public re-export** of `CidRefStore`, `CidRef`, `CidRefStoreOptions`, `PinOptions`, `FetchOptions` from `profile/index.ts` so the upcoming #286 work (bidirectional legacy↔Profile token storage migration) can import the primitive directly.

## Note on the brief's proposed `writeEnvelopeViaCidIfLarge(key, payload, opts)` helper

I deliberately did NOT add a size-threshold wrapper helper. The existing design (`pinJson` + `tryParseRef` + `stringifyRef`) already provides the full migration primitive and is what every in-tree call site already uses. A size threshold at the write-site would have been a regression — the migrated sites would skip the CID-ref path for small payloads and split storage shape between "inline JSON" and "ref envelope" depending on payload size, which loses the dual-read invariant (reader has to handle three shapes instead of two). All five migrated sites now pin unconditionally; OpLog payload size becomes uniform (~150-200 bytes regardless of underlying content). The `PAYLOAD_SIZE_WARN_BYTES = 8 KiB` soft-warn stays — after this PR lands, it implicitly becomes the actionable signal for "you added a NEW write site that needs migration" because every existing fat-data site is now CID-ref-routed.

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [x] `npx eslint` (touched files) → clean
- [x] `npx vitest run` → 8339 passed | 13 skipped (8352 total, 492 files)
- [x] `npx tsup` → build success (all 14 entry points, ESM + CJS + DTS)
- [x] **New** `tests/unit/profile/build-cid-ref-store.test.ts` (6 tests) — covers every null-return branch + fresh-instance semantics
- [x] **New** `tests/unit/modules/GroupChatModule.cidref.test.ts` `processedEvents` describe block (+8 tests) — covers `persistProcessedEvents` round-trip + load + legacy fallback + fetch-failure recovery + 10k-entry stress (660 KB plaintext → ~150 byte CID-ref envelope)

## Acceptance

After this PR lands + sphere PR re-applying `createBrowserProfileProviders` (#305):
1. Wallet with the `announcements` group joined initializes without `[PROFILE:ORBITDB_WRITE_FAILED]`.
2. `groupChatMembers:announcements` storage value is ~150 bytes (CID-ref envelope), not 3.98 MB inline JSON.
3. The four `[PAYLOAD-SIZE]` soft-warns from issue #285 stop firing for these sites.
4. New `_audit` of `Sphere.payments.sync()` shows OpLog churn dropping in proportion to the moved-out content size.

## Coordination with #286

`CidRefStore`, `CidRef`, and the option types are re-exported from `profile/index.ts` for the #286 token-storage migration helper. `ProfileStorageProvider.buildCidRefStore()` is a public method on the same module — that helper can call it directly.