### PR TITLE
feat(profile)(#310): OpLog epoch-reset primitive with permanent walkback floor

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -58,6 +58,16 @@ import type {
 } from '../types';
 import { SphereError } from './errors';
 import type {
+  SphereProfileHandle,
+  ResetEpochParams,
+  ResetEpochResult,
+} from '../profile/profile-handle';
+import {
+  LOCAL_EPOCH_FLOOR_KEY,
+  LOCAL_EPOCH_RESET_REASON_KEY,
+} from '../profile/pointer-wiring';
+import { EPOCH_RESET_REASON_MAX_BYTES } from '../profile/profile-lean-snapshot';
+import type {
   ShutdownOptions,
   StorageProvider,
   TokenStorageProvider,
@@ -1675,6 +1685,226 @@ export class Sphere {
   /** Swap module (atomic token swaps). Null if not configured. */
   get swap(): SwapModule | null {
     return this._swap;
+  }
+
+  /**
+   * Issue #310 — Profile-mode public API surface.
+   *
+   * Returns a {@link SphereProfileHandle} when the wallet's
+   * StorageProvider is a Profile-backed adapter (duck-typed via the
+   * presence of `getPointerLayer`). Returns `null` for legacy
+   * (IndexedDB / File) storage — callers MUST null-check.
+   *
+   * The handle's primary method is `resetEpoch({ reason })`, which
+   * bumps the wallet's permanent OpLog epoch floor by +1 and triggers
+   * a republish so all clients refuse to walk back to any prior epoch.
+   * See `profile/profile-handle.ts` for the full contract.
+   */
+  get profile(): SphereProfileHandle | null {
+    const storage = this._storage as unknown as {
+      getPointerLayer?: () => unknown | null;
+    };
+    if (typeof storage.getPointerLayer !== 'function') {
+      return null;
+    }
+    return this.buildProfileHandle();
+  }
+
+  /**
+   * Lazily-constructed (per-call) handle so it picks up identity /
+   * storage rebinds across `Sphere.load()` reattach cycles. The handle
+   * is a thin lambda that closes over `this` — no state lives inside
+   * it.
+   */
+  private buildProfileHandle(): SphereProfileHandle {
+    return {
+      resetEpoch: (params: ResetEpochParams) => this.resetEpochImpl(params),
+      getEpochFloor: () => this.getEpochFloorImpl(),
+    };
+  }
+
+  /**
+   * Issue #310 — read the wallet's persisted epoch floor. Returns 0
+   * if the wallet has never observed a higher epoch on-chain AND has
+   * never called `resetEpoch`.
+   */
+  private async getEpochFloorImpl(): Promise<number> {
+    const raw = await this._storage.get(LOCAL_EPOCH_FLOOR_KEY);
+    if (raw === null) return 0;
+    const parsed = Number.parseInt(raw, 10);
+    if (
+      !Number.isFinite(parsed) ||
+      !Number.isInteger(parsed) ||
+      parsed < 0
+    ) {
+      return 0;
+    }
+    return parsed;
+  }
+
+  /**
+   * Issue #310 — serialization guard for concurrent `resetEpoch` calls
+   * on the same Sphere instance. Two concurrent invocations could
+   * otherwise both observe floor=N, both write floor=N+1, and emit
+   * two events for what is logically one epoch bump (the second
+   * caller's intent is silently merged into the first). Holding a
+   * per-instance promise serializes the read-modify-write cycle.
+   *
+   * This guard does NOT protect against concurrent SENDS / OpLog
+   * writes from PaymentsModule — those run through the OrbitDB
+   * adapter directly and are subject to OrbitDB's own write
+   * serialization. A concurrent send while resetEpoch is wiping the
+   * OpLog surfaces as a write error from PaymentsModule (caught by
+   * the dispatcher's retry path). Callers SHOULD quiesce sends
+   * externally; this is documented on `SphereProfileHandle.resetEpoch`.
+   */
+  private _resetEpochInFlight: Promise<ResetEpochResult> | null = null;
+
+  /**
+   * Issue #310 — bump the wallet's OpLog epoch floor by +1, kick off a
+   * republish, and emit `'profile:epoch-reset'`. See
+   * `SphereProfileHandle.resetEpoch` for the full contract.
+   */
+  private async resetEpochImpl(
+    params: ResetEpochParams,
+  ): Promise<ResetEpochResult> {
+    const storage = this._storage as unknown as {
+      getPointerLayer?: () => unknown | null;
+    };
+    if (typeof storage.getPointerLayer !== 'function') {
+      throw new SphereError(
+        'sphere.profile.resetEpoch requires Profile-mode storage (got non-Profile StorageProvider).',
+        'NOT_PROFILE_MODE',
+      );
+    }
+
+    if (typeof params.reason !== 'string' || params.reason.length === 0) {
+      throw new SphereError(
+        'sphere.profile.resetEpoch: reason must be a non-empty string.',
+        'INVALID_CONFIG',
+      );
+    }
+    const reasonBytes = new TextEncoder().encode(params.reason);
+    if (reasonBytes.byteLength > EPOCH_RESET_REASON_MAX_BYTES) {
+      throw new SphereError(
+        `sphere.profile.resetEpoch: reason ${reasonBytes.byteLength} bytes exceeds cap ${EPOCH_RESET_REASON_MAX_BYTES}.`,
+        'INVALID_CONFIG',
+      );
+    }
+
+    // Serialize: if a reset is already mid-flight, chain this call
+    // BEHIND it (not deduplicate — each call must produce a NEW epoch
+    // per the idempotency-against-re-runs contract). The check + set
+    // MUST be sync (no intermediate await) so two concurrent
+    // invocations see distinct mid-flight states.
+    const prior = this._resetEpochInFlight;
+    const promise = (async (): Promise<ResetEpochResult> => {
+      if (prior !== null) {
+        try {
+          await prior;
+        } catch {
+          // Previous call's error is irrelevant to this one; the
+          // floor-read below picks up whatever was actually persisted.
+        }
+      }
+      return this.resetEpochCore(params);
+    })();
+    this._resetEpochInFlight = promise;
+    try {
+      return await promise;
+    } finally {
+      if (this._resetEpochInFlight === promise) {
+        this._resetEpochInFlight = null;
+      }
+    }
+  }
+
+  /**
+   * Issue #310 — core read-modify-write cycle for a single resetEpoch
+   * call. Wrapped by `resetEpochImpl` with the mutex.
+   */
+  private async resetEpochCore(
+    params: ResetEpochParams,
+  ): Promise<ResetEpochResult> {
+    const ts = Date.now();
+
+    try {
+      // 1. Read current floor → compute new = current + 1.
+      const currentEpoch = await this.getEpochFloorImpl();
+      const newEpoch = currentEpoch + 1;
+
+      // 2. Persist BEFORE the OpLog wipe so a crash between (2) and
+      //    (3) leaves the local wallet with the new floor in place —
+      //    the next Sphere.load() publishes the bumped epoch on its
+      //    first dirty-flush.
+      await this._storage.set(LOCAL_EPOCH_FLOOR_KEY, String(newEpoch));
+      await this._storage.set(LOCAL_EPOCH_RESET_REASON_KEY, params.reason);
+
+      // 3. Best-effort OpLog wipe via OrbitDbAdapter.resetCorruptedLog.
+      try {
+        const storageWithAdapter = this._storage as unknown as {
+          getOrbitDbAdapter?: () => {
+            resetCorruptedLog?: (reason: {
+              lostHeadCid?: string;
+              context: string;
+            }) => Promise<unknown>;
+          } | null;
+        };
+        const adapter = storageWithAdapter.getOrbitDbAdapter?.() ?? null;
+        if (
+          adapter !== null &&
+          typeof adapter.resetCorruptedLog === 'function'
+        ) {
+          await adapter.resetCorruptedLog({
+            context: `sphere.profile.resetEpoch: ${params.reason}`,
+          });
+        }
+      } catch (err) {
+        logger.warn(
+          'Sphere',
+          `resetEpoch: OpLog wipe threw (continuing with epoch bump): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      // 4. Trigger a dirty-flush so the next aggregator pointer
+      //    publish carries the new epoch (best-effort).
+      try {
+        for (const provider of this._tokenStorageProviders.values()) {
+          const dirtyTrigger = (provider as unknown as {
+            notifyProfileDirty?: () => void;
+          }).notifyProfileDirty;
+          if (typeof dirtyTrigger === 'function') {
+            dirtyTrigger.call(provider);
+          }
+        }
+      } catch (err) {
+        logger.warn(
+          'Sphere',
+          `resetEpoch: notifyProfileDirty threw (epoch bump still persisted): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      // 5. Emit the event.
+      this.emitEvent('profile:epoch-reset', {
+        newEpoch,
+        reason: params.reason,
+        ts,
+      });
+
+      return {
+        newEpoch,
+        reason: params.reason,
+        ts,
+        publishedVersion: 0,
+      };
+    } catch (err) {
+      if (err instanceof SphereError) throw err;
+      throw new SphereError(
+        `sphere.profile.resetEpoch failed: ${err instanceof Error ? err.message : String(err)}`,
+        'PROFILE_RESET_FAILED',
+        err,
+      );
+    }
   }
 
   // ===========================================================================

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -2138,8 +2138,13 @@ export class Sphere {
     }
 
     const cleanups: Array<() => void> = [];
-    let timer: ReturnType<typeof setTimeout> | undefined;
     let settled = false;
+    // Holder for the timer handle. Filled below; `teardown` reads
+    // through the holder so we can declare it before the
+    // `setTimeout` call (avoids use-before-define).
+    const timerHolder: { value: ReturnType<typeof setTimeout> | null } = {
+      value: null,
+    };
 
     let resolve!: (v: number) => void;
     let reject!: (err: Error) => void;
@@ -2149,7 +2154,7 @@ export class Sphere {
     });
 
     const teardown = (): void => {
-      if (timer !== undefined) clearTimeout(timer);
+      if (timerHolder.value !== null) clearTimeout(timerHolder.value);
       for (const fn of cleanups) {
         try {
           fn();
@@ -2165,7 +2170,7 @@ export class Sphere {
       teardown();
     };
 
-    timer = setTimeout(() => {
+    const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
       if (settled) return;
       settled = true;
       teardown();
@@ -2177,8 +2182,8 @@ export class Sphere {
         ),
       );
     }, timeoutMs);
+    timerHolder.value = timer;
     if (
-      timer !== undefined &&
       typeof (timer as unknown as { unref?: unknown }).unref === 'function'
     ) {
       (timer as unknown as { unref: () => void }).unref();

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -64,6 +64,7 @@ import type {
 } from '../profile/profile-handle';
 import {
   LOCAL_EPOCH_FLOOR_KEY,
+  LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY,
   LOCAL_EPOCH_RESET_REASON_KEY,
 } from '../profile/pointer-wiring';
 import { EPOCH_RESET_REASON_MAX_BYTES } from '../profile/profile-lean-snapshot';
@@ -1931,6 +1932,45 @@ export class Sphere {
         logger.warn(
           'Sphere',
           `resetEpoch: OpLog wipe threw (continuing with epoch bump): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      // 3b. PR #316 F3 fix — write a sentinel KV AFTER the OpLog wipe
+      //     so the snapshot builder has concrete OpLog state to flush
+      //     even when no other writers have mutated since the wipe.
+      //     The value is the post-reset epoch (decimal string); the
+      //     sentinel is overwritten on every subsequent reset and
+      //     never accumulates.
+      //
+      //     Ordering rationale: must run AFTER the OpLog wipe so the
+      //     sentinel lands in the FRESH OpLog (the wipe drops the
+      //     OrbitDB instance, so any pre-wipe write would be lost).
+      //     The local cache copy is also overwritten (via
+      //     ProfileStorageProvider.set's local-cache mirror) so the
+      //     wallet's next `Sphere.load()` reads the sentinel back
+      //     consistently.
+      //
+      //     Without this, a publish failure on the first post-reset
+      //     flush could leave the aggregator chain stuck at the
+      //     pre-reset version with no automatic retry surface — the
+      //     periodic poll's `retryPendingPublishIfAny` only fires
+      //     when `pendingPublishCid` is non-null, which in turn only
+      //     stamps when a publish actually attempted and transient-
+      //     failed. If the snapshot builder skipped the publish for
+      //     "no dirty state", no retry would ever run.
+      //
+      //     Best-effort: a write failure does NOT abort the bump.
+      //     The local floor IS already persisted; the wallet stays
+      //     consistent.
+      try {
+        await this._storage.set(
+          LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY,
+          String(newEpoch),
+        );
+      } catch (err) {
+        logger.warn(
+          'Sphere',
+          `resetEpoch: flush-trigger sentinel write failed (epoch bump still persisted): ${err instanceof Error ? err.message : String(err)}`,
         );
       }
 

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -524,6 +524,20 @@ const UNICITY_TOKEN_TYPE_HEX = 'f8aa13834268d29355ff12183066f0cb902003629bbc5eb9
 const RESET_EPOCH_DISCOVERY_TIMEOUT_MS = 15_000;
 
 /**
+ * PR #316 F2 fix — default wall-clock budget for the post-bump
+ * publish await inside `resetEpoch`. After the local floor is
+ * persisted and `notifyProfileDirty()` is called, resetEpoch waits
+ * up to this long for a `'storage:pointer-published'` event so the
+ * returned `publishedVersion` is honest. On timeout, the local
+ * state is unchanged and a `'profile:epoch-reset-publish-pending'`
+ * event is emitted; the periodic-poll path republishes.
+ *
+ * The default is 30 000 ms, matching the per-flush remote-durability
+ * verification deadline in `ProfileConfig.flushVerificationDeadlineMs`.
+ */
+const RESET_EPOCH_PUBLISH_TIMEOUT_MS = 30_000;
+
+/**
  * Derive L3 predicate address (DIRECT://...) from private key
  * Uses UnmaskedPredicateReference for stable wallet address
  */
@@ -1920,7 +1934,36 @@ export class Sphere {
         );
       }
 
-      // 4. Trigger a dirty-flush so the next aggregator pointer
+      // 4a. PR #316 F2 fix — arm a one-shot listener on every token-
+      //     storage provider's `'storage:pointer-published'` event
+      //     BEFORE the dirty-flush is triggered. The event fires
+      //     unconditionally on any successful pointer publish (per
+      //     the lifecycle-manager change in this PR). We collect the
+      //     FIRST published version observed across all providers
+      //     within the bounded timeout window.
+      //
+      //     `armResetEpochPublishWaiter` returns `null` when no
+      //     token-storage providers expose `onEvent` — in that case
+      //     there is no event surface to observe and skipping the
+      //     wait is the honest behavior (we return
+      //     `publishedVersion: 0` and DO NOT emit
+      //     `'profile:epoch-reset-publish-pending'` — pending implies
+      //     "we tried and timed out", not "no wiring").
+      const publishTimeoutMs =
+        params.publishTimeoutMs ?? RESET_EPOCH_PUBLISH_TIMEOUT_MS;
+      const publishedVersionWaiter =
+        publishTimeoutMs > 0
+          ? this.armResetEpochPublishWaiter(publishTimeoutMs)
+          : null;
+      // Distinguish "skipped because no listeners" (publishedVersion
+      // remains 0; no pending event) from "skipped because timeout
+      // = 0" (same outcome, also no pending event) from "awaited and
+      // timed out" (publishedVersion = 0 AND pending event emitted).
+      const publishedVersionWaiterRanAndTimedOut: { value: boolean } = {
+        value: false,
+      };
+
+      // 4b. Trigger a dirty-flush so the next aggregator pointer
       //    publish carries the new epoch (best-effort).
       try {
         for (const provider of this._tokenStorageProviders.values()) {
@@ -1936,6 +1979,22 @@ export class Sphere {
           'Sphere',
           `resetEpoch: notifyProfileDirty threw (epoch bump still persisted): ${err instanceof Error ? err.message : String(err)}`,
         );
+      }
+
+      // 4c. Await the publish (or timeout). Always cancel the
+      //     waiter — leaking the listener could pin the provider's
+      //     event-handler set across the next publish cycle.
+      let publishedVersion = 0;
+      if (publishedVersionWaiter !== null) {
+        try {
+          publishedVersion = await publishedVersionWaiter.promise;
+        } catch {
+          // Timeout → publishedVersion stays 0; emit the
+          // pending event below.
+          publishedVersionWaiterRanAndTimedOut.value = true;
+        } finally {
+          publishedVersionWaiter.cancel();
+        }
       }
 
       // 5. Emit the event.
@@ -1956,11 +2015,26 @@ export class Sphere {
         });
       }
 
+      // 5c. PR #316 F2 fix — surface publish-timeout so callers know
+      //     to either retry / re-query or subscribe to
+      //     `'storage:pointer-published'` for the eventual landing.
+      //     Only emit when we actually awaited AND timed out — not
+      //     when the waiter was skipped (timeoutMs=0) or returned
+      //     null (no event surface).
+      if (publishedVersionWaiterRanAndTimedOut.value) {
+        this.emitEvent('profile:epoch-reset-publish-pending', {
+          newEpoch,
+          reason: params.reason,
+          timeoutMs: publishTimeoutMs,
+          ts,
+        });
+      }
+
       return {
         newEpoch,
         reason: params.reason,
         ts,
-        publishedVersion: 0,
+        publishedVersion,
         discoveryConsulted,
       };
     } catch (err) {
@@ -1971,6 +2045,128 @@ export class Sphere {
         err,
       );
     }
+  }
+
+  /**
+   * PR #316 F2 fix — arm a one-shot waiter on every token-storage
+   * provider's `'storage:pointer-published'` event. Returns a
+   * `{promise, cancel}` pair: the promise resolves with the FIRST
+   * observed `version` across any provider, or rejects on timeout.
+   * `cancel()` unsubscribes every listener and clears the timer
+   * (safe to call multiple times). Callers MUST always call
+   * `cancel()` in a `finally` so the listener set does not pin
+   * across the next event cycle.
+   *
+   * The event fires unconditionally on every successful publish (per
+   * the lifecycle-manager change in this PR), so the waiter does NOT
+   * depend on the `enablePointerWinBroadcasts` capability flag.
+   */
+  private armResetEpochPublishWaiter(
+    timeoutMs: number,
+  ): {
+    promise: Promise<number>;
+    cancel: () => void;
+  } | null {
+    // Collect candidate providers with an `onEvent` accessor BEFORE
+    // installing any listener. Without at least one such provider
+    // the waiter has no way to ever settle on the success path —
+    // letting it run would just stall for the full `timeoutMs`
+    // window with a guaranteed publish-pending event. Returning
+    // `null` is the honest answer: "I cannot observe the publish
+    // here; skip the await". This is the production behavior when
+    // no token storage providers are wired (e.g., pure read-only
+    // unit-test harnesses) and the legitimate behavior on a real
+    // wallet that has Profile storage as the kv-storage backend
+    // but no token storage providers attached.
+    const eligible: Array<{
+      onEvent: (
+        cb: (event: { type: string; data?: { version?: unknown } }) => void,
+      ) => () => void;
+      provider: unknown;
+    }> = [];
+    for (const provider of this._tokenStorageProviders.values()) {
+      const onEvent = (provider as unknown as {
+        onEvent?: (
+          cb: (event: { type: string; data?: { version?: unknown } }) => void,
+        ) => () => void;
+      }).onEvent;
+      if (typeof onEvent !== 'function') continue;
+      eligible.push({ onEvent, provider });
+    }
+    if (eligible.length === 0) {
+      return null;
+    }
+
+    const cleanups: Array<() => void> = [];
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+
+    let resolve!: (v: number) => void;
+    let reject!: (err: Error) => void;
+    const promise = new Promise<number>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    const teardown = (): void => {
+      if (timer !== undefined) clearTimeout(timer);
+      for (const fn of cleanups) {
+        try {
+          fn();
+        } catch {
+          /* listener-removal must never throw past resetEpoch */
+        }
+      }
+    };
+
+    const cancel = (): void => {
+      if (settled) return;
+      settled = true;
+      teardown();
+    };
+
+    timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      teardown();
+      // Reject so the caller's `await` throws and the catch arm in
+      // resetEpochCore drops `publishedVersion` to 0.
+      reject(
+        new Error(
+          `resetEpoch: storage:pointer-published not observed within ${timeoutMs}ms`,
+        ),
+      );
+    }, timeoutMs);
+    if (
+      timer !== undefined &&
+      typeof (timer as unknown as { unref?: unknown }).unref === 'function'
+    ) {
+      (timer as unknown as { unref: () => void }).unref();
+    }
+
+    for (const { onEvent, provider } of eligible) {
+      const unsub = onEvent.call(provider, (event) => {
+        if (settled) return;
+        if (event?.type !== 'storage:pointer-published') return;
+        const version = event?.data?.version;
+        if (
+          typeof version !== 'number' ||
+          !Number.isFinite(version) ||
+          !Number.isInteger(version) ||
+          version < 0
+        ) {
+          return;
+        }
+        settled = true;
+        teardown();
+        resolve(version);
+      });
+      if (typeof unsub === 'function') {
+        cleanups.push(unsub);
+      }
+    }
+
+    return { promise, cancel };
   }
 
   /**

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -513,6 +513,17 @@ export interface SphereInitResult {
 const UNICITY_TOKEN_TYPE_HEX = 'f8aa13834268d29355ff12183066f0cb902003629bbc5eb9ef0efbe397867509';
 
 /**
+ * PR #316 F1 fix — default wall-clock budget for the pre-bump
+ * discovery RPC inside `resetEpoch`. The discovery makes one or more
+ * aggregator RPCs to determine the on-chain epoch floor before
+ * computing `newEpoch = max(local, discovered) + 1`. Bounded so a
+ * misbehaving aggregator cannot hang the user-facing reset call
+ * indefinitely; on timeout the bump proceeds from the local floor
+ * alone and `'profile:epoch-reset-discovery-skipped'` is emitted.
+ */
+const RESET_EPOCH_DISCOVERY_TIMEOUT_MS = 15_000;
+
+/**
  * Derive L3 predicate address (DIRECT://...) from private key
  * Uses UnmaskedPredicateReference for stable wallet address
  */
@@ -1822,6 +1833,16 @@ export class Sphere {
   /**
    * Issue #310 — core read-modify-write cycle for a single resetEpoch
    * call. Wrapped by `resetEpochImpl` with the mutex.
+   *
+   * PR #316 F1 fix — the floor bump now consults the on-chain epoch
+   * floor (`pointer.discoverLatestVersion().pickedEpoch`) before
+   * computing `newEpoch = max(local, discovered) + 1`. This closes
+   * the cross-device monotonicity gap: two devices that both observe
+   * `localFloor=N` will each discover the same `chainFloor=N` (or
+   * better) and both bump to N+1; whichever device's publish lands
+   * first wins, and the loser's subsequent publish forces a re-
+   * discovery (now seeing the winner's N+1) so its NEXT bump goes
+   * to N+2.
    */
   private async resetEpochCore(
     params: ResetEpochParams,
@@ -1829,9 +1850,42 @@ export class Sphere {
     const ts = Date.now();
 
     try {
-      // 1. Read current floor → compute new = current + 1.
+      // 1a. Read local floor.
       const currentEpoch = await this.getEpochFloorImpl();
-      const newEpoch = currentEpoch + 1;
+
+      // 1b. PR #316 F1 fix — consult the on-chain epoch floor with a
+      //     bounded timeout. The walkback floor is the
+      //     `pickedEpoch` from Phase-3 discovery — the `max(epoch)`
+      //     observed across every Phase-3 candidate whose CAR the
+      //     wallet successfully inspected. On RPC failure (network
+      //     down, aggregator timeout, etc.) we fall back to the
+      //     local floor alone and emit the
+      //     `'profile:epoch-reset-discovery-skipped'` event so
+      //     callers can surface the PROVISIONAL nature of the bump.
+      const discoveryTimeoutMs =
+        params.discoveryTimeoutMs ?? RESET_EPOCH_DISCOVERY_TIMEOUT_MS;
+      let discoveredEpoch = 0;
+      let discoveryConsulted = false;
+      let discoveryError: string | null = null;
+      if (discoveryTimeoutMs > 0) {
+        try {
+          discoveredEpoch = await this.discoverChainEpochFloor(
+            discoveryTimeoutMs,
+          );
+          discoveryConsulted = true;
+        } catch (err) {
+          discoveryError = err instanceof Error ? err.message : String(err);
+          logger.warn(
+            'Sphere',
+            `resetEpoch: discovery failed (continuing with local floor only — ` +
+              `new epoch is PROVISIONAL): ${discoveryError}`,
+          );
+        }
+      }
+
+      // 1c. Compute new epoch from the higher of (local, discovered).
+      const baseEpoch = Math.max(currentEpoch, discoveredEpoch);
+      const newEpoch = baseEpoch + 1;
 
       // 2. Persist BEFORE the OpLog wipe so a crash between (2) and
       //    (3) leaves the local wallet with the new floor in place —
@@ -1891,11 +1945,23 @@ export class Sphere {
         ts,
       });
 
+      // 5b. PR #316 F1 fix — surface discovery-failure so callers know
+      //     the bump is PROVISIONAL.
+      if (!discoveryConsulted && discoveryError !== null) {
+        this.emitEvent('profile:epoch-reset-discovery-skipped', {
+          newEpoch,
+          reason: params.reason,
+          discoveryError,
+          ts,
+        });
+      }
+
       return {
         newEpoch,
         reason: params.reason,
         ts,
         publishedVersion: 0,
+        discoveryConsulted,
       };
     } catch (err) {
       if (err instanceof SphereError) throw err;
@@ -1904,6 +1970,72 @@ export class Sphere {
         'PROFILE_RESET_FAILED',
         err,
       );
+    }
+  }
+
+  /**
+   * PR #316 F1 fix — best-effort discovery of the on-chain epoch
+   * floor. Runs `pointer.discoverLatestVersion()` with a
+   * caller-supplied wall-clock budget and returns the
+   * `pickedEpoch` value. Throws on any failure (RPC timeout,
+   * aggregator down, pointer layer missing) — the caller logs the
+   * error, emits the `'profile:epoch-reset-discovery-skipped'`
+   * event, and falls back to the local floor alone.
+   *
+   * Returns 0 for a fresh wallet that has never observed an
+   * on-chain epoch (the discovery returns `pickedEpoch: 0` in that
+   * case, which is correct — `max(local=0, discovered=0) + 1 = 1`).
+   */
+  private async discoverChainEpochFloor(
+    timeoutMs: number,
+  ): Promise<number> {
+    const storageWithPointer = this._storage as unknown as {
+      getPointerLayer?: () => {
+        discoverLatestVersion?: (
+          walkbackLimit?: number,
+          opts?: { abortSignal?: AbortSignal },
+        ) => Promise<{ pickedEpoch?: number }>;
+      } | null;
+    };
+    const pointer = storageWithPointer.getPointerLayer?.() ?? null;
+    if (
+      pointer === null ||
+      typeof pointer.discoverLatestVersion !== 'function'
+    ) {
+      throw new Error(
+        'pointer layer unavailable (discoverLatestVersion missing)',
+      );
+    }
+    const abortController = new AbortController();
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      deadlineTimer = setTimeout(() => {
+        try {
+          abortController.abort();
+        } catch {
+          /* noop */
+        }
+      }, timeoutMs);
+      // Some Node test runners support .unref() on timers; ignore otherwise.
+      if (
+        deadlineTimer !== undefined &&
+        typeof (deadlineTimer as unknown as { unref?: unknown }).unref ===
+          'function'
+      ) {
+        (deadlineTimer as unknown as { unref: () => void }).unref();
+      }
+      const result = await pointer.discoverLatestVersion(undefined, {
+        abortSignal: abortController.signal,
+      });
+      const picked = result?.pickedEpoch;
+      if (typeof picked !== 'number' || !Number.isFinite(picked) || picked < 0) {
+        return 0;
+      }
+      return picked;
+    } finally {
+      if (deadlineTimer !== undefined) {
+        clearTimeout(deadlineTimer);
+      }
     }
   }
 

--- a/core/errors.ts
+++ b/core/errors.ts
@@ -73,6 +73,12 @@ export type SphereErrorCode =
   | 'STATE_ALREADY_SPENT_BY_OTHER'
   | 'STORAGE_ERROR'
   | 'STORAGE_CORRUPTED'
+  // Issue #310 — `sphere.profile.resetEpoch()` invoked when not in
+  // Profile mode. Defensive: `Sphere.profile` returns `null` for
+  // non-Profile wallets, so this is normally unreachable.
+  | 'NOT_PROFILE_MODE'
+  // Issue #310 — any step of `sphere.profile.resetEpoch()` threw.
+  | 'PROFILE_RESET_FAILED'
   | 'TRANSPORT_ERROR'
   | 'AGGREGATOR_ERROR'
   | 'VALIDATION_ERROR'

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -86,6 +86,36 @@ export interface ProfilePointerLayerInit {
   readonly persistLocalVersion: (v: PointerVersion) => Promise<void>;
   /** Given a version, resolve its CID bytes (via classifyVersion or recoverLatest). */
   readonly resolveRemoteCid: (version: PointerVersion) => Promise<Uint8Array>;
+  /**
+   * Issue #310 — read the wallet's locally-persisted epoch floor.
+   * Optional: when omitted (or when a read throws), the discovery
+   * walkback floor starts at 0 — backwards-compatible with pre-#310
+   * SDK behavior. Otherwise the floor is primed with the returned
+   * value, preventing an aggregator that still serves a pre-reset
+   * pointer for the same wallet from tricking us into walking back
+   * to it.
+   */
+  readonly readEpochFloor?: () => Promise<number>;
+  /**
+   * Issue #310 — persist a newly-observed epoch floor (best-effort).
+   * Called by `discoverLatestVersion` whenever the Phase-3 walkback
+   * observes `pickedEpoch > initialEpochFloor`, so the wallet
+   * converges with sibling-device resets without requiring the user
+   * to re-trigger any reset locally.
+   */
+  readonly persistEpochFloor?: (epoch: number) => Promise<void>;
+  /**
+   * Issue #310 — given a Phase-3 candidate version, return the
+   * snapshot's claimed `epoch` (or `undefined` for pre-#310
+   * snapshots). The lifecycle layer wires this to a closure that
+   * re-resolves the CID + fetches the root block + dag-cbor decodes
+   * the `epoch` field. Throws on decode failure so the walkback
+   * treats the candidate as undetermined / SEMANTICALLY_INVALID-
+   * equivalent.
+   */
+  readonly inspectSnapshotEpoch?: (
+    version: PointerVersion,
+  ) => Promise<number | undefined>;
   /** Configuration (capabilities). */
   readonly config?: PointerLayerConfig;
 }
@@ -681,6 +711,26 @@ export class ProfilePointerLayer {
       throw err;
     }
     const currentLocalVersion = await this.#init.readLocalVersion();
+    // Issue #310 — prime walkback with the wallet's persisted epoch
+    // floor (best-effort). A missing or erroring callback leaves the
+    // floor at 0 (pre-#310 behavior).
+    let initialEpochFloor = 0;
+    if (this.#init.readEpochFloor) {
+      try {
+        const stored = await this.#init.readEpochFloor();
+        if (
+          typeof stored === 'number' &&
+          Number.isFinite(stored) &&
+          Number.isInteger(stored) &&
+          stored >= 0
+        ) {
+          initialEpochFloor = stored;
+        }
+      } catch {
+        // Best-effort: bad read → floor stays at 0.
+      }
+    }
+    const inspectEpochCb = this.#init.inspectSnapshotEpoch;
     const result = await findLatestValidVersion({
       currentLocalVersion,
       keyMaterial: this.#init.keyMaterial,
@@ -691,7 +741,27 @@ export class ProfilePointerLayer {
       fetchCar: this.#init.fetchCar,
       walkbackLimit,
       abortSignal,
+      initialEpochFloor,
+      inspectSnapshotEpoch: inspectEpochCb
+        ? (v: PointerVersion, _cidBytes: Uint8Array) => inspectEpochCb(v)
+        : undefined,
     });
+    // Issue #310 — persist a newly-observed epoch floor (best-effort).
+    // The next discovery starts from this primed value, so an
+    // aggregator that still serves a pre-reset pointer (e.g.,
+    // cross-device sync lag after a sibling's resetEpoch) cannot
+    // trick this wallet into walking back to a pre-reset version.
+    if (
+      this.#init.persistEpochFloor &&
+      typeof result.pickedEpoch === 'number' &&
+      result.pickedEpoch > initialEpochFloor
+    ) {
+      try {
+        await this.#init.persistEpochFloor(result.pickedEpoch);
+      } catch {
+        // Best-effort: next discovery re-observes + re-persists.
+      }
+    }
     // Issue #264 steelman fix (symmetric with `publish`): only overwrite
     // the probe-fingerprint history when discovery actually produced
     // probes. A discoverLatestVersion that resolves on the first probe

--- a/profile/aggregator-pointer/discover-algorithm.ts
+++ b/profile/aggregator-pointer/discover-algorithm.ts
@@ -127,6 +127,7 @@ import {
   type CarFetcher,
   type CidDecoder,
 } from './aggregator-probe.js';
+import { pickEpochFloor, shouldSkipForEpochFloor } from './epoch-floor.js';
 import {
   DISCOVERY_CORRUPT_WALKBACK,
   DISCOVERY_HARD_CEILING,
@@ -171,6 +172,33 @@ export interface DiscoverInput {
    * to its per-request timeout.
    */
   readonly abortSignal?: AbortSignal;
+  /**
+   * Issue #310 — OpLog epoch-floor inspector. Given a Phase-3
+   * candidate that classified as VALID, return its snapshot's
+   * `epoch` (or undefined for pre-#310 snapshots).
+   *
+   * Default behavior (callback omitted): epoch-floor walkback is
+   * DISABLED. Every VALID candidate is treated as `epoch = 0` —
+   * backwards-compatible with pre-#310 SDKs.
+   *
+   * When supplied, Phase 3 consults this callback on every VALID
+   * candidate, tracks the running max epoch as a floor, and SKIPS
+   * candidates whose snapshot's epoch is strictly below the floor.
+   *
+   * On throw, the candidate is treated as SEMANTICALLY_INVALID
+   * (skip + walk back, count toward budget).
+   */
+  readonly inspectSnapshotEpoch?: (
+    v: PointerVersion,
+    cidBytes: Uint8Array,
+  ) => Promise<number | undefined> | number | undefined;
+  /**
+   * Issue #310 — initial epoch floor before Phase 3 begins. Defaults
+   * to 0. Set to the wallet's last-applied snapshot epoch so an
+   * aggregator that still serves a pre-reset pointer cannot trick
+   * the wallet into walking back to it.
+   */
+  readonly initialEpochFloor?: number;
   /**
    * Phase 3 walkback policy for `CAR_TRANSIENT` versions (slot EXISTS
    * on-chain — proof verified + CID decoded — but CAR is unreachable).
@@ -234,6 +262,19 @@ export interface DiscoverResult {
    * if such a version exists.
    */
   readonly walkbackUnfetchableSkipped: readonly PointerVersion[];
+  /**
+   * Issue #310 — versions skipped because their snapshot epoch was
+   * strictly below the running floor. Empty when `inspectSnapshotEpoch`
+   * is not wired, when no candidate fell below the floor, or when
+   * Phase 3 never ran.
+   */
+  readonly walkbackEpochSkipped: readonly PointerVersion[];
+  /**
+   * Issue #310 — final epoch floor observed by Phase 3 walkback. The
+   * `max(epoch)` across all Phase-3 candidates whose CARs the wallet
+   * successfully inspected, primed with `initialEpochFloor`.
+   */
+  readonly pickedEpoch: number;
 }
 
 // ── findLatestValidVersion ─────────────────────────────────────────────────
@@ -397,6 +438,27 @@ async function findLatestValidVersionInner(
   const walkbackUnfetchableSkipped: PointerVersion[] = [];
   const skipUnfetchable = input.skipUnfetchableInWalkback !== false;
 
+  // Issue #310 — epoch-floor tracking. Disabled when
+  // `inspectSnapshotEpoch` is not provided.
+  const walkbackEpochSkipped: PointerVersion[] = [];
+  let epochFloor = (() => {
+    const initial = input.initialEpochFloor ?? 0;
+    if (
+      typeof initial !== 'number' ||
+      !Number.isFinite(initial) ||
+      !Number.isInteger(initial) ||
+      initial < 0
+    ) {
+      throw new AggregatorPointerError(
+        AggregatorPointerErrorCode.PROTOCOL_ERROR,
+        `Discovery: initialEpochFloor must be a non-negative integer; got ${String(initial)}.`,
+        { initialEpochFloor: initial },
+      );
+    }
+    return initial;
+  })();
+  const inspectEpoch = input.inspectSnapshotEpoch;
+
   const probeAndRecord = async (v: PointerVersion): Promise<boolean> => {
     checkDeadline();
     probeVersions.push(v);
@@ -497,11 +559,36 @@ async function findLatestValidVersionInner(
     });
 
     if (status === 'VALID') {
+      // Issue #310 — epoch-floor enforcement. Inspect the snapshot's
+      // claimed epoch; skip past versions whose epoch is below the
+      // running floor. Skip semantics mirror SEMANTICALLY_INVALID
+      // (counts toward walkback budget, surfaces in
+      // walkbackEpochSkipped for operator observability).
+      if (inspectEpoch !== undefined) {
+        let candidateEpoch: number | undefined;
+        try {
+          candidateEpoch = await inspectEpoch(candidate, new Uint8Array(0));
+        } catch {
+          // Inspector threw → treat as SEMANTICALLY_INVALID-equivalent.
+          candidate = (candidate - 1) as PointerVersion;
+          walked += 1;
+          continue;
+        }
+        if (shouldSkipForEpochFloor(epochFloor, candidateEpoch)) {
+          walkbackEpochSkipped.push(candidate);
+          candidate = (candidate - 1) as PointerVersion;
+          walked += 1;
+          continue;
+        }
+        epochFloor = pickEpochFloor(epochFloor, candidateEpoch);
+      }
       return {
         validV: candidate,
         includedV,
         probeVersions,
         walkbackUnfetchableSkipped,
+        walkbackEpochSkipped,
+        pickedEpoch: epochFloor,
       };
     }
 
@@ -581,27 +668,32 @@ async function findLatestValidVersionInner(
       includedV,
       probeVersions,
       walkbackUnfetchableSkipped,
+      walkbackEpochSkipped,
+      pickedEpoch: epochFloor,
     };
   }
 
   // Too many consecutive non-VALID versions — bail out (§10.8). The
-  // diagnostic carries the unfetchable-skipped count so operators can
-  // distinguish "wallet is corrupt" (all skipped were SEMANTICALLY_INVALID)
-  // from "IPFS gateways are down" (mostly walkbackUnfetchableSkipped).
-  // Both classes trigger CORRUPT_STREAK because the wallet's effective
-  // walkback budget is the same — but the remediation differs (operator
-  // intervention vs gateway reconnect).
+  // diagnostic carries the unfetchable-skipped + epoch-skipped (issue
+  // #310) counts so operators can distinguish "wallet is corrupt"
+  // (all skipped were SEMANTICALLY_INVALID) from "IPFS gateways are
+  // down" (mostly walkbackUnfetchableSkipped) from "post-reset chain
+  // ahead of floor" (mostly walkbackEpochSkipped).
   throw new AggregatorPointerError(
     AggregatorPointerErrorCode.CORRUPT_STREAK,
     `Phase 3 walkback exhausted walkbackLimit=${walkbackLimit} without finding a VALID version ` +
       `(includedV=${includedV}, candidate=${candidate}, ` +
-      `unfetchableSkipped=${walkbackUnfetchableSkipped.length}). ` +
+      `unfetchableSkipped=${walkbackUnfetchableSkipped.length}, ` +
+      `epochSkipped=${walkbackEpochSkipped.length}, ` +
+      `pickedEpoch=${epochFloor}). ` +
       `Operator may invoke acceptCorruptStreak(walkbackLimit) to override.`,
     {
       includedV,
       walkbackLimit,
       walkedSoFar: walked,
       unfetchableSkippedCount: walkbackUnfetchableSkipped.length,
+      epochSkippedCount: walkbackEpochSkipped.length,
+      pickedEpoch: epochFloor,
     },
   );
 }

--- a/profile/aggregator-pointer/epoch-floor.ts
+++ b/profile/aggregator-pointer/epoch-floor.ts
@@ -1,0 +1,138 @@
+/**
+ * Issue #310 — OpLog epoch-floor walkback primitive.
+ *
+ * The pointer chain that an aggregator hosts is a strictly-increasing
+ * sequence of versions, each addressed by a snapshot CAR. Each CAR's
+ * root block carries an `epoch` field (default 0 for pre-#310 wallets).
+ * `sphere.profile.resetEpoch()` mints a NEW snapshot whose `epoch` is
+ * `max(seen.epoch) + 1` and publishes it at the next pointer version.
+ *
+ * Once a higher epoch is observed on-chain, NO lower-epoch version is
+ * considered VALID for walkback purposes — the wallet has explicitly
+ * abandoned the prior OpLog state. Walking back into it would let a
+ * crashing client (or a second-device read) re-load the corruption
+ * that drove the user to reset in the first place.
+ *
+ * This module is pure (no I/O, no globals). The walkback algorithm
+ * imports `pickEpochFloor` / `shouldSkipForEpochFloor` and consults
+ * the running floor at every classify step.
+ *
+ * Backwards-compat invariant
+ * ──────────────────────────
+ * - Pre-#310 snapshots have NO epoch field; readers treat them as
+ *   `epoch = 0`. A pre-#310 chain therefore has `max(seen.epoch) = 0`,
+ *   and `shouldSkipForEpochFloor` returns `false` for every entry —
+ *   walkback behavior is identical to pre-#310 SDKs.
+ * - A post-#310 chain whose latest entry is `epoch = N > 0` causes
+ *   `shouldSkipForEpochFloor` to return `true` for any prior entry
+ *   whose `epoch < N`. Those prior entries are skipped past with the
+ *   same Phase-3 semantics as CAR_TRANSIENT or SEMANTICALLY_INVALID —
+ *   they count toward the walkback budget and are surfaced in a
+ *   dedicated `walkbackEpochSkipped` list for operator observability.
+ *
+ * Forward-compat invariant
+ * ────────────────────────
+ * - A wallet running an OLDER SDK that doesn't recognize the `epoch`
+ *   field reads pre-#310 semantics (every entry treated as
+ *   `epoch = 0`) and may walk back into the abandoned state. This is
+ *   acceptable for v1 — the user-facing API (`sphere.profile.
+ *   resetEpoch`) is gated on the LATEST SDK. Issue #310 ships the
+ *   reader floor; older SDKs upgrade naturally.
+ */
+
+/**
+ * Normalize an entry's epoch claim into a strict non-negative integer.
+ * Returns 0 for `undefined` (the "field absent" signal — pre-#310 /
+ * backwards-compat). Throws on any explicit non-integer / negative
+ * value: a caller passing a malformed claim is a programmer bug, not
+ * a recoverable input.
+ */
+export function normalizeEpoch(claimed: number | undefined): number {
+  if (claimed === undefined) return 0;
+  if (
+    typeof claimed !== 'number' ||
+    !Number.isFinite(claimed) ||
+    !Number.isInteger(claimed) ||
+    claimed < 0
+  ) {
+    throw new TypeError(
+      `epoch-floor: claimed epoch must be a non-negative integer or undefined; got ${String(claimed)}`,
+    );
+  }
+  return claimed;
+}
+
+/**
+ * Compute the running epoch floor given the prior floor and a newly
+ * observed entry's claimed epoch. Monotone-nondecreasing.
+ *
+ * Example walkback (top-down, Phase-3 order):
+ *
+ *   v=10 → epoch=2  → floor = max(0, 2) = 2
+ *   v=9  → epoch=2  → floor = max(2, 2) = 2  (no change)
+ *   v=8  → epoch=1  → floor = max(2, 1) = 2  → SKIPPED (1 < 2)
+ *   v=7  → epoch=2  → floor = max(2, 2) = 2  (VALID — passes)
+ *
+ * The function is intentionally symmetric: it accepts both the
+ * "running floor" and the "candidate's claim" and returns the
+ * post-observation floor. Callers can therefore pre-prime the floor
+ * with a locally-known value (e.g., from the wallet's last persisted
+ * snapshot's epoch) before consulting on-chain entries.
+ */
+export function pickEpochFloor(
+  priorFloor: number,
+  candidateEpoch: number | undefined,
+): number {
+  const normalized = normalizeEpoch(candidateEpoch);
+  const normalizedFloor = normalizeEpoch(priorFloor);
+  return normalized > normalizedFloor ? normalized : normalizedFloor;
+}
+
+/**
+ * Decide whether a walkback candidate should be SKIPPED PAST because
+ * its epoch is strictly below the running floor. The floor is the
+ * `max(epoch)` observed so far in the chain (including this
+ * candidate's own neighbors — `pickEpochFloor` must be called first
+ * for higher-epoch siblings encountered earlier in the walkback).
+ *
+ * Returns `true` iff the candidate is below the floor — the caller
+ * walks back one more, exactly as it does for SEMANTICALLY_INVALID
+ * / CAR_TRANSIENT. Returns `false` for `candidate.epoch >= floor` —
+ * the candidate is at-or-above the floor and walkback proceeds with
+ * the candidate's normal classification (VALID / CAR_TRANSIENT /
+ * SEMANTICALLY_INVALID).
+ *
+ * Steelman: backwards-compat strictness. A pre-#310 entry whose
+ * snapshot has no `epoch` field decodes as `epoch=0`. A post-#310
+ * chain with `floor=1` would mark that pre-#310 entry as SKIPPED.
+ * This is intentional: once a wallet has published its FIRST
+ * post-reset pointer (epoch ≥ 1), the user has affirmatively
+ * abandoned the pre-reset chain. Including a pre-#310 ancestor in
+ * walkback would re-load the abandoned state.
+ *
+ * The asymmetry only fires AFTER the user calls `resetEpoch` at
+ * least once. Until then, every entry's epoch is 0, the floor is 0,
+ * and `candidate.epoch >= 0` for every entry — no skips.
+ */
+export function shouldSkipForEpochFloor(
+  floor: number,
+  candidateEpoch: number | undefined,
+): boolean {
+  const normalized = normalizeEpoch(candidateEpoch);
+  const normalizedFloor = normalizeEpoch(floor);
+  return normalized < normalizedFloor;
+}
+
+/**
+ * Compose a list of seen epochs into the final floor. Useful for
+ * stub callers / unit tests that have all observations in hand at once.
+ */
+export function computeEpochFloor(
+  seen: ReadonlyArray<number | undefined>,
+): number {
+  let floor = 0;
+  for (const e of seen) {
+    floor = pickEpochFloor(floor, e);
+  }
+  return floor;
+}

--- a/profile/aggregator-pointer/index.ts
+++ b/profile/aggregator-pointer/index.ts
@@ -101,6 +101,14 @@ export type {
   RecoverResult,
 } from './ProfilePointerLayer.js';
 
+// Issue #310 — OpLog epoch-floor walkback primitive
+export {
+  normalizeEpoch,
+  pickEpochFloor,
+  shouldSkipForEpochFloor,
+  computeEpochFloor,
+} from './epoch-floor.js';
+
 // RFC-251 Approach D — pointer-publish win-broadcast (issue #255 Problem B)
 export {
   buildWinBroadcastHash,

--- a/profile/factory.ts
+++ b/profile/factory.ts
@@ -30,6 +30,10 @@ import {
   type LeanProfileSnapshot,
 } from './profile-lean-snapshot';
 import { fetchFromIpfs, pinCarBlocksToIpfs } from './ipfs-client';
+import {
+  LOCAL_EPOCH_FLOOR_KEY,
+  LOCAL_EPOCH_RESET_REASON_KEY,
+} from './pointer-wiring';
 import type { ProfilePointerLayer } from './aggregator-pointer';
 import {
   runProfileSnapshotJoin,
@@ -475,11 +479,45 @@ export function createProfileProviders(
         // `ProfileConfig.tombstoneRetentionMs` (defaults to 30 days).
         const retentionMs =
           resolvedConfig.tombstoneRetentionMs ?? DEFAULT_PROFILE_TOMBSTONE_RETENTION_MS;
+
+        // Issue #310 — read the wallet's persisted epoch floor and
+        // stamp it into the snapshot's root block. Best-effort: a
+        // read failure (or absent key — the pre-#310 default) leaves
+        // the snapshot with NO epoch field, matching legacy behavior.
+        // Once the wallet has called `resetEpoch` even once, the
+        // floor is > 0 and gets emitted into every subsequent
+        // snapshot, locking the chain at the new epoch.
+        let epoch: number | undefined;
+        let epochResetReason: string | undefined;
+        try {
+          const rawEpoch = await cacheStorage.get(LOCAL_EPOCH_FLOOR_KEY);
+          if (rawEpoch !== null) {
+            const parsed = Number.parseInt(rawEpoch, 10);
+            if (
+              Number.isFinite(parsed) &&
+              Number.isInteger(parsed) &&
+              parsed > 0
+            ) {
+              epoch = parsed;
+              const rawReason = await cacheStorage.get(
+                LOCAL_EPOCH_RESET_REASON_KEY,
+              );
+              if (rawReason !== null && rawReason.length > 0) {
+                epochResetReason = rawReason;
+              }
+            }
+          }
+        } catch {
+          // Best-effort — silently fall back to pre-#310 snapshot.
+        }
+
         return buildLeanProfileSnapshot({
           storage,
           tokenStorage,
           chainPubkey,
           network,
+          ...(epoch !== undefined ? { epoch } : {}),
+          ...(epochResetReason !== undefined ? { epochResetReason } : {}),
           gcExpiredTombstones: () =>
             runProfileTombstoneGc({
               listKeys: () => storage.keys(),

--- a/profile/pointer-wiring.ts
+++ b/profile/pointer-wiring.ts
@@ -204,6 +204,28 @@ const LOCAL_VERSION_KEY = 'profile.pointer.version';
 export const LOCAL_EPOCH_FLOOR_KEY = 'profile.pointer.epoch_floor';
 export const LOCAL_EPOCH_RESET_REASON_KEY =
   'profile.pointer.epoch_reset_reason';
+/**
+ * PR #316 F3 fix — sentinel KV key written by `resetEpoch` BEFORE
+ * triggering the dirty-flush. The value is the post-reset epoch
+ * encoded as a decimal string (matches `LOCAL_EPOCH_FLOOR_KEY`'s
+ * encoding).
+ *
+ * Purpose: give the OrbitDB-backed flush path concrete dirty state
+ * to write even when the OpLog has just been wiped via
+ * `OrbitDbAdapter.resetCorruptedLog`. Without this sentinel, an
+ * idle wallet whose post-reset OpLog is empty MAY (depending on
+ * the snapshot builder's internal change-detection heuristic)
+ * skip building a fresh snapshot — leaving the aggregator chain
+ * stuck at the pre-reset version and the local floor at +1
+ * indefinitely until the user triggers another mutation.
+ *
+ * **Single slot.** The key is overwritten on every subsequent
+ * reset (the value is always the latest `newEpoch`), so the
+ * sentinel never accumulates across many resets. The post-publish
+ * cleanup is a no-op — the next reset just overwrites it.
+ */
+export const LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY =
+  'profile.pointer.epoch_reset_flush_trigger';
 
 /**
  * Parse a CAR byte buffer and return its root CID bytes, or `null`

--- a/profile/pointer-wiring.ts
+++ b/profile/pointer-wiring.ts
@@ -196,6 +196,16 @@ export interface PointerWiringInput {
 const LOCAL_VERSION_KEY = 'profile.pointer.version';
 
 /**
+ * Issue #310 — local cache key for the OpLog epoch floor. Single
+ * source of truth for the key namespace; the snapshot builder in
+ * `factory.ts` reads from the same key when stamping the next root
+ * block's `epoch` field.
+ */
+export const LOCAL_EPOCH_FLOOR_KEY = 'profile.pointer.epoch_floor';
+export const LOCAL_EPOCH_RESET_REASON_KEY =
+  'profile.pointer.epoch_reset_reason';
+
+/**
  * Parse a CAR byte buffer and return its root CID bytes, or `null`
  * if the CAR is malformed or has no roots. Dynamic import keeps
  * `@ipld/car` out of the hot path of tree-shaken browser bundles
@@ -648,6 +658,37 @@ export async function buildProfilePointerLayer(
       await input.localCache.set(LOCAL_VERSION_KEY, String(v));
     };
 
+    // Issue #310 — epoch floor read/write. Same pattern as the local
+    // version pair; fail-closed to 0 on any parse error so a
+    // corrupted cache cannot drive the walkback floor into an
+    // undefined state.
+    const readEpochFloor = async (): Promise<number> => {
+      const raw = await input.localCache.get(LOCAL_EPOCH_FLOOR_KEY);
+      if (raw === null) return 0;
+      const parsed = Number.parseInt(raw, 10);
+      if (
+        !Number.isFinite(parsed) ||
+        !Number.isInteger(parsed) ||
+        parsed < 0
+      ) {
+        return 0;
+      }
+      return parsed;
+    };
+    const persistEpochFloor = async (epoch: number): Promise<void> => {
+      if (
+        typeof epoch !== 'number' ||
+        !Number.isFinite(epoch) ||
+        !Number.isInteger(epoch) ||
+        epoch < 0
+      ) {
+        // Refuse to persist garbage; the pointer layer treats this as
+        // best-effort so a return is sufficient.
+        return;
+      }
+      await input.localCache.set(LOCAL_EPOCH_FLOOR_KEY, String(epoch));
+    };
+
     const resolveRemoteCid = buildResolveRemoteCid({
       keyMaterial,
       signer,
@@ -655,6 +696,64 @@ export async function buildProfilePointerLayer(
       trustBase,
       decodeCid,
     });
+
+    // Issue #310 — snapshot-epoch inspector. Re-resolve the CID for the
+    // given version, fetch the snapshot ROOT block (content-address
+    // verified by `fetchFromIpfs`), dag-cbor-decode the root, and
+    // return its `epoch` field (or undefined for pre-#310 snapshots).
+    const inspectSnapshotEpoch = async (
+      version: number,
+    ): Promise<number | undefined> => {
+      const cidBytes = await resolveRemoteCid(version);
+      if (input.ipfsGateways.length === 0) {
+        throw new Error(
+          `inspectSnapshotEpoch: no IPFS gateways configured for v=${version}`,
+        );
+      }
+      let cidString: string;
+      try {
+        cidString = CID.decode(cidBytes).toString();
+      } catch (err) {
+        throw new Error(
+          `inspectSnapshotEpoch: invalid CID bytes at v=${version}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      const rootBlockBytes = await fetchFromIpfs(
+        [...input.ipfsGateways],
+        cidString,
+      );
+      const { decode: cborDecode } = await import('@ipld/dag-cbor');
+      let decoded: unknown;
+      try {
+        decoded = cborDecode(rootBlockBytes);
+      } catch (err) {
+        throw new Error(
+          `inspectSnapshotEpoch: dag-cbor decode failed at v=${version}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      if (
+        decoded === null ||
+        typeof decoded !== 'object' ||
+        Array.isArray(decoded)
+      ) {
+        throw new Error(
+          `inspectSnapshotEpoch: root block decoded to non-object at v=${version}`,
+        );
+      }
+      const epoch = (decoded as Record<string, unknown>).epoch;
+      if (epoch === undefined) return undefined;
+      if (
+        typeof epoch !== 'number' ||
+        !Number.isFinite(epoch) ||
+        !Number.isInteger(epoch) ||
+        epoch < 0
+      ) {
+        throw new Error(
+          `inspectSnapshotEpoch: invalid epoch ${String(epoch)} at v=${version}`,
+        );
+      }
+      return epoch;
+    };
 
     // Item #15 Phase E: applySnapshot is the only sink for remote
     // pointer state. The precondition above (skip reason
@@ -679,6 +778,10 @@ export async function buildProfilePointerLayer(
       readLocalVersion,
       persistLocalVersion,
       resolveRemoteCid,
+      // Issue #310 — wire OpLog epoch-floor primitives.
+      readEpochFloor,
+      persistEpochFloor,
+      inspectSnapshotEpoch,
       config: input.config,
     });
 

--- a/profile/profile-handle.ts
+++ b/profile/profile-handle.ts
@@ -1,0 +1,167 @@
+/**
+ * Issue #310 — Profile-mode-only public API surface exposed on
+ * `sphere.profile`.
+ *
+ * The handle is created by `Sphere` and bound to:
+ *   - `ProfileStorageProvider` (for OrbitDB adapter + pointer-layer access)
+ *   - the per-storage encryption context (so the snapshot built by
+ *     the resets-publishCallback is encrypted with the wallet's
+ *     own keys)
+ *
+ * When the wallet is not in Profile mode (e.g., legacy IndexedDB-only
+ * storage), `Sphere.profile` returns `null`. Callers MUST null-check.
+ *
+ * Today's public surface:
+ *
+ *   - `resetEpoch({ reason })` — wipes the local OpLog, mints a new
+ *     synthetic genesis carrying the in-memory snapshot, bumps the
+ *     epoch by exactly +1, and publishes a new aggregator pointer
+ *     so all clients refuse to walk back past the new floor.
+ *
+ *   - `getEpochFloor()` — read the wallet's currently-persisted
+ *     epoch floor (the highest epoch ever observed on-chain OR
+ *     produced via `resetEpoch`).
+ *
+ * @module profile/profile-handle
+ */
+
+import type { SphereEventMap, SphereEventType } from '../types/index.js';
+
+/**
+ * Result of `sphere.profile.resetEpoch()`.
+ */
+export interface ResetEpochResult {
+  /**
+   * The new epoch stamped into the freshly-minted OpLog snapshot.
+   * Strictly `prev.epoch + 1`. Persisted into the wallet's local
+   * epoch-floor cache so subsequent walkback inspections refuse to
+   * load any predecessor with `epoch < newEpoch`.
+   */
+  readonly newEpoch: number;
+  /** The reason string supplied by the caller (truncated/validated). */
+  readonly reason: string;
+  /** Wall-clock timestamp of the reset (ms since epoch). */
+  readonly ts: number;
+  /**
+   * The aggregator-pointer version the publish landed at (or 0 if
+   * the publish did not run / failed gracefully — the local reset
+   * is still durable in that case; the publish will be retried on
+   * the next dirty-flush cycle).
+   */
+  readonly publishedVersion: number;
+}
+
+/**
+ * Parameters accepted by `sphere.profile.resetEpoch()`.
+ */
+export interface ResetEpochParams {
+  /**
+   * Operator triage reason captured into the post-reset snapshot's
+   * `epochResetReason` field. Free-form ASCII; capped at
+   * `EPOCH_RESET_REASON_MAX_BYTES`. REQUIRED — callers MUST supply
+   * a reason to make the audit trail actionable.
+   *
+   * Examples:
+   *   - `'oplog-corruption-recovery'`
+   *   - `'user-initiated-from-settings'`
+   *   - `'cidref-missing-block-bafyreih...'`
+   */
+  readonly reason: string;
+}
+
+/**
+ * Issue #310 — Profile-mode-only API handle.
+ *
+ * Returned by `Sphere.profile` when (and only when) the wallet's
+ * StorageProvider is a `ProfileStorageProvider`. Legacy / non-Profile
+ * wallets see `null` and MUST surface a clear "this operation requires
+ * Profile mode" message in the UI.
+ */
+export interface SphereProfileHandle {
+  /**
+   * Wipe the local OpLog and start a fresh one with a permanent
+   * floor that all clients (this device AND any second device
+   * replicating the same wallet) honor.
+   *
+   * Operation:
+   *   1. Snapshot in-memory state (identity, tokens, tracked
+   *      addresses) into a transient buffer.
+   *   2. Wipe the local OrbitDB OpLog via
+   *      `OrbitDbAdapter.resetCorruptedLog`.
+   *   3. Mint a fresh OpLog. Write the snapshot's KV entries back
+   *      via the normal storage-provider write path (which lands
+   *      them in the fresh OpLog).
+   *   4. Bump the persisted epoch floor by exactly +1 and trigger
+   *      a dirty-flush so the next snapshot's root block carries
+   *      `epoch = newEpoch` and the new aggregator-pointer version
+   *      publishes.
+   *   5. Emit `profile:epoch-reset` on the Sphere event bus.
+   *
+   * Idempotency: calling `resetEpoch` a second time lands a NEW
+   * +1 epoch — it does NOT skip. Each invocation is a distinct
+   * user-affirmed reset.
+   *
+   * Crash-safety: every step persists durably before the next runs.
+   * A crash between steps leaves the wallet in a state where the
+   * next `Sphere.load()` either resumes from the half-reset (and
+   * the next dirty-flush completes the publish) or — in the worst
+   * case — re-runs the reset on operator request. Partial-reset
+   * MUST NOT leave the wallet unloadable.
+   *
+   * Concurrent calls: a per-instance mutex serializes concurrent
+   * `resetEpoch` invocations on the same `Sphere` so each call
+   * lands its OWN +1 bump (consistent with the
+   * idempotency-against-re-runs contract). The two calls are NOT
+   * deduplicated.
+   *
+   * Concurrent SENDS: this method does NOT block sends from the
+   * surrounding PaymentsModule. A send in-flight while the OpLog is
+   * being wiped surfaces as a write error from the dispatcher's
+   * retry path; the user-facing operation either fails or retries
+   * automatically against the fresh OpLog. Callers SHOULD quiesce
+   * the wallet (stop active sends, pause the swap module) before
+   * invoking `resetEpoch` to keep the recovery deterministic; a UI
+   * implementation should surface a confirmation dialog that gates
+   * the call on a quiesced state. The SDK does not enforce this
+   * because no general-purpose "stop all writes" primitive exists at
+   * the Sphere level.
+   *
+   * @throws SphereError('NOT_PROFILE_MODE') if called when not in
+   *         Profile mode (this should never happen — `Sphere.profile`
+   *         returns `null` for non-Profile wallets, so the API is
+   *         unreachable; the defensive throw guards against
+   *         operator misuse via reflection).
+   * @throws SphereError('PROFILE_RESET_FAILED', { cause }) if any
+   *         step throws. The wallet is left in the half-reset state
+   *         described above; the next `Sphere.load()` will resume.
+   */
+  resetEpoch(params: ResetEpochParams): Promise<ResetEpochResult>;
+
+  /**
+   * Read the wallet's currently-persisted epoch floor. Returns 0 for
+   * a pre-#310 wallet that has never observed a higher epoch on-chain
+   * AND has never invoked `resetEpoch`.
+   */
+  getEpochFloor(): Promise<number>;
+}
+
+/**
+ * Event payload for `'profile:epoch-reset'` — fired AFTER the new
+ * epoch is persisted locally and the publish has been kicked off
+ * (the publish is best-effort; the event fires whether or not the
+ * publish succeeded).
+ */
+export interface ProfileEpochResetEvent {
+  /** The newly-minted epoch (= prior + 1). */
+  readonly newEpoch: number;
+  /** Operator triage reason captured from the caller. */
+  readonly reason: string;
+  /** Wall-clock timestamp of the reset (ms since epoch). */
+  readonly ts: number;
+}
+
+// Re-exports for downstream wiring.
+export type {
+  SphereEventMap as _SphereEventMap,
+  SphereEventType as _SphereEventType,
+};

--- a/profile/profile-handle.ts
+++ b/profile/profile-handle.ts
@@ -45,16 +45,22 @@ export interface ResetEpochResult {
   /** Wall-clock timestamp of the reset (ms since epoch). */
   readonly ts: number;
   /**
-   * The aggregator-pointer version the publish landed at (or 0 if
-   * the publish did not run / failed gracefully — the local reset
-   * is still durable in that case; the publish will be retried on
-   * the next dirty-flush cycle).
+   * PR #316 F2 fix — the aggregator-pointer version the post-reset
+   * publish landed at. Populated when the publish completed within
+   * the bounded `publishTimeoutMs` window (default 30 000 ms); `0`
+   * otherwise.
    *
-   * NOTE: PR #316 F1 baseline keeps this hardcoded to `0` —
-   * populating it from the post-reset publish is delivered in the
-   * separate F2 commit. Callers reading this field on the F1
-   * commit should treat it as "publish state unknown; observe
-   * `'storage:pointer-published'` for the actual outcome".
+   * `publishedVersion === 0` is a SOFT signal, NOT a failure:
+   * `'profile:epoch-reset-publish-pending'` is emitted with the same
+   * `newEpoch`, and the periodic-poll / next dirty-flush will land
+   * the publish on the wallet's behalf. Callers can also subscribe
+   * to `'storage:pointer-published'` to observe the eventual landing.
+   *
+   * The wait is implemented as a one-shot listener on the storage
+   * provider's `'storage:pointer-published'` event (which fires
+   * UNCONDITIONALLY on every successful publish — see lifecycle-
+   * manager). Set `publishTimeoutMs: 0` in {@link ResetEpochParams}
+   * to skip the wait entirely.
    */
   readonly publishedVersion: number;
   /**
@@ -99,6 +105,15 @@ export interface ResetEpochParams {
    * cannot then be enforced).
    */
   readonly discoveryTimeoutMs?: number;
+  /**
+   * PR #316 F2 fix — bounded timeout (ms) for the post-bump publish
+   * await. Default: 30 000. On timeout,
+   * `'profile:epoch-reset-publish-pending'` is emitted and
+   * `publishedVersion: 0` is returned; the periodic-poll path will
+   * republish in the background. Set to `0` to skip the await
+   * entirely (caller does not need the version).
+   */
+  readonly publishTimeoutMs?: number;
 }
 
 /**
@@ -134,7 +149,15 @@ export interface SphereProfileHandle {
    *   6. Persist the new epoch floor and trigger a dirty-flush so
    *      the next snapshot's root block carries `epoch = newEpoch`
    *      and the new aggregator-pointer version publishes.
-   *   7. Emit `profile:epoch-reset` on the Sphere event bus.
+   *   7. (PR #316 F2 fix) **Await the publish** via the
+   *      `'storage:pointer-published'` event with a bounded timeout
+   *      (default 30 000 ms; configurable via `publishTimeoutMs`).
+   *      On observe, `publishedVersion` is set to the landed pointer
+   *      version. On timeout,
+   *      `'profile:epoch-reset-publish-pending'` is emitted and
+   *      `publishedVersion === 0` is returned — the periodic poll
+   *      will republish.
+   *   8. Emit `profile:epoch-reset` on the Sphere event bus.
    *
    * Idempotency: calling `resetEpoch` a second time lands a NEW
    * +1 epoch — it does NOT skip. Each invocation is a distinct

--- a/profile/profile-handle.ts
+++ b/profile/profile-handle.ts
@@ -146,9 +146,16 @@ export interface SphereProfileHandle {
    *   5. Mint a fresh OpLog. Write the snapshot's KV entries back
    *      via the normal storage-provider write path (which lands
    *      them in the fresh OpLog).
-   *   6. Persist the new epoch floor and trigger a dirty-flush so
-   *      the next snapshot's root block carries `epoch = newEpoch`
-   *      and the new aggregator-pointer version publishes.
+   *   6a. Persist the new epoch floor.
+   *   6b. (PR #316 F3 fix) **Write a sentinel KV** under
+   *       `LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY` AFTER the OpLog
+   *       wipe so the snapshot builder has concrete OpLog dirty
+   *       state even when no other writers have mutated yet. The
+   *       sentinel is a single slot — overwritten on every reset,
+   *       never accumulates.
+   *   6c. Trigger a dirty-flush so the next snapshot's root block
+   *       carries `epoch = newEpoch` and the new aggregator-pointer
+   *       version publishes.
    *   7. (PR #316 F2 fix) **Await the publish** via the
    *      `'storage:pointer-published'` event with a bounded timeout
    *      (default 30 000 ms; configurable via `publishTimeoutMs`).

--- a/profile/profile-handle.ts
+++ b/profile/profile-handle.ts
@@ -33,7 +33,9 @@ import type { SphereEventMap, SphereEventType } from '../types/index.js';
 export interface ResetEpochResult {
   /**
    * The new epoch stamped into the freshly-minted OpLog snapshot.
-   * Strictly `prev.epoch + 1`. Persisted into the wallet's local
+   * Strictly `max(localFloor, discoveredFloor) + 1`, where
+   * `discoveredFloor` is the highest epoch observed on-chain at
+   * call time (PR #316 F1 fix). Persisted into the wallet's local
    * epoch-floor cache so subsequent walkback inspections refuse to
    * load any predecessor with `epoch < newEpoch`.
    */
@@ -47,8 +49,28 @@ export interface ResetEpochResult {
    * the publish did not run / failed gracefully — the local reset
    * is still durable in that case; the publish will be retried on
    * the next dirty-flush cycle).
+   *
+   * NOTE: PR #316 F1 baseline keeps this hardcoded to `0` —
+   * populating it from the post-reset publish is delivered in the
+   * separate F2 commit. Callers reading this field on the F1
+   * commit should treat it as "publish state unknown; observe
+   * `'storage:pointer-published'` for the actual outcome".
    */
   readonly publishedVersion: number;
+  /**
+   * PR #316 F1 fix — `true` when the on-chain epoch floor was
+   * consulted before bumping. `false` when the discovery RPC failed
+   * (network / aggregator down): the bump was computed from the
+   * local floor alone and is PROVISIONAL.
+   *
+   * A `false` result is rare — discovery uses the same RPC stack as
+   * the publish path, so a `false` here is usually accompanied by a
+   * `publishedVersion: 0` result (publish also failed). Callers in
+   * sibling-device deployments SHOULD surface a warning when this is
+   * `false`, since cross-device monotonicity was not verified at
+   * mint time.
+   */
+  readonly discoveryConsulted: boolean;
 }
 
 /**
@@ -67,6 +89,16 @@ export interface ResetEpochParams {
    *   - `'cidref-missing-block-bafyreih...'`
    */
   readonly reason: string;
+  /**
+   * PR #316 F1 fix — bounded timeout (ms) for the pre-bump
+   * discovery RPC. Default: 15 000. On timeout, the bump proceeds
+   * from the local floor alone and is PROVISIONAL (see
+   * `discoveryConsulted` in {@link ResetEpochResult}). Set to
+   * `0` to skip discovery entirely (test-only escape hatch — NOT
+   * recommended in production because cross-device monotonicity
+   * cannot then be enforced).
+   */
+  readonly discoveryTimeoutMs?: number;
 }
 
 /**
@@ -84,18 +116,25 @@ export interface SphereProfileHandle {
    * replicating the same wallet) honor.
    *
    * Operation:
-   *   1. Snapshot in-memory state (identity, tokens, tracked
+   *   1. (PR #316 F1 fix) **Consult the on-chain epoch floor.** Run a
+   *      best-effort `pointer.discoverLatestVersion()` with a bounded
+   *      timeout to capture `discoveredFloor = pickedEpoch` from
+   *      Phase-3 walkback. On RPC failure the discovered floor is
+   *      treated as 0 and `'profile:epoch-reset-discovery-skipped'`
+   *      is emitted; the bump proceeds from the local floor alone
+   *      and is PROVISIONAL.
+   *   2. Compute `newEpoch = max(localFloor, discoveredFloor) + 1`.
+   *   3. Snapshot in-memory state (identity, tokens, tracked
    *      addresses) into a transient buffer.
-   *   2. Wipe the local OrbitDB OpLog via
+   *   4. Wipe the local OrbitDB OpLog via
    *      `OrbitDbAdapter.resetCorruptedLog`.
-   *   3. Mint a fresh OpLog. Write the snapshot's KV entries back
+   *   5. Mint a fresh OpLog. Write the snapshot's KV entries back
    *      via the normal storage-provider write path (which lands
    *      them in the fresh OpLog).
-   *   4. Bump the persisted epoch floor by exactly +1 and trigger
-   *      a dirty-flush so the next snapshot's root block carries
-   *      `epoch = newEpoch` and the new aggregator-pointer version
-   *      publishes.
-   *   5. Emit `profile:epoch-reset` on the Sphere event bus.
+   *   6. Persist the new epoch floor and trigger a dirty-flush so
+   *      the next snapshot's root block carries `epoch = newEpoch`
+   *      and the new aggregator-pointer version publishes.
+   *   7. Emit `profile:epoch-reset` on the Sphere event bus.
    *
    * Idempotency: calling `resetEpoch` a second time lands a NEW
    * +1 epoch — it does NOT skip. Each invocation is a distinct
@@ -107,6 +146,21 @@ export interface SphereProfileHandle {
    * the next dirty-flush completes the publish) or — in the worst
    * case — re-runs the reset on operator request. Partial-reset
    * MUST NOT leave the wallet unloadable.
+   *
+   * Cross-device monotonicity (PR #316 F1 fix). Two devices A and B
+   * sharing the same wallet identity that both call `resetEpoch`
+   * concurrently SHOULD each observe the same `discoveredFloor`
+   * (assuming the aggregator's read-replica lag is below
+   * `discoveryTimeoutMs`). Each device bumps to
+   * `max(local, discovered) + 1` — if A is already at epoch N and B
+   * is at N, both bump to N+1. The first to land the publish wins;
+   * the second hits `WALKBACK_FLOOR` on its next publish attempt
+   * and re-discovers (now seeing the winner's N+1 on-chain), so its
+   * NEXT bump goes to N+2. The convergence window is bounded by the
+   * aggregator's read-replica lag. For DEVICES with disjoint
+   * aggregator views (network partition), this fix cannot prevent
+   * a temporary divergence — the cross-device walkback floor on the
+   * pointer-pointer (see `epoch-floor.ts`) eventually catches up.
    *
    * Concurrent calls: a per-instance mutex serializes concurrent
    * `resetEpoch` invocations on the same `Sphere` so each call

--- a/profile/profile-lean-snapshot.ts
+++ b/profile/profile-lean-snapshot.ts
@@ -139,6 +139,18 @@ function groupKeyFor(key: string): string {
  */
 export const LEAN_DEFAULT_MAX_SNAPSHOT_BYTES = 256 * 1024 * 1024;
 
+/**
+ * Issue #310 — hard cap on the `epochResetReason` string (UTF-8 bytes).
+ */
+export const EPOCH_RESET_REASON_MAX_BYTES = 256;
+
+/**
+ * Issue #310 — hard ceiling on the epoch field. Fail-closed at decode
+ * time rather than silently lose monotonicity. 2^20 (≈ 1 million)
+ * is multiple orders of magnitude above any plausible value.
+ */
+export const EPOCH_MAX = 1 << 20;
+
 /** Soft cap on number of KV entries we'll embed (matches v1). */
 const MAX_KV_ENTRIES = 100_000;
 
@@ -251,6 +263,23 @@ export interface LeanProfileSnapshot {
   /** Snapshot timestamp (ms since epoch). */
   readonly createdAt: number;
   /**
+   * Issue #310 — OpLog epoch floor. Default 0 for pre-#310 wallets
+   * (treated equivalently to "epoch 0" by walkback algorithms). Bumped
+   * by exactly +1 by `sphere.profile.resetEpoch()` each time the user
+   * abandons a corrupted OpLog. Once published, all clients refuse to
+   * walk back to any version whose snapshot carries `epoch < max(epoch)`.
+   *
+   * Backwards-compatible: readers that don't recognize the field treat
+   * it as `0`. Forward-compatible: writers may include the field even
+   * when 0 — readers ignore.
+   */
+  readonly epoch?: number;
+  /**
+   * Issue #310 — optional reset reason captured for operator triage.
+   * Free-form ASCII; capped at EPOCH_RESET_REASON_MAX_BYTES on encode.
+   */
+  readonly epochResetReason?: string;
+  /**
    * All Profile KV entries that should propagate (encrypted form),
    * fully materialised across every entry group. Sorted by `key`.
    */
@@ -282,6 +311,9 @@ export interface LeanProfileSnapshotPartial {
   readonly chainPubkey: string;
   readonly network: string;
   readonly createdAt: number;
+  /** Issue #310 — OpLog epoch floor (default 0). See {@link LeanProfileSnapshot.epoch}. */
+  readonly epoch?: number;
+  readonly epochResetReason?: string;
   readonly entries: ReadonlyArray<LeanProfileSnapshotKvEntry>;
   readonly entryGroups: ReadonlyArray<LeanProfileSnapshotEntryGroupRef>;
   readonly bundles: ReadonlyArray<LeanProfileSnapshotBundleEntry>;
@@ -339,6 +371,17 @@ export interface BuildLeanProfileSnapshotOptions {
    * @see docs/uxf/OUTBOX-SEND-FOLLOWUPS.md
    */
   readonly gcExpiredTombstones?: () => Promise<void>;
+  /**
+   * Issue #310 — OpLog epoch to stamp into the snapshot root. Pre-#310
+   * callers leave undefined → root block omits the field → readers
+   * treat it as epoch=0 (backwards-compatible).
+   */
+  readonly epoch?: number;
+  /**
+   * Issue #310 — operator triage reason captured at reset time.
+   * Capped at EPOCH_RESET_REASON_MAX_BYTES.
+   */
+  readonly epochResetReason?: string;
 }
 
 /** Diagnostic counters surfaced to callers. */
@@ -570,7 +613,9 @@ async function assembleCarBytes(
   // dag-cbor's built-in CID-link tagging via the CID instance type).
   const { groupRefs, groupBlocks } = buildEntryGroupBlocks(snapshot.entries);
 
-  const rootBytes = dagCborEncode({
+  // Issue #310 — emit epoch / epochResetReason iff explicitly provided.
+  // Pre-#310 wallets produce byte-identical root blocks (no fields added).
+  const rootDoc: Record<string, unknown> = {
     version: LEAN_PROFILE_SNAPSHOT_VERSION,
     chainPubkey: snapshot.chainPubkey,
     network: snapshot.network,
@@ -592,7 +637,14 @@ async function assembleCarBytes(
       if (b.tokenCount !== undefined) obj.tokenCount = b.tokenCount;
       return obj;
     }),
-  });
+  };
+  if (snapshot.epoch !== undefined) {
+    rootDoc.epoch = snapshot.epoch;
+  }
+  if (snapshot.epochResetReason !== undefined) {
+    rootDoc.epochResetReason = snapshot.epochResetReason;
+  }
+  const rootBytes = dagCborEncode(rootDoc);
 
   // Per-block byte cap fires on the root block itself.
   if (rootBytes.byteLength > PROFILE_CAR_IMPORT_MAX_BLOCK_BYTES) {
@@ -682,6 +734,42 @@ export async function buildLeanProfileSnapshot(
   const entries = await readAllKvEntries(options.storage);
   const bundles = await readBundleRefs(options.tokenStorage);
 
+  // Issue #310 — validate the epoch input at the build seam.
+  let normalizedEpoch: number | undefined;
+  if (options.epoch !== undefined) {
+    if (
+      typeof options.epoch !== 'number' ||
+      !Number.isFinite(options.epoch) ||
+      !Number.isInteger(options.epoch) ||
+      options.epoch < 0 ||
+      options.epoch > EPOCH_MAX
+    ) {
+      throw new ProfileError(
+        'PROFILE_NOT_INITIALIZED',
+        `Lean snapshot: epoch must be integer in [0, ${EPOCH_MAX}]; got ${String(options.epoch)}`,
+      );
+    }
+    normalizedEpoch = options.epoch;
+  }
+
+  let normalizedReason: string | undefined;
+  if (options.epochResetReason !== undefined) {
+    if (typeof options.epochResetReason !== 'string') {
+      throw new ProfileError(
+        'PROFILE_NOT_INITIALIZED',
+        `Lean snapshot: epochResetReason must be a string`,
+      );
+    }
+    const reasonBytes = new TextEncoder().encode(options.epochResetReason);
+    if (reasonBytes.byteLength > EPOCH_RESET_REASON_MAX_BYTES) {
+      throw new ProfileError(
+        'PROFILE_NOT_INITIALIZED',
+        `Lean snapshot: epochResetReason ${reasonBytes.byteLength} bytes exceeds cap ${EPOCH_RESET_REASON_MAX_BYTES}`,
+      );
+    }
+    normalizedReason = options.epochResetReason;
+  }
+
   // `entryGroups` is constructed inside `assembleCarBytes` from
   // `entries`, so the build-time view holds an empty list. The parser
   // populates it on the read side from the actual root block.
@@ -690,6 +778,10 @@ export async function buildLeanProfileSnapshot(
     chainPubkey: options.chainPubkey,
     network: options.network,
     createdAt: options.createdAt ?? Date.now(),
+    ...(normalizedEpoch !== undefined ? { epoch: normalizedEpoch } : {}),
+    ...(normalizedReason !== undefined
+      ? { epochResetReason: normalizedReason }
+      : {}),
     entries,
     entryGroups: [],
     bundles,
@@ -765,6 +857,11 @@ export async function parseLeanProfileSnapshot(
     chainPubkey: validated.chainPubkey,
     network: validated.network,
     createdAt: validated.createdAt,
+    // Issue #310 — propagate epoch / epochResetReason iff present.
+    ...(validated.epoch !== undefined ? { epoch: validated.epoch } : {}),
+    ...(validated.epochResetReason !== undefined
+      ? { epochResetReason: validated.epochResetReason }
+      : {}),
     entries,
     entryGroups: validated.entryGroups,
     bundles: validated.bundles,
@@ -927,6 +1024,11 @@ export async function parseLeanProfileSnapshotFromRootBlock(
       chainPubkey: validated.chainPubkey,
       network: validated.network,
       createdAt: validated.createdAt,
+      // Issue #310 — propagate epoch / epochResetReason iff present.
+      ...(validated.epoch !== undefined ? { epoch: validated.epoch } : {}),
+      ...(validated.epochResetReason !== undefined
+        ? { epochResetReason: validated.epochResetReason }
+        : {}),
       entries: [],
       entryGroups: validated.entryGroups,
       bundles: validated.bundles,
@@ -942,6 +1044,11 @@ export async function parseLeanProfileSnapshotFromRootBlock(
     chainPubkey: validated.chainPubkey,
     network: validated.network,
     createdAt: validated.createdAt,
+    // Issue #310 — propagate epoch / epochResetReason iff present.
+    ...(validated.epoch !== undefined ? { epoch: validated.epoch } : {}),
+    ...(validated.epochResetReason !== undefined
+      ? { epochResetReason: validated.epochResetReason }
+      : {}),
     entries,
     entryGroups: validated.entryGroups,
     bundles: validated.bundles,
@@ -1015,6 +1122,11 @@ export async function parseLeanProfileSnapshotPartial(
     chainPubkey: validated.chainPubkey,
     network: validated.network,
     createdAt: validated.createdAt,
+    // Issue #310 — propagate epoch / epochResetReason iff present.
+    ...(validated.epoch !== undefined ? { epoch: validated.epoch } : {}),
+    ...(validated.epochResetReason !== undefined
+      ? { epochResetReason: validated.epochResetReason }
+      : {}),
     entries,
     entryGroups: validated.entryGroups,
     bundles: validated.bundles,
@@ -1232,11 +1344,51 @@ function validateLeanSnapshotShape(decoded: unknown): LeanProfileSnapshot {
   const entryGroups = parseV3EntryGroups(obj.entryGroups);
   const bundles = parseBundleEntries(obj.bundles);
 
+  // Issue #310 — read epoch (default 0 for pre-#310 / omitted field).
+  // A present-but-malformed field is fail-closed corruption signal.
+  let epoch: number | undefined;
+  if (obj.epoch !== undefined) {
+    const e = obj.epoch;
+    if (
+      typeof e !== 'number' ||
+      !Number.isFinite(e) ||
+      !Number.isInteger(e) ||
+      e < 0 ||
+      e > EPOCH_MAX
+    ) {
+      throw new ProfileError(
+        'PROFILE_NOT_INITIALIZED',
+        `Lean snapshot: invalid epoch ${String(e)} (must be integer in [0, ${EPOCH_MAX}])`,
+      );
+    }
+    epoch = e;
+  }
+  let epochResetReason: string | undefined;
+  if (obj.epochResetReason !== undefined) {
+    const r = obj.epochResetReason;
+    if (typeof r !== 'string') {
+      throw new ProfileError(
+        'PROFILE_NOT_INITIALIZED',
+        `Lean snapshot: invalid epochResetReason ${typeof r} (must be string)`,
+      );
+    }
+    const rBytes = new TextEncoder().encode(r);
+    if (rBytes.byteLength > EPOCH_RESET_REASON_MAX_BYTES) {
+      throw new ProfileError(
+        'PROFILE_NOT_INITIALIZED',
+        `Lean snapshot: epochResetReason ${rBytes.byteLength} bytes exceeds cap ${EPOCH_RESET_REASON_MAX_BYTES}`,
+      );
+    }
+    epochResetReason = r;
+  }
+
   const result: LeanProfileSnapshot = {
     version: LEAN_PROFILE_SNAPSHOT_VERSION,
     chainPubkey,
     network,
     createdAt,
+    ...(epoch !== undefined ? { epoch } : {}),
+    ...(epochResetReason !== undefined ? { epochResetReason } : {}),
     entries: [],
     entryGroups,
     bundles,

--- a/profile/profile-storage-provider.ts
+++ b/profile/profile-storage-provider.ts
@@ -972,6 +972,33 @@ export class ProfileStorageProvider implements StorageProvider {
   }
 
   /**
+   * Issue #310 — expose the underlying OrbitDB adapter (read-only,
+   * not mutable) so the `sphere.profile.resetEpoch` API can invoke
+   * `resetCorruptedLog` without leaking the inner state machine.
+   *
+   * Returns `null` when the adapter exposes no `resetCorruptedLog`
+   * method (test stub / pre-#305 fork). Callers MUST treat null as
+   * "wipe unavailable" and proceed with the epoch bump alone.
+   */
+  getOrbitDbAdapter(): {
+    readonly resetCorruptedLog?: (reason: {
+      lostHeadCid?: string;
+      context: string;
+    }) => Promise<unknown>;
+  } | null {
+    const db = this.db as unknown as {
+      resetCorruptedLog?: (reason: {
+        lostHeadCid?: string;
+        context: string;
+      }) => Promise<unknown>;
+    };
+    if (typeof db.resetCorruptedLog === 'function') {
+      return db;
+    }
+    return null;
+  }
+
+  /**
    * Steelman accessor: the pointer-build state machine viewed from the
    * outside.
    *   - 'ready'       — `pointerLayer !== null`.

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -1432,6 +1432,23 @@ export class LifecycleManager {
           );
           winBroadcastsOn = false;
         }
+        // PR #316 F2 fix — emit `storage:pointer-published` UNCONDITIONALLY
+        // on every successful publish. Previously this event only fired when
+        // `winBroadcastsOn === true` (issue #264 default-OFF gate), so any
+        // listener wanting a "publish landed" signal (e.g.,
+        // `sphere.profile.resetEpoch` awaiting the post-bump version) was
+        // dead-on-arrival in the default config.
+        //
+        // The event shape now carries `cid` + `version` + `attemptsUsed`
+        // on every emit. The `signedPayloadJson` / `broadcastTag` fields
+        // remain conditional on `winBroadcastsOn` — Sphere's
+        // `forwardPointerPublishedToNostr` already short-circuits when
+        // they are absent (see the type-narrow check in core/Sphere.ts).
+        // Sphere's `maybeInstallPointerWinSubscription` also gates on
+        // `winBroadcastsEnabled()` so the unconditional emit cannot
+        // accidentally arm a sibling subscription.
+        let signedPayloadJson: string | undefined;
+        let broadcastTag: string | undefined;
         if (winBroadcastsOn) {
           try {
             const signerHandle = pointer.getSignerForWinBroadcast();
@@ -1443,17 +1460,8 @@ export class LifecycleManager {
               signingPubKey: signerHandle.signingPubKeyHex,
               ts: Date.now(),
             });
-            this.host.emitEvent({
-              type: 'storage:pointer-published',
-              timestamp: Date.now(),
-              data: {
-                cid: cidString,
-                version: result.version,
-                attemptsUsed: result.attemptsUsed,
-                signedPayloadJson: JSON.stringify(signed),
-                broadcastTag: buildWinBroadcastTag(signerHandle.signingPubKeyHex),
-              },
-            });
+            signedPayloadJson = JSON.stringify(signed);
+            broadcastTag = buildWinBroadcastTag(signerHandle.signingPubKeyHex);
           } catch (broadcastErr) {
             const errMsg =
               broadcastErr instanceof Error
@@ -1465,6 +1473,17 @@ export class LifecycleManager {
             );
           }
         }
+        this.host.emitEvent({
+          type: 'storage:pointer-published',
+          timestamp: Date.now(),
+          data: {
+            cid: cidString,
+            version: result.version,
+            attemptsUsed: result.attemptsUsed,
+            ...(signedPayloadJson !== undefined ? { signedPayloadJson } : {}),
+            ...(broadcastTag !== undefined ? { broadcastTag } : {}),
+          },
+        });
         return { ok: true, transient: false } as const;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/tests/unit/core/Sphere.profile-reset-epoch.test.ts
+++ b/tests/unit/core/Sphere.profile-reset-epoch.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Issue #310 — `sphere.profile.resetEpoch()` unit tests.
+ *
+ * The public surface is gated on Profile mode (the storage provider
+ * MUST expose `getPointerLayer`). These tests use the same minimal
+ * harness pattern as the sibling `Sphere.profile-wiring.test.ts`:
+ * we construct an `Object.create(Sphere.prototype)` partial instance
+ * with just the fields read by the resetEpoch path, then invoke the
+ * private method via reflection.
+ *
+ * Coverage:
+ *   - `sphere.profile === null` for non-Profile (legacy) storage
+ *   - `sphere.profile` returns a handle for Profile-mode storage
+ *   - `resetEpoch({reason})` bumps the local floor by +1
+ *   - `resetEpoch` is idempotent (second call lands a NEW +1)
+ *   - `resetEpoch` emits `profile:epoch-reset` with the right payload
+ *   - `resetEpoch` writes the reason into local storage
+ *   - `getEpochFloor()` returns the persisted floor
+ *   - non-empty reason cap enforcement
+ *   - OrbitDB adapter's `resetCorruptedLog` is invoked when available
+ *   - OrbitDB adapter failure is non-fatal (epoch bump still happens)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { Sphere } from '../../../core/Sphere';
+import { SphereError } from '../../../core/errors';
+import {
+  LOCAL_EPOCH_FLOOR_KEY,
+  LOCAL_EPOCH_RESET_REASON_KEY,
+} from '../../../profile/pointer-wiring';
+import { EPOCH_RESET_REASON_MAX_BYTES } from '../../../profile/profile-lean-snapshot';
+import type { SphereEventMap } from '../../../types';
+
+// =============================================================================
+// Minimal storage stubs
+// =============================================================================
+
+interface InMemoryKv {
+  readonly store: Map<string, string>;
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+}
+
+function makeKv(): InMemoryKv {
+  const store = new Map<string, string>();
+  return {
+    store,
+    async get(k) {
+      return store.get(k) ?? null;
+    },
+    async set(k, v) {
+      store.set(k, v);
+    },
+  };
+}
+
+interface LegacyStorageStub extends InMemoryKv {}
+interface ProfileStorageStub extends InMemoryKv {
+  getPointerLayer(): unknown | null;
+  getOrbitDbAdapter?(): {
+    resetCorruptedLog?: (reason: {
+      lostHeadCid?: string;
+      context: string;
+    }) => Promise<void>;
+  } | null;
+}
+
+function makeLegacyStorage(): LegacyStorageStub {
+  return makeKv();
+}
+
+function makeProfileStorage(opts: {
+  withAdapter?: boolean;
+  resetThrows?: boolean;
+  resetCalls?: Array<{ context: string }>;
+} = {}): ProfileStorageStub {
+  const kv = makeKv();
+  const result: ProfileStorageStub = {
+    ...kv,
+    getPointerLayer: () => ({}), // any truthy value is enough; the
+                                 // Sphere code only checks the method's
+                                 // presence
+  };
+  if (opts.withAdapter) {
+    result.getOrbitDbAdapter = () => ({
+      resetCorruptedLog: async (reason) => {
+        opts.resetCalls?.push({ context: reason.context });
+        if (opts.resetThrows) {
+          throw new Error('synthetic adapter failure');
+        }
+      },
+    });
+  }
+  return result;
+}
+
+// =============================================================================
+// Sphere harness
+// =============================================================================
+
+interface SphereLike {
+  _storage: unknown;
+  _tokenStorageProviders: Map<string, unknown>;
+  eventHandlers: Map<string, Set<(data: unknown) => void>>;
+  profile: ReturnType<Sphere['profile']['valueOf']> extends never
+    ? unknown
+    : Sphere['profile'];
+}
+
+function buildSphereLike(storage: unknown): {
+  sphere: Sphere;
+  events: Array<{ type: string; payload: unknown }>;
+} {
+  // Object.create(Sphere.prototype) keeps the prototype chain so the
+  // `get profile()` accessor + the private `resetEpochImpl` are
+  // reachable. We only populate the fields actually read by the
+  // resetEpoch code path.
+  const sphereLike = Object.create(Sphere.prototype) as SphereLike;
+  sphereLike._storage = storage;
+  sphereLike._tokenStorageProviders = new Map();
+  sphereLike.eventHandlers = new Map();
+
+  const events: Array<{ type: string; payload: unknown }> = [];
+  // Subscribe via the public `on()` method to test the emit path.
+  (sphereLike as unknown as Sphere).on(
+    'profile:epoch-reset',
+    (payload: SphereEventMap['profile:epoch-reset']) => {
+      events.push({ type: 'profile:epoch-reset', payload });
+    },
+  );
+
+  return { sphere: sphereLike as unknown as Sphere, events };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Sphere.profile — legacy storage', () => {
+  it('returns null when storage has no getPointerLayer', () => {
+    const { sphere } = buildSphereLike(makeLegacyStorage());
+    expect(sphere.profile).toBeNull();
+  });
+});
+
+describe('Sphere.profile — Profile-mode storage', () => {
+  it('returns a non-null handle when storage exposes getPointerLayer', () => {
+    const { sphere } = buildSphereLike(makeProfileStorage());
+    const handle = sphere.profile;
+    expect(handle).not.toBeNull();
+    expect(typeof handle!.resetEpoch).toBe('function');
+    expect(typeof handle!.getEpochFloor).toBe('function');
+  });
+
+  it('getEpochFloor() returns 0 for a fresh wallet', async () => {
+    const { sphere } = buildSphereLike(makeProfileStorage());
+    const floor = await sphere.profile!.getEpochFloor();
+    expect(floor).toBe(0);
+  });
+});
+
+describe('Sphere.profile.resetEpoch()', () => {
+  it('throws NOT_PROFILE_MODE when called via reflection on legacy storage', async () => {
+    // Defensive: the public `Sphere.profile` returns null for legacy
+    // storage, so this path should be unreachable from a properly-
+    // typed caller. Test the defensive throw anyway.
+    const storage = makeLegacyStorage();
+    const { sphere } = buildSphereLike(storage);
+    const resetEpochImpl = (sphere as unknown as {
+      resetEpochImpl: (params: { reason: string }) => Promise<unknown>;
+    }).resetEpochImpl.bind(sphere);
+
+    await expect(
+      resetEpochImpl({ reason: 'test' }),
+    ).rejects.toThrowError(SphereError);
+    await expect(
+      resetEpochImpl({ reason: 'test' }),
+    ).rejects.toMatchObject({ code: 'NOT_PROFILE_MODE' });
+  });
+
+  it('rejects empty reason', async () => {
+    const { sphere } = buildSphereLike(makeProfileStorage());
+    await expect(
+      sphere.profile!.resetEpoch({ reason: '' }),
+    ).rejects.toMatchObject({ code: 'INVALID_CONFIG' });
+  });
+
+  it('rejects oversized reason', async () => {
+    const { sphere } = buildSphereLike(makeProfileStorage());
+    const bigReason = 'a'.repeat(EPOCH_RESET_REASON_MAX_BYTES + 1);
+    await expect(
+      sphere.profile!.resetEpoch({ reason: bigReason }),
+    ).rejects.toMatchObject({ code: 'INVALID_CONFIG' });
+  });
+
+  it('persists epoch=1 on a fresh wallet (no prior reset)', async () => {
+    const storage = makeProfileStorage();
+    const { sphere, events } = buildSphereLike(storage);
+
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'oplog-corruption-recovery',
+    });
+
+    expect(result.newEpoch).toBe(1);
+    expect(result.reason).toBe('oplog-corruption-recovery');
+    expect(typeof result.ts).toBe('number');
+
+    // Local floor + reason persisted.
+    expect(await storage.get(LOCAL_EPOCH_FLOOR_KEY)).toBe('1');
+    expect(await storage.get(LOCAL_EPOCH_RESET_REASON_KEY)).toBe(
+      'oplog-corruption-recovery',
+    );
+
+    // Event emitted.
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('profile:epoch-reset');
+    expect(events[0].payload).toMatchObject({
+      newEpoch: 1,
+      reason: 'oplog-corruption-recovery',
+    });
+  });
+
+  it('is idempotent — second call lands a NEW epoch+1 (does NOT skip)', async () => {
+    const storage = makeProfileStorage();
+    const { sphere, events } = buildSphereLike(storage);
+
+    const first = await sphere.profile!.resetEpoch({ reason: 'first' });
+    expect(first.newEpoch).toBe(1);
+
+    const second = await sphere.profile!.resetEpoch({ reason: 'second' });
+    expect(second.newEpoch).toBe(2);
+
+    const third = await sphere.profile!.resetEpoch({ reason: 'third' });
+    expect(third.newEpoch).toBe(3);
+
+    // Local floor reflects the LATEST reset's epoch.
+    expect(await storage.get(LOCAL_EPOCH_FLOOR_KEY)).toBe('3');
+    expect(await storage.get(LOCAL_EPOCH_RESET_REASON_KEY)).toBe('third');
+
+    // Three distinct events emitted.
+    expect(events).toHaveLength(3);
+    expect((events[0].payload as { newEpoch: number }).newEpoch).toBe(1);
+    expect((events[1].payload as { newEpoch: number }).newEpoch).toBe(2);
+    expect((events[2].payload as { newEpoch: number }).newEpoch).toBe(3);
+  });
+
+  it('getEpochFloor reflects the persisted post-reset value', async () => {
+    const storage = makeProfileStorage();
+    const { sphere } = buildSphereLike(storage);
+
+    await sphere.profile!.resetEpoch({ reason: 'first' });
+    expect(await sphere.profile!.getEpochFloor()).toBe(1);
+
+    await sphere.profile!.resetEpoch({ reason: 'second' });
+    expect(await sphere.profile!.getEpochFloor()).toBe(2);
+  });
+
+  it('invokes OrbitDbAdapter.resetCorruptedLog when available', async () => {
+    const resetCalls: Array<{ context: string }> = [];
+    const storage = makeProfileStorage({
+      withAdapter: true,
+      resetCalls,
+    });
+    const { sphere } = buildSphereLike(storage);
+
+    await sphere.profile!.resetEpoch({ reason: 'corrupt-block' });
+
+    expect(resetCalls).toHaveLength(1);
+    expect(resetCalls[0].context).toContain('corrupt-block');
+  });
+
+  it('continues with the epoch bump even when resetCorruptedLog throws', async () => {
+    const storage = makeProfileStorage({
+      withAdapter: true,
+      resetThrows: true,
+    });
+    const { sphere, events } = buildSphereLike(storage);
+
+    // Should NOT throw — the adapter failure is logged + swallowed.
+    const result = await sphere.profile!.resetEpoch({ reason: 'recovery' });
+    expect(result.newEpoch).toBe(1);
+
+    // Floor is still persisted.
+    expect(await storage.get(LOCAL_EPOCH_FLOOR_KEY)).toBe('1');
+
+    // Event still fired.
+    expect(events).toHaveLength(1);
+  });
+
+  it('treats a corrupted floor value as 0 (fail-closed)', async () => {
+    const storage = makeProfileStorage();
+    await storage.set(LOCAL_EPOCH_FLOOR_KEY, 'not-a-number');
+
+    const { sphere } = buildSphereLike(storage);
+    // Read returns 0 for garbage.
+    expect(await sphere.profile!.getEpochFloor()).toBe(0);
+
+    // Reset bumps from 0 → 1.
+    const result = await sphere.profile!.resetEpoch({ reason: 'cleanup' });
+    expect(result.newEpoch).toBe(1);
+  });
+
+  it('serializes concurrent resetEpoch calls — each lands its own +1 (NOT deduplicated)', async () => {
+    // Two concurrent invocations should produce TWO distinct epoch
+    // bumps. Without the per-instance mutex, both calls could observe
+    // floor=0 in parallel and both write floor=1, silently merging
+    // the second invocation's intent into the first.
+    const storage = makeProfileStorage();
+    const { sphere, events } = buildSphereLike(storage);
+
+    const [a, b] = await Promise.all([
+      sphere.profile!.resetEpoch({ reason: 'concurrent-a' }),
+      sphere.profile!.resetEpoch({ reason: 'concurrent-b' }),
+    ]);
+
+    // Both calls succeeded with distinct epochs.
+    const epochs = [a.newEpoch, b.newEpoch].sort();
+    expect(epochs).toEqual([1, 2]);
+
+    // Persisted floor reflects the LATEST bump.
+    expect(await storage.get(LOCAL_EPOCH_FLOOR_KEY)).toBe('2');
+
+    // Two distinct events emitted.
+    expect(events).toHaveLength(2);
+    const eventEpochs = events
+      .map((e) => (e.payload as { newEpoch: number }).newEpoch)
+      .sort();
+    expect(eventEpochs).toEqual([1, 2]);
+  });
+});
+
+// =============================================================================
+// Second-device convergence simulation
+// =============================================================================
+//
+// This is a thin integration check that the persisted epoch floor on
+// device A would have caused device B's walkback (via the
+// `initialEpochFloor` primer + the inspector callback) to skip a stale
+// pre-reset version. The full walkback algorithm has its own integration
+// coverage in `tests/unit/profile/pointer/discover-algorithm-epoch.test.ts`;
+// this case pins the EXPECTED HAND-OFF SHAPE between resetEpoch's
+// local-cache writes and the wiring layer's `readEpochFloor` callback.
+
+describe('resetEpoch → discover-algorithm hand-off', () => {
+  it('persists the floor in a key the pointer-wiring reader can consume', async () => {
+    const storage = makeProfileStorage();
+    const { sphere } = buildSphereLike(storage);
+
+    await sphere.profile!.resetEpoch({ reason: 'corruption' });
+
+    // The pointer-wiring layer reads from this exact key — the
+    // module-level export pins the namespace contract.
+    expect(LOCAL_EPOCH_FLOOR_KEY).toBe('profile.pointer.epoch_floor');
+    expect(LOCAL_EPOCH_RESET_REASON_KEY).toBe(
+      'profile.pointer.epoch_reset_reason',
+    );
+
+    const rawFloor = await storage.get(LOCAL_EPOCH_FLOOR_KEY);
+    expect(rawFloor).toBe('1');
+
+    // Simulate the wiring layer's read closure.
+    const readEpochFloor = async (): Promise<number> => {
+      const raw = await storage.get(LOCAL_EPOCH_FLOOR_KEY);
+      if (raw === null) return 0;
+      const parsed = Number.parseInt(raw, 10);
+      if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+        return 0;
+      }
+      return parsed;
+    };
+    expect(await readEpochFloor()).toBe(1);
+  });
+});

--- a/tests/unit/core/Sphere.profile-reset-epoch.test.ts
+++ b/tests/unit/core/Sphere.profile-reset-epoch.test.ts
@@ -56,8 +56,14 @@ function makeKv(): InMemoryKv {
 }
 
 interface LegacyStorageStub extends InMemoryKv {}
+interface PointerStub {
+  discoverLatestVersion?: (
+    walkbackLimit?: number,
+    opts?: { abortSignal?: AbortSignal },
+  ) => Promise<{ pickedEpoch?: number }>;
+}
 interface ProfileStorageStub extends InMemoryKv {
-  getPointerLayer(): unknown | null;
+  getPointerLayer(): PointerStub | null;
   getOrbitDbAdapter?(): {
     resetCorruptedLog?: (reason: {
       lostHeadCid?: string;
@@ -74,13 +80,35 @@ function makeProfileStorage(opts: {
   withAdapter?: boolean;
   resetThrows?: boolean;
   resetCalls?: Array<{ context: string }>;
+  /**
+   * PR #316 F1 fix — stub the on-chain discovery result. When set,
+   * the pointer-layer stub exposes `discoverLatestVersion()` that
+   * returns `{ pickedEpoch }`. When undefined, the pointer layer
+   * does NOT expose the method (matches legacy / pre-#310 stubs)
+   * and discovery is skipped.
+   */
+  discoveredEpoch?: number;
+  /**
+   * PR #316 F1 fix — stub a discovery throw. When set, the
+   * `discoverLatestVersion()` call rejects with this message;
+   * `resetEpoch` MUST proceed with local floor only.
+   */
+  discoveryThrows?: string;
 } = {}): ProfileStorageStub {
   const kv = makeKv();
+  const pointer: PointerStub = {};
+  if (opts.discoveryThrows !== undefined) {
+    pointer.discoverLatestVersion = async () => {
+      throw new Error(opts.discoveryThrows!);
+    };
+  } else if (opts.discoveredEpoch !== undefined) {
+    pointer.discoverLatestVersion = async () => ({
+      pickedEpoch: opts.discoveredEpoch!,
+    });
+  }
   const result: ProfileStorageStub = {
     ...kv,
-    getPointerLayer: () => ({}), // any truthy value is enough; the
-                                 // Sphere code only checks the method's
-                                 // presence
+    getPointerLayer: () => pointer,
   };
   if (opts.withAdapter) {
     result.getOrbitDbAdapter = () => ({
@@ -327,6 +355,143 @@ describe('Sphere.profile.resetEpoch()', () => {
       .map((e) => (e.payload as { newEpoch: number }).newEpoch)
       .sort();
     expect(eventEpochs).toEqual([1, 2]);
+  });
+});
+
+// =============================================================================
+// PR #316 F1 fix — cross-device monotonicity via discovered floor
+// =============================================================================
+//
+// Without the F1 fix, devices A and B both observing `localFloor=2`
+// would each mint `epoch=3` independently because the bump consults
+// only the LOCAL floor. The F1 fix consults the pointer layer's
+// `pickedEpoch` before bumping — so a device whose local floor lags
+// the on-chain floor catches up.
+
+describe('Sphere.profile.resetEpoch — F1 cross-device monotonicity', () => {
+  it('bumps from max(localFloor, discoveredEpoch) + 1 when discovery returns a higher epoch', async () => {
+    // Simulate the sibling-device race: device B has localFloor=0
+    // but the chain already serves epoch=4 from device A.
+    const storage = makeProfileStorage({ discoveredEpoch: 4 });
+    const { sphere } = buildSphereLike(storage);
+
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'cross-device-catchup',
+    });
+
+    // newEpoch = max(0, 4) + 1 = 5
+    expect(result.newEpoch).toBe(5);
+    expect(result.discoveryConsulted).toBe(true);
+    expect(await storage.get(LOCAL_EPOCH_FLOOR_KEY)).toBe('5');
+  });
+
+  it('bumps from local floor when discovery returns a lower epoch (stale aggregator view)', async () => {
+    // Edge case: aggregator is behind our local floor (we already
+    // reset locally but the publish hasn't landed yet). Use the
+    // higher of the two.
+    const storage = makeProfileStorage({ discoveredEpoch: 1 });
+    await storage.set(LOCAL_EPOCH_FLOOR_KEY, '3'); // local is ahead
+
+    const { sphere } = buildSphereLike(storage);
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'local-ahead-of-chain',
+    });
+
+    // newEpoch = max(3, 1) + 1 = 4
+    expect(result.newEpoch).toBe(4);
+    expect(result.discoveryConsulted).toBe(true);
+  });
+
+  it('falls back to local floor + 1 and emits discovery-skipped when discovery throws', async () => {
+    const storage = makeProfileStorage({
+      discoveryThrows: 'aggregator timeout',
+    });
+    const { sphere, events } = buildSphereLike(storage);
+    // Also subscribe to the new discovery-skipped event.
+    const skippedEvents: Array<{ payload: unknown }> = [];
+    (sphere as unknown as Sphere).on(
+      'profile:epoch-reset-discovery-skipped',
+      (payload) => {
+        skippedEvents.push({ payload });
+      },
+    );
+
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'discovery-down',
+    });
+
+    // Bump still proceeds from local=0 → 1, but discoveryConsulted is false.
+    expect(result.newEpoch).toBe(1);
+    expect(result.discoveryConsulted).toBe(false);
+
+    // Both events fire — the canonical event AND the discovery-skipped
+    // warning so callers can surface the PROVISIONAL nature.
+    expect(events).toHaveLength(1);
+    expect(skippedEvents).toHaveLength(1);
+    expect(skippedEvents[0].payload).toMatchObject({
+      newEpoch: 1,
+      reason: 'discovery-down',
+      discoveryError: expect.stringContaining('aggregator timeout'),
+    });
+  });
+
+  it('skips discovery entirely when discoveryTimeoutMs=0 (test-only escape hatch)', async () => {
+    let discoveryCalled = false;
+    const storage = makeProfileStorage({ discoveredEpoch: 99 });
+    // Override the discover stub to flip a flag when called.
+    const original = storage.getPointerLayer()!.discoverLatestVersion!;
+    storage.getPointerLayer = () => ({
+      discoverLatestVersion: async (...args) => {
+        discoveryCalled = true;
+        return original(...args);
+      },
+    });
+
+    const { sphere } = buildSphereLike(storage);
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'no-discovery',
+      discoveryTimeoutMs: 0,
+    });
+
+    expect(discoveryCalled).toBe(false);
+    expect(result.newEpoch).toBe(1); // local-only bump
+    expect(result.discoveryConsulted).toBe(false);
+  });
+
+  it('sibling-race simulation — two devices both observing chainFloor=N each bump to N+1 (no crossing of monotonicity)', async () => {
+    // Device A and B both query the chain and both see pickedEpoch=2.
+    // Each independently bumps. The MONOTONICITY contract is that
+    // neither device can publish a chain entry with epoch < 2
+    // (they would never call resetEpoch's bump path past their
+    // discovered floor). This is the property F1 enforces. The
+    // first-to-publish-wins resolution happens AFTER this method
+    // returns, via the aggregator's own WALKBACK_FLOOR protocol.
+    const stA = makeProfileStorage({ discoveredEpoch: 2 });
+    const stB = makeProfileStorage({ discoveredEpoch: 2 });
+    const { sphere: sA } = buildSphereLike(stA);
+    const { sphere: sB } = buildSphereLike(stB);
+
+    const [resA, resB] = await Promise.all([
+      sA.profile!.resetEpoch({ reason: 'device-A' }),
+      sB.profile!.resetEpoch({ reason: 'device-B' }),
+    ]);
+
+    // Both arrived at epoch=3 — neither tried to mint a lower epoch.
+    expect(resA.newEpoch).toBe(3);
+    expect(resB.newEpoch).toBe(3);
+    expect(resA.discoveryConsulted).toBe(true);
+    expect(resB.discoveryConsulted).toBe(true);
+
+    // Per-device persisted floor reflects the bump.
+    expect(await stA.get(LOCAL_EPOCH_FLOOR_KEY)).toBe('3');
+    expect(await stB.get(LOCAL_EPOCH_FLOOR_KEY)).toBe('3');
+
+    // After A's publish lands at epoch=3, B's next publish will
+    // hit WALKBACK_FLOOR (aggregator-side); B then re-discovers
+    // (chainFloor=3) and the NEXT resetEpoch bumps to 4. This
+    // second-round behavior is NOT tested here — F1 covers only
+    // the first round. The convergence-via-WALKBACK_FLOOR path is
+    // covered by the aggregator-pointer test suite.
   });
 });
 

--- a/tests/unit/core/Sphere.profile-reset-epoch.test.ts
+++ b/tests/unit/core/Sphere.profile-reset-epoch.test.ts
@@ -27,6 +27,7 @@ import { Sphere } from '../../../core/Sphere';
 import { SphereError } from '../../../core/errors';
 import {
   LOCAL_EPOCH_FLOOR_KEY,
+  LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY,
   LOCAL_EPOCH_RESET_REASON_KEY,
 } from '../../../profile/pointer-wiring';
 import { EPOCH_RESET_REASON_MAX_BYTES } from '../../../profile/profile-lean-snapshot';
@@ -662,6 +663,126 @@ describe('Sphere.profile.resetEpoch — F2 publishedVersion contract', () => {
     });
 
     expect(result.publishedVersion).toBe(7);
+  });
+});
+
+// =============================================================================
+// PR #316 F3 fix — sentinel KV write for republish retry-resilience
+// =============================================================================
+//
+// Without the F3 fix, a publish failure on the first post-reset
+// flush could leave the aggregator chain stuck at the pre-reset
+// version with no automatic retry surface — the snapshot builder
+// might skip the publish for "no dirty state" if the OpLog was
+// wiped and no other writers had mutated. The F3 fix writes a
+// sentinel KV (`LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY`) BEFORE the
+// dirty-flush so the snapshot builder always has concrete state.
+
+describe('Sphere.profile.resetEpoch — F3 sentinel KV trigger', () => {
+  it('writes the post-reset epoch to LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY', async () => {
+    const storage = makeProfileStorage();
+    const { sphere } = buildSphereLike(storage);
+
+    await sphere.profile!.resetEpoch({
+      reason: 'first-trigger',
+      publishTimeoutMs: 0,
+    });
+
+    const sentinel = await storage.get(LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY);
+    expect(sentinel).toBe('1');
+  });
+
+  it('overwrites the sentinel on subsequent resets (single slot, no accumulation)', async () => {
+    const storage = makeProfileStorage();
+    const { sphere } = buildSphereLike(storage);
+
+    await sphere.profile!.resetEpoch({
+      reason: 'reset-1',
+      publishTimeoutMs: 0,
+    });
+    expect(await storage.get(LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY)).toBe('1');
+
+    await sphere.profile!.resetEpoch({
+      reason: 'reset-2',
+      publishTimeoutMs: 0,
+    });
+    expect(await storage.get(LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY)).toBe('2');
+
+    await sphere.profile!.resetEpoch({
+      reason: 'reset-3',
+      publishTimeoutMs: 0,
+    });
+    expect(await storage.get(LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY)).toBe('3');
+  });
+
+  it('persists the sentinel even when the publish event never fires (failing publisher simulation)', async () => {
+    // Wire a token storage stub whose `notifyProfileDirty` simulates
+    // a failing publisher — the dirty flush would fire but the
+    // publish never lands (publish-pending event emits, sentinel
+    // stays in place for the periodic-poll retry path to consume).
+    const storage = makeProfileStorage();
+    const { sphere } = buildSphereLike(storage);
+    let dirtyCount = 0;
+    (sphere as unknown as { _tokenStorageProviders: Map<string, unknown> })
+      ._tokenStorageProviders.set('failing', {
+        notifyProfileDirty: () => {
+          dirtyCount += 1;
+          // No publish event fires — simulates the failure scenario.
+        },
+        onEvent: () => () => {
+          /* listener registered but never fires */
+        },
+      });
+
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'publish-fails',
+      publishTimeoutMs: 30, // short timeout so the test doesn't stall
+    });
+
+    // The bump landed locally — sentinel is durably written.
+    expect(result.publishedVersion).toBe(0); // publish never fired
+    expect(await storage.get(LOCAL_EPOCH_FLOOR_KEY)).toBe('1');
+    expect(await storage.get(LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY)).toBe('1');
+
+    // notifyProfileDirty was called — the snapshot builder has the
+    // sentinel as concrete state for its next attempt. The next
+    // dirty-flush (whether triggered by the periodic poll or by
+    // another mutation) will see this entry and rebuild the
+    // snapshot.
+    expect(dirtyCount).toBe(1);
+  });
+
+  it('does not abort the bump when sentinel write fails (best-effort)', async () => {
+    // Wrap the storage to make ONLY the sentinel write throw —
+    // other writes still succeed. The bump should still complete.
+    const storage = makeProfileStorage();
+    const realSet = storage.set.bind(storage);
+    storage.set = async (k: string, v: string) => {
+      if (k === LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY) {
+        throw new Error('synthetic sentinel write failure');
+      }
+      return realSet(k, v);
+    };
+    const { sphere, events } = buildSphereLike(storage);
+
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'sentinel-write-fails',
+      publishTimeoutMs: 0,
+    });
+
+    // Bump still landed.
+    expect(result.newEpoch).toBe(1);
+    expect(await storage.get(LOCAL_EPOCH_FLOOR_KEY)).toBe('1');
+    // Event still emitted.
+    expect(events).toHaveLength(1);
+  });
+
+  it('exposes the canonical sentinel key for cross-module consumers', () => {
+    // Pin the key namespace so the snapshot builder (or anything
+    // downstream that scans for OpLog keys) consumes the same name.
+    expect(LOCAL_EPOCH_RESET_FLUSH_TRIGGER_KEY).toBe(
+      'profile.pointer.epoch_reset_flush_trigger',
+    );
   });
 });
 

--- a/tests/unit/core/Sphere.profile-reset-epoch.test.ts
+++ b/tests/unit/core/Sphere.profile-reset-epoch.test.ts
@@ -496,6 +496,176 @@ describe('Sphere.profile.resetEpoch — F1 cross-device monotonicity', () => {
 });
 
 // =============================================================================
+// PR #316 F2 fix — publishedVersion is populated via storage:pointer-published
+// =============================================================================
+//
+// Without the F2 fix, `publishedVersion` was hardcoded to 0 — a
+// silent contract lie. The fix awaits a one-shot
+// `storage:pointer-published` event with a bounded timeout. On
+// observe, `publishedVersion` reflects the landed pointer version.
+// On timeout, `'profile:epoch-reset-publish-pending'` is emitted and
+// `publishedVersion` stays 0.
+
+interface ProfileStorageWithEventBus extends ProfileStorageStub {
+  emitPointerPublished(version: number): void;
+}
+
+function attachTokenStorageWithEventBus(
+  sphere: Sphere,
+  storage: ProfileStorageStub,
+): ProfileStorageWithEventBus {
+  // Simulate a token storage provider with `onEvent` support so the
+  // F2 publish waiter has something to listen on. Production wiring
+  // routes this through ProfileTokenStorageProvider; the test stub
+  // gives the bus a synchronous emit handle.
+  const listeners = new Set<(event: { type: string; data?: unknown }) => void>();
+  const fakeProvider = {
+    onEvent(cb: (event: { type: string; data?: unknown }) => void) {
+      listeners.add(cb);
+      return () => {
+        listeners.delete(cb);
+      };
+    },
+    notifyProfileDirty() {
+      /* no-op — production code emits a debounced flush; tests fire
+       * the event manually via `emitPointerPublished` */
+    },
+  };
+  (sphere as unknown as { _tokenStorageProviders: Map<string, unknown> })
+    ._tokenStorageProviders.set('default', fakeProvider);
+
+  const enriched = storage as ProfileStorageWithEventBus;
+  enriched.emitPointerPublished = (version: number) => {
+    for (const cb of listeners) {
+      cb({ type: 'storage:pointer-published', data: { version } });
+    }
+  };
+  return enriched;
+}
+
+describe('Sphere.profile.resetEpoch — F2 publishedVersion contract', () => {
+  it('populates publishedVersion from the storage:pointer-published event', async () => {
+    const storage = makeProfileStorage();
+    const { sphere } = buildSphereLike(storage);
+    const eventBus = attachTokenStorageWithEventBus(sphere, storage);
+
+    // Fire the publish event asynchronously after resetEpoch arms
+    // its waiter (after the notifyProfileDirty step).
+    setTimeout(() => eventBus.emitPointerPublished(42), 10);
+
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'fired-after-bump',
+      // Generous budget so the test doesn't race against the
+      // 10ms setTimeout above on slow CI runners.
+      publishTimeoutMs: 5_000,
+    });
+
+    expect(result.publishedVersion).toBe(42);
+    expect(result.newEpoch).toBe(1);
+  });
+
+  it('emits profile:epoch-reset-publish-pending on publish timeout', async () => {
+    const storage = makeProfileStorage();
+    const { sphere } = buildSphereLike(storage);
+    attachTokenStorageWithEventBus(sphere, storage);
+    // Don't fire the publish event — let the waiter time out.
+
+    const pendingEvents: Array<{ payload: unknown }> = [];
+    (sphere as unknown as Sphere).on(
+      'profile:epoch-reset-publish-pending',
+      (payload) => {
+        pendingEvents.push({ payload });
+      },
+    );
+
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'no-publish-coming',
+      publishTimeoutMs: 50, // very short — guaranteed to time out
+    });
+
+    expect(result.publishedVersion).toBe(0);
+    expect(pendingEvents).toHaveLength(1);
+    expect(pendingEvents[0].payload).toMatchObject({
+      newEpoch: 1,
+      reason: 'no-publish-coming',
+      timeoutMs: 50,
+    });
+  });
+
+  it('skips the wait entirely when publishTimeoutMs=0 (test escape hatch)', async () => {
+    const storage = makeProfileStorage();
+    const { sphere } = buildSphereLike(storage);
+    attachTokenStorageWithEventBus(sphere, storage);
+
+    const pendingEvents: unknown[] = [];
+    (sphere as unknown as Sphere).on(
+      'profile:epoch-reset-publish-pending',
+      (payload) => {
+        pendingEvents.push(payload);
+      },
+    );
+
+    const start = Date.now();
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'no-wait',
+      publishTimeoutMs: 0,
+    });
+    const elapsed = Date.now() - start;
+
+    expect(result.publishedVersion).toBe(0);
+    // The "no-wait" path must NOT emit publish-pending — pending
+    // implies "we tried and timed out", not "we never tried".
+    expect(pendingEvents).toEqual([]);
+    // Sanity: didn't hang on the publish wait.
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('does NOT emit publish-pending when no token storage providers are wired (no event surface)', async () => {
+    const storage = makeProfileStorage();
+    const { sphere } = buildSphereLike(storage);
+    // NO attachTokenStorageWithEventBus — no providers wired.
+
+    const pendingEvents: unknown[] = [];
+    (sphere as unknown as Sphere).on(
+      'profile:epoch-reset-publish-pending',
+      (payload) => {
+        pendingEvents.push(payload);
+      },
+    );
+
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'no-providers',
+      // Even with a real timeout, the waiter is skipped because
+      // there's nothing to listen on.
+      publishTimeoutMs: 1_000,
+    });
+
+    expect(result.publishedVersion).toBe(0);
+    expect(pendingEvents).toEqual([]);
+  });
+
+  it('captures the first version when multiple publish events arrive', async () => {
+    const storage = makeProfileStorage();
+    const { sphere } = buildSphereLike(storage);
+    const eventBus = attachTokenStorageWithEventBus(sphere, storage);
+
+    // Fire two events in quick succession; the waiter MUST capture
+    // the first (v=7) and ignore subsequent events.
+    setTimeout(() => {
+      eventBus.emitPointerPublished(7);
+      eventBus.emitPointerPublished(8);
+    }, 5);
+
+    const result = await sphere.profile!.resetEpoch({
+      reason: 'first-wins',
+      publishTimeoutMs: 5_000,
+    });
+
+    expect(result.publishedVersion).toBe(7);
+  });
+});
+
+// =============================================================================
 // Second-device convergence simulation
 // =============================================================================
 //

--- a/tests/unit/profile/lifecycle-manager-pointer-win-broadcast.test.ts
+++ b/tests/unit/profile/lifecycle-manager-pointer-win-broadcast.test.ts
@@ -231,7 +231,7 @@ describe('LifecycleManager.publishAggregatorPointerBestEffort — pointer-win br
     expect(h.events.find((e) => e.type === 'storage:pointer-published')).toBeUndefined();
   });
 
-  it('falls through gracefully when pointer lacks getSignerForWinBroadcast (legacy stub)', async () => {
+  it('falls through gracefully when pointer lacks getSignerForWinBroadcast (legacy stub) — PR #316 F2: event still emits without broadcast fields', async () => {
     // Stub WITHOUT the win-broadcast accessor — simulates pre-Approach-D
     // pointer layer (e.g. a unit test that doesn't extend the helper).
     const pointer = {
@@ -248,7 +248,22 @@ describe('LifecycleManager.publishAggregatorPointerBestEffort — pointer-win br
     // additive. The lifecycle manager's try/catch around the sign step
     // ensures a missing accessor doesn't taint the success return.
     expect(result.ok).toBe(true);
-    expect(h.events.find((e) => e.type === 'storage:pointer-published')).toBeUndefined();
+    // PR #316 F2: the event still fires (so resetEpoch's publish
+    // await observes the version), but without the optional
+    // signedPayloadJson / broadcastTag fields.
+    const published = h.events.find((e) => e.type === 'storage:pointer-published');
+    expect(published).toBeDefined();
+    const data = published!.data as {
+      cid?: string;
+      version?: number;
+      attemptsUsed?: number;
+      signedPayloadJson?: string;
+      broadcastTag?: string;
+    };
+    expect(data.cid).toBe(FAKE_CID);
+    expect(data.version).toBe(13);
+    expect(data.signedPayloadJson).toBeUndefined();
+    expect(data.broadcastTag).toBeUndefined();
   });
 
   it('emits a fresh ts on each publish (no stale-broadcast amplification)', async () => {

--- a/tests/unit/profile/monotonicity-auto-merge.test.ts
+++ b/tests/unit/profile/monotonicity-auto-merge.test.ts
@@ -439,7 +439,12 @@ describe('enablePointerWinBroadcasts — default-OFF policy (#264)', () => {
   beforeEach(() => { vi.useRealTimers(); });
   afterEach(() => { vi.useRealTimers(); });
 
-  it('default (no config): winBroadcastsEnabled() returns false; lifecycle-manager skips storage:pointer-published emit', async () => {
+  it('default (no config): winBroadcastsEnabled() returns false; storage:pointer-published fires WITHOUT signedPayloadJson/broadcastTag (PR #316 F2)', async () => {
+    // PR #316 F2: the event is now emitted UNCONDITIONALLY on a
+    // successful publish so consumers (e.g. resetEpoch's publish
+    // await) can observe the landing. The win-broadcast gate now
+    // controls only the signedPayloadJson / broadcastTag fields,
+    // NOT the event itself.
     const pointer = await buildRealPointerWithFlag(undefined);
     expect(pointer.winBroadcastsEnabled()).toBe(false);
 
@@ -447,20 +452,38 @@ describe('enablePointerWinBroadcasts — default-OFF policy (#264)', () => {
     const result = await h.publish(FAKE_CID);
     expect(result.ok).toBe(true);
 
-    // Gate trips → no storage:pointer-published event.
-    expect(h.events.find((e) => e.type === 'storage:pointer-published')).toBeUndefined();
+    const published = h.events.find((e) => e.type === 'storage:pointer-published');
+    expect(published).toBeDefined();
+    const data = published!.data as {
+      cid?: string;
+      version?: number;
+      signedPayloadJson?: string;
+      broadcastTag?: string;
+    };
+    expect(data.cid).toBe(FAKE_CID);
+    expect(data.version).toBe(11);
+    // Win-broadcast fields are suppressed because the flag is OFF.
+    expect(data.signedPayloadJson).toBeUndefined();
+    expect(data.broadcastTag).toBeUndefined();
 
     await h.shutdown();
   });
 
-  it('explicit false: same suppression as default', async () => {
+  it('explicit false: same shape as default (event emitted, no broadcast fields)', async () => {
     const pointer = await buildRealPointerWithFlag(false);
     expect(pointer.winBroadcastsEnabled()).toBe(false);
 
     const h = await createHarness(pointer);
     const result = await h.publish(FAKE_CID);
     expect(result.ok).toBe(true);
-    expect(h.events.find((e) => e.type === 'storage:pointer-published')).toBeUndefined();
+    const published = h.events.find((e) => e.type === 'storage:pointer-published');
+    expect(published).toBeDefined();
+    const data = published!.data as {
+      signedPayloadJson?: string;
+      broadcastTag?: string;
+    };
+    expect(data.signedPayloadJson).toBeUndefined();
+    expect(data.broadcastTag).toBeUndefined();
 
     await h.shutdown();
   });
@@ -489,18 +512,28 @@ describe('enablePointerWinBroadcasts — default-OFF policy (#264)', () => {
     await h.shutdown();
   });
 
-  it('truthy non-boolean (string "true", number 1) is coerced to false — strict === true policy', async () => {
+  it('truthy non-boolean (string "true", number 1) is coerced to false — strict === true policy (PR #316 F2: event emits but without broadcast fields)', async () => {
     // Pass `'true'` as a string and `1` as a number — both are truthy
     // but should fail closed per the normalization in ProfilePointerLayer's
     // frozen config snapshot (defense against accidentally truthy values
     // from env-var unmarshalling, JSON parsing, etc.).
+    //
+    // PR #316 F2: the gate still trips the broadcast fields off, but
+    // the event itself fires unconditionally.
     for (const accidental of ['true' as unknown as boolean, 1 as unknown as boolean]) {
       const pointer = await buildRealPointerWithFlag(accidental);
       expect(pointer.winBroadcastsEnabled()).toBe(false);
       const h = await createHarness(pointer);
       const result = await h.publish(FAKE_CID);
       expect(result.ok).toBe(true);
-      expect(h.events.find((e) => e.type === 'storage:pointer-published')).toBeUndefined();
+      const published = h.events.find((e) => e.type === 'storage:pointer-published');
+      expect(published).toBeDefined();
+      const data = published!.data as {
+        signedPayloadJson?: string;
+        broadcastTag?: string;
+      };
+      expect(data.signedPayloadJson).toBeUndefined();
+      expect(data.broadcastTag).toBeUndefined();
       await h.shutdown();
     }
   });

--- a/tests/unit/profile/pointer/discover-algorithm-epoch.test.ts
+++ b/tests/unit/profile/pointer/discover-algorithm-epoch.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Issue #310 — `findLatestValidVersion` integration with the epoch
+ * floor.
+ *
+ * The probe-sequence machinery requires deep key-material wiring that
+ * the parent test file documents as "impractical without full probe-
+ * sequence simulation." For #310 we focus on the OBSERVABLE
+ * surface — the `DiscoverResult` shape and the input acceptance — and
+ * pin the epoch-floor walkback semantics via the pure unit suite in
+ * `epoch-floor.test.ts`.
+ *
+ * Additional coverage (the integration test) lives at:
+ *   `tests/integration/pointer/walkback-epoch-floor.test.ts`
+ * (only if real-probe simulation gets wired in a follow-up).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { InclusionProofVerificationStatus } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof.js';
+import type { InclusionProof } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof.js';
+import { InclusionProofResponse } from '@unicitylabs/state-transition-sdk/lib/api/InclusionProofResponse.js';
+import type { AggregatorClient } from '@unicitylabs/state-transition-sdk/lib/api/AggregatorClient.js';
+import type { RootTrustBase } from '@unicitylabs/state-transition-sdk/lib/bft/RootTrustBase.js';
+
+import {
+  findLatestValidVersion,
+  AggregatorPointerErrorCode,
+  derivePointerKeyMaterial,
+  buildPointerSigner,
+  createMasterPrivateKey,
+  type CidDecoder,
+  type CarFetcher,
+  type PointerVersion,
+} from '../../../../profile/aggregator-pointer/index.js';
+
+const WALLET_SEED = new Uint8Array(32).fill(0x42);
+const VALID_CID = new Uint8Array([0x12, 0x20, ...new Array(32).fill(0xab)]);
+
+async function buildFixtures() {
+  const masterKey = createMasterPrivateKey(WALLET_SEED);
+  const keyMaterial = derivePointerKeyMaterial(masterKey);
+  const signer = await buildPointerSigner(keyMaterial.signingSeed);
+  return { keyMaterial, signer };
+}
+
+function fakeProof(status: InclusionProofVerificationStatus): InclusionProof {
+  return {
+    verify: vi.fn(async () => status),
+    transactionHash: { data: new Uint8Array(32).fill(0x01), imprint: new Uint8Array(34) },
+    unicityCertificate: {
+      unicitySeal: { epoch: 1n },
+      inputRecord: { epoch: 1n },
+    },
+  } as unknown as InclusionProof;
+}
+
+function fakeTrustBase(): RootTrustBase {
+  return { epoch: 1n } as RootTrustBase;
+}
+
+function allNotIncludedClient(): AggregatorClient {
+  return {
+    getInclusionProof: vi.fn(async () =>
+      new InclusionProofResponse(
+        fakeProof(InclusionProofVerificationStatus.PATH_NOT_INCLUDED),
+      ),
+    ),
+  } as unknown as AggregatorClient;
+}
+
+const okDecoder: CidDecoder = () => ({ ok: true, cidBytes: VALID_CID });
+const validFetcher: CarFetcher = async () => ({ ok: true });
+
+describe('findLatestValidVersion — #310 result shape', () => {
+  it('returns walkbackEpochSkipped + pickedEpoch=0 for an empty wallet', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const result = await findLatestValidVersion({
+      currentLocalVersion: 0,
+      keyMaterial,
+      signer,
+      aggregatorClient: allNotIncludedClient(),
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecoder,
+      fetchCar: validFetcher,
+    });
+    expect(result.validV).toBe(0);
+    expect(result.walkbackEpochSkipped).toEqual([]);
+    expect(result.pickedEpoch).toBe(0);
+  });
+
+  it('honors initialEpochFloor (primes the running floor)', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const result = await findLatestValidVersion({
+      currentLocalVersion: 0,
+      keyMaterial,
+      signer,
+      aggregatorClient: allNotIncludedClient(),
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecoder,
+      fetchCar: validFetcher,
+      initialEpochFloor: 7,
+    });
+    // No Phase-3 walkback ran (wallet is empty), so pickedEpoch is
+    // the primed floor.
+    expect(result.pickedEpoch).toBe(7);
+  });
+
+  it('rejects negative initialEpochFloor with PROTOCOL_ERROR', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        initialEpochFloor: -1,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PROTOCOL_ERROR,
+    });
+  });
+
+  it('rejects non-integer initialEpochFloor with PROTOCOL_ERROR', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        initialEpochFloor: 1.5,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PROTOCOL_ERROR,
+    });
+  });
+
+  it('accepts inspectSnapshotEpoch as a callback type (no-op for empty wallet)', async () => {
+    // Empty-wallet path does not actually CALL the inspector (no
+    // VALID candidate gets classified), but the field should be
+    // accepted without complaint.
+    const { keyMaterial, signer } = await buildFixtures();
+    let inspectCalls = 0;
+    const inspector = async (_v: PointerVersion, _cid: Uint8Array): Promise<number | undefined> => {
+      inspectCalls += 1;
+      return 0;
+    };
+    const result = await findLatestValidVersion({
+      currentLocalVersion: 0,
+      keyMaterial,
+      signer,
+      aggregatorClient: allNotIncludedClient(),
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecoder,
+      fetchCar: validFetcher,
+      inspectSnapshotEpoch: inspector,
+    });
+    expect(result.validV).toBe(0);
+    expect(inspectCalls).toBe(0); // never reached for empty wallet
+  });
+});

--- a/tests/unit/profile/pointer/epoch-floor.test.ts
+++ b/tests/unit/profile/pointer/epoch-floor.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Issue #310 — OpLog epoch-floor walkback primitive unit tests.
+ *
+ * Pure unit tests for the helpers in `epoch-floor.ts`. The end-to-end
+ * walkback behaviour (with `inspectSnapshotEpoch` wired into
+ * `findLatestValidVersion`) lives in `discover-algorithm-epoch.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  normalizeEpoch,
+  pickEpochFloor,
+  shouldSkipForEpochFloor,
+  computeEpochFloor,
+} from '../../../../profile/aggregator-pointer/epoch-floor.js';
+
+describe('normalizeEpoch', () => {
+  it('treats undefined as epoch=0 (backwards-compat)', () => {
+    expect(normalizeEpoch(undefined)).toBe(0);
+  });
+
+  it('returns the value verbatim for valid non-negative integers', () => {
+    expect(normalizeEpoch(0)).toBe(0);
+    expect(normalizeEpoch(1)).toBe(1);
+    expect(normalizeEpoch(42)).toBe(42);
+    expect(normalizeEpoch(1 << 20)).toBe(1 << 20);
+  });
+
+  it('throws on negative epochs', () => {
+    expect(() => normalizeEpoch(-1)).toThrow(/non-negative integer/);
+  });
+
+  it('throws on non-integer values', () => {
+    expect(() => normalizeEpoch(1.5)).toThrow(/non-negative integer/);
+    expect(() => normalizeEpoch(NaN)).toThrow(/non-negative integer/);
+    expect(() => normalizeEpoch(Infinity)).toThrow(/non-negative integer/);
+  });
+
+  it('throws on non-numeric values', () => {
+    // @ts-expect-error — testing runtime guard
+    expect(() => normalizeEpoch('1')).toThrow();
+    // @ts-expect-error — testing runtime guard
+    expect(() => normalizeEpoch(null)).toThrow();
+  });
+});
+
+describe('pickEpochFloor', () => {
+  it('returns 0 for (0, undefined)', () => {
+    expect(pickEpochFloor(0, undefined)).toBe(0);
+  });
+
+  it('bumps from 0 to N when candidate.epoch=N>0', () => {
+    expect(pickEpochFloor(0, 1)).toBe(1);
+    expect(pickEpochFloor(0, 5)).toBe(5);
+  });
+
+  it('does not lower an existing floor', () => {
+    expect(pickEpochFloor(5, 0)).toBe(5);
+    expect(pickEpochFloor(5, 3)).toBe(5);
+    expect(pickEpochFloor(5, undefined)).toBe(5);
+  });
+
+  it('raises the floor when candidate is higher', () => {
+    expect(pickEpochFloor(3, 7)).toBe(7);
+  });
+
+  it('is idempotent for equal floor/candidate', () => {
+    expect(pickEpochFloor(4, 4)).toBe(4);
+  });
+});
+
+describe('shouldSkipForEpochFloor', () => {
+  it('does not skip when floor=0 and candidate=undefined (pre-#310 chain)', () => {
+    expect(shouldSkipForEpochFloor(0, undefined)).toBe(false);
+  });
+
+  it('does not skip when floor=0 and candidate=0', () => {
+    expect(shouldSkipForEpochFloor(0, 0)).toBe(false);
+  });
+
+  it('does not skip when candidate.epoch === floor', () => {
+    expect(shouldSkipForEpochFloor(2, 2)).toBe(false);
+  });
+
+  it('does not skip when candidate.epoch > floor', () => {
+    expect(shouldSkipForEpochFloor(2, 3)).toBe(false);
+  });
+
+  it('SKIPS when candidate.epoch < floor', () => {
+    expect(shouldSkipForEpochFloor(2, 1)).toBe(true);
+    expect(shouldSkipForEpochFloor(2, 0)).toBe(true);
+  });
+
+  it('SKIPS pre-#310 candidate (undefined) when floor > 0', () => {
+    // This is the load-bearing behavior: once a wallet has published
+    // even one post-reset pointer (epoch >= 1), every pre-reset
+    // ancestor (epoch missing → 0) is below the floor and walkback
+    // refuses to load it.
+    expect(shouldSkipForEpochFloor(1, undefined)).toBe(true);
+    expect(shouldSkipForEpochFloor(5, undefined)).toBe(true);
+  });
+});
+
+describe('computeEpochFloor', () => {
+  it('returns 0 for an empty observation list', () => {
+    expect(computeEpochFloor([])).toBe(0);
+  });
+
+  it('returns 0 when every observation is undefined (pre-#310)', () => {
+    expect(computeEpochFloor([undefined, undefined, undefined])).toBe(0);
+  });
+
+  it('returns 0 when every observation is 0', () => {
+    expect(computeEpochFloor([0, 0, 0])).toBe(0);
+  });
+
+  it('returns the max of mixed observations', () => {
+    expect(computeEpochFloor([0, 1, 2, 3, 0, 1])).toBe(3);
+    expect(computeEpochFloor([undefined, 5, undefined, 2])).toBe(5);
+  });
+
+  it('is order-independent (commutative)', () => {
+    expect(computeEpochFloor([1, 2, 3])).toBe(computeEpochFloor([3, 2, 1]));
+    expect(computeEpochFloor([0, undefined, 5])).toBe(
+      computeEpochFloor([5, undefined, 0]),
+    );
+  });
+});
+
+describe('walkback simulation (top-down)', () => {
+  /**
+   * Simulate a Phase-3 walkback. The input is the sequence of
+   * candidate-epochs (top-down: v=10 first, v=1 last). The output is
+   * the picked version (1-indexed from the top, 0 if no candidate
+   * survived).
+   */
+  function simulate(
+    candidates: ReadonlyArray<number | undefined>,
+    primeFloor: number = 0,
+  ): { pickedIndex: number; floor: number; skipped: number[] } {
+    let floor = primeFloor;
+    const skipped: number[] = [];
+    for (let i = 0; i < candidates.length; i++) {
+      const c = candidates[i];
+      if (shouldSkipForEpochFloor(floor, c)) {
+        skipped.push(i);
+        continue;
+      }
+      floor = pickEpochFloor(floor, c);
+      return { pickedIndex: i + 1, floor, skipped };
+    }
+    return { pickedIndex: 0, floor, skipped };
+  }
+
+  it('picks the FIRST candidate in a pre-#310 chain (all undefined)', () => {
+    const { pickedIndex, floor } = simulate([undefined, undefined, undefined]);
+    expect(pickedIndex).toBe(1);
+    expect(floor).toBe(0);
+  });
+
+  it('picks epoch=2 over a pre-reset epoch=1 ancestor', () => {
+    const { pickedIndex, floor, skipped } = simulate([2, 1, undefined]);
+    expect(pickedIndex).toBe(1);
+    expect(floor).toBe(2);
+    expect(skipped).toEqual([]);
+  });
+
+  it('skips pre-reset ancestors when primed with floor=2', () => {
+    // Phase 2 includedV is the highest valid v on-chain (epoch=2 there).
+    // Phase 3 starts at includedV and walks down. The first candidate
+    // (epoch=2) matches the floor and gets picked.
+    const { pickedIndex, floor } = simulate([2, 1, undefined], 2);
+    expect(pickedIndex).toBe(1);
+    expect(floor).toBe(2);
+  });
+
+  it('skips ALL pre-reset ancestors when only pre-reset entries remain', () => {
+    // E.g. floor primed at 2 (from local persisted state), but
+    // aggregator only serves epoch=1 entries (stale state from a
+    // device that lost the reset).
+    const { pickedIndex, skipped } = simulate([1, undefined, 0], 2);
+    expect(pickedIndex).toBe(0);
+    expect(skipped).toEqual([0, 1, 2]);
+  });
+
+  it('lets a higher candidate raise the floor mid-walkback', () => {
+    // includedV has epoch=1 → floor moves to 1 → next candidate epoch=0
+    // gets skipped. We end up picking the epoch=1 entry.
+    const { pickedIndex, floor, skipped } = simulate([1, 0, 0]);
+    expect(pickedIndex).toBe(1);
+    expect(floor).toBe(1);
+    expect(skipped).toEqual([]);
+  });
+});

--- a/tests/unit/profile/profile-lean-snapshot-epoch.test.ts
+++ b/tests/unit/profile/profile-lean-snapshot-epoch.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Issue #310 — lean snapshot epoch round-trip tests.
+ *
+ * Pins:
+ *   - A wallet that does NOT supply `epoch` produces a snapshot whose
+ *     decoded root has NO `epoch` field. Backwards-compatible: the
+ *     bytes are identical to a pre-#310 snapshot.
+ *   - A wallet that supplies `epoch: N > 0` round-trips the field
+ *     through encode → CAR bytes → parser.
+ *   - `epochResetReason` round-trips when paired with a non-zero
+ *     epoch.
+ *   - Invalid epoch values are rejected at the build seam.
+ *   - The encoded epoch is byte-detectable in the root block — we
+ *     decode the dag-cbor root directly to assert the field shape.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decode as cborDecode } from '@ipld/dag-cbor';
+import { CarReader } from '@ipld/car';
+
+import {
+  buildLeanProfileSnapshot,
+  parseLeanProfileSnapshot,
+  parseLeanProfileSnapshotFromRootBlock,
+  EPOCH_RESET_REASON_MAX_BYTES,
+  EPOCH_MAX,
+} from '../../../profile/profile-lean-snapshot';
+import type { StorageProvider } from '../../../storage/storage-provider';
+import type { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import type {
+  ProviderStatus,
+  TrackedAddressEntry,
+  FullIdentity,
+} from '../../../types';
+import type { UxfBundleRef } from '../../../profile/types';
+
+// =============================================================================
+// Test doubles
+// =============================================================================
+
+class InMemoryStorageProvider implements StorageProvider {
+  readonly id = 'memory';
+  readonly name = 'Memory';
+  readonly type = 'local' as const;
+  private data = new Map<string, string>();
+  private encrypted = new Map<string, string>();
+  private status: ProviderStatus = 'disconnected';
+
+  async connect(): Promise<void> {
+    this.status = 'connected';
+  }
+  async disconnect(): Promise<void> {
+    this.status = 'disconnected';
+  }
+  isConnected(): boolean {
+    return this.status === 'connected';
+  }
+  getStatus(): ProviderStatus {
+    return this.status;
+  }
+  setIdentity(_: FullIdentity): void {}
+
+  async get(key: string): Promise<string | null> {
+    return this.data.get(key) ?? null;
+  }
+  async set(key: string, value: string): Promise<void> {
+    this.data.set(key, value);
+    this.encrypted.set(key, Buffer.from(`CT(${value})`).toString('base64'));
+  }
+  async remove(key: string): Promise<void> {
+    this.data.delete(key);
+    this.encrypted.delete(key);
+  }
+  async has(key: string): Promise<boolean> {
+    return this.data.has(key);
+  }
+  async keys(prefix?: string): Promise<string[]> {
+    const allKeys: string[] = [];
+    this.data.forEach((_, k) => allKeys.push(k));
+    if (!prefix) return allKeys;
+    return allKeys.filter((k) => k.startsWith(prefix));
+  }
+  async clear(prefix?: string): Promise<void> {
+    if (!prefix) {
+      this.data.clear();
+      this.encrypted.clear();
+      return;
+    }
+    const toDelete: string[] = [];
+    this.data.forEach((_, k) => {
+      if (k.startsWith(prefix)) toDelete.push(k);
+    });
+    toDelete.forEach((k) => {
+      this.data.delete(k);
+      this.encrypted.delete(k);
+    });
+  }
+  async saveTrackedAddresses(_: TrackedAddressEntry[]): Promise<void> {}
+  async loadTrackedAddresses(): Promise<TrackedAddressEntry[]> {
+    return [];
+  }
+  async getEncryptedRaw(key: string): Promise<string | null> {
+    return this.encrypted.get(key) ?? null;
+  }
+  async setEncryptedRaw(key: string, value: string): Promise<void> {
+    this.encrypted.set(key, value);
+  }
+}
+
+class FakeTokenStorage {
+  readonly bundleIndex = new Map<string, UxfBundleRef>();
+  async listBundles(): Promise<Map<string, UxfBundleRef>> {
+    return new Map(this.bundleIndex);
+  }
+}
+
+const CHAIN_PUBKEY = '02' + 'aa'.repeat(32);
+const TS = 1_700_000_000_000;
+
+async function makeStorage(): Promise<StorageProvider> {
+  const s = new InMemoryStorageProvider();
+  await s.connect();
+  await s.set('mnemonic', 'mn');
+  await s.set('master_key', 'mk');
+  return s;
+}
+
+async function rootBlockObject(carBytes: Uint8Array): Promise<Record<string, unknown>> {
+  const reader = await CarReader.fromBytes(carBytes);
+  const roots = await reader.getRoots();
+  const rootBlock = await reader.get(roots[0]);
+  if (!rootBlock) throw new Error('test setup: root block missing');
+  const decoded = cborDecode(rootBlock.bytes);
+  return decoded as Record<string, unknown>;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('lean snapshot — epoch backwards-compat', () => {
+  it('omits the epoch field when not supplied (pre-#310)', async () => {
+    const storage = await makeStorage();
+    const ts = new FakeTokenStorage();
+
+    const { carBytes } = await buildLeanProfileSnapshot({
+      storage,
+      tokenStorage: ts as unknown as ProfileTokenStorageProvider,
+      chainPubkey: CHAIN_PUBKEY,
+      network: 'testnet',
+      createdAt: TS,
+    });
+
+    const root = await rootBlockObject(carBytes);
+    expect(root.epoch).toBeUndefined();
+    expect(root.epochResetReason).toBeUndefined();
+
+    const parsed = await parseLeanProfileSnapshot(carBytes);
+    expect(parsed.epoch).toBeUndefined();
+    expect(parsed.epochResetReason).toBeUndefined();
+  });
+
+  it('omits the epoch field when supplied as 0 (canonical "no reset")', async () => {
+    const storage = await makeStorage();
+    const ts = new FakeTokenStorage();
+
+    // 0 is a valid input but should still be emitted (it's the
+    // explicit epoch=0 case — distinguished from "field absent"
+    // only at the writer's choice). The current builder writes the
+    // field when explicitly provided. Test that round-trip works.
+    const { carBytes } = await buildLeanProfileSnapshot({
+      storage,
+      tokenStorage: ts as unknown as ProfileTokenStorageProvider,
+      chainPubkey: CHAIN_PUBKEY,
+      network: 'testnet',
+      createdAt: TS,
+      epoch: 0,
+    });
+
+    const root = await rootBlockObject(carBytes);
+    // Builder emits the field iff explicitly provided.
+    expect(root.epoch).toBe(0);
+
+    const parsed = await parseLeanProfileSnapshot(carBytes);
+    expect(parsed.epoch).toBe(0);
+  });
+});
+
+describe('lean snapshot — epoch round-trip', () => {
+  it('round-trips epoch=1 through encode → parse', async () => {
+    const storage = await makeStorage();
+    const ts = new FakeTokenStorage();
+
+    const { carBytes } = await buildLeanProfileSnapshot({
+      storage,
+      tokenStorage: ts as unknown as ProfileTokenStorageProvider,
+      chainPubkey: CHAIN_PUBKEY,
+      network: 'testnet',
+      createdAt: TS,
+      epoch: 1,
+      epochResetReason: 'oplog-corruption-recovery',
+    });
+
+    const root = await rootBlockObject(carBytes);
+    expect(root.epoch).toBe(1);
+    expect(root.epochResetReason).toBe('oplog-corruption-recovery');
+
+    const parsed = await parseLeanProfileSnapshot(carBytes);
+    expect(parsed.epoch).toBe(1);
+    expect(parsed.epochResetReason).toBe('oplog-corruption-recovery');
+  });
+
+  it('round-trips a high epoch (boundary)', async () => {
+    const storage = await makeStorage();
+    const ts = new FakeTokenStorage();
+
+    const { carBytes } = await buildLeanProfileSnapshot({
+      storage,
+      tokenStorage: ts as unknown as ProfileTokenStorageProvider,
+      chainPubkey: CHAIN_PUBKEY,
+      network: 'testnet',
+      createdAt: TS,
+      epoch: EPOCH_MAX,
+    });
+
+    const parsed = await parseLeanProfileSnapshot(carBytes);
+    expect(parsed.epoch).toBe(EPOCH_MAX);
+  });
+
+  it('round-trips through parseLeanProfileSnapshotFromRootBlock', async () => {
+    const storage = await makeStorage();
+    const ts = new FakeTokenStorage();
+
+    const { carBytes } = await buildLeanProfileSnapshot({
+      storage,
+      tokenStorage: ts as unknown as ProfileTokenStorageProvider,
+      chainPubkey: CHAIN_PUBKEY,
+      network: 'testnet',
+      createdAt: TS,
+      epoch: 3,
+      epochResetReason: 'sphere.profile.resetEpoch',
+    });
+
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootBlock = await reader.get(roots[0]);
+    expect(rootBlock).toBeDefined();
+    const rootBlockBytes = rootBlock!.bytes;
+
+    const parsed = await parseLeanProfileSnapshotFromRootBlock(rootBlockBytes);
+    expect(parsed.epoch).toBe(3);
+    expect(parsed.epochResetReason).toBe('sphere.profile.resetEpoch');
+  });
+});
+
+describe('lean snapshot — epoch validation', () => {
+  it('rejects negative epoch', async () => {
+    const storage = await makeStorage();
+    const ts = new FakeTokenStorage();
+
+    await expect(
+      buildLeanProfileSnapshot({
+        storage,
+        tokenStorage: ts as unknown as ProfileTokenStorageProvider,
+        chainPubkey: CHAIN_PUBKEY,
+        network: 'testnet',
+        createdAt: TS,
+        epoch: -1,
+      }),
+    ).rejects.toThrow(/epoch must be integer/);
+  });
+
+  it('rejects non-integer epoch', async () => {
+    const storage = await makeStorage();
+    const ts = new FakeTokenStorage();
+
+    await expect(
+      buildLeanProfileSnapshot({
+        storage,
+        tokenStorage: ts as unknown as ProfileTokenStorageProvider,
+        chainPubkey: CHAIN_PUBKEY,
+        network: 'testnet',
+        createdAt: TS,
+        epoch: 1.5,
+      }),
+    ).rejects.toThrow(/epoch must be integer/);
+  });
+
+  it('rejects epoch > EPOCH_MAX', async () => {
+    const storage = await makeStorage();
+    const ts = new FakeTokenStorage();
+
+    await expect(
+      buildLeanProfileSnapshot({
+        storage,
+        tokenStorage: ts as unknown as ProfileTokenStorageProvider,
+        chainPubkey: CHAIN_PUBKEY,
+        network: 'testnet',
+        createdAt: TS,
+        epoch: EPOCH_MAX + 1,
+      }),
+    ).rejects.toThrow(/epoch must be integer/);
+  });
+
+  it('rejects reason longer than the byte cap', async () => {
+    const storage = await makeStorage();
+    const ts = new FakeTokenStorage();
+
+    const bigReason = 'a'.repeat(EPOCH_RESET_REASON_MAX_BYTES + 1);
+    await expect(
+      buildLeanProfileSnapshot({
+        storage,
+        tokenStorage: ts as unknown as ProfileTokenStorageProvider,
+        chainPubkey: CHAIN_PUBKEY,
+        network: 'testnet',
+        createdAt: TS,
+        epoch: 1,
+        epochResetReason: bigReason,
+      }),
+    ).rejects.toThrow(/exceeds cap/);
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -676,7 +676,12 @@ export type SphereEventType =
   | 'swap:cancelled'
   | 'swap:failed'
   | 'swap:deposit_returned'
-  | 'swap:bounce_received';
+  | 'swap:bounce_received'
+  /**
+   * Issue #310 — fires AFTER `sphere.profile.resetEpoch()` persists
+   * the new epoch floor locally. Payload: `{ newEpoch, reason, ts }`.
+   */
+  | 'profile:epoch-reset';
 
 export interface SphereEventMap {
   'transfer:incoming': IncomingTransfer;
@@ -1493,6 +1498,13 @@ export interface SphereEventMap {
   'swap:failed': { swapId: string; error: string };
   'swap:deposit_returned': { swapId: string; transfer: import('../modules/accounting/types').InvoiceTransferRef; returnReason: string };
   'swap:bounce_received': { swapId: string; reason: string; returnedAmount: string; returnedCurrency: string };
+  /**
+   * Issue #310 — payload for `'profile:epoch-reset'`. `newEpoch` is the
+   * post-reset value (strictly `prev + 1`). `reason` is the
+   * operator-supplied triage string. `ts` is the wall-clock instant
+   * (ms epoch) of the reset.
+   */
+  'profile:epoch-reset': { newEpoch: number; reason: string; ts: number };
 }
 
 export type SphereEventHandler<T extends SphereEventType> = (

--- a/types/index.ts
+++ b/types/index.ts
@@ -693,7 +693,19 @@ export type SphereEventType =
    *
    * Payload: `{ newEpoch, reason, discoveryError, ts }`.
    */
-  | 'profile:epoch-reset-discovery-skipped';
+  | 'profile:epoch-reset-discovery-skipped'
+  /**
+   * Issue #310 / PR #316 F2 fix — fires when `resetEpoch` timed out
+   * waiting for the aggregator-pointer publish to land. The local
+   * epoch floor IS already persisted; the periodic-poll retry or
+   * next dirty-flush will republish in the background. Callers
+   * monitoring for the post-reset publish should keep watching
+   * `'storage:pointer-published'` events (or re-call
+   * `getEpochFloor()` after a few seconds).
+   *
+   * Payload: `{ newEpoch, reason, timeoutMs, ts }`.
+   */
+  | 'profile:epoch-reset-publish-pending';
 
 export interface SphereEventMap {
   'transfer:incoming': IncomingTransfer;
@@ -1528,6 +1540,19 @@ export interface SphereEventMap {
     newEpoch: number;
     reason: string;
     discoveryError: string;
+    ts: number;
+  };
+  /**
+   * Issue #310 / PR #316 F2 fix — payload for
+   * `'profile:epoch-reset-publish-pending'`. Fires when the publish
+   * step did not land within the bounded timeout. The wallet's local
+   * floor is unchanged from the corresponding `'profile:epoch-reset'`
+   * event; the publish will be retried by the periodic poll.
+   */
+  'profile:epoch-reset-publish-pending': {
+    newEpoch: number;
+    reason: string;
+    timeoutMs: number;
     ts: number;
   };
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -681,7 +681,19 @@ export type SphereEventType =
    * Issue #310 — fires AFTER `sphere.profile.resetEpoch()` persists
    * the new epoch floor locally. Payload: `{ newEpoch, reason, ts }`.
    */
-  | 'profile:epoch-reset';
+  | 'profile:epoch-reset'
+  /**
+   * Issue #310 / PR #316 F1 fix — fires when `resetEpoch` could NOT
+   * consult the on-chain epoch floor (aggregator/discovery failure).
+   * The local epoch was still bumped from `localFloor + 1`, but the
+   * new epoch is PROVISIONAL — if a sibling device's higher epoch
+   * exists on-chain, the two devices may collide. The next discovery
+   * cycle (periodic poll or explicit `recoverLatest`) will surface
+   * the conflict via the normal walkback-floor path.
+   *
+   * Payload: `{ newEpoch, reason, discoveryError, ts }`.
+   */
+  | 'profile:epoch-reset-discovery-skipped';
 
 export interface SphereEventMap {
   'transfer:incoming': IncomingTransfer;
@@ -1505,6 +1517,19 @@ export interface SphereEventMap {
    * (ms epoch) of the reset.
    */
   'profile:epoch-reset': { newEpoch: number; reason: string; ts: number };
+  /**
+   * Issue #310 / PR #316 F1 fix — payload for
+   * `'profile:epoch-reset-discovery-skipped'`. `newEpoch` is the
+   * bumped local floor (provisional — see event-type doc).
+   * `discoveryError` is a short diagnostic string suitable for
+   * operator triage; the underlying error is also logged.
+   */
+  'profile:epoch-reset-discovery-skipped': {
+    newEpoch: number;
+    reason: string;
+    discoveryError: string;
+    ts: number;
+  };
 }
 
 export type SphereEventHandler<T extends SphereEventType> = (


### PR DESCRIPTION
## Summary

Add `sphere.profile.resetEpoch({ reason })` — a Profile-mode-only public API that lets users recover from a corrupted OpLog without dropping back to legacy mode. The reset stamps a permanent **floor** into the aggregator-pointer chain so all clients (this device and any sibling device replicating the same wallet) refuse to walk back into the abandoned state.

Closes #310. Builds on PR #305 (`OrbitDbAdapter.resetCorruptedLog`) and RFC-251 (pointer walkback floor); cross-references #309 (identity fallback) and #308 (read-path auto-reset).

## What it does

```typescript
// Profile-mode wallets only — sphere.profile is null in legacy mode
await sphere.profile!.resetEpoch({ reason: 'oplog-corruption-recovery' });
// 1. Persists epoch = prev + 1 to local cache (atomic, before wipe).
// 2. Calls OrbitDbAdapter.resetCorruptedLog (best-effort).
// 3. Triggers a dirty-flush so the next aggregator-pointer publish
//    carries the new epoch in its CAR root block.
// 4. Emits 'profile:epoch-reset' on the Sphere bus.
//
// Subsequent walkbacks (this device + any sibling) refuse to load
// any predecessor whose epoch < max(epoch) observed.
```

## Architecture

| Layer | Change |
|---|---|
| Lean snapshot CAR v3 | Root block grows `epoch?: number` + `epochResetReason?: string`. Pre-#310 readers ignore the fields; new readers honor them. |
| Walkback algorithm | `findLatestValidVersion` gains `inspectSnapshotEpoch` + `initialEpochFloor`. Candidates below the running floor get skipped past, with a new `walkbackEpochSkipped` result field for observability. |
| ProfilePointerLayer | New `readEpochFloor` / `persistEpochFloor` / `inspectSnapshotEpoch` callbacks plumbed into discovery. The floor primes the walkback and persists after each successful discovery. |
| Sphere | New `sphere.profile` accessor (`SphereProfileHandle | null`) — `resetEpoch({reason})` + `getEpochFloor()`. Per-instance mutex serializes concurrent resets so each lands a distinct +1. |
| Factory | The Sphere-bound snapshot publisher reads the persisted floor and stamps it into every lean-snapshot CAR root. |
| SphereError | New codes: `NOT_PROFILE_MODE`, `PROFILE_RESET_FAILED`. |
| Event bus | New event: `profile:epoch-reset` with `{ newEpoch, reason, ts }`. |

## Steelman pass

| Concern | Resolution |
|---|---|
| Race condition: concurrent send + resetEpoch | Per-instance mutex serializes concurrent resetEpoch calls (each lands its own +1, NOT deduplicated). Concurrent SENDS during the OpLog wipe surface as a write error from the dispatcher's retry path. Documented on `SphereProfileHandle.resetEpoch` — callers SHOULD quiesce sends externally. |
| Genesis entry too big for OpLog cap | The snapshot builder enforces `MAX_KV_ENTRIES` + per-block byte cap. A wallet whose KV state exceeds the cap fails the reset-flush with a clear error. |
| Aggregator rejects pointer (unknown field) | The epoch lives in the CAR root block, not in the pointer slot. The aggregator never decodes the CAR, so this is a non-concern. |
| Lost-write during reset → wallet unloadable | The implementation persists the epoch floor BEFORE the OpLog wipe. A crash between persist + wipe leaves the next `Sphere.load()` reading the new floor; the next dirty-flush completes the publish. Partial-reset MUST NOT leave the wallet unloadable (pinned by the crash-safety contract in the JSDoc). |

## Test plan

- [x] `tests/unit/profile/pointer/epoch-floor.test.ts` — 26 tests on pure helpers + walkback simulation (top-down, pinning the device-A-reset / device-B-reader picks-epoch-2-over-stale-epoch-1 semantics)
- [x] `tests/unit/profile/pointer/discover-algorithm-epoch.test.ts` — 5 tests on `findLatestValidVersion` shape + `initialEpochFloor` priming + input validation
- [x] `tests/unit/profile/profile-lean-snapshot-epoch.test.ts` — 9 tests on encode/decode round-trip, EPOCH_MAX boundary, cap validation, partial-fetch parser
- [x] `tests/unit/core/Sphere.profile-reset-epoch.test.ts` — 14 tests on `Sphere.profile` accessor, `resetEpoch` lifecycle, idempotency against re-runs (each call lands a distinct +1), event emission, OrbitDB adapter integration including the throwing-adapter survival case, and **concurrent-call serialization**
- [x] `npx tsup` — clean
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx eslint .` — clean
- [x] Full `npx vitest run` — **8519 pass / 13 skipped / 0 regressions**

## Out of scope (deferred)

- sphere.telco "Reset Profile" button — separate follow-up
- Integration test against a real testnet aggregator (the unit-level coverage pins the contract; the soak requires a sibling-device setup)