### PR TITLE
fix(profile,sphere): identity-key fallback storage + LoadBlockFailedError tolerance

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -249,6 +249,11 @@ export interface SphereCreateOptions {
 export interface SphereLoadOptions {
   /** Storage provider instance */
   storage: StorageProvider;
+  /**
+   * Optional read-only fallback storage. See
+   * {@link SphereInitOptions.fallbackStorage} for semantics.
+   */
+  fallbackStorage?: StorageProvider;
   /** Optional token storage provider (for IPFS sync) */
   tokenStorage?: TokenStorageProvider<TxfStorageDataBase>;
   /** Transport provider instance */
@@ -387,6 +392,18 @@ export interface L1Config {
 export interface SphereInitOptions {
   /** Storage provider instance */
   storage: StorageProvider;
+  /**
+   * Optional read-only fallback storage consulted when the primary
+   * storage returns null or throws a recoverable error (e.g.
+   * `LoadBlockFailedError` for a missing OrbitDB content block) while
+   * `loadIdentityFromStorage` is reading wallet keys. Intended for
+   * Profile-mode boots where a previously-working legacy
+   * `IndexedDBStorageProvider` still holds the encrypted-with-password
+   * identity material at the same key shape — supplying it lets the
+   * wallet boot from cached local state even if Profile/OrbitDB
+   * has lost the block. Never written to.
+   */
+  fallbackStorage?: StorageProvider;
   /** Transport provider instance */
   transport: TransportProvider;
   /** Oracle provider instance */
@@ -684,6 +701,14 @@ export class Sphere {
 
   // Providers
   private _storage: StorageProvider;
+  /**
+   * Read-only fallback storage consulted by `loadIdentityFromStorage`
+   * when the primary returns null or throws a recoverable error for an
+   * identity-key read. See {@link SphereInitOptions.fallbackStorage}.
+   * Set once at construction by the static factories; never mutated
+   * after wallet load. `null` when no fallback was supplied.
+   */
+  private _fallbackStorage: StorageProvider | null = null;
   private _tokenStorageProviders: Map<string, TokenStorageProvider<TxfStorageDataBase>> = new Map();
   private _transport: TransportProvider;
   private _oracle: OracleProvider;
@@ -891,6 +916,7 @@ export class Sphere {
       // Load existing wallet
       const sphere = await Sphere.load({
         storage: options.storage,
+        fallbackStorage: options.fallbackStorage,
         transport: options.transport,
         oracle: options.oracle,
         tokenStorage: options.tokenStorage,
@@ -1229,10 +1255,31 @@ export class Sphere {
     // before `initializeModules()` threads it into PaymentsModule.
     sphere._publishToIpfs = options.publishToIpfs ?? null;
     sphere._cidFetchGateways = options.cidFetchGateways ?? null;
+    // Issue #309 — read-only fallback storage for identity-key reads.
+    // Consulted by loadIdentityFromStorage() when the primary returns
+    // null or throws a recoverable LoadBlockFailedError. Used in
+    // Profile-mode boots where the legacy IndexedDB still holds the
+    // encrypted-with-password identity material.
+    sphere._fallbackStorage = options.fallbackStorage ?? null;
 
     // exists() restores original (disconnected) state — reconnect for reads
     if (!options.storage.isConnected()) {
       await options.storage.connect();
+    }
+    // Same for fallback if supplied — it must be connected before the
+    // identity-load helper consults it.
+    if (sphere._fallbackStorage && !sphere._fallbackStorage.isConnected()) {
+      try {
+        await sphere._fallbackStorage.connect();
+      } catch (err) {
+        logger.warn(
+          'Sphere',
+          `fallbackStorage.connect failed; proceeding without fallback: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        sphere._fallbackStorage = null;
+      }
     }
 
     // Load identity from storage
@@ -5137,15 +5184,66 @@ export class Sphere {
   // ===========================================================================
 
   private async loadIdentityFromStorage(): Promise<void> {
+    // Issue #309 — read each identity key with a primary→fallback
+    // retry. The primary path can fail in two ways for a Profile-mode
+    // boot whose local Helia blockstore has lost a referenced block:
+    //   (a) the read throws a chained `LoadBlockFailedError`
+    //       (OrbitDB walks the OpLog head, hits the missing block);
+    //   (b) the read swallows the throw upstream and returns `null`
+    //       (e.g. Profile's getEnvelopePayload catches the envelope
+    //       decode failure but still can't reach the raw bytes).
+    // In either case, if a legacy IndexedDB fallback is available it
+    // still holds the encrypted-with-password identity material at the
+    // same key shape, so the wallet can boot from cached local state.
+    // The helper retries the same key against `this._fallbackStorage`
+    // on any null-or-throw outcome from the primary.
+    const readIdentityKey = async (key: string): Promise<string | null> => {
+      let primaryValue: string | null = null;
+      let primaryThrew: unknown = null;
+      try {
+        primaryValue = await this._storage.get(key);
+      } catch (err) {
+        primaryThrew = err;
+      }
+      if (primaryValue !== null && primaryValue !== undefined) {
+        return primaryValue;
+      }
+      if (!this._fallbackStorage) {
+        if (primaryThrew !== null) throw primaryThrew;
+        return null;
+      }
+      // Fallback path. Log so operators can see we're booting from
+      // legacy state, not the post-migration Profile state. A throw
+      // from the fallback itself is forwarded to the caller — the
+      // caller's existing error-handling treats it the same as a
+      // primary-storage failure.
+      logger.warn(
+        'Sphere',
+        `Identity read for "${key}" missing from primary storage` +
+          (primaryThrew instanceof Error
+            ? ` (threw: ${primaryThrew.message})`
+            : '') +
+          `; consulting fallbackStorage (legacy cached identity).`,
+      );
+      const fallbackValue = await this._fallbackStorage.get(key);
+      if (fallbackValue !== null && fallbackValue !== undefined) {
+        return fallbackValue;
+      }
+      // Neither side has it. Preserve the original throw if there
+      // was one, so the caller surfaces the most informative error.
+      if (primaryThrew !== null) throw primaryThrew;
+      return null;
+    };
+
     // Load keys that are saved with 'default' address (before identity is set)
-    const encryptedMnemonic = await this._storage.get(STORAGE_KEYS_GLOBAL.MNEMONIC);
-    const encryptedMasterKey = await this._storage.get(STORAGE_KEYS_GLOBAL.MASTER_KEY);
-    const chainCode = await this._storage.get(STORAGE_KEYS_GLOBAL.CHAIN_CODE);
-    const derivationPath = await this._storage.get(STORAGE_KEYS_GLOBAL.DERIVATION_PATH);
-    const savedBasePath = await this._storage.get(STORAGE_KEYS_GLOBAL.BASE_PATH);
-    const savedDerivationMode = await this._storage.get(STORAGE_KEYS_GLOBAL.DERIVATION_MODE);
-    const savedSource = await this._storage.get(STORAGE_KEYS_GLOBAL.WALLET_SOURCE);
-    const savedAddressIndex = await this._storage.get(STORAGE_KEYS_GLOBAL.CURRENT_ADDRESS_INDEX);
+    const encryptedMnemonic = await readIdentityKey(STORAGE_KEYS_GLOBAL.MNEMONIC);
+    const encryptedMasterKey = await readIdentityKey(STORAGE_KEYS_GLOBAL.MASTER_KEY);
+    const chainCode = await readIdentityKey(STORAGE_KEYS_GLOBAL.CHAIN_CODE);
+    const derivationPath = await readIdentityKey(STORAGE_KEYS_GLOBAL.DERIVATION_PATH);
+    const savedBasePath = await readIdentityKey(STORAGE_KEYS_GLOBAL.BASE_PATH);
+    const savedDerivationMode = await readIdentityKey(STORAGE_KEYS_GLOBAL.DERIVATION_MODE);
+    const savedSource = await readIdentityKey(STORAGE_KEYS_GLOBAL.WALLET_SOURCE);
+    const savedAddressIndex = await readIdentityKey(STORAGE_KEYS_GLOBAL.CURRENT_ADDRESS_INDEX);
 
     // Steelman⁵² CRITICAL: detect partial-write corruption. F.56's
     // best-effort rollback in storeMnemonic/storeMasterKey may itself

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -402,6 +402,11 @@ export interface SphereInitOptions {
    * identity material at the same key shape — supplying it lets the
    * wallet boot from cached local state even if Profile/OrbitDB
    * has lost the block. Never written to.
+   *
+   * NOT applicable to `Sphere.create()` / `Sphere.import()` — those
+   * flows write a fresh identity to the primary storage; a fallback
+   * read makes no sense there. Intentionally omitted from those
+   * option types.
    */
   fallbackStorage?: StorageProvider;
   /** Transport provider instance */
@@ -709,6 +714,13 @@ export class Sphere {
    * after wallet load. `null` when no fallback was supplied.
    */
   private _fallbackStorage: StorageProvider | null = null;
+  /**
+   * Issue #309 review — set when `fallbackStorage.connect()` failed
+   * during load/init. The fallback is demoted to `null` so the rest of
+   * the boot proceeds; this field preserves the original error for
+   * forensics. `null` when there's no fallback or the connect succeeded.
+   */
+  private _fallbackStorageError: Error | null = null;
   private _tokenStorageProviders: Map<string, TokenStorageProvider<TxfStorageDataBase>> = new Map();
   private _transport: TransportProvider;
   private _oracle: OracleProvider;
@@ -1268,17 +1280,33 @@ export class Sphere {
     }
     // Same for fallback if supplied — it must be connected before the
     // identity-load helper consults it.
+    //
+    // Review fix #2 — Demote fallback to `null` on connect failure with
+    // ERROR level (not warn) plus a structured Sphere event. If the
+    // caller went to the trouble of supplying a fallback, a silent
+    // demotion can turn a recoverable boot into a fatal one downstream
+    // with only a buried log line. The event lets consumers (UI banners,
+    // operator dashboards) observe the demotion.
     if (sphere._fallbackStorage && !sphere._fallbackStorage.isConnected()) {
       try {
         await sphere._fallbackStorage.connect();
       } catch (err) {
-        logger.warn(
+        const errMessage = err instanceof Error ? err.message : String(err);
+        logger.error(
           'Sphere',
-          `fallbackStorage.connect failed; proceeding without fallback: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
+          `fallbackStorage.connect failed; proceeding WITHOUT fallback ` +
+            `(identity recovery will not be attempted from legacy storage): ${errMessage}`,
         );
         sphere._fallbackStorage = null;
+        sphere._fallbackStorageError = err instanceof Error ? err : new Error(errMessage);
+        // Best-effort event so consumers can surface the demotion in UI
+        // / monitoring. Fires synchronously inside `emitEvent`; handler
+        // throws are swallowed by the bus.
+        sphere.emitEvent('storage:fallback-demoted', {
+          reason: 'connect-failed',
+          error: errMessage,
+          at: Date.now(),
+        });
       }
     }
 
@@ -5213,10 +5241,7 @@ export class Sphere {
         return null;
       }
       // Fallback path. Log so operators can see we're booting from
-      // legacy state, not the post-migration Profile state. A throw
-      // from the fallback itself is forwarded to the caller — the
-      // caller's existing error-handling treats it the same as a
-      // primary-storage failure.
+      // legacy state, not the post-migration Profile state.
       logger.warn(
         'Sphere',
         `Identity read for "${key}" missing from primary storage` +
@@ -5225,13 +5250,53 @@ export class Sphere {
             : '') +
           `; consulting fallbackStorage (legacy cached identity).`,
       );
-      const fallbackValue = await this._fallbackStorage.get(key);
+      // Review fix #1 — Wrap the fallback read in its own try/catch.
+      // Previously a throw from the fallback shadowed the primary's
+      // throw on the way out; operators care most about the primary
+      // (typically a chained LoadBlockFailedError) because it identifies
+      // the missing block CID. On a both-throw outcome the primary error
+      // is rethrown, with the fallback error attached as `cause` for
+      // forensics.
+      let fallbackValue: string | null = null;
+      let fallbackThrew: unknown = null;
+      try {
+        fallbackValue = await this._fallbackStorage.get(key);
+      } catch (err) {
+        fallbackThrew = err;
+      }
       if (fallbackValue !== null && fallbackValue !== undefined) {
         return fallbackValue;
       }
-      // Neither side has it. Preserve the original throw if there
-      // was one, so the caller surfaces the most informative error.
-      if (primaryThrew !== null) throw primaryThrew;
+      // Neither side has it. The primary error wins when both threw —
+      // it's the more diagnostic of the two for the typical Profile-
+      // mode failure mode. Fallback error is preserved as `cause`.
+      if (primaryThrew !== null) {
+        if (
+          fallbackThrew !== null &&
+          primaryThrew instanceof Error &&
+          fallbackThrew instanceof Error &&
+          (primaryThrew as { cause?: unknown }).cause === undefined
+        ) {
+          try {
+            Object.defineProperty(primaryThrew, 'cause', {
+              value: fallbackThrew,
+              enumerable: false,
+              writable: true,
+              configurable: true,
+            });
+          } catch {
+            // Defining `cause` on the original error is best-effort;
+            // a frozen or hostile Error subclass would refuse.
+          }
+        }
+        throw primaryThrew;
+      }
+      if (fallbackThrew !== null) {
+        // Primary returned null cleanly but fallback threw —
+        // surface the fallback error so the operator sees a
+        // diagnosable failure rather than a silent "no wallet".
+        throw fallbackThrew;
+      }
       return null;
     };
 
@@ -5261,6 +5326,17 @@ export class Sphere {
     // result from an aborted multi-key write whose rollback also
     // failed, and silently applying defaults to the missing fields
     // would derive the wrong identity for the persisted MNEMONIC.
+    //
+    // Issue #309 review (Finding #3) — when `fallbackStorage` is set,
+    // these values are the MERGED view: any key not in primary was
+    // satisfied from fallback. The partial-write detector's invariant
+    // therefore weakens: a "primary partial + fallback complete" wallet
+    // looks identical to a "primary complete + fallback unused" wallet.
+    // Acceptable for the migration-recovery flow this option exists for
+    // — both shapes derive the SAME identity, so the wallet boots
+    // correctly. A genuine partial-write that ALSO had a holey fallback
+    // would still trip the detector. Document the weakening explicitly
+    // so future readers don't tighten the check by accident.
     if (encryptedMnemonic || encryptedMasterKey) {
       const present: string[] = [];
       const missing: string[] = [];

--- a/profile/profile-storage-provider.ts
+++ b/profile/profile-storage-provider.ts
@@ -35,6 +35,7 @@ import { CidRefStore } from './cid-ref-store';
 import { Lamport } from './lamport';
 import { buildLocalEntry } from './oplog-entry';
 import { getEnvelopePayload } from './oplog-envelope-io';
+import { extractLostHeadCid } from './orbitdb-adapter';
 import type { OpLogEntryType } from './aggregator-pointer/originated-tag';
 import type { ProfilePointerLayer } from './aggregator-pointer';
 import {
@@ -1393,7 +1394,41 @@ export class ProfileStorageProvider implements StorageProvider {
       return null;
     }
 
-    const encrypted = await this.readEnvelopePayload(translated.profileKey);
+    // Issue #309 — `readEnvelopePayload` can throw a chained
+    // `LoadBlockFailedError` when the OpLog head references a content
+    // block that's no longer in the local Helia blockstore (browser
+    // eviction, origin purge, quota error during write, etc.). Letting
+    // that throw propagate makes the caller's identity-load fatal
+    // even though there's almost always a usable fallback (the legacy
+    // IndexedDB still has the same key with the same shape).
+    //
+    // Convert that specific failure shape into `return null` with a
+    // structured warning. Sphere.loadIdentityFromStorage will then
+    // consult its `fallbackStorage` if one was supplied; consumers
+    // without a fallback see "key not found" instead of a hard crash
+    // — which preserves the previous-behavior intent ("Profile read
+    // couldn't satisfy this") without nuking the boot.
+    //
+    // All OTHER throws (decode errors, decryption failures, unknown
+    // I/O errors) still propagate — only the specific "block missing
+    // from local store" signature is downgraded.
+    let encrypted: Uint8Array | null;
+    try {
+      encrypted = await this.readEnvelopePayload(translated.profileKey);
+    } catch (err) {
+      const lostCid = extractLostHeadCid(err);
+      if (lostCid !== null) {
+        logger.warn(
+          'ProfileStorage',
+          `[LOAD-BLOCK-MISSING] Local Helia blockstore is missing block ${lostCid} ` +
+            `for key="${translated.profileKey}". Returning null so a caller with a ` +
+            `fallback storage can attempt to satisfy the read from legacy cache. ` +
+            `Run an OpLog auto-reset (write a fresh entry) to clear the dangling head.`,
+        );
+        return null;
+      }
+      throw err;
+    }
     if (encrypted === null) {
       return null;
     }

--- a/types/index.ts
+++ b/types/index.ts
@@ -620,6 +620,17 @@ export type SphereEventType =
    * not a paging signal.
    */
   | 'storage:monotonicity-recovered'
+  /**
+   * Issue #309 — Fires when the caller-supplied `fallbackStorage`
+   * (typically the legacy IndexedDB) fails to connect during Sphere
+   * load/init. The fallback is demoted to `null` so the rest of the
+   * boot proceeds, but identity-key reads that would have consulted it
+   * are now strictly bound to the primary's success. UI surfaces and
+   * monitoring dashboards listen for this so they can warn users that
+   * a Profile-mode wallet whose primary state has lost a block will
+   * not recover from cache on this boot.
+   */
+  | 'storage:fallback-demoted'
   | 'groupchat:message'
   | 'groupchat:joined'
   | 'groupchat:left'
@@ -1408,6 +1419,11 @@ export interface SphereEventMap {
     recoveredOutboxIdsDroppedAsSent: string[];
     recoveredOutboxIdsDroppedAsSentCount: number;
     truncated: boolean;
+  };
+  'storage:fallback-demoted': {
+    reason: 'connect-failed' | 'isConnected-false-after-connect';
+    error: string;
+    at: number;
   };
   'groupchat:message': import('../modules/groupchat/types').GroupMessageData;
   'groupchat:joined': { groupId: string; groupName: string };


### PR DESCRIPTION
## Summary

When a Profile-mode wallet's local Helia browser blockstore loses an OpLog-referenced block (eviction / GC / quota), every read that walks the OpLog head throws `LoadBlockFailedError`. Pre-fix, `Sphere.loadIdentityFromStorage` treats this as fatal — the wallet is locked out even though the encrypted-with-password identity is still sitting at `sphere_master_key` in the legacy IndexedDB.

Two coordinated changes:

1. **`core/Sphere.ts`** — new optional `fallbackStorage` on `SphereInitOptions` / `SphereLoadOptions`. `loadIdentityFromStorage` reads each identity key (MNEMONIC / MASTER_KEY / CHAIN_CODE / DERIVATION_PATH / BASE_PATH / DERIVATION_MODE / WALLET_SOURCE / CURRENT_ADDRESS_INDEX) via a primary→fallback helper that catches throws from primary (or treats `null` as miss) and retries against the fallback when set.
2. **`profile/profile-storage-provider.ts`** — `get()` detects `LoadBlockFailedError` chained via `extractLostHeadCid`, emits a structured `[LOAD-BLOCK-MISSING]` warn, and returns `null` instead of throwing. All other exception classes still propagate.

Verified live on `sphere-telco-test.dyndns.org` against a real wallet whose Helia blockstore was missing block `bafyreihx3oa...`. Boot sequence in the log:

```
[ProfileStorage] [LOAD-BLOCK-MISSING] Local Helia blockstore is missing block bafyreihx3oa... for key="identity.masterKey". Returning null so a caller with a fallback storage can attempt to satisfy the read from legacy cache.
[Sphere] Identity read for "master_key" missing from primary storage; consulting fallbackStorage (legacy cached identity).
[IndexedDB] Identity set: alpha1qcvg6ntwckerfy6a0cx3pz6mvt2tmtqpqhaq37m
[Sphere] Wired profile-resident OutboxWriter + SentLedgerWriter
```

## Companion consumer wiring

sphere.telco `SphereProvider` (separate PR in the `sphere` repo) preserves the legacy `browserProviders.storage` reference before swapping in Profile storage, and passes it as `fallbackStorage` to the next `Sphere.init()`.

## Test plan

- [x] Tsc passes
- [x] Live verification on production-shape wallet — identity recovered from legacy IndexedDB fallback
- [ ] Unit tests for the primary→fallback helper (TODO — adding in follow-up)
- [ ] Unit test for `ProfileStorageProvider.get()` LoadBlockFailedError → return-null path (TODO)

## Known follow-ups (filed as separate issues)

- Token-storage fallback (mirror primitive for the payments path — wallet still shows 0 tokens after this fix because Profile token storage is also broken by the same corrupt block)
- Helia block pinning + `navigator.storage.persist()` — prevent recurrence
- OpLog epoch-reset primitive — recover into Profile mode without manual legacy-mode rollback
- Connectivity / offline-mode surface
- Lazy IPFS load (boot from local cache first, sync from remote in background)
- Boot-time perf — per-key 10s timeout chain adds up to ~80s on cold boot