### PR TITLE
fix(payments/transfer): same-process source lock for conservative-sender (Audit #333 H1)

### DIFF
--- a/modules/payments/transfer/conservative-sender.ts
+++ b/modules/payments/transfer/conservative-sender.ts
@@ -116,6 +116,7 @@ import {
   type PreflightFinalizeOptions,
 } from './preflight-finalize';
 import { validateTargets, type ValidatedTargets } from './target-validator';
+import { acquireSourceLocks } from './source-locks';
 
 // =============================================================================
 // 1. Public types — commit + select callbacks, deps, return value
@@ -413,6 +414,16 @@ export interface ConservativeSenderDeps {
    * injection.
    */
   readonly __faultInject?: FaultInjectionHooks;
+  /**
+   * **TEST-ONLY** override for the source-lock max-hold timeout
+   * (Audit #333 H1). Defaults to 60_000ms in production; tests override
+   * to a smaller value to exercise the force-release path without
+   * burning real wall-clock seconds. Symmetric with
+   * `InstantSenderDeps.__sourceLockMaxHoldMs`.
+   *
+   * @internal Test seam only.
+   */
+  readonly __sourceLockMaxHoldMs?: number;
 }
 
 /**
@@ -644,6 +655,11 @@ export async function sendConservativeUxf(
     tokenTransfers: [],
   };
 
+  // Audit #333 H1 — same-process source-lock seam, symmetric with
+  // sendInstantUxf. Bound to `null` until selection completes; released
+  // in the outer `finally`. See `./source-locks.ts` for the rationale.
+  let releaseSourceLocks: (() => void) | null = null;
+
   try {
     // -----------------------------------------------------------------
     // Step 1: validate target list (T.2.B).
@@ -715,6 +731,28 @@ export async function sendConservativeUxf(
       );
     }
     result.tokens = [...selected];
+
+    // -----------------------------------------------------------------
+    // Step 2.5 (Audit #333 H1): acquire per-source in-memory locks.
+    //
+    // Mirrors the instant-sender pattern (Wave 4 #171). Held across the
+    // entire preflight → commit → transport → mark sequence so two
+    // parallel sendConservativeUxf calls (or one conservative + one
+    // instant) sharing source tokens cannot both pass selection and
+    // race to commit on-chain. Without this, the aggregator catches
+    // the duplicate-spend after a source is already burned, leaving
+    // the loser's outbox in a recoverable-but-broken state.
+    //
+    // Locks acquired in lex-sorted order of tokenId (deadlock-prevention
+    // discipline shared with instant-sender). Released in the outer
+    // `finally` regardless of success/failure.
+    // -----------------------------------------------------------------
+    const sourceTokenIds = selected.map((t) => t.id);
+    releaseSourceLocks = await acquireSourceLocks(
+      sourceTokenIds,
+      deps.__sourceLockMaxHoldMs,
+      'sendConservativeUxf',
+    );
 
     // -----------------------------------------------------------------
     // Step 3: preflight finalize (T.2.A).
@@ -1207,6 +1245,14 @@ export async function sendConservativeUxf(
     result.error = err instanceof Error ? err.message : String(err);
     deps.emit('transfer:failed', result as TransferResult);
     throw err;
+  } finally {
+    // Audit #333 H1: release per-source locks regardless of success or
+    // failure. Bound to `null` until selection completes; if we threw
+    // before locks were acquired (e.g. validateTargets rejection, empty
+    // selection) there is nothing to release.
+    if (releaseSourceLocks !== null) {
+      releaseSourceLocks();
+    }
   }
 }
 

--- a/modules/payments/transfer/instant-sender.ts
+++ b/modules/payments/transfer/instant-sender.ts
@@ -408,193 +408,19 @@ export interface InstantSenderDeps {
 // 2. Internal helpers
 // =============================================================================
 
-/**
- * Per-source in-memory lock registry — Wave 4 steelman fix #171 issue 1.
- *
- * **The race we close.** Wave 3's fix (#170) deferred `markSourcePending`
- * until AFTER `transport.sendTokenTransfer` succeeds. That eliminates the
- * "transport-fails-leaving-stuck-pending" failure mode, but introduces a
- * *same-process* double-spend window: two parallel `sendInstantUxf` calls
- * in the SAME Sphere instance may both observe sources as
- * `confirmed`/non-pending, both pass selection, both publish via
- * transport, and only THEN race to call `markSourcePending`. The
- * recipient receives BOTH bundles; the aggregator rejects the second
- * commitment as duplicate-spend; the sender's outbox holds one
- * `delivered-instant` and one entry that must transition to
- * `failed-permanent`.
- *
- * **The fix.** Acquire a per-tokenId mutex on every selected source
- * BEFORE source selection completes, hold it across the entire
- * selection→commit→transport→mark sequence, and release in `finally`.
- * Concurrent sends sharing any source token serialize through the lock;
- * sends with disjoint sources proceed concurrently as before.
- *
- * **Deadlock prevention.** Locks are acquired in lex-sorted order of
- * tokenId so two concurrent sends sharing tokens always agree on
- * acquisition order. Without the sort, send A (tokens [X, Y]) and send B
- * (tokens [Y, X]) could each hold one lock and wait forever for the
- * other.
- *
- * **Liveness floor.** A 60-second max-hold timeout fires if a lock is
- * held longer (e.g. transport hangs forever); the lock is force-released
- * with a `console.warn` so a stuck send cannot wedge unrelated future
- * sends. The original send still throws/recovers per its own error path.
- *
- * **Same-token-set re-entry.** A user genuinely sending the same source
- * twice in parallel (split mode for huge balances) is serialized by the
- * lock — by design. Document this if surfaced to API consumers.
- *
- * **Process-global state — Wave 5 steelman fix #171.** The `sourceLocks`
- * map is a MODULE-LEVEL singleton. Two `Sphere` instances running in the
- * same process share this map. In production this is benign: each wallet's
- * source tokenIds are HD-derived from a unique master key, so cross-wallet
- * collision is cryptographically improbable (the chance of a collision is
- * the chance of a public-key collision in the BIP-32 derivation tree).
- * Tests that drive multiple Sphere instances against fixed string tokenIds
- * MUST call {@link __resetSourceLocksForTesting} between cases to prevent
- * state bleed across tests; production callers MUST NOT invoke it.
- *
- * Spec refs: §6.1 sender-side semantics; §7.1 CRDT invariants (no
- * commitment may be observed by two outbox entries with overlapping
- * source-token sets).
- *
- * @internal
- */
-const sourceLocks = new Map<string, Promise<void>>();
+// Audit #333 H1: the per-source lock registry was extracted to
+// `./source-locks.ts` so the conservative-sender can share the same
+// process-global map (previously only instant-sender had locking and
+// concurrent conservative+instant sends sharing a source could race).
+// The `__resetSourceLocksForTesting` symbol is re-exported here so the
+// existing test imports (tests/unit/payments/transfer/instant-sender.test.ts)
+// continue to resolve without churn.
+import {
+  acquireSourceLocks,
+  __resetSourceLocksForTesting,
+} from './source-locks';
 
-/**
- * Test-only escape hatch — clear the process-global {@link sourceLocks}
- * map. Wave 5 steelman fix #171: tests that exercise the lock behavior
- * (or otherwise touch `acquireSourceLocks`) MUST invoke this in
- * `beforeEach` so a hung/leaked lock from a prior test cannot wedge a
- * subsequent one. Production code MUST NOT call this — clearing locks
- * mid-flight would re-open the same-process double-spend window the
- * lock exists to close.
- *
- * Pending acquirers that are awaiting a cleared lock-promise will loop
- * once and observe the empty slot on the next microtask, then proceed
- * normally — they do not get rejected. Lock-promises themselves are
- * forgotten (the holder's release is a no-op against the absent slot).
- *
- * Wave 6 steelman fix: runtime guard. The export was previously
- * advisory-only ("MUST NOT" in JSDoc) — a production consumer doing
- * `import * as instantSender` could still invoke it and clear locks
- * mid-flight, re-opening the double-spend window.
- *
- * Wave 7 steelman fix: FAIL-CLOSED. The Wave 6 guard fired only when
- * `NODE_ENV === 'production'`. In browser bundles where `process` is
- * stripped, `typeof process === 'undefined'` evaluated false-y for the
- * outer condition and the reset proceeded — the exact attack the
- * function exists to prevent. The guard is now allow-list: reset is
- * forbidden by default everywhere, and only succeeds when the runtime
- * is provably a test environment (NODE_ENV explicitly === 'test', or
- * `SPHERE_ALLOW_TEST_RESET=1` for deliberate test harnesses).
- *
- * @internal
- */
-export function __resetSourceLocksForTesting(): void {
-  // Fail-closed: production / browser / unknown environments all reject.
-  // Test environments must opt in. Browser bundles strip `process`, so
-  // absence-of-process means "not in a test runner" — denying reset is
-  // safer than the alternative.
-  const isTestEnv =
-    typeof process !== 'undefined' &&
-    (process.env?.NODE_ENV === 'test' ||
-      process.env?.SPHERE_ALLOW_TEST_RESET === '1');
-  if (!isTestEnv) {
-    throw new Error(
-      '__resetSourceLocksForTesting is only available in test environments. ' +
-        'Clearing locks mid-flight re-opens the same-process double-spend ' +
-        'window the lock exists to close. Set NODE_ENV=test or ' +
-        'SPHERE_ALLOW_TEST_RESET=1 to enable (testing only).',
-    );
-  }
-  sourceLocks.clear();
-}
-
-/** Default max-hold for any single source lock. Configurable via the
- *  `LOCK_MAX_HOLD_MS` parameter for testability. */
-const DEFAULT_LOCK_MAX_HOLD_MS = 60_000;
-
-/**
- * Acquire locks on every supplied tokenId in lex-sorted order. Returns
- * a `release()` function that callers MUST invoke in `finally`.
- *
- * Each lock entry is a `Promise<void>` that resolves when the holder
- * releases. Subsequent acquirers loop until the slot is empty,
- * re-attempting after each prior holder's release. The
- * `Map.has`+`await`+`Map.set` sequence is safe because every
- * micro-tick between awaits checks the slot afresh — and ALL set
- * operations occur on the SAME microtask the await resumes on.
- *
- * @param tokenIds - sources to lock. Duplicates are deduped via Set.
- * @param maxHoldMs - liveness timeout. Defaults to {@link
- *                    DEFAULT_LOCK_MAX_HOLD_MS}.
- *
- * @internal
- */
-async function acquireSourceLocks(
-  tokenIds: ReadonlyArray<string>,
-  maxHoldMs: number = DEFAULT_LOCK_MAX_HOLD_MS,
-): Promise<() => void> {
-  const sortedIds = [...new Set(tokenIds)].sort();
-  const releases: Array<() => void> = [];
-  for (const tokenId of sortedIds) {
-    // Wait until the slot is empty. Each iteration awaits the prior
-    // holder, then re-checks; if a third caller raced in we loop again.
-    while (sourceLocks.has(tokenId)) {
-      try {
-        await sourceLocks.get(tokenId);
-      } catch {
-        // Prior holder rejected its lock-promise (it shouldn't, but
-        // defense-in-depth). Loop and re-check.
-      }
-    }
-    let releaseFn!: () => void;
-    const lockPromise = new Promise<void>((resolve) => {
-      releaseFn = resolve;
-    });
-    sourceLocks.set(tokenId, lockPromise);
-
-    // Per-lock liveness timer. If `release()` hasn't fired within
-    // `maxHoldMs`, force-release with a warning so unrelated future
-    // sends can proceed.
-    let released = false;
-    const timer = setTimeout(() => {
-      if (!released && sourceLocks.get(tokenId) === lockPromise) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `sendInstantUxf: source lock for tokenId=${tokenId} held >${maxHoldMs}ms; ` +
-            'force-releasing. The originating send may still complete its own error path, ' +
-            'but unrelated future sends can now proceed.',
-        );
-        sourceLocks.delete(tokenId);
-        releaseFn();
-      }
-    }, maxHoldMs);
-    // The timer must NOT keep the Node.js event loop alive — pure
-    // best-effort liveness, never a blocker for graceful shutdown.
-    if (typeof timer === 'object' && timer !== null && 'unref' in timer) {
-      (timer as { unref: () => void }).unref();
-    }
-
-    releases.push(() => {
-      released = true;
-      clearTimeout(timer);
-      // Only delete if the slot still references our lock-promise — a
-      // force-release timer may have already evicted us.
-      if (sourceLocks.get(tokenId) === lockPromise) {
-        sourceLocks.delete(tokenId);
-      }
-      releaseFn();
-    });
-  }
-  return () => {
-    for (const release of releases) {
-      release();
-    }
-  };
-}
+export { __resetSourceLocksForTesting };
 
 /**
  * Sort by source tokenId, lex-ascending. Same rule the
@@ -925,6 +751,7 @@ export async function sendInstantUxf(
     releaseSourceLocks = await acquireSourceLocks(
       sourceTokenIds,
       deps.__sourceLockMaxHoldMs,
+      'sendInstantUxf',
     );
 
     // -----------------------------------------------------------------

--- a/modules/payments/transfer/source-locks.ts
+++ b/modules/payments/transfer/source-locks.ts
@@ -1,0 +1,210 @@
+/**
+ * Per-source in-memory lock registry — shared by both senders.
+ *
+ * The original implementation was a module-local in `instant-sender.ts`
+ * (Wave 4 #171 / Wave 5–7 hardening). Audit #333 H1 surfaced that
+ * `conservative-sender.ts` had no equivalent — two concurrent sends
+ * sharing a source token could both pass selection, both publish, and
+ * only the aggregator caught the duplicate-spend. Extracted here so
+ * BOTH senders (and any future sender variant) serialize through the
+ * SAME process-global map.
+ *
+ * The semantics are preserved verbatim from the original Wave 4 fix.
+ * Existing tests import `__resetSourceLocksForTesting` from
+ * `instant-sender.ts` for backwards compatibility — that file re-exports
+ * the symbol from here.
+ *
+ * @module modules/payments/transfer/source-locks
+ * @internal
+ */
+
+/**
+ * Per-source in-memory lock registry — Wave 4 steelman fix #171 issue 1.
+ *
+ * **The race we close.** Wave 3's fix (#170) deferred `markSourcePending`
+ * until AFTER `transport.sendTokenTransfer` succeeds. That eliminates the
+ * "transport-fails-leaving-stuck-pending" failure mode, but introduces a
+ * *same-process* double-spend window: two parallel `sendInstantUxf` /
+ * `sendConservativeUxf` calls in the SAME Sphere instance may both
+ * observe sources as `confirmed`/non-pending, both pass selection, both
+ * publish via transport, and only THEN race to call `markSourcePending`.
+ * The recipient receives BOTH bundles; the aggregator rejects the second
+ * commitment as duplicate-spend; the sender's outbox holds one
+ * `delivered-instant` and one entry that must transition to
+ * `failed-permanent`.
+ *
+ * **The fix.** Acquire a per-tokenId mutex on every selected source
+ * BEFORE source selection completes, hold it across the entire
+ * selection→commit→transport→mark sequence, and release in `finally`.
+ * Concurrent sends sharing any source token serialize through the lock;
+ * sends with disjoint sources proceed concurrently as before.
+ *
+ * **Deadlock prevention.** Locks are acquired in lex-sorted order of
+ * tokenId so two concurrent sends sharing tokens always agree on
+ * acquisition order. Without the sort, send A (tokens [X, Y]) and send B
+ * (tokens [Y, X]) could each hold one lock and wait forever for the
+ * other.
+ *
+ * **Liveness floor.** A 60-second max-hold timeout fires if a lock is
+ * held longer (e.g. transport hangs forever); the lock is force-released
+ * with a `console.warn` so a stuck send cannot wedge unrelated future
+ * sends. The original send still throws/recovers per its own error path.
+ *
+ * **Same-token-set re-entry.** A user genuinely sending the same source
+ * twice in parallel (split mode for huge balances) is serialized by the
+ * lock — by design. Document this if surfaced to API consumers.
+ *
+ * **Process-global state — Wave 5 steelman fix #171.** The `sourceLocks`
+ * map is a MODULE-LEVEL singleton. Two `Sphere` instances running in the
+ * same process share this map. In production this is benign: each wallet's
+ * source tokenIds are HD-derived from a unique master key, so cross-wallet
+ * collision is cryptographically improbable (the chance of a collision is
+ * the chance of a public-key collision in the BIP-32 derivation tree).
+ * Tests that drive multiple Sphere instances against fixed string tokenIds
+ * MUST call {@link __resetSourceLocksForTesting} between cases to prevent
+ * state bleed across tests; production callers MUST NOT invoke it.
+ *
+ * Spec refs: §6.1 sender-side semantics; §7.1 CRDT invariants (no
+ * commitment may be observed by two outbox entries with overlapping
+ * source-token sets).
+ *
+ * @internal
+ */
+const sourceLocks = new Map<string, Promise<void>>();
+
+/**
+ * Test-only escape hatch — clear the process-global {@link sourceLocks}
+ * map. Wave 5 steelman fix #171: tests that exercise the lock behavior
+ * (or otherwise touch {@link acquireSourceLocks}) MUST invoke this in
+ * `beforeEach` so a hung/leaked lock from a prior test cannot wedge a
+ * subsequent one. Production code MUST NOT call this — clearing locks
+ * mid-flight would re-open the same-process double-spend window the
+ * lock exists to close.
+ *
+ * Pending acquirers that are awaiting a cleared lock-promise will loop
+ * once and observe the empty slot on the next microtask, then proceed
+ * normally — they do not get rejected. Lock-promises themselves are
+ * forgotten (the holder's release is a no-op against the absent slot).
+ *
+ * Wave 6 steelman fix: runtime guard. The export was previously
+ * advisory-only ("MUST NOT" in JSDoc) — a production consumer doing
+ * `import * as instantSender` could still invoke it and clear locks
+ * mid-flight, re-opening the double-spend window.
+ *
+ * Wave 7 steelman fix: FAIL-CLOSED. The Wave 6 guard fired only when
+ * `NODE_ENV === 'production'`. In browser bundles where `process` is
+ * stripped, `typeof process === 'undefined'` evaluated false-y for the
+ * outer condition and the reset proceeded — the exact attack the
+ * function exists to prevent. The guard is now allow-list: reset is
+ * forbidden by default everywhere, and only succeeds when the runtime
+ * is provably a test environment (NODE_ENV explicitly === 'test', or
+ * `SPHERE_ALLOW_TEST_RESET=1` for deliberate test harnesses).
+ *
+ * @internal
+ */
+export function __resetSourceLocksForTesting(): void {
+  // Fail-closed: production / browser / unknown environments all reject.
+  // Test environments must opt in. Browser bundles strip `process`, so
+  // absence-of-process means "not in a test runner" — denying reset is
+  // safer than the alternative.
+  const isTestEnv =
+    typeof process !== 'undefined' &&
+    (process.env?.NODE_ENV === 'test' ||
+      process.env?.SPHERE_ALLOW_TEST_RESET === '1');
+  if (!isTestEnv) {
+    throw new Error(
+      '__resetSourceLocksForTesting is only available in test environments. ' +
+        'Clearing locks mid-flight re-opens the same-process double-spend ' +
+        'window the lock exists to close. Set NODE_ENV=test or ' +
+        'SPHERE_ALLOW_TEST_RESET=1 to enable (testing only).',
+    );
+  }
+  sourceLocks.clear();
+}
+
+/** Default max-hold for any single source lock. Configurable via the
+ *  `maxHoldMs` parameter on {@link acquireSourceLocks} for testability. */
+export const DEFAULT_LOCK_MAX_HOLD_MS = 60_000;
+
+/**
+ * Acquire locks on every supplied tokenId in lex-sorted order. Returns
+ * a `release()` function that callers MUST invoke in `finally`.
+ *
+ * Each lock entry is a `Promise<void>` that resolves when the holder
+ * releases. Subsequent acquirers loop until the slot is empty,
+ * re-attempting after each prior holder's release. The
+ * `Map.has`+`await`+`Map.set` sequence is safe because every
+ * micro-tick between awaits checks the slot afresh — and ALL set
+ * operations occur on the SAME microtask the await resumes on.
+ *
+ * @param tokenIds - sources to lock. Duplicates are deduped via Set.
+ * @param maxHoldMs - liveness timeout. Defaults to {@link DEFAULT_LOCK_MAX_HOLD_MS}.
+ * @param callerLabel - logging label used in the force-release warning
+ *   (e.g. 'sendInstantUxf' or 'sendConservativeUxf'). Helps operators
+ *   tell which sender wedged a lock when triaging force-release events.
+ *
+ * @internal
+ */
+export async function acquireSourceLocks(
+  tokenIds: ReadonlyArray<string>,
+  maxHoldMs: number = DEFAULT_LOCK_MAX_HOLD_MS,
+  callerLabel: string = 'sender',
+): Promise<() => void> {
+  const sortedIds = [...new Set(tokenIds)].sort();
+  const releases: Array<() => void> = [];
+  for (const tokenId of sortedIds) {
+    // Wait until the slot is empty. Each iteration awaits the prior
+    // holder, then re-checks; if a third caller raced in we loop again.
+    while (sourceLocks.has(tokenId)) {
+      try {
+        await sourceLocks.get(tokenId);
+      } catch {
+        // Prior holder rejected its lock-promise (it shouldn't, but
+        // defense-in-depth). Loop and re-check.
+      }
+    }
+    let releaseFn!: () => void;
+    const lockPromise = new Promise<void>((resolve) => {
+      releaseFn = resolve;
+    });
+    sourceLocks.set(tokenId, lockPromise);
+
+    // Per-lock liveness timer. If `release()` hasn't fired within
+    // `maxHoldMs`, force-release with a warning so unrelated future
+    // sends can proceed.
+    let released = false;
+    const timer = setTimeout(() => {
+      if (!released && sourceLocks.get(tokenId) === lockPromise) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `${callerLabel}: source lock for tokenId=${tokenId} held >${maxHoldMs}ms; ` +
+            'force-releasing. The originating send may still complete its own error path, ' +
+            'but unrelated future sends can now proceed.',
+        );
+        sourceLocks.delete(tokenId);
+        releaseFn();
+      }
+    }, maxHoldMs);
+    // The timer must NOT keep the Node.js event loop alive — pure
+    // best-effort liveness, never a blocker for graceful shutdown.
+    if (typeof timer === 'object' && timer !== null && 'unref' in timer) {
+      (timer as { unref: () => void }).unref();
+    }
+
+    releases.push(() => {
+      released = true;
+      clearTimeout(timer);
+      // Only delete if the slot still references our lock-promise — a
+      // force-release timer may have already evicted us.
+      if (sourceLocks.get(tokenId) === lockPromise) {
+        sourceLocks.delete(tokenId);
+      }
+      releaseFn();
+    });
+  }
+  return () => {
+    for (const release of releases) {
+      release();
+    }
+  };
+}

