### PR TITLE
fix(profile/flush-scheduler): probe before destructive oplog reset (Audit #333 C3)

### DIFF
--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -62,7 +62,11 @@
 // block-by-block via `pinCarBlocksToIpfs`; per-block IPFS dedup is
 // restored, closing the byte-cost-per-token-mutation regression
 // introduced by the #212 monolithic-raw interim.
-import { fetchCarFromIpfs, pinCarBlocksToIpfs } from '../ipfs-client.js';
+import {
+  fetchCarFromIpfs,
+  pinCarBlocksToIpfs,
+  verifyCidAccessibleWithRetry,
+} from '../ipfs-client.js';
 import { extractCarRootCid } from '../../uxf/transfer-payload.js';
 import { extractLostHeadCid } from '../orbitdb-adapter.js';
 import type { OrbitDbAdapter } from '../orbitdb-adapter.js';
@@ -143,6 +147,29 @@ export const POINTER_MONOTONICITY_RECOVERED = 'POINTER_MONOTONICITY_RECOVERED';
  * detectable via the boundary tests in `tests/unit/profile/`.
  */
 export const MONOTONICITY_RECOVERY_PAYLOAD_CAP = 100;
+
+/**
+ * Audit #333 C3 — OpLog auto-reset probe budget.
+ *
+ * Before `addBundleWithOplogAutoReset` falls through to the destructive
+ * `db.drop()` reset, it probes the configured IPFS gateways for the
+ * unreachable head CID with exponential backoff. The matcher
+ * (`extractLostHeadCid`) cannot distinguish a permanently-corrupt head
+ * (Helia GC) from a transiently-unreachable one (gateway blip /
+ * propagation lag), so a 30 s probe window — matching the Issue #239
+ * shutdown gate convention for testnet propagation — gives a single
+ * miss a chance to recover before we commit to wiping all not-yet-
+ * bundled OUTBOX/SENT/disposition/finalization state.
+ *
+ * A genuinely-corrupt head will fail every gateway HEAD probe across
+ * the window; the reset then proceeds as before. The cost in the bad-
+ * case is +30 s before destructive teardown — a small price relative
+ * to the data-loss exposure on the false-positive path.
+ */
+export const OPLOG_RESET_PROBE_DEADLINE_MS = 30_000;
+
+/** Per-attempt HEAD timeout inside the probe loop. */
+export const OPLOG_RESET_PROBE_PER_ATTEMPT_MS = 5_000;
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -1744,25 +1771,133 @@ export class FlushScheduler {
         throw err;
       }
 
+      const context = 'flush-scheduler.bundle-write';
+
+      // C3 (Audit #333): probe BEFORE the destructive reset.
+      //
+      // `extractLostHeadCid` matches both permanently-corrupt heads
+      // (Helia GC ran on a memory-blockstore wallet) and transiently
+      // unreachable ones (gateway blip, peer offline, propagation
+      // lag). The pre-fix code went straight from "matcher matched" to
+      // `db.drop()`, wiping all OUTBOX/SENT/disposition/finalization
+      // entries not yet captured in a pinned bundle — a permanent loss
+      // on a transient fetch failure.
+      //
+      // Probe the configured IPFS gateways for the lost CID with
+      // exponential backoff. If any gateway serves it within the
+      // deadline, retry `addBundle` ONCE — a transient miss often
+      // clears within the propagation window. Only fall through to
+      // the reset when the probe confirms unrecoverability OR the
+      // gateway-retry STILL fails the same way (in which case the
+      // local Helia blockstore is the bottleneck, not the network).
+      //
+      // Skipped only when no gateways are configured at all — that
+      // setup has no recovery surface, so destructive reset is the
+      // only forward path (preserves pre-fix behaviour).
+      //
+      // `effectiveLostHeadCid` may be updated by the probe-retry
+      // branch if a follow-up addBundle attempt surfaces a fresher
+      // unreachable CID; the reset call then uses the freshest one.
+      let effectiveLostHeadCid = lostHeadCid;
+
+      if (this.host.ipfsGateways.length > 0) {
+        this.host.log(
+          `OpLog head unreachable (lostHeadCid=${lostHeadCid}); probing ` +
+            `${this.host.ipfsGateways.length} gateway(s) before destructive reset ` +
+            `(Audit #333 C3, deadline=${OPLOG_RESET_PROBE_DEADLINE_MS}ms)`,
+        );
+        let probeOk = false;
+        let probeAttempts = 0;
+        let probeElapsedMs = 0;
+        try {
+          const probe = await verifyCidAccessibleWithRetry(
+            this.host.ipfsGateways,
+            lostHeadCid,
+            {
+              deadlineMs: OPLOG_RESET_PROBE_DEADLINE_MS,
+              perAttemptTimeoutMs: OPLOG_RESET_PROBE_PER_ATTEMPT_MS,
+            },
+          );
+          probeOk = probe.ok;
+          probeAttempts = probe.attempts;
+          probeElapsedMs = probe.elapsedMs;
+        } catch (probeErr) {
+          // Probe itself threw (e.g., gateway URL validation failure
+          // before any HEAD ran). Treat as "probe did not confirm
+          // recoverability" — log and fall through to reset, since
+          // we cannot prove the head is recoverable.
+          this.host.log(
+            `OpLog head probe threw before completing: ` +
+              `${probeErr instanceof Error ? probeErr.message : String(probeErr)}; ` +
+              `proceeding to reset (Audit #333 C3)`,
+          );
+        }
+
+        if (probeOk) {
+          this.host.log(
+            `OpLog head IS accessible via gateway after ${probeAttempts} ` +
+              `attempt(s) in ${probeElapsedMs}ms; retrying addBundle once before reset ` +
+              `(Audit #333 C3)`,
+          );
+          try {
+            await this.bundleIndex.addBundle(cid, bundleRef);
+            // Probe-retry succeeded — the original failure was
+            // transient. Reset NOT performed. Caller (flush body)
+            // continues normally; no operational state was lost.
+            return;
+          } catch (retryErr) {
+            const retryLostHeadCid = extractLostHeadCid(retryErr);
+            if (retryLostHeadCid === null) {
+              // Retry hit a DIFFERENT error class (e.g., monotonicity
+              // violation, network down). Re-throw the new error;
+              // resetting the log would not help here.
+              throw retryErr;
+            }
+            // Same auto-reset signature again, despite the gateway
+            // probe succeeding. Local Helia is the bottleneck — fall
+            // through to the destructive reset, but use the
+            // most-recent lostHeadCid (which may differ if the
+            // baseline advanced during the probe).
+            this.host.log(
+              `Probe succeeded but addBundle still failed with ` +
+                `lostHeadCid=${retryLostHeadCid}; proceeding to reset ` +
+                `(Audit #333 C3)`,
+            );
+            effectiveLostHeadCid = retryLostHeadCid;
+          }
+        } else {
+          this.host.log(
+            `OpLog head NOT accessible via any gateway after ${probeAttempts} ` +
+              `attempt(s) in ${probeElapsedMs}ms; head is genuinely unrecoverable. ` +
+              `Proceeding to reset (Audit #333 C3)`,
+          );
+        }
+      } else {
+        this.host.log(
+          `OpLog head unreachable (lostHeadCid=${lostHeadCid}) and no IPFS ` +
+            `gateways configured; no recovery surface available. Proceeding to ` +
+            `reset (Audit #333 C3)`,
+        );
+      }
+
       this.host.log(
-        `OpLog head unreachable (lostHeadCid=${lostHeadCid}); auto-resetting Profile DB. ` +
+        `OpLog head unreachable (lostHeadCid=${effectiveLostHeadCid}); auto-resetting Profile DB. ` +
           `Prior OpLog history is permanently inaccessible. Token data on local IndexedDB is preserved.`,
       );
 
-      const context = 'flush-scheduler.bundle-write';
       // 3. Trigger event BEFORE the reset so operators see it even if
       // the reset itself fails.
       this.host.emitEvent({
         type: 'profile:oplog-auto-resetting',
         timestamp: Date.now(),
-        data: { lostHeadCid, context },
+        data: { lostHeadCid: effectiveLostHeadCid, context },
       });
 
       // 4. Run the reset.
       let resetResult: { recovered: true; lostHeadCid?: string; recoveredAt: number };
       try {
         resetResult = await dbWithReset.resetCorruptedLog({
-          lostHeadCid,
+          lostHeadCid: effectiveLostHeadCid,
           context,
         });
       } catch (resetErr) {
@@ -1774,7 +1909,7 @@ export class FlushScheduler {
           type: 'profile:recovered',
           timestamp: Date.now(),
           data: {
-            lostHeadCid,
+            lostHeadCid: effectiveLostHeadCid,
             recoveredAt: Date.now(),
             context,
             retrySucceeded: false,
@@ -1795,7 +1930,7 @@ export class FlushScheduler {
       const marker: ProfileRecoveryMarker = {
         version: 1,
         recoveredAt: resetResult.recoveredAt,
-        lostHeadCid: resetResult.lostHeadCid ?? lostHeadCid,
+        lostHeadCid: resetResult.lostHeadCid ?? effectiveLostHeadCid,
         context,
         walkBackClosed: true,
         note:
@@ -1823,7 +1958,7 @@ export class FlushScheduler {
           type: 'profile:recovered',
           timestamp: Date.now(),
           data: {
-            lostHeadCid,
+            lostHeadCid: effectiveLostHeadCid,
             recoveredAt: resetResult.recoveredAt,
             context,
             retrySucceeded: false,
@@ -1838,7 +1973,7 @@ export class FlushScheduler {
         type: 'profile:recovered',
         timestamp: Date.now(),
         data: {
-          lostHeadCid,
+          lostHeadCid: effectiveLostHeadCid,
           recoveredAt: resetResult.recoveredAt,
           context,
           retrySucceeded: true,

--- a/tests/unit/profile/flush-scheduler-c3-oplog-reset-probe.test.ts
+++ b/tests/unit/profile/flush-scheduler-c3-oplog-reset-probe.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Tests for Audit #333 C3: auto-drop on transient block-load error.
+ *
+ * Background
+ * ----------
+ * Before the C3 fix, `FlushScheduler.addBundleWithOplogAutoReset`
+ * transitioned straight from "extractLostHeadCid matched the error" to
+ * `resetCorruptedLog()` (which does `db.drop()`). The matcher cannot
+ * distinguish a permanently-corrupt head (Helia GC ran on a memory-
+ * blockstore wallet) from a transiently-unreachable one (gateway blip,
+ * peer offline, propagation lag). A momentary fetch failure thus wiped
+ * all OUTBOX/SENT/disposition/finalization entries not yet captured in
+ * a pinned bundle — permanent data loss on a recoverable error.
+ *
+ * Fix
+ * ---
+ *   - Probe configured IPFS gateways with exponential backoff
+ *     (`verifyCidAccessibleWithRetry`) BEFORE the destructive reset.
+ *   - On a successful probe, retry `addBundle` ONCE. If the retry
+ *     succeeds the reset is SKIPPED — no operational state is lost.
+ *   - On probe failure (CID NOT served by any gateway within the
+ *     deadline) OR a retry that still hits the same auto-reset
+ *     signature, fall through to the existing reset path.
+ *   - With no gateways configured, the fix is a no-op (matches
+ *     pre-fix behaviour) since there is no recovery surface.
+ *
+ * These tests assert each path.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  BundleIndex,
+  FlushScheduler,
+  type ProfileTokenStorageHost,
+} from '../../../profile/profile-token-storage';
+import type { StorageEvent } from '../../../storage/storage-provider';
+import type { UxfBundleRef } from '../../../profile/types';
+
+// Mock the gateway-probe helper so tests control the probe outcome
+// without spinning up real HTTP. The mock is keyed on the CID to
+// distinguish "served" vs "unreachable" across calls.
+vi.mock('../../../profile/ipfs-client', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    verifyCidAccessibleWithRetry: vi.fn(
+      async (
+        _gateways: string[],
+        cid: string,
+        _opts: { deadlineMs: number; perAttemptTimeoutMs?: number },
+      ) => {
+        const outcome = (globalThis as unknown as {
+          __c3MockProbe?: Record<string, { ok: boolean; attempts: number; elapsedMs: number }>;
+        }).__c3MockProbe?.[cid];
+        return (
+          outcome ?? {
+            ok: false,
+            attempts: 1,
+            elapsedMs: 0,
+            failureKind: 'gateway-not-serving' as const,
+          }
+        );
+      },
+    ),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Harness — minimal shape we need to drive
+// `addBundleWithOplogAutoReset` through the C3 paths.
+// ---------------------------------------------------------------------------
+
+interface Harness {
+  scheduler: FlushScheduler;
+  bundleIndex: BundleIndex;
+  emittedEvents: StorageEvent[];
+  resetCorruptedLog: ReturnType<typeof vi.fn>;
+  writeRecoveryMarker: ReturnType<typeof vi.fn>;
+  logLines: string[];
+  addBundleSpy: ReturnType<typeof vi.fn>;
+}
+
+function buildHarness(opts: {
+  /** Behaviour of bundleIndex.addBundle, invoked on each attempt. */
+  addBundleSequence: Array<Error | 'ok'>;
+  /** Gateways to expose on host.ipfsGateways. */
+  ipfsGateways?: string[];
+  resetImpl?: (reason: {
+    lostHeadCid?: string;
+    context: string;
+  }) => Promise<{ recovered: true; lostHeadCid?: string; recoveredAt: number }>;
+}): Harness {
+  const emittedEvents: StorageEvent[] = [];
+  const logLines: string[] = [];
+
+  const resetCorruptedLog = vi.fn(
+    opts.resetImpl ??
+      (async (reason: { lostHeadCid?: string; context: string }) => ({
+        recovered: true as const,
+        lostHeadCid: reason.lostHeadCid,
+        recoveredAt: Date.now(),
+      })),
+  );
+  const writeRecoveryMarker = vi.fn(async () => {});
+
+  const dbBase: Record<string, unknown> = {
+    async connect() {},
+    async put() {},
+    async get() { return null; },
+    async del() {},
+    async all() { return new Map(); },
+    async close() {},
+    onReplication() { return () => {}; },
+    isConnected() { return true; },
+    resetCorruptedLog,
+  };
+
+  const host: ProfileTokenStorageHost = {
+    db: dbBase as unknown as ProfileTokenStorageHost['db'],
+    ipfsGateways: opts.ipfsGateways ?? [],
+    options: undefined,
+    localCache: null,
+    flushDebounceMs: 0,
+    eventCallbacks: new Set(),
+    getHelia: () => null,
+    getStatus: () => 'ready',
+    setStatus: () => {},
+    getInitialized: () => true,
+    setInitialized: () => {},
+    getIsShuttingDown: () => false,
+    setIsShuttingDown: () => {},
+    getIdentity: () => null,
+    setIdentityState: () => {},
+    getEncryptionKey: () => null,
+    setEncryptionKey: () => {},
+    getComputedAddressId: () => null,
+    setComputedAddressId: () => {},
+    getReplicationUnsub: () => null,
+    setReplicationUnsub: () => {},
+    getPendingData: () => null,
+    setPendingData: () => {},
+    getFlushTimer: () => null,
+    setFlushTimer: () => {},
+    getFlushPromise: () => null,
+    setFlushPromise: () => {},
+    getLastPinnedCid: () => null,
+    setLastPinnedCid: () => {},
+    getLastPinnedBundleCid: () => null,
+    setLastPinnedBundleCid: () => {},
+    getLastVerifiedBundleCid: () => null,
+    setLastVerifiedBundleCid: () => {},
+    getLastVerifiedSnapshotCid: () => null,
+    setLastVerifiedSnapshotCid: () => {},
+    getLastDiscoveredPointerCid: () => null,
+    setLastDiscoveredPointerCid: () => {},
+    getPendingPublishCid: () => null,
+    setPendingPublishCid: () => {},
+    getKnownBundleCids: () => new Set<string>(),
+    setKnownBundleCids: () => {},
+    getLastLoadedData: () => null,
+    setLastLoadedData: () => {},
+    getLastLoadedFromBundleCids: () => null,
+    setLastLoadedFromBundleCids: () => {},
+    getLastTokenManifest: () => null,
+    setLastTokenManifest: () => {},
+    getAddressId: () => 'DIRECT_abc_def',
+    log: (m) => { logLines.push(m); },
+    emitEvent: (e) => { emittedEvents.push(e); },
+    buildErrorEvent: (type, err) => ({
+      type,
+      timestamp: Date.now(),
+      error: err instanceof Error ? err.message : String(err),
+    }),
+    writeProfileKey: async () => {},
+    readProfileKey: async () => null,
+    readProfileKeyJson: async () => null,
+    writeRecoveryMarker,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  const bundleIndex = new BundleIndex(host);
+  const scheduler = new FlushScheduler(host, bundleIndex);
+
+  // Spy on bundleIndex.addBundle. Each call consumes the next sequence
+  // entry; throws when the entry is an Error, resolves otherwise.
+  let callIndex = 0;
+  const addBundleSpy = vi.fn(async (_cid: string, _ref: UxfBundleRef) => {
+    const step = opts.addBundleSequence[callIndex];
+    callIndex++;
+    if (step === undefined) {
+      throw new Error(
+        `addBundleSequence exhausted at call ${callIndex} — test bug`,
+      );
+    }
+    if (step === 'ok') return;
+    throw step;
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (bundleIndex as any).addBundle = addBundleSpy;
+
+  return {
+    scheduler,
+    bundleIndex,
+    emittedEvents,
+    resetCorruptedLog,
+    writeRecoveryMarker,
+    logLines,
+    addBundleSpy,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SAMPLE_CID = 'bafy1234567890headcid';
+const ANOTHER_CID = 'bafy1234567890othercid';
+const SAMPLE_BUNDLE_REF: UxfBundleRef = {
+  cid: 'bafyzzzzzzzzzzzzzzzzzzzzbundleref',
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+function lostBlockError(cid: string): Error {
+  return new Error(`Failed to load block for ${cid}`);
+}
+
+function setMockProbe(cid: string, ok: boolean, attempts = 1, elapsedMs = 100): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const g = globalThis as any;
+  if (!g.__c3MockProbe) g.__c3MockProbe = {};
+  g.__c3MockProbe[cid] = ok
+    ? { ok: true, attempts, elapsedMs }
+    : { ok: false, attempts, elapsedMs, failureKind: 'gateway-not-serving' };
+}
+
+function clearMockProbes(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).__c3MockProbe = undefined;
+}
+
+async function callAddBundleWithOplogAutoReset(
+  harness: Harness,
+  cid: string,
+): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (harness.scheduler as any).addBundleWithOplogAutoReset(
+    cid,
+    SAMPLE_BUNDLE_REF,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Audit #333 C3 — oplog auto-reset probe gate', () => {
+  beforeEach(() => clearMockProbes());
+  afterEach(() => clearMockProbes());
+
+  describe('transient blip — probe recovers, NO reset', () => {
+    it('skips destructive reset when probe succeeds and retry succeeds', async () => {
+      const harness = buildHarness({
+        addBundleSequence: [lostBlockError(SAMPLE_CID), 'ok'],
+        ipfsGateways: ['http://gateway.test'],
+      });
+      setMockProbe(SAMPLE_CID, true, 2, 1200);
+
+      await callAddBundleWithOplogAutoReset(harness, SAMPLE_CID);
+
+      // addBundle was called twice: initial fail + post-probe retry.
+      expect(harness.addBundleSpy).toHaveBeenCalledTimes(2);
+      // CRUCIAL: reset NEVER ran.
+      expect(harness.resetCorruptedLog).not.toHaveBeenCalled();
+      // No reset events emitted (no profile:oplog-auto-resetting,
+      // no profile:recovered).
+      expect(
+        harness.emittedEvents.filter((e) =>
+          ['profile:oplog-auto-resetting', 'profile:recovered'].includes(e.type),
+        ),
+      ).toHaveLength(0);
+      // Logged that the probe succeeded.
+      expect(
+        harness.logLines.some((l) => /IS accessible via gateway/.test(l)),
+      ).toBe(true);
+    });
+  });
+
+  describe('permanent loss — probe fails, RESET happens', () => {
+    it('proceeds to reset when probe returns ok=false', async () => {
+      const harness = buildHarness({
+        addBundleSequence: [lostBlockError(SAMPLE_CID), 'ok'],
+        ipfsGateways: ['http://gateway.test'],
+      });
+      setMockProbe(SAMPLE_CID, false, 5, 30_000);
+
+      await callAddBundleWithOplogAutoReset(harness, SAMPLE_CID);
+
+      // Probe failed → reset ran → addBundle retried once after reset.
+      expect(harness.resetCorruptedLog).toHaveBeenCalledTimes(1);
+      // resetCorruptedLog called with the original lostHeadCid.
+      expect(harness.resetCorruptedLog).toHaveBeenCalledWith(
+        expect.objectContaining({ lostHeadCid: SAMPLE_CID }),
+      );
+      // Events fired in the right order: auto-resetting, then recovered.
+      const types = harness.emittedEvents.map((e) => e.type);
+      expect(types).toContain('profile:oplog-auto-resetting');
+      expect(types).toContain('profile:recovered');
+      // Marker written.
+      expect(harness.writeRecoveryMarker).toHaveBeenCalledTimes(1);
+      // Logged the no-gateway-served message.
+      expect(
+        harness.logLines.some((l) => /NOT accessible via any gateway/.test(l)),
+      ).toBe(true);
+    });
+  });
+
+  describe('probe ok but retry still fails — RESET happens with fresh CID', () => {
+    it('falls through to reset using the freshest lostHeadCid', async () => {
+      const harness = buildHarness({
+        // Initial fail with SAMPLE_CID; post-probe retry fails with
+        // ANOTHER_CID (a fresher unreachable head); after-reset retry
+        // succeeds.
+        addBundleSequence: [
+          lostBlockError(SAMPLE_CID),
+          lostBlockError(ANOTHER_CID),
+          'ok',
+        ],
+        ipfsGateways: ['http://gateway.test'],
+      });
+      setMockProbe(SAMPLE_CID, true, 1, 200);
+
+      await callAddBundleWithOplogAutoReset(harness, SAMPLE_CID);
+
+      // resetCorruptedLog called with the FRESH lostHeadCid (the one
+      // from the post-probe retry, not the original one).
+      expect(harness.resetCorruptedLog).toHaveBeenCalledTimes(1);
+      expect(harness.resetCorruptedLog).toHaveBeenCalledWith(
+        expect.objectContaining({ lostHeadCid: ANOTHER_CID }),
+      );
+      // The oplog-auto-resetting event also carries the fresh CID.
+      const resettingEvent = harness.emittedEvents.find(
+        (e) => e.type === 'profile:oplog-auto-resetting',
+      );
+      expect(resettingEvent?.data).toMatchObject({ lostHeadCid: ANOTHER_CID });
+    });
+  });
+
+  describe('probe ok but retry hits DIFFERENT error class — RETHROW (no reset)', () => {
+    it('re-throws the new error class without resetting', async () => {
+      const otherErr = new Error('POINTER_MONOTONICITY_VIOLATION at refresh');
+      const harness = buildHarness({
+        addBundleSequence: [lostBlockError(SAMPLE_CID), otherErr],
+        ipfsGateways: ['http://gateway.test'],
+      });
+      setMockProbe(SAMPLE_CID, true, 1, 200);
+
+      await expect(
+        callAddBundleWithOplogAutoReset(harness, SAMPLE_CID),
+      ).rejects.toBe(otherErr);
+
+      // Reset never ran — the new error class doesn't match the
+      // auto-reset signature, so resetting wouldn't help.
+      expect(harness.resetCorruptedLog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('no gateways configured — preserves pre-fix behaviour', () => {
+    it('skips the probe entirely and goes straight to reset', async () => {
+      const harness = buildHarness({
+        addBundleSequence: [lostBlockError(SAMPLE_CID), 'ok'],
+        ipfsGateways: [],
+      });
+
+      await callAddBundleWithOplogAutoReset(harness, SAMPLE_CID);
+
+      // Reset ran (no probe stood in the way).
+      expect(harness.resetCorruptedLog).toHaveBeenCalledTimes(1);
+      // Logged the no-gateways message.
+      expect(
+        harness.logLines.some(
+          (l) => /no IPFS gateways configured/.test(l) || /no recovery surface/.test(l),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('probe itself throws — fall through to reset (cannot prove recoverability)', () => {
+    it('falls through to reset when the probe throws unexpectedly', async () => {
+      // Make verifyCidAccessibleWithRetry mock throw for this test by
+      // returning a special sentinel that triggers a throw inside the
+      // mock body. Simpler: spy on the mock and have it reject.
+      const ipfsClient = await import('../../../profile/ipfs-client');
+      const spy = vi.spyOn(ipfsClient, 'verifyCidAccessibleWithRetry')
+        .mockRejectedValueOnce(new Error('gateway URL validation threw'));
+
+      const harness = buildHarness({
+        addBundleSequence: [lostBlockError(SAMPLE_CID), 'ok'],
+        ipfsGateways: ['http://gateway.test'],
+      });
+
+      await callAddBundleWithOplogAutoReset(harness, SAMPLE_CID);
+
+      // Probe threw → treated as "cannot confirm recoverability" → reset.
+      expect(harness.resetCorruptedLog).toHaveBeenCalledTimes(1);
+      expect(
+        harness.logLines.some((l) => /probe threw before completing/.test(l)),
+      ).toBe(true);
+
+      spy.mockRestore();
+    });
+  });
+
+  describe('unrelated errors — no probe, no reset (pass-through)', () => {
+    it('re-throws non-matching errors immediately', async () => {
+      const unrelated = new Error('network unreachable');
+      const harness = buildHarness({
+        addBundleSequence: [unrelated],
+        ipfsGateways: ['http://gateway.test'],
+      });
+
+      await expect(
+        callAddBundleWithOplogAutoReset(harness, SAMPLE_CID),
+      ).rejects.toBe(unrelated);
+
+      // Neither probe nor reset ran.
+      expect(harness.resetCorruptedLog).not.toHaveBeenCalled();
+      // Only the initial addBundle attempt — no retry.
+      expect(harness.addBundleSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
> Re-filed from closed PR #348 — closed by GitHub when its base branch (fix/issue-333-c2-migration-flush-before-cleanup) was auto-deleted on #347's merge. The commit content + tests are unchanged; only the PR is new.

Closes the **C3 critical** finding of audit #333 — auto-`db.drop()` on a transient block-load error. Before this PR, `FlushScheduler.addBundleWithOplogAutoReset` (`profile/profile-token-storage/flush-scheduler.ts:1722`) transitioned straight from "`extractLostHeadCid` matched the error" to `resetCorruptedLog()` (which calls `db.drop()`). The matcher cannot distinguish a permanently-corrupt head (Helia GC ran) from a transiently-unreachable one (gateway blip / propagation lag) — a momentary fetch failure wiped all OUTBOX/SENT/disposition/finalization entries not yet captured in a pinned bundle.

## Fix

Before the destructive reset, **probe configured IPFS gateways** for the lost head CID with exponential backoff (`verifyCidAccessibleWithRetry`, 30 s deadline, 5 s per-attempt HEAD timeout — matching the Issue #239 shutdown-gate convention).

| Probe outcome | Post-probe addBundle retry | Action |
|---|---|---|
| `ok: true` | succeeds | **SKIP reset** (transient miss recovered) |
| `ok: true` | fails with same auto-reset signature | reset with the freshest `lostHeadCid` |
| `ok: true` | fails with DIFFERENT error class | re-throw the new error (no reset) |
| `ok: false` | — | reset (existing behaviour) |
| probe itself throws | — | reset (cannot prove recoverability) |
| no gateways configured | — | reset (pre-fix behaviour; no recovery surface) |

The `effectiveLostHeadCid` local rebinding ensures the reset reason, marker, and event data carry the freshest unreachable CID when the probe-retry surfaces a different head.

## Cost analysis

- **Worst case:** +30 s before destructive teardown on a genuine corruption.
- **Best case (transient blip):** ~200 ms — single successful gateway HEAD, immediate addBundle retry, no reset, **zero data loss**.
- Trade: 30 s of latency on the bad path against permanent loss of operational state on the false-positive path.

## Test plan

- 7 new C3 regression tests in `tests/unit/profile/flush-scheduler-c3-oplog-reset-probe.test.ts`:
  - Transient blip → no reset
  - Permanent loss → reset
  - Probe ok but retry fails same signature → reset with freshest CID
  - Probe ok but retry fails DIFFERENT signature → re-throw, no reset
  - No gateways configured → preserve pre-fix behaviour
  - Probe itself throws → fall through to reset
  - Unrelated errors → no probe, no reset
- All 7 existing `flush-scheduler-oplog-reset.test.ts` tests pass unchanged
- `tsc --noEmit` clean

## Audit traceability

- Issue: #333 (C3)
- Audit recommendation followed: *"gate the destructive reset behind a retry/backoff that confirms the head is genuinely unrecoverable"*. The companion *"and/or snapshot before drop"* is left as a deferred follow-up.

## Stack note

This is the third PR in the audit #333 stack. Stack order:
- #346 (C1) ✅ **merged**
- #347 (C2) ✅ **merged**
- **this** (C3)
- #349 (H1), #351 (H2), #352 (H3), #353 (H4), #354 (H5), #355 (H7), #358 (V6-RECOVER test gap) — pending