### PR TITLE
fix(infra)(#321): aggregator-proxy /health passes through to backend

### DIFF
--- a/tests/e2e/local-infra/aggregator-image/proxy/nginx.conf.template
+++ b/tests/e2e/local-infra/aggregator-image/proxy/nginx.conf.template
@@ -38,11 +38,18 @@ server {
         proxy_send_timeout 600s;
     }
 
-    # Lightweight liveness — short-circuits the backend so the proxy
-    # itself can fail-fast if nginx is wedged but the backend is fine.
+    # /health passes through to the backend so callers see the full
+    # response (status, role, sharding, database details, etc.). The
+    # proxy's own liveness is implicit — if nginx is up enough to
+    # forward the request and read the reply, both halves are alive.
+    # Hiding the backend response behind a static 200 made tools like
+    # unicity-infra-probe report "degraded" because they couldn't see
+    # database state.
     location = /health {
         access_log off;
-        return 200 '{"status":"ok"}';
-        default_type application/json;
+        proxy_pass http://aggregator_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_read_timeout 10s;
     }
 }


### PR DESCRIPTION
## Summary

The proxy was returning a hardcoded `{"status":"ok"}` for `/health`, hiding the backend's rich health response (role, sharding, commitment_queue, database). Tools like `unicity-infra-probe` marked the aggregator DEGRADED because they couldn't distinguish a healthy backend from a wedged one.

Pass `/health` through to the backend. Proxy liveness becomes implicit.

## Verified live

```
$ curl -s https://aggregator-unicity-dev.dyndns.org/health | jq -c
{"status":"ok","role":"standalone","serverId":"0b96d7aa0059-1",
 "sharding":{"mode":"standalone","shardIdLen":4,"shardId":0},
 "details":{"commitment_queue":"0","commitment_queue_status":"healthy",
              "database":"connected"}}
```

## Follow-ups

- `unicity-infra-probe` still reports DEGRADED because it expects `{status:"healthy", database:"ok"}` rather than the actual aggregator schema `{status:"ok", details.database:"connected"}`. That's probe-side schema drift, separate fix in unicitynetwork/infra-probe.

## Test plan
- [x] `curl https://aggregator-unicity-dev.dyndns.org/health` returns the rich payload (verified)
- [x] proxy container is healthy (verified)
- [x] JSON-RPC POST still works (proxy unchanged for other locations)