### PR TITLE
feat(infra)(#321): proxy serves trust-base + faucet surfaces verified nametag

### DIFF
--- a/tests/e2e/local-infra/aggregator-image/docker-compose.yml
+++ b/tests/e2e/local-infra/aggregator-image/docker-compose.yml
@@ -273,6 +273,11 @@ services:
       - haproxy-net
     volumes:
       - agg-letsencrypt:/etc/letsencrypt
+      # Read-only bind-mount of the genesis dir so the proxy nginx can
+      # serve trust-base.json at /.well-known/trust-base.json. Wallets
+      # talking to this aggregator need OUR trust base (not the testnet
+      # one) to verify inclusion proofs against this chain's genesis.
+      - ./data/genesis:/etc/aggregator-config:ro
     environment:
       # ${AGG_DOMAIN} and ${SSL_EMAIL} are validated at the wrapper-
       # script level (run-aggregator.sh) so `docker compose down`

--- a/tests/e2e/local-infra/aggregator-image/proxy/nginx.conf.template
+++ b/tests/e2e/local-infra/aggregator-image/proxy/nginx.conf.template
@@ -52,4 +52,21 @@ server {
         proxy_set_header Host $host;
         proxy_read_timeout 10s;
     }
+
+    # Serve OUR aggregator's trust-base.json so wallets can verify
+    # inclusion proofs against this chain's genesis. The file is
+    # bind-mounted into /etc/aggregator-config/ from the same host
+    # path the aggregator binary reads its config from (./data/genesis/
+    # in the compose file's working directory). When fresh genesis is
+    # minted via `run-aggregator.sh --fresh`, this URL serves the new
+    # trust-base on the next nginx reload — no restart required as
+    # long as the file's inode is preserved (which Docker bind-mounts
+    # of single files do).
+    location = /.well-known/trust-base.json {
+        access_log off;
+        default_type application/json;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Cache-Control "no-cache, must-revalidate";
+        alias /etc/aggregator-config/trust-base.json;
+    }
 }

--- a/tests/e2e/local-infra/faucet-image/render-discovery.sh
+++ b/tests/e2e/local-infra/faucet-image/render-discovery.sh
@@ -13,8 +13,27 @@ set -euo pipefail
 
 IDENTITY_FILE="${IDENTITY_FILE:-/var/lib/faucet/identity.json}"
 CURRENT_PUBKEY=
+CURRENT_NAMETAG=
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
+
+render() {
+    local pubkey="$1" nametag="$2"
+    local direct="DIRECT://${pubkey}"
+    cat > "$TMP_DIR/identity.json" <<EOF
+{
+  "status": "running",
+  "domain": "${SSL_DOMAIN:-localhost}",
+  "network": "${UNICITY_NETWORK:-testnet}",
+  "chain_pubkey": "${pubkey}",
+  "direct_address": "${direct}",
+  "nametag": $([ -n "$nametag" ] && printf '"%s"' "$nametag" || echo "null"),
+  "supported_coins": []
+}
+EOF
+    mv "$TMP_DIR/identity.json" "$IDENTITY_FILE"
+    chmod 644 "$IDENTITY_FILE" 2>/dev/null || true
+}
 
 while IFS= read -r line; do
     # Pass the line through to stdout (so docker logs still see it).
@@ -27,21 +46,29 @@ while IFS= read -r line; do
         | grep -oE '0[23][0-9a-fA-F]{64}' \
         | head -1 || true)
 
+    # Also extract the nametag when it shows up. js-faucet logs:
+    # {"nametag":"xaleava","msg":"nametag_verified"} after a successful
+    # mint+resolve cycle. Earlier "registering_nametag" lines come BEFORE
+    # the mint completes — they don't prove the nametag exists yet, so
+    # we wait for nametag_verified.
+    if printf '%s' "$line" | grep -q 'nametag_verified'; then
+        nametag=$(printf '%s\n' "$line" \
+            | grep -oE '"nametag"\s*:\s*"[^"]*"' \
+            | head -1 \
+            | sed -E 's/.*:\s*"([^"]*)".*/\1/' \
+            || true)
+        if [ -n "$nametag" ] && [ "$nametag" != "$CURRENT_NAMETAG" ]; then
+            CURRENT_NAMETAG="$nametag"
+            if [ -n "$CURRENT_PUBKEY" ]; then
+                render "$CURRENT_PUBKEY" "$CURRENT_NAMETAG"
+                printf '[faucet-discovery] nametag verified: %s\n' "$nametag" >&2
+            fi
+        fi
+    fi
+
     if [ -n "$pubkey" ] && [ "$pubkey" != "$CURRENT_PUBKEY" ]; then
         CURRENT_PUBKEY="$pubkey"
