### PR TITLE
perf(profile)(issue-367): per-bundle provenance gate for Rule-4 skip

### DIFF
--- a/profile/factory.ts
+++ b/profile/factory.ts
@@ -370,10 +370,12 @@ export interface ProfileSnapshotApplyDeps {
 export function runProfileSnapshotApply(
   snapshot: LeanProfileSnapshot,
   deps: ProfileSnapshotApplyDeps,
+  sourcePointerCid?: string,
 ): Promise<ApplySnapshotResult> {
   return runProfileSnapshotJoin(snapshot, {
     writersFor: deps.writersFor,
     bundleIndex: deps.getBundleIndex(),
+    sourcePointerCid,
     log: deps.log,
   });
 }
@@ -704,6 +706,7 @@ export function createProfileProviders(
   // instances (the adapter is a thin handle over `db` + key).
   const dispatchParsedSnapshot = (
     snapshot: LeanProfileSnapshot,
+    sourcePointerCid?: string,
   ): Promise<ApplySnapshotResult> =>
     runProfileSnapshotApply(snapshot, {
       writersFor: (addressId) => {
@@ -792,9 +795,11 @@ export function createProfileProviders(
         return writers;
       },
       getBundleIndex: () => tokenStorage.getBundleIndex(),
-    });
+    }, sourcePointerCid);
 
-  storage.setSnapshotApplier((snapshot) => dispatchParsedSnapshot(snapshot));
+  storage.setSnapshotApplier((snapshot, sourcePointerCid) =>
+    dispatchParsedSnapshot(snapshot, sourcePointerCid),
+  );
 
   // Item #15 Phase E follow-up — install the pull-side dispatcher for
   // the periodic-poll / cold-start recovery paths. Symmetric to
@@ -848,7 +853,7 @@ export function createProfileProviders(
           fetchFromIpfs(ipfsGateways, subBlockCid, undefined, undefined, helia),
       ),
     );
-    const result = await time('applySnapshotCb.dispatchMs', () => dispatchParsedSnapshot(snapshot));
+    const result = await time('applySnapshotCb.dispatchMs', () => dispatchParsedSnapshot(snapshot, cidString));
     observeMs('applySnapshotCb.totalMs', performance.now() - __cbStart);
     return result;
   });

