### PR TITLE
Handle lowercase transport address schemes

### DIFF
--- a/core/transport-resolver.ts
+++ b/core/transport-resolver.ts
@@ -114,7 +114,8 @@ export function createTransportAddressResolver(
     }
 
     // DIRECT:// or PROXY:// — resolve via transport address lookup
-    if (address.startsWith('DIRECT://') || address.startsWith('PROXY://')) {
+    const upperAddress = address.toUpperCase();
+    if (upperAddress.startsWith('DIRECT://') || upperAddress.startsWith('PROXY://')) {
       // Primary: transport.resolve() handles all address formats
       if (transport.resolve) {
         const peerInfo = await transport.resolve(address);
@@ -130,7 +131,7 @@ export function createTransportAddressResolver(
         }
       }
       // Last resort: strip prefix and try as raw pubkey
-      const prefix = address.startsWith('DIRECT://') ? 'DIRECT://' : 'PROXY://';
+      const prefix = upperAddress.startsWith('DIRECT://') ? 'DIRECT://' : 'PROXY://';
       const raw = address.slice(prefix.length);
       if (raw.length === 0) {
         throw new SphereError(`Invalid ${prefix} address: empty value`, 'INVALID_RECIPIENT');

--- a/tests/unit/transport/transport-resolver.test.ts
+++ b/tests/unit/transport/transport-resolver.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTransportAddressResolver } from '../../../core/transport-resolver';
+
+describe('createTransportAddressResolver', () => {
+  it('resolves DIRECT addresses with lowercase scheme fallback', async () => {
+    const resolver = createTransportAddressResolver({
+      resolve: vi.fn().mockResolvedValue(null),
+      resolveAddressInfo: vi.fn().mockResolvedValue(null),
+    });
+
+    await expect(resolver.resolve('direct://' + '02' + 'a'.repeat(64))).resolves.toEqual({
+      pubkey: 'a'.repeat(64),
+    });
+  });
+});


### PR DESCRIPTION
Fixes transport address scheme handling for `DIRECT://` / `PROXY://` inputs.

The address normalizer already lowercases direct/proxy addresses in `core/address.ts`, but `createTransportAddressResolver()` only recognized uppercase schemes. A normalized `direct://...` address could therefore skip the direct/proxy fallback path and fail resolution.

This makes the scheme check case-insensitive while preserving the original address passed to transport lookups, and adds a regression test for lowercase `direct://`.

Tested:

```bash
npx vitest run tests/unit/transport/transport-resolver.test.ts
```