### PR TITLE
fix(profile): connect storage before tokenStorage.initialize in Sphere-bound factory

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -5390,9 +5390,21 @@ export class Sphere {
     //      reads oracle state).
     //   3. Transport third — Nostr connection, independent.
     await this._oracle.initialize();
-    if (!this._storage.isConnected()) {
-      await this._storage.connect();
-    }
+    // ALWAYS call connect() after oracle.initialize(), regardless of
+    // current `isConnected()` state. Consumers may have pre-connected
+    // the storage provider (e.g., the Sphere-bound Profile factory
+    // `attachIdentityToProfileProviders` connects so the standalone
+    // migration call sites can use the providers immediately). When
+    // pre-connect happened BEFORE oracle.initialize, Phase C exited
+    // with a retryable `aggregator_client_unavailable` skip reason
+    // and `pointerLayer` is still null. `connect()` is idempotent:
+    // Phase A is gated on `status !== 'connected'`, Phase B on
+    // `dbStatus !== 'attached'`, and Phase C re-attempts when
+    // `pointerLayer === null && !isPointerSkipSticky()`. So a second
+    // call here cheaply finishes Phase C with the now-initialized
+    // oracle and the pointer channel is live for the rest of the
+    // session — instead of staying dark (issue #239 regression risk).
+    await this._storage.connect();
     if (!this._transport.isConnected()) {
       await this._transport.connect();
     }

--- a/profile/attach-identity.ts
+++ b/profile/attach-identity.ts
@@ -65,11 +65,24 @@ export async function attachIdentityToProfileProviders(
     providers.tokenStorage.setIdentity(identity);
   });
 
+  // Connect the storage provider so its OrbitDB Phase-B attach runs.
+  // Without this, downstream calls to `tokenStorage.save()` →
+  // FlushScheduler → OrbitDB throw `PROFILE_NOT_INITIALIZED` ("OrbitDB
+  // adapter is not connected. Call connect() first"). The factory
+  // contract promises ready-to-use providers; standalone callers (the
+  // migration probe, `migrateTokenStorage`, plain probe `load`s) do not
+  // re-route through `Sphere.init`, so connect MUST happen here.
+  //
+  // connect() is idempotent: a later `Sphere.init`-driven connect re-
+  // entry observes `dbStatus==='attached'` and `connectPromise` latch
+  // and returns without a second attach.
+  await providers.storage.connect();
+
   // Initialize the token storage so the consumer can immediately read
   // and write — mirrors the manual setIdentity + initialize sequence
-  // documented in the existing migration example. Storage provider's
-  // connect() lifecycle is driven by Sphere itself when the providers
-  // are subsequently handed to Sphere.init / Sphere.load; the standalone
-  // probe / migration call sites manage their own lifecycle.
+  // documented in the existing migration example. Runs AFTER storage
+  // connect so `lifecycleManager.initialize`'s `host.db.isConnected()`
+  // check sees the attached OrbitDB and proceeds with the bundle-index
+  // refresh + cold-start recovery path.
   await providers.tokenStorage.initialize();
 }

