### PR TITLE
perf(profile/pointer)(issue-366): recoverLatest cache with publish-time invalidation

### DIFF
--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -575,6 +575,31 @@ export class ProfilePointerLayer {
       resolveRemoteCid: this.#init.resolveRemoteCid,
       abortSignal,
     });
+    // Issue #366 — invalidate the recoverLatest head cache after a
+    // successful publish. The cache's pre-#366 design assumed the
+    // aggregator view was the only source of pointer-version change
+    // observable to this layer; a local publish that commits a new
+    // version (`reconcileAndPublish` returns without throwing) breaks
+    // that assumption. Downstream readers — chiefly the read-back loop
+    // at `LifecycleManager.awaitAggregatorPointerReadBack`, but also
+    // any caller polling after a flush — must see the freshly-committed
+    // version, not the cached pre-publish view served for the rest of
+    // the TTL window. The §D.4 wall-clock degradation observed in PR
+    // #365's A/B (243s → 467s when the cache was enabled) traced
+    // directly to this gap: the read-back loop spent the cache TTL
+    // re-asserting a stale answer.
+    //
+    // Cleared inside the `#publishInner` body (post-publish, pre-
+    // return) so EVERY successful publish path invalidates — including
+    // the fast-path that skips Step B (`result.attemptsUsed === 0`).
+    // The in-flight slot is NOT touched here: a concurrent recover
+    // that's already awaiting `#inFlightRecover` will still receive
+    // that round-trip's result. A NEW recover after this point starts
+    // fresh.
+    if (this.#cachedRecover !== null) {
+      incr('pointerLayer.recoverLatest.cacheInvalidatedOnPublish');
+      this.#cachedRecover = null;
+    }
     // Issue #264 steelman fix: only overwrite the probe history when
     // the publish actually ran a discovery walkback. The fast-path
     // (#263, attempts === 0) skips Step B and returns

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -60,7 +60,7 @@ import type { PointerMutex } from './mutex-lock.js';
 import { reconcileAndPublish, type FetchAndJoinCallback } from './reconcile-algorithm.js';
 import type { PointerSigner } from './signing.js';
 import type { BlockedState, PointerVersion } from './types.js';
-import { time } from '../../core/perf-counters.js';
+import { incr, time } from '../../core/perf-counters.js';
 
 // ── Constructor input ──────────────────────────────────────────────────────
 
@@ -121,6 +121,35 @@ export interface ProfilePointerLayerInit {
   ) => Promise<number | undefined>;
   /** Configuration (capabilities). */
   readonly config?: PointerLayerConfig;
+  /**
+   * Issue #364 Item #1 — TTL (ms) for the `recoverLatest()` head cache.
+   *
+   * A short cache eliminates the read-back tight-loop's redundant
+   * aggregator round-trips: the §D.4 recovery soak observed 108
+   * recoverLatest calls in 123 s (0.88/s), driven by the
+   * `awaitAggregatorPointerReadBack` loop polling every 500 ms while
+   * the per-call cost averages 250 ms. With this cache, only the first
+   * call in each TTL window hits the aggregator; subsequent calls
+   * within the window return the cached value in sub-millisecond time
+   * and bump the `pointerLayer.recoverLatest.cacheHit` counter.
+   *
+   * Concurrent callers that arrive while a call is in flight attach to
+   * the in-flight promise (`pointerLayer.recoverLatest.inFlightDedup`)
+   * rather than launching a parallel aggregator round-trip.
+   *
+   * Default: 10_000 (10 s). Trade-off rationale:
+   *   - The read-back loop's 500 ms poll cadence over a typical 30 s
+   *     shutdown-durability deadline drops from 60 calls to 3.
+   *   - The periodic pointer poll's 30-90 s cadence is unaffected
+   *     (each poll exceeds the TTL).
+   *   - New pointer versions are still observed within 10 s, which is
+   *     well inside the worst-case aggregator read-replica lag this
+   *     loop is designed to absorb.
+   *
+   * Set `0` to disable the cache entirely (every call hits the
+   * aggregator — restores pre-#364 behavior).
+   */
+  readonly recoverLatestCacheTtlMs?: number;
 }
 
 // ── Public result types ────────────────────────────────────────────────────
