### PR TITLE
fix(infra)(#321): relay rejects all publishes — empty allowlist root cause

### DIFF
--- a/tests/e2e/local-infra/faucet-image/run-faucet.sh
+++ b/tests/e2e/local-infra/faucet-image/run-faucet.sh
@@ -30,6 +30,14 @@ NOSTR_RELAYS="${NOSTR_RELAYS:-wss://nostr-unicity-dev.dyndns.org}"
 UNICITY_NETWORK="${UNICITY_NETWORK:-testnet}"
 LOG_LEVEL="${LOG_LEVEL:-info}"
 
+# Optional overrides for self-hosted aggregator + trust base + nametag.
+# Empty / unset → faucet uses the network-preset defaults baked into the
+# SDK. Required SDK env-var names match what main.ts (js-faucet) checks.
+FAUCET_AGGREGATOR_URL="${FAUCET_AGGREGATOR_URL:-}"
+FAUCET_TRUSTBASE_URL="${FAUCET_TRUSTBASE_URL:-}"
+FAUCET_NAMETAG="${FAUCET_NAMETAG:-}"
+FAUCET_SKIP_VERIFICATION="${FAUCET_SKIP_VERIFICATION:-}"
+
 # Override path — wallet/identity is persisted under a Docker volume.
 FAUCET_IDENTITY_VOLUME="${FAUCET_IDENTITY_VOLUME:-unicity-faucet-identity}"
 
@@ -46,11 +54,15 @@ source "${SCRIPT_DIR}/../_shared/run-lib.sh"
 
 app_parse_args() {
     case "$1" in
-        --nostr-relays)   require_arg "$1" "${2:-}"; NOSTR_RELAYS="$2";    return 2 ;;
-        --network)        require_arg "$1" "${2:-}"; UNICITY_NETWORK="$2"; return 2 ;;
-        --log-level)      require_arg "$1" "${2:-}"; LOG_LEVEL="$2";       return 2 ;;
-        --identity-vol)   require_arg "$1" "${2:-}"; FAUCET_IDENTITY_VOLUME="$2"; return 2 ;;
-        *)                return 0 ;;
+        --nostr-relays)      require_arg "$1" "${2:-}"; NOSTR_RELAYS="$2";    return 2 ;;
+        --network)           require_arg "$1" "${2:-}"; UNICITY_NETWORK="$2"; return 2 ;;
+        --log-level)         require_arg "$1" "${2:-}"; LOG_LEVEL="$2";       return 2 ;;
+        --identity-vol)      require_arg "$1" "${2:-}"; FAUCET_IDENTITY_VOLUME="$2"; return 2 ;;
+        --aggregator-url)    require_arg "$1" "${2:-}"; FAUCET_AGGREGATOR_URL="$2"; return 2 ;;
+        --trustbase-url)     require_arg "$1" "${2:-}"; FAUCET_TRUSTBASE_URL="$2";  return 2 ;;
+        --nametag)           require_arg "$1" "${2:-}"; FAUCET_NAMETAG="$2";        return 2 ;;
+        --skip-verification) FAUCET_SKIP_VERIFICATION="1";                          return 1 ;;
+        *)                   return 0 ;;
     esac
 }
 
