### PR TITLE
fix(profile/pointer): PID-liveness probe to clear stale CLI file locks (#336)

### DIFF
--- a/profile/aggregator-pointer/mutex-lock.ts
+++ b/profile/aggregator-pointer/mutex-lock.ts
@@ -227,6 +227,163 @@ export interface NodeLockPrimitives {
   acquireFileLock(path: string, staleMs: number): Promise<() => Promise<void>>;
 }
 
+/**
+ * Issue #336: PID-liveness probe for stale file locks.
+ *
+ * proper-lockfile's `stale` parameter is mtime-based: it considers the lock
+ * stale only after `stale` ms have elapsed since the lockfile was last
+ * touched. FILE_LOCK_STALE_MS is calibrated to ~15min to cover the worst-case
+ * publishOnce hold time for browser/daemon contexts — far longer than the
+ * 30s mutex acquire timeout. A CLI process that crashes (SIGKILL, OOM, soak
+ * teardown) before releasing its lock leaves the next CLI invocation
+ * spinning for 30s and giving up with PUBLISH_BUSY even though no process
+ * holds the lock.
+ *
+ * The fix is to supplement mtime-staleness with a PID-liveness probe:
+ *
+ *   1. After acquiring the lock, write a sibling `${lockPath}.owner.json`
+ *      file containing {pid, hostname, acquiredAt}.
+ *   2. When a contender encounters ELOCKED, read the owner metadata. If the
+ *      hostname matches the local host AND `process.kill(pid, 0)` reports
+ *      the PID is dead (ESRCH), forcibly remove the lock dir + metadata and
+ *      retry the acquire. This bypasses the FILE_LOCK_STALE_MS window
+ *      entirely for the (common) crashed-CLI-on-same-host case.
+ *   3. Cross-host or unreadable metadata: skip the probe and fall back to
+ *      the existing FILE_LOCK_STALE_MS path. PID probing across hosts is
+ *      meaningless (and dangerous — pid 1234 on this host has nothing to
+ *      do with pid 1234 on another host).
+ *
+ * Safety invariants (DEFENSIVE — false-positive "dead" detection causes
+ * data corruption from concurrent writers):
+ *   - If hostname mismatch → treat as alive (skip probe).
+ *   - If metadata file missing/unreadable/malformed → treat as alive
+ *     (we don't know who holds it).
+ *   - If PID equals our own process.pid → treat as alive (defensive; the
+ *     in-process async-mutex already prevents this, but belt-and-suspenders).
+ *   - If process.kill(pid, 0) throws EPERM → treat as alive (process
+ *     exists but is owned by another user).
+ *   - If process.kill(pid, 0) succeeds → alive.
+ *   - Only ESRCH (no such process) is treated as dead.
+ *   - Any other error from kill/fs → treat as alive (conservative fallback).
+ *
+ * The steal step (rmdir + unlink) is best-effort and races against other
+ * contenders attempting the same steal — but the subsequent
+ * proper-lockfile mkdir is atomic (O_EXCL), so only one steal-then-acquire
+ * sequence can succeed even with concurrent stealers.
+ */
+interface LockOwnerMetadata {
+  readonly pid: number;
+  readonly hostname: string;
+  readonly acquiredAt: number;
+}
+
+const OWNER_METADATA_SUFFIX = '.owner.json';
+
+/**
+ * Read and parse owner metadata from a sibling .owner.json file.
+ * Returns null on ANY failure — caller treats null as "unknown owner;
+ * assume alive". The conservative default avoids false-positive steals
+ * that would cause concurrent-writer data corruption.
+ */
+async function readOwnerMetadata(lockFilePath: string): Promise<LockOwnerMetadata | null> {
+  try {
+    const { readFile } = await import('node:fs/promises');
+    const raw = await readFile(lockFilePath + OWNER_METADATA_SUFFIX, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      typeof (parsed as { pid?: unknown }).pid !== 'number' ||
+      !Number.isInteger((parsed as { pid: number }).pid) ||
+      (parsed as { pid: number }).pid <= 0 ||
+      typeof (parsed as { hostname?: unknown }).hostname !== 'string' ||
+      (parsed as { hostname: string }).hostname.length === 0 ||
+      typeof (parsed as { acquiredAt?: unknown }).acquiredAt !== 'number' ||
+      !Number.isFinite((parsed as { acquiredAt: number }).acquiredAt)
+    ) {
+      return null;
+    }
+    return parsed as LockOwnerMetadata;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write owner metadata to the sibling .owner.json file. Failures are
+ * logged but non-fatal — the lock is still held by proper-lockfile; we
+ * simply lose the PID-probe optimization for any future contender.
+ */
+async function writeOwnerMetadata(lockFilePath: string): Promise<void> {
+  try {
+    const { writeFile } = await import('node:fs/promises');
+    const os = await import('node:os');
+    const meta: LockOwnerMetadata = {
+      pid: process.pid,
+      hostname: os.hostname(),
+      acquiredAt: Date.now(),
+    };
+    await writeFile(lockFilePath + OWNER_METADATA_SUFFIX, JSON.stringify(meta), 'utf8');
+  } catch {
+    /* non-fatal — see comment above */
+  }
+}
+
+/**
+ * Best-effort cleanup of the owner metadata file on release.
+ */
+async function removeOwnerMetadata(lockFilePath: string): Promise<void> {
+  try {
+    const { unlink } = await import('node:fs/promises');
+    await unlink(lockFilePath + OWNER_METADATA_SUFFIX);
+  } catch {
+    /* non-fatal — leftover metadata is harmless; the next acquire will
+       overwrite it, and stale metadata is treated conservatively */
+  }
+}
+
+/**
+ * Probe whether a given (hostname, pid) pair represents a still-running
+ * process on the LOCAL host. Returns true if alive (or unknown — the
+ * conservative default), false ONLY if we can prove the PID is dead.
+ *
+ * Cross-host probing is meaningless — pid N on host A has nothing to do
+ * with pid N on host B. We short-circuit to "alive" in that case.
+ */
+async function isLockHolderAlive(meta: LockOwnerMetadata): Promise<boolean> {
+  let localHostname: string;
+  try {
+    const os = await import('node:os');
+    localHostname = os.hostname();
+  } catch {
+    return true; // cannot determine local hostname → conservative
+  }
+  if (meta.hostname !== localHostname) {
+    return true; // cross-host → skip PID probe; fall back to mtime-based stale
+  }
+  if (meta.pid === process.pid) {
+    // Self-PID. In-process async-mutex layer prevents reaching here, but
+    // defend anyway: treat self as alive — we never want to "steal" our
+    // own live lock.
+    return true;
+  }
+  try {
+    // signal 0 = existence check; no signal delivered.
+    // Returns true → process exists. We never reach the truthy branch in
+    // a way that means "dead"; the dead path is the ESRCH catch below.
+    process.kill(meta.pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === 'ESRCH') {
+      return false; // proven dead
+    }
+    // EPERM: process exists but we lack permission to signal — treat as alive.
+    // Anything else: conservative — treat as alive.
+    return true;
+  }
+}
+
 async function defaultNodeLockPrimitives(lockFilePath: string): Promise<NodeLockPrimitives> {
   const { Mutex } = await import('async-mutex');
   const mutex = new Mutex();
@@ -236,9 +393,79 @@ async function defaultNodeLockPrimitives(lockFilePath: string): Promise<NodeLock
       const lockfile = await import('proper-lockfile');
       const { writeFile } = await import('node:fs/promises');
       await writeFile(p, '', { flag: 'a' });
-      return lockfile.lock(p, { stale: staleMs, realpath: false, retries: { retries: 0 } });
+      // Issue #336: before each acquire attempt, check whether an existing
+      // lock dir is held by a dead PID on the local host. If so, force-clean
+      // it so the immediate mkdir below can succeed. This is best-effort;
+      // any failure falls through to the normal proper-lockfile acquire
+      // (which then either succeeds, returns ELOCKED for caller retry, or
+      // reaps via mtime-staleness after FILE_LOCK_STALE_MS).
+      await maybeStealDeadLock(p);
+      const release = await lockfile.lock(p, {
+        stale: staleMs,
+        realpath: false,
+        retries: { retries: 0 },
+      });
+      // We hold the lock now — record our ownership for future contenders.
+      await writeOwnerMetadata(p);
+      // Wrap release so the metadata file is cleaned up before the lock dir.
+      // Order matters: if we removed the lock dir first, a contender could
+      // mkdir between our two cleanups, then read OUR stale metadata and
+      // wrongly attribute the lock to us.
+      return async () => {
+        await removeOwnerMetadata(p);
+        await release();
+      };
     },
   };
+}
+
+/**
+ * If a lock dir exists at `p` and its owner metadata reports a dead
+ * local-host PID, forcibly remove both the lock dir and the metadata
+ * so the next `lockfile.lock` mkdir can succeed.
+ *
+ * All failures are swallowed — falling back to the existing
+ * FILE_LOCK_STALE_MS path is always safe (just slower).
+ */
+async function maybeStealDeadLock(p: string): Promise<void> {
+  try {
+    const { stat } = await import('node:fs/promises');
+    // Probe whether the lock dir actually exists. If not, nothing to steal.
+    try {
+      await stat(p + '.lock');
+    } catch {
+      return;
+    }
+    const meta = await readOwnerMetadata(p);
+    if (meta === null) {
+      // No metadata → unknown owner → conservative: do not steal.
+      return;
+    }
+    const alive = await isLockHolderAlive(meta);
+    if (alive) {
+      return;
+    }
+    // Proven dead local PID — steal. Best-effort; ignore failures.
+    const { rm, unlink } = await import('node:fs/promises');
+    try {
+      await rm(p + '.lock', { recursive: true, force: true });
+    } catch {
+      /* concurrent stealer or transient fs error */
+    }
+    try {
+      await unlink(p + OWNER_METADATA_SUFFIX);
+    } catch {
+      /* already gone */
+    }
+    // Best-effort logging — visibility for operators investigating recoveries.
+    console.warn(
+      `[pointer-mutex] stole lock at ${p}: previous holder pid=${meta.pid} ` +
+        `(hostname=${meta.hostname}, acquiredAt=${new Date(meta.acquiredAt).toISOString()}) ` +
+        `not alive (issue #336)`,
+    );
+  } catch {
+    /* any unexpected error → conservative fallback */
+  }
 }
 
 class NodeMutex implements PointerMutex {

--- a/tests/unit/profile/pointer/mutex-pid-probe.test.ts
+++ b/tests/unit/profile/pointer/mutex-pid-probe.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Issue #336 — PID-liveness probe for stale CLI locks.
+ *
+ * Background: FILE_LOCK_STALE_MS (~920s) is calibrated for the worst-case
+ * browser publishOnce hold time, but CLI processes spawn-publish-exit in
+ * seconds. When a CLI crashes (SIGKILL, OOM, soak teardown) before
+ * releasing its proper-lockfile marker, the next CLI invocation has to
+ * wait ~15 minutes for proper-lockfile's mtime-based stale detection,
+ * but the 30s mutex-acquire timeout trips first, surfacing PUBLISH_BUSY
+ * even though no process holds the lock.
+ *
+ * Fix: write a sibling `<lockPath>.owner.json` containing {pid, hostname,
+ * acquiredAt} on acquire. Before retrying on ELOCKED, probe the holder:
+ * if the hostname matches local AND `process.kill(pid, 0)` reports ESRCH,
+ * steal the lock immediately.
+ *
+ * Safety properties verified here:
+ *   (a) live PID lock held → next acquire waits the full timeout (no false-stale)
+ *   (b) dead PID lock stolen → next acquire succeeds quickly
+ *   (c) cross-host metadata → no PID probe, falls back to timeout path
+ *   (d) self-PID metadata → treated as alive (defensive against impossible
+ *       same-process steal that would break in-process Mutex)
+ *   (e) malformed/missing metadata → treated as alive (conservative)
+ *   (f) clean acquire/release writes and removes owner metadata
+ *   (g) stolen lock surfaces a warning log for operator visibility
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { spawn } from 'node:child_process';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  createPointerMutex,
+  AggregatorPointerErrorCode,
+} from '../../../../profile/aggregator-pointer/index.js';
+
+const OWNER_SUFFIX = '.owner.json';
+
+interface LockOwnerMetadata {
+  pid: number;
+  hostname: string;
+  acquiredAt: number;
+}
+
+async function writeOwnerFile(lockPath: string, meta: LockOwnerMetadata): Promise<void> {
+  await fsp.writeFile(lockPath + OWNER_SUFFIX, JSON.stringify(meta), 'utf8');
+}
+
+/**
+ * Forge a "stale CLI lock" on disk: create the lockfile placeholder, the
+ * proper-lockfile lock dir (`${p}.lock`), and an owner.json claiming the
+ * supplied PID/hostname. This is what the filesystem looks like after a
+ * CLI process crashed mid-publish without cleaning up.
+ */
+async function forgeOrphanedLock(
+  lockPath: string,
+  meta: LockOwnerMetadata,
+): Promise<void> {
+  // proper-lockfile expects the target file to exist.
+  await fsp.writeFile(lockPath, '', { flag: 'a' });
+  // The atomic mkdir marker.
+  await fsp.mkdir(lockPath + '.lock');
+  // Our PID metadata sibling.
+  await writeOwnerFile(lockPath, meta);
+}
+
+/** Spawn an actually-running child process and return its (live) PID. */
+function spawnLiveChild(): { pid: number; kill: () => void } {
+  // Sleep-forever child; cheap and portable.
+  const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    stdio: 'ignore',
+    detached: false,
+  });
+  if (typeof child.pid !== 'number') {
+    throw new Error('failed to spawn child process for live-PID test');
+  }
+  return {
+    pid: child.pid,
+    kill: () => { try { child.kill('SIGKILL'); } catch { /* noop */ } },
+  };
+}
+
+/**
+ * Find an unused PID on the local host. We probe upward from a high base
+ * to minimise collisions with normal pid allocation. Returns a PID that
+ * `process.kill(pid, 0)` confirms ESRCH (does not exist).
+ */
+function findDeadPid(): number {
+  // Try a few candidates. On Linux the default pid_max is 32768 or 4 million;
+  // pids near 2^30 are virtually never allocated. We still verify ESRCH.
+  const candidates = [999_999, 999_998, 999_997, 888_888, 777_777, 666_666];
+  for (const pid of candidates) {
+    try {
+      process.kill(pid, 0);
+      // alive → skip
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ESRCH') {
+        return pid;
+      }
+      // EPERM means "exists but not ours" → skip
+    }
+  }
+  throw new Error('could not find an unused PID for dead-PID test');
+}
+
+describe('NodeMutex PID-liveness probe (issue #336)', () => {
+  let tmpDir: string;
+  let lockFile: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'pointer-mutex-pid-probe-'));
+    lockFile = path.join(tmpDir, 'publish.lock');
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    warnSpy.mockRestore();
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── (a) live PID → no steal ──────────────────────────────────────────────
+
+  it('does NOT steal a lock held by a still-alive local PID — short acquire times out', async () => {
+    const child = spawnLiveChild();
+    try {
+      await forgeOrphanedLock(lockFile, {
+        pid: child.pid,
+        hostname: os.hostname(),
+        acquiredAt: Date.now(),
+      });
+
+      const mutex = createPointerMutex('pid-probe-test', { lockFilePath: lockFile });
+
+      // Short timeout: if the steal logic were buggy and stole a live lock,
+      // this acquire would succeed quickly. Instead, it MUST surface
+      // PUBLISH_BUSY because the holder is alive.
+      const start = Date.now();
+      await expect(mutex.acquire({ timeoutMs: 800 })).rejects.toMatchObject({
+        code: AggregatorPointerErrorCode.PUBLISH_BUSY,
+      });
+      const elapsed = Date.now() - start;
+      // Should consume ~most of the timeout, not finish near-instantly.
+      expect(elapsed).toBeGreaterThanOrEqual(700);
+
+      // Owner metadata still references the live child.
+      const stillThere = await fsp.readFile(lockFile + OWNER_SUFFIX, 'utf8');
+      expect(JSON.parse(stillThere).pid).toBe(child.pid);
+    } finally {
+      child.kill();
+    }
+  }, 15_000);
+
+  // ── (b) dead PID → steal + immediate success ─────────────────────────────
+
+  it('steals a lock held by a dead local PID and acquires within <2s', async () => {
+    const deadPid = findDeadPid();
+    await forgeOrphanedLock(lockFile, {
+      pid: deadPid,
+      hostname: os.hostname(),
+      acquiredAt: Date.now() - 60_000,
+    });
+
+    const mutex = createPointerMutex('pid-probe-test', { lockFilePath: lockFile });
+
+    const start = Date.now();
+    // 5s budget is generous — the steal should land in well under a second,
+    // far below FILE_LOCK_STALE_MS (~920s).
+    const handle = await mutex.acquire({ timeoutMs: 5_000 });
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(2_000);
+
+    // After the steal, our acquire wrote NEW metadata identifying us.
+    const newMetaRaw = await fsp.readFile(lockFile + OWNER_SUFFIX, 'utf8');
+    const newMeta = JSON.parse(newMetaRaw) as LockOwnerMetadata;
+    expect(newMeta.pid).toBe(process.pid);
+    expect(newMeta.hostname).toBe(os.hostname());
+
+    await handle.release();
+
+    // Release removed the owner metadata.
+    expect(fs.existsSync(lockFile + OWNER_SUFFIX)).toBe(false);
+
+    // Operator visibility: a warning was logged with the stolen PID.
+    expect(warnSpy).toHaveBeenCalled();
+    const warnText = warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(warnText).toMatch(/stole lock/);
+    expect(warnText).toMatch(new RegExp(`pid=${deadPid}\\b`));
+    expect(warnText).toMatch(/#336/);
+  }, 15_000);
+
+  // ── (c) cross-host metadata → skip probe, fall back to timeout ───────────
+
+  it('does NOT steal a lock with cross-host metadata (PID probing across hosts is meaningless)', async () => {
+    // Use a PID that IS dead locally — but mark it as held by a different
+    // host. The probe MUST short-circuit "alive" rather than steal based on
+    // the local PID check, because pid N on host A != pid N on host B.
+    const deadPidLocally = findDeadPid();
+    await forgeOrphanedLock(lockFile, {
+      pid: deadPidLocally,
+      hostname: 'some-other-host-' + Math.random().toString(36).slice(2),
+      acquiredAt: Date.now(),
+    });
+
+    const mutex = createPointerMutex('pid-probe-test', { lockFilePath: lockFile });
+
+    const start = Date.now();
+    await expect(mutex.acquire({ timeoutMs: 800 })).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PUBLISH_BUSY,
+    });
+    expect(Date.now() - start).toBeGreaterThanOrEqual(700);
+
+    // Cross-host metadata was preserved (not overwritten).
+    const stillThere = JSON.parse(await fsp.readFile(lockFile + OWNER_SUFFIX, 'utf8'));
+    expect(stillThere.pid).toBe(deadPidLocally);
+    expect(stillThere.hostname).not.toBe(os.hostname());
+  }, 10_000);
+
+  // ── (d) self-PID → never stolen (defensive) ──────────────────────────────
+
+  it('treats a lock claiming our own PID as alive (never false-positives self-steal)', async () => {
+    await forgeOrphanedLock(lockFile, {
+      pid: process.pid,
+      hostname: os.hostname(),
+      acquiredAt: Date.now(),
+    });
+
+    const mutex = createPointerMutex('pid-probe-test', { lockFilePath: lockFile });
+
+    // Even though the owner metadata claims our own PID (which is by
+    // definition alive), the probe must short-circuit and NOT attempt a
+    // process.kill that succeeds. Acquire must time out cleanly.
+    const start = Date.now();
+    await expect(mutex.acquire({ timeoutMs: 800 })).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PUBLISH_BUSY,
+    });
+    expect(Date.now() - start).toBeGreaterThanOrEqual(700);
+
+    const stillThere = JSON.parse(await fsp.readFile(lockFile + OWNER_SUFFIX, 'utf8'));
+    expect(stillThere.pid).toBe(process.pid);
+  }, 10_000);
+
+  // ── (e) missing / malformed metadata → conservative ──────────────────────
+
+  it('does NOT steal a lock with missing owner metadata (conservative)', async () => {
+    // Lock dir present but NO owner.json — pre-fix locks won't have it.
+    await fsp.writeFile(lockFile, '', { flag: 'a' });
+    await fsp.mkdir(lockFile + '.lock');
+
+    const mutex = createPointerMutex('pid-probe-test', { lockFilePath: lockFile });
+
+    const start = Date.now();
+    await expect(mutex.acquire({ timeoutMs: 800 })).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PUBLISH_BUSY,
+    });
+    expect(Date.now() - start).toBeGreaterThanOrEqual(700);
+  }, 10_000);
+
+  it('does NOT steal a lock with malformed owner metadata (conservative)', async () => {
+    await fsp.writeFile(lockFile, '', { flag: 'a' });
+    await fsp.mkdir(lockFile + '.lock');
+    await fsp.writeFile(lockFile + OWNER_SUFFIX, 'this is not json', 'utf8');
+
+    const mutex = createPointerMutex('pid-probe-test', { lockFilePath: lockFile });
+
+    const start = Date.now();
+    await expect(mutex.acquire({ timeoutMs: 800 })).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PUBLISH_BUSY,
+    });
+    expect(Date.now() - start).toBeGreaterThanOrEqual(700);
+  }, 10_000);
+
+  // ── (f) clean acquire writes & release removes the metadata ──────────────
+
+  it('writes owner metadata on acquire and removes it on release', async () => {
+    const mutex = createPointerMutex('pid-probe-test', { lockFilePath: lockFile });
+    const handle = await mutex.acquire({ timeoutMs: 5_000 });
+
+    const meta = JSON.parse(
+      await fsp.readFile(lockFile + OWNER_SUFFIX, 'utf8'),
+    ) as LockOwnerMetadata;
+    expect(meta.pid).toBe(process.pid);
+    expect(meta.hostname).toBe(os.hostname());
+    expect(meta.acquiredAt).toBeGreaterThan(0);
+    expect(meta.acquiredAt).toBeLessThanOrEqual(Date.now());
+
+    await handle.release();
+
+    expect(fs.existsSync(lockFile + OWNER_SUFFIX)).toBe(false);
+    // proper-lockfile also removed the lock dir.
+    expect(fs.existsSync(lockFile + '.lock')).toBe(false);
+  }, 10_000);
+});


