### PR TITLE
fix(page-freeze): GroupChat fan-out + CBOR + snapshot-epoch + soak hardening

### DIFF
--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -202,11 +202,37 @@ assert_diff_empty() {
   fi
 }
 
+# Wall-clock anchor + per-section elapsed. SECTION_T0 is set the first
+# time `banner` is invoked; SECTION_LAST_TS tracks the previous banner so
+# each new section prints how long the previous one took. The full
+# breakdown is the diff between any two section-banner timestamps.
+SECTION_T0=0
+SECTION_LAST_TS=0
+SECTION_LAST_NAME=""
 banner() {
+  local now ts iso elapsed_total elapsed_section
+  ts=$(date +%s)
+  iso=$(date -Iseconds)
+  if (( SECTION_T0 == 0 )); then
+    SECTION_T0=$ts
+    SECTION_LAST_TS=$ts
+    elapsed_total=0
+    elapsed_section=0
+  else
+    elapsed_total=$((ts - SECTION_T0))
+    elapsed_section=$((ts - SECTION_LAST_TS))
+  fi
   echo
   echo "================================================================"
+  if [[ -n "$SECTION_LAST_NAME" ]]; then
+    printf "[%s] +%-4ds (prev section %s took %ds)\n" "$iso" "$elapsed_total" "$SECTION_LAST_NAME" "$elapsed_section"
+  else
+    printf "[%s] +0s (soak start)\n" "$iso"
+  fi
   echo "$*"
   echo "================================================================"
+  SECTION_LAST_TS=$ts
+  SECTION_LAST_NAME="$*"
 }
 
 # ---------------------------------------------------------------------------

--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -120,6 +120,48 @@ wait_for_log() {
   return 1
 }
 
+# Poll `sphere invoice status $INVOICE` until peer2 has replicated the
+# invoice, OR fail after TIMEOUT seconds. Cross-device invoice visibility
+# requires three legs to complete:
+#
+#   1. Sender (Bob)'s profile-token IPFS publish lands durably.
+#   2. Sender's Nostr at-least-once mux acks (60s cooldown on retry).
+#   3. Receiver (peer2-alice)'s OrbitDB replicates the accounting key.
+#
+# Under flaky testnet conditions (e.g. unicity-ipfs1.dyndns.org HTTP 500
+# observed 2026-05-29), any leg can stall. Without this loop a transient
+# stall trips `set -euo pipefail` and aborts the soak at §C.4 even though
+# the wallet code is correct. Treats ONLY "No invoice found" as transient;
+# other errors (e.g. "Database is not open") still propagate immediately.
+wait_for_invoice_visible() {
+  local invoice="$1" output_file="$2" timeout="${3:-150}"
+  local elapsed=0 step=15 rc
+  : > "$output_file"
+  while (( elapsed < timeout )); do
+    if sphere invoice status "$invoice" > "$output_file" 2>&1; then
+      if ! grep -q 'No invoice found' "$output_file"; then
+        cat "$output_file"
+        return 0
+      fi
+      # Found a "No invoice" — transient. Retry after sleep.
+    else
+      rc=$?
+      if ! grep -q 'No invoice found' "$output_file"; then
+        # CLI failed for a non-transient reason (e.g. DB lock, network
+        # config). Surface immediately so the soak fails informatively.
+        cat "$output_file" >&2
+        echo "sphere invoice status failed with rc=$rc (non-transient — not retrying)" >&2
+        return "$rc"
+      fi
+    fi
+    sleep "$step"
+    elapsed=$((elapsed + step))
+  done
+  cat "$output_file" >&2
+  echo "TIMEOUT (${timeout}s) waiting for peer2 to see invoice $invoice — testnet replication stalled" >&2
+  return 1
+}
+
 # Normalize a snapshot before byte-comparison. Strips lines that are
 # legitimately volatile across runs but do NOT reflect logical wallet
 # state. False positives observed on 2026-05-29 (issue: page-freeze):
@@ -412,7 +454,10 @@ cd "$PEER2_BOB"   && sphere daemon stop || true
 sleep 2
 
 cd "$PEER2_ALICE"
-sphere invoice status "$INV" 2>&1 | tee "$SNAP/peer2-alice-invoice-status.log"
+# Wait for cross-device replication to complete before asserting peer2's
+# view. Under flaky testnet conditions the invoice can take 30s+ to land.
+# Treats "No invoice found" as transient; other errors propagate.
+wait_for_invoice_visible "$INV" "$SNAP/peer2-alice-invoice-status.log" 150
 sphere balance               | tee "$SNAP/peer2-alice-postC-balance.txt"
 
 cd "$PEER2_BOB"

--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -120,12 +120,41 @@ wait_for_log() {
   return 1
 }
 