@@ -227,6 +256,21 @@ export class ProfilePointerLayer {
   // immediately after shutdown starts.
   #shuttingDown = false;
 
+  // ── Issue #364 Item #1 — recoverLatest head cache ──────────────────────
+  // Cached most-recent result of recoverLatest() with a short TTL.
+  // Subsequent calls within the TTL return the cached value, eliminating
+  // the read-back tight-loop's redundant aggregator round-trips.
+  // Cleared on shutdown(); concurrent callers attach to #inFlightRecover.
+  readonly #recoverCacheTtlMs: number;
+  #cachedRecover: {
+    readonly result: RecoverResult | RecoverAllUnfetchableResult | null;
+    readonly expiresAt: number;
+  } | null = null;
+  // In-flight dedup: when set, a concurrent recoverLatest awaits this
+  // promise instead of launching a parallel aggregator round-trip.
+  // Cleared in finally after settle (success or failure).
+  #inFlightRecover: Promise<RecoverResult | RecoverAllUnfetchableResult | null> | null = null;
+
   constructor(init: ProfilePointerLayerInit) {
     this.#init = init;
     // Steelman² remediation: extract just the known boolean fields
@@ -259,6 +303,17 @@ export class ProfilePointerLayer {
       enablePointerWinBroadcasts:
         suppliedConfig.enablePointerWinBroadcasts === true,
     });
