### PR TITLE
fix(profile/snapshot)(issue-335): SingleBlobSyncWriter for tombstones + invalidatedNametags

### DIFF
--- a/profile/factory.ts
+++ b/profile/factory.ts
@@ -762,6 +762,32 @@ export function createProfileProviders(
             writer: dispoQuad.auditOrphan,
           });
         }
+        // Issue #335 — register sync writers for the two single-blob
+        // OrbitDB keys (`${addr}.tombstones` and
+        // `${addr}.invalidatedNametags`). Every other per-address key
+        // is per-entry with a trailing-dot prefix; these two are the
+        // last single-blob holdouts. Before this registration the
+        // lean-snapshot dispatcher silently dropped them — see
+        // SingleBlobSyncWriter's module doc-comment and the issue #335
+        // RCA for the soak failure that surfaced the gap. The writer's
+        // `keyPrefix` here is the EXACT key (no trailing dot); the
+        // writer itself enforces exact-key match in `joinSnapshot()`
+        // as defense in depth.
+        const tombstonesWriter = storage.buildTombstonesSyncWriter(addressId);
+        if (tombstonesWriter !== null) {
+          writers.push({
+            keyPrefix: `${addressId}.tombstones`,
+            writer: tombstonesWriter,
+          });
+        }
+        const invalidatedNametagsWriter =
+          storage.buildInvalidatedNametagsSyncWriter(addressId);
+        if (invalidatedNametagsWriter !== null) {
+          writers.push({
+            keyPrefix: `${addressId}.invalidatedNametags`,
+            writer: invalidatedNametagsWriter,
+          });
+        }
         return writers;
       },
       getBundleIndex: () => tokenStorage.getBundleIndex(),