--- a/tests/unit/payments/transfer/conservative-sender-h1-source-lock.test.ts
+++ b/tests/unit/payments/transfer/conservative-sender-h1-source-lock.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Tests for Audit #333 H1 — conservative-sender same-process source lock.
+ *
+ * Background
+ * ----------
+ * Before this fix, `conservative-sender.ts` had ZERO locking primitives.
+ * `instant-sender.ts` declared a process-global `sourceLocks` map (Wave
+ * 5 #171). Conservative sends and instant-vs-conservative cross-pairs
+ * therefore did NOT serialize on shared source tokens: two concurrent
+ * sends could both pass selection, both commit on-chain, and only the
+ * aggregator caught the duplicate-spend after a source was burned.
+ *
+ * The fix extracted the lock registry to `./source-locks.ts` (see
+ * `source-locks-h1-shared.test.ts` for direct-module tests) and wired
+ * `conservative-sender.ts` to acquire/release through the same map
+ * after source selection completes.
+ *
+ * This file verifies the conservative-sender pipeline actually invokes
+ * the lock:
+ *   - Two concurrent `sendConservativeUxf` calls sharing a source
+ *     SERIALIZE — the second cannot enter `commitSources` until the
+ *     first releases.
+ *   - The lock is RELEASED on success (subsequent send proceeds
+ *     immediately).
+ *   - The lock is RELEASED on failure (subsequent send proceeds even
+ *     after the first throws inside the pipeline).
+ *   - Disjoint sources PROCEED CONCURRENTLY (sanity check — locking is
+ *     not over-broad).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  sendConservativeUxf,
+  type ConservativeCommitResult,
+  type ConservativeSenderDeps,
+} from '../../../../modules/payments/transfer/conservative-sender';
+import { __resetSourceLocksForTesting } from '../../../../modules/payments/transfer/source-locks';
+import type { TokenLike } from '../../../../modules/payments/transfer/classify-token';
+import type { PreflightFinalizeOptions } from '../../../../modules/payments/transfer/preflight-finalize';
+import type { OracleProvider } from '../../../../oracle/oracle-provider';
+import type { TransportProvider } from '../../../../transport';
+import type { PeerInfo } from '../../../../transport/transport-provider';
+import type {
+  FullIdentity,
+  SphereEventMap,
+  SphereEventType,
+  Token,
+  TransferRequest,
+} from '../../../../types';
+import { TOKEN_A } from '../../../fixtures/uxf-mock-tokens';
+
+// ---------------------------------------------------------------------------
+// Minimal harness — just enough to drive sendConservativeUxf to the
+// commit step where the lock is observably held.
+// ---------------------------------------------------------------------------
+
+function makeToken(id: string, fixture: Record<string, unknown>): Token {
+  return {
+    id,
+    coinId: 'UCT',
+    symbol: 'UCT',
+    name: 'Unicity',
+    decimals: 8,
+    amount: '1000000',
+    status: 'confirmed',
+    createdAt: 0,
+    updatedAt: 0,
+    sdkData: JSON.stringify(fixture),
+  };
+}
+
+function makeCommitResult(sourceTokenId: string): ConservativeCommitResult {
+  return {
+    sourceTokenId,
+    method: 'direct',
+    requestIdHex: `req-${sourceTokenId}`,
+    recipientTokenJson: { ...TOKEN_A },
+  };
+}
+
+function makeOracleStub(): OracleProvider {
+  return {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'network',
+    description: 'Test stub',
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    isConnected: () => true,
+    getStatus: () => 'connected' as const,
+    initialize: vi.fn(),
+    submitCommitment: vi.fn(),
+    getProof: vi.fn(),
+    waitForProof: vi.fn(),
+    validateToken: vi.fn(),
+    isSpent: vi.fn().mockResolvedValue(false),
+    getTokenState: vi.fn().mockResolvedValue(null),
+    getCurrentRound: vi.fn().mockResolvedValue(1),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function makeTransportStub(): TransportProvider {
+  return {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p',
+    description: 'Test stub',
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    isConnected: () => true,
+    getStatus: () => 'connected' as const,
+    setIdentity: vi.fn(),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => undefined),
+    sendTokenTransfer: vi.fn().mockResolvedValue('event-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => undefined),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function makeIdentity(): FullIdentity {
+  return {
+    chainPubkey: '02aaaa'.padEnd(66, 'a'),
+    l1Address: 'alpha1mock',
+    directAddress: 'DIRECT://mock-direct',
+    privateKey: '01'.repeat(32),
+  };
+}
+
+function makePeerInfo(): PeerInfo {
+  return {
+    transportPubkey: '02bbbb'.padEnd(64, 'b'),
+    chainPubkey: '02cccc'.padEnd(66, 'c'),
+    l1Address: 'alpha1bob',
+    directAddress: 'DIRECT://bob-direct',
+    timestamp: 0,
+    nametag: 'bob',
+  };
+}
+
+function defaultTokenLikeForTest(token: Token): TokenLike {
+  return {
+    id: token.id,
+    coins: [{ coinId: token.coinId, amount: BigInt(token.amount) }],
+  };
+}
+
+interface DepsConfig {
+  readonly source: Token;
+  readonly onCommitEnter: () => Promise<void>;
+  readonly onCommitThrows?: Error;
+}
+
+function makeDeps(cfg: DepsConfig): {
+  readonly deps: ConservativeSenderDeps;
+  readonly events: Array<{ type: SphereEventType; data: unknown }>;
+} {
+  const events: Array<{ type: SphereEventType; data: unknown }> = [];
+  const emit = <T extends SphereEventType>(
+    type: T,
+    data: SphereEventMap[T],
+  ): void => {
+    events.push({ type, data });
+  };
+  const deps: ConservativeSenderDeps = {
+    aggregator: makeOracleStub(),
+    transport: makeTransportStub(),
+    identity: makeIdentity(),
+    senderTransportPubkey: '02bbbb'.padEnd(64, 'b'),
+    emit,
+    availableSources: () => [cfg.source],
+    selectSources: async () => [cfg.source],
+    preflightOptions: () => ({
+      resolveRequestId: () => {
+        throw new Error('resolveRequestId not expected in H1 lock tests');
+      },
+      extractPendingChain: () => [],
+    } satisfies Omit<PreflightFinalizeOptions, 'aggregator'>),
+    commitSources: async () => {
+      await cfg.onCommitEnter();
+      if (cfg.onCommitThrows) {
+        throw cfg.onCommitThrows;
+      }
+      return [makeCommitResult(cfg.source.id)];
+    },
+    toTokenLike: defaultTokenLikeForTest,
+  };
+  return { deps, events };
+}
+
+function basicRequest(): TransferRequest {
+  return {
+    recipient: '@bob',
+    coinId: 'UCT',
+    amount: '1000000',
+    transferMode: 'conservative',
+  };
+}
+
+/** Resolvable gate used to observe ordering. */
+function makeGate(): { wait: () => Promise<void>; resolve: () => void } {
+  let resolveFn!: () => void;
+  const p = new Promise<void>((r) => { resolveFn = r; });
+  return { wait: () => p, resolve: resolveFn };
+}
+
+/** Yield enough microtasks to let the pipeline progress between awaits. */
+async function tick(ms = 10): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Audit #333 H1 — conservative-sender source lock integration', () => {
+  beforeEach(() => __resetSourceLocksForTesting());
+  afterEach(() => __resetSourceLocksForTesting());
+
+  describe('two conservative sends sharing a source serialize', () => {
+    it('the second send cannot reach commitSources until the first releases', async () => {
+      const shared = makeToken('tok-shared-h1', TOKEN_A);
+      const order: string[] = [];
+
+      const firstGate = makeGate();
+      const secondGate = makeGate();
+
+      const first = makeDeps({
+        source: shared,
+        onCommitEnter: async () => {
+          order.push('first-commit-start');
+          await firstGate.wait();
+        },
+        // Force a clean throw so we don't have to drive the full post-
+        // commit pipeline. The lock release runs in `finally` regardless.
+        onCommitThrows: new Error('first-commit-deliberate-throw'),
+      });
+
+      const second = makeDeps({
+        source: shared,
+        onCommitEnter: async () => {
+          order.push('second-commit-start');
+          await secondGate.wait();
+        },
+        onCommitThrows: new Error('second-commit-deliberate-throw'),
+      });
+
+      const p1 = sendConservativeUxf(basicRequest(), makePeerInfo(), first.deps)
+        .catch((err) => err);
+      const p2 = sendConservativeUxf(basicRequest(), makePeerInfo(), second.deps)
+        .catch((err) => err);
+
+      // Let both sends advance through validateTargets → selectSources →
+      // acquireSourceLocks → preflight. Only the FIRST should have
+      // reached commitSources; the second is parked at the lock.
+      await tick(20);
+      expect(order).toEqual(['first-commit-start']);
+
+      // Release the first send. After cleanup it releases the lock in
+      // its `finally`. The second send then acquires and reaches its
+      // commitSources.
+      firstGate.resolve();
+      await tick(20);
+      expect(order).toEqual(['first-commit-start', 'second-commit-start']);
+
+      // Cleanup.
+      secondGate.resolve();
+      await Promise.allSettled([p1, p2]);
+    });
+  });
+
+  describe('lock is released on success', () => {
+    it('a subsequent send on the same source proceeds without waiting', async () => {
+      const shared = makeToken('tok-success-h1', TOKEN_A);
+
+      // We deliberately throw inside commitSources to short-circuit the
+      // post-commit pipeline (we are not driving the full CAR / outbox
+      // path here — the lock's `finally` release fires regardless).
+      const first = makeDeps({
+        source: shared,
+        onCommitEnter: async () => {},
+        onCommitThrows: new Error('first-cleanup-throw'),
+      });
+
+      await sendConservativeUxf(basicRequest(), makePeerInfo(), first.deps)
+        .catch(() => undefined);
+
+      // The lock SHOULD now be released. Second send proceeds immediately.
+      const second = makeDeps({
+        source: shared,
+        onCommitEnter: async () => {},
+        onCommitThrows: new Error('second-cleanup-throw'),
+      });
+
+      const start = Date.now();
+      await sendConservativeUxf(basicRequest(), makePeerInfo(), second.deps)
+        .catch(() => undefined);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(200);
+    });
+  });
+
+  describe('lock is released on failure (try/finally invariant)', () => {
+    it('after a send throws mid-pipeline, the lock for its sources is freed', async () => {
+      const shared = makeToken('tok-failure-h1', TOKEN_A);
+
+      const failing = makeDeps({
+        source: shared,
+        onCommitEnter: async () => {},
+        onCommitThrows: new Error('deliberate-mid-pipeline-fault'),
+      });
+      const failingResult = await sendConservativeUxf(
+        basicRequest(),
+        makePeerInfo(),
+        failing.deps,
+      ).catch((err) => err);
+      expect((failingResult as Error).message).toMatch(/deliberate-mid-pipeline-fault/);
+
+      // The lock MUST have been released in `finally` despite the throw.
+      const recovery = makeDeps({
+        source: shared,
+        onCommitEnter: async () => {},
+        onCommitThrows: new Error('recovery-throw'),
+      });
+      const start = Date.now();
+      await sendConservativeUxf(
+        basicRequest(),
+        makePeerInfo(),
+        recovery.deps,
+      ).catch(() => undefined);
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(200);
+    });
+  });
+
+  describe('disjoint sources proceed concurrently (locking is not over-broad)', () => {
+    it('two sends with non-overlapping source tokens run in parallel', async () => {
+      const tokenA = makeToken('tok-disjoint-h1-A', TOKEN_A);
+      const tokenB = makeToken('tok-disjoint-h1-B', TOKEN_A);
+      const order: string[] = [];
+
+      const gateA = makeGate();
+      const gateB = makeGate();
+
+      const sendA = makeDeps({
+        source: tokenA,
+        onCommitEnter: async () => {
+          order.push('A-commit-start');
+          await gateA.wait();
+        },
+        onCommitThrows: new Error('A-throw'),
+      });
+      const sendB = makeDeps({
+        source: tokenB,
+        onCommitEnter: async () => {
+          order.push('B-commit-start');
+          await gateB.wait();
+        },
+        onCommitThrows: new Error('B-throw'),
+      });
+
+      const pA = sendConservativeUxf(basicRequest(), makePeerInfo(), sendA.deps)
+        .catch((err) => err);
+      const pB = sendConservativeUxf(basicRequest(), makePeerInfo(), sendB.deps)
+        .catch((err) => err);
+
+      // BOTH should reach commit concurrently — disjoint tokenIds.
+      await tick(20);
+      expect(order.sort()).toEqual(['A-commit-start', 'B-commit-start']);
+
+      gateA.resolve();
+      gateB.resolve();
+      await Promise.allSettled([pA, pB]);
+    });
+  });
+});

--- a/tests/unit/payments/transfer/source-locks-h1-shared.test.ts
+++ b/tests/unit/payments/transfer/source-locks-h1-shared.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for Audit #333 H1: same-process source lock — shared module.
+ *
+ * Background
+ * ----------
+ * Before the H1 fix, the per-source lock registry was module-local to
+ * `instant-sender.ts`. `conservative-sender.ts` had zero locking
+ * primitives — two concurrent conservative sends (or an instant + a
+ * conservative concurrent send) sharing a source token could both
+ * pass selection, both commit on-chain, and only the aggregator
+ * caught the duplicate-spend after a source was already burned.
+ *
+ * The lock registry has been extracted to `./source-locks.ts` and
+ * both senders now share the SAME process-global map. This file
+ * verifies the shared-module contract:
+ *   - Direct unit tests on `acquireSourceLocks` from the shared module
+ *   - The lock map is GENUINELY shared (calls via different sender
+ *     entry points serialize against each other)
+ *   - `__resetSourceLocksForTesting` works through both re-export
+ *     paths (back-compat for existing instant-sender test imports)
+ *
+ * Integration tests proving conservative-sender's pipeline acquires
+ * and releases the lock live in a separate test file
+ * (conservative-sender-h1-source-lock.test.ts).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  acquireSourceLocks,
+  __resetSourceLocksForTesting,
+} from '../../../../modules/payments/transfer/source-locks';
+import {
+  __resetSourceLocksForTesting as __resetFromInstantSender,
+} from '../../../../modules/payments/transfer/instant-sender';
+
+describe('Audit #333 H1 — shared source-lock module', () => {
+  beforeEach(() => __resetSourceLocksForTesting());
+  afterEach(() => __resetSourceLocksForTesting());
+
+  describe('acquireSourceLocks contract', () => {
+    it('two concurrent acquires on the SAME tokenId serialize', async () => {
+      const order: string[] = [];
+
+      const releaseA = await acquireSourceLocks(['tok-shared'], 60_000, 'A');
+      order.push('A-acquired');
+
+      // B starts but cannot acquire — it will await until A releases.
+      const bPromise = (async () => {
+        const release = await acquireSourceLocks(['tok-shared'], 60_000, 'B');
+        order.push('B-acquired');
+        release();
+      })();
+
+      // Give the microtask queue a chance to advance — B should NOT
+      // have acquired yet because A still holds the lock.
+      await new Promise((r) => setTimeout(r, 10));
+      expect(order).toEqual(['A-acquired']);
+
+      // Release A. Now B can acquire.
+      releaseA();
+      await bPromise;
+
+      expect(order).toEqual(['A-acquired', 'B-acquired']);
+    });
+
+    it('disjoint tokenIds proceed concurrently', async () => {
+      const start = Date.now();
+      const [releaseA, releaseB] = await Promise.all([
+        acquireSourceLocks(['tok-disjoint-1'], 60_000, 'A'),
+        acquireSourceLocks(['tok-disjoint-2'], 60_000, 'B'),
+      ]);
+      const elapsed = Date.now() - start;
+
+      // Both completed concurrently — no waiting.
+      expect(elapsed).toBeLessThan(100);
+      releaseA();
+      releaseB();
+    });
+
+    it('lex-sorted acquisition prevents deadlock on overlapping sets', async () => {
+      // Send A locks [X, Y]; Send B locks [Y, X]. Without lex-sort,
+      // each holds one and waits for the other. The sort ensures both
+      // try X first, then Y.
+      const releaseA = await acquireSourceLocks(['tok-Y', 'tok-X'], 60_000, 'A');
+      // B starts and blocks on X (A holds it).
+      let bDone = false;
+      const bPromise = (async () => {
+        const release = await acquireSourceLocks(['tok-X', 'tok-Y'], 60_000, 'B');
+        bDone = true;
+        release();
+      })();
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(bDone).toBe(false);
+
+      releaseA();
+      await bPromise;
+      expect(bDone).toBe(true);
+    });
+
+    it('deduplicates tokenIds within a single acquire call', async () => {
+      // Acquiring the same id twice in one call should not deadlock
+      // itself (the Set dedup eliminates the duplicate).
+      const release = await acquireSourceLocks(
+        ['tok-dup', 'tok-dup', 'tok-dup'],
+        60_000,
+        'A',
+      );
+      release();
+    });
+  });
+
+  describe('cross-sender lock sharing (the H1 invariant)', () => {
+    it('lock acquired via "instant" path is honored by an "conservative" caller and vice versa', async () => {
+      // Audit #333 H1 specifically calls out the instant-vs-conservative
+      // cross-pair race. The shared module guarantees both senders
+      // serialize on the SAME map regardless of caller label.
+      const order: string[] = [];
+
+      const releaseInstant = await acquireSourceLocks(
+        ['tok-cross'],
+        60_000,
+        'sendInstantUxf',
+      );
+      order.push('instant-acquired');
+
+      const conservativePromise = (async () => {
+        const release = await acquireSourceLocks(
+          ['tok-cross'],
+          60_000,
+          'sendConservativeUxf',
+        );
+        order.push('conservative-acquired');
+        release();
+      })();
+
+      await new Promise((r) => setTimeout(r, 10));
+      // Conservative MUST be blocked by the instant lock.
+      expect(order).toEqual(['instant-acquired']);
+
+      releaseInstant();
+      await conservativePromise;
+      expect(order).toEqual(['instant-acquired', 'conservative-acquired']);
+    });
+  });
+
+  describe('__resetSourceLocksForTesting back-compat re-export', () => {
+    it('the symbol exported from instant-sender is the SAME function as the shared module', () => {
+      // Tests existing before this refactor import the reset hook from
+      // instant-sender. Keep that path working with a re-export.
+      expect(__resetFromInstantSender).toBe(__resetSourceLocksForTesting);
+    });
+
+    it('clears in-flight locks regardless of which entry-point path called acquireSourceLocks', async () => {
+      // Acquire a never-released lock via the shared module.
+      await acquireSourceLocks(['tok-reset-test'], 60_000, 'A');
+      // Re-export reset clears it.
+      __resetFromInstantSender();
+      // A second acquire on the same id proceeds immediately.
+      const start = Date.now();
+      const release = await acquireSourceLocks(['tok-reset-test'], 60_000, 'B');
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(100);
+      release();
+    });
+
+    it('refuses to clear locks outside test environments (fail-closed guard preserved)', () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      const originalAllowReset = process.env.SPHERE_ALLOW_TEST_RESET;
+      try {
+        process.env.NODE_ENV = 'production';
+        process.env.SPHERE_ALLOW_TEST_RESET = undefined as unknown as string;
+        delete process.env.SPHERE_ALLOW_TEST_RESET;
+        expect(() => __resetSourceLocksForTesting()).toThrow(
+          /only available in test environments/,
+        );
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+        if (originalAllowReset !== undefined) {
+          process.env.SPHERE_ALLOW_TEST_RESET = originalAllowReset;
+        }
+      }
+    });
+  });
+
+  describe('force-release liveness floor', () => {
+    it('a lock held longer than maxHoldMs is force-released so future acquirers can proceed', async () => {
+      // Acquire with a tiny max-hold to exercise the timer.
+      await acquireSourceLocks(['tok-liveness'], 30, 'A');
+      // Wait longer than the timeout so the force-release fires.
+      await new Promise((r) => setTimeout(r, 80));
+
+      // B should acquire immediately — the force-release evicted A's lock.
+      const start = Date.now();
+      const release = await acquireSourceLocks(['tok-liveness'], 60_000, 'B');
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(50);
+      release();
+    });
+  });
+});