-        direct="DIRECT://${pubkey}"
-        cat > "$TMP_DIR/identity.json" <<EOF
-{
-  "status": "running",
-  "domain": "${SSL_DOMAIN:-localhost}",
-  "network": "${UNICITY_NETWORK:-testnet}",
-  "chain_pubkey": "${pubkey}",
-  "direct_address": "${direct}",
-  "supported_coins": []
-}
-EOF
-        mv "$TMP_DIR/identity.json" "$IDENTITY_FILE"
-        chmod 644 "$IDENTITY_FILE" 2>/dev/null || true
+        render "$CURRENT_PUBKEY" "$CURRENT_NAMETAG"
         printf '[faucet-discovery] identity updated: %s\n' "$pubkey" >&2
     fi
 done


### PR DESCRIPTION
## Summary

Closes the loop on self-hosted nametag minting (xaleava-style use case from #321). With the changes in PRs #323 + #324 + js-faucet #3, the faucet can boot against our aggregator but the nametag mint silently failed because:

1. The SDK calls `oracle.getTrustBase()` during mint
2. `UnicityAggregatorProvider.getTrustBase()` returns `null` unless the trust base was loaded at `initialize()`
3. The trust base loader only runs when `!skipVerification && trustBaseLoader` — so a wallet that wants to use a self-hosted aggregator HAS to also supply a matching trust-base URL

This PR makes that possible by serving our trust-base from the aggregator proxy itself.

## Two changes

### 1. aggregator-proxy serves `/.well-known/trust-base.json`

`docker-compose.yml` bind-mounts `./data/genesis:/etc/aggregator-config:ro` into agg-proxy. `nginx.conf.template` adds a location that aliases the trust-base.json file from that mount. Wallets pointed at this aggregator can now download the matching trust base over HTTPS.

`/health` also picks up the pass-through fix from #323 (which has to land in the same commit to avoid a textual conflict).

### 2. render-discovery.sh surfaces the verified nametag

The discovery doc was showing `nametag: null` even after a successful mint. The watcher now tails for the `nametag_verified` log line (emitted by js-faucet AFTER mint+resolve completes) and rewrites identity.json with the verified nametag.

`registering_nametag` is NOT used as a signal because it fires BEFORE the mint commits — it would surface unverified state.

## Verified live

```
$ curl -s https://aggregator-unicity-dev.dyndns.org/.well-known/trust-base.json | jq -c '{networkId, rootNode: .rootNodes[0].nodeId}'
{"networkId":3,"rootNode":"16Uiu2HAmCRn8..."}

$ docker exec agg-mongodb mongosh --quiet --eval 'db.commitments.countDocuments()'
1

$ curl -s https://faucet-unicity-dev.dyndns.org/.well-known/faucet.json | jq -c '{nametag, chain_pubkey}'
{"nametag":"xaleava","chain_pubkey":"02d41a68efdf70663b97582b35b89dd27b4133b68621e9664c6fadf2974925dc14"}
```

NAMETAG_BINDING (kind 30078) event for xaleava verified on our relay.

## Companion PRs

- sphere-sdk #324 — relay allowlist fix + run-faucet.sh env passthrough
- js-faucet #3 — SPHERE_AGGREGATOR_URL + SPHERE_TRUSTBASE_URL env overrides
- (probe-side schema fix is a separate concern; not blocking this)

## Test plan

- [x] `./run-aggregator.sh --fresh` mints new genesis; proxy serves the new trust-base on next reload
- [x] `curl https://<agg>/.well-known/trust-base.json` returns the correct networkId + rootNodeId
- [x] With `SPHERE_TRUSTBASE_URL` pointing at that URL and `SPHERE_AGGREGATOR_SKIP_VERIFICATION=false`, faucet completes nametag mint (1 commitment lands in mongo)
- [x] Faucet discovery doc shows `nametag: "xaleava"` post-mint