### PR TITLE
fix(profile)(#308): auto-reset corrupt OpLog on the bundle-index read path

### DIFF
--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -73,6 +73,7 @@ import {
 import type { ShutdownOptions } from '../../storage/storage-provider.js';
 import type { BundleIndex } from './bundle-index.js';
 import type { ProfileTokenStorageHost } from './host.js';
+import { tryAutoResetCorruptedOplog } from './oplog-auto-reset.js';
 // RFC-251 Approach D / issue #255 Problem B — pointer-publish win-broadcast.
 // Imported only for the publish-success path; absent pointer layer ⇒ skipped.
 import {
@@ -386,17 +387,20 @@ export class LifecycleManager {
       // subsequent `save()` then rejects with `"Provider not initialized"`,
       // making the wallet effectively unusable for the session.
       //
-      // **Scope of this band-aid.** Tolerating the throw here ONLY
-      // unblocks `initialize()`. Subsequent calls to `db.all()` —
-      // notably `provider.load()`, `provider.sync()`, and the flush
-      // scheduler's bundle-monotonicity checks — still throw on the
-      // same corrupt block (those paths have pre-existing try/catch
-      // swallows that may silently degrade further). The structural
-      // fix is to make `OrbitDbAdapter.all()` tolerate per-OpLog-entry
-      // block-load failures the same way it tolerates per-entry
-      // coercion failures (see `tryCoerce` in orbitdb-adapter.ts). That
-      // larger fix is tracked separately — search the issue tracker
-      // for "OrbitDbAdapter.all per-block tolerance".
+      // **Recovery (Issue #308).** When the throw carries the
+      // "Failed to load block for <CID>" signature, the catch below now
+      // routes through `tryAutoResetCorruptedOplog` to reset the corrupt
+      // OpLog, write a recovery marker, and retry `refreshKnownBundles`
+      // ONCE — the same recovery the WRITE path got in PR #305. Only when
+      // that recovery does not apply (signature mismatch, no
+      // `resetCorruptedLog` on the adapter, or the reset/retry fails) do
+      // we fall back to the tolerant band-aid below: tolerate the throw
+      // to unblock `initialize()` and proceed with an empty bundle set.
+      // Note that a still-orthogonal improvement — making
+      // `OrbitDbAdapter.all()` skip individual unreadable OpLog entries
+      // the way `tryCoerce` skips per-entry coercion failures — would let
+      // the read recover the *readable* bundles instead of resetting the
+      // whole log; that per-entry tolerance is tracked separately.
       //
       // **Operator observability.** The catch emits a `storage:error`
       // event with code `BUNDLE_INDEX_REFRESH_FAILED` so consumers
@@ -412,32 +416,59 @@ export class LifecycleManager {
       try {
         await this.bundleIndex.refreshKnownBundles();
       } catch (err) {
-        this.host.log(
-          `bundleIndex.refreshKnownBundles failed (proceeding with empty ` +
-            `bundle set; cold-start recovery may repopulate, but cross-` +
-            `device sync and load() will continue to fail until the ` +
-            `corrupt OpLog entry is bypassed): ${
-              err instanceof Error ? err.message : String(err)
-            }`,
+        // Issue #308 — mirror the WRITE-path corrupt-OpLog auto-reset
+        // (PR #305, `FlushScheduler.addBundleWithOplogAutoReset`) onto
+        // this READ path. When `db.all('tokens.bundle.')` throws the
+        // "Failed to load block for <CID>" signature, reset the corrupt
+        // log, write a recovery marker, and retry `refreshKnownBundles`
+        // ONCE against the fresh log. Without this, a wallet that does no
+        // bundle writes re-reads the unreachable head block — and
+        // re-emits the warning below — on every boot, because the
+        // write-path reset is gated on a write that never happens.
+        const outcome = await tryAutoResetCorruptedOplog(
+          this.host,
+          err,
+          'lifecycle-manager.bundle-index-refresh',
+          () => this.bundleIndex.refreshKnownBundles(),
         );
-        // Emit the degraded-state event so operator dashboards and the
-        // sphere.telco UI's migration banner can surface the condition
-        // BEFORE the user clicks Migrate and unwittingly publishes a
-        // partial-view bundle pointer.
-        this.host.emitEvent(
-          this.host.buildErrorEvent(
-            'storage:error',
-            err,
-            'BUNDLE_INDEX_REFRESH_FAILED',
-          ),
-        );
-        // Defense-in-depth reset. `refreshKnownBundles` builds its
-        // result locally and only writes to host AFTER `db.all()`
-        // succeeds, so a partial walk does NOT leak state under the
-        // current implementation. We still reset here so a future
-        // refactor that introduces incremental writes cannot silently
-        // bypass the catch.
-        this.host.setKnownBundleCids(new Set());
+
+        if (!outcome.retrySucceeded) {
+          // Pre-existing tolerant fallback (Issue #239 / #301). Reached
+          // when: the error is not the lost-head-CID signature; OR the
+          // adapter exposes no `resetCorruptedLog` (legacy stub); OR the
+          // reset / retry itself failed. Surface the degraded state and
+          // proceed with an empty bundle set so the cold-start recovery
+          // branch below can repopulate from the aggregator pointer layer.
+          this.host.log(
+            `bundleIndex.refreshKnownBundles failed (proceeding with empty ` +
+              `bundle set; cold-start recovery may repopulate): ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+          );
+          // Emit the degraded-state event so operator dashboards and the
+          // sphere.telco UI's migration banner can surface the condition
+          // BEFORE the user clicks Migrate and unwittingly publishes a
+          // partial-view bundle pointer.
+          this.host.emitEvent(
+            this.host.buildErrorEvent(
+              'storage:error',
+              err,
+              'BUNDLE_INDEX_REFRESH_FAILED',
+            ),
+          );
+          // Defense-in-depth reset. `refreshKnownBundles` builds its
+          // result locally and only writes to host AFTER `db.all()`
+          // succeeds, so a partial walk does NOT leak state under the
+          // current implementation. We still reset here so a future
+          // refactor that introduces incremental writes cannot silently
+          // bypass the catch.
+          this.host.setKnownBundleCids(new Set());
+        }
+        // else: the auto-reset succeeded and `refreshKnownBundles` re-ran
+        // against the fresh log, populating `knownBundleCids` via
+        // `host.setKnownBundleCids`. The helper already emitted
+        // `profile:oplog-auto-resetting` + `profile:recovered`; no
+        // degraded-state warning is emitted because we recovered.
       }
 
       // COLD-START RECOVERY: if OrbitDB has no bundles locally, this

--- a/profile/profile-token-storage/oplog-auto-reset.ts
+++ b/profile/profile-token-storage/oplog-auto-reset.ts
@@ -1,0 +1,205 @@
+/**
+ * Shared corrupt-OpLog auto-reset primitive.
+ *
+ * Issue #305 added auto-reset on the WRITE path
+ * (`FlushScheduler.addBundleWithOplogAutoReset`): when an OrbitDB
+ * operation throws the "Failed to load block for <CID>" signature, the
+ * corrupt log is reset via `OrbitDbAdapter.resetCorruptedLog`, a
+ * `ProfileRecoveryMarker` is written, and the operation is retried once.
+ *
+ * Issue #308 — the same corruption also surfaces from the READ path
+ * (`LifecycleManager.initialize()` → `BundleIndex.refreshKnownBundles()`
+ * → `db.all('tokens.bundle.')`). That path previously only swallowed the
+ * error and proceeded with an empty bundle set, never invoking the
+ * reset. On a wallet that performs no bundle writes for a long time, the
+ * write-path reset never fires, so the unreachable head block is re-read
+ * — and the degraded-state warning re-emitted — on every boot.
+ *
+ * This helper factors the detect → reset → marker → retry → emit
+ * sequence out so the read path reuses the exact recovery contract the
+ * write path already has. It NEVER throws for control flow: it reports
+ * the outcome and lets the caller decide whether to fall back (read
+ * path) or re-throw (write path).
+ *
+ * @module profile/profile-token-storage/oplog-auto-reset
+ */
+
+import { extractLostHeadCid } from '../orbitdb-adapter.js';
+import type { OrbitDbAdapter } from '../orbitdb-adapter.js';
+import type { ProfileDatabase, ProfileRecoveryMarker } from '../types.js';
+import type { ProfileTokenStorageHost } from './host.js';
+
+/** The subset of the host the auto-reset primitive depends on. */
+export type OplogAutoResetHost = Pick<
+  ProfileTokenStorageHost,
+  'db' | 'log' | 'emitEvent' | 'writeRecoveryMarker'
+>;
+
+export interface OplogAutoResetOutcome {
+  /** The error carried the "Failed to load block for <CID>" signature. */
+  readonly matchedSignature: boolean;
+  /** `db.resetCorruptedLog` ran and resolved successfully. */
+  readonly reset: boolean;
+  /** The post-reset `retry()` resolved successfully. */
+  readonly retrySucceeded: boolean;
+  /** The unreachable head CID, when the signature matched (else null). */
+  readonly lostHeadCid: string | null;
+}
+
+/**
+ * Attempt to recover from a corrupt-OpLog read/write error by resetting
+ * the corrupted OrbitDB log and retrying the operation once.
+ *
+ * Mirrors `FlushScheduler.addBundleWithOplogAutoReset` so both the read
+ * and write paths emit the same `profile:oplog-auto-resetting` /
+ * `profile:recovered` events and write the same `ProfileRecoveryMarker`.
+ *
+ * @param host    Host seam exposing `db`, `log`, `emitEvent`, `writeRecoveryMarker`.
+ * @param err     The error thrown by the OrbitDB operation.
+ * @param context Stable label for the call site; recorded on the marker
+ *                and events, e.g. `lifecycle-manager.bundle-index-refresh`.
+ * @param retry   The operation to re-run ONCE after a successful reset.
+ */
+export async function tryAutoResetCorruptedOplog(
+  host: OplogAutoResetHost,
+  err: unknown,
+  context: string,
+  retry: () => Promise<void>,
+): Promise<OplogAutoResetOutcome> {
+  const lostHeadCid = extractLostHeadCid(err);
+  // Not the unreachable-block signature — nothing this primitive can do.
+  if (lostHeadCid === null) {
+    return {
+      matchedSignature: false,
+      reset: false,
+      retrySucceeded: false,
+      lostHeadCid: null,
+    };
+  }
+
+  // `resetCorruptedLog` lives on the concrete `OrbitDbAdapter`, not on the
+  // `ProfileDatabase` interface. Production wiring always uses the adapter;
+  // legacy in-memory stubs / test doubles may omit it, in which case we
+  // cannot recover and the caller keeps its pre-existing behavior.
+  const dbWithReset = host.db as ProfileDatabase & {
+    resetCorruptedLog?: typeof OrbitDbAdapter.prototype.resetCorruptedLog;
+  };
+  if (typeof dbWithReset.resetCorruptedLog !== 'function') {
+    return {
+      matchedSignature: true,
+      reset: false,
+      retrySucceeded: false,
+      lostHeadCid,
+    };
+  }
+
+  host.log(
+    `OpLog head unreachable (lostHeadCid=${lostHeadCid}; context=${context}); ` +
+      `auto-resetting Profile DB. Prior OpLog history is permanently ` +
+      `inaccessible. Token data on local IndexedDB is preserved.`,
+  );
+
+  // Emit BEFORE the reset so operators see the trigger even if the reset
+  // itself fails.
+  host.emitEvent({
+    type: 'profile:oplog-auto-resetting',
+    timestamp: Date.now(),
+    data: { lostHeadCid, context },
+  });
+
+  let resetResult: {
+    recovered: true;
+    lostHeadCid?: string;
+    recoveredAt: number;
+  };
+  try {
+    resetResult = await dbWithReset.resetCorruptedLog({ lostHeadCid, context });
+  } catch (resetErr) {
+    host.emitEvent({
+      type: 'profile:recovered',
+      timestamp: Date.now(),
+      data: {
+        lostHeadCid,
+        recoveredAt: Date.now(),
+        context,
+        retrySucceeded: false,
+        resetFailed: true,
+      },
+      error: resetErr instanceof Error ? resetErr.message : String(resetErr),
+      cause: resetErr,
+    });
+    return {
+      matchedSignature: true,
+      reset: false,
+      retrySucceeded: false,
+      lostHeadCid,
+    };
+  }
+
+  // Best-effort persistent recovery marker. A marker-write failure does
+  // not block the retry — the in-memory recovery still applies for this
+  // session.
+  const marker: ProfileRecoveryMarker = {
+    version: 1,
+    recoveredAt: resetResult.recoveredAt,
+    lostHeadCid: resetResult.lostHeadCid ?? lostHeadCid,
+    context,
+    walkBackClosed: true,
+    note:
+      'Profile OpLog auto-reset: an OrbitDB head block was unreachable ' +
+      'and could not be served by any known store (Helia blockstore, ' +
+      'operator gateways). Walk-back past this point is permanently ' +
+      'closed; some operational metadata (outbox/sent/history not yet ' +
+      'pinned in a UXF bundle) may have been lost. Token data on ' +
+      'local IndexedDB token storage is preserved.',
+  };
+  try {
+    await host.writeRecoveryMarker(marker);
+  } catch (markerErr) {
+    host.log(
+      `Recovery marker write failed (continuing): ` +
+        `${markerErr instanceof Error ? markerErr.message : String(markerErr)}`,
+    );
+  }
+
+  // Retry the operation ONCE against the fresh log.
+  try {
+    await retry();
+  } catch (retryErr) {
+    host.emitEvent({
+      type: 'profile:recovered',
+      timestamp: Date.now(),
+      data: {
+        lostHeadCid,
+        recoveredAt: resetResult.recoveredAt,
+        context,
+        retrySucceeded: false,
+      },
+      error: retryErr instanceof Error ? retryErr.message : String(retryErr),
+      cause: retryErr,
+    });
+    return {
+      matchedSignature: true,
+      reset: true,
+      retrySucceeded: false,
+      lostHeadCid,
+    };
+  }
+
+  host.emitEvent({
+    type: 'profile:recovered',
+    timestamp: Date.now(),
+    data: {
+      lostHeadCid,
+      recoveredAt: resetResult.recoveredAt,
+      context,
+      retrySucceeded: true,
+    },
+  });
+  return {
+    matchedSignature: true,
+    reset: true,
+    retrySucceeded: true,
+    lostHeadCid,
+  };
+}

--- a/tests/unit/profile/lifecycle-manager-read-path-oplog-reset-308.test.ts
+++ b/tests/unit/profile/lifecycle-manager-read-path-oplog-reset-308.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Issue #308 — read-path corrupt-OpLog auto-reset.
+ *
+ * PR #305 added auto-reset on the WRITE path
+ * (`FlushScheduler.addBundleWithOplogAutoReset`). But the same
+ * "Failed to load block for <CID>" corruption also surfaces from the
+ * READ path during `LifecycleManager.initialize()` →
+ * `BundleIndex.refreshKnownBundles()` → `db.all('tokens.bundle.')`.
+ * Before this fix that path only swallowed the error and proceeded with
+ * an empty bundle set, so a wallet that performs no bundle writes
+ * re-read the unreachable head block — and re-emitted the
+ * `BUNDLE_INDEX_REFRESH_FAILED` warning — on every boot, never invoking
+ * the reset.
+ *
+ * What this test pins:
+ *
+ *   1. When `db.all('tokens.bundle.')` throws the lost-head-CID
+ *      signature AND the adapter exposes `resetCorruptedLog`,
+ *      `initialize()` triggers the reset and retries
+ *      `refreshKnownBundles` ONCE against the fresh log.
+ *   2. The recovery is observable: `profile:oplog-auto-resetting` and a
+ *      `profile:recovered` (retrySucceeded: true) event fire.
+ *   3. On successful recovery the degraded-state `BUNDLE_INDEX_REFRESH_FAILED`
+ *      warning is NOT emitted (we recovered, so we do not fall back).
+ *   4. Counter-case: when the adapter has NO `resetCorruptedLog`, the
+ *      pre-existing tolerant fallback still applies — exactly one
+ *      `BUNDLE_INDEX_REFRESH_FAILED` event, empty bundle set, no
+ *      `profile:recovered`.
+ *
+ * @see https://github.com/unicity-sphere/sphere-sdk/issues/308
+ * @see profile/profile-token-storage/oplog-auto-reset.ts
+ * @see profile/profile-token-storage/lifecycle-manager.ts
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import type { ProfileDatabase, OrbitDbConfig } from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+const LOST_HEAD_CID =
+  'bafyreihx3oaghj4gzbpvp57pz3i5ytl3ptjwdbjsymuucdfl6xkffvn2by';
+
+/**
+ * Mock OrbitDB whose `all('tokens.bundle.')` throws the lost-head-CID
+ * signature until `resetCorruptedLog` runs, after which it returns an
+ * empty (fresh) bundle set — modelling a corrupt OpLog head block that
+ * the reset clears.
+ */
+function createResettableCorruptDb(opts: { withReset: boolean }) {
+  const store = new Map<string, Uint8Array>();
+  let resetDone = false;
+  let bundleAllCalls = 0;
+  const resetCorruptedLog = vi.fn(
+    async (reason: { lostHeadCid?: string; context: string }) => {
+      resetDone = true;
+      return {
+        recovered: true as const,
+        lostHeadCid: reason.lostHeadCid,
+        recoveredAt: Date.now(),
+      };
+    },
+  );
+
+  const base = {
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const isBundleScan = prefix?.startsWith('tokens.bundle') ?? false;
+      if (isBundleScan) {
+        bundleAllCalls += 1;
+        if (!resetDone) {
+          const err = new Error(
+            '[PROFILE:ORBITDB_READ_FAILED] Failed to read all entries with ' +
+              `prefix "tokens.bundle.": Failed to load block for ${LOST_HEAD_CID}`,
+          );
+          (err as { code?: string }).code = 'ORBITDB_READ_FAILED';
+          throw err;
+        }
+        // Fresh log after reset — no bundles to enumerate.
+        return new Map<string, Uint8Array>();
+      }
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) {
+        if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      }
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  };
+
+  const db = (
+    opts.withReset ? { ...base, resetCorruptedLog } : { ...base }
+  ) as ProfileDatabase & { resetCorruptedLog?: typeof resetCorruptedLog };
+
+  return {
+    db,
+    resetCorruptedLog,
+    get bundleAllCalls() {
+      return bundleAllCalls;
+    },
+  };
+}
+
+function createProvider(db: ProfileDatabase): ProfileTokenStorageProvider {
+  const provider = new ProfileTokenStorageProvider(
+    db,
+    new Uint8Array(32).fill(0x11),
+    ['https://mock-ipfs.test'],
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId: 'test',
+      encrypt: true,
+    },
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  return provider;
+}
+
+interface CapturedEvent {
+  type: string;
+  code?: string;
+  retrySucceeded?: boolean;
+}
+
+function captureEvents(provider: ProfileTokenStorageProvider): CapturedEvent[] {
+  const events: CapturedEvent[] = [];
+  provider.onEvent((ev) => {
+    events.push({
+      type: ev.type,
+      code: (ev as { code?: string }).code,
+      retrySucceeded: (ev as { data?: { retrySucceeded?: boolean } }).data
+        ?.retrySucceeded,
+    });
+  });
+  return events;
+}
+
+describe('LifecycleManager.initialize() — read-path corrupt-OpLog auto-reset (#308)', () => {
+  describe('adapter exposes resetCorruptedLog', () => {
+    let harness: ReturnType<typeof createResettableCorruptDb>;
+    let provider: ProfileTokenStorageProvider;
+    let events: CapturedEvent[];
+
+    beforeEach(() => {
+      harness = createResettableCorruptDb({ withReset: true });
+      provider = createProvider(harness.db);
+      events = captureEvents(provider);
+    });
+
+    it('initialize() resolves true after auto-reset', async () => {
+      const ok = await provider.initialize();
+      expect(ok).toBe(true);
+    });
+
+    it('triggers resetCorruptedLog exactly once on the read path', async () => {
+      await provider.initialize();
+      expect(harness.resetCorruptedLog).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries refreshKnownBundles against the fresh log (db.all bundle scan ≥ 2)', async () => {
+      await provider.initialize();
+      // First call throws the signature; the post-reset retry succeeds.
+      expect(harness.bundleAllCalls).toBeGreaterThanOrEqual(2);
+    });
+
+    it('emits profile:oplog-auto-resetting and profile:recovered(retrySucceeded:true)', async () => {
+      await provider.initialize();
+      expect(events.some((e) => e.type === 'profile:oplog-auto-resetting')).toBe(
+        true,
+      );
+      expect(
+        events.some(
+          (e) => e.type === 'profile:recovered' && e.retrySucceeded === true,
+        ),
+      ).toBe(true);
+    });
+
+    it('does NOT emit the degraded BUNDLE_INDEX_REFRESH_FAILED warning when recovery succeeds', async () => {
+      await provider.initialize();
+      const degraded = events.filter(
+        (e) => e.code === 'BUNDLE_INDEX_REFRESH_FAILED',
+      );
+      expect(degraded.length).toBe(0);
+    });
+  });
+
+  describe('adapter has NO resetCorruptedLog — pre-existing tolerant fallback preserved', () => {
+    let harness: ReturnType<typeof createResettableCorruptDb>;
+    let provider: ProfileTokenStorageProvider;
+    let events: CapturedEvent[];
+
+    beforeEach(() => {
+      harness = createResettableCorruptDb({ withReset: false });
+      provider = createProvider(harness.db);
+      events = captureEvents(provider);
+    });
+
+    it('initialize() still resolves true (tolerant fallback)', async () => {
+      const ok = await provider.initialize();
+      expect(ok).toBe(true);
+    });
+
+    it('emits exactly one BUNDLE_INDEX_REFRESH_FAILED and no profile:recovered', async () => {
+      await provider.initialize();
+      const degraded = events.filter(
+        (e) => e.code === 'BUNDLE_INDEX_REFRESH_FAILED',
+      );
+      expect(degraded.length).toBe(1);
+      expect(events.some((e) => e.type === 'profile:recovered')).toBe(false);
+    });
+
+    it('leaves knownBundleCids empty', async () => {
+      await provider.initialize();
+      const known = (
+        provider as unknown as { knownBundleCids: Set<string> }
+      ).knownBundleCids;
+      expect(known).toBeInstanceOf(Set);
+      expect(known.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #308. PR #305 added corrupt-OpLog auto-reset on the **write** path (`FlushScheduler.addBundleWithOplogAutoReset`), but the same `Failed to load block for <CID>` corruption also surfaces from the **read** path during boot (`LifecycleManager.initialize()` → `BundleIndex.refreshKnownBundles()` → `db.all('tokens.bundle.')`). That path only swallowed the error and proceeded with an empty bundle set, so on a wallet that performs no bundle writes the write-path reset never fires — the unreachable head block is re-read and the `BUNDLE_INDEX_REFRESH_FAILED` warning re-emitted on every boot (the log line even promised a bypass that never ran).

This implements acceptance-criteria **option 2** from the issue: trigger PR #305's auto-reset from the read path.

## Changes

- **New** `profile/profile-token-storage/oplog-auto-reset.ts` — shared `tryAutoResetCorruptedOplog(host, err, context, retry)` primitive that factors out the detect (`extractLostHeadCid`) → emit `profile:oplog-auto-resetting` → `db.resetCorruptedLog` → write `ProfileRecoveryMarker` → retry-once → emit `profile:recovered` sequence, mirroring the write path's exact event/marker contract. It never throws for control flow; it returns an outcome so each caller decides whether to fall back or re-throw.
- **`lifecycle-manager.ts`** — the read-path catch routes through the helper and retries `refreshKnownBundles` once against the fresh log. It falls back to the pre-existing tolerant behavior (`BUNDLE_INDEX_REFRESH_FAILED` + empty bundle set) only when recovery does not apply: signature mismatch, no `resetCorruptedLog` on the adapter (legacy stub), or reset/retry failure. Amended the misleading log message and the now-stale lead-in comment.
- **New test** `tests/unit/profile/lifecycle-manager-read-path-oplog-reset-308.test.ts` (8 cases) — auto-reset fires once on the read path, retries against the fresh log, emits the recovery events, and suppresses the degraded warning on success; counter-case (adapter without `resetCorruptedLog`) preserves the old tolerant fallback exactly.

I deliberately did **not** refactor the write-path `addBundleWithOplogAutoReset` onto the shared helper — that path is already well-tested and changing it adds regression risk for no functional gain here. That DRY consolidation is a reasonable follow-up.

## Test plan

- [x] `tsc --noEmit` — 0 errors
- [x] `eslint` on changed files — clean
- [x] New #308 test — 8/8 pass
- [x] Existing related tests (`lifecycle-manager-initialize-bundle-index-tolerant`, `flush-scheduler-oplog-reset`, `orbitdb-adapter-reset-corrupted-log`) — pass, no regressions
- [x] Full `tests/unit/profile/` suite — 2209 tests pass

Targeted at `integration/all-fixes` since the `profile/` subsystem lives on that branch.