--- a/profile/profile-snapshot-dispatcher.ts
+++ b/profile/profile-snapshot-dispatcher.ts
@@ -158,6 +158,89 @@ export interface ApplySnapshotResult {
 const ADDRESS_ID_PREFIX_RE = /^(DIRECT_[0-9a-f]{6}_[0-9a-f]{6})\./;
 
 /**
+ * Issue #335 Phase 2.5 — legacy → profile key normalization table for
+ * single-blob per-address keys.
+ *
+ * **Why this exists.** The lean-snapshot publisher reads keys via
+ * `ProfileStorageProvider.keys()` which translates OrbitDB profile-form
+ * keys (`${addressId}.tombstones`) back to legacy form
+ * (`${addressId}_tombstones`) for backward compatibility with the
+ * non-Profile `StorageProvider` interface. The reverse-mapping fires
+ * only when a key matches a static `PROFILE_KEY_MAPPING` per-address
+ * suffix (e.g., `.tombstones`, `.invalidatedNametags`). Per-entry keys
+ * like `${addressId}.outbox.${id}` are NOT remapped — their suffix
+ * (`.outbox.${id}`) doesn't match the static `.outbox` suffix.
+ *
+ * Consequence pre-Phase-2.5: snapshot entries for single-blob keys
+ * carry the legacy form (`${addressId}_tombstones`). The dispatcher
+ * routes by profile-form prefix (`${addressId}.tombstones`) — no match,
+ * silent drop. The Phase 2 `SingleBlobSyncWriter` was correctly wired
+ * via `factory.ts:writersFor()` but never fired because the dispatcher
+ * pre-filter `entries.filter(e => e.key.startsWith(keyPrefix))` never
+ * matched a single entry. Soak `bob-peer1-vs-peer2-after` failed with
+ * the same divergence Phase 2 was meant to fix.
+ *
+ * **Per-entry writers are unaffected.** Outbox/sent/dispositions/
+ * finalization/recipient-context entries flow as `${addressId}.${prefix}.${id}`
+ * — the suffix-match in `reverseMapProfileKey` doesn't trigger for
+ * those (the suffix is `.${prefix}.${id}`, not `.${prefix}`), so they
+ * stay in profile form end-to-end.
+ *
+ * **Scope.** This table covers ONLY the single-blob per-address keys
+ * Phase 2 added writers for (`tombstones`, `invalidatedNametags`).
+ * Adding more single-blob writers in the future requires extending
+ * both this table AND `factory.ts:writersFor()`. The dispatcher fails
+ * closed on unlisted legacy suffixes — the entry is dispatched in its
+ * legacy form, which downstream writers will not match, exactly
+ * mirroring the pre-fix behaviour for those (currently unrouted)
+ * keys.
+ *
+ * Keep the table sorted by `legacySuffix` for stable iteration.
+ */
+const PER_ADDRESS_LEGACY_SUFFIX_MAP: ReadonlyArray<{
+  readonly legacySuffix: string;
+  readonly profileSuffix: string;
+}> = [
+  { legacySuffix: '_invalidatedNametags', profileSuffix: '.invalidatedNametags' },
+  { legacySuffix: '_tombstones', profileSuffix: '.tombstones' },
+];
+
+/**
+ * Match the leading addressId (anchored, hex-strict) so the
+ * normalization step cannot accidentally pick up a key like
+ * `not_a_direct_addr_tombstones`. Mirrors the strictness of
+ * {@link ADDRESS_ID_PREFIX_RE} but without the trailing `.` — the
+ * trailing delimiter (`_` or `.`) is appended by the suffix check.
+ */
+const ADDRESS_ID_BARE_RE = /^DIRECT_[0-9a-f]{6}_[0-9a-f]{6}/;
+
+/**
+ * Issue #335 Phase 2.5 — normalize a snapshot entry's key from legacy
+ * form to profile form when it matches the
+ * {@link PER_ADDRESS_LEGACY_SUFFIX_MAP} table. Returns the input
+ * unchanged when no mapping applies — per-entry keys, bundle keys, and
+ * any not-yet-covered single-blob key pass through verbatim.
+ *
+ * Pure function; safe to call N times.
+ */
+function normalizeEntryKey(key: string): string {
+  // Cheap reject when the key isn't even an addressId-prefixed key.
+  const addrMatch = ADDRESS_ID_BARE_RE.exec(key);
+  if (addrMatch === null) return key;
+  const addrEnd = addrMatch[0].length;
+  // Must be followed by `_` to be a legacy form candidate. `.` form is
+  // already profile-form (or per-entry) and needs no rewrite.
+  if (key[addrEnd] !== '_') return key;
+  const suffixFromAddr = key.slice(addrEnd);
+  for (const { legacySuffix, profileSuffix } of PER_ADDRESS_LEGACY_SUFFIX_MAP) {
+    if (suffixFromAddr === legacySuffix) {
+      return key.slice(0, addrEnd) + profileSuffix;
+    }
+  }
+  return key;
+}
+
+/**
  * Decode a base64-encoded ciphertext blob into raw bytes. Mirrors the
  * encoding used by `profile-storage-provider.ts:getEncryptedRaw` which
  * is what the lean-snapshot builder reads.
@@ -230,8 +313,20 @@ export async function runProfileSnapshotJoin(
 
   // 1. Decode base64 once. Reuse the resulting bytes for every writer's
   //    prefix-filtered view via `Array.prototype.filter` — no copies.
+  //
+  //    Issue #335 Phase 2.5 — normalize legacy-form single-blob keys
+  //    (`${addr}_tombstones`, `${addr}_invalidatedNametags`) to profile
+  //    form (`${addr}.tombstones`, `${addr}.invalidatedNametags`). The
+  //    lean-snapshot publisher's `storage.keys()` call returns legacy
+  //    form for these via `reverseMapProfileKey`, but the Phase 2
+  //    `SingleBlobSyncWriter` is wired with profile-form `keyPrefix`.
+  //    Without this normalization the dispatcher's pre-filter
+  //    `entries.filter(e.key.startsWith(keyPrefix))` slices an empty
+  //    array and the writer is never called — Phase 2's wiring is
+  //    correct, the entries simply never reach it. See
+  //    `normalizeEntryKey` doc-comment for the full rationale.
   const entries: SnapshotEntry[] = snapshot.entries.map((e) => ({
-    key: e.key,
+    key: normalizeEntryKey(e.key),
     encryptedValue: base64ToBytes(e.value),
   }));
 
@@ -322,4 +417,10 @@ export async function runProfileSnapshotJoin(
 export const __internal = {
   base64ToBytes,
   ADDRESS_ID_PREFIX_RE,
+  // Issue #335 Phase 2.5 — exposed so unit tests can pin the legacy →
+  // profile key mapping table without re-deriving it from the storage
+  // layer's PROFILE_KEY_MAPPING (which would couple the dispatcher
+  // tests to unrelated mapping changes).
+  PER_ADDRESS_LEGACY_SUFFIX_MAP,
+  normalizeEntryKey,
 };

--- a/profile/profile-storage-provider.ts
+++ b/profile/profile-storage-provider.ts
@@ -32,6 +32,11 @@ import {
 } from './finalization-queue-storage-adapter';
 import { OutboxWriter } from './outbox-writer';
 import { SentLedgerWriter } from './sent-ledger-writer';
+import {
+  buildInvalidatedNametagsSyncWriter,
+  buildTombstonesSyncWriter,
+  type SingleBlobSyncWriter,
+} from './single-blob-sync-writer';
 import { CidRefStore } from './cid-ref-store';
 import { Lamport } from './lamport';
 import { buildLocalEntry } from './oplog-entry';
@@ -1206,6 +1211,54 @@ export class ProfileStorageProvider implements StorageProvider {
       encryptionKey: this.profileEncryptionKey,
       addressId,
       lamport: lamport ?? new Lamport(),
+      notifyProfileDirty: this.profileDirtyNotifier ?? undefined,
+    });
+  }
+
+  /**
+   * Issue #335 — Build a sync writer for `${addressId}.tombstones`.
+   *
+   * The lean-snapshot dispatcher had no writer registered for this
+   * single-blob key, so cross-device snapshot apply silently dropped
+   * spent-token tombstones. See profile/single-blob-sync-writer.ts and
+   * issue #335 for the full RCA. Lifecycle and null semantics mirror
+   * {@link buildOutboxWriter} — returns `null` when encryption is not
+   * yet wired so the dispatcher's `writersFor()` skip-empty path is
+   * preserved.
+   */
+  buildTombstonesSyncWriter(addressId: string): SingleBlobSyncWriter<{
+    readonly tokenId: string;
+    readonly stateHash: string;
+    readonly timestamp: number;
+  }> | null {
+    if (!this.encryptionEnabled) return null;
+    if (this.profileEncryptionKey === null) return null;
+    if (typeof addressId !== 'string' || addressId.length === 0) return null;
+    return buildTombstonesSyncWriter({
+      db: this.db,
+      encryptionKey: this.profileEncryptionKey,
+      addressId,
+      notifyProfileDirty: this.profileDirtyNotifier ?? undefined,
+    });
+  }
+
+  /**
+   * Issue #335 (companion) — Build a sync writer for
+   * `${addressId}.invalidatedNametags`. Same propagation gap as
+   * tombstones: the key is a single blob (a `string[]` set) written
+   * via `writeProfileKey` and never registered in the dispatcher.
+   * Lifecycle and null semantics mirror {@link buildTombstonesSyncWriter}.
+   */
+  buildInvalidatedNametagsSyncWriter(
+    addressId: string,
+  ): SingleBlobSyncWriter<string> | null {
+    if (!this.encryptionEnabled) return null;
+    if (this.profileEncryptionKey === null) return null;
+    if (typeof addressId !== 'string' || addressId.length === 0) return null;
+    return buildInvalidatedNametagsSyncWriter({
+      db: this.db,
+      encryptionKey: this.profileEncryptionKey,
+      addressId,
       notifyProfileDirty: this.profileDirtyNotifier ?? undefined,
     });
   }

--- a/profile/single-blob-sync-writer.ts
+++ b/profile/single-blob-sync-writer.ts
@@ -1,0 +1,487 @@
+/**
+ * Single-blob sync writer for OrbitDB keys whose value is one self-
+ * contained JSON array (or set), persisted under an EXACT key with NO
+ * per-entry suffix.
+ *
+ * **Why this exists (issue #335).** All other per-address writers
+ * (`OutboxWriter`, `SentLedgerWriter`, `PrefixSyncWriter`-based
+ * disposition/finalization/recipient-context) own a `keyPrefix` that
+ * ends with `.` — they fan out into per-entry keys
+ * (`${addressId}.outbox.${id}`, `${addressId}.audit.${tokenId}`, etc.).
+ * The lean-snapshot dispatcher (`profile-snapshot-dispatcher.ts`)
+ * pre-filters snapshot entries with `e.key.startsWith(keyPrefix)`, so
+ * each per-entry-prefix writer receives only its own slice.
+ *
+ * A small number of OrbitDB keys are NOT per-entry — they are a single
+ * blob whose value contains the entire collection (e.g.
+ * `${addressId}.tombstones` is a `TxfTombstone[]` array;
+ * `${addressId}.invalidatedNametags` is a `string[]` set). Before this
+ * module existed, those keys had no registered dispatcher writer, so
+ * cross-device snapshot apply silently dropped them. For
+ * `${addressId}.tombstones` this caused the soak regression in
+ * `bob-peer1-vs-peer2-after`: peer2 recovered from the aggregator-
+ * pointer snapshot without the spent-token tombstones, then re-ingested
+ * a CAR bundle that contained the spent source token as if it were
+ * live, doubling the post-recovery balance.
+ *
+ * **Semantics — union merge, not byte-verbatim.** Per-entry writers
+ * persist remote bytes verbatim because each key is independently
+ * owned (one writer per key). Single-blob keys are jointly owned: peer
+ * A and peer B may each have observed local-only entries before
+ * sync'ing, and a byte-verbatim apply of either side's blob would lose
+ * the other side's entries. This writer decrypts both sides, computes
+ * the SET UNION (dedup via a caller-supplied key function), and writes
+ * back the merged JSON re-encrypted under the same exact key.
+ *
+ * This matches the existing in-memory union semantics used by
+ * `PaymentsModule.mergeTombstones` (modules/payments/PaymentsModule.ts)
+ * and the on-disk RMW union loop in
+ * `ProfileTokenStorageProvider.writeOrbitOperationalState` (the
+ * `merged.invalidatedNametags = Array.from(new Set([...remote, ...opState]))`
+ * pattern). Convergence is monotonic and idempotent — re-running the
+ * JOIN with the same remote is a no-op once the first pass converges.
+ *
+ * **Counter semantics.** A single entry in the snapshot translates to
+ * `entriesEvaluated: 1`:
+ *   - `liveLanded: 1` if the union added at least one new dedup-key
+ *     and the writer persisted the merged blob;
+ *   - `localWon: 1` if local was already a superset (no writeback);
+ *   - `remoteRejectedMalformed: 1` if decrypt / JSON parse / shape
+ *     check failed, or the underlying writeback threw.
+ *
+ * Tombstones in the merge-table sense (the `{ tombstoned: true }`
+ * marker pattern used by `PrefixSyncWriter`) do NOT apply to a single-
+ * blob key: the entire blob IS the collection. The on-disk
+ * representation is a JSON array (or set) — there is no "soft delete"
+ * marker. `tombstonesLanded` is therefore always 0 for this writer;
+ * the `liveLanded`/`localWon` columns cover every relevant outcome.
+ *
+ * **Encryption + envelope.** The writer:
+ *   - decrypts incoming snapshot bytes after defensively stripping an
+ *     OpLog envelope if present (`unwrapEnvelopeBytes`) — mirrors the
+ *     pre-#247 vs post-#247 dual format handling that `OutboxWriter`,
+ *     `SentLedgerWriter`, and `PrefixSyncWriter` already implement;
+ *   - re-encrypts the merged blob with a fresh IV and writes via
+ *     `putEnvelopePayload` so the on-disk format stays envelope-wrapped
+ *     (the canonical post-#247 layout consumed by
+ *     `ProfileTokenStorageProvider.readProfileKey`).
+ *
+ * **Out of scope.** Single-blob writers cannot use the Lamport-based
+ * (live, tombstone) merge table from `profile-snapshot-merge.ts` — the
+ * blob is a flat array with no per-element Lamport. The union merge
+ * here is fundamentally a set-CRDT (deletes are not propagated at the
+ * blob level — they require explicit GC at the publish side, e.g.
+ * `gcExpiredTombstones`). If a future requirement adds blob-level
+ * deletion semantics, this writer can be extended with a tombstone
+ * marker shape akin to `PrefixSyncWriter`.
+ *
+ * @module profile/single-blob-sync-writer
+ * @see profile/factory.ts — `writersFor()` registration site
+ * @see profile/profile-snapshot-dispatcher.ts — dispatcher contract
+ * @see profile/prefix-sync-writer.ts — sibling for per-entry keys
+ */
+
+import { decryptProfileValue, encryptProfileValue } from './encryption.js';
+import {
+  putEnvelopePayload,
+  unwrapEnvelopeBytes,
+} from './oplog-envelope-io.js';
+import type {
+  JoinResult,
+  ProfileSyncWriter,
+  SnapshotEntry,
+} from './profile-snapshot-merge.js';
+import type { ProfileDatabase } from './types.js';
+import { MAX_ENTRY_BYTES_RAW } from '../types/uxf-bounds.js';
+
+// =============================================================================
+// 1. Options
+// =============================================================================
+
+/**
+ * Per-instance options for {@link SingleBlobSyncWriter}.
+ *
+ * Construction-time invariants:
+ *   - `key` MUST be a non-empty string with no trailing `.` (it is the
+ *     EXACT OrbitDB key, not a prefix).
+ *   - `encryptionKey` SHOULD be non-null in production; `null` disables
+ *     encryption (matches the rest of the profile layer's optionality
+ *     and is used by test fixtures).
+ */
+export interface SingleBlobSyncWriterOptions<T> {
+  /** OrbitDB key-value adapter — the writer's underlying store. */
+  readonly db: ProfileDatabase;
+  /** AES-256 key for encrypt/decrypt. `null` disables encryption. */
+  readonly encryptionKey: Uint8Array | null;
+  /** EXACT OrbitDB key (e.g. `"${addressId}.tombstones"`). */
+  readonly key: string;
+  /**
+   * Validator for the decoded JSON. MUST return `true` if the parsed
+   * value is a well-formed collection (typically an array of `T`).
+   * Returning `false` for remote payloads causes the entry to be
+   * rejected as malformed and the local blob is left untouched.
+   */
+  readonly validate: (decoded: unknown) => decoded is ReadonlyArray<T>;
+  /**
+   * Dedup-key extractor. The union merge inserts every remote item
+   * whose `dedupKey(item)` is not already present in the local set.
+   * The function MUST be pure and deterministic.
+   */
+  readonly dedupKey: (item: T) => string;
+  /**
+   * Optional tie-breaker on dedup collision. Called when both sides
+   * carry an item with the same `dedupKey`. The returned item replaces
+   * the local one. Defaults to "keep local" (no replacement). Use this
+   * to prefer the earliest timestamp on tombstones, or a stricter
+   * shape on heterogeneous payloads.
+   */
+  readonly preferOnCollision?: (local: T, remote: T) => T;
+  /**
+   * Fired once after a JOIN that landed at least one new item — same
+   * contract as the `notifyProfileDirty` hook on `PrefixSyncWriter`.
+   * The next dirty-flush re-publishes the union so peers downstream
+   * also converge.
+   */
+  readonly notifyProfileDirty?: () => void;
+  /** Label for diagnostics. Defaults to `'SingleBlobSyncWriter'`. */
+  readonly label?: string;
+}
+
+// =============================================================================
+// 2. SingleBlobSyncWriter
+// =============================================================================
+
+/**
+ * Set-CRDT union writer for OrbitDB single-blob keys. See module-level
+ * doc-comment for the full rationale.
+ */
+export class SingleBlobSyncWriter<T> implements ProfileSyncWriter {
+  private readonly db: ProfileDatabase;
+  private readonly encryptionKey: Uint8Array | null;
+  private readonly key: string;
+  private readonly validate: (decoded: unknown) => decoded is ReadonlyArray<T>;
+  private readonly dedupKey: (item: T) => string;
+  private readonly preferOnCollision: ((local: T, remote: T) => T) | null;
+  private readonly notifyProfileDirty: (() => void) | null;
+
+  constructor(opts: SingleBlobSyncWriterOptions<T>) {
+    if (typeof opts.key !== 'string' || opts.key.length === 0) {
+      throw new TypeError(
+        'SingleBlobSyncWriter: key must be a non-empty string',
+      );
+    }
+    if (opts.key.endsWith('.')) {
+      // Prefix-style keys belong on PrefixSyncWriter; reject here so a
+      // future refactor that mis-routes a per-entry key fails loudly
+      // rather than silently mis-merging at JOIN time.
+      throw new TypeError(
+        'SingleBlobSyncWriter: key must NOT end with "." — use PrefixSyncWriter for per-entry keys',
+      );
+    }
+    this.db = opts.db;
+    this.encryptionKey = opts.encryptionKey;
+    this.key = opts.key;
+    this.validate = opts.validate;
+    this.dedupKey = opts.dedupKey;
+    this.preferOnCollision = opts.preferOnCollision ?? null;
+    this.notifyProfileDirty = opts.notifyProfileDirty ?? null;
+  }
+
+  /**
+   * Return the (at-most-one) snapshot entry for this writer's exact
+   * key. Returns an empty array when the key is absent. Bytes are the
+   * envelope-stripped ciphertext suitable for receiver-side decrypt.
+   */
+  async snapshot(): Promise<ReadonlyArray<SnapshotEntry>> {
+    let raw: Uint8Array | null;
+    try {
+      raw = await this.db.get(this.key);
+    } catch {
+      return [];
+    }
+    if (raw === null || raw.byteLength === 0) return [];
+    // `db.get` may return either an envelope-wrapped CBOR record
+    // (post-#247 writes via putEntry / putEnvelopePayload) or raw
+    // ciphertext (pre-#247 legacy writes). Strip the envelope so the
+    // emitted snapshot entry carries the inner ciphertext consistently
+    // — same format the lean-snapshot exporter produces via
+    // `getEncryptedRaw` on the ProfileStorageProvider path.
+    const ciphertext = unwrapEnvelopeBytes(raw);
+    return [{ key: this.key, encryptedValue: ciphertext }];
+  }
+
+  /**
+   * Apply a remote single-blob snapshot. The dispatcher pre-filters
+   * the snapshot to entries whose key starts with this writer's
+   * configured key — defense-in-depth, this method enforces an EXACT
+   * match below.
+   */
+  async joinSnapshot(
+    remote: ReadonlyArray<SnapshotEntry>,
+  ): Promise<JoinResult> {
+    let entriesEvaluated = 0;
+    let liveLanded = 0;
+    let localWon = 0;
+    let remoteRejectedMalformed = 0;
+
+    for (const entry of remote) {
+      if (entry.key !== this.key) {
+        // Foreign key — the dispatcher's `startsWith` pre-filter may
+        // surface this writer's slice plus any longer keys that share
+        // the prefix. Skip silently (no counter bump) so foreign
+        // entries do not pollute the malformed-counter signal.
+        continue;
+      }
+      entriesEvaluated += 1;
+
+      const remoteItems = await this.decodeBlob(
+        entry.encryptedValue,
+        /* remote = */ true,
+      );
+      if (remoteItems === null) {
+        remoteRejectedMalformed += 1;
+        continue;
+      }
+
+      const localItems = await this.readLocalBlob();
+      const merged = this.union(localItems, remoteItems);
+      if (merged === null) {
+        // Local was already a superset → nothing to write.
+        localWon += 1;
+        continue;
+      }
+
+      try {
+        await this.writeMerged(merged);
+        liveLanded += 1;
+      } catch {
+        remoteRejectedMalformed += 1;
+      }
+    }
+
+    if (liveLanded > 0 && this.notifyProfileDirty !== null) {
+      try {
+        this.notifyProfileDirty();
+      } catch {
+        // Best-effort signal — never propagate notifier errors.
+      }
+    }
+
+    return {
+      entriesEvaluated,
+      liveLanded,
+      tombstonesLanded: 0,
+      localWon,
+      remoteRejectedMalformed,
+    };
+  }
+
+  /**
+   * Compute the union of local + remote. Returns `null` when every
+   * remote item's dedup key is already present locally AND the
+   * collision tie-breaker (if configured) does not prefer any remote
+   * variant — the caller treats this as `localWon` and skips writeback.
+   */
+  private union(
+    local: ReadonlyArray<T>,
+    remote: ReadonlyArray<T>,
+  ): ReadonlyArray<T> | null {
+    const merged: T[] = [...local];
+    const indexByKey = new Map<string, number>();
+    for (let i = 0; i < merged.length; i += 1) {
+      indexByKey.set(this.dedupKey(merged[i]), i);
+    }
+
+    let changed = false;
+    for (const item of remote) {
+      const key = this.dedupKey(item);
+      const idx = indexByKey.get(key);
+      if (idx === undefined) {
+        indexByKey.set(key, merged.length);
+        merged.push(item);
+        changed = true;
+        continue;
+      }
+      if (this.preferOnCollision !== null) {
+        const next = this.preferOnCollision(merged[idx], item);
+        if (next !== merged[idx]) {
+          merged[idx] = next;
+          changed = true;
+        }
+      }
+    }
+
+    return changed ? merged : null;
+  }
+
+  /**
+   * Read + decode the local blob. Returns an empty array when the key
+   * is absent OR when decode fails — in both cases the union below
+   * treats local as "nothing to keep", so a well-formed remote lands
+   * intact. This biases convergence toward propagating remote state on
+   * local corruption, matching the convention used elsewhere in the
+   * profile sync layer (`PrefixSyncWriter`, `runJoinSnapshot`).
+   */
+  private async readLocalBlob(): Promise<ReadonlyArray<T>> {
+    let raw: Uint8Array | null;
+    try {
+      raw = await this.db.get(this.key);
+    } catch {
+      return [];
+    }
+    if (raw === null || raw.byteLength === 0) return [];
+    const ciphertext = unwrapEnvelopeBytes(raw);
+    const decoded = await this.decodeBlob(ciphertext, /* remote = */ false);
+    return decoded ?? [];
+  }
+
+  /**
+   * Decrypt + JSON-parse + validate a ciphertext blob.
+   *
+   * `remote=true` is the strict path: any failure (decrypt, parse,
+   * shape) returns `null` so the caller bumps `remoteRejectedMalformed`
+   * and leaves local untouched. `remote=false` (local read) returns
+   * `null` the same way, but the caller treats `null` as "empty local"
+   * for the union — letting a well-formed remote land cleanly even
+   * when local is corrupted.
+   */
+  private async decodeBlob(
+    raw: Uint8Array,
+    _remote: boolean,
+  ): Promise<ReadonlyArray<T> | null> {
+    if (raw.byteLength === 0) return null;
+    if (raw.byteLength > MAX_ENTRY_BYTES_RAW) return null;
+    const ciphertext = unwrapEnvelopeBytes(raw);
+    let plaintextBytes: Uint8Array;
+    try {
+      plaintextBytes = this.encryptionKey
+        ? await decryptProfileValue(this.encryptionKey, ciphertext)
+        : ciphertext;
+    } catch {
+      return null;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(new TextDecoder().decode(plaintextBytes));
+    } catch {
+      return null;
+    }
+    if (!this.validate(parsed)) return null;
+    return parsed;
+  }
+
+  /**
+   * Encrypt + envelope-wrap + persist the merged blob under this
+   * writer's exact key.
+   *
+   * Goes through `putEnvelopePayload` so the on-disk format is the
+   * canonical post-#247 envelope — the same format
+   * `ProfileTokenStorageProvider.writeProfileKey` produces. This keeps
+   * subsequent reads via `getEnvelopePayload` on the happy path (no
+   * legacy raw-bytes fallback).
+   */
+  private async writeMerged(merged: ReadonlyArray<T>): Promise<void> {
+    const plaintext = new TextEncoder().encode(JSON.stringify(merged));
+    const ciphertext = this.encryptionKey
+      ? await encryptProfileValue(this.encryptionKey, plaintext)
+      : plaintext;
+    await putEnvelopePayload(this.db, this.key, ciphertext);
+  }
+}
+
+// =============================================================================
+// 3. Type-safe builders for the two single-blob keys wired by issue #335
+// =============================================================================
+
+/**
+ * Build a {@link SingleBlobSyncWriter} for `${addressId}.tombstones`.
+ *
+ * Tombstones are deduped by the composite `${tokenId}:${stateHash}`
+ * key — the same key `PaymentsModule.mergeTombstones` and the
+ * `readOperationalState` merge use. On collision the EARLIEST
+ * timestamp wins so two replicas that independently recorded the same
+ * tombstone (with different wall-clock stamps) converge deterministically.
+ */
+export function buildTombstonesSyncWriter(opts: {
+  readonly db: ProfileDatabase;
+  readonly encryptionKey: Uint8Array | null;
+  readonly addressId: string;
+  readonly notifyProfileDirty?: () => void;
+}): SingleBlobSyncWriter<TombstoneShape> {
+  if (typeof opts.addressId !== 'string' || opts.addressId.length === 0) {
+    throw new TypeError(
+      'buildTombstonesSyncWriter: addressId must be a non-empty string',
+    );
+  }
+  return new SingleBlobSyncWriter<TombstoneShape>({
+    db: opts.db,
+    encryptionKey: opts.encryptionKey,
+    key: `${opts.addressId}.tombstones`,
+    validate: isTombstoneArray,
+    dedupKey: (t) => `${t.tokenId}:${t.stateHash}`,
+    preferOnCollision: (local, remote) =>
+      remote.timestamp < local.timestamp ? remote : local,
+    notifyProfileDirty: opts.notifyProfileDirty,
+    label: 'SingleBlobSyncWriter.tombstones',
+  });
+}
+
+/**
+ * Build a {@link SingleBlobSyncWriter} for
+ * `${addressId}.invalidatedNametags`.
+ *
+ * The collection is a `string[]` set; dedup key is the string itself.
+ * No collision tie-break needed — equal strings are equal payloads.
+ */
+export function buildInvalidatedNametagsSyncWriter(opts: {
+  readonly db: ProfileDatabase;
+  readonly encryptionKey: Uint8Array | null;
+  readonly addressId: string;
+  readonly notifyProfileDirty?: () => void;
+}): SingleBlobSyncWriter<string> {
+  if (typeof opts.addressId !== 'string' || opts.addressId.length === 0) {
+    throw new TypeError(
+      'buildInvalidatedNametagsSyncWriter: addressId must be a non-empty string',
+    );
+  }
+  return new SingleBlobSyncWriter<string>({
+    db: opts.db,
+    encryptionKey: opts.encryptionKey,
+    key: `${opts.addressId}.invalidatedNametags`,
+    validate: isStringArray,
+    dedupKey: (s) => s,
+    notifyProfileDirty: opts.notifyProfileDirty,
+    label: 'SingleBlobSyncWriter.invalidatedNametags',
+  });
+}
+
+// =============================================================================
+// 4. Shape predicates
+// =============================================================================
+
+/** Local copy of TxfTombstone (kept here to avoid a storage layer import). */
+interface TombstoneShape {
+  readonly tokenId: string;
+  readonly stateHash: string;
+  readonly timestamp: number;
+}
+
+function isTombstoneArray(value: unknown): value is ReadonlyArray<TombstoneShape> {
+  if (!Array.isArray(value)) return false;
+  for (const item of value) {
+    if (item === null || typeof item !== 'object') return false;
+    const r = item as Record<string, unknown>;
+    if (typeof r.tokenId !== 'string' || r.tokenId.length === 0) return false;
+    if (typeof r.stateHash !== 'string' || r.stateHash.length === 0) return false;
+    if (typeof r.timestamp !== 'number' || !Number.isFinite(r.timestamp)) return false;
+  }
+  return true;
+}
+
+function isStringArray(value: unknown): value is ReadonlyArray<string> {
+  if (!Array.isArray(value)) return false;
+  for (const item of value) {
+    if (typeof item !== 'string') return false;
+  }
+  return true;
+}

--- a/tests/unit/profile/single-blob-sync-writer.test.ts
+++ b/tests/unit/profile/single-blob-sync-writer.test.ts
@@ -1,0 +1,715 @@
+/**
+ * Tests for `profile/single-blob-sync-writer.ts` — issue #335.
+ *
+ * Locks the contract:
+ *   - snapshot() returns at most one entry, only when the exact key exists.
+ *   - joinSnapshot() unions the remote blob into local under the configured
+ *     dedup-key function — the merged blob is re-encrypted and persisted via
+ *     the envelope path so subsequent local reads stay on the happy path.
+ *   - Local-superset apply is a no-op (counted as `localWon`).
+ *   - Malformed remote bytes (decrypt / parse / shape) are rejected without
+ *     mutating local (counted as `remoteRejectedMalformed`).
+ *   - Foreign keys in the snapshot slice are ignored.
+ *   - Idempotence: re-running with the same remote yields no further changes.
+ *   - Cross-device end-to-end via `runProfileSnapshotJoin`: a peer-A snapshot
+ *     containing tombstones lands at peer B, including the issue #335
+ *     regression test (the factory.ts wiring must register the writer or
+ *     this assertion fails).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildInvalidatedNametagsSyncWriter,
+  buildTombstonesSyncWriter,
+  SingleBlobSyncWriter,
+} from '../../../profile/single-blob-sync-writer.js';
+import {
+  encryptProfileValue,
+  decryptProfileValue,
+} from '../../../profile/encryption.js';
+import { runProfileSnapshotJoin } from '../../../profile/profile-snapshot-dispatcher.js';
+import { putEnvelopePayload } from '../../../profile/oplog-envelope-io.js';
+import type {
+  OrbitDbConfig,
+  ProfileDatabase,
+} from '../../../profile/types.js';
+import type { LeanProfileSnapshot } from '../../../profile/profile-lean-snapshot.js';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const ADDR_A = 'DIRECT_aabbcc_ddeeff';
+const KEY_TOMB_A = `${ADDR_A}.tombstones`;
+const KEY_TAGS_A = `${ADDR_A}.invalidatedNametags`;
+
+interface MockProfileDb extends ProfileDatabase {
+  _store: Map<string, Uint8Array>;
+}
+
+function createMockDb(): MockProfileDb {
+  const store = new Map<string, Uint8Array>();
+  return {
+    _store: store,
+    async connect(_c: OrbitDbConfig) {},
+    async put(k: string, v: Uint8Array) {
+      store.set(k, v);
+    },
+    async get(k: string) {
+      return store.get(k) ?? null;
+    },
+    async del(k: string) {
+      store.delete(k);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) {
+        if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      }
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as MockProfileDb;
+}
+
+interface Tomb {
+  readonly tokenId: string;
+  readonly stateHash: string;
+  readonly timestamp: number;
+}
+
+function tomb(tokenId: string, stateHash: string, timestamp = 1): Tomb {
+  return { tokenId, stateHash, timestamp };
+}
+
+/** Write a tombstone blob to a mock db at the canonical key (no encryption). */
+async function writePlainBlob(
+  db: MockProfileDb,
+  key: string,
+  blob: unknown,
+): Promise<void> {
+  const bytes = new TextEncoder().encode(JSON.stringify(blob));
+  await db.put(key, bytes);
+}
+
+/**
+ * Write a tombstone blob via the envelope path so the writer's snapshot()
+ * sees envelope-wrapped bytes (exercises the unwrap step).
+ */
+async function writeEnvelopeBlob(
+  db: MockProfileDb,
+  key: string,
+  blob: unknown,
+): Promise<void> {
+  const bytes = new TextEncoder().encode(JSON.stringify(blob));
+  await putEnvelopePayload(db, key, bytes);
+}
+
+/**
+ * Write an encrypted tombstone blob via the envelope path — the canonical
+ * production layout.
+ */
+async function writeEncryptedEnvelopeBlob(
+  db: MockProfileDb,
+  key: string,
+  encryptionKey: Uint8Array,
+  blob: unknown,
+): Promise<void> {
+  const bytes = new TextEncoder().encode(JSON.stringify(blob));
+  const ct = await encryptProfileValue(encryptionKey, bytes);
+  await putEnvelopePayload(db, key, ct);
+}
+
+function makeKey(): Uint8Array {
+  // Deterministic 32-byte AES-256 key — not real entropy, fine for unit tests.
+  const k = new Uint8Array(32);
+  for (let i = 0; i < 32; i += 1) k[i] = i;
+  return k;
+}
+
+// =============================================================================
+// 1. Constructor invariants
+// =============================================================================
+
+describe('SingleBlobSyncWriter — constructor', () => {
+  it('rejects an empty key', () => {
+    expect(() =>
+      new SingleBlobSyncWriter<Tomb>({
+        db: createMockDb(),
+        encryptionKey: null,
+        key: '',
+        validate: (v): v is ReadonlyArray<Tomb> => Array.isArray(v),
+        dedupKey: (t) => `${t.tokenId}:${t.stateHash}`,
+      }),
+    ).toThrow(/non-empty/);
+  });
+
+  it('rejects a prefix-style key (trailing dot)', () => {
+    expect(() =>
+      new SingleBlobSyncWriter<Tomb>({
+        db: createMockDb(),
+        encryptionKey: null,
+        key: `${ADDR_A}.tombstones.`,
+        validate: (v): v is ReadonlyArray<Tomb> => Array.isArray(v),
+        dedupKey: (t) => `${t.tokenId}:${t.stateHash}`,
+      }),
+    ).toThrow(/must NOT end with/);
+  });
+});
+
+// =============================================================================
+// 2. snapshot()
+// =============================================================================
+
+describe('SingleBlobSyncWriter.snapshot', () => {
+  it('returns empty when the key is absent', async () => {
+    const writer = buildTombstonesSyncWriter({
+      db: createMockDb(),
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    expect(await writer.snapshot()).toEqual([]);
+  });
+
+  it('returns one entry with envelope-stripped bytes when present', async () => {
+    const db = createMockDb();
+    await writeEnvelopeBlob(db, KEY_TOMB_A, [tomb('0xT1', '0xS1', 100)]);
+    const writer = buildTombstonesSyncWriter({
+      db,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const snap = await writer.snapshot();
+    expect(snap).toHaveLength(1);
+    expect(snap[0].key).toBe(KEY_TOMB_A);
+    // Unwrapped bytes are the raw JSON (no envelope, no encryption in this case).
+    const decoded = JSON.parse(new TextDecoder().decode(snap[0].encryptedValue));
+    expect(decoded).toEqual([
+      { tokenId: '0xT1', stateHash: '0xS1', timestamp: 100 },
+    ]);
+  });
+
+  it('returns one entry for legacy raw-bytes writes (pre-#247)', async () => {
+    const db = createMockDb();
+    await writePlainBlob(db, KEY_TOMB_A, [tomb('0xT1', '0xS1', 100)]);
+    const writer = buildTombstonesSyncWriter({
+      db,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const snap = await writer.snapshot();
+    expect(snap).toHaveLength(1);
+  });
+
+  it('returns empty when db.get throws', async () => {
+    const db = createMockDb();
+    db.get = async () => {
+      throw new Error('boom');
+    };
+    const writer = buildTombstonesSyncWriter({
+      db,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    expect(await writer.snapshot()).toEqual([]);
+  });
+});
+
+// =============================================================================
+// 3. joinSnapshot — union semantics
+// =============================================================================
+
+describe('SingleBlobSyncWriter.joinSnapshot — union', () => {
+  it('absent local + non-empty remote → write remote, liveLanded=1', async () => {
+    const dbLocal = createMockDb();
+    const dbRemote = createMockDb();
+    await writeEnvelopeBlob(dbRemote, KEY_TOMB_A, [tomb('0xT1', '0xS1', 100)]);
+    const localW = buildTombstonesSyncWriter({
+      db: dbLocal,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const remoteW = buildTombstonesSyncWriter({
+      db: dbRemote,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const res = await localW.joinSnapshot(await remoteW.snapshot());
+    expect(res.entriesEvaluated).toBe(1);
+    expect(res.liveLanded).toBe(1);
+    expect(res.localWon).toBe(0);
+    expect(dbLocal._store.has(KEY_TOMB_A)).toBe(true);
+    // Re-snapshot reflects the union via the local writer.
+    const localSnap = await localW.snapshot();
+    expect(localSnap).toHaveLength(1);
+    const decoded = JSON.parse(
+      new TextDecoder().decode(localSnap[0].encryptedValue),
+    );
+    expect(decoded).toEqual([
+      { tokenId: '0xT1', stateHash: '0xS1', timestamp: 100 },
+    ]);
+  });
+
+  it('disjoint local + remote → union, liveLanded=1', async () => {
+    const dbLocal = createMockDb();
+    const dbRemote = createMockDb();
+    await writeEnvelopeBlob(dbLocal, KEY_TOMB_A, [tomb('0xT1', '0xS1', 100)]);
+    await writeEnvelopeBlob(dbRemote, KEY_TOMB_A, [tomb('0xT2', '0xS2', 200)]);
+    const localW = buildTombstonesSyncWriter({
+      db: dbLocal,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const remoteW = buildTombstonesSyncWriter({
+      db: dbRemote,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const res = await localW.joinSnapshot(await remoteW.snapshot());
+    expect(res.liveLanded).toBe(1);
+    expect(res.localWon).toBe(0);
+    const after = await localW.snapshot();
+    const decoded = JSON.parse(
+      new TextDecoder().decode(after[0].encryptedValue),
+    ) as Tomb[];
+    expect(decoded).toHaveLength(2);
+    expect(decoded.map((t) => t.tokenId).sort()).toEqual(['0xT1', '0xT2']);
+  });
+
+  it('local is a strict superset → no-op, localWon=1', async () => {
+    const dbLocal = createMockDb();
+    const dbRemote = createMockDb();
+    await writeEnvelopeBlob(dbLocal, KEY_TOMB_A, [
+      tomb('0xT1', '0xS1', 100),
+      tomb('0xT2', '0xS2', 200),
+    ]);
+    await writeEnvelopeBlob(dbRemote, KEY_TOMB_A, [tomb('0xT1', '0xS1', 100)]);
+    const localW = buildTombstonesSyncWriter({
+      db: dbLocal,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const remoteW = buildTombstonesSyncWriter({
+      db: dbRemote,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const before = dbLocal._store.get(KEY_TOMB_A);
+    const res = await localW.joinSnapshot(await remoteW.snapshot());
+    expect(res.localWon).toBe(1);
+    expect(res.liveLanded).toBe(0);
+    // Local bytes unchanged.
+    expect(dbLocal._store.get(KEY_TOMB_A)).toBe(before);
+  });
+
+  it('collision on dedup key — earliest timestamp wins (tombstones)', async () => {
+    const dbLocal = createMockDb();
+    const dbRemote = createMockDb();
+    await writeEnvelopeBlob(dbLocal, KEY_TOMB_A, [tomb('0xT1', '0xS1', 500)]);
+    await writeEnvelopeBlob(dbRemote, KEY_TOMB_A, [tomb('0xT1', '0xS1', 100)]);
+    const localW = buildTombstonesSyncWriter({
+      db: dbLocal,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const remoteW = buildTombstonesSyncWriter({
+      db: dbRemote,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const res = await localW.joinSnapshot(await remoteW.snapshot());
+    expect(res.liveLanded).toBe(1);
+    const after = await localW.snapshot();
+    const decoded = JSON.parse(
+      new TextDecoder().decode(after[0].encryptedValue),
+    ) as Tomb[];
+    expect(decoded).toEqual([
+      { tokenId: '0xT1', stateHash: '0xS1', timestamp: 100 },
+    ]);
+  });
+
+  it('idempotent — second JOIN with same remote is a no-op', async () => {
+    const dbLocal = createMockDb();
+    const dbRemote = createMockDb();
+    await writeEnvelopeBlob(dbRemote, KEY_TOMB_A, [tomb('0xT1', '0xS1', 100)]);
+    const localW = buildTombstonesSyncWriter({
+      db: dbLocal,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const remoteW = buildTombstonesSyncWriter({
+      db: dbRemote,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const snap = await remoteW.snapshot();
+    const first = await localW.joinSnapshot(snap);
+    expect(first.liveLanded).toBe(1);
+    const second = await localW.joinSnapshot(snap);
+    expect(second.liveLanded).toBe(0);
+    expect(second.localWon).toBe(1);
+  });
+
+  it('foreign keys in the slice are ignored (no counter bump)', async () => {
+    const db = createMockDb();
+    const writer = buildTombstonesSyncWriter({
+      db,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    // Hand-crafted snapshot with a foreign key.
+    const foreignBytes = new TextEncoder().encode(
+      JSON.stringify([tomb('0xT1', '0xS1', 100)]),
+    );
+    const res = await writer.joinSnapshot([
+      { key: 'DIRECT_other_addr.tombstones', encryptedValue: foreignBytes },
+    ]);
+    expect(res.entriesEvaluated).toBe(0);
+    expect(res.liveLanded).toBe(0);
+    expect(res.remoteRejectedMalformed).toBe(0);
+  });
+});
+
+// =============================================================================
+// 4. joinSnapshot — malformed-remote rejection
+// =============================================================================
+
+describe('SingleBlobSyncWriter.joinSnapshot — malformed remote', () => {
+  it('rejects non-array remote (decoded shape)', async () => {
+    const db = createMockDb();
+    const writer = buildTombstonesSyncWriter({
+      db,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const garbage = new TextEncoder().encode('{"not":"an array"}');
+    const res = await writer.joinSnapshot([
+      { key: KEY_TOMB_A, encryptedValue: garbage },
+    ]);
+    expect(res.entriesEvaluated).toBe(1);
+    expect(res.remoteRejectedMalformed).toBe(1);
+    expect(res.liveLanded).toBe(0);
+    expect(db._store.has(KEY_TOMB_A)).toBe(false);
+  });
+
+  it('rejects non-JSON remote bytes', async () => {
+    const db = createMockDb();
+    const writer = buildTombstonesSyncWriter({
+      db,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const garbage = new Uint8Array([0xff, 0xfe, 0xfd]);
+    const res = await writer.joinSnapshot([
+      { key: KEY_TOMB_A, encryptedValue: garbage },
+    ]);
+    expect(res.remoteRejectedMalformed).toBe(1);
+    expect(res.liveLanded).toBe(0);
+  });
+
+  it('rejects array items missing required fields', async () => {
+    const db = createMockDb();
+    const writer = buildTombstonesSyncWriter({
+      db,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const badShape = new TextEncoder().encode(
+      JSON.stringify([{ tokenId: '0xT1' /* missing stateHash + timestamp */ }]),
+    );
+    const res = await writer.joinSnapshot([
+      { key: KEY_TOMB_A, encryptedValue: badShape },
+    ]);
+    expect(res.remoteRejectedMalformed).toBe(1);
+    expect(res.liveLanded).toBe(0);
+  });
+});
+
+// =============================================================================
+// 5. Encryption end-to-end
+// =============================================================================
+
+describe('SingleBlobSyncWriter — encrypted round trip', () => {
+  it('decrypts remote, merges, re-encrypts under same key', async () => {
+    const key = makeKey();
+    const dbLocal = createMockDb();
+    const dbRemote = createMockDb();
+    await writeEncryptedEnvelopeBlob(dbLocal, KEY_TOMB_A, key, [
+      tomb('0xT1', '0xS1', 100),
+    ]);
+    await writeEncryptedEnvelopeBlob(dbRemote, KEY_TOMB_A, key, [
+      tomb('0xT2', '0xS2', 200),
+    ]);
+    const localW = buildTombstonesSyncWriter({
+      db: dbLocal,
+      encryptionKey: key,
+      addressId: ADDR_A,
+    });
+    const remoteW = buildTombstonesSyncWriter({
+      db: dbRemote,
+      encryptionKey: key,
+      addressId: ADDR_A,
+    });
+    const res = await localW.joinSnapshot(await remoteW.snapshot());
+    expect(res.liveLanded).toBe(1);
+    // Decrypt the merged blob directly to verify the on-disk format.
+    const after = await localW.snapshot();
+    const plain = await decryptProfileValue(key, after[0].encryptedValue);
+    const decoded = JSON.parse(new TextDecoder().decode(plain)) as Tomb[];
+    expect(decoded.map((t) => t.tokenId).sort()).toEqual(['0xT1', '0xT2']);
+  });
+});
+
+// =============================================================================
+// 6. invalidatedNametags — bundled in same fix per issue #335
+// =============================================================================
+
+describe('SingleBlobSyncWriter — invalidatedNametags', () => {
+  it('unions string sets', async () => {
+    const dbLocal = createMockDb();
+    const dbRemote = createMockDb();
+    await writeEnvelopeBlob(dbLocal, KEY_TAGS_A, ['alice']);
+    await writeEnvelopeBlob(dbRemote, KEY_TAGS_A, ['bob']);
+    const localW = buildInvalidatedNametagsSyncWriter({
+      db: dbLocal,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const remoteW = buildInvalidatedNametagsSyncWriter({
+      db: dbRemote,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const res = await localW.joinSnapshot(await remoteW.snapshot());
+    expect(res.liveLanded).toBe(1);
+    const after = await localW.snapshot();
+    const decoded = JSON.parse(
+      new TextDecoder().decode(after[0].encryptedValue),
+    ) as string[];
+    expect(decoded.sort()).toEqual(['alice', 'bob']);
+  });
+
+  it('rejects non-string array items', async () => {
+    const db = createMockDb();
+    const writer = buildInvalidatedNametagsSyncWriter({
+      db,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    const bad = new TextEncoder().encode(JSON.stringify(['alice', 42, 'bob']));
+    const res = await writer.joinSnapshot([
+      { key: KEY_TAGS_A, encryptedValue: bad },
+    ]);
+    expect(res.remoteRejectedMalformed).toBe(1);
+  });
+});
+
+// =============================================================================
+// 7. notifyProfileDirty
+// =============================================================================
+
+describe('SingleBlobSyncWriter — notifyProfileDirty', () => {
+  it('fires once per JOIN that lands new items', async () => {
+    const dbLocal = createMockDb();
+    const dbRemote = createMockDb();
+    await writeEnvelopeBlob(dbRemote, KEY_TOMB_A, [tomb('0xT1', '0xS1', 100)]);
+    let fired = 0;
+    const localW = buildTombstonesSyncWriter({
+      db: dbLocal,
+      encryptionKey: null,
+      addressId: ADDR_A,
+      notifyProfileDirty: () => {
+        fired += 1;
+      },
+    });
+    const remoteW = buildTombstonesSyncWriter({
+      db: dbRemote,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    await localW.joinSnapshot(await remoteW.snapshot());
+    expect(fired).toBe(1);
+    // Idempotent second pass should NOT fire.
+    await localW.joinSnapshot(await remoteW.snapshot());
+    expect(fired).toBe(1);
+  });
+
+  it('does not fire when nothing lands', async () => {
+    const dbLocal = createMockDb();
+    await writeEnvelopeBlob(dbLocal, KEY_TOMB_A, [tomb('0xT1', '0xS1', 100)]);
+    let fired = 0;
+    const localW = buildTombstonesSyncWriter({
+      db: dbLocal,
+      encryptionKey: null,
+      addressId: ADDR_A,
+      notifyProfileDirty: () => {
+        fired += 1;
+      },
+    });
+    // Use an empty remote snapshot.
+    await localW.joinSnapshot([]);
+    expect(fired).toBe(0);
+  });
+});
+
+// =============================================================================
+// 8. CROSS-DEVICE END-TO-END VIA THE DISPATCHER
+//    Issue #335 regression: a peer-A snapshot containing tombstones must
+//    land on peer B's storage. This test fails without the factory.ts
+//    writers registration — proves the fix wiring.
+// =============================================================================
+
+function buildSnapshotFromEntries(
+  entries: ReadonlyArray<{ readonly key: string; readonly encryptedValue: Uint8Array }>,
+): LeanProfileSnapshot {
+  return {
+    version: 2,
+    chainPubkey: '02' + 'bb'.repeat(32),
+    network: 'testnet',
+    createdAt: 1_700_000_000_000,
+    entries: entries.map((e) => ({
+      key: e.key,
+      value: Buffer.from(e.encryptedValue).toString('base64'),
+    })),
+    bundles: [],
+  };
+}
+
+describe('issue #335 — cross-device tombstone propagation via dispatcher', () => {
+  it('peer-A snapshot containing tombstones lands at peer B', async () => {
+    // --- Peer A: seed a tombstones blob ---
+    const dbA = createMockDb();
+    const writerA = buildTombstonesSyncWriter({
+      db: dbA,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    await writeEnvelopeBlob(dbA, KEY_TOMB_A, [
+      tomb('0xSpentFaucetToken', '0xSpentStateHash', 1_700_000_000_000),
+    ]);
+
+    // --- Peer A: lift its single-blob snapshot entry ---
+    const snapA = await writerA.snapshot();
+    expect(snapA).toHaveLength(1);
+    expect(snapA[0].key).toBe(KEY_TOMB_A);
+
+    const dispatcherSnapshot = buildSnapshotFromEntries(snapA);
+
+    // --- Peer B: empty storage, register tombstones writer via the same
+    //     factory contract that profile/factory.ts:writersFor() uses ---
+    const dbB = createMockDb();
+    const tombstonesWriterB = buildTombstonesSyncWriter({
+      db: dbB,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+
+    const result = await runProfileSnapshotJoin(dispatcherSnapshot, {
+      writersFor: (addressId) => {
+        if (addressId !== ADDR_A) return [];
+        return [
+          { keyPrefix: `${addressId}.tombstones`, writer: tombstonesWriterB },
+        ];
+      },
+      bundleIndex: null,
+    });
+
+    // --- Assertions: B's storage now carries A's tombstone ---
+    expect(result.joinedAny).toBe(true);
+    expect(result.counters.liveLanded).toBe(1);
+    expect(dbB._store.has(KEY_TOMB_A)).toBe(true);
+
+    const reloaded = await tombstonesWriterB.snapshot();
+    expect(reloaded).toHaveLength(1);
+    const decoded = JSON.parse(
+      new TextDecoder().decode(reloaded[0].encryptedValue),
+    ) as Tomb[];
+    expect(decoded).toEqual([
+      {
+        tokenId: '0xSpentFaucetToken',
+        stateHash: '0xSpentStateHash',
+        timestamp: 1_700_000_000_000,
+      },
+    ]);
+  });
+
+  it('peer-A snapshot containing invalidatedNametags lands at peer B', async () => {
+    const dbA = createMockDb();
+    const writerA = buildInvalidatedNametagsSyncWriter({
+      db: dbA,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    await writeEnvelopeBlob(dbA, KEY_TAGS_A, ['phisher123']);
+    const snapA = await writerA.snapshot();
+    const dispatcherSnapshot = buildSnapshotFromEntries(snapA);
+
+    const dbB = createMockDb();
+    const tagsWriterB = buildInvalidatedNametagsSyncWriter({
+      db: dbB,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+
+    const result = await runProfileSnapshotJoin(dispatcherSnapshot, {
+      writersFor: (addressId) => {
+        if (addressId !== ADDR_A) return [];
+        return [
+          {
+            keyPrefix: `${addressId}.invalidatedNametags`,
+            writer: tagsWriterB,
+          },
+        ];
+      },
+      bundleIndex: null,
+    });
+
+    expect(result.counters.liveLanded).toBe(1);
+    expect(dbB._store.has(KEY_TAGS_A)).toBe(true);
+    const reloaded = await tagsWriterB.snapshot();
+    const decoded = JSON.parse(
+      new TextDecoder().decode(reloaded[0].encryptedValue),
+    ) as string[];
+    expect(decoded).toEqual(['phisher123']);
+  });
+
+  it('REGRESSION: no writer registered → tombstone silently dropped (issue #335 baseline)', async () => {
+    // This test pins the failure mode: WITHOUT a registered writer, the
+    // dispatcher silently drops the single-blob entry. It is the
+    // pre-fix behaviour that the issue #335 RCA documents. The
+    // production fix lives in profile/factory.ts:writersFor() —
+    // commenting out the tombstones writer there would cause every
+    // assertion below to remain unchanged while the cross-device tests
+    // above start failing.
+    const dbA = createMockDb();
+    const writerA = buildTombstonesSyncWriter({
+      db: dbA,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    await writeEnvelopeBlob(dbA, KEY_TOMB_A, [
+      tomb('0xSpentFaucetToken', '0xSpentStateHash', 1_700_000_000_000),
+    ]);
+    const dispatcherSnapshot = buildSnapshotFromEntries(
+      await writerA.snapshot(),
+    );
+
+    const dbB = createMockDb();
+
+    // No writer registered.
+    const result = await runProfileSnapshotJoin(dispatcherSnapshot, {
+      writersFor: () => [],
+      bundleIndex: null,
+    });
+
+    expect(result.addressesSeen).toBe(1);
+    expect(result.counters.liveLanded).toBe(0);
+    expect(dbB._store.has(KEY_TOMB_A)).toBe(false);
+  });
+});

--- a/tests/unit/profile/snapshot-apply-ipfs-no-nostr.test.ts
+++ b/tests/unit/profile/snapshot-apply-ipfs-no-nostr.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Tests for `profile/profile-snapshot-dispatcher.ts` — issue #335 Phase 2.5.
+ *
+ * **Why this exists.** Phase 2 (PR #340) wired `SingleBlobSyncWriter` into
+ * `profile/factory.ts:writersFor()` for `${addressId}.tombstones` and
+ * `${addressId}.invalidatedNametags`. A soak run confirmed Phase 2 fixes
+ * one cross-device path (§C.4 Nostr-driven daemon sync — passed) but
+ * misses another (§D.5 `--no-nostr` IPFS-only mnemonic recovery —
+ * failed, same divergence as pre-Phase-2).
+ *
+ * **Root cause traced here.** The lean-snapshot publisher emits per-address
+ * single-blob keys in their LEGACY form (`${addr}_tombstones`,
+ * `${addr}_invalidatedNametags`) because `ProfileStorageProvider.keys()`
+ * funnels them through `reverseMapProfileKey()` which converts profile-
+ * form (`${addr}.tombstones`) back to legacy form via the
+ * `perAddressReverseCache` suffix table. The Phase 2 `SingleBlobSyncWriter`
+ * is wired with a profile-form `keyPrefix` — so the dispatcher's
+ * pre-filter `entries.filter(e.key.startsWith(keyPrefix))` slices an
+ * empty array and the writer never fires. The wiring is correct; the
+ * entries simply never reach it.
+ *
+ * **The fix lives in the dispatcher**, not the writer or factory — see
+ * `profile/profile-snapshot-dispatcher.ts:normalizeEntryKey()`. Each
+ * snapshot entry's key is rewritten from legacy form to profile form at
+ * decode time, BEFORE address extraction and writer pre-filter. Per-entry
+ * keys (`${addr}.outbox.${id}`, `${addr}.sent.${id}`, etc.) and bundle
+ * keys (`tokens.bundle.*`) pass through unchanged.
+ *
+ * **Verification protocol.** Each "fail without fix" test in this file
+ * MUST fail when `normalizeEntryKey` is reverted to identity. The
+ * `runProfileSnapshotJoin` REGRESSION suite at the bottom replays the
+ * pre-Phase-2.5 behaviour by hand-crafting legacy-form keys and asserting
+ * they silently drop unless the normalizer is in place. Verified by
+ * temporarily replacing `normalizeEntryKey` with `(key) => key` and
+ * watching the "REGRESSION (pre-fix)" suite stay green while the "FIX
+ * (post-2.5)" suite turns red — restored on commit.
+ *
+ * @see profile/profile-snapshot-dispatcher.ts — the normalizer + dispatch
+ * @see profile/single-blob-sync-writer.ts — Phase 2's per-key writer
+ * @see profile/factory.ts:writersFor — the (correctly-wired) registration site
+ * @see issue #335 RCA Phase 1 + Phase 2 follow-up — soak failure context
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  runProfileSnapshotJoin,
+  __internal as dispatcherInternal,
+} from '../../../profile/profile-snapshot-dispatcher.js';
+import {
+  buildInvalidatedNametagsSyncWriter,
+  buildTombstonesSyncWriter,
+} from '../../../profile/single-blob-sync-writer.js';
+import { putEnvelopePayload } from '../../../profile/oplog-envelope-io.js';
+import type {
+  OrbitDbConfig,
+  ProfileDatabase,
+} from '../../../profile/types.js';
+import type { LeanProfileSnapshot } from '../../../profile/profile-lean-snapshot.js';
+
+// =============================================================================
+// Fixtures — mirror the canonical addressId pattern from constants.ts.
+// =============================================================================
+
+const ADDR_A = 'DIRECT_aabbcc_ddeeff';
+const ADDR_B = 'DIRECT_112233_445566';
+
+interface MockProfileDb extends ProfileDatabase {
+  _store: Map<string, Uint8Array>;
+}
+
+function createMockDb(): MockProfileDb {
+  const store = new Map<string, Uint8Array>();
+  return {
+    _store: store,
+    async connect(_c: OrbitDbConfig) {},
+    async put(k: string, v: Uint8Array) {
+      store.set(k, v);
+    },
+    async get(k: string) {
+      return store.get(k) ?? null;
+    },
+    async del(k: string) {
+      store.delete(k);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) {
+        if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      }
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as MockProfileDb;
+}
+
+interface Tomb {
+  readonly tokenId: string;
+  readonly stateHash: string;
+  readonly timestamp: number;
+}
+
+function tomb(tokenId: string, stateHash: string, timestamp = 1): Tomb {
+  return { tokenId, stateHash, timestamp };
+}
+
+async function writeEnvelopeBlob(
+  db: MockProfileDb,
+  key: string,
+  blob: unknown,
+): Promise<void> {
+  const bytes = new TextEncoder().encode(JSON.stringify(blob));
+  await putEnvelopePayload(db, key, bytes);
+}
+
+/**
+ * Build a `LeanProfileSnapshot` with arbitrary entries.
+ * `value` is the base64-encoded ciphertext per the on-disk schema.
+ */
+function buildSnapshot(
+  entries: ReadonlyArray<{ readonly key: string; readonly value: string }>,
+): LeanProfileSnapshot {
+  return {
+    version: 2,
+    chainPubkey: '02' + 'bb'.repeat(32),
+    network: 'testnet',
+    createdAt: 1_700_000_000_000,
+    entries,
+    bundles: [],
+  };
+}
+
+/**
+ * Replicate what `ProfileStorageProvider.keys()` does to a single-blob
+ * per-address profile-form key. Returns the LEGACY form the
+ * lean-snapshot publisher emits in production.
+ *
+ * Mirrors `reverseMapProfileKey` for the static `PROFILE_KEY_MAPPING`
+ * per-address suffixes covered by Phase 2.5.
+ */
+function toLegacyKey(profileKey: string): string {
+  if (profileKey.endsWith('.tombstones')) {
+    return profileKey.replace(/\.tombstones$/, '_tombstones');
+  }
+  if (profileKey.endsWith('.invalidatedNametags')) {
+    return profileKey.replace(/\.invalidatedNametags$/, '_invalidatedNametags');
+  }
+  return profileKey;
+}
+
+// =============================================================================
+// 1. Pure normalizer — the centerpiece of Phase 2.5.
+// =============================================================================
+
+describe('normalizeEntryKey (issue #335 Phase 2.5)', () => {
+  const { normalizeEntryKey } = dispatcherInternal;
+
+  it('converts ${addr}_tombstones → ${addr}.tombstones', () => {
+    expect(normalizeEntryKey(`${ADDR_A}_tombstones`)).toBe(
+      `${ADDR_A}.tombstones`,
+    );
+  });
+
+  it('converts ${addr}_invalidatedNametags → ${addr}.invalidatedNametags', () => {
+    expect(normalizeEntryKey(`${ADDR_A}_invalidatedNametags`)).toBe(
+      `${ADDR_A}.invalidatedNametags`,
+    );
+  });
+
+  it('leaves profile-form ${addr}.tombstones unchanged (idempotent)', () => {
+    expect(normalizeEntryKey(`${ADDR_A}.tombstones`)).toBe(
+      `${ADDR_A}.tombstones`,
+    );
+  });
+
+  it('leaves per-entry outbox key unchanged', () => {
+    expect(normalizeEntryKey(`${ADDR_A}.outbox.someEntryId`)).toBe(
+      `${ADDR_A}.outbox.someEntryId`,
+    );
+  });
+
+  it('leaves bundle key unchanged', () => {
+    expect(normalizeEntryKey('tokens.bundle.bafyXyz')).toBe(
+      'tokens.bundle.bafyXyz',
+    );
+  });
+
+  it('leaves global keys unchanged', () => {
+    expect(normalizeEntryKey('identity.mnemonic')).toBe('identity.mnemonic');
+    expect(normalizeEntryKey('addresses.tracked')).toBe('addresses.tracked');
+  });
+
+  it('rejects non-DIRECT addressId prefixes (defense in depth)', () => {
+    // A maliciously crafted key that happens to start with DIRECT_ but
+    // has wrong-length / non-hex chars must NOT be normalized. The
+    // strict `DIRECT_[0-9a-f]{6}_[0-9a-f]{6}` regex guards this — a
+    // non-match leaves the key untouched (defense in depth so a future
+    // bug in the publisher cannot escalate to a JOIN over an attacker-
+    // controlled namespace).
+    expect(normalizeEntryKey('DIRECT_GHIJKL_MNOPQR_tombstones')).toBe(
+      'DIRECT_GHIJKL_MNOPQR_tombstones',
+    );
+    expect(normalizeEntryKey('DIRECT_abc_def_tombstones')).toBe(
+      'DIRECT_abc_def_tombstones',
+    );
+  });
+
+  it('rejects unknown legacy suffixes (silent passthrough — fail-closed)', () => {
+    // A key that LOOKS like a legacy per-address single-blob key but
+    // whose suffix is not in the Phase 2.5 normalization table is
+    // returned verbatim. Downstream this means the entry stays in
+    // legacy form, the dispatcher's address-extraction regex doesn't
+    // match, the entry silently drops — exactly the pre-fix behaviour
+    // for that (unrouted) key. Adding a writer for it MUST extend
+    // both the table AND `factory.ts:writersFor()`.
+    expect(normalizeEntryKey(`${ADDR_A}_pendingTransfers`)).toBe(
+      `${ADDR_A}_pendingTransfers`,
+    );
+  });
+
+  it('handles two distinct addressIds in succession (no state leakage)', () => {
+    // Sanity check: the function is pure with no module-level cache.
+    expect(normalizeEntryKey(`${ADDR_A}_tombstones`)).toBe(
+      `${ADDR_A}.tombstones`,
+    );
+    expect(normalizeEntryKey(`${ADDR_B}_tombstones`)).toBe(
+      `${ADDR_B}.tombstones`,
+    );
+    expect(normalizeEntryKey(`${ADDR_A}_tombstones`)).toBe(
+      `${ADDR_A}.tombstones`,
+    );
+  });
+});
+
+// =============================================================================
+// 2. End-to-end: legacy-form tombstone snapshot lands at peer B.
+//
+//    This is the §D.5 soak failure at unit-test scale. Peer A
+//    serializes its tombstone blob via the lean-snapshot publisher's
+//    path (key in LEGACY form because storage.keys() reverse-maps the
+//    static suffix). Peer B receives the snapshot and dispatches it
+//    through the Phase 2 + 2.5 stack. The tombstone must land in peer
+//    B's storage.
+//
+//    This test MUST FAIL when `normalizeEntryKey` is reverted to
+//    identity — verifies the Phase 2.5 hook is on the critical path.
+// =============================================================================
+
+describe('issue #335 Phase 2.5 — legacy-key tombstone snapshot lands at peer B', () => {
+  it('peer A publishes ${addr}_tombstones (legacy form); peer B writes ${addr}.tombstones', async () => {
+    // --- Peer A: seed a tombstone via the production writer ---
+    const dbA = createMockDb();
+    const writerA = buildTombstonesSyncWriter({
+      db: dbA,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    await writeEnvelopeBlob(dbA, `${ADDR_A}.tombstones`, [
+      tomb('0xSpentSourceToken', '0xSpentStateHash', 1_700_000_000_000),
+    ]);
+
+    // --- Peer A: lift the writer's snapshot, then rewrite the entry's
+    //     key to LEGACY form to simulate what the lean-snapshot
+    //     publisher's `storage.keys()` path emits. The ciphertext bytes
+    //     (entry.value) are NOT touched — only the key is rewritten. ---
+    const snapA = await writerA.snapshot();
+    expect(snapA).toHaveLength(1);
+    expect(snapA[0].key).toBe(`${ADDR_A}.tombstones`); // profile form from the writer
+
+    const dispatcherSnapshot = buildSnapshot([
+      {
+        key: toLegacyKey(snapA[0].key), // <-- the production-realistic shape
+        value: Buffer.from(snapA[0].encryptedValue).toString('base64'),
+      },
+    ]);
+
+    // Sanity: the entry IS in legacy form.
+    expect(dispatcherSnapshot.entries[0].key).toBe(`${ADDR_A}_tombstones`);
+
+    // --- Peer B: empty storage, factory-style writer registration ---
+    const dbB = createMockDb();
+    const tombstonesWriterB = buildTombstonesSyncWriter({
+      db: dbB,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+
+    const result = await runProfileSnapshotJoin(dispatcherSnapshot, {
+      writersFor: (addressId) => {
+        if (addressId !== ADDR_A) return [];
+        return [
+          { keyPrefix: `${addressId}.tombstones`, writer: tombstonesWriterB },
+        ];
+      },
+      bundleIndex: null,
+    });
+
+    // --- Assertions: B's storage carries A's tombstone at the profile-
+    //     form key. The dispatcher's address-extraction counter saw 1
+    //     addressId (Phase 2.5 normalization fed the regex), and the
+    //     writer landed 1 live entry. Pre-fix: addresses=0, liveLanded=0. ---
+    expect(result.addressesSeen).toBe(1);
+    expect(result.counters.liveLanded).toBe(1);
+    expect(result.joinedAny).toBe(true);
+    expect(dbB._store.has(`${ADDR_A}.tombstones`)).toBe(true);
+
+    // Round-trip: peer B's writer's own snapshot now contains the same
+    // tombstone (proves the on-disk envelope path is well-formed).
+    const reloadedB = await tombstonesWriterB.snapshot();
+    expect(reloadedB).toHaveLength(1);
+    const decoded = JSON.parse(
+      new TextDecoder().decode(reloadedB[0].encryptedValue),
+    ) as Tomb[];
+    expect(decoded).toEqual([
+      {
+        tokenId: '0xSpentSourceToken',
+        stateHash: '0xSpentStateHash',
+        timestamp: 1_700_000_000_000,
+      },
+    ]);
+  });
+
+  it('peer A publishes ${addr}_invalidatedNametags (legacy form); peer B writes ${addr}.invalidatedNametags', async () => {
+    const dbA = createMockDb();
+    const writerA = buildInvalidatedNametagsSyncWriter({
+      db: dbA,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    await writeEnvelopeBlob(dbA, `${ADDR_A}.invalidatedNametags`, ['phisher123']);
+
+    const snapA = await writerA.snapshot();
+    const dispatcherSnapshot = buildSnapshot([
+      {
+        key: toLegacyKey(snapA[0].key),
+        value: Buffer.from(snapA[0].encryptedValue).toString('base64'),
+      },
+    ]);
+    expect(dispatcherSnapshot.entries[0].key).toBe(
+      `${ADDR_A}_invalidatedNametags`,
+    );
+
+    const dbB = createMockDb();
+    const tagsWriterB = buildInvalidatedNametagsSyncWriter({
+      db: dbB,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+
+    const result = await runProfileSnapshotJoin(dispatcherSnapshot, {
+      writersFor: (addressId) => {
+        if (addressId !== ADDR_A) return [];
+        return [
+          {
+            keyPrefix: `${addressId}.invalidatedNametags`,
+            writer: tagsWriterB,
+          },
+        ];
+      },
+      bundleIndex: null,
+    });
+
+    expect(result.addressesSeen).toBe(1);
+    expect(result.counters.liveLanded).toBe(1);
+    expect(dbB._store.has(`${ADDR_A}.invalidatedNametags`)).toBe(true);
+  });
+
+  it('mixed snapshot: legacy-form tombstones AND profile-form per-entry outbox both reach writers', async () => {
+    // The publisher emits per-entry keys (outbox/sent/dispositions) in
+    // PROFILE form (the suffix-match in reverseMapProfileKey doesn't
+    // trigger for those — the suffix is `.outbox.${id}`, not `.outbox`).
+    // Single-blob per-address keys come through in LEGACY form. The
+    // dispatcher must route BOTH correctly in the same JOIN.
+    const dbA = createMockDb();
+    const tombWriterA = buildTombstonesSyncWriter({
+      db: dbA,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+    await writeEnvelopeBlob(dbA, `${ADDR_A}.tombstones`, [
+      tomb('0xT', '0xS', 100),
+    ]);
+    const tombSnap = await tombWriterA.snapshot();
+
+    const dispatcherSnapshot = buildSnapshot([
+      {
+        key: toLegacyKey(tombSnap[0].key), // legacy form
+        value: Buffer.from(tombSnap[0].encryptedValue).toString('base64'),
+      },
+      {
+        key: `${ADDR_A}.outbox.someEntryId`, // already profile form
+        value: Buffer.from(new Uint8Array([0xde, 0xad])).toString('base64'),
+      },
+    ]);
+
+    const dbB = createMockDb();
+    const tombWriterB = buildTombstonesSyncWriter({
+      db: dbB,
+      encryptionKey: null,
+      addressId: ADDR_A,
+    });
+
+    // Capture what the stub outbox writer receives so we can assert
+    // both writers got their slices.
+    let outboxSliceKeys: string[] = [];
+    const stubOutboxWriter = {
+      async snapshot() {
+        return [];
+      },
+      async joinSnapshot(entries: ReadonlyArray<{ key: string }>) {
+        outboxSliceKeys = entries.map((e) => e.key);
+        return {
+          entriesEvaluated: entries.length,
+          liveLanded: entries.length,
+          tombstonesLanded: 0,
+          localWon: 0,
+          remoteRejectedMalformed: 0,
+        };
+      },
+    };
+
+    const result = await runProfileSnapshotJoin(dispatcherSnapshot, {
+      writersFor: (addressId) => {
+        if (addressId !== ADDR_A) return [];
+        return [
+          { keyPrefix: `${addressId}.tombstones`, writer: tombWriterB },
+          { keyPrefix: `${addressId}.outbox.`, writer: stubOutboxWriter },
+        ];
+      },
+      bundleIndex: null,
+    });
+
+    expect(result.addressesSeen).toBe(1);
+    // Outbox slice came through PROFILE-form key unchanged.
+    expect(outboxSliceKeys).toEqual([`${ADDR_A}.outbox.someEntryId`]);
+    // Tombstone slice landed via the SingleBlobSyncWriter.
+    expect(dbB._store.has(`${ADDR_A}.tombstones`)).toBe(true);
+    expect(result.counters.liveLanded).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// =============================================================================
+// 3. REGRESSION: without the Phase 2.5 normalizer, legacy-form keys are
+//    silently dropped — the §D.5 soak failure at unit scale.
+//
+//    The "REGRESSION" suite pins what would happen if the normalizer
+//    were reverted. It feeds the dispatcher a legacy-form key WITHOUT a
+//    normalizer call by faking what the publisher emits and checking
+//    that the address-extraction regex misses it. This is the
+//    pre-Phase-2.5 baseline.
+// =============================================================================
+
+describe('issue #335 Phase 2.5 REGRESSION — legacy-form keys silently drop without normalization', () => {
+  it('without the normalizer, ${addr}_tombstones does NOT count as an address', () => {
+    // ADDRESS_ID_PREFIX_RE requires a trailing `.` — the legacy
+    // underscore form fails the regex, so addressIds.size stays 0 in
+    // the dispatcher's address-extraction loop. This is the failure
+    // mode the production soak observed: peer2's snapshot had bundles
+    // but no per-address entries because every address-prefixed key
+    // was in underscore form.
+    const { ADDRESS_ID_PREFIX_RE } = dispatcherInternal;
+    expect(ADDRESS_ID_PREFIX_RE.exec(`${ADDR_A}_tombstones`)).toBeNull();
+    expect(ADDRESS_ID_PREFIX_RE.exec(`${ADDR_A}.tombstones`)).not.toBeNull();
+  });
+
+  it('verifies the Phase 2.5 normalization table covers tombstones + invalidatedNametags', () => {
+    // The fix is intentionally scoped to the two single-blob keys
+    // Phase 2 added writers for. Adding more single-blob writers
+    // requires extending the table AND wiring them in
+    // factory.ts:writersFor(). This assertion makes that contract
+    // visible so a future contributor sees the linkage.
+    const { PER_ADDRESS_LEGACY_SUFFIX_MAP } = dispatcherInternal;
+    const suffixes = PER_ADDRESS_LEGACY_SUFFIX_MAP.map(
+      (e: { legacySuffix: string }) => e.legacySuffix,
+    );
+    expect(suffixes).toEqual(
+      expect.arrayContaining(['_tombstones', '_invalidatedNametags']),
+    );
+    // Fail-closed contract: no other unrelated suffixes should appear
+    // in the table without an accompanying writer registration.
+    expect(suffixes).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the fix for **sphere-sdk #335** — `bob-peer1-vs-peer2-after` soak regression. Phase 1 RCA (comment): https://github.com/unicity-sphere/sphere-sdk/issues/335#issuecomment-4574693593

**One-line restatement.** Cross-device snapshot apply silently dropped the single-blob OrbitDB keys `${addressId}.tombstones` and `${addressId}.invalidatedNametags` because the lean-snapshot dispatcher had no writer registered for them — every other per-address key flows through a per-entry trailing-dot prefix writer, and these two single-blob holdouts were missing from `profile/factory.ts:writersFor()`.

Implementation is **single-blob (Option A from RCA §6)**, NOT per-entry — per user direction ("We should work probably no per entry, but per blob"). Per-entry migration (Option B) stays on the Phase D backlog.

## What landed

- `profile/single-blob-sync-writer.ts` (new) — `SingleBlobSyncWriter<T>` class with set-CRDT union semantics. Decrypts local + remote blobs, dedups by a caller-supplied key, writes back the merged blob re-encrypted through the canonical envelope path (`putEnvelopePayload`). Idempotent and monotone — re-running the JOIN with the same remote is a no-op once the first pass converges. Tombstones-in-the-merge-table-sense don't apply (the blob IS the collection); `tombstonesLanded` is always 0.
- `profile/profile-storage-provider.ts` — adds `buildTombstonesSyncWriter(addressId)` and `buildInvalidatedNametagsSyncWriter(addressId)` (null-when-encryption-unwired, mirrors `buildOutboxWriter`).
- `profile/factory.ts` — registers both writers in `writersFor()` alongside outbox/sent/finalization/recipient-context/disposition.
- `tests/unit/profile/single-blob-sync-writer.test.ts` (new) — 23 tests covering constructor invariants, snapshot/joinSnapshot for both tombstones and invalidatedNametags, malformed-remote rejection, encryption round-trip, idempotence, `notifyProfileDirty`, AND a cross-device dispatcher end-to-end test that replays peer A's tombstones snapshot into peer B. A companion "REGRESSION" test pins the pre-fix behaviour (no writer registered → bytes silently dropped).

## Why `invalidatedNametags` was bundled

Phase 1 RCA §8.2 explicitly flagged it as a likely-identical gap. Verified before bundling:

- Write site: `profile/profile-token-storage-provider.ts:2273-2282` calls `writeProfileKey(\`${addr}.invalidatedNametags\`, JSON.stringify(opState.invalidatedNametags))` — same single-blob shape as the tombstones path at lines 2284-2306.
- Read site: `profile/profile-token-storage-provider.ts:2681` via `readProfileKeyJson<unknown[]>` — single-blob array.
- No writer for it appears anywhere in `profile/factory.ts:writersFor()`.

It is the only other single-blob key in the per-address namespace; bundling avoids a second round-trip on the next time someone has to hunt this down.

## Verification

- **Unit tests on the new file**: `npx vitest run tests/unit/profile/single-blob-sync-writer.test.ts` → 23/23 pass.
- **Cross-device test fails without the writer**: confirmed by manually commenting out the `writersFor()` registration in `profile/factory.ts` — the "REGRESSION" test section (suite 8) of `single-blob-sync-writer.test.ts` pins this baseline by directly invoking the dispatcher with no writer registered and asserting the bytes are silently dropped. Restored on commit.
- **Pointer tests**: `npx vitest run tests/unit/profile/pointer/` → 482/482 pass. (RCA Phase 1 cited 489; baseline on current `origin/integration/all-fixes` HEAD `664a36f` is 482 — no regressions, the difference is in tests added/removed between RCA snapshot and current HEAD.)
- **Full profile tests**: `npx vitest run tests/unit/profile/` → 2236/2236 pass.
- **Build**: `npx tsup` → success.
- **Typecheck**: `npm run typecheck` → success.
- **Lint**: `npx eslint .` on changed files → clean. Pre-existing warning at `profile/aggregator-pointer/mutex-lock.ts:230` (was `:387` in Phase 1 RCA — same warning, moved) unchanged. 7 pre-existing errors in unrelated files unchanged.

## Out of scope (per user direction)

- `Sphere.clear()` / `PROFILE_SNAPSHOT_BLOB_<addressId>` cache survival across clear — tracked as **issue #339** (related-but-separate, NOT fixed here): https://github.com/unicity-sphere/sphere-sdk/issues/339
- Per-entry migration (Option B from RCA §6) — Phase D backlog.
- `UxfPackage` archive/live classification loss (RCA §6 Option C) — existing JOIN-AUDIT roadmap.

## Test plan

- [ ] Soak `manual-test-full-recovery.sh` 3 consecutive runs to confirm `bob-peer1-vs-peer2-after` passes (issue #335 acceptance criterion).
- [ ] Confirm no regression in `alice-peer1-vs-peer2-after`.
- [ ] Confirm no regression in §B/C soak sections.