### PR TITLE
fix(ci): skip helia-blockstore-shim-fd on Node 20 (Promise.withResolvers)

### DIFF
--- a/tests/integration/helia-blockstore-shim-fd.test.ts
+++ b/tests/integration/helia-blockstore-shim-fd.test.ts
@@ -25,7 +25,18 @@ import { installHeliaBlockstoreGetShim } from '../../profile/helia-blockstore-sh
 const FD_DIR = '/proc/self/fd';
 const FD_AVAILABLE = existsSync(FD_DIR);
 
-const run = FD_AVAILABLE ? describe : describe.skip;
+// Helia v6 + libp2p stack uses `Promise.withResolvers` transitively via
+// `it-queue` / `mortice` / `@libp2p/peer-store`. On Node 20 the libp2p
+// shutdown path (`Registrar.unhandle` → `PersistentPeerStore.patch`)
+// throws `TypeError: Promise.withResolvers is not a function` during
+// `afterAll`. Matches the existing Node ≥ 22 gate on
+// `tests/integration/orbitdb-adapter.test.ts:32` — same root cause,
+// same fix. Both gates lift when the project drops Node 20 entirely
+// (sphere-sdk#105 follow-up).
+const NODE_MAJOR = parseInt(process.versions.node.split('.')[0], 10);
+const NODE_OK = NODE_MAJOR >= 22;
+
+const run = FD_AVAILABLE && NODE_OK ? describe : describe.skip;
 
 run('helia-blockstore-shim — real FsBlockstore FD bound (#278)', () => {
   let tmp: string;


### PR DESCRIPTION
## Summary

Unblocks the Node 20 CI matrix leg, which has been red since 2026-05-29 (commit af41bea, the integration/all-fixes merge into main):

```
TypeError: Promise.withResolvers is not a function
 ❯ new JobRecipient node_modules/it-queue/src/recipient.ts:9:29
 ❯ … (libp2p shutdown chain)
 ❯ DefaultDCUtRService.stop node_modules/@libp2p/dcutr/src/dcutr.ts:106:26
```

## Root cause

`Promise.withResolvers` is a Node 22+ feature. The libp2p shutdown path inside Helia v6's `afterAll` teardown calls it transitively via `it-queue` → `mortice` → `@libp2p/peer-store`. Helia v6 + libp2p current require Node 22 — confirmed by the in-tree comment at `tests/integration/orbitdb-adapter.test.ts:32`:

> @orbitdb/core v3 uses Promise.withResolvers, which is a Node 22+ feature. CI's Node-20 matrix leg is excluded here; when the project drops Node 20 (see #105 follow-up) this guard can go.

The `orbitdb-adapter` test already applies the gate; this test (#278, the FsBlockstore FD-bound shim) had the same root cause but lacked the guard.

## Fix

Mirror the `nodeVersion >= 22` guard pattern from `orbitdb-adapter.test.ts`, with a comment linking back to the precedent so the next person hitting this finds both gates at once.

## Scope note — Node 20 deprecation

This is a stopgap. The forward path is documented in #105 follow-up: drop Node 20 from `engines.node` and the CI matrix entirely (Node 20 entered maintenance LTS in Oct 2024 and reaches EOL April 2026). Doing so in this PR would be a larger scope change requiring a project-wide decision; this PR only unblocks the immediate CI failure.

## Test plan

- [x] Verified on Node 22 (active LTS): both tests in `tests/integration/helia-blockstore-shim-fd.test.ts` still pass (~70 ms).
- [x] On Node 20 the suite is skipped instead of failing — the rest of the test suite runs and CI surfaces the actual pass/fail signal for every other file.

## Unblocks

Audit #333 stack: #346 (C1), #347 (C2), #348 (C3), #349 (H1), #351 (H2), #352 (H3), #353 (H4), #354 (H5), #355 (H7), #358 (V6-RECOVER test gap) — every PR in that stack inherits this red CI run via its base chain.