### PR TITLE
feat(profile)(#286): bidirectional legacy↔Profile token storage migration

### DIFF
--- a/profile/index.ts
+++ b/profile/index.ts
@@ -146,6 +146,28 @@ export type {
   LegacyImportResult,
 } from './import-from-legacy';
 
+// Bidirectional token-storage migration (Issue #286). Operates at the
+// TokenStorageProvider boundary — copies a full TxfStorageDataBase
+// snapshot between any two providers (legacy ↔ Profile) with
+// idempotency, crash-safety, and optional aggregator-spent gating.
+// See profile/token-storage-migration.ts module docstring for the
+// consumer integration pattern (sphere.telco SphereProvider.initialize).
+export {
+  migrateTokenStorage,
+  migrateLegacyToProfile,
+  migrateProfileToLegacy,
+  isTokenStorageMigrationComplete,
+  clearTokenStorageMigrationMarker,
+  TOKEN_STORAGE_MIGRATION_MARKER_VERSION,
+} from './token-storage-migration';
+export type {
+  MigrationDirection,
+  TokenStorageMigrationOptions,
+  TokenStorageMigrationProgress,
+  TokenStorageMigrationCounts,
+  TokenStorageMigrationResult,
+} from './token-storage-migration';
+
 // =============================================================================
 // Deriver (local-cached structural views)
 // =============================================================================

--- a/profile/token-storage-migration.ts
+++ b/profile/token-storage-migration.ts
@@ -1,0 +1,933 @@
+/**
+ * Bidirectional Token Storage Migration (Issue #286)
+ *
+ * Copies a wallet's token inventory between two `TokenStorageProvider`
+ * implementations, preserving every TXF-level structural field
+ * (`_meta`, tokens, archived tokens, `_tombstones`, `_outbox`, `_sent`,
+ * `_invalid`, `_history`, `_audit`, `_finalizationQueue`).
+ *
+ * Designed to support consumer-driven storage swaps such as the
+ * sphere.telco PR #305 regression (an upgrade from
+ * `IndexedDBTokenStorageProvider` to `ProfileTokenStorageProvider`
+ * silently zeroed every existing wallet's balance because the new
+ * Profile store opens fresh, no migration runs). Calling
+ * `migrateTokenStorage()` BEFORE swapping the provider passed to
+ * `Sphere.init` makes the swap safe — and the same primitive supports
+ * a rollback to legacy if the new store is later disabled.
+ *
+ * ## Semantics
+ *
+ * - **Bidirectional.** Pass `direction: 'legacy-to-profile'` or
+ *   `'profile-to-legacy'`. The function treats the two providers
+ *   symmetrically — only the marker keyspace differs.
+ * - **Non-destructive.** The source provider is never written to. After
+ *   a successful migration the source still holds the original data,
+ *   so a future rollback in the OTHER direction reproduces the
+ *   original wallet state.
+ * - **Idempotent.** A per-direction marker
+ *   (`legacy_migration_v1_complete:<addressId>` /
+ *   `profile_migration_v1_complete:<addressId>`) is written to the
+ *   `markerStorage` after a successful copy. A second invocation in
+ *   the same direction with the marker present short-circuits.
+ *   Pass `force: true` to bypass the marker (e.g., the user added
+ *   tokens to legacy after the first migration and wants to refresh
+ *   the joint inventory).
+ * - **Crash-safe.** The target's `save()` is a full overwrite, not an
+ *   append — a crash mid-flight leaves the target with either the
+ *   pre-migration state (write didn't land) or the post-migration
+ *   state (write landed). Re-running re-loads the source snapshot
+ *   and re-writes the target. The marker is the LAST operation, so
+ *   any crash before it triggers a re-run on the next launch.
+ * - **Aggregator-spent aware.** When an `oracle` is passed, every
+ *   active token's current state hash is probed via `oracle.isSpent()`
+ *   before the target write. Tokens reported `spent` are demoted from
+ *   the active inventory to the `archived-` slot — they remain in the
+ *   user's history but no longer appear in `getAssets()` / spend
+ *   selection. This sits BESIDE the runtime `SpentStateRescanWorker`
+ *   (auto-installed by PaymentsModule, issue #281); the migration
+ *   probe is a one-shot equivalent for the wallet's first post-swap
+ *   load so the user doesn't see "phantom" spent balances even before
+ *   the worker's first scan cycle.
+ * - **OpLog cap safe.** `ProfileTokenStorageProvider.save()` does NOT
+ *   inline the TxfStorageDataBase in OpLog — it writes a UXF CAR to
+ *   IPFS and stamps a thin bundle CID ref in OrbitDB. So migrating
+ *   thousands of tokens is structurally bounded by IPFS payload size,
+ *   not the 128 KiB MAX_PAYLOAD_BYTES cap. The marker write itself is
+ *   ~200 bytes — well below the cap — and uses the system-class
+ *   `'cache_index'` entry type when the marker storage supports
+ *   `setEntry`.
+ *
+ * ## What this primitive does NOT migrate
+ *
+ * - Key-value storage entries (mnemonic, derivation path, group-chat,
+ *   pending V5 tokens, accounting state, proof-polling jobs). Those
+ *   live in the `StorageProvider` layer, which is a separate
+ *   abstraction (both Profile and legacy providers expose KV
+ *   compatible interfaces, so they survive a Profile swap on their
+ *   own without help from this primitive).
+ *
+ * Forked-token entries (`_forked_*`) ARE migrated as-is — they carry
+ * alternate state-history for a tokenId and live in their own
+ * keyspace slot (no collision with the active `_<tokenId>` key).
+ * The count is exposed via `forksMigrated` for operator visibility.
+ *
+ * ## Comparison with `importLegacyTokens`
+ *
+ * `importLegacyTokens` (the existing legacy → Profile helper) operates
+ * at the `PaymentsModule.importTokens` level. It re-builds the
+ * in-memory token map plus the local derived cache (history,
+ * tombstones, etc.) on a LIVE PaymentsModule. It is the right
+ * primitive when the caller has a live `Sphere` instance and wants
+ * to merge legacy tokens into the active wallet view.
+ *
+ * `migrateTokenStorage` operates at the `TokenStorageProvider` level.
+ * It is the right primitive when the caller is preparing storage
+ * BEFORE constructing `Sphere`, or rolling back from one storage
+ * shape to another. Both helpers can coexist: a typical sphere.telco
+ * `SphereProvider.initialize` calls `migrateTokenStorage()` to seed
+ * the Profile-backed target, then constructs Sphere with the Profile
+ * providers — and a subsequent in-app "merge legacy file" UI gesture
+ * calls `importLegacyTokens` to additively union an external TXF
+ * file.
+ *
+ * @example sphere.telco SphereProvider.initialize integration
+ * ```ts
+ * import { createBrowserProfileProviders } from '@unicitylabs/sphere-sdk/profile/browser';
+ * import { createBrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
+ * import { migrateLegacyToProfile } from '@unicitylabs/sphere-sdk/profile';
+ *
+ * // Build legacy + Profile providers side-by-side
+ * const legacy = createBrowserProviders({ network: 'mainnet' });
+ * const profile = createBrowserProfileProviders({ network: 'mainnet' });
+ *
+ * // Initialize both with the same identity (so the addressId matches)
+ * legacy.tokenStorage.setIdentity(identity);
+ * profile.tokenStorage.setIdentity(identity);
+ * await legacy.tokenStorage.initialize();
+ * await profile.tokenStorage.initialize();
+ *
+ * // Migrate legacy → Profile, with aggregator-spent gating
+ * const result = await migrateLegacyToProfile({
+ *   legacy: legacy.tokenStorage,
+ *   profile: profile.tokenStorage,
+ *   identity,
+ *   oracle: providers.oracle,
+ *   markerStorage: profile.storage,
+ * });
+ * if (!result.success) {
+ *   console.error('migration failed', result.errors);
+ * }
+ *
+ * // Now construct Sphere with Profile providers — tokens visible
+ * const { sphere } = await Sphere.init({
+ *   ...profile,
+ *   transport: providers.transport,
+ *   oracle: providers.oracle,
+ * });
+ * ```
+ *
+ * @module profile/token-storage-migration
+ */
+
+import { logger } from '../core/logger.js';
+import { getAddressId, STORAGE_PREFIX } from '../constants.js';
+import type {
+  TokenStorageProvider,
+  TxfStorageDataBase,
+  StorageProvider,
+} from '../storage/storage-provider.js';
+import type { OracleProvider } from '../oracle/oracle-provider.js';
+import type { FullIdentity } from '../types';
+import { isTokenKey, isArchivedKey, isForkedKey, archivedKeyFromTokenId } from '../types/txf.js';
+import type { TxfToken } from '../types/txf.js';
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/** Migration direction. */
+export type MigrationDirection = 'legacy-to-profile' | 'profile-to-legacy';
+
+/** Per-phase progress callback payload. */
+export interface TokenStorageMigrationProgress {
+  /** Address being migrated. */
+  readonly addressId: string;
+  /** Direction of the migration. */
+  readonly direction: MigrationDirection;
+  /** Phase name. */
+  readonly phase:
+    | 'check-marker'
+    | 'source-load'
+    | 'oracle-probe'
+    | 'target-save'
+    | 'await-flush'
+    | 'stamp-marker'
+    | 'complete';
+  /** Tokens processed so far in the current phase. */
+  readonly processed: number;
+  /** Total tokens expected in the current phase. */
+  readonly total: number;
+}
+
+/** Options for {@link migrateTokenStorage}. */
+export interface TokenStorageMigrationOptions {
+  /** Source provider — read-only. */
+  readonly source: TokenStorageProvider<TxfStorageDataBase>;
+  /** Target provider — receives a single `save()` call. */
+  readonly target: TokenStorageProvider<TxfStorageDataBase>;
+  /** Direction (drives marker keyspace only). */
+  readonly direction: MigrationDirection;
+  /**
+   * Wallet identity. Both providers MUST already accept this identity
+   * (call `setIdentity` + `initialize` BEFORE invoking the migration).
+   * The function uses `identity.directAddress` to compute the marker
+   * keyspace and to call `oracle.isSpent(identity.chainPubkey, ...)`.
+   */
+  readonly identity: FullIdentity;
+  /**
+   * Optional aggregator. When provided, every active token's current
+   * state hash is probed. Tokens reported `spent` are demoted to the
+   * `archived-` slot in the target. Tokens whose probe THROWS are
+   * left in the active slot (defensive — same fail-closed semantics
+   * as the runtime worker).
+   */
+  readonly oracle?: OracleProvider;
+  /**
+   * Where to store the idempotency marker. Typical choice: the
+   * `StorageProvider` of the TARGET environment (Profile's
+   * `ProfileStorageProvider` for legacy→Profile; the legacy
+   * `IndexedDBStorageProvider` / `FileStorageProvider` for the
+   * reverse direction). When omitted, the marker phase is skipped
+   * entirely — every call re-runs the copy. Pass `null` explicitly
+   * for the same effect.
+   */
+  readonly markerStorage?: StorageProvider | null;
+  /**
+   * Optional per-phase progress callback.
+   */
+  readonly onProgress?: (p: TokenStorageMigrationProgress) => void;
+  /**
+   * Enumerate without writing. The target is NOT modified; the
+   * marker is NOT stamped. Useful for a CLI `--dry-run` flag.
+   */
+  readonly dryRun?: boolean;
+  /**
+   * Bypass the idempotency marker. The migration runs even if the
+   * marker is already set. The marker IS rewritten on success so
+   * subsequent calls observe the latest timestamp.
+   */
+  readonly force?: boolean;
+}
+
+/** Per-bucket counts captured by the migration. */
+export interface TokenStorageMigrationCounts {
+  /** Active token entries (`_<tokenId>` keys, NOT including archived). */
+  readonly tokensMigrated: number;
+  /** Archived token entries (`archived-<tokenId>` keys). */
+  readonly archivedMigrated: number;
+  /** Tombstones (entries in `_tombstones`). */
+  readonly tombstonesMigrated: number;
+  /** OUTBOX entries (entries in `_outbox`). */
+  readonly outboxMigrated: number;
+  /** SENT entries (entries in `_sent`). */
+  readonly sentMigrated: number;
+  /** History entries (entries in `_history`). */
+  readonly historyMigrated: number;
+  /** Audit entries (entries in `_audit`). */
+  readonly auditMigrated: number;
+  /** Finalization queue entries (entries in `_finalizationQueue`). */
+  readonly finalizationQueueMigrated: number;
+  /** Invalid entries (entries in `_invalid`). */
+  readonly invalidMigrated: number;
+  /**
+   * Forked-token entries (`_forked_<tokenId>_<stateHash>`) copied
+   * as-is. Forks are alternate state-history for a tokenId; they
+   * live in their own keyspace slot and never collide with the
+   * active `_<tokenId>` key, so a literal byte-copy is safe and
+   * preserves the wallet's audit trail. Exposed separately from
+   * `tokensMigrated` for operator visibility.
+   */
+  readonly forksMigrated: number;
+  /**
+   * Active tokens demoted to `archived-` due to `oracle.isSpent === true`.
+   * Always 0 when `oracle` is omitted. Counted independently from
+   * `archivedMigrated` (those were already archived in source).
+   */
+  readonly spentTokensArchived: number;
+  /**
+   * Oracle probes that threw (network / RPC error). The token is left
+   * in its source bucket and is NOT demoted. The wallet's runtime
+   * `SpentStateRescanWorker` will re-probe after the wallet boots.
+   */
+  readonly oracleProbeErrors: number;
+}
+
+/** Result of a single {@link migrateTokenStorage} invocation. */
+export interface TokenStorageMigrationResult extends TokenStorageMigrationCounts {
+  /** True when the migration ran without fatal errors. */
+  readonly success: boolean;
+  /** Computed addressId for the migrated identity. */
+  readonly addressId: string;
+  /** Direction passed to {@link migrateTokenStorage}. */
+  readonly direction: MigrationDirection;
+  /**
+   * True when the marker was set and `force` was false — the function
+   * returned early without touching the target. All counts are 0.
+   */
+  readonly skippedDueToMarker: boolean;
+  /** True when `dryRun` was set — counts are real but no writes happened. */
+  readonly dryRun: boolean;
+  /** Wall-clock duration. */
+  readonly durationMs: number;
+  /** Fatal-and-non-fatal failures collected during the run. */
+  readonly errors: ReadonlyArray<{
+    readonly phase: TokenStorageMigrationProgress['phase'];
+    readonly error: string;
+  }>;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Schema version of the migration marker payload. Bump when the
+ * marker JSON shape changes in a way that older readers can't parse.
+ */
+export const TOKEN_STORAGE_MIGRATION_MARKER_VERSION = 1 as const;
+
+const MARKER_KEY_PREFIX_LEGACY_TO_PROFILE = 'legacy_migration_v1_complete';
+const MARKER_KEY_PREFIX_PROFILE_TO_LEGACY = 'profile_migration_v1_complete';
+
+/**
+ * Reserved keys that never carry a token payload. These are the
+ * structural / operational slots on `TxfStorageDataBase` (kept in sync
+ * with `RESERVED_KEYS` in `types/txf.ts` plus the post-merge T.0.G7
+ * fields).
+ */
+const RESERVED_KEYS = new Set<string>([
+  '_meta',
+  '_tombstones',
+  '_outbox',
+  '_sent',
+  '_invalid',
+  '_history',
+  '_integrity',
+  '_audit',
+  '_finalizationQueue',
+  '_nametag',
+  '_nametags',
+  '_invalidatedNametags',
+  '_mintOutbox',
+]);
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Migrate a wallet's TXF token inventory from `source` to `target`,
+ * preserving every structural field of `TxfStorageDataBase`.
+ *
+ * See the module docstring for the full contract — idempotency,
+ * crash-safety, aggregator-spent gating, OpLog cap safety, and what
+ * is intentionally NOT migrated.
+ *
+ * @param opts See {@link TokenStorageMigrationOptions}.
+ * @returns See {@link TokenStorageMigrationResult}.
+ */
+export async function migrateTokenStorage(
+  opts: TokenStorageMigrationOptions,
+): Promise<TokenStorageMigrationResult> {
+  const startTime = Date.now();
+  const errors: Array<{ phase: TokenStorageMigrationProgress['phase']; error: string }> = [];
+
+  if (!opts.identity.directAddress) {
+    return failureResult({
+      addressId: '',
+      direction: opts.direction,
+      errors: [{ phase: 'check-marker', error: 'identity.directAddress is required' }],
+      dryRun: !!opts.dryRun,
+      durationMs: Date.now() - startTime,
+    });
+  }
+
+  const addressId = getAddressId(opts.identity.directAddress);
+  const markerKey = markerKeyFor(opts.direction, addressId);
+
+  // ── Phase 1: idempotency marker check ──────────────────────────────────
+  emitProgress(opts.onProgress, addressId, opts.direction, 'check-marker', 0, 0);
+
+  if (!opts.force && opts.markerStorage) {
+    try {
+      const existing = await opts.markerStorage.get(markerKey);
+      if (existing) {
+        logger.debug(
+          'TokenStorageMigration',
+          `marker present (${markerKey}); skipping (use force:true to override)`,
+        );
+        return {
+          success: true,
+          addressId,
+          direction: opts.direction,
+          skippedDueToMarker: true,
+          dryRun: !!opts.dryRun,
+          tokensMigrated: 0,
+          archivedMigrated: 0,
+          tombstonesMigrated: 0,
+          outboxMigrated: 0,
+          sentMigrated: 0,
+          historyMigrated: 0,
+          auditMigrated: 0,
+          finalizationQueueMigrated: 0,
+          invalidMigrated: 0,
+          forksMigrated: 0,
+          spentTokensArchived: 0,
+          oracleProbeErrors: 0,
+          durationMs: Date.now() - startTime,
+          errors: [],
+        };
+      }
+    } catch (err) {
+      // Marker read failure is non-fatal — proceed with the migration.
+      // The marker write at the end may also fail, in which case the
+      // next run repeats the migration (idempotent at the data layer).
+      errors.push({
+        phase: 'check-marker',
+        error: `marker read failed: ${errMsg(err)} (proceeding)`,
+      });
+    }
+  }
+
+  // ── Phase 2: load source snapshot ──────────────────────────────────────
+  emitProgress(opts.onProgress, addressId, opts.direction, 'source-load', 0, 0);
+
+  let sourceData: TxfStorageDataBase;
+  try {
+    const loaded = await opts.source.load();
+    if (!loaded.success || !loaded.data) {
+      return failureResult({
+        addressId,
+        direction: opts.direction,
+        errors: [
+          ...errors,
+          {
+            phase: 'source-load',
+            error: loaded.error ?? 'source.load() returned no data',
+          },
+        ],
+        dryRun: !!opts.dryRun,
+        durationMs: Date.now() - startTime,
+      });
+    }
+    sourceData = loaded.data;
+  } catch (err) {
+    return failureResult({
+      addressId,
+      direction: opts.direction,
+      errors: [...errors, { phase: 'source-load', error: errMsg(err) }],
+      dryRun: !!opts.dryRun,
+      durationMs: Date.now() - startTime,
+    });
+  }
+
+  // ── Phase 3: bucket inventory + optional oracle-spent probe ────────────
+  const buckets = classifyBuckets(sourceData);
+  emitProgress(
+    opts.onProgress,
+    addressId,
+    opts.direction,
+    'oracle-probe',
+    0,
+    buckets.activeTokens.length,
+  );
+
+  let spentTokensArchived = 0;
+  let oracleProbeErrors = 0;
+  // Build the target snapshot by starting from the source and applying
+  // post-probe migrations. We mutate a NEW object so the original
+  // `sourceData` reference is never mutated (some providers cache the
+  // loaded snapshot and rely on identity-stability).
+  const targetData: TxfStorageDataBase = shallowCopyStorageData(sourceData);
+
+  if (opts.oracle) {
+    const pubkey = opts.identity.chainPubkey;
+    if (!pubkey) {
+      errors.push({
+        phase: 'oracle-probe',
+        error: 'oracle provided but identity.chainPubkey is missing — skipping probe',
+      });
+    } else {
+      // Concurrency-capped probes — at scale (1500+ tokens) a sequential
+      // loop would block the migration for minutes. The cap matches the
+      // SpentStateRescanWorker's default (MAX_CONCURRENT_SPENT_RESCANS=4)
+      // so we don't out-load the runtime worker. The oracle is expected
+      // to internally rate-limit / dedupe (UnicityAggregatorProvider
+      // caches isSpent results with a TTL), so concurrent calls are
+      // benign.
+      const ORACLE_PROBE_CONCURRENCY = 4;
+      const candidates = buckets.activeTokens
+        .map((entry) => ({
+          ...entry,
+          stateHash: extractCurrentStateHashFromTxf(entry.txf),
+        }))
+        .filter((c) => c.stateHash.length > 0);
+
+      for (let i = 0; i < candidates.length; i += ORACLE_PROBE_CONCURRENCY) {
+        const batch = candidates.slice(i, i + ORACLE_PROBE_CONCURRENCY);
+        const outcomes = await Promise.all(
+          batch.map(async (c) => {
+            try {
+              const spent = await opts.oracle!.isSpent(pubkey, c.stateHash);
+              return { ok: true as const, key: c.key, txf: c.txf, spent };
+            } catch (err) {
+              return { ok: false as const, key: c.key, err };
+            }
+          }),
+        );
+        for (const outcome of outcomes) {
+          if (!outcome.ok) {
+            oracleProbeErrors += 1;
+            logger.debug(
+              'TokenStorageMigration',
+              `oracle.isSpent threw for ${outcome.key}: ${errMsg(outcome.err)} (leaving in active slot)`,
+            );
+            continue;
+          }
+          if (outcome.spent) {
+            // Demote active → archived. Preserves the token payload in
+            // the inventory so getHistory() / archived views still see
+            // it; only spend selection / getAssets() will skip it.
+            const tokenId = outcome.key.startsWith('_') ? outcome.key.slice(1) : outcome.key;
+            const archivedKey = archivedKeyFromTokenId(tokenId);
+            (targetData as unknown as Record<string, unknown>)[archivedKey] = outcome.txf;
+            delete (targetData as unknown as Record<string, unknown>)[outcome.key];
+            spentTokensArchived += 1;
+          }
+        }
+      }
+    }
+  }
+
+  // Refresh the `_meta` slot so the target carries the migration
+  // timestamp (the legacy save() honors whatever `_meta` we hand it;
+  // the Profile save() uses the existing _meta path). Without an
+  // explicit refresh the target inherits the source's `updatedAt`,
+  // which can look stale to operators inspecting the target.
+  if (targetData._meta) {
+    targetData._meta = {
+      ...targetData._meta,
+      updatedAt: Date.now(),
+    };
+  }
+
+  // ── Phase 4: dry-run early exit ────────────────────────────────────────
+  const finalBuckets = classifyBuckets(targetData);
+  const counts: TokenStorageMigrationCounts = {
+    tokensMigrated: finalBuckets.activeTokens.length,
+    archivedMigrated: finalBuckets.archivedTokens.length,
+    tombstonesMigrated: targetData._tombstones?.length ?? 0,
+    outboxMigrated: targetData._outbox?.length ?? 0,
+    sentMigrated: targetData._sent?.length ?? 0,
+    historyMigrated: targetData._history?.length ?? 0,
+    auditMigrated: targetData._audit?.length ?? 0,
+    finalizationQueueMigrated: targetData._finalizationQueue?.length ?? 0,
+    invalidMigrated: targetData._invalid?.length ?? 0,
+    forksMigrated: buckets.forksMigrated,
+    spentTokensArchived,
+    oracleProbeErrors,
+  };
+
+  if (opts.dryRun) {
+    emitProgress(opts.onProgress, addressId, opts.direction, 'complete', 0, 0);
+    return {
+      success: true,
+      addressId,
+      direction: opts.direction,
+      skippedDueToMarker: false,
+      dryRun: true,
+      ...counts,
+      durationMs: Date.now() - startTime,
+      errors,
+    };
+  }
+
+  // ── Phase 5: write target ──────────────────────────────────────────────
+  emitProgress(
+    opts.onProgress,
+    addressId,
+    opts.direction,
+    'target-save',
+    counts.tokensMigrated,
+    counts.tokensMigrated,
+  );
+
+  try {
+    const saved = await opts.target.save(targetData);
+    if (!saved.success) {
+      return failureResult({
+        addressId,
+        direction: opts.direction,
+        errors: [
+          ...errors,
+          { phase: 'target-save', error: saved.error ?? 'target.save() returned !success' },
+        ],
+        dryRun: false,
+        durationMs: Date.now() - startTime,
+        // Preserve the counts we computed pre-save so callers can see
+        // what would have been migrated.
+        counts,
+      });
+    }
+  } catch (err) {
+    return failureResult({
+      addressId,
+      direction: opts.direction,
+      errors: [...errors, { phase: 'target-save', error: errMsg(err) }],
+      dryRun: false,
+      durationMs: Date.now() - startTime,
+      counts,
+    });
+  }
+
+  // ── Phase 6: drain any debounced flush so the marker stamp lands
+  //            ONLY after the target write is durable. Without this
+  //            a Profile-backed target may return from save() with the
+  //            data still queued in the flush scheduler — and a marker
+  //            stamped early would let a crash leave us with a marker
+  //            but no data on the target.
+  emitProgress(opts.onProgress, addressId, opts.direction, 'await-flush', 0, 0);
+
+  if (typeof opts.target.awaitNextFlush === 'function') {
+    try {
+      await opts.target.awaitNextFlush();
+    } catch (err) {
+      // A flush failure means the data is NOT durable. Do NOT stamp
+      // the marker — return a failure so the next run retries.
+      return failureResult({
+        addressId,
+        direction: opts.direction,
+        errors: [
+          ...errors,
+          { phase: 'await-flush', error: `awaitNextFlush failed: ${errMsg(err)}` },
+        ],
+        dryRun: false,
+        durationMs: Date.now() - startTime,
+        counts,
+      });
+    }
+  }
+
+  // ── Phase 7: stamp marker ──────────────────────────────────────────────
+  emitProgress(opts.onProgress, addressId, opts.direction, 'stamp-marker', 0, 0);
+
+  if (opts.markerStorage) {
+    const markerPayload = JSON.stringify({
+      v: TOKEN_STORAGE_MIGRATION_MARKER_VERSION,
+      direction: opts.direction,
+      addressId,
+      completedAt: Date.now(),
+      counts,
+    });
+    try {
+      // System-class entry type — the marker is operator-bookkeeping
+      // not a user action. Falls through to plain set() when the
+      // provider doesn't implement setEntry (file / legacy IndexedDB).
+      const markerStorageWithSetEntry = opts.markerStorage as StorageProvider & {
+        setEntry?: (key: string, value: string, entryType: string) => Promise<void>;
+      };
+      if (typeof markerStorageWithSetEntry.setEntry === 'function') {
+        await markerStorageWithSetEntry.setEntry(markerKey, markerPayload, 'cache_index');
+      } else {
+        await opts.markerStorage.set(markerKey, markerPayload);
+      }
+    } catch (err) {
+      // Non-fatal: the data IS durable on the target. The next
+      // invocation will re-run the migration (a wasted pass but
+      // idempotent — target.save is a full overwrite).
+      errors.push({
+        phase: 'stamp-marker',
+        error: `marker write failed: ${errMsg(err)} (data is durable on target)`,
+      });
+    }
+  }
+
+  emitProgress(opts.onProgress, addressId, opts.direction, 'complete', 0, 0);
+
+  return {
+    success: true,
+    addressId,
+    direction: opts.direction,
+    skippedDueToMarker: false,
+    dryRun: false,
+    ...counts,
+    durationMs: Date.now() - startTime,
+    errors,
+  };
+}
+
+/**
+ * Convenience wrapper for the common case: migrating from a legacy
+ * `IndexedDBTokenStorageProvider` / `FileTokenStorageProvider` to a
+ * Profile-backed `ProfileTokenStorageProvider`.
+ *
+ * Equivalent to `migrateTokenStorage({ source: legacy, target: profile,
+ * direction: 'legacy-to-profile', ... })`.
+ */
+export async function migrateLegacyToProfile(opts: {
+  readonly legacy: TokenStorageProvider<TxfStorageDataBase>;
+  readonly profile: TokenStorageProvider<TxfStorageDataBase>;
+  readonly identity: FullIdentity;
+  readonly oracle?: OracleProvider;
+  readonly markerStorage?: StorageProvider | null;
+  readonly onProgress?: (p: TokenStorageMigrationProgress) => void;
+  readonly dryRun?: boolean;
+  readonly force?: boolean;
+}): Promise<TokenStorageMigrationResult> {
+  return migrateTokenStorage({
+    source: opts.legacy,
+    target: opts.profile,
+    direction: 'legacy-to-profile',
+    identity: opts.identity,
+    oracle: opts.oracle,
+    markerStorage: opts.markerStorage,
+    onProgress: opts.onProgress,
+    dryRun: opts.dryRun,
+    force: opts.force,
+  });
+}
+
+/**
+ * Convenience wrapper for the rollback direction:
+ * `ProfileTokenStorageProvider` → legacy
+ * `IndexedDBTokenStorageProvider` / `FileTokenStorageProvider`.
+ *
+ * Equivalent to `migrateTokenStorage({ source: profile, target: legacy,
+ * direction: 'profile-to-legacy', ... })`.
+ */
+export async function migrateProfileToLegacy(opts: {
+  readonly profile: TokenStorageProvider<TxfStorageDataBase>;
+  readonly legacy: TokenStorageProvider<TxfStorageDataBase>;
+  readonly identity: FullIdentity;
+  readonly oracle?: OracleProvider;
+  readonly markerStorage?: StorageProvider | null;
+  readonly onProgress?: (p: TokenStorageMigrationProgress) => void;
+  readonly dryRun?: boolean;
+  readonly force?: boolean;
+}): Promise<TokenStorageMigrationResult> {
+  return migrateTokenStorage({
+    source: opts.profile,
+    target: opts.legacy,
+    direction: 'profile-to-legacy',
+    identity: opts.identity,
+    oracle: opts.oracle,
+    markerStorage: opts.markerStorage,
+    onProgress: opts.onProgress,
+    dryRun: opts.dryRun,
+    force: opts.force,
+  });
+}
+
+/**
+ * Check whether a migration marker is present for `(direction,
+ * addressId)`. Useful for UIs that want to surface "wallet already
+ * migrated" without running the full helper.
+ */
+export async function isTokenStorageMigrationComplete(opts: {
+  readonly markerStorage: StorageProvider;
+  readonly direction: MigrationDirection;
+  readonly identity: FullIdentity;
+}): Promise<boolean> {
+  if (!opts.identity.directAddress) return false;
+  const addressId = getAddressId(opts.identity.directAddress);
+  const key = markerKeyFor(opts.direction, addressId);
+  const value = await opts.markerStorage.get(key);
+  return value !== null && value !== '';
+}
+
+/**
+ * Clear a previously-stamped migration marker. Use this when the
+ * consumer wants to force-rerun the migration on the next invocation
+ * (e.g., the user added more tokens to legacy after the first
+ * migration).
+ *
+ * Note: clearing the marker does NOT delete the migrated data on the
+ * target. The next migration run will re-write the target with the
+ * latest source snapshot.
+ */
+export async function clearTokenStorageMigrationMarker(opts: {
+  readonly markerStorage: StorageProvider;
+  readonly direction: MigrationDirection;
+  readonly identity: FullIdentity;
+}): Promise<void> {
+  if (!opts.identity.directAddress) return;
+  const addressId = getAddressId(opts.identity.directAddress);
+  const key = markerKeyFor(opts.direction, addressId);
+  await opts.markerStorage.remove(key);
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/**
+ * Build the marker key for a (direction, addressId) pair. The
+ * keyspace deliberately overlaps with `STORAGE_KEYS_GLOBAL` shape
+ * (`sphere_` prefix added by the provider) — addressId is appended
+ * with `:` so the marker is per-address even when wallets manage
+ * multiple HD addresses.
+ */
+function markerKeyFor(direction: MigrationDirection, addressId: string): string {
+  const prefix =
+    direction === 'legacy-to-profile'
+      ? MARKER_KEY_PREFIX_LEGACY_TO_PROFILE
+      : MARKER_KEY_PREFIX_PROFILE_TO_LEGACY;
+  // The StorageProvider implementations internally strip / add the
+  // `sphere_` prefix as needed. We pass the bare key so it works
+  // uniformly across IndexedDB / file / Profile providers.
+  void STORAGE_PREFIX; // documented dependency — no transformation needed here
+  return `${prefix}:${addressId}`;
+}
+
+interface TxfBuckets {
+  /** Active token entries (`_<tokenId>` keys, excluding reserved). */
+  activeTokens: Array<{ key: string; txf: TxfToken }>;
+  /** Archived token entries (`archived-<tokenId>` keys). */
+  archivedTokens: Array<{ key: string; txf: TxfToken }>;
+  /** Number of `_forked_*` keys observed (copied as-is to target). */
+  forksMigrated: number;
+}
+
+/**
+ * Walk a TxfStorageDataBase and bucket its keys. Reserved operational
+ * keys are recognized via {@link RESERVED_KEYS}; everything else is
+ * classified via the txf key helpers.
+ */
+function classifyBuckets(data: TxfStorageDataBase): TxfBuckets {
+  const activeTokens: Array<{ key: string; txf: TxfToken }> = [];
+  const archivedTokens: Array<{ key: string; txf: TxfToken }> = [];
+  let forksMigrated = 0;
+
+  for (const [key, value] of Object.entries(data)) {
+    if (RESERVED_KEYS.has(key)) continue;
+    if (isForkedKey(key)) {
+      // Forks are copied as-is by save() (whole-snapshot overwrite).
+      // We surface the count for operator visibility.
+      if (value && typeof value === 'object') forksMigrated += 1;
+      continue;
+    }
+    if (!value || typeof value !== 'object') continue;
+    const txf = value as TxfToken;
+    if (isArchivedKey(key)) {
+      archivedTokens.push({ key, txf });
+    } else if (isTokenKey(key)) {
+      activeTokens.push({ key, txf });
+    }
+  }
+
+  return { activeTokens, archivedTokens, forksMigrated };
+}
+
+/**
+ * Build a new TxfStorageDataBase whose top-level keys reference the
+ * same value objects as `data`. We do NOT deep-clone — the migration
+ * is treated as a read-only consumer of the source values, and the
+ * target.save() implementations are expected to serialize/copy on
+ * write.
+ */
+function shallowCopyStorageData(data: TxfStorageDataBase): TxfStorageDataBase {
+  const out: TxfStorageDataBase = {
+    _meta: { ...data._meta },
+  };
+  for (const [key, value] of Object.entries(data)) {
+    if (key === '_meta') continue;
+    (out as unknown as Record<string, unknown>)[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Extract the current state hash from a TxfToken by reading the last
+ * non-null inclusion proof's authenticator. Returns the empty string
+ * when the token has no committed state transitions (a pending mint
+ * — no state hash to probe).
+ */
+function extractCurrentStateHashFromTxf(txf: TxfToken): string {
+  if (!txf) return '';
+  // Walk transactions backwards — the latest committed transition is
+  // the one whose inclusionProof is non-null. Pending (uncommitted)
+  // transitions carry `inclusionProof: null` and have no committed
+  // state hash.
+  if (Array.isArray(txf.transactions) && txf.transactions.length > 0) {
+    for (let i = txf.transactions.length - 1; i >= 0; i -= 1) {
+      const tx = txf.transactions[i];
+      if (tx?.inclusionProof?.authenticator?.stateHash) {
+        return tx.inclusionProof.authenticator.stateHash;
+      }
+    }
+  }
+  // No committed transition — use the genesis inclusion proof's
+  // state hash (the mint commitment binds the genesis state).
+  if (txf.genesis?.inclusionProof?.authenticator?.stateHash) {
+    return txf.genesis.inclusionProof.authenticator.stateHash;
+  }
+  return '';
+}
+
+function emitProgress(
+  cb: ((p: TokenStorageMigrationProgress) => void) | undefined,
+  addressId: string,
+  direction: MigrationDirection,
+  phase: TokenStorageMigrationProgress['phase'],
+  processed: number,
+  total: number,
+): void {
+  if (!cb) return;
+  try {
+    cb({ addressId, direction, phase, processed, total });
+  } catch (err) {
+    // Never let a user-supplied progress callback abort the migration.
+    logger.debug(
+      'TokenStorageMigration',
+      `onProgress threw (ignored): ${errMsg(err)}`,
+    );
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+interface FailureResultArgs {
+  readonly addressId: string;
+  readonly direction: MigrationDirection;
+  readonly errors: ReadonlyArray<{ phase: TokenStorageMigrationProgress['phase']; error: string }>;
+  readonly dryRun: boolean;
+  readonly durationMs: number;
+  readonly counts?: TokenStorageMigrationCounts;
+}
+
+function failureResult(args: FailureResultArgs): TokenStorageMigrationResult {
+  const c = args.counts;
+  return {
+    success: false,
+    addressId: args.addressId,
+    direction: args.direction,
+    skippedDueToMarker: false,
+    dryRun: args.dryRun,
+    tokensMigrated: c?.tokensMigrated ?? 0,
+    archivedMigrated: c?.archivedMigrated ?? 0,
+    tombstonesMigrated: c?.tombstonesMigrated ?? 0,
+    outboxMigrated: c?.outboxMigrated ?? 0,
+    sentMigrated: c?.sentMigrated ?? 0,
+    historyMigrated: c?.historyMigrated ?? 0,
+    auditMigrated: c?.auditMigrated ?? 0,
+    finalizationQueueMigrated: c?.finalizationQueueMigrated ?? 0,
+    invalidMigrated: c?.invalidMigrated ?? 0,
+    forksMigrated: c?.forksMigrated ?? 0,
+    spentTokensArchived: c?.spentTokensArchived ?? 0,
+    oracleProbeErrors: c?.oracleProbeErrors ?? 0,
+    durationMs: args.durationMs,
+    errors: args.errors,
+  };
+}

--- a/profile/token-storage-migration.ts
+++ b/profile/token-storage-migration.ts
@@ -361,7 +361,7 @@ export async function migrateTokenStorage(
   if (!opts.force && opts.markerStorage) {
     try {
       const existing = await opts.markerStorage.get(markerKey);
-      if (existing) {
+      if (existing && isHonoredMarkerPayload(existing)) {
         logger.debug(
           'TokenStorageMigration',
           `marker present (${markerKey}); skipping (use force:true to override)`,
@@ -500,8 +500,23 @@ export async function migrateTokenStorage(
             // it; only spend selection / getAssets() will skip it.
             const tokenId = outcome.key.startsWith('_') ? outcome.key.slice(1) : outcome.key;
             const archivedKey = archivedKeyFromTokenId(tokenId);
-            (targetData as unknown as Record<string, unknown>)[archivedKey] = outcome.txf;
-            delete (targetData as unknown as Record<string, unknown>)[outcome.key];
+            const slot = targetData as unknown as Record<string, unknown>;
+            // Steelman fix (collision-safe): if the wallet ALREADY has
+            // an archived entry for this tokenId (legitimate after a
+            // reissue cycle), do NOT overwrite — the existing archived
+            // payload is its own historical record. Leave the active
+            // slot untouched in that case so the next load surfaces
+            // the apparent conflict (the disposition engine will
+            // resolve it via the standard archived/active rules).
+            if (slot[archivedKey] !== undefined) {
+              logger.debug(
+                'TokenStorageMigration',
+                `oracle reported ${outcome.key} spent, but target already has ${archivedKey} — leaving in active slot to avoid clobbering existing archived payload`,
+              );
+              continue;
+            }
+            slot[archivedKey] = outcome.txf;
+            delete slot[outcome.key];
             spentTokensArchived += 1;
           }
         }
@@ -509,17 +524,22 @@ export async function migrateTokenStorage(
     }
   }
 
-  // Refresh the `_meta` slot so the target carries the migration
-  // timestamp (the legacy save() honors whatever `_meta` we hand it;
-  // the Profile save() uses the existing _meta path). Without an
-  // explicit refresh the target inherits the source's `updatedAt`,
-  // which can look stale to operators inspecting the target.
-  if (targetData._meta) {
-    targetData._meta = {
-      ...targetData._meta,
-      updatedAt: Date.now(),
-    };
-  }
+  // Refresh / synthesize the `_meta` slot. The Profile and legacy
+  // providers always populate `_meta` on load(), so the source path
+  // typically already provides it. We defensively synthesize the
+  // four required TxfMeta fields here so a buggy source (or an
+  // imported file with a partial `_meta`) doesn't propagate
+  // malformed metadata to the target. The `updatedAt` is always
+  // refreshed to the migration time so operators can distinguish
+  // the post-migration meta from the source's pre-migration meta.
+  const sourceMeta = targetData._meta ?? ({} as Partial<TxfStorageDataBase['_meta']>);
+  targetData._meta = {
+    version: sourceMeta.version ?? 1,
+    address: sourceMeta.address ?? (opts.identity.l1Address ?? ''),
+    formatVersion: sourceMeta.formatVersion ?? '2.0',
+    ipnsName: sourceMeta.ipnsName,
+    updatedAt: Date.now(),
+  };
 
   // ── Phase 4: dry-run early exit ────────────────────────────────────────
   const finalBuckets = classifyBuckets(targetData);
@@ -777,6 +797,48 @@ export async function clearTokenStorageMigrationMarker(opts: {
  * with `:` so the marker is per-address even when wallets manage
  * multiple HD addresses.
  */
+/**
+ * Decide whether a stored marker value should be HONORED as
+ * "migration complete." Honored markers short-circuit the migration;
+ * non-honored markers cause the helper to re-run.
+ *
+ * The honored set is:
+ *   - any value missing the `v` field (legacy / pre-versioned marker
+ *     — treated as v=1 for backward compat)
+ *   - any value whose `v` is ≤ {@link TOKEN_STORAGE_MIGRATION_MARKER_VERSION}
+ *
+ * Markers from a FUTURE schema version are NOT honored — a v:2
+ * marker from a newer SDK may describe data the older v:1 reader
+ * cannot represent, so the safer behavior is to re-run the
+ * migration (which is data-idempotent) than to assume forward-
+ * compat. Steelman finding 2 (PR #289 review).
+ */
+function isHonoredMarkerPayload(raw: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Pre-versioned plain-string marker (or corruption). Treat as
+    // honored — preserves backward-compat for any consumer who
+    // wrote a non-JSON marker through an older API surface.
+    return true;
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    // Same backward-compat reasoning.
+    return true;
+  }
+  const obj = parsed as { v?: unknown };
+  if (obj.v === undefined) {
+    // Pre-versioned JSON marker — honored.
+    return true;
+  }
+  if (typeof obj.v !== 'number' || !Number.isFinite(obj.v) || obj.v < 0) {
+    // Malformed `v` field — re-run is the safe choice.
+    return false;
+  }
+  return obj.v <= TOKEN_STORAGE_MIGRATION_MARKER_VERSION;
+}
+
 function markerKeyFor(direction: MigrationDirection, addressId: string): string {
   const prefix =
     direction === 'legacy-to-profile'

--- a/tests/integration/profile/token-storage-migration.test.ts
+++ b/tests/integration/profile/token-storage-migration.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Integration tests for profile/token-storage-migration.ts (Issue #286).
+ *
+ * Uses real `FileTokenStorageProvider` + `FileStorageProvider` (no
+ * IPFS, no OrbitDB) to verify the migration helper at the storage-
+ * provider boundary. The Profile-backed providers are exercised only
+ * by the unit test (Profile setup is heavy) — the file-based
+ * integration is the closest representative we can run in CI without
+ * spinning IPFS gateways.
+ *
+ * The integration test focuses on two scenarios:
+ *   - End-to-end round-trip: legacy → "target" → reverse legacy → bytes
+ *     preserved (the acceptance scenario from the issue body).
+ *   - Replay of the sphere.telco PR #305 regression: a fresh target
+ *     provider with no migration sees no tokens; the same target after
+ *     migration sees the original token set.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { FileTokenStorageProvider } from '../../../impl/nodejs/storage/FileTokenStorageProvider';
+import { FileStorageProvider } from '../../../impl/nodejs/storage/FileStorageProvider';
+import {
+  migrateLegacyToProfile,
+  migrateProfileToLegacy,
+  isTokenStorageMigrationComplete,
+} from '../../../profile/token-storage-migration';
+import type { FullIdentity } from '../../../types';
+import type { TxfToken } from '../../../types/txf';
+import type { TxfStorageDataBase } from '../../../storage';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const IDENTITY: FullIdentity = {
+  privateKey: '00' + '11'.repeat(31),
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddr',
+  directAddress: 'DIRECT://test',
+  nametag: 'testuser',
+};
+
+function buildTxfToken(tokenId: string): TxfToken {
+  return {
+    version: '2.0',
+    genesis: {
+      data: {
+        tokenId,
+        tokenType: '01'.repeat(32),
+        coinData: [['UCT_HEX', '1000']],
+        tokenData: '',
+        salt: '55'.repeat(32),
+        recipient: 'DIRECT://test',
+        recipientDataHash: null,
+        reason: null,
+      },
+      inclusionProof: {
+        authenticator: {
+          algorithm: 'secp256k1',
+          publicKey: '02' + 'aa'.repeat(32),
+          signature: '30' + '44'.repeat(35),
+          stateHash: '0000' + 'a'.repeat(64),
+        },
+        merkleTreePath: { root: '00'.repeat(32), steps: [] },
+        transactionHash: 'cd'.repeat(32),
+        unicityCertificate: 'ab'.repeat(32),
+      },
+    },
+    state: { data: '', predicate: 'de'.repeat(32) },
+    transactions: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('migrateTokenStorage — file-storage integration', () => {
+  let sourceDir: string;
+  let targetDir: string;
+  let kvDir: string;
+
+  beforeEach(() => {
+    sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-src-'));
+    targetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-tgt-'));
+    kvDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-kv-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+    fs.rmSync(targetDir, { recursive: true, force: true });
+    fs.rmSync(kvDir, { recursive: true, force: true });
+  });
+
+  it('end-to-end migrates a populated legacy provider to a fresh target', async () => {
+    // Stage 1: seed the source provider with two tokens.
+    const source = new FileTokenStorageProvider({ tokensDir: sourceDir });
+    source.setIdentity(IDENTITY);
+    await source.initialize();
+
+    const tokenA = '0' + 'a'.repeat(63);
+    const tokenB = '0' + 'b'.repeat(63);
+    const seedData: TxfStorageDataBase = {
+      _meta: {
+        version: 1,
+        address: IDENTITY.l1Address,
+        formatVersion: '2.0',
+        updatedAt: Date.now(),
+      },
+      [`_${tokenA}`]: buildTxfToken(tokenA),
+      [`_${tokenB}`]: buildTxfToken(tokenB),
+      _tombstones: [
+        { tokenId: 'old', stateHash: 'x', timestamp: Date.now() },
+      ],
+    };
+    await source.save(seedData);
+    await source.shutdown();
+
+    // Stage 2: spin up source and a fresh target. The target should
+    // start empty — this models the PR #305 regression (a wallet that
+    // swapped tokenStorage to a fresh provider and saw balance go to 0).
+    const sourceReadOnly = new FileTokenStorageProvider({ tokensDir: sourceDir });
+    sourceReadOnly.setIdentity(IDENTITY);
+    await sourceReadOnly.initialize();
+
+    const target = new FileTokenStorageProvider({ tokensDir: targetDir });
+    target.setIdentity(IDENTITY);
+    await target.initialize();
+
+    // Pre-migration baseline — target sees nothing (the regression).
+    const preLoad = await target.load();
+    expect(preLoad.success).toBe(true);
+    const preTokenKeys = Object.keys(preLoad.data ?? {}).filter(
+      (k) => k.startsWith('_') && k !== '_meta' && k !== '_tombstones',
+    );
+    expect(preTokenKeys.length).toBe(0);
+
+    // Stage 3: migrate. Use the convenience wrapper.
+    const kv = new FileStorageProvider({ dataDir: kvDir });
+    kv.setIdentity(IDENTITY);
+    await kv.connect();
+
+    const result = await migrateLegacyToProfile({
+      legacy: sourceReadOnly,
+      // FileTokenStorageProvider is a stand-in for the Profile target —
+      // we exercise the migration helper at the TokenStorageProvider
+      // boundary, so any provider works for the storage round-trip
+      // contract. Profile-specific behavior (CAR encoding, OpLog
+      // caps) is covered by the Profile unit tests.
+      profile: target,
+      identity: IDENTITY,
+      markerStorage: kv,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.skippedDueToMarker).toBe(false);
+    expect(result.tokensMigrated).toBe(2);
+    expect(result.tombstonesMigrated).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    // Stage 4: re-open target and confirm tokens are visible.
+    const targetReload = new FileTokenStorageProvider({ tokensDir: targetDir });
+    targetReload.setIdentity(IDENTITY);
+    await targetReload.initialize();
+    const postLoad = await targetReload.load();
+    expect(postLoad.success).toBe(true);
+    expect(postLoad.data?.[`_${tokenA}`]).toBeDefined();
+    expect(postLoad.data?.[`_${tokenB}`]).toBeDefined();
+    expect(postLoad.data?._tombstones).toHaveLength(1);
+
+    // Stage 5: marker is set; re-running is a no-op.
+    expect(
+      await isTokenStorageMigrationComplete({
+        markerStorage: kv,
+        direction: 'legacy-to-profile',
+        identity: IDENTITY,
+      }),
+    ).toBe(true);
+
+    const secondRun = await migrateLegacyToProfile({
+      legacy: sourceReadOnly,
+      profile: target,
+      identity: IDENTITY,
+      markerStorage: kv,
+    });
+    expect(secondRun.skippedDueToMarker).toBe(true);
+    expect(secondRun.tokensMigrated).toBe(0);
+
+    // Cleanup
+    await sourceReadOnly.shutdown();
+    await target.shutdown();
+    await targetReload.shutdown();
+    await kv.disconnect();
+  });
+
+  it('reverse migration (profile → legacy) preserves token payload bytes', async () => {
+    // Seed source
+    const source = new FileTokenStorageProvider({ tokensDir: sourceDir });
+    source.setIdentity(IDENTITY);
+    await source.initialize();
+
+    const tokenA = '0' + 'a'.repeat(63);
+    const seed: TxfStorageDataBase = {
+      _meta: {
+        version: 1,
+        address: IDENTITY.l1Address,
+        formatVersion: '2.0',
+        updatedAt: 1000,
+      },
+      [`_${tokenA}`]: buildTxfToken(tokenA),
+    };
+    await source.save(seed);
+    await source.shutdown();
+
+    // Migrate forward (legacy → "profile")
+    const sourceReadOnly = new FileTokenStorageProvider({ tokensDir: sourceDir });
+    sourceReadOnly.setIdentity(IDENTITY);
+    await sourceReadOnly.initialize();
+    const profileLike = new FileTokenStorageProvider({ tokensDir: targetDir });
+    profileLike.setIdentity(IDENTITY);
+    await profileLike.initialize();
+
+    await migrateLegacyToProfile({
+      legacy: sourceReadOnly,
+      profile: profileLike,
+      identity: IDENTITY,
+    });
+
+    // Now reverse: profile-like → fresh legacy
+    const reverseLegacyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-rev-'));
+    try {
+      const reverseLegacy = new FileTokenStorageProvider({ tokensDir: reverseLegacyDir });
+      reverseLegacy.setIdentity(IDENTITY);
+      await reverseLegacy.initialize();
+
+      const result = await migrateProfileToLegacy({
+        profile: profileLike,
+        legacy: reverseLegacy,
+        identity: IDENTITY,
+      });
+      expect(result.success).toBe(true);
+      expect(result.direction).toBe('profile-to-legacy');
+      expect(result.tokensMigrated).toBe(1);
+
+      // Verify the reverse legacy provider sees the token after reload.
+      await reverseLegacy.shutdown();
+      const reverseReload = new FileTokenStorageProvider({ tokensDir: reverseLegacyDir });
+      reverseReload.setIdentity(IDENTITY);
+      await reverseReload.initialize();
+      const final = await reverseReload.load();
+      expect(final.success).toBe(true);
+      expect(final.data?.[`_${tokenA}`]).toBeDefined();
+
+      // The payload bytes match the seed (excluding _meta.updatedAt
+      // which the migration refreshes).
+      expect(final.data?.[`_${tokenA}`]).toEqual(seed[`_${tokenA}`]);
+
+      await reverseReload.shutdown();
+    } finally {
+      fs.rmSync(reverseLegacyDir, { recursive: true, force: true });
+    }
+
+    await sourceReadOnly.shutdown();
+    await profileLike.shutdown();
+  });
+
+  it('rerunning after marker clear re-migrates fresh source data', async () => {
+    const source = new FileTokenStorageProvider({ tokensDir: sourceDir });
+    source.setIdentity(IDENTITY);
+    await source.initialize();
+    const tokenA = '0' + 'a'.repeat(63);
+    await source.save({
+      _meta: {
+        version: 1,
+        address: IDENTITY.l1Address,
+        formatVersion: '2.0',
+        updatedAt: 1,
+      },
+      [`_${tokenA}`]: buildTxfToken(tokenA),
+    } as TxfStorageDataBase);
+
+    const target = new FileTokenStorageProvider({ tokensDir: targetDir });
+    target.setIdentity(IDENTITY);
+    await target.initialize();
+
+    const kv = new FileStorageProvider({ dataDir: kvDir });
+    kv.setIdentity(IDENTITY);
+    await kv.connect();
+
+    // First run
+    await migrateLegacyToProfile({
+      legacy: source,
+      profile: target,
+      identity: IDENTITY,
+      markerStorage: kv,
+    });
+
+    // Add a second token to source
+    const tokenB = '0' + 'b'.repeat(63);
+    const sourceData = (await source.load()).data!;
+    sourceData[`_${tokenB}` as keyof TxfStorageDataBase] = buildTxfToken(tokenB);
+    await source.save(sourceData);
+
+    // Second run with marker present — skipped.
+    const skipped = await migrateLegacyToProfile({
+      legacy: source,
+      profile: target,
+      identity: IDENTITY,
+      markerStorage: kv,
+    });
+    expect(skipped.skippedDueToMarker).toBe(true);
+
+    // Now force-rerun → tokenB is migrated.
+    const forced = await migrateLegacyToProfile({
+      legacy: source,
+      profile: target,
+      identity: IDENTITY,
+      markerStorage: kv,
+      force: true,
+    });
+    expect(forced.skippedDueToMarker).toBe(false);
+    expect(forced.tokensMigrated).toBe(2);
+
+    await source.shutdown();
+    await target.shutdown();
+    await kv.disconnect();
+  });
+});

--- a/tests/unit/profile/token-storage-migration.test.ts
+++ b/tests/unit/profile/token-storage-migration.test.ts
@@ -1,0 +1,998 @@
+/**
+ * Tests for profile/token-storage-migration.ts (Issue #286)
+ *
+ * Verifies the bidirectional legacy ↔ Profile token-storage migration
+ * helper. The helper is deliberately decoupled from PaymentsModule —
+ * it operates at the `TokenStorageProvider` level — so the tests use
+ * in-memory mock providers rather than a live SDK.
+ *
+ * Coverage:
+ *   - 0-token migration is a noop with the marker set.
+ *   - Token + archived + tombstone + OUTBOX + SENT + history + audit
+ *     + finalizationQueue + invalid copy across with identical bytes.
+ *   - Forked entries are counted but never copied (avoid silent state
+ *     regressions).
+ *   - 1500-token migration completes without error (no MAX_PAYLOAD_BYTES
+ *     fail-loud — the helper writes via target.save which uses CARs).
+ *   - Aggregator-spent gating: spent tokens are demoted to archived.
+ *   - Aggregator probe error: token left in source slot, error counted.
+ *   - Re-entry with marker set is a no-op (skippedDueToMarker).
+ *   - Re-entry with force:true bypasses the marker.
+ *   - Partial-progress recovery: marker write fails mid-run → second
+ *     run resumes safely (re-writes target, re-stamps marker).
+ *   - Reverse direction: profile → legacy preserves bytes.
+ *   - Dry-run: counts non-zero but target.save not called.
+ *   - Crash-safety: target.save failure does NOT stamp marker.
+ *   - awaitNextFlush failure does NOT stamp marker.
+ *   - identity without directAddress fails fast.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  migrateTokenStorage,
+  migrateLegacyToProfile,
+  migrateProfileToLegacy,
+  isTokenStorageMigrationComplete,
+  clearTokenStorageMigrationMarker,
+  TOKEN_STORAGE_MIGRATION_MARKER_VERSION,
+} from '../../../profile/token-storage-migration';
+import type {
+  TokenStorageProvider,
+  TxfStorageDataBase,
+  StorageProvider,
+} from '../../../storage';
+import type { OracleProvider } from '../../../oracle';
+import type { FullIdentity } from '../../../types';
+import type { TxfToken } from '../../../types/txf';
+import { getAddressId } from '../../../constants';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TOKEN_A = 'aa' + '00'.repeat(31);
+const TOKEN_B = 'bb' + '00'.repeat(31);
+const TOKEN_C = 'cc' + '00'.repeat(31);
+const TOKEN_D = 'dd' + '00'.repeat(31);
+const STATE_HASH_A = '0000' + 'a'.repeat(64);
+const STATE_HASH_B = '0000' + 'b'.repeat(64);
+const STATE_HASH_C = '0000' + 'c'.repeat(64);
+
+const IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1test',
+  directAddress: 'DIRECT://test',
+  privateKey: '00' + '11'.repeat(31),
+};
+
+const ADDRESS_ID = getAddressId(IDENTITY.directAddress!);
+
+function buildTxf(tokenId: string, stateHash?: string): TxfToken {
+  return {
+    version: '2.0',
+    genesis: {
+      data: {
+        tokenId,
+        tokenType: '01'.repeat(32),
+        coinData: [['UCT_HEX', '1000']],
+        tokenData: '',
+        salt: '55'.repeat(32),
+        recipient: 'DIRECT://test',
+        recipientDataHash: null,
+        reason: null,
+      },
+      inclusionProof: {
+        authenticator: {
+          algorithm: 'secp256k1',
+          publicKey: '02' + 'aa'.repeat(32),
+          signature: '30' + '44'.repeat(35),
+          stateHash: stateHash ?? STATE_HASH_A,
+        },
+        merkleTreePath: { root: '00'.repeat(32), steps: [] },
+        transactionHash: 'cd'.repeat(32),
+        unicityCertificate: 'ab'.repeat(32),
+      },
+    },
+    state: { data: '', predicate: 'de'.repeat(32) },
+    transactions: [],
+  };
+}
+
+interface MockProviderOptions {
+  failLoad?: boolean;
+  failSave?: boolean;
+  /** When set, awaitNextFlush throws on call. */
+  failFlush?: boolean;
+  /** When set, the provider exposes awaitNextFlush as a vi.fn. */
+  exposeAwaitNextFlush?: boolean;
+}
+
+interface MockProvider extends TokenStorageProvider<TxfStorageDataBase> {
+  /** Operations the test should observe. */
+  _calls: string[];
+  /** Last data passed to save(). */
+  _lastSavedData: TxfStorageDataBase | null;
+  /** Mutate the stored snapshot directly (test helper). */
+  _setStored(data: TxfStorageDataBase | null): void;
+}
+
+function createMockProvider(
+  initial: TxfStorageDataBase | null = null,
+  opts: MockProviderOptions = {},
+): MockProvider {
+  const calls: string[] = [];
+  let stored: TxfStorageDataBase | null = initial;
+  const provider: MockProvider = {
+    id: 'mock',
+    name: 'mock',
+    type: 'local',
+    _calls: calls,
+    _lastSavedData: null,
+    _setStored(data) {
+      stored = data;
+    },
+    async connect() {
+      calls.push('connect');
+    },
+    async disconnect() {
+      calls.push('disconnect');
+    },
+    isConnected() {
+      return true;
+    },
+    getStatus() {
+      return 'connected';
+    },
+    setIdentity() {
+      calls.push('setIdentity');
+    },
+    async initialize() {
+      calls.push('initialize');
+      return true;
+    },
+    async shutdown() {
+      calls.push('shutdown');
+    },
+    async load() {
+      calls.push('load');
+      if (opts.failLoad) {
+        return {
+          success: false,
+          source: 'local',
+          timestamp: Date.now(),
+          error: 'mock load failed',
+        };
+      }
+      return {
+        success: true,
+        data: stored ?? undefined,
+        source: 'local',
+        timestamp: Date.now(),
+      };
+    },
+    async save(data: TxfStorageDataBase) {
+      calls.push('save');
+      provider._lastSavedData = data;
+      if (opts.failSave) {
+        return {
+          success: false,
+          timestamp: Date.now(),
+          error: 'mock save failed',
+        };
+      }
+      stored = data;
+      return { success: true, timestamp: Date.now() };
+    },
+    async sync(localData) {
+      calls.push('sync');
+      return { success: true, merged: localData, added: 0, removed: 0, conflicts: 0 };
+    },
+  };
+
+  if (opts.exposeAwaitNextFlush) {
+    provider.awaitNextFlush = async () => {
+      calls.push('awaitNextFlush');
+      if (opts.failFlush) {
+        throw new Error('mock flush failure');
+      }
+    };
+  }
+
+  return provider;
+}
+
+function createMockKvStorage(): StorageProvider & {
+  _store: Map<string, string>;
+  _calls: string[];
+} {
+  const store = new Map<string, string>();
+  const calls: string[] = [];
+  return {
+    _store: store,
+    _calls: calls,
+    id: 'mock-kv',
+    name: 'mock-kv',
+    type: 'local',
+    async connect() {},
+    async disconnect() {},
+    isConnected() {
+      return true;
+    },
+    getStatus() {
+      return 'connected';
+    },
+    setIdentity() {},
+    async get(key: string) {
+      calls.push(`get:${key}`);
+      return store.get(key) ?? null;
+    },
+    async set(key: string, value: string) {
+      calls.push(`set:${key}`);
+      store.set(key, value);
+    },
+    async remove(key: string) {
+      calls.push(`remove:${key}`);
+      store.delete(key);
+    },
+    async has(key: string) {
+      return store.has(key);
+    },
+    async keys(prefix?: string) {
+      const all = Array.from(store.keys());
+      return prefix ? all.filter((k) => k.startsWith(prefix)) : all;
+    },
+    async clear(prefix?: string) {
+      if (prefix) {
+        for (const k of Array.from(store.keys())) {
+          if (k.startsWith(prefix)) store.delete(k);
+        }
+      } else {
+        store.clear();
+      }
+    },
+    async saveTrackedAddresses() {},
+    async loadTrackedAddresses() {
+      return [];
+    },
+  };
+}
+
+function buildSourceData(opts: {
+  active?: string[];
+  archived?: string[];
+  forked?: Array<{ tokenId: string; stateHash: string }>;
+  withTombstones?: boolean;
+  withOutbox?: boolean;
+  withSent?: boolean;
+  withHistory?: boolean;
+  withAudit?: boolean;
+  withFinalizationQueue?: boolean;
+  withInvalid?: boolean;
+  customStateHashes?: Record<string, string>;
+}): TxfStorageDataBase {
+  const data: Record<string, unknown> = {
+    _meta: {
+      version: 1,
+      address: IDENTITY.l1Address,
+      formatVersion: '2.0',
+      updatedAt: 1000,
+    },
+  };
+  for (const tid of opts.active ?? []) {
+    data[`_${tid}`] = buildTxf(tid, opts.customStateHashes?.[tid]);
+  }
+  for (const tid of opts.archived ?? []) {
+    data[`archived-${tid}`] = buildTxf(tid);
+  }
+  for (const f of opts.forked ?? []) {
+    data[`_forked_${f.tokenId}_${f.stateHash}`] = buildTxf(f.tokenId);
+  }
+  if (opts.withTombstones) {
+    data._tombstones = [{ tokenId: TOKEN_D, stateHash: STATE_HASH_C, timestamp: 1234 }];
+  }
+  if (opts.withOutbox) {
+    data._outbox = [
+      { id: 'o1', status: 'pending', tokenId: TOKEN_A, recipient: 'r', createdAt: 0, data: {} },
+    ];
+  }
+  if (opts.withSent) {
+    data._sent = [
+      { tokenId: TOKEN_A, recipient: 'r', txHash: 'h', sentAt: 0 },
+    ];
+  }
+  if (opts.withHistory) {
+    data._history = [
+      {
+        dedupKey: 'SENT_x',
+        id: 'h1',
+        type: 'SENT',
+        amount: '100',
+        coinId: 'UCT',
+        symbol: 'UCT',
+        timestamp: 1,
+      },
+    ];
+  }
+  if (opts.withAudit) {
+    data._audit = [
+      { id: `${TOKEN_A}.h`, tokenId: TOKEN_A, disposition: 'NOT_OUR_CURRENT_STATE', detectedAt: 1 },
+    ];
+  }
+  if (opts.withFinalizationQueue) {
+    data._finalizationQueue = [{ id: 'req1', status: 'pending', enqueuedAt: 0 }];
+  }
+  if (opts.withInvalid) {
+    data._invalid = [{ tokenId: TOKEN_A, reason: 'test', detectedAt: 0 }];
+  }
+  return data as TxfStorageDataBase;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('migrateTokenStorage — happy path', () => {
+  it('0-token migration → noop with marker set', async () => {
+    const source = createMockProvider(buildSourceData({}));
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.tokensMigrated).toBe(0);
+    expect(result.skippedDueToMarker).toBe(false);
+    // Target.save was called once (with the empty TxfStorageDataBase).
+    expect(target._calls.filter((c) => c === 'save').length).toBe(1);
+    // Marker is set.
+    const markerKey = `legacy_migration_v1_complete:${ADDRESS_ID}`;
+    expect(marker._store.has(markerKey)).toBe(true);
+    const payload = JSON.parse(marker._store.get(markerKey)!);
+    expect(payload.v).toBe(TOKEN_STORAGE_MIGRATION_MARKER_VERSION);
+    expect(payload.direction).toBe('legacy-to-profile');
+  });
+
+  it('copies every TxfStorageDataBase field', async () => {
+    const source = createMockProvider(
+      buildSourceData({
+        active: [TOKEN_A, TOKEN_B],
+        archived: [TOKEN_C],
+        withTombstones: true,
+        withOutbox: true,
+        withSent: true,
+        withHistory: true,
+        withAudit: true,
+        withFinalizationQueue: true,
+        withInvalid: true,
+      }),
+    );
+    const target = createMockProvider(null);
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.tokensMigrated).toBe(2);
+    expect(result.archivedMigrated).toBe(1);
+    expect(result.tombstonesMigrated).toBe(1);
+    expect(result.outboxMigrated).toBe(1);
+    expect(result.sentMigrated).toBe(1);
+    expect(result.historyMigrated).toBe(1);
+    expect(result.auditMigrated).toBe(1);
+    expect(result.finalizationQueueMigrated).toBe(1);
+    expect(result.invalidMigrated).toBe(1);
+
+    // Verify the target snapshot is identical to source minus _meta.updatedAt
+    const targetData = target._lastSavedData!;
+    expect(targetData).not.toBeNull();
+    expect(targetData[`_${TOKEN_A}`]).toBeDefined();
+    expect(targetData[`_${TOKEN_B}`]).toBeDefined();
+    expect(targetData[`archived-${TOKEN_C}`]).toBeDefined();
+    expect(targetData._tombstones).toHaveLength(1);
+    expect(targetData._outbox).toHaveLength(1);
+    expect(targetData._sent).toHaveLength(1);
+    expect(targetData._history).toHaveLength(1);
+    expect(targetData._audit).toHaveLength(1);
+    expect(targetData._finalizationQueue).toHaveLength(1);
+    expect(targetData._invalid).toHaveLength(1);
+  });
+
+  it('source is read-only (no save/sync called on source)', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+    });
+    // Only `load` should have been called on source.
+    expect(source._calls.filter((c) => c !== 'load')).toEqual([]);
+  });
+
+  it('forked entries are migrated as-is (no key collision; preserves audit trail)', async () => {
+    const source = createMockProvider(
+      buildSourceData({
+        active: [TOKEN_A],
+        forked: [{ tokenId: TOKEN_B, stateHash: STATE_HASH_A }],
+      }),
+    );
+    const target = createMockProvider(null);
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+    });
+    // forksMigrated counts the forks copied. tokensMigrated only counts
+    // ACTIVE token entries (`_<tokenId>` keys excluding reserved /
+    // archived / forked).
+    expect(result.tokensMigrated).toBe(1);
+    expect(result.forksMigrated).toBe(1);
+    // Forked key IS present on target (storage-level byte-copy).
+    const targetData = target._lastSavedData!;
+    const forkedKey = `_forked_${TOKEN_B}_${STATE_HASH_A}`;
+    expect(targetData[forkedKey as keyof TxfStorageDataBase]).toBeDefined();
+  });
+});
+
+describe('migrateTokenStorage — scale', () => {
+  it('1500-token migration completes without payload-cap errors', async () => {
+    const activeTokens = Array.from(
+      { length: 1500 },
+      (_, i) => i.toString(16).padStart(2, '0').repeat(32),
+    );
+    const source = createMockProvider(buildSourceData({ active: activeTokens }));
+    const target = createMockProvider(null);
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+    });
+    expect(result.success).toBe(true);
+    expect(result.tokensMigrated).toBe(1500);
+    // Single save call regardless of token count — target.save() handles
+    // chunking internally (UXF CAR for Profile, multi-file for legacy).
+    expect(target._calls.filter((c) => c === 'save').length).toBe(1);
+  });
+});
+
+describe('migrateTokenStorage — aggregator-spent gating', () => {
+  it('spent token is demoted from active to archived', async () => {
+    const source = createMockProvider(
+      buildSourceData({
+        active: [TOKEN_A, TOKEN_B],
+        customStateHashes: { [TOKEN_A]: STATE_HASH_A, [TOKEN_B]: STATE_HASH_B },
+      }),
+    );
+    const target = createMockProvider(null);
+    const oracle = {
+      isSpent: vi.fn(async (_pk: string, stateHash: string) => stateHash === STATE_HASH_A),
+    } as unknown as OracleProvider;
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      oracle,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.tokensMigrated).toBe(1); // TOKEN_B only
+    expect(result.archivedMigrated).toBe(1); // TOKEN_A demoted to archived
+    expect(result.spentTokensArchived).toBe(1);
+    expect(result.oracleProbeErrors).toBe(0);
+
+    const targetData = target._lastSavedData!;
+    expect(targetData[`_${TOKEN_A}`]).toBeUndefined();
+    expect(targetData[`archived-${TOKEN_A}`]).toBeDefined();
+    expect(targetData[`_${TOKEN_B}`]).toBeDefined();
+  });
+
+  it('oracle probe throws → token stays in active slot, error counted', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const oracle = {
+      isSpent: vi.fn(async () => {
+        throw new Error('aggregator unreachable');
+      }),
+    } as unknown as OracleProvider;
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      oracle,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.tokensMigrated).toBe(1);
+    expect(result.spentTokensArchived).toBe(0);
+    expect(result.oracleProbeErrors).toBe(1);
+
+    // Token still in active slot on target.
+    const targetData = target._lastSavedData!;
+    expect(targetData[`_${TOKEN_A}`]).toBeDefined();
+  });
+
+  it('oracle present but no chainPubkey on identity → probe skipped with error', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const oracle = {
+      isSpent: vi.fn(async () => true),
+    } as unknown as OracleProvider;
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: { ...IDENTITY, chainPubkey: '' },
+      oracle,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.spentTokensArchived).toBe(0);
+    // isSpent was not called (no pubkey).
+    expect(oracle.isSpent).not.toHaveBeenCalled();
+    expect(result.errors.some((e) => /chainPubkey/.test(e.error))).toBe(true);
+  });
+});
+
+describe('migrateTokenStorage — idempotency', () => {
+  it('marker present + no force → second run is a no-op', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+
+    const first = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+    expect(first.success).toBe(true);
+    expect(first.skippedDueToMarker).toBe(false);
+
+    const second = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+    expect(second.success).toBe(true);
+    expect(second.skippedDueToMarker).toBe(true);
+    expect(second.tokensMigrated).toBe(0);
+    // Target.save NOT called the second time.
+    expect(target._calls.filter((c) => c === 'save').length).toBe(1);
+  });
+
+  it('force:true bypasses the marker', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+
+    await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+    const second = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+      force: true,
+    });
+    expect(second.skippedDueToMarker).toBe(false);
+    expect(second.tokensMigrated).toBe(1);
+    expect(target._calls.filter((c) => c === 'save').length).toBe(2);
+  });
+
+  it('no marker storage provided → never short-circuits', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+
+    const first = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+    });
+    const second = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+    });
+    expect(first.tokensMigrated).toBe(1);
+    expect(second.tokensMigrated).toBe(1);
+    expect(target._calls.filter((c) => c === 'save').length).toBe(2);
+  });
+
+  it('legacy-to-profile marker does not collide with profile-to-legacy marker', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+
+    // First direction stamps its marker.
+    await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+
+    // Reverse direction sees no marker → runs.
+    const reverse = await migrateTokenStorage({
+      source: target, // swapped
+      target: source, // swapped (the function does not actually mutate source —
+                       // a mock provider will just save into the data slot)
+      direction: 'profile-to-legacy',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+    expect(reverse.skippedDueToMarker).toBe(false);
+  });
+});
+
+describe('migrateTokenStorage — partial-progress recovery', () => {
+  it('marker write fails mid-run → data is durable; second run completes', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+
+    // Patch marker.set to throw once.
+    let setCallCount = 0;
+    const originalSet = marker.set.bind(marker);
+    marker.set = vi.fn(async (key: string, value: string) => {
+      setCallCount += 1;
+      if (setCallCount === 1) {
+        throw new Error('mock marker write failure');
+      }
+      return originalSet(key, value);
+    });
+
+    const first = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+    // Migration is reported as SUCCESS even if marker stamp failed:
+    // the data IS durable, the next run will simply re-stamp.
+    expect(first.success).toBe(true);
+    expect(first.tokensMigrated).toBe(1);
+    expect(first.errors.some((e) => e.phase === 'stamp-marker')).toBe(true);
+
+    // Second run: marker not set → migration repeats → marker stamped.
+    const second = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+    expect(second.skippedDueToMarker).toBe(false);
+    expect(second.tokensMigrated).toBe(1);
+    const markerKey = `legacy_migration_v1_complete:${ADDRESS_ID}`;
+    expect(marker._store.has(markerKey)).toBe(true);
+  });
+
+  it('target.save failure does NOT stamp marker', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null, { failSave: true });
+    const marker = createMockKvStorage();
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((e) => e.phase === 'target-save')).toBe(true);
+    // Marker NOT stamped.
+    const markerKey = `legacy_migration_v1_complete:${ADDRESS_ID}`;
+    expect(marker._store.has(markerKey)).toBe(false);
+  });
+
+  it('awaitNextFlush failure does NOT stamp marker', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null, {
+      exposeAwaitNextFlush: true,
+      failFlush: true,
+    });
+    const marker = createMockKvStorage();
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((e) => e.phase === 'await-flush')).toBe(true);
+    const markerKey = `legacy_migration_v1_complete:${ADDRESS_ID}`;
+    expect(marker._store.has(markerKey)).toBe(false);
+  });
+
+  it('awaitNextFlush is called when target exposes it', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null, { exposeAwaitNextFlush: true });
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+    });
+    expect(result.success).toBe(true);
+    expect(target._calls.includes('awaitNextFlush')).toBe(true);
+  });
+
+  it('source.load failure → fast-fail result without target write', async () => {
+    const source = createMockProvider(null, { failLoad: true });
+    const target = createMockProvider(null);
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+    });
+    expect(result.success).toBe(false);
+    expect(target._calls.includes('save')).toBe(false);
+  });
+});
+
+describe('migrateTokenStorage — reverse direction (rollback)', () => {
+  it('migrateProfileToLegacy preserves all fields', async () => {
+    const sourceData = buildSourceData({
+      active: [TOKEN_A, TOKEN_B],
+      archived: [TOKEN_C],
+      withTombstones: true,
+      withOutbox: true,
+      withSent: true,
+    });
+    const profile = createMockProvider(sourceData);
+    const legacy = createMockProvider(null);
+
+    const result = await migrateProfileToLegacy({
+      profile,
+      legacy,
+      identity: IDENTITY,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.direction).toBe('profile-to-legacy');
+    expect(result.tokensMigrated).toBe(2);
+    expect(result.archivedMigrated).toBe(1);
+    expect(result.tombstonesMigrated).toBe(1);
+
+    const targetData = legacy._lastSavedData!;
+    expect(targetData[`_${TOKEN_A}`]).toBeDefined();
+    expect(targetData[`_${TOKEN_B}`]).toBeDefined();
+    expect(targetData[`archived-${TOKEN_C}`]).toBeDefined();
+  });
+
+  it('full round-trip: legacy → profile → legacy preserves bytes', async () => {
+    const initial = buildSourceData({
+      active: [TOKEN_A, TOKEN_B],
+      archived: [TOKEN_C],
+      withTombstones: true,
+      withHistory: true,
+    });
+    const legacy = createMockProvider(initial);
+    const profile = createMockProvider(null);
+    const reverseLegacy = createMockProvider(null);
+
+    await migrateLegacyToProfile({ legacy, profile, identity: IDENTITY });
+    // Round-trip back to a fresh legacy target.
+    await migrateProfileToLegacy({
+      profile,
+      legacy: reverseLegacy,
+      identity: IDENTITY,
+    });
+
+    const final = reverseLegacy._lastSavedData!;
+    // Token payload bytes are byte-identical (excluding _meta.updatedAt,
+    // which the migration refreshes deliberately).
+    expect(final[`_${TOKEN_A}`]).toEqual(initial[`_${TOKEN_A}`]);
+    expect(final[`_${TOKEN_B}`]).toEqual(initial[`_${TOKEN_B}`]);
+    expect(final[`archived-${TOKEN_C}`]).toEqual(initial[`archived-${TOKEN_C}`]);
+    expect(final._tombstones).toEqual(initial._tombstones);
+    expect(final._history).toEqual(initial._history);
+  });
+});
+
+describe('migrateTokenStorage — dry run', () => {
+  it('dryRun: counts non-zero but target.save not called and marker not set', async () => {
+    const source = createMockProvider(
+      buildSourceData({ active: [TOKEN_A, TOKEN_B] }),
+    );
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.tokensMigrated).toBe(2);
+    expect(target._calls.includes('save')).toBe(false);
+    expect(marker._store.size).toBe(0);
+  });
+});
+
+describe('migrateTokenStorage — edge cases', () => {
+  it('identity without directAddress → fast-fail', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: { ...IDENTITY, directAddress: undefined },
+    });
+
+    expect(result.success).toBe(false);
+    expect(target._calls.includes('save')).toBe(false);
+  });
+
+  it('marker read failure is non-fatal — migration proceeds', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+    marker.get = vi.fn(async () => {
+      throw new Error('mock marker read failure');
+    });
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+
+    // The migration proceeds despite the read failure.
+    expect(result.success).toBe(true);
+    expect(result.tokensMigrated).toBe(1);
+    expect(result.errors.some((e) => e.phase === 'check-marker')).toBe(true);
+  });
+
+  it('progress callback fires for each phase', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+    const phases: string[] = [];
+
+    await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+      onProgress: (p) => phases.push(p.phase),
+    });
+
+    expect(phases).toContain('check-marker');
+    expect(phases).toContain('source-load');
+    expect(phases).toContain('target-save');
+    expect(phases).toContain('stamp-marker');
+    expect(phases).toContain('complete');
+  });
+
+  it('throwing progress callback does not abort the migration', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      onProgress: () => {
+        throw new Error('callback boom');
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('migration marker helpers', () => {
+  it('isTokenStorageMigrationComplete reflects marker presence', async () => {
+    const marker = createMockKvStorage();
+    expect(
+      await isTokenStorageMigrationComplete({
+        markerStorage: marker,
+        direction: 'legacy-to-profile',
+        identity: IDENTITY,
+      }),
+    ).toBe(false);
+
+    // Run a migration to set the marker.
+    const source = createMockProvider(buildSourceData({}));
+    const target = createMockProvider(null);
+    await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+
+    expect(
+      await isTokenStorageMigrationComplete({
+        markerStorage: marker,
+        direction: 'legacy-to-profile',
+        identity: IDENTITY,
+      }),
+    ).toBe(true);
+  });
+
+  it('clearTokenStorageMigrationMarker removes the marker', async () => {
+    const marker = createMockKvStorage();
+    const source = createMockProvider(buildSourceData({}));
+    const target = createMockProvider(null);
+
+    await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+    expect(
+      await isTokenStorageMigrationComplete({
+        markerStorage: marker,
+        direction: 'legacy-to-profile',
+        identity: IDENTITY,
+      }),
+    ).toBe(true);
+
+    await clearTokenStorageMigrationMarker({
+      markerStorage: marker,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+    });
+
+    expect(
+      await isTokenStorageMigrationComplete({
+        markerStorage: marker,
+        direction: 'legacy-to-profile',
+        identity: IDENTITY,
+      }),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/profile/token-storage-migration.test.ts
+++ b/tests/unit/profile/token-storage-migration.test.ts
@@ -930,6 +930,163 @@ describe('migrateTokenStorage — edge cases', () => {
   });
 });
 
+describe('migrateTokenStorage — steelman fixes (PR #289 review)', () => {
+  it('spent-token demote does NOT overwrite a pre-existing archived entry', async () => {
+    // Source has BOTH an active token AND an archived entry for the
+    // same tokenId — legitimate after a reissue cycle.
+    const source = createMockProvider({
+      _meta: {
+        version: 1,
+        address: IDENTITY.l1Address,
+        formatVersion: '2.0',
+        updatedAt: 1,
+      },
+      [`_${TOKEN_A}`]: buildTxf(TOKEN_A, STATE_HASH_A),
+      [`archived-${TOKEN_A}`]: buildTxf(TOKEN_A, STATE_HASH_B), // distinct state
+    } as TxfStorageDataBase);
+    const target = createMockProvider(null);
+    const oracle = {
+      isSpent: vi.fn(async () => true), // reports active spent
+    } as unknown as OracleProvider;
+
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      oracle,
+    });
+    expect(result.success).toBe(true);
+    // The demote is REFUSED because target already had archived-<TOKEN_A>.
+    // Token stays in active slot; archived payload preserved.
+    expect(result.spentTokensArchived).toBe(0);
+    const targetData = target._lastSavedData!;
+    expect(targetData[`_${TOKEN_A}`]).toBeDefined();
+    expect(targetData[`archived-${TOKEN_A}`]).toBeDefined();
+    // Original archived payload is preserved (stateHash=STATE_HASH_B).
+    const archivedPayload = targetData[`archived-${TOKEN_A}`] as TxfToken;
+    expect(archivedPayload.genesis.inclusionProof.authenticator.stateHash).toBe(STATE_HASH_B);
+  });
+
+  it('honors v=1 marker', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+    const markerKey = `legacy_migration_v1_complete:${ADDRESS_ID}`;
+    marker._store.set(
+      markerKey,
+      JSON.stringify({
+        v: TOKEN_STORAGE_MIGRATION_MARKER_VERSION,
+        direction: 'legacy-to-profile',
+        addressId: ADDRESS_ID,
+        completedAt: 0,
+      }),
+    );
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+    expect(result.skippedDueToMarker).toBe(true);
+  });
+
+  it('does NOT honor a future-version marker (v=2)', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+    const markerKey = `legacy_migration_v1_complete:${ADDRESS_ID}`;
+    marker._store.set(
+      markerKey,
+      JSON.stringify({ v: 2, direction: 'legacy-to-profile', addressId: ADDRESS_ID }),
+    );
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+    // v=2 marker NOT honored → migration runs.
+    expect(result.skippedDueToMarker).toBe(false);
+    expect(result.tokensMigrated).toBe(1);
+  });
+
+  it('honors pre-versioned (non-JSON or no `v` field) markers for backward compat', async () => {
+    // Case 1: non-JSON marker (plain string)
+    const source1 = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target1 = createMockProvider(null);
+    const marker1 = createMockKvStorage();
+    marker1._store.set(`legacy_migration_v1_complete:${ADDRESS_ID}`, 'true');
+    const result1 = await migrateTokenStorage({
+      source: source1,
+      target: target1,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker1,
+    });
+    expect(result1.skippedDueToMarker).toBe(true);
+
+    // Case 2: JSON marker without `v` field
+    const source2 = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target2 = createMockProvider(null);
+    const marker2 = createMockKvStorage();
+    marker2._store.set(
+      `legacy_migration_v1_complete:${ADDRESS_ID}`,
+      JSON.stringify({ direction: 'legacy-to-profile', addressId: ADDRESS_ID }),
+    );
+    const result2 = await migrateTokenStorage({
+      source: source2,
+      target: target2,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker2,
+    });
+    expect(result2.skippedDueToMarker).toBe(true);
+  });
+
+  it('does NOT honor a marker with malformed `v` (e.g., string)', async () => {
+    const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
+    const target = createMockProvider(null);
+    const marker = createMockKvStorage();
+    marker._store.set(
+      `legacy_migration_v1_complete:${ADDRESS_ID}`,
+      JSON.stringify({ v: 'one' }),
+    );
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+      markerStorage: marker,
+    });
+    expect(result.skippedDueToMarker).toBe(false);
+    expect(result.tokensMigrated).toBe(1);
+  });
+
+  it('synthesizes _meta when source provides none', async () => {
+    // Construct a source with NO _meta field (a malformed source).
+    const source = createMockProvider({
+      [`_${TOKEN_A}`]: buildTxf(TOKEN_A),
+    } as unknown as TxfStorageDataBase);
+    const target = createMockProvider(null);
+    const result = await migrateTokenStorage({
+      source,
+      target,
+      direction: 'legacy-to-profile',
+      identity: IDENTITY,
+    });
+    expect(result.success).toBe(true);
+    const targetData = target._lastSavedData!;
+    expect(targetData._meta).toBeDefined();
+    expect(targetData._meta.version).toBe(1);
+    expect(targetData._meta.address).toBe(IDENTITY.l1Address);
+    expect(targetData._meta.formatVersion).toBe('2.0');
+    expect(typeof targetData._meta.updatedAt).toBe('number');
+  });
+});
+
 describe('migration marker helpers', () => {
   it('isTokenStorageMigrationComplete reflects marker presence', async () => {
     const marker = createMockKvStorage();


### PR DESCRIPTION
## Summary

Closes #286.

Adds `migrateTokenStorage` (with `migrateLegacyToProfile` / `migrateProfileToLegacy` convenience wrappers) so consumers can safely swap a wallet's token storage between legacy (`IndexedDBTokenStorageProvider` / `FileTokenStorageProvider`) and Profile (`ProfileTokenStorageProvider`) **without stranding tokens**.

This closes the regression sphere.telco PR #305 surfaced: swapping `tokenStorage` to a fresh Profile-backed provider zeroed every existing wallet's balance because the new store opens empty and no migration runs. The new primitive runs at the `TokenStorageProvider` boundary so consumers call it from `SphereProvider.initialize` BEFORE `Sphere.init` is given the Profile providers.

## Migration walk (legacy → Profile, default direction)

```
┌──────────────────────────┐
│ 1. check-marker          │   markerStorage.get(legacy_migration_v1_complete:<addressId>)
│    (skip if present and  │   — short-circuit no-op when set, unless force:true
│    force !== true)       │
└──────────┬───────────────┘
           │
┌──────────▼───────────────┐
│ 2. source-load           │   legacy.load() → TxfStorageDataBase snapshot
└──────────┬───────────────┘   (NO mutations on source; read-only)
           │
┌──────────▼───────────────┐
│ 3. oracle-probe (opt-in) │   For each active token: oracle.isSpent(pk, stateHash)
│    concurrency 4         │   spent → demote to `archived-` slot
└──────────┬───────────────┘
           │
┌──────────▼───────────────┐
│ 4. target-save           │   profile.save(mergedData)  ← full snapshot,
└──────────┬───────────────┘   CAR-pinned to IPFS (not OpLog inlined)
           │
┌──────────▼───────────────┐
│ 5. await-flush           │   profile.awaitNextFlush?()  ← ensures durability
│    (failure ⇒ no marker) │   before stamping the marker
└──────────┬───────────────┘
           │
┌──────────▼───────────────┐
│ 6. stamp-marker          │   markerStorage.setEntry(key, payload, 'cache_index')
└──────────────────────────┘   (system-class — operator bookkeeping)
```

## Per-entry-shape mapping (TxfStorageDataBase → target)

Every structural field of `TxfStorageDataBase` is copied via `target.save()`:

| Source field | Target slot | Notes |
|--------------|-------------|-------|
| `_meta` | `_meta` | `updatedAt` refreshed to migration time |
| `_<tokenId>` (active) | `_<tokenId>` | Demoted to `archived-<tokenId>` if oracle reports spent |
| `archived-<tokenId>` | `archived-<tokenId>` | Byte-identical copy |
| `_forked_<tokenId>_<stateHash>` | `_forked_<tokenId>_<stateHash>` | Byte-identical copy (no key collision with active slot) |
| `_tombstones[]` | `_tombstones[]` | Whole array |
| `_outbox[]` | `_outbox[]` | Whole array |
| `_sent[]` | `_sent[]` | Whole array |
| `_invalid[]` | `_invalid[]` | Whole array |
| `_history[]` | `_history[]` | Whole array |
| `_audit[]` | `_audit[]` | Whole array (UXF-TRANSFER-PROTOCOL §5.4) |
| `_finalizationQueue[]` | `_finalizationQueue[]` | Whole array (UXF-TRANSFER-PROTOCOL §5.5) |

**Not migrated** (lives in `StorageProvider` KV layer, both providers expose it independently):
- Mnemonic, derivation path, group-chat state, pending V5 tokens, accounting state, proof-polling jobs.

## Idempotency marker spec

- **Keyspace**: `legacy_migration_v1_complete:<addressId>` / `profile_migration_v1_complete:<addressId>`
- **Payload**: `{ v: 1, direction, addressId, completedAt, counts }`
- **OpLog class**: `'cache_index'` (system, operator bookkeeping)
- **Force re-run**: pass `force: true` (e.g., user added tokens to legacy after first migration)
- **Per-direction**: each direction has its own marker key — the two cannot interfere
- **Crash-safety**: marker is the LAST write. Crash before stamping ⇒ next run re-runs (target.save is a full overwrite ⇒ idempotent)

## Aggregator-spent gating

Opt-in via the `oracle` parameter. Concurrency cap 4 (matches the runtime `SpentStateRescanWorker.MAX_CONCURRENT_SPENT_RESCANS`). Tokens reported `spent` are demoted from active slot to `archived-` BEFORE the target write. Probes that throw are non-fatal (token left in active slot — runtime worker probes on every wallet boot, so transient RPC failures self-heal).

Distinct from but compatible with the `SpentStateRescanWorker` auto-installed by PaymentsModule. Migration probe is a one-shot equivalent for the FIRST post-swap load so the user doesn't see "phantom" spent balances before the worker's first scan cycle.

## OpLog payload cap safety

`ProfileTokenStorageProvider.save()` writes the snapshot via a UXF CAR pinned to IPFS — only a thin bundle CID ref goes into the OrbitDB OpLog. So migrating 1500+ tokens stays well below `MAX_PAYLOAD_BYTES=131072`. The marker write is ~200 bytes and routes through the system-class `cache_index` OpLog entry type when the marker storage supports `setEntry`.

No use of `writeEnvelopeViaCidIfLarge` is needed here because the helper does not perform large inline OpLog writes — it delegates the bulk write to `target.save()`, which already handles chunking via UXF CARs.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint profile/token-storage-migration.ts tests/...` — clean
- [x] `npx vitest run tests/unit/profile/token-storage-migration.test.ts` — 26 / 26 passing
- [x] `npx vitest run tests/integration/profile/token-storage-migration.test.ts` — 3 / 3 passing
- [x] `npx vitest run` (full suite) — 8368 / 8381 (13 pre-existing skips, 0 new failures)

### Key unit test scenarios

- 0-token migration → noop with marker set
- Full TxfStorageDataBase round-trip (tokens, archived, tombstones, outbox, sent, history, audit, finalizationQueue, invalid)
- 1500-token migration completes without payload-cap errors
- Aggregator-spent: spent token demoted to archived
- Aggregator-spent: probe throws ⇒ token left in active slot, error counted
- Aggregator-spent: oracle without chainPubkey ⇒ probe skipped with error
- Re-entry with marker set → `skippedDueToMarker: true`
- Re-entry with `force: true` → bypasses marker
- Partial-progress: marker write fails mid-run ⇒ data IS durable; second run completes
- `target.save` failure does NOT stamp marker
- `awaitNextFlush` failure does NOT stamp marker
- Reverse direction (Profile → legacy) preserves bytes
- Round-trip: legacy → profile → legacy → bytes preserved
- Source is read-only (no save/sync called on source)

### Integration test scenarios

- End-to-end legacy → fresh target migration (real `FileTokenStorageProvider`)
- Profile-to-legacy reverse migration preserves bytes
- Re-running after marker clear re-migrates fresh source data

## Acceptance — PR #305 regression replay

```
Stage 1: source has 2 tokens + 1 tombstone (seeded via legacy save())
Stage 2: target pre-migration → 0 tokens visible (THE REGRESSION)
Stage 3: migrateLegacyToProfile() → success, 2 tokens migrated, 1 tombstone
Stage 4: target post-migration → 2 tokens visible (IDENTICAL to source)
Stage 5: marker set; re-running is a no-op
```

Confirmed by `tests/integration/profile/token-storage-migration.test.ts:end-to-end migrates a populated legacy provider to a fresh target`.

## Consumer integration snippet (sphere.telco)

```ts
import { createBrowserProfileProviders } from '@unicitylabs/sphere-sdk/profile/browser';
import { createBrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
import { migrateLegacyToProfile } from '@unicitylabs/sphere-sdk/profile';

// Build legacy + Profile providers side-by-side
const legacy = createBrowserProviders({ network: 'mainnet' });
const profile = createBrowserProfileProviders({ network: 'mainnet' });

// Initialize both with the same identity (so the addressId matches)
legacy.tokenStorage.setIdentity(identity);
profile.tokenStorage.setIdentity(identity);
await legacy.tokenStorage.initialize();
await profile.tokenStorage.initialize();

// Migrate legacy → Profile, with aggregator-spent gating
const result = await migrateLegacyToProfile({
  legacy: legacy.tokenStorage,
  profile: profile.tokenStorage,
  identity,
  oracle: providers.oracle,
  markerStorage: profile.storage,
});
if (!result.success) console.error('migration failed', result.errors);

// Now construct Sphere with Profile providers — tokens visible
const { sphere } = await Sphere.init({
  ...profile,
  transport: providers.transport,
  oracle: providers.oracle,
});
```

## Dependencies / interactions

- Builds on #281 (`SpentStateRescanWorker`) — does not modify it; the migration's optional probe is a one-shot complement.
- Builds on #285 / #287 (`CidRefStore.buildCidRefStore`) — not used directly because `target.save()` already routes bulk data through UXF CARs (not OpLog inlining).
- Does NOT touch: transport (#275 / #277), helia-blockstore-shim (#278 / #279), CBOR fallback (#280), payments asset sort or invoice round-trip (#282 / #283), or `writeEnvelopeViaCidIfLarge` itself (#285).
- Coexists with the existing `importLegacyTokens` (PaymentsModule-level import helper) — different abstraction layers, both retained.