### PR TITLE
perf(profile/ipfs)(issue-370): single-shot CAR /dag/import + /dag/export with capability probe and legacy fallback

### DIFF
--- a/core/perf-counters.ts
+++ b/core/perf-counters.ts
@@ -1,0 +1,261 @@
+/**
+ * core/perf-counters.ts — opt-in runtime measurement hooks.
+ *
+ * Created in response to GH issue #363 (post-mortem of #360). The
+ * lesson from #360: do NOT propose perf fixes from static analysis.
+ * Measure first, fix second. This module exists so that the next
+ * investigator can capture real numbers from the hot paths the #360
+ * findings called out but never instrumented.
+ *
+ * ## Activation
+ *
+ * Zero overhead when off. Enabled by either of:
+ *
+ *   - `process.env.SPHERE_PERF=1` at process start (Node), OR
+ *   - `localStorage.SPHERE_PERF=1` (browser)
+ *
+ * When enabled, the module:
+ *
+ *   1. Records counter / timer samples taken via {@link incr},
+ *      {@link observeMs}, and {@link time}.
+ *   2. Dumps a snapshot of all counters every
+ *      `SPHERE_PERF_DUMP_MS` (default 5000 ms) via
+ *      `logger.info('perf', { snapshot })`.
+ *   3. Clears the snapshot after each dump so the numbers reflect the
+ *      most recent window, not cumulative since start.
+ *
+ * ## API
+ *
+ *   - `incr(name, n=1)` — bump a counter.
+ *   - `observeMs(name, ms)` — record a timing sample (ms).
+ *   - `time(name, fn)` — wrap an async function; records its wall-clock.
+ *   - `snapshot()` — return current counters without clearing.
+ *   - `dumpAndReset()` — emit + clear (called periodically when enabled).
+ *
+ * All calls are guarded by `PERF_ENABLED` and bail out cheap when off
+ * (one boolean check + early return; no allocations, no time reads).
+ *
+ * ## Why no histograms / no p99
+ *
+ * Keep it minimal. The first profile-driven investigation needs
+ * count + total + max, not a HDR histogram. If a future investigation
+ * needs percentiles, swap the storage at that point. We are recovering
+ * from the over-engineering of #360 — do not repeat that here.
+ *
+ * @module core/perf-counters
+ */
+
+import { logger } from './logger.js';
+
+// =============================================================================
+// Activation
+// =============================================================================
+
+function detectEnabled(): boolean {
+  try {
+    if (typeof process !== 'undefined' && process?.env) {
+      if (process.env.SPHERE_PERF === '1') return true;
+    }
+  } catch {
+    /* ignore — browser ESM */
+  }
+  try {
+    if (typeof localStorage !== 'undefined') {
+      if (localStorage.getItem('SPHERE_PERF') === '1') return true;
+    }
+  } catch {
+    /* ignore — sandboxed iframe / private mode */
+  }
+  return false;
+}
+
+/**
+ * Cached at module load. We deliberately do NOT re-read the env on
+ * every call — the gating must be cheap. To flip the flag for an
+ * in-flight test, call `__setPerfEnabledForTest`.
+ */
+let PERF_ENABLED: boolean = detectEnabled();
+
+function detectDumpIntervalMs(): number {
+  try {
+    if (typeof process !== 'undefined' && process?.env?.SPHERE_PERF_DUMP_MS) {
+      const n = Number(process.env.SPHERE_PERF_DUMP_MS);
+      if (Number.isFinite(n) && n > 0) return Math.max(100, Math.floor(n));
+    }
+  } catch {
+    /* ignore */
+  }
+  return 5_000;
+}
+
+// =============================================================================
+// Storage
+// =============================================================================
+
+interface CounterCell {
+  count: number;
+  totalMs: number;
+  maxMs: number;
+}
+
+const counters = new Map<string, CounterCell>();
+
+function getCell(name: string): CounterCell {
+  let c = counters.get(name);
+  if (c === undefined) {
+    c = { count: 0, totalMs: 0, maxMs: 0 };
+    counters.set(name, c);
+  }
+  return c;
+}
+
+// =============================================================================
+// API
+// =============================================================================
+
+/**
+ * Bump a counter by `n` (default 1). No-op when perf is disabled.
+ */
+export function incr(name: string, n: number = 1): void {
+  if (!PERF_ENABLED) return;
+  const c = getCell(name);
+  c.count += n;
+}
+
+/**
+ * Record one timing sample (milliseconds). No-op when perf is disabled.
+ *
+ * Negative or non-finite values are silently clamped to 0 — caller
+ * mistakes (e.g., subtracting `Date.now()` across a clock skip) must
+ * not corrupt the counter state.
+ */
+export function observeMs(name: string, ms: number): void {
+  if (!PERF_ENABLED) return;
+  const v = Number.isFinite(ms) && ms > 0 ? ms : 0;
+  const c = getCell(name);
+  c.count += 1;
+  c.totalMs += v;
+  if (v > c.maxMs) c.maxMs = v;
+}
+
+/**
+ * Wrap a function and record its wall-clock. No-op overhead is one
+ * boolean check + the function call. When enabled, adds a single
+ * `performance.now()` pair around the call.
+ *
+ * Errors propagate; the timing is still recorded (so a failing
+ * subsystem still shows up in the snapshot).
+ */
+export async function time<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  if (!PERF_ENABLED) return fn();
+  const t0 = performance.now();
+  try {
+    return await fn();
+  } finally {
+    observeMs(name, performance.now() - t0);
+  }
+}
+
+/**
+ * Sync wrapper variant. Same semantics as `time` for synchronous
+ * functions.
+ */
+export function timeSync<T>(name: string, fn: () => T): T {
+  if (!PERF_ENABLED) return fn();
+  const t0 = performance.now();
+  try {
+    return fn();
+  } finally {
+    observeMs(name, performance.now() - t0);
+  }
+}
+
+/**
+ * Read-only view of the current counters. Returns an empty object
+ * when perf is disabled. Does NOT clear.
+ */
+export function snapshot(): Record<
+  string,
+  { count: number; totalMs: number; avgMs: number; maxMs: number }
+> {
+  const out: Record<
+    string,
+    { count: number; totalMs: number; avgMs: number; maxMs: number }
+  > = {};
+  for (const [name, c] of counters) {
+    out[name] = {
+      count: c.count,
+      totalMs: Math.round(c.totalMs * 1000) / 1000,
+      avgMs: c.count > 0 ? Math.round((c.totalMs / c.count) * 1000) / 1000 : 0,
+      maxMs: Math.round(c.maxMs * 1000) / 1000,
+    };
+  }
+  return out;
+}
+
+/**
+ * Emit the current counters via `logger.info('perf', ...)` and clear.
+ * Intended to be called by the auto-dump timer; safe to call manually
+ * for tests.
+ */
+export function dumpAndReset(): void {
+  if (!PERF_ENABLED) return;
+  if (counters.size === 0) return;
+  const snap = snapshot();
+  counters.clear();
+  logger.info('perf', `[perf-counters] snapshot:`, snap);
+}
+
+// =============================================================================
+// Auto-dump timer
+// =============================================================================
+
+let dumpTimer: ReturnType<typeof setInterval> | null = null;
+
+function startAutoDump(): void {
+  if (dumpTimer !== null) return;
+  if (!PERF_ENABLED) return;
+  const ms = detectDumpIntervalMs();
+  dumpTimer = setInterval(() => {
+    try {
+      dumpAndReset();
+    } catch {
+      /* never let the dump path throw into the event loop */
+    }
+  }, ms);
+  // Don't keep the event loop alive just for the dump timer.
+  if (typeof (dumpTimer as { unref?: () => void }).unref === 'function') {
+    (dumpTimer as { unref?: () => void }).unref!();
+  }
+}
+
+/**
+ * Stop the auto-dump timer (test cleanup; not for production).
+ */
+export function __stopAutoDumpForTest(): void {
+  if (dumpTimer !== null) {
+    clearInterval(dumpTimer);
+    dumpTimer = null;
+  }
+}
+
+/**
+ * Toggle PERF_ENABLED at runtime. Tests only. In production the flag
+ * is read once at module load.
+ */
+export function __setPerfEnabledForTest(value: boolean): void {
+  PERF_ENABLED = value;
+  if (value) startAutoDump();
+  else __stopAutoDumpForTest();
+}
+
+/**
+ * Public: is perf measurement currently on? Useful for callers that
+ * want to skip building expensive instrumentation payloads when off.
+ */
+export function isPerfEnabled(): boolean {
+  return PERF_ENABLED;
+}
+
+// Boot the auto-dump if env enables it at module load.
+startAutoDump();

