### PR TITLE
perf(profile)(issue-364): Items #2 + #3 + #6 — clear-time applySnapshot suppression, attribution counters, test-harness perf-block strip

### DIFF
--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -174,17 +174,55 @@ wait_for_invoice_visible() {
 #     output captured when the CLI runs in verbose mode. Wall-clock
 #     timestamps + monotonic counters (event IDs, bundle counts) make
 #     these lines pure noise for state comparison.
+#   - "[perf-counters] snapshot: { ... }" — MULTI-LINE perf dump emitted
+#     by core/perf-counters.ts on a setInterval when SPHERE_PERF=1. The
+#     opening line is timestamped (and would be stripped by the ISO rule
+#     below), but the continuation lines and the bare closing `}` at
+#     column 0 survive a per-line sed filter and produce spurious
+#     diffs between otherwise-equal snapshots. Issue #364 Item #6.
 #
 # Filtering operates on a temp file the caller hands to diff, leaving
 # the original snapshot untouched for forensics.
+#
+# Implementation note: the awk pass runs FIRST so it can detect the
+# opening `[perf-counters] snapshot: {` line even when that line is
+# timestamped (and would otherwise be eaten by the ISO sed rule before
+# awk gets to see it). The awk state machine drops every line from
+# the opening through the matching closing `}` at column 0 inclusive.
 normalize_snapshot() {
   # shellcheck disable=SC2016
-  sed -E \
+  awk '
+    BEGIN { in_perf = 0 }
+    {
+      if (in_perf) {
+        # Closing brace of the perf-block — always at column 0 because
+        # Node util.inspect renders the top-level } unindented.
+        if ($0 ~ /^\}[[:space:]]*$/) {
+          in_perf = 0
+        }
+        next
+      }
+      # Detect opening of a perf-counters snapshot block. Substring
+      # match works for both timestamped ("[ISO] [INFO ] [perf] ...")
+      # and untimestamped ("[perf] ...") logger output.
+      if (index($0, "[perf-counters] snapshot:") > 0) {
+        # Single-line snapshot (1-counter case): line ends with "}".
+        # Drop and stay outside block mode.
+        if ($0 ~ /\}[[:space:]]*$/) {
+          next
+        }
+        # Multi-line snapshot: line ends with "{". Drop and enter
+        # block mode so subsequent continuation lines are dropped too.
+        in_perf = 1
+        next
+      }
+      print
+    }
+  ' "$1" | sed -E \
     -e '/^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z\] /d' \
     -e '/^  IPFS: \+[0-9]+ added, -[0-9]+ removed$/d' \
     -e '/^Syncing\.\.\.$/d' \
-    -e '/^  Ready\.$/d' \
-    "$1"
+    -e '/^  Ready\.$/d'
 }
 
 assert_diff_empty() {
@@ -201,6 +239,182 @@ assert_diff_empty() {
     return 1
   fi
 }
+
+# ---------------------------------------------------------------------------
+# Optional self-test for normalize_snapshot()
+#
+# Run with: RUN_NORMALIZE_TESTS=1 bash manual-test-full-recovery.sh
+#
+# Pipes synthetic snapshots that EQUAL each other modulo `[perf-counters]
+# snapshot:` blocks through normalize_snapshot() and asserts the diff is
+# empty. Protects against regressions of the #364 Item #6 fix where the
+# multi-line perf dump contaminates byte comparisons between
+# logically-equivalent `sphere status` / `sphere balance` outputs.
+#
+# Exits 0 on pass, non-zero on fail. Bypasses the teardown trap.
+# ---------------------------------------------------------------------------
+
+run_normalize_self_tests() {
+  local tmpdir a b na nb rc=0
+  tmpdir="$(mktemp -d -t normalize-tests.XXXXXX)"
+  a="$tmpdir/a.txt"
+  b="$tmpdir/b.txt"
+  na="$tmpdir/a.norm"
+  nb="$tmpdir/b.norm"
+
+  echo "=== normalize_snapshot self-tests ==="
+
+  # ---- T1: multi-line perf block (untimestamped) ----
+  cat > "$a" <<'EOF'
+Balance: 11 UCT
+Tokens: 3
+EOF
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[perf] [perf-counters] snapshot: {
+  'profile.applySnapshot': { count: 42, totalMs: 123.4, avgMs: 2.9, maxMs: 9.8 },
+  'aggregator.fetch': { count: 7, totalMs: 12.3, avgMs: 1.7, maxMs: 4.5 }
+}
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T1 OK: multi-line untimestamped perf block stripped"
+  else
+    echo "T1 FAIL: multi-line untimestamped perf block leaked" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T2: multi-line perf block (timestamped opening) ----
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[2026-05-31T12:34:56.789Z] [INFO ] [perf] [perf-counters] snapshot: {
+  'profile.applySnapshot': { count: 42, totalMs: 123.4, avgMs: 2.9, maxMs: 9.8 },
+  'aggregator.fetch': { count: 7, totalMs: 12.3, avgMs: 1.7, maxMs: 4.5 }
+}
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T2 OK: timestamped-opening perf block stripped"
+  else
+    echo "T2 FAIL: timestamped-opening perf block leaked" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T3: single-line perf block (1-counter case) ----
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[perf] [perf-counters] snapshot: { a: { count: 1, totalMs: 2, avgMs: 2, maxMs: 2 } }
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T3 OK: single-line perf block stripped"
+  else
+    echo "T3 FAIL: single-line perf block leaked" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T4: multiple consecutive perf blocks ----
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[perf] [perf-counters] snapshot: {
+  'a.b.c': { count: 1, totalMs: 2, avgMs: 2, maxMs: 2 },
+  'd.e.f': { count: 3, totalMs: 4, avgMs: 4, maxMs: 4 }
+}
+[perf] [perf-counters] snapshot: {
+  'g.h.i': { count: 5, totalMs: 6, avgMs: 6, maxMs: 6 }
+}
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T4 OK: multiple consecutive perf blocks stripped"
+  else
+    echo "T4 FAIL: multiple consecutive perf blocks leaked" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T5: existing strips still work (ISO + IPFS + Syncing + Ready) ----
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[2026-05-31T12:34:56.789Z] [INFO ] [Sphere] something happened
+  IPFS: +3 added, -1 removed
+Syncing...
+  Ready.
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T5 OK: legacy strips intact"
+  else
+    echo "T5 FAIL: legacy strips broken" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T6: counter name containing '}' must not exit perf block early ----
+  # Defensive: counter names in our codebase are dot-paths, but a future
+  # operator-style counter could contain literal braces. We trust the
+  # column-0 anchor of the closing `}` per Node util.inspect formatting.
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[perf] [perf-counters] snapshot: {
+  'odd}name': { count: 1, totalMs: 2, avgMs: 2, maxMs: 2 },
+  'other': { count: 3, totalMs: 4, avgMs: 4, maxMs: 4 }
+}
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T6 OK: indented '}' inside counter name does not exit block"
+  else
+    echo "T6 FAIL: indented '}' inside counter name exited block early" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T7: no perf block — identical inputs stay identical ----
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T7 OK: identity passthrough"
+  else
+    echo "T7 FAIL: passthrough corrupted equal inputs" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  rm -rf "$tmpdir"
+  if (( rc == 0 )); then
+    echo "=== normalize_snapshot self-tests: ALL PASS ==="
+  else
+    echo "=== normalize_snapshot self-tests: FAILED ===" >&2
+  fi
+  return "$rc"
+}
+
+if [[ "${RUN_NORMALIZE_TESTS:-}" == "1" ]]; then
+  run_normalize_self_tests
+  # Bypass teardown trap — nothing was created.
+  trap - EXIT INT TERM
+  exit $?
+fi
 
 # Wall-clock anchor + per-section elapsed. SECTION_T0 is set the first
 # time `banner` is invoked; SECTION_LAST_TS tracks the previous banner so

--- a/profile/helia-blockstore-pin-shim.ts
+++ b/profile/helia-blockstore-pin-shim.ts
@@ -55,6 +55,7 @@
  */
 
 import { logger } from '../core/logger';
+import { incr, observeMs } from '../core/perf-counters.js';
 
 /** Minimal structural shape of the Helia v6+ pins API. */
 export interface HeliaPinsLike {
@@ -237,25 +238,34 @@ export function installHeliaBlockstorePinShim(
       source: AsyncIterable<{ cid: unknown; block: unknown }>,
       options?: unknown,
     ): AsyncIterable<unknown> {
+      incr('helia.blockstore.putMany.calls');
+      const __pmStart = performance.now();
       const upstream = originalPutMany(source, options);
       // Return an async generator that pins each yielded CID before
       // forwarding it. Pin is fire-and-forget per CID so a slow pin
       // doesn't stall the iterator chain.
       return (async function* pinningPutManyGen() {
-        for await (const yieldedCid of upstream) {
-          pinAttempted++;
-          // Pin in the background; the put is already complete by
-          // the time the iterator yielded the CID.
-          schedulePin(yieldedCid, pins, Promise.resolve())
-            .then((outcome) => {
-              if (outcome === 'pinned') pinSucceeded++;
-              else if (outcome === 'skipped') pinSkipped++;
-              else pinFailed++;
-            })
-            .catch(() => {
-              pinFailed++;
-            });
-          yield yieldedCid;
+        let itemCount = 0;
+        try {
+          for await (const yieldedCid of upstream) {
+            itemCount++;
+            pinAttempted++;
+            // Pin in the background; the put is already complete by
+            // the time the iterator yielded the CID.
+            schedulePin(yieldedCid, pins, Promise.resolve())
+              .then((outcome) => {
+                if (outcome === 'pinned') pinSucceeded++;
+                else if (outcome === 'skipped') pinSkipped++;
+                else pinFailed++;
+              })
+              .catch(() => {
+                pinFailed++;
+              });
+            yield yieldedCid;
+          }
+        } finally {
+          incr('helia.blockstore.putMany.items', itemCount);
+          observeMs('helia.blockstore.putMany.totalMs', performance.now() - __pmStart);
         }
       })();
     };
@@ -308,9 +318,12 @@ export function installHeliaBlockstorePinShim(
     // DevTools). The Set is the authoritative in-session tracker
     // populated below on success.
     if (pinnedCids.has(cidStr)) {
+      incr('helia.pins.add.cached');
       return 'pinned';
     }
 
+    incr('helia.pins.add.calls');
+    const __pStart = performance.now();
     try {
       const result = pinsApi.add(cid);
       // Helia v6 returns AsyncIterable<CID>; older / test stubs may
@@ -338,6 +351,7 @@ export function installHeliaBlockstorePinShim(
       // throwaway array — so the push did nothing. The actual
       // persistence is `pinnedCids.add(cidStr)` below.
       pinnedCids.add(cidStr);
+      observeMs('helia.pins.add.successMs', performance.now() - __pStart);
       return 'pinned';
     } catch (err) {
       // "Already pinned" is NOT a failure — Helia rejects re-adds with
@@ -351,6 +365,8 @@ export function installHeliaBlockstorePinShim(
       const msg = err instanceof Error ? err.message : String(err);
       if (/already pinned/i.test(msg)) {
         pinnedCids.add(cidStr);
+        incr('helia.pins.add.alreadyPinned');
+        observeMs('helia.pins.add.alreadyPinnedMs', performance.now() - __pStart);
         return 'pinned';
       }
       // Best-effort: log at warn level and move on. The single most
@@ -361,6 +377,8 @@ export function installHeliaBlockstorePinShim(
         'ProfilePinShim',
         `helia.pins.add failed for ${cidStr.slice(0, 16)}…: ${msg}`,
       );
+      incr('helia.pins.add.failed');
+      observeMs('helia.pins.add.failedMs', performance.now() - __pStart);
       return 'failed';
     }
   }

--- a/profile/helia-blockstore-shim.ts
+++ b/profile/helia-blockstore-shim.ts
@@ -61,6 +61,8 @@
  * @module profile/helia-blockstore-shim
  */
 
+import { incr, observeMs } from '../core/perf-counters.js';
+
 /**
  * Default maximum LRU entries. 64 entries comfortably covers the
  * OpLog head + recent snapshot + tens of bundle CIDs the load path
@@ -275,6 +277,8 @@ export function installHeliaBlockstoreGetShim(
     cid: unknown,
     opts?: unknown,
   ): Promise<Uint8Array | undefined> => {
+    incr('helia.blockstore.get.calls');
+    const __gStart = performance.now();
     const key = cidKey(cid);
 
     if (key !== null) {
@@ -286,16 +290,22 @@ export function installHeliaBlockstoreGetShim(
         lru.delete(key);
         lru.set(key, cached);
         hits++;
+        incr('helia.blockstore.get.cacheHit');
+        observeMs('helia.blockstore.get.cacheHitMs', performance.now() - __gStart);
         return cached;
       }
       const pending = inflight.get(key);
       if (pending !== undefined) {
         hits++;
-        return pending;
+        incr('helia.blockstore.get.inflightHit');
+        const result = await pending;
+        observeMs('helia.blockstore.get.inflightHitMs', performance.now() - __gStart);
+        return result;
       }
     }
 
     misses++;
+    incr('helia.blockstore.get.miss');
     const work = (async (): Promise<Uint8Array | undefined> => {
       try {
         const source = originalGet(cid, opts) as AsyncIterable<Uint8Array>;
@@ -313,7 +323,9 @@ export function installHeliaBlockstoreGetShim(
     const result = await work;
     if (key !== null && result instanceof Uint8Array) {
       touch(key, result);
+      incr('helia.blockstore.get.bytes', result.byteLength);
     }
+    observeMs('helia.blockstore.get.missMs', performance.now() - __gStart);
     return result;
   };
 
@@ -322,12 +334,21 @@ export function installHeliaBlockstoreGetShim(
   let wrappedPut: ((cid: unknown, val: unknown, opts?: unknown) => unknown) | null = null;
   if (originalPut !== null) {
     wrappedPut = (cid: unknown, val: unknown, opts?: unknown): unknown => {
+      incr('helia.blockstore.put.calls');
+      const __pStart = performance.now();
       const key = cidKey(cid);
       if (key !== null) {
         lru.delete(key);
         inflight.delete(key);
       }
-      return originalPut(cid, val, opts);
+      const result = originalPut(cid, val, opts);
+      if (result && typeof (result as { then?: unknown }).then === 'function') {
+        return (result as Promise<unknown>).finally(() => {
+          observeMs('helia.blockstore.put.totalMs', performance.now() - __pStart);
+        });
+      }
+      observeMs('helia.blockstore.put.totalMs', performance.now() - __pStart);
+      return result;
     };
     blockstore.put = wrappedPut as HeliaBlockstoreLike['put'];
   }
@@ -341,12 +362,21 @@ export function installHeliaBlockstoreGetShim(
   let wrappedDelete: ((cid: unknown, opts?: unknown) => unknown) | null = null;
   if (originalDelete !== null) {
     wrappedDelete = (cid: unknown, opts?: unknown): unknown => {
+      incr('helia.blockstore.delete.calls');
+      const __dStart = performance.now();
       const key = cidKey(cid);
       if (key !== null) {
         lru.delete(key);
         inflight.delete(key);
       }
-      return originalDelete(cid, opts);
+      const result = originalDelete(cid, opts);
+      if (result && typeof (result as { then?: unknown }).then === 'function') {
+        return (result as Promise<unknown>).finally(() => {
+          observeMs('helia.blockstore.delete.totalMs', performance.now() - __dStart);
+        });
+      }
+      observeMs('helia.blockstore.delete.totalMs', performance.now() - __dStart);
+      return result;
     };
     blockstore.delete = wrappedDelete as HeliaBlockstoreLike['delete'];
   }

--- a/profile/orbitdb-adapter.ts
+++ b/profile/orbitdb-adapter.ts
@@ -751,22 +751,32 @@ export class OrbitDbAdapter implements ProfileDatabase {
 
   async put(key: string, value: Uint8Array): Promise<void> {
     this.ensureConnected();
+    const __t0 = performance.now();
+    const isBundleKey = key.startsWith('tokens.bundle.');
     try {
       await this.db.put(key, value);
     } catch (err) {
+      incr('orbitdb.put.error');
       throw new ProfileError(
         'ORBITDB_WRITE_FAILED',
         `Failed to write key "${key}": ${err instanceof Error ? err.message : String(err)}`,
         err,
+      );
+    } finally {
+      observeMs(
+        isBundleKey ? 'orbitdb.put.bundle' : 'orbitdb.put.other',
+        performance.now() - __t0,
       );
     }
   }
 
   async get(key: string): Promise<Uint8Array | null> {
     this.ensureConnected();
+    const __t0 = performance.now();
     try {
       const value = await this.db.get(key);
       if (value === undefined || value === null) {
+        observeMs('orbitdb.get.missMs', performance.now() - __t0);
         return null;
       }
       // Steelman² remediation: shape validation now lives inside
@@ -774,8 +784,12 @@ export class OrbitDbAdapter implements ProfileDatabase {
       // getEntry() and all()). A peer-crafted LWW write that puts a
       // pathological object in the value slot is rejected uniformly
       // across all three entry points.
-      return coerceToUint8Array(value);
+      const result = coerceToUint8Array(value);
+      observeMs('orbitdb.get.hitMs', performance.now() - __t0);
+      return result;
     } catch (err) {
+      incr('orbitdb.get.error');
+      observeMs('orbitdb.get.errorMs', performance.now() - __t0);
       if (err instanceof ProfileError) throw err;
       throw new ProfileError(
         'ORBITDB_READ_FAILED',
@@ -787,14 +801,18 @@ export class OrbitDbAdapter implements ProfileDatabase {
 
   async del(key: string): Promise<void> {
     this.ensureConnected();
+    const __t0 = performance.now();
     try {
       await this.db.del(key);
     } catch (err) {
+      incr('orbitdb.del.error');
       throw new ProfileError(
         'ORBITDB_WRITE_FAILED',
         `Failed to delete key "${key}": ${err instanceof Error ? err.message : String(err)}`,
         err,
       );
+    } finally {
+      observeMs('orbitdb.del.totalMs', performance.now() - __t0);
     }
   }
 
@@ -882,14 +900,27 @@ export class OrbitDbAdapter implements ProfileDatabase {
     } = {},
   ): Promise<OpLogEntryEnvelope | null> {
     this.ensureConnected();
+    const __geStart = performance.now();
+    const isBundleKey = key.startsWith('tokens.bundle.');
     try {
       const raw = await this.db.get(key);
-      if (raw === undefined || raw === null) return null;
+      if (raw === undefined || raw === null) {
+        observeMs(
+          isBundleKey ? 'orbitdb.getEntry.bundleMissMs' : 'orbitdb.getEntry.missMs',
+          performance.now() - __geStart,
+        );
+        return null;
+      }
       const bytes = coerceToUint8Array(raw);
 
       // Explicit downgrade requested → route through the ingress path.
       if (opts.downgradeAsReplicated === true) {
-        return decodeAndDowngradeReplicated(bytes);
+        const result = decodeAndDowngradeReplicated(bytes);
+        observeMs(
+          isBundleKey ? 'orbitdb.getEntry.bundleHitMs' : 'orbitdb.getEntry.hitMs',
+          performance.now() - __geStart,
+        );
+        return result;
       }
 
       // Default: decode, then enforce the downgrade UNLESS the caller
@@ -899,11 +930,19 @@ export class OrbitDbAdapter implements ProfileDatabase {
       // Legacy entries (v=0) always carry the synthesized system tag —
       // pass through unchanged; the v=0 sentinel tells the caller.
       if (envelope.v === 0) {
+        observeMs(
+          isBundleKey ? 'orbitdb.getEntry.bundleHitMs' : 'orbitdb.getEntry.hitMs',
+          performance.now() - __geStart,
+        );
         return envelope;
       }
 
       const trusted = opts.trustLocalClaim === true && this.localAuthoredKeys.has(key);
       if (trusted) {
+        observeMs(
+          isBundleKey ? 'orbitdb.getEntry.bundleHitMs' : 'orbitdb.getEntry.hitMs',
+          performance.now() - __geStart,
+        );
         return envelope;
       }
 
@@ -920,8 +959,15 @@ export class OrbitDbAdapter implements ProfileDatabase {
       // default. A future enhancement could verify the OpLog entry's
       // identity field against the wallet's chainPubkey to recognize
       // sibling-tab writes; deferred until a use case justifies it.
-      return decodeAndDowngradeReplicated(bytes);
+      const downgraded = decodeAndDowngradeReplicated(bytes);
+      observeMs(
+        isBundleKey ? 'orbitdb.getEntry.bundleHitMs' : 'orbitdb.getEntry.hitMs',
+        performance.now() - __geStart,
+      );
+      return downgraded;
     } catch (err) {
+      incr('orbitdb.getEntry.error');
+      observeMs('orbitdb.getEntry.errorMs', performance.now() - __geStart);
       // Steelman³ remediation: pass ProfileError through unchanged.
       // Re-wrapping double-prefixes the error code (`[PROFILE:ORBITDB_READ_FAILED]
       // ... [PROFILE:ORBITDB_READ_FAILED]`) and obscures the original
@@ -941,11 +987,15 @@ export class OrbitDbAdapter implements ProfileDatabase {
     opts?: { readonly maxResults?: number },
   ): Promise<Map<string, Uint8Array>> {
     this.ensureConnected();
+    incr('orbitdb.all.calls');
+    const __allStart = performance.now();
     try {
       const result = new Map<string, Uint8Array>();
       // OrbitDB keyvalue databases expose an `all()` method that returns
       // all entries as an object or iterable.
+      const __dbAllStart = performance.now();
       const allEntries = await this.db.all();
+      observeMs('orbitdb.all.dbAllMs', performance.now() - __dbAllStart);
       // Round 5 (FIX 3) — short-circuit iteration once the requested
       // `maxResults` matching entries have been buffered. Defends
       // against a hostile peer planting millions of crafted prefix
@@ -1064,8 +1114,12 @@ export class OrbitDbAdapter implements ProfileDatabase {
         );
       }
 
+      incr('orbitdb.all.entries', result.size);
+      observeMs('orbitdb.all.totalMs', performance.now() - __allStart);
       return result;
     } catch (err) {
+      incr('orbitdb.all.error');
+      observeMs('orbitdb.all.totalMs', performance.now() - __allStart);
       if (err instanceof ProfileError) throw err;
       throw new ProfileError(
         'ORBITDB_READ_FAILED',

--- a/profile/profile-snapshot-dispatcher.ts
+++ b/profile/profile-snapshot-dispatcher.ts
@@ -44,6 +44,7 @@
  */
 
 import { logger } from '../core/logger';
+import { incr, observeMs } from '../core/perf-counters.js';
 import type { LeanProfileSnapshot } from './profile-lean-snapshot';
 import type {
   JoinResult,
@@ -311,6 +312,9 @@ export async function runProfileSnapshotJoin(
 ): Promise<ApplySnapshotResult> {
   const log = deps.log ?? ((msg: string): void => logger.debug('SnapshotDispatcher', msg));
 
+  const __sjStart = performance.now();
+  incr('profile.snapshotJoin.calls');
+
   // 1. Decode base64 once. Reuse the resulting bytes for every writer's
   //    prefix-filtered view via `Array.prototype.filter` — no copies.
   //
@@ -325,10 +329,13 @@ export async function runProfileSnapshotJoin(
   //    array and the writer is never called — Phase 2's wiring is
   //    correct, the entries simply never reach it. See
   //    `normalizeEntryKey` doc-comment for the full rationale.
+  const __decodeStart = performance.now();
   const entries: SnapshotEntry[] = snapshot.entries.map((e) => ({
     key: normalizeEntryKey(e.key),
     encryptedValue: base64ToBytes(e.value),
   }));
+  observeMs('profile.snapshotJoin.decodeMs', performance.now() - __decodeStart);
+  incr('profile.snapshotJoin.decodedEntries', entries.length);
 
   // 2. Extract unique addressIds.
   const addressIds = new Set<string>();
@@ -361,6 +368,8 @@ export async function runProfileSnapshotJoin(
       // `remoteRejectedMalformed` counter signal-only.
       const slice = entries.filter((e) => e.key.startsWith(keyPrefix));
       if (slice.length === 0) continue;
+      incr('profile.snapshotJoin.perWriterDispatchCalls');
+      const __wStart = performance.now();
       try {
         const result = await writer.joinSnapshot(slice);
         accumulate(aggregated, result);
@@ -373,6 +382,8 @@ export async function runProfileSnapshotJoin(
           `runProfileSnapshotJoin: writer @ ${keyPrefix} threw — skipping ` +
             `(error: ${err instanceof Error ? err.message : String(err)})`,
         );
+      } finally {
+        observeMs('profile.snapshotJoin.perWriterDispatchMs', performance.now() - __wStart);
       }
     }
   }
@@ -382,6 +393,8 @@ export async function runProfileSnapshotJoin(
     const bundleSlice = entries.filter((e) => e.key.startsWith(BUNDLE_KEY_PREFIX));
     bundleEntriesSeen = bundleSlice.length;
     if (bundleSlice.length > 0) {
+      incr('profile.snapshotJoin.bundleIndexJoinCalls');
+      const __bStart = performance.now();
       try {
         const result = await deps.bundleIndex.joinSnapshot(bundleSlice);
         accumulate(aggregated, result);
@@ -390,6 +403,8 @@ export async function runProfileSnapshotJoin(
           `runProfileSnapshotJoin: bundleIndex.joinSnapshot threw — skipping ` +
             `(error: ${err instanceof Error ? err.message : String(err)})`,
         );
+      } finally {
+        observeMs('profile.snapshotJoin.bundleIndexJoinMs', performance.now() - __bStart);
       }
     }
   } else {
@@ -397,6 +412,8 @@ export async function runProfileSnapshotJoin(
       'runProfileSnapshotJoin: bundleIndex not available — bundle JOIN skipped',
     );
   }
+
+  observeMs('profile.snapshotJoin.totalMs', performance.now() - __sjStart);
 
   const joinedAny = aggregated.liveLanded > 0 || aggregated.tombstonesLanded > 0;
   return {

--- a/profile/profile-snapshot-merge.ts
+++ b/profile/profile-snapshot-merge.ts
@@ -73,6 +73,8 @@
  * @see profile/lamport.ts — §7.1 Lamport invariants, W39 bounds defence
  */
 
+import { incr, observeMs } from '../core/perf-counters.js';
+
 // =============================================================================
 // 1. Constants
 // =============================================================================
@@ -348,16 +350,20 @@ export async function runJoinSnapshot(
 
   for (const entry of remote) {
     entriesEvaluated += 1;
+    incr('profile.snapshotJoin.perKeyApplyCalls');
+    const __keyStart = performance.now();
 
     let remoteSlot: ClassifiedSlot | null;
     try {
       remoteSlot = await deps.classifyRemote(entry);
     } catch {
       remoteRejectedMalformed += 1;
+      observeMs('profile.snapshotJoin.perKeyApplyMs', performance.now() - __keyStart);
       continue;
     }
     if (remoteSlot === null || remoteSlot.kind === 'absent') {
       remoteRejectedMalformed += 1;
+      observeMs('profile.snapshotJoin.perKeyApplyMs', performance.now() - __keyStart);
       continue;
     }
 
@@ -373,6 +379,7 @@ export async function runJoinSnapshot(
     const action = mergeSlots(localSlot, remoteSlot);
     if (action.kind === 'noop') {
       localWon += 1;
+      observeMs('profile.snapshotJoin.perKeyApplyMs', performance.now() - __keyStart);
       continue;
     }
 
@@ -385,6 +392,8 @@ export async function runJoinSnapshot(
       }
     } catch {
       remoteRejectedMalformed += 1;
+    } finally {
+      observeMs('profile.snapshotJoin.perKeyApplyMs', performance.now() - __keyStart);
     }
   }
 

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -136,6 +136,16 @@ export class ProfileTokenStorageProvider
   private encryptionKey: Uint8Array | null = null;
   private initialized = false;
   private isShuttingDown = false;
+  /**
+   * Issue #364 Item #2 — true between {@link clear} entry and exit.
+   * `clear()` is destructive; allowing the periodic pointer-poll's
+   * `applySnapshotIfWired` to run mid-clear would dispatch a snapshot
+   * against state that is about to be wiped, wasting IPFS round-trips
+   * and risking partial seeding of about-to-be-deleted data. The
+   * shutdown gate (`isShuttingDown`/`hasShutdown`) does not cover the
+   * clear-on-a-live-provider path, hence the separate latch.
+   */
+  private isClearing = false;
 
   // --- Write-behind buffer ---
   private pendingData: TxfStorageDataBase | null = null;
@@ -852,6 +862,10 @@ export class ProfileTokenStorageProvider
   private async _applySnapshotIfWiredImpl(
     cidString: string,
   ): Promise<import('./profile-snapshot-dispatcher.js').ApplySnapshotResult | null> {
+    if (this.isClearing) {
+      incr('profile.applySnapshot.suppressedDuringClear');
+      return null;
+    }
     if (this.isShuttingDown || this.hasShutdown) return null;
     // Late-bound setter wins; falls back to construction-time option
     // for callers that prefer the static-config style.
@@ -1852,6 +1866,11 @@ export class ProfileTokenStorageProvider
   async clear(): Promise<boolean> {
     if (!this.initialized) return false;
 
+    // Issue #364 Item #2 — gate concurrent applySnapshotIfWired calls
+    // for the duration of clear(). A periodic pointer-poll that fires
+    // during destructive teardown would dispatch a snapshot against
+    // about-to-be-wiped state, racing the deletes below.
+    this.isClearing = true;
     try {
       // Remove all bundle refs from OrbitDB
       const allBundles = await this.db.all(BUNDLE_KEY_PREFIX);
@@ -1888,6 +1907,8 @@ export class ProfileTokenStorageProvider
     } catch (err) {
       this.log(`clear() failed: ${err instanceof Error ? err.message : String(err)}`);
       return false;
+    } finally {
+      this.isClearing = false;
     }
   }
 

--- a/serialization/txf-serializer.ts
+++ b/serialization/txf-serializer.ts
@@ -31,6 +31,7 @@ import {
 import type { Token, TokenStatus } from '../types';
 import { TokenRegistry } from '../registry/TokenRegistry';
 import { INVOICE_TOKEN_TYPE_HEX } from '../constants';
+import { incr, observeMs } from '../core/perf-counters.js';
 
 // =============================================================================
 // SDK Token Normalization
@@ -234,6 +235,16 @@ function determineTokenStatus(txf: TxfToken): TokenStatus {
  * for any persisted invoice.
  */
 export function txfToToken(tokenId: string, txf: TxfToken): Token {
+  incr('serialization.txfSerializer.txfToToken.calls');
+  const __t0 = performance.now();
+  try {
+    return __txfToTokenImpl(tokenId, txf);
+  } finally {
+    observeMs('serialization.txfSerializer.txfToToken.totalMs', performance.now() - __t0);
+  }
+}
+
+function __txfToTokenImpl(tokenId: string, txf: TxfToken): Token {
   const coinData = txf.genesis.data.coinData ?? [];
   const totalAmount = coinData.reduce((sum, [, amt]) => {
     return sum + BigInt(amt || '0');
@@ -400,6 +411,19 @@ export interface ParsedStorageData {
  * Parse TXF storage data
  */
 export function parseTxfStorageData(data: unknown): ParsedStorageData {
+  incr('serialization.txfSerializer.parseStorageData.calls');
+  const __pStart = performance.now();
+  try {
+    return __parseTxfStorageDataImpl(data);
+  } finally {
+    observeMs(
+      'serialization.txfSerializer.parseStorageData.totalMs',
+      performance.now() - __pStart,
+    );
+  }
+}
+
+function __parseTxfStorageDataImpl(data: unknown): ParsedStorageData {
   const result: ParsedStorageData = {
     tokens: [],
     meta: null,

--- a/tests/unit/profile/profile-token-storage-clear-suppress-apply-snapshot-364.test.ts
+++ b/tests/unit/profile/profile-token-storage-clear-suppress-apply-snapshot-364.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Issue #364 Item #2 — Suppress `applySnapshotIfWired` invocations
+ * during {@link ProfileTokenStorageProvider.clear}.
+ *
+ * Trace (from issue #363 §D.3 baseline): the periodic pointer-poll
+ * fires during `Sphere.clear()` teardown. `pointerLayer.recoverLatest()`
+ * returns a CID; `applySnapshotIfWired(cid)` runs the wired callback,
+ * which fetches the CAR, parses it as a lean snapshot, and dispatches
+ * a per-writer JOIN against state that is about to be wiped. 23
+ * invocations were observed in a 41 s clear-all-wallets phase, wasting
+ * IPFS round-trips and racing the destructive deletes.
+ *
+ * The fix is a per-provider `isClearing` latch checked by
+ * `_applySnapshotIfWiredImpl`. Set at the top of `clear()`, unset on
+ * completion; a concurrent applySnapshot returns null and bumps
+ * `profile.applySnapshot.suppressedDuringClear`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import type { ApplySnapshotResult } from '../../../profile/profile-snapshot-dispatcher';
+import {
+  __setPerfEnabledForTest,
+  __stopAutoDumpForTest,
+  dumpAndReset,
+  snapshot,
+} from '../../../core/perf-counters.js';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1test',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+function createMockDb(): ProfileDatabase {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as ProfileDatabase;
+}
+
+function makeApplyResult(joinedAny = false): ApplySnapshotResult {
+  return {
+    joinedAny,
+    addressesSeen: joinedAny ? 1 : 0,
+    bundleEntriesSeen: 0,
+    counters: {
+      entriesEvaluated: joinedAny ? 1 : 0,
+      liveLanded: joinedAny ? 1 : 0,
+      tombstonesLanded: 0,
+      localWon: 0,
+      remoteRejectedMalformed: 0,
+    },
+  };
+}
+
+function createProvider(): ProfileTokenStorageProvider {
+  const provider = new ProfileTokenStorageProvider(
+    createMockDb(),
+    new Uint8Array(32).fill(0x11),
+    ['https://mock-ipfs.test'],
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId: 'test',
+      encrypt: true,
+    },
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  return provider;
+}
+
+describe('Issue #364 Item #2 — applySnapshot suppression during clear()', () => {
+  beforeEach(() => {
+    __stopAutoDumpForTest();
+    __setPerfEnabledForTest(true);
+    // Drop any cross-test residue from the shared counter map.
+    dumpAndReset();
+  });
+
+  afterEach(() => {
+    __setPerfEnabledForTest(false);
+    __stopAutoDumpForTest();
+  });
+
+  it('applySnapshotIfWired() called during clear() returns null without invoking callback', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    // Spy on db.all so we can intercept mid-clear and fire an
+    // applySnapshotIfWired race during the await chain inside clear().
+    const db = (provider as unknown as { db: ProfileDatabase }).db;
+    const realAll = db.all.bind(db);
+    let raceResult: ApplySnapshotResult | null | undefined;
+    let allCalls = 0;
+    db.all = (async (prefix?: string) => {
+      allCalls += 1;
+      if (allCalls === 1) {
+        // Fire the race BEFORE returning from db.all() — the clear()
+        // method is awaiting us, so isClearing is already true.
+        raceResult = await provider.applySnapshotIfWired('bafy-snapshot-cid');
+      }
+      return realAll(prefix);
+    }) as ProfileDatabase['all'];
+
+    const ok = await provider.clear();
+    expect(ok).toBe(true);
+
+    expect(raceResult).toBeNull();
+    expect(applier).not.toHaveBeenCalled();
+  });
+
+  it('bumps profile.applySnapshot.suppressedDuringClear when the gate trips', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    const db = (provider as unknown as { db: ProfileDatabase }).db;
+    const realAll = db.all.bind(db);
+    let allCalls = 0;
+    db.all = (async (prefix?: string) => {
+      allCalls += 1;
+      if (allCalls === 1) {
+        await provider.applySnapshotIfWired('bafy-cid-1');
+        await provider.applySnapshotIfWired('bafy-cid-2');
+      }
+      return realAll(prefix);
+    }) as ProfileDatabase['all'];
+
+    await provider.clear();
+
+    const counters = snapshot();
+    expect(counters['profile.applySnapshot.suppressedDuringClear']?.count).toBe(2);
+    expect(counters['profile.applySnapshot.fired']?.count ?? 0).toBe(0);
+    expect(applier).not.toHaveBeenCalled();
+  });
+
+  it('applySnapshotIfWired() works normally after clear() completes', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    const ok = await provider.clear();
+    expect(ok).toBe(true);
+
+    // Gate has been unset in finally — a fresh call should proceed.
+    const result = await provider.applySnapshotIfWired('bafy-after-clear');
+    expect(result).not.toBeNull();
+    expect(applier).toHaveBeenCalledTimes(1);
+    expect(applier).toHaveBeenCalledWith('bafy-after-clear');
+  });
+
+  it('unsets isClearing even when clear() throws mid-way', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    // Force db.all to reject so clear() takes the catch branch.
+    const db = (provider as unknown as { db: ProfileDatabase }).db;
+    db.all = (async () => {
+      throw new Error('synthetic db.all failure');
+    }) as ProfileDatabase['all'];
+
+    const ok = await provider.clear();
+    expect(ok).toBe(false);
+
+    // Latch released in `finally`; a subsequent applySnapshot should
+    // dispatch normally.
+    const result = await provider.applySnapshotIfWired('bafy-after-failed-clear');
+    expect(result).not.toBeNull();
+    expect(applier).toHaveBeenCalledTimes(1);
+  });
+
+  it('isClearing gate takes precedence over shutdown gate', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    // Force the isClearing latch directly to simulate an in-flight clear.
+    (provider as unknown as { isClearing: boolean }).isClearing = true;
+    try {
+      const result = await provider.applySnapshotIfWired('bafy-cid');
+      expect(result).toBeNull();
+      expect(applier).not.toHaveBeenCalled();
+
+      const counters = snapshot();
+      expect(
+        counters['profile.applySnapshot.suppressedDuringClear']?.count,
+      ).toBeGreaterThanOrEqual(1);
+    } finally {
+      (provider as unknown as { isClearing: boolean }).isClearing = false;
+    }
+  });
+
+  it('returns false (without setting isClearing) when provider not initialized', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+
+    // Skip initialize() — clear() should short-circuit.
+    const ok = await provider.clear();
+    expect(ok).toBe(false);
+
+    // Gate must be in the un-set state — applySnapshot proceeds normally.
+    const result = await provider.applySnapshotIfWired('bafy-cid');
+    expect(result).not.toBeNull();
+    expect(applier).toHaveBeenCalledTimes(1);
+  });
+});

--- a/uxf/UxfPackage.ts
+++ b/uxf/UxfPackage.ts
@@ -562,6 +562,8 @@ export function ingest(
   token: unknown,
   opts?: { updatedAt?: number },
 ): void {
+  incr('uxf.ingest.calls');
+  const __iStart = performance.now();
   const pool = wrapPool(pkg);
   const rootHash = deconstructToken(pool, token);
   syncPool(pkg, pool);
@@ -583,6 +585,7 @@ export function ingest(
 
   // Update secondary indexes
   updateIndexesForToken(pkg, tokenId, rootHash);
+  observeMs('uxf.ingest.totalMs', performance.now() - __iStart);
 }
 
 /**
@@ -611,10 +614,15 @@ export function ingestAll(
   opts?: { updatedAt?: number },
 ): void {
   if (tokens.length === 0) return;
+  incr('uxf.ingestAll.calls');
+  incr('uxf.ingestAll.tokens', tokens.length);
+  const __iaStart = performance.now();
   const pool = wrapPool(pkg);
   const newTokens: Array<{ tokenId: string; rootHash: ContentHash }> = [];
   for (const token of tokens) {
+    const __dStart = performance.now();
     const rootHash = deconstructToken(pool, token);
+    observeMs('uxf.ingestAll.perTokenDeconstructMs', performance.now() - __dStart);
     const rootElement = pool.get(rootHash)!;
     const rootContent = rootElement.content as unknown as TokenRootContent;
     newTokens.push({ tokenId: rootContent.tokenId, rootHash });
@@ -703,11 +711,13 @@ export function ingestAll(
     } catch {
       /* best-effort — pool integrity already compromised, throw the original error */
     }
+    observeMs('uxf.ingestAll.totalMs', performance.now() - __iaStart);
     throw err;
   }
   // Stamp envelope updatedAt; caller can lock for determinism.
   (pkg.envelope as { updatedAt: number }).updatedAt =
     opts?.updatedAt ?? Math.floor(Date.now() / 1000);
+  observeMs('uxf.ingestAll.totalMs', performance.now() - __iaStart);
 }
 
 /**
@@ -718,8 +728,13 @@ export function assemble(
   tokenId: string,
   strategy: InstanceSelectionStrategy = STRATEGY_LATEST,
 ): unknown {
-  const pool = wrapPool(pkg);
-  return assembleToken(pool, pkg.manifest, tokenId, pkg.instanceChains, strategy);
+  incr('uxf.assemble.calls');
+  const __aStart = performance.now();
+  try {
+    return assembleToken(wrapPool(pkg), pkg.manifest, tokenId, pkg.instanceChains, strategy);
+  } finally {
+    observeMs('uxf.assemble.totalMs', performance.now() - __aStart);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Three items from #364:

- **Item #2 (P2)** — Suppress `profile.applySnapshot` during `tokenStorage.clear()` via an `isClearing` latch. Eliminates wasted snapshot applies on a wallet about to be wiped.
- **Item #3 (P2)** — Add 29 attribution counters across `profile-snapshot-dispatcher`, UXF/TXF parse, Helia blockstore, and the OrbitDB adapter to close the §D.4 instrumentation gap from #363.
- **Item #6 (P3)** — Extend `manual-test-full-recovery.sh` `normalize_snapshot()` with an awk state machine that strips multi-line `[perf-counters] snapshot: { ... }` blocks. First time soak passes §D.5 assertions with `SPHERE_PERF=1`.

## What's NOT in this PR

Items #1 and #4 were dropped after A/B soaks showed they degraded total wall-clock from 721s → 2909s (+303%) by triggering V6-RECOVER retry storms in §D.1. They're tracked as follow-up issues for re-design with safer signals:

- **Item #1 (cache)** — `recoverLatest` cache lacked publish-time invalidation; stale aggregator views poisoned downstream paths
- **Item #4 (gate)** — `loadSourcedFromSnapshot` breadcrumb armed by every `applySnapshot` fire (incl. periodic-poll), bypassed Rule-4 enrichment where it was needed, leaving stranded receives unfinalizable

## Validation

- `npm run typecheck` clean
- `npm run lint` identical to baseline (605 problems / 43 errors / 562 warnings — all pre-existing)
- `npm run test:run` — **539 files / 8808 tests passed / 13 skipped / 0 failed**
- Soak: diagnostic with Item #4 disabled passed end-to-end (`verdict=PASS`, 888s vs baseline 721s). Multiple final-soak attempts on clean integration blocked by testnet flakiness (§C.4 Nostr DM propagation, IPFS gateway single-point-of-failure) — pre-existing, not regressions from this work.

## Test plan
- [ ] CI green on `integration/issue-364-items-2-3-6`
- [ ] Soak on a stable testnet day reaches §D.5 with `verdict=PASS`
- [ ] §D.3 counter `profile.applySnapshot.suppressedDuringClear` bumps on a wallet's own clear path

## Refs
- Closes-in-part #364 (Items #2, #3, #6)
- Defers #364 Items #1, #4 to dedicated follow-up issues