+
+    // Issue #364 Item #1 — clamp the recoverLatest cache TTL. A non-
+    // finite / negative value disables the cache (treated as 0). The
+    // upper bound (60s) prevents pathological misconfigurations from
+    // pinning a stale aggregator view for arbitrarily long.
+    const rawTtl = init.recoverLatestCacheTtlMs;
+    const ttlCandidate =
+      typeof rawTtl === 'number' && Number.isFinite(rawTtl) && rawTtl >= 0
+        ? rawTtl
+        : 10_000;
+    this.#recoverCacheTtlMs = Math.min(ttlCandidate, 60_000);
   }
 
   /**
@@ -459,6 +514,11 @@ export class ProfilePointerLayer {
     // shutdown cycle. The fingerprint API is not safe to call after
     // shutdown anyway (#assertNotShuttingDown gates it).
     this.#lastProbeVersions = [];
+    // Issue #364 Item #1 — clear the recoverLatest cache so a future
+    // re-init reading a fresh aggregator view never observes stale
+    // bytes. The in-flight slot is cleared by the operation's own
+    // finally arm during the drain above.
+    this.#cachedRecover = null;
   }
 
   // ── publish ──────────────────────────────────────────────────────────────
@@ -567,9 +627,73 @@ export class ProfilePointerLayer {
   async recoverLatest(opts?: {
     abortSignal?: AbortSignal;
   }): Promise<RecoverResult | RecoverAllUnfetchableResult | null> {
-    return time('pointerLayer.recoverLatest', () => {
+    return time('pointerLayer.recoverLatest', async () => {
       this.#assertNotShuttingDown('recoverLatest');
-      return this.#tracked(this.#recoverLatestInner(opts?.abortSignal));
+      // Issue #364 Item #1 — cache-first path. The cache sits INSIDE
+      // the `time()` wrapper so hit/miss latencies both count toward
+      // the aggregate cost recorded in `pointerLayer.recoverLatest`.
+      // Cache hits are sub-millisecond, which shows up in the counter
+      // snapshot as a dramatic drop in totalMs/avgMs without changing
+      // the call count semantic (every public call is counted once).
+      const abortSignal = opts?.abortSignal;
+      if (abortSignal?.aborted) {
+        const err = new Error('recoverLatest aborted by caller');
+        err.name = 'AbortError';
+        throw err;
+      }
+      // Cache hit: serve from #cachedRecover when within TTL. The
+      // cached value is shared across callers — this is sound because
+      // RecoverResult / RecoverAllUnfetchableResult / null are
+      // immutable value types from the caller's perspective.
+      if (this.#recoverCacheTtlMs > 0 && this.#cachedRecover !== null) {
+        if (Date.now() < this.#cachedRecover.expiresAt) {
+          incr('pointerLayer.recoverLatest.cacheHit');
+          return this.#cachedRecover.result;
+        }
+        // TTL expired — fall through to a fresh aggregator round-trip.
+        incr('pointerLayer.recoverLatest.cacheStale');
+        this.#cachedRecover = null;
+      }
+      // In-flight dedup: a concurrent caller already triggered the
+      // aggregator call. Attach to the same promise instead of
+      // launching a parallel round-trip. The attached caller does NOT
+      // share the upstream call's abort signal — aborting one waiter
+      // must not cancel the request for the others (we've already
+      // checked our own signal above).
+      if (this.#inFlightRecover !== null) {
+        incr('pointerLayer.recoverLatest.inFlightDedup');
+        return this.#inFlightRecover;
+      }
+      // cacheMiss is only meaningful when caching is enabled. With
+      // TTL=0 (cache disabled) every call is structurally a miss and
+      // emitting the counter would conflate the two modes.
+      if (this.#recoverCacheTtlMs > 0) {
+        incr('pointerLayer.recoverLatest.cacheMiss');
+      }
+      const inner = this.#tracked(this.#recoverLatestInner(abortSignal));
+      this.#inFlightRecover = inner;
+      try {
+        const result = await inner;
+        // Populate the cache only when the TTL is enabled. A fresh
+        // shutdown() between launch and settle clears #cachedRecover
+        // below; we still record the result on the local variable so
+        // any awaiting callers receive it consistently.
+        if (this.#recoverCacheTtlMs > 0 && !this.#shuttingDown) {
+          this.#cachedRecover = {
+            result,
+            expiresAt: Date.now() + this.#recoverCacheTtlMs,
+          };
+        }
+        return result;
+      } finally {
+        // Always clear the in-flight slot, even on failure — the next
+        // call should retry the aggregator rather than re-throwing the
+        // cached rejection (which would defeat the read-back retry
+        // loop's recovery semantics).
+        if (this.#inFlightRecover === inner) {
+          this.#inFlightRecover = null;
+        }
+      }
     });
   }
 

--- a/tests/integration/pointer/recover-latest-cache.test.ts
+++ b/tests/integration/pointer/recover-latest-cache.test.ts
@@ -464,4 +464,121 @@ describe('ProfilePointerLayer recoverLatest cache (issue #364 Item #1)', () => {
       layer.recoverLatest({ abortSignal: controller.signal }),
     ).rejects.toThrow(/abort/i);
   });
+
+  // ---------------------------------------------------------------------------
+  // Issue #366 — publish-time invalidation
+  // ---------------------------------------------------------------------------
+
+  it('publish() invalidates the cache: subsequent recoverLatest is a fresh round-trip', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    // Seed v=1 so a recoverLatest has something to return.
+    const firstCid = cidForBytes(new TextEncoder().encode('first-payload'));
+    await layer.publish(async () => firstCid.bytes);
+
+    // Warm the cache.
+    agg.callCount.value = 0;
+    const cachedBefore = await layer.recoverLatest();
+    expect(cachedBefore).not.toBeNull();
+    const callsForFirstRecover = agg.callCount.value;
+    expect(callsForFirstRecover).toBeGreaterThan(0);
+
+    // Within TTL → cache hit → no new aggregator activity.
+    agg.callCount.value = 0;
+    await layer.recoverLatest();
+    expect(agg.callCount.value).toBe(0);
+
+    // Publish a NEW pointer (v=2). This MUST invalidate the cache so the
+    // next recoverLatest reads through to the aggregator rather than
+    // returning the v=1 view.
+    agg.callCount.value = 0;
+    const secondCid = cidForBytes(new TextEncoder().encode('second-payload'));
+    await layer.publish(async () => secondCid.bytes);
+
+    // Counter signal: the invalidation fired (cache was warm at publish time).
+    const counters = snapshot();
+    expect(
+      counters['pointerLayer.recoverLatest.cacheInvalidatedOnPublish']?.count,
+    ).toBeGreaterThan(0);
+
+    // Next recoverLatest is a fresh round-trip and surfaces v=2.
+    agg.callCount.value = 0;
+    const fresh = await layer.recoverLatest();
+    expect(fresh).not.toBeNull();
+    expect(agg.callCount.value).toBeGreaterThan(0);
+    if (fresh && 'version' in fresh) {
+      expect(fresh.version).toBe(2);
+      expect(CID.decode(fresh.cid).toString()).toBe(secondCid.toString());
+    }
+  });
+
+  it('publish() with no cached value is a no-op for the invalidation counter', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    // No recoverLatest before publish → cache stays null → invalidation
+    // should NOT fire (the guard only bumps the counter when there's
+    // something to clear).
+    const cid = cidForBytes(new TextEncoder().encode('no-cache-payload'));
+    await layer.publish(async () => cid.bytes);
+
+    const counters = snapshot();
+    expect(
+      counters['pointerLayer.recoverLatest.cacheInvalidatedOnPublish'],
+    ).toBeUndefined();
+  });
+
+  it('publish() invalidation does not abort an in-flight recoverLatest started before publish', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    const firstCid = cidForBytes(new TextEncoder().encode('first-inflight'));
+    await layer.publish(async () => firstCid.bytes);
+
+    // Start a recoverLatest and a publish concurrently. The publish's
+    // invalidation must not corrupt the in-flight recover's result —
+    // the in-flight slot is owned by the operation already in motion.
+    const inflightRecover = layer.recoverLatest();
+    const secondCid = cidForBytes(new TextEncoder().encode('second-inflight'));
+    const publishPromise = layer.publish(async () => secondCid.bytes);
+
+    const [recovered, published] = await Promise.all([
+      inflightRecover,
+      publishPromise,
+    ]);
+
+    expect(recovered).not.toBeNull();
+    expect(published.version).toBe(2);
+
+    // A FRESH recoverLatest after both settle must see v=2 (invalidation
+    // applied; the cache no longer holds the pre-publish v=1 view).
+    agg.callCount.value = 0;
+    const post = await layer.recoverLatest();
+    expect(post).not.toBeNull();
+    if (post && 'version' in post) {
+      expect(post.version).toBe(2);
+    }
+  });
 });

--- a/tests/integration/pointer/recover-latest-cache.test.ts
+++ b/tests/integration/pointer/recover-latest-cache.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Issue #364 Item #1 — recoverLatest head cache tests.
+ *
+ * Verifies that the cache + in-flight dedup added to
+ * `ProfilePointerLayer.recoverLatest()` correctly:
+ *   1. Serves a cached value within TTL without round-tripping the
+ *      aggregator (cacheHit counter).
+ *   2. Coalesces concurrent in-flight calls to a single round-trip
+ *      (inFlightDedup counter).
+ *   3. Re-hits the aggregator after TTL expires (cacheStale + cacheMiss).
+ *   4. Clears the cache on shutdown so a re-init starts fresh.
+ *   5. Reports a cacheMiss on the very first call (cold start).
+ *
+ * The baseline impact: §D.4 (full mnemonic recovery soak per issue #363)
+ * observed 108 recoverLatest calls in 123 s. The same pattern under
+ * default 10 s TTL drops to ~12 — a >9× reduction — without changing
+ * recovery semantics.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import type { AggregatorClient } from '@unicitylabs/state-transition-sdk/lib/api/AggregatorClient.js';
+import type { RootTrustBase } from '@unicitylabs/state-transition-sdk/lib/bft/RootTrustBase.js';
+import {
+  SubmitCommitmentResponse,
+  SubmitCommitmentStatus,
+} from '@unicitylabs/state-transition-sdk/lib/api/SubmitCommitmentResponse.js';
+import { InclusionProofVerificationStatus } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof.js';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { create as createDigest } from 'multiformats/hashes/digest';
+
+import {
+  ProfilePointerLayer,
+  createMasterPrivateKey,
+  derivePointerKeyMaterial,
+  buildPointerSigner,
+  FlagStore,
+  DURABLE_STORAGE,
+  type CarFetcher,
+  type CidDecoder,
+  type FetchAndJoinCallback,
+} from '../../../profile/aggregator-pointer/index.js';
+import { decodeVersionCid } from '../../../profile/aggregator-pointer/aggregator-probe.js';
+import {
+  __setPerfEnabledForTest,
+  __stopAutoDumpForTest,
+  snapshot,
+  dumpAndReset,
+} from '../../../core/perf-counters.js';
+
+const WALLET_SEED = new Uint8Array(32).fill(0x77);
+
+function makeDurableStore() {
+  const kv = new Map<string, string>();
+  return {
+    get: async (k: string) => kv.get(k) ?? null,
+    set: async (k: string, v: string) => {
+      kv.set(k, v);
+    },
+    remove: async (k: string) => {
+      kv.delete(k);
+    },
+    has: async (k: string) => kv.has(k),
+    keys: async () => [...kv.keys()],
+    clear: async () => {
+      kv.clear();
+    },
+    setIdentity: () => {},
+    saveTrackedAddresses: async () => {},
+    loadTrackedAddresses: async () => [],
+    initialize: async () => {},
+    shutdown: async () => {},
+    name: 'test-recover-cache',
+    [DURABLE_STORAGE]: true as const,
+  };
+}
+
+interface CountingAggregator {
+  client: AggregatorClient;
+  commitments: Map<string, Uint8Array>;
+  /**
+   * Increments on every call to either submitCommitment or
+   * getInclusionProof. The pointer layer's discover walkback makes
+   * many probe calls per recoverLatest — we count the AGGREGATE wire
+   * activity so a cache hit shows up as zero new calls.
+   */
+  callCount: { value: number };
+}
+
+function makeCountingAggregator(): CountingAggregator {
+  const commitments = new Map<string, Uint8Array>();
+  const callCount = { value: 0 };
+  const client = {
+    async submitCommitment(
+      requestId: { toString(): string },
+      transactionHash: { data: Uint8Array },
+      _authenticator: unknown,
+    ) {
+      callCount.value += 1;
+      commitments.set(requestId.toString(), new Uint8Array(transactionHash.data));
+      return new SubmitCommitmentResponse(SubmitCommitmentStatus.SUCCESS);
+    },
+    async getInclusionProof(requestId: { toString(): string }) {
+      callCount.value += 1;
+      const data = commitments.get(requestId.toString());
+      if (!data) {
+        return {
+          inclusionProof: {
+            verify: async () => InclusionProofVerificationStatus.PATH_NOT_INCLUDED,
+            transactionHash: null,
+          },
+        };
+      }
+      return {
+        inclusionProof: {
+          verify: async () => InclusionProofVerificationStatus.OK,
+          transactionHash: { data },
+        },
+      };
+    },
+  } as unknown as AggregatorClient;
+  return { client, commitments, callCount };
+}
+
+function cidForBytes(bytes: Uint8Array): CID {
+  const digest = createDigest(0x12, sha256(bytes));
+  return CID.createV1(raw.code, digest);
+}
+
+const alwaysOkCarFetcher: CarFetcher = async () => ({ ok: true });
+
+const multiformatsDecoder: CidDecoder = (full: Uint8Array) => {
+  try {
+    if (full.length === 0) return { ok: false };
+    const cidLen = full[0];
+    if (cidLen === undefined || cidLen === 0 || cidLen > full.length - 1) {
+      return { ok: false };
+    }
+    const cid = CID.decode(full.subarray(1, 1 + cidLen));
+    return { ok: true, cidBytes: new Uint8Array(cid.bytes) };
+  } catch {
+    return { ok: false };
+  }
+};
+
+interface BuildLayerDeps {
+  aggregatorClient: AggregatorClient;
+  readLocal: () => Promise<number>;
+  persistLocal: (v: number) => Promise<void>;
+  recoverLatestCacheTtlMs?: number;
+}
+
+async function buildLayer(deps: BuildLayerDeps): Promise<ProfilePointerLayer> {
+  const masterKey = createMasterPrivateKey(WALLET_SEED);
+  const keyMaterial = derivePointerKeyMaterial(masterKey);
+  const signer = await buildPointerSigner(keyMaterial.signingSeed);
+  const storage = makeDurableStore();
+  const flagStore = FlagStore.create(storage as never, signer.signingPubKeyHex);
+
+  let held = false;
+  const queue: Array<() => void> = [];
+  const mutex = {
+    async acquire() {
+      if (held) {
+        await new Promise<void>((resolve) => queue.push(resolve));
+      }
+      held = true;
+      return {
+        release: async () => {
+          held = false;
+          const next = queue.shift();
+          if (next) next();
+        },
+        assertHeld: () => {
+          if (!held) throw new Error('fake mutex: lock lost');
+        },
+      };
+    },
+  };
+
+  const trustBase = {} as unknown as RootTrustBase;
+
+  const fetchAndJoin: FetchAndJoinCallback = async () => {
+    throw new Error('fetchAndJoin should not fire in this test');
+  };
+
+  const resolveRemoteCid = async (version: number): Promise<Uint8Array> => {
+    const result = await decodeVersionCid({
+      v: version,
+      keyMaterial,
+      signer,
+      aggregatorClient: deps.aggregatorClient,
+      trustBase,
+      decodeCid: multiformatsDecoder,
+    });
+    if (!result.ok) {
+      throw new Error(`decodeVersionCid failed: ${result.reason}`);
+    }
+    return result.cidBytes;
+  };
+
+  return new ProfilePointerLayer({
+    keyMaterial,
+    signer,
+    aggregatorClient: deps.aggregatorClient,
+    trustBase,
+    flagStore,
+    mutex,
+    decodeCid: multiformatsDecoder,
+    fetchCar: alwaysOkCarFetcher,
+    fetchAndJoin,
+    readLocalVersion: deps.readLocal,
+    persistLocalVersion: deps.persistLocal,
+    resolveRemoteCid,
+    recoverLatestCacheTtlMs: deps.recoverLatestCacheTtlMs,
+  });
+}
+
+describe('ProfilePointerLayer recoverLatest cache (issue #364 Item #1)', () => {
+  let localVersion = 0;
+
+  beforeEach(() => {
+    localVersion = 0;
+    __stopAutoDumpForTest();
+    // Enable first so dumpAndReset() actually clears the in-memory
+    // counters Map (it short-circuits when PERF is disabled).
+    __setPerfEnabledForTest(true);
+    dumpAndReset();
+  });
+
+  afterEach(() => {
+    // Re-enable + clear so a downstream test in this process starts
+    // with empty counters even if it never runs its own beforeEach.
+    __setPerfEnabledForTest(true);
+    dumpAndReset();
+    __setPerfEnabledForTest(false);
+    __stopAutoDumpForTest();
+  });
+
+  it('first call is a cacheMiss; second call within TTL is a cacheHit (no aggregator round-trip)', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-1'));
+    await layer.publish(async () => cid.bytes);
+
+    const baselineCalls = agg.callCount.value;
+
+    // First recover — cold, must hit the aggregator.
+    const first = await layer.recoverLatest();
+    expect(first).not.toBeNull();
+    expect(agg.callCount.value).toBeGreaterThan(baselineCalls);
+    const afterFirst = agg.callCount.value;
+
+    const snap1 = snapshot();
+    expect(snap1['pointerLayer.recoverLatest.cacheMiss']?.count ?? 0).toBe(1);
+    expect(snap1['pointerLayer.recoverLatest.cacheHit']?.count ?? 0).toBe(0);
+
+    // Second recover — within TTL, must NOT hit the aggregator.
+    const second = await layer.recoverLatest();
+    expect(second).not.toBeNull();
+    expect(agg.callCount.value).toBe(afterFirst);
+
+    const snap2 = snapshot();
+    expect(snap2['pointerLayer.recoverLatest.cacheHit']?.count ?? 0).toBe(1);
+    expect(snap2['pointerLayer.recoverLatest.cacheMiss']?.count ?? 0).toBe(1);
+
+    // Cached result must be referentially identical (we share the
+    // immutable cached object across callers).
+    expect(second).toBe(first);
+  });
+
+  it('5 concurrent calls collapse to 1 aggregator round-trip via inFlightDedup', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-conc'));
+    await layer.publish(async () => cid.bytes);
+
+    // Measure the cost of ONE serial recoverLatest first, so we can
+    // assert the concurrent burst stays close to that cost (not 5×).
+    // We reset the layer's cache+counters between the two phases by
+    // toggling the perf flag and resetting localVersion stays put.
+    const layerSerial = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+    const beforeSerial = agg.callCount.value;
+    await layerSerial.recoverLatest();
+    const serialCost = agg.callCount.value - beforeSerial;
+    // sanity: the discover walkback touches the aggregator at least once
+    expect(serialCost).toBeGreaterThan(0);
+
+    dumpAndReset(); // drop counters from publish + serial baseline
+    __setPerfEnabledForTest(true);
+    const baselineCalls = agg.callCount.value;
+
+    // Fire 5 concurrent recoverLatest calls. The first one starts the
+    // aggregator round-trip; the other 4 must attach via inFlightDedup.
+    const results = await Promise.all([
+      layer.recoverLatest(),
+      layer.recoverLatest(),
+      layer.recoverLatest(),
+      layer.recoverLatest(),
+      layer.recoverLatest(),
+    ]);
+
+    // All 5 callers receive the same result.
+    expect(results.length).toBe(5);
+    for (let i = 1; i < results.length; i += 1) {
+      expect(results[i]).toBe(results[0]);
+    }
+
+    // The aggregator saw only ONE round-trip's worth of activity (the
+    // 4 deduped callers attached to the in-flight promise). The
+    // concurrent-burst cost must be < 2 × serial cost (some slack for
+    // microtask races in a real concurrent scheduler) — far less than
+    // the 5× we'd see without dedup.
+    const callsThisRound = agg.callCount.value - baselineCalls;
+    expect(callsThisRound).toBeGreaterThan(0);
+    expect(callsThisRound).toBeLessThan(serialCost * 2);
+
+    const snap = snapshot();
+    expect(snap['pointerLayer.recoverLatest.cacheMiss']?.count ?? 0).toBe(1);
+    expect(snap['pointerLayer.recoverLatest.inFlightDedup']?.count ?? 0).toBe(4);
+    // No cacheHit — by construction every concurrent caller hit the
+    // in-flight path, not the cache path.
+    expect(snap['pointerLayer.recoverLatest.cacheHit']?.count ?? 0).toBe(0);
+  });
+
+  it('cache expires after TTL: subsequent call is cacheStale + cacheMiss and hits the aggregator', async () => {
+    const agg = makeCountingAggregator();
+    // Tiny TTL so we can test expiry without sleeping a long time.
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 50, // 50ms
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-ttl'));
+    await layer.publish(async () => cid.bytes);
+
+    // Drop counters from publish so the subsequent assertions see
+    // only the recoverLatest activity we're interested in.
+    dumpAndReset();
+    __setPerfEnabledForTest(true);
+
+    // First call — cold.
+    await layer.recoverLatest();
+    const callsAfterFirst = agg.callCount.value;
+
+    // Wait past TTL.
+    await new Promise<void>((resolve) => setTimeout(resolve, 70));
+
+    // Second call — TTL expired, must hit the aggregator again.
+    await layer.recoverLatest();
+    expect(agg.callCount.value).toBeGreaterThan(callsAfterFirst);
+
+    const snap = snapshot();
+    expect(snap['pointerLayer.recoverLatest.cacheMiss']?.count ?? 0).toBe(2);
+    expect(snap['pointerLayer.recoverLatest.cacheStale']?.count ?? 0).toBe(1);
+    expect(snap['pointerLayer.recoverLatest.cacheHit']?.count ?? 0).toBe(0);
+  });
+
+  it('TTL=0 disables the cache: every call hits the aggregator (pre-#364 behavior)', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 0,
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-nocache'));
+    await layer.publish(async () => cid.bytes);
+
+    const baselineCalls = agg.callCount.value;
+    await layer.recoverLatest();
+    const callsAfterFirst = agg.callCount.value;
+    expect(callsAfterFirst).toBeGreaterThan(baselineCalls);
+
+    await layer.recoverLatest();
+    // Second call must ALSO hit the aggregator (no caching).
+    expect(agg.callCount.value).toBeGreaterThan(callsAfterFirst);
+
+    const snap = snapshot();
+    expect(snap['pointerLayer.recoverLatest.cacheHit']?.count ?? 0).toBe(0);
+    // cacheMiss is only counted when TTL > 0. With TTL=0 the cache
+    // path is short-circuited entirely — no miss/hit counters fire.
+    expect(snap['pointerLayer.recoverLatest.cacheMiss']?.count ?? 0).toBe(0);
+  });
+
+  it('shutdown clears the cache so a re-init reading the same layer starts fresh', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-shutdown'));
+    await layer.publish(async () => cid.bytes);
+
+    // Populate cache.
+    const first = await layer.recoverLatest();
+    expect(first).not.toBeNull();
+
+    // Shutdown — should clear the cache and refuse further calls.
+    await layer.shutdown();
+
+    // After shutdown, recoverLatest must throw (per assertNotShuttingDown).
+    await expect(layer.recoverLatest()).rejects.toThrow(/shutdown/i);
+  });
+
+  it('aborted call returns AbortError before reading cache', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-abort'));
+    await layer.publish(async () => cid.bytes);
+
+    // Warm the cache.
+    await layer.recoverLatest();
+
+    // Pre-aborted signal — must throw AbortError even though cache is warm.
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      layer.recoverLatest({ abortSignal: controller.signal }),
+    ).rejects.toThrow(/abort/i);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #366. Re-incarnates the closed Item #1 (\`fix/issue-364-item1-pointer-recover-cache\`, commit \`e3959e3\`) with the missing publish-time invalidation hook that caused PR #365 to drop it.

