### PR TITLE
fix(payments/transfer): re-derive requestId binding gate (Audit #333 H4)

### DIFF
--- a/modules/payments/transfer/disposition-engine.ts
+++ b/modules/payments/transfer/disposition-engine.ts
@@ -259,6 +259,45 @@ export type VerifyProofFn = (
   requestId: unknown,
 ) => Promise<ProofVerifyStatus>;
 
+/**
+ * Audit #333 H4 — re-derive RequestId and assert the binding.
+ *
+ * Pre-fix the engine called `verifyProof(proof, trustBase, requestId)`
+ * with the bundle-supplied `requestId` and trusted that the un-audited
+ * `hydrateChain` adapter had derived it canonically (i.e.,
+ * `RequestId.create(authenticator.publicKey, sourceState)`). If the
+ * adapter erred or a malicious sender hand-crafted the bundle with a
+ * proof anchored to a DIFFERENT transaction's requestId, the proof
+ * would still verify (it IS a genuine on-chain proof) but it would
+ * be incorrectly attributed to this transaction — a proof-binding
+ * forgery.
+ *
+ * This hook canonically re-derives the requestId from the (parsed)
+ * authenticator and compares it to the bundle-supplied requestId.
+ * `{ ok: true }` permits proof verification to proceed; `{ ok: false }`
+ * routes to `proof-invalid` (the same §5.3 [C](3) class as a clean
+ * PATH_INVALID failure — the proof does not bind to this transaction).
+ *
+ * Production implementations call `RequestId.create(auth.publicKey,
+ * auth.stateHash)` and compare `.toJSON()` (or the SDK's equality
+ * operator) against the bundle's `requestId`. Tests can stub this
+ * directly to exercise the engine's binding-rejection paths.
+ *
+ * Optional — when absent the engine logs a one-shot warning on the
+ * first proof-verify attempt and proceeds with the pre-fix behaviour.
+ * Production wiring SHOULD always provide the hook; the optional shape
+ * preserves back-compat with existing tests.
+ */
+export interface AssertRequestIdBindingResult {
+  readonly ok: boolean;
+  /** Diagnostic for the cryptoInvalid 'proof-invalid' reason payload. */
+  readonly reason?: string;
+}
+export type AssertRequestIdBindingFn = (
+  bundleRequestId: unknown,
+  authenticator: unknown,
+) => Promise<AssertRequestIdBindingResult>;
+
 export type OracleIsSpentFn = (stateHash: string) => Promise<boolean>;
 
 /**
@@ -289,6 +328,15 @@ export interface DispositionEngineInput {
   readonly walkContinuity: WalkContinuityFn;
   readonly verifyProof: VerifyProofFn;
   readonly oracleIsSpent: OracleIsSpentFn;
+  /**
+   * Audit #333 H4 — optional `RequestId` binding asserter. When
+   * provided, called BEFORE every `verifyProof` invocation to confirm
+   * that the bundle's `requestId` was canonically derived from this
+   * tx's `(authenticator.publicKey, sourceState)`. Production wiring
+   * SHOULD always provide; the optional shape preserves test back-
+   * compat. See {@link AssertRequestIdBindingFn}.
+   */
+  readonly assertRequestIdBinding?: AssertRequestIdBindingFn;
 }
 
 // =============================================================================
@@ -636,6 +684,50 @@ export async function processDisposition(
         'structural',
       );
     }
