### PR TITLE
fix(profile): unbound migration flush + parallelize CAR block pinning

### DIFF
--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -231,6 +231,24 @@ const DEFAULT_IPFS_API_URL = 'https://ipfs.unicity.network';
 /** Default timeout for pin operations (ms). */
 const DEFAULT_PIN_TIMEOUT_MS = 60_000;
 
+/**
+ * Default concurrency for `pinCarBlocksToIpfs`. Each in-flight slot is a
+ * single HTTP POST to the sidecar; round-trip is ~80-150 ms regardless of
+ * payload size, so serial = N × RTT and dominates wall-clock for any
+ * non-trivial wallet (a 24-token migration emits ~250 blocks, which at
+ * 100 ms each is ~25 s serial). 10 concurrent in-flight pins reduces the
+ * same workload to ~2.5 s while staying well under typical browser
+ * per-origin connection caps (Chrome's 6 HTTP/1.1 cap is multiplexed by
+ * HTTP/2 on the sidecar). Overridable per-call to support stress tests
+ * or sidecars with explicit per-client rate limits.
+ *
+ * Concurrency is bounded by a worker pool (not Promise.all over all
+ * blocks) so memory stays O(concurrency × block-size) rather than
+ * O(blocks × block-size) — important for migration of large wallets
+ * where the CAR may contain thousands of blocks.
+ */
+const DEFAULT_PIN_CONCURRENCY = 10;
+
 /** Default timeout for fetch operations (ms). */
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
 
@@ -660,6 +678,11 @@ async function pinSingleBlock(
  * @param timeoutMs         - Timeout per gateway+block (default: 60 000)
  * @param helia             - Optional local Helia node (see issue #236).
  *                            Pass the result of `OrbitDbAdapter.getHelia()`.
+ * @param concurrency       - Maximum simultaneous in-flight block pins
+ *                            (default: 10). Higher values may saturate
+ *                            slow sidecars; lower values increase serial
+ *                            tail. Non-positive / non-finite values are
+ *                            clamped to 1.
  * @returns The `expectedRootCid` on success.
  * @throws {ProfileError} `ORBITDB_WRITE_FAILED` if all gateways fail to
  *         accept a pin or the CAR doesn't contain the expected root.
@@ -670,6 +693,7 @@ export async function pinCarBlocksToIpfs(
   expectedRootCid: string,
   timeoutMs: number = DEFAULT_PIN_TIMEOUT_MS,
   helia?: unknown,
+  concurrency: number = DEFAULT_PIN_CONCURRENCY,
 ): Promise<string> {
   const localHelia = asHelia(helia);
   // Parse the CAR locally to extract each block. Done up front so a
@@ -730,10 +754,27 @@ export async function pinCarBlocksToIpfs(
     );
   }
 
-  // Pin each block sequentially. A single block failure aborts the
-  // whole import: callers MUST see "all blocks pinned" or "publish
+  // Pin blocks with bounded concurrency. A single block failure aborts
+  // the whole import: callers MUST see "all blocks pinned" or "publish
   // failed" — never a partial import that would leave the rootCid
   // pointing into a hole.
+  //
+  // Concurrency model: a fixed-size worker pool draws from a shared
+  // monotonic index into `blocks`. Each worker iterates until the index
+  // is exhausted, processing one block at a time (local Helia put then
+  // HTTP pin). This bounds memory at O(concurrency × block-size) and
+  // bounds in-flight HTTP at exactly `concurrency` — important for
+  // sidecars / browsers with per-origin connection caps.
+  //
+  // Error handling: a single worker's throw surfaces via `Promise.all`,
+  // aborting the operation. Other in-flight workers' pin POSTs continue
+  // to completion in the background (the sidecar trims them with its
+  // own timeouts; no orphan state because IPFS pins are idempotent at
+  // the same CID). We do not introduce an `AbortController` here
+  // because the additional plumbing through `pinSingleBlock` →
+  // `fetch(..., {signal})` would couple every worker to a shared
+  // cancellation surface for negligible benefit (the next save-driven
+  // flush would re-pin the same blocks under the same CIDs anyway).
   //
   // Issue #236 — when a local Helia handle is supplied, write each
   // block to its on-disk blockstore BEFORE the HTTP pin. This makes
@@ -760,7 +801,14 @@ export async function pinCarBlocksToIpfs(
   // pre-#236 behaviour (Kubo redirects to truthful CID, lie becomes
   // unreachable) is preserved bit-for-bit. We log loudly so a
   // regression in our own CAR builder is visible in operator telemetry.
-  for (const block of blocks) {
+  const effectiveConcurrency = Math.max(
+    1,
+    Number.isFinite(concurrency) ? Math.floor(concurrency) : DEFAULT_PIN_CONCURRENCY,
+  );
+  const workerCount = Math.min(effectiveConcurrency, blocks.length);
+
+  let nextIndex = 0;
+  const processOne = async (block: { cid: string; bytes: Uint8Array }): Promise<void> => {
     if (localHelia !== null) {
       let cidBindingOk = true;
       try {
@@ -780,7 +828,19 @@ export async function pinCarBlocksToIpfs(
       }
     }
     await pinSingleBlock(gateways, block.bytes, block.cid, timeoutMs);
-  }
+  };
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const i = nextIndex++;
+      if (i >= blocks.length) return;
+      await processOne(blocks[i]);
+    }
+  };
+
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < workerCount; i++) workers.push(worker());
+  await Promise.all(workers);
 
   return expectedRootCid;
 }

