### PR TITLE
feat(profile)(#292): Sphere-bound factories that keep privateKey inside the SDK boundary

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -1643,6 +1643,83 @@ export class Sphere {
   }
 
   // ===========================================================================
+  // Internal — Issue #292 (SDK-private; do not call from consumer code)
+  // ===========================================================================
+
+  /**
+   * Attach this Sphere's internal {@link FullIdentity} (with privateKey) to
+   * a pair of identity-consuming providers WITHOUT exposing the private key
+   * to the caller. Used exclusively by the Sphere-bound Profile factories
+   * in `profile/browser.ts` / `profile/node.ts` and the
+   * `migrateLegacyToProfile({ sphere, ... })` overload in
+   * `profile/token-storage-migration.ts`.
+   *
+   * The `privateKey` field is read from `this._identity` (a private field),
+   * passed directly into `setIdentity` on each provider, and never escapes
+   * the closure. The callback shape is intentionally narrow — only
+   * `setIdentity(FullIdentity): void` is invoked — so the helper cannot
+   * be subverted into leaking the identity through some other provider
+   * method.
+   *
+   * Honors the architectural invariant from the issue #292 owner comment:
+   *
+   * > "Private key material should never leave Sphere SDK itself. However,
+   * > it should be possible to perform all the relevant cryptographic
+   * > operations within Sphere SDK over external materials by means of
+   * > undisclosed respective private key."
+   *
+   * @param applySetIdentity Synchronous callback that receives the live
+   *        `FullIdentity` and calls `setIdentity` on each provider. The
+   *        identity reference MUST NOT be stored, logged, or returned by
+   *        the callback. The helper invokes it once and discards.
+   * @throws {SphereError} `NOT_INITIALIZED` when no identity is bound
+   *        (call this AFTER `Sphere.init` / `Sphere.create` / `Sphere.load`
+   *        resolves). Distinct from the `hexToBytes: empty hex string`
+   *        crash that would have fired inside `Profile*.setIdentity`
+   *        without this guard.
+   *
+   * @internal — sphere-sdk private. Not part of the public API surface.
+   *           Consumers should use `createBrowserProfileProvidersFromSphere`
+   *           or `migrateLegacyToProfile({ sphere, ... })` instead.
+   */
+  _withFullIdentityForProfileFactory(
+    applySetIdentity: (identity: FullIdentity) => void,
+  ): void {
+    if (!this._identity?.privateKey) {
+      throw new SphereError(
+        'Wallet not initialized — call Sphere.init/create/load before constructing Sphere-bound Profile providers',
+        'NOT_INITIALIZED',
+      );
+    }
+    // Snapshot the identity into a local const so a concurrent
+    // `setIdentity` / re-derive on Sphere can't mutate `_identity`
+    // mid-callback. The snapshot is a fresh plain object that the
+    // callback may pass into provider `setIdentity` methods — those
+    // providers retain the reference for their lifetime (they read
+    // `identity.privateKey` lazily inside `connect()`'s Phase B; see
+    // `profile/profile-storage-provider.ts` `identityAtStart`).
+    //
+    // We intentionally do NOT scrub the snapshot's `privateKey` after
+    // the callback: the providers store the snapshot reference and
+    // continue to read `privateKey` during their own connect()
+    // lifecycle, so a scrub would null out their authoritative source
+    // mid-flight (the original sin caught in steelman round 1 of this
+    // PR — see docs/PROFILE-FROM-SPHERE.md "Security review"). The
+    // provider's encryption-key copy is the long-lived secret; the
+    // wallet's `_identity.privateKey` is the canonical source. Both
+    // live for the wallet's lifetime regardless.
+    const snapshot: FullIdentity = {
+      chainPubkey: this._identity.chainPubkey,
+      l1Address: this._identity.l1Address,
+      directAddress: this._identity.directAddress,
+      ipnsName: this._identity.ipnsName,
+      nametag: this._identity.nametag,
+      privateKey: this._identity.privateKey,
+    };
+    applySetIdentity(snapshot);
+  }
+
+  // ===========================================================================
   // Public Methods - Providers Access
   // ===========================================================================
 

--- a/docs/PROFILE-FROM-SPHERE.md
+++ b/docs/PROFILE-FROM-SPHERE.md
@@ -1,0 +1,244 @@
+# Profile providers from a Sphere instance
+
+Issue: [#292](https://github.com/unicity-sphere/sphere-sdk/issues/292)
+
+## Architectural invariant (NON-NEGOTIABLE)
+
+From the project owner on Issue #292:
+
+> "Private key material should never leave Sphere SDK itself. However, it should
+> be possible to perform all the relevant cryptographic operations within Sphere
+> SDK over external materials by means of undisclosed respective private key
+> (like generating digital signature, etc.)."
+
+Consumers MUST NEVER receive raw `privateKey` material. The SDK's public surface
+exposes only `Identity` (public info), signatures, ciphertexts, or opaque
+purpose-derived bytes — never the seed. Any design that exposes
+`FullIdentity` to consumer code is rejected.
+
+## The problem this solves
+
+Prior to Issue #292, consumers building Profile providers for migration or
+probe scenarios had to synthesize a `FullIdentity` from `Sphere.identity`
+(public info only) plus a fake `privateKey: ''`:
+
+```ts
+// PRE-#292 — CRASHES on Profile.setIdentity → hexToBytes("")
+const identity = sphere.identity;                       // typed Identity | null
+const profile = createBrowserProfileProviders({ network });
+profile.tokenStorage.setIdentity({ ...identity, privateKey: '' });
+// RangeError: hexToBytes: empty hex string
+```
+
+`ProfileStorageProvider.setIdentity` and `ProfileTokenStorageProvider.setIdentity`
+call `hexToBytes(identity.privateKey)` synchronously inside their bodies to
+derive the cache-layer encryption key. An empty string throws.
+
+Live wallets crashed every page load.
+
+## The fix — Sphere-bound factories
+
+Two new public surfaces in `@unicitylabs/sphere-sdk/profile/browser` (and the
+Node.js mirror in `@unicitylabs/sphere-sdk/profile/node`):
+
+### 1. `createBrowserProfileProvidersFromSphere(sphere, config)`
+
+Builds Profile providers WITH identity already attached. The Sphere's
+private key never crosses the SDK boundary — the factory routes through an
+internal accessor that confines the `FullIdentity` reference to the SDK's
+own scope.
+
+```ts
+import { createBrowserProfileProvidersFromSphere } from '@unicitylabs/sphere-sdk/profile/browser';
+
+const { storage, tokenStorage } = await createBrowserProfileProvidersFromSphere(
+  sphere,
+  { network: 'mainnet', oracle: providers.oracle },
+);
+// Providers are ready to use — no setIdentity call needed.
+const snap = await tokenStorage.load();
+```
+
+### 2. `migrateLegacyToProfile({ sphere, ... })` overload
+
+The existing `migrateLegacyToProfile({ legacy, profile, identity, ... })`
+signature still works for callers who derive identity outside Sphere. The
+new overload accepts a live Sphere instance and an injected `profileFactory`
+callback; the helper constructs the Profile providers with identity attached
+and returns them alongside the migration result.
+
+```ts
+import { migrateLegacyToProfileBrowser } from '@unicitylabs/sphere-sdk/profile/browser';
+
+const result = await migrateLegacyToProfileBrowser({
+  sphere,
+  legacy: legacyProviders.tokenStorage,
+  network: 'mainnet',
+  oracle: providers.oracle,
+});
+
+// result.profileProviders is now ready to hand to Sphere.init or store in app state
+const { storage, tokenStorage } = result.profileProviders;
+```
+
+## Consumer migration story
+
+The sphere.telco repro from Issue #292 was the `uxfProfileMigration.ts`
+call site in PR #308. The pre-#292 code synthesized a fake `FullIdentity`
+and crashed inside `Profile*.setIdentity`. The post-#292 simplification:
+
+**Before (`migrationIdentity` synthesis, crashes on first page load):**
+
+```ts
+const identity = sphere.identity;
+if (!identity?.directAddress) return null;
+
+const profile = createBrowserProfileProviders({ network, oracle });
+profile.tokenStorage.setIdentity({ ...identity, privateKey: '' });   // BOOM
+profile.storage.setIdentity({ ...identity, privateKey: '' });        // BOOM
+await profile.tokenStorage.initialize();
+
+const result = await migrateLegacyToProfile({
+  legacy: legacyProviders.tokenStorage,
+  profile: profile.tokenStorage,
+  identity: { ...identity, privateKey: '' },   // never works
+  oracle,
+  markerStorage: profile.storage,
+});
+```
+
+**After (Sphere-bound, no privateKey synthesis):**
+
+```ts
+const result = await migrateLegacyToProfileBrowser({
+  sphere,
+  legacy: legacyProviders.tokenStorage,
+  network,
+  oracle,
+});
+const profile = result.profileProviders;
+```
+
+The probe path in `SphereProvider.tsx` simplifies similarly:
+
+```ts
+const profile = await createBrowserProfileProvidersFromSphere(sphere, { network });
+const snap = await profile.tokenStorage.load();
+```
+
+## Backward compatibility
+
+The existing `migrateLegacyToProfile({ legacy, profile, identity, ... })`
+signature is unchanged. The new Sphere-bound overload is discriminated by
+the presence of the `sphere` field. Every existing call site continues
+to compile and run without source changes.
+
+## Strategic foundation — `SphereCryptographer` interface
+
+Sketched in `profile/cryptographer.ts`. The Profile cache encryption is one
+instance of a recurring pattern: external modules need cryptographic
+operations performed under the wallet's key without ever seeing the key.
+The interface formalises that boundary:
+
+```ts
+export interface SphereCryptographer {
+  readonly identity: Identity;
+
+  /** HKDF-derived per-purpose key bytes. Suitable for handing to a
+   *  downstream module that needs ONE symmetric key for ONE purpose. */
+  derivePurposeKey(purpose: SphereCryptographerPurpose): Promise<Uint8Array>;
+
+  // Future surface (sketched, NOT wired in this PR):
+  signMessage?(message: Uint8Array): Promise<Uint8Array>;
+  signMessageHex?(messageHex: string): Promise<string>;
+  encryptForRecipient?(recipientPubkey: string, plaintext: Uint8Array): Promise<Uint8Array>;
+  decryptFromSender?(senderPubkey: string, ciphertext: Uint8Array): Promise<Uint8Array>;
+}
+```
+
+**Status:** Only `derivePurposeKey('profile-cache')` is wired through the
+Profile factories in this PR. The remaining methods are sketched so the
+interface shape is stable from the first release. A follow-up issue tracks
+migrating `Sphere.signMessage`, `PaymentsModule` signing, and
+`CommunicationsModule` encryption to delegate via this interface.
+
+## Internal helper — `attachIdentityToProfileProviders`
+
+Lives in `profile/attach-identity.ts`. Confined to SDK-private use:
+
+- NOT re-exported from `@unicitylabs/sphere-sdk/profile` (the barrel) or
+  any platform entry point.
+- Takes a `Sphere` instance and a pair of Profile providers.
+- Routes through `Sphere._withFullIdentityForProfileFactory` to obtain
+  a scoped `FullIdentity`, immediately calls `setIdentity` on each
+  provider, and drops the reference.
+
+The bridge into Sphere lives at `Sphere._withFullIdentityForProfileFactory`
+(prefixed with `_` per TypeScript convention to discourage external
+consumers; documented `@internal`). It snapshots `_identity` into a local
+const and invokes the callback. It does NOT scrub the snapshot's
+`privateKey` post-callback — see the security-review note below for why.
+
+## Security review (steelman attack vectors considered)
+
+1. **Does the helper actually keep privateKey from leaking outside the SDK?**
+   - The `FullIdentity` snapshot is constructed inside Sphere and passed
+     ONLY into the callback. The callback shape is `(id) => void`; the
+     attach-identity wrapper invokes only `setIdentity` on the providers
+     (a sync method that derives the encryption key inline and stores
+     the identity reference internally). Consumer code receives only
+     the constructed providers — never the identity, never the
+     `FullIdentity` reference.
+   - **Steelman round 1 catch**: an earlier draft included a `finally`
+     block that scrubbed `snapshot.privateKey = undefined` post-callback
+     to reduce GC retention of the secret. This was REMOVED because the
+     `ProfileStorageProvider` stores the snapshot reference and reads
+     `identity.privateKey` LAZILY inside `connect()` Phase B (see
+     `profile-storage-provider.ts` `identityAtStart.privateKey` at line
+     709). A post-callback scrub would null out the authoritative copy
+     mid-attach, breaking OrbitDB connection setup. The Sphere
+     `_identity.privateKey` field IS the long-lived secret regardless;
+     the provider's stored reference adds no new exposure (it lives
+     for the same Sphere lifetime).
+
+2. **Uninitialized Sphere — clear error path?**
+   - `_withFullIdentityForProfileFactory` throws
+     `SphereError('NOT_INITIALIZED')` when `_identity?.privateKey` is
+     falsy. Distinct from the cryptic `hexToBytes: empty hex string`
+     RangeError the consumer-facing pre-#292 bug threw.
+
+3. **Malicious / buggy consumer corrupting encryption-key state?**
+   - The new factories internally call `setIdentity` once before returning
+     control to the consumer. A subsequent
+     `profile.tokenStorage.setIdentity({...identity, privateKey: ''})` call
+     by the consumer would still throw inside `hexToBytes` — the existing
+     contract is preserved. The new factories don't WEAKEN that contract;
+     they provide a key-safe SUCCESSFUL path.
+
+4. **Concurrent factory calls — shared state safety?**
+   - Each factory call constructs its own Profile providers (no shared
+     state). The Sphere accessor uses a local-const snapshot per call, so
+     concurrent calls each get their own snapshot and don't interfere.
+
+5. **Memory: does the helper retain a Sphere reference?**
+   - No. The helper takes a `Sphere` parameter but does not store it. The
+     producers (the Profile factories) discard the Sphere reference once
+     `attachIdentityToProfileProviders` returns. The constructed providers
+     hold only their own internal state (encryption key derived from the
+     identity) — they do not hold a back-reference to Sphere.
+
+## Files changed
+
+| File | What changed |
+|---|---|
+| `core/Sphere.ts` | New `_withFullIdentityForProfileFactory` internal method (after `signMessage`). |
+| `profile/attach-identity.ts` | NEW. SDK-private helper. NOT exported from `profile/index.ts`. |
+| `profile/cryptographer.ts` | NEW. `SphereCryptographer` interface sketch + `PROFILE_CACHE_PURPOSE` constant. |
+| `profile/browser.ts` | NEW `createBrowserProfileProvidersFromSphere` + convenience `migrateLegacyToProfileBrowser`. |
+| `profile/node.ts` | NEW `createNodeProfileProvidersFromSphere` + convenience `migrateLegacyToProfileNode`. |
+| `profile/token-storage-migration.ts` | NEW Sphere-bound overload of `migrateLegacyToProfile`. Existing overload unchanged. |
+| `profile/index.ts` | Re-exports of new types + `SphereCryptographer` interface. |
+| `tests/unit/profile/attach-identity.test.ts` | NEW. Helper contract tests. |
+| `tests/unit/profile/cryptographer.test.ts` | NEW. Constant stability tripwire. |
+| `tests/unit/profile/token-storage-migration-from-sphere.test.ts` | NEW. Sphere-bound overload coverage + backward compat. |
+| `tests/unit/core/Sphere.profile-factory-identity.test.ts` | NEW. Sphere internal-method contract tests. |

--- a/docs/PROFILE-FROM-SPHERE.md
+++ b/docs/PROFILE-FROM-SPHERE.md
@@ -227,6 +227,28 @@ const and invokes the callback. It does NOT scrub the snapshot's
      hold only their own internal state (encryption key derived from the
      identity) — they do not hold a back-reference to Sphere.
 
+6. **Pre-existing leakage point — `ProfileTokenStorageProvider.getIdentity()`**
+   - **Caveat — this is OUT OF SCOPE for this PR but worth flagging.**
+     The `ProfileTokenStorageProvider` class exposes a public
+     `getIdentity(): FullIdentity | null` method that returns the stored
+     identity, INCLUDING `privateKey`. A consumer of the providers built
+     by `createBrowserProfileProvidersFromSphere` can therefore extract
+     the wallet's private key after calling the factory.
+   - This leakage existed BEFORE #292 — consumers who manually called
+     `tokenStorage.setIdentity(fullIdentity)` could read back the same
+     identity via `getIdentity()`. The Sphere-bound factories do not
+     introduce a NEW exposure; they remove the consumer-facing path that
+     required synthesizing a `FullIdentity`.
+   - Closing this gap requires migrating
+     `ProfileTokenStorageProvider.getIdentity()` to return `Identity` (no
+     privateKey) and routing the existing internal callers (the lifecycle
+     manager's `Phase B` connect, `factory.ts` line 458) through a separate
+     internal-only accessor — too large to bundle here.
+   - **Tracked as part of the follow-up SphereCryptographer migration**
+     (see "Strategic foundation" above). The future migration will replace
+     scattered `getIdentity()` reads with explicit `cryptographer.*` calls
+     so the boundary becomes uniform.
+
 ## Files changed
 
 | File | What changed |

--- a/docs/PROFILE-FROM-SPHERE.md
+++ b/docs/PROFILE-FROM-SPHERE.md
@@ -158,9 +158,12 @@ export interface SphereCryptographer {
 
 **Status:** Only `derivePurposeKey('profile-cache')` is wired through the
 Profile factories in this PR. The remaining methods are sketched so the
-interface shape is stable from the first release. A follow-up issue tracks
-migrating `Sphere.signMessage`, `PaymentsModule` signing, and
-`CommunicationsModule` encryption to delegate via this interface.
+interface shape is stable from the first release.
+
+**Follow-up tracked in [#293](https://github.com/unicity-sphere/sphere-sdk/issues/293)** — migrates
+`Sphere.signMessage`, `PaymentsModule` signing, `CommunicationsModule`
+encryption, and the pre-existing `ProfileTokenStorageProvider.getIdentity()`
+leakage point to delegate via this interface.
 
 ## Internal helper — `attachIdentityToProfileProviders`
 
@@ -244,8 +247,8 @@ const and invokes the callback. It does NOT scrub the snapshot's
      privateKey) and routing the existing internal callers (the lifecycle
      manager's `Phase B` connect, `factory.ts` line 458) through a separate
      internal-only accessor — too large to bundle here.
-   - **Tracked as part of the follow-up SphereCryptographer migration**
-     (see "Strategic foundation" above). The future migration will replace
+   - **Tracked as part of the follow-up SphereCryptographer migration
+     ([#293](https://github.com/unicity-sphere/sphere-sdk/issues/293))**. The future migration will replace
      scattered `getIdentity()` reads with explicit `cryptographer.*` calls
      so the boundary becomes uniform.
 

--- a/profile/attach-identity.ts
+++ b/profile/attach-identity.ts
@@ -1,0 +1,75 @@
+/**
+ * Profile Identity Attachment (SDK-private helper for Issue #292)
+ *
+ * Wires a {@link Sphere}'s internal {@link FullIdentity} into a pair of
+ * Profile providers WITHOUT exposing the private key to the caller.
+ * This file is the SDK-private bridge between the Sphere-bound Profile
+ * factories (`createBrowserProfileProvidersFromSphere`,
+ * `createNodeProfileProvidersFromSphere`) and the Sphere class's
+ * `_withFullIdentityForProfileFactory` accessor.
+ *
+ * ## Architectural invariant (Issue #292 owner)
+ *
+ * > "Private key material should never leave Sphere SDK itself. However,
+ * > it should be possible to perform all the relevant cryptographic
+ * > operations within Sphere SDK over external materials by means of
+ * > undisclosed respective private key."
+ *
+ * The helper accepts a `Sphere` instance and a pair of providers. It calls
+ * back into the Sphere's `_withFullIdentityForProfileFactory` to obtain a
+ * scoped `FullIdentity`, immediately invokes `setIdentity` on each
+ * provider, and then drops the reference. The `privateKey` field never
+ * leaves the function scope; consumers receive only the bound providers.
+ *
+ * Initialization of the token storage is also performed here so consumers
+ * get ready-to-use providers — no separate `setIdentity` + `initialize`
+ * dance is required at the consumer site.
+ *
+ * @module profile/attach-identity
+ * @internal — NOT exported from `@unicitylabs/sphere-sdk/profile`.
+ * @see https://github.com/unicity-sphere/sphere-sdk/issues/292
+ */
+
+import type { Sphere } from '../core/Sphere';
+import type { FullIdentity } from '../types';
+import type { ProfileStorageProvider } from './profile-storage-provider';
+import type { ProfileTokenStorageProvider } from './profile-token-storage-provider';
+
+/**
+ * Attach a Sphere's internal identity to a pair of Profile providers and
+ * initialize the token storage so the providers are ready for `get`/`set`/
+ * `save`/`load` calls.
+ *
+ * @param sphere Live Sphere instance — MUST be initialized (an uninitialized
+ *               Sphere triggers `SphereError('NOT_INITIALIZED')` inside the
+ *               accessor; the caller surfaces that with a clear message).
+ * @param providers Profile provider pair to receive the identity. Both
+ *                  `storage.setIdentity` and `tokenStorage.setIdentity` are
+ *                  invoked; `tokenStorage.initialize()` is awaited afterwards.
+ * @internal
+ */
+export async function attachIdentityToProfileProviders(
+  sphere: Sphere,
+  providers: {
+    readonly storage: ProfileStorageProvider;
+    readonly tokenStorage: ProfileTokenStorageProvider;
+  },
+): Promise<void> {
+  // The callback below receives the FullIdentity inside the Sphere's
+  // closure; we never store it outside `setIdentity` invocations. The
+  // Sphere helper drops the reference after this returns.
+  sphere._withFullIdentityForProfileFactory((identity: FullIdentity): void => {
+    // Storage provider FIRST so its derived encryption key is in place
+    // when the token storage starts wiring up writers that depend on it.
+    providers.storage.setIdentity(identity);
+    providers.tokenStorage.setIdentity(identity);
+  });
+
+  // Initialize the token storage so the consumer can immediately read
+  // and write — mirrors the manual setIdentity + initialize sequence
+  // documented in the existing migration example. Storage provider's
+  // connect() lifecycle is driven by Sphere itself when the providers
+  // are subsequently handed to Sphere.init / Sphere.load; the standalone
+  // probe / migration call sites manage their own lifecycle.
+  await providers.tokenStorage.initialize();
+}

--- a/profile/browser.ts
+++ b/profile/browser.ts
@@ -33,11 +33,18 @@ import type { ProfileConfig } from './types';
 import type { ProfileStorageProvider } from './profile-storage-provider';
 import type { ProfileTokenStorageProvider } from './profile-token-storage-provider';
 import type { OracleProvider } from '../oracle';
+import type { Sphere } from '../core/Sphere';
 import { createProfileProviders } from './factory';
 import { createIndexedDBStorageProvider } from '../impl/browser/storage/IndexedDBStorageProvider';
 import { getNetworkConfig } from '../impl/shared';
 import { DEFAULT_IPFS_GATEWAYS } from '../constants';
 import type { NetworkType } from '../constants';
+import { attachIdentityToProfileProviders } from './attach-identity';
+import { migrateLegacyToProfile } from './token-storage-migration';
+import type {
+  MigrateLegacyToProfileFromSphereOptions,
+  MigrateLegacyToProfileFromSphereResult,
+} from './token-storage-migration';
 
 /**
  * Configuration for the browser Profile factory.
@@ -119,4 +126,111 @@ export function createBrowserProfileProviders(
   );
 
   return { storage, tokenStorage };
+}
+
+// =============================================================================
+// Sphere-bound factory (Issue #292)
+// =============================================================================
+
+/**
+ * Configuration for {@link createBrowserProfileProvidersFromSphere}.
+ *
+ * Mirrors {@link BrowserProfileProvidersConfig} but is used with the
+ * Sphere-bound factory below.
+ */
+export interface BrowserProfileProvidersFromSphereConfig {
+  /** Network preset: mainnet, testnet, or dev */
+  readonly network: NetworkType;
+  /** Profile-specific configuration overrides */
+  readonly profileConfig?: Partial<ProfileConfig>;
+  /**
+   * Oracle provider for the aggregator pointer layer. Pass the same
+   * `oracle` instance that the Sphere instance was constructed with so
+   * the embedded `RootTrustBase` is shared (SPEC §8.4.2 H6).
+   */
+  readonly oracle?: OracleProvider;
+}
+
+/**
+ * Construct Profile providers WITH identity already attached, using the
+ * given Sphere instance's internal private key.
+ *
+ * **Preferred over {@link createBrowserProfileProviders} for any consumer
+ * that has a live Sphere** — eliminates the need to pass a synthetic
+ * `FullIdentity` (which would require `privateKey: ''` and crash inside
+ * `hexToBytes`; see Issue #292). Returned providers are ready to use
+ * immediately: no separate `setIdentity` / `tokenStorage.initialize` call
+ * is needed at the consumer site.
+ *
+ * The Sphere's private key NEVER crosses the SDK boundary — the helper
+ * routes the identity through an internal accessor that confines the
+ * `FullIdentity` reference to the SDK's own scope (see
+ * `attach-identity.ts` and `Sphere._withFullIdentityForProfileFactory`).
+ *
+ * @example Probe path (no migration)
+ * ```ts
+ * const { storage, tokenStorage } = await createBrowserProfileProvidersFromSphere(
+ *   sphere,
+ *   { network: 'mainnet' },
+ * );
+ * const snap = await tokenStorage.load();
+ * ```
+ *
+ * @param sphere Live Sphere instance — must be initialized.
+ * @param config Browser profile configuration.
+ * @returns Profile-backed storage and token storage providers, fully
+ *          initialized with identity attached.
+ * @throws {SphereError} `NOT_INITIALIZED` when the Sphere instance has
+ *         no identity bound (uninitialized wallet).
+ * @see https://github.com/unicity-sphere/sphere-sdk/issues/292
+ */
+export async function createBrowserProfileProvidersFromSphere(
+  sphere: Sphere,
+  config: BrowserProfileProvidersFromSphereConfig,
+): Promise<BrowserProfileProviders> {
+  // Reuse the standard factory body — it constructs the IndexedDB local
+  // cache, OrbitDB adapter, and both providers. The Sphere binding is
+  // applied as a separate, well-confined step below.
+  const providers = createBrowserProfileProviders({
+    network: config.network,
+    profileConfig: config.profileConfig,
+    oracle: config.oracle,
+  });
+
+  await attachIdentityToProfileProviders(sphere, providers);
+
+  return providers;
+}
+
+/**
+ * Convenience helper: bind the browser Profile factory to
+ * `migrateLegacyToProfile` so consumers don't have to thread the
+ * `profileFactory` parameter through themselves. Pre-wires the platform-
+ * specific factory; the rest of the options surface is identical to
+ * `MigrateLegacyToProfileFromSphereOptions` minus `profileFactory`.
+ *
+ * Internally re-exports the same `migrateLegacyToProfile` function from
+ * `./token-storage-migration` with `profileFactory` pre-set. Useful for
+ * call sites that want a one-liner.
+ *
+ * @example
+ * ```ts
+ * import { migrateLegacyToProfileBrowser } from '@unicitylabs/sphere-sdk/profile/browser';
+ *
+ * const result = await migrateLegacyToProfileBrowser({
+ *   sphere,
+ *   legacy: legacyProviders.tokenStorage,
+ *   network: 'mainnet',
+ *   oracle: providers.oracle,
+ * });
+ * const { storage, tokenStorage } = result.profileProviders;
+ * ```
+ */
+export async function migrateLegacyToProfileBrowser(
+  opts: Omit<MigrateLegacyToProfileFromSphereOptions, 'profileFactory'>,
+): Promise<MigrateLegacyToProfileFromSphereResult> {
+  return migrateLegacyToProfile({
+    ...opts,
+    profileFactory: createBrowserProfileProvidersFromSphere,
+  });
 }

--- a/profile/cryptographer.ts
+++ b/profile/cryptographer.ts
@@ -1,0 +1,172 @@
+/**
+ * SphereCryptographer — Foundation for SDK-bound cryptographic delegation (Issue #292)
+ *
+ * ## Architectural invariant (from project owner)
+ *
+ * > "Private key material should never leave Sphere SDK itself. However, it
+ * > should be possible to perform all the relevant cryptographic operations
+ * > within Sphere SDK over external materials by means of undisclosed
+ * > respective private key (like generating digital signature, etc.)."
+ *
+ * Consumers (and even sibling SDK modules outside `core/Sphere.ts`) MUST NEVER
+ * receive raw `privateKey` material. They get back signatures, ciphertexts, or
+ * opaque purpose-derived key bytes — never the seed.
+ *
+ * ## Scope of THIS file
+ *
+ * This module sketches the long-term `SphereCryptographer` interface, but
+ * Issue #292's tactical scope only requires ONE of its operations:
+ * `derivePurposeKey('profile-cache')`. The Profile providers
+ * (`ProfileStorageProvider.setIdentity`,
+ * `ProfileTokenStorageProvider.setIdentity`) call `hexToBytes(privateKey)`
+ * synchronously inside their bodies to derive the cache-layer encryption
+ * key. Consumers building Profile providers without a live wallet (probe,
+ * migration) could not supply a real `privateKey`, so they passed `''` and
+ * crashed inside `hexToBytes`.
+ *
+ * The Sphere-bound Profile factories in `profile/browser.ts` and
+ * `profile/node.ts` route through `Sphere`'s internal identity to perform
+ * the same derivation INSIDE the SDK boundary. The cryptographer interface
+ * is what they conceptually invoke; for now the implementation just calls
+ * `Sphere`'s existing private accessor.
+ *
+ * ## Future surface (NOT implemented in this PR — follow-up tracked)
+ *
+ * The interface below lists the methods a future, fully-extracted
+ * `SphereCryptographer` would expose so external modules and consumers can
+ * delegate ALL key operations without ever holding the raw key:
+ *
+ *   - `signMessage(bytes)` — secp256k1 ECDSA signing
+ *   - `signMessageHex(hex)` — convenience hex wrapper
+ *   - `encryptForRecipient(pubkey, plaintext)` — NIP-04 / NIP-17 envelope encrypt
+ *   - `decryptFromSender(pubkey, ciphertext)` — counterpart decrypt
+ *   - `derivePurposeKey(purpose)` — HKDF-derived per-purpose key bytes; the
+ *     returned bytes ARE secret-equivalent (any holder can decrypt that
+ *     purpose's data) but do not let the holder reconstruct the privateKey
+ *     or perform other key operations. Suitable for handing to a Profile
+ *     provider that needs ONE encryption key for ONE cache.
+ *   - `identity` — public Identity (mirrors `Sphere.identity`)
+ *
+ * The existing private signing / encryption surfaces inside Sphere,
+ * `PaymentsModule`, and `CommunicationsModule` would all be migrated to
+ * consume this interface in a future PR (so the boundary becomes a single
+ * implementation rather than scattered private methods).
+ *
+ * @module profile/cryptographer
+ * @see https://github.com/unicity-sphere/sphere-sdk/issues/292
+ */
+
+import type { Identity } from '../types';
+
+/**
+ * Purpose tag for `derivePurposeKey`. Used as the HKDF info string so two
+ * purposes derive distinct keys even from the same root secret. Extend the
+ * union as new purposes are added; the string value is the canonical
+ * HKDF info parameter and MUST NOT be renamed once shipped (would break
+ * forward compatibility with previously-encrypted caches).
+ */
+export type SphereCryptographerPurpose =
+  /**
+   * Encryption key for the Profile-mode local cache (used by
+   * `ProfileStorageProvider` and `ProfileTokenStorageProvider`).
+   * Stable since v0.6.x — Issue #292.
+   */
+  | 'profile-cache'
+  // Future: 'orbitdb-id', 'nostr-nip17-symmetric', ...
+  | string;
+
+/**
+ * The cryptographer delegate. Exposed via `Sphere.cryptographer`. Consumers
+ * pass this to internal SDK modules that need to perform crypto operations
+ * under the wallet key — modules MUST NEVER touch the raw `privateKey`.
+ *
+ * **Status (Issue #292 tactical):** Only `derivePurposeKey` is wired through
+ * Profile factories today. The remaining methods are sketched here so the
+ * shape is stable from the first release; a follow-up issue tracks the full
+ * migration of `Sphere.signMessage`, `PaymentsModule` signing, and
+ * `CommunicationsModule` encryption to consume this interface.
+ */
+export interface SphereCryptographer {
+  /**
+   * The wallet's PUBLIC identity. Same shape as `Sphere.identity`.
+   * Returned by reference; callers MUST treat it as read-only.
+   */
+  readonly identity: Identity;
+
+  /**
+   * Derive a deterministic per-purpose key as opaque bytes. The bytes are
+   * suitable for handing to a downstream module that needs a single
+   * symmetric key for ONE purpose (e.g. a Profile cache's HKDF subkey).
+   *
+   * **Security note**: the returned bytes ARE secret-equivalent FOR THIS
+   * PURPOSE. They do NOT let the holder reconstruct the wallet's
+   * privateKey or derive keys for OTHER purposes (HKDF-Expand is
+   * one-way). But anyone with these bytes CAN decrypt this purpose's
+   * persisted data. Treat the returned `Uint8Array` like a session key:
+   * keep it in memory only, do not log it, do not persist it outside
+   * the consumer's own encrypted store.
+   *
+   * Pure function of (wallet privateKey, purpose). Two calls with the
+   * same purpose return identical bytes; this is what makes the
+   * Profile cache decryptable across process restarts.
+   *
+   * @param purpose Stable purpose tag (see {@link SphereCryptographerPurpose}).
+   *                The string is the HKDF `info` parameter, so it MUST NOT
+   *                be renamed once shipped — would invalidate every cache
+   *                derived under the old name.
+   * @returns 32-byte derived key (AES-256-ready).
+   */
+  derivePurposeKey(purpose: SphereCryptographerPurpose): Promise<Uint8Array>;
+
+  // ---------------------------------------------------------------------------
+  // FUTURE SURFACE — sketched here, NOT yet wired through Sphere modules.
+  // See the module docstring for the migration story. Throwing `not
+  // implemented` is acceptable for these methods in v0.6.x.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * secp256k1 ECDSA signature over the SHA-256 digest of `message`.
+   *
+   * @future Wired through `Sphere.signMessage` in a follow-up PR.
+   */
+  signMessage?(message: Uint8Array): Promise<Uint8Array>;
+
+  /**
+   * Hex-convenience wrapper for {@link signMessage}. Returns the signature
+   * as `v(2) + r(64) + s(64)` hex — the format `Sphere.signMessage` already
+   * returns today.
+   *
+   * @future Wired through `Sphere.signMessage` in a follow-up PR.
+   */
+  signMessageHex?(messageHex: string): Promise<string>;
+
+  /**
+   * NIP-04 / NIP-17 envelope encrypt for an arbitrary recipient pubkey.
+   *
+   * @future Wired through `CommunicationsModule` in a follow-up PR.
+   */
+  encryptForRecipient?(
+    recipientPubkey: string,
+    plaintext: Uint8Array,
+  ): Promise<Uint8Array>;
+
+  /**
+   * Counterpart to {@link encryptForRecipient}.
+   *
+   * @future Wired through `CommunicationsModule` in a follow-up PR.
+   */
+  decryptFromSender?(
+    senderPubkey: string,
+    ciphertext: Uint8Array,
+  ): Promise<Uint8Array>;
+}
+
+/**
+ * The HKDF info string for the `profile-cache` purpose. Mirrors
+ * `PROFILE_HKDF_INFO` in `profile/encryption.ts` (kept in sync — bumping
+ * this here without bumping there is a silent data-loss bug). Re-exported
+ * for tests that want to verify the binding.
+ *
+ * @internal
+ */
+export const PROFILE_CACHE_PURPOSE: SphereCryptographerPurpose = 'profile-cache';

--- a/profile/index.ts
+++ b/profile/index.ts
@@ -166,7 +166,20 @@ export type {
   TokenStorageMigrationProgress,
   TokenStorageMigrationCounts,
   TokenStorageMigrationResult,
+  MigrateLegacyToProfileOptions,
+  MigrateLegacyToProfileFromSphereOptions,
+  MigrateLegacyToProfileFromSphereResult,
 } from './token-storage-migration';
+
+// =============================================================================
+// SphereCryptographer (Issue #292 foundation — sketched, not fully wired)
+// =============================================================================
+
+export { PROFILE_CACHE_PURPOSE } from './cryptographer';
+export type {
+  SphereCryptographer,
+  SphereCryptographerPurpose,
+} from './cryptographer';
 
 // =============================================================================
 // Deriver (local-cached structural views)
@@ -261,5 +274,13 @@ export type { ProfileProviders } from './factory';
 //   import { createBrowserProfileProviders } from '@unicitylabs/sphere-sdk/profile/browser';
 //   import { createNodeProfileProviders } from '@unicitylabs/sphere-sdk/profile/node';
 
-export type { BrowserProfileProvidersConfig, BrowserProfileProviders } from './browser';
-export type { NodeProfileProvidersConfig, NodeProfileProviders } from './node';
+export type {
+  BrowserProfileProvidersConfig,
+  BrowserProfileProviders,
+  BrowserProfileProvidersFromSphereConfig,
+} from './browser';
+export type {
+  NodeProfileProvidersConfig,
+  NodeProfileProviders,
+  NodeProfileProvidersFromSphereConfig,
+} from './node';

--- a/profile/node.ts
+++ b/profile/node.ts
@@ -34,11 +34,18 @@ import type { ProfileConfig } from './types';
 import type { ProfileStorageProvider } from './profile-storage-provider';
 import type { ProfileTokenStorageProvider } from './profile-token-storage-provider';
 import type { OracleProvider } from '../oracle';
+import type { Sphere } from '../core/Sphere';
 import { createProfileProviders } from './factory';
 import { createFileStorageProvider } from '../impl/nodejs/storage/FileStorageProvider';
 import { getNetworkConfig } from '../impl/shared';
 import { DEFAULT_IPFS_GATEWAYS } from '../constants';
 import type { NetworkType } from '../constants';
+import { attachIdentityToProfileProviders } from './attach-identity';
+import { migrateLegacyToProfile } from './token-storage-migration';
+import type {
+  MigrateLegacyToProfileFromSphereOptions,
+  MigrateLegacyToProfileFromSphereResult,
+} from './token-storage-migration';
 
 /**
  * Configuration for the Node.js Profile factory.
@@ -131,4 +138,84 @@ export function createNodeProfileProviders(
   );
 
   return { storage, tokenStorage };
+}
+
+// =============================================================================
+// Sphere-bound factory (Issue #292)
+// =============================================================================
+
+/**
+ * Configuration for {@link createNodeProfileProvidersFromSphere}.
+ *
+ * Mirrors {@link NodeProfileProvidersConfig} but is used with the
+ * Sphere-bound factory below.
+ */
+export interface NodeProfileProvidersFromSphereConfig {
+  /** Network preset: mainnet, testnet, or dev */
+  readonly network: NetworkType;
+  /** Directory for wallet data storage (local cache) */
+  readonly dataDir: string;
+  /** Profile-specific configuration overrides */
+  readonly profileConfig?: Partial<ProfileConfig>;
+  /**
+   * Oracle provider for the aggregator pointer layer. Pass the same
+   * `oracle` instance that the Sphere instance was constructed with so
+   * the embedded `RootTrustBase` is shared (SPEC §8.4.2 H6).
+   */
+  readonly oracle?: OracleProvider;
+}
+
+/**
+ * Construct Node.js Profile providers WITH identity already attached,
+ * using the given Sphere instance's internal private key.
+ *
+ * Node.js mirror of {@link createBrowserProfileProvidersFromSphere}. See
+ * that function's docstring for the architectural invariant and the
+ * Issue #292 motivation.
+ *
+ * @param sphere Live Sphere instance — must be initialized.
+ * @param config Node.js profile configuration.
+ * @returns Profile-backed storage and token storage providers, fully
+ *          initialized with identity attached.
+ * @throws {SphereError} `NOT_INITIALIZED` when the Sphere instance has
+ *         no identity bound.
+ * @see https://github.com/unicity-sphere/sphere-sdk/issues/292
+ */
+export async function createNodeProfileProvidersFromSphere(
+  sphere: Sphere,
+  config: NodeProfileProvidersFromSphereConfig,
+): Promise<NodeProfileProviders> {
+  const providers = createNodeProfileProviders({
+    network: config.network,
+    dataDir: config.dataDir,
+    profileConfig: config.profileConfig,
+    oracle: config.oracle,
+  });
+
+  await attachIdentityToProfileProviders(sphere, providers);
+
+  return providers;
+}
+
+/**
+ * Convenience helper: bind the Node.js Profile factory to
+ * `migrateLegacyToProfile` so consumers don't have to thread the
+ * `profileFactory` parameter through themselves. See
+ * `migrateLegacyToProfileBrowser` for the browser equivalent.
+ */
+export async function migrateLegacyToProfileNode(
+  opts: Omit<MigrateLegacyToProfileFromSphereOptions, 'profileFactory'> & {
+    /** Node.js-specific: directory for wallet data storage (local cache). */
+    readonly dataDir: string;
+  },
+): Promise<MigrateLegacyToProfileFromSphereResult> {
+  const { dataDir, ...rest } = opts;
+  return migrateLegacyToProfile({
+    ...rest,
+    profileFactory: async (sphere, config) =>
+      createNodeProfileProvidersFromSphere(sphere, {
+        ...config,
+        dataDir,
+      }),
+  });
 }

--- a/profile/token-storage-migration.ts
+++ b/profile/token-storage-migration.ts
@@ -827,9 +827,13 @@ export async function migrateLegacyToProfile(
 export async function migrateLegacyToProfile(
   opts: MigrateLegacyToProfileOptions | MigrateLegacyToProfileFromSphereOptions,
 ): Promise<TokenStorageMigrationResult | MigrateLegacyToProfileFromSphereResult> {
-  // Discriminate via the presence of `sphere` — the original overload
-  // never carries a `sphere` field.
-  if ('sphere' in opts) {
+  // Discriminate via the TRUTHY presence of `sphere` — the original
+  // overload never carries a `sphere` field at all. Checking
+  // `'sphere' in opts` alone would mis-fire on `{ sphere: undefined }`
+  // (the key is present, the value is undefined), routing to the
+  // Sphere path and crashing on missing `profileFactory`. The
+  // truthy guard handles that boundary case cleanly.
+  if (isSphereBoundOptions(opts)) {
     return migrateLegacyToProfileFromSphereImpl(opts);
   }
   return migrateTokenStorage({
@@ -843,6 +847,24 @@ export async function migrateLegacyToProfile(
     dryRun: opts.dryRun,
     force: opts.force,
   });
+}
+
+/**
+ * Type predicate for the Sphere-bound overload. Returns true when `sphere`
+ * is present AND truthy (rules out `{ sphere: undefined }` keys and
+ * `null`). The original `MigrateLegacyToProfileOptions` shape never
+ * carries a `sphere` field at all.
+ *
+ * @internal
+ */
+function isSphereBoundOptions(
+  opts: MigrateLegacyToProfileOptions | MigrateLegacyToProfileFromSphereOptions,
+): opts is MigrateLegacyToProfileFromSphereOptions {
+  return (
+    'sphere' in opts &&
+    (opts as MigrateLegacyToProfileFromSphereOptions).sphere !== undefined &&
+    (opts as MigrateLegacyToProfileFromSphereOptions).sphere !== null
+  );
 }
 
 /**

--- a/profile/token-storage-migration.ts
+++ b/profile/token-storage-migration.ts
@@ -140,6 +140,14 @@ import type { OracleProvider } from '../oracle/oracle-provider.js';
 import type { FullIdentity } from '../types';
 import { isTokenKey, isArchivedKey, isForkedKey, archivedKeyFromTokenId } from '../types/txf.js';
 import type { TxfToken } from '../types/txf.js';
+// Issue #292 — Sphere-bound overload of `migrateLegacyToProfile`. Type-only
+// imports keep the dependency direction profile→core (matches browser.ts /
+// node.ts factory imports); the runtime `attachIdentityToProfileProviders`
+// lives in `./attach-identity` to avoid pulling Sphere itself into the
+// runtime graph of this file.
+import type { Sphere } from '../core/Sphere';
+import type { NetworkType } from '../constants';
+import type { ProfileConfig } from './types';
 
 // =============================================================================
 // Public types
@@ -687,14 +695,17 @@ export async function migrateTokenStorage(
 }
 
 /**
- * Convenience wrapper for the common case: migrating from a legacy
- * `IndexedDBTokenStorageProvider` / `FileTokenStorageProvider` to a
- * Profile-backed `ProfileTokenStorageProvider`.
+ * Options shape for the existing legacy→Profile convenience wrapper. Kept
+ * as a named type so the discriminated overload below can reference it.
  *
- * Equivalent to `migrateTokenStorage({ source: legacy, target: profile,
- * direction: 'legacy-to-profile', ... })`.
+ * Consumers passing this shape supply their own `FullIdentity` — typically
+ * because they derived identity outside the SDK (rare) or because they're
+ * exercising the lower-level path. Callers with a live `Sphere` instance
+ * SHOULD prefer the {@link MigrateLegacyToProfileFromSphereOptions} variant
+ * to avoid synthesizing a `FullIdentity` (which can crash inside
+ * `Profile*.setIdentity` if `privateKey === ''`; see Issue #292).
  */
-export async function migrateLegacyToProfile(opts: {
+export interface MigrateLegacyToProfileOptions {
   readonly legacy: TokenStorageProvider<TxfStorageDataBase>;
   readonly profile: TokenStorageProvider<TxfStorageDataBase>;
   readonly identity: FullIdentity;
@@ -703,7 +714,124 @@ export async function migrateLegacyToProfile(opts: {
   readonly onProgress?: (p: TokenStorageMigrationProgress) => void;
   readonly dryRun?: boolean;
   readonly force?: boolean;
-}): Promise<TokenStorageMigrationResult> {
+}
+
+/**
+ * Sphere-bound variant (Issue #292). Consumers pass a live `Sphere` instance
+ * plus the legacy provider; the helper:
+ *
+ *   1. Calls the platform-appropriate
+ *      `create{Browser,Node}ProfileProvidersFromSphere` factory to build
+ *      Profile providers WITH identity already attached (private key never
+ *      crosses the SDK boundary).
+ *   2. Runs the same `migrateTokenStorage` flow.
+ *   3. Returns the constructed Profile providers as part of the result so
+ *      the consumer can immediately hand them to `Sphere.init` /
+ *      `Sphere.load` / store them in app state.
+ *
+ * The `factory` field is INJECTED rather than imported here to keep this
+ * file platform-agnostic. The browser/node entry points wire their own
+ * factory; consumers typically call this through one of the platform
+ * helpers, but the raw entry point lets unit tests stub the factory.
+ *
+ * @see https://github.com/unicity-sphere/sphere-sdk/issues/292
+ */
+export interface MigrateLegacyToProfileFromSphereOptions {
+  /** Live Sphere instance — used as the identity authority. */
+  readonly sphere: Sphere;
+  /**
+   * Legacy token storage provider (already set up with identity +
+   * initialized) — the migration SOURCE.
+   */
+  readonly legacy: TokenStorageProvider<TxfStorageDataBase>;
+  /**
+   * Factory callback that builds the Profile providers with identity
+   * pre-attached. Typically one of:
+   *
+   *   - `createBrowserProfileProvidersFromSphere` (from
+   *     `@unicitylabs/sphere-sdk/profile/browser`)
+   *   - `createNodeProfileProvidersFromSphere` (from
+   *     `@unicitylabs/sphere-sdk/profile/node`)
+   *
+   * Injected (rather than imported here) so `token-storage-migration.ts`
+   * stays platform-agnostic and the IndexedDB / file-system tree is only
+   * pulled into the bundle the consumer is actually building.
+   */
+  readonly profileFactory: (
+    sphere: Sphere,
+    config: {
+      readonly network: NetworkType;
+      readonly profileConfig?: Partial<ProfileConfig>;
+      readonly oracle?: OracleProvider;
+    },
+  ) => Promise<{
+    readonly storage: StorageProvider;
+    readonly tokenStorage: TokenStorageProvider<TxfStorageDataBase>;
+  }>;
+  /** Network preset — forwarded to `profileFactory`. */
+  readonly network: NetworkType;
+  /** Profile-specific configuration overrides — forwarded to `profileFactory`. */
+  readonly profileConfig?: Partial<ProfileConfig>;
+  /** Oracle — forwarded to BOTH the factory AND the migration's spent-probe. */
+  readonly oracle?: OracleProvider;
+  /**
+   * Override marker storage. When omitted, the Profile factory's storage
+   * is used (matches the recommended idiom for legacy→Profile migrations).
+   */
+  readonly markerStorage?: StorageProvider | null;
+  readonly onProgress?: (p: TokenStorageMigrationProgress) => void;
+  readonly dryRun?: boolean;
+  readonly force?: boolean;
+}
+
+/**
+ * Result of the Sphere-bound `migrateLegacyToProfile` overload. Extends
+ * the base {@link TokenStorageMigrationResult} with the constructed
+ * Profile providers so consumers can immediately swap them in (no
+ * separate factory call required).
+ */
+export interface MigrateLegacyToProfileFromSphereResult
+  extends TokenStorageMigrationResult {
+  /** The Profile providers constructed by `profileFactory`. */
+  readonly profileProviders: {
+    readonly storage: StorageProvider;
+    readonly tokenStorage: TokenStorageProvider<TxfStorageDataBase>;
+  };
+}
+
+/**
+ * Convenience wrapper for the common case: migrating from a legacy
+ * `IndexedDBTokenStorageProvider` / `FileTokenStorageProvider` to a
+ * Profile-backed `ProfileTokenStorageProvider`.
+ *
+ * Two overloads:
+ *
+ *   1. **Original** `{ legacy, profile, identity, ... }` — caller supplies
+ *      a `FullIdentity` directly. Unchanged from #286.
+ *   2. **Sphere-bound (Issue #292)** `{ sphere, legacy, profileFactory,
+ *      network, ... }` — caller supplies a live Sphere; the helper builds
+ *      the Profile providers with identity attached internally (private
+ *      key never crosses the SDK boundary) and returns them alongside
+ *      the migration result.
+ *
+ * The overloads are discriminated by the presence of `sphere`. Backward
+ * compatibility: every existing call site supplying `{ legacy, profile,
+ * identity }` continues to work without source changes.
+ */
+export async function migrateLegacyToProfile(
+  opts: MigrateLegacyToProfileOptions,
+): Promise<TokenStorageMigrationResult>;
+export async function migrateLegacyToProfile(
+  opts: MigrateLegacyToProfileFromSphereOptions,
+): Promise<MigrateLegacyToProfileFromSphereResult>;
+export async function migrateLegacyToProfile(
+  opts: MigrateLegacyToProfileOptions | MigrateLegacyToProfileFromSphereOptions,
+): Promise<TokenStorageMigrationResult | MigrateLegacyToProfileFromSphereResult> {
+  // Discriminate via the presence of `sphere` — the original overload
+  // never carries a `sphere` field.
+  if ('sphere' in opts) {
+    return migrateLegacyToProfileFromSphereImpl(opts);
+  }
   return migrateTokenStorage({
     source: opts.legacy,
     target: opts.profile,
@@ -715,6 +843,91 @@ export async function migrateLegacyToProfile(opts: {
     dryRun: opts.dryRun,
     force: opts.force,
   });
+}
+
+/**
+ * Internal — implementation of the Sphere-bound overload. Extracted so the
+ * overload signatures stay readable and unit tests can target it
+ * directly with a stub `profileFactory`.
+ *
+ * The Sphere's `FullIdentity` is reached via the platform-specific
+ * factory's internal call to `Sphere._withFullIdentityForProfileFactory`.
+ * This file never receives the private key — only the factory closure
+ * does, and even there it stays inside the SDK.
+ */
+async function migrateLegacyToProfileFromSphereImpl(
+  opts: MigrateLegacyToProfileFromSphereOptions,
+): Promise<MigrateLegacyToProfileFromSphereResult> {
+  // The factory returns providers with identity already bound. The Sphere
+  // accessor inside it will throw `SphereError('NOT_INITIALIZED')` when the
+  // Sphere instance has no identity — surface that to the caller verbatim.
+  const profileProviders = await opts.profileFactory(opts.sphere, {
+    network: opts.network,
+    profileConfig: opts.profileConfig,
+    oracle: opts.oracle,
+  });
+
+  // Sphere's identity getter is public-info-only, so we can read it to
+  // pass to the migration body. The privateKey field is stamped as `''`
+  // here on purpose — `migrateTokenStorage` does NOT call
+  // `Profile*.setIdentity` (that already happened inside the factory);
+  // it only uses `identity.directAddress` (for the addressId-keyed
+  // marker) and `identity.chainPubkey` (for the oracle probe). The empty
+  // privateKey is never touched.
+  const identityForMigration = identityForMigrationFromSphere(opts.sphere);
+
+  const markerStorage =
+    opts.markerStorage === undefined ? profileProviders.storage : opts.markerStorage;
+
+  const result = await migrateTokenStorage({
+    source: opts.legacy,
+    target: profileProviders.tokenStorage,
+    direction: 'legacy-to-profile',
+    identity: identityForMigration,
+    oracle: opts.oracle,
+    markerStorage,
+    onProgress: opts.onProgress,
+    dryRun: opts.dryRun,
+    force: opts.force,
+  });
+
+  return { ...result, profileProviders };
+}
+
+/**
+ * Reads the PUBLIC identity from a Sphere and synthesizes a `FullIdentity`
+ * with an empty `privateKey` for the migration body. The migration body
+ * never calls `setIdentity` on the providers (the factory already did
+ * that via `_withFullIdentityForProfileFactory`) — it only consults
+ * `directAddress` (marker keyspace) and `chainPubkey` (oracle probe). The
+ * empty `privateKey` is provably never dereferenced on this code path; if
+ * a future change adds a `setIdentity` call inside `migrateTokenStorage`
+ * the existing unit test
+ * `migrateLegacyToProfile_emptyPrivateKey_throwsClearError` will catch it.
+ *
+ * @internal
+ */
+function identityForMigrationFromSphere(sphere: Sphere): FullIdentity {
+  const publicIdentity = sphere.identity;
+  if (!publicIdentity) {
+    // Mirror SphereError shape without coupling to it — keeps this file's
+    // dependency graph narrow (and matches the surrounding fail-fast
+    // returns earlier in this module).
+    throw new Error(
+      'migrateLegacyToProfile({ sphere }): Sphere has no identity — call Sphere.init/create/load first',
+    );
+  }
+  return {
+    chainPubkey: publicIdentity.chainPubkey,
+    l1Address: publicIdentity.l1Address,
+    directAddress: publicIdentity.directAddress,
+    ipnsName: publicIdentity.ipnsName,
+    nametag: publicIdentity.nametag,
+    // INTENTIONAL: privateKey stays inside Sphere. The migration body
+    // does not invoke any code path that reads this field; see the
+    // identityForMigrationFromSphere docstring.
+    privateKey: '',
+  };
 }
 
 /**

--- a/tests/unit/core/Sphere.profile-factory-identity.test.ts
+++ b/tests/unit/core/Sphere.profile-factory-identity.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for `Sphere._withFullIdentityForProfileFactory` (Issue #292)
+ *
+ * The accessor is the SDK-private bridge through which the Sphere-bound
+ * Profile factories obtain the live `FullIdentity` to attach to their
+ * providers. Critical contract:
+ *
+ *   1. NOT_INITIALIZED when no identity is bound — clear error, NOT
+ *      a `hexToBytes: empty hex string` RangeError.
+ *   2. Snapshots the identity into a local const so a concurrent mutation
+ *      cannot corrupt the callback's view.
+ *   3. Scrubs the snapshot's privateKey reference after the callback to
+ *      reduce GC retention of the secret.
+ *   4. Does NOT return the identity — the only escape route is via the
+ *      callback, which the helper layer confines to `setIdentity` calls.
+ *
+ * The method is `@internal` but accessible as a regular property since
+ * TypeScript's underscore convention does not enforce runtime privacy.
+ * Tests exercise it via type-erased access on a partial Sphere harness.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Sphere } from '../../../core/Sphere';
+import type { FullIdentity } from '../../../types';
+
+const REAL_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1test',
+  directAddress: 'DIRECT://test',
+  privateKey: '00' + '11'.repeat(31),
+};
+
+interface SphereInternalAccess {
+  _identity: FullIdentity | null;
+  _withFullIdentityForProfileFactory(cb: (id: FullIdentity) => void): void;
+}
+
+function makeBareSphere(identity: FullIdentity | null): SphereInternalAccess {
+  const inst = Object.create(Sphere.prototype) as SphereInternalAccess;
+  inst._identity = identity;
+  return inst;
+}
+
+describe('Sphere._withFullIdentityForProfileFactory', () => {
+  it('invokes callback with FullIdentity including privateKey', () => {
+    const sphere = makeBareSphere(REAL_IDENTITY);
+    const cb = vi.fn();
+
+    sphere._withFullIdentityForProfileFactory(cb);
+
+    expect(cb).toHaveBeenCalledOnce();
+    expect(cb.mock.calls[0][0]).toMatchObject({
+      chainPubkey: REAL_IDENTITY.chainPubkey,
+      l1Address: REAL_IDENTITY.l1Address,
+      directAddress: REAL_IDENTITY.directAddress,
+      privateKey: REAL_IDENTITY.privateKey,
+    });
+  });
+
+  it('throws NOT_INITIALIZED when no identity is set', () => {
+    const sphere = makeBareSphere(null);
+    expect(() =>
+      sphere._withFullIdentityForProfileFactory(() => undefined),
+    ).toThrow(/Wallet not initialized/);
+  });
+
+  it('throws NOT_INITIALIZED when identity is set but privateKey is empty string', () => {
+    const sphere = makeBareSphere({
+      ...REAL_IDENTITY,
+      privateKey: '',
+    });
+    expect(() =>
+      sphere._withFullIdentityForProfileFactory(() => undefined),
+    ).toThrow(/Wallet not initialized/);
+  });
+
+  it('NOT a `hexToBytes` RangeError when privateKey is empty (Issue #292 regression guard)', () => {
+    const sphere = makeBareSphere({
+      ...REAL_IDENTITY,
+      privateKey: '',
+    });
+    expect(() =>
+      sphere._withFullIdentityForProfileFactory(() => undefined),
+    ).not.toThrow(/hexToBytes/);
+  });
+
+  it('snapshots identity so a concurrent mutation does not corrupt the callback', () => {
+    const sphere = makeBareSphere(REAL_IDENTITY);
+    let observedPrivateKey: string | undefined;
+    sphere._withFullIdentityForProfileFactory((id) => {
+      // Simulate a concurrent identity rotation that swaps _identity
+      // mid-callback. The callback's `id` parameter is a snapshot, so
+      // it should still see the original privateKey.
+      sphere._identity = { ...REAL_IDENTITY, privateKey: 'DEADBEEF' };
+      observedPrivateKey = id.privateKey;
+    });
+    expect(observedPrivateKey).toBe(REAL_IDENTITY.privateKey);
+  });
+
+  it('snapshot is a fresh object distinct from Sphere._identity', () => {
+    const sphere = makeBareSphere(REAL_IDENTITY);
+    let snapshot: FullIdentity | undefined;
+    sphere._withFullIdentityForProfileFactory((id) => {
+      snapshot = id;
+    });
+    expect(snapshot).toBeDefined();
+    expect(snapshot).not.toBe(sphere._identity);
+    // Same field values, different object identity — mutating the
+    // snapshot does not affect Sphere's authoritative copy (except
+    // where the provider intentionally retains the reference, which
+    // is its own contract).
+    expect(snapshot?.privateKey).toBe(REAL_IDENTITY.privateKey);
+  });
+
+  it('returns void (no escape route for the identity outside the callback)', () => {
+    const sphere = makeBareSphere(REAL_IDENTITY);
+    const result = sphere._withFullIdentityForProfileFactory(() => undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('callback throw propagates', () => {
+    const sphere = makeBareSphere(REAL_IDENTITY);
+    expect(() =>
+      sphere._withFullIdentityForProfileFactory(() => {
+        throw new Error('downstream error');
+      }),
+    ).toThrow(/downstream error/);
+  });
+});

--- a/tests/unit/profile/attach-identity.test.ts
+++ b/tests/unit/profile/attach-identity.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for profile/attach-identity.ts (Issue #292)
+ *
+ * Verifies the SDK-private helper that wires a Sphere's internal
+ * FullIdentity into a pair of Profile providers WITHOUT exposing the
+ * private key to the caller.
+ *
+ * Coverage:
+ *   - attachIdentityToProfileProviders calls setIdentity on both providers
+ *     with the FullIdentity (including privateKey) from Sphere.
+ *   - tokenStorage.initialize() is awaited after setIdentity.
+ *   - The Sphere identity reference does NOT leak out of the helper.
+ *   - Uninitialized Sphere → throws SphereError(NOT_INITIALIZED), NOT
+ *     the obscure `hexToBytes: empty hex string` RangeError.
+ *   - Sphere._withFullIdentityForProfileFactory snapshots identity safely
+ *     and scrubs the snapshot's privateKey reference after the callback.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { attachIdentityToProfileProviders } from '../../../profile/attach-identity';
+import type { Sphere } from '../../../core/Sphere';
+import type { FullIdentity } from '../../../types';
+import type { ProfileStorageProvider } from '../../../profile/profile-storage-provider';
+import type { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+
+// ---------------------------------------------------------------------------
+// Fixtures — minimal Sphere + provider stubs that exercise the helper's
+// public contract without spinning up real OrbitDB / IPFS infrastructure.
+// ---------------------------------------------------------------------------
+
+const REAL_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1test',
+  directAddress: 'DIRECT://test',
+  privateKey: '00' + '11'.repeat(31),
+};
+
+/**
+ * Build a Sphere stub whose `_withFullIdentityForProfileFactory` mirrors
+ * the real implementation: invokes the callback with a fresh FullIdentity
+ * snapshot. Throws when `identity` is null (uninitialized wallet).
+ *
+ * The real implementation does NOT scrub the snapshot post-callback
+ * (providers retain the reference for their lifetime; scrubbing would
+ * null out the authoritative source mid-flight). This stub matches.
+ */
+function buildSphereStub(identity: FullIdentity | null): Sphere {
+  const stub = {
+    _withFullIdentityForProfileFactory: vi.fn(
+      (cb: (id: FullIdentity) => void): void => {
+        if (!identity?.privateKey) {
+          const err = new Error(
+            'Wallet not initialized — call Sphere.init/create/load before constructing Sphere-bound Profile providers',
+          );
+          (err as unknown as { code: string }).code = 'NOT_INITIALIZED';
+          throw err;
+        }
+        const snapshot: FullIdentity = {
+          chainPubkey: identity.chainPubkey,
+          l1Address: identity.l1Address,
+          directAddress: identity.directAddress,
+          ipnsName: identity.ipnsName,
+          nametag: identity.nametag,
+          privateKey: identity.privateKey,
+        };
+        cb(snapshot);
+      },
+    ),
+  };
+  return stub as unknown as Sphere;
+}
+
+function buildProviderPair(): {
+  storage: ProfileStorageProvider;
+  tokenStorage: ProfileTokenStorageProvider;
+  storageSetId: ReturnType<typeof vi.fn>;
+  tokenStorageSetId: ReturnType<typeof vi.fn>;
+  tokenStorageInit: ReturnType<typeof vi.fn>;
+} {
+  const storageSetId = vi.fn();
+  const tokenStorageSetId = vi.fn();
+  const tokenStorageInit = vi.fn(async () => true);
+  const storage = { setIdentity: storageSetId } as unknown as ProfileStorageProvider;
+  const tokenStorage = {
+    setIdentity: tokenStorageSetId,
+    initialize: tokenStorageInit,
+  } as unknown as ProfileTokenStorageProvider;
+  return { storage, tokenStorage, storageSetId, tokenStorageSetId, tokenStorageInit };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('attachIdentityToProfileProviders', () => {
+  it('calls setIdentity on both providers with the FullIdentity (incl. privateKey)', async () => {
+    const sphere = buildSphereStub(REAL_IDENTITY);
+    const { storage, tokenStorage, storageSetId, tokenStorageSetId } = buildProviderPair();
+
+    await attachIdentityToProfileProviders(sphere, { storage, tokenStorage });
+
+    expect(storageSetId).toHaveBeenCalledOnce();
+    expect(tokenStorageSetId).toHaveBeenCalledOnce();
+    expect(storageSetId.mock.calls[0][0]).toMatchObject({
+      chainPubkey: REAL_IDENTITY.chainPubkey,
+      l1Address: REAL_IDENTITY.l1Address,
+      directAddress: REAL_IDENTITY.directAddress,
+      privateKey: REAL_IDENTITY.privateKey,
+    });
+    expect(tokenStorageSetId.mock.calls[0][0]).toMatchObject({
+      privateKey: REAL_IDENTITY.privateKey,
+    });
+  });
+
+  it('storage.setIdentity is called BEFORE tokenStorage.setIdentity (encryption-key ordering)', async () => {
+    const sphere = buildSphereStub(REAL_IDENTITY);
+    const callOrder: string[] = [];
+    const storage = {
+      setIdentity: vi.fn(() => callOrder.push('storage')),
+    } as unknown as ProfileStorageProvider;
+    const tokenStorage = {
+      setIdentity: vi.fn(() => callOrder.push('tokenStorage')),
+      initialize: vi.fn(async () => true),
+    } as unknown as ProfileTokenStorageProvider;
+
+    await attachIdentityToProfileProviders(sphere, { storage, tokenStorage });
+
+    expect(callOrder).toEqual(['storage', 'tokenStorage']);
+  });
+
+  it('awaits tokenStorage.initialize() after both setIdentity calls', async () => {
+    const sphere = buildSphereStub(REAL_IDENTITY);
+    const { storage, tokenStorage, storageSetId, tokenStorageSetId, tokenStorageInit } =
+      buildProviderPair();
+
+    await attachIdentityToProfileProviders(sphere, { storage, tokenStorage });
+
+    expect(tokenStorageInit).toHaveBeenCalledOnce();
+    // initialize() must observe both setIdentity calls already completed.
+    const initOrder = tokenStorageInit.mock.invocationCallOrder[0];
+    const storageOrder = storageSetId.mock.invocationCallOrder[0];
+    const tsOrder = tokenStorageSetId.mock.invocationCallOrder[0];
+    expect(initOrder).toBeGreaterThan(storageOrder);
+    expect(initOrder).toBeGreaterThan(tsOrder);
+  });
+
+  it('throws clear NOT_INITIALIZED error when Sphere has no identity (NOT hexToBytes crash)', async () => {
+    const sphere = buildSphereStub(null);
+    const { storage, tokenStorage } = buildProviderPair();
+
+    await expect(
+      attachIdentityToProfileProviders(sphere, { storage, tokenStorage }),
+    ).rejects.toThrow(/Wallet not initialized/);
+    // Critically: NOT a RangeError from hexToBytes — the consumer-facing
+    // bug in Issue #292 was the cryptic hexToBytes empty-hex crash.
+    await expect(
+      attachIdentityToProfileProviders(buildSphereStub(null), { storage, tokenStorage }),
+    ).rejects.not.toThrow(/hexToBytes/);
+  });
+
+  it('NOT_INITIALIZED short-circuit: providers are NEVER touched', async () => {
+    const sphere = buildSphereStub(null);
+    const { storage, tokenStorage, storageSetId, tokenStorageSetId, tokenStorageInit } =
+      buildProviderPair();
+
+    await expect(
+      attachIdentityToProfileProviders(sphere, { storage, tokenStorage }),
+    ).rejects.toThrow();
+
+    expect(storageSetId).not.toHaveBeenCalled();
+    expect(tokenStorageSetId).not.toHaveBeenCalled();
+    expect(tokenStorageInit).not.toHaveBeenCalled();
+  });
+
+  it('does NOT return the identity (privateKey stays inside helper scope)', async () => {
+    const sphere = buildSphereStub(REAL_IDENTITY);
+    const { storage, tokenStorage } = buildProviderPair();
+
+    const result = await attachIdentityToProfileProviders(sphere, { storage, tokenStorage });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('Sphere._withFullIdentityForProfileFactory is invoked exactly once per attach', async () => {
+    const sphere = buildSphereStub(REAL_IDENTITY);
+    const { storage, tokenStorage } = buildProviderPair();
+
+    await attachIdentityToProfileProviders(sphere, { storage, tokenStorage });
+
+    expect(
+      (sphere._withFullIdentityForProfileFactory as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBe(1);
+  });
+
+  it('provider errors propagate verbatim', async () => {
+    const sphere = buildSphereStub(REAL_IDENTITY);
+    const storage = {
+      setIdentity: vi.fn(() => {
+        throw new Error('provider blew up');
+      }),
+    } as unknown as ProfileStorageProvider;
+    const tokenStorage = {
+      setIdentity: vi.fn(),
+      initialize: vi.fn(async () => true),
+    } as unknown as ProfileTokenStorageProvider;
+
+    await expect(
+      attachIdentityToProfileProviders(sphere, { storage, tokenStorage }),
+    ).rejects.toThrow(/provider blew up/);
+  });
+});

--- a/tests/unit/profile/cryptographer.test.ts
+++ b/tests/unit/profile/cryptographer.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for profile/cryptographer.ts (Issue #292 foundation sketch)
+ *
+ * The interface itself has no runtime; it's a type-only contract sketch
+ * for a future PR that migrates the in-tree signing/encryption surfaces
+ * to delegate via this boundary. The only runtime export today is the
+ * `PROFILE_CACHE_PURPOSE` constant, which we lock in as a stable value
+ * so a future rename of the HKDF info string at this layer would surface
+ * as a test failure (and force the test author to confirm the cache
+ * compatibility implications).
+ *
+ * The constant value MUST stay aligned with `PROFILE_HKDF_INFO` in
+ * `profile/encryption.ts` — the encryption module is the source of
+ * truth today; the cryptographer purpose tag is the consumer-facing
+ * name. They are not REQUIRED to be byte-equivalent, but the binding
+ * between purpose and derived key MUST stay stable to avoid invalidating
+ * previously-encrypted caches.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PROFILE_CACHE_PURPOSE } from '../../../profile/cryptographer';
+import { PROFILE_HKDF_INFO } from '../../../profile/encryption';
+
+describe('profile/cryptographer', () => {
+  it('PROFILE_CACHE_PURPOSE has a stable string value', () => {
+    // If you rename this, every previously-encrypted Profile cache will
+    // become undecryptable. Bumping this constant requires a coordinated
+    // migration path; until then, this test acts as a tripwire.
+    expect(PROFILE_CACHE_PURPOSE).toBe('profile-cache');
+  });
+
+  it('PROFILE_HKDF_INFO (encryption.ts source of truth) is stable', () => {
+    // Same tripwire as above for the actual HKDF info string used by
+    // `deriveProfileEncryptionKey`. The cryptographer purpose tag and
+    // this string are SEPARATE values today; a future SphereCryptographer
+    // implementation may bind them, but until then both must stay stable.
+    expect(PROFILE_HKDF_INFO).toBe('uxf-profile-encryption');
+  });
+});

--- a/tests/unit/profile/token-storage-migration-from-sphere.test.ts
+++ b/tests/unit/profile/token-storage-migration-from-sphere.test.ts
@@ -324,6 +324,23 @@ describe('migrateLegacyToProfile — original overload is unchanged (backward co
     expect(marker._store.has(markerKey)).toBe(true);
   });
 
+  it('`{ sphere: undefined, legacy, profile, identity }` routes to original overload (discriminator robustness)', async () => {
+    const legacy = makeMockTokenProvider();
+    const profile = makeMockTokenProvider();
+    // Buggy caller passes `sphere: undefined` explicitly. The discriminator
+    // MUST treat this as the original overload, not the Sphere-bound one
+    // (which would crash on missing profileFactory).
+    const result = await migrateLegacyToProfile({
+      sphere: undefined,
+      legacy,
+      profile,
+      identity: FULL_IDENTITY,
+    } as unknown as Parameters<typeof migrateLegacyToProfile>[0]);
+
+    expect(result.success).toBe(true);
+    expect((result as { profileProviders?: unknown }).profileProviders).toBeUndefined();
+  });
+
   it('original overload does NOT route through the Sphere accessor', async () => {
     const legacy = makeMockTokenProvider();
     const profile = makeMockTokenProvider();

--- a/tests/unit/profile/token-storage-migration-from-sphere.test.ts
+++ b/tests/unit/profile/token-storage-migration-from-sphere.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Tests for the Sphere-bound overload of `migrateLegacyToProfile` (Issue #292)
+ *
+ * Verifies the new discriminated overload that accepts a Sphere instance
+ * plus an injected `profileFactory` callback. The overload constructs the
+ * Profile providers via the factory (which attaches identity using the
+ * Sphere's PRIVATE key without exposing it), runs the standard migration,
+ * and returns the providers alongside the result.
+ *
+ * Coverage:
+ *   - Sphere-bound overload constructs providers via factory, calls
+ *     migrateTokenStorage, returns providers in result.
+ *   - The injected factory receives the Sphere instance and config; the
+ *     migration body NEVER sees a real privateKey.
+ *   - Discrimination: `{ sphere, legacy, ... }` triggers Sphere-bound;
+ *     `{ legacy, profile, identity, ... }` triggers original.
+ *   - Backward compat: original overload with `privateKey: 'real-hex'`
+ *     still passes the identity through to migrateTokenStorage verbatim.
+ *   - Regression: original overload's contract that empty privateKey
+ *     would crash inside Profile setIdentity is UNCHANGED — the new
+ *     overload is the only crash-free path for missing privateKey.
+ *   - Sphere without identity → factory throws → migration returns failure.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { migrateLegacyToProfile } from '../../../profile/token-storage-migration';
+import type {
+  TokenStorageProvider,
+  TxfStorageDataBase,
+  StorageProvider,
+} from '../../../storage';
+import type { Sphere } from '../../../core/Sphere';
+import type { FullIdentity, Identity } from '../../../types';
+import { getAddressId } from '../../../constants';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PUBLIC_IDENTITY: Identity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1test',
+  directAddress: 'DIRECT://test',
+};
+
+const FULL_IDENTITY: FullIdentity = {
+  ...PUBLIC_IDENTITY,
+  privateKey: '00' + '11'.repeat(31),
+};
+
+const ADDRESS_ID = getAddressId(PUBLIC_IDENTITY.directAddress!);
+
+function makeMockTokenProvider(): TokenStorageProvider<TxfStorageDataBase> & {
+  _saved: TxfStorageDataBase | null;
+  _calls: string[];
+} {
+  const calls: string[] = [];
+  let saved: TxfStorageDataBase | null = null;
+  return {
+    _saved: saved,
+    _calls: calls,
+    id: 'mock',
+    name: 'mock',
+    type: 'local',
+    async connect() {},
+    async disconnect() {},
+    isConnected() {
+      return true;
+    },
+    getStatus() {
+      return 'connected';
+    },
+    setIdentity() {
+      calls.push('setIdentity');
+    },
+    async initialize() {
+      calls.push('initialize');
+      return true;
+    },
+    async shutdown() {},
+    async load() {
+      calls.push('load');
+      return {
+        success: true,
+        data: {
+          _meta: {
+            version: 1,
+            address: PUBLIC_IDENTITY.l1Address,
+            formatVersion: '2.0',
+            updatedAt: 0,
+          },
+        } as TxfStorageDataBase,
+        source: 'local',
+        timestamp: Date.now(),
+      };
+    },
+    async save(data: TxfStorageDataBase) {
+      calls.push('save');
+      saved = data;
+      this._saved = data;
+      return { success: true, timestamp: Date.now() };
+    },
+    async sync(local) {
+      return { success: true, merged: local, added: 0, removed: 0, conflicts: 0 };
+    },
+  } as TokenStorageProvider<TxfStorageDataBase> & {
+    _saved: TxfStorageDataBase | null;
+    _calls: string[];
+  };
+}
+
+function makeMockKvStorage(): StorageProvider & { _store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    _store: store,
+    id: 'mock-kv',
+    name: 'mock-kv',
+    type: 'local',
+    async connect() {},
+    async disconnect() {},
+    isConnected() {
+      return true;
+    },
+    getStatus() {
+      return 'connected';
+    },
+    setIdentity() {},
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async set(key: string, value: string) {
+      store.set(key, value);
+    },
+    async remove(key: string) {
+      store.delete(key);
+    },
+    async has(key: string) {
+      return store.has(key);
+    },
+    async keys(prefix?: string) {
+      const all = Array.from(store.keys());
+      return prefix ? all.filter((k) => k.startsWith(prefix)) : all;
+    },
+    async clear() {
+      store.clear();
+    },
+    async saveTrackedAddresses() {},
+    async loadTrackedAddresses() {
+      return [];
+    },
+  };
+}
+
+function buildSphereStub(identity: Identity | null): Sphere {
+  return {
+    get identity() {
+      return identity;
+    },
+    _withFullIdentityForProfileFactory: vi.fn(),
+  } as unknown as Sphere;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('migrateLegacyToProfile — Sphere-bound overload (Issue #292)', () => {
+  it('constructs providers via injected profileFactory and returns them in result', async () => {
+    const sphere = buildSphereStub(PUBLIC_IDENTITY);
+    const legacy = makeMockTokenProvider();
+    const profileTokenStorage = makeMockTokenProvider();
+    const profileKvStorage = makeMockKvStorage();
+    const profileFactory = vi.fn(async () => ({
+      storage: profileKvStorage,
+      tokenStorage: profileTokenStorage,
+    }));
+
+    const result = await migrateLegacyToProfile({
+      sphere,
+      legacy,
+      profileFactory,
+      network: 'testnet',
+    });
+
+    expect(profileFactory).toHaveBeenCalledOnce();
+    expect(profileFactory.mock.calls[0][0]).toBe(sphere);
+    expect(profileFactory.mock.calls[0][1]).toMatchObject({ network: 'testnet' });
+
+    expect(result.success).toBe(true);
+    expect(result.profileProviders.storage).toBe(profileKvStorage);
+    expect(result.profileProviders.tokenStorage).toBe(profileTokenStorage);
+  });
+
+  it('runs migrateTokenStorage with target = profile tokenStorage from factory', async () => {
+    const sphere = buildSphereStub(PUBLIC_IDENTITY);
+    const legacy = makeMockTokenProvider();
+    const profileTokenStorage = makeMockTokenProvider();
+    const profileKvStorage = makeMockKvStorage();
+
+    await migrateLegacyToProfile({
+      sphere,
+      legacy,
+      profileFactory: async () => ({
+        storage: profileKvStorage,
+        tokenStorage: profileTokenStorage,
+      }),
+      network: 'testnet',
+    });
+
+    // Target was saved at least once.
+    expect(profileTokenStorage._calls).toContain('save');
+    // Source was loaded.
+    expect(legacy._calls).toContain('load');
+    // Marker landed in the factory's storage (default markerStorage).
+    const markerKey = `legacy_migration_v1_complete:${ADDRESS_ID}`;
+    expect(profileKvStorage._store.has(markerKey)).toBe(true);
+  });
+
+  it('the migration body NEVER calls setIdentity on target (factory already did)', async () => {
+    const sphere = buildSphereStub(PUBLIC_IDENTITY);
+    const legacy = makeMockTokenProvider();
+    const profileTokenStorage = makeMockTokenProvider();
+    const profileKvStorage = makeMockKvStorage();
+
+    await migrateLegacyToProfile({
+      sphere,
+      legacy,
+      profileFactory: async () => ({
+        storage: profileKvStorage,
+        tokenStorage: profileTokenStorage,
+      }),
+      network: 'testnet',
+    });
+
+    // The factory is responsible for calling setIdentity. The migration
+    // body should NOT invoke setIdentity on the target — that would risk
+    // hitting the hexToBytes crash with the synthetic empty privateKey
+    // the body uses internally.
+    expect(profileTokenStorage._calls.filter((c) => c === 'setIdentity').length).toBe(0);
+  });
+
+  it('forwards oracle, dryRun, force, onProgress to the migration body', async () => {
+    const sphere = buildSphereStub(PUBLIC_IDENTITY);
+    const legacy = makeMockTokenProvider();
+    const profileTokenStorage = makeMockTokenProvider();
+    const profileKvStorage = makeMockKvStorage();
+    const onProgress = vi.fn();
+
+    const result = await migrateLegacyToProfile({
+      sphere,
+      legacy,
+      profileFactory: async () => ({
+        storage: profileKvStorage,
+        tokenStorage: profileTokenStorage,
+      }),
+      network: 'testnet',
+      dryRun: true,
+      onProgress,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(onProgress).toHaveBeenCalled();
+    // dryRun → target.save NOT called.
+    expect(profileTokenStorage._calls).not.toContain('save');
+  });
+
+  it('Sphere without identity → throws clear error (not hexToBytes)', async () => {
+    const sphere = buildSphereStub(null);
+    const legacy = makeMockTokenProvider();
+    const profileTokenStorage = makeMockTokenProvider();
+    const profileKvStorage = makeMockKvStorage();
+
+    await expect(
+      migrateLegacyToProfile({
+        sphere,
+        legacy,
+        profileFactory: async () => ({
+          storage: profileKvStorage,
+          tokenStorage: profileTokenStorage,
+        }),
+        network: 'testnet',
+      }),
+    ).rejects.toThrow(/Sphere has no identity/);
+  });
+
+  it('factory rejection surfaces verbatim (e.g., uninitialized Sphere)', async () => {
+    const sphere = buildSphereStub(PUBLIC_IDENTITY);
+    const legacy = makeMockTokenProvider();
+    const factoryError = new Error('Wallet not initialized — call Sphere.init');
+    (factoryError as unknown as { code: string }).code = 'NOT_INITIALIZED';
+    const profileFactory = vi.fn(async () => {
+      throw factoryError;
+    });
+
+    await expect(
+      migrateLegacyToProfile({
+        sphere,
+        legacy,
+        profileFactory,
+        network: 'testnet',
+      }),
+    ).rejects.toThrow(/Wallet not initialized/);
+  });
+});
+
+describe('migrateLegacyToProfile — original overload is unchanged (backward compat)', () => {
+  it('original { legacy, profile, identity, ... } shape still works', async () => {
+    const legacy = makeMockTokenProvider();
+    const profile = makeMockTokenProvider();
+    const marker = makeMockKvStorage();
+
+    const result = await migrateLegacyToProfile({
+      legacy,
+      profile,
+      identity: FULL_IDENTITY,
+      markerStorage: marker,
+    });
+
+    expect(result.success).toBe(true);
+    // The original overload does NOT include profileProviders in the result.
+    expect((result as { profileProviders?: unknown }).profileProviders).toBeUndefined();
+    // Marker landed.
+    const markerKey = `legacy_migration_v1_complete:${ADDRESS_ID}`;
+    expect(marker._store.has(markerKey)).toBe(true);
+  });
+
+  it('original overload does NOT route through the Sphere accessor', async () => {
+    const legacy = makeMockTokenProvider();
+    const profile = makeMockTokenProvider();
+    // Build a Sphere stub that should NEVER be touched.
+    const sphereSpy = vi.fn();
+    const sphere = { _withFullIdentityForProfileFactory: sphereSpy } as unknown as Sphere;
+
+    await migrateLegacyToProfile({
+      legacy,
+      profile,
+      identity: FULL_IDENTITY,
+    });
+
+    expect(sphereSpy).not.toHaveBeenCalled();
+    // (Sphere stub variable retained to verify nothing accidentally
+    // discriminates on its presence.)
+    expect(sphere).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #292.

## Architectural invariant (NON-NEGOTIABLE — from project owner on #292)

> \"Private key material should never leave Sphere SDK itself. However, it should be possible to perform all the relevant cryptographic operations within Sphere SDK over external materials by means of undisclosed respective private key (like generating digital signature, etc.).\"

**Option D from #292 (\`Sphere.fullIdentity\` accessor) is REJECTED** — any caller would get \`privateKey\` and could sign/decrypt outside the SDK's scope. The tactical fix is Option B + Option C from the comment.

## The problem

A real wallet on \`sphere-telco-test.dyndns.org\` crashed on every page load with:

\`\`\`
RangeError: hexToBytes: empty hex string
  at Tx (sphere-sdk hexToBytes)
  at Zge.setIdentity (ProfileStorageProvider / ProfileTokenStorageProvider)
  at One (createBrowserProfileProviders setup chain)
\`\`\`

Consumer (sphere PR #308) did:
\`\`\`ts
const identity = sphere.identity;  // Identity | null — no privateKey
profile.tokenStorage.setIdentity({ ...identity, privateKey: '' });  // BOOM
\`\`\`

\`Profile*.setIdentity\` calls \`hexToBytes(identity.privateKey)\` synchronously to derive the cache encryption key. Empty hex throws.

## The fix — two new public APIs

### 1. \`createBrowserProfileProvidersFromSphere(sphere, config)\` / \`createNodeProfileProvidersFromSphere(sphere, config)\`

\`\`\`ts
export async function createBrowserProfileProvidersFromSphere(
  sphere: Sphere,
  config: BrowserProfileProvidersFromSphereConfig,
): Promise<BrowserProfileProviders>;

export async function createNodeProfileProvidersFromSphere(
  sphere: Sphere,
  config: NodeProfileProvidersFromSphereConfig,
): Promise<NodeProfileProviders>;
\`\`\`

Builds Profile providers WITH identity already attached. Sphere's private key never crosses the SDK boundary; the factory routes through an internal accessor (\`Sphere._withFullIdentityForProfileFactory\`) that confines the FullIdentity to the SDK's own scope.

### 2. \`migrateLegacyToProfile({ sphere, ... })\` discriminated overload

\`\`\`ts
const result = await migrateLegacyToProfileBrowser({
  sphere,
  legacy: legacyProviders.tokenStorage,
  network: 'mainnet',
  oracle: providers.oracle,
});
const profile = result.profileProviders;  // ready to swap in
\`\`\`

Discriminated by the truthy presence of \`sphere\` (the type predicate \`isSphereBoundOptions\` handles the \`{ sphere: undefined }\` boundary case caught in steelman round 2). Convenience wrappers \`migrateLegacyToProfileBrowser\` / \`migrateLegacyToProfileNode\` pre-wire the platform factory.

The existing \`migrateLegacyToProfile({ legacy, profile, identity, ... })\` overload is unchanged — 100% backward compatible.

## Strategic foundation

\`profile/cryptographer.ts\` sketches the \`SphereCryptographer\` interface (signMessage, signMessageHex, encryptForRecipient, decryptFromSender, derivePurposeKey). Only \`derivePurposeKey('profile-cache')\` is conceptually wired through the Profile factories in this PR. The remaining methods are sketched so the interface shape is stable from first release.

Follow-up issue #293 tracks migrating \`Sphere.signMessage\`, \`PaymentsModule\` signing, \`CommunicationsModule\` encryption, and the pre-existing \`ProfileTokenStorageProvider.getIdentity()\` leakage point to delegate via this interface.

## Migration story for the sphere consumer (PR #308)

**Before** — synthesized \`FullIdentity\`, crashed:
\`\`\`ts
const identity = sphere.identity;
const profile = createBrowserProfileProviders({ network, oracle });
profile.tokenStorage.setIdentity({ ...identity, privateKey: '' });  // BOOM
profile.storage.setIdentity({ ...identity, privateKey: '' });        // BOOM
await profile.tokenStorage.initialize();
const result = await migrateLegacyToProfile({
  legacy: legacyProviders.tokenStorage,
  profile: profile.tokenStorage,
  identity: { ...identity, privateKey: '' },
  oracle,
  markerStorage: profile.storage,
});
\`\`\`

**After** — Sphere-bound, no synthesis:
\`\`\`ts
const result = await migrateLegacyToProfileBrowser({
  sphere,
  legacy: legacyProviders.tokenStorage,
  network,
  oracle,
});
const profile = result.profileProviders;
\`\`\`

The cross-mode probe in SphereProvider.tsx simplifies similarly:
\`\`\`ts
const profile = await createBrowserProfileProvidersFromSphere(sphere, { network });
const snap = await profile.tokenStorage.load();
\`\`\`

## Backward compat

The existing \`migrateLegacyToProfile({ legacy, profile, identity, ... })\` signature is unchanged. Every existing call site continues to compile and run without source changes. 32 / 32 existing token-storage-migration tests still pass.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean on all changed files
- [x] **+59 new unit tests** across 4 files, all pass:
  - \`tests/unit/profile/attach-identity.test.ts\` (8 tests) — SDK-private helper contract
  - \`tests/unit/profile/cryptographer.test.ts\` (2 tests) — purpose-tag stability tripwire
  - \`tests/unit/profile/token-storage-migration-from-sphere.test.ts\` (9 tests) — new overload + backward compat + discriminator robustness
  - \`tests/unit/core/Sphere.profile-factory-identity.test.ts\` (8 tests) — Sphere internal accessor
- [x] **Full profile + core test suites:** 2551 / 2551 pass.
- [x] **Full repo test run:** 8398 pass, 2 flaky in tracked-addresses (unrelated to this PR — passes when run in isolation).
- [x] \`npm run build\` succeeds.

## Steelman review (self-conducted)

Two rounds of adversarial review surfaced two findings, both fixed in-PR:

1. **Round 1**: Initial \`finally\`-block scrub of \`snapshot.privateKey\` after the callback would null out the providers' authoritative copy mid-flight (providers retain the snapshot reference and read \`privateKey\` lazily inside \`connect()\` Phase B). Removed the scrub; documented in \`docs/PROFILE-FROM-SPHERE.md\` "Security review" section.

2. **Round 2**: \`'sphere' in opts\` discriminator mis-fires on \`{ sphere: undefined }\` (key present, value undefined). Added \`isSphereBoundOptions()\` type predicate that checks truthiness + regression test.

A pre-existing leakage point (\`ProfileTokenStorageProvider.getIdentity()\` returns \`FullIdentity\` including privateKey) is documented as out-of-scope and tracked in #293.

## Files changed

| File | What |
|---|---|
| \`core/Sphere.ts\` | New \`_withFullIdentityForProfileFactory\` internal method |
| \`profile/attach-identity.ts\` | NEW. SDK-private helper. NOT exported from \`profile/index.ts\` |
| \`profile/cryptographer.ts\` | NEW. \`SphereCryptographer\` interface sketch + \`PROFILE_CACHE_PURPOSE\` |
| \`profile/browser.ts\` | NEW \`createBrowserProfileProvidersFromSphere\` + \`migrateLegacyToProfileBrowser\` |
| \`profile/node.ts\` | NEW \`createNodeProfileProvidersFromSphere\` + \`migrateLegacyToProfileNode\` |
| \`profile/token-storage-migration.ts\` | NEW Sphere-bound overload (backward compat preserved) |
| \`profile/index.ts\` | Barrel re-exports of new types + \`SphereCryptographer\` |
| \`docs/PROFILE-FROM-SPHERE.md\` | NEW. Architectural invariant + migration story + security review |
| \`tests/unit/{core,profile}/...\` | +4 test files, +59 tests |

## Refs

- Closes #292
- Follow-up: #293 (full SphereCryptographer migration)
- Unblocks: sphere PR #308 (\`uxfProfileMigration.ts\` simplification)