+# Normalize a snapshot before byte-comparison. Strips lines that are
+# legitimately volatile across runs but do NOT reflect logical wallet
+# state. False positives observed on 2026-05-29 (issue: page-freeze):
+#
+#   - "  IPFS: +N added, -M removed" — transient sync-status emitted
+#     when `sphere balance` notices background IPFS sync activity. The
+#     count varies depending on whether a prior write is still landing.
+#   - "Syncing..." / "  Ready." — wallet-load progress banner.
+#   - "[YYYY-MM-DDThh:mm:ss.sssZ] [LEVEL] [Component] ..." — debug
+#     output captured when the CLI runs in verbose mode. Wall-clock
+#     timestamps + monotonic counters (event IDs, bundle counts) make
+#     these lines pure noise for state comparison.
+#
+# Filtering operates on a temp file the caller hands to diff, leaving
+# the original snapshot untouched for forensics.
+normalize_snapshot() {
+  # shellcheck disable=SC2016
+  sed -E \
+    -e '/^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z\] /d' \
+    -e '/^  IPFS: \+[0-9]+ added, -[0-9]+ removed$/d' \
+    -e '/^Syncing\.\.\.$/d' \
+    -e '/^  Ready\.$/d' \
+    "$1"
+}
+
 assert_diff_empty() {
   local label="$1" a="$2" b="$3"
-  if diff -u "$a" "$b" > "$SNAP/${label}.diff"; then
+  local na="$SNAP/${label}.a.norm" nb="$SNAP/${label}.b.norm"
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" > "$SNAP/${label}.diff"; then
     echo "ASSERT OK ($label): $(basename "$a") == $(basename "$b")"
   else
     echo "ASSERT FAIL ($label): see $SNAP/${label}.diff" >&2
+    echo "  (compared normalized snapshots: ${label}.a.norm vs ${label}.b.norm)" >&2
     cat "$SNAP/${label}.diff" >&2 || true
     return 1
   fi

--- a/modules/groupchat/GroupChatModule.ts
+++ b/modules/groupchat/GroupChatModule.ts
@@ -76,6 +76,48 @@ const MAX_GROUP_MESSAGE_SIZE = 64 * 1024;
  */
 const MAX_INDEX_ITEMS = 10_000;
 
+/**
+ * Concurrency cap for per-message CID fetches on load (Pattern B index).
+ *
+ * Before this cap, `fetched.items.map(async i => fetchJson(i))` + Promise.all
+ * spawned up to MAX_INDEX_ITEMS (10k) parallel HTTP requests per group, with
+ * additional fan-out across groups. With a single slow/sick gateway (e.g.
+ * unicity-ipfs1.dyndns.org returning 404/502), that fan-out becomes a
+ * thundering-herd: each request pins one socket for the 30s fetch timeout,
+ * and the cumulative wall-time grows quadratically.
+ *
+ * 4 keeps the existing "parallel-not-serial" speed-up (a small batch still
+ * overlaps network + decode latency) while leaving headroom for the rest of
+ * the page (transport, payments, profile-storage) to make progress on shared
+ * gateways. The page-freeze symptom (issue: 2026-05-29) was driven primarily
+ * by this unbounded fan-out colliding with a degraded testnet gateway.
+ */
+const LOAD_FETCH_CONCURRENCY = 4;
+
+/**
+ * Run an async mapper across `items` with a bounded number of concurrent
+ * workers. Preserves order in the output. Failures inside `fn` propagate to
+ * the caller (matching `Promise.all(items.map(fn))` semantics).
+ */
+async function mapWithConcurrency<T, R>(
+  items: ReadonlyArray<T>,
+  limit: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workerCount = Math.min(Math.max(1, limit), items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
 interface GroupChatMessagesIndexItem {
   /** Stable message id (from Nostr event id). Always present for persisted messages. */
   readonly id: string;
@@ -354,20 +396,26 @@ export class GroupChatModule {
       let parsed: GroupData[] | null = null;
       if (ref) {
         if (!this.deps!.cidRefStore) {
-          const { ProfileError } = await import('../../profile/errors.js');
-          throw new ProfileError(
-            'CID_REF_UNREADABLE',
-            `GroupChatModule.load: groups key contains a CID ref (cid=${ref.cid}) ` +
-              `but no cidRefStore was injected. Check module init.`,
+          // Degrade rather than brick load. Symmetric to the catch below: a
+          // missing cidRefStore is treated like a fetch failure — start with
+          // an empty groups set; relay re-delivery repopulates. The previous
+          // fatal throw bricked the whole wallet load when this happened,
+          // taking down every other module's load with it (issue:
+          // page-freeze 2026-05-29).
+          logger.warn(
+            'GroupChat',
+            `[CID_REF_DEGRADE] groups key contains a CID ref (cid=${ref.cid}) ` +
+              `but no cidRefStore was injected; starting fresh.`,
           );
-        }
-        try {
-          parsed = await this.deps!.cidRefStore.fetchJson<GroupData[]>(
-            ref,
-            { requireEncrypted: true },
-          );
-        } catch (err) {
-          logger.error('GroupChat', '[GROUP_CHAT_GROUPS] CID-ref fetch failed', err);
+        } else {
+          try {
+            parsed = await this.deps!.cidRefStore.fetchJson<GroupData[]>(
+              ref,
+              { requireEncrypted: true },
+            );
+          } catch (err) {
+            logger.error('GroupChat', '[GROUP_CHAT_GROUPS] CID-ref fetch failed', err);
+          }
         }
       } else {
         try {
@@ -425,12 +473,14 @@ export class GroupChatModule {
       let assembledMessages: GroupMessageData[] | null = null;
       if (ref) {
         if (!this.deps!.cidRefStore) {
-          const { ProfileError } = await import('../../profile/errors.js');
-          throw new ProfileError(
-            'CID_REF_UNREADABLE',
-            `GroupChatModule.load: messages:${groupId} contains a CID ref ` +
-              `(cid=${ref.cid}) but no cidRefStore was injected.`,
+          // Degrade: skip this group's messages; relay re-delivery repopulates.
+          // See [CID_REF_DEGRADE] note above the groups-key site.
+          logger.warn(
+            'GroupChat',
+            `[CID_REF_DEGRADE] messages:${groupId} contains a CID ref ` +
+              `(cid=${ref.cid}) but no cidRefStore was injected; skipping.`,
           );
+          continue;
         }
         let fetched: unknown;
         try {
@@ -464,7 +514,14 @@ export class GroupChatModule {
             continue;
           }
           const cidRefStoreRef = this.deps!.cidRefStore;
-          const fetches = fetched.items.map(async (item) => {
+          // Bound concurrency to LOAD_FETCH_CONCURRENCY (default 4) so a
+          // group with thousands of messages doesn't spawn thousands of
+          // parallel HTTP requests against a single gateway. The previous
+          // unbounded Promise.all(items.map(...)) was the primary driver of
+          // the 404-storm freeze observed 2026-05-29 — every miss pinned a
+          // socket for the 30 s fetch timeout. See LOAD_FETCH_CONCURRENCY
+          // doc-comment for the rationale on the limit.
+          const results = await mapWithConcurrency(fetched.items, LOAD_FETCH_CONCURRENCY, async (item) => {
             if (!isValidIndexItem(item)) {
               logger.error(
                 'GroupChat',
@@ -508,7 +565,6 @@ export class GroupChatModule {
               return null;
             }
           });
-          const results = await Promise.all(fetches);
           assembledMessages = results.filter((m): m is GroupMessageData => m !== null);
           // Seed the per-group index memo so an immediate re-persist
           // doesn't re-pin the whole index for unchanged state.
@@ -636,12 +692,14 @@ export class GroupChatModule {
       let parsed: unknown = null;
       if (ref) {
         if (!this.deps!.cidRefStore) {
-          const { ProfileError } = await import('../../profile/errors.js');
-          throw new ProfileError(
-            'CID_REF_UNREADABLE',
-            `GroupChatModule.load: members:${groupId} contains a CID ref ` +
-              `(cid=${ref.cid}) but no cidRefStore was injected.`,
+          // Degrade: skip this group's members; relay re-delivery repopulates.
+          // See [CID_REF_DEGRADE] note above the groups-key site.
+          logger.warn(
+            'GroupChat',
+            `[CID_REF_DEGRADE] members:${groupId} contains a CID ref ` +
+              `(cid=${ref.cid}) but no cidRefStore was injected; skipping.`,
           );
+          continue;
         }
         try {
           parsed = await this.deps!.cidRefStore.fetchJson(ref, { requireEncrypted: true });
@@ -725,28 +783,32 @@ export class GroupChatModule {
       let parsed: string[] | null = null;
       if (ref) {
         if (!this.deps!.cidRefStore) {
-          const { ProfileError } = await import('../../profile/errors.js');
-          throw new ProfileError(
-            'CID_REF_UNREADABLE',
-            `GroupChatModule.load: processedEvents key contains a CID ref ` +
-              `(cid=${ref.cid}) but no cidRefStore was injected.`,
-          );
-        }
-        try {
-          parsed = await this.deps!.cidRefStore.fetchJson<string[]>(
-            ref,
-            { requireEncrypted: true },
-          );
-        } catch (err) {
-          // Best-effort: continue with empty set rather than poisoning load.
-          // The ledger is recoverable — relay re-delivery will re-populate
-          // on the next sync (worst case: a few duplicate event-handler
-          // dispatches; the handlers themselves are idempotent).
-          logger.error(
+          // Degrade: start with an empty processed-events set; relay
+          // re-delivery repopulates via idempotent event handlers. See
+          // [CID_REF_DEGRADE] note above the groups-key site.
+          logger.warn(
             'GroupChat',
-            '[GROUP_CHAT_PROCESSED_EVENTS] CID-ref fetch failed; starting fresh',
-            err,
+            `[CID_REF_DEGRADE] processedEvents key contains a CID ref ` +
+              `(cid=${ref.cid}) but no cidRefStore was injected; ` +
+              `starting fresh.`,
           );
+        } else {
+          try {
+            parsed = await this.deps!.cidRefStore.fetchJson<string[]>(
+              ref,
+              { requireEncrypted: true },
+            );
+          } catch (err) {
+            // Best-effort: continue with empty set rather than poisoning load.
+            // The ledger is recoverable — relay re-delivery will re-populate
+            // on the next sync (worst case: a few duplicate event-handler
+            // dispatches; the handlers themselves are idempotent).
+            logger.error(
+              'GroupChat',
+              '[GROUP_CHAT_PROCESSED_EVENTS] CID-ref fetch failed; starting fresh',
+              err,
+            );
+          }
         }
       } else {
         try {

--- a/modules/groupchat/GroupChatModule.ts
+++ b/modules/groupchat/GroupChatModule.ts
@@ -96,8 +96,22 @@ const LOAD_FETCH_CONCURRENCY = 4;
 
 /**
  * Run an async mapper across `items` with a bounded number of concurrent
- * workers. Preserves order in the output. Failures inside `fn` propagate to
- * the caller (matching `Promise.all(items.map(fn))` semantics).
+ * workers. Preserves order in the output.
+ *
+ * Error semantics: each worker pulls items off a shared cursor and calls
+ * `fn`. The expectation at every call site in this file is that `fn`
+ * handles per-item errors and returns a sentinel (typically `null`)
+ * rather than throwing. If `fn` does throw, the thrower's worker sets
+ * `aborted` so sibling workers stop pulling NEW items from the cursor
+ * — in-flight `fn` calls already dispatched still settle. The aggregate
+ * promise then rejects with the first thrown error via `Promise.all`.
+ *
+ * This is STRICTER than `Promise.all(items.map(fn))`, which keeps
+ * dispatching new work after the first rejection until it hits the end
+ * of the input — that looser semantic is the exact fan-out leak this
+ * helper exists to avoid (page-freeze 2026-05-29, where an unbounded
+ * `Promise.all(items.map(fetchJson))` on a sick gateway issued 30 s
+ * sockets per item even after the first 404).
  */
 async function mapWithConcurrency<T, R>(
   items: ReadonlyArray<T>,
@@ -106,12 +120,18 @@ async function mapWithConcurrency<T, R>(
 ): Promise<R[]> {
   const results: R[] = new Array(items.length);
   let next = 0;
+  let aborted = false;
   const workerCount = Math.min(Math.max(1, limit), items.length);
   const workers = Array.from({ length: workerCount }, async () => {
-    while (true) {
+    while (!aborted) {
       const i = next++;
       if (i >= items.length) return;
-      results[i] = await fn(items[i], i);
+      try {
+        results[i] = await fn(items[i], i);
+      } catch (err) {
+        aborted = true;
+        throw err;
+      }
     }
   });
   await Promise.all(workers);

--- a/profile/oplog-envelope-io.ts
+++ b/profile/oplog-envelope-io.ts
@@ -131,6 +131,20 @@ export function unwrapEnvelopeBytes(bytes: Uint8Array): Uint8Array {
 export type GetEnvelopePayloadFallbackHook = (info: {
   readonly key: string;
   readonly errorMessage: string;
+  /**
+   * `true` when the underlying failure was a raw CBOR decode error
+   * (the bytes do not decode as CBOR at all). This is the dominant
+   * signature for pre-#247 raw-bytes writes (e.g. SentLedgerWriter at
+   * `${addressId}.sent.${id}`): the bytes are AES-GCM ciphertext whose
+   * random IV occasionally starts with a CBOR major-type-7 simple-value
+   * code that cborg rejects ("simple values are not supported"). In
+   * that case the fallback path is the CORRECT path and the WARN log
+   * is misleading. `false` means decode succeeded but the resulting
+   * shape was not a valid envelope — that DOES indicate real envelope
+   * corruption (unexpected field / unknown v / wrong decoded kind) and
+   * should be logged at WARN.
+   */
+  readonly isCborDecodeError: boolean;
 }) => void;
 
 /**
@@ -189,10 +203,20 @@ export async function getEnvelopePayload(
       // can detect live corruption (the silent path also masked
       // genuine envelope-write damage, not just legacy bytes).
       if (onFallback !== undefined) {
+        // Distinguish raw-CBOR-decode failure (legacy pre-#247 raw bytes —
+        // expected, not corruption) from envelope-shape failure (real
+        // corruption — wrong v / wrong field / wrong decoded kind).
+        // `OpLogEntryCorrupt` carries `details.cborError === true` ONLY
+        // for the raw-decode case; see `decodeEntry` catch at
+        // `oplog-entry.ts:188`. Anything else has details without that
+        // flag (or no details at all on synthetic legacy entries).
+        const details = (err as { details?: Record<string, unknown> } | null)?.details;
+        const isCborDecodeError = details?.cborError === true;
         try {
           onFallback({
             key,
             errorMessage: err instanceof Error ? err.message : String(err),
+            isCborDecodeError,
           });
         } catch {
           // Best-effort signal — never propagate hook errors into the

--- a/profile/pointer-wiring.ts
+++ b/profile/pointer-wiring.ts
@@ -723,58 +723,110 @@ export async function buildProfilePointerLayer(
     // given version, fetch the snapshot ROOT block (content-address
     // verified by `fetchFromIpfs`), dag-cbor-decode the root, and
     // return its `epoch` field (or undefined for pre-#310 snapshots).
+    //
+    // Page-freeze 2026-05-29 fix — closure-scope memoization.
+    //
+    // Without a memo, every pointer-poll cycle re-issues the full
+    // `resolveRemoteCid(v) → fetchFromIpfs(cid)` round-trip for every
+    // version it walks back through, even when the previous poll
+    // already learned the version's epoch (positive result) or its
+    // CID 404s (negative result). Under a degraded testnet gateway
+    // that floods the browser console with `/sidecar/blob?cid=… 404`
+    // and pegs the daemon CPU, this is the dominant source of
+    // redundant work. The memo TTL of 30 s ≥ POINTER_POLL_MIN_MS so
+    // a single full poll cycle dedups; values older than that are
+    // recomputed in case a stuck gateway has recovered.
+    //
+    // Memo key = version (a number). Positive entries cache the epoch
+    // (`value`); negative entries cache the error so callers see the
+    // same failure signature instead of re-walking the same
+    // 404/decode/shape failure. The memo lives in the closure of the
+    // surrounding layer-build call and is GC'd when the layer is.
+    const INSPECT_EPOCH_MEMO_TTL_MS = 30_000;
+    interface EpochMemoEntry {
+      readonly expiresAt: number;
+      readonly value?: number;
+      readonly error?: Error;
+    }
+    const epochMemo = new Map<number, EpochMemoEntry>();
+
     const inspectSnapshotEpoch = async (
       version: number,
     ): Promise<number | undefined> => {
-      const cidBytes = await resolveRemoteCid(version);
-      if (input.ipfsGateways.length === 0) {
-        throw new Error(
-          `inspectSnapshotEpoch: no IPFS gateways configured for v=${version}`,
-        );
+      const now = Date.now();
+      const cached = epochMemo.get(version);
+      if (cached !== undefined && cached.expiresAt > now) {
+        if (cached.error !== undefined) throw cached.error;
+        return cached.value;
       }
-      let cidString: string;
+
+      const compute = async (): Promise<number | undefined> => {
+        const cidBytes = await resolveRemoteCid(version);
+        if (input.ipfsGateways.length === 0) {
+          throw new Error(
+            `inspectSnapshotEpoch: no IPFS gateways configured for v=${version}`,
+          );
+        }
+        let cidString: string;
+        try {
+          cidString = CID.decode(cidBytes).toString();
+        } catch (err) {
+          throw new Error(
+            `inspectSnapshotEpoch: invalid CID bytes at v=${version}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        const rootBlockBytes = await fetchFromIpfs(
+          [...input.ipfsGateways],
+          cidString,
+        );
+        const { decode: cborDecode } = await import('@ipld/dag-cbor');
+        let decoded: unknown;
+        try {
+          decoded = cborDecode(rootBlockBytes);
+        } catch (err) {
+          throw new Error(
+            `inspectSnapshotEpoch: dag-cbor decode failed at v=${version}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        if (
+          decoded === null ||
+          typeof decoded !== 'object' ||
+          Array.isArray(decoded)
+        ) {
+          throw new Error(
+            `inspectSnapshotEpoch: root block decoded to non-object at v=${version}`,
+          );
+        }
+        const epoch = (decoded as Record<string, unknown>).epoch;
+        if (epoch === undefined) return undefined;
+        if (
+          typeof epoch !== 'number' ||
+          !Number.isFinite(epoch) ||
+          !Number.isInteger(epoch) ||
+          epoch < 0
+        ) {
+          throw new Error(
+            `inspectSnapshotEpoch: invalid epoch ${String(epoch)} at v=${version}`,
+          );
+        }
+        return epoch;
+      };
+
       try {
-        cidString = CID.decode(cidBytes).toString();
+        const result = await compute();
+        epochMemo.set(version, {
+          value: result,
+          expiresAt: Date.now() + INSPECT_EPOCH_MEMO_TTL_MS,
+        });
+        return result;
       } catch (err) {
-        throw new Error(
-          `inspectSnapshotEpoch: invalid CID bytes at v=${version}: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        const error = err instanceof Error ? err : new Error(String(err));
+        epochMemo.set(version, {
+          error,
+          expiresAt: Date.now() + INSPECT_EPOCH_MEMO_TTL_MS,
+        });
+        throw error;
       }
-      const rootBlockBytes = await fetchFromIpfs(
-        [...input.ipfsGateways],
-        cidString,
-      );
-      const { decode: cborDecode } = await import('@ipld/dag-cbor');
-      let decoded: unknown;
-      try {
-        decoded = cborDecode(rootBlockBytes);
-      } catch (err) {
-        throw new Error(
-          `inspectSnapshotEpoch: dag-cbor decode failed at v=${version}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-      if (
-        decoded === null ||
-        typeof decoded !== 'object' ||
-        Array.isArray(decoded)
-      ) {
-        throw new Error(
-          `inspectSnapshotEpoch: root block decoded to non-object at v=${version}`,
-        );
-      }
-      const epoch = (decoded as Record<string, unknown>).epoch;
-      if (epoch === undefined) return undefined;
-      if (
-        typeof epoch !== 'number' ||
-        !Number.isFinite(epoch) ||
-        !Number.isInteger(epoch) ||
-        epoch < 0
-      ) {
-        throw new Error(
-          `inspectSnapshotEpoch: invalid epoch ${String(epoch)} at v=${version}`,
-        );
-      }
-      return epoch;
     };
 
     // Item #15 Phase E: applySnapshot is the only sink for remote

--- a/profile/profile-storage-provider.ts
+++ b/profile/profile-storage-provider.ts
@@ -575,7 +575,13 @@ export class ProfileStorageProvider implements StorageProvider {
    * The hook contract MUST NOT throw — exceptions are swallowed.
    */
   setEnvelopeFallbackNotifier(
-    notifier: ((info: { readonly key: string; readonly errorMessage: string }) => void) | null,
+    notifier:
+      | ((info: {
+          readonly key: string;
+          readonly errorMessage: string;
+          readonly isCborDecodeError?: boolean;
+        }) => void)
+      | null,
   ): void {
     this.envelopeFallbackNotifier = notifier;
   }
@@ -604,7 +610,11 @@ export class ProfileStorageProvider implements StorageProvider {
   }
 
   private envelopeFallbackNotifier:
-    | ((info: { readonly key: string; readonly errorMessage: string }) => void)
+    | ((info: {
+        readonly key: string;
+        readonly errorMessage: string;
+        readonly isCborDecodeError?: boolean;
+      }) => void)
     | null = null;
 
   /**
@@ -1779,6 +1789,7 @@ export class ProfileStorageProvider implements StorageProvider {
   private handleEnvelopeFallback(info: {
     readonly key: string;
     readonly errorMessage: string;
+    readonly isCborDecodeError?: boolean;
   }): void {
     // Delimiter (`\x1f` = ASCII Unit Separator) prevents collisions
     // between (key="ab", err="cd") and (key="a", err="bcd"). Profile
@@ -1804,16 +1815,37 @@ export class ProfileStorageProvider implements StorageProvider {
       return;
     }
     this.envelopeFallbackSeen.add(dedupKey);
-    logger.warn(
-      'ProfileStorage',
-      `[ENVELOPE-FALLBACK] OpLog envelope decode failed for key="${redactProfileKey(info.key)}" ` +
-        `— served raw bytes via legacy compat path. ` +
-        `This is expected for pre-#247 wallets but indicates live envelope ` +
-        `corruption when seen on freshly-written entries. ` +
-        `error="${info.errorMessage}"`,
-    );
+    // Raw-CBOR-decode failures are the dominant signature of pre-#247
+    // raw-bytes writes (e.g. SentLedgerWriter writes ciphertext directly
+    // via `db.put` — random AES-GCM IVs occasionally start with a CBOR
+    // simple-value code that cborg rejects). The fallback path is the
+    // intended path; logging at WARN was the source of soak-log noise
+    // (e.g. "CBOR decode error: simple values are not supported" hits
+    // observed 2026-05-29) without indicating any real problem. Real
+    // envelope corruption surfaces as a non-cbor-decode failure (wrong
+    // shape, unknown v, unexpected field) — keep WARN for that case.
+    if (info.isCborDecodeError === true) {
+      logger.debug(
+        'ProfileStorage',
+        `[ENVELOPE-FALLBACK] legacy raw-bytes read for key="${redactProfileKey(info.key)}" ` +
+          `— served via db.get compat path (CBOR decode failed, expected for ` +
+          `pre-#247 raw-bytes writers like SentLedgerWriter).`,
+      );
+    } else {
+      logger.warn(
+        'ProfileStorage',
+        `[ENVELOPE-FALLBACK] OpLog envelope shape invalid for key="${redactProfileKey(info.key)}" ` +
+          `— served raw bytes via legacy compat path. ` +
+          `Indicates live envelope corruption (decoded to a non-envelope ` +
+          `shape) — operator triage recommended. ` +
+          `error="${info.errorMessage}"`,
+      );
+    }
     if (this.envelopeFallbackNotifier !== null) {
       try {
+        // Notifier always fires — observability hook lets consumers
+        // decide their own threshold for both legacy-noise and
+        // genuine-corruption signals.
         this.envelopeFallbackNotifier(info);
       } catch {
         // Best-effort signal; never propagate notifier errors.

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -220,6 +220,30 @@ export class LifecycleManager {
   private pointerPollTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
+   * Aborted in `shutdown()` to cancel any in-flight `pointer.recoverLatest()`
+   * calls that don't otherwise have a signal threaded through from a
+   * higher caller. Page-freeze 2026-05-29: without this, a `Sphere.destroy()`
+   * during a slow IPFS gateway round-trip leaves the recoverLatest walkback
+   * issuing requests for tens of seconds AFTER the user has reloaded the
+   * page or unmounted the provider — feeding the dual-instance leak we saw
+   * in the browser flame graph.
+   */
+  private destroyController: AbortController | null = null;
+
+  /**
+   * Lazily-allocated accessor for the destroy controller's signal. We create
+   * the controller on first use (after `initialize()` runs and before the
+   * first pointer poll) so test harnesses that wire up a `LifecycleManager`
+   * without ever polling don't pay the allocation cost.
+   */
+  private getDestroySignal(): AbortSignal {
+    if (this.destroyController === null) {
+      this.destroyController = new AbortController();
+    }
+    return this.destroyController.signal;
+  }
+
+  /**
    * Issue #245 #3 — wall-clock deadline (ms epoch) until which a
    * publish attempt should short-circuit because a recent attempt
    * hit `AGGREGATOR_POINTER_WALKBACK_FLOOR`. Zero when no throttle is
@@ -501,6 +525,18 @@ export class LifecycleManager {
     if (this.pointerPollTimer !== null) {
       clearTimeout(this.pointerPollTimer);
       this.pointerPollTimer = null;
+    }
+
+    // Abort any in-flight pointer.recoverLatest() calls that don't have a
+    // signal threaded through from a higher caller. Page-freeze 2026-05-29:
+    // a slow IPFS gateway can keep the discovery walkback alive for tens of
+    // seconds after the user closes/reloads the tab, doubling resource use
+    // until the network round-trip finally returns. The abort here lets
+    // those promises settle (with an AbortError) so the rest of shutdown
+    // can proceed promptly.
+    if (this.destroyController !== null) {
+      this.destroyController.abort();
+      this.destroyController = null;
     }
 
     // Cancel debounce timer
@@ -1683,7 +1719,9 @@ export class LifecycleManager {
           });
           let reconciledDownward = false;
           try {
-            const recovered = await pointer.recoverLatest();
+            const recovered = await pointer.recoverLatest({
+              abortSignal: this.getDestroySignal(),
+            });
             // Only attempt downward reconcile when we have a concrete RecoverResult
             // (cid + version). RecoverAllUnfetchableResult (all-unfetchable) has no
             // fetchable version to adopt as a new baseline, so skip the downgrade.
@@ -1879,7 +1917,9 @@ export class LifecycleManager {
 
     let recovered: Awaited<ReturnType<typeof pointer.recoverLatest>>;
     try {
-      recovered = await pointer.recoverLatest();
+      recovered = await pointer.recoverLatest({
+        abortSignal: this.getDestroySignal(),
+      });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (this.isPermanentPointerError(err)) {
@@ -2196,7 +2236,9 @@ export class LifecycleManager {
 
     let recovered: Awaited<ReturnType<typeof pointer.recoverLatest>> = null;
     try {
-      recovered = await pointer.recoverLatest();
+      recovered = await pointer.recoverLatest({
+        abortSignal: this.getDestroySignal(),
+      });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (this.isPermanentPointerError(err)) {

--- a/tests/unit/modules/GroupChatModule.cidref.test.ts
+++ b/tests/unit/modules/GroupChatModule.cidref.test.ts
@@ -464,10 +464,17 @@ describe('GroupChatModule — CID-refs persistence (commit 7b.2)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Config error: CID_REF_UNREADABLE
+  // Config degrade: CID_REF_DEGRADE
+  //
+  // When a stored value carries a CID ref but the wallet was opened without
+  // a cidRefStore (e.g. legacy `createBrowserProviders` factory), load() used
+  // to throw `ProfileError(CID_REF_UNREADABLE)` and brick every other module's
+  // load via the shared `Promise.allSettled`. The page-freeze investigation
+  // 2026-05-29 moved this to a logger.warn + start-empty fallback so relay
+  // re-delivery can repopulate the state on the next sync.
   // ---------------------------------------------------------------------------
 
-  it('throws CID_REF_UNREADABLE when ref present and cidRefStore absent', async () => {
+  it('degrades to empty state when groups ref present and cidRefStore absent', async () => {
     // Inject cidRefStore only to create the ref, then detach.
     const { fakeStore } = makeFakeCidRefStore();
     const ref = await fakeStore.pinJson([makeGroup('g1')]);
@@ -475,7 +482,11 @@ describe('GroupChatModule — CID-refs persistence (commit 7b.2)', () => {
 
     const mod = new GroupChatModule();
     mod.initialize(createDeps(storage)); // NO cidRefStore
-    await expect(mod.load()).rejects.toThrow(/CID_REF_UNREADABLE/);
+
+    // No throw: load resolves, but the groups Map is empty because we
+    // can't dereference the CID without a store.
+    await expect(mod.load()).resolves.toBeUndefined();
+    expect((mod as any).groups.size).toBe(0);
   });
 
   // ---------------------------------------------------------------------------
@@ -1050,7 +1061,11 @@ describe('GroupChatModule — CID-refs persistence (commit 7b.2)', () => {
     expect(fakeStore.fetchJson).not.toHaveBeenCalled();
   });
 
-  it('processedEvents: load CID-ref-without-store throws CID_REF_UNREADABLE', async () => {
+  it('processedEvents: load CID-ref-without-store degrades to empty set', async () => {
+    // Matches the groups-key fallback added 2026-05-29 — when the legacy
+    // factory wires the module without a cidRefStore, the processedEvents
+    // ledger starts fresh and relay re-delivery rehydrates via the
+    // idempotent event handlers. The previous throw bricked module load.
     const { fakeStore } = makeFakeCidRefStore();
     const ref = await fakeStore.pinJson(['evt']);
     storage._data.set(STORAGE_KEYS_ADDRESS.GROUP_CHAT_PROCESSED_EVENTS, JSON.stringify(ref));
@@ -1059,7 +1074,8 @@ describe('GroupChatModule — CID-refs persistence (commit 7b.2)', () => {
     const mod = new GroupChatModule();
     mod.initialize(createDeps(storage, undefined));
 
-    await expect(mod.load()).rejects.toMatchObject({ code: 'CID_REF_UNREADABLE' });
+    await expect(mod.load()).resolves.toBeUndefined();
+    expect((mod as any).processedEventIds.size).toBe(0);
   });
 
   it('processedEvents: load CID-ref fetch failure starts fresh (best-effort)', async () => {


### PR DESCRIPTION
## Summary

Five commits addressing the 2026-05-29 page-freeze investigation. Targets Sections **B/C/D** of the review-agent freeze findings; companion changes to enable **Section E/A** ship in the sphere.telco-side PR.

- **B+C: GroupChat fan-out + degrade** (`7421386`) — Replace 4 fatal `ProfileError(CID_REF_UNREADABLE)` throws with `logger.warn` + start-empty fallback; bound per-message Pattern-B fan-out to `LOAD_FETCH_CONCURRENCY=4` via a `mapWithConcurrency` helper (previously unbounded `Promise.all(items.map(...))`).
- **CBOR + §D.5 normalizer** (`ca74b42`) — Thread `isCborDecodeError` flag through `getEnvelopePayload` → `handleEnvelopeFallback`, demote the false-positive `ENVELOPE-FALLBACK` warn to debug for the pre-#247 legacy raw-bytes path while keeping it loud for real envelope-shape corruption. Soak script's §D.5 byte-compare now normalizes transient sync/debug lines so the false-positive `alice-peer1-before-vs-after` assert no longer fires.
- **§C.4 wait helper** (`0920b4e`) — `wait_for_invoice_visible` polls `sphere invoice status` for up to 150s before failing, so transient testnet replication lag no longer aborts the whole soak at §C.4 (treats "No invoice found" as transient; other errors still propagate).
- **Per-section timing** (`ebe107b`) — `banner()` now prints `[ISO timestamp] +<total>s (prev section "<name>" took <Δ>s)` so soak runs are self-timing without external date anchors.
- **inspectSnapshotEpoch memo + AbortController** (`3af2139`) — Closure-scope `Map<version, {value?, error?, expiresAt}>` with TTL = 30s ≥ POINTER_POLL_MIN_MS dedups same-CID re-walks across pointer polls. Three previously-bare `pointer.recoverLatest()` callsites in `lifecycle-manager.ts` now pass `{abortSignal: this.getDestroySignal()}`; the controller is aborted in `shutdown()`.

## Soak validation

Three healthy end-to-end soak runs, all reaching §D.5:

| Run | Total | §D.4 | EXIT | ASSERTs |
|---|---|---|---|---|
| `c1f2ac0` baseline (no fixes) | 608s | 222s | 1 | 5 OK / 2 FAIL (one false-positive normalizer-fixable; one bob divergence) |
| `528823b` (B+C+CBOR+§D.5+§C.4+timing) | 608s | 222s | 1 | 6 OK / 1 FAIL (only the pre-existing bob divergence) |
| `bcb649c` (above + D) | 600s | 217s | 1 | 6 OK / 1 FAIL (same bob divergence) |

The remaining `bob-peer1-vs-peer2-after` failure is a pre-existing recovery-pipeline divergence (visible in `soak-7a12ac8-rebuilt` too — *not* introduced by this PR; tracked in #335).

## Companion PR

[unicity-sphere/sphere#326](https://github.com/unicity-sphere/sphere/pull/326) ships Section A (pagehide teardown) and Section E (deprecated `IpfsStorageProvider` default-off) for the actual user-visible freeze. **THE freeze fix lives there**; this PR is the supporting hardening + the SDK-side dedup/abort plumbing.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] 2213/2213 unit tests pass (50/50 GroupChat tests)
- [x] Three soak runs reach §D.5 with consistent results
- [x] §D.5 normalizer eliminates the timestamp-only `alice-peer1-before-vs-after` false positive
- [x] CBOR fix: 0 false-positive WARNs from random AES-GCM IVs; real envelope-shape corruption still surfaces
- [ ] Manual verification against the deployed `sphere-telco-test.dyndns.org` after companion PR lands

## Follow-up issues (filed alongside this PR)

- #335 — `bob-peer1-vs-peer2-after` recovery-pipeline divergence (pre-existing across all branches; NOT introduced here)
- #336 — `FILE_LOCK_STALE_MS=920s` is too long for CLI workflows; add PID-liveness probe
- #337 — Delete deprecated `IpfsStorageProvider` after sphere#326 stabilises in production
- [unicitynetwork/ipfs-storage#13](https://github.com/unicitynetwork/ipfs-storage/issues/13) — bump `SIDECAR_CACHE_MAX_ENTRIES` 10k → 100k to reduce `/sidecar/blob` 404 floor

## Notes

The root-cause analysis for the page freeze (deprecated `IpfsStorageProvider` chain-break flood, 14,575 sidecar rejections/30min) lives in the companion PR's description and in the auto-memory anchor `project_freeze_fix_pause_20260529.md`.