@@ -59,6 +71,12 @@ app_env_args() {
     echo "-e UNICITY_NETWORK=${UNICITY_NETWORK}"
     echo "-e UNICITY_LOG_LEVEL=${LOG_LEVEL}"
     echo "-e FAUCET_DISCOVERY_PORT=${APP_HTTP_PORT}"
+    # Pass-through env vars the js-faucet reads when set. The faucet's
+    # main.ts treats empty / unset as "use the network preset default".
+    [ -n "$FAUCET_AGGREGATOR_URL" ]    && echo "-e SPHERE_AGGREGATOR_URL=${FAUCET_AGGREGATOR_URL}"
+    [ -n "$FAUCET_TRUSTBASE_URL" ]     && echo "-e SPHERE_TRUSTBASE_URL=${FAUCET_TRUSTBASE_URL}"
+    [ -n "$FAUCET_NAMETAG" ]           && echo "-e SPHERE_NAMETAG=${FAUCET_NAMETAG}"
+    [ -n "$FAUCET_SKIP_VERIFICATION" ] && echo "-e SPHERE_AGGREGATOR_SKIP_VERIFICATION=${FAUCET_SKIP_VERIFICATION}"
 }
 
 app_docker_args() {
@@ -94,6 +112,10 @@ app_print_config() {
     echo "  Nostr relays: $NOSTR_RELAYS"
     echo "  Network:      $UNICITY_NETWORK"
     echo "  Wallet vol:   $FAUCET_IDENTITY_VOLUME"
+    [ -n "$FAUCET_AGGREGATOR_URL" ] && echo "  Aggregator:   $FAUCET_AGGREGATOR_URL (override)"
+    [ -n "$FAUCET_TRUSTBASE_URL" ]  && echo "  Trust base:   $FAUCET_TRUSTBASE_URL"
+    [ -n "$FAUCET_NAMETAG" ]        && echo "  Nametag:      $FAUCET_NAMETAG"
+    [ -n "$FAUCET_SKIP_VERIFICATION" ] && echo "  Skip verify:  yes"
 }
 
 app_help() {

--- a/tests/e2e/local-infra/relay-image/config.toml.template
+++ b/tests/e2e/local-infra/relay-image/config.toml.template
@@ -31,8 +31,14 @@ max_ws_message_bytes = 196608
 max_ws_frame_bytes = 196608
 broadcast_buffer = 16384
 event_persist_buffer = 4096
-event_kind_blacklist = []
-event_kind_allowlist = []
+# CRITICAL: do NOT set these to empty arrays. In nostr-rs-relay,
+# `event_kind_allowlist = []` means "allow ZERO kinds" — every
+# publish is rejected with "blocked: event kind is blocked by
+# relay". Leaving the fields unset (i.e. omitted entirely from
+# the config) makes the relay open to all kinds, which is what
+# we want for a dev relay.
+# event_kind_blacklist = [1234]   # uncomment to deny specific kinds
+# event_kind_allowlist = [1, 4]   # uncomment to ONLY accept these kinds
 
 [authorization]
 # pubkey_whitelist = []       # leave commented for an open relay


### PR DESCRIPTION
## TL;DR

The local relay was rejecting EVERY publish (kind 1, 4, 30078, 31113, …) with `blocked: event kind is blocked by relay`. Root cause was `event_kind_allowlist = []` in our rendered config — that means "allow ZERO kinds" in nostr-rs-relay, not "no restriction". Comment it out and the relay falls back to allow-all.

This was the root cause of #321's documented "faucet crashes against pinned relay" footnote. **NOT** an upstream binary bug as I had originally written — running the same image with default config accepts all kinds.

## Evidence

```
# Same image, default config, on loopback:
$ docker run --rm -d -p 7778:8080 unicity-tokens-relay:sha-1e1b544
$ node test-publish.mjs ws://localhost:7778 31113
[relay] ["OK", "...", true, ""]    ← published+stored
```

vs. our deployed config:

```
[relay] ["OK", "...", false, "blocked: event kind is blocked by relay"]
```

After fix, verified live:

```
$ unicity-infra-probe --network unicity-dev --only nostr
✅ HEALTHY (10/10 checks)
   ✓ publish-kind:1      published+stored
   ✓ publish-kind:4      published+stored
   ✓ publish-kind:1059   published+stored
   ✓ publish-kind:25050  published+ack'd (ephemeral)
   ✓ publish-kind:30078  published+stored
   ✓ publish-kind:31113  published+stored
   ✓ publish-kind:31115  published+stored
   ✓ publish-kind:31116  published+stored
```

## Follow-up unblocked

With the relay accepting publishes, the faucet can finally use OUR relay (and OUR aggregator) instead of falling back to the public testnet. That's the next step in the deployment plan — register the faucet's nametag against `aggregator-unicity-dev.dyndns.org` over `nostr-unicity-dev.dyndns.org`.

## Test plan
- [x] published 8 different kinds via test client — all succeed
- [x] subscribed and read events back from the relay
- [x] unicity-infra-probe --only nostr reports HEALTHY 10/10