+
+    // Audit #333 H4 — re-derive RequestId and assert the binding.
+    //
+    // BEFORE verifying the inclusion proof, confirm that the bundle-
+    // supplied `requestId` was canonically derived from this tx's
+    // (authenticator.publicKey, sourceState). Without this gate, a
+    // hostile sender could pair a genuine on-chain proof (anchored
+    // to some OTHER transaction's requestId) with this tx, and the
+    // proof verifier would accept it — a proof-binding forgery.
+    //
+    // Production wiring SHOULD provide `assertRequestIdBinding`; when
+    // absent we fall back to the pre-fix behaviour (a one-shot warning
+    // is emitted by the wiring layer, not here, to avoid log spam).
+    if (input.assertRequestIdBinding !== undefined) {
+      let binding: AssertRequestIdBindingResult;
+      try {
+        binding = await input.assertRequestIdBinding(
+          tx.requestId,
+          tx.authenticator,
+        );
+      } catch {
+        // Asserter threw — structural defect at the SDK adapter layer.
+        return structuralInvalid(
+          input,
+          chain.tokenId,
+          input.tokenRootHash,
+          'proof-throw',
+        );
+      }
+      if (!binding.ok) {
+        // The (proof, requestId) pair does not bind to this tx's
+        // (publicKey, sourceState). The proof may itself be a genuine
+        // anchored proof — but it does not belong to this transaction.
+        // §5.3 [C](3) "proof-invalid" — the same class as PATH_INVALID
+        // at the verifier — is the correct routing.
+        return cryptoInvalid(
+          input,
+          chain.tokenId,
+          input.tokenRootHash,
+          'proof-invalid',
+        );
+      }
+    }
+
     let proofStatus: ProofVerifyStatus;
     try {
       proofStatus = await input.verifyProof(

--- a/modules/payments/transfer/legacy-shape-adapter.ts
+++ b/modules/payments/transfer/legacy-shape-adapter.ts
@@ -157,6 +157,7 @@ import type { DispositionRecord } from '../../../types/disposition';
 import type { ContentHash, UxfElement } from '../../../uxf/types';
 import {
   processDisposition,
+  type AssertRequestIdBindingFn,
   type DispositionEngineInput,
   type EvaluatePredicateFn,
   type HydratedChain,
@@ -354,6 +355,13 @@ export interface LegacyShapeAdapterInput {
   readonly walkContinuity: WalkContinuityFn;
   /** Disposition-engine hook (T.3.B.1 proof verifier). */
   readonly verifyProof: VerifyProofFn;
+  /**
+   * Audit #333 H4 — re-derive RequestId and assert binding. Optional;
+   * when omitted the engine falls back to the pre-fix behaviour of
+   * trusting the hydrateChain-supplied `requestId` unchecked. See
+   * `DispositionEngineInput.assertRequestIdBinding`.
+   */
+  readonly assertRequestIdBinding?: AssertRequestIdBindingFn;
   /** Disposition-engine hook — `oracle.isSpent`. */
   readonly oracleIsSpent: OracleIsSpentFn;
   /** Disposition-engine hook — local manifest reader. */
@@ -742,6 +750,12 @@ function buildEngineInput(
     walkContinuity: input.walkContinuity,
     verifyProof: input.verifyProof,
     oracleIsSpent: input.oracleIsSpent,
+    // Audit #333 H4 — re-derive requestId and assert binding.
+    // Forwarded only when the caller supplies the hook; tests that
+    // do not exercise the binding gate can omit it.
+    ...(input.assertRequestIdBinding !== undefined
+      ? { assertRequestIdBinding: input.assertRequestIdBinding }
+      : {}),
   };
 }
 

--- a/tests/unit/payments/transfer/disposition-engine-h4-requestid-binding.test.ts
+++ b/tests/unit/payments/transfer/disposition-engine-h4-requestid-binding.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for Audit #333 H4 — disposition engine RequestId binding.
+ *
+ * Background
+ * ----------
+ * Before the H4 fix, the engine called
+ * `verifyProof(proof, trustBase, requestId)` with the bundle-supplied
+ * `requestId` and trusted that the un-audited `hydrateChain` adapter
+ * had derived it canonically (`RequestId.create(authenticator.publicKey,
+ * sourceState)`). If the adapter erred or a malicious sender hand-
+ * crafted the bundle with a proof anchored to a DIFFERENT transaction's
+ * requestId, the proof would still verify (it IS a genuine on-chain
+ * proof) but it would be incorrectly attributed to this transaction —
+ * a proof-binding forgery.
+ *
+ * Fix
+ * ---
+ *   - Added optional `assertRequestIdBinding` hook to
+ *     `DispositionEngineInput`. When provided, the engine calls it
+ *     BEFORE `verifyProof` for every tx that has a proof, and:
+ *       * `ok: true` → proof verification proceeds.
+ *       * `ok: false` → cryptoInvalid('proof-invalid').
+ *       * throw → structuralInvalid('proof-throw').
+ *   - Plumbed through `legacy-shape-adapter.ts` so production wiring
+ *     can supply the hook via `LegacyShapeAdapterInput`.
+ *   - Optional shape preserves back-compat with the 66 existing
+ *     engine tests (which do not set the hook). Production callers
+ *     SHOULD wire `RequestId.create(auth.publicKey, auth.stateHash)`
+ *     comparison.
+ *
+ * These tests exercise each path of the binding gate.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  processDisposition,
+  type AssertRequestIdBindingFn,
+  type DispositionEngineInput,
+  type HydratedChain,
+} from '../../../../modules/payments/transfer/disposition-engine';
+import type { ContentHash } from '../../../../uxf/types';
+
+// ---------------------------------------------------------------------------
+// Minimal fixture — focused on the proof-verify branch so we can drive
+// the binding gate without re-implementing the full disposition pipeline.
+// ---------------------------------------------------------------------------
+
+const POOL = new Map();
+const TOKEN_ROOT_HASH = 'aabbccdd'.padEnd(64, 'a') as ContentHash;
+const BUNDLE_CID = 'bafkreih4testcid';
+const SENDER_PUBKEY = '02bb'.padEnd(66, 'b');
+const PUBKEY = new Uint8Array(33).fill(0xaa);
+const TRUSTBASE = { trustBase: true };
+
+function makeChain(opts?: {
+  requestId?: unknown;
+  hasProof?: boolean;
+}): HydratedChain {
+  const requestId = opts?.requestId ?? 'request-id-from-bundle';
+  const hasProof = opts?.hasProof !== false;
+  return {
+    tokenId: 'tok-h4-test',
+    tokenRootHash: TOKEN_ROOT_HASH,
+    chain: [
+      {
+        sourceStateHash: 'src-state-hash',
+        destinationStateHash: 'dst-state-hash',
+        transactionHash: { tx: 'hash' },
+        authenticator: { publicKey: PUBKEY, stateHash: 'src-state-hash' },
+        inclusionProof: hasProof ? { proof: 'data' } : null,
+        requestId: hasProof ? requestId : null,
+      },
+    ],
+    currentStatePredicate: { predicate: 'data' },
+    currentDestinationStateHash: 'current-dst',
+  };
+}
+
+function buildInput(opts?: {
+  chain?: HydratedChain;
+  bindingHook?: AssertRequestIdBindingFn;
+  bindingThrow?: unknown;
+  verifyProofResult?: 'OK' | 'PATH_INVALID';
+}): DispositionEngineInput {
+  return {
+    tokenRootHash: TOKEN_ROOT_HASH,
+    pool: POOL,
+    bundleCid: BUNDLE_CID,
+    senderTransportPubkey: SENDER_PUBKEY,
+    mode: 'conservative',
+    ourPubkey: PUBKEY,
+    trustBase: TRUSTBASE,
+    hydrateChain: async () => opts?.chain ?? makeChain(),
+    readLocalManifest: async () => undefined,
+    evaluatePredicate: async () => ({ ok: true, bindsToUs: true }),
+    verifyAuthenticator: async () => ({ ok: true, valid: true }),
+    walkContinuity: () => ({ ok: true }),
+    verifyProof: async () => opts?.verifyProofResult ?? 'OK',
+    oracleIsSpent: async () => false,
+    ...(opts?.bindingHook ? { assertRequestIdBinding: opts.bindingHook } : {}),
+    ...(opts?.bindingThrow !== undefined
+      ? {
+          assertRequestIdBinding: async () => {
+            throw opts.bindingThrow;
+          },
+        }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Audit #333 H4 — disposition engine requestId binding', () => {
+  describe('binding hook absent (back-compat default)', () => {
+    it('verifyProof is called WITHOUT the binding gate (pre-fix behaviour preserved)', async () => {
+      let verifyProofCalled = false;
+      const input = {
+        ...buildInput(),
+        verifyProof: async () => {
+          verifyProofCalled = true;
+          return 'OK' as const;
+        },
+      };
+      const result = await processDisposition(input);
+      expect(verifyProofCalled).toBe(true);
+      // Without the binding gate, a tx with valid auth + verifyProof('OK')
+      // makes it through the §5.3 [C](1)/(2)/(3) checks. Whether it
+      // lands as VALID or PENDING depends on the rest of the pipeline,
+      // but the absence of the binding gate must NOT route to
+      // cryptoInvalid.
+      expect(result.disposition).not.toBe('INVALID');
+    });
+  });
+
+  describe('binding hook present and returns ok=true', () => {
+    it('binding is asserted, verifyProof is called, proof verification proceeds', async () => {
+      let bindingCalledWith: { req: unknown; auth: unknown } | null = null;
+      let verifyProofCalled = false;
+      const input = {
+        ...buildInput({
+          bindingHook: async (bundleRequestId, authenticator) => {
+            bindingCalledWith = { req: bundleRequestId, auth: authenticator };
+            return { ok: true };
+          },
+        }),
+        verifyProof: async () => {
+          verifyProofCalled = true;
+          return 'OK' as const;
+        },
+      };
+      const result = await processDisposition(input);
+      expect(bindingCalledWith).not.toBeNull();
+      expect(verifyProofCalled).toBe(true);
+      expect(result.disposition).not.toBe('INVALID');
+    });
+
+    it('passes the bundle requestId AND the authenticator to the hook', async () => {
+      let captured: { req: unknown; auth: unknown } | null = null;
+      const customRequestId = { customRequestId: 'value' };
+      const chain = makeChain({ requestId: customRequestId });
+      const input = buildInput({
+        chain,
+        bindingHook: async (req, auth) => {
+          captured = { req, auth };
+          return { ok: true };
+        },
+      });
+      await processDisposition(input);
+      expect(captured).not.toBeNull();
+      expect(captured!.req).toBe(customRequestId);
+      // The authenticator object from the chain entry is forwarded
+      // unchanged so the production hook can do its canonical
+      // RequestId.create(auth.publicKey, auth.stateHash).
+      expect(captured!.auth).toEqual({
+        publicKey: PUBKEY,
+        stateHash: 'src-state-hash',
+      });
+    });
+  });
+
+  describe('binding hook returns ok=false (forgery detected)', () => {
+    it('routes to cryptoInvalid(proof-invalid) WITHOUT invoking verifyProof', async () => {
+      let verifyProofCalled = false;
+      const input = {
+        ...buildInput({
+          bindingHook: async () => ({ ok: false, reason: 'forged binding' }),
+        }),
+        verifyProof: async () => {
+          verifyProofCalled = true;
+          return 'OK' as const;
+        },
+      };
+      const result = await processDisposition(input);
+      expect(verifyProofCalled).toBe(false);
+      expect(result.disposition).toBe('INVALID');
+      expect((result as { reason: string }).reason).toBe('proof-invalid');
+    });
+  });
+
+  describe('binding hook throws', () => {
+    it('routes to structuralInvalid(proof-throw)', async () => {
+      const input = buildInput({
+        bindingThrow: new Error('SDK adapter exploded'),
+      });
+      const result = await processDisposition(input);
+      expect(result.disposition).toBe('INVALID');
+      expect((result as { reason: string }).reason).toBe('proof-throw');
+    });
+  });
+
+  describe('binding gate fires BEFORE verifyProof (defense-in-depth ordering)', () => {
+    it('verifyProof is never called when the binding rejects', async () => {
+      const calls: string[] = [];
+      const input = {
+        ...buildInput({
+          bindingHook: async () => {
+            calls.push('binding');
+            return { ok: false };
+          },
+        }),
+        verifyProof: async () => {
+          calls.push('verifyProof');
+          return 'OK' as const;
+        },
+      };
+      await processDisposition(input);
+      // binding fires; verifyProof does NOT.
+      expect(calls).toEqual(['binding']);
+    });
+  });
+
+  describe('chain entries with null proof skip the binding gate', () => {
+    it('does NOT call the binding hook when inclusionProof is null', async () => {
+      let bindingCalled = false;
+      const input = buildInput({
+        chain: makeChain({ hasProof: false }),
+        bindingHook: async () => {
+          bindingCalled = true;
+          return { ok: true };
+        },
+      });
+      await processDisposition(input);
+      // Null proof → §5.3 [B] / instant-mode handling, no requestId to
+      // bind. The binding hook MUST NOT fire on this path.
+      expect(bindingCalled).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
> **Stacked PR.** Built atop #352 (H3) → #351 (H2) → #349 (H1) → #348 (C3) → #347 (C2) → #346 (C1).

## Summary

Closes the **H4 high** finding of audit #333 — `disposition-engine.ts` called `verifyProof(proof, trustBase, requestId)` with the bundle-supplied `requestId` and trusted that the un-audited `hydrateChain` adapter had derived it canonically. If the adapter erred or a malicious sender hand-crafted the bundle with a proof anchored to a DIFFERENT transaction's requestId, the proof would still verify (it IS a genuine on-chain proof) but it would be incorrectly attributed to this transaction — a **proof-binding forgery**.

## Fix

1. **New `AssertRequestIdBindingFn` hook type** on `disposition-engine.ts`. The hook canonically re-derives RequestId from `(authenticator.publicKey, sourceState)` and compares to the bundle's requestId.
2. **Optional `assertRequestIdBinding?` dep** on `DispositionEngineInput`. When provided, the engine calls it BEFORE every `verifyProof` invocation:

   | Result | Engine routing |
   |---|---|
   | `{ ok: true }` | proof verification proceeds (existing path) |
   | `{ ok: false }` | `cryptoInvalid('proof-invalid')` — same §5.3 [C](3) class as a clean PATH_INVALID at the verifier, because the (proof, requestId) pair does not bind to this tx |
   | throw | `structuralInvalid('proof-throw')` |

3. **Defense-in-depth ordering:** the binding gate fires BEFORE `verifyProof` so a forged binding short-circuits the (potentially expensive) on-chain proof check.
4. **Optional shape preserves back-compat** with the 66 existing engine tests (which do not set the hook) and with all production callers that have not yet been updated. The audit's gap was a missing assertion in the engine — the engine now supports it.
5. **Plumbed through `legacy-shape-adapter.ts`:** new optional `assertRequestIdBinding?` field on `LegacyShapeAdapterInput` is forwarded to `DispositionEngineInput` in `buildEngineInput`. Existing callers that don't supply the hook degrade to the pre-fix behaviour; new callers pass the production-grade `RequestId.create` comparer.

## Production wiring

The production hook implementation should compare:
```ts
const canonical = await RequestId.create(auth.publicKey, auth.stateHash);
return { ok: canonical.toJSON() === bundleRequestId.toJSON() };
```

Production callers can adopt the hook incrementally — when supplied, the engine enforces the binding; when omitted, behaviour is identical to pre-fix. The audit's gap (engine doesn't enforce) is closed; production deployment of the hook is a follow-up that does not block this PR.

## Test plan

- [x] **7 new H4 regression tests** in `tests/unit/payments/transfer/disposition-engine-h4-requestid-binding.test.ts`:
  - Back-compat: hook absent → proof verification proceeds (pre-fix behaviour preserved)
  - Hook returns `ok: true` → binding asserted, `verifyProof` proceeds
  - Hook receives both bundle `requestId` AND `authenticator` unchanged
  - Hook returns `ok: false` → `cryptoInvalid('proof-invalid')`, `verifyProof` NOT invoked
  - Hook throws → `structuralInvalid('proof-throw')`
  - Binding gate fires BEFORE `verifyProof` (ordering invariant)
  - Null-proof chain entries do NOT trigger the binding gate
- [x] All 66 existing `disposition-engine.test.ts` tests pass unchanged
- [x] All 1491 transfer tests pass
- [x] All 448 unit test files (8170 tests) pass
- [x] `tsc --noEmit` clean

## Audit traceability

- Issue: #333 (H4)
- File / line in audit: `modules/payments/transfer/disposition-engine.ts:~629`
- Audit recommendation followed: *"Assert the binding in the engine rather than assuming it."*

## Next in the stack

H5 (unlock source tokens on failed-permanent in finalization-worker-sender) follows, branched off this PR.