- Commit 1 cherry-picks the original \`recoverLatest\` head cache + in-flight dedup. 10s default TTL, configurable via \`recoverLatestCacheTtlMs\`. Same counters as the original (\`cacheHit\` / \`cacheMiss\` / \`cacheStale\` / \`inFlightDedup\`).
- Commit 2 adds the invalidation hook in \`#publishInner\` (after \`reconcileAndPublish\` returns) so any caller polling after a flush sees the freshly-committed pointer instead of the cached pre-publish view. New counter \`pointerLayer.recoverLatest.cacheInvalidatedOnPublish\` fires only when there was something to clear.

## Why this fixes the §D.4 degradation that closed PR #365's Item #1

The closed Item #1 worked counter-wise (cacheHit / inFlightDedup firing as designed) but had no invalidation on local publish. In §D.4:

1. The wallet publishes a pointer at T=2s.
2. \`awaitAggregatorPointerReadBack\` polls \`recoverLatest()\` at T=3s expecting fresh data.
3. The cache returns the pre-publish CID for the rest of the 10s TTL.
4. The read-back loop spends the cache TTL re-asserting a stale answer.
5. Soak A/B showed §D.4 wall-clock 243s → 467s with cache enabled.

The invalidation hook in this PR closes the read-back loop's gap:

\`\`\`ts
const result = await reconcileAndPublish({ /* ... */ });
if (this.#cachedRecover !== null) {
  incr('pointerLayer.recoverLatest.cacheInvalidatedOnPublish');
  this.#cachedRecover = null;
}
\`\`\`

Properties of the hook:

- **Every successful publish path invalidates** — including the fast path that skips Step B (\`result.attemptsUsed === 0\`).
- **Conditional on a populated cache** — the counter only fires when there's actually something to clear.
- **In-flight slot is intentionally not touched** — a recoverLatest already awaiting \`#inFlightRecover\` will still receive that round-trip's result. A NEW recover after the publish starts fresh.

## Tests

\`tests/integration/pointer/recover-latest-cache.test.ts\` (6 original cases via cherry-pick) gains 3 new cases:

1. **publish() invalidates the cache** — seeds v=1, warms cache, asserts cache-hit, publishes v=2, asserts counter fired, asserts next recoverLatest is a fresh round-trip surfacing v=2.
2. **publish() with no cached value is a no-op for the invalidation counter** — cold-cache publish must not bump the counter.
3. **publish() invalidation does not abort an in-flight recoverLatest started before publish** — pins the in-flight semantics: concurrent recover+publish resolves cleanly, and a fresh recover after both settle observes v=2.

## Validation

- [x] \`npm run typecheck\` — clean
- [x] Targeted lint clean on the two changed files
- [x] \`npx vitest run tests/unit/profile/pointer/ tests/integration/pointer/\` — 587 / 9 skipped / 0 failed across 39 test files

## Refs

- Closes #366
- Cherry-picks the original \`fix/issue-364-item1-pointer-recover-cache\` (\`e3959e3\`) as commit 1; new invalidation hook in commit 2.
- Sibling to #367 (PR #373) — both close gaps from PR #365's dropped items.
- Original A/B data: \`/tmp/soak-metrics/issue-363/REPORT.md\`