### PR DESCRIPTION
## Summary

Closes #336.

`FILE_LOCK_STALE_MS = 920_000ms (~15.3 min)` is calibrated for the worst-case browser publishOnce hold time, but CLI processes spawn-publish-exit in seconds. When a CLI crashes (SIGKILL, OOM, soak teardown) before releasing its `proper-lockfile` marker, the next CLI invocation has to wait ~15 minutes for proper-lockfile's mtime-based stale detection — but the 30s mutex acquire timeout (`MutexAcquireOptions.timeoutMs`) trips first, surfacing `AGGREGATOR_POINTER_PUBLISH_BUSY` even though no process actually holds the lock. Hit during the 2026-05-29 soak (#334 §D.4).

## Fix

Supplement mtime-staleness with a PID-liveness probe:

1. After acquiring the lock, write a sibling `<lockPath>.owner.json` containing `{pid, hostname, acquiredAt}`.
2. Before each acquire attempt, if a lock dir exists, read the owner metadata. If hostname matches local **and** `process.kill(pid, 0)` reports `ESRCH`, steal the lock (rmdir + unlink) and retry. The subsequent `proper-lockfile` mkdir is atomic (O_EXCL), so concurrent stealers cannot double-steal.
3. On release, remove the owner metadata **before** releasing the lock dir to prevent a contender from mkdir-ing then reading our stale owner entry.

