### PR TITLE
fix(connectivity): aggregator pinger false-negative when round=0

### DIFF
--- a/core/connectivity.ts
+++ b/core/connectivity.ts
@@ -585,11 +585,18 @@ export class AggregatorPinger implements Pinger {
     if (signal.aborted) return 'down';
     if (this.provider) {
       try {
-        // `getCurrentRound()` returns 0 on the legacy "no aggregator client"
-        // fallback path — treat that as degraded so the UI shows trouble
-        // without locking the wallet into hard offline.
+        // Any finite numeric round (including 0) is a structured response
+        // from the aggregator and counts as alive — matches the reference
+        // infra-probe semantics (any JSON-RPC `result` ⇒ alive) and the
+        // URL-mode fallback below. Fresh shards / between-batch states
+        // can legitimately surface a `0` block height; demoting those to
+        // `'degraded'` would surface a false "Aggregator unavailable" in
+        // the wallet UI. The legacy "no aggregator client" stub path
+        // (UnicityAggregatorProvider before `initialize()`) now throws
+        // instead of returning `0`, so the catch below routes it to
+        // `'down'` as intended.
         const round = await this.provider.getCurrentRound();
-        if (typeof round === 'number' && Number.isFinite(round) && round > 0) {
+        if (typeof round === 'number' && Number.isFinite(round) && round >= 0) {
           return 'up';
         }
         return 'degraded';

--- a/oracle/UnicityAggregatorProvider.ts
+++ b/oracle/UnicityAggregatorProvider.ts
@@ -947,11 +947,21 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async getCurrentRound(): Promise<number> {
-    if (this.aggregatorClient) {
-      const blockHeight = await this.aggregatorClient.getBlockHeight();
-      return Number(blockHeight);
+    if (!this.aggregatorClient) {
+      // Defensive: aggregator client is constructed in `initialize()`. If
+      // `getCurrentRound()` is called before `initialize()` (or after a
+      // failed init), we have no live RPC channel — surface that as a
+      // throw so the AggregatorPinger correctly classifies the wallet as
+      // `'down'` rather than silently treating "no client" as a numeric
+      // round value. Prior code returned `0` here, which leaked the stub
+      // sentinel into the connectivity layer and demoted a healthy
+      // aggregator to `'degraded'` whenever any real-shard `0` round
+      // looked indistinguishable from this fallback (issue: page top-bar
+      // false-negative "Aggregator service unavailable").
+      throw new Error('UnicityAggregatorProvider: aggregator client not initialized');
     }
-    return 0;
+    const blockHeight = await this.aggregatorClient.getBlockHeight();
+    return Number(blockHeight);
   }
 
   async mint(params: MintParams): Promise<MintResult> {

--- a/tests/unit/core/connectivity.test.ts
+++ b/tests/unit/core/connectivity.test.ts
@@ -412,18 +412,62 @@ describe('AggregatorPinger', () => {
     expect(await p.ping(new AbortController().signal)).toBe('up');
   });
 
-  it('returns degraded when provider.getCurrentRound() returns 0 (legacy fallback)', async () => {
+  // Fresh shards / between-batch states can legitimately return a `0`
+  // block height. The reference infra-probe treats ANY structured
+  // JSON-RPC response as alive, and URL-mode (below) accepts any
+  // finite numeric `result`. Provider-mode must match — previously
+  // `0` was demoted to `'degraded'` and the wallet UI surfaced a
+  // false "Aggregator service unavailable" banner.
+  it('returns up when provider.getCurrentRound() returns 0 (real aggregator response)', async () => {
     const p = new AggregatorPinger({
       provider: { getCurrentRound: async () => 0 },
     });
-    expect(await p.ping(new AbortController().signal)).toBe('degraded');
+    expect(await p.ping(new AbortController().signal)).toBe('up');
   });
 
-  it('returns down when provider.getCurrentRound() throws', async () => {
+  it('returns up for large positive numbers (no upper bound)', async () => {
     const p = new AggregatorPinger({
+      provider: { getCurrentRound: async () => Number.MAX_SAFE_INTEGER },
+    });
+    expect(await p.ping(new AbortController().signal)).toBe('up');
+  });
+
+  it('returns degraded when provider.getCurrentRound() returns a non-finite/negative number', async () => {
+    const nan = new AggregatorPinger({
+      provider: { getCurrentRound: async () => Number.NaN },
+    });
+    expect(await nan.ping(new AbortController().signal)).toBe('degraded');
+
+    const inf = new AggregatorPinger({
+      provider: { getCurrentRound: async () => Number.POSITIVE_INFINITY },
+    });
+    expect(await inf.ping(new AbortController().signal)).toBe('degraded');
+
+    const neg = new AggregatorPinger({
+      provider: { getCurrentRound: async () => -1 },
+    });
+    expect(await neg.ping(new AbortController().signal)).toBe('degraded');
+  });
+
+  it('returns down when provider.getCurrentRound() throws (including the legacy "no aggregator client" stub path)', async () => {
+    // Any thrown error → 'down'. The stub path in
+    // UnicityAggregatorProvider.getCurrentRound() now throws when
+    // `aggregatorClient` is null (pre-`initialize()`), so the pinger
+    // correctly classifies an uninitialized provider as offline rather
+    // than silently treating `0` as a real round value.
+    const stub = new AggregatorPinger({
+      provider: {
+        getCurrentRound: async () => {
+          throw new Error('UnicityAggregatorProvider: aggregator client not initialized');
+        },
+      },
+    });
+    expect(await stub.ping(new AbortController().signal)).toBe('down');
+
+    const generic = new AggregatorPinger({
       provider: { getCurrentRound: async () => { throw new Error('503'); } },
     });
-    expect(await p.ping(new AbortController().signal)).toBe('down');
+    expect(await generic.ping(new AbortController().signal)).toBe('down');
   });
 
   it('returns down when neither provider nor URL is supplied', async () => {

--- a/tests/unit/oracle/UnicityAggregatorProvider.rpc-methods.test.ts
+++ b/tests/unit/oracle/UnicityAggregatorProvider.rpc-methods.test.ts
@@ -250,4 +250,62 @@ describe('UnicityAggregatorProvider — JSON-RPC wire method names', () => {
       expect(calls[0].method).not.toBe('submitCommitment');
     });
   });
+
+  describe('getCurrentRound()', () => {
+    // Before this fix `getCurrentRound()` returned `0` when
+    // `aggregatorClient` was null (the pre-`initialize()` stub path).
+    // The AggregatorPinger was using `round > 0` to discriminate that
+    // stub case from a real aggregator response — but the stub
+    // sentinel collided with legitimate `0` round numbers from fresh
+    // shards / between-batch states, producing false-negative
+    // "Aggregator service unavailable" banners. The fix throws on
+    // the uninitialized path so the pinger routes it to `'down'` and
+    // can treat any finite numeric round (including 0) as alive.
+    it('throws when aggregator client is not initialized (no initialize() call)', async () => {
+      const provider = new UnicityAggregatorProvider({
+        url: 'https://test.example/',
+        timeout: 1000,
+        skipVerification: true,
+      });
+      // NOTE: deliberately NOT calling initialize() — aggregatorClient is null.
+      await expect(provider.getCurrentRound()).rejects.toThrow(/not initialized/);
+    });
+
+    it('returns the live block height (as a number) when the aggregator client is wired', async () => {
+      const provider = new UnicityAggregatorProvider({
+        url: 'https://test.example/',
+        timeout: 1000,
+        skipVerification: true,
+      });
+      // Stub `aggregatorClient` directly to avoid the real SDK init path
+      // (which would require fetching a trust base from the network).
+      const fakeClient = {
+        getBlockHeight: vi.fn(async () => 42n),
+      };
+      (provider as unknown as { aggregatorClient: typeof fakeClient }).aggregatorClient = fakeClient;
+
+      const round = await provider.getCurrentRound();
+      expect(round).toBe(42);
+      expect(fakeClient.getBlockHeight).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 0 (numeric) when the aggregator reports block height 0 — does NOT swallow the response', async () => {
+      // Regression: a fresh shard or between-batch state can return 0
+      // from `get_block_height`. The pinger must see this as a real
+      // numeric value (and treat it as alive), not as the stub sentinel.
+      const provider = new UnicityAggregatorProvider({
+        url: 'https://test.example/',
+        timeout: 1000,
+        skipVerification: true,
+      });
+      const fakeClient = {
+        getBlockHeight: vi.fn(async () => 0n),
+      };
+      (provider as unknown as { aggregatorClient: typeof fakeClient }).aggregatorClient = fakeClient;
+
+      const round = await provider.getCurrentRound();
+      expect(round).toBe(0);
+      expect(Number.isFinite(round)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- The Sphere page top bar surfaced "Aggregator service unavailable" while the aggregator was actually live. Root cause: `AggregatorPinger` provider-mode required `round > 0` to count as `'up'`, but URL-mode and the reference infra-probe accept any structured response. Fresh shards / between-batch states can legitimately return `0` block height.
- The previous code used `0` as a sentinel for the legacy "no aggregator client" stub path in `UnicityAggregatorProvider.getCurrentRound()`. That sentinel collided with legitimate `0` round responses from the aggregator.
- This PR aligns provider-mode with URL-mode semantics: any finite numeric round (including `0`) is `'up'`. The stub path now throws (routed to `'down'`) instead of returning `0`.

## Files changed

- `oracle/UnicityAggregatorProvider.ts` — throw on uninitialized aggregator client (was: return `0`).
- `core/connectivity.ts` — accept any finite `round >= 0` as `'up'` in provider-mode.
- `tests/unit/core/connectivity.test.ts` — round=0 → up, MAX_SAFE_INTEGER → up, NaN/Infinity/negative → degraded, stub throw → down.
- `tests/unit/oracle/UnicityAggregatorProvider.rpc-methods.test.ts` — new `getCurrentRound()` suite: uninitialized throws, wired client returns number, shard returns 0 → 0 (not stub).

## Verification

- `npx vitest run tests/unit/core/connectivity.test.ts tests/unit/oracle/UnicityAggregatorProvider.rpc-methods.test.ts` — 48/48 pass.
- `npx vitest run tests/unit/oracle tests/unit/core` — 621/621 pass.
- `npx tsup` — clean.
- `npx eslint core/connectivity.ts oracle/UnicityAggregatorProvider.ts tests/unit/core/connectivity.test.ts tests/unit/oracle/UnicityAggregatorProvider.rpc-methods.test.ts` — only the pre-existing `RpcSpentResponse` unused-warn (unrelated).
- Tests verified to FAIL without the fix via `git stash` round-trip: `'returns up when round=0'` produces "expected up, received degraded" and `'throws when not initialized'` produces "promise resolved 0 instead of rejecting".

## Test plan

- [ ] Reviewer: confirm `sphere.telco` vendored `dist/` will need refresh — sphere.telco vendors sphere-sdk via the deploy chain (`sphere-sdk → sphere.telco vendor-bump → sphere main → deploy-manual.yml`). The live `sphere-telco-test.dyndns.org` host won't pick this up until that chain runs.
- [ ] Reviewer: confirm no other production caller of `UnicityAggregatorProvider.getCurrentRound()` (none found in tree — only `core/connectivity.ts` Sphere wiring).

## Out of scope (deferred follow-ups)

- A `/health` JSON-RPC probe layer that matches the infra-probe's `GET /health` path. Mentioned by the task brief as a separate enhancement. The reference probe is a strict superset of `getCurrentRound`, so adding `/health` would improve diagnosis (database/shard breakdown) but isn't required to fix the false-negative.
- Refactor `OracleProvider.getCurrentRound()` signature to make the "alive sentinel" explicit (e.g., return `number | null` instead of relying on throw). Would require touching every test mock; left for a follow-up if the convention gets more consumers.