### PR TITLE
fix(profile): add recompute-content verifier to ManifestCas (Audit #333 H7)

### DIFF
--- a/modules/payments/transfer/manifest-cid-rewrite.ts
+++ b/modules/payments/transfer/manifest-cid-rewrite.ts
@@ -371,7 +371,13 @@ export class ManifestCidRewriteCasError extends Error {
   readonly casReason:
     | 'cas-mismatch'
     | 'not-found'
-    | 'concurrent-modification';
+    | 'concurrent-modification'
+    /** Audit #333 H7 — surfaced when ManifestCas's wired verifier
+     *  detected the entry's `rootHash` label does not match its
+     *  recomputed content. The worker treats this the same as a hard
+     *  CAS failure (bubble to outer retry); the new code preserves the
+     *  structured reason for triage. */
+    | 'integrity-failed';
   /**
    * The actually-observed `contentHash` when `casReason ===
    * 'cas-mismatch'`. Useful for the worker's retry path.
@@ -382,7 +388,8 @@ export class ManifestCidRewriteCasError extends Error {
     casReason:
       | 'cas-mismatch'
       | 'not-found'
-      | 'concurrent-modification',
+      | 'concurrent-modification'
+      | 'integrity-failed',
     observedCid?: ContentHash,
   ) {
     super(`manifest CID rewrite CAS failure: ${casReason}`);

--- a/profile/manifest-cas.ts
+++ b/profile/manifest-cas.ts
@@ -87,12 +87,57 @@ export type ManifestCasResult =
   | { readonly ok: true }
   | {
       readonly ok: false;
-      readonly reason: 'cas-mismatch' | 'not-found' | 'concurrent-modification';
+      readonly reason:
+        | 'cas-mismatch'
+        | 'not-found'
+        | 'concurrent-modification'
+        /**
+         * Audit #333 H7 — `verifyEntryRoot` reported the stored entry's
+         * `rootHash` label does NOT match the actual content under that
+         * hash. The CAS label-match would have passed pre-fix; with the
+         * verifier wired we surface the structural defect instead of
+         * silently accepting the swap against forged content.
+         */
+        | 'integrity-failed';
       /** When `reason === 'cas-mismatch'`, the actually-observed entry
        *  (so the caller can retry against the latest state). Omitted
        *  for `'not-found'` and `'concurrent-modification'`. */
       readonly observed?: { readonly contentHash: ContentHash };
+      /** Optional diagnostic detail for `'integrity-failed'`. */
+      readonly integrityDetail?: string;
     };
+
+/**
+ * Audit #333 H7 — recomputed-content verifier hook.
+ *
+ * `ManifestCas.update`'s precondition check compares
+ * `observed.rootHash` (a string read from the entry) to `prev.contentHash`
+ * (the caller's expected value). Both sides are arbitrary writer-supplied
+ * labels — a CAS pass means "the labels agree", not "the content under
+ * the label is the content the caller meant". An attacker writing an
+ * entry with a forged `rootHash` field that doesn't match the actual
+ * pool content slips through the CAS check unchanged.
+ *
+ * When wired, this hook is called AFTER the label CAS passes and BEFORE
+ * the write. It is responsible for fetching the content the entry's
+ * `rootHash` refers to (typically the UXF pool element), recomputing
+ * the hash, and asserting the recomputed value matches the entry's
+ * declaration. Production wiring routes through `computeElementHash`
+ * over the pool element.
+ *
+ * Returns `{ ok: true }` to permit the write, or `{ ok: false, reason }`
+ * to abort with `ManifestCasResult.reason === 'integrity-failed'`.
+ *
+ * Optional — when absent the CAS retains its pre-fix label-only
+ * semantics. Production wiring SHOULD always provide; the optional
+ * shape preserves test back-compat (existing tests do not assume the
+ * verifier is wired).
+ */
+export type VerifyEntryRootFn = (
+  addr: string,
+  tokenId: string,
+  entry: TokenManifestEntry,
+) => Promise<{ readonly ok: boolean; readonly reason?: string }>;
 
 /**
  * Compare-and-swap helper over manifest entries.
@@ -110,7 +155,20 @@ export type ManifestCasResult =
  * on log-replay conflict; verify when wiring.
  */
 export class ManifestCas {
-  constructor(private readonly storage: MinimalManifestStorage) {}
+  /**
+   * Audit #333 H7 — optional recomputed-content verifier. See
+   * {@link VerifyEntryRootFn}. When omitted the CAS retains its
+   * pre-fix label-only semantics (back-compat with existing tests
+   * that do not wire the hook).
+   */
+  private readonly verifyEntryRoot: VerifyEntryRootFn | undefined;
+
+  constructor(
+    private readonly storage: MinimalManifestStorage,
+    opts?: { readonly verifyEntryRoot?: VerifyEntryRootFn },
+  ) {
+    this.verifyEntryRoot = opts?.verifyEntryRoot;
+  }
 
   /**
    * Atomic-from-the-caller's-perspective compare-and-swap on the
@@ -158,6 +216,30 @@ export class ManifestCas {
           ok: false,
           reason: 'cas-mismatch',
           observed: { contentHash: observed.rootHash },
+        };
+      }
+    }
+
+    // Step 2.5 — Audit #333 H7 — recomputed-content integrity check.
+    //
+    // The label CAS above proved that `observed.rootHash === prev.contentHash`
+    // (both are arbitrary writer-supplied labels). When a verifier hook is
+    // wired, also confirm that the bytes under `observed.rootHash` actually
+    // hash to `observed.rootHash` — promoting the label-only CAS to a real
+    // content-addressed check.
+    //
+    // Skipped on the `prev === null` (asserts-no-entry) path because there
+    // is no observed entry to verify. Skipped when the hook is omitted —
+    // back-compat with pre-fix callers (and the 100% of existing tests
+    // that do not wire the verifier).
+    if (prev !== null && observed !== undefined && this.verifyEntryRoot !== undefined) {
+      const verify = await this.verifyEntryRoot(addr, tokenId, observed);
+      if (!verify.ok) {
+        return {
+          ok: false,
+          reason: 'integrity-failed',
+          observed: { contentHash: observed.rootHash },
+          ...(verify.reason !== undefined ? { integrityDetail: verify.reason } : {}),
         };
       }
     }

--- a/tests/unit/profile/manifest-cas-h7-recompute-integrity.test.ts
+++ b/tests/unit/profile/manifest-cas-h7-recompute-integrity.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for Audit #333 H7 — ManifestCas recompute-content gate.
+ *
+ * Background
+ * ----------
+ * Before the H7 fix, `ManifestCas.update`'s precondition check compared
+ * `observed.rootHash` (a string read from the entry) to
+ * `prev.contentHash` (the caller's expected value). Both sides are
+ * arbitrary writer-supplied labels — a CAS pass meant "the labels
+ * agree", not "the content under the label is the content the caller
+ * meant". An attacker writing an entry with a forged `rootHash` field
+ * that doesn't match the actual pool content slipped through unchanged.
+ *
+ * Fix
+ * ---
+ *   - New optional `VerifyEntryRootFn` hook accepted via the
+ *     `ManifestCas` constructor's `opts.verifyEntryRoot`.
+ *   - When wired, the hook is invoked AFTER the label CAS passes and
+ *     BEFORE the write. The hook fetches the content under the
+ *     entry's `rootHash` (production: the UXF pool element),
+ *     recomputes the hash, and asserts it matches the declaration.
+ *   - On `{ ok: false }`, `update()` returns
+ *     `{ ok: false, reason: 'integrity-failed', integrityDetail }`.
+ *   - Optional — when omitted the CAS retains its pre-fix label-only
+ *     semantics for back-compat with existing tests.
+ *   - `ManifestCidRewriteCasError` widened to surface
+ *     `'integrity-failed'` in its `casReason` field so the worker's
+ *     outer retry loop sees the new reason as a hard CAS failure.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ManifestCas,
+  type MinimalManifestStorage,
+  type VerifyEntryRootFn,
+} from '../../../profile/manifest-cas';
+import type { TokenManifestEntry } from '../../../profile/token-manifest';
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory storage adapter (same shape as the existing tests
+// use; intentionally self-contained so future refactors of the broader
+// test file don't disturb this regression surface).
+// ---------------------------------------------------------------------------
+
+function makeMemoryStorage(): MinimalManifestStorage & {
+  _map: Map<string, TokenManifestEntry>;
+} {
+  const m = new Map<string, TokenManifestEntry>();
+  return {
+    _map: m,
+    async readEntry(addr: string, tokenId: string) {
+      return m.get(`${addr}/${tokenId}`);
+    },
+    async writeEntry(addr: string, tokenId: string, entry: TokenManifestEntry) {
+      m.set(`${addr}/${tokenId}`, entry);
+    },
+  };
+}
+
+const ADDR = 'DIRECT_aabbcc';
+const TOKEN_ID = 'aa'.repeat(32);
+const PREVIOUS_HASH = 'cc'.repeat(32);
+const NEXT_HASH = 'dd'.repeat(32);
+
+function makeEntry(rootHash: string): TokenManifestEntry {
+  return { rootHash, status: 'valid' };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Audit #333 H7 — ManifestCas recompute integrity', () => {
+  let storage: ReturnType<typeof makeMemoryStorage>;
+
+  beforeEach(() => {
+    storage = makeMemoryStorage();
+  });
+
+  describe('verifyEntryRoot OMITTED (back-compat — label-only CAS)', () => {
+    it('succeeds when the label CAS matches (no integrity check)', async () => {
+      storage._map.set(`${ADDR}/${TOKEN_ID}`, makeEntry(PREVIOUS_HASH));
+      const cas = new ManifestCas(storage);
+      const result = await cas.update(
+        ADDR,
+        TOKEN_ID,
+        { contentHash: PREVIOUS_HASH },
+        makeEntry(NEXT_HASH),
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('verifyEntryRoot wired — happy path', () => {
+    it('calls the verifier AFTER label CAS and BEFORE write', async () => {
+      storage._map.set(`${ADDR}/${TOKEN_ID}`, makeEntry(PREVIOUS_HASH));
+      const calls: Array<{ stage: string }> = [];
+      const verifier: VerifyEntryRootFn = async (a, t, entry) => {
+        calls.push({ stage: 'verify' });
+        expect(a).toBe(ADDR);
+        expect(t).toBe(TOKEN_ID);
+        expect(entry.rootHash).toBe(PREVIOUS_HASH);
+        return { ok: true };
+      };
+      const proxied: MinimalManifestStorage = {
+        readEntry: storage.readEntry.bind(storage),
+        writeEntry: async (a, t, e) => {
+          calls.push({ stage: 'write' });
+          return storage.writeEntry(a, t, e);
+        },
+      };
+      const cas = new ManifestCas(proxied, { verifyEntryRoot: verifier });
+      const result = await cas.update(
+        ADDR,
+        TOKEN_ID,
+        { contentHash: PREVIOUS_HASH },
+        makeEntry(NEXT_HASH),
+      );
+      expect(result.ok).toBe(true);
+      expect(calls).toEqual([{ stage: 'verify' }, { stage: 'write' }]);
+    });
+  });
+
+  describe('verifyEntryRoot wired — integrity failure', () => {
+    it('returns integrity-failed and does NOT write', async () => {
+      storage._map.set(`${ADDR}/${TOKEN_ID}`, makeEntry(PREVIOUS_HASH));
+      const verifier: VerifyEntryRootFn = async () => ({
+        ok: false,
+        reason: 'recomputed-hash-mismatch',
+      });
+      let writeCalled = false;
+      const proxied: MinimalManifestStorage = {
+        readEntry: storage.readEntry.bind(storage),
+        writeEntry: async (a, t, e) => {
+          writeCalled = true;
+          return storage.writeEntry(a, t, e);
+        },
+      };
+      const cas = new ManifestCas(proxied, { verifyEntryRoot: verifier });
+      const result = await cas.update(
+        ADDR,
+        TOKEN_ID,
+        { contentHash: PREVIOUS_HASH },
+        makeEntry(NEXT_HASH),
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return; // type narrowing
+      expect(result.reason).toBe('integrity-failed');
+      expect(result.observed?.contentHash).toBe(PREVIOUS_HASH);
+      expect(result.integrityDetail).toBe('recomputed-hash-mismatch');
+      // Critical: the write did NOT happen.
+      expect(writeCalled).toBe(false);
+      // And the storage is unchanged.
+      expect(storage._map.get(`${ADDR}/${TOKEN_ID}`)).toEqual(
+        makeEntry(PREVIOUS_HASH),
+      );
+    });
+  });
+
+  describe('verifyEntryRoot wired — skipped on prev=null path', () => {
+    it('does NOT call the verifier when caller asserts no entry exists', async () => {
+      let verifierCalled = false;
+      const verifier: VerifyEntryRootFn = async () => {
+        verifierCalled = true;
+        return { ok: true };
+      };
+      const cas = new ManifestCas(storage, { verifyEntryRoot: verifier });
+      const result = await cas.update(
+        ADDR,
+        TOKEN_ID,
+        null,
+        makeEntry(NEXT_HASH),
+      );
+      expect(result.ok).toBe(true);
+      // No observed entry → nothing to verify integrity of.
+      expect(verifierCalled).toBe(false);
+    });
+  });
+
+  describe('verifyEntryRoot wired — skipped on label-CAS-mismatch', () => {
+    it('does NOT call the verifier when the label CAS already failed', async () => {
+      storage._map.set(`${ADDR}/${TOKEN_ID}`, makeEntry('FF'.repeat(32)));
+      let verifierCalled = false;
+      const verifier: VerifyEntryRootFn = async () => {
+        verifierCalled = true;
+        return { ok: true };
+      };
+      const cas = new ManifestCas(storage, { verifyEntryRoot: verifier });
+      const result = await cas.update(
+        ADDR,
+        TOKEN_ID,
+        { contentHash: PREVIOUS_HASH }, // doesn't match
+        makeEntry(NEXT_HASH),
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toBe('cas-mismatch');
+      // Verifier never ran — short-circuit on label mismatch.
+      expect(verifierCalled).toBe(false);
+    });
+  });
+
+  describe('integrity-failed reason has its own discriminator', () => {
+    it('is structurally distinct from cas-mismatch / not-found / concurrent-modification', async () => {
+      storage._map.set(`${ADDR}/${TOKEN_ID}`, makeEntry(PREVIOUS_HASH));
+      const cas = new ManifestCas(storage, {
+        verifyEntryRoot: async () => ({ ok: false, reason: 'forged' }),
+      });
+      const result = await cas.update(
+        ADDR,
+        TOKEN_ID,
+        { contentHash: PREVIOUS_HASH },
+        makeEntry(NEXT_HASH),
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      const otherReasons = [
+        'cas-mismatch',
+        'not-found',
+        'concurrent-modification',
+      ];
+      expect(otherReasons).not.toContain(result.reason);
+      expect(result.reason).toBe('integrity-failed');
+    });
+  });
+});


### PR DESCRIPTION
> **Stacked PR.** Built atop #354 (H5) → #353 (H4) → #352 (H3) → #351 (H2) → #349 (H1) → #348 (C3) → #347 (C2) → #346 (C1).

## Summary

Closes the **H7 high** finding of audit #333 — `ManifestCas.update`'s precondition check compared `observed.rootHash` (a string read from the entry) to `prev.contentHash` (the caller's expected value). Both sides are arbitrary writer-supplied labels — a CAS pass meant "the labels agree", not "the content under the label is the content the caller meant". An attacker writing an entry with a forged `rootHash` field that doesn't match the actual pool content slipped through unchanged.

## Fix

1. **New optional `VerifyEntryRootFn` hook** accepted via the `ManifestCas` constructor's `opts.verifyEntryRoot`. When wired, the hook is invoked AFTER the label CAS passes and BEFORE the write. The hook fetches the content the entry's `rootHash` references (production: the UXF pool element via `computeElementHash`), recomputes the hash, and asserts it matches the declaration.
2. **New `'integrity-failed'` discriminator** on `ManifestCasResult.reason` with structured `integrityDetail` for triage. The result also carries `observed.contentHash` so callers can re-read state.
3. **`ManifestCidRewriteCasError.casReason` widened** to surface `'integrity-failed'`. The worker's outer retry loop already treats any throw from `manifest-cid-rewrite` as a hard CAS failure that bubbles up; the new reason rides through unchanged but preserves structure for operator triage.
4. **Skip conditions:**
   - `prev === null` (asserts-no-entry) path — no observed entry to verify
   - Label-CAS mismatch — the swap has already been rejected, so the verifier short-circuits
5. **Optional shape preserves back-compat:** all 9 existing manifest-cas tests and 100% of production callers that do not (yet) supply the verifier continue to behave identically. Production wiring is a follow-up that does not block this PR.

## Production wiring

```ts
const cas = new ManifestCas(storage, {
  verifyEntryRoot: async (addr, tokenId, entry) => {
    const poolElement = await loadPoolElement(entry.rootHash);
    if (poolElement === undefined) {
      return { ok: false, reason: 'pool-element-missing' };
    }
    const recomputed = computeElementHash(poolElement);
    return {
      ok: recomputed === entry.rootHash,
      reason: recomputed === entry.rootHash ? undefined : `recomputed=${recomputed}`,
    };
  },
});
```

The audit's gap (the CAS doesn't recompute) is now closed at the engine level; production wiring of the hook is the next step.

## Test plan

- [x] **6 new H7 regression tests** in `tests/unit/profile/manifest-cas-h7-recompute-integrity.test.ts`:
  - Back-compat (verifier omitted → label-only CAS as before)
  - Happy path (verifier called AFTER label CAS, BEFORE write — explicit ordering assertion)
  - Integrity failure → `'integrity-failed'`, no write, storage unchanged, `integrityDetail` propagated
  - Skip on `prev = null` (no observed entry to verify)
  - Skip on label-CAS-mismatch (short-circuit before verifier — verifier never called)
  - `'integrity-failed'` has its own discriminator distinct from `cas-mismatch` / `not-found` / `concurrent-modification`
- [x] All 9 existing `manifest-cas.test.ts` tests pass unchanged
- [x] All 1512 transfer tests pass
- [x] All 450 unit test files (8181 tests) pass
- [x] `tsc --noEmit` clean

## Audit traceability

- Issue: #333 (H7)
- File / line in audit: `profile/manifest-cas.ts:139-171`
- Audit recommendation followed: promote the integrity-label check to a real recomputed-content integrity check.

## Stack summary

This PR completes the actionable High tier from audit #333:

| Tier | PRs |
|---|---|
| **Release-gate Criticals** | #346 (C1), #347 (C2), #348 (C3) |
| **Highs (this stack)** | #349 (H1), #351 (H2), #352 (H3), #353 (H4), #354 (H5), this (H7) |
| **Deferred** | H6 (lamport=0 convergence), H8 (reconcile CID compare) — to be filed as follow-up issues; audit specifically flagged these as "reproduce with multi-device test matrix before fix-now" |

## What's next

Per user direction, H6 and H8 will be filed as deferred follow-up GitHub issues capturing the audit findings + the requirement to build the multi-device reproduction harness first.