### PR TITLE
fix(profile)(#330): browser durability — IDBBlockstore + pointer-publish gate + token fallback

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -1373,6 +1373,39 @@ export class Sphere {
     // `getTokenStorage().setFallbackTokenStorage(...)` further below.
     sphere._fallbackTokenStorage = options.fallbackTokenStorage ?? null;
 
+    // Issue #330 — warn loudly when the underlying storage carries the
+    // legacy-migration marker but no `fallbackTokenStorage` was wired.
+    // This catches consumer apps that updated their SDK but did not
+    // migrate to the auto-wiring factory (`createBrowserProfileProvidersAuto`
+    // / equivalent). Without a fallback, pre-migration tokens are
+    // unrecoverable if the Profile blockstore loses them — exactly
+    // the symptom #330 sought to fix. Best-effort: any error during
+    // the probe is swallowed (the storage may not yet be connected,
+    // or the legacy KV may not implement `get`).
+    if (sphere._fallbackTokenStorage === null) {
+      try {
+        if (
+          typeof options.storage.isConnected === 'function' &&
+          options.storage.isConnected() &&
+          typeof options.storage.get === 'function'
+        ) {
+          const markerValue = await options.storage.get('migration.migratedAt');
+          if (typeof markerValue === 'string' && markerValue.length > 0) {
+            logger.warn(
+              'Sphere',
+              'Issue #330: legacy-migration marker detected on storage but no `fallbackTokenStorage` ' +
+                'was provided to Sphere.init/load. Tokens that were durable in the legacy IndexedDB ' +
+                'before Profile migration are NOT recoverable from this session. Use ' +
+                '`createBrowserProfileProvidersAuto` (or wire a legacy `IndexedDBTokenStorageProvider` ' +
+                'as `fallbackTokenStorage` manually) to close this gap.',
+            );
+          }
+        }
+      } catch {
+        // Probe is best-effort. Continue without warning.
+      }
+    }
+
     // Issue #330 — propagate the fallback into any token storage
     // provider that supports it (Profile-mode providers expose
     // `setFallbackTokenStorage`). Done here, before initialize() runs,
@@ -1667,6 +1700,9 @@ export class Sphere {
    * await Sphere.clear({
    *   storage: providers.storage,
    *   tokenStorage: providers.tokenStorage,
+   *   // Issue #330 — pass the legacy fallback if the wallet was
+   *   // migrated, so the resurrection footgun is closed.
+   *   fallbackTokenStorage: providers.fallbackTokenStorage,
    * });
    *
    * @example
@@ -1674,10 +1710,25 @@ export class Sphere {
    * await Sphere.clear(storage);
    */
   static async clear(
-    storageOrOptions: StorageProvider | { storage: StorageProvider; tokenStorage?: TokenStorageProvider<TxfStorageDataBase> },
+    storageOrOptions:
+      | StorageProvider
+      | {
+          storage: StorageProvider;
+          tokenStorage?: TokenStorageProvider<TxfStorageDataBase>;
+          /**
+           * Issue #330 — read-only fallback token storage that was
+           * passed to `Sphere.init`/`load`. If supplied, `clear()`
+           * wipes it too. Without this, a user calling `clear()` and
+           * then re-running `init()` with the same mnemonic would see
+           * pre-clear tokens resurrected from the legacy IDB.
+           */
+          fallbackTokenStorage?: TokenStorageProvider<TxfStorageDataBase>;
+        },
   ): Promise<void> {
     const storage = 'get' in storageOrOptions ? storageOrOptions as StorageProvider : storageOrOptions.storage;
     const tokenStorage = 'get' in storageOrOptions ? undefined : storageOrOptions.tokenStorage;
+    const fallbackTokenStorage =
+      'get' in storageOrOptions ? undefined : storageOrOptions.fallbackTokenStorage;
 
     // 1. Destroy Sphere instance — flushes pending IPFS writes (saves good
     //    state), then closes all connections. Awaited so IPFS completes
@@ -1709,6 +1760,34 @@ export class Sphere {
       }
     } else {
       logger.debug('Sphere', 'No token storage provider to clear');
+    }
+
+    // 4b. Issue #330 — also wipe the read-only fallback token storage
+    // (legacy IndexedDB from before Profile migration). Without this,
+    // a user who calls `clear()` to start over with the same mnemonic
+    // would see pre-clear tokens resurrected via the fallback wiring.
+    // This violates the "clear means clear" invariant and is a real
+    // data-integrity hazard, not just UX confusion.
+    //
+    // Idempotent and best-effort: a missing `clear` method (older
+    // legacy providers) or an exception is logged but does not block
+    // the rest of the cleanup. The fallback was never written to by
+    // this SDK; the bytes here are pre-migration legacy data.
+    if (fallbackTokenStorage?.clear) {
+      logger.debug('Sphere', 'Clearing fallback (legacy) token storage...');
+      try {
+        if (
+          typeof fallbackTokenStorage.isConnected === 'function' &&
+          !fallbackTokenStorage.isConnected() &&
+          typeof fallbackTokenStorage.connect === 'function'
+        ) {
+          await fallbackTokenStorage.connect();
+        }
+        await fallbackTokenStorage.clear();
+        logger.debug('Sphere', 'Fallback token storage cleared');
+      } catch (err) {
+        logger.warn('Sphere', 'Fallback token storage clear failed:', err);
+      }
     }
 
     // 5. Delete KV database (sphere-storage)

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -274,6 +274,20 @@ export interface SphereLoadOptions {
   fallbackStorage?: StorageProvider;
   /** Optional token storage provider (for IPFS sync) */
   tokenStorage?: TokenStorageProvider<TxfStorageDataBase>;
+  /**
+   * Issue #330 — Optional read-only fallback TOKEN storage consulted by
+   * Profile-mode token reads when the primary (OrbitDB-backed) read
+   * returns nothing or fails (e.g. `CRITICAL-BLOCK-EVICTED`). Intended
+   * for Profile-mode boots where a previously-working legacy
+   * `IndexedDBTokenStorageProvider` still holds tokens from before the
+   * migration to Profile. Token-side analogue of `fallbackStorage`.
+   * Never written to.
+   *
+   * Use `migrateLegacyToProfileBrowser` / `migrateLegacyToProfile` to
+   * write a "migrated" marker so legacy is preserved as read-only
+   * fallback (the post-#330 default) rather than wiped (pre-#330).
+   */
+  fallbackTokenStorage?: TokenStorageProvider<TxfStorageDataBase>;
   /** Transport provider instance */
   transport: TransportProvider;
   /** Oracle provider instance */
@@ -427,6 +441,11 @@ export interface SphereInitOptions {
    * option types.
    */
   fallbackStorage?: StorageProvider;
+  /**
+   * Issue #330 — Optional read-only fallback TOKEN storage. See
+   * {@link SphereLoadOptions.fallbackTokenStorage} for semantics.
+   */
+  fallbackTokenStorage?: TokenStorageProvider<TxfStorageDataBase>;
   /** Transport provider instance */
   transport: TransportProvider;
   /** Oracle provider instance */
@@ -764,6 +783,18 @@ export class Sphere {
    * forensics. `null` when there's no fallback or the connect succeeded.
    */
   private _fallbackStorageError: Error | null = null;
+  /**
+   * Issue #330 — read-only fallback TOKEN storage consulted by the
+   * primary token-storage provider on read miss or eviction. Set once
+   * at construction by the static factories. `null` when no fallback
+   * was supplied. Token-side analogue of `_fallbackStorage`.
+   *
+   * Wired into ProfileTokenStorageProvider via the
+   * `fallbackTokenStorage` option so the provider can consult the
+   * legacy `IndexedDBTokenStorageProvider` when a Profile block read
+   * fails (e.g. `[CRITICAL-BLOCK-EVICTED]`). Never written to.
+   */
+  private _fallbackTokenStorage: TokenStorageProvider<TxfStorageDataBase> | null = null;
   private _tokenStorageProviders: Map<string, TokenStorageProvider<TxfStorageDataBase>> = new Map();
   private _transport: TransportProvider;
   private _oracle: OracleProvider;
@@ -991,6 +1022,7 @@ export class Sphere {
       const sphere = await Sphere.load({
         storage: options.storage,
         fallbackStorage: options.fallbackStorage,
+        fallbackTokenStorage: options.fallbackTokenStorage,
         transport: options.transport,
         oracle: options.oracle,
         tokenStorage: options.tokenStorage,
@@ -1335,6 +1367,29 @@ export class Sphere {
     // Profile-mode boots where the legacy IndexedDB still holds the
     // encrypted-with-password identity material.
     sphere._fallbackStorage = options.fallbackStorage ?? null;
+    // Issue #330 — read-only fallback TOKEN storage for Profile-mode
+    // token reads. Consulted on miss/eviction. See
+    // {@link SphereLoadOptions.fallbackTokenStorage} and the wiring at
+    // `getTokenStorage().setFallbackTokenStorage(...)` further below.
+    sphere._fallbackTokenStorage = options.fallbackTokenStorage ?? null;
+
+    // Issue #330 — propagate the fallback into any token storage
+    // provider that supports it (Profile-mode providers expose
+    // `setFallbackTokenStorage`). Done here, before initialize() runs,
+    // so the first `load()` call sees the fallback. Other providers
+    // (legacy IndexedDB) silently ignore — duck-type check.
+    if (sphere._fallbackTokenStorage !== null) {
+      for (const provider of sphere._tokenStorageProviders.values()) {
+        const setter = (provider as {
+          setFallbackTokenStorage?: (
+            fb: TokenStorageProvider<TxfStorageDataBase>,
+          ) => void;
+        }).setFallbackTokenStorage;
+        if (typeof setter === 'function') {
+          setter.call(provider, sphere._fallbackTokenStorage);
+        }
+      }
+    }
 
     // exists() restores original (disconnected) state — reconnect for reads
     if (!options.storage.isConnected()) {
@@ -2500,6 +2555,22 @@ export class Sphere {
   async addTokenStorageProvider(provider: TokenStorageProvider<TxfStorageDataBase>): Promise<void> {
     if (this._tokenStorageProviders.has(provider.id)) {
       throw new SphereError(`Token storage provider '${provider.id}' already exists`, 'INVALID_CONFIG');
+    }
+
+    // Issue #330 — apply the fallback before initialize() so the first
+    // load() call on the newly-added provider can fall through to the
+    // legacy IDB if the Profile path returns empty/fails. Duck-typed:
+    // providers that don't expose `setFallbackTokenStorage` are
+    // silently skipped (legacy `IndexedDBTokenStorageProvider`).
+    if (this._fallbackTokenStorage !== null) {
+      const setter = (provider as {
+        setFallbackTokenStorage?: (
+          fb: TokenStorageProvider<TxfStorageDataBase>,
+        ) => void;
+      }).setFallbackTokenStorage;
+      if (typeof setter === 'function') {
+        setter.call(provider, this._fallbackTokenStorage);
+      }
     }
 
     // Set identity if wallet is initialized

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "async-mutex": "^0.5.0",
         "bip39": "^3.1.0",
         "blockstore-fs": "^4.0.1",
+        "blockstore-idb": "^4.0.1",
         "buffer": "^6.0.3",
         "canonicalize": "^3.0.0",
         "crypto-js": "^4.2.0",
@@ -5087,6 +5088,82 @@
       "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
       "license": "Apache-2.0 OR MIT"
     },
+    "node_modules/blockstore-idb": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/blockstore-idb/-/blockstore-idb-4.0.1.tgz",
+      "integrity": "sha512-ZfqKiJZ7wCokOrWsKtGULypIEYH+58mS/jvLk43wDMMjvNxAUPobzblzGtf+uDEE3qpYELTqjeBbS+5YCGUwFA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "abort-error": "^1.0.2",
+        "blockstore-core": "^7.0.0",
+        "idb": "^8.0.3",
+        "interface-blockstore": "^7.0.0",
+        "interface-store": "^8.0.0",
+        "it-all": "^3.0.9",
+        "it-to-buffer": "^5.0.0",
+        "multiformats": "^14.0.0",
+        "race-signal": "^2.0.0"
+      }
+    },
+    "node_modules/blockstore-idb/node_modules/blockstore-core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-7.0.1.tgz",
+      "integrity": "sha512-HgLzdH8oL6DrMC6J7snxmV0TXzJ/BMPSbskH4v7BBuUO9foDBOMEKUfoMX9yoBpxbH+r3Z9afXHDgXlTifMxHQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/logger": "^6.2.4",
+        "abort-error": "^1.0.2",
+        "interface-blockstore": "^7.0.0",
+        "interface-store": "^8.0.0",
+        "it-all": "^3.0.9",
+        "it-filter": "^3.1.4",
+        "it-merge": "^3.0.12",
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/blockstore-idb/node_modules/interface-blockstore": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-7.0.1.tgz",
+      "integrity": "sha512-a3NsgRXpRppVWtQnJjmZ9jxvjcttY1+WNWqHFWwgKhRcNMMGwWGtFNYpQmcZ+mEnIt5NTJVYzNwLCcALMWPNsA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "interface-store": "^8.0.0",
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/blockstore-idb/node_modules/interface-store": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "abort-error": "^1.0.2"
+      }
+    },
+    "node_modules/blockstore-idb/node_modules/it-to-buffer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-5.0.0.tgz",
+      "integrity": "sha512-DyinWj+79wxFDQNiPZcmV8Fz2PJFOcM3KRRN4GiZiIdEfxO11cCkrZJMfUMrxryy+rLoNhAfh1bpoVUFHPR6pQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/blockstore-idb/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/blockstore-idb/node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
     "node_modules/bn.js": {
       "version": "4.12.2",
       "license": "MIT"
@@ -7095,6 +7172,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "async-mutex": "^0.5.0",
     "bip39": "^3.1.0",
     "blockstore-fs": "^4.0.1",
+    "blockstore-idb": "^4.0.1",
     "buffer": "^6.0.3",
     "canonicalize": "^3.0.0",
     "crypto-js": "^4.2.0",

--- a/profile/browser.ts
+++ b/profile/browser.ts
@@ -34,13 +34,18 @@ import type { ProfileStorageProvider } from './profile-storage-provider';
 import type { ProfileTokenStorageProvider } from './profile-token-storage-provider';
 import type { OracleProvider } from '../oracle';
 import type { Sphere } from '../core/Sphere';
+import type { TokenStorageProvider, TxfStorageDataBase } from '../storage';
 import { createProfileProviders } from './factory';
-import { createIndexedDBStorageProvider } from '../impl/browser/storage/IndexedDBStorageProvider';
+import {
+  createIndexedDBStorageProvider,
+  createIndexedDBTokenStorageProvider,
+} from '../impl/browser/storage';
 import { getNetworkConfig } from '../impl/shared';
 import { DEFAULT_IPFS_GATEWAYS } from '../constants';
 import type { NetworkType } from '../constants';
 import { attachIdentityToProfileProviders } from './attach-identity';
 import { migrateLegacyToProfile } from './token-storage-migration';
+import { LEGACY_MIGRATED_MARKER } from './migration';
 import type {
   MigrateLegacyToProfileFromSphereOptions,
   MigrateLegacyToProfileFromSphereResult,
@@ -71,6 +76,21 @@ export interface BrowserProfileProviders {
   readonly storage: ProfileStorageProvider;
   /** Profile-backed token storage provider (drop-in for IndexedDBTokenStorageProvider) */
   readonly tokenStorage: ProfileTokenStorageProvider;
+  /**
+   * Issue #330 — read-only fallback token storage, present only when
+   * the underlying legacy `sphere-storage` IDB carries the migration
+   * marker (`migration.migratedAt`). Pass through to `Sphere.init` /
+   * `Sphere.load` as `fallbackTokenStorage` so tokens that were
+   * durable in the legacy IDB pre-migration are recoverable when the
+   * Profile blockstore loses them. Wired automatically by
+   * {@link createBrowserProfileProvidersAuto}; absent for sync
+   * `createBrowserProfileProviders` callers.
+   *
+   * Spreading the providers into `Sphere.init({ ...providers })`
+   * propagates this transparently since `SphereInitOptions` already
+   * has the same field name.
+   */
+  readonly fallbackTokenStorage?: TokenStorageProvider<TxfStorageDataBase>;
 }
 
 /**
@@ -126,6 +146,82 @@ export function createBrowserProfileProviders(
   );
 
   return { storage, tokenStorage };
+}
+
+// =============================================================================
+// Issue #330 — auto-wiring async factory with legacy-fallback detection
+// =============================================================================
+
+/**
+ * Async variant of {@link createBrowserProfileProviders} that also
+ * probes the legacy `sphere-storage` IndexedDB for the migration
+ * marker (`migration.migratedAt`) and, when present, constructs a
+ * legacy {@link IndexedDBTokenStorageProvider} as a read-only
+ * fallback token storage. The result's `fallbackTokenStorage` field
+ * is the wired fallback (or `undefined` for fresh, never-migrated
+ * wallets).
+ *
+ * **Recommended for production browser wallets** that may have been
+ * migrated from a pre-Profile layout. The sync sister factory is kept
+ * for backward compatibility but does NOT detect or wire the fallback.
+ *
+ * Spreading the result into `Sphere.init` / `Sphere.load` propagates
+ * the fallback transparently (the field names match):
+ *
+ * @example
+ * ```ts
+ * const providers = await createBrowserProfileProvidersAuto({
+ *   network: 'testnet',
+ * });
+ * const { sphere } = await Sphere.init({
+ *   ...providers,           // storage, tokenStorage, fallbackTokenStorage
+ *   transport,
+ *   oracle,
+ * });
+ * ```
+ *
+ * Detection is best-effort: a missing marker, a marker that decodes
+ * to an invalid timestamp, or any IDB-side failure during probe all
+ * yield no fallback. The primary Profile path remains fully functional;
+ * only the post-migration recovery contract is lost in that case.
+ *
+ * @see LEGACY_MIGRATED_MARKER for the marker key written by
+ *      `profile/migration.ts` step 5c.
+ */
+export async function createBrowserProfileProvidersAuto(
+  config: BrowserProfileProvidersConfig,
+): Promise<BrowserProfileProviders> {
+  // 1. Construct the primary Profile providers via the sync factory.
+  const primary = createBrowserProfileProviders(config);
+
+  // 2. Probe the legacy KV for the migration marker. Uses a separate,
+  //    temporary `IndexedDBStorageProvider` connection — the marker
+  //    write happens against the same DB the local cache reads from,
+  //    so the lookup is cheap. Any failure here yields no fallback.
+  let fallbackTokenStorage: TokenStorageProvider<TxfStorageDataBase> | undefined;
+  try {
+    const probe = createIndexedDBStorageProvider();
+    if (!probe.isConnected()) {
+      await probe.connect();
+    }
+    const markerValue = await probe.get(LEGACY_MIGRATED_MARKER);
+    if (typeof markerValue === 'string' && markerValue.length > 0) {
+      // Marker present — the legacy IDB token storage holds
+      // pre-migration tokens. Construct a fresh provider over the
+      // same per-address DBs and expose it as the fallback.
+      fallbackTokenStorage = createIndexedDBTokenStorageProvider();
+    }
+    // Do NOT close the probe here — `IndexedDBStorageProvider` shares
+    // a singleton DB handle; closing it would invalidate the
+    // primary's local cache connection. The handle is reused by the
+    // Sphere boot path via `localCache` inside the primary providers.
+  } catch {
+    // Probe failed (no IDB, locked DB, quota exceeded, ...). Continue
+    // without a fallback — primary Profile path is unchanged.
+    fallbackTokenStorage = undefined;
+  }
+
+  return { ...primary, fallbackTokenStorage };
 }
 
 // =============================================================================

--- a/profile/factory.ts
+++ b/profile/factory.ts
@@ -586,6 +586,13 @@ export function createProfileProviders(
     // wallets the verification contract.
     flushVerificationDeadlineMs:
       resolvedConfig.flushVerificationDeadlineMs ?? 30_000,
+    // Issue #330 — propagate the inline durability gate on
+    // `publishAggregatorPointerBestEffort`. Default 5_000 ms for the
+    // factory (production wallets); direct-construction default in
+    // the provider is 0 (off) for test compatibility. See
+    // `ProfileTokenStorageProviderOptions.pointerPublishDurabilityGateMs`.
+    pointerPublishDurabilityGateMs:
+      resolvedConfig.pointerPublishDurabilityGateMs ?? 5_000,
     oracle,
     // Lazy accessor: the pointer layer is built inside
     // `storage.doConnect()` after OrbitDB attach, long after the

--- a/profile/helia-blockstore-shim.ts
+++ b/profile/helia-blockstore-shim.ts
@@ -157,10 +157,22 @@ async function drainGenerator(
 /**
  * True when the thrown value is a "block not present" signal that
  * upstream callers expect to surface as `undefined` (NOT as an
- * exception). Covers both the canonical interface-store
- * `NotFoundError` (`name === 'NotFoundError'`, `code === 'ERR_NOT_FOUND'`)
- * AND the Helia `InvalidConfigurationError` thrown when
- * `blockBrokers: []` and the block isn't local.
+ * exception). Covers:
+ *   - the canonical interface-store `NotFoundError` (`name ===
+ *     'NotFoundError'`, `code === 'ERR_NOT_FOUND'`);
+ *   - the Helia `InvalidConfigurationError` thrown when
+ *     `blockBrokers: []` and the block isn't local;
+ *   - **Issue #330** — `PutFailedError` thrown by `blockstore-idb`
+ *     when an IDB read errors out. The library wraps any IDB-side
+ *     throw inside its `getAll()` generator as a `PutFailedError`
+ *     (`name === 'PutFailedError'`, `code === 'ERR_PUT_FAILED'`)
+ *     even though the throw came from a GET path —
+ *     `blockstore-idb@4.0.1` `dist/src/index.js:88`. Since this
+ *     matcher is consulted ONLY inside `wrappedGet`, treating
+ *     `PutFailedError` as a miss is safe: a true put failure cannot
+ *     surface through a get's error path, and the alternative is a
+ *     hard throw that breaks OrbitDB OpLog replay on transient IDB
+ *     errors — exactly the failure mode #330 sought to fix.
  */
 function isMissError(err: unknown): boolean {
   if (err === null || typeof err !== 'object') return false;
@@ -169,7 +181,9 @@ function isMissError(err: unknown): boolean {
     e.name === 'NotFoundError' ||
     e.code === 'ERR_NOT_FOUND' ||
     e.name === 'InvalidConfigurationError' ||
-    e.code === 'ERR_NO_BLOCK_BROKERS'
+    e.code === 'ERR_NO_BLOCK_BROKERS' ||
+    e.name === 'PutFailedError' ||
+    e.code === 'ERR_PUT_FAILED'
   );
 }
 

--- a/profile/migration.ts
+++ b/profile/migration.ts
@@ -49,6 +49,21 @@ const MIGRATION_PHASE_KEY = 'migration.phase';
 const MIGRATION_STARTED_AT_KEY = 'migration.startedAt';
 
 /**
+ * Issue #330 — marker key written into the LEGACY token storage when
+ * migration step 5c completes, in lieu of wiping it. Signals that the
+ * legacy token DB is post-migration and should be treated as a read-
+ * only fallback (not as the live token store). The marker carries the
+ * migration completion timestamp for forensics.
+ *
+ * Pre-#330 step 5c wiped the legacy token DB entirely. Post-#330 we
+ * keep the bytes in place so the runtime read fallback
+ * (`ProfileTokenStorageProvider.setFallbackTokenStorage`) can recover
+ * tokens whose Profile blockstore copies are lost (memory-blockstore
+ * eviction + gateway 404 = the failure mode in #330).
+ */
+const LEGACY_MIGRATED_MARKER_KEY = 'migration.migratedAt';
+
+/**
  * Regex pattern matching legacy IPFS sequence keys.
  * These indicate that the wallet has previously synced via IPFS/IPNS.
  */
@@ -771,7 +786,13 @@ export class ProfileMigration {
       const stripped = key.startsWith(STORAGE_PREFIX)
         ? key.slice(STORAGE_PREFIX.length)
         : key;
-      if (stripped === MIGRATION_PHASE_KEY || stripped === MIGRATION_STARTED_AT_KEY) {
+      // Issue #330 — also preserve the legacy-migrated marker so a
+      // defensive re-run of migration does not nuke the fallback signal.
+      if (
+        stripped === MIGRATION_PHASE_KEY ||
+        stripped === MIGRATION_STARTED_AT_KEY ||
+        stripped === LEGACY_MIGRATED_MARKER_KEY
+      ) {
         continue;
       }
 
@@ -786,17 +807,30 @@ export class ProfileMigration {
       }
     }
 
-    // --- 5c. Clear legacy token storage ---
-    if (legacyTokenStorage.clear) {
-      try {
-        await legacyTokenStorage.clear();
-        this.log('Legacy token storage cleared');
-      } catch (err) {
-        this.log(
-          'Failed to clear legacy token storage:',
-          err instanceof Error ? err.message : String(err),
-        );
-      }
+    // --- 5c. Mark legacy token storage as migrated (preserve, don't wipe) ---
+    //
+    // Issue #330 — pre-fix this step called `legacyTokenStorage.clear()`
+    // which dropped the entire legacy token IDB. That made the legacy
+    // DB unusable as a fallback when the Profile blockstore loses
+    // tokens (the memory-only-blockstore + gateway-eviction race
+    // documented in #330). We now keep the bytes and write a marker
+    // alongside, so the runtime can wire the legacy DB as a read-only
+    // fallback (see `ProfileTokenStorageProvider.setFallbackTokenStorage`
+    // and `SphereLoadOptions.fallbackTokenStorage`).
+    //
+    // The marker is stored on the LEGACY KV store (passed in via the
+    // existing `legacyStorage` arg in step 5b's caller chain), not on
+    // the legacy token store — token stores don't have a generic kv
+    // surface. Callers that need to read the marker do so via the
+    // legacy `StorageProvider`. Token data persists; nothing is wiped.
+    try {
+      await legacyStorage.set(LEGACY_MIGRATED_MARKER_KEY, String(Date.now()));
+      this.log('Legacy token storage marked as migrated (preserved as fallback)');
+    } catch (err) {
+      this.log(
+        'Failed to write legacy migrated marker (non-fatal — token data still preserved):',
+        err instanceof Error ? err.message : String(err),
+      );
     }
 
     // --- 5d. Attempt to unpin last known IPFS CID (best-effort) ---

--- a/profile/migration.ts
+++ b/profile/migration.ts
@@ -64,6 +64,24 @@ const MIGRATION_STARTED_AT_KEY = 'migration.startedAt';
 const LEGACY_MIGRATED_MARKER_KEY = 'migration.migratedAt';
 
 /**
+ * Issue #330 — public re-export of the legacy-migrated marker key.
+ *
+ * Factories and consumer apps can probe `legacyStorage.get(...)` for
+ * this key to auto-wire a `fallbackTokenStorage` when the wallet was
+ * migrated from a pre-Profile layout. Returns the migration-completion
+ * timestamp (ms since epoch, as a string) when present, null when
+ * the wallet either was never migrated or is a fresh Profile wallet.
+ *
+ * Storage shape: written via `legacyStorage.set(KEY, String(ts))` in
+ * `profile/migration.ts` step 5c. The KV provider prefixes with
+ * `STORAGE_PREFIX` ('sphere_') so the on-disk key is typically
+ * `sphere_migration.migratedAt`. Pass the unprefixed name to
+ * `StorageProvider.get` — providers do the prefix translation
+ * internally.
+ */
+export const LEGACY_MIGRATED_MARKER = LEGACY_MIGRATED_MARKER_KEY;
+
+/**
  * Regex pattern matching legacy IPFS sequence keys.
  * These indicate that the wallet has previously synced via IPFS/IPNS.
  */

--- a/profile/orbitdb-adapter.ts
+++ b/profile/orbitdb-adapter.ts
@@ -385,6 +385,57 @@ export class OrbitDbAdapter implements ProfileDatabase {
           // (cross-process recovery will not work). Logged via the host's
           // event surface elsewhere.
         }
+      } else if (isBrowserEnvironment()) {
+        // Issue #330 — install an IndexedDB-backed Helia blockstore in
+        // the browser. Without this, Helia v6 falls back to its default
+        // `MemoryBlockstore` and EVERY OpLog block (`helia.blockstore.put`
+        // from OrbitDB) and CAR block (`pinSingleBlock` write-back fast-
+        // path) lives only in tab memory. OrbitDB's level state IS
+        // persisted to IndexedDB, so after a page reload the head CID
+        // pointer survives but the block bytes it references are gone —
+        // every subsequent append fails with the same error, forever
+        // (the symptom described in #330 and called out verbatim in the
+        // JSDoc of `resetAndReconnect` below).
+        //
+        // The `helia-blockstore-pin-shim` (installed below) auto-pins
+        // every written block via `helia.pins.add(cid)` so the new
+        // IDBBlockstore retains them across reloads. The pin shim's
+        // defence against eviction is meaningful only against a
+        // persistent backing store; pinning a MemoryBlockstore is a
+        // no-op against reload.
+        //
+        // We use the same major as `blockstore-fs` (`^4.0.1`) so the
+        // `interface-blockstore` contract aligns with Helia v6's
+        // expectation. The DB name defaults to `'sphere-helia-blocks'`
+        // and is overridable via `config.browserBlockstorePath` for
+        // callers who want per-wallet isolation.
+        try {
+          const blockstoreIdbModule: any = await import('blockstore-idb' as string);
+          const IDBBlockstoreCtor =
+            blockstoreIdbModule.IDBBlockstore ?? blockstoreIdbModule.default?.IDBBlockstore;
+          if (typeof IDBBlockstoreCtor === 'function') {
+            const dbName =
+              typeof config.browserBlockstorePath === 'string' &&
+              config.browserBlockstorePath.length > 0
+                ? config.browserBlockstorePath
+                : 'sphere-helia-blocks';
+            const idbBlockstore = new IDBBlockstoreCtor(dbName);
+            // blockstore-idb requires `open()` to be awaited before the
+            // store can serve get/put. Tolerate either a synchronous or
+            // an async open(); a missing open() is also acceptable for
+            // forward-compat with stores that auto-open on first use.
+            if (typeof idbBlockstore.open === 'function') {
+              await idbBlockstore.open();
+            }
+            heliaOptions.blockstore = idbBlockstore;
+          }
+        } catch {
+          // blockstore-idb not installed or open() failed — fall back to
+          // Helia's MemoryBlockstore default. The wallet still functions
+          // for the lifetime of this tab but loses durability across
+          // reloads (the pre-#330 behaviour). The pin shim that follows
+          // will still attempt pin, but pinning memory is a no-op.
+        }
       }
 
       // Build libp2p config with gossipsub if available

--- a/profile/orbitdb-adapter.ts
+++ b/profile/orbitdb-adapter.ts
@@ -409,8 +409,17 @@ export class OrbitDbAdapter implements ProfileDatabase {
         // expectation. The DB name defaults to `'sphere-helia-blocks'`
         // and is overridable via `config.browserBlockstorePath` for
         // callers who want per-wallet isolation.
+        // Use a STATIC-string dynamic import (no `as string` cast). The
+        // `as string` form in the Node `blockstore-fs` branch above
+        // tells tsup / consumer bundlers to leave the import alone as
+        // a runtime expression — which is fine for Node where the
+        // package is on the filesystem. For browser bundling we want
+        // tsup AND consumer bundlers (Vite / Webpack / esbuild) to
+        // statically discover `blockstore-idb` and include it in the
+        // output bundle. The string-literal form gives the bundler
+        // a deterministic target.
         try {
-          const blockstoreIdbModule: any = await import('blockstore-idb' as string);
+          const blockstoreIdbModule: any = await import('blockstore-idb');
           const IDBBlockstoreCtor =
             blockstoreIdbModule.IDBBlockstore ?? blockstoreIdbModule.default?.IDBBlockstore;
           if (typeof IDBBlockstoreCtor === 'function') {
@@ -421,20 +430,43 @@ export class OrbitDbAdapter implements ProfileDatabase {
                 : 'sphere-helia-blocks';
             const idbBlockstore = new IDBBlockstoreCtor(dbName);
             // blockstore-idb requires `open()` to be awaited before the
-            // store can serve get/put. Tolerate either a synchronous or
-            // an async open(); a missing open() is also acceptable for
-            // forward-compat with stores that auto-open on first use.
+            // store can serve get/put. Wrap with a generous deadline so
+            // a stuck IDB upgrade (sibling tab holding an older version)
+            // does not hang the entire wallet init. On timeout we fall
+            // through to MemoryBlockstore — same as if the dependency
+            // had been missing.
             if (typeof idbBlockstore.open === 'function') {
-              await idbBlockstore.open();
+              await Promise.race([
+                idbBlockstore.open(),
+                new Promise<never>((_, reject) =>
+                  setTimeout(
+                    () => reject(new Error('blockstore-idb open() timed out after 5_000ms')),
+                    5_000,
+                  ),
+                ),
+              ]);
             }
             heliaOptions.blockstore = idbBlockstore;
           }
-        } catch {
-          // blockstore-idb not installed or open() failed — fall back to
-          // Helia's MemoryBlockstore default. The wallet still functions
-          // for the lifetime of this tab but loses durability across
-          // reloads (the pre-#330 behaviour). The pin shim that follows
-          // will still attempt pin, but pinning memory is a no-op.
+        } catch (err) {
+          // blockstore-idb not installed, open() rejected, or open()
+          // exceeded the 5s deadline — fall back to Helia's
+          // MemoryBlockstore default. The wallet still functions for
+          // the lifetime of this tab but loses durability across
+          // reloads (the pre-#330 behaviour). Log loudly so the
+          // operator can investigate; the pin shim that follows will
+          // still attempt pin, but pinning memory is a no-op.
+          //
+          // Suppress logger import to keep the failure path small; the
+          // caller's outer connect()/init() telemetry will reflect the
+          // degraded mode via subsequent `storage:error` events.
+          if (typeof console !== 'undefined' && console.warn) {
+            console.warn(
+              '[OrbitDB] IDBBlockstore install failed; falling back to Helia MemoryBlockstore. ' +
+                'Browser wallet durability across reloads is degraded. ' +
+                `cause=${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
         }
       }
 

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -299,6 +299,19 @@ export class ProfileTokenStorageProvider
   // so we don't attempt the delete on every save.
   private legacyKeysCleaned = false;
 
+  // ---------------------------------------------------------------------------
+  // Issue #330 — read-only fallback token storage (legacy IDB)
+  //
+  // When the Profile load path returns empty or fails on a wallet that
+  // was migrated from a legacy `IndexedDBTokenStorageProvider`, this
+  // fallback is consulted as a last-resort read source. Wired by
+  // `Sphere.load()` after construction via {@link setFallbackTokenStorage}.
+  //
+  // Strictly read-only: never written to. If a successful primary load
+  // observes tokens, the fallback is NOT consulted for that call.
+  // ---------------------------------------------------------------------------
+  private fallbackTokenStorage: TokenStorageProvider<TxfStorageDataBase> | null = null;
+
   // --- Sub-modules (Phase 8 facade refactor) ---
   private readonly bundleIndex: BundleIndex;
   private readonly historyStore: HistoryStore;
@@ -871,6 +884,27 @@ export class ProfileTokenStorageProvider
   }
 
   /**
+   * Issue #330 — install a read-only fallback token-storage provider.
+   *
+   * Consulted by `load()` when the primary path returns empty (no
+   * bundles + no cached seed) or fails (e.g. `[CRITICAL-BLOCK-EVICTED]`).
+   * Token-side analogue of `Sphere.fallbackStorage` (which only covers
+   * identity keys). Set once at startup; subsequent calls overwrite.
+   * Pass `null` to clear.
+   *
+   * The fallback is strictly read-only: this provider NEVER writes to
+   * it. Migration from legacy IDB to Profile no longer wipes the
+   * legacy DB (see `migration.ts` step 5c) precisely so it can serve
+   * as a last-resort recovery source for tokens that were durable in
+   * legacy before the Profile blockstore lost them.
+   */
+  setFallbackTokenStorage(
+    fallback: TokenStorageProvider<TxfStorageDataBase> | null,
+  ): void {
+    this.fallbackTokenStorage = fallback;
+  }
+
+  /**
    * Item #15 Phase C.3 — public read accessor for the bound identity.
    * Returns `null` until {@link setIdentity} has been called.
    *
@@ -1209,6 +1243,49 @@ export class ProfileTokenStorageProvider
   }
 
   // ---------------------------------------------------------------------------
+  // Issue #330 — fallback-load helper
+  //
+  // Consult `fallbackTokenStorage` (if wired) as a last-resort read
+  // source. Returns the fallback's full load result only when it
+  // contains at least one token key; otherwise returns null so the
+  // caller's normal "empty" path runs (avoids masking a legitimately-
+  // empty wallet with stale fallback junk).
+  //
+  // Never throws — any error from the fallback is logged and treated
+  // as "no fallback data available." The fallback is strictly read-
+  // only; this helper never invokes `save`.
+  // ---------------------------------------------------------------------------
+  private async tryFallbackLoad(
+    reason: 'no-bundles' | 'no-bundles-fetched' | 'load-error',
+  ): Promise<TxfStorageDataBase | null> {
+    const fallback = this.fallbackTokenStorage;
+    if (!fallback) return null;
+    try {
+      if (typeof fallback.isConnected === 'function' && !fallback.isConnected()) {
+        if (typeof fallback.connect === 'function') {
+          await fallback.connect();
+        }
+      }
+      const result = await fallback.load();
+      if (!result.success || !result.data) return null;
+      const data = result.data;
+      const hasTokens = Object.keys(data).some((k) => isTokenKey(k));
+      if (!hasTokens) return null;
+      this.log(
+        `fallback-load: consulted fallbackTokenStorage (reason=${reason}); ` +
+          `recovered ${Object.keys(data).filter(isTokenKey).length} token key(s).`,
+      );
+      return data;
+    } catch (err) {
+      this.log(
+        `fallback-load: fallbackTokenStorage.load() threw (reason=${reason}): ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // load() -- Multi-bundle merge
   // ---------------------------------------------------------------------------
 
@@ -1292,6 +1369,24 @@ export class ProfileTokenStorageProvider
           };
         }
 
+        // Issue #330 — before returning empty, consult the read-only
+        // fallback token storage (legacy IDB from pre-Profile-migration).
+        // Covers the symptom in #330 where Profile reports `tokens=0
+        // bundles=0` after a memory-only blockstore reload but tokens
+        // were durably persisted to legacy IDB by an earlier session.
+        const fallback = await this.tryFallbackLoad('no-bundles');
+        if (fallback !== null) {
+          this.lastLoadedData = fallback;
+          this.lastLoadedFromBundleCids = new Set();
+          this.emitEvent({ type: 'storage:loaded', timestamp: Date.now() });
+          return {
+            success: true,
+            data: fallback,
+            source: 'cache',
+            timestamp: Date.now(),
+          };
+        }
+
         // No bundles -- return empty data
         const emptyData = this.buildEmptyTxfData();
         this.lastLoadedData = emptyData;
@@ -1370,6 +1465,31 @@ export class ProfileTokenStorageProvider
           loadedBundles.push({ cid, pkg });
         } catch (err) {
           this.log(`Failed to load bundle ${cid}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+
+      // Issue #330 — if every bundle fetch failed but bundle refs DID
+      // exist, the Profile path is currently unreadable (e.g. all CIDs
+      // 404 from the gateway because the operator gateway evicted them,
+      // AND the local Helia blockstore was memory-only pre-#330 fix
+      // (a) and lost them on reload). Without this gate we would fall
+      // through to the merge over an empty loadedBundles set and return
+      // success with an empty wallet — silently losing tokens that ARE
+      // recoverable from the legacy IDB fallback.
+      if (loadedBundles.length === 0 && activeBundles.size > 0) {
+        const fallback = await this.tryFallbackLoad('no-bundles-fetched');
+        if (fallback !== null) {
+          this.lastLoadedData = fallback;
+          // Do NOT update lastLoadedFromBundleCids — we did not actually
+          // load these bundles. Leaving it at its prior state (or
+          // null) keeps the monotonicity assertion's baseline correct.
+          this.emitEvent({ type: 'storage:loaded', timestamp: Date.now() });
+          return {
+            success: true,
+            data: fallback,
+            source: 'cache',
+            timestamp: Date.now(),
+          };
         }
       }
 
@@ -1486,6 +1606,25 @@ export class ProfileTokenStorageProvider
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       this.emitEvent(this.buildErrorEvent('storage:error', err));
+
+      // Issue #330 — outermost recovery. When the Profile load path
+      // throws (e.g. `LoadBlockFailedError` from a missing OrbitDB
+      // OpLog block — the `bafyreihmwunmk75i3h…` symptom in #330),
+      // consult the legacy fallback as a last resort. The fallback
+      // is the only on-device source that survives a memory-blockstore
+      // wipe + gateway eviction race.
+      const fallback = await this.tryFallbackLoad('load-error');
+      if (fallback !== null) {
+        this.lastLoadedData = fallback;
+        this.emitEvent({ type: 'storage:loaded', timestamp: Date.now() });
+        return {
+          success: true,
+          data: fallback,
+          source: 'cache',
+          timestamp: Date.now(),
+        };
+      }
+
       return {
         success: false,
         error: errorMsg,

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -1378,6 +1378,12 @@ export class ProfileTokenStorageProvider
         if (fallback !== null) {
           this.lastLoadedData = fallback;
           this.lastLoadedFromBundleCids = new Set();
+          // Issue #330 — defensive: fallback bytes bypass the merge
+          // pipeline that normally populates `lastTokenManifest`.
+          // Reset to an empty manifest so a subsequent `getTokenManifest()`
+          // does not return whatever stale value was left from a prior
+          // primary load.
+          this.lastTokenManifest = new Map();
           this.emitEvent({ type: 'storage:loaded', timestamp: Date.now() });
           return {
             success: true,
@@ -1483,6 +1489,9 @@ export class ProfileTokenStorageProvider
           // Do NOT update lastLoadedFromBundleCids — we did not actually
           // load these bundles. Leaving it at its prior state (or
           // null) keeps the monotonicity assertion's baseline correct.
+          // Reset the manifest defensively (see #330 note at the
+          // no-bundles site above).
+          this.lastTokenManifest = new Map();
           this.emitEvent({ type: 'storage:loaded', timestamp: Date.now() });
           return {
             success: true,
@@ -1616,6 +1625,11 @@ export class ProfileTokenStorageProvider
       const fallback = await this.tryFallbackLoad('load-error');
       if (fallback !== null) {
         this.lastLoadedData = fallback;
+        // Reset the manifest defensively (see #330 note at the
+        // no-bundles site above). On error we do not touch
+        // `lastLoadedFromBundleCids` either — leave it at its prior
+        // value so any subsequent flush sees a consistent baseline.
+        this.lastTokenManifest = new Map();
         this.emitEvent({ type: 'storage:loaded', timestamp: Date.now() });
         return {
           success: true,

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -1378,23 +1378,34 @@ export class LifecycleManager {
       try {
         const cidBytes = CID.parse(cidString).bytes;
         const result = await pointer.publish(async () => cidBytes);
-        this.host.setLastDiscoveredPointerCid(cidString);
 
-        // Issue #330 — inline durability gate. Before clearing
-        // `pendingPublishCid`, HEAD-verify the just-published snapshot
-        // CID is fetchable from the configured IPFS gateways. This
-        // prevents the marker from being cleared on a pointer that
-        // advertises a CID the operator gateway hasn't yet propagated
-        // (the "publish-before-durable" gap that produces the cross-
-        // device 404s in #330).
+        // Issue #330 — inline durability gate. Before stamping
+        // `lastDiscoveredPointerCid` (which is read by the no-data
+        // flush short-circuit at `flush-scheduler.ts:700` and would
+        // otherwise mask deferred work behind a stale CID) AND before
+        // clearing `pendingPublishCid`, HEAD-verify the just-published
+        // snapshot CID is fetchable from the configured IPFS gateways.
+        // This closes the "publish-before-durable" gap that produces
+        // the cross-device 404s in #330.
         //
         // The gate uses the same `verifyPinLeg` machinery as
         // `verifyFlushDurability` (which after PR #272 runs in
         // background). The flush still completes synchronously — only
         // the marker-clear is gated. On HEAD-verify timeout we treat
         // the publish as transient-failed (marker stays, retry on next
-        // flush / pointer poll) and emit `storage:pending-publish` so
-        // operators see the deferred state.
+        // flush / pointer poll); the FlushScheduler routes the typed
+        // result to `storage:pending-publish` so operators see the
+        // deferred state.
+        //
+        // We pass `snapshotCid: null` (NOT the same `cidString` again):
+        // `verifyFlushDurability` pushes one `verifyPinLeg` per non-
+        // null CID, so passing it twice would double the HEAD probes
+        // against the same CID — pointless and doubles gateway load.
+        // The semantics of `verifyFlushDurability` are "verify
+        // bundle (mandatory) + snapshot (when provided)"; here the
+        // snapshot CID and the bundle CID are the same thing (it's
+        // the only CID this publish references), so the snapshot leg
+        // is folded into the bundle leg.
         //
         // Default 0 (no gate) preserves current behaviour for tests
         // and stub-pointer fixtures. The wallet factories opt-in with
@@ -1404,27 +1415,30 @@ export class LifecycleManager {
           this.host.options?.pointerPublishDurabilityGateMs ?? 0;
         if (inlineGateMs > 0) {
           try {
-            await this.verifyFlushDurability(cidString, cidString, inlineGateMs);
+            await this.verifyFlushDurability(cidString, null, inlineGateMs);
           } catch (verifyErr) {
             // HEAD-verify failed within the gate deadline. Keep the
             // marker live so a subsequent flush / pointer poll re-runs
             // this method (and re-HEADs the same CID against the
-            // gateway). Treat as a transient failure for the caller
-            // (FlushScheduler routes it to `storage:pending-publish`).
+            // gateway). DO NOT stamp `lastDiscoveredPointerCid` —
+            // leaving it at its previous (verified) value keeps the
+            // no-data flush short-circuit honest.
+            //
+            // Event emit: the FlushScheduler caller emits
+            // `storage:pending-publish` on transient publish failure
+            // (`flush-scheduler.ts:1490-1501`). Suppress the emit here
+            // to avoid the double-event in the flush path. The
+            // pointer-poll path (`runPointerPollOnce` →
+            // `retryPendingPublishIfAny`) does not emit on transient
+            // either, so the gate-failure case there is silent at the
+            // event surface; the log line below covers operator
+            // forensics for both paths.
             this.host.setPendingPublishCid(cidString);
-            this.host.emitEvent({
-              type: 'storage:pending-publish',
-              timestamp: Date.now(),
-              data: {
-                cid: cidString,
-                code: 'IPFS_NOT_YET_DURABLE',
-                gateDeadlineMs: inlineGateMs,
-              },
-            });
             this.host.log(
               `Pointer publish ok (aggregator) but IPFS HEAD-verify timed out within ${inlineGateMs}ms gate ` +
                 `for cid=${cidString} — keeping pendingPublishCid for retry. ` +
-                `Local state is durable; cross-device recovery is held until gateway propagation completes.`,
+                `Local state is durable; cross-device recovery is held until gateway propagation completes. ` +
+                `verifyErr=${verifyErr instanceof Error ? verifyErr.message : String(verifyErr)}`,
             );
             return {
               ok: false as const,
@@ -1434,6 +1448,9 @@ export class LifecycleManager {
           }
         }
 
+        // Gate passed (or was disabled) — NOW stamp the verified CID
+        // and clear the retry marker.
+        this.host.setLastDiscoveredPointerCid(cidString);
         // Clear any previously-pending marker — this publish succeeded,
         // so the cross-device recovery path can now reach the bundle.
         this.host.setPendingPublishCid(null);

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -1379,6 +1379,61 @@ export class LifecycleManager {
         const cidBytes = CID.parse(cidString).bytes;
         const result = await pointer.publish(async () => cidBytes);
         this.host.setLastDiscoveredPointerCid(cidString);
+
+        // Issue #330 — inline durability gate. Before clearing
+        // `pendingPublishCid`, HEAD-verify the just-published snapshot
+        // CID is fetchable from the configured IPFS gateways. This
+        // prevents the marker from being cleared on a pointer that
+        // advertises a CID the operator gateway hasn't yet propagated
+        // (the "publish-before-durable" gap that produces the cross-
+        // device 404s in #330).
+        //
+        // The gate uses the same `verifyPinLeg` machinery as
+        // `verifyFlushDurability` (which after PR #272 runs in
+        // background). The flush still completes synchronously — only
+        // the marker-clear is gated. On HEAD-verify timeout we treat
+        // the publish as transient-failed (marker stays, retry on next
+        // flush / pointer poll) and emit `storage:pending-publish` so
+        // operators see the deferred state.
+        //
+        // Default 0 (no gate) preserves current behaviour for tests
+        // and stub-pointer fixtures. The wallet factories opt-in with
+        // 5_000 ms (`createBrowserProfileProviders`,
+        // `createNodeProfileProviders`).
+        const inlineGateMs =
+          this.host.options?.pointerPublishDurabilityGateMs ?? 0;
+        if (inlineGateMs > 0) {
+          try {
+            await this.verifyFlushDurability(cidString, cidString, inlineGateMs);
+          } catch (verifyErr) {
+            // HEAD-verify failed within the gate deadline. Keep the
+            // marker live so a subsequent flush / pointer poll re-runs
+            // this method (and re-HEADs the same CID against the
+            // gateway). Treat as a transient failure for the caller
+            // (FlushScheduler routes it to `storage:pending-publish`).
+            this.host.setPendingPublishCid(cidString);
+            this.host.emitEvent({
+              type: 'storage:pending-publish',
+              timestamp: Date.now(),
+              data: {
+                cid: cidString,
+                code: 'IPFS_NOT_YET_DURABLE',
+                gateDeadlineMs: inlineGateMs,
+              },
+            });
+            this.host.log(
+              `Pointer publish ok (aggregator) but IPFS HEAD-verify timed out within ${inlineGateMs}ms gate ` +
+                `for cid=${cidString} — keeping pendingPublishCid for retry. ` +
+                `Local state is durable; cross-device recovery is held until gateway propagation completes.`,
+            );
+            return {
+              ok: false as const,
+              transient: true as const,
+              code: 'IPFS_NOT_YET_DURABLE' as const,
+            };
+          }
+        }
+
         // Clear any previously-pending marker — this publish succeeded,
         // so the cross-device recovery path can now reach the bundle.
         this.host.setPendingPublishCid(null);

--- a/profile/types.ts
+++ b/profile/types.ts
@@ -130,6 +130,19 @@ export interface OrbitDbConfig {
   readonly dbNameOverride?: string;
   /** Local storage directory for OrbitDB data (Node.js only) */
   readonly directory?: string;
+  /**
+   * Issue #330 — IndexedDB database name for Helia's blockstore in the
+   * browser. When `directory` is not set and the runtime is a browser,
+   * the adapter installs `blockstore-idb` so OpLog + CAR blocks persist
+   * across page reloads (the pre-fix default was Helia's
+   * `MemoryBlockstore`, which evaporates on tab unload — root cause
+   * of #330). Defaults to `'sphere-helia-blocks'` when omitted; set
+   * a per-wallet name (e.g. `sphere-helia-blocks-<addressId>`) for
+   * full isolation between wallets sharing one origin.
+   *
+   * Ignored on Node (FsBlockstore is used instead).
+   */
+  readonly browserBlockstorePath?: string;
   /** libp2p bootstrap peers for peer discovery */
   readonly bootstrapPeers?: string[];
   /** Enable libp2p pubsub for replication (default: true) */
@@ -232,6 +245,30 @@ export interface ProfileConfig {
    * for full semantics.
    */
   readonly flushVerificationDeadlineMs?: number;
+  /**
+   * Issue #330 — inline durability gate on `publishAggregatorPointerBestEffort`.
+   *
+   * When set to a positive number, the publish path performs an inline
+   * HEAD-verify of the just-published snapshot CID against the configured
+   * IPFS gateways *before* clearing `pendingPublishCid`. If HEAD-verify
+   * does not confirm the CID within the deadline, the marker is kept
+   * (publish is treated as transient-failure for retry purposes) and a
+   * `storage:pending-publish` event fires.
+   *
+   * Distinct from `flushVerificationDeadlineMs` (which PR #272 moved off
+   * the critical path to background): this gate is on the marker-clear,
+   * not the flush completion. It enforces "the pointer never advertises
+   * a CID that isn't durably remote." The at-least-once Nostr ack gate
+   * is unaffected — the flush still completes; only the pending-publish
+   * retry marker is held until durability is confirmed.
+   *
+   * Default: 0 (no gate, preserves pre-#330 behaviour). The wallet
+   * factories (`createBrowserProfileProviders`, `createNodeProfileProviders`)
+   * override to a sensible production value (5 000 ms).
+   *
+   * Pass `0` to opt out (tests, dev fixtures, stub pointers).
+   */
+  readonly pointerPublishDurabilityGateMs?: number;
   /**
    * Item #15 Phase F — retention window (in ms) for OUTBOX/SENT
    * tombstones before they are GC'd at snapshot-build time. Tombstones
@@ -575,6 +612,22 @@ export interface ProfileTokenStorageProviderOptions {
    * cross-device recovery surface exists to verify).
    */
   readonly flushVerificationDeadlineMs?: number;
+  /**
+   * Issue #330 — inline durability gate on `publishAggregatorPointerBestEffort`.
+   * See `ProfileConfig.pointerPublishDurabilityGateMs` for full semantics.
+   *
+   * Default when constructed via `createProfileProviders`: **5 000** (5s,
+   * production contract; closes the #330 cross-device gap where the
+   * pointer can advertise a CID that the operator gateway hasn't yet
+   * propagated). Default when the provider is constructed directly
+   * without the factory: **0** (off) — same compatibility rationale as
+   * `flushVerificationDeadlineMs`.
+   *
+   * Set to `0` to disable inline gate entirely; the background verifier
+   * (`flushVerificationDeadlineMs`) still runs and emits
+   * `storage:durability-deferred` on failure.
+   */
+  readonly pointerPublishDurabilityGateMs?: number;
   /** Enable debug logging */
   readonly debug?: boolean;
 }

--- a/tests/unit/profile/lifecycle-manager-publish-durability-gate-330.test.ts
+++ b/tests/unit/profile/lifecycle-manager-publish-durability-gate-330.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Issue #330 — Tests for the inline pointer-publish durability gate.
+ *
+ * After PR #272, HEAD-verify of newly-pinned CIDs runs in background,
+ * decoupled from the synchronous flush path. That decoupling fixed an
+ * at-least-once Nostr replay loop but left a gap: the aggregator pointer
+ * could be advanced before the just-pinned snapshot CID was durably
+ * fetchable from the operator gateway. A cross-device reader that
+ * resolved the pointer would then 404 on the snapshot CID — exactly the
+ * symptom in #330.
+ *
+ * The fix adds an inline HEAD-verify gate inside
+ * `publishAggregatorPointerBestEffort`. When configured (default 5s via
+ * factory; 0 = off for legacy tests), the marker `pendingPublishCid` is
+ * NOT cleared until the just-published snapshot CID is HEAD-verifiable
+ * on at least one configured gateway. On gate timeout the publish is
+ * classified as transient — marker stays, retry on next flush/poll.
+ *
+ * Tests below exercise the gate semantics directly against the
+ * lifecycle-manager (not via a full flush) to keep the assertions
+ * focused.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import type { ProfilePointerLayer } from '../../../profile/aggregator-pointer';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+const FAKE_CID = 'bafkreigh2akiscaildc6ovwc6m3fy5puxhxcw7qveyf2nbn7xmqwfajeuy';
+
+function createMockDb(): ProfileDatabase {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as ProfileDatabase;
+}
+
+function createMockLocalCache() {
+  const store = new Map<string, string>();
+  return {
+    storage: {
+      async get(k: string) {
+        return store.get(k) ?? null;
+      },
+      async set(k: string, v: string) {
+        store.set(k, v);
+      },
+      async remove(k: string) {
+        store.delete(k);
+      },
+      async clear() {
+        store.clear();
+      },
+    },
+    store,
+  };
+}
+
+function stubPointer(overrides: Partial<ProfilePointerLayer>): ProfilePointerLayer {
+  return {
+    async recoverLatest() {
+      return null;
+    },
+    async publish() {
+      return { cid: new Uint8Array(0), version: 1, attemptsUsed: 1 } as never;
+    },
+    ...overrides,
+  } as unknown as ProfilePointerLayer;
+}
+
+async function makeProvider(opts: {
+  gateMs: number;
+  ipfsGateways: string[];
+  pointer: ProfilePointerLayer;
+}) {
+  const db = createMockDb();
+  const localCache = createMockLocalCache();
+  const provider = new ProfileTokenStorageProvider(
+    db,
+    new Uint8Array(32).fill(0x11),
+    opts.ipfsGateways,
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId: 'test',
+      encrypt: true,
+      getPointerLayer: () => opts.pointer,
+      pointerPublishDurabilityGateMs: opts.gateMs,
+    },
+    localCache.storage as unknown as never,
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  await provider.initialize();
+  const lifecycle = (provider as unknown as { lifecycleManager: {
+    publishAggregatorPointerBestEffort: (
+      cid: string,
+    ) => Promise<{ ok: boolean; transient: boolean; code?: string }>;
+  } }).lifecycleManager;
+  const getPendingPublishCid = (): string | null =>
+    (provider as unknown as { pendingPublishCid: string | null }).pendingPublishCid;
+  return { provider, lifecycle, getPendingPublishCid };
+}
+
+describe('Issue #330 — pointerPublishDurabilityGateMs', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it('clears pendingPublishCid when gate is disabled (gateMs=0) — preserves PR #272 behaviour', async () => {
+    // No fetch mock needed — the gate is skipped entirely.
+    const pointer = stubPointer({
+      publish: vi.fn(async () => ({
+        cid: new Uint8Array(0),
+        version: 7,
+        attemptsUsed: 1,
+      })) as never,
+    });
+    const handle = await makeProvider({
+      gateMs: 0,
+      ipfsGateways: ['https://does-not-matter.test'],
+      pointer,
+    });
+    try {
+      const result = await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(result.ok).toBe(true);
+      expect(result.transient).toBe(false);
+      expect(handle.getPendingPublishCid()).toBeNull();
+    } finally {
+      await handle.provider.shutdown();
+    }
+  });
+
+  it('clears pendingPublishCid when gate is enabled AND HEAD-verify succeeds', async () => {
+    // Stub fetch so the HEAD-verify leg sees the CID as accessible.
+    // `verifyCidAccessible` issues `HEAD ${gateway}/ipfs/<cid>`; return
+    // 200 for any such probe so the verifier short-circuits to ok.
+    const fetchStub = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (init?.method === 'HEAD' && url.includes('/ipfs/')) {
+        return new Response('', { status: 200 });
+      }
+      return new Response('', { status: 404 });
+    });
+    globalThis.fetch = fetchStub as unknown as typeof fetch;
+
+    const pointer = stubPointer({
+      publish: vi.fn(async () => ({
+        cid: new Uint8Array(0),
+        version: 8,
+        attemptsUsed: 1,
+      })) as never,
+    });
+    const handle = await makeProvider({
+      gateMs: 2_000,
+      ipfsGateways: ['https://test-gateway.example'],
+      pointer,
+    });
+    try {
+      const result = await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(result.ok).toBe(true);
+      expect(result.transient).toBe(false);
+      expect(handle.getPendingPublishCid()).toBeNull();
+      expect(fetchStub).toHaveBeenCalled();
+    } finally {
+      await handle.provider.shutdown();
+    }
+  });
+
+  it('KEEPS pendingPublishCid when gate is enabled AND HEAD-verify times out (the #330 fix)', async () => {
+    // Stub fetch to 404 every probe so the verifier never sees the CID.
+    const fetchStub = vi.fn(async () => new Response('', { status: 404 }));
+    globalThis.fetch = fetchStub as unknown as typeof fetch;
+
+    const pointer = stubPointer({
+      publish: vi.fn(async () => ({
+        cid: new Uint8Array(0),
+        version: 9,
+        attemptsUsed: 1,
+      })) as never,
+    });
+    // Use a tight gate so the test completes quickly.
+    const handle = await makeProvider({
+      gateMs: 200,
+      ipfsGateways: ['https://test-gateway.example'],
+      pointer,
+    });
+    try {
+      const result = await handle.lifecycle.publishAggregatorPointerBestEffort(FAKE_CID);
+      expect(result.ok).toBe(false);
+      expect(result.transient).toBe(true);
+      expect(result.code).toBe('IPFS_NOT_YET_DURABLE');
+      // CRITICAL: marker MUST be retained so the next flush/poll retries.
+      expect(handle.getPendingPublishCid()).toBe(FAKE_CID);
+      expect(fetchStub).toHaveBeenCalled();
+    } finally {
+      await handle.provider.shutdown();
+    }
+  });
+});

--- a/tests/unit/profile/migration.test.ts
+++ b/tests/unit/profile/migration.test.ts
@@ -660,8 +660,14 @@ describe('ProfileMigration', () => {
       const profileStorage = createMockProfileStorage();
       const profileTokenStorage = createMockProfileTokenStorage(null);
 
-      // Track what gets called on legacy storage and token storage
+      // Track what gets called on legacy storage and token storage.
+      // Issue #330: step 5c no longer calls `legacyTokenStorage.clear()`
+      // — the legacy token DB is preserved as a read-only fallback and
+      // step 5c instead writes a `migration.migratedAt` marker into
+      // `legacyStorage` (the KV store). We assert both: legacy KV is
+      // touched, AND legacy token clear is NOT called.
       const removeSpy = vi.spyOn(legacyStorage, 'remove');
+      const setSpy = vi.spyOn(legacyStorage, 'set');
       const clearSpy = vi.spyOn(legacyTokenStorage, 'clear' as any);
 
       await migration.migrate(
@@ -671,11 +677,26 @@ describe('ProfileMigration', () => {
         profileTokenStorage as any,
       );
 
-      // Cleanup should only call legacyStorage.remove() (KV store)
-      // and legacyTokenStorage.clear() -- neither of which touches
-      // SphereVestingCacheV5 (a separate IndexedDB database)
+      // Cleanup touches legacyStorage.remove() (5b wipe of legacy KV)
+      // AND legacyStorage.set() for the post-#330 migrated marker (5c).
+      // Neither path touches SphereVestingCacheV5.
       expect(removeSpy).toHaveBeenCalled();
-      expect(clearSpy).toHaveBeenCalled();
+      expect(setSpy).toHaveBeenCalled();
+
+      // Issue #330 — step 5c MUST NOT wipe the legacy token storage.
+      // Pre-#330 behaviour was `legacyTokenStorage.clear()`; we now
+      // preserve the bytes so they can serve as a runtime fallback
+      // when the Profile blockstore loses tokens (memory-blockstore
+      // eviction + gateway 404 = #330's symptom).
+      expect(clearSpy).not.toHaveBeenCalled();
+
+      // The post-#330 migrated marker is written to the KV under
+      // `migration.migratedAt` (with the project storage prefix).
+      const markerWritten = setSpy.mock.calls.some(
+        (call) =>
+          typeof call[0] === 'string' && call[0].includes('migration.migratedAt'),
+      );
+      expect(markerWritten).toBe(true);
 
       // Verify no call references VestingClassifier or its DB
       for (const call of removeSpy.mock.calls) {

--- a/tests/unit/profile/profile-token-storage-fallback-330.test.ts
+++ b/tests/unit/profile/profile-token-storage-fallback-330.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Issue #330 — Tests for the read-only token-storage fallback path.
+ *
+ * Pre-#330 the Profile token-storage provider had no fallback when the
+ * primary (OrbitDB) read returned empty or failed. After memory-only
+ * blockstore eviction + gateway 404, the wallet silently reported "0
+ * tokens" — losing tokens that WERE durable in the legacy IDB.
+ *
+ * The fix adds `setFallbackTokenStorage(legacy)` on
+ * `ProfileTokenStorageProvider`. The fallback is consulted at three
+ * sites inside `load()`:
+ *   1. `activeBundles.size === 0` AND no seed in `lastLoadedData` — would
+ *      otherwise return empty.
+ *   2. All bundle fetches failed despite bundle refs existing — would
+ *      otherwise return success with empty `loadedBundles`.
+ *   3. Outer catch — would otherwise propagate the error.
+ *
+ * The fallback is strictly read-only.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import type { LoadResult, TokenStorageProvider } from '../../../storage';
+import type { TxfStorageDataBase } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+function createMockDb(): ProfileDatabase {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as ProfileDatabase;
+}
+
+function createMockLocalCache() {
+  const store = new Map<string, string>();
+  return {
+    storage: {
+      async get(k: string) {
+        return store.get(k) ?? null;
+      },
+      async set(k: string, v: string) {
+        store.set(k, v);
+      },
+      async remove(k: string) {
+        store.delete(k);
+      },
+      async clear() {
+        store.clear();
+      },
+    },
+    store,
+  };
+}
+
+/**
+ * Minimal fake `TokenStorageProvider` for the fallback slot. Returns the
+ * configured load result; tracks whether `save`/`clear` were called so
+ * we can assert read-only invariant.
+ */
+function createFakeFallback(loadData: TxfStorageDataBase | null): {
+  provider: TokenStorageProvider<TxfStorageDataBase>;
+  loadCalls: number;
+  saveCalls: number;
+  clearCalls: number;
+} {
+  const counters = { loadCalls: 0, saveCalls: 0, clearCalls: 0 };
+  const provider = {
+    id: 'fake-fallback',
+    async connect() {},
+    async disconnect() {},
+    isConnected() {
+      return true;
+    },
+    setIdentity() {},
+    async initialize() {},
+    async load(): Promise<LoadResult<TxfStorageDataBase>> {
+      counters.loadCalls += 1;
+      if (!loadData) {
+        return {
+          success: true,
+          data: { _meta: { version: 1 } } as unknown as TxfStorageDataBase,
+          source: 'cache',
+          timestamp: Date.now(),
+        };
+      }
+      return {
+        success: true,
+        data: loadData,
+        source: 'cache',
+        timestamp: Date.now(),
+      };
+    },
+    async save() {
+      counters.saveCalls += 1;
+      return { success: true, timestamp: Date.now() };
+    },
+    async clear() {
+      counters.clearCalls += 1;
+    },
+    on() {
+      return () => {};
+    },
+  } as unknown as TokenStorageProvider<TxfStorageDataBase>;
+  return {
+    provider,
+    get loadCalls() {
+      return counters.loadCalls;
+    },
+    get saveCalls() {
+      return counters.saveCalls;
+    },
+    get clearCalls() {
+      return counters.clearCalls;
+    },
+  };
+}
+
+async function makeProvider() {
+  const db = createMockDb();
+  const localCache = createMockLocalCache();
+  const provider = new ProfileTokenStorageProvider(
+    db,
+    new Uint8Array(32).fill(0x11),
+    ['https://mock-ipfs.test'],
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId: 'test',
+      encrypt: true,
+    },
+    localCache.storage as unknown as never,
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  await provider.initialize();
+  return provider;
+}
+
+describe('Issue #330 — ProfileTokenStorageProvider.setFallbackTokenStorage', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('load() returns fallback data when primary has no bundles and no seed', async () => {
+    const provider = await makeProvider();
+    try {
+      const fallbackTokenData: TxfStorageDataBase = {
+        _meta: { version: 1 } as never,
+        '_aaa': { mock: true } as never,
+        '_bbb': { mock: true } as never,
+      } as TxfStorageDataBase;
+      const fallback = createFakeFallback(fallbackTokenData);
+      provider.setFallbackTokenStorage(fallback.provider);
+
+      const result = await provider.load();
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      // The exact key set is opaque; assert the two token keys made it through.
+      const tokenKeys = Object.keys(result.data!).filter((k) =>
+        k.startsWith('_') && k !== '_meta' && k !== '_tombstones' && k !== '_sent' && k !== '_outbox' && k !== '_history' && k !== '_nametag' && k !== '_nametags' && k !== '_mintOutbox' && k !== '_invalid' && k !== '_invalidatedNametags' && k !== '_integrity',
+      );
+      expect(tokenKeys.sort()).toEqual(['_aaa', '_bbb']);
+
+      expect(fallback.loadCalls).toBeGreaterThan(0);
+      expect(fallback.saveCalls).toBe(0);
+      expect(fallback.clearCalls).toBe(0);
+    } finally {
+      await provider.shutdown();
+    }
+  });
+
+  it('load() returns empty (NOT fallback) when fallback also has no tokens', async () => {
+    const provider = await makeProvider();
+    try {
+      // Fallback is wired but has no token data — should NOT be used as
+      // a stale seed; the empty-wallet path applies.
+      const fallback = createFakeFallback(null);
+      provider.setFallbackTokenStorage(fallback.provider);
+
+      const result = await provider.load();
+      expect(result.success).toBe(true);
+      const tokenKeys = Object.keys(result.data!).filter((k) =>
+        k.startsWith('_') && k !== '_meta' && k !== '_tombstones' && k !== '_sent' && k !== '_outbox' && k !== '_history' && k !== '_nametag' && k !== '_nametags' && k !== '_mintOutbox' && k !== '_invalid' && k !== '_invalidatedNametags' && k !== '_integrity',
+      );
+      expect(tokenKeys).toEqual([]);
+    } finally {
+      await provider.shutdown();
+    }
+  });
+
+  it('load() returns empty when no fallback is wired (regression check)', async () => {
+    const provider = await makeProvider();
+    try {
+      const result = await provider.load();
+      expect(result.success).toBe(true);
+      expect(Object.keys(result.data!).filter((k) => k.startsWith('_') && k !== '_meta' && k !== '_tombstones' && k !== '_sent' && k !== '_outbox' && k !== '_history' && k !== '_nametag' && k !== '_nametags' && k !== '_mintOutbox' && k !== '_invalid' && k !== '_invalidatedNametags' && k !== '_integrity')).toEqual([]);
+    } finally {
+      await provider.shutdown();
+    }
+  });
+
+  it('fallback is never written to (read-only invariant)', async () => {
+    const provider = await makeProvider();
+    try {
+      const fallbackTokenData: TxfStorageDataBase = {
+        _meta: { version: 1 } as never,
+        '_xyz': { mock: true } as never,
+      } as TxfStorageDataBase;
+      const fallback = createFakeFallback(fallbackTokenData);
+      provider.setFallbackTokenStorage(fallback.provider);
+
+      // Multiple load calls
+      await provider.load();
+      await provider.load();
+
+      // Now mutate via save() — should NOT route to fallback
+      await provider.save({
+        _meta: { version: 2 } as never,
+        '_new': { mock: true } as never,
+      } as TxfStorageDataBase);
+
+      expect(fallback.saveCalls).toBe(0);
+      expect(fallback.clearCalls).toBe(0);
+    } finally {
+      await provider.shutdown();
+    }
+  });
+
+  it('null fallback clears the wiring', async () => {
+    const provider = await makeProvider();
+    try {
+      const fallbackTokenData: TxfStorageDataBase = {
+        _meta: { version: 1 } as never,
+        '_only-in-fallback': { mock: true } as never,
+      } as TxfStorageDataBase;
+      const fallback = createFakeFallback(fallbackTokenData);
+
+      provider.setFallbackTokenStorage(fallback.provider);
+      const r1 = await provider.load();
+      expect(
+        Object.keys(r1.data!).filter((k) => k.startsWith('_') && k !== '_meta' && k !== '_tombstones' && k !== '_sent' && k !== '_outbox' && k !== '_history' && k !== '_nametag' && k !== '_nametags' && k !== '_mintOutbox' && k !== '_invalid' && k !== '_invalidatedNametags' && k !== '_integrity'),
+      ).toEqual(['_only-in-fallback']);
+
+      // Clear the fallback — next load should NOT see fallback tokens.
+      provider.setFallbackTokenStorage(null);
+      // Force a fresh load by invalidating pending data — re-set
+      // identity is overkill; just call load directly. The provider's
+      // pendingData / lastLoadedData caches will short-circuit, so to
+      // verify the wiring change we read after a save+clear cycle.
+      await provider.clear();
+      // After clear() the in-memory caches are reset; load() now hits
+      // the activeBundles path which is empty, with no fallback.
+      const r2 = await provider.load();
+      expect(
+        Object.keys(r2.data!).filter((k) => k.startsWith('_') && k !== '_meta' && k !== '_tombstones' && k !== '_sent' && k !== '_outbox' && k !== '_history' && k !== '_nametag' && k !== '_nametags' && k !== '_mintOutbox' && k !== '_invalid' && k !== '_invalidatedNametags' && k !== '_integrity'),
+      ).toEqual([]);
+    } finally {
+      await provider.shutdown();
+    }
+  });
+});

--- a/tests/unit/profile/profile-token-storage-fallback-330.test.ts
+++ b/tests/unit/profile/profile-token-storage-fallback-330.test.ts
@@ -263,6 +263,120 @@ describe('Issue #330 — ProfileTokenStorageProvider.setFallbackTokenStorage', (
     }
   });
 
+  it('load() returns fallback data when all bundle fetches fail (site #2)', async () => {
+    const provider = await makeProvider();
+    try {
+      const fallbackTokenData: TxfStorageDataBase = {
+        _meta: { version: 1 } as never,
+        '_recovered-from-fallback': { mock: true } as never,
+      } as TxfStorageDataBase;
+      const fallback = createFakeFallback(fallbackTokenData);
+      provider.setFallbackTokenStorage(fallback.provider);
+
+      // Monkey-patch the bundleIndex to return one active bundle that
+      // will fail to fetch (the gateway URL `https://mock-ipfs.test`
+      // does not resolve, so `fetchCarFromIpfs` throws for every CID).
+      // This drives `loadedBundles.length === 0 && activeBundles.size > 0`
+      // — the site-#2 condition.
+      const inner = (provider as unknown as {
+        bundleIndex: {
+          listActiveBundles: () => Promise<Map<string, unknown>>;
+        };
+      }).bundleIndex;
+      const originalList = inner.listActiveBundles.bind(inner);
+      inner.listActiveBundles = async () => {
+        return new Map<string, unknown>([
+          [
+            'bafkreigh2akiscaildc6ovwc6m3fy5puxhxcw7qveyf2nbn7xmqwfajeuy',
+            { cid: 'bafkreigh2akiscaildc6ovwc6m3fy5puxhxcw7qveyf2nbn7xmqwfajeuy', status: 'active' },
+          ],
+        ]);
+      };
+
+      try {
+        const result = await provider.load();
+        expect(result.success).toBe(true);
+        const tokenKeys = Object.keys(result.data!).filter(
+          (k) =>
+            k.startsWith('_') &&
+            k !== '_meta' &&
+            k !== '_tombstones' &&
+            k !== '_sent' &&
+            k !== '_outbox' &&
+            k !== '_history' &&
+            k !== '_nametag' &&
+            k !== '_nametags' &&
+            k !== '_mintOutbox' &&
+            k !== '_invalid' &&
+            k !== '_invalidatedNametags' &&
+            k !== '_integrity',
+        );
+        expect(tokenKeys).toEqual(['_recovered-from-fallback']);
+        expect(fallback.loadCalls).toBeGreaterThan(0);
+      } finally {
+        inner.listActiveBundles = originalList;
+      }
+    } finally {
+      await provider.shutdown();
+    }
+  }, 30_000);
+
+  it('load() returns fallback data when an inner error throws (site #3 outer-catch)', async () => {
+    const provider = await makeProvider();
+    try {
+      const fallbackTokenData: TxfStorageDataBase = {
+        _meta: { version: 1 } as never,
+        '_recovered-on-error': { mock: true } as never,
+      } as TxfStorageDataBase;
+      const fallback = createFakeFallback(fallbackTokenData);
+      provider.setFallbackTokenStorage(fallback.provider);
+
+      // Make bundleIndex.listActiveBundles itself THROW to drive the
+      // outer try/catch path (`load-error` reason). Mirrors what a
+      // CRITICAL-BLOCK-EVICTED would do when reading the OrbitDB
+      // OpLog head fails.
+      const inner = (provider as unknown as {
+        bundleIndex: {
+          listActiveBundles: () => Promise<Map<string, unknown>>;
+        };
+      }).bundleIndex;
+      const originalList = inner.listActiveBundles.bind(inner);
+      inner.listActiveBundles = async () => {
+        const err = new Error('simulated LoadBlockFailedError') as Error & {
+          code?: string;
+        };
+        err.code = 'LOAD_BLOCK_FAILED';
+        throw err;
+      };
+
+      try {
+        const result = await provider.load();
+        expect(result.success).toBe(true);
+        const tokenKeys = Object.keys(result.data!).filter(
+          (k) =>
+            k.startsWith('_') &&
+            k !== '_meta' &&
+            k !== '_tombstones' &&
+            k !== '_sent' &&
+            k !== '_outbox' &&
+            k !== '_history' &&
+            k !== '_nametag' &&
+            k !== '_nametags' &&
+            k !== '_mintOutbox' &&
+            k !== '_invalid' &&
+            k !== '_invalidatedNametags' &&
+            k !== '_integrity',
+        );
+        expect(tokenKeys).toEqual(['_recovered-on-error']);
+        expect(fallback.loadCalls).toBeGreaterThan(0);
+      } finally {
+        inner.listActiveBundles = originalList;
+      }
+    } finally {
+      await provider.shutdown();
+    }
+  });
+
   it('null fallback clears the wiring', async () => {
     const provider = await makeProvider();
     try {


### PR DESCRIPTION
## Summary

Closes the three architectural faults underlying [#330](https://github.com/unicity-sphere/sphere-sdk/issues/330) — browser Profile wallets losing all tokens on reload — in one branch, three commits.

The investigation traced a working IPFS gateway (proven live) but a wallet still lost tokens because:
1. The browser Helia blockstore was memory-only by design (no `blockstore-idb` was wired).
2. The aggregator pointer was advanced before the just-pinned snapshot CID was durably remote — and `pendingPublishCid` was cleared at the same point, so cross-device readers could 404 on a CID the wallet considered "published."
3. Tokens had no fallback path equivalent to `fallbackStorage` for identity; migration's step 5c actively wiped the legacy IDB token storage, destroying the last on-device source.

### Fix (a) — Persistent browser blockstore (`fbdb24a`)

`profile/orbitdb-adapter.ts:353-388` now installs an `IDBBlockstore` in the browser branch (no `directory` set + `isBrowserEnvironment()`), symmetric to the existing Node-side `FsBlockstore` install. The companion `helia-blockstore-pin-shim` (#311) becomes meaningful — `pins.add(cid)` now defends a persistent backing store.

Configurable via new `OrbitDbConfig.browserBlockstorePath` (default `'sphere-helia-blocks'`).

### Fix (b) — Inline durability gate on pointer publish (`0efecf0`)

`publishAggregatorPointerBestEffort` now HEAD-verifies the just-published snapshot CID against the configured gateways **before** clearing `pendingPublishCid`. On gate timeout the publish is classified as transient (code `IPFS_NOT_YET_DURABLE`), the marker is KEPT, and `storage:pending-publish` fires. The flush itself completes — the at-least-once Nostr ack gate is **unchanged** (preserves PR #272's fix).

Configurable via new `ProfileConfig.pointerPublishDurabilityGateMs`:
- direct-construction default: `0` (off, preserves legacy test behaviour)
- factory default (`createProfileProviders`): `5_000` ms (production)

### Fix (c) — Read-only token fallback + preserve legacy on migration (`04eaf32`)

Two-part:
1. **Don't wipe legacy on migration.** `profile/migration.ts` step 5c writes a `migration.migratedAt` marker into the legacy KV store instead of calling `legacyTokenStorage.clear()`. Legacy token data stays available as a read-only fallback.
2. **Wire a runtime fallback path.** New `SphereInitOptions.fallbackTokenStorage` / `SphereLoadOptions.fallbackTokenStorage` propagated via duck-typed `ProfileTokenStorageProvider.setFallbackTokenStorage(legacy)`. The provider consults the fallback at three sites inside `load()`: empty bundle index + no seed; all-fetches-failed; outer catch (e.g. `LoadBlockFailedError`). Strictly read-only.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — success
- [x] `npm run lint` — exit 0
- [x] `npx vitest run tests/unit/` — **8059 passed**, 2 skipped, 0 failures (added 8 new tests for #330; updated 1 existing migration test to reflect the no-wipe contract)
- [ ] **Browser manual verification at https://sphere-telco-test.dyndns.org**: fresh wallet → top-up → reload → balance is preserved across reload. The reproduction described in #330 should no longer fire.
- [ ] **CLI soak (`manual-test-full-recovery.sh §D.4`)**: should still pass — Node path uses `FsBlockstore` regardless of this change.

## Notes for reviewers

- Each fix is independent enough to revert individually if a regression is found.
- The inline durability gate (b) reuses the existing `verifyFlushDurability` machinery (which already has a verified-watermark short-circuit), so re-publishing the same CID is cheap.
- The migration change (c) deletes a destructive operation; existing wallets that already migrated pre-#330 do not get their tokens back (those bytes are already gone), but going forward no migration will lose token bytes.
- New `OrbitDbConfig.browserBlockstorePath` defaults to a per-origin shared DB. Content-addressed CIDs make this safe across wallets sharing an origin — unused blocks accumulate but never collide.

## Related

- Issue [#330](https://github.com/unicity-sphere/sphere-sdk/issues/330) — root issue.
- PR #240 — Helia v6 + FsBlockstore on Node (the Node-side fix for the same family).
- PR #266 — HTTP-only IPFS default (set up the `httpOnlyIpfs: true` mode that this PR makes safe in the browser).
- PR #268 — flush-durability verify gate (this PR's gate (b) is layered atop the existing machinery).
- PR #272 — moved HEAD-verify to background (preserved by this PR — the new gate is on the marker-clear, not the flush completion).