### PR TITLE
fix(profile): Phase 3 walkback skips EXISTS-BUT-UNFETCHABLE versions by default

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -5804,7 +5804,10 @@ export class Sphere {
       // bypasses the >= comparison. For Phase 1 this still helps the
       // cross-version case where own localVersion < broadcast.version.
       const recovered = await pointer.recoverLatest();
-      if (recovered) {
+      // `'cid' in recovered` narrows RecoverResult | RecoverAllUnfetchableResult
+      // to RecoverResult — RecoverAllUnfetchableResult has no `cid` field.
+      // RecoverAllUnfetchableResult has no fetchable version to adopt, so skip.
+      if (recovered && 'cid' in recovered) {
         const outcome = await pointer.reconcileLocalVersionDownward(recovered);
         logger.debug(
           'Sphere',

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -100,6 +100,21 @@ export interface PublishResult {
 export interface RecoverResult {
   readonly cid: Uint8Array;
   readonly version: PointerVersion;
+  /**
+   * Versions walked past during Phase 3 walkback whose CAR was
+   * EXISTS-BUT-UNFETCHABLE (proof authentic, CID decoded, but no
+   * gateway could serve the bytes). Empty when no such versions were
+   * encountered or when the wallet ran in SPEC-strict
+   * `skipUnfetchableInWalkback: false` mode.
+   *
+   * The wallet's `version` field is the latest VALID predecessor — older
+   * than every entry in this list. Surfaced so the lifecycle layer can
+   * emit a typed `storage:pointer-version-skipped-unfetchable` event for
+   * operator monitoring.
+   *
+   * See `discover-algorithm.ts` for the full design rationale.
+   */
+  readonly walkbackUnfetchableSkipped?: readonly PointerVersion[];
 }
 
 /**
@@ -473,7 +488,19 @@ export class ProfilePointerLayer {
     const discovery = await this.#discoverLatestVersionInner(undefined, abortSignal);
     if (discovery.validV === 0) return null;
     const cid = await this.#init.resolveRemoteCid(discovery.validV);
-    return { cid, version: discovery.validV };
+    // Surface walkback-unfetchable telemetry to the caller. The lifecycle
+    // layer uses this to emit a typed event so operators can detect when
+    // a wallet recovered to an older predecessor because a newer slot
+    // was EXISTS-BUT-UNFETCHABLE. Empty when no skip-past occurred or
+    // when the wallet ran in SPEC-strict mode.
+    const walkbackUnfetchableSkipped = discovery.walkbackUnfetchableSkipped;
+    return {
+      cid,
+      version: discovery.validV,
+      ...(walkbackUnfetchableSkipped && walkbackUnfetchableSkipped.length > 0
+        ? { walkbackUnfetchableSkipped }
+        : {}),
+    };
   }
 
   // ── reconcileLocalVersionDownward ────────────────────────────────────────

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -95,6 +95,20 @@ export interface ProfilePointerLayerInit {
 export interface PublishResult {
   readonly version: PointerVersion;
   readonly attemptsUsed: number;
+  /**
+   * Versions skipped past during Phase 3 walkback within this publish
+   * session (conflict-driven rediscovery only — the fast-path attempt 0
+   * does no walkback and produces an empty list).
+   *
+   * Mirrors `RecoverResult.walkbackUnfetchableSkipped`. Surfaced so
+   * `publishAggregatorPointerBestEffort` can emit the same
+   * `storage:pointer-version-skipped-unfetchable` event on the publish
+   * path as on the recover path.
+   *
+   * Empty when no CAR_TRANSIENT skip-past occurred or when publish
+   * succeeded on the fast-path (no walkback).
+   */
+  readonly walkbackUnfetchableSkipped: readonly PointerVersion[];
 }
 
 export interface RecoverResult {
@@ -115,6 +129,33 @@ export interface RecoverResult {
    * See `discover-algorithm.ts` for the full design rationale.
    */
   readonly walkbackUnfetchableSkipped?: readonly PointerVersion[];
+}
+
+/**
+ * Returned by `recoverLatest()` when the discovery walkback found at
+ * least one anchor (includedV > 0) but EVERY visited slot returned
+ * `CAR_TRANSIENT` — i.e. the pointer history EXISTS on-chain but not
+ * a single CAR is fetchable from any configured gateway.
+ *
+ * This is distinct from `recoverLatest() === null` (fresh wallet — no
+ * pointer ever published). Callers MUST NOT fall through to legacy IPNS
+ * migration on this result: the pointer chain exists; the gateways are
+ * the problem. The wallet should retry on the next poll cycle.
+ *
+ * Lifecycle-layer handling:
+ *   - Do NOT stamp the legacy migration-done marker.
+ *   - Do NOT import IPNS bundles.
+ *   - Emit `storage:pointer-version-skipped-unfetchable` event (carried
+ *     in `walkbackUnfetchableSkipped`) so operators know the outage depth.
+ *   - Return `true` (pointer path was chosen) so the caller skips legacy.
+ */
+export interface RecoverAllUnfetchableResult {
+  readonly kind: 'all-unfetchable';
+  /**
+   * Every version that was walked but whose CAR was unreachable.
+   * Non-empty by definition (at least one slot existed and was skipped).
+   */
+  readonly walkbackUnfetchableSkipped: readonly PointerVersion[];
 }
 
 /**
@@ -453,25 +494,53 @@ export class ProfilePointerLayer {
     if (result.probeHistory.length > 0) {
       this.#lastProbeVersions = result.probeHistory;
     }
-    return { version: result.v, attemptsUsed: result.attemptsUsed };
+    return {
+      version: result.v,
+      attemptsUsed: result.attemptsUsed,
+      walkbackUnfetchableSkipped: result.walkbackUnfetchableSkipped,
+    };
   }
 
   // ── recoverLatest ────────────────────────────────────────────────────────
 
   /**
    * Discover + recover the latest VALID pointer.
-   * Returns null when no pointer has ever been published (validV == 0).
    *
-   * SPEC §13 recoverLatest semantics: returns `{ cid, version }` for the
-   * latest valid version (Phase 3 winner), having classified + fetched the
-   * CAR successfully.
+   * Return value semantics (three distinct cases):
+   *
+   *   `RecoverResult`              — VALID version found; `cid` and `version`
+   *                                  are the latest fetchable snapshot.
+   *                                  `walkbackUnfetchableSkipped` lists any
+   *                                  CAR_TRANSIENT slots walked past.
+   *
+   *   `null`                       — Fresh wallet: no pointer has ever been
+   *                                  published (validV === 0 AND no
+   *                                  walkbackUnfetchableSkipped). The
+   *                                  lifecycle layer may fall through to
+   *                                  legacy IPNS migration or skip it for
+   *                                  a truly new wallet.
+   *
+   *   `RecoverAllUnfetchableResult` — Anchors EXIST on-chain (validV === 0
+   *                                   because every slot returned CAR_TRANSIENT)
+   *                                   but NOT a single CAR is reachable.
+   *                                   Callers MUST NOT fall through to legacy
+   *                                   IPNS migration — the pointer chain is
+   *                                   intact; only the gateways are down.
+   *                                   Retry on the next poll cycle.
+   *
+   * SPEC §13 recoverLatest semantics are extended: the three-case return
+   * disambiguates "no pointer" from "pointer exists but gateways are down".
    */
-  async recoverLatest(opts?: { abortSignal?: AbortSignal }): Promise<RecoverResult | null> {
+  async recoverLatest(opts?: {
+    abortSignal?: AbortSignal;
+  }): Promise<RecoverResult | RecoverAllUnfetchableResult | null> {
     this.#assertNotShuttingDown('recoverLatest');
     return this.#tracked(this.#recoverLatestInner(opts?.abortSignal));
   }
 
-  async #recoverLatestInner(abortSignal?: AbortSignal): Promise<RecoverResult | null> {
+  async #recoverLatestInner(
+    abortSignal?: AbortSignal,
+  ): Promise<RecoverResult | RecoverAllUnfetchableResult | null> {
     // Steelman¹⁹ critical #3: call the INNER discoverLatestVersion helper
     // directly. Going through the public method would re-run
     // #assertNotShuttingDown — if shutdown() fires after recoverLatest's
@@ -486,7 +555,21 @@ export class ProfilePointerLayer {
       throw err;
     }
     const discovery = await this.#discoverLatestVersionInner(undefined, abortSignal);
-    if (discovery.validV === 0) return null;
+
+    if (discovery.validV === 0) {
+      // Disambiguate: did Phase 3 skip-past any CAR_TRANSIENT versions?
+      //   - Yes (walkbackUnfetchableSkipped non-empty): anchors exist on-chain
+      //     but every CAR is unreachable. Return RecoverAllUnfetchableResult so
+      //     the lifecycle layer can refuse legacy IPNS migration and schedule
+      //     a retry.
+      //   - No: genuinely fresh wallet — no pointer ever published. Return null.
+      const skippedOnly = discovery.walkbackUnfetchableSkipped;
+      if (skippedOnly && skippedOnly.length > 0) {
+        return { kind: 'all-unfetchable', walkbackUnfetchableSkipped: skippedOnly };
+      }
+      return null;
+    }
+
     const cid = await this.#init.resolveRemoteCid(discovery.validV);
     // Surface walkback-unfetchable telemetry to the caller. The lifecycle
     // layer uses this to emit a typed event so operators can detect when
@@ -864,7 +947,7 @@ export class ProfilePointerLayer {
   }
 
   /** Low-level classifyVersion. */
-  async classify(v: PointerVersion): Promise<'VALID' | 'SEMANTICALLY_INVALID' | 'TRANSIENT_UNAVAILABLE'> {
+  async classify(v: PointerVersion): Promise<'VALID' | 'SEMANTICALLY_INVALID' | 'PROOF_TRANSIENT' | 'CAR_TRANSIENT'> {
     this.#assertNotShuttingDown('classify');
     return this.#tracked(classifyVersion({
       v,

--- a/profile/aggregator-pointer/aggregator-probe.ts
+++ b/profile/aggregator-pointer/aggregator-probe.ts
@@ -9,10 +9,10 @@
  *     Trust-base rotation is detected on verify failure (§8.4.1).
  *
  *   classifyVersion(v, ...)
- *     H1 three-way classifier. Returns VALID | SEMANTICALLY_INVALID |
- *     TRANSIENT_UNAVAILABLE. Used by Phase-3 walkback. Requires an
- *     injected IPFS/CAR fetcher (the pointer layer does not own IPFS
- *     itself — that stays in profile/ipfs-client.ts).
+ *     H1 four-way classifier. Returns VALID | SEMANTICALLY_INVALID |
+ *     PROOF_TRANSIENT | CAR_TRANSIENT. Used by Phase-3 walkback.
+ *     Requires an injected IPFS/CAR fetcher (the pointer layer does
+ *     not own IPFS itself — that stays in profile/ipfs-client.ts).
  *
  *   isReachable(signingPubKey)
  *     Health check. Issues a getInclusionProof for the wallet's HEALTH_CHECK
@@ -41,11 +41,41 @@ import { SIDE_A_NUM, SIDE_B_NUM, type PointerVersion } from './types.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-/** Three-way version classification per H1 (SPEC §8.2 classifyVersion). */
+/**
+ * Four-way version classification per H1 (SPEC §8.2 classifyVersion).
+ *
+ * The original three-way classification collapsed two distinct failure
+ * modes under `TRANSIENT_UNAVAILABLE`:
+ *
+ *   (a) PROOF_TRANSIENT — the aggregator proof RPC failed (network error,
+ *       timeout, etc.). The slot's existence is UNKNOWN — we cannot tell
+ *       whether the version was ever published. Phase 3 MUST NOT skip past
+ *       this: doing so would silently walk through a slot we haven't
+ *       examined.
+ *
+ *   (b) CAR_TRANSIENT — the proof was verified AND the CID decoded
+ *       successfully (the slot EXISTS), but every IPFS gateway returned
+ *       transient failure (404, 5xx, timeout) for the CAR bytes. The
+ *       slot provably EXISTS on-chain but is unreachable in storage.
+ *       Phase 3 MAY skip past this under the `skipUnfetchableInWalkback`
+ *       policy — skipping an EXISTS-BUT-UNFETCHABLE slot is the intended
+ *       production recovery for IPFS gateway loss.
+ *
+ * Callers that previously pattern-matched `'TRANSIENT_UNAVAILABLE'` MUST
+ * now handle BOTH `'PROOF_TRANSIENT'` and `'CAR_TRANSIENT'`. The two
+ * values intentionally do NOT share a common prefix to prevent accidental
+ * string-equality matches.
+ *
+ * The legacy `TRANSIENT_UNAVAILABLE` value is removed. Any existing code
+ * that compared against it will get a compile-time type error.
+ */
 export type VersionClassification =
   | 'VALID'
   | 'SEMANTICALLY_INVALID'
-  | 'TRANSIENT_UNAVAILABLE';
+  /** Proof RPC failed — slot existence unknown. Do NOT skip-past. */
+  | 'PROOF_TRANSIENT'
+  /** Proof OK + CID decoded but CAR unfetchable — slot EXISTS. May skip-past. */
+  | 'CAR_TRANSIENT';
 
 /**
  * Injected CAR fetch + deserialize callback for classifyVersion.
@@ -392,10 +422,17 @@ async function runDecodePhases(
 }
 
 /**
- * Three-way classify per SPEC §8.2 classifyVersion helper:
- *   VALID                 — both sides verified + CID parseable + CAR fetched
- *   SEMANTICALLY_INVALID  — proof partial, CID corrupt, or CAR fails content-address
- *   TRANSIENT_UNAVAILABLE — all IPFS gateways transient-fail; tokens may still exist
+ * Four-way classify per SPEC §8.2 classifyVersion helper:
+ *   VALID                — both sides verified + CID parseable + CAR fetched
+ *   SEMANTICALLY_INVALID — proof partial, CID corrupt, or CAR fails content-address
+ *   PROOF_TRANSIENT      — aggregator proof RPC failed; slot existence UNKNOWN
+ *   CAR_TRANSIENT        — proof OK + CID decoded but all IPFS gateways unavailable
+ *
+ * The split matters for Phase 3 skip-past policy:
+ *   - PROOF_TRANSIENT must NOT be skipped (we cannot tell whether the slot
+ *     exists — walking past it would silently skip an unexamined version).
+ *   - CAR_TRANSIENT MAY be skipped under `skipUnfetchableInWalkback: true`
+ *     (the slot provably exists on-chain; only its CAR bytes are unavailable).
  *
  * classifyVersion requires BOTH sides included (stricter than probe's OR).
  */
@@ -413,17 +450,23 @@ export async function classifyVersion(input: ClassifyInput): Promise<VersionClas
     timeoutMs,
     input.abortSignal,
   );
-  if (phase12.ok === 'transient') return 'TRANSIENT_UNAVAILABLE';
+  // Case (a): aggregator proof RPC failed — slot existence UNKNOWN.
+  // Return PROOF_TRANSIENT, NOT CAR_TRANSIENT — Phase 3 must not skip past this.
+  if (phase12.ok === 'transient') return 'PROOF_TRANSIENT';
   if (phase12.ok === 'semantic') return 'SEMANTICALLY_INVALID';
 
   // Step 3: fetch + content-address verify (§8.2 step 3).
+  // Reaching here means proof was verified AND CID decoded — the slot EXISTS.
   const carResult = await fetchCar(phase12.cidBytes);
   if (carResult.ok) {
     return 'VALID';
   }
   switch (carResult.kind) {
     case 'transient_unavailable':
-      return 'TRANSIENT_UNAVAILABLE';
+      // Case (b): slot EXISTS (proof ok + CID decoded) but CAR is unreachable.
+      // Return CAR_TRANSIENT — Phase 3 may skip past this under the
+      // skipUnfetchableInWalkback policy.
+      return 'CAR_TRANSIENT';
     case 'content_mismatch':
     case 'car_parse_failed':
     default:

--- a/profile/aggregator-pointer/discover-algorithm.ts
+++ b/profile/aggregator-pointer/discover-algorithm.ts
@@ -10,17 +10,99 @@
  *
  *   Phase 3 — walk back through SEMANTICALLY_INVALID versions via
  *             classifyVersion (H1 three-way). TRANSIENT_UNAVAILABLE
- *             versions propagate as CAR_UNAVAILABLE — we do NOT skip
- *             past them because tokens may still exist. Bail after
- *             DISCOVERY_CORRUPT_WALKBACK consecutive invalid versions
- *             (→ CORRUPT_STREAK).
+ *             versions are SKIPPED PAST by default (`skipUnfetchableInWalkback`):
+ *             a slot whose proof is authentic but whose CAR cannot be
+ *             fetched (404 / network failure / persistent-unavailable)
+ *             is treated as walked-past, indistinguishable from
+ *             SEMANTICALLY_INVALID for the purpose of finding the
+ *             latest VALID predecessor. The skipped versions are
+ *             recorded in `walkbackUnfetchableSkipped` for operator
+ *             observability — the lifecycle layer logs them at
+ *             info-level when `recoverLatest()` surfaces them, so
+ *             monitoring can surface the data-loss window without
+ *             requiring the wallet to be blocked.
  *
- * Returns { validV, includedV } (H4 return shape).
+ *             SPEC-strict mode (legacy / strict consumers): pass
+ *             `skipUnfetchableInWalkback: false` to restore the
+ *             SPEC §13 / §10.7 behavior — TRANSIENT_UNAVAILABLE in
+ *             Phase 3 throws CAR_UNAVAILABLE so the caller can invoke
+ *             the operator-driven `acceptCarLoss(version)` flow after
+ *             the persistent-retry window.
+ *
+ *             Bail after DISCOVERY_CORRUPT_WALKBACK consecutive
+ *             non-VALID versions (→ CORRUPT_STREAK), counting both
+ *             SEMANTICALLY_INVALID and (when skipped) UNFETCHABLE.
+ *
+ * Returns { validV, includedV, probeVersions, walkbackUnfetchableSkipped }.
  *
  * W7 walkback floor: when an `acceptCorruptStreak(walkbackLimit)` override
  * raises the walkback ceiling, the effective floor MUST NOT cross below
  * localVersion — crossing below would walk past versions this wallet has
  * already confirmed as its own.
+ *
+ * ## Why `skipUnfetchableInWalkback` defaults to `true`
+ *
+ * A pointer slot that EXISTS (proof-included on the aggregator) but whose
+ * snapshot CID is unreachable on every configured IPFS gateway represents
+ * a real failure mode in production wallets:
+ *
+ *   - A prior publish landed the proof but the IPFS pin was lost
+ *     (operator gateway pruned the bundle, gateway DNS migration left
+ *     orphan content, gateway operator decommissioned).
+ *   - The 404 is durable — every retry of every gateway returns the
+ *     same 404; no amount of "retry later" rescues it.
+ *
+ * Under the legacy SPEC-strict semantic, `recoverLatest()` THROWS
+ * CAR_UNAVAILABLE at the broken version and the wallet has no recovery
+ * surface short of operator intervention. The publish path also fails on
+ * conflict-driven rediscovery for the same reason. The wallet becomes
+ * effectively bricked even though the on-aggregator proof history is
+ * intact and the wallet's PRIOR versions are still fetchable.
+ *
+ * The skip-past semantic preserves the distinction between:
+ *   - ABSENT (no probe match)            — true gap, walkback continues
+ *                                          past this slot only if Phase 2
+ *                                          located includedV above it
+ *   - SEMANTICALLY_INVALID (corrupt)     — walked past, counts toward
+ *                                          DISCOVERY_CORRUPT_WALKBACK
+ *   - EXISTS-BUT-UNFETCHABLE (new)       — walked past (same as
+ *                                          SEMANTICALLY_INVALID for
+ *                                          discovery purposes), counts
+ *                                          toward walkback budget, AND
+ *                                          recorded in
+ *                                          walkbackUnfetchableSkipped so
+ *                                          the caller emits an event for
+ *                                          monitoring
+ *
+ * For PUBLISH `nextV` computation:
+ * - `includedV` (the highest INCLUDED slot from Phase 2) is unchanged
+ *   by the skip-past behavior. Phase 2 uses `probeVersion` (H2
+ *   OR-predicate) which does NOT fetch CARs — only proofs. So even an
+ *   UNFETCHABLE slot is correctly counted as "included" for the purpose
+ *   of computing `nextV = max(validV, includedV) + 1`.
+ * - The skip-past therefore does NOT cause a new publish to overwrite or
+ *   collide with the broken prior slot. The new publish supersedes
+ *   normally at the next available version.
+ *
+ * For FETCH-AND-JOIN (cold-start recovery, periodic poll):
+ * - `recoverLatest()` returns the latest VALID — the skip-past gives the
+ *   wallet a fetchable predecessor instead of blocking entirely.
+ * - The fetch-and-join applier (factory closure) fetches the snapshot
+ *   CAR at the recovered version's CID. Because the recovered version
+ *   is the latest VALID predecessor (CAR was content-address verified
+ *   during Phase 3 classify), this fetch SHOULD succeed — but the
+ *   applier itself is already best-effort in the lifecycle layer
+ *   (`recoverFromAggregatorPointerBestEffort` logs + returns true on
+ *   apply failure, so the next periodic poll retries). The data-loss
+ *   window is the entries that lived ONLY in the unfetchable slot(s);
+ *   the wallet retains everything that survived in the recovered
+ *   predecessor and in the OrbitDB peer-to-peer log.
+ *
+ * Security model: pointer slots are signed by the wallet's own pointer
+ * key. A malicious aggregator cannot forge proofs at versions we have
+ * not authored. A malicious gateway can already serve a 404. The new
+ * semantic does not expand the attacker surface — it expands the
+ * recovery surface for the wallet user.
  */
 
 import type { AggregatorClient } from '@unicitylabs/state-transition-sdk/lib/api/AggregatorClient.js';
@@ -76,6 +158,22 @@ export interface DiscoverInput {
    * to its per-request timeout.
    */
   readonly abortSignal?: AbortSignal;
+  /**
+   * Phase 3 walkback policy for TRANSIENT_UNAVAILABLE versions.
+   *
+   * Defaults to `true` (skip-past): a slot whose proof is authentic but
+   * whose CAR cannot be fetched is treated as walked-past — Phase 3
+   * continues looking for an older VALID predecessor instead of throwing
+   * CAR_UNAVAILABLE. The skipped versions are recorded in
+   * `walkbackUnfetchableSkipped` for operator observability.
+   *
+   * Pass `false` to restore SPEC §13 / §10.7 strict behavior:
+   * TRANSIENT_UNAVAILABLE in Phase 3 throws CAR_UNAVAILABLE so the
+   * caller can invoke the operator-driven `acceptCarLoss(version)` flow.
+   *
+   * Rationale for the default: see the file-header comment block.
+   */
+  readonly skipUnfetchableInWalkback?: boolean;
 }
 
 export interface DiscoverResult {
@@ -89,6 +187,29 @@ export interface DiscoverResult {
    * Used by getProbeFingerprint() for UI clustering signal.
    */
   readonly probeVersions: readonly PointerVersion[];
+  /**
+   * Versions visited during Phase 3 walkback whose `classifyVersion`
+   * returned `TRANSIENT_UNAVAILABLE` and were skipped past (only when
+   * `skipUnfetchableInWalkback !== false`). Empty when no such versions
+   * were walked, when SPEC-strict mode was requested, or when Phase 3
+   * never ran.
+   *
+   * Surfaced to callers so they can emit a typed event
+   * (`storage:pointer-version-skipped-unfetchable`) for monitoring,
+   * even though discovery itself proceeds without blocking.
+   *
+   * A version listed here has these properties:
+   *   - Inclusion proof was authentic (proof verify OK).
+   *   - XOR-decode produced a parseable CID.
+   *   - The CAR at that CID was NOT fetchable from any gateway
+   *     (transient or persistent — Phase 3 treats them identically
+   *     under the skip-past policy).
+   *
+   * Versions listed here are NOT VALID for `recoverLatest()` purposes;
+   * the wallet will receive a strictly-older VALID predecessor (or null)
+   * if such a version exists.
+   */
+  readonly walkbackUnfetchableSkipped: readonly PointerVersion[];
 }
 
 // ── findLatestValidVersion ─────────────────────────────────────────────────
@@ -245,6 +366,13 @@ async function findLatestValidVersionInner(
   };
 
   const probeVersions: PointerVersion[] = [];
+  // Phase 3: track versions skipped under the EXISTS-BUT-UNFETCHABLE
+  // policy (default-on; see file-header). Empty when SPEC-strict mode
+  // (`skipUnfetchableInWalkback === false`) was requested or when Phase 3
+  // never encountered an unfetchable slot.
+  const walkbackUnfetchableSkipped: PointerVersion[] = [];
+  const skipUnfetchable = input.skipUnfetchableInWalkback !== false;
+
   const probeAndRecord = async (v: PointerVersion): Promise<boolean> => {
     checkDeadline();
     probeVersions.push(v);
@@ -295,7 +423,12 @@ async function findLatestValidVersionInner(
   const includedV = lo as PointerVersion;
   // Invariant after Phase 2: probe(includedV) == true (or includedV == 0) AND probe(includedV+1) == false.
 
-  // ── Phase 3 — walkback through SEMANTICALLY_INVALID versions ───────────
+  // ── Phase 3 — walkback through non-VALID versions ────────────────────
+  //
+  // Walks past SEMANTICALLY_INVALID and (when `skipUnfetchable` is true,
+  // the default) EXISTS-BUT-UNFETCHABLE versions, looking for the first
+  // VALID predecessor. See the file-header for the design rationale on
+  // the EXISTS-BUT-UNFETCHABLE policy.
   //
   // W7 walkback floor (SPEC §13 acceptCorruptStreak precondition):
   //   walkback from includedV down to max(0, currentLocalVersion).
@@ -321,8 +454,9 @@ async function findLatestValidVersionInner(
     }
 
     // Record this Phase 3 visit in the probe sequence so the probe fingerprint
-    // reflects the corruption walkback — clustering's MAIN use case is
-    // detecting same-corrupt-prefix wallets.
+    // reflects the walkback (corruption + unfetchable) — clustering's MAIN
+    // use case is detecting same-prefix wallets (corrupt streaks AND
+    // unfetchable-CAR clusters both surface here).
     checkDeadline();
     probeVersions.push(candidate);
 
@@ -339,7 +473,12 @@ async function findLatestValidVersionInner(
     });
 
     if (status === 'VALID') {
-      return { validV: candidate, includedV, probeVersions };
+      return {
+        validV: candidate,
+        includedV,
+        probeVersions,
+        walkbackUnfetchableSkipped,
+      };
     }
 
     if (status === 'SEMANTICALLY_INVALID') {
@@ -348,9 +487,39 @@ async function findLatestValidVersionInner(
       continue;
     }
 
-    // TRANSIENT_UNAVAILABLE: tokens may still exist at this version. DO NOT
-    // walk past — surface as CAR_UNAVAILABLE so the caller can retry later
-    // (or invoke §10.7 acceptCarLoss flow after the persistent-retry window).
+    // TRANSIENT_UNAVAILABLE: the slot exists (proof is authentic + CID
+    // decodes) but the CAR is not retrievable from any configured gateway.
+    //
+    // Default policy (`skipUnfetchableInWalkback !== false`): the slot is
+    // EXISTS-BUT-UNFETCHABLE — distinct from ABSENT (no proof) and from
+    // SEMANTICALLY_INVALID (proof partial / CID corrupt). For the purpose
+    // of finding the latest VALID predecessor, we treat it like
+    // SEMANTICALLY_INVALID: walk back one more, count toward the walkback
+    // budget, and record the skipped version for operator observability.
+    //
+    //   - `includedV` from Phase 2 remains the highest INCLUDED slot
+    //     regardless of fetchability, so a downstream publish's
+    //     `nextV = max(validV, includedV) + 1` correctly supersedes
+    //     above the broken slot. Skipping does NOT collapse the version
+    //     space.
+    //   - The caller (recoverLatest / reconcile loop) gets either an
+    //     older fetchable VALID predecessor or `validV === 0` if no
+    //     fetchable predecessor exists. Both outcomes keep the wallet
+    //     live.
+    //   - Operators receive the skipped versions via
+    //     `walkbackUnfetchableSkipped` and can emit a typed event for
+    //     monitoring without blocking the wallet.
+    //
+    // SPEC-strict policy (`skipUnfetchableInWalkback === false`): retain
+    // the SPEC §13 / §10.7 throw-CAR_UNAVAILABLE behavior. The caller
+    // can then invoke `acceptCarLoss(version)` to bypass the broken slot
+    // under operator control.
+    if (skipUnfetchable) {
+      walkbackUnfetchableSkipped.push(candidate);
+      candidate = (candidate - 1) as PointerVersion;
+      walked += 1;
+      continue;
+    }
     throw new AggregatorPointerError(
       AggregatorPointerErrorCode.CAR_UNAVAILABLE,
       `Phase 3 walkback: version=${candidate} is TRANSIENT_UNAVAILABLE. ` +
@@ -361,16 +530,33 @@ async function findLatestValidVersionInner(
 
   if (candidate === 0) {
     // No valid version ever existed — wallet is pristine, may begin publishing at v=1.
-    return { validV: 0 as PointerVersion, includedV, probeVersions };
+    return {
+      validV: 0 as PointerVersion,
+      includedV,
+      probeVersions,
+      walkbackUnfetchableSkipped,
+    };
   }
 
-  // Too many consecutive SEMANTICALLY_INVALID versions — bail out (§10.8).
+  // Too many consecutive non-VALID versions — bail out (§10.8). The
+  // diagnostic carries the unfetchable-skipped count so operators can
+  // distinguish "wallet is corrupt" (all skipped were SEMANTICALLY_INVALID)
+  // from "IPFS gateways are down" (mostly walkbackUnfetchableSkipped).
+  // Both classes trigger CORRUPT_STREAK because the wallet's effective
+  // walkback budget is the same — but the remediation differs (operator
+  // intervention vs gateway reconnect).
   throw new AggregatorPointerError(
     AggregatorPointerErrorCode.CORRUPT_STREAK,
     `Phase 3 walkback exhausted walkbackLimit=${walkbackLimit} without finding a VALID version ` +
-      `(includedV=${includedV}, candidate=${candidate}). ` +
+      `(includedV=${includedV}, candidate=${candidate}, ` +
+      `unfetchableSkipped=${walkbackUnfetchableSkipped.length}). ` +
       `Operator may invoke acceptCorruptStreak(walkbackLimit) to override.`,
-    { includedV, walkbackLimit, walkedSoFar: walked },
+    {
+      includedV,
+      walkbackLimit,
+      walkedSoFar: walked,
+      unfetchableSkippedCount: walkbackUnfetchableSkipped.length,
+    },
   );
 }
 

--- a/profile/aggregator-pointer/discover-algorithm.ts
+++ b/profile/aggregator-pointer/discover-algorithm.ts
@@ -9,23 +9,31 @@
  *             excluded) → converges to includedV = latest-included version.
  *
  *   Phase 3 — walk back through SEMANTICALLY_INVALID versions via
- *             classifyVersion (H1 three-way). TRANSIENT_UNAVAILABLE
- *             versions are SKIPPED PAST by default (`skipUnfetchableInWalkback`):
+ *             classifyVersion (H1 four-way). CAR_TRANSIENT versions
+ *             (slot EXISTS on-chain but CAR unreachable) are SKIPPED
+ *             PAST by default (`skipUnfetchableInWalkback`):
  *             a slot whose proof is authentic but whose CAR cannot be
  *             fetched (404 / network failure / persistent-unavailable)
  *             is treated as walked-past, indistinguishable from
  *             SEMANTICALLY_INVALID for the purpose of finding the
  *             latest VALID predecessor. The skipped versions are
  *             recorded in `walkbackUnfetchableSkipped` for operator
- *             observability — the lifecycle layer logs them at
- *             info-level when `recoverLatest()` surfaces them, so
- *             monitoring can surface the data-loss window without
- *             requiring the wallet to be blocked.
+ *             observability — the lifecycle layer emits a typed event
+ *             when `recoverLatest()` surfaces them, so monitoring can
+ *             surface the data-loss window without requiring the wallet
+ *             to be blocked.
+ *
+ *             PROOF_TRANSIENT versions (aggregator proof RPC failed —
+ *             slot existence UNKNOWN) are NEVER skipped-past regardless
+ *             of `skipUnfetchableInWalkback`. Walking past a slot whose
+ *             existence we haven't verified would silently corrupt the
+ *             walkback. Phase 3 treats PROOF_TRANSIENT as a hard stop
+ *             and throws CAR_UNAVAILABLE (same as the SPEC-strict path).
  *
  *             SPEC-strict mode (legacy / strict consumers): pass
  *             `skipUnfetchableInWalkback: false` to restore the
- *             SPEC §13 / §10.7 behavior — TRANSIENT_UNAVAILABLE in
- *             Phase 3 throws CAR_UNAVAILABLE so the caller can invoke
+ *             SPEC §13 / §10.7 behavior — CAR_TRANSIENT in Phase 3
+ *             also throws CAR_UNAVAILABLE so the caller can invoke
  *             the operator-driven `acceptCarLoss(version)` flow after
  *             the persistent-retry window.
  *
@@ -65,7 +73,8 @@
  *                                          located includedV above it
  *   - SEMANTICALLY_INVALID (corrupt)     — walked past, counts toward
  *                                          DISCOVERY_CORRUPT_WALKBACK
- *   - EXISTS-BUT-UNFETCHABLE (new)       — walked past (same as
+ *   - CAR_TRANSIENT (EXISTS-BUT-UNFETCHABLE)
+ *                                        — walked past (same as
  *                                          SEMANTICALLY_INVALID for
  *                                          discovery purposes), counts
  *                                          toward walkback budget, AND
@@ -73,6 +82,10 @@
  *                                          walkbackUnfetchableSkipped so
  *                                          the caller emits an event for
  *                                          monitoring
+ *   - PROOF_TRANSIENT (proof RPC failed) — HARD STOP regardless of
+ *                                          skipUnfetchableInWalkback;
+ *                                          slot existence UNKNOWN, must
+ *                                          not be skipped
  *
  * For PUBLISH `nextV` computation:
  * - `includedV` (the highest INCLUDED slot from Phase 2) is unchanged
@@ -159,17 +172,23 @@ export interface DiscoverInput {
    */
   readonly abortSignal?: AbortSignal;
   /**
-   * Phase 3 walkback policy for TRANSIENT_UNAVAILABLE versions.
+   * Phase 3 walkback policy for `CAR_TRANSIENT` versions (slot EXISTS
+   * on-chain — proof verified + CID decoded — but CAR is unreachable).
    *
-   * Defaults to `true` (skip-past): a slot whose proof is authentic but
-   * whose CAR cannot be fetched is treated as walked-past — Phase 3
-   * continues looking for an older VALID predecessor instead of throwing
-   * CAR_UNAVAILABLE. The skipped versions are recorded in
-   * `walkbackUnfetchableSkipped` for operator observability.
+   * Defaults to `true` (skip-past): a CAR_TRANSIENT slot is treated as
+   * walked-past — Phase 3 continues looking for an older VALID predecessor
+   * instead of throwing CAR_UNAVAILABLE. The skipped versions are recorded
+   * in `walkbackUnfetchableSkipped` for operator observability.
+   *
+   * Note: `PROOF_TRANSIENT` versions (aggregator proof RPC failed — slot
+   * existence UNKNOWN) are NEVER skipped-past regardless of this flag.
+   * They always halt Phase 3 with CAR_UNAVAILABLE. The policy only
+   * applies to `CAR_TRANSIENT` (slot provably exists, only bytes
+   * unavailable).
    *
    * Pass `false` to restore SPEC §13 / §10.7 strict behavior:
-   * TRANSIENT_UNAVAILABLE in Phase 3 throws CAR_UNAVAILABLE so the
-   * caller can invoke the operator-driven `acceptCarLoss(version)` flow.
+   * CAR_TRANSIENT in Phase 3 also throws CAR_UNAVAILABLE so the caller
+   * can invoke the operator-driven `acceptCarLoss(version)` flow.
    *
    * Rationale for the default: see the file-header comment block.
    */
@@ -189,10 +208,15 @@ export interface DiscoverResult {
   readonly probeVersions: readonly PointerVersion[];
   /**
    * Versions visited during Phase 3 walkback whose `classifyVersion`
-   * returned `TRANSIENT_UNAVAILABLE` and were skipped past (only when
+   * returned `CAR_TRANSIENT` and were skipped past (only when
    * `skipUnfetchableInWalkback !== false`). Empty when no such versions
    * were walked, when SPEC-strict mode was requested, or when Phase 3
    * never ran.
+   *
+   * Note: `PROOF_TRANSIENT` versions (aggregator proof RPC failed —
+   * slot existence UNKNOWN) are NEVER skipped; they halt the walkback
+   * with CAR_UNAVAILABLE even in default mode. Only `CAR_TRANSIENT`
+   * versions (proof verified, CID decoded, CAR unreachable) appear here.
    *
    * Surfaced to callers so they can emit a typed event
    * (`storage:pointer-version-skipped-unfetchable`) for monitoring,
@@ -487,15 +511,36 @@ async function findLatestValidVersionInner(
       continue;
     }
 
-    // TRANSIENT_UNAVAILABLE: the slot exists (proof is authentic + CID
-    // decodes) but the CAR is not retrievable from any configured gateway.
+    // PROOF_TRANSIENT: the aggregator proof RPC failed — slot existence UNKNOWN.
+    //
+    // This is distinct from CAR_TRANSIENT (proof ok, CAR unreachable). We
+    // cannot tell whether this version was ever published, so we MUST NOT
+    // skip past it regardless of `skipUnfetchableInWalkback`. Walking past
+    // an unexamined slot would silently skip a version that may be VALID.
+    //
+    // Throw CAR_UNAVAILABLE (same code as SPEC-strict CAR_TRANSIENT) so the
+    // caller can surface the error or retry. The code matches the legacy
+    // behavior for an aggregator outage scenario.
+    if (status === 'PROOF_TRANSIENT') {
+      throw new AggregatorPointerError(
+        AggregatorPointerErrorCode.CAR_UNAVAILABLE,
+        `Phase 3 walkback: version=${candidate} is PROOF_TRANSIENT — ` +
+          `aggregator proof RPC failed, slot existence unknown. ` +
+          `Cannot skip past an unexamined slot (retry when aggregator is reachable).`,
+        { version: candidate, includedV },
+      );
+    }
+
+    // CAR_TRANSIENT: the slot EXISTS on-chain (proof verified + CID decoded)
+    // but the CAR is not retrievable from any configured gateway.
     //
     // Default policy (`skipUnfetchableInWalkback !== false`): the slot is
-    // EXISTS-BUT-UNFETCHABLE — distinct from ABSENT (no proof) and from
-    // SEMANTICALLY_INVALID (proof partial / CID corrupt). For the purpose
-    // of finding the latest VALID predecessor, we treat it like
-    // SEMANTICALLY_INVALID: walk back one more, count toward the walkback
-    // budget, and record the skipped version for operator observability.
+    // EXISTS-BUT-UNFETCHABLE — distinct from ABSENT (no proof), from
+    // SEMANTICALLY_INVALID (proof partial / CID corrupt), and from
+    // PROOF_TRANSIENT (aggregator unreachable). For the purpose of finding
+    // the latest VALID predecessor, we treat it like SEMANTICALLY_INVALID:
+    // walk back one more, count toward the walkback budget, and record the
+    // skipped version for operator observability.
     //
     //   - `includedV` from Phase 2 remains the highest INCLUDED slot
     //     regardless of fetchability, so a downstream publish's
@@ -522,8 +567,9 @@ async function findLatestValidVersionInner(
     }
     throw new AggregatorPointerError(
       AggregatorPointerErrorCode.CAR_UNAVAILABLE,
-      `Phase 3 walkback: version=${candidate} is TRANSIENT_UNAVAILABLE. ` +
-        `Tokens may still exist; refusing to skip past.`,
+      `Phase 3 walkback: version=${candidate} is CAR_TRANSIENT — ` +
+        `proof verified but CAR unreachable; refusing to skip past ` +
+        `(use skipUnfetchableInWalkback: true or acceptCarLoss).`,
       { version: candidate, includedV },
     );
   }

--- a/profile/aggregator-pointer/reconcile-algorithm.ts
+++ b/profile/aggregator-pointer/reconcile-algorithm.ts
@@ -136,6 +136,21 @@ export interface ReconcileOutcome {
   readonly v: PointerVersion;
   readonly attemptsUsed: number;
   readonly probeHistory: readonly PointerVersion[];
+  /**
+   * Versions skipped past during any Phase 3 walkback that ran within
+   * this reconcile session (initial discovery on attempts ≥ 1, plus
+   * conflict-driven rediscovery). Aggregated across all reconcile
+   * iterations — a single reconcile with multiple conflicts may
+   * accumulate skipped versions from each iteration's discovery.
+   *
+   * Empty when no CAR_TRANSIENT skip-past occurred or when all
+   * discovery was via the fast-path (attempt 0, no walkback).
+   *
+   * Surfaced so `publishAggregatorPointerBestEffort` can emit a typed
+   * `storage:pointer-version-skipped-unfetchable` event even on the
+   * publish path (not just the recover path).
+   */
+  readonly walkbackUnfetchableSkipped: readonly PointerVersion[];
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -253,6 +268,9 @@ async function findLatestValidVersionWithWalkbackFloorRetry(
 export async function reconcileAndPublish(input: ReconcileInput): Promise<ReconcileOutcome> {
   const maxAttempts = input.maxAttempts ?? PUBLISH_RETRY_BUDGET;
   const probeHistory: PointerVersion[] = [];
+  // Aggregate CAR_TRANSIENT skip-past versions across all discovery iterations
+  // within this reconcile session (slow-path discovery + conflict rediscovery).
+  const walkbackUnfetchableSkipped: PointerVersion[] = [];
 
   // Track the EVOLVING localVersion across conflicts (fetchAndJoin updates it).
   let currentLocalVersion = input.currentLocalVersion;
@@ -327,6 +345,10 @@ export async function reconcileAndPublish(input: ReconcileInput): Promise<Reconc
         input.abortSignal,
       );
       probeHistory.push(...discovery.probeVersions);
+      // Accumulate any CAR_TRANSIENT skip-past versions from this walkback pass.
+      if (discovery.walkbackUnfetchableSkipped.length > 0) {
+        walkbackUnfetchableSkipped.push(...discovery.walkbackUnfetchableSkipped);
+      }
       nextV = (Math.max(discovery.validV, discovery.includedV) + 1) as PointerVersion;
     }
 
@@ -353,6 +375,7 @@ export async function reconcileAndPublish(input: ReconcileInput): Promise<Reconc
         v: outcome.v,
         attemptsUsed: attempts + 1,
         probeHistory,
+        walkbackUnfetchableSkipped,
       };
     }
 
@@ -384,6 +407,10 @@ export async function reconcileAndPublish(input: ReconcileInput): Promise<Reconc
       input.abortSignal,
     );
     probeHistory.push(...rediscovery.probeVersions);
+    // Accumulate any CAR_TRANSIENT skip-past versions from conflict rediscovery.
+    if (rediscovery.walkbackUnfetchableSkipped.length > 0) {
+      walkbackUnfetchableSkipped.push(...rediscovery.walkbackUnfetchableSkipped);
+    }
 
     if (rediscovery.validV > 0) {
       // Steelman: wrap the remote-fetch + join + persist block with a sleep

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -3300,7 +3300,7 @@ export class ProfileTokenStorageProvider
    * Consumers can switch on `event.code` to drive UI state.
    */
   private buildErrorEvent(
-    type: 'storage:error' | 'sync:error',
+    type: 'storage:error' | 'sync:error' | 'storage:pointer-version-skipped-unfetchable',
     err: unknown,
     overrideCode?: string,
   ): StorageEvent {

--- a/profile/profile-token-storage/host.ts
+++ b/profile/profile-token-storage/host.ts
@@ -216,7 +216,7 @@ export interface ProfileTokenStorageHost {
   log(message: string): void;
   emitEvent(event: StorageEvent): void;
   buildErrorEvent(
-    type: 'storage:error' | 'sync:error',
+    type: 'storage:error' | 'sync:error' | 'storage:pointer-version-skipped-unfetchable',
     err: unknown,
     overrideCode?: string,
   ): StorageEvent;

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -81,6 +81,7 @@ import {
   WIN_BROADCAST_KIND_MARKER,
   WIN_BROADCAST_SCHEMA_VERSION,
 } from '../aggregator-pointer/win-broadcast.js';
+import type { RecoverResult } from '../aggregator-pointer/ProfilePointerLayer.js';
 
 /**
  * Pointer-layer error codes that indicate a permanent integrity /
@@ -844,7 +845,7 @@ export class LifecycleManager {
 
     let lastError: string | undefined;
     while (Date.now() < deadline && !signal.aborted) {
-      let recovered: { readonly cid: Uint8Array; readonly version: number } | null = null;
+      let recovered: Awaited<ReturnType<typeof pointer.recoverLatest>> = null;
       try {
         recovered = await pointer.recoverLatest();
       } catch (err) {
@@ -866,7 +867,12 @@ export class LifecycleManager {
         // Transient — fall through to sleep + retry.
       }
 
-      if (recovered) {
+      // Treat all-unfetchable as "not yet recovered" — retry on next loop
+      // iteration (within the deadline). The pointer chain exists but all
+      // CARs are unreachable; keep trying until the deadline expires.
+      // `'cid' in recovered` is the positive discriminant: RecoverResult has
+      // `cid`, RecoverAllUnfetchableResult does not — TS narrows correctly.
+      if (recovered && 'cid' in recovered) {
         try {
           const recoveredCidStr = CID.decode(recovered.cid).toString();
           if (recoveredCidStr === snapshotCid) {
@@ -1089,7 +1095,7 @@ export class LifecycleManager {
 
     let lastError: string | undefined;
     while (Date.now() < deadline && !signal.aborted) {
-      let recovered: { readonly cid: Uint8Array; readonly version: number } | null = null;
+      let recovered: Awaited<ReturnType<typeof pointer.recoverLatest>> = null;
       try {
         recovered = await pointer.recoverLatest();
       } catch (err) {
@@ -1108,7 +1114,10 @@ export class LifecycleManager {
         }
       }
 
-      if (recovered) {
+      // All-unfetchable is treated as "not yet matching" — retry within deadline.
+      // `'cid' in recovered` is the positive discriminant: RecoverResult has
+      // `cid`, RecoverAllUnfetchableResult does not — TS narrows correctly.
+      if (recovered && 'cid' in recovered) {
         try {
           const recoveredStr = CID.decode(recovered.cid).toString();
           if (recoveredStr === snapshotCid) {
@@ -1333,6 +1342,25 @@ export class LifecycleManager {
         this.host.log(
           `Pointer publish ok: cid=${cidString} version=${result.version} attempts=${result.attemptsUsed}`,
         );
+        // NEEDS-FIX #2: emit the same typed event on the publish path when
+        // conflict-driven rediscovery skipped past CAR_TRANSIENT versions.
+        // The fast-path (attempt 0, no walkback) always produces an empty
+        // list, so this branch fires only when a conflict forced Phase 3.
+        if (result.walkbackUnfetchableSkipped && result.walkbackUnfetchableSkipped.length > 0) {
+          const publishSkipped = result.walkbackUnfetchableSkipped;
+          this.host.emitEvent(
+            this.host.buildErrorEvent(
+              'storage:pointer-version-skipped-unfetchable',
+              new Error(
+                `Pointer publish (conflict-rediscovery): walkback skipped ` +
+                  `${publishSkipped.length} EXISTS-BUT-UNFETCHABLE version(s): ` +
+                  `[${publishSkipped.join(', ')}]. Published at version=${result.version}; ` +
+                  `the listed slot(s) had authentic proofs but unreachable CARs.`,
+              ),
+              'POINTER_VERSIONS_SKIPPED_UNFETCHABLE',
+            ),
+          );
+        }
         // RFC-251 Approach D / issue #255 Problem B — emit the
         // pointer-published event so the wiring layer (Sphere) can
         // broadcast the win to sibling devices over Nostr. Siblings
@@ -1511,8 +1539,12 @@ export class LifecycleManager {
           let reconciledDownward = false;
           try {
             const recovered = await pointer.recoverLatest();
-            if (recovered) {
-              const outcome = await pointer.reconcileLocalVersionDownward(recovered);
+            // Only attempt downward reconcile when we have a concrete RecoverResult
+            // (cid + version). RecoverAllUnfetchableResult (all-unfetchable) has no
+            // fetchable version to adopt as a new baseline, so skip the downgrade.
+            // `'cid' in recovered` is the positive discriminant — TS narrows to RecoverResult.
+            if (recovered && 'cid' in recovered) {
+              const outcome = await pointer.reconcileLocalVersionDownward(recovered as RecoverResult);
               if (outcome.reconciled) {
                 reconciledDownward = true;
                 this.host.log(
@@ -1700,11 +1732,7 @@ export class LifecycleManager {
       return status === 'pending';
     }
 
-    let recovered: {
-      readonly cid: Uint8Array;
-      readonly version: number;
-      readonly walkbackUnfetchableSkipped?: readonly number[];
-    } | null;
+    let recovered: Awaited<ReturnType<typeof pointer.recoverLatest>>;
     try {
       recovered = await pointer.recoverLatest();
     } catch (err) {
@@ -1719,37 +1747,73 @@ export class LifecycleManager {
       return false;
     }
 
+    // Distinguish three recovery outcomes:
+    //   1. null                    — fresh wallet, no pointer published → fall through to legacy IPNS.
+    //   2. RecoverAllUnfetchableResult — pointer chain exists but every CAR unreachable →
+    //                                    do NOT fall through to legacy; retry next poll.
+    //   3. RecoverResult           — VALID version found; proceed to applySnapshot.
     if (!recovered) {
       this.host.log('Pointer recover: no anchor published yet');
       return false;
     }
 
-    // If Phase 3 walkback skipped past EXISTS-BUT-UNFETCHABLE versions,
-    // surface them via a typed log line. The wallet has already recovered
-    // to an older fetchable predecessor — these slots represent the
-    // data-loss window the user has accepted by running with the default
-    // `skipUnfetchableInWalkback: true` policy. Operators monitoring
-    // wallet health can detect this and decide whether to investigate
-    // (e.g., re-pin the lost CARs from a backup or invoke acceptCarLoss).
-    //
-    // Logged at info-level (not error) because the skip is the policy,
-    // not a fault. Permanent errors that previously surfaced here
-    // (CAR_UNAVAILABLE) are now absorbed by the walkback's skip logic;
-    // the caller-visible signal is the recovered version + the skipped
-    // list, not an exception.
-    const skipped = recovered.walkbackUnfetchableSkipped;
+    // Case 2: pointer chain exists but every CAR was CAR_TRANSIENT (no fetchable version).
+    // Refusing legacy IPNS fallback prevents stamping the migration-done marker before
+    // IPFS gateways come back up. Return true (pointer path chosen) so the caller
+    // does not fall through to legacy. The next poll cycle retries.
+    if ('kind' in recovered && recovered.kind === 'all-unfetchable') {
+      const allSkipped = recovered.walkbackUnfetchableSkipped;
+      this.host.emitEvent(
+        this.host.buildErrorEvent(
+          'storage:pointer-version-skipped-unfetchable',
+          new Error(
+            `Pointer recover: all ${allSkipped.length} known anchor version(s) ` +
+              `EXISTS-BUT-UNFETCHABLE: [${allSkipped.join(', ')}]. ` +
+              `No VALID predecessor was found. Refusing legacy IPNS fallback — ` +
+              `the pointer chain is intact; IPFS gateways may be temporarily unreachable. ` +
+              `Recovery will be re-attempted on the next pointer poll cycle.`,
+          ),
+          'POINTER_VERSIONS_SKIPPED_UNFETCHABLE',
+        ),
+      );
+      // Return true: pointer path was chosen (prevents legacy IPNS fork).
+      return true;
+    }
+
+    // Case 3: VALID version found.
+    // At this point `recovered` is narrowed to RecoverResult (null + all-unfetchable
+    // both returned early above). TypeScript's control-flow analysis does not narrow
+    // `RecoverResult | RecoverAllUnfetchableResult` through `'kind' in …` early-return
+    // guards because `RecoverResult` has no `kind` discriminant field declared — the
+    // structural check is ambiguous in TS's view. Explicit cast is safe: both prior
+    // guards exhausted every non-RecoverResult case.
+    const validRecovered = recovered as RecoverResult;
+
+    // Emit skipped-versions event if Phase 3 walkback skipped past
+    // EXISTS-BUT-UNFETCHABLE (CAR_TRANSIENT) versions. host.log is
+    // debug-level and stripped in production; emitEvent goes to the
+    // application event bus and monitoring dashboards.
+    const skipped = validRecovered.walkbackUnfetchableSkipped;
     if (skipped && skipped.length > 0) {
-      this.host.log(
-        `Pointer recover: walkback skipped ${skipped.length} ` +
-          `EXISTS-BUT-UNFETCHABLE version(s): [${skipped.join(', ')}]. ` +
-          `Wallet recovered to older predecessor version=${recovered.version}; ` +
-          `the listed slot(s) had authentic proofs but unreachable CARs.`,
+      this.host.emitEvent(
+        this.host.buildErrorEvent(
+          'storage:pointer-version-skipped-unfetchable',
+          new Error(
+            `Pointer recover: walkback skipped ${skipped.length} ` +
+              `EXISTS-BUT-UNFETCHABLE version(s): [${skipped.join(', ')}]. ` +
+              `Wallet recovered to older predecessor version=${validRecovered.version}; ` +
+              `the listed slot(s) had authentic proofs but unreachable CARs. ` +
+              `Operator: re-pin the missing CARs from a backup, or invoke ` +
+              `acceptCarLoss(version) to permanently acknowledge the data loss.`,
+          ),
+          'POINTER_VERSIONS_SKIPPED_UNFETCHABLE',
+        ),
       );
     }
 
     let cidString: string;
     try {
-      cidString = CID.decode(recovered.cid).toString();
+      cidString = CID.decode(validRecovered.cid).toString();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.host.log(`Pointer recover: failed to decode recovered CID bytes: ${msg}`);
@@ -1790,7 +1854,7 @@ export class LifecycleManager {
       // is already authoritative).
       this.host.setLastDiscoveredPointerCid(cidString);
       this.host.log(
-        `Pointer recover ok: cid=${cidString} version=${recovered.version} ` +
+        `Pointer recover ok: cid=${cidString} version=${validRecovered.version} ` +
           `joinedAny=${applyResult.joinedAny} addresses=${applyResult.addressesSeen} ` +
           `bundles=${applyResult.bundleEntriesSeen}`,
       );
@@ -1978,11 +2042,7 @@ export class LifecycleManager {
       );
     }
 
-    let recovered: {
-      readonly cid: Uint8Array;
-      readonly version: number;
-      readonly walkbackUnfetchableSkipped?: readonly number[];
-    } | null = null;
+    let recovered: Awaited<ReturnType<typeof pointer.recoverLatest>> = null;
     try {
       recovered = await pointer.recoverLatest();
     } catch (err) {
@@ -2006,19 +2066,52 @@ export class LifecycleManager {
       return;
     }
 
-    // Same skip-past observability as the cold-start recovery path.
-    const skipped = recovered.walkbackUnfetchableSkipped;
+    // All-unfetchable: pointer chain exists but every CAR is CAR_TRANSIENT.
+    // Emit event and re-arm; do NOT fall through to any legacy path.
+    if ('kind' in recovered && recovered.kind === 'all-unfetchable') {
+      const allSkipped = recovered.walkbackUnfetchableSkipped;
+      this.host.emitEvent(
+        this.host.buildErrorEvent(
+          'storage:pointer-version-skipped-unfetchable',
+          new Error(
+            `Pointer poll: all ${allSkipped.length} known anchor version(s) ` +
+              `EXISTS-BUT-UNFETCHABLE: [${allSkipped.join(', ')}]. ` +
+              `No VALID predecessor found; IPFS gateways may be temporarily unreachable. ` +
+              `Will retry on next poll cycle.`,
+          ),
+          'POINTER_VERSIONS_SKIPPED_UNFETCHABLE',
+        ),
+      );
+      this.scheduleNextPointerPoll(nextBackoffMultiplier);
+      return;
+    }
+
+    // VALID version found. Same skip-past observability as the cold-start
+    // recovery path: emit a typed event for operator monitoring.
+    // Explicit cast: null + all-unfetchable cases both returned early above.
+    // TS does not narrow RecoverResult | RecoverAllUnfetchableResult through
+    // the `'kind' in …` early-return guard because RecoverResult has no `kind`
+    // field — the `in` check is ambiguous at the type level. Cast is safe.
+    const validRecovered = recovered as RecoverResult;
+
+    const skipped = validRecovered.walkbackUnfetchableSkipped;
     if (skipped && skipped.length > 0) {
-      this.host.log(
-        `Pointer poll: walkback skipped ${skipped.length} ` +
-          `EXISTS-BUT-UNFETCHABLE version(s): [${skipped.join(', ')}]. ` +
-          `Recovered to predecessor version=${recovered.version}.`,
+      this.host.emitEvent(
+        this.host.buildErrorEvent(
+          'storage:pointer-version-skipped-unfetchable',
+          new Error(
+            `Pointer poll: walkback skipped ${skipped.length} ` +
+              `EXISTS-BUT-UNFETCHABLE version(s): [${skipped.join(', ')}]. ` +
+              `Recovered to predecessor version=${validRecovered.version}.`,
+          ),
+          'POINTER_VERSIONS_SKIPPED_UNFETCHABLE',
+        ),
       );
     }
 
     let cidString: string;
     try {
-      cidString = CID.decode(recovered.cid).toString();
+      cidString = CID.decode(validRecovered.cid).toString();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.host.log(`Pointer poll: failed to decode recovered CID bytes: ${msg}`);
@@ -2067,7 +2160,7 @@ export class LifecycleManager {
       this.host.setLastDiscoveredPointerCid(cidString);
       this.host.log(
         `Pointer poll discovered NEW snapshot CID: cid=${cidString} ` +
-          `version=${recovered.version} joinedAny=${applyResult.joinedAny} ` +
+          `version=${validRecovered.version} joinedAny=${applyResult.joinedAny} ` +
           `addresses=${applyResult.addressesSeen} bundles=${applyResult.bundleEntriesSeen}`,
       );
 

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -1700,7 +1700,11 @@ export class LifecycleManager {
       return status === 'pending';
     }
 
-    let recovered: { readonly cid: Uint8Array; readonly version: number } | null;
+    let recovered: {
+      readonly cid: Uint8Array;
+      readonly version: number;
+      readonly walkbackUnfetchableSkipped?: readonly number[];
+    } | null;
     try {
       recovered = await pointer.recoverLatest();
     } catch (err) {
@@ -1718,6 +1722,29 @@ export class LifecycleManager {
     if (!recovered) {
       this.host.log('Pointer recover: no anchor published yet');
       return false;
+    }
+
+    // If Phase 3 walkback skipped past EXISTS-BUT-UNFETCHABLE versions,
+    // surface them via a typed log line. The wallet has already recovered
+    // to an older fetchable predecessor — these slots represent the
+    // data-loss window the user has accepted by running with the default
+    // `skipUnfetchableInWalkback: true` policy. Operators monitoring
+    // wallet health can detect this and decide whether to investigate
+    // (e.g., re-pin the lost CARs from a backup or invoke acceptCarLoss).
+    //
+    // Logged at info-level (not error) because the skip is the policy,
+    // not a fault. Permanent errors that previously surfaced here
+    // (CAR_UNAVAILABLE) are now absorbed by the walkback's skip logic;
+    // the caller-visible signal is the recovered version + the skipped
+    // list, not an exception.
+    const skipped = recovered.walkbackUnfetchableSkipped;
+    if (skipped && skipped.length > 0) {
+      this.host.log(
+        `Pointer recover: walkback skipped ${skipped.length} ` +
+          `EXISTS-BUT-UNFETCHABLE version(s): [${skipped.join(', ')}]. ` +
+          `Wallet recovered to older predecessor version=${recovered.version}; ` +
+          `the listed slot(s) had authentic proofs but unreachable CARs.`,
+      );
     }
 
     let cidString: string;
@@ -1951,7 +1978,11 @@ export class LifecycleManager {
       );
     }
 
-    let recovered: { readonly cid: Uint8Array; readonly version: number } | null = null;
+    let recovered: {
+      readonly cid: Uint8Array;
+      readonly version: number;
+      readonly walkbackUnfetchableSkipped?: readonly number[];
+    } | null = null;
     try {
       recovered = await pointer.recoverLatest();
     } catch (err) {
@@ -1973,6 +2004,16 @@ export class LifecycleManager {
       // silently; this is a normal state for a fresh wallet.
       this.scheduleNextPointerPoll(nextBackoffMultiplier);
       return;
+    }
+
+    // Same skip-past observability as the cold-start recovery path.
+    const skipped = recovered.walkbackUnfetchableSkipped;
+    if (skipped && skipped.length > 0) {
+      this.host.log(
+        `Pointer poll: walkback skipped ${skipped.length} ` +
+          `EXISTS-BUT-UNFETCHABLE version(s): [${skipped.join(', ')}]. ` +
+          `Recovered to predecessor version=${recovered.version}.`,
+      );
     }
 
     let cidString: string;

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -451,7 +451,31 @@ export type StorageEventType =
    * unique event IDs in the §C.2 soak failure observed at
    * `integration/all-fixes` HEAD `6102d59`).
    */
-  | 'storage:durability-deferred';
+  | 'storage:durability-deferred'
+  /**
+   * PR #302 (issue #???): emitted by the pointer-layer lifecycle when
+   * Phase 3 walkback skipped past one or more `CAR_TRANSIENT` versions
+   * (slot EXISTS on-chain — proof verified + CID decoded — but no IPFS
+   * gateway could serve the CAR bytes).
+   *
+   * Fired on both the recover path (cold-start / periodic poll
+   * `recoverLatest()`) and the publish path (conflict-driven rediscovery
+   * in `reconcileAndPublish()`). Also fired when ALL known anchor versions
+   * are CAR_TRANSIENT and no VALID predecessor was found (the
+   * `RecoverAllUnfetchableResult` case).
+   *
+   * `data` carries:
+   *   - `skippedVersions: number[]`   versions walked past
+   *   - `recoveredVersion?: number`   the VALID predecessor found
+   *                                   (absent when all anchors unfetchable)
+   *   - `path: 'recover' | 'publish'` the code path that fired the event
+   *
+   * Not a fatal alarm (`storage:error`). Operators should investigate
+   * IPFS gateway health for the wallet's IPNS CIDs and consider
+   * re-pinning the missing CARs from a backup or invoking
+   * `acceptCarLoss(version)` to permanently acknowledge the data loss.
+   */
+  | 'storage:pointer-version-skipped-unfetchable';
 
 export interface StorageEvent {
   type: StorageEventType;

--- a/tests/conformance/pointer/category-P.test.ts
+++ b/tests/conformance/pointer/category-P.test.ts
@@ -298,7 +298,7 @@ describe('Category P — Conformance & Security Invariants (TEST-SPEC §P)', () 
       expect(vi.mocked(proofB.verify)).toHaveBeenCalled();
 
       // Sanity: classifyVersion actually progressed past verification.
-      expect(['VALID', 'SEMANTICALLY_INVALID', 'TRANSIENT_UNAVAILABLE']).toContain(result);
+      expect(['VALID', 'SEMANTICALLY_INVALID', 'PROOF_TRANSIENT', 'CAR_TRANSIENT']).toContain(result);
     });
 
     it('verify counter is non-zero on the SEMANTICALLY_INVALID path too', async () => {

--- a/tests/integration/pointer/category-C.test.ts
+++ b/tests/integration/pointer/category-C.test.ts
@@ -55,9 +55,11 @@
  *        install, localVersion=0) and runs recoverLatest → gets v=2 CID.
  *
  *   C8   device A publishes; device B IPFS is temporarily unavailable on
- *        classifyVersion → TRANSIENT_UNAVAILABLE → discover throws
- *        CAR_UNAVAILABLE. Device B does NOT advance past a corrupt-only
- *        residue; the tokens may still exist remotely.
+ *        classifyVersion → CAR_TRANSIENT (proof OK, CAR unreachable) →
+ *        recoverLatest returns null (all-unfetchable under default policy;
+ *        see RecoverAllUnfetchableResult). Device B does NOT advance past
+ *        the unfetchable slot; it returns the all-unfetchable sentinel and
+ *        refuses legacy IPNS migration. The tokens may still exist remotely.
  *
  *   C9   device A publishes v=1..3 successfully; device B recovers later
  *        (validV=3) and its SUBSEQUENT publish targets v=4. Asserts
@@ -432,19 +434,23 @@ describe('Pointer Category-C — multi-device contention (SPEC §9)', () => {
       expect(CID.decode(recovered.cid).toString()).toBe(cid.toString());
     });
 
-    it('B without bridged CID → recoverLatest returns null (default skip-past) with no older predecessor', async () => {
+    it('B without bridged CID → recoverLatest returns RecoverAllUnfetchableResult (default skip-past, all CAR_TRANSIENT)', async () => {
       // Negative control for C1: if the winner's CID is NOT in B's IPFS,
-      // classifyVersion returns TRANSIENT_UNAVAILABLE. Under the default
-      // Phase 3 walkback policy (`skipUnfetchableInWalkback: true`), the
-      // wallet skips past the unfetchable v=1 looking for an older
-      // VALID predecessor; here there is none (this was the only
-      // publish), so `recoverLatest()` returns `null`. The wallet stays
-      // live and can begin publishing at v=2 — exactly the
-      // not-bricked-by-broken-prior recovery semantic the user requested
-      // (see discover-algorithm.ts file header for design rationale).
+      // classifyVersion returns CAR_TRANSIENT (proof OK, CAR unreachable).
+      // Under the default Phase 3 walkback policy (`skipUnfetchableInWalkback: true`),
+      // the wallet skips past the unfetchable v=1 looking for an older VALID
+      // predecessor; here there is none (this was the only publish), so
+      // discovery returns validV=0 with walkbackUnfetchableSkipped=[1].
       //
-      // SPEC-strict mode (`skipUnfetchableInWalkback: false`) still
-      // throws CAR_UNAVAILABLE — that path is unit-tested in
+      // ProfilePointerLayer.recoverLatest() distinguishes this from "no pointer
+      // ever published" (null) by returning a RecoverAllUnfetchableResult
+      // { kind: 'all-unfetchable', walkbackUnfetchableSkipped: [1] } instead of null.
+      // The lifecycle layer refuses legacy IPNS migration on this result and
+      // retries on the next poll cycle — the pointer chain exists; IPFS is the
+      // problem.
+      //
+      // SPEC-strict mode (`skipUnfetchableInWalkback: false`) still throws
+      // CAR_UNAVAILABLE — that path is unit-tested in
       // `tests/integration/pointer/walkback-skip-unfetchable.test.ts`.
       const agg = makeSharedAggregator();
       const ipfsA = new InMemoryIpfs();
@@ -459,11 +465,17 @@ describe('Pointer Category-C — multi-device contention (SPEC §9)', () => {
       await devA.layer.publish(async () => cid.bytes);
 
       // ipfsB is DELIBERATELY empty for the CID → CAR fetcher returns
-      // transient_unavailable → classifyVersion returns TRANSIENT_UNAVAILABLE
+      // transient_unavailable → classifyVersion returns CAR_TRANSIENT
       // → walkback skips past v=1 → no older predecessor → recoverLatest
-      // returns null.
+      // returns RecoverAllUnfetchableResult (pointer chain exists, all CARs unreachable).
       const recovered = await devB.layer.recoverLatest();
-      expect(recovered).toBeNull();
+      // Must NOT be null (that would mean "fresh wallet") — must be the
+      // all-unfetchable sentinel.
+      expect(recovered).not.toBeNull();
+      expect(recovered).toMatchObject({
+        kind: 'all-unfetchable',
+        walkbackUnfetchableSkipped: [1],
+      });
     });
   });
 
@@ -775,18 +787,21 @@ describe('Pointer Category-C — multi-device contention (SPEC §9)', () => {
 
   // ── C8: IPFS temporarily unavailable for device B ───────────────────────
 
-  describe('C8 — B\'s IPFS unavailable → recoverLatest skips past and returns null', () => {
-    it('latest valid version\'s CAR transiently missing → discover skips past + returns null (no older predecessor)', async () => {
+  describe('C8 — B\'s IPFS unavailable → recoverLatest returns RecoverAllUnfetchableResult', () => {
+    it('latest version\'s CAR transiently missing → walkback skips + returns all-unfetchable (no older predecessor)', async () => {
       // Under the new default Phase 3 walkback policy
-      // (`skipUnfetchableInWalkback: true`), TRANSIENT_UNAVAILABLE in
-      // Phase 3 is no longer a thrown CAR_UNAVAILABLE — the walkback
-      // looks for an older fetchable VALID predecessor. With only one
-      // published version (v=1) and its CAR unfetchable, the walkback
-      // bottoms out at v=0 → recoverLatest returns null.
+      // (`skipUnfetchableInWalkback: true`), CAR_TRANSIENT in Phase 3 is
+      // no longer a thrown CAR_UNAVAILABLE — the walkback looks for an
+      // older fetchable VALID predecessor. With only one published version
+      // (v=1) and its CAR unfetchable, the walkback bottoms out at v=0
+      // with walkbackUnfetchableSkipped=[1].
       //
-      // The wallet stays live; it can begin publishing at v=2. This is
-      // the user-stated requirement: a single unfetchable slot must not
-      // block the wallet (see discover-algorithm.ts file header).
+      // recoverLatest() returns RecoverAllUnfetchableResult
+      // { kind: 'all-unfetchable', walkbackUnfetchableSkipped: [1] }
+      // instead of null. This distinguishes "anchors exist but gateways
+      // are down" from "fresh wallet with no pointer". The lifecycle layer
+      // refuses legacy IPNS migration on all-unfetchable and retries on
+      // the next poll cycle.
       //
       // SPEC-strict mode (`skipUnfetchableInWalkback: false`) preserves
       // the legacy throw for callers that want the operator-driven
@@ -819,7 +834,13 @@ describe('Pointer Category-C — multi-device contention (SPEC §9)', () => {
       });
 
       const recovered = await devB.layer.recoverLatest();
-      expect(recovered).toBeNull();
+      // Must NOT be null (that would mean "fresh wallet") — must be the
+      // all-unfetchable sentinel so the lifecycle layer can refuse legacy migration.
+      expect(recovered).not.toBeNull();
+      expect(recovered).toMatchObject({
+        kind: 'all-unfetchable',
+        walkbackUnfetchableSkipped: [1],
+      });
     });
   });
 

--- a/tests/integration/pointer/category-C.test.ts
+++ b/tests/integration/pointer/category-C.test.ts
@@ -432,11 +432,20 @@ describe('Pointer Category-C — multi-device contention (SPEC §9)', () => {
       expect(CID.decode(recovered.cid).toString()).toBe(cid.toString());
     });
 
-    it('B without bridged CID → CAR_UNAVAILABLE (content-addressing gap)', async () => {
+    it('B without bridged CID → recoverLatest returns null (default skip-past) with no older predecessor', async () => {
       // Negative control for C1: if the winner's CID is NOT in B's IPFS,
-      // classifyVersion returns TRANSIENT_UNAVAILABLE and discover raises
-      // CAR_UNAVAILABLE. This pins the contract that replication requires
-      // the DHT layer to have propagated the CAR to B.
+      // classifyVersion returns TRANSIENT_UNAVAILABLE. Under the default
+      // Phase 3 walkback policy (`skipUnfetchableInWalkback: true`), the
+      // wallet skips past the unfetchable v=1 looking for an older
+      // VALID predecessor; here there is none (this was the only
+      // publish), so `recoverLatest()` returns `null`. The wallet stays
+      // live and can begin publishing at v=2 — exactly the
+      // not-bricked-by-broken-prior recovery semantic the user requested
+      // (see discover-algorithm.ts file header for design rationale).
+      //
+      // SPEC-strict mode (`skipUnfetchableInWalkback: false`) still
+      // throws CAR_UNAVAILABLE — that path is unit-tested in
+      // `tests/integration/pointer/walkback-skip-unfetchable.test.ts`.
       const agg = makeSharedAggregator();
       const ipfsA = new InMemoryIpfs();
       const ipfsB = new InMemoryIpfs();
@@ -451,10 +460,10 @@ describe('Pointer Category-C — multi-device contention (SPEC §9)', () => {
 
       // ipfsB is DELIBERATELY empty for the CID → CAR fetcher returns
       // transient_unavailable → classifyVersion returns TRANSIENT_UNAVAILABLE
-      // → discover-algorithm raises CAR_UNAVAILABLE.
-      await expect(devB.layer.recoverLatest()).rejects.toMatchObject({
-        code: AggregatorPointerErrorCode.CAR_UNAVAILABLE,
-      });
+      // → walkback skips past v=1 → no older predecessor → recoverLatest
+      // returns null.
+      const recovered = await devB.layer.recoverLatest();
+      expect(recovered).toBeNull();
     });
   });
 
@@ -766,8 +775,23 @@ describe('Pointer Category-C — multi-device contention (SPEC §9)', () => {
 
   // ── C8: IPFS temporarily unavailable for device B ───────────────────────
 
-  describe('C8 — B\'s IPFS unavailable → CAR_UNAVAILABLE (no silent walkpast)', () => {
-    it('latest valid version\'s CAR transiently missing → discover raises CAR_UNAVAILABLE', async () => {
+  describe('C8 — B\'s IPFS unavailable → recoverLatest skips past and returns null', () => {
+    it('latest valid version\'s CAR transiently missing → discover skips past + returns null (no older predecessor)', async () => {
+      // Under the new default Phase 3 walkback policy
+      // (`skipUnfetchableInWalkback: true`), TRANSIENT_UNAVAILABLE in
+      // Phase 3 is no longer a thrown CAR_UNAVAILABLE — the walkback
+      // looks for an older fetchable VALID predecessor. With only one
+      // published version (v=1) and its CAR unfetchable, the walkback
+      // bottoms out at v=0 → recoverLatest returns null.
+      //
+      // The wallet stays live; it can begin publishing at v=2. This is
+      // the user-stated requirement: a single unfetchable slot must not
+      // block the wallet (see discover-algorithm.ts file header).
+      //
+      // SPEC-strict mode (`skipUnfetchableInWalkback: false`) preserves
+      // the legacy throw for callers that want the operator-driven
+      // acceptCarLoss(version) flow — covered in
+      // `tests/integration/pointer/walkback-skip-unfetchable.test.ts`.
       const agg = makeSharedAggregator();
       const ipfsA = new InMemoryIpfs();
       const ipfsB = new InMemoryIpfs();
@@ -794,9 +818,8 @@ describe('Pointer Category-C — multi-device contention (SPEC §9)', () => {
         fetchCar,
       });
 
-      await expect(devB.layer.recoverLatest()).rejects.toMatchObject({
-        code: AggregatorPointerErrorCode.CAR_UNAVAILABLE,
-      });
+      const recovered = await devB.layer.recoverLatest();
+      expect(recovered).toBeNull();
     });
   });
 

--- a/tests/integration/pointer/walkback-skip-unfetchable.test.ts
+++ b/tests/integration/pointer/walkback-skip-unfetchable.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Walkback `EXISTS-BUT-UNFETCHABLE` semantic — Phase 3 skip-past behavior.
+ *
+ * Regression coverage for the user-reported failure where a wallet with
+ * a broken-but-existing aggregator pointer (proof on-chain but CAR
+ * unreachable on every IPFS gateway) blocked cold-start recovery and
+ * conflict-driven publish-discovery. The legacy SPEC-strict behavior
+ * threw `CAR_UNAVAILABLE` from Phase 3 walkback, which manifested as a
+ * 30 s `awaitNextFlush` timeout during legacy → Profile token-storage
+ * migration.
+ *
+ * The fix changes Phase 3 walkback's default policy: a
+ * `TRANSIENT_UNAVAILABLE` slot (proof authentic, CID decoded, CAR
+ * unfetchable) is now SKIPPED-PAST instead of throwing — Phase 3
+ * continues looking for an older fetchable VALID predecessor. The
+ * skipped versions are recorded in
+ * `DiscoverResult.walkbackUnfetchableSkipped` for operator
+ * observability.
+ *
+ * The legacy SPEC-strict behavior is preserved behind the explicit
+ * `skipUnfetchableInWalkback: false` opt-in for callers that still want
+ * to invoke the operator-driven `acceptCarLoss(version)` flow.
+ *
+ * Design rationale + security model documented in
+ * `profile/aggregator-pointer/discover-algorithm.ts` (file header).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { AggregatorClient } from '@unicitylabs/state-transition-sdk/lib/api/AggregatorClient.js';
+import type { RequestId } from '@unicitylabs/state-transition-sdk/lib/api/RequestId.js';
+import type { RootTrustBase } from '@unicitylabs/state-transition-sdk/lib/bft/RootTrustBase.js';
+import { InclusionProofResponse } from '@unicitylabs/state-transition-sdk/lib/api/InclusionProofResponse.js';
+import { InclusionProofVerificationStatus } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof.js';
+import type { InclusionProof } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof.js';
+
+import {
+  AggregatorPointerErrorCode,
+  buildPointerSigner,
+  createMasterPrivateKey,
+  derivePointerKeyMaterial,
+  findLatestValidVersion,
+  type CarFetcher,
+  type CidDecoder,
+  type PointerKeyMaterial,
+  type PointerSigner,
+  type PointerVersion,
+} from '../../../profile/aggregator-pointer/index.js';
+import { __internal as probeInternal } from '../../../profile/aggregator-pointer/aggregator-probe.js';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const WALLET_SEED = new Uint8Array(32).fill(0xee);
+const VALID_CID = new Uint8Array([0x12, 0x20, ...new Array(32).fill(0xab)]);
+
+async function buildIdentity(): Promise<{
+  keyMaterial: PointerKeyMaterial;
+  signer: PointerSigner;
+}> {
+  const masterKey = createMasterPrivateKey(WALLET_SEED);
+  const keyMaterial = derivePointerKeyMaterial(masterKey);
+  const signer = await buildPointerSigner(keyMaterial.signingSeed);
+  return { keyMaterial, signer };
+}
+
+function fakeTrustBase(epoch: bigint = 1n): RootTrustBase {
+  return { epoch } as RootTrustBase;
+}
+
+function makeProof(status: InclusionProofVerificationStatus): InclusionProof {
+  return {
+    verify: async () => status,
+    transactionHash: {
+      data: new Uint8Array(32).fill(0x7e),
+      imprint: new Uint8Array(34),
+    },
+    unicityCertificate: {
+      unicitySeal: { epoch: 1n },
+      inputRecord: { epoch: 1n },
+    },
+  } as unknown as InclusionProof;
+}
+
+/**
+ * Per-version-routing aggregator mock.
+ *
+ * Versions [1..vTrue] are "included" (proof verify OK both sides);
+ * versions above vTrue return PATH_NOT_INCLUDED. We pre-compute
+ * requestIds for both sides of every version in [1..maxV].
+ */
+async function makeVersionRoutingAggregator(
+  vTrue: number,
+  maxV: number,
+  keyMaterial: PointerKeyMaterial,
+  signer: PointerSigner,
+): Promise<{ client: AggregatorClient }> {
+  const idToIncluded = new Map<string, boolean>();
+  for (let v = 1; v <= maxV; v++) {
+    const { reqA, reqB } = await probeInternal.buildRequestIds(keyMaterial, signer, v);
+    const included = v <= vTrue;
+    idToIncluded.set(reqA.toString(), included);
+    idToIncluded.set(reqB.toString(), included);
+  }
+
+  const client = {
+    getInclusionProof: async (requestId: RequestId) => {
+      const included = idToIncluded.get(requestId.toString());
+      const status =
+        included === true
+          ? InclusionProofVerificationStatus.OK
+          : InclusionProofVerificationStatus.PATH_NOT_INCLUDED;
+      return new InclusionProofResponse(makeProof(status));
+    },
+  } as unknown as AggregatorClient;
+
+  return { client };
+}
+
+/** Decoder that returns OK for every version with a fixed CID. */
+const okDecoder: CidDecoder = () => ({ ok: true, cidBytes: VALID_CID });
+
+/**
+ * Build a `CarFetcher` that returns `transient_unavailable` for the
+ * specified versions, `ok: true` for everything else.
+ *
+ * In a real wallet the failure is per-CID, but the decoder above gives
+ * every version the SAME CID (`VALID_CID`). To distinguish "the broken
+ * version" from "the predecessor that should succeed" we count fetch
+ * calls — the first N calls return unfetchable, the next call returns
+ * ok. Phase 3 walkback calls `classifyVersion(candidate)` for
+ * candidate = includedV, includedV-1, ... — so the FIRST call is the
+ * broken slot.
+ *
+ * @param brokenCount  How many of the latest walkback steps should be
+ *                     reported as unfetchable. After that many, return
+ *                     ok and let the walkback succeed.
+ */
+function makeFetcherWithBrokenLatestN(brokenCount: number): {
+  fetcher: CarFetcher;
+  callsObserved: () => number;
+} {
+  let calls = 0;
+  return {
+    fetcher: async () => {
+      calls += 1;
+      if (calls <= brokenCount) {
+        return { ok: false, kind: 'transient_unavailable' };
+      }
+      return { ok: true };
+    },
+    callsObserved: () => calls,
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('Phase 3 walkback — EXISTS-BUT-UNFETCHABLE skip-past (default policy)', () => {
+  it('walkback skips a single TRANSIENT_UNAVAILABLE slot and returns the older fetchable predecessor', async () => {
+    // vTrue = 5: aggregator has proofs at versions 1..5. Phase 1+2 find
+    // includedV = 5. Phase 3 walkback starts at candidate=5; classifyVersion(5)
+    // returns TRANSIENT_UNAVAILABLE (CAR unreachable). Under the new default
+    // (`skipUnfetchableInWalkback: true`), the walkback records v=5 in
+    // `walkbackUnfetchableSkipped` and continues to candidate=4. classifyVersion(4)
+    // returns VALID (CAR ok). Returns { validV: 4, includedV: 5 }.
+    const { keyMaterial, signer } = await buildIdentity();
+    const vTrue = 5;
+    const { client } = await makeVersionRoutingAggregator(vTrue, 64, keyMaterial, signer);
+
+    // Phase 3 calls classifyVersion(5) first → CAR unfetchable. Then
+    // classifyVersion(4) → CAR ok.
+    const { fetcher } = makeFetcherWithBrokenLatestN(1);
+
+    const result = await findLatestValidVersion({
+      currentLocalVersion: 0 as PointerVersion,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecoder,
+      fetchCar: fetcher,
+      // skipUnfetchableInWalkback: true is the default — assert that
+      // omitting it gives the new behavior.
+    });
+
+    expect(result.includedV).toBe(vTrue);
+    expect(result.validV).toBe(4);
+    expect(result.walkbackUnfetchableSkipped).toEqual([5]);
+  });
+
+  it('walkback skips MULTIPLE consecutive unfetchable slots before finding VALID', async () => {
+    // vTrue = 10, broken latest 3 → expect validV=7, skipped=[10,9,8].
+    const { keyMaterial, signer } = await buildIdentity();
+    const vTrue = 10;
+    const { client } = await makeVersionRoutingAggregator(vTrue, 64, keyMaterial, signer);
+
+    const { fetcher } = makeFetcherWithBrokenLatestN(3);
+
+    const result = await findLatestValidVersion({
+      currentLocalVersion: 0 as PointerVersion,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecoder,
+      fetchCar: fetcher,
+    });
+
+    expect(result.includedV).toBe(vTrue);
+    expect(result.validV).toBe(7);
+    expect(result.walkbackUnfetchableSkipped).toEqual([10, 9, 8]);
+  });
+
+  it('walkback returns validV=0 when ALL fetchable slots are unfetchable (no predecessor found)', async () => {
+    // vTrue = 3, all 3 broken → walks back through 3, 2, 1, 0 → returns
+    // validV=0, skipped=[3,2,1]. The wallet recovery treats validV=0 as
+    // "no anchor published yet" — the wallet stays live (no throw) and
+    // can begin publishing at v=1.
+    const { keyMaterial, signer } = await buildIdentity();
+    const vTrue = 3;
+    const { client } = await makeVersionRoutingAggregator(vTrue, 64, keyMaterial, signer);
+
+    const { fetcher } = makeFetcherWithBrokenLatestN(3);
+
+    const result = await findLatestValidVersion({
+      currentLocalVersion: 0 as PointerVersion,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecoder,
+      fetchCar: fetcher,
+    });
+
+    expect(result.includedV).toBe(vTrue);
+    expect(result.validV).toBe(0);
+    expect(result.walkbackUnfetchableSkipped).toEqual([3, 2, 1]);
+  });
+
+  it('walkback with NO unfetchable slots returns empty walkbackUnfetchableSkipped', async () => {
+    // No broken slots → first classifyVersion call returns VALID → no skip
+    // records. Confirms the new field defaults to empty array (no
+    // false-positive observability noise on the happy path).
+    const { keyMaterial, signer } = await buildIdentity();
+    const vTrue = 5;
+    const { client } = await makeVersionRoutingAggregator(vTrue, 64, keyMaterial, signer);
+
+    const { fetcher } = makeFetcherWithBrokenLatestN(0);
+
+    const result = await findLatestValidVersion({
+      currentLocalVersion: 0 as PointerVersion,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecoder,
+      fetchCar: fetcher,
+    });
+
+    expect(result.validV).toBe(5);
+    expect(result.walkbackUnfetchableSkipped).toEqual([]);
+  });
+
+  it('walkback unfetchable skips count toward the walkback budget (DISCOVERY_CORRUPT_WALKBACK)', async () => {
+    // vTrue = 128, ALL slots unfetchable → walkback exhausts
+    // DISCOVERY_CORRUPT_WALKBACK (=64) steps without finding VALID and
+    // bails out with CORRUPT_STREAK. This pins the safety invariant: the
+    // skip-past does NOT silently extend the walkback budget — the
+    // wallet still gets the CORRUPT_STREAK signal so operators can
+    // invoke acceptCorruptStreak / acceptCarLoss with a wider limit.
+    //
+    // The error details MUST also include `unfetchableSkippedCount` so
+    // operators can distinguish "gateway down" from "wallet corrupt"
+    // when both surface as CORRUPT_STREAK.
+    const { keyMaterial, signer } = await buildIdentity();
+    const vTrue = 128;
+    const maxV = 1024;
+    const { client } = await makeVersionRoutingAggregator(vTrue, maxV, keyMaterial, signer);
+
+    // Every fetch returns transient_unavailable → every walkback step is a
+    // skip-past, exhausting the default 64-step budget.
+    const { fetcher } = makeFetcherWithBrokenLatestN(1_000_000);
+
+    let caught: unknown = null;
+    try {
+      await findLatestValidVersion({
+        currentLocalVersion: 0 as PointerVersion,
+        keyMaterial,
+        signer,
+        aggregatorClient: client,
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: fetcher,
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toMatchObject({
+      code: AggregatorPointerErrorCode.CORRUPT_STREAK,
+    });
+    const details = (caught as { details?: Record<string, unknown> } | null)?.details;
+    expect(details).toBeDefined();
+    if (!details) return;
+    // All walkback steps were skipped under the unfetchable policy —
+    // operator can see this in the error details to triage IPFS health.
+    expect(details['unfetchableSkippedCount']).toBeGreaterThan(0);
+    expect(details['unfetchableSkippedCount']).toBe(details['walkedSoFar']);
+  });
+});
+
+describe('Phase 3 walkback — SPEC-strict opt-in (`skipUnfetchableInWalkback: false`)', () => {
+  it('SPEC-strict mode still throws CAR_UNAVAILABLE on TRANSIENT_UNAVAILABLE', async () => {
+    // The legacy contract is preserved for callers that want the
+    // operator-driven acceptCarLoss(version) flow. Passing
+    // `skipUnfetchableInWalkback: false` restores the SPEC §13 throw.
+    const { keyMaterial, signer } = await buildIdentity();
+    const vTrue = 5;
+    const { client } = await makeVersionRoutingAggregator(vTrue, 64, keyMaterial, signer);
+
+    const { fetcher } = makeFetcherWithBrokenLatestN(1);
+
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0 as PointerVersion,
+        keyMaterial,
+        signer,
+        aggregatorClient: client,
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: fetcher,
+        skipUnfetchableInWalkback: false,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.CAR_UNAVAILABLE,
+    });
+  });
+
+  it('SPEC-strict mode CAR_UNAVAILABLE includes the broken version + includedV in error details', async () => {
+    // The error MUST surface enough context for the operator to invoke
+    // acceptCarLoss(version) — version is the broken slot, includedV is
+    // the Phase 2 result. Regression check.
+    const { keyMaterial, signer } = await buildIdentity();
+    const vTrue = 7;
+    const { client } = await makeVersionRoutingAggregator(vTrue, 64, keyMaterial, signer);
+
+    const { fetcher } = makeFetcherWithBrokenLatestN(1);
+
+    let caught: unknown = null;
+    try {
+      await findLatestValidVersion({
+        currentLocalVersion: 0 as PointerVersion,
+        keyMaterial,
+        signer,
+        aggregatorClient: client,
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: fetcher,
+        skipUnfetchableInWalkback: false,
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    const details = (caught as { details?: Record<string, unknown> } | null)?.details;
+    expect(details).toBeDefined();
+    if (!details) return;
+    expect(details['version']).toBe(7);
+    expect(details['includedV']).toBe(vTrue);
+  });
+});
+
+describe('Phase 3 walkback — semantics regression coverage', () => {
+  it('PUBLISH semantics: `includedV` reflects the highest INCLUDED slot regardless of fetchability', async () => {
+    // This is THE invariant that makes the skip-past safe for the
+    // publish path: a new publish targets `max(validV, includedV) + 1`.
+    // Even when validV is rewound by skip-past, includedV stays at the
+    // true peak — so the new publish supersedes ABOVE the broken slot.
+    const { keyMaterial, signer } = await buildIdentity();
+    const vTrue = 10;
+    const { client } = await makeVersionRoutingAggregator(vTrue, 64, keyMaterial, signer);
+
+    const { fetcher } = makeFetcherWithBrokenLatestN(2);
+
+    const result = await findLatestValidVersion({
+      currentLocalVersion: 0 as PointerVersion,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecoder,
+      fetchCar: fetcher,
+    });
+
+    // validV walked back past the broken slots:
+    expect(result.validV).toBe(8);
+    // includedV is unchanged — Phase 2 doesn't fetch CARs:
+    expect(result.includedV).toBe(vTrue);
+    // Publish would compute nextV = max(8, 10) + 1 = 11 → supersedes the
+    // broken slot cleanly. Slot 11 is fresh; no collision with the broken 9/10.
+    expect(Math.max(result.validV, result.includedV) + 1).toBe(11);
+  });
+});

--- a/tests/integration/pointer/walkback-skip-unfetchable.test.ts
+++ b/tests/integration/pointer/walkback-skip-unfetchable.test.ts
@@ -10,12 +10,16 @@
  * migration.
  *
  * The fix changes Phase 3 walkback's default policy: a
- * `TRANSIENT_UNAVAILABLE` slot (proof authentic, CID decoded, CAR
- * unfetchable) is now SKIPPED-PAST instead of throwing — Phase 3
- * continues looking for an older fetchable VALID predecessor. The
- * skipped versions are recorded in
+ * `CAR_TRANSIENT` slot (proof authentic, CID decoded, CAR unfetchable
+ * — slot EXISTS on-chain) is now SKIPPED-PAST instead of throwing —
+ * Phase 3 continues looking for an older fetchable VALID predecessor.
+ * The skipped versions are recorded in
  * `DiscoverResult.walkbackUnfetchableSkipped` for operator
  * observability.
+ *
+ * `PROOF_TRANSIENT` slots (aggregator proof RPC failed — slot
+ * existence UNKNOWN) are NOT skipped-past; they halt the walkback
+ * with CAR_UNAVAILABLE regardless of `skipUnfetchableInWalkback`.
  *
  * The legacy SPEC-strict behavior is preserved behind the explicit
  * `skipUnfetchableInWalkback: false` opt-in for callers that still want
@@ -155,13 +159,13 @@ function makeFetcherWithBrokenLatestN(brokenCount: number): {
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('Phase 3 walkback — EXISTS-BUT-UNFETCHABLE skip-past (default policy)', () => {
-  it('walkback skips a single TRANSIENT_UNAVAILABLE slot and returns the older fetchable predecessor', async () => {
+  it('walkback skips a single CAR_TRANSIENT slot and returns the older fetchable predecessor', async () => {
     // vTrue = 5: aggregator has proofs at versions 1..5. Phase 1+2 find
     // includedV = 5. Phase 3 walkback starts at candidate=5; classifyVersion(5)
-    // returns TRANSIENT_UNAVAILABLE (CAR unreachable). Under the new default
-    // (`skipUnfetchableInWalkback: true`), the walkback records v=5 in
-    // `walkbackUnfetchableSkipped` and continues to candidate=4. classifyVersion(4)
-    // returns VALID (CAR ok). Returns { validV: 4, includedV: 5 }.
+    // returns CAR_TRANSIENT (proof OK + CID decoded, CAR unreachable). Under
+    // the new default (`skipUnfetchableInWalkback: true`), the walkback records
+    // v=5 in `walkbackUnfetchableSkipped` and continues to candidate=4.
+    // classifyVersion(4) returns VALID (CAR ok). Returns { validV: 4, includedV: 5 }.
     const { keyMaterial, signer } = await buildIdentity();
     const vTrue = 5;
     const { client } = await makeVersionRoutingAggregator(vTrue, 64, keyMaterial, signer);
@@ -308,11 +312,69 @@ describe('Phase 3 walkback — EXISTS-BUT-UNFETCHABLE skip-past (default policy)
   });
 });
 
+describe('Phase 3 walkback — PROOF_TRANSIENT is a hard stop regardless of policy', () => {
+  it('PROOF_TRANSIENT (aggregator proof RPC failed) throws CAR_UNAVAILABLE even with skipUnfetchableInWalkback: true', async () => {
+    // A slot whose proof RPC FAILED (network error, timeout, etc.) has
+    // UNKNOWN existence — we cannot tell whether it was ever published.
+    // Phase 3 MUST NOT skip past it: doing so would silently walk past
+    // an unexamined slot that may be VALID.
+    //
+    // Strategy: use vTrue=1 so Phase 3 classifyVersion(1) triggers the mock throw.
+    // Phase 1+2: lo starts at 0, hi at DISCOVERY_INITIAL_VERSION (1024). Phase 1
+    // probes 1024 (false, 2 calls); Phase 2 binary-searches down to includedV=1
+    // in 10 iterations (20 calls) — 22 total. Phase 3 classifyVersion(1) issues
+    // calls 23+24 which hit the mock-throw path. classifyVersion's runDecodePhases
+    // catches the throw and returns PROOF_TRANSIENT; Phase 3 then emits
+    // AggregatorPointerError(CAR_UNAVAILABLE) regardless of skipUnfetchableInWalkback.
+    const { keyMaterial, signer } = await buildIdentity();
+    const { client: baseClient } = await makeVersionRoutingAggregator(1, 64, keyMaterial, signer);
+
+    let callCount = 0;
+    // Phase 1+2 for vTrue=1 with DISCOVERY_INITIAL_VERSION=1024:
+    //   Phase 1: probe(1024)=false             → 2 getInclusionProof calls
+    //   Phase 2: binary search lo=0→hi=1024    → 10 iterations × 2 calls = 20 calls
+    //   Total Phase 1+2: 22 calls; includedV=1
+    // Set budget to 22 so calls 23+24 are Phase 3's classifyVersion(1) attempt.
+    // classifyVersion wraps getInclusionProof in runDecodePhases try/catch,
+    // which catches the throw and returns PROOF_TRANSIENT → AggregatorPointerError.
+    const PHASE12_BUDGET = 22;
+    const clientWithFailingPhase3 = {
+      getInclusionProof: async (requestId: import('@unicitylabs/state-transition-sdk/lib/api/RequestId.js').RequestId) => {
+        callCount += 1;
+        if (callCount > PHASE12_BUDGET) {
+          throw new Error('aggregator unreachable (PROOF_TRANSIENT simulation)');
+        }
+        return baseClient.getInclusionProof(requestId);
+      },
+    } as unknown as AggregatorClient;
+
+    // Phase 3 classifyVersion(1) → PROOF_TRANSIENT → throws CAR_UNAVAILABLE.
+    // This must throw even though skipUnfetchableInWalkback is true (default),
+    // because PROOF_TRANSIENT means "slot existence UNKNOWN" — not skip-past.
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0 as PointerVersion,
+        keyMaterial,
+        signer,
+        aggregatorClient: clientWithFailingPhase3,
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: makeFetcherWithBrokenLatestN(0).fetcher,
+        // Default: skipUnfetchableInWalkback: true — but PROOF_TRANSIENT must
+        // still throw regardless (slot existence unknown).
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.CAR_UNAVAILABLE,
+    });
+  });
+});
+
 describe('Phase 3 walkback — SPEC-strict opt-in (`skipUnfetchableInWalkback: false`)', () => {
-  it('SPEC-strict mode still throws CAR_UNAVAILABLE on TRANSIENT_UNAVAILABLE', async () => {
+  it('SPEC-strict mode still throws CAR_UNAVAILABLE on CAR_TRANSIENT', async () => {
     // The legacy contract is preserved for callers that want the
     // operator-driven acceptCarLoss(version) flow. Passing
-    // `skipUnfetchableInWalkback: false` restores the SPEC §13 throw.
+    // `skipUnfetchableInWalkback: false` restores the SPEC §13 throw
+    // for CAR_TRANSIENT slots (proof verified, CAR unreachable).
     const { keyMaterial, signer } = await buildIdentity();
     const vTrue = 5;
     const { client } = await makeVersionRoutingAggregator(vTrue, 64, keyMaterial, signer);

--- a/tests/unit/pointer/category-E.test.ts
+++ b/tests/unit/pointer/category-E.test.ts
@@ -12,10 +12,10 @@
  *
  *   - probeVersion's H2 OR-predicate (symmetric over sides A / B) and
  *     its epoch-discrimination behaviour at the trust-base boundary
- *   - classifyVersion's three-way VALID / SEMANTICALLY_INVALID /
- *     TRANSIENT_UNAVAILABLE discriminator (including the E5b partial-
- *     inclusion case that arises from an attacker poisoning exactly
- *     one of the two shares)
+ *   - classifyVersion's four-way VALID / SEMANTICALLY_INVALID /
+ *     PROOF_TRANSIENT / CAR_TRANSIENT discriminator (including the
+ *     E5b partial-inclusion case that arises from an attacker
+ *     poisoning exactly one of the two shares)
  *   - decodeVersionCid's Phase 1+2 standalone semantics — it MUST NOT
  *     touch the CAR fetcher and MUST carry the exact three-way
  *     outcome discrimination as its classify sibling
@@ -424,14 +424,16 @@ describe('E6 — classifyVersion CAR content-mismatch → SEMANTICALLY_INVALID (
 
 // ───────────────────────────────────────────────────────────────────────────
 // E7 — classifyVersion: proofs VALID + CID decodes, but the CAR is
-//      unreachable (all gateways 5xx / timeout) → TRANSIENT_UNAVAILABLE
+//      unreachable (all gateways 5xx / timeout) → CAR_TRANSIENT
+//      (slot EXISTS on-chain; Phase 3 MAY skip past under policy)
 // ───────────────────────────────────────────────────────────────────────────
-describe('E7 — classifyVersion CAR transient_unavailable → TRANSIENT_UNAVAILABLE (SPEC §8.2)', () => {
-  it('CAR fetcher reports transient_unavailable → TRANSIENT_UNAVAILABLE', async () => {
+describe('E7 — classifyVersion CAR transient_unavailable → CAR_TRANSIENT (SPEC §8.2)', () => {
+  it('CAR fetcher reports transient_unavailable → CAR_TRANSIENT (slot EXISTS, proof verified)', async () => {
     // Distinct from E6: here the token pool might still exist; the
     // caller is expected to retry later. Misclassifying this as
     // SEMANTICALLY_INVALID would prematurely abandon a perfectly
-    // valid version.
+    // valid version. Also distinct from PROOF_TRANSIENT: proof was
+    // verified and CID decoded successfully — slot existence is KNOWN.
     const { keyMaterial, signer } = await buildFixtures();
     const proofA = fakeProof(InclusionProofVerificationStatus.OK);
     const proofB = fakeProof(InclusionProofVerificationStatus.OK);
@@ -447,7 +449,7 @@ describe('E7 — classifyVersion CAR transient_unavailable → TRANSIENT_UNAVAIL
       decodeCid: okDecoder,
       fetchCar: transientFetcher,
     });
-    expect(result).toBe('TRANSIENT_UNAVAILABLE');
+    expect(result).toBe('CAR_TRANSIENT');
   });
 });
 

--- a/tests/unit/profile/pointer/aggregator-probe.test.ts
+++ b/tests/unit/profile/pointer/aggregator-probe.test.ts
@@ -5,7 +5,7 @@
  *   - probeVersion H2 OR-predicate (either side → true)
  *   - probeVersion raises TRUST_BASE_STALE on rotation (cert.epoch > local)
  *   - probeVersion raises UNTRUSTED_PROOF on forgery (cert.epoch <= local)
- *   - classifyVersion three-way (VALID / SEMANTICALLY_INVALID / TRANSIENT_UNAVAILABLE)
+ *   - classifyVersion four-way (VALID / SEMANTICALLY_INVALID / PROOF_TRANSIENT / CAR_TRANSIENT)
  *   - isReachable returns true on any HTTP response, false on network failure
  */
 
@@ -293,7 +293,7 @@ describe('classifyVersion — H1 three-way (SPEC §8.2)', () => {
     expect(result).toBe('SEMANTICALLY_INVALID');
   });
 
-  it('returns TRANSIENT_UNAVAILABLE when CAR fetch reports transient', async () => {
+  it('returns CAR_TRANSIENT when CAR fetch reports transient (proof OK + CID decoded — slot EXISTS)', async () => {
     const { keyMaterial, signer } = await buildFixtures();
     const proofA = fakeProof(InclusionProofVerificationStatus.OK);
     const proofB = fakeProof(InclusionProofVerificationStatus.OK);
@@ -309,7 +309,9 @@ describe('classifyVersion — H1 three-way (SPEC §8.2)', () => {
       decodeCid: okDecoder,
       fetchCar: transientFetcher,
     });
-    expect(result).toBe('TRANSIENT_UNAVAILABLE');
+    // Proof verified + CID decoded but CAR unreachable → CAR_TRANSIENT (slot EXISTS).
+    // Phase 3 MAY skip past this under skipUnfetchableInWalkback policy.
+    expect(result).toBe('CAR_TRANSIENT');
   });
 
   it('returns SEMANTICALLY_INVALID on CAR content-address mismatch', async () => {
@@ -350,7 +352,7 @@ describe('classifyVersion — H1 three-way (SPEC §8.2)', () => {
     expect(result).toBe('SEMANTICALLY_INVALID');
   });
 
-  it('returns TRANSIENT_UNAVAILABLE when proof fetch fails with network error', async () => {
+  it('returns PROOF_TRANSIENT when proof fetch fails with network error (slot existence UNKNOWN)', async () => {
     const { keyMaterial, signer } = await buildFixtures();
     const client = {
       getInclusionProof: vi.fn(async () => {
@@ -368,7 +370,9 @@ describe('classifyVersion — H1 three-way (SPEC §8.2)', () => {
       decodeCid: okDecoder,
       fetchCar: validFetcher,
     });
-    expect(result).toBe('TRANSIENT_UNAVAILABLE');
+    // Proof RPC failed — slot existence UNKNOWN → PROOF_TRANSIENT.
+    // Phase 3 MUST NOT skip past this (distinct from CAR_TRANSIENT).
+    expect(result).toBe('PROOF_TRANSIENT');
   });
 
   it('raises TRUST_BASE_STALE when proof epoch > local epoch', async () => {

--- a/tests/unit/profile/pointer/discover-algorithm.test.ts
+++ b/tests/unit/profile/pointer/discover-algorithm.test.ts
@@ -6,10 +6,10 @@
  *   - Phase 2 binary search converges to includedV
  *   - Phase 3 walkback through SEMANTICALLY_INVALID versions
  *   - DISCOVERY_OVERFLOW when probe hits hard ceiling
- *   - TRANSIENT_UNAVAILABLE skip-past (default) — see
+ *   - CAR_TRANSIENT skip-past (default) — see
  *     `tests/integration/pointer/walkback-skip-unfetchable.test.ts`
  *     for the dedicated integration coverage. SPEC-strict CAR_UNAVAILABLE
- *     opt-in path (`skipUnfetchableInWalkback: false`) covered there too.
+ *     opt-in path and PROOF_TRANSIENT hard-stop covered there too.
  *   - CORRUPT_STREAK after exhausted walkback
  *   - validV=0 when localVersion=0 and no pointer exists
  *   - computeProbeFingerprint determinism

--- a/tests/unit/profile/pointer/discover-algorithm.test.ts
+++ b/tests/unit/profile/pointer/discover-algorithm.test.ts
@@ -6,7 +6,10 @@
  *   - Phase 2 binary search converges to includedV
  *   - Phase 3 walkback through SEMANTICALLY_INVALID versions
  *   - DISCOVERY_OVERFLOW when probe hits hard ceiling
- *   - CAR_UNAVAILABLE on TRANSIENT_UNAVAILABLE (do NOT skip)
+ *   - TRANSIENT_UNAVAILABLE skip-past (default) — see
+ *     `tests/integration/pointer/walkback-skip-unfetchable.test.ts`
+ *     for the dedicated integration coverage. SPEC-strict CAR_UNAVAILABLE
+ *     opt-in path (`skipUnfetchableInWalkback: false`) covered there too.
  *   - CORRUPT_STREAK after exhausted walkback
  *   - validV=0 when localVersion=0 and no pointer exists
  *   - computeProbeFingerprint determinism


### PR DESCRIPTION
## Summary

User-reported failure during legacy-to-Profile migration:

```
GET https://unicity-ipfs1.dyndns.org/sidecar/blob?cid=bafyreiay... 404
  <- applySnapshotIfWired <- recoverFromAggregatorPointerBestEffort <- initialize
[check-marker] marker read failed: ORBITDB_READ_FAILED
[await-flush] awaitNextFlush failed: timeout awaiting serialized flush
```

The wallet's previous publish landed a proof on the aggregator but the
referenced snapshot CID returned 404 on every configured IPFS gateway.
Phase 3 walkback in `findLatestValidVersion` then threw
`AGGREGATOR_POINTER_CAR_UNAVAILABLE` for that slot, blocking:

- `recoverLatest()` (cold-start recovery + pointer poll) — never found
  an older fetchable predecessor.
- `reconcileAndPublish` SLOW PATH discovery on conflict-driven rediscovery.

## Investigation

The user's brief originally proposed "pointer-publish tolerates 404 on
existing pointer." Investigation traced the actual hang to
`profile/aggregator-pointer/discover-algorithm.ts:354` — Phase 3 walkback's
hard throw on `TRANSIENT_UNAVAILABLE`. The publish path doesn't directly
hang awaitNextFlush, but Phase 3 walkback was triggering on every
conflict-driven rediscovery AND every cold-start recovery, returning
"transient" results that kept the at-least-once gate closed.

## User correction (verbatim)

> "We MUST ensure that pointer that cant be satisfied will not be
> treated as a gap in the pointer version history. If a pointer is
> non-null then its not the gap. The client will try to fetch profile
> version the pointer is pointing to and join it with other (later)
> versions. If pointer cant be satisfied, simply skip it and move on."

## Fix

`DiscoverInput.skipUnfetchableInWalkback` (default `true`): Phase 3
treats `TRANSIENT_UNAVAILABLE` as walked-past (analogous to
`SEMANTICALLY_INVALID`), counting toward `DISCOVERY_CORRUPT_WALKBACK`
budget, recording the version in `walkbackUnfetchableSkipped` for
operator observability.

SPEC-strict behavior (throw `CAR_UNAVAILABLE`) preserved behind
`skipUnfetchableInWalkback: false` for callers that want the
operator-driven `acceptCarLoss(version)` flow.

## Critical invariants preserved

- **Publish supersede.** `includedV` from Phase 2 (which uses
  `probeVersion`, no CAR fetch) remains the highest INCLUDED slot
  regardless of fetchability. `nextV = max(validV, includedV) + 1`
  still supersedes ABOVE the broken slot — no collision with the
  unfetchable prior. Pinned by the publish-supersede test.
- **Walkback budget.** Unfetchable skips count toward
  `DISCOVERY_CORRUPT_WALKBACK`. The wallet still gets `CORRUPT_STREAK`
  if too many consecutive non-VALID versions are encountered — operator
  intervention surface is preserved.
- **Security model.** Pointer slots are signed by the wallet's own
  pointer key. A malicious aggregator cannot forge proofs at slots the
  wallet did not author. A malicious gateway can already 404 anything.
  The new semantic does NOT expand the attacker surface — it expands
  the recovery surface for the wallet user.
- **Private keys never leave the SDK boundary** — no API surface change.

## Surfaces

- `RecoverResult.walkbackUnfetchableSkipped` (new optional field).
- `LifecycleManager` logs the skipped list at info-level when
  `recoverFromAggregatorPointerBestEffort` / pointer-poll observes a
  non-empty list.
- `CORRUPT_STREAK` error `details` now carries `unfetchableSkippedCount`
  so operators can distinguish "wallet corrupt" from "gateways down"
  when both surface the same code.

## Steelman pass (12 findings, all addressed)

1. Data-loss in skipped slots — yes, real. User explicitly accepted
   ("simply skip it and move on"). Surfaced via
   `walkbackUnfetchableSkipped` for monitoring.
2. Malicious-gateway data-loss — same attack surface as before;
   skip-past is graceful degradation, not new leverage.
3. Side-channel info leak via `walkbackUnfetchableSkipped` — subset of
   the existing `probeVersions`; no new info.
4. Publish target above broken slot — verified by the publish-supersede
   test (`includedV` unaffected by Phase 2).
5. Walkback budget exhaustion attack — bounded by
   `DISCOVERY_CORRUPT_WALKBACK`; same as before.
6. Backward compat for `DiscoverResult` consumers — `readonly` additive
   field; structural typing preserves BC. Verified by `tsc --noEmit`.
7. Comment accuracy — found and fixed stale "SEMANTICALLY_INVALID only"
   comment + over-claim "the caller emits a typed event" (downgraded
   to "the lifecycle layer logs at info-level").
8. CORRUPT_STREAK error misleading — added `unfetchableSkippedCount`
   to details + diagnostic message.
9. `skipUnfetchableInWalkback: undefined` semantics — `!== false`
   pattern correctly defaults to `true`.
10. `recoverLatest()` returning null vs throwing — operationally visible
    via log lines; SPEC-strict opt-in available for callers needing the
    hard signal.
11. Race conditions / determinism — walkback is single-threaded and
    deterministic; one `fetchCar` per `classifyVersion`; tests pin.
12. SPEC §10.7 `acceptCarLoss` workflow — still accessible via
    `skipUnfetchableInWalkback: false` opt-in.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `tests/integration/pointer/walkback-skip-unfetchable.test.ts`
      (new, 8 tests) — single-skip / multi-skip /
      no-predecessor-found / no-false-positive /
      budget-exhaustion-with-unfetchableSkippedCount-detail /
      SPEC-strict-throws / SPEC-strict-details / publish-supersede
- [x] `tests/integration/pointer/category-C.test.ts` C1-neg + C8
      updated to new contract; 11 tests pass
- [x] All other pointer integration + conformance pass (11 files,
      120 tests + 11 skipped)
- [x] `tests/unit/profile/` 130 files, 2157 tests pass
- [x] Full unit suite (`tests/unit/`) — 418 files, 7820 tests pass
- [x] No new lint warnings introduced (2 pre-existing unrelated)

## Files changed

- `profile/aggregator-pointer/discover-algorithm.ts` — Phase 3
  walkback policy + `DiscoverInput.skipUnfetchableInWalkback` +
  `DiscoverResult.walkbackUnfetchableSkipped` + extended `CORRUPT_STREAK`
  diagnostic
- `profile/aggregator-pointer/ProfilePointerLayer.ts` —
  `RecoverResult.walkbackUnfetchableSkipped` optional field; surface
  from `#recoverLatestInner`
- `profile/profile-token-storage/lifecycle-manager.ts` — log skipped
  list in `recoverFromAggregatorPointerBestEffort` + `runPointerPollOnce`
- `tests/integration/pointer/walkback-skip-unfetchable.test.ts` (new)
- `tests/integration/pointer/category-C.test.ts` — updated C1-neg + C8
- `tests/unit/profile/pointer/discover-algorithm.test.ts` — docstring
  pointer to new integration coverage