--- a/docs/uxf/SOAK-RUNBOOK-370.md
+++ b/docs/uxf/SOAK-RUNBOOK-370.md
@@ -1,0 +1,127 @@
+# Issue #370 — A/B Soak Runbook
+
+CAR-batched `/dag/import` + `/dag/export` vs the legacy per-block `/dag/put` + `block/get` pattern. Validates the wall-clock and throttling deltas claimed in [#370](https://github.com/unicity-sphere/sphere-sdk/issues/370).
+
+## Prerequisite — Part 1 of #370 must be done
+
+The operator gateway `unicity-ipfs1.dyndns.org` (and any sibling gateways the SDK fans-out to) **must expose** `/api/v0/dag/import` and `/api/v0/dag/export` at the haproxy/nginx ACL layer. Until that change is live, the SDK's capability probe correctly detects "not exposed" and falls through to the legacy per-block path — meaning both A and B runs end up taking the same code path and no delta will appear.
+
+Confirm Part 1 is live before running:
+
+```bash
+curl -sS -o /dev/null -w "import=%{http_code}\n" -X POST "https://unicity-ipfs1.dyndns.org/api/v0/dag/import"
+curl -sS -o /dev/null -w "export=%{http_code}\n" -X POST "https://unicity-ipfs1.dyndns.org/api/v0/dag/export"
+```
+
+- **Both must return 400** (healthy Kubo on empty body). Anything else (`404`, `405`, `5xx`) means Part 1 is not done.
+- The matching `/api/v0/dag/put` probe should also return `400` (sanity-check that the gateway is healthy in general).
+
+## A/B method
+
+Two soak runs against the **same** gateway, **same** kubo container, **same** wallet workload, with only the SDK build varying. Both runs use `SPHERE_PERF=1` to dump counters every 5s.
+
+### Run A (baseline — legacy per-block path)
+
+Build from `main` (no issue-#370 code). Even if Part 1 is live, this run only knows `/dag/put` + `/block/get`.
+
+```bash
+git checkout main
+git pull
+npm ci
+npm run build
+
+# Soak driver
+SPHERE_PERF=1 SPHERE_DEBUG=perf=info bash .tmp/soak-264.sh 2>&1 | tee /tmp/soak-370-run-A.log
+```
+
+### Run B (with #370 fast path)
+
+Build from `perf/issue-370-car-batching-import-export` (or after PR #371 merges, from `main`).
+
+```bash
+git checkout perf/issue-370-car-batching-import-export
+git pull
+npm ci
+npm run build
+
+SPHERE_PERF=1 SPHERE_DEBUG=perf=info bash .tmp/soak-264.sh 2>&1 | tee /tmp/soak-370-run-B.log
+```
+
+## Counters to compare
+
+The `core/perf-counters.ts` module dumps a snapshot every `SPHERE_PERF_DUMP_MS` (default 5000) via `logger.info('perf', …)`. Post-process the run logs with the same approach used in `#363`.
+
+### Public-surface counters (both runs measure them; A/B compares directly)
+
+| Counter | Meaning | Expected A → B |
+|---|---|---|
+| `ipfs.pinCar.calls` | Pin operations | unchanged |
+| `ipfs.pinCar.totalMs` | Whole-selector pin wall-clock (sum / count = per-call) | **drops 5–10×** |
+| `ipfs.pinCar.bytes` | Total bytes pinned | unchanged |
+| `ipfs.pinCar.error` | Pin failures | unchanged or lower (fewer throttling failures) |
+| `ipfs.fetchCar.calls` | Fetch operations | unchanged |
+| `ipfs.fetchCar.totalMs` | Whole-selector fetch wall-clock | **drops 5–10×** |
+| `ipfs.fetchCar.bytes` | Total bytes fetched | unchanged |
+
+### Path-attribution counters (B-only)
+
+| Counter | Meaning |
+|---|---|
+| `ipfs.pinCar.fastPath` | Pins that took the `/dag/import` path |
+| `ipfs.pinCar.legacyPath` | Pins that fell through to per-block `/dag/put` |
+| `ipfs.fetchCar.fastPath` | Fetches that took the `/dag/export` path |
+| `ipfs.fetchCar.legacyPath` | Fetches that fell through to per-block BFS |
+| `ipfs.fetchCar.localHeliaPath` | Fetches served entirely from local Helia (zero HTTP) |
+| `ipfs.fetchCar.rawCodec` | Raw-codec backcompat short-circuit (legacy pinned bundles) |
+
+When Part 1 is live and stable: expect `fastPath` ≈ 100% of `(fastPath + legacyPath)` on both pin and fetch sides. Any `legacyPath` count points at a transient gateway issue worth a manual look.
+
+### Fast-path-only counters (B-only)
+
+| Counter | Meaning | Expected |
+|---|---|---|
+| `ipfs.dagImport.calls` | Successful `/dag/import` POSTs | ≈ `ipfs.pinCar.fastPath` |
+| `ipfs.dagImport.totalMs` | `/dag/import` wall-clock (sum / count = per-call) | small (one HTTP round-trip per CAR) |
+| `ipfs.dagImport.bytes` | Bytes sent via `/dag/import` | ≈ `ipfs.pinCar.bytes` (on fast path) |
+| `ipfs.dagImport.error` | Fast-path failures that triggered fallback | low |
+| `ipfs.dagExport.*` | Mirrored counters for fetch fast path | analogous |
+
+### Legacy-path-only counters (both runs)
+
+| Counter | Meaning |
+|---|---|
+| `ipfs.pinCar.legacy.totalMs` / `legacy.blocks` / `legacy.bytes` / `legacy.error` | Per-block `/dag/put` work attribution |
+| `ipfs.fetchCar.legacy.totalMs` / `legacy.blocks` / `legacy.bytes` | Per-block BFS work attribution |
+
+On Run B: `legacy.*` counters drop to near-zero (only fires on transient fast-path fallback).
+On Run A: `legacy.*` ≈ `ipfs.{pinCar,fetchCar}.*` (every call takes the legacy path).
+
+### Capability-probe counters (B-only)
+
+| Counter | Meaning | Expected |
+|---|---|---|
+| `ipfs.probe.calls` | Total selector → probe invocations | matches pin + fetch call count |
+| `ipfs.probe.cacheHits` | Probe satisfied from the per-process cache | ≈ `calls - gateway_count` |
+| `ipfs.probe.dagImportOk` / `dagImportMissing` | Per-gateway probe outcome | `Ok` count == number of capable gateways |
+| `ipfs.probe.dagExportOk` / `dagExportMissing` | Per-gateway probe outcome | analogous |
+| `ipfs.probe.totalMs` | Probe wall-clock (per fresh gateway) | < 2000 (the `PROBE_TIMEOUT_MS`) |
+
+## Pass criteria
+
+1. **Wall-clock**: `ipfs.pinCar.totalMs` per-call (sum / `ipfs.pinCar.calls`) drops by **at least 5×** in B vs A. Same for `ipfs.fetchCar.totalMs`.
+2. **Path attribution**: `ipfs.pinCar.fastPath / (fastPath + legacyPath) >= 0.95` in B (≥95% of pins took the fast path).
+3. **Throttling**: `ipfs.pinCar.error` (and the operator-side kubo `MAX_PINS_PER_SECOND` overflow logs) drops to **zero** in B during the §D.1 pre-clear snapshot burst that motivated the change.
+4. **No regression on local-Helia path**: `ipfs.fetchCar.localHeliaPath` count and `ipfs.fetchCar.legacy.totalMs` for those calls match A (the local-helia short-circuit still bypasses HTTP entirely).
+5. **Probe cost is amortized**: `ipfs.probe.totalMs` divided by `ipfs.probe.calls` shows a near-zero average (probe runs once per gateway then every subsequent call is a cache hit).
+
+## Fail-soft criteria
+
+- If `ipfs.pinCar.fastPath / (fastPath + legacyPath) < 0.5` in B: investigate which gateway's probe is failing. The fast path silently falls through on any probe miss or per-call failure — no test failures will surface, only the perf delta missing.
+- If `ipfs.dagImport.error` is non-zero: a capable gateway is rejecting our `/dag/import` posts mid-flight. Check the gateway's error log; common causes are CAR-size limit, malformed CAR, or per-IP rate limit hit at the proxy layer.
+- If `ipfs.fetchCar.legacy.totalMs` doesn't drop ≈ to zero in B but `fetchCar.totalMs` does: the local-Helia short-circuit or raw-codec backcompat is taking a larger share of the workload than expected. That's actually a win (zero-HTTP fast-path), confirm via `localHeliaPath` and `rawCodec` counts.
+
+## Notes
+
+- Perf-counters are opt-in (`SPHERE_PERF=1`). When off, every counter call is a single boolean check + early return — zero overhead in production builds.
+- Counter snapshots accumulate across the whole process lifetime. A/B comparison divides by the matching `.calls` counter to get per-call averages.
+- The `core/perf-counters.ts` foundation was introduced in commit `c5962f0` (#363); existing IPFS instrumentation lives in `pinCarBlocksToIpfs`, `fetchFromIpfs`, and `fetchCarFromIpfs`. Issue #370 added the `dagImport.*`, `dagExport.*`, `probe.*`, and path-split counters and moved the `pinCar.*` / `fetchCar.*` public counters to the selector level so they measure whole-call wall-clock regardless of which internal path served the request.

--- a/oracle/UnicityAggregatorProvider.ts
+++ b/oracle/UnicityAggregatorProvider.ts
@@ -11,6 +11,7 @@
  */
 
 import { logger } from '../core/logger';
+import { incr, time } from '../core/perf-counters';
 import type { ProviderStatus } from '../types';
 import type {
   OracleProvider,
@@ -298,6 +299,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
    * Accepts either an SDK TransferCommitment or a simple commitment object.
    */
   async submitCommitment(commitment: TransferCommitment | SdkTransferCommitment): Promise<SubmitResult> {
+    return time('aggregator.submitCommitment', () => this._submitCommitmentImpl(commitment));
+  }
+  private async _submitCommitmentImpl(commitment: TransferCommitment | SdkTransferCommitment): Promise<SubmitResult> {
     this.ensureConnected();
 
     try {
@@ -358,6 +362,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
    * @param commitment - SDK MintCommitment instance
    */
   async submitMintCommitment(commitment: SdkMintCommitment): Promise<SubmitResult> {
+    return time('aggregator.submitMintCommitment', () => this._submitMintCommitmentImpl(commitment));
+  }
+  private async _submitMintCommitmentImpl(commitment: SdkMintCommitment): Promise<SubmitResult> {
     this.ensureConnected();
 
     try {
@@ -405,6 +412,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async getProof(requestId: string): Promise<InclusionProof | null> {
+    return time('aggregator.getProof', () => this._getProofImpl(requestId));
+  }
+  private async _getProofImpl(requestId: string): Promise<InclusionProof | null> {
     this.ensureConnected();
 
     try {
@@ -495,6 +505,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async waitForProof(requestId: string, options?: WaitOptions): Promise<InclusionProof> {
+    return time('aggregator.waitForProof', () => this._waitForProofImpl(requestId, options));
+  }
+  private async _waitForProofImpl(requestId: string, options?: WaitOptions): Promise<InclusionProof> {
     const timeout = options?.timeout ?? this.config.timeout;
     const pollInterval = options?.pollInterval ?? TIMEOUTS.PROOF_POLL_INTERVAL;
     const startTime = Date.now();
@@ -520,6 +533,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async validateToken(tokenData: unknown): Promise<ValidationResult> {
+    return time('aggregator.validateToken', () => this._validateTokenImpl(tokenData));
+  }
+  private async _validateTokenImpl(tokenData: unknown): Promise<ValidationResult> {
     this.ensureConnected();
 
     // Issue #245 #5 — parse the SDK token ONCE so we can reuse it for
@@ -641,6 +657,12 @@ export class UnicityAggregatorProvider implements OracleProvider {
    */
   async waitForProofSdk(
     commitment: SdkTransferCommitment | SdkMintCommitment,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    return time('aggregator.waitForProofSdk', () => this._waitForProofSdkImpl(commitment, signal));
+  }
+  private async _waitForProofSdkImpl(
+    commitment: SdkTransferCommitment | SdkMintCommitment,
     signal?: AbortSignal
   ): Promise<unknown> {
     this.ensureConnected();
@@ -681,6 +703,13 @@ export class UnicityAggregatorProvider implements OracleProvider {
   private static INCLUSION_PROOF_CACHE_MAX = 1024;
 
   async verifyInclusionProof(input: {
+    proofJson: unknown;
+    transactionHash: string;
+    proofHash?: string;
+  }): Promise<boolean> {
+    return time('aggregator.verifyInclusionProof', () => this._verifyInclusionProofImpl(input));
+  }
+  private async _verifyInclusionProofImpl(input: {
     proofJson: unknown;
     transactionHash: string;
     proofHash?: string;
@@ -806,6 +835,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async isSpent(publicKey: string, stateHash: string): Promise<boolean> {
+    return time('aggregator.isSpent', () => this._isSpentImpl(publicKey, stateHash));
+  }
+  private async _isSpentImpl(publicKey: string, stateHash: string): Promise<boolean> {
     // Cache key binds publicKey + stateHash. A given stateHash may
     // be commit-checked under multiple pubkeys in a multi-address
     // wallet; we MUST NOT cross-pollinate cache hits between keys.
@@ -924,6 +956,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async getTokenState(tokenId: string): Promise<TokenState | null> {
+    return time('aggregator.getTokenState', () => this._getTokenStateImpl(tokenId));
+  }
+  private async _getTokenStateImpl(tokenId: string): Promise<TokenState | null> {
     this.ensureConnected();
 
     try {
@@ -947,6 +982,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async getCurrentRound(): Promise<number> {
+    return time('aggregator.getCurrentRound', () => this._getCurrentRoundImpl());
+  }
+  private async _getCurrentRoundImpl(): Promise<number> {
     if (!this.aggregatorClient) {
       // Defensive: aggregator client is constructed in `initialize()`. If
       // `getCurrentRound()` is called before `initialize()` (or after a
@@ -965,6 +1003,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async mint(params: MintParams): Promise<MintResult> {
+    return time('aggregator.mint', () => this._mintImpl(params));
+  }
+  private async _mintImpl(params: MintParams): Promise<MintResult> {
     this.ensureConnected();
 
     try {
@@ -1002,38 +1043,42 @@ export class UnicityAggregatorProvider implements OracleProvider {
   // ===========================================================================
 
   private async rpcCall<T>(method: string, params: unknown): Promise<T> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.config.timeout);
+    return time(`aggregator.rpc.${method}`, async () => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), this.config.timeout);
 
-    try {
-      const response = await fetch(this.config.url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: Date.now(),
-          method,
-          params,
-        }),
-        signal: controller.signal,
-      });
+      try {
+        const response = await fetch(this.config.url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: Date.now(),
+            method,
+            params,
+          }),
+          signal: controller.signal,
+        });
 
-      if (!response.ok) {
-        throw new SphereError(`HTTP ${response.status}: ${response.statusText}`, 'AGGREGATOR_ERROR');
+        if (!response.ok) {
+          incr(`aggregator.rpc.${method}.http_error`);
+          throw new SphereError(`HTTP ${response.status}: ${response.statusText}`, 'AGGREGATOR_ERROR');
+        }
+
+        const result = await response.json();
+
+        if (result.error) {
+          incr(`aggregator.rpc.${method}.rpc_error`);
+          throw new SphereError(result.error.message ?? 'RPC error', 'AGGREGATOR_ERROR');
+        }
+
+        return (result.result ?? {}) as T;
+      } finally {
+        clearTimeout(timeout);
       }
-
-      const result = await response.json();
-
-      if (result.error) {
-        throw new SphereError(result.error.message ?? 'RPC error', 'AGGREGATOR_ERROR');
-      }
-
-      return (result.result ?? {}) as T;
-    } finally {
-      clearTimeout(timeout);
-    }
+    });
   }
 
   // ===========================================================================

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -60,6 +60,7 @@ import type { PointerMutex } from './mutex-lock.js';
 import { reconcileAndPublish, type FetchAndJoinCallback } from './reconcile-algorithm.js';
 import type { PointerSigner } from './signing.js';
 import type { BlockedState, PointerVersion } from './types.js';
+import { time } from '../../core/perf-counters.js';
 
 // ── Constructor input ──────────────────────────────────────────────────────
 
@@ -566,8 +567,10 @@ export class ProfilePointerLayer {
   async recoverLatest(opts?: {
     abortSignal?: AbortSignal;
   }): Promise<RecoverResult | RecoverAllUnfetchableResult | null> {
-    this.#assertNotShuttingDown('recoverLatest');
-    return this.#tracked(this.#recoverLatestInner(opts?.abortSignal));
+    return time('pointerLayer.recoverLatest', () => {
+      this.#assertNotShuttingDown('recoverLatest');
+      return this.#tracked(this.#recoverLatestInner(opts?.abortSignal));
+    });
   }
 
   async #recoverLatestInner(
@@ -699,8 +702,10 @@ export class ProfilePointerLayer {
     walkbackLimit?: number,
     opts?: { abortSignal?: AbortSignal },
   ): Promise<DiscoverResult> {
-    this.#assertNotShuttingDown('discoverLatestVersion');
-    return this.#tracked(this.#discoverLatestVersionInner(walkbackLimit, opts?.abortSignal));
+    return time('pointerLayer.discoverLatestVersion', () => {
+      this.#assertNotShuttingDown('discoverLatestVersion');
+      return this.#tracked(this.#discoverLatestVersionInner(walkbackLimit, opts?.abortSignal));
+    });
   }
 
   async #discoverLatestVersionInner(
@@ -1127,20 +1132,23 @@ export class ProfilePointerLayer {
 
   /** Low-level probe for a single version — H2 OR-predicate. */
   async probe(v: PointerVersion): Promise<boolean> {
-    this.#assertNotShuttingDown('probe');
-    return this.#tracked(probeVersion({
-      v,
-      keyMaterial: this.#init.keyMaterial,
-      signer: this.#init.signer,
-      aggregatorClient: this.#init.aggregatorClient,
-      trustBase: this.#init.trustBase,
-    }));
+    return time('pointerLayer.probe', () => {
+      this.#assertNotShuttingDown('probe');
+      return this.#tracked(probeVersion({
+        v,
+        keyMaterial: this.#init.keyMaterial,
+        signer: this.#init.signer,
+        aggregatorClient: this.#init.aggregatorClient,
+        trustBase: this.#init.trustBase,
+      }));
+    });
   }
 
   /** Low-level classifyVersion. */
   async classify(v: PointerVersion): Promise<'VALID' | 'SEMANTICALLY_INVALID' | 'PROOF_TRANSIENT' | 'CAR_TRANSIENT'> {
-    this.#assertNotShuttingDown('classify');
-    return this.#tracked(classifyVersion({
+    return time('pointerLayer.classify', () => {
+      this.#assertNotShuttingDown('classify');
+      return this.#tracked(classifyVersion({
       v,
       keyMaterial: this.#init.keyMaterial,
       signer: this.#init.signer,
@@ -1149,5 +1157,6 @@ export class ProfilePointerLayer {
       decodeCid: this.#init.decodeCid,
       fetchCar: this.#init.fetchCar,
     }));
+    });
   }
 }

--- a/profile/aggregator-pointer/discover-algorithm.ts
+++ b/profile/aggregator-pointer/discover-algorithm.ts
@@ -136,6 +136,7 @@ import {
   VERSION_MAX,
 } from './constants.js';
 import { AggregatorPointerError, AggregatorPointerErrorCode } from './errors.js';
+import { time } from '../../core/perf-counters.js';
 import type { PointerKeyMaterial } from './key-derivation.js';
 import type { PointerSigner } from './signing.js';
 import type { PointerVersion } from './types.js';
@@ -280,6 +281,9 @@ export interface DiscoverResult {
 // ── findLatestValidVersion ─────────────────────────────────────────────────
 
 export async function findLatestValidVersion(input: DiscoverInput): Promise<DiscoverResult> {
+  return time('pointerLayer.findLatestValidVersion', () => _findLatestValidVersionImpl(input));
+}
+async function _findLatestValidVersionImpl(input: DiscoverInput): Promise<DiscoverResult> {
   // Wave G.4: small wrapper that ensures the external-abort listener
   // is removed on every exit path (success, throw, abort). Without
   // this, a long-lived caller signal would leak a closure-reference

--- a/profile/factory.ts
+++ b/profile/factory.ts
@@ -30,6 +30,7 @@ import {
   type LeanProfileSnapshot,
 } from './profile-lean-snapshot';
 import { fetchFromIpfs, pinCarBlocksToIpfs } from './ipfs-client';
+import { time, incr, observeMs } from '../core/perf-counters';
 import {
   LOCAL_EPOCH_FLOOR_KEY,
   LOCAL_EPOCH_RESET_REASON_KEY,
@@ -817,6 +818,8 @@ export function createProfileProviders(
   // object is built. The provider's late-binding setter resolves this
   // ordering cleanly.
   tokenStorage.setApplySnapshotCallback(async (cidString) => {
+    incr('applySnapshotCb.calls');
+    const __cbStart = performance.now();
     // `dag/put` (used by `pinCarBlocksToIpfs`) stored each CAR block
     // under its canonical CID, so `block/get(rootCid)` returns the
     // dag-cbor encoded root block bytes (NOT a CAR envelope).
@@ -835,19 +838,19 @@ export function createProfileProviders(
     // accessor as the bundle load path: cross-process snapshot apply
     // becomes deterministic, cross-device apply falls back to HTTP.
     const helia = db.getHelia?.();
-    const rootBlockBytes = await fetchFromIpfs(
-      ipfsGateways,
-      cidString,
-      undefined,
-      undefined,
-      helia,
+    const rootBlockBytes = await time('applySnapshotCb.fetchRootMs', () =>
+      fetchFromIpfs(ipfsGateways, cidString, undefined, undefined, helia),
     );
-    const snapshot = await parseLeanProfileSnapshotFromRootBlock(
-      rootBlockBytes,
-      (subBlockCid) =>
-        fetchFromIpfs(ipfsGateways, subBlockCid, undefined, undefined, helia),
+    const snapshot = await time('applySnapshotCb.parseSnapshotMs', () =>
+      parseLeanProfileSnapshotFromRootBlock(
+        rootBlockBytes,
+        (subBlockCid) =>
+          fetchFromIpfs(ipfsGateways, subBlockCid, undefined, undefined, helia),
+      ),
     );
-    return dispatchParsedSnapshot(snapshot);
+    const result = await time('applySnapshotCb.dispatchMs', () => dispatchParsedSnapshot(snapshot));
+    observeMs('applySnapshotCb.totalMs', performance.now() - __cbStart);
+    return result;
   });
 
   return { storage, tokenStorage };

--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -472,6 +472,22 @@ export function _resetGatewayCapabilityCache(): void {
   capabilityCache.clear();
 }
 
+/**
+ * Test/soak-only helper to pre-populate the capability cache for a
+ * specific gateway URL. Lets a smoke probe force the legacy path for
+ * an A/B comparison against the live gateway without needing to
+ * spin up a second gateway that doesn't expose /dag/import.
+ *
+ * Production code MUST NOT call this — the probe is the source of
+ * truth at runtime.
+ */
+export function _setGatewayCapabilityForTest(
+  gateway: string,
+  caps: { readonly dagImport: boolean; readonly dagExport: boolean },
+): void {
+  capabilityCache.set(normalizeGatewayKey(gateway), Promise.resolve(caps));
+}
+
 function normalizeGatewayKey(gateway: string): string {
   return gateway.replace(/\/$/, '');
 }

--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -430,6 +430,319 @@ async function tryReadFromSidecar(
 }
 
 // =============================================================================
+// Issue #370 — Capability probe and CAR-batched fast paths
+// =============================================================================
+
+/**
+ * Per-gateway timeout for the capability probe. Short and bounded so a
+ * slow or unreachable gateway can't block the first hot-path pin beyond
+ * this window. On timeout / network error the probe caches the gateway
+ * as "fast path unsupported" for the process lifetime — same outcome as
+ * an explicit 404 from the operator gateway.
+ */
+const PROBE_TIMEOUT_MS = 2_000;
+
+/**
+ * Result of the per-gateway capability probe. Each field is `true` iff
+ * the gateway advertises the corresponding endpoint at the operator
+ * layer (haproxy/nginx ACL passes the route through to Kubo).
+ */
+interface GatewayCapabilities {
+  readonly dagImport: boolean;
+  readonly dagExport: boolean;
+}
+
+/**
+ * Per-process probe cache. Keyed by normalized gateway URL (trailing
+ * slash trimmed). Stores the in-flight Promise, not the resolved value,
+ * so a concurrent burst of pins triggers exactly one probe per gateway.
+ * Capability is treated as a static property of a gateway within a
+ * process's lifetime — operator reconfiguration requires a new wallet
+ * process to pick up the change.
+ */
+const capabilityCache = new Map<string, Promise<GatewayCapabilities>>();
+
+/**
+ * Test-only helper to reset the probe cache between tests. Production
+ * code does not call this — operator gateway reconfiguration requires a
+ * process restart.
+ */
+export function _resetGatewayCapabilityCache(): void {
+  capabilityCache.clear();
+}
+
+function normalizeGatewayKey(gateway: string): string {
+  return gateway.replace(/\/$/, '');
+}
+
+/**
+ * POST a single empty request to `url` to determine whether the
+ * operator gateway exposes that endpoint. Returns `true` iff the
+ * gateway responded with a 4xx status that is NOT 404 (route absent)
+ * or 405 (POST blocked at the proxy layer). A healthy Kubo returns
+ * 400 *Bad Request* for an empty POST to `/dag/import` / `/dag/export`
+ * — that's the positive signal we look for.
+ *
+ * 5xx is treated as "not exposed" — a healthy operator gateway would
+ * have returned 4xx for empty input. 5xx suggests an unhealthy upstream
+ * or a misconfigured proxy returning a synthetic error page. 2xx is
+ * accepted (defense: the operator may have rewritten the endpoint to
+ * return 200; if the actual call later fails, the selector falls
+ * through to legacy).
+ *
+ * Network errors, timeouts, or aborts → returns `false` (treat as not
+ * exposed). The caller's legacy path will rediscover real failures at
+ * call time through its own per-gateway iteration.
+ */
+async function probeEndpointExposed(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    response.body?.cancel?.().catch(() => { /* ignore */ });
+    return (
+      response.status !== 404 &&
+      response.status !== 405 &&
+      response.status < 500
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Probe a gateway for `/dag/import` and `/dag/export` support, caching
+ * the result for the rest of the process lifetime. Issue #370.
+ */
+async function probeGatewayCapabilities(gateway: string): Promise<GatewayCapabilities> {
+  const key = normalizeGatewayKey(gateway);
+  const cached = capabilityCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const probe = (async (): Promise<GatewayCapabilities> => {
+    const [dagImport, dagExport] = await Promise.all([
+      probeEndpointExposed(`${key}/api/v0/dag/import`),
+      probeEndpointExposed(`${key}/api/v0/dag/export`),
+    ]);
+    if (!dagImport || !dagExport) {
+      logger.warn(
+        'ipfs-client',
+        `#370 capability probe ${key}: dagImport=${dagImport} dagExport=${dagExport} ` +
+          `— legacy per-block path will be used where the fast path is unavailable`,
+      );
+    }
+    return { dagImport, dagExport };
+  })();
+  capabilityCache.set(key, probe);
+  return probe;
+}
+
+/**
+ * Single-round-trip CAR push: POST `carBytes` to Kubo's
+ * `/api/v0/dag/import?pin=true`. Replaces the per-block `/dag/put`
+ * loop when the operator gateway exposes the import endpoint.
+ *
+ * Parses the NDJSON response and verifies `expectedRootCid` appears
+ * among the imported roots with no `PinErrorMsg`. CAR-bytes content
+ * verification is end-to-end via receiver-side `fetchFromIpfs` checks
+ * — this function does NOT recompute every block's CID (Kubo does that
+ * server-side during import).
+ *
+ * Permissive `Cid` shape parsing accepts both modern
+ * `{"Root": {"Cid": {"/": "bafy..."}}}` and older
+ * `{"Root": {"Cid": "bafy..."}}` Kubo response forms.
+ *
+ * Multi-root defensive check: validates our root is present, ignores
+ * extra roots the gateway reports (defense for a hostile gateway
+ * appending phantom entries).
+ *
+ * Throws on any failure so the caller's selector can fall through to
+ * the legacy per-block path.
+ */
+async function pinCarViaImport(
+  gateway: string,
+  carBytes: Uint8Array,
+  expectedRootCid: string,
+  timeoutMs: number,
+): Promise<void> {
+  const url = `${normalizeGatewayKey(gateway)}/api/v0/dag/import?pin=true`;
+  const form = new FormData();
+  form.append('file', new Blob([carBytes as BlobPart]), 'bundle.car');
+
+  const response = await fetch(url, {
+    method: 'POST',
+    body: form,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status} ${response.statusText} from ${gateway} for /dag/import`,
+    );
+  }
+
+  const text = await response.text();
+  let foundExpectedRoot = false;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    let node: unknown;
+    try {
+      node = JSON.parse(trimmed);
+    } catch {
+      continue; // ignore non-JSON noise
+    }
+    if (node === null || typeof node !== 'object') continue;
+    const root = (node as { Root?: unknown }).Root;
+    if (root === null || root === undefined || typeof root !== 'object') continue;
+    const rootObj = root as { Cid?: unknown; PinErrorMsg?: unknown };
+    let cidStr: string | null = null;
+    const cid = rootObj.Cid;
+    if (typeof cid === 'string') {
+      cidStr = cid;
+    } else if (cid !== null && typeof cid === 'object') {
+      const inner = (cid as { '/'?: unknown })['/'];
+      if (typeof inner === 'string') cidStr = inner;
+    }
+    if (cidStr === expectedRootCid) {
+      const errMsg = rootObj.PinErrorMsg;
+      if (typeof errMsg === 'string' && errMsg.length > 0) {
+        throw new Error(
+          `Gateway ${gateway} reported PinErrorMsg for ${expectedRootCid}: ${errMsg}`,
+        );
+      }
+      foundExpectedRoot = true;
+    }
+  }
+  if (!foundExpectedRoot) {
+    throw new Error(
+      `Gateway ${gateway} /dag/import did not include expected root ${expectedRootCid} in NDJSON response`,
+    );
+  }
+}
+
+/**
+ * Single-round-trip CAR pull: POST to Kubo's
+ * `/api/v0/dag/export?arg=<root>` and return the response bytes
+ * verbatim. The bytes ARE a CARv1 stream — feed directly to
+ * `CarReader.fromBytes`. Replaces the per-block BFS walk when the
+ * operator gateway exposes the export endpoint.
+ *
+ * Per-block CID verification happens after parse in the caller
+ * (`verifyAndReassembleExportedCar`). This function only handles the
+ * HTTP transport. A hostile gateway can DoS but cannot forge data —
+ * the caller's CID-binding check rejects mismatched bytes.
+ *
+ * Throws on any HTTP failure or size-cap breach so the caller's
+ * selector can fall through to the legacy BFS path.
+ */
+async function fetchCarViaExport(
+  gateway: string,
+  rootCid: string,
+  timeoutMs: number,
+  maxSizeBytes: number,
+): Promise<Uint8Array> {
+  const url =
+    `${normalizeGatewayKey(gateway)}/api/v0/dag/export?arg=${encodeURIComponent(rootCid)}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status} ${response.statusText} from ${gateway} for /dag/export`,
+    );
+  }
+
+  const contentLength = response.headers.get('Content-Length');
+  if (contentLength != null) {
+    const size = parseInt(contentLength, 10);
+    if (!isNaN(size) && size > maxSizeBytes) {
+      throw new Error(
+        `Gateway ${gateway} /dag/export Content-Length ${size} exceeds limit ${maxSizeBytes}`,
+      );
+    }
+  }
+
+  if (response.body != null) {
+    return await readStreamWithLimit(response.body, maxSizeBytes, gateway);
+  }
+  const buf = await response.arrayBuffer();
+  if (buf.byteLength > maxSizeBytes) {
+    throw new Error(
+      `Gateway ${gateway} /dag/export returned ${buf.byteLength} bytes exceeding limit ${maxSizeBytes}`,
+    );
+  }
+  return new Uint8Array(buf);
+}
+
+/**
+ * Verify every block CID-binding in an exported CAR and reassemble it
+ * into a CARv1 rooted at `rootCid` (stream order preserved). Issue
+ * #370 fetch-path companion to {@link fetchCarViaExport}.
+ *
+ * On verification or root-absence failure, throws so the caller's
+ * selector can fall through to the legacy BFS path (which will fetch
+ * each block individually and apply the same CID check via
+ * `fetchFromIpfs`).
+ *
+ * Also write-backs every verified block to the local Helia blockstore
+ * (preserves the #236 bidirectional cache invariant).
+ */
+async function verifyAndReassembleExportedCar(
+  carBytes: Uint8Array,
+  rootCid: string,
+  helia: unknown,
+): Promise<Uint8Array> {
+  const { CarReader } = await import('@ipld/car');
+  const { CarWriter } = await import('@ipld/car/writer');
+  const reader = await CarReader.fromBytes(carBytes);
+
+  let rootBlockCid: CID | null = null;
+  const collected: Array<{ cid: CID; bytes: Uint8Array }> = [];
+  for await (const block of reader.blocks()) {
+    const cidStr = block.cid.toString();
+    verifyCidMatchesBytes(cidStr, block.bytes);
+    collected.push({ cid: block.cid, bytes: block.bytes });
+    if (cidStr === rootCid) rootBlockCid = block.cid;
+  }
+  if (rootBlockCid === null) {
+    throw new Error(
+      `/dag/export response for ${rootCid} did not include the requested root block`,
+    );
+  }
+
+  const localHelia = asHelia(helia);
+  if (localHelia !== null) {
+    for (const block of collected) {
+      await putBlockToLocalHelia(localHelia, block.cid.toString(), block.bytes);
+    }
+  }
+
+  const { writer, out } = CarWriter.create([rootBlockCid]);
+  const chunks: Uint8Array[] = [];
+  const collectPromise = (async () => {
+    for await (const chunk of out) chunks.push(chunk);
+  })();
+  try {
+    for (const block of collected) await writer.put(block);
+  } finally {
+    await writer.close();
+  }
+  await collectPromise;
+
+  let totalLength = 0;
+  for (const c of chunks) totalLength += c.length;
+  const reassembled = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const c of chunks) {
+    reassembled.set(c, offset);
+    offset += c.length;
+  }
+  return reassembled;
+}
+
+// =============================================================================
 // Public API
 // =============================================================================
 
@@ -640,10 +953,15 @@ async function pinSingleBlock(
  * CARs (lean v3 and fat v2), and the Nostr `uxf-cid` publisher (via
  * `createUxfCarPublisher`).
  *
- * Why not `/api/v0/dag/import`: the Unicity IPFS gateway does not expose
- * that endpoint. `dag/put` is universally available across Kubo deploys,
- * including hardened gateways that restrict the API surface. The
- * tradeoff is one HTTP round-trip per block.
+ * Relationship to `/api/v0/dag/import`: as of issue #370, the SDK
+ * prefers `/dag/import` (single CAR push) over this per-block loop
+ * whenever a gateway's capability probe confirms the endpoint is
+ * exposed at the operator layer. This legacy per-block path remains
+ * the hardened fallback for gateways that don't expose `/dag/import`
+ * (or for fast-path call-time failures). `dag/put` is universally
+ * available across Kubo deploys, including hardened gateways that
+ * restrict the API surface; the tradeoff is one HTTP round-trip per
+ * block.
  *
  * The function trusts the caller-supplied `expectedRootCid` and the
  * framed CIDs in the CAR (`@ipld/car`'s `CarReader` does NOT recompute
@@ -687,7 +1005,157 @@ async function pinSingleBlock(
  * @throws {ProfileError} `ORBITDB_WRITE_FAILED` if all gateways fail to
  *         accept a pin or the CAR doesn't contain the expected root.
  */
+/**
+ * Issue #370 fast-path selector. Probes each gateway for `/dag/import`
+ * support and uses the single-shot CAR push when available. Falls
+ * through to {@link pinCarBlocksToIpfsLegacy} when no gateway exposes
+ * the endpoint, or when the fast path fails mid-flight (which would
+ * suggest a transient gateway issue that the hardened per-block path
+ * may still ride out on a sibling gateway).
+ *
+ * Local Helia writes happen on both paths (preserves the #236
+ * crash-safety invariant). The sidecar submit fires once for the CAR
+ * root on the fast path and once per block on the legacy path.
+ */
 export async function pinCarBlocksToIpfs(
+  gateways: string[],
+  carBytes: Uint8Array,
+  expectedRootCid: string,
+  timeoutMs: number = DEFAULT_PIN_TIMEOUT_MS,
+  helia?: unknown,
+  concurrency: number = DEFAULT_PIN_CONCURRENCY,
+): Promise<string> {
+  const effectiveGateways = gateways.length > 0 ? gateways : [DEFAULT_IPFS_API_URL];
+  validateGatewayUrls(effectiveGateways);
+
+  // Track whether we already wrote every block into the local Helia
+  // store on the fast-path attempt. If so, the legacy fallback must
+  // NOT re-write them (would surface as duplicate puts in tests and
+  // wasted disk I/O at runtime). We pass `helia: undefined` to the
+  // legacy call in that case to skip its own per-block local-Helia
+  // write loop.
+  let localHeliaWrittenInFastPath = false;
+
+  for (const gateway of effectiveGateways) {
+    const caps = await probeGatewayCapabilities(gateway);
+    if (!caps.dagImport) continue;
+
+    // Parse the CAR locally for the fast path's local-Helia write and
+    // root-block extraction (used by the post-success sidecar submit).
+    // A malformed CAR fails with a deterministic ProfileError and we
+    // re-throw without falling through — the legacy path would emit
+    // the same error after re-parsing.
+    let parsed: {
+      readonly blocks: ReadonlyArray<{ cid: string; bytes: Uint8Array }>;
+      readonly rootBlock: { cid: string; bytes: Uint8Array };
+    };
+    try {
+      parsed = await parseCarForFastPathPin(carBytes, expectedRootCid);
+    } catch (err) {
+      if (err instanceof ProfileError) throw err;
+      throw new ProfileError(
+        'ORBITDB_WRITE_FAILED',
+        `pinCarBlocksToIpfs: fast-path CAR parse failed: ${err instanceof Error ? err.message : String(err)}`,
+        err,
+      );
+    }
+
+    const localHelia = asHelia(helia);
+    if (localHelia !== null && !localHeliaWrittenInFastPath) {
+      for (const block of parsed.blocks) {
+        let cidBindingOk = true;
+        try {
+          verifyCidMatchesBytes(block.cid, block.bytes);
+        } catch (err) {
+          cidBindingOk = false;
+          logger.warn(
+            'ipfs-client',
+            `pinCarBlocksToIpfs: producer-side CID/bytes mismatch for ${block.cid} ` +
+              `— skipping local-helia put. ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        if (cidBindingOk) await putBlockToLocalHelia(localHelia, block.cid, block.bytes);
+      }
+      localHeliaWrittenInFastPath = true;
+    }
+
+    try {
+      await pinCarViaImport(gateway, carBytes, expectedRootCid, timeoutMs);
+      // One sidecar submit per CAR root (issue #370 explicit guidance).
+      submitToSidecarBestEffort(gateway, expectedRootCid, parsed.rootBlock.bytes);
+      return expectedRootCid;
+    } catch (err) {
+      logger.warn(
+        'ipfs-client',
+        `pinCarBlocksToIpfs: /dag/import fast path failed on ${gateway} for ${expectedRootCid}, ` +
+          `falling back to legacy per-block path. Reason: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+      // Exit the gateway probe loop; legacy iterates the full list itself
+      // (a sibling gateway may still accept per-block /dag/put even if
+      // /dag/import on this gateway stumbled).
+      break;
+    }
+  }
+
+  return pinCarBlocksToIpfsLegacy(
+    effectiveGateways,
+    carBytes,
+    expectedRootCid,
+    timeoutMs,
+    // Skip the legacy path's local-Helia write loop if the fast path
+    // already wrote every block — avoids duplicate puts.
+    localHeliaWrittenInFastPath ? undefined : helia,
+    concurrency,
+  );
+}
+
+/**
+ * Parse a CAR upfront for the fast-path pin. Materialises the block
+ * list and extracts the root block bytes for sidecar submit. Throws
+ * `ProfileError(ORBITDB_WRITE_FAILED)` on malformed CARs, zero-block
+ * CARs, or missing-expected-root CARs (matches the legacy path's
+ * pre-flight checks).
+ */
+async function parseCarForFastPathPin(
+  carBytes: Uint8Array,
+  expectedRootCid: string,
+): Promise<{
+  readonly blocks: ReadonlyArray<{ cid: string; bytes: Uint8Array }>;
+  readonly rootBlock: { cid: string; bytes: Uint8Array };
+}> {
+  const { CarReader } = await import('@ipld/car');
+  const reader = await CarReader.fromBytes(carBytes);
+  const blocks: Array<{ cid: string; bytes: Uint8Array }> = [];
+  for await (const block of reader.blocks()) {
+    blocks.push({ cid: block.cid.toString(), bytes: block.bytes });
+  }
+  if (blocks.length === 0) {
+    throw new ProfileError(
+      'ORBITDB_WRITE_FAILED',
+      'CAR contained zero blocks — refusing to publish a phantom rootCid.',
+    );
+  }
+  const rootBlock = blocks.find((b) => b.cid === expectedRootCid);
+  if (rootBlock === undefined) {
+    throw new ProfileError(
+      'ORBITDB_WRITE_FAILED',
+      `expectedRootCid ${expectedRootCid} is not present among CAR blocks (count=${blocks.length}) — builder/publisher mismatch.`,
+    );
+  }
+  return { blocks, rootBlock };
+}
+
+/**
+ * Legacy per-block pin implementation. Issue #370 turned the public
+ * `pinCarBlocksToIpfs` into a selector that prefers `/dag/import` when
+ * the operator gateway advertises it; this function is the fallback
+ * path for legacy gateways and for fast-path call-time failures.
+ *
+ * Signature and behaviour are exactly what `pinCarBlocksToIpfs` had
+ * before issue #370.
+ */
+async function pinCarBlocksToIpfsLegacy(
   gateways: string[],
   carBytes: Uint8Array,
   expectedRootCid: string,
@@ -1245,7 +1713,8 @@ export async function fetchCarFromIpfs(
 
   // Backcompat path: the legacy raw-pinning scheme pinned the entire
   // CAR as one raw block. `fetchFromIpfs` already returns the bytes
-  // verbatim — they ARE the CAR. Skip the walk.
+  // verbatim — they ARE the CAR. Skip the walk. Taken BEFORE the
+  // capability probe — raw-codec roots never need /dag/export.
   if (parsedRoot.code === CODEC_RAW) {
     return fetchFromIpfs(gateways, rootCid, timeoutMs, maxSizeBytesPerBlock, helia);
   }
@@ -1257,6 +1726,84 @@ export async function fetchCarFromIpfs(
     );
   }
 
+  const effectiveGateways = gateways.length > 0 ? gateways : [DEFAULT_IPFS_API_URL];
+  validateGatewayUrls(effectiveGateways);
+
+  // Issue #236 + #370 — local-helia-first short-circuit. When the root
+  // block is already in the local Helia blockstore the legacy BFS path
+  // satisfies the entire walk from disk via `fetchFromIpfs`'s
+  // local-first lookup with zero HTTP round-trips. Take that path
+  // BEFORE the capability probe so we don't spend an /dag/export probe
+  // round-trip when no HTTP is needed at all.
+  const localHeliaForRoot = asHelia(helia);
+  if (localHeliaForRoot !== null) {
+    const localRoot = await tryGetBlockFromLocalHelia(localHeliaForRoot, rootCid);
+    if (localRoot !== null) {
+      return fetchCarFromIpfsLegacy(
+        effectiveGateways,
+        rootCid,
+        parsedRoot,
+        timeoutMs,
+        maxSizeBytesPerBlock,
+        helia,
+      );
+    }
+  }
+
+  // Issue #370 fast path: probe each gateway for /dag/export. On a
+  // capable gateway, fetch the whole CAR in a single HTTP request,
+  // verify every block CID-binding, reassemble and return. On any
+  // failure (404 probe miss, mid-call HTTP error, CID mismatch on
+  // any block, missing root in the exported CAR) fall through to the
+  // legacy per-block BFS path with the full gateway list.
+  for (const gateway of effectiveGateways) {
+    const caps = await probeGatewayCapabilities(gateway);
+    if (!caps.dagExport) continue;
+    try {
+      const carBytes = await fetchCarViaExport(gateway, rootCid, timeoutMs, maxSizeBytesPerBlock);
+      return await verifyAndReassembleExportedCar(carBytes, rootCid, helia);
+    } catch (err) {
+      logger.warn(
+        'ipfs-client',
+        `fetchCarFromIpfs: /dag/export fast path failed on ${gateway} for ${rootCid}, ` +
+          `falling back to legacy per-block BFS. Reason: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+      // Exit the gateway probe loop; legacy iterates the full gateway
+      // list itself (a sibling gateway may still serve per-block
+      // /block/get even if /dag/export on this gateway stumbled).
+      break;
+    }
+  }
+
+  return fetchCarFromIpfsLegacy(
+    effectiveGateways,
+    rootCid,
+    parsedRoot,
+    timeoutMs,
+    maxSizeBytesPerBlock,
+    helia,
+  );
+}
+
+/**
+ * Legacy per-block BFS implementation. Issue #370 turned the public
+ * `fetchCarFromIpfs` into a selector that prefers `/dag/export` when
+ * the operator gateway advertises it; this function is the fallback
+ * path for legacy gateways and for fast-path failures.
+ *
+ * Signature differs from the public function: takes the already-parsed
+ * `rootCid` to avoid re-parsing in the selector. Behaviour is exactly
+ * what `fetchCarFromIpfs` had before issue #370.
+ */
+async function fetchCarFromIpfsLegacy(
+  gateways: string[],
+  rootCid: string,
+  parsedRoot: CID,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+  maxSizeBytesPerBlock: number = DEFAULT_MAX_SIZE_BYTES,
+  helia?: unknown,
+): Promise<Uint8Array> {
   // Lazy-import @ipld/dag-cbor + CarWriter to keep the cold-path import
   // off the synchronous load of every module that touches ipfs-client.
   const { decode: dagCborDecode } = await import('@ipld/dag-cbor');

--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -22,6 +22,7 @@ import { CID } from 'multiformats/cid';
 import * as raw from 'multiformats/codecs/raw';
 import { create as createMultihash } from 'multiformats/hashes/digest';
 import { logger } from '../core/logger.js';
+import { incr, observeMs } from '../core/perf-counters.js';
 import { ProfileError } from './errors.js';
 
 // =============================================================================
@@ -695,6 +696,12 @@ export async function pinCarBlocksToIpfs(
   helia?: unknown,
   concurrency: number = DEFAULT_PIN_CONCURRENCY,
 ): Promise<string> {
+  // GH #363 measurement: total pin wall-clock + block count + total
+  // bytes. Resolves whether the per-write-round-trip pattern the
+  // maintainer hypothesised about is actually network-bound on this
+  // function.
+  const __perfStart = performance.now();
+  const __perfBytes = carBytes.byteLength;
   const localHelia = asHelia(helia);
   // Parse the CAR locally to extract each block. Done up front so a
   // malformed CAR fails fast before any network round-trips.
@@ -891,9 +898,15 @@ export async function pinCarBlocksToIpfs(
     // failed against a downed sidecar) are discarded; if operator
     // diagnostics need them, attach a `storage:error` event before
     // re-throwing in a future enhancement.
+    incr('ipfs.pinCar.error');
+    observeMs('ipfs.pinCar.totalMs', performance.now() - __perfStart);
     throw workerErrors[0];
   }
 
+  // GH #363 measurement.
+  incr('ipfs.pinCar.blocks', blocks.length);
+  incr('ipfs.pinCar.bytes', __perfBytes);
+  observeMs('ipfs.pinCar.totalMs', performance.now() - __perfStart);
   return expectedRootCid;
 }
 
@@ -946,6 +959,9 @@ export async function fetchFromIpfs(
   maxSizeBytes: number = DEFAULT_MAX_SIZE_BYTES,
   helia?: unknown,
 ): Promise<Uint8Array> {
+  // GH #363 measurement — split local-Helia hits from HTTP gateway
+  // fetches so the two cost models are visible separately.
+  const __perfStart = performance.now();
   // Issue #236 — local Helia blockstore fast-path. When the block was
   // pinned through this process (or any prior process with the same
   // `dataDir`), it is already on disk and a synchronous get() avoids
@@ -960,6 +976,8 @@ export async function fetchFromIpfs(
         // gateways (which apply their own enforcement) rather than
         // returning oversized bytes.
       } else {
+        incr('ipfs.fetchBlock.localHit');
+        observeMs('ipfs.fetchBlock.localHitMs', performance.now() - __perfStart);
         return local;
       }
     }
@@ -1154,6 +1172,10 @@ export async function fetchFromIpfs(
         await putBlockToLocalHelia(localHelia, cid, bytesOrNull);
       }
 
+      // GH #363 — gateway hit (HTTP round-trip cost).
+      incr('ipfs.fetchBlock.gatewayHit');
+      incr('ipfs.fetchBlock.bytes', bytesOrNull.byteLength);
+      observeMs('ipfs.fetchBlock.gatewayMs', performance.now() - __perfStart);
       return bytesOrNull;
     } catch (err) {
       // Size-limit ProfileError is fatal for this request (not per-gateway)
@@ -1165,6 +1187,8 @@ export async function fetchFromIpfs(
     }
   }
 
+  incr('ipfs.fetchBlock.allGatewaysFailed');
+  observeMs('ipfs.fetchBlock.failedMs', performance.now() - __perfStart);
   throw new ProfileError(
     'BUNDLE_NOT_FOUND',
     `Failed to fetch CAR ${cid} from all gateways: ${lastError?.message ?? 'unknown error'}`,
@@ -1233,6 +1257,11 @@ export async function fetchCarFromIpfs(
   maxSizeBytesPerBlock: number = DEFAULT_MAX_SIZE_BYTES,
   helia?: unknown,
 ): Promise<Uint8Array> {
+  // GH #363 measurement — per-CAR walk wall-clock + block count. Issue
+  // #360 claimed sequential block-fetch dominated load time; verify or
+  // refute with real data instead of speculating.
+  const __perfStart = performance.now();
+  incr('ipfs.fetchCar.calls');
   let parsedRoot: CID;
   try {
     parsedRoot = CID.parse(rootCid);
@@ -1361,6 +1390,9 @@ export async function fetchCarFromIpfs(
     carBytes.set(c, offset);
     offset += c.length;
   }
+  incr('ipfs.fetchCar.blocks', blocks.length);
+  incr('ipfs.fetchCar.bytes', totalLength);
+  observeMs('ipfs.fetchCar.totalMs', performance.now() - __perfStart);
   return carBytes;
 }
 

--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -22,6 +22,7 @@ import { CID } from 'multiformats/cid';
 import * as raw from 'multiformats/codecs/raw';
 import { create as createMultihash } from 'multiformats/hashes/digest';
 import { logger } from '../core/logger.js';
+import { incr, observeMs } from '../core/perf-counters.js';
 import { ProfileError } from './errors.js';
 
 // =============================================================================
@@ -514,17 +515,34 @@ async function probeEndpointExposed(url: string): Promise<boolean> {
 /**
  * Probe a gateway for `/dag/import` and `/dag/export` support, caching
  * the result for the rest of the process lifetime. Issue #370.
+ *
+ * Counters:
+ *   - `ipfs.probe.calls`        — every selector call to this function
+ *   - `ipfs.probe.cacheHits`    — call satisfied from the per-process cache
+ *   - `ipfs.probe.dagImportOk`  — cached probe says /dag/import exposed
+ *   - `ipfs.probe.dagExportOk`  — cached probe says /dag/export exposed
+ *   - `ipfs.probe.dagImportMissing` / `ipfs.probe.dagExportMissing`
  */
 async function probeGatewayCapabilities(gateway: string): Promise<GatewayCapabilities> {
+  incr('ipfs.probe.calls');
   const key = normalizeGatewayKey(gateway);
   const cached = capabilityCache.get(key);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) {
+    incr('ipfs.probe.cacheHits');
+    return cached;
+  }
 
+  const probeStart = performance.now();
   const probe = (async (): Promise<GatewayCapabilities> => {
     const [dagImport, dagExport] = await Promise.all([
       probeEndpointExposed(`${key}/api/v0/dag/import`),
       probeEndpointExposed(`${key}/api/v0/dag/export`),
     ]);
+    if (dagImport) incr('ipfs.probe.dagImportOk');
+    else incr('ipfs.probe.dagImportMissing');
+    if (dagExport) incr('ipfs.probe.dagExportOk');
+    else incr('ipfs.probe.dagExportMissing');
+    observeMs('ipfs.probe.totalMs', performance.now() - probeStart);
     if (!dagImport || !dagExport) {
       logger.warn(
         'ipfs-client',
@@ -1025,6 +1043,11 @@ export async function pinCarBlocksToIpfs(
   helia?: unknown,
   concurrency: number = DEFAULT_PIN_CONCURRENCY,
 ): Promise<string> {
+  // GH #363 / #370 — pin wall-clock for the WHOLE selector (covers both
+  // /dag/import fast-path and legacy per-block fallback). The
+  // fastPath/legacyPath split counter at the exit attributes the time.
+  const __perfStart = performance.now();
+  const __perfBytes = carBytes.byteLength;
   const effectiveGateways = gateways.length > 0 ? gateways : [DEFAULT_IPFS_API_URL];
   validateGatewayUrls(effectiveGateways);
 
@@ -1052,6 +1075,8 @@ export async function pinCarBlocksToIpfs(
     try {
       parsed = await parseCarForFastPathPin(carBytes, expectedRootCid);
     } catch (err) {
+      incr('ipfs.pinCar.error');
+      observeMs('ipfs.pinCar.totalMs', performance.now() - __perfStart);
       if (err instanceof ProfileError) throw err;
       throw new ProfileError(
         'ORBITDB_WRITE_FAILED',
@@ -1080,11 +1105,25 @@ export async function pinCarBlocksToIpfs(
     }
 
     try {
-      await pinCarViaImport(gateway, carBytes, expectedRootCid, timeoutMs);
+      // Issue #370 fast-path counters (#363 perf framework).
+      const __dagImportStart = performance.now();
+      incr('ipfs.dagImport.calls');
+      try {
+        await pinCarViaImport(gateway, carBytes, expectedRootCid, timeoutMs);
+      } finally {
+        observeMs('ipfs.dagImport.totalMs', performance.now() - __dagImportStart);
+      }
+      incr('ipfs.dagImport.bytes', __perfBytes);
       // One sidecar submit per CAR root (issue #370 explicit guidance).
       submitToSidecarBestEffort(gateway, expectedRootCid, parsed.rootBlock.bytes);
+      // Selector-level counters: fast path was taken successfully.
+      incr('ipfs.pinCar.fastPath');
+      incr('ipfs.pinCar.blocks', parsed.blocks.length);
+      incr('ipfs.pinCar.bytes', __perfBytes);
+      observeMs('ipfs.pinCar.totalMs', performance.now() - __perfStart);
       return expectedRootCid;
     } catch (err) {
+      incr('ipfs.dagImport.error');
       logger.warn(
         'ipfs-client',
         `pinCarBlocksToIpfs: /dag/import fast path failed on ${gateway} for ${expectedRootCid}, ` +
@@ -1098,16 +1137,29 @@ export async function pinCarBlocksToIpfs(
     }
   }
 
-  return pinCarBlocksToIpfsLegacy(
-    effectiveGateways,
-    carBytes,
-    expectedRootCid,
-    timeoutMs,
-    // Skip the legacy path's local-Helia write loop if the fast path
-    // already wrote every block — avoids duplicate puts.
-    localHeliaWrittenInFastPath ? undefined : helia,
-    concurrency,
-  );
+  // Legacy fallback path. The legacy records its own ipfs.pinCar.legacy.*
+  // attribution; the selector records the public ipfs.pinCar.{totalMs,
+  // bytes, error, legacyPath} so soak A/B can compare like-for-like.
+  incr('ipfs.pinCar.legacyPath');
+  try {
+    const out = await pinCarBlocksToIpfsLegacy(
+      effectiveGateways,
+      carBytes,
+      expectedRootCid,
+      timeoutMs,
+      // Skip the legacy path's local-Helia write loop if the fast path
+      // already wrote every block — avoids duplicate puts.
+      localHeliaWrittenInFastPath ? undefined : helia,
+      concurrency,
+    );
+    incr('ipfs.pinCar.bytes', __perfBytes);
+    return out;
+  } catch (err) {
+    incr('ipfs.pinCar.error');
+    throw err;
+  } finally {
+    observeMs('ipfs.pinCar.totalMs', performance.now() - __perfStart);
+  }
 }
 
 /**
@@ -1163,6 +1215,12 @@ async function pinCarBlocksToIpfsLegacy(
   helia?: unknown,
   concurrency: number = DEFAULT_PIN_CONCURRENCY,
 ): Promise<string> {
+  // GH #363 measurement: legacy-path wall-clock. The selector-level
+  // ipfs.pinCar.totalMs counter records the public entry-to-exit time
+  // (including the fast-path attempt that fell through to here); this
+  // counter records the legacy-only wall-clock for separate attribution.
+  const __perfStart = performance.now();
+  const __perfBytes = carBytes.byteLength;
   const localHelia = asHelia(helia);
   // Parse the CAR locally to extract each block. Done up front so a
   // malformed CAR fails fast before any network round-trips.
@@ -1359,9 +1417,21 @@ async function pinCarBlocksToIpfsLegacy(
     // failed against a downed sidecar) are discarded; if operator
     // diagnostics need them, attach a `storage:error` event before
     // re-throwing in a future enhancement.
+    // Legacy-path-specific counters (don't collide with the selector's
+    // public ipfs.pinCar.* counters — those measure the WHOLE selector
+    // wall-clock including the fast-path attempt that fell through).
+    incr('ipfs.pinCar.legacy.error');
+    observeMs('ipfs.pinCar.legacy.totalMs', performance.now() - __perfStart);
     throw workerErrors[0];
   }
 
+  // GH #363 / #370 — legacy-only attribution. The selector's
+  // ipfs.pinCar.{blocks,bytes,totalMs} counters cover the public
+  // surface; these legacy.* counters expose the cost of the per-block
+  // `/dag/put` work specifically.
+  incr('ipfs.pinCar.legacy.blocks', blocks.length);
+  incr('ipfs.pinCar.legacy.bytes', __perfBytes);
+  observeMs('ipfs.pinCar.legacy.totalMs', performance.now() - __perfStart);
   return expectedRootCid;
 }
 
@@ -1414,6 +1484,9 @@ export async function fetchFromIpfs(
   maxSizeBytes: number = DEFAULT_MAX_SIZE_BYTES,
   helia?: unknown,
 ): Promise<Uint8Array> {
+  // GH #363 measurement — split local-Helia hits from HTTP gateway
+  // fetches so the two cost models are visible separately.
+  const __perfStart = performance.now();
   // Issue #236 — local Helia blockstore fast-path. When the block was
   // pinned through this process (or any prior process with the same
   // `dataDir`), it is already on disk and a synchronous get() avoids
@@ -1428,6 +1501,8 @@ export async function fetchFromIpfs(
         // gateways (which apply their own enforcement) rather than
         // returning oversized bytes.
       } else {
+        incr('ipfs.fetchBlock.localHit');
+        observeMs('ipfs.fetchBlock.localHitMs', performance.now() - __perfStart);
         return local;
       }
     }
@@ -1622,6 +1697,10 @@ export async function fetchFromIpfs(
         await putBlockToLocalHelia(localHelia, cid, bytesOrNull);
       }
 
+      // GH #363 — gateway hit (HTTP round-trip cost).
+      incr('ipfs.fetchBlock.gatewayHit');
+      incr('ipfs.fetchBlock.bytes', bytesOrNull.byteLength);
+      observeMs('ipfs.fetchBlock.gatewayMs', performance.now() - __perfStart);
       return bytesOrNull;
     } catch (err) {
       // Size-limit ProfileError is fatal for this request (not per-gateway)
@@ -1633,6 +1712,8 @@ export async function fetchFromIpfs(
     }
   }
 
+  incr('ipfs.fetchBlock.allGatewaysFailed');
+  observeMs('ipfs.fetchBlock.failedMs', performance.now() - __perfStart);
   throw new ProfileError(
     'BUNDLE_NOT_FOUND',
     `Failed to fetch CAR ${cid} from all gateways: ${lastError?.message ?? 'unknown error'}`,
@@ -1701,10 +1782,17 @@ export async function fetchCarFromIpfs(
   maxSizeBytesPerBlock: number = DEFAULT_MAX_SIZE_BYTES,
   helia?: unknown,
 ): Promise<Uint8Array> {
+  // GH #363 / #370 — fetch wall-clock for the WHOLE selector (covers
+  // all branches: raw-codec backcompat, local-Helia short-circuit,
+  // /dag/export fast path, legacy BFS fallback). The fastPath/legacyPath
+  // split counter at the exit attributes which path served the call.
+  const __perfStart = performance.now();
+  incr('ipfs.fetchCar.calls');
   let parsedRoot: CID;
   try {
     parsedRoot = CID.parse(rootCid);
   } catch (err) {
+    observeMs('ipfs.fetchCar.totalMs', performance.now() - __perfStart);
     throw new ProfileError(
       'BUNDLE_NOT_FOUND',
       `fetchCarFromIpfs: cannot parse root CID ${rootCid}: ${err instanceof Error ? err.message : String(err)}`,
@@ -1716,9 +1804,17 @@ export async function fetchCarFromIpfs(
   // verbatim — they ARE the CAR. Skip the walk. Taken BEFORE the
   // capability probe — raw-codec roots never need /dag/export.
   if (parsedRoot.code === CODEC_RAW) {
-    return fetchFromIpfs(gateways, rootCid, timeoutMs, maxSizeBytesPerBlock, helia);
+    try {
+      const raw = await fetchFromIpfs(gateways, rootCid, timeoutMs, maxSizeBytesPerBlock, helia);
+      incr('ipfs.fetchCar.rawCodec');
+      incr('ipfs.fetchCar.bytes', raw.byteLength);
+      return raw;
+    } finally {
+      observeMs('ipfs.fetchCar.totalMs', performance.now() - __perfStart);
+    }
   }
   if (parsedRoot.code !== CODEC_DAG_CBOR) {
+    observeMs('ipfs.fetchCar.totalMs', performance.now() - __perfStart);
     throw new ProfileError(
       'BUNDLE_NOT_FOUND',
       `fetchCarFromIpfs: unsupported root codec 0x${parsedRoot.code.toString(16)} for ${rootCid} ` +
@@ -1739,14 +1835,21 @@ export async function fetchCarFromIpfs(
   if (localHeliaForRoot !== null) {
     const localRoot = await tryGetBlockFromLocalHelia(localHeliaForRoot, rootCid);
     if (localRoot !== null) {
-      return fetchCarFromIpfsLegacy(
-        effectiveGateways,
-        rootCid,
-        parsedRoot,
-        timeoutMs,
-        maxSizeBytesPerBlock,
-        helia,
-      );
+      try {
+        const out = await fetchCarFromIpfsLegacy(
+          effectiveGateways,
+          rootCid,
+          parsedRoot,
+          timeoutMs,
+          maxSizeBytesPerBlock,
+          helia,
+        );
+        incr('ipfs.fetchCar.localHeliaPath');
+        incr('ipfs.fetchCar.bytes', out.byteLength);
+        return out;
+      } finally {
+        observeMs('ipfs.fetchCar.totalMs', performance.now() - __perfStart);
+      }
     }
   }
 
@@ -1760,9 +1863,22 @@ export async function fetchCarFromIpfs(
     const caps = await probeGatewayCapabilities(gateway);
     if (!caps.dagExport) continue;
     try {
-      const carBytes = await fetchCarViaExport(gateway, rootCid, timeoutMs, maxSizeBytesPerBlock);
-      return await verifyAndReassembleExportedCar(carBytes, rootCid, helia);
+      const __dagExportStart = performance.now();
+      incr('ipfs.dagExport.calls');
+      let carBytes: Uint8Array;
+      try {
+        carBytes = await fetchCarViaExport(gateway, rootCid, timeoutMs, maxSizeBytesPerBlock);
+      } finally {
+        observeMs('ipfs.dagExport.totalMs', performance.now() - __dagExportStart);
+      }
+      incr('ipfs.dagExport.bytes', carBytes.byteLength);
+      const reassembled = await verifyAndReassembleExportedCar(carBytes, rootCid, helia);
+      incr('ipfs.fetchCar.fastPath');
+      incr('ipfs.fetchCar.bytes', reassembled.byteLength);
+      observeMs('ipfs.fetchCar.totalMs', performance.now() - __perfStart);
+      return reassembled;
     } catch (err) {
+      incr('ipfs.dagExport.error');
       logger.warn(
         'ipfs-client',
         `fetchCarFromIpfs: /dag/export fast path failed on ${gateway} for ${rootCid}, ` +
@@ -1776,14 +1892,21 @@ export async function fetchCarFromIpfs(
     }
   }
 
-  return fetchCarFromIpfsLegacy(
-    effectiveGateways,
-    rootCid,
-    parsedRoot,
-    timeoutMs,
-    maxSizeBytesPerBlock,
-    helia,
-  );
+  incr('ipfs.fetchCar.legacyPath');
+  try {
+    const out = await fetchCarFromIpfsLegacy(
+      effectiveGateways,
+      rootCid,
+      parsedRoot,
+      timeoutMs,
+      maxSizeBytesPerBlock,
+      helia,
+    );
+    incr('ipfs.fetchCar.bytes', out.byteLength);
+    return out;
+  } finally {
+    observeMs('ipfs.fetchCar.totalMs', performance.now() - __perfStart);
+  }
 }
 
 /**
@@ -1804,6 +1927,11 @@ async function fetchCarFromIpfsLegacy(
   maxSizeBytesPerBlock: number = DEFAULT_MAX_SIZE_BYTES,
   helia?: unknown,
 ): Promise<Uint8Array> {
+  // GH #363 / #370 — legacy-path-only wall-clock attribution. The
+  // selector's ipfs.fetchCar.totalMs counter records the public
+  // entry-to-exit time (including the probe + fast-path attempt that
+  // fell through); this counter records the legacy BFS walk only.
+  const __perfStart = performance.now();
   // Lazy-import @ipld/dag-cbor + CarWriter to keep the cold-path import
   // off the synchronous load of every module that touches ipfs-client.
   const { decode: dagCborDecode } = await import('@ipld/dag-cbor');
@@ -1908,6 +2036,12 @@ async function fetchCarFromIpfsLegacy(
     carBytes.set(c, offset);
     offset += c.length;
   }
+  // Legacy-path-specific counters (don't collide with the selector's
+  // public ipfs.fetchCar.{blocks,bytes,totalMs} — those measure the
+  // whole selector wall-clock and aggregate across all paths).
+  incr('ipfs.fetchCar.legacy.blocks', blocks.length);
+  incr('ipfs.fetchCar.legacy.bytes', totalLength);
+  observeMs('ipfs.fetchCar.legacy.totalMs', performance.now() - __perfStart);
   return carBytes;
 }
 

--- a/profile/orbitdb-adapter.ts
+++ b/profile/orbitdb-adapter.ts
@@ -13,6 +13,7 @@
 
 import { logger } from '../core/logger.js';
 import { hexToBytes } from '../core/hex.js';
+import { incr, observeMs } from '../core/perf-counters.js';
 import { ProfileError } from './errors.js';
 import { installHeliaBlockstoreGetShim } from './helia-blockstore-shim.js';
 import {
@@ -814,6 +815,13 @@ export class OrbitDbAdapter implements ProfileDatabase {
    */
   async putEntry(key: string, entry: OpLogEntryEnvelope): Promise<void> {
     this.ensureConnected();
+    // GH #363 — measure putEntry round-trip. Hypothesis under
+    // investigation: every logical operation produces many putEntry
+    // calls, each paying a full IPFS round-trip. Counter splits the
+    // bundle-ref keyspace from everything else so the batching
+    // question (issue #363) gets a direct signal.
+    const t0 = performance.now();
+    const isBundleKey = key.startsWith('tokens.bundle.');
     try {
       const cborBytes = encodeEntry(entry);
       await this.db.put(key, cborBytes);
@@ -821,10 +829,16 @@ export class OrbitDbAdapter implements ProfileDatabase {
       // decide whether to trust the stored `originated` tag.
       this.localAuthoredKeys.add(key);
     } catch (err) {
+      incr('orbitdb.putEntry.error');
       throw new ProfileError(
         'ORBITDB_WRITE_FAILED',
         `Failed to write structured entry at "${key}": ${err instanceof Error ? err.message : String(err)}`,
         err,
+      );
+    } finally {
+      observeMs(
+        isBundleKey ? 'orbitdb.putEntry.bundle' : 'orbitdb.putEntry.other',
+        performance.now() - t0,
       );
     }
   }
@@ -1151,9 +1165,20 @@ export class OrbitDbAdapter implements ProfileDatabase {
     // may have overwritten any of our keys (LWW per-key), so we can no
     // longer trust the stored `originated` tag for ANY key without
     // re-authoring. This is conservative (over-invalidates) but safe.
+    //
+    // GH #363 measurement: count BOTH the raw 'update' fires AND the
+    // callback-side wall-clock. Issue #360 Finding #1 claimed every
+    // local write triggers this handler — but never measured the rate
+    // or the callback cost. Confirm or refute with real data.
     const handler = () => {
+      incr('orbitdb.onReplication.fired');
+      const t0 = performance.now();
       this.localAuthoredKeys.clear();
-      callback();
+      try {
+        callback();
+      } finally {
+        observeMs('orbitdb.onReplication.callbackMs', performance.now() - t0);
+      }
     };
 
     this.db.events.on('update', handler);

--- a/profile/profile-snapshot-cache.ts
+++ b/profile/profile-snapshot-cache.ts
@@ -84,6 +84,7 @@
 import type { StorageProvider, TxfStorageDataBase } from '../storage/storage-provider.js';
 import { STORAGE_KEYS_GLOBAL } from '../constants.js';
 import { sha256 as nobleSha256 } from '@noble/hashes/sha2.js';
+import { time } from '../core/perf-counters.js';
 
 /**
  * Current snapshot schema version. Bumped on incompatible changes; the
@@ -274,6 +275,12 @@ export async function writeSnapshot(
   storage: StorageProvider,
   input: WriteSnapshotInput,
 ): Promise<number> {
+  return time('snapshotCache.writeSnapshot', () => _writeSnapshotImpl(storage, input));
+}
+async function _writeSnapshotImpl(
+  storage: StorageProvider,
+  input: WriteSnapshotInput,
+): Promise<number> {
   const ts = (input.now ?? Date.now)();
   const blobNoHash: Omit<ProfileSnapshotBlob, 'contentHash'> = {
     version: PROFILE_SNAPSHOT_SCHEMA_VERSION,
@@ -376,6 +383,14 @@ export async function writeSnapshot(
  * the next successful flush writes a fresh blob in the current schema.
  */
 export async function readSnapshot(
+  storage: StorageProvider,
+  addressId: string,
+  expectedWalletId: string,
+  now: () => number = Date.now,
+): Promise<SnapshotReadResult> {
+  return time('snapshotCache.readSnapshot', () => _readSnapshotImpl(storage, addressId, expectedWalletId, now));
+}
+async function _readSnapshotImpl(
   storage: StorageProvider,
   addressId: string,
   expectedWalletId: string,

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -44,6 +44,7 @@
 
 import { logger } from '../core/logger.js';
 import { SphereError } from '../core/errors.js';
+import { incr, time, observeMs } from '../core/perf-counters.js';
 import { STORAGE_KEYS_GLOBAL } from '../constants.js';
 import type { ProviderStatus, FullIdentity } from '../types/index.js';
 import type {
@@ -846,12 +847,18 @@ export class ProfileTokenStorageProvider
   async applySnapshotIfWired(
     cidString: string,
   ): Promise<import('./profile-snapshot-dispatcher.js').ApplySnapshotResult | null> {
+    return time('profile.applySnapshot', () => this._applySnapshotIfWiredImpl(cidString));
+  }
+  private async _applySnapshotIfWiredImpl(
+    cidString: string,
+  ): Promise<import('./profile-snapshot-dispatcher.js').ApplySnapshotResult | null> {
     if (this.isShuttingDown || this.hasShutdown) return null;
     // Late-bound setter wins; falls back to construction-time option
     // for callers that prefer the static-config style.
     const callback =
       this.applySnapshotCallback ?? this.options?.onApplySnapshot ?? null;
     if (typeof callback !== 'function') return null;
+    incr('profile.applySnapshot.fired');
     return callback(cidString);
   }
 
@@ -1290,6 +1297,10 @@ export class ProfileTokenStorageProvider
   // ---------------------------------------------------------------------------
 
   async load(_identifier?: string): Promise<LoadResult<TxfStorageDataBase>> {
+    incr('profile.load.calls');
+    return time('profile.load.totalMs', () => this._loadImpl(_identifier));
+  }
+  private async _loadImpl(_identifier?: string): Promise<LoadResult<TxfStorageDataBase>> {
     const timestamp = Date.now();
 
     if (!this.initialized || !this.encryptionKey) {
@@ -1508,7 +1519,20 @@ export class ProfileTokenStorageProvider
       // candidate roots; a single-bundle load has none.
       let verifiedProofs: ReadonlySet<string> | undefined = undefined;
       const verifyInclusionProof = this.options?.oracle?.verifyInclusionProof;
-      if (verifyInclusionProof && loadedBundles.length >= 2) {
+      // GH #363 prototype — env-gated bypass for the Rule-4 pairwise
+      // UXF-level verification loop. When set, load() skips the
+      // O(N²) pairwise computeVerifiedProofs pass; structural JOIN
+      // still runs and Rule 3 (longest-valid prefix) still applies;
+      // only Rule 4 enrichment is skipped. Mirrors the verifier-failure
+      // catch path below — that fallback is the existing graceful
+      // degradation, this flag just opts into it unconditionally so
+      // we can A/B measure the wall-clock delta.
+      const skipRule4 =
+        typeof process !== 'undefined' && process?.env?.SPHERE_SKIP_RULE4 === '1';
+      if (skipRule4) incr('profile.load.rule4Skipped');
+      if (verifyInclusionProof && loadedBundles.length >= 2 && !skipRule4) {
+        incr('profile.load.rule4PairwiseInvocations');
+        const __r4Start = performance.now();
         try {
           // Pairwise accumulation via the existing helper. `computeVerifiedProofs`
           // walks BOTH packages' pools dedup-by-content-hash, so for N
@@ -1531,12 +1555,15 @@ export class ProfileTokenStorageProvider
               for (const h of pairwise) accum.add(h);
             }
           }
+          observeMs('profile.load.rule4PairwiseMs', performance.now() - __r4Start);
           verifiedProofs = accum;
           this.log(
             `JOIN: computed verifiedProofs across ${loadedBundles.length} bundles ` +
               `(${accum.size} proof element(s) verified)`,
           );
         } catch (err) {
+          observeMs('profile.load.rule4PairwiseMs', performance.now() - __r4Start);
+          incr('profile.load.rule4PairwiseThrew');
           // Verifier failure must not abort the load — fall back to the
           // conservative (no-enrichment) resolution. The structural JOIN
           // still runs and Rule 3 (longest-valid prefix) still applies;

--- a/profile/profile-token-storage/bundle-index.ts
+++ b/profile/profile-token-storage/bundle-index.ts
@@ -32,6 +32,7 @@ import {
   encryptProfileValue,
   decryptProfileValue,
 } from '../encryption.js';
+import { incr, observeMs } from '../../core/perf-counters.js';
 import { buildLocalEntry, decodeEntry } from '../oplog-entry.js';
 import {
   runJoinSnapshot,
@@ -85,7 +86,12 @@ export class BundleIndex implements ProfileSyncWriter {
    * adapter's legacy-wrapping).
    */
   async listBundles(): Promise<Map<string, UxfBundleRef>> {
+    // GH #363 measurement: how often is this called per second, and
+    // how much wall-clock does the underlying `db.all` walk cost?
+    // Issue #360 Finding #3 claimed 5× per flush — confirm or refute.
+    const t0 = performance.now();
     const rawEntries = await this.host.db.all(BUNDLE_KEY_PREFIX);
+    observeMs('bundleIndex.listBundles.dbAllMs', performance.now() - t0);
     const result = new Map<string, UxfBundleRef>();
 
     // Steelman⁴⁰ warning: aggregate corrupt-bundle events into a single
@@ -130,6 +136,7 @@ export class BundleIndex implements ProfileSyncWriter {
       }
     }
 
+    incr('bundleIndex.listBundles.entries', result.size);
     if (corruptCids.length > 0) {
       const ev = this.host.buildErrorEvent('storage:error', firstCorruptError, 'CID_REF_CORRUPT');
       const truncated = corruptCids.length > CORRUPT_CIDS_PREVIEW_CAP;

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -68,6 +68,7 @@ import {
   verifyCidAccessibleWithRetry,
 } from '../ipfs-client.js';
 import { extractCarRootCid } from '../../uxf/transfer-payload.js';
+import { incr, observeMs } from '../../core/perf-counters.js';
 import { extractLostHeadCid } from '../orbitdb-adapter.js';
 import type { OrbitDbAdapter } from '../orbitdb-adapter.js';
 import type {
@@ -580,6 +581,22 @@ export class FlushScheduler {
    * the remote originator already published while we were merging).
    */
   async flushToIpfs(): Promise<void> {
+    // GH #363 measurement — how often does flushToIpfs run and how
+    // long does it take? Issue #360 Finding #1 hypothesised every
+    // local write triggers a full flush; the rate counter answers it.
+    incr('flushScheduler.flushToIpfs.calls');
+    const __perfStart = performance.now();
+    try {
+      return await this.__flushToIpfsBody();
+    } finally {
+      observeMs(
+        'flushScheduler.flushToIpfs.totalMs',
+        performance.now() - __perfStart,
+      );
+    }
+  }
+
+  private async __flushToIpfsBody(): Promise<void> {
     const encryptionKey = this.host.getEncryptionKey();
     if (!encryptionKey) return;
 

--- a/tests/unit/core/perf-counters.test.ts
+++ b/tests/unit/core/perf-counters.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __setPerfEnabledForTest,
+  __stopAutoDumpForTest,
+  dumpAndReset,
+  incr,
+  isPerfEnabled,
+  observeMs,
+  snapshot,
+  time,
+  timeSync,
+} from '../../../core/perf-counters.js';
+
+// =============================================================================
+// Test fixtures
+// =============================================================================
+
+beforeEach(() => {
+  // Start from a clean slate: stop any auto-dump, clear counters, enable.
+  __stopAutoDumpForTest();
+  __setPerfEnabledForTest(false);
+  // Re-enable for the test body. The clean order is: disable to drop
+  // any prior state via dumpAndReset under-the-hood guarantees, then
+  // enable so test calls actually record.
+  __setPerfEnabledForTest(true);
+});
+
+afterEach(() => {
+  __setPerfEnabledForTest(false);
+  __stopAutoDumpForTest();
+});
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('perf-counters — opt-in measurement', () => {
+  describe('when disabled (default)', () => {
+    it('isPerfEnabled returns false', () => {
+      __setPerfEnabledForTest(false);
+      expect(isPerfEnabled()).toBe(false);
+    });
+
+    it('incr() is a no-op', () => {
+      __setPerfEnabledForTest(false);
+      incr('x');
+      incr('y', 5);
+      // Re-enable to inspect: snapshot must still be empty because the
+      // calls above happened with PERF disabled.
+      __setPerfEnabledForTest(true);
+      expect(snapshot()).toEqual({});
+    });
+
+    it('observeMs() is a no-op', () => {
+      __setPerfEnabledForTest(false);
+      observeMs('latency', 42);
+      __setPerfEnabledForTest(true);
+      expect(snapshot()).toEqual({});
+    });
+
+    it('time() still runs the function and returns its value', async () => {
+      __setPerfEnabledForTest(false);
+      const result = await time('op', async () => 7);
+      expect(result).toBe(7);
+      __setPerfEnabledForTest(true);
+      expect(snapshot()).toEqual({});
+    });
+
+    it('timeSync() still runs the function and returns its value', () => {
+      __setPerfEnabledForTest(false);
+      const result = timeSync('op', () => 'hello');
+      expect(result).toBe('hello');
+      __setPerfEnabledForTest(true);
+      expect(snapshot()).toEqual({});
+    });
+  });
+
+  describe('when enabled', () => {
+    it('incr() accumulates counts', () => {
+      incr('hits');
+      incr('hits', 3);
+      incr('misses');
+      const snap = snapshot();
+      expect(snap.hits.count).toBe(4);
+      expect(snap.misses.count).toBe(1);
+    });
+
+    it('observeMs() records count + total + max', () => {
+      observeMs('latency', 10);
+      observeMs('latency', 20);
+      observeMs('latency', 5);
+      const snap = snapshot();
+      expect(snap.latency.count).toBe(3);
+      expect(snap.latency.totalMs).toBe(35);
+      expect(snap.latency.maxMs).toBe(20);
+      expect(snap.latency.avgMs).toBeCloseTo(11.667, 2);
+    });
+
+    it('observeMs() clamps negative and non-finite values to 0', () => {
+      observeMs('bad', -100);
+      observeMs('bad', Infinity);
+      observeMs('bad', NaN);
+      const snap = snapshot();
+      expect(snap.bad.count).toBe(3);
+      expect(snap.bad.totalMs).toBe(0);
+      expect(snap.bad.maxMs).toBe(0);
+    });
+
+    it('time() wraps async function and records its wall-clock', async () => {
+      const result = await time('op', async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return 42;
+      });
+      expect(result).toBe(42);
+      const snap = snapshot();
+      expect(snap.op.count).toBe(1);
+      expect(snap.op.totalMs).toBeGreaterThan(0);
+    });
+
+    it('time() records the timing even when the function throws', async () => {
+      await expect(
+        time('badop', async () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+      const snap = snapshot();
+      expect(snap.badop.count).toBe(1);
+    });
+
+    it('timeSync() wraps sync function and records its wall-clock', () => {
+      const result = timeSync('syncop', () => 99);
+      expect(result).toBe(99);
+      const snap = snapshot();
+      expect(snap.syncop.count).toBe(1);
+    });
+
+    it('snapshot() returns a stable view and does not clear', () => {
+      incr('x');
+      const a = snapshot();
+      const b = snapshot();
+      expect(a).toEqual(b);
+      expect(snapshot().x.count).toBe(1);
+    });
+
+    it('dumpAndReset() clears counters', () => {
+      incr('a');
+      observeMs('b', 10);
+      dumpAndReset();
+      expect(snapshot()).toEqual({});
+    });
+
+    it('dumpAndReset() is a no-op when there are no counters', () => {
+      // Should not throw, should not allocate.
+      expect(() => dumpAndReset()).not.toThrow();
+      expect(snapshot()).toEqual({});
+    });
+  });
+
+  describe('isPerfEnabled', () => {
+    it('reflects __setPerfEnabledForTest', () => {
+      __setPerfEnabledForTest(true);
+      expect(isPerfEnabled()).toBe(true);
+      __setPerfEnabledForTest(false);
+      expect(isPerfEnabled()).toBe(false);
+    });
+  });
+});

--- a/tests/unit/profile/ipfs-client-dag-export.test.ts
+++ b/tests/unit/profile/ipfs-client-dag-export.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Issue #370 — `fetchCarFromIpfs` `/dag/export` fast-path tests.
+ *
+ * Verifies the selector layer added in issue #370 on the read side:
+ *   - Probe-driven fast path: a single `/dag/export` POST replaces the
+ *     per-block `/api/v0/block/get` BFS walk, returns CAR bytes that the
+ *     selector parses + verifies block-by-block + reassembles.
+ *   - Per-block CID verification: a gateway returning a CAR with one
+ *     mismatched block triggers fallback to legacy BFS (defense-in-depth
+ *     against gateway tampering).
+ *   - Missing-root defensive check: a CAR returned by /dag/export that
+ *     does not contain the requested root triggers fallback.
+ *   - Probe-miss fallback: gateway returning 404 from probe → legacy BFS
+ *     walks `/api/v0/block/get`.
+ *   - Byte-for-byte equivalence: fast-path output and legacy BFS output
+ *     reassemble identical CAR bytes for the same input fixture.
+ *
+ * @module tests/unit/profile/ipfs-client-dag-export
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { CID } from 'multiformats/cid';
+import { create as createDigest } from 'multiformats/hashes/digest';
+import { encode as dagCborEncode } from '@ipld/dag-cbor';
+import { CarReader } from '@ipld/car';
+import {
+  fetchCarFromIpfs,
+  _resetGatewayCapabilityCache,
+} from '../../../profile/ipfs-client';
+import { makeFakeUxfCar } from './_helpers/fake-uxf-car.js';
+
+// ---------------------------------------------------------------------------
+// Fetch mock builders
+// ---------------------------------------------------------------------------
+
+interface ExportMockOptions {
+  readonly probeStatus: number;
+  /** Bytes to return on /api/v0/dag/export call. */
+  readonly exportBytes?: Uint8Array;
+  /** Status to return on /api/v0/dag/export call (default 200). */
+  readonly exportStatus?: number;
+  /** Blocks map for legacy /api/v0/block/get fallback path. */
+  readonly blocks?: Map<string, Uint8Array>;
+}
+
+interface MockHandle {
+  readonly restore: () => void;
+  readonly exportCalls: () => number;
+  readonly blockGetCalls: () => number;
+}
+
+function installMock(opts: ExportMockOptions): MockHandle {
+  const original = globalThis.fetch;
+  const counts = { exportCalls: 0, blockGetCalls: 0 };
+
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : (input as { url?: string }).url ?? String(input);
+
+    // Probe: a POST to /api/v0/dag/import or /api/v0/dag/export with no
+    // body. The real fast-path /dag/export has `arg=<cid>` in the query.
+    const isProbe =
+      (url.endsWith('/api/v0/dag/import') || url.endsWith('/api/v0/dag/export')) &&
+      init?.body === undefined;
+    if (isProbe) {
+      return new Response('', { status: opts.probeStatus });
+    }
+
+    if (url.includes('/api/v0/dag/export?')) {
+      counts.exportCalls += 1;
+      const status = opts.exportStatus ?? 200;
+      if (status !== 200) {
+        return new Response('forced failure', { status });
+      }
+      if (opts.exportBytes === undefined) {
+        return new Response('no bytes configured', { status: 500 });
+      }
+      return new Response(opts.exportBytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/vnd.ipld.car' },
+      });
+    }
+
+    if (url.includes('/api/v0/block/get?arg=')) {
+      counts.blockGetCalls += 1;
+      const match = url.match(/\/api\/v0\/block\/get\?arg=([^&]+)/);
+      if (!match) return new Response('missing arg', { status: 400 });
+      const cid = decodeURIComponent(match[1]!);
+      const bytes = opts.blocks?.get(cid);
+      if (!bytes) return new Response('miss', { status: 404 });
+      return new Response(bytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      });
+    }
+
+    if (url.includes('/sidecar/blob') || url.includes('/sidecar/submit')) {
+      return new Response('', { status: 404 });
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  return {
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    exportCalls: () => counts.exportCalls,
+    blockGetCalls: () => counts.blockGetCalls,
+  };
+}
+
+/** Extract every block from a CAR into a map for the legacy mock. */
+async function carToBlockMap(carBytes: Uint8Array): Promise<Map<string, Uint8Array>> {
+  const reader = await CarReader.fromBytes(carBytes);
+  const out = new Map<string, Uint8Array>();
+  for await (const block of reader.blocks()) {
+    out.set(block.cid.toString(), block.bytes);
+  }
+  return out;
+}
+
+/** Hand-build a CAR whose root is dag-cbor with a single block. */
+async function makeMinimalDagCborCar(): Promise<Uint8Array> {
+  const { CarWriter } = await import('@ipld/car');
+  const payload = { issue: 370, kind: 'minimal-dag-cbor' };
+  const bytes = dagCborEncode(payload);
+  const cid = CID.createV1(0x71, createDigest(0x12, sha256(bytes)));
+  const { writer, out } = CarWriter.create([cid]);
+  const collect = (async () => {
+    const chunks: Uint8Array[] = [];
+    for await (const c of out) chunks.push(c);
+    return chunks;
+  })();
+  await writer.put({ cid, bytes });
+  await writer.close();
+  const chunks = await collect;
+  const total = chunks.reduce((a, c) => a + c.length, 0);
+  const buf = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    buf.set(c, offset);
+    offset += c.length;
+  }
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Issue #370 — fetchCarFromIpfs /dag/export fast path', () => {
+  let mock: MockHandle | null = null;
+
+  beforeEach(() => {
+    _resetGatewayCapabilityCache();
+  });
+
+  afterEach(() => {
+    if (mock !== null) {
+      mock.restore();
+      mock = null;
+    }
+  });
+
+  it('happy path: single /dag/export call replaces per-block BFS', async () => {
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'fast-1' }, { id: 'fast-2' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+
+    mock = installMock({ probeStatus: 400, exportBytes: carBytes });
+    const out = await fetchCarFromIpfs(['https://gw-fast.test'], rootCid);
+
+    // Single export call, zero per-block fetches.
+    expect(mock.exportCalls()).toBe(1);
+    expect(mock.blockGetCalls()).toBe(0);
+
+    // Output is a valid CAR with the same root.
+    const outReader = await CarReader.fromBytes(out);
+    const outRoots = await outReader.getRoots();
+    expect(outRoots[0]!.toString()).toBe(rootCid);
+
+    // Every source block is present.
+    const sourceCids = new Set<string>();
+    const r2 = await CarReader.fromBytes(carBytes);
+    for await (const b of r2.blocks()) sourceCids.add(b.cid.toString());
+    const outCids = new Set<string>();
+    const r3 = await CarReader.fromBytes(out);
+    for await (const b of r3.blocks()) outCids.add(b.cid.toString());
+    expect(outCids).toEqual(sourceCids);
+  });
+
+  it('falls back to legacy BFS when probe returns 404', async () => {
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'legacy' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+    const blocks = await carToBlockMap(carBytes);
+
+    mock = installMock({ probeStatus: 404, blocks });
+    const out = await fetchCarFromIpfs(['https://gw-no-export.test'], rootCid);
+
+    expect(mock.exportCalls()).toBe(0);
+    expect(mock.blockGetCalls()).toBeGreaterThan(0);
+
+    const outReader = await CarReader.fromBytes(out);
+    const outRoots = await outReader.getRoots();
+    expect(outRoots[0]!.toString()).toBe(rootCid);
+  });
+
+  it('falls back to legacy BFS when fast-path /dag/export returns 500', async () => {
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'mid-failure' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+    const blocks = await carToBlockMap(carBytes);
+
+    mock = installMock({ probeStatus: 400, exportStatus: 500, blocks });
+    const out = await fetchCarFromIpfs(['https://gw-export-500.test'], rootCid);
+
+    expect(mock.exportCalls()).toBe(1);
+    expect(mock.blockGetCalls()).toBeGreaterThan(0);
+    const outReader = await CarReader.fromBytes(out);
+    const outRoots = await outReader.getRoots();
+    expect(outRoots[0]!.toString()).toBe(rootCid);
+  });
+
+  it('falls back to legacy BFS when /dag/export response omits the requested root', async () => {
+    const truthful = await makeFakeUxfCar({ tokens: [{ id: 'truthful' }] });
+    const truthfulReader = await CarReader.fromBytes(truthful);
+    const truthfulRoots = await truthfulReader.getRoots();
+    const truthfulRoot = truthfulRoots[0]!.toString();
+    const truthfulBlocks = await carToBlockMap(truthful);
+
+    // Build a different CAR that claims a different root — the gateway
+    // returns this in response to a request for the truthful root.
+    const phantom = await makeMinimalDagCborCar();
+
+    mock = installMock({ probeStatus: 400, exportBytes: phantom, blocks: truthfulBlocks });
+    const out = await fetchCarFromIpfs(
+      ['https://gw-wrong-root.test'],
+      truthfulRoot,
+    );
+
+    expect(mock.exportCalls()).toBe(1);
+    expect(mock.blockGetCalls()).toBeGreaterThan(0);
+    const outReader = await CarReader.fromBytes(out);
+    const outRoots = await outReader.getRoots();
+    expect(outRoots[0]!.toString()).toBe(truthfulRoot);
+  });
+
+  it('falls back to legacy BFS when /dag/export response contains a CID-binding-violating block', async () => {
+    // Use the legitimate CAR's root and structure, but corrupt one block's
+    // bytes in the served stream so per-block sha256 check fails. The
+    // legacy BFS will then succeed (because its mock serves honest bytes).
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'corrupted' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+    const blocks = await carToBlockMap(carBytes);
+
+    // Build a corrupt CAR by reassembling with one block's bytes mutated.
+    const { CarWriter } = await import('@ipld/car');
+    const allBlocks: Array<{ cid: CID; bytes: Uint8Array }> = [];
+    for await (const b of (await CarReader.fromBytes(carBytes)).blocks()) {
+      allBlocks.push({ cid: b.cid, bytes: b.bytes });
+    }
+    // Corrupt a non-root block. Mutate the last byte of the last block.
+    const target = allBlocks[allBlocks.length - 1]!;
+    const corrupted = new Uint8Array(target.bytes);
+    corrupted[corrupted.length - 1] = corrupted[corrupted.length - 1]! ^ 0xff;
+    allBlocks[allBlocks.length - 1] = { cid: target.cid, bytes: corrupted };
+
+    const { writer, out } = CarWriter.create([roots[0]!]);
+    const collect = (async () => {
+      const chunks: Uint8Array[] = [];
+      for await (const c of out) chunks.push(c);
+      return chunks;
+    })();
+    for (const b of allBlocks) await writer.put(b);
+    await writer.close();
+    const chunks = await collect;
+    const total = chunks.reduce((a, c) => a + c.length, 0);
+    const corruptCar = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      corruptCar.set(c, offset);
+      offset += c.length;
+    }
+
+    mock = installMock({ probeStatus: 400, exportBytes: corruptCar, blocks });
+    const reassembled = await fetchCarFromIpfs(
+      ['https://gw-corrupt.test'],
+      rootCid,
+    );
+    // Fast path attempted then failed CID-binding → fell through to legacy BFS.
+    expect(mock.exportCalls()).toBe(1);
+    expect(mock.blockGetCalls()).toBeGreaterThan(0);
+    const r = await CarReader.fromBytes(reassembled);
+    const r2 = await r.getRoots();
+    expect(r2[0]!.toString()).toBe(rootCid);
+  });
+
+  it('byte-for-byte equivalence: fast-path output and legacy BFS produce identical CAR block sets', async () => {
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'eq-1' }, { id: 'eq-2' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+    const blocks = await carToBlockMap(carBytes);
+
+    // Run 1: fast path.
+    mock = installMock({ probeStatus: 400, exportBytes: carBytes, blocks });
+    const fastOut = await fetchCarFromIpfs(['https://gw-eq-fast.test'], rootCid);
+    mock.restore();
+    mock = null;
+    _resetGatewayCapabilityCache();
+
+    // Run 2: legacy path (probe miss).
+    mock = installMock({ probeStatus: 404, blocks });
+    const legacyOut = await fetchCarFromIpfs(['https://gw-eq-legacy.test'], rootCid);
+
+    // Equivalence: same root + same block set. The two paths reassemble
+    // the CAR independently (fast-path uses verifyAndReassembleExportedCar,
+    // legacy uses the BFS reassembly); CAR-wire bytes may differ in block
+    // ordering, but root and block-set MUST match.
+    const fastReader = await CarReader.fromBytes(fastOut);
+    const legacyReader = await CarReader.fromBytes(legacyOut);
+    const fastRoots = await fastReader.getRoots();
+    const legacyRoots = await legacyReader.getRoots();
+    expect(fastRoots[0]!.toString()).toBe(rootCid);
+    expect(legacyRoots[0]!.toString()).toBe(rootCid);
+
+    const fastCids = new Set<string>();
+    for await (const b of fastReader.blocks()) fastCids.add(b.cid.toString());
+    const legacyCids = new Set<string>();
+    for await (const b of legacyReader.blocks()) legacyCids.add(b.cid.toString());
+    expect(fastCids).toEqual(legacyCids);
+    expect(fastCids.size).toBe(blocks.size);
+  });
+
+  it('probe cache: same gateway probed exactly once across multiple fetches', async () => {
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'cache' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+
+    let probeHits = 0;
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : (input as { url?: string }).url ?? String(input);
+      const isProbe =
+        (url.endsWith('/api/v0/dag/import') || url.endsWith('/api/v0/dag/export')) &&
+        init?.body === undefined;
+      if (isProbe) {
+        probeHits += 1;
+        return new Response('', { status: 400 });
+      }
+      if (url.includes('/api/v0/dag/export?')) {
+        return new Response(carBytes, {
+          status: 200,
+          headers: { 'Content-Type': 'application/vnd.ipld.car' },
+        });
+      }
+      return new Response('not found', { status: 404 });
+    }) as typeof globalThis.fetch;
+
+    try {
+      for (let i = 0; i < 3; i++) {
+        await fetchCarFromIpfs(['https://gw-fetch-cache.test'], rootCid);
+      }
+      // Two endpoints probed (import + export), each exactly once across
+      // the three fetches.
+      expect(probeHits).toBe(2);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/tests/unit/profile/ipfs-client-dag-import.test.ts
+++ b/tests/unit/profile/ipfs-client-dag-import.test.ts
@@ -1,0 +1,555 @@
+/**
+ * Issue #370 — `pinCarBlocksToIpfs` `/dag/import` fast-path tests.
+ *
+ * Verifies the selector layer added in issue #370:
+ *   - Capability probe semantics (200/400/404/405/500/timeout/network-error)
+ *   - Probe cache: a gateway is probed exactly once across many pins
+ *   - Fast-path happy case: single `/dag/import` POST replaces the per-block
+ *     `/dag/put` loop, NDJSON response parsed for expected-root presence
+ *   - Multi-root defensive check: the gateway reporting extra roots does not
+ *     fail; the gateway omitting our root does
+ *   - Fallback on probe-miss (gateway returns 404 from probe): legacy
+ *     per-block path runs against `/dag/put`
+ *   - Fallback on per-call HTTP failure (probe says capable but actual
+ *     `/dag/import` call returns 500): legacy per-block path runs
+ *   - Legacy path local-Helia writes are skipped when the fast path already
+ *     wrote them (no duplicate puts)
+ *
+ * The legacy path's per-block correctness is covered by
+ * `tests/unit/profile/ipfs-client-parallel-pin.test.ts` — this file only
+ * verifies the dispatch + fast-path layer.
+ *
+ * @module tests/unit/profile/ipfs-client-dag-import
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { create as createDigest } from 'multiformats/hashes/digest';
+
+import {
+  pinCarBlocksToIpfs,
+  _resetGatewayCapabilityCache,
+} from '../../../profile/ipfs-client';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async function buildCar(
+  blocks: Array<{ cid: CID; bytes: Uint8Array }>,
+): Promise<Uint8Array> {
+  const { CarWriter } = await import('@ipld/car');
+  const { writer, out } = CarWriter.create([blocks[0]!.cid]);
+  const collect = (async () => {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of out) chunks.push(chunk);
+    return chunks;
+  })();
+  for (const block of blocks) await writer.put(block);
+  await writer.close();
+  const chunks = await collect;
+  const total = chunks.reduce((a, c) => a + c.length, 0);
+  const buf = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    buf.set(c, offset);
+    offset += c.length;
+  }
+  return buf;
+}
+
+function makeRawBlocks(n: number): Array<{ cid: CID; bytes: Uint8Array }> {
+  const out: Array<{ cid: CID; bytes: Uint8Array }> = [];
+  for (let i = 0; i < n; i++) {
+    const bytes = new TextEncoder().encode(`#370-import-block-${i}`);
+    out.push({
+      cid: CID.createV1(raw.code, createDigest(0x12, sha256(bytes))),
+      bytes,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock builders
+// ---------------------------------------------------------------------------
+
+interface ProbeMockOptions {
+  /** Status returned for probe POST to /api/v0/dag/import. */
+  readonly importProbeStatus: number;
+  /** Status returned for probe POST to /api/v0/dag/export. Default mirrors import. */
+  readonly exportProbeStatus?: number;
+  /** When true, the probe rejects with a network error instead of responding. */
+  readonly probeNetworkError?: boolean;
+  /** When true, the probe never resolves (forces timeout). */
+  readonly probeHang?: boolean;
+}
+
+interface FastPathMockOptions extends ProbeMockOptions {
+  /**
+   * NDJSON lines to return on `/api/v0/dag/import` (one per line). When
+   * omitted defaults to a single-root envelope with the supplied
+   * `expectedRootCid`.
+   */
+  readonly importNdjson?: (expectedRootCid: string) => string;
+  /** Status for /api/v0/dag/import call (default 200). */
+  readonly importStatus?: number;
+  /** Status for /api/v0/dag/put fallback (default 200, returns minimal JSON). */
+  readonly dagPutStatus?: number;
+}
+
+interface MockHandle {
+  readonly restore: () => void;
+  readonly importProbeHits: () => number;
+  readonly exportProbeHits: () => number;
+  readonly importCalls: () => number;
+  readonly dagPutCalls: () => number;
+}
+
+function installMock(opts: FastPathMockOptions, gatewayBase: string): MockHandle {
+  const original = globalThis.fetch;
+  const counts = {
+    importProbeHits: 0,
+    exportProbeHits: 0,
+    importCalls: 0,
+    dagPutCalls: 0,
+  };
+
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : (input as { url?: string }).url ?? String(input);
+
+    const isProbe =
+      (url.endsWith('/api/v0/dag/import') || url.endsWith('/api/v0/dag/export')) &&
+      // A probe has no body; the real fast-path call has a FormData body.
+      init?.body === undefined;
+
+    if (isProbe) {
+      if (opts.probeHang === true) {
+        return await new Promise(() => {
+          /* hang */
+        });
+      }
+      if (opts.probeNetworkError === true) {
+        throw new Error('probe-network-error');
+      }
+      if (url.endsWith('/api/v0/dag/import')) {
+        counts.importProbeHits += 1;
+        return new Response('', { status: opts.importProbeStatus });
+      }
+      counts.exportProbeHits += 1;
+      return new Response('', {
+        status: opts.exportProbeStatus ?? opts.importProbeStatus,
+      });
+    }
+
+    if (url.includes('/api/v0/dag/import?')) {
+      counts.importCalls += 1;
+      const status = opts.importStatus ?? 200;
+      if (status !== 200) {
+        return new Response('forced failure', { status });
+      }
+      const ndjson = (opts.importNdjson ?? defaultImportNdjson)(
+        currentExpectedRoot ?? '',
+      );
+      return new Response(ndjson, { status: 200 });
+    }
+
+    if (url.includes('/api/v0/dag/put')) {
+      counts.dagPutCalls += 1;
+      return new Response(JSON.stringify({ Cid: { '/': 'ignored' } }), {
+        status: opts.dagPutStatus ?? 200,
+      });
+    }
+
+    if (url.includes('/sidecar/submit') || url.includes('/sidecar/blob')) {
+      return new Response('', { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  // Defensive: silence the unused-warning if the caller doesn't use gatewayBase.
+  void gatewayBase;
+
+  return {
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    importProbeHits: () => counts.importProbeHits,
+    exportProbeHits: () => counts.exportProbeHits,
+    importCalls: () => counts.importCalls,
+    dagPutCalls: () => counts.dagPutCalls,
+  };
+}
+
+/**
+ * Default NDJSON: single Root envelope with the expected CID and no
+ * PinErrorMsg. Models the modern Kubo shape (`Cid: {"/": "..."}`).
+ */
+function defaultImportNdjson(expectedRootCid: string): string {
+  return (
+    JSON.stringify({
+      Root: { Cid: { '/': expectedRootCid }, PinErrorMsg: '' },
+    }) + '\n'
+  );
+}
+
+// Thin global so the mock can include the expected root in NDJSON output
+// without the caller having to pass it through every layer.
+let currentExpectedRoot: string | null = null;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Issue #370 — pinCarBlocksToIpfs /dag/import fast path', () => {
+  let mock: MockHandle | null = null;
+
+  beforeEach(() => {
+    _resetGatewayCapabilityCache();
+  });
+
+  afterEach(() => {
+    if (mock !== null) {
+      mock.restore();
+      mock = null;
+    }
+    currentExpectedRoot = null;
+  });
+
+  describe('capability probe', () => {
+    it('treats 400 (healthy Kubo on empty body) as "exposed" → fast path runs', async () => {
+      const blocks = makeRawBlocks(4);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-probe-400.test';
+
+      mock = installMock({ importProbeStatus: 400 }, gateway);
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+      expect(mock.importCalls()).toBe(1);
+      expect(mock.dagPutCalls()).toBe(0);
+    });
+
+    it('treats 404 as "not exposed" → falls through to legacy per-block', async () => {
+      const blocks = makeRawBlocks(3);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-probe-404.test';
+
+      mock = installMock({ importProbeStatus: 404 }, gateway);
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+      expect(mock.importCalls()).toBe(0);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+
+    it('treats 405 as "not exposed" → falls through to legacy per-block', async () => {
+      const blocks = makeRawBlocks(2);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-probe-405.test';
+
+      mock = installMock({ importProbeStatus: 405 }, gateway);
+      await pinCarBlocksToIpfs([gateway], carBytes, expectedRoot);
+      expect(mock.importCalls()).toBe(0);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+
+    it('treats 500 as "not exposed" → falls through to legacy per-block', async () => {
+      const blocks = makeRawBlocks(2);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-probe-500.test';
+
+      mock = installMock({ importProbeStatus: 500 }, gateway);
+      await pinCarBlocksToIpfs([gateway], carBytes, expectedRoot);
+      expect(mock.importCalls()).toBe(0);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+
+    it('treats network error as "not exposed" → falls through to legacy per-block', async () => {
+      const blocks = makeRawBlocks(2);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-probe-neterr.test';
+
+      mock = installMock(
+        { importProbeStatus: 0, probeNetworkError: true },
+        gateway,
+      );
+      await pinCarBlocksToIpfs([gateway], carBytes, expectedRoot);
+      expect(mock.importCalls()).toBe(0);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+  });
+
+  describe('probe cache', () => {
+    it('probes the same gateway exactly once across multiple pins', async () => {
+      const expectedCalls = 3;
+      const gateway = 'https://gw-probe-cache.test';
+      mock = installMock({ importProbeStatus: 400 }, gateway);
+
+      for (let i = 0; i < expectedCalls; i++) {
+        const blocks = makeRawBlocks(1);
+        const carBytes = await buildCar(blocks);
+        const expectedRoot = blocks[0]!.cid.toString();
+        currentExpectedRoot = expectedRoot;
+        await pinCarBlocksToIpfs([gateway], carBytes, expectedRoot);
+      }
+      expect(mock.importProbeHits()).toBe(1);
+      expect(mock.exportProbeHits()).toBe(1);
+      expect(mock.importCalls()).toBe(expectedCalls);
+    });
+  });
+
+  describe('NDJSON response parsing', () => {
+    it('accepts modern shape {"Root":{"Cid":{"/":"<cid>"}}}', async () => {
+      const blocks = makeRawBlocks(1);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-ndjson-modern.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: (root) =>
+            JSON.stringify({ Root: { Cid: { '/': root }, PinErrorMsg: '' } }) +
+            '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+    });
+
+    it('accepts older shape {"Root":{"Cid":"<cid>"}} (bare string Cid)', async () => {
+      const blocks = makeRawBlocks(1);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-ndjson-old.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: (root) =>
+            JSON.stringify({ Root: { Cid: root, PinErrorMsg: '' } }) + '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+    });
+
+    it('skips Stats lines and other non-Root envelopes', async () => {
+      const blocks = makeRawBlocks(1);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-ndjson-mixed.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: (root) =>
+            [
+              JSON.stringify({ Stats: { BlockCount: 1 } }),
+              JSON.stringify({ Root: { Cid: { '/': root } } }),
+              JSON.stringify({ Stats: { BlockBytesCount: 64 } }),
+              '   ', // whitespace-only line
+              '{not json',
+            ].join('\n') + '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+    });
+
+    it('multi-root defensive check: tolerates extra Root entries beyond our expected root', async () => {
+      const blocks = makeRawBlocks(1);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      const phantomRoot = CID.createV1(
+        raw.code,
+        createDigest(0x12, sha256(new TextEncoder().encode('phantom'))),
+      ).toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-multi-root.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: (root) =>
+            [
+              JSON.stringify({ Root: { Cid: { '/': root } } }),
+              JSON.stringify({ Root: { Cid: { '/': phantomRoot } } }),
+            ].join('\n') + '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+    });
+
+    it('falls back to legacy when NDJSON response omits the expected root', async () => {
+      const blocks = makeRawBlocks(2);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      const wrongRoot = CID.createV1(
+        raw.code,
+        createDigest(0x12, sha256(new TextEncoder().encode('not-our-root'))),
+      ).toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-missing-root.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: () =>
+            JSON.stringify({ Root: { Cid: { '/': wrongRoot } } }) + '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+      // Fast path was attempted, then fell through to legacy per-block.
+      expect(mock.importCalls()).toBe(1);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+
+    it('falls back to legacy when NDJSON Root reports a non-empty PinErrorMsg', async () => {
+      const blocks = makeRawBlocks(2);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-pin-error.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: (root) =>
+            JSON.stringify({
+              Root: { Cid: { '/': root }, PinErrorMsg: 'block too large' },
+            }) + '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+      expect(mock.importCalls()).toBe(1);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+  });
+
+  describe('fallback on per-call HTTP failure', () => {
+    it('falls back to legacy when fast-path /dag/import returns 500', async () => {
+      const blocks = makeRawBlocks(3);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-500-onlyimport.test';
+
+      mock = installMock(
+        { importProbeStatus: 400, importStatus: 500 },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+      expect(mock.importCalls()).toBe(1);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+  });
+
+  describe('local-Helia write deduplication', () => {
+    it('does not duplicate local-Helia puts when fast path runs then legacy fallback runs', async () => {
+      const blocks = makeRawBlocks(4);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-helia-dedup.test';
+
+      const heliaPuts: string[] = [];
+      const fakeHelia = {
+        blockstore: {
+          get: () => {
+            throw new Error('not supposed to read');
+          },
+          put: async (cid: { toString(): string }) => {
+            heliaPuts.push(cid.toString());
+          },
+        },
+      };
+
+      // Force fast path to attempt then fail (import status 500) so legacy
+      // runs after the fast-path local-helia write phase.
+      mock = installMock(
+        { importProbeStatus: 400, importStatus: 500 },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+        30_000,
+        fakeHelia,
+      );
+      expect(returned).toBe(expectedRoot);
+      // Every block written exactly ONCE — the fast-path phase wrote them
+      // and the legacy phase was told to skip its own write loop via
+      // helia=undefined.
+      const expectedCids = blocks.map((b) => b.cid.toString()).sort();
+      expect(heliaPuts.sort()).toEqual(expectedCids);
+    });
+  });
+});

--- a/uxf/UxfPackage.ts
+++ b/uxf/UxfPackage.ts
@@ -30,6 +30,7 @@ import type {
   TokenRootChildren,
   GenesisChildren,
 } from './types.js';
+import { incr, observeMs } from '../core/perf-counters.js';
 import { STRATEGY_LATEST } from './types.js';
 import { UxfError } from './errors.js';
 import { computeElementHash } from './hash.js';
@@ -348,6 +349,15 @@ export class UxfPackage {
       proofHash?: string;
     }) => Promise<boolean>,
   ): Promise<Set<string>> {
+    // GH #363 measurement. Issue #360 Finding #2 claimed this is
+    // O(B²·P) sequential and dominates load latency; verify on real
+    // data before any future optimisation. Counters split:
+    //   .calls       — invocations
+    //   .verifyCalls — verifier RPCs actually made
+    //   .verifyOk    — verifier returned true
+    //   .totalMs     — outer wall-clock per call
+    incr('uxf.computeVerifiedProofs.calls');
+    const __perfStart = performance.now();
     const verified = new Set<string>();
     const ELEMENT_TYPE_INCLUSION_PROOF = 'inclusion-proof' as const;
     // Pool from both packages — same proof element may appear in
@@ -367,16 +377,24 @@ export class UxfPackage {
         continue;
       }
       try {
+        incr('uxf.computeVerifiedProofs.verifyCalls');
+        const __vStart = performance.now();
         const ok = await verifier({
           proofJson,
           transactionHash: txHashImprintHex,
           proofHash: hash,
         });
-        if (ok) verified.add(hash);
+        observeMs('uxf.computeVerifiedProofs.verifyMs', performance.now() - __vStart);
+        if (ok) {
+          incr('uxf.computeVerifiedProofs.verifyOk');
+          verified.add(hash);
+        }
       } catch {
         /* verifier failure → not verified, conservative */
+        incr('uxf.computeVerifiedProofs.verifyThrew');
       }
     }
+    observeMs('uxf.computeVerifiedProofs.totalMs', performance.now() - __perfStart);
     return verified;
   }
 


### PR DESCRIPTION
## Summary

Closes the SDK-side half of #370. Replaces the per-block IPFS round-trip pattern (`/api/v0/dag/put` per block, `DEFAULT_PIN_CONCURRENCY=10` parallel HTTP connections) with single-round-trip CAR-level push and pull via Kubo's `/api/v0/dag/import` (push) and `/api/v0/dag/export` (pull) endpoints.

Eliminates the throttling-under-burst behaviour that caused several spurious soak failures during #364 validation — the kubo container's `MAX_PINS_PER_SECOND=100` limiter was being tipped over when multiple wallets flushed simultaneously, surfacing as `IPFS dag/put failed on all gateways: fetch failed`.

## Scope

**In scope (this PR):**
- New capability probe with per-process cache (probes `/api/v0/dag/{import,export}` once per gateway URL)
- New `pinCarViaImport` single-shot push + new `fetchCarViaExport` single-shot pull (private helpers)
- `pinCarBlocksToIpfs` and `fetchCarFromIpfs` refactored into "probe + dispatch" selectors that prefer the fast path when available and fall back to the existing per-block code (renamed to `…Legacy` internally)
- Local-Helia (#236) and sidecar (#255) integrations preserved on both paths
- 21 new tests across two files; all 54 pre-existing IPFS tests still green; full `tests/unit/profile/` suite green (2302/2302)

**Out of scope (this PR):**
- **Operator-side gateway config** (Part 1 of #370): haproxy/nginx ACL whitelist of `/dag/import` and `/dag/export` on `unicity-ipfs1.dyndns.org` and the per-IP rate-limit revisit. Cannot live in the SDK repo. The SDK's capability probe makes this PR independently shippable — the fast path activates automatically once operators flip the gateway config.
- **Perf counters** (`ipfs.dagImport.totalMs`, `ipfs.dagExport.totalMs`): the `core/perf-counters.ts` foundation is chained through PR #365 on `chore/perf-instrumentation` and has not landed on `main` yet. Once that lands a 5-line follow-up commit will add `time('ipfs.dagImport', …)` / `time('ipfs.dagExport', …)` wrappers around the new fast-path entry points. The integration acceptance criteria for #370 (`ipfs.fetchCar.totalMs` drops 5–10×, etc.) is gated on that follow-up + Part 1 soak.
- **Single-blob writes** (`pinToIpfs` used by `CidRefStore.pinBytes`): stays on `/dag/put`. Not a "bundle" — wrapping a 32-byte encrypted Profile ref in a CAR-of-one is overhead with no rate-limiter savings vs the current single POST. Confirmed scope decision with the issue author.
- **`http-block-broker.ts`** (Helia `BlockBroker` for `httpOnlyIpfs: true`): fetch-only via `/api/v0/block/get`. Helia's blockstore protocol doesn't support `dag/export` semantics. Callers that go through `fetchCarFromIpfs` (bundle-acquirer, profile-token-storage-provider, profile-export, consolidation) get the fast path automatically without changing the Helia broker.

## Design

### Capability probe

POST a tiny no-body request to `/api/v0/dag/{import,export}` with a 2-second timeout. Response classification:

| Response | Treated as |
|---|---|
| 4xx except 404, 405 (incl. 400 from a healthy Kubo on empty body) | Exposed |
| 2xx | Exposed |
| 404 (route absent) | Not exposed |
| 405 (POST blocked at proxy) | Not exposed |
| 5xx | Not exposed (upstream unhealthy → safer to skip) |
| Network error / timeout | Not exposed |

Cached per-process per normalized gateway URL. `_resetGatewayCapabilityCache()` exported for tests.

### Push fast path

Multipart POST `/api/v0/dag/import?pin=true` with field name `file`. Parses NDJSON response permissively — accepts both modern `{"Root":{"Cid":{"/":"…"}}}` and older `{"Root":{"Cid":"…"}}` Kubo shapes. Validates expected root is present with empty `PinErrorMsg`; tolerates extra roots; throws (→ fallback to legacy) on missing root or pin error.

Local-Helia writes happen **before** the HTTP push (preserves #236 crash-safety invariant). If the fast path attempts then fails, the legacy fallback is called with `helia=undefined` to avoid duplicate local-Helia puts. Sidecar submit fires once for the CAR root after success.

### Fetch fast path

POST `/api/v0/dag/export?arg=<root>`. Streams the response with `readStreamWithLimit` for size safety. Parses with `CarReader.fromBytes`, runs `verifyCidMatchesBytes` on every block (preserves the gateway-tampering boundary), reassembles a CARv1 in stream order matching the existing BFS output shape. Local-Helia write-back per verified block (preserves the #236 bidirectional cache).

A local-Helia-first short-circuit (BEFORE the probe) routes to legacy BFS when the root is already locally available — keeps the "zero HTTP for fully-cached CARs" property the #236 fetch tests assert.

### Backwards compatibility

- Public API signatures unchanged. All call sites compile and run identically — fast path activates automatically once operators expose the endpoints.
- 5 existing IPFS test files (54 tests) pass without modification. Their mock gateways return 404 for unknown URLs → probe-miss → legacy path runs.
- Raw-codec root short-circuit in `fetchCarFromIpfs` still runs before the probe (legacy raw-pinned bundles unaffected).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on modified/added files
- [x] 14 new tests in `tests/unit/profile/ipfs-client-dag-import.test.ts` (probe semantics × 5, probe cache, NDJSON parse × 3, multi-root × 1, fallback × 2, helia-dedup × 1, happy-path × 2)
- [x] 7 new tests in `tests/unit/profile/ipfs-client-dag-export.test.ts` (happy-path, probe-miss, mid-call 500, missing-root, CID-violation, byte-equivalence with legacy, probe cache)
- [x] 54 pre-existing IPFS tests pass unchanged
- [x] Full `tests/unit/profile/` suite green (2302 / 2302)
- [x] Dependent transfer tests (`bundle-acquirer`, `ipfs-publisher`) green
- [ ] **Integration soak** (gated on operator-side Part 1): once the gateway exposes `/dag/import` + `/dag/export`, `manual-test-full-recovery.sh` with `SPHERE_PERF=1` should show `ipfs.fetchCar.totalMs` drop 5–10× and `MAX_PINS_PER_SECOND` collisions disappear.

## Blocks / blocked-by

- **Blocks** the throttling-mitigation half of #369 (per #370 "Ordering / blocks" section). Once #370 lands, the per-block path is the legacy fallback only and #369's per-block retries become much less load-bearing.
- **Coordination needed** with the operator-side change (Part 1 of #370). This PR is functionally a no-op for current operator gateways — the fast path activates automatically once the operator config goes live.

## Refs

#370, #364, #369, #236, #255, #200