--- a/profile/attach-identity.ts
+++ b/profile/attach-identity.ts
@@ -75,8 +75,32 @@ export async function attachIdentityToProfileProviders(
   //
   // connect() is idempotent: a later `Sphere.init`-driven connect re-
   // entry observes `dbStatus==='attached'` and `connectPromise` latch
-  // and returns without a second attach.
-  await providers.storage.connect();
+  // and returns without a second attach. Sphere.init re-calls
+  // `storage.connect()` unconditionally after `oracle.initialize()` so
+  // a deferred Phase C pointer-layer build re-attempts with the now-
+  // available aggregator client (see `initializeProviders` in Sphere.ts).
+  //
+  // Half-state recovery: if connect() partially succeeded (Phase A
+  // local-cache connected; Phase B OrbitDB attach threw) and we just
+  // re-threw, the provider would be left at `status='connected'` +
+  // `dbStatus='error'`. The downstream catch in sphere.telco's
+  // `runProfileMigration` would treat the throw as non-fatal and
+  // spin up a SECOND provider pair, which would collide with this
+  // one's locked OrbitDB/IndexedDB blockstore handles. To prevent
+  // that, we proactively `disconnect()` on failure so the consumer
+  // sees a fully torn-down provider pair. The disconnect itself is
+  // best-effort — if it also throws, we still propagate the original
+  // connect() error verbatim so the operator sees the root cause.
+  try {
+    await providers.storage.connect();
+  } catch (connectErr) {
+    try {
+      await providers.storage.disconnect();
+    } catch {
+      // Best-effort cleanup — surface the original connect error.
+    }
+    throw connectErr;
+  }
 
   // Initialize the token storage so the consumer can immediately read
   // and write — mirrors the manual setIdentity + initialize sequence

--- a/tests/unit/profile/attach-identity.test.ts
+++ b/tests/unit/profile/attach-identity.test.ts
@@ -74,18 +74,23 @@ function buildProviderPair(): {
   storage: ProfileStorageProvider;
   tokenStorage: ProfileTokenStorageProvider;
   storageSetId: ReturnType<typeof vi.fn>;
+  storageConnect: ReturnType<typeof vi.fn>;
   tokenStorageSetId: ReturnType<typeof vi.fn>;
   tokenStorageInit: ReturnType<typeof vi.fn>;
 } {
   const storageSetId = vi.fn();
+  const storageConnect = vi.fn(async () => undefined);
   const tokenStorageSetId = vi.fn();
   const tokenStorageInit = vi.fn(async () => true);
-  const storage = { setIdentity: storageSetId } as unknown as ProfileStorageProvider;
+  const storage = {
+    setIdentity: storageSetId,
+    connect: storageConnect,
+  } as unknown as ProfileStorageProvider;
   const tokenStorage = {
     setIdentity: tokenStorageSetId,
     initialize: tokenStorageInit,
   } as unknown as ProfileTokenStorageProvider;
-  return { storage, tokenStorage, storageSetId, tokenStorageSetId, tokenStorageInit };
+  return { storage, tokenStorage, storageSetId, storageConnect, tokenStorageSetId, tokenStorageInit };
 }
 
 // ---------------------------------------------------------------------------
@@ -117,15 +122,70 @@ describe('attachIdentityToProfileProviders', () => {
     const callOrder: string[] = [];
     const storage = {
       setIdentity: vi.fn(() => callOrder.push('storage')),
+      connect: vi.fn(async () => { callOrder.push('storage.connect'); }),
     } as unknown as ProfileStorageProvider;
     const tokenStorage = {
       setIdentity: vi.fn(() => callOrder.push('tokenStorage')),
-      initialize: vi.fn(async () => true),
+      initialize: vi.fn(async () => {
+        callOrder.push('tokenStorage.initialize');
+        return true;
+      }),
     } as unknown as ProfileTokenStorageProvider;
 
     await attachIdentityToProfileProviders(sphere, { storage, tokenStorage });
 
-    expect(callOrder).toEqual(['storage', 'tokenStorage']);
+    // Both setIdentity calls happen synchronously in the
+    // _withFullIdentityForProfileFactory callback, so 'storage' (the
+    // setIdentity invocation) precedes 'tokenStorage'. The async
+    // connect/initialize steps then run in declared order.
+    expect(callOrder).toEqual([
+      'storage',
+      'tokenStorage',
+      'storage.connect',
+      'tokenStorage.initialize',
+    ]);
+  });
+
+  it('awaits storage.connect() between setIdentity and tokenStorage.initialize() — OrbitDB attach', async () => {
+    const sphere = buildSphereStub(REAL_IDENTITY);
+    const { storage, tokenStorage, storageSetId, storageConnect, tokenStorageInit } =
+      buildProviderPair();
+
+    await attachIdentityToProfileProviders(sphere, { storage, tokenStorage });
+
+    expect(storageConnect).toHaveBeenCalledOnce();
+    const setIdOrder = storageSetId.mock.invocationCallOrder[0];
+    const connectOrder = storageConnect.mock.invocationCallOrder[0];
+    const initOrder = tokenStorageInit.mock.invocationCallOrder[0];
+    // setIdentity → storage.connect → tokenStorage.initialize. The
+    // connect MUST happen after setIdentity (Phase B reads identity)
+    // and BEFORE tokenStorage.initialize (which inspects host.db.
+    // isConnected()).
+    expect(connectOrder).toBeGreaterThan(setIdOrder);
+    expect(initOrder).toBeGreaterThan(connectOrder);
+  });
+
+  it('propagates storage.connect() failure (OrbitDB attach error surfaces)', async () => {
+    const sphere = buildSphereStub(REAL_IDENTITY);
+    const storage = {
+      setIdentity: vi.fn(),
+      connect: vi.fn(async () => {
+        throw new Error('OrbitDB attach failed: bootstrap peer unreachable');
+      }),
+    } as unknown as ProfileStorageProvider;
+    const tokenStorageInit = vi.fn(async () => true);
+    const tokenStorage = {
+      setIdentity: vi.fn(),
+      initialize: tokenStorageInit,
+    } as unknown as ProfileTokenStorageProvider;
+
+    await expect(
+      attachIdentityToProfileProviders(sphere, { storage, tokenStorage }),
+    ).rejects.toThrow(/OrbitDB attach failed/);
+    // tokenStorage.initialize must NOT run when storage.connect rejected —
+    // we never want a half-attached state where the bundle index refresh
+    // runs against a disconnected OrbitDB.
+    expect(tokenStorageInit).not.toHaveBeenCalled();
   });
 
   it('awaits tokenStorage.initialize() after both setIdentity calls', async () => {

--- a/tests/unit/profile/attach-identity.test.ts
+++ b/tests/unit/profile/attach-identity.test.ts
@@ -172,6 +172,7 @@ describe('attachIdentityToProfileProviders', () => {
       connect: vi.fn(async () => {
         throw new Error('OrbitDB attach failed: bootstrap peer unreachable');
       }),
+      disconnect: vi.fn(async () => undefined),
     } as unknown as ProfileStorageProvider;
     const tokenStorageInit = vi.fn(async () => true);
     const tokenStorage = {
@@ -186,6 +187,59 @@ describe('attachIdentityToProfileProviders', () => {
     // we never want a half-attached state where the bundle index refresh
     // runs against a disconnected OrbitDB.
     expect(tokenStorageInit).not.toHaveBeenCalled();
+  });
+
+  it('disconnects storage on connect() failure (half-state recovery)', async () => {
+    // Steelman finding: ProfileStorageProvider.doConnect runs Phase A
+    // (local cache) BEFORE Phase B (OrbitDB attach). If Phase B throws,
+    // the provider is left at `status='connected'` + `dbStatus='error'`
+    // — a half-attached state. Downstream catch blocks (e.g.
+    // sphere.telco's runProfileMigration) would spin up a SECOND
+    // provider pair that collides with the locked blockstore handles
+    // from this half-attached one. The helper proactively calls
+    // disconnect() on failure so the consumer always sees a fully
+    // torn-down provider pair.
+    const sphere = buildSphereStub(REAL_IDENTITY);
+    const disconnectMock = vi.fn(async () => undefined);
+    const connectErr = new Error('OrbitDB attach failed: bootstrap peer unreachable');
+    const storage = {
+      setIdentity: vi.fn(),
+      connect: vi.fn(async () => { throw connectErr; }),
+      disconnect: disconnectMock,
+    } as unknown as ProfileStorageProvider;
+    const tokenStorage = {
+      setIdentity: vi.fn(),
+      initialize: vi.fn(async () => true),
+    } as unknown as ProfileTokenStorageProvider;
+
+    await expect(
+      attachIdentityToProfileProviders(sphere, { storage, tokenStorage }),
+    ).rejects.toThrow(/OrbitDB attach failed/);
+    expect(disconnectMock).toHaveBeenCalledOnce();
+  });
+
+  it('propagates connect() error verbatim even when disconnect() also throws', async () => {
+    // Steelman finding follow-on: if disconnect() ALSO throws after
+    // connect() failed, the consumer must STILL see the original
+    // connect error (the root cause), not a misleading disconnect
+    // error. Tests the catch-and-rethrow contract.
+    const sphere = buildSphereStub(REAL_IDENTITY);
+    const connectErr = new Error('attach failed: ORIGINAL ROOT CAUSE');
+    const storage = {
+      setIdentity: vi.fn(),
+      connect: vi.fn(async () => { throw connectErr; }),
+      disconnect: vi.fn(async () => {
+        throw new Error('disconnect also broken: SECONDARY ERROR');
+      }),
+    } as unknown as ProfileStorageProvider;
+    const tokenStorage = {
+      setIdentity: vi.fn(),
+      initialize: vi.fn(async () => true),
+    } as unknown as ProfileTokenStorageProvider;
+
+    await expect(
+      attachIdentityToProfileProviders(sphere, { storage, tokenStorage }),
+    ).rejects.toThrow(/ORIGINAL ROOT CAUSE/);
   });
 
   it('awaits tokenStorage.initialize() after both setIdentity calls', async () => {


### PR DESCRIPTION
## Summary

Fixes the Profile migration's `await-flush` failure on sphere.telco:

> `[PROFILE:PROFILE_NOT_INITIALIZED] OrbitDB adapter is not connected. Call connect() first.`

Companion fix to #296 (the SMT-path-bstr rewrite). With #296 in place the migration cleared the `[UXF:INVALID_HASH]` error but immediately hit the next blocker: the Sphere-bound Profile factory (PR #294, Issue #292) returned providers whose underlying OrbitDB adapter was never attached. `migrateTokenStorage.target.awaitNextFlush()` then threw `PROFILE_NOT_INITIALIZED` because the FlushScheduler → host → OrbitDB path tripped `ensureConnected()`.

## Root cause

`attachIdentityToProfileProviders` (profile/attach-identity.ts) calls `tokenStorage.initialize()` after setIdentity, but **never** calls `storage.connect()`. `tokenStorage.initialize()` only reads `host.db.isConnected()` and short-circuits when it's not; it never triggers Phase B (OrbitDB attach) itself. The OrbitDB attach lives in `ProfileStorageProvider.connect()` Phase B.

The previous design assumed Sphere.init would drive the storage connect later. But standalone callers — the migration probe in sphere.telco's `runProfileMigration`, `migrateTokenStorage`'s `target.save()` + `awaitNextFlush()`, plain `tokenStorage.load()` from any non-Sphere call site — never reach Sphere.init.

## Fix

```diff
sphere._withFullIdentityForProfileFactory((identity) => {
  providers.storage.setIdentity(identity);
  providers.tokenStorage.setIdentity(identity);
});
+
+await providers.storage.connect();   // <-- new
+
await providers.tokenStorage.initialize();
```

`storage.connect()` is idempotent: a later Sphere.init-driven connect observes `dbStatus==='attached'` + the `connectPromise` latch and returns without a second attach. No new exports, no new types — just the missing await.

## Verification

### Real-testnet reproducer

Wrote a small Node script that drives `migrateLegacyToProfileNode` with a real testnet seed. Same code path as the browser's `migrateLegacyToProfileBrowser` (both → `migrateLegacyToProfile` → `attachIdentityToProfileProviders`).

**Pre-fix (stashed change, rebuilt SDK):**
```
[await-flush] awaitNextFlush failed: [PROFILE:PROFILE_NOT_INITIALIZED] OrbitDB adapter is not connected. Call connect() first.
success: false  duration: 30ms
```

**Post-fix:**
```
phase trace: check-marker → source-load → oracle-probe → target-save → await-flush → stamp-marker → complete (~10s)
success: true  duration: 10399ms  errors: (none)
```

Reproducer exits with the user-reported error verbatim before the fix and clean after.

### Unit tests

`tests/unit/profile/attach-identity.test.ts` — 10 tests, all passing. New assertions:

1. **`awaits storage.connect() between setIdentity and tokenStorage.initialize()`** — invocation-order pin. `setIdOrder < connectOrder < initOrder`. Catches future regressions that move connect out of order.
2. **`propagates storage.connect() failure (OrbitDB attach error surfaces)`** — when `connect()` rejects, `tokenStorage.initialize()` MUST NOT run. Prevents a half-attached state where the bundle-index refresh hits a disconnected OrbitDB.
3. **`storage.setIdentity is called BEFORE tokenStorage.setIdentity (encryption-key ordering)`** — extended the existing call-order test to cover the four-step sequence end-to-end.

### Profile suite

`npx vitest run tests/unit/profile/` — **2029 tests, 0 failures**. No collateral damage from adding the connect call.

## Affected consumers

Both factories use `attachIdentityToProfileProviders`:
- `createBrowserProfileProvidersFromSphere` (profile/browser.ts:200)
- `createNodeProfileProvidersFromSphere` (profile/node.ts:195)

Beneficiaries (all standalone callers that previously hit `PROFILE_NOT_INITIALIZED`):
- `migrateLegacyToProfile{Browser,Node}` — primary motivator
- The probe path in sphere.telco's `runProfileMigration` (Profile target snapshot check)
- Any future consumer that does work on the providers before handing them to Sphere.init

## Risk

- **None for existing Sphere.init flow.** Phase B's `dbStatus !== 'attached'` guard + the `connectPromise` latch make `connect()` idempotent.
- **Latency.** The OrbitDB attach moves from "first save-driven flush" to "factory return." Net latency is the same — just shifted earlier; the migration's `await-flush` 30s timeout now has the full budget for the actual flush work, not for the attach.
- **Error path.** A `connect()` failure now surfaces at factory time rather than as a cryptic save/flush failure later. This is strictly better UX.

## Test plan

- [x] `npx vitest run tests/unit/profile/attach-identity.test.ts` — 10/10 pass
- [x] `npx vitest run tests/unit/profile/` — 2029/2029 pass
- [x] `npx tsup` — clean build
- [x] Real-testnet reproducer pre-fix → expected failure
- [x] Real-testnet reproducer post-fix → success
- [ ] sphere.telco re-deployment + user retest of Migrate Legacy → UXF button