--- a/profile/pointer-wiring.ts
+++ b/profile/pointer-wiring.ts
@@ -180,9 +180,19 @@ export interface PointerWiringInput {
    * `snapshot_applier_missing` skip reason — the wallet then runs
    * without aggregator-pointer recovery rather than silently writing
    * the wrong CAR shape to the bundle index.
+   *
+   * Issue #367 — accepts an optional `sourcePointerCid` carrying the
+   * IPFS CID of the snapshot blob being applied. The dispatcher uses
+   * it to annotate each landed bundle ref with its source snapshot so
+   * a subsequent `load()` can skip Rule-4 pairwise verification when
+   * every active bundle traces to the same single trusted snapshot.
+   * Pre-#367 callers may omit the parameter — the dispatcher then
+   * treats the apply as "context-unknown" (no annotation) and the
+   * Rule-4 gate degrades safely (Rule-4 runs).
    */
   readonly applySnapshot: (
     snapshot: LeanProfileSnapshot,
+    sourcePointerCid?: string,
   ) => Promise<ApplySnapshotResult>;
   /** Turn on verbose logging for the wiring helper itself. */
   readonly debug?: boolean;
@@ -444,6 +454,7 @@ function buildFetchAndJoin(deps: {
    */
   applySnapshot: (
     snapshot: LeanProfileSnapshot,
+    sourcePointerCid?: string,
   ) => Promise<ApplySnapshotResult>;
 }): FetchAndJoinCallback {
   return async (remoteCid: Uint8Array, remoteVersion: PointerVersion) => {
@@ -517,7 +528,10 @@ function buildFetchAndJoin(deps: {
     }
 
     try {
-      await deps.applySnapshot(snapshot);
+      // Issue #367 — pass the snapshot's IPFS pointer CID so the
+      // dispatcher can annotate each landed bundle ref. Already
+      // decoded at line ~453 above.
+      await deps.applySnapshot(snapshot, cidString);
     } catch (err) {
       // Throwing here keeps the cursor behind the unconsumed
       // remote, so the next reconcile pass re-fetches + re-applies.

--- a/profile/profile-snapshot-dispatcher.ts
+++ b/profile/profile-snapshot-dispatcher.ts
@@ -97,10 +97,41 @@ export interface ProfileSnapshotJoinDeps {
    * the token storage layer is not ready (e.g., shutdown in progress).
    * BundleIndex implements `ProfileSyncWriter` directly and owns the
    * `tokens.bundle.*` namespace.
+   *
+   * Issue #367 — when the concrete type also exposes
+   * {@link BundleIndexSnapshotContextSetter.setCurrentSnapshotApplyCid},
+   * the dispatcher arms it with {@link sourcePointerCid} before calling
+   * `joinSnapshot()` so each landed bundle ref can be annotated with the
+   * source snapshot's pointer CID for downstream Rule-4 provenance gating.
    */
   readonly bundleIndex: ProfileSyncWriter | null;
+  /**
+   * Issue #367 — IPFS pointer CID of the lean-snapshot blob currently
+   * being applied. Propagates into each landed bundle ref via
+   * `BundleIndex.joinSnapshot`'s `writeRemote` callback so a subsequent
+   * `load()` can identify pure-snapshot bundle sets and skip Rule-4
+   * pairwise verification (no cross-device sibling collisions possible
+   * when every bundle came through a single trusted snapshot blob).
+   *
+   * Empty string indicates "context not propagated" — preserves the
+   * pre-#367 behaviour where bundle refs land without provenance and
+   * the gate degrades safely (Rule-4 runs).
+   */
+  readonly sourcePointerCid?: string;
   /** Optional debug logger; falls back to the SDK logger. */
   readonly log?: (msg: string) => void;
+}
+
+/**
+ * Issue #367 — structural type the dispatcher duck-types against to
+ * arm the snapshot-source context on `BundleIndex` before its
+ * `joinSnapshot` runs. The setter is OPTIONAL on the dispatcher-facing
+ * interface so legacy bundle-index doubles (test stubs) and other
+ * future writers can satisfy `ProfileSyncWriter` without implementing
+ * the snapshot-annotation contract.
+ */
+interface BundleIndexSnapshotContextSetter {
+  setCurrentSnapshotApplyCid(cid: string | null): void;
 }
 
 /**
@@ -382,6 +413,26 @@ export async function runProfileSnapshotJoin(
     const bundleSlice = entries.filter((e) => e.key.startsWith(BUNDLE_KEY_PREFIX));
     bundleEntriesSeen = bundleSlice.length;
     if (bundleSlice.length > 0) {
+      // Issue #367 — arm the snapshot-source context if the concrete
+      // bundle-index implementation exposes the setter (production
+      // `BundleIndex` does; test stubs typically don't). Clearing in
+      // `finally` keeps the field at `null` between applies so a stale
+      // CID can never leak into a later non-snapshot path.
+      const setter = (
+        deps.bundleIndex as ProfileSyncWriter & Partial<BundleIndexSnapshotContextSetter>
+      ).setCurrentSnapshotApplyCid;
+      const armed = typeof setter === 'function';
+      const cidForContext = deps.sourcePointerCid ?? '';
+      if (armed && cidForContext.length > 0) {
+        try {
+          setter.call(deps.bundleIndex, cidForContext);
+        } catch (err) {
+          log(
+            `runProfileSnapshotJoin: setCurrentSnapshotApplyCid threw — proceeding without provenance annotation ` +
+              `(error: ${err instanceof Error ? err.message : String(err)})`,
+          );
+        }
+      }
       try {
         const result = await deps.bundleIndex.joinSnapshot(bundleSlice);
         accumulate(aggregated, result);
@@ -390,6 +441,14 @@ export async function runProfileSnapshotJoin(
           `runProfileSnapshotJoin: bundleIndex.joinSnapshot threw — skipping ` +
             `(error: ${err instanceof Error ? err.message : String(err)})`,
         );
+      } finally {
+        if (armed) {
+          try {
+            setter.call(deps.bundleIndex, null);
+          } catch {
+            /* swallow — setter must not break the JOIN result reporting */
+          }
+        }
       }
     }
   } else {

--- a/profile/profile-storage-provider.ts
+++ b/profile/profile-storage-provider.ts
@@ -506,8 +506,10 @@ export class ProfileStorageProvider implements StorageProvider {
    * In practice the factory sets it once at construction.
    */
   private snapshotApplier:
-    | ((snapshot: import('./profile-lean-snapshot').LeanProfileSnapshot)
-        => Promise<import('./profile-snapshot-dispatcher').ApplySnapshotResult>)
+    | ((
+        snapshot: import('./profile-lean-snapshot').LeanProfileSnapshot,
+        sourcePointerCid?: string,
+      ) => Promise<import('./profile-snapshot-dispatcher').ApplySnapshotResult>)
     | null = null;
 
   /**
@@ -553,8 +555,10 @@ export class ProfileStorageProvider implements StorageProvider {
    */
   setSnapshotApplier(
     applier:
-      | ((snapshot: import('./profile-lean-snapshot').LeanProfileSnapshot)
-          => Promise<import('./profile-snapshot-dispatcher').ApplySnapshotResult>)
+      | ((
+          snapshot: import('./profile-lean-snapshot').LeanProfileSnapshot,
+          sourcePointerCid?: string,
+        ) => Promise<import('./profile-snapshot-dispatcher').ApplySnapshotResult>)
       | null,
   ): void {
     this.snapshotApplier = applier;

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -1453,8 +1453,12 @@ export class ProfileTokenStorageProvider
       // we can pre-compute verifiedProofs across the full set before
       // running the resolver. Per-bundle fetch failures are non-fatal
       // (partial load is better than failure).
-      const loadedBundles: Array<{ cid: string; pkg: UxfPackageInstance }> = [];
-      for (const [cid] of activeBundles) {
+      const loadedBundles: Array<{
+        cid: string;
+        pkg: UxfPackageInstance;
+        sourcedFromSnapshotPointerCid: string | null;
+      }> = [];
+      for (const [cid, ref] of activeBundles) {
         try {
           // Issue #200 Phase 2: bundle CIDs are now dag-cbor envelope
           // CIDs (per-block pinned), not raw-CIDs over the CAR bytes.
@@ -1479,7 +1483,11 @@ export class ProfileTokenStorageProvider
             this.db.getHelia?.(),
           );
           const pkg = await UxfPackage.fromCar(carBytes);
-          loadedBundles.push({ cid, pkg });
+          loadedBundles.push({
+            cid,
+            pkg,
+            sourcedFromSnapshotPointerCid: ref.sourcedFromSnapshotPointerCid ?? null,
+          });
         } catch (err) {
           this.log(`Failed to load bundle ${cid}: ${err instanceof Error ? err.message : String(err)}`);
         }
@@ -1527,9 +1535,41 @@ export class ProfileTokenStorageProvider
       // catch path below — that fallback is the existing graceful
       // degradation, this flag just opts into it unconditionally so
       // we can A/B measure the wall-clock delta.
-      const skipRule4 =
+      const skipRule4Env =
         typeof process !== 'undefined' && process?.env?.SPHERE_SKIP_RULE4 === '1';
-      if (skipRule4) incr('profile.load.rule4Skipped');
+      if (skipRule4Env) incr('profile.load.rule4Skipped');
+
+      // GH #367 — per-bundle provenance gate. Skip Rule-4 pairwise
+      // verification when every active bundle was placed into the
+      // local OrbitDB store by the snapshot dispatcher's `writeRemote`
+      // path and they ALL trace to the same source snapshot. In that
+      // case the snapshot producer's local merge already resolved any
+      // siblings before publishing — the receiver's pairwise loop is
+      // redundant.
+      //
+      // The gate fails-safe: any bundle without provenance (locally-
+      // published, replication-arrived, or legacy pre-#367), or a
+      // mix of source snapshots, leaves Rule-4 enabled. Single-bundle
+      // loads are handled by the `>= 2` guard below — Rule-4 doesn't
+      // fire on single bundles anyway.
+      let skipRule4Snapshot = false;
+      if (loadedBundles.length >= 2) {
+        const firstCid = loadedBundles[0].sourcedFromSnapshotPointerCid;
+        if (firstCid !== null) {
+          skipRule4Snapshot = loadedBundles.every(
+            (b) => b.sourcedFromSnapshotPointerCid === firstCid,
+          );
+        }
+      }
+      if (skipRule4Snapshot) {
+        incr('profile.load.rule4SkippedSnapshot');
+        this.log(
+          `JOIN: Rule-4 pairwise skipped — all ${loadedBundles.length} bundles ` +
+            `sourced from snapshot ${loadedBundles[0].sourcedFromSnapshotPointerCid?.slice(0, 12)}…`,
+        );
+      }
+
+      const skipRule4 = skipRule4Env || skipRule4Snapshot;
       if (verifyInclusionProof && loadedBundles.length >= 2 && !skipRule4) {
         incr('profile.load.rule4PairwiseInvocations');
         const __r4Start = performance.now();

--- a/profile/profile-token-storage/bundle-index.ts
+++ b/profile/profile-token-storage/bundle-index.ts
@@ -57,7 +57,41 @@ export const CONSOLIDATION_WARNING_THRESHOLD = 3;
 const CORRUPT_CIDS_PREVIEW_CAP = 100;
 
 export class BundleIndex implements ProfileSyncWriter {
+  /**
+   * Issue #367 — set by {@link runProfileSnapshotJoin} BEFORE invoking
+   * this writer's `joinSnapshot()` and cleared in `finally` after.
+   * Read inside `joinSnapshot`'s `writeRemote` callback to annotate
+   * each landed bundle ref with its source snapshot's pointer CID.
+   *
+   * Null outside of an active snapshot apply — covers production code
+   * paths (where the dispatcher always arms it for non-empty bundle
+   * slices) AND legacy code paths / test doubles (where the dispatcher
+   * may not arm it at all). The `writeRemote` callback treats null as
+   * "no provenance available" and writes the bundle ref bytes verbatim,
+   * matching the pre-#367 behaviour.
+   */
+  private currentSnapshotApplyCid: string | null = null;
+
   constructor(private readonly host: ProfileTokenStorageHost) {}
+
+  /**
+   * Issue #367 — arm/clear the source-snapshot context consulted by
+   * `joinSnapshot`'s `writeRemote` callback. Invoked by the snapshot
+   * dispatcher around its BundleIndex JOIN call. Never throws.
+   *
+   * The setter is idempotent and does NOT enforce ownership — callers
+   * are responsible for clearing after their JOIN completes (the
+   * dispatcher's `finally` block satisfies this). A leaked non-null
+   * value into a later apply with a stale CID is the worst-case
+   * downside; the Rule-4 gate would then group bundles under the
+   * wrong source — but Rule-4 is an enrichment skip, not a correctness
+   * gate, so the cost is at most a missed optimisation, never lost
+   * tokens. The serialized `_applySnapshotIfWiredImpl` call site
+   * prevents this in practice.
+   */
+  setCurrentSnapshotApplyCid(cid: string | null): void {
+    this.currentSnapshotApplyCid = cid;
+  }
 
   /**
    * List all bundle refs from OrbitDB, filtered to active status.
@@ -315,16 +349,56 @@ export class BundleIndex implements ProfileSyncWriter {
         // Falling back to raw `db.put` when `putEntry` is unavailable
         // matches `addBundle()`'s pattern — the adapter's read-time
         // legacy wrap (v=0 synthetic envelope) handles those bytes.
+        //
+        // Issue #367 — annotate the landed bundle ref with the source
+        // snapshot's pointer CID so a subsequent `load()` can identify
+        // pure-snapshot bundle sets and skip Rule-4 pairwise verification.
+        // The annotation is best-effort: any failure (decrypt, JSON
+        // parse, re-encrypt) falls back to the verbatim write — the JOIN
+        // still lands and the Rule-4 gate degrades safely (Rule-4 runs).
+        let bytesToWrite = bytes;
+        const sourceCid = this.currentSnapshotApplyCid;
+        const encryptionKey = this.host.getEncryptionKey();
+        if (sourceCid !== null && sourceCid.length > 0 && encryptionKey !== null) {
+          try {
+            let encryptedPayload: Uint8Array = bytes;
+            try {
+              const envelope = decodeEntry(bytes);
+              if (envelope.v === 1) {
+                encryptedPayload = envelope.payload;
+              }
+            } catch {
+              /* legacy raw-bytes — encryptedPayload is `bytes` already */
+            }
+            const decrypted = await decryptProfileValue(encryptionKey, encryptedPayload);
+            const parsed = JSON.parse(new TextDecoder().decode(decrypted)) as unknown;
+            if (isUxfBundleRef(parsed)) {
+              const annotated: UxfBundleRef = {
+                ...parsed,
+                sourcedFromSnapshotPointerCid: sourceCid,
+              };
+              const reSerialized = new TextEncoder().encode(JSON.stringify(annotated));
+              bytesToWrite = await encryptProfileValue(encryptionKey, reSerialized);
+            }
+          } catch (err) {
+            this.host.log(
+              `BundleIndex.joinSnapshot: provenance annotation failed for ${key}; persisting verbatim ` +
+                `(${err instanceof Error ? err.message : String(err)})`,
+            );
+            bytesToWrite = bytes;
+          }
+        }
+
         const db = this.host.db;
         if (typeof db.putEntry === 'function') {
           const envelope = buildLocalEntry({
             type: 'cache_index',
             originated: 'system',
-            payload: bytes,
+            payload: bytesToWrite,
           });
           await db.putEntry(key, envelope);
         } else {
-          await db.put(key, bytes);
+          await db.put(key, bytesToWrite);
           const markHook = (db as { markLocallyAuthored?: (k: string) => void }).markLocallyAuthored;
           if (typeof markHook === 'function') {
             markHook.call(db, key);

--- a/profile/types.ts
+++ b/profile/types.ts
@@ -351,6 +351,26 @@ export interface UxfBundleRef {
   readonly removeFromProfileAfter?: number;
   /** Number of tokens in this bundle (for quick display without fetching CAR) */
   readonly tokenCount?: number;
+  /**
+   * Issue #367 — pointer CID of the lean-snapshot blob that placed this
+   * bundle ref into the local OrbitDB store via a snapshot-apply dispatch.
+   *
+   * Set ONLY when the writer that landed the ref was the snapshot
+   * dispatcher's `writeRemote` path inside `BundleIndex.joinSnapshot`.
+   * Unset (undefined) on:
+   *   - locally-published bundles written via `BundleIndex.addBundle`;
+   *   - bundles arriving via OrbitDB cross-device pubsub replication
+   *     (which doesn't flow through the snapshot dispatcher);
+   *   - legacy bundle refs persisted before this field existed.
+   *
+   * Read by `load()`'s Rule-4 pairwise gate: when every active bundle's
+   * `sourcedFromSnapshotPointerCid` is non-null AND identical, the load
+   * is sourced from a single trusted snapshot blob and Rule-4 enrichment
+   * can be skipped (the snapshot producer's local merge already resolved
+   * any siblings before publication). Any non-snapshot bundle in the
+   * active set forces Rule-4 to run.
+   */
+  readonly sourcedFromSnapshotPointerCid?: string;
 }
 
 // =============================================================================

--- a/tests/unit/profile/load-rule4-snapshot-gate.test.ts
+++ b/tests/unit/profile/load-rule4-snapshot-gate.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Issue #367 — per-bundle provenance gate for Rule-4 pairwise verification.
+ *
+ * The provider's `_loadImpl` skips the O(N²) `computeVerifiedProofs`
+ * pairwise loop when every active bundle was placed into the local
+ * OrbitDB store by the snapshot dispatcher's `writeRemote` path AND they
+ * all trace to the same source snapshot. Snapshot-sourced means the
+ * `UxfBundleRef.sourcedFromSnapshotPointerCid` field is set on every
+ * loaded bundle to the same non-null value. Any non-snapshot bundle in
+ * the active set, or a mix of source snapshots, leaves Rule-4 enabled.
+ *
+ * This file pins the gate at the `load()` layer using planted refs.
+ * The crypto/persistence paths are exercised in the existing
+ * `load-rule4-wiring.test.ts`; here we only assert the gate's decision
+ * matrix.
+ *
+ * Cases:
+ *   - All bundles share one snapshot CID → skip (computeVerifiedProofs NOT called).
+ *   - All bundles are local (field absent) → no skip.
+ *   - Mixed bundles (some snapshot, some local) → no skip.
+ *   - Bundles span two different snapshot CIDs → no skip.
+ *   - Single-bundle snapshot-sourced load → no skip path is irrelevant
+ *     (the `>= 2` guard in the gate prevents the pairwise loop anyway).
+ *
+ * Strategy mirrors `load-rule4-wiring.test.ts`:
+ *   - In-memory MockProfileDb with planted encrypted bundle refs.
+ *   - Spy on `UxfPackage.prototype.computeVerifiedProofs` and
+ *     `UxfPackage.prototype.merge` to observe Rule-4 invocation.
+ *   - Stub the CAR fetch so the actual bundle bytes are irrelevant —
+ *     we only care about the gate's decision.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+  UxfBundleRef,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import type { OracleProvider } from '../../../oracle';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import {
+  deriveProfileEncryptionKey,
+  encryptProfileValue,
+} from '../../../profile/encryption';
+import { UxfPackage } from '../../../uxf/UxfPackage';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+const EXPECTED_ADDRESS_ID = 'DIRECT_aabbcc_ddeeff';
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+const BUNDLE_KEY_PREFIX = 'tokens.bundle.';
+
+const SNAPSHOT_CID_A = 'bafyreigh2akiscaildc6zdrgwqjevvw2tbifg6vkv7gh2akiscaildc6zda';
+const SNAPSHOT_CID_B = 'bafyreigh2akiscaildc6zdrgwqjevvw2tbifg6vkv7gh2akiscaildc6zdb';
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function getEncryptionKey(): Uint8Array {
+  return deriveProfileEncryptionKey(hexToBytes(TEST_PRIVATE_KEY));
+}
+
+interface MockProfileDb extends ProfileDatabase {
+  _store: Map<string, Uint8Array>;
+}
+
+function createMockDb(): MockProfileDb {
+  const store = new Map<string, Uint8Array>();
+  return {
+    _store: store,
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as MockProfileDb;
+}
+
+async function plantBundleInOrbit(
+  db: MockProfileDb,
+  cid: string,
+  ref: UxfBundleRef,
+): Promise<void> {
+  const encKey = getEncryptionKey();
+  db._store.set(
+    `${BUNDLE_KEY_PREFIX}${cid}`,
+    await encryptProfileValue(
+      encKey,
+      new TextEncoder().encode(JSON.stringify(ref)),
+    ),
+  );
+}
+
+async function buildEmptyBundle(seed: string): Promise<{ cid: string; carBytes: Uint8Array }> {
+  const pkg = UxfPackage.create({ description: seed });
+  const carBytes = await pkg.toCar();
+  const { CID } = await import('multiformats/cid');
+  const { sha256 } = await import('@noble/hashes/sha2.js');
+  const raw = await import('multiformats/codecs/raw');
+  const { create: createDigest } = await import('multiformats/hashes/digest');
+  const cid = CID.createV1(raw.code, createDigest(0x12, sha256(carBytes))).toString();
+  return { cid, carBytes };
+}
+
+const originalFetch = globalThis.fetch;
+function installCarFetchMock(carBytesByCid: Map<string, Uint8Array>): void {
+  globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const ipfsMatch = url.match(/\/ipfs\/([^/?]+)/);
+    const blockMatch = url.match(/\/api\/v0\/block\/get\?arg=([^&]+)/);
+    const cid = ipfsMatch
+      ? ipfsMatch[1]
+      : blockMatch
+        ? decodeURIComponent(blockMatch[1]!)
+        : null;
+    if (cid && carBytesByCid.has(cid)) {
+      return new Response(carBytesByCid.get(cid), { status: 200 });
+    }
+    return new Response('', { status: 404 });
+  }) as typeof fetch;
+}
+
+function createProvider(
+  db: MockProfileDb,
+  oracle?: OracleProvider,
+): ProfileTokenStorageProvider {
+  const provider = new ProfileTokenStorageProvider(
+    db,
+    getEncryptionKey(),
+    ['https://mock-ipfs.test'],
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId: EXPECTED_ADDRESS_ID,
+      encrypt: true,
+      oracle,
+    },
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  return provider;
+}
+
+function stubOracle(verify: ReturnType<typeof vi.fn>): OracleProvider {
+  return {
+    verifyInclusionProof: verify,
+  } as unknown as OracleProvider;
+}
+
+describe('ProfileTokenStorageProvider.load — Issue #367 Rule-4 snapshot gate', () => {
+  let db: MockProfileDb;
+
+  beforeEach(() => {
+    db = createMockDb();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('skips Rule-4 when all loaded bundles share the same snapshot pointer CID', async () => {
+    const computeSpy = vi
+      .spyOn(UxfPackage.prototype, 'computeVerifiedProofs')
+      .mockResolvedValue(new Set<string>());
+    const mergeSpy = vi.spyOn(UxfPackage.prototype, 'merge');
+
+    const verifier = vi.fn(async () => true);
+    const provider = createProvider(db, stubOracle(verifier));
+    await provider.initialize();
+
+    const bundleA = await buildEmptyBundle('A');
+    const bundleB = await buildEmptyBundle('B');
+    await plantBundleInOrbit(db, bundleA.cid, {
+      cid: bundleA.cid,
+      status: 'active',
+      createdAt: 1000,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_A,
+    });
+    await plantBundleInOrbit(db, bundleB.cid, {
+      cid: bundleB.cid,
+      status: 'active',
+      createdAt: 1001,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_A,
+    });
+
+    installCarFetchMock(
+      new Map<string, Uint8Array>([
+        [bundleA.cid, bundleA.carBytes],
+        [bundleB.cid, bundleB.carBytes],
+      ]),
+    );
+
+    const result = await provider.load();
+    expect(result.success).toBe(true);
+
+    // Gate fired → pairwise loop skipped.
+    expect(computeSpy).not.toHaveBeenCalled();
+    // Merge calls SHOULD NOT carry verifiedProofs in this branch
+    // (the catch arm that also skips Rule-4 enriches with an empty
+    // set; the gate skip path leaves verifiedProofs undefined).
+    const callWithVerified = mergeSpy.mock.calls.find((args) => {
+      const opts = args[1] as { verifiedProofs?: ReadonlySet<string> } | undefined;
+      return opts !== undefined && opts.verifiedProofs !== undefined;
+    });
+    expect(callWithVerified).toBeUndefined();
+
+    await provider.shutdown();
+  });
+
+  it('does NOT skip Rule-4 when bundles have no provenance (locally-published)', async () => {
+    const computeSpy = vi
+      .spyOn(UxfPackage.prototype, 'computeVerifiedProofs')
+      .mockResolvedValue(new Set<string>());
+    vi.spyOn(UxfPackage.prototype, 'merge');
+
+    const verifier = vi.fn(async () => true);
+    const provider = createProvider(db, stubOracle(verifier));
+    await provider.initialize();
+
+    const bundleA = await buildEmptyBundle('A');
+    const bundleB = await buildEmptyBundle('B');
+    // No sourcedFromSnapshotPointerCid → locally-published bundles.
+    await plantBundleInOrbit(db, bundleA.cid, {
+      cid: bundleA.cid,
+      status: 'active',
+      createdAt: 1000,
+    });
+    await plantBundleInOrbit(db, bundleB.cid, {
+      cid: bundleB.cid,
+      status: 'active',
+      createdAt: 1001,
+    });
+
+    installCarFetchMock(
+      new Map<string, Uint8Array>([
+        [bundleA.cid, bundleA.carBytes],
+        [bundleB.cid, bundleB.carBytes],
+      ]),
+    );
+
+    const result = await provider.load();
+    expect(result.success).toBe(true);
+    // Gate did NOT fire → pairwise loop ran.
+    expect(computeSpy).toHaveBeenCalled();
+
+    await provider.shutdown();
+  });
+
+  it('does NOT skip Rule-4 on a mix of snapshot-sourced and local bundles', async () => {
+    const computeSpy = vi
+      .spyOn(UxfPackage.prototype, 'computeVerifiedProofs')
+      .mockResolvedValue(new Set<string>());
+
+    const verifier = vi.fn(async () => true);
+    const provider = createProvider(db, stubOracle(verifier));
+    await provider.initialize();
+
+    const bundleA = await buildEmptyBundle('A');
+    const bundleB = await buildEmptyBundle('B');
+    // A is snapshot-sourced.
+    await plantBundleInOrbit(db, bundleA.cid, {
+      cid: bundleA.cid,
+      status: 'active',
+      createdAt: 1000,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_A,
+    });
+    // B is locally-published (no annotation).
+    await plantBundleInOrbit(db, bundleB.cid, {
+      cid: bundleB.cid,
+      status: 'active',
+      createdAt: 1001,
+    });
+
+    installCarFetchMock(
+      new Map<string, Uint8Array>([
+        [bundleA.cid, bundleA.carBytes],
+        [bundleB.cid, bundleB.carBytes],
+      ]),
+    );
+
+    const result = await provider.load();
+    expect(result.success).toBe(true);
+    // Mixed provenance → conservative gate keeps Rule-4 on.
+    expect(computeSpy).toHaveBeenCalled();
+
+    await provider.shutdown();
+  });
+
+  it('does NOT skip Rule-4 when bundles span two different snapshot CIDs', async () => {
+    const computeSpy = vi
+      .spyOn(UxfPackage.prototype, 'computeVerifiedProofs')
+      .mockResolvedValue(new Set<string>());
+
+    const verifier = vi.fn(async () => true);
+    const provider = createProvider(db, stubOracle(verifier));
+    await provider.initialize();
+
+    const bundleA = await buildEmptyBundle('A');
+    const bundleB = await buildEmptyBundle('B');
+    await plantBundleInOrbit(db, bundleA.cid, {
+      cid: bundleA.cid,
+      status: 'active',
+      createdAt: 1000,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_A,
+    });
+    await plantBundleInOrbit(db, bundleB.cid, {
+      cid: bundleB.cid,
+      status: 'active',
+      createdAt: 1001,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_B,
+    });
+
+    installCarFetchMock(
+      new Map<string, Uint8Array>([
+        [bundleA.cid, bundleA.carBytes],
+        [bundleB.cid, bundleB.carBytes],
+      ]),
+    );
+
+    const result = await provider.load();
+    expect(result.success).toBe(true);
+    // Two distinct snapshots → JOIN across them is exactly when
+    // Rule-4 is needed. Gate must NOT fire.
+    expect(computeSpy).toHaveBeenCalled();
+
+    await provider.shutdown();
+  });
+
+  it('single-bundle snapshot-sourced load — pairwise loop is structurally skipped (gate is moot)', async () => {
+    const computeSpy = vi
+      .spyOn(UxfPackage.prototype, 'computeVerifiedProofs')
+      .mockResolvedValue(new Set<string>());
+
+    const verifier = vi.fn(async () => true);
+    const provider = createProvider(db, stubOracle(verifier));
+    await provider.initialize();
+
+    const bundle = await buildEmptyBundle('only');
+    await plantBundleInOrbit(db, bundle.cid, {
+      cid: bundle.cid,
+      status: 'active',
+      createdAt: 1000,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_A,
+    });
+
+    installCarFetchMock(new Map<string, Uint8Array>([[bundle.cid, bundle.carBytes]]));
+
+    const result = await provider.load();
+    expect(result.success).toBe(true);
+    // Single-bundle: the `loadedBundles.length >= 2` guard short-
+    // circuits the pairwise loop independently of the gate.
+    expect(computeSpy).not.toHaveBeenCalled();
+
+    await provider.shutdown();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #367. Re-incarnates the closed Item #4 (`fix/issue-364-item4-rule4-design-gate`) with a per-bundle provenance gate instead of a provider-global mutable breadcrumb.

- New optional `sourcedFromSnapshotPointerCid` field on `UxfBundleRef`, set only by the snapshot dispatcher's `writeRemote` path inside `BundleIndex.joinSnapshot`. Locally-published refs (`addBundle`) and replication-arrived refs (OrbitDB pubsub) leave it unset, as do legacy refs persisted pre-#367.
- `_loadImpl` Rule-4 gate: skip iff every active loaded bundle (≥ 2) shares the same non-null source CID. Any non-snapshot bundle, or a mix of source snapshots, keeps Rule-4 on.
- New perf counter `profile.load.rule4SkippedSnapshot`. The `SPHERE_SKIP_RULE4` env-gated A/B path is retained alongside.

## Why this fixes the §D.1 retry storm the original Item #4 reopened

The prior breadcrumb flipped to `true` at the end of `_applySnapshotIfWiredImpl` and back to `false` at `addBundle` / `handleReplication(hasNew)`. In §D.1 the periodic-poll keeps firing `applySnapshot` between disarm sites, re-arming the breadcrumb just before V6-RECOVER probe `load()` calls. With per-bundle provenance, the signal lives in the loaded data, not in mutable provider state — so a periodic-poll that lands 0 new bundles changes nothing in the loaded set's annotations and the gate stays off.

## Plumbing

1. `profile/types.ts` — new optional field on `UxfBundleRef`.
2. `profile/pointer-wiring.ts` — `applySnapshot` callback signature widens to `(snapshot, sourcePointerCid?)`; the `fetchAndJoin` callback passes the decoded `cidString` into the applier.
3. `profile/profile-storage-provider.ts` — `snapshotApplier` / `setSnapshotApplier` accept the same optional source CID.
4. `profile/factory.ts` — `runProfileSnapshotApply` and `dispatchParsedSnapshot` accept and forward `sourcePointerCid`. Both apply paths (periodic-poll `setApplySnapshotCallback` and pointer-wired `setSnapshotApplier`) pass through the pointer CID they decoded at fetch time.
5. `profile/profile-snapshot-dispatcher.ts` — `ProfileSnapshotJoinDeps` gains optional `sourcePointerCid`. Before invoking `BundleIndex.joinSnapshot`, the dispatcher duck-types `setCurrentSnapshotApplyCid` on the bundle-index handle, arms it, and clears in `finally`.
6. `profile/profile-token-storage/bundle-index.ts` — `BundleIndex` gains `currentSnapshotApplyCid: string | null` and a setter. `joinSnapshot`'s `writeRemote` decodes the envelope, decrypts, parses the ref, re-stamps with the source CID, re-encrypts, re-envelopes. Any failure in the annotation pass falls back to the verbatim write — the JOIN still lands and the gate degrades safely (Rule-4 runs).
7. `profile/profile-token-storage-provider.ts` — `loadedBundles` entries now carry `sourcedFromSnapshotPointerCid`. The Rule-4 gate computes `skipRule4Snapshot` and ORs with the existing `SPHERE_SKIP_RULE4` env path.

## Tests

`tests/unit/profile/load-rule4-snapshot-gate.test.ts` (new) — 5 cases pinning the gate decision matrix at the `load()` layer:

- all bundles share one source CID → skip;
- all bundles have no provenance (locally-published) → no skip;
- mixed snapshot-sourced + local → no skip;
- bundles span two distinct source CIDs → no skip;
- single-bundle snapshot-sourced load — the `>= 2` structural guard short-circuits the pairwise loop independently of the gate (gate is moot).

The existing `tests/unit/profile/load-rule4-wiring.test.ts` (4 cases) still passes — its bundles plant the ref without the new field, so the gate stays off and Rule-4 fires exactly as before.

## Validation

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 0 warnings (full repo)
- [x] `npm run test:run` — 8805/8820 pass; 13 skipped; 2 pre-existing flakes in `tests/integration/nametag-normalization.test.ts` (parallel-execution TEST_DIR race documented in memory; passes 7/7 in isolation, unrelated)

## Soak A/B (per issue acceptance) — pending

The issue's acceptance target — A/B soak total wall-clock comparable to #363 SKIP_RULE4 (~413s) and `profile.load.rule4SkippedSnapshot` firing only during recovery-load — is a separate run after this lands. Happy to attach soak numbers in a follow-up comment.

## Refs

- Closes #367
- Re-incarnates the closed branch `fix/issue-364-item4-rule4-design-gate` (commit 7b60df4)
- Original #363 SKIP_RULE4 prototype data: `/tmp/soak-metrics/issue-363/REPORT.md`