`FILE_LOCK_STALE_MS` is preserved as the safety-net fallback for the cross-host case where PID probing is meaningless.

### Defensive properties

False-positive "dead" detection causes data corruption from concurrent writers. The probe treats the holder as **alive** on any of:

- hostname mismatch (cross-host PID probing is meaningless — pid N on host A != pid N on host B)
- metadata file missing / unreadable / malformed (we don't know who holds it)
- `pid === process.pid` (impossible via the in-process Mutex layer, but defended anyway — never false-positive self-steal)
- `process.kill(pid, 0)` returns `EPERM` (process exists but owned by another user)
- any other unexpected fs/probe error

Only `ESRCH` is treated as proven dead.

## Files changed

- `profile/aggregator-pointer/mutex-lock.ts` — owner-metadata read/write helpers, `isLockHolderAlive` probe, `maybeStealDeadLock` cleanup, wired into `defaultNodeLockPrimitives.acquireFileLock` + release wrapper.
- `tests/unit/profile/pointer/mutex-pid-probe.test.ts` — 7 new tests.

## Test plan

- [x] Existing `tests/unit/profile/pointer/mutex.test.ts` — 10/10 pass
- [x] New `tests/unit/profile/pointer/mutex-pid-probe.test.ts` — 7/7 pass:
  - (a) live local PID → acquire times out (no false-positive steal)
  - (b) dead local PID → acquire succeeds in <2s (steal works)
  - (c) cross-host metadata → acquire times out (no cross-host PID probing)
  - (d) self-PID metadata → acquire times out (never false-positive self-steal)
  - (e) missing owner metadata → acquire times out (conservative)
  - (f) malformed owner metadata → acquire times out (conservative)
  - (g) clean acquire/release writes and removes owner metadata
- [x] Full `tests/unit/profile/pointer/` — 489/489 pass (no regression)
- [x] `npx tsup` — build success
- [x] `npx eslint` — no new errors/warnings (one pre-existing `lockFilePath` unused-var warning at line 387 remains)

## Acceptance criteria from #336

- [x] `sphere init` survives an orphaned lock file from a killed prior CLI invocation without 30s timeout — dead-PID steal completes in <2s
- [x] No regression in browser multi-tab arbitration (cross-tab mutex via Web Locks unchanged)
- [x] Unit test: orphaned marker + dead PID → next acquire succeeds in <1s (actually <2s budget for fs noise; observed <1s in practice)
- [x] Unit test: orphaned marker + live PID → next acquire waits the full timeout (no false-stale)