### PR TITLE
fix(payments)(#312): soften connectivity gate to advisory

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -2318,11 +2318,13 @@ export class Sphere {
    * `'connectivity:offline-degraded'` on the Sphere event bus on every
    * transition — bind via `sphere.on(...)` for the UI banner.
    *
-   * Send-path gating: `payments.send()` refuses with
-   * `SphereError('OFFLINE', { which: 'aggregator' })` (no state mutation)
-   * when `status().aggregator === 'down'`. The `'degraded'` state is
-   * allowed — the SDK's retry layer handles slow / partially-failing
-   * aggregators.
+   * Advisory only: `payments.send()` reads this status once at entry and
+   * logs a warning if `status().aggregator === 'down'`, but DOES NOT
+   * refuse the send. The state-transition-sdk transport is the
+   * authoritative health signal — it surfaces `JsonRpcNetworkError` on
+   * real transport failures, and ST-SDK exposes no health/ping API,
+   * so any preflight refuse is a Sphere-SDK invention that risks
+   * blocking sends a recovered aggregator would have accepted.
    *
    * Returns a no-op stub if accessed before `initializeModules()` ran —
    * production callers go through `Sphere.init()`, which calls

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1741,18 +1741,19 @@ export class PaymentsModule {
   private readonly parsedTokenCache: Map<string, ParsedTokenEntry> = new Map();
 
   /**
-   * Issue #312 — send-path offline gate. When wired, every `send()` call
-   * reads this getter once at the very top of the public entry point and
-   * throws `SphereError('OFFLINE', { which: 'aggregator' })` (no state
-   * mutation) if the gate reports `'down'`. `'degraded'` / `'unknown'` /
-   * `'up'` all pass through — the SDK's retry layer absorbs degraded
-   * states, and we MUST NOT block sends pre-first-probe (the design
-   * constraint that `Sphere.init()` resolves before the manager has
-   * confirmed reachability).
+   * Issue #312 — advisory connectivity hint (NOT a send-path gate). When
+   * wired, every `send()` call reads this getter once at the top of the
+   * public entry point. A `'down'` return is LOGGED as a warning but
+   * does not block the send — the state-transition-sdk pattern is to
+   * call the real op and let transport surface a `JsonRpcNetworkError`
+   * on failure. ST-SDK has no health/ping API, so any preflight probe
+   * is a Sphere-SDK invention without an upstream contract; refusing
+   * preemptively would block sends that the aggregator would actually
+   * accept (e.g. recovery between probe and submit).
    *
    * Wired by `Sphere.initializeModules()` via
-   * {@link configureConnectivityGate}. Null = unwired (no gating); the
-   * module behaves exactly as it did pre-#312.
+   * {@link configureConnectivityGate}. Null = unwired (no advisory log);
+   * the module behaves exactly as it did pre-#312.
    */
   private _connectivityGate: (() => 'up' | 'down' | 'degraded' | 'unknown') | null = null;
 
@@ -1908,23 +1909,20 @@ export class PaymentsModule {
   }
 
   /**
-   * Issue #312 — wire the offline-mode send-path gate.
+   * Issue #312 — wire the advisory connectivity hint.
    *
    * Sphere calls this once during `initializeModules()` with a getter
    * that reads `sphere.connectivity.status().aggregator`. The getter is
    * invoked once per `send()` call at the very top of the public entry
-   * point, BEFORE any state mutation, and a `'down'` return triggers a
-   * `SphereError('OFFLINE', { which: 'aggregator' })` throw.
+   * point. A `'down'` return is LOGGED as a warning; it does NOT abort
+   * the send. The real op (submitCommitment via state-transition-sdk)
+   * is the authoritative health signal — if the aggregator is truly
+   * unreachable, transport throws `JsonRpcNetworkError` and the SDK's
+   * retry/recovery layer handles it.
    *
-   * Pass `null` to unwire (the module behaves exactly as pre-#312:
-   * no gating). Wired callers MAY replace the gate at runtime — the
-   * latest call wins.
-   *
-   * Steelman: the gate is a getter, not a snapshot, so a send that
-   * starts under `'up'` and transitions to `'down'` mid-send is NOT
-   * cancelled. That is by design — the aggregator retry layer absorbs
-   * mid-flight transitions, and we MUST NOT throw `OFFLINE` after
-   * partial state mutation (the no-side-effect contract).
+   * Pass `null` to unwire (no advisory log; exactly as pre-#312).
+   * Wired callers MAY replace the gate at runtime — the latest call
+   * wins.
    */
   configureConnectivityGate(
     fn: (() => 'up' | 'down' | 'degraded' | 'unknown') | null,
@@ -5519,24 +5517,23 @@ export class PaymentsModule {
   ): Promise<TransferResult> {
     this.ensureInitialized();
 
-    // Issue #312 — offline-mode send-path gate. BEFORE any state mutation
-    // (no aggregator call, no reservation, no Nostr publish), refuse the
-    // send if the aggregator backend is observed `'down'` by the
-    // connectivity manager. `'degraded'` and `'unknown'` pass through;
-    // the SDK's retry layer handles slow / partially-failing aggregators
-    // and we MUST NOT block sends pre-first-probe (the design constraint
-    // that init() resolves before reachability is confirmed). The gate
-    // is read once here, NOT polled mid-send — see the rationale in
-    // `configureConnectivityGate`.
+    // Issue #312 — advisory offline-mode signal. The connectivity gate is
+    // a hint from the manager; ALL states pass through to the dispatcher.
+    // We MUST NOT preemptively refuse sends based on a probe: the
+    // state-transition-sdk pattern is to call the real op and surface a
+    // `JsonRpcNetworkError` on transport failure. A momentarily-sick
+    // aggregator that recovers between probe and submit would otherwise
+    // be needlessly blocked here, and ST-SDK exposes no health/ping
+    // API so any preflight probe is a Sphere-SDK invention with no
+    // upstream contract behind it. We log when the gate reads `'down'`
+    // for operator visibility, then let the real op decide.
     if (this._connectivityGate) {
       let gateValue: 'up' | 'down' | 'degraded' | 'unknown' = 'unknown';
       try {
         gateValue = this._connectivityGate();
       } catch (err) {
         // A throwing gate must not break sends. Best-effort: treat as
-        // 'unknown' (pass-through). The wallet's send-side retry layer
-        // remains the authoritative recovery path if the aggregator
-        // truly is down.
+        // 'unknown' (pass-through).
         logger.warn(
           'PaymentsModule',
           `Connectivity gate threw (treating as 'unknown'): ${err instanceof Error ? err.message : String(err)}`,
@@ -5544,10 +5541,9 @@ export class PaymentsModule {
         gateValue = 'unknown';
       }
       if (gateValue === 'down') {
-        throw new SphereError(
-          'Aggregator is offline — send refused',
-          'OFFLINE',
-          { which: 'aggregator' },
+        logger.warn(
+          'PaymentsModule',
+          "Connectivity gate reports aggregator 'down'; proceeding with send and letting transport surface any real failure",
         );
       }
     }

--- a/tests/unit/payments/connectivity-gate.test.ts
+++ b/tests/unit/payments/connectivity-gate.test.ts
@@ -1,17 +1,20 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Issue #312 — PaymentsModule.send() offline gate.
+ * Issue #312 — PaymentsModule.send() advisory connectivity hint.
  *
- * The send-path is gated by a callback wired by `Sphere.initializeModules()`
- * that returns `sphere.connectivity.status().aggregator`. When the gate
- * returns `'down'`, send refuses with `SphereError('OFFLINE', { which:
- * 'aggregator' })` BEFORE any state mutation (no aggregator call, no
- * reservation, no Nostr publish).
+ * The send-path reads a callback wired by `Sphere.initializeModules()`
+ * that returns `sphere.connectivity.status().aggregator`. The hint is
+ * ADVISORY: a `'down'` reading is logged but does NOT refuse the send.
+ * The state-transition-sdk transport is the authoritative health
+ * signal — it throws `JsonRpcNetworkError` on real transport failures,
+ * and ST-SDK exposes no health/ping API so any preflight refuse is a
+ * Sphere-SDK invention that risks blocking sends a recovered
+ * aggregator would have accepted.
  *
- * This test exercises the gate at the public entry point. We do NOT
- * fully initialize the module (which would require a real
- * StateTransitionClient) — the gate throws BEFORE `ensureInitialized`
- * even matters because we install our own `_initialized` flag.
+ * Prior behavior (throwing `SphereError('OFFLINE')` on `'down'`) was
+ * removed because a transient testnet aggregator outage propagated to
+ * a hard-refuse and broke CLI soak §C.2 (invoice pay) and the
+ * browser-side send path.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -37,39 +40,40 @@ function buildStubModule(): PaymentsModule {
   return module;
 }
 
-describe('PaymentsModule offline gate (Issue #312)', () => {
+describe('PaymentsModule advisory gate (Issue #312)', () => {
   const REQUEST = {
     recipient: '@bob',
     coinId: 'UCT',
     amount: '1000000',
   } as const;
 
-  it('throws OFFLINE without side effects when gate returns down', async () => {
+  it("proceeds past the gate when it returns 'down' (advisory only)", async () => {
     const module = buildStubModule();
     // Wire the connectivity gate as if Sphere did
     const gateFn = vi.fn(() => 'down' as const);
     (module as any).configureConnectivityGate(gateFn);
-    // Spy on the first downstream call inside send() after the gate —
-    // `maybeEmitCapabilityWarning` is the first inner method invoked.
-    // If the gate works correctly, this MUST NOT be called.
-    const downstreamSpy = vi.spyOn(module as any, 'maybeEmitCapabilityWarning' as any).mockImplementation(() => {
-      throw new Error('maybeEmitCapabilityWarning should not have been called');
-    });
+    // Spy on the first downstream call inside send() after the gate.
+    // The advisory hint MUST NOT short-circuit the dispatcher — this
+    // spy MUST be invoked.
+    const downstreamSpy = vi.spyOn(
+      module as any,
+      'maybeEmitCapabilityWarning' as any,
+    );
     let caught: unknown;
     try {
       await module.send(REQUEST);
     } catch (e) {
       caught = e;
     }
-    expect(caught).toBeDefined();
-    expect(isSphereError(caught)).toBe(true);
-    expect((caught as any).code).toBe('OFFLINE');
-    // SphereError redaction layer copies the cause object into `context`.
-    expect((caught as any).context).toEqual({ which: 'aggregator' });
     // Gate was called once
     expect(gateFn).toHaveBeenCalledTimes(1);
-    // No downstream side effect
-    expect(downstreamSpy).not.toHaveBeenCalled();
+    // Downstream WAS invoked — the send proceeded.
+    expect(downstreamSpy).toHaveBeenCalled();
+    // Whatever error eventually surfaces, it MUST NOT be the legacy
+    // 'OFFLINE' refuse (which is what we just removed).
+    if (isSphereError(caught)) {
+      expect((caught as any).code).not.toBe('OFFLINE');
+    }
   });
 
   it('proceeds past the gate when gate returns up', async () => {
@@ -151,10 +155,17 @@ describe('PaymentsModule offline gate (Issue #312)', () => {
 
   it('can be unwired via configureConnectivityGate(null)', async () => {
     const module = buildStubModule();
-    (module as any).configureConnectivityGate(() => 'down' as const);
-    // Confirm it gates first
-    await expect(module.send(REQUEST)).rejects.toThrow(/offline/i);
-    // Now unwire
+    const gateFn = vi.fn(() => 'down' as const);
+    (module as any).configureConnectivityGate(gateFn);
+    // First call: gate is invoked but advisory only — send proceeds.
+    try {
+      await module.send(REQUEST);
+    } catch {
+      // Downstream error from the partially-stubbed module is expected;
+      // we only care that the gate was consulted.
+    }
+    expect(gateFn).toHaveBeenCalledTimes(1);
+    // Now unwire — subsequent sends MUST NOT touch the gate.
     (module as any).configureConnectivityGate(null);
     let caught: unknown;
     try {
@@ -162,6 +173,8 @@ describe('PaymentsModule offline gate (Issue #312)', () => {
     } catch (e) {
       caught = e;
     }
+    // Still no extra gate calls after unwiring.
+    expect(gateFn).toHaveBeenCalledTimes(1);
     if (isSphereError(caught)) {
       expect((caught as any).code).not.toBe('OFFLINE');
     }


### PR DESCRIPTION
## Summary
- Replace the `OFFLINE` throw at `PaymentsModule.ts:5546` with a `logger.warn`; gate is now advisory only.
- Rationale: state-transition-sdk exposes **no** health/ping/round API. Its `StateTransitionClient` public surface is `submitMintCommitment` / `submitTransferCommitment` / `finalizeTransaction` / `getInclusionProof` / `isStateSpent` / `isTokenStateSpent` / `isMinted`. The standard pattern is "call the real op; transport throws `JsonRpcNetworkError` on failure" — preflight probing is a Sphere-SDK invention without an upstream contract.
- Update related doc blocks on `_connectivityGate`, `configureConnectivityGate`, and `sphere.connectivity` getter.
- Flip the test at `tests/unit/payments/connectivity-gate.test.ts` from `down → throws` to `down → logs + proceeds`; tighten the unwire test.

## Why this PR exists
The CLI soak (`.tmp/soak-verbose-1780003451/script.log`) failed at §C.2 (Bob pays invoice) with `Error: Aggregator is offline — send refused`. Root cause: testnet aggregator was briefly down → connectivity probe read `'down'` → the PR #312 gate hard-refused the send. The same probe call (`POST goggregator-test → 400`) was also spamming the browser-side load.

Refusing on a probe blocks sends a recovered aggregator would accept (between probe and submit) and re-implements behavior ST-SDK does not have a contract for.

## Kept for backward compat
- `SphereErrorCode 'OFFLINE'` stays in `core/errors.ts`. No caller emits it now, but removing the code is a separate type-surface break.
- `configureConnectivityGate` / `sphere.connectivity` public API are unchanged. The gate is still consulted and still drives the `connectivity:*` event bus — only the throw is gone.

## Test plan
- [x] `npx vitest run tests/unit/payments/connectivity-gate.test.ts` → 7/7 pass
- [x] `npx vitest run tests/unit/payments tests/unit/core/connectivity` → 1587/1587 pass
- [x] `npm run typecheck` → 0 errors
- [x] `npx eslint` on touched files → 0 errors (5 pre-existing warnings outside edits)
- [ ] Re-run `manual-test-full-recovery.sh` soak against `integration/all-fixes` after merge; confirm §C.2 invoice pay no longer blocks on probe.