### PR DESCRIPTION
> **Stacked PR.** Built atop #348 (C3) which is stacked on #347 (C2) on #346 (C1). The release-gate tier (C1+C2+C3) lands first; this PR begins the High tier.

## Summary

Closes the **H1 high** finding of audit #333 — `conservative-sender.ts` had **zero locking primitives**. `instant-sender.ts` declared a process-global `sourceLocks` map (Wave 5 #171), but conservative sends and instant-vs-conservative cross-pairs did NOT serialize on shared source tokens: two concurrent sends could both pass selection, both commit on-chain, and only the aggregator caught the duplicate-spend after a source was burned.

## Audit caveat confirmed before fixing

The audit flagged: *"whether `PaymentsModule`'s `PerTokenMutex`/spend-queue (`PaymentsModule.ts:2505`) serializes the conservative path at a higher layer. If it does, severity drops."*

I traced this: the `PerTokenMutex` at line 2505 lives inside the **ingest pool** (receive side, not send side). The `reservationLedger` + `spendQueue` (line 1737) DO serialize the **legacy TXF send path** (lines 5769, 6368), but the UXF conservative path (`dispatchUxfConservativeSend` → `sendConservativeUxf`, line 5613) bypasses both and entered the sender body with no per-source lock. The audit's claim is therefore live on the active code path, not subsumed by a higher-layer guard.

