### PR TITLE
perf(profile)(issue-368): process-wide applySnapshot suppression during Sphere.clear

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -75,6 +75,7 @@ import {
   LOCAL_EPOCH_RESET_REASON_KEY,
 } from '../profile/pointer-wiring';
 import { EPOCH_RESET_REASON_MAX_BYTES } from '../profile/profile-lean-snapshot';
+import { beginGlobalClear, endGlobalClear } from '../profile/global-clear-gate';
 import type {
   ShutdownOptions,
   StorageProvider,
@@ -1730,82 +1731,105 @@ export class Sphere {
     const fallbackTokenStorage =
       'get' in storageOrOptions ? undefined : storageOrOptions.fallbackTokenStorage;
 
-    // 1. Destroy Sphere instance — flushes pending IPFS writes (saves good
-    //    state), then closes all connections. Awaited so IPFS completes
-    //    before we delete databases.
-    if (Sphere.instance) {
-      logger.debug('Sphere', 'Destroying Sphere instance...');
-      await Sphere.instance.destroy();
-      logger.debug('Sphere', 'Sphere instance destroyed');
-    }
-
-    // 2. Clear L1 vesting cache
-    logger.debug('Sphere', 'Clearing L1 vesting cache...');
-    await vestingClassifier.destroy();
-
-    // 3. Yield to let IndexedDB finalize pending transactions after close().
-    //    db.close() is synchronous but the connection isn't fully released
-    //    until all in-flight transactions complete.
-    logger.debug('Sphere', 'Yielding 50ms for IDB transaction settlement...');
-    await new Promise((r) => setTimeout(r, 50));
-
-    // 4. Delete token databases (sphere-token-storage-*)
-    if (tokenStorage?.clear) {
-      logger.debug('Sphere', 'Clearing token storage...');
-      try {
-        await tokenStorage.clear();
-        logger.debug('Sphere', 'Token storage cleared');
-      } catch (err) {
-        logger.warn('Sphere', 'Token storage clear failed:', err);
-      }
-    } else {
-      logger.debug('Sphere', 'No token storage provider to clear');
-    }
-
-    // 4b. Issue #330 — also wipe the read-only fallback token storage
-    // (legacy IndexedDB from before Profile migration). Without this,
-    // a user who calls `clear()` to start over with the same mnemonic
-    // would see pre-clear tokens resurrected via the fallback wiring.
-    // This violates the "clear means clear" invariant and is a real
-    // data-integrity hazard, not just UX confusion.
+    // Issue #368 — bracket the destructive body with the process-wide
+    // global-clear gate. While the bracket is held, every
+    // `ProfileTokenStorageProvider._applySnapshotIfWiredImpl` call in
+    // this process early-returns and bumps
+    // `profile.applySnapshot.suppressedDuringGlobalClear`. Closes the
+    // multi-wallet gap left by the per-instance `isClearing` latch:
+    // sibling wallets' periodic pointer-polls must not seed snapshot
+    // state mid-batch while another wallet's `clear()` is in flight.
     //
-    // Idempotent and best-effort: a missing `clear` method (older
-    // legacy providers) or an exception is logged but does not block
-    // the rest of the cleanup. The fallback was never written to by
-    // this SDK; the bytes here are pre-migration legacy data.
-    if (fallbackTokenStorage?.clear) {
-      logger.debug('Sphere', 'Clearing fallback (legacy) token storage...');
-      try {
-        if (
-          typeof fallbackTokenStorage.isConnected === 'function' &&
-          !fallbackTokenStorage.isConnected() &&
-          typeof fallbackTokenStorage.connect === 'function'
-        ) {
-          await fallbackTokenStorage.connect();
-        }
-        await fallbackTokenStorage.clear();
-        logger.debug('Sphere', 'Fallback token storage cleared');
-      } catch (err) {
-        logger.warn('Sphere', 'Fallback token storage clear failed:', err);
+    // The bracket nests safely (reference-counted), so an orchestrator
+    // wrapping its own sequence of `Sphere.clear()` calls in a higher-
+    // level bracket sees both layers compose. `endGlobalClear()` is
+    // no-op-safe at depth 0, so a stray double-end is harmless.
+    beginGlobalClear();
+    try {
+      // 1. Destroy Sphere instance — flushes pending IPFS writes (saves good
+      //    state), then closes all connections. Awaited so IPFS completes
+      //    before we delete databases.
+      if (Sphere.instance) {
+        logger.debug('Sphere', 'Destroying Sphere instance...');
+        await Sphere.instance.destroy();
+        logger.debug('Sphere', 'Sphere instance destroyed');
       }
-    }
 
-    // 5. Delete KV database (sphere-storage)
-    logger.debug('Sphere', 'Clearing KV storage...');
-    if (!storage.isConnected()) {
-      try {
-        await storage.connect();
-      } catch {
-        // May fail if database was already deleted — that's fine
+      // 2. Clear L1 vesting cache
+      logger.debug('Sphere', 'Clearing L1 vesting cache...');
+      await vestingClassifier.destroy();
+
+      // 3. Yield to let IndexedDB finalize pending transactions after close().
+      //    db.close() is synchronous but the connection isn't fully released
+      //    until all in-flight transactions complete.
+      logger.debug('Sphere', 'Yielding 50ms for IDB transaction settlement...');
+      await new Promise((r) => setTimeout(r, 50));
+
+      // 4. Delete token databases (sphere-token-storage-*)
+      if (tokenStorage?.clear) {
+        logger.debug('Sphere', 'Clearing token storage...');
+        try {
+          await tokenStorage.clear();
+          logger.debug('Sphere', 'Token storage cleared');
+        } catch (err) {
+          logger.warn('Sphere', 'Token storage clear failed:', err);
+        }
+      } else {
+        logger.debug('Sphere', 'No token storage provider to clear');
       }
+
+      // 4b. Issue #330 — also wipe the read-only fallback token storage
+      // (legacy IndexedDB from before Profile migration). Without this,
+      // a user who calls `clear()` to start over with the same mnemonic
+      // would see pre-clear tokens resurrected via the fallback wiring.
+      // This violates the "clear means clear" invariant and is a real
+      // data-integrity hazard, not just UX confusion.
+      //
+      // Idempotent and best-effort: a missing `clear` method (older
+      // legacy providers) or an exception is logged but does not block
+      // the rest of the cleanup. The fallback was never written to by
+      // this SDK; the bytes here are pre-migration legacy data.
+      if (fallbackTokenStorage?.clear) {
+        logger.debug('Sphere', 'Clearing fallback (legacy) token storage...');
+        try {
+          if (
+            typeof fallbackTokenStorage.isConnected === 'function' &&
+            !fallbackTokenStorage.isConnected() &&
+            typeof fallbackTokenStorage.connect === 'function'
+          ) {
+            await fallbackTokenStorage.connect();
+          }
+          await fallbackTokenStorage.clear();
+          logger.debug('Sphere', 'Fallback token storage cleared');
+        } catch (err) {
+          logger.warn('Sphere', 'Fallback token storage clear failed:', err);
+        }
+      }
+
+      // 5. Delete KV database (sphere-storage)
+      logger.debug('Sphere', 'Clearing KV storage...');
+      if (!storage.isConnected()) {
+        try {
+          await storage.connect();
+        } catch {
+          // May fail if database was already deleted — that's fine
+        }
+      }
+      if (storage.isConnected()) {
+        await storage.clear();
+        logger.debug('Sphere', 'KV storage cleared');
+      } else {
+        logger.debug('Sphere', 'KV storage not connected, skipping');
+      }
+      logger.debug('Sphere', 'Done');
+    } finally {
+      // Issue #368 — release the global-clear bracket. Reached even on
+      // a destructive failure inside the try body so a partial clear
+      // never leaves the gate stuck closed (which would silently
+      // disable applySnapshot dispatch for the rest of the process
+      // lifetime).
+      endGlobalClear();
     }
-    if (storage.isConnected()) {
-      await storage.clear();
-      logger.debug('Sphere', 'KV storage cleared');
-    } else {
-      logger.debug('Sphere', 'KV storage not connected, skipping');
-    }
-    logger.debug('Sphere', 'Done');
   }
 
   /**

--- a/profile/global-clear-gate.ts
+++ b/profile/global-clear-gate.ts
@@ -1,0 +1,95 @@
+/**
+ * profile/global-clear-gate.ts — process-wide gate consulted by
+ * `ProfileTokenStorageProvider._applySnapshotIfWiredImpl` to suppress
+ * snapshot dispatch during multi-wallet `Sphere.clear()` sequences.
+ *
+ * # Why a separate module
+ *
+ * Item #2 (issue #364) ships the per-instance `isClearing` latch on
+ * `ProfileTokenStorageProvider`. It correctly suppresses
+ * `applySnapshotIfWired` for THE provider whose `clear()` is in flight.
+ * It does NOT cover the multi-wallet workflow where `Sphere.clear()` is
+ * invoked sequentially across several wallets in the same process (or
+ * where multi-wallet apps like sphere.telco have many providers running
+ * concurrently): while wallet A is being cleared, wallets B/C/D's
+ * periodic pointer-polls keep firing `applySnapshotIfWired` against
+ * state that is about to be wiped when their own `clear()` runs next.
+ *
+ * Putting the state on `ProfileTokenStorageProvider` as a class-static
+ * would couple `core/Sphere.ts` directly to the provider class. A small
+ * dedicated module keeps the dependency direction clean: both
+ * `core/Sphere.ts` and `profile/profile-token-storage-provider.ts`
+ * import this leaf module.
+ *
+ * # Semantics
+ *
+ *   - Reference counted, not boolean. Multiple orchestrators (a batch
+ *     wrapper AND the per-call `Sphere.clear()` body) may bracket the
+ *     same range; both increments and the matching decrements compose.
+ *   - {@link endGlobalClear} is no-op-safe when the depth is already 0
+ *     so a stray double-end can't push the counter negative.
+ *   - Process-scoped — there is one counter per JS realm. Cross-process
+ *     coordination is not in scope (each process is its own clear; the
+ *     filesystem/IndexedDB locks already serialize cross-process
+ *     wallet wipes).
+ *
+ * # Usage
+ *
+ * ```ts
+ * import { beginGlobalClear, endGlobalClear } from './global-clear-gate';
+ *
+ * beginGlobalClear();
+ * try {
+ *   // existing destructive sequence …
+ * } finally {
+ *   endGlobalClear();
+ * }
+ * ```
+ *
+ * @module profile/global-clear-gate
+ * @see profile/profile-token-storage-provider.ts:_applySnapshotIfWiredImpl
+ * @see core/Sphere.ts:Sphere.clear
+ */
+
+let depth = 0;
+
+/**
+ * Increment the process-wide global-clear depth. MUST be paired with
+ * {@link endGlobalClear} in a `try/finally`. Idempotent on the
+ * increment side — nesting composes.
+ */
+export function beginGlobalClear(): void {
+  depth += 1;
+}
+
+/**
+ * Decrement the process-wide global-clear depth. No-op-safe when the
+ * depth is already 0 — a stray extra-end is harmless rather than
+ * negative-going corruption.
+ */
+export function endGlobalClear(): void {
+  if (depth > 0) {
+    depth -= 1;
+  }
+}
+
+/**
+ * Read the current process-wide global-clear depth. Returns `true`
+ * whenever at least one orchestrator currently holds the bracket.
+ * Exposed for tests and operator surfaces; production callers should
+ * use {@link beginGlobalClear} / {@link endGlobalClear} rather than
+ * polling.
+ */
+export function isGlobalClearActive(): boolean {
+  return depth > 0;
+}
+
+/**
+ * Test-only — reset the counter to 0. Other production paths must NOT
+ * call this; the begin/end protocol is the public contract. Tests
+ * occasionally need a hard reset to recover from a failure that left
+ * a bracket unclosed.
+ */
+export function __resetGlobalClearForTest(): void {
+  depth = 0;
+}

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -45,6 +45,7 @@
 import { logger } from '../core/logger.js';
 import { SphereError } from '../core/errors.js';
 import { incr, time, observeMs } from '../core/perf-counters.js';
+import { isGlobalClearActive } from './global-clear-gate.js';
 import { STORAGE_KEYS_GLOBAL } from '../constants.js';
 import type { ProviderStatus, FullIdentity } from '../types/index.js';
 import type {
@@ -146,6 +147,12 @@ export class ProfileTokenStorageProvider
    * clear-on-a-live-provider path, hence the separate latch.
    */
   private isClearing = false;
+
+  // Issue #368 — the process-wide global-clear gate lives in a
+  // dedicated leaf module (`profile/global-clear-gate.ts`) so
+  // `core/Sphere.ts` can bracket multi-wallet clears without taking a
+  // hard import on `ProfileTokenStorageProvider`. The gate is consulted
+  // inside `_applySnapshotIfWiredImpl` below.
 
   // --- Write-behind buffer ---
   private pendingData: TxfStorageDataBase | null = null;
@@ -864,6 +871,17 @@ export class ProfileTokenStorageProvider
   ): Promise<import('./profile-snapshot-dispatcher.js').ApplySnapshotResult | null> {
     if (this.isClearing) {
       incr('profile.applySnapshot.suppressedDuringClear');
+      return null;
+    }
+    // Issue #368 — process-wide gate. Suppresses applySnapshot across
+    // EVERY provider in this process while ANY `Sphere.clear()` (or
+    // batch orchestrator) holds the global-clear bracket. Closes the
+    // multi-wallet gap left by the per-instance `isClearing` latch:
+    // wallets B/C/D's periodic pointer-polls must not seed snapshot
+    // state mid-batch while wallet A's clear() is in flight, because
+    // B/C/D are about to be cleared next.
+    if (isGlobalClearActive()) {
+      incr('profile.applySnapshot.suppressedDuringGlobalClear');
       return null;
     }
     if (this.isShuttingDown || this.hasShutdown) return null;

--- a/tests/unit/profile/global-clear-gate-368.test.ts
+++ b/tests/unit/profile/global-clear-gate-368.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Issue #368 — process-wide `applySnapshot` suppression during
+ * multi-wallet `Sphere.clear()` batches.
+ *
+ * Item #2 (issue #364, sibling PR #365) added the per-instance
+ * `isClearing` latch on `ProfileTokenStorageProvider`. It correctly
+ * suppresses `applySnapshotIfWired` for THE provider whose `clear()`
+ * is in flight but leaves a gap when `Sphere.clear()` is invoked
+ * sequentially across several wallets in the same process (or when
+ * multi-wallet apps run many providers concurrently): while wallet A's
+ * `clear()` is running, wallets B/C/D's periodic pointer-polls keep
+ * firing `applySnapshotIfWired` against state that is about to be
+ * wiped next.
+ *
+ * The fix is a process-wide reference-counted gate
+ * (`profile/global-clear-gate.ts`) consulted by
+ * `_applySnapshotIfWiredImpl` AFTER the per-instance latch. While the
+ * gate is held (depth > 0), every provider in the process suppresses
+ * snapshot dispatch and bumps
+ * `profile.applySnapshot.suppressedDuringGlobalClear`.
+ *
+ * This test file pins the gate's semantics in isolation — it does NOT
+ * exercise the full `Sphere.clear()` body (that's covered by the
+ * Item #2 file). It verifies:
+ *
+ *   - depth tracking composes (begin / end nest);
+ *   - end is no-op-safe at depth 0;
+ *   - a HELD gate suppresses applySnapshot even when isClearing=false;
+ *   - the counter `profile.applySnapshot.suppressedDuringGlobalClear`
+ *     fires the expected number of times;
+ *   - after the gate releases, applySnapshot proceeds normally.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import type { ApplySnapshotResult } from '../../../profile/profile-snapshot-dispatcher';
+import {
+  beginGlobalClear,
+  endGlobalClear,
+  isGlobalClearActive,
+  __resetGlobalClearForTest,
+} from '../../../profile/global-clear-gate';
+import {
+  __setPerfEnabledForTest,
+  __stopAutoDumpForTest,
+  dumpAndReset,
+  snapshot,
+} from '../../../core/perf-counters.js';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1test',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+function createMockDb(): ProfileDatabase {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as ProfileDatabase;
+}
+
+function makeApplyResult(): ApplySnapshotResult {
+  return {
+    joinedAny: true,
+    addressesSeen: 1,
+    bundleEntriesSeen: 0,
+    counters: {
+      entriesEvaluated: 1,
+      liveLanded: 1,
+      tombstonesLanded: 0,
+      localWon: 0,
+      remoteRejectedMalformed: 0,
+    },
+  };
+}
+
+function createProvider(addressId: string): ProfileTokenStorageProvider {
+  const provider = new ProfileTokenStorageProvider(
+    createMockDb(),
+    new Uint8Array(32).fill(0x11),
+    ['https://mock-ipfs.test'],
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId,
+      encrypt: true,
+    },
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  return provider;
+}
+
+describe('Issue #368 — process-wide global-clear gate', () => {
+  beforeEach(() => {
+    __stopAutoDumpForTest();
+    __setPerfEnabledForTest(true);
+    dumpAndReset();
+    __resetGlobalClearForTest();
+  });
+
+  afterEach(() => {
+    __setPerfEnabledForTest(false);
+    __stopAutoDumpForTest();
+    __resetGlobalClearForTest();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Counter semantics
+  // ---------------------------------------------------------------------------
+
+  it('begin / end track depth and isGlobalClearActive() returns true while held', () => {
+    expect(isGlobalClearActive()).toBe(false);
+    beginGlobalClear();
+    expect(isGlobalClearActive()).toBe(true);
+    endGlobalClear();
+    expect(isGlobalClearActive()).toBe(false);
+  });
+
+  it('depth nests: two begins require two ends to release', () => {
+    beginGlobalClear();
+    beginGlobalClear();
+    expect(isGlobalClearActive()).toBe(true);
+    endGlobalClear();
+    expect(isGlobalClearActive()).toBe(true);
+    endGlobalClear();
+    expect(isGlobalClearActive()).toBe(false);
+  });
+
+  it('endGlobalClear is no-op-safe at depth 0 — a stray double-end cannot go negative', () => {
+    expect(isGlobalClearActive()).toBe(false);
+    endGlobalClear();
+    endGlobalClear();
+    expect(isGlobalClearActive()).toBe(false);
+
+    // Subsequent begin still moves the gate to 1 cleanly.
+    beginGlobalClear();
+    expect(isGlobalClearActive()).toBe(true);
+    endGlobalClear();
+    expect(isGlobalClearActive()).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Gate effect on applySnapshotIfWired
+  // ---------------------------------------------------------------------------
+
+  it('held gate suppresses applySnapshotIfWired across an UNRELATED provider (isClearing=false)', async () => {
+    // Two providers: A is "being cleared" via the bracket; B is a
+    // sibling whose periodic-poll fires while A is mid-clear. The
+    // per-instance `isClearing` latch on B is unset.
+    const providerA = createProvider('addrA');
+    const providerB = createProvider('addrB');
+    const applierA = vi.fn(async () => makeApplyResult());
+    const applierB = vi.fn(async () => makeApplyResult());
+    providerA.setApplySnapshotCallback(applierA);
+    providerB.setApplySnapshotCallback(applierB);
+    await providerA.initialize();
+    await providerB.initialize();
+
+    beginGlobalClear();
+    try {
+      const a = await providerA.applySnapshotIfWired('bafy-A');
+      const b = await providerB.applySnapshotIfWired('bafy-B');
+      expect(a).toBeNull();
+      expect(b).toBeNull();
+      expect(applierA).not.toHaveBeenCalled();
+      expect(applierB).not.toHaveBeenCalled();
+    } finally {
+      endGlobalClear();
+    }
+  });
+
+  it('bumps profile.applySnapshot.suppressedDuringGlobalClear exactly once per gated call', async () => {
+    const provider = createProvider('addr');
+    const applier = vi.fn(async () => makeApplyResult());
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    beginGlobalClear();
+    try {
+      await provider.applySnapshotIfWired('bafy-1');
+      await provider.applySnapshotIfWired('bafy-2');
+      await provider.applySnapshotIfWired('bafy-3');
+    } finally {
+      endGlobalClear();
+    }
+
+    const counters = snapshot();
+    expect(
+      counters['profile.applySnapshot.suppressedDuringGlobalClear']?.count,
+    ).toBe(3);
+    expect(counters['profile.applySnapshot.fired']?.count ?? 0).toBe(0);
+    expect(applier).not.toHaveBeenCalled();
+  });
+
+  it('per-instance isClearing takes precedence over the global gate', async () => {
+    // When BOTH latches would gate, the per-instance one fires first
+    // (it's checked earlier in `_applySnapshotIfWiredImpl`). This pins
+    // the ordering so counters stay attributable.
+    const provider = createProvider('addr');
+    const applier = vi.fn(async () => makeApplyResult());
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    (provider as unknown as { isClearing: boolean }).isClearing = true;
+    beginGlobalClear();
+    try {
+      await provider.applySnapshotIfWired('bafy-1');
+    } finally {
+      endGlobalClear();
+      (provider as unknown as { isClearing: boolean }).isClearing = false;
+    }
+
+    const counters = snapshot();
+    expect(counters['profile.applySnapshot.suppressedDuringClear']?.count).toBe(1);
+    // Global gate stayed quiet (the per-instance branch returned first).
+    expect(
+      counters['profile.applySnapshot.suppressedDuringGlobalClear']?.count ?? 0,
+    ).toBe(0);
+  });
+
+  it('after the gate releases, applySnapshot proceeds normally', async () => {
+    const provider = createProvider('addr');
+    const applier = vi.fn(async () => makeApplyResult());
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    beginGlobalClear();
+    const blocked = await provider.applySnapshotIfWired('bafy-blocked');
+    expect(blocked).toBeNull();
+    endGlobalClear();
+
+    const allowed = await provider.applySnapshotIfWired('bafy-allowed');
+    expect(allowed).not.toBeNull();
+    expect(applier).toHaveBeenCalledTimes(1);
+    expect(applier).toHaveBeenCalledWith('bafy-allowed');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #368. Closes the multi-wallet gap left by Item #2 (PR #365). The per-instance `isClearing` latch suppresses \`applySnapshotIfWired\` for THE provider being cleared, but a sibling provider's periodic pointer-poll keeps firing — its own \`isClearing\` is false. §D.3 baseline shows 23 \`profile.applySnapshot.fired\` events across the clear-all-wallets phase; PR #365 reduces that only for the actively-cleared wallet.

This PR adds a process-wide reference-counted gate that \`Sphere.clear()\` brackets around its destructive body. While the bracket is held, EVERY provider in the process suppresses \`applySnapshot\` and bumps the new counter \`profile.applySnapshot.suppressedDuringGlobalClear\`.

## Design — separate leaf module

The gate state lives in \`profile/global-clear-gate.ts\` (no exported class — three top-level functions over a module-private \`depth\` counter). Both \`core/Sphere.ts\` and \`profile/profile-token-storage-provider.ts\` import this leaf. Putting the state as a class-static on \`ProfileTokenStorageProvider\` would force \`core/Sphere.ts\` to import the provider class directly; the leaf module keeps the dependency direction clean.

## Semantics

- **Reference counted.** Nesting composes — an orchestrator may bracket a multi-wallet batch in a higher-level pair while each \`Sphere.clear()\` body also brackets itself.
- **No-op-safe at depth 0.** A stray double-end is harmless; \`endGlobalClear()\` only decrements when depth > 0. Prevents silent gate-stuck-closed failures from a buggy orchestrator.
- **Process-scoped.** One counter per JS realm. Cross-process coordination is out of scope; filesystem / IndexedDB locks already serialize cross-process wallet wipes.

## Files

- \`profile/global-clear-gate.ts\` (new) — \`beginGlobalClear()\`, \`endGlobalClear()\`, \`isGlobalClearActive()\`, plus \`__resetGlobalClearForTest()\` for test setup/teardown.
- \`profile/profile-token-storage-provider.ts\` — \`_applySnapshotIfWiredImpl\` now checks \`isGlobalClearActive()\` AFTER the per-instance \`isClearing\` latch (preserving Item #2's counter attribution). When the global gate fires, it bumps \`profile.applySnapshot.suppressedDuringGlobalClear\` and returns null without invoking the wired callback.
- \`core/Sphere.ts\` — \`Sphere.clear()\` wraps its destructive sequence in \`beginGlobalClear()\` / \`try\` / \`finally\` / \`endGlobalClear()\`. The bracket is released even on a destructive failure inside the body so a partial clear never leaves the gate stuck closed.

## Tests

\`tests/unit/profile/global-clear-gate-368.test.ts\` (new) — 7 cases:

1. begin / end track depth; \`isGlobalClearActive()\` reflects state.
2. Two begins require two ends to release (nesting composes).
3. \`endGlobalClear()\` no-op-safe at depth 0; subsequent begin still moves the gate to 1 cleanly.
4. Held gate suppresses \`applySnapshotIfWired\` across an UNRELATED provider whose \`isClearing\` is false — the multi-wallet scenario.
5. Counter fires exactly once per gated call (3-of-3 in a tight loop).
6. Per-instance \`isClearing\` takes precedence — counters stay attributable.
7. After the gate releases, \`applySnapshotIfWired\` proceeds normally.

The Item #2 sibling tests (\`profile-token-storage-clear-suppress-apply-snapshot-364.test.ts\`) remain green (6/6) — global gate is checked AFTER the per-instance latch, so existing semantics are preserved.

## Validation

- [x] \`npm run typecheck\` — clean
- [x] Targeted lint clean on the 4 changed files
- [x] \`npx vitest run tests/unit/profile/ tests/unit/core/Sphere.clear.test.ts\` — 2309 / 0 failed across 145 test files

## Soak A/B (per issue acceptance) — pending

The issue's acceptance target — §D.3 \`profile.applySnapshot.fired\` count drops to 0 and §D.3 wall-clock drops to <15s — is a separate run after this lands. Happy to attach soak numbers in a follow-up comment.

## Refs

- Closes #368
- Builds on PR #365 (\`integration/issue-364-items-2-3-6\`) — same base; gets the per-instance latch this PR composes with.
- Sibling to PRs #373 (Rule-4 gate, issue #367) and #374 (recoverLatest cache, issue #366) — all three close gaps from PR #365's dropped items.