--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -762,19 +762,31 @@ export async function pinCarBlocksToIpfs(
   // Concurrency model: a fixed-size worker pool draws from a shared
   // monotonic index into `blocks`. Each worker iterates until the index
   // is exhausted, processing one block at a time (local Helia put then
-  // HTTP pin). This bounds memory at O(concurrency × block-size) and
-  // bounds in-flight HTTP at exactly `concurrency` — important for
-  // sidecars / browsers with per-origin connection caps.
+  // HTTP pin). In-flight HTTP is bounded at exactly `concurrency` —
+  // important for sidecars / browsers with per-origin connection caps.
   //
-  // Error handling: a single worker's throw surfaces via `Promise.all`,
-  // aborting the operation. Other in-flight workers' pin POSTs continue
-  // to completion in the background (the sidecar trims them with its
-  // own timeouts; no orphan state because IPFS pins are idempotent at
-  // the same CID). We do not introduce an `AbortController` here
-  // because the additional plumbing through `pinSingleBlock` →
-  // `fetch(..., {signal})` would couple every worker to a shared
-  // cancellation surface for negligible benefit (the next save-driven
-  // flush would re-pin the same blocks under the same CIDs anyway).
+  // Memory: once `CarReader.fromBytes(carBytes)` materialises the block
+  // index, the full `blocks[]` array is held in scope for the entire
+  // pin operation (every worker closes over it). So peak memory is
+  // O(N_blocks × block-size) + O(concurrency) for HTTP buffers —
+  // dominated by the parsed CAR, not the pin parallelism. (A future
+  // optimisation could stream blocks via `reader.blocks()` with a
+  // producer-consumer queue, but the CAR-as-bytes input already
+  // requires the full payload in memory, so this is bounded by the
+  // CAR-build step upstream.)
+  //
+  // Error handling: a worker that fails sets the shared `aborted` flag
+  // so peer workers short-circuit on their next iteration. Each worker
+  // is wrapped via `.catch()` so a late rejection AFTER the first
+  // failure cannot surface as `UnhandledPromiseRejection` (which would
+  // either log spurious warnings or — in strict / `--unhandled-
+  // rejections=strict` mode — terminate the host process). All worker
+  // errors are collected into `workerErrors[]`; we throw the first one
+  // so the caller sees the deterministic root cause rather than a
+  // race-dependent variant. In-flight pin POSTs at the moment of abort
+  // run to completion naturally (sidecar timeout) — no resource leak
+  // because IPFS pins are idempotent at the same CID and the sidecar
+  // bounds its own request lifetime.
   //
   // Issue #236 — when a local Helia handle is supplied, write each
   // block to its on-disk blockstore BEFORE the HTTP pin. This makes
@@ -808,6 +820,9 @@ export async function pinCarBlocksToIpfs(
   const workerCount = Math.min(effectiveConcurrency, blocks.length);
 
   let nextIndex = 0;
+  let aborted = false;
+  const workerErrors: unknown[] = [];
+
   const processOne = async (block: { cid: string; bytes: Uint8Array }): Promise<void> => {
     if (localHelia !== null) {
       let cidBindingOk = true;
@@ -831,16 +846,53 @@ export async function pinCarBlocksToIpfs(
   };
 
   const worker = async (): Promise<void> => {
-    while (true) {
+    while (!aborted) {
+      // Atomic index claim — V8 single-threaded model guarantees no
+      // microtask interleaves between read and write of `nextIndex++`.
+      // (Any future refactor that adds an `await` between read and
+      // write would break this and is caught by the index-tracking
+      // assertion in `tests/unit/profile/ipfs-client-parallel-pin.test.ts`.)
       const i = nextIndex++;
       if (i >= blocks.length) return;
-      await processOne(blocks[i]);
+      try {
+        await processOne(blocks[i]);
+      } catch (err) {
+        // First failure tips the shared abort flag so peer workers
+        // exit on their next iteration rather than uselessly pinning
+        // additional blocks that the caller will discard anyway.
+        aborted = true;
+        throw err;
+      }
     }
   };
 
+  // Wrap each worker in a `.catch()` so a late rejection (after the
+  // first failure already armed `aborted`) is absorbed locally rather
+  // than escaping as an UnhandledPromiseRejection — operationally
+  // visible (Node logs a warning, strict mode aborts the host process)
+  // even though the original throw is already surfaced via `workerErrors`.
+  // Steelman finding P1#1 — pre-fix `Promise.all(workers)` would short-
+  // circuit on the first reject and leave 9 peer workers' eventual
+  // rejections unattached.
   const workers: Promise<void>[] = [];
-  for (let i = 0; i < workerCount; i++) workers.push(worker());
+  for (let i = 0; i < workerCount; i++) {
+    workers.push(
+      worker().catch((err: unknown) => {
+        workerErrors.push(err);
+      }),
+    );
+  }
   await Promise.all(workers);
+
+  if (workerErrors.length > 0) {
+    // Throw the first observed failure so the caller sees a
+    // deterministic root cause rather than a race-dependent variant.
+    // Subsequent errors (typically the same shape — e.g., all workers
+    // failed against a downed sidecar) are discarded; if operator
+    // diagnostics need them, attach a `storage:error` event before
+    // re-throwing in a future enhancement.
+    throw workerErrors[0];
+  }
 
   return expectedRootCid;
 }

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -985,10 +985,21 @@ export class ProfileTokenStorageProvider
    * advance Nostr `since` → re-replay on next reconnect (idempotent
    * via addToken stateHash dedup).
    *
-   * @param timeoutMs Max wall-clock time. Default 30s.
+   * @param timeoutMs Max wall-clock time. Default 30s. Pass 0 (or any
+   *   non-finite / non-positive value) to disable the wall-clock deadline
+   *   entirely — appropriate for one-shot bulk operations like
+   *   `migrateTokenStorage()` whose duration legitimately scales with
+   *   input size. The 4-iteration runaway guard still applies regardless,
+   *   so a genuinely stuck save-flush feedback loop cannot run forever.
    */
   async awaitNextFlush(timeoutMs = 30_000): Promise<void> {
     if (!this.initialized || !this.encryptionKey) return;
+
+    // Treat 0, negative, NaN, and ±Infinity as "no deadline". The flush
+    // chain still propagates errors and the 4-iteration cap below catches
+    // runaway save→flush races, but we don't impose an arbitrary wall-
+    // clock ceiling on operations whose work scales with input.
+    const noDeadline = !Number.isFinite(timeoutMs) || timeoutMs <= 0;
 
     // Issue #274 — perf instrumentation. Entry log + duration mark on each
     // iteration so operators can distinguish "first flush slow" from
@@ -999,11 +1010,12 @@ export class ProfileTokenStorageProvider
     logger.debug(
       'profile:flush',
       'awaitNextFlush enter',
-      { timeoutMs },
+      { timeoutMs, noDeadline },
     );
 
-    const deadline = Date.now() + timeoutMs;
-    const remainingMs = (): number => Math.max(0, deadline - Date.now());
+    const deadline = noDeadline ? Number.POSITIVE_INFINITY : Date.now() + timeoutMs;
+    const remainingMs = (): number =>
+      noDeadline ? 0 : Math.max(0, deadline - Date.now());
 
     // Gap 4 (POINTER_MONOTONICITY_VIOLATION recovery): once per
     // `awaitNextFlush` invocation we permit a single in-loop baseline
@@ -1062,21 +1074,29 @@ export class ProfileTokenStorageProvider
       // awaitNextFlush callers, these timer handles accumulate.
       let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       try {
-        await Promise.race([
-          chained,
-          new Promise<never>((_, reject) => {
-            timeoutHandle = setTimeout(
-              () =>
-                reject(
-                  new SphereError(
-                    'awaitNextFlush: timeout awaiting serialized flush',
-                    'TIMEOUT',
+        if (noDeadline) {
+          // Skip Promise.race entirely — no timer to allocate, no spurious
+          // late-fire on settled chains. The 4-iteration cap and the
+          // chain's own error propagation remain the only termination
+          // conditions.
+          await chained;
+        } else {
+          await Promise.race([
+            chained,
+            new Promise<never>((_, reject) => {
+              timeoutHandle = setTimeout(
+                () =>
+                  reject(
+                    new SphereError(
+                      'awaitNextFlush: timeout awaiting serialized flush',
+                      'TIMEOUT',
+                    ),
                   ),
-                ),
-              remainingMs(),
-            );
-          }),
-        ]);
+                remainingMs(),
+              );
+            }),
+          ]);
+        }
       } catch (err) {
         if (err instanceof SphereError && err.code === 'TIMEOUT') throw err;
 

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -986,11 +986,18 @@ export class ProfileTokenStorageProvider
    * via addToken stateHash dedup).
    *
    * @param timeoutMs Max wall-clock time. Default 30s. Pass 0 (or any
-   *   non-finite / non-positive value) to disable the wall-clock deadline
-   *   entirely — appropriate for one-shot bulk operations like
-   *   `migrateTokenStorage()` whose duration legitimately scales with
-   *   input size. The 4-iteration runaway guard still applies regardless,
-   *   so a genuinely stuck save-flush feedback loop cannot run forever.
+   *   non-finite / non-positive value, including `Number.POSITIVE_INFINITY`
+   *   and `Number.NaN`) to disable the wall-clock deadline entirely —
+   *   appropriate for one-shot bulk operations like `migrateTokenStorage()`
+   *   whose duration legitimately scales with input size. The 4-iteration
+   *   runaway guard still applies regardless, so a genuinely stuck save-
+   *   flush feedback loop cannot run forever.
+   *
+   *   Note: this differs from `pinCarBlocksToIpfs(..., concurrency)`,
+   *   which treats `+Infinity` / `NaN` as "fall back to default
+   *   concurrency=10" rather than "no cap". The two parameters have
+   *   different shapes (time budget vs in-flight pool size); the shared
+   *   non-finite handling here is "disable", there is "use default".
    */
   async awaitNextFlush(timeoutMs = 30_000): Promise<void> {
     if (!this.initialized || !this.encryptionKey) return;

--- a/profile/token-storage-migration.ts
+++ b/profile/token-storage-migration.ts
@@ -628,7 +628,18 @@ export async function migrateTokenStorage(
 
   if (typeof opts.target.awaitNextFlush === 'function') {
     try {
-      await opts.target.awaitNextFlush();
+      // Bulk import: the post-save flush has to pin one CAR block per
+      // sub-element across every migrated token, and that scales linearly
+      // with wallet size. The hot-path 30s default is correct for
+      // incoming-transfer ack latency; it is the wrong shape for a
+      // one-shot operation whose duration grows with input. Pass 0 to
+      // disable the wall-clock deadline (the 4-iteration runaway guard
+      // inside awaitNextFlush still trips on a genuine save→flush feedback
+      // loop). Callers that need a cap (e.g., a CLI with its own
+      // user-cancellable progress UI) can wrap the migration in their own
+      // AbortSignal / setTimeout, or set the target's flushScheduler
+      // budgets at provider construction.
+      await opts.target.awaitNextFlush(0);
     } catch (err) {
       // A flush failure means the data is NOT durable. Do NOT stamp
       // the marker — return a failure so the next run retries.

--- a/tests/unit/profile/ipfs-client-parallel-pin.test.ts
+++ b/tests/unit/profile/ipfs-client-parallel-pin.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Tests for parallel block pinning in `pinCarBlocksToIpfs`.
+ *
+ * Diagnosis (2026-05-27): the pre-fix loop pinned each CAR block
+ * sequentially via HTTP POST to the sidecar. With ~80-150ms per round-
+ * trip, a ~250-block migration CAR ran for ~25-30s, exceeding the 30s
+ * `awaitNextFlush` budget and failing the legacy → Profile migration at
+ * the "Flushing Profile storage to disk" phase. The fix introduces a
+ * bounded worker pool — `concurrency` workers each draw blocks from a
+ * shared monotonic index — so wall-clock drops from `N × RTT` to
+ * `ceil(N / concurrency) × RTT`.
+ *
+ * Coverage:
+ *   1. All blocks pinned (correctness preserved).
+ *   2. Max simultaneous in-flight pins ≤ configured concurrency.
+ *   3. With concurrency=10, 30 blocks complete in ≤ 4 batches.
+ *   4. Single block failure aborts the operation (`Promise.all` reject).
+ *   5. Concurrency parameter clamped (0 / negative / NaN → 1).
+ *   6. Concurrency clamped DOWN to `blocks.length` when smaller than
+ *      configured concurrency (no spurious idle workers).
+ *   7. Default concurrency (10) used when arg omitted.
+ *   8. Order-independence: pins arrive at the sidecar in any order, all
+ *      blocks accepted under their own CID.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { create as createDigest } from 'multiformats/hashes/digest';
+
+import { pinCarBlocksToIpfs } from '../../../profile/ipfs-client';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function buildCarBytes(
+  roots: CID[],
+  entries: Array<{ cid: CID; bytes: Uint8Array }>,
+): Promise<Uint8Array> {
+  const { CarWriter } = await import('@ipld/car');
+  const { writer, out } = CarWriter.create(roots);
+  const collect = (async () => {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of out) chunks.push(chunk);
+    return chunks;
+  })();
+  for (const entry of entries) {
+    await writer.put({ cid: entry.cid, bytes: entry.bytes });
+  }
+  await writer.close();
+  const chunks = await collect;
+  const total = chunks.reduce((acc, c) => acc + c.length, 0);
+  const buf = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    buf.set(c, offset);
+    offset += c.length;
+  }
+  return buf;
+}
+
+function makeBlocks(n: number): Array<{ cid: CID; bytes: Uint8Array }> {
+  const out: Array<{ cid: CID; bytes: Uint8Array }> = [];
+  for (let i = 0; i < n; i++) {
+    const bytes = new TextEncoder().encode(`block-${i}-payload-${'x'.repeat(8)}`);
+    const cid = CID.createV1(raw.code, createDigest(0x12, sha256(bytes)));
+    out.push({ cid, bytes });
+  }
+  return out;
+}
+
+/**
+ * Fetch mock that:
+ *   - increments `inFlight` on entry to /api/v0/dag/put, decrements on exit
+ *   - tracks `maxInFlight`
+ *   - sleeps `delayMs` before responding (forces concurrency to be
+ *     observable — without a delay, the entire worker pool drains
+ *     synchronously and `inFlight` may never observe > 1 transiently)
+ *   - returns 200 from dag/put; sidecar submit best-effort
+ *   - records every CID that was pinned for correctness assertions
+ */
+interface PinTracker {
+  inFlight: number;
+  maxInFlight: number;
+  pinnedCids: string[];
+  startCount: number;
+  endCount: number;
+  failNthBlock: number | null;
+}
+
+function installConcurrencyMock(delayMs: number): {
+  tracker: PinTracker;
+  restore: () => void;
+} {
+  const original = globalThis.fetch;
+  const tracker: PinTracker = {
+    inFlight: 0,
+    maxInFlight: 0,
+    pinnedCids: [],
+    startCount: 0,
+    endCount: 0,
+    failNthBlock: null,
+  };
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : (input as { url?: string }).url ?? String(input);
+
+    if (url.includes('/sidecar/submit') || url.includes('/sidecar/blob')) {
+      // Sidecar fan-out is fire-and-forget; respond fast, no concurrency
+      // accounting needed.
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+
+    if (url.includes('/api/v0/dag/put')) {
+      // Extract CID for tracking — pinSingleBlock POSTs the bytes,
+      // not the CID, but the URL itself encodes the codec and the
+      // sidecar/submit fan-out URL DOES carry the CID query param.
+      // We track via the dag/put body's CID indirectly: trust that
+      // the sidecar/submit will record it, but here we just count
+      // start/end + concurrency.
+      const myIdx = tracker.startCount++;
+      tracker.inFlight++;
+      if (tracker.inFlight > tracker.maxInFlight) {
+        tracker.maxInFlight = tracker.inFlight;
+      }
+      try {
+        await new Promise((r) => setTimeout(r, delayMs));
+        if (tracker.failNthBlock !== null && myIdx === tracker.failNthBlock) {
+          return new Response('forced failure', { status: 500 });
+        }
+        // Pull the CID from the body's binary content (we don't have it
+        // in the URL). Instead, derive from sidecar/submit fan-out
+        // requests below.
+        let cid: string | null = null;
+        if (init?.body instanceof FormData) {
+          const file = init.body.get('data') as Blob | null;
+          if (file) {
+            const bytes = new Uint8Array(await file.arrayBuffer());
+            const c = CID.createV1(raw.code, createDigest(0x12, sha256(bytes)));
+            cid = c.toString();
+          }
+        }
+        if (cid) tracker.pinnedCids.push(cid);
+        return new Response(JSON.stringify({ Cid: { '/': 'ignored' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      } finally {
+        tracker.inFlight--;
+        tracker.endCount++;
+      }
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  return {
+    tracker,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+const TEST_GATEWAY = 'https://ipfs.test';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
+  let mock: ReturnType<typeof installConcurrencyMock> | null = null;
+
+  afterEach(() => {
+    if (mock) {
+      mock.restore();
+      mock = null;
+    }
+  });
+
+  it('pins every block exactly once (correctness invariant preserved)', async () => {
+    const blocks = makeBlocks(12);
+    const carBytes = await buildCarBytes([blocks[0].cid], blocks);
+    mock = installConcurrencyMock(5);
+
+    await pinCarBlocksToIpfs(
+      [TEST_GATEWAY],
+      carBytes,
+      blocks[0].cid.toString(),
+      30_000,
+      undefined,
+      4,
+    );
+
+    expect(mock.tracker.endCount).toBe(12);
+    // Every block CID present in pinned set, no duplicates.
+    const uniquePinned = new Set(mock.tracker.pinnedCids);
+    expect(uniquePinned.size).toBe(12);
+    for (const b of blocks) {
+      expect(uniquePinned.has(b.cid.toString())).toBe(true);
+    }
+  });
+
+  it('respects the concurrency bound — max in-flight ≤ configured', async () => {
+    const blocks = makeBlocks(20);
+    const carBytes = await buildCarBytes([blocks[0].cid], blocks);
+    mock = installConcurrencyMock(15);
+
+    const CONCURRENCY = 4;
+    await pinCarBlocksToIpfs(
+      [TEST_GATEWAY],
+      carBytes,
+      blocks[0].cid.toString(),
+      30_000,
+      undefined,
+      CONCURRENCY,
+    );
+
+    expect(mock.tracker.maxInFlight).toBeLessThanOrEqual(CONCURRENCY);
+    // Must have actually observed parallelism — if mock.tracker.maxInFlight
+    // is 1, the worker pool degenerated to serial and the perf fix didn't
+    // land. With 20 blocks and 15ms delay per pin, we expect to saturate
+    // the pool for most of the run.
+    expect(mock.tracker.maxInFlight).toBeGreaterThanOrEqual(2);
+  });
+
+  it('default concurrency=10 saturates pool for large block counts', async () => {
+    const blocks = makeBlocks(40);
+    const carBytes = await buildCarBytes([blocks[0].cid], blocks);
+    mock = installConcurrencyMock(15);
+
+    // Omit the concurrency arg — should default to 10.
+    await pinCarBlocksToIpfs(
+      [TEST_GATEWAY],
+      carBytes,
+      blocks[0].cid.toString(),
+    );
+
+    expect(mock.tracker.endCount).toBe(40);
+    // With 40 blocks and default 10 concurrency, max in-flight should
+    // reach close to 10 (within race timing).
+    expect(mock.tracker.maxInFlight).toBeGreaterThanOrEqual(5);
+    expect(mock.tracker.maxInFlight).toBeLessThanOrEqual(10);
+  });
+
+  it('clamps non-positive / non-finite concurrency to 1 (degrades to serial)', async () => {
+    const blocks = makeBlocks(8);
+    const carBytes = await buildCarBytes([blocks[0].cid], blocks);
+
+    for (const badValue of [0, -1, -100, Number.NaN, Number.POSITIVE_INFINITY]) {
+      mock = installConcurrencyMock(5);
+      await pinCarBlocksToIpfs(
+        [TEST_GATEWAY],
+        carBytes,
+        blocks[0].cid.toString(),
+        30_000,
+        undefined,
+        badValue,
+      );
+
+      if (Number.isFinite(badValue)) {
+        // Non-positive finite → clamp to 1 (serial). Max in-flight = 1.
+        expect(mock.tracker.maxInFlight).toBe(1);
+      } else {
+        // Non-finite (NaN, +Infinity) → fall back to DEFAULT_PIN_CONCURRENCY
+        // (10). Max in-flight bounded by Math.min(10, blocks.length=8).
+        expect(mock.tracker.maxInFlight).toBeLessThanOrEqual(8);
+      }
+      expect(mock.tracker.endCount).toBe(8);
+      mock.restore();
+      mock = null;
+    }
+  });
+
+  it('clamps concurrency DOWN to block count (no spurious idle workers)', async () => {
+    const blocks = makeBlocks(3);
+    const carBytes = await buildCarBytes([blocks[0].cid], blocks);
+    mock = installConcurrencyMock(5);
+
+    // Ask for concurrency 20, but only 3 blocks — should spawn only 3 workers.
+    await pinCarBlocksToIpfs(
+      [TEST_GATEWAY],
+      carBytes,
+      blocks[0].cid.toString(),
+      30_000,
+      undefined,
+      20,
+    );
+
+    expect(mock.tracker.endCount).toBe(3);
+    expect(mock.tracker.maxInFlight).toBeLessThanOrEqual(3);
+  });
+
+  it('single-block failure aborts the whole operation', async () => {
+    const blocks = makeBlocks(10);
+    const carBytes = await buildCarBytes([blocks[0].cid], blocks);
+    mock = installConcurrencyMock(5);
+    // Force the 3rd pin (index 2) to return 500.
+    mock.tracker.failNthBlock = 2;
+
+    await expect(
+      pinCarBlocksToIpfs(
+        [TEST_GATEWAY],
+        carBytes,
+        blocks[0].cid.toString(),
+        30_000,
+        undefined,
+        4,
+      ),
+    ).rejects.toThrow(/ORBITDB_WRITE_FAILED|dag\/put failed|HTTP 500/);
+  });
+
+  it('order-independent: pins arrive in any order, all CIDs are pinned', async () => {
+    // The worker pool draws blocks via shared index — the order pins
+    // hit the sidecar depends on worker scheduling. We assert ONLY
+    // that every CID was pinned, not the order.
+    const blocks = makeBlocks(15);
+    const carBytes = await buildCarBytes([blocks[0].cid], blocks);
+    mock = installConcurrencyMock(5);
+
+    await pinCarBlocksToIpfs(
+      [TEST_GATEWAY],
+      carBytes,
+      blocks[0].cid.toString(),
+      30_000,
+      undefined,
+      5,
+    );
+
+    const expectedCids = new Set(blocks.map((b) => b.cid.toString()));
+    const actualCids = new Set(mock.tracker.pinnedCids);
+    expect(actualCids.size).toBe(expectedCids.size);
+    for (const cid of expectedCids) {
+      expect(actualCids.has(cid)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Perf sanity: serial vs parallel wall-clock on simulated 30ms RTT
+// ---------------------------------------------------------------------------
+
+describe('pinCarBlocksToIpfs — wall-clock perf characteristic', () => {
+  let mock: ReturnType<typeof installConcurrencyMock> | null = null;
+  afterEach(() => {
+    if (mock) {
+      mock.restore();
+      mock = null;
+    }
+  });
+
+  it('20 blocks × 30ms RTT with concurrency=10 completes well under serial time', async () => {
+    // Serial would take 20 × 30 = 600ms minimum.
+    // Concurrency=10 should take ~2 batches × 30ms = ~60ms (plus
+    // scheduling overhead). Assert well under the serial baseline so a
+    // regression that re-introduces the serial loop fails this test.
+    const blocks = makeBlocks(20);
+    const carBytes = await buildCarBytes([blocks[0].cid], blocks);
+    mock = installConcurrencyMock(30);
+
+    const start = Date.now();
+    await pinCarBlocksToIpfs(
+      [TEST_GATEWAY],
+      carBytes,
+      blocks[0].cid.toString(),
+      30_000,
+      undefined,
+      10,
+    );
+    const elapsed = Date.now() - start;
+
+    // Generous ceiling (300ms) to avoid CI flakes from scheduler jitter;
+    // serial would still be > 600ms even with timer rounding. The
+    // important regression-catching property is "parallel << serial".
+    expect(elapsed).toBeLessThan(300);
+    expect(mock.tracker.endCount).toBe(20);
+  });
+});

--- a/tests/unit/profile/ipfs-client-parallel-pin.test.ts
+++ b/tests/unit/profile/ipfs-client-parallel-pin.test.ts
@@ -72,6 +72,23 @@ function makeBlocks(n: number): Array<{ cid: CID; bytes: Uint8Array }> {
 }
 
 /**
+ * Hash bytes → hex string. Used to build an INDEX lookup so the mock
+ * can attribute each POST back to its producer-side `blocks[i]` index,
+ * not to a re-hashed CID. Steelman P1#2 — the previous version derived
+ * CIDs by re-hashing POST bodies, which could not distinguish "every
+ * block pinned once" from "block X pinned twice + block Y skipped"
+ * because both produce the same set of unique CIDs (when the set check
+ * stays at N, length and dedup would surface the dup). The strict
+ * regression guard is to assert that each producer-side INDEX appears
+ * exactly once across all POSTs.
+ */
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = '';
+  for (const b of bytes) hex += b.toString(16).padStart(2, '0');
+  return hex;
+}
+
+/**
  * Fetch mock that:
  *   - increments `inFlight` on entry to /api/v0/dag/put, decrements on exit
  *   - tracks `maxInFlight`
@@ -79,26 +96,50 @@ function makeBlocks(n: number): Array<{ cid: CID; bytes: Uint8Array }> {
  *     observable — without a delay, the entire worker pool drains
  *     synchronously and `inFlight` may never observe > 1 transiently)
  *   - returns 200 from dag/put; sidecar submit best-effort
- *   - records every CID that was pinned for correctness assertions
+ *   - looks up each POST body's bytes in `indexByHash` to attribute
+ *     the pin to a producer-side `blocks[i]` index — used by the
+ *     correctness invariant assertion
  */
 interface PinTracker {
   inFlight: number;
   maxInFlight: number;
-  pinnedCids: string[];
+  /**
+   * Ordered list of producer-side `blocks[i]` indices observed via
+   * POST body lookup. A correct pool processes each index exactly
+   * once; a duplicate-process bug shows up as a repeated index, a
+   * skip bug as a missing index.
+   */
+  processedIndices: number[];
+  /**
+   * Per-index pin count. Same data as `processedIndices` but indexed
+   * for fast O(1) duplicate detection in assertions.
+   */
+  pinCountByIndex: Map<number, number>;
   startCount: number;
   endCount: number;
   failNthBlock: number | null;
 }
 
-function installConcurrencyMock(delayMs: number): {
+function installConcurrencyMock(
+  delayMs: number,
+  blocks: Array<{ cid: CID; bytes: Uint8Array }>,
+): {
   tracker: PinTracker;
   restore: () => void;
 } {
   const original = globalThis.fetch;
+  // Build hash → producer-index lookup BEFORE any worker runs so the
+  // mock can attribute each POST body back to its source index.
+  const indexByHash = new Map<string, number>();
+  for (let i = 0; i < blocks.length; i++) {
+    indexByHash.set(bytesToHex(blocks[i].bytes), i);
+  }
+
   const tracker: PinTracker = {
     inFlight: 0,
     maxInFlight: 0,
-    pinnedCids: [],
+    processedIndices: [],
+    pinCountByIndex: new Map<number, number>(),
     startCount: 0,
     endCount: 0,
     failNthBlock: null,
@@ -117,35 +158,33 @@ function installConcurrencyMock(delayMs: number): {
     }
 
     if (url.includes('/api/v0/dag/put')) {
-      // Extract CID for tracking — pinSingleBlock POSTs the bytes,
-      // not the CID, but the URL itself encodes the codec and the
-      // sidecar/submit fan-out URL DOES carry the CID query param.
-      // We track via the dag/put body's CID indirectly: trust that
-      // the sidecar/submit will record it, but here we just count
-      // start/end + concurrency.
       const myIdx = tracker.startCount++;
       tracker.inFlight++;
       if (tracker.inFlight > tracker.maxInFlight) {
         tracker.maxInFlight = tracker.inFlight;
       }
       try {
-        await new Promise((r) => setTimeout(r, delayMs));
-        if (tracker.failNthBlock !== null && myIdx === tracker.failNthBlock) {
-          return new Response('forced failure', { status: 500 });
-        }
-        // Pull the CID from the body's binary content (we don't have it
-        // in the URL). Instead, derive from sidecar/submit fan-out
-        // requests below.
-        let cid: string | null = null;
+        // Read POST body BEFORE the artificial delay so we attribute
+        // every observed pin, even on the abort path.
+        let producerIndex: number | undefined;
         if (init?.body instanceof FormData) {
           const file = init.body.get('data') as Blob | null;
           if (file) {
             const bytes = new Uint8Array(await file.arrayBuffer());
-            const c = CID.createV1(raw.code, createDigest(0x12, sha256(bytes)));
-            cid = c.toString();
+            producerIndex = indexByHash.get(bytesToHex(bytes));
           }
         }
-        if (cid) tracker.pinnedCids.push(cid);
+        if (producerIndex !== undefined) {
+          tracker.processedIndices.push(producerIndex);
+          tracker.pinCountByIndex.set(
+            producerIndex,
+            (tracker.pinCountByIndex.get(producerIndex) ?? 0) + 1,
+          );
+        }
+        await new Promise((r) => setTimeout(r, delayMs));
+        if (tracker.failNthBlock !== null && myIdx === tracker.failNthBlock) {
+          return new Response('forced failure', { status: 500 });
+        }
         return new Response(JSON.stringify({ Cid: { '/': 'ignored' } }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -185,7 +224,7 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
   it('pins every block exactly once (correctness invariant preserved)', async () => {
     const blocks = makeBlocks(12);
     const carBytes = await buildCarBytes([blocks[0].cid], blocks);
-    mock = installConcurrencyMock(5);
+    mock = installConcurrencyMock(5, blocks);
 
     await pinCarBlocksToIpfs(
       [TEST_GATEWAY],
@@ -196,19 +235,25 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
       4,
     );
 
+    // Total pins = block count. Catches under-counting (skipped block)
+    // AND over-counting (duplicate processing) without conflating them.
+    expect(mock.tracker.processedIndices.length).toBe(12);
     expect(mock.tracker.endCount).toBe(12);
-    // Every block CID present in pinned set, no duplicates.
-    const uniquePinned = new Set(mock.tracker.pinnedCids);
-    expect(uniquePinned.size).toBe(12);
-    for (const b of blocks) {
-      expect(uniquePinned.has(b.cid.toString())).toBe(true);
+    // Per-index count must be exactly 1 for every producer index. A
+    // duplicate-processing bug would show up as count >= 2 for some
+    // index; a skip would show up as a missing entry (count === 0).
+    // Asserting both bounds covers the full failure surface that the
+    // CID-set-based check could not distinguish (steelman P1#2).
+    for (let i = 0; i < blocks.length; i++) {
+      expect(mock.tracker.pinCountByIndex.get(i)).toBe(1);
     }
+    expect(mock.tracker.pinCountByIndex.size).toBe(12);
   });
 
   it('respects the concurrency bound — max in-flight ≤ configured', async () => {
     const blocks = makeBlocks(20);
     const carBytes = await buildCarBytes([blocks[0].cid], blocks);
-    mock = installConcurrencyMock(15);
+    mock = installConcurrencyMock(15, blocks);
 
     const CONCURRENCY = 4;
     await pinCarBlocksToIpfs(
@@ -231,7 +276,7 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
   it('default concurrency=10 saturates pool for large block counts', async () => {
     const blocks = makeBlocks(40);
     const carBytes = await buildCarBytes([blocks[0].cid], blocks);
-    mock = installConcurrencyMock(15);
+    mock = installConcurrencyMock(15, blocks);
 
     // Omit the concurrency arg — should default to 10.
     await pinCarBlocksToIpfs(
@@ -252,7 +297,7 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
     const carBytes = await buildCarBytes([blocks[0].cid], blocks);
 
     for (const badValue of [0, -1, -100, Number.NaN, Number.POSITIVE_INFINITY]) {
-      mock = installConcurrencyMock(5);
+      mock = installConcurrencyMock(5, blocks);
       await pinCarBlocksToIpfs(
         [TEST_GATEWAY],
         carBytes,
@@ -279,7 +324,7 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
   it('clamps concurrency DOWN to block count (no spurious idle workers)', async () => {
     const blocks = makeBlocks(3);
     const carBytes = await buildCarBytes([blocks[0].cid], blocks);
-    mock = installConcurrencyMock(5);
+    mock = installConcurrencyMock(5, blocks);
 
     // Ask for concurrency 20, but only 3 blocks — should spawn only 3 workers.
     await pinCarBlocksToIpfs(
@@ -298,7 +343,7 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
   it('single-block failure aborts the whole operation', async () => {
     const blocks = makeBlocks(10);
     const carBytes = await buildCarBytes([blocks[0].cid], blocks);
-    mock = installConcurrencyMock(5);
+    mock = installConcurrencyMock(5, blocks);
     // Force the 3rd pin (index 2) to return 500.
     mock.tracker.failNthBlock = 2;
 
@@ -314,13 +359,13 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
     ).rejects.toThrow(/ORBITDB_WRITE_FAILED|dag\/put failed|HTTP 500/);
   });
 
-  it('order-independent: pins arrive in any order, all CIDs are pinned', async () => {
+  it('order-independent: pins arrive in any order, every index processed exactly once', async () => {
     // The worker pool draws blocks via shared index — the order pins
     // hit the sidecar depends on worker scheduling. We assert ONLY
-    // that every CID was pinned, not the order.
+    // that every producer index was processed, not the order.
     const blocks = makeBlocks(15);
     const carBytes = await buildCarBytes([blocks[0].cid], blocks);
-    mock = installConcurrencyMock(5);
+    mock = installConcurrencyMock(5, blocks);
 
     await pinCarBlocksToIpfs(
       [TEST_GATEWAY],
@@ -331,12 +376,53 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
       5,
     );
 
-    const expectedCids = new Set(blocks.map((b) => b.cid.toString()));
-    const actualCids = new Set(mock.tracker.pinnedCids);
-    expect(actualCids.size).toBe(expectedCids.size);
-    for (const cid of expectedCids) {
-      expect(actualCids.has(cid)).toBe(true);
+    expect(mock.tracker.processedIndices.length).toBe(15);
+    for (let i = 0; i < 15; i++) {
+      expect(mock.tracker.pinCountByIndex.get(i)).toBe(1);
     }
+  });
+
+  // Steelman P1#1 regression guard — when the first failure trips the
+  // shared abort flag, peer workers' late rejections must NOT escape
+  // as UnhandledPromiseRejection. We simulate by failing the first pin
+  // immediately and having the other workers' pins take longer (so
+  // they're in-flight when the abort lands). The mock fetches resolve
+  // 200 for everything except `failNthBlock=0`. After the rethrow we
+  // wait long enough for any in-flight pin to settle and inspect the
+  // Node process's unhandled-rejection signal.
+  it('peer-worker late rejections do NOT surface as UnhandledPromiseRejection', async () => {
+    const blocks = makeBlocks(10);
+    const carBytes = await buildCarBytes([blocks[0].cid], blocks);
+    mock = installConcurrencyMock(50, blocks);
+    // Two workers will fail (index 0 and 1, near-simultaneous since
+    // delayMs=50 means the others are mid-flight when these resolve).
+    // The harness pinSingleBlock retries against gateways before
+    // throwing — for a single gateway, it throws on the first 500.
+    mock.tracker.failNthBlock = 0;
+
+    const unhandledRejections: unknown[] = [];
+    const handler = (reason: unknown): void => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', handler);
+    try {
+      await expect(
+        pinCarBlocksToIpfs(
+          [TEST_GATEWAY],
+          carBytes,
+          blocks[0].cid.toString(),
+          30_000,
+          undefined,
+          4,
+        ),
+      ).rejects.toThrow(/ORBITDB_WRITE_FAILED|HTTP 500/);
+      // Give the peer workers enough time to finish their in-flight
+      // pin POSTs and any post-throw microtask processing.
+      await new Promise((r) => setTimeout(r, 150));
+    } finally {
+      process.off('unhandledRejection', handler);
+    }
+    expect(unhandledRejections).toEqual([]);
   });
 });
 
@@ -360,7 +446,7 @@ describe('pinCarBlocksToIpfs — wall-clock perf characteristic', () => {
     // regression that re-introduces the serial loop fails this test.
     const blocks = makeBlocks(20);
     const carBytes = await buildCarBytes([blocks[0].cid], blocks);
-    mock = installConcurrencyMock(30);
+    mock = installConcurrencyMock(30, blocks);
 
     const start = Date.now();
     await pinCarBlocksToIpfs(

--- a/tests/unit/profile/profile-token-storage-awaitnextflush-nodeadline.test.ts
+++ b/tests/unit/profile/profile-token-storage-awaitnextflush-nodeadline.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Regression tests for `awaitNextFlush(timeoutMs)` — no-deadline mode.
+ *
+ * Diagnosis (2026-05-27): the legacy → Profile migration timed out at
+ * "Flushing Profile storage to disk" because `awaitNextFlush()` defaults
+ * to a 30s wall-clock cap and the migration's post-save flush had to pin
+ * ~250+ CAR blocks serially against the HTTP sidecar (~100ms each ≈
+ * 25-30s). Capping a one-shot bulk operation on wall-clock time is
+ * incorrect API design: the operation's duration legitimately scales
+ * with input. The fix teaches `awaitNextFlush(0)` (and any non-finite
+ * / non-positive value) to skip the deadline race entirely, so the
+ * migration helper can opt out of the cap while every other caller
+ * keeps its hot-path 30s budget unchanged.
+ *
+ * The 4-iteration runaway guard inside the flush loop is NOT relaxed —
+ * a genuinely stuck save→flush feedback loop still surfaces as TIMEOUT,
+ * independent of the wall-clock deadline. This file pins both behaviors.
+ *
+ * Coverage:
+ *   1. timeoutMs=0 → flush longer than 30s completes without TIMEOUT
+ *   2. timeoutMs=30000 (default) → flush longer than budget throws TIMEOUT
+ *   3. timeoutMs=Number.POSITIVE_INFINITY → treated as no-deadline
+ *   4. timeoutMs=NaN → treated as no-deadline
+ *   5. timeoutMs=-1 → treated as no-deadline (defensive)
+ *   6. Runaway save→flush still throws TIMEOUT even with no-deadline
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import type { TxfStorageDataBase } from '../../../storage/storage-provider';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import { deriveProfileEncryptionKey } from '../../../profile/encryption';
+
+const TEST_PRIVATE_KEY =
+  'ccddeeffccddeeffccddeeffccddeeffccddeeffccddeeffccddeeffccddeeff';
+const EXPECTED_ADDRESS_ID = 'DIRECT_ccddee_ffaabb';
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'cc'.repeat(32),
+  l1Address: 'alpha1nodeadlinetest',
+  directAddress: 'DIRECT://CCDDEEFFAABB112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function getEncryptionKey(): Uint8Array {
+  return deriveProfileEncryptionKey(hexToBytes(TEST_PRIVATE_KEY));
+}
+
+function buildTxfData(tokens: Record<string, unknown> = {}): TxfStorageDataBase {
+  return {
+    _meta: {
+      version: 1,
+      address: EXPECTED_ADDRESS_ID,
+      formatVersion: '1.0.0',
+      updatedAt: 1_700_000_000_000,
+    },
+    ...tokens,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock ProfileDatabase
+// ---------------------------------------------------------------------------
+
+interface MockProfileDb extends ProfileDatabase {
+  _store: Map<string, Uint8Array>;
+}
+
+function createMockDb(): MockProfileDb {
+  const store = new Map<string, Uint8Array>();
+  let connected = true;
+  return {
+    _store: store,
+    async connect(_config: OrbitDbConfig) {
+      connected = true;
+    },
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {
+      connected = false;
+    },
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return connected;
+    },
+  } as MockProfileDb;
+}
+
+// ---------------------------------------------------------------------------
+// Provider factory + fetch mock (every pin succeeds; the flush body's
+// duration is controlled below by injecting a slow flushToIpfs).
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+
+function installMockFetch() {
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    if (url.includes('/api/v0/dag/put') || url.includes('/api/v0/block/put')) {
+      return new Response(JSON.stringify({ Cid: { '/': 'bafymockcid' } }), {
+        status: 200,
+      });
+    }
+    return new Response('', { status: 404 });
+  };
+}
+
+function uninstallMockFetch() {
+  globalThis.fetch = originalFetch;
+}
+
+function createProvider(db: MockProfileDb): ProfileTokenStorageProvider {
+  const provider = new ProfileTokenStorageProvider(
+    db,
+    getEncryptionKey(),
+    ['https://mock-ipfs.test'],
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId: EXPECTED_ADDRESS_ID,
+      encrypt: true,
+      flushDebounceMs: 10,
+    },
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  return provider;
+}
+
+interface FlushSchedulerInternals {
+  flushToIpfs: () => Promise<void>;
+}
+
+/**
+ * Replace `flushScheduler.flushToIpfs` with a no-op that sleeps for
+ * `delayMs` then clears `pendingData` so `awaitNextFlush` returns.
+ * Lets the test drive the "flush takes N ms" axis directly without
+ * needing to time real CAR builds.
+ */
+function installSlowFlush(provider: ProfileTokenStorageProvider, delayMs: number): void {
+  const fs = (provider as unknown as { flushScheduler: FlushSchedulerInternals }).flushScheduler;
+  fs.flushToIpfs = async function () {
+    await new Promise((r) => setTimeout(r, delayMs));
+    // Clear pendingData so the loop terminates after this iteration.
+    (provider as unknown as { pendingData: TxfStorageDataBase | null }).pendingData = null;
+  };
+}
+
+/**
+ * Install a flushToIpfs that keeps regenerating pendingData on each
+ * iteration — drives the 4-iteration runaway guard. The flush itself
+ * completes quickly each time; what's runaway is the save → flush →
+ * save loop.
+ */
+function installRunawayFlush(provider: ProfileTokenStorageProvider): void {
+  const fs = (provider as unknown as { flushScheduler: FlushSchedulerInternals }).flushScheduler;
+  fs.flushToIpfs = async function () {
+    // Each flush clears, then a "concurrent save" lands fresh data
+    // immediately. With 4 iterations max, the loop terminates with
+    // TIMEOUT regardless of wall-clock deadline.
+    (provider as unknown as { pendingData: TxfStorageDataBase | null }).pendingData = null;
+    await new Promise((r) => setTimeout(r, 1));
+    (provider as unknown as { pendingData: TxfStorageDataBase | null }).pendingData =
+      buildTxfData({ _t: { id: '_t', genesis: { tokenId: 't' } } });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('awaitNextFlush — no-deadline mode (migration bulk-import fix)', () => {
+  let db: MockProfileDb;
+
+  beforeEach(() => {
+    db = createMockDb();
+    installMockFetch();
+  });
+
+  afterEach(() => {
+    uninstallMockFetch();
+  });
+
+  it('timeoutMs=0 — completes even when flush takes longer than 30s default', async () => {
+    const provider = createProvider(db);
+    await provider.initialize();
+
+    // Flush that takes 200ms. With the legacy default we would not see
+    // a timeout for so short a flush; the point of THIS assertion is
+    // that the no-deadline path doesn't add latency or hang. The slow-
+    // path proof comes from running this whole test in <1s.
+    installSlowFlush(provider, 200);
+    (provider as unknown as { pendingData: TxfStorageDataBase | null }).pendingData =
+      buildTxfData({ _t: { id: '_t', genesis: { tokenId: 't' } } });
+
+    const start = Date.now();
+    await provider.awaitNextFlush(0);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(200);
+    // Must not throw, must not be capped — a 30s cap with a 200ms flush
+    // would not have surfaced either way; this assertion is here as
+    // the call shape we expect callers (migration) to use.
+
+    await provider.shutdown();
+  });
+
+  it('timeoutMs=30000 default — TIMEOUT when flush exceeds budget', async () => {
+    const provider = createProvider(db);
+    await provider.initialize();
+
+    // 200ms flush + 50ms test budget = TIMEOUT.
+    installSlowFlush(provider, 200);
+    (provider as unknown as { pendingData: TxfStorageDataBase | null }).pendingData =
+      buildTxfData({ _t: { id: '_t', genesis: { tokenId: 't' } } });
+
+    await expect(provider.awaitNextFlush(50)).rejects.toMatchObject({
+      code: 'TIMEOUT',
+    });
+
+    await provider.shutdown();
+  });
+
+  it.each([
+    ['Number.POSITIVE_INFINITY', Number.POSITIVE_INFINITY],
+    ['Number.NEGATIVE_INFINITY', Number.NEGATIVE_INFINITY],
+    ['NaN', Number.NaN],
+    ['negative value (-1)', -1],
+    ['negative value (-100000)', -100000],
+  ])('treats %s as no-deadline (no TIMEOUT)', async (_label, value) => {
+    const provider = createProvider(db);
+    await provider.initialize();
+
+    installSlowFlush(provider, 100);
+    (provider as unknown as { pendingData: TxfStorageDataBase | null }).pendingData =
+      buildTxfData({ _t: { id: '_t', genesis: { tokenId: 't' } } });
+
+    // Must NOT throw TIMEOUT — even though 100ms > a hypothetical tight cap.
+    await expect(provider.awaitNextFlush(value)).resolves.toBeUndefined();
+
+    await provider.shutdown();
+  });
+
+  it('runaway save→flush loop still throws TIMEOUT under no-deadline (4-iteration guard)', async () => {
+    const provider = createProvider(db);
+    await provider.initialize();
+
+    installRunawayFlush(provider);
+    (provider as unknown as { pendingData: TxfStorageDataBase | null }).pendingData =
+      buildTxfData({ _t: { id: '_t', genesis: { tokenId: 't' } } });
+
+    // Even with no-deadline, the 4-iteration guard must trip — a genuine
+    // runaway is bounded by iteration count, not wall-clock. Without
+    // this assertion a regression that removed the iteration cap would
+    // silently let the provider spin forever on a stuck save loop.
+    await expect(provider.awaitNextFlush(0)).rejects.toMatchObject({
+      code: 'TIMEOUT',
+      message: expect.stringContaining('pendingData kept regenerating'),
+    });
+
+    await provider.shutdown();
+  });
+
+  it('timer is NOT allocated in no-deadline mode (no late-fire risk)', async () => {
+    // The pre-fix code unconditionally created a setTimeout(...) racer
+    // even when not needed. With no-deadline mode we skip Promise.race
+    // entirely. We probe this by counting setTimeout invocations
+    // around a single awaitNextFlush call.
+    const provider = createProvider(db);
+    await provider.initialize();
+
+    installSlowFlush(provider, 10);
+    (provider as unknown as { pendingData: TxfStorageDataBase | null }).pendingData =
+      buildTxfData({ _t: { id: '_t', genesis: { tokenId: 't' } } });
+
+    // Spy on global setTimeout. Existing timers in the flush body
+    // (debounce, internal yields) will still call setTimeout, so we
+    // only assert that the count is bounded — specifically, no per-
+    // iteration TIMEOUT racer was created. A reasonable upper bound:
+    // 1 (flush yield) + a handful of internal helpers ≤ 8. Without the
+    // fix the racer adds one per iteration (≤4 extra in this test).
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    await provider.awaitNextFlush(0);
+    setTimeoutSpy.mockRestore();
+
+    // Assertion shape: there exists no allocated timer whose handler
+    // closure includes our TIMEOUT-rejection sentinel. Practical
+    // implementation: assert call count is below a generous ceiling
+    // proving the unconditional racer is not present.
+    // (Strict count would couple to internal flush instrumentation;
+    // ceiling is robust.)
+    expect(setTimeoutSpy.mock.calls.length).toBeLessThan(8);
+
+    await provider.shutdown();
+  });
+});

--- a/tests/unit/profile/profile-token-storage-awaitnextflush-nodeadline.test.ts
+++ b/tests/unit/profile/profile-token-storage-awaitnextflush-nodeadline.test.ts
@@ -292,11 +292,15 @@ describe('awaitNextFlush — no-deadline mode (migration bulk-import fix)', () =
     await provider.shutdown();
   });
 
-  it('timer is NOT allocated in no-deadline mode (no late-fire risk)', async () => {
+  it('TIMEOUT-rejection setTimeout is NOT allocated in no-deadline mode', async () => {
     // The pre-fix code unconditionally created a setTimeout(...) racer
-    // even when not needed. With no-deadline mode we skip Promise.race
-    // entirely. We probe this by counting setTimeout invocations
-    // around a single awaitNextFlush call.
+    // whose callback rejected with `new SphereError('awaitNextFlush:
+    // timeout awaiting serialized flush', 'TIMEOUT')`. The no-deadline
+    // mode skips Promise.race entirely. Steelman P2#8: a bare call-
+    // count ceiling (< 8) silently rots as unrelated future code adds
+    // timers; we instead inspect each registered callback's source for
+    // the TIMEOUT-rejection signature so the assertion catches only
+    // the regression we care about.
     const provider = createProvider(db);
     await provider.initialize();
 
@@ -304,23 +308,26 @@ describe('awaitNextFlush — no-deadline mode (migration bulk-import fix)', () =
     (provider as unknown as { pendingData: TxfStorageDataBase | null }).pendingData =
       buildTxfData({ _t: { id: '_t', genesis: { tokenId: 't' } } });
 
-    // Spy on global setTimeout. Existing timers in the flush body
-    // (debounce, internal yields) will still call setTimeout, so we
-    // only assert that the count is bounded — specifically, no per-
-    // iteration TIMEOUT racer was created. A reasonable upper bound:
-    // 1 (flush yield) + a handful of internal helpers ≤ 8. Without the
-    // fix the racer adds one per iteration (≤4 extra in this test).
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     await provider.awaitNextFlush(0);
     setTimeoutSpy.mockRestore();
 
-    // Assertion shape: there exists no allocated timer whose handler
-    // closure includes our TIMEOUT-rejection sentinel. Practical
-    // implementation: assert call count is below a generous ceiling
-    // proving the unconditional racer is not present.
-    // (Strict count would couple to internal flush instrumentation;
-    // ceiling is robust.)
-    expect(setTimeoutSpy.mock.calls.length).toBeLessThan(8);
+    // Walk every registered callback. A regression that re-introduced
+    // the unconditional racer would register a callback whose toString
+    // includes the SphereError 'TIMEOUT' construction. Unrelated
+    // setTimeout calls (debounce, throttle, internal yields) pass.
+    const timeoutRacerCalls = setTimeoutSpy.mock.calls.filter((call) => {
+      const cb = call[0];
+      if (typeof cb !== 'function') return false;
+      const src = String(cb);
+      return (
+        src.includes('awaitNextFlush') ||
+        src.includes("'TIMEOUT'") ||
+        src.includes('"TIMEOUT"') ||
+        src.includes('timeout awaiting serialized flush')
+      );
+    });
+    expect(timeoutRacerCalls).toEqual([]);
 
     await provider.shutdown();
   });

--- a/tests/unit/profile/token-storage-migration.test.ts
+++ b/tests/unit/profile/token-storage-migration.test.ts
@@ -190,8 +190,11 @@ function createMockProvider(
   };
 
   if (opts.exposeAwaitNextFlush) {
-    provider.awaitNextFlush = async () => {
-      calls.push('awaitNextFlush');
+    provider.awaitNextFlush = async (timeoutMs?: number) => {
+      // Record the call AND the timeoutMs argument so tests can assert
+      // that bulk operations (migration) pass 0 / no-deadline and
+      // hot-path callers pass a finite budget.
+      calls.push(`awaitNextFlush:${timeoutMs ?? 'undefined'}`);
       if (opts.failFlush) {
         throw new Error('mock flush failure');
       }
@@ -740,7 +743,7 @@ describe('migrateTokenStorage — partial-progress recovery', () => {
     expect(marker._store.has(markerKey)).toBe(false);
   });
 
-  it('awaitNextFlush is called when target exposes it', async () => {
+  it('awaitNextFlush is called when target exposes it, with no-deadline argument', async () => {
     const source = createMockProvider(buildSourceData({ active: [TOKEN_A] }));
     const target = createMockProvider(null, { exposeAwaitNextFlush: true });
 
@@ -751,7 +754,17 @@ describe('migrateTokenStorage — partial-progress recovery', () => {
       identity: IDENTITY,
     });
     expect(result.success).toBe(true);
-    expect(target._calls.includes('awaitNextFlush')).toBe(true);
+    // Migration MUST call awaitNextFlush with timeoutMs=0 — the bulk-
+    // import flush legitimately scales with wallet size and the 30s
+    // default deadline is for hot-path incoming-transfer acks only. A
+    // regression that re-introduced a wall-clock cap here would
+    // re-create the user-visible flush timeout reported in the migration
+    // diagnosis on 2026-05-27.
+    expect(target._calls).toContain('awaitNextFlush:0');
+    // Defensive: no call with the legacy default surfaced.
+    expect(
+      target._calls.filter((c) => c.startsWith('awaitNextFlush:') && c !== 'awaitNextFlush:0'),
+    ).toEqual([]);
   });
 
   it('source.load failure → fast-fail result without target write', async () => {


### PR DESCRIPTION
## Summary

Fixes the legacy → Profile migration failure at \"Flushing Profile storage to disk\" reported on sphere-telco-test.dyndns.org (2026-05-27). Two root causes; both fixed in this PR.

## Root cause

1. **30s wall-clock cap on a bulk operation.** `ProfileTokenStorageProvider.awaitNextFlush()` defaulted to 30s. The migration's post-save flush has to pin every CAR sub-block via HTTP POST to the sidecar (~80–150 ms each). A 24-token wallet emits ~250 blocks → guaranteed timeout at exactly 30s.

2. **Serial pin loop.** `pinCarBlocksToIpfs` ran a for-loop with `await pinSingleBlock(...)` inside — every round-trip was strictly sequential, so wall-clock was \`N × RTT\`.

Console trace from the failing browser session:
- \`17:40:45.905 [profile:flush] awaitNextFlush enter timeoutMs=30000\`
- \`17:40:46.320\` first \`[IPFS-Sidecar] submit ... → 200\`
- ... ~250 serial sidecar submits at ~50–150 ms each ...
- \`17:41:15.495\` last submit (29s of pinning)
- \`17:41:15.908\` TIMEOUT (exactly 30 s after enter)

## Changes

### Fix A — no-deadline mode for bulk operations

\`ProfileTokenStorageProvider.awaitNextFlush(timeoutMs)\` now treats \`0\`, negative, NaN, and ±Infinity as \"no wall-clock deadline\". The \`Promise.race\` against a setTimeout racer is skipped entirely (no spurious late-fire rejections, no per-iteration timer allocation). The 4-iteration runaway guard (pendingData regenerating across iterations) remains the only termination condition for genuinely stuck save→flush feedback loops.

\`migrateTokenStorage()\` now calls \`target.awaitNextFlush(0)\` after the bulk save — migration duration is bounded by input size, not an arbitrary clock budget.

### Fix B — bounded-concurrency pin worker pool

\`pinCarBlocksToIpfs\` replaces the serial for-loop with a fixed-size worker pool (default 10, optional override). Workers draw blocks from a shared monotonic index. With ~250 blocks: serial ≈ 25 s → parallel-10 ≈ 2.5 s.

Concurrency=10 chosen for:
- Browser per-origin connection caps (Chrome 6 HTTP/1.1, multiplexed on HTTP/2 sidecars)
- No observed sidecar back-pressure at this level on testnet
- 250 blocks / 10 ≈ 2.5 s with 100 ms RTT — well inside any reasonable budget

## Steelman pass (commit a825267)

Adversarial review found 2 P1 issues, both fixed in the second commit:

1. **Unhandled-rejection storm on partial pin failure.** Pre-fix \`Promise.all\` short-circuited but peer workers' late rejections escaped. Fix: cooperative abort flag + per-worker \`.catch()\` collector. Regression guard installed via \`process.on('unhandledRejection', ...)\`.

2. **Test could not actually detect a worker-pool race.** Pre-fix tracked unique CIDs by re-hashing bodies; could not distinguish skip+duplicate from clean pass. Fix: hash → producer-index lookup, assert per-index count exactly 1.

Plus 2 P2 doc/test improvements (Infinity-semantics cross-reference, precise TIMEOUT-handler probe instead of brittle call-count ceiling).

P2 #5 (sidecar 429 back-pressure) deferred — will track as follow-up issue.

## Test plan

- [x] 9 new tests in \`ipfs-client-parallel-pin.test.ts\` (correctness, concurrency bound, default, clamping, single-block failure, order-independence, unhandled-rejection regression guard, perf characteristic)
- [x] 9 new tests in \`profile-token-storage-awaitnextflush-nodeadline.test.ts\` (0, +∞, -∞, NaN, negative all treated as no-deadline; default still trips; 4-iteration runaway still trips under no-deadline; no spurious setTimeout)
- [x] 1 updated test in \`token-storage-migration.test.ts\` (asserts migration calls \`awaitNextFlush:0\`)
- [x] All existing profile tests pass (121 files, 2054 tests)
- [x] Full unit suite: 8436 pass, 13 skipped, 0 fail
- [x] Typecheck clean
- [x] Lint clean

## Follow-up

Will file separate issue for **bulk-CAR sidecar endpoint** (single POST imports the whole CAR server-side, eliminating N client→sidecar round-trips entirely). With that, even concurrency=1 would be fast. Out of scope here; this PR is the immediate user unblock.