## Fix

Three coordinated changes:

1. **Extracted the per-source lock registry** from `instant-sender.ts` to a new `modules/payments/transfer/source-locks.ts`. The Wave 4-7 semantics are preserved verbatim — lex-sorted acquisition for deadlock prevention, 60 s liveness floor with force-release, `Set` dedup, fail-closed `__resetSourceLocksForTesting` guard. Adds a `callerLabel` parameter so the force-release warning identifies which sender wedged the lock.
2. **`instant-sender.ts` re-exports `__resetSourceLocksForTesting`** so the existing 36 instant-sender tests' import path keeps working without a single change.
3. **`conservative-sender.ts` now acquires per-source locks** after source selection completes (Step 2.5, mirroring the instant pattern) and releases them in the outer `finally`. Adds a TEST-ONLY `__sourceLockMaxHoldMs` override on `ConservativeSenderDeps`, symmetric with `InstantSenderDeps`.

### Cross-pair invariant

Because both senders now share the SAME process-global map, an in-flight instant send blocks a concurrent conservative send sharing a source token, **and vice versa**. The audit's specific case is closed.

## Test plan

- [x] **9 new direct-module tests** on `tests/unit/payments/transfer/source-locks-h1-shared.test.ts`:
  - Two concurrent acquires on the SAME tokenId serialize
  - Disjoint tokenIds proceed concurrently
  - Lex-sorted acquisition prevents deadlock on overlapping sets
  - Dedup within a single acquire call
  - Cross-sender lock sharing (the H1 cross-pair invariant)
  - `__resetSourceLocksForTesting` from `instant-sender` is `===` the symbol from `source-locks` (re-export identity)
  - Reset hook clears in-flight locks regardless of acquisition origin
  - Fail-closed guard preserved (production environment refuses reset)
  - Force-release liveness floor
- [x] **4 new integration tests** on `tests/unit/payments/transfer/conservative-sender-h1-source-lock.test.ts`:
  - Two conservative sends sharing a source — second cannot reach `commitSources` until first releases
  - Lock released on success (subsequent send proceeds without waiting)
  - Lock released on failure (try/finally invariant — subsequent send proceeds even after the first throws)
  - Disjoint sources proceed concurrently (locking is not over-broad)
- [x] All 36 existing `instant-sender.test.ts` tests pass unchanged
- [x] All 1567 unit tests in `tests/unit/payments/` pass
- [x] All 445 unit test files (8147 tests) pass (2 pre-existing skipped)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files

## Audit traceability

- Issue: #333 (H1)
- Files / lines in audit: `modules/payments/transfer/conservative-sender.ts` (no locks), `modules/payments/transfer/instant-sender.ts:463` (`sourceLocks` was module-local)
- Audit recommendation followed: extract the lock map so the asymmetry between the two senders is closed; preserve the Wave 5 #171 semantics verbatim.

## Next in the stack

H2 (manifest `tokenId` ↔ genesis binding) follows, branched off this PR.