### PR TITLE
perf(profile/ipfs-client)(issue-369): retry-with-backoff + lower DEFAULT_PIN_CONCURRENCY

### DIFF
--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -237,18 +237,155 @@ const DEFAULT_PIN_TIMEOUT_MS = 60_000;
  * single HTTP POST to the sidecar; round-trip is ~80-150 ms regardless of
  * payload size, so serial = N × RTT and dominates wall-clock for any
  * non-trivial wallet (a 24-token migration emits ~250 blocks, which at
- * 100 ms each is ~25 s serial). 10 concurrent in-flight pins reduces the
- * same workload to ~2.5 s while staying well under typical browser
- * per-origin connection caps (Chrome's 6 HTTP/1.1 cap is multiplexed by
- * HTTP/2 on the sidecar). Overridable per-call to support stress tests
- * or sidecars with explicit per-client rate limits.
+ * 100 ms each is ~25 s serial).
+ *
+ * Issue #369 — lowered from 10 → 5. The Unicity kubo container caps at
+ * `MAX_PINS_PER_SECOND=100`; 10 concurrent slots × ~10 pin/s/slot peaks
+ * at ~100 pin/s and routinely brushed the limit on bursts, producing
+ * intermittent `IPFS dag/put failed on all gateways for <CID>: fetch
+ * failed` surface errors that the soak couldn't reproduce on demand.
+ * 5 concurrent slots stay comfortably under the cap (~50 pin/s peak)
+ * while still parallelizing meaningfully — the 250-block migration
+ * pays ~5 s instead of ~2.5 s, but with substantially fewer
+ * rate-limit-induced retry storms. Overridable per-call for stress
+ * tests or operator deployments with explicit per-client rate limits.
  *
  * Concurrency is bounded by a worker pool (not Promise.all over all
  * blocks) so memory stays O(concurrency × block-size) rather than
  * O(blocks × block-size) — important for migration of large wallets
  * where the CAR may contain thousands of blocks.
  */
-const DEFAULT_PIN_CONCURRENCY = 10;
+const DEFAULT_PIN_CONCURRENCY = 5;
+
+// =============================================================================
+// Issue #369 — retry-with-backoff for transient pin failures.
+// =============================================================================
+
+/**
+ * Backoff schedule for a single pin attempt's retries (ms). The
+ * indices line up 1:1 with retry attempts AFTER the initial pass:
+ * a single call to {@link withPinRetry} makes `1 + backoffs.length`
+ * attempts total before throwing.
+ *
+ * 100 / 500 / 2000 ms is the issue #369 recommendation — fast first
+ * retry to absorb the dominant TCP retransmit-window blip, longer
+ * second retry to ride through a gateway hiccup, and a third retry
+ * for the rare extended outage. After 2.6 s of accumulated backoff,
+ * if the gateway still rejects, the failure is unlikely to clear in
+ * the operation's deadline.
+ */
+const PIN_RETRY_BACKOFFS_MS: readonly number[] = [100, 500, 2000];
+
+/**
+ * Classify whether a pin failure is worth retrying.
+ *
+ * Transient (retry):
+ *   - Native `fetch()` throws — network blip, ECONNRESET, ETIMEDOUT,
+ *     TLS handshake stall, AbortError from the per-attempt timeout.
+ *   - HTTP 5xx — gateway-side transient (overload, bad backend).
+ *   - HTTP 429 — explicit rate-limit signal; backoff is the right
+ *     response.
+ *
+ * Permanent (do NOT retry):
+ *   - Other HTTP 4xx — deterministic client-side failures (bad
+ *     request, unauthorized, not found, payload too large).
+ *
+ * Default is transient — leniency favours availability over giving
+ * up on an unrecognised error shape; the bounded backoff schedule
+ * caps the cost.
+ *
+ * The classifier inspects the error's `message` against the shape
+ * `pinToIpfs` / `pinSingleBlock` use for their own throws
+ * (`"HTTP <code> <statusText> from <gw>"`) so a synthetic test error
+ * with that prefix is classified identically to a real one.
+ */
+export function isTransientPinError(err: unknown): boolean {
+  if (!(err instanceof Error)) return true;
+  const msg = err.message;
+
+  // HTTP-derived errors carry the explicit status in the message. We
+  // match anywhere in the string so a wrapped failure (e.g.,
+  // `pinToIpfs` packaging the last gateway's "HTTP 400 …" into its
+  // `IPFS pin failed on all gateways: HTTP 400 …` final throw) still
+  // classifies on the inner status code rather than falling through
+  // to the lenient default.
+  const httpMatch = /\bHTTP (\d{3})\b/.exec(msg);
+  if (httpMatch !== null) {
+    const status = Number.parseInt(httpMatch[1], 10);
+    if (status === 429) return true;
+    if (status >= 500 && status < 600) return true;
+    if (status >= 400 && status < 500) return false;
+  }
+
+  // Network / abort errors propagate from `fetch()` directly. Patterns
+  // observed across Node 18+ undici (`fetch failed`, `Connect Timeout
+  // Error`) and the platform `AbortError` from `AbortSignal.timeout`.
+  if (
+    msg.toLowerCase().includes('fetch failed') ||
+    msg.toLowerCase().includes('network') ||
+    msg.includes('ECONNRESET') ||
+    msg.includes('ETIMEDOUT') ||
+    msg.includes('ECONNREFUSED') ||
+    msg.includes('EAI_AGAIN') ||
+    err.name === 'AbortError' ||
+    err.name === 'TimeoutError'
+  ) {
+    return true;
+  }
+
+  // Lenient default — unrecognised shape is treated as transient. The
+  // bounded backoff schedule caps the cost; a truly-permanent failure
+  // exhausts the retries in 2.6 s and surfaces normally.
+  return true;
+}
+
+/**
+ * Run `fn` with retry-with-backoff for transient pin failures. Makes
+ * up to `1 + backoffs.length` attempts; the first attempt fires
+ * immediately, each subsequent retry waits `backoffs[i]` ms.
+ *
+ * `isRetryable` classifies the thrown error. On the FINAL attempt a
+ * failure short-circuits — no further backoff is paid. On a permanent
+ * (non-retryable) failure the function throws immediately with the
+ * observed error, regardless of the retry budget.
+ *
+ * Counters (fired only when `SPHERE_PERF=1`):
+ *   - `ipfs.pin.retry.attempt` — bumped on each transient retry just
+ *     before the backoff sleep. Total fires = number of paid retries.
+ *   - `ipfs.pin.retry.exhausted` — bumped when all retries fail with
+ *     transient errors AND we throw the last one. Distinct from
+ *     `ipfs.pin.retry.permanent` (a permanent failure exits before the
+ *     retry budget runs out).
+ *   - `ipfs.pin.retry.permanent` — bumped when the classifier returns
+ *     `false` and the function throws the permanent error without
+ *     consuming further retries.
+ */
+export async function withPinRetry<T>(
+  fn: () => Promise<T>,
+  isRetryable: (err: unknown) => boolean = isTransientPinError,
+  backoffs: readonly number[] = PIN_RETRY_BACKOFFS_MS,
+): Promise<T> {
+  for (let attempt = 0; attempt <= backoffs.length; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const isLast = attempt >= backoffs.length;
+      if (isLast) {
+        incr('ipfs.pin.retry.exhausted');
+        throw err;
+      }
+      if (!isRetryable(err)) {
+        incr('ipfs.pin.retry.permanent');
+        throw err;
+      }
+      incr('ipfs.pin.retry.attempt');
+      await new Promise<void>((resolve) => setTimeout(resolve, backoffs[attempt]));
+    }
+  }
+  // Unreachable — the loop above either returns or throws on every
+  // path. This satisfies TypeScript's exhaustiveness check.
+  throw new Error('withPinRetry: unreachable');
+}
 
 /** Default timeout for fetch operations (ms). */
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
@@ -452,6 +589,21 @@ export async function pinToIpfs(
 ): Promise<string> {
   const effectiveGateways = gateways.length > 0 ? gateways : [DEFAULT_IPFS_API_URL];
   validateGatewayUrls(effectiveGateways);
+
+  // Issue #369 — wrap the gateway-iteration in retry-with-backoff so a
+  // single transient hiccup (network blip, brief TLS slowdown, 429 from
+  // a rate-limited gateway) no longer aborts the pin. The retry only
+  // fires when EVERY configured gateway has failed in the current
+  // attempt — a single healthy gateway still satisfies the pin without
+  // paying any backoff cost.
+  return withPinRetry(() => pinToIpfsOnce(effectiveGateways, data, timeoutMs));
+}
+
+async function pinToIpfsOnce(
+  effectiveGateways: string[],
+  data: Uint8Array,
+  timeoutMs: number,
+): Promise<string> {
   let lastError: Error | null = null;
 
   for (const gateway of effectiveGateways) {
@@ -570,6 +722,22 @@ async function pinSingleBlock(
   const effectiveGateways = gateways.length > 0 ? gateways : [DEFAULT_IPFS_API_URL];
   validateGatewayUrls(effectiveGateways);
 
+  // Issue #369 — wrap the per-block pin in retry-with-backoff so a
+  // single transient network/gateway failure on this one block doesn't
+  // abort the whole CAR pin (a 250-block CAR has 250 retry slots — a
+  // single 1% failure rate without retries cascades to ~92% chance of
+  // at-least-one-failure per CAR).
+  return withPinRetry(() =>
+    pinSingleBlockOnce(effectiveGateways, blockBytes, expectedCid, timeoutMs),
+  );
+}
+
+async function pinSingleBlockOnce(
+  effectiveGateways: string[],
+  blockBytes: Uint8Array,
+  expectedCid: string,
+  timeoutMs: number,
+): Promise<void> {
   // Derive the Kubo codec token from the CID's multicodec prefix.
   // Unknown codecs fall back to `raw` so we still store the bytes (the
   // gateway will compute a different CID, but our locally-computed

--- a/tests/unit/profile/ipfs-client-parallel-pin.test.ts
+++ b/tests/unit/profile/ipfs-client-parallel-pin.test.ts
@@ -183,7 +183,14 @@ function installConcurrencyMock(
         }
         await new Promise((r) => setTimeout(r, delayMs));
         if (tracker.failNthBlock !== null && myIdx === tracker.failNthBlock) {
-          return new Response('forced failure', { status: 500 });
+          // Issue #369 — HTTP 400 is classified as a PERMANENT failure
+          // by `isTransientPinError`, so `withPinRetry` short-circuits
+          // the retry budget and surfaces the error immediately. This
+          // preserves the original test intent of these abort-propagation
+          // scenarios (single failure → abort the whole CAR pin) under
+          // the new retry-with-backoff wrap; transient codes (5xx, 429,
+          // network errors) would now be retried instead.
+          return new Response('forced failure', { status: 400 });
         }
         return new Response(JSON.stringify({ Cid: { '/': 'ignored' } }), {
           status: 200,
@@ -356,7 +363,7 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
         undefined,
         4,
       ),
-    ).rejects.toThrow(/ORBITDB_WRITE_FAILED|dag\/put failed|HTTP 500/);
+    ).rejects.toThrow(/ORBITDB_WRITE_FAILED|dag\/put failed|HTTP 400/);
   });
 
   it('order-independent: pins arrive in any order, every index processed exactly once', async () => {
@@ -415,7 +422,7 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
           undefined,
           4,
         ),
-      ).rejects.toThrow(/ORBITDB_WRITE_FAILED|HTTP 500/);
+      ).rejects.toThrow(/ORBITDB_WRITE_FAILED|HTTP 400/);
       // Give the peer workers enough time to finish their in-flight
       // pin POSTs and any post-throw microtask processing.
       await new Promise((r) => setTimeout(r, 150));

--- a/tests/unit/profile/ipfs-client-pin-retry-369.test.ts
+++ b/tests/unit/profile/ipfs-client-pin-retry-369.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Issue #369 — retry-with-backoff for transient IPFS pin failures.
+ *
+ * The SDK's pin path (`pinToIpfs`, `pinSingleBlock`) historically did
+ * a single `fetch()` per gateway with NO retry on transient errors
+ * (network blip, brief TLS slowdown, rate-limit 429). The observed
+ * surface error was `IPFS dag/put failed on all gateways for <CID>:
+ * fetch failed`, not reproducible on demand because the gateway worked
+ * ~99% of the time when tested directly. A single 1% per-block error
+ * rate cascades to ~92% chance of at-least-one-failure across a
+ * 250-block migration CAR.
+ *
+ * This test file covers:
+ *
+ *   - `isTransientPinError` classifier across the failure-mode matrix
+ *     the pin path actually produces (HTTP-status strings, fetch
+ *     throws, AbortError).
+ *   - `withPinRetry` retry / backoff / counter semantics.
+ *   - End-to-end: `pinToIpfs` succeeds on the third attempt when the
+ *     first two transient-fail (proves the wrap is in the right
+ *     place).
+ *   - Permanent failures (HTTP 4xx other than 429) short-circuit the
+ *     retry budget.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isTransientPinError, withPinRetry, pinToIpfs } from '../../../profile/ipfs-client';
+import {
+  __setPerfEnabledForTest,
+  __stopAutoDumpForTest,
+  dumpAndReset,
+  snapshot,
+} from '../../../core/perf-counters.js';
+
+describe('Issue #369 — isTransientPinError classifier', () => {
+  it('classifies HTTP 5xx as transient', () => {
+    expect(isTransientPinError(new Error('HTTP 500 Internal Server Error from https://gw.test'))).toBe(true);
+    expect(isTransientPinError(new Error('HTTP 502 Bad Gateway from https://gw.test'))).toBe(true);
+    expect(isTransientPinError(new Error('HTTP 503 Service Unavailable from https://gw.test'))).toBe(true);
+  });
+
+  it('classifies HTTP 429 (rate limit) as transient', () => {
+    expect(isTransientPinError(new Error('HTTP 429 Too Many Requests from https://gw.test'))).toBe(true);
+  });
+
+  it('classifies other HTTP 4xx as permanent', () => {
+    expect(isTransientPinError(new Error('HTTP 400 Bad Request from https://gw.test'))).toBe(false);
+    expect(isTransientPinError(new Error('HTTP 401 Unauthorized from https://gw.test'))).toBe(false);
+    expect(isTransientPinError(new Error('HTTP 403 Forbidden from https://gw.test'))).toBe(false);
+    expect(isTransientPinError(new Error('HTTP 404 Not Found from https://gw.test'))).toBe(false);
+    expect(isTransientPinError(new Error('HTTP 413 Payload Too Large from https://gw.test'))).toBe(false);
+  });
+
+  it('classifies fetch network errors as transient', () => {
+    expect(isTransientPinError(new Error('fetch failed'))).toBe(true);
+    expect(isTransientPinError(new Error('Network request failed'))).toBe(true);
+    expect(isTransientPinError(new Error('connect ECONNRESET 1.2.3.4:443'))).toBe(true);
+    expect(isTransientPinError(new Error('connect ETIMEDOUT 1.2.3.4:443'))).toBe(true);
+    expect(isTransientPinError(new Error('connect ECONNREFUSED 1.2.3.4:443'))).toBe(true);
+    expect(isTransientPinError(new Error('getaddrinfo EAI_AGAIN gw.test'))).toBe(true);
+  });
+
+  it('classifies AbortError / TimeoutError by Error.name', () => {
+    const abort = new Error('aborted');
+    abort.name = 'AbortError';
+    expect(isTransientPinError(abort)).toBe(true);
+
+    const timeout = new Error('timed out');
+    timeout.name = 'TimeoutError';
+    expect(isTransientPinError(timeout)).toBe(true);
+  });
+
+  it('classifies non-Error throws and unrecognised shapes as transient (lenient default)', () => {
+    expect(isTransientPinError('a bare string')).toBe(true);
+    expect(isTransientPinError({ shape: 'weird' })).toBe(true);
+    expect(isTransientPinError(new Error('something else entirely'))).toBe(true);
+  });
+});
+
+describe('Issue #369 — withPinRetry', () => {
+  beforeEach(() => {
+    __stopAutoDumpForTest();
+    __setPerfEnabledForTest(true);
+    dumpAndReset();
+  });
+
+  afterEach(() => {
+    __setPerfEnabledForTest(false);
+    __stopAutoDumpForTest();
+  });
+
+  it('returns the value on the first successful attempt — no retries paid', async () => {
+    const fn = vi.fn(async () => 'ok');
+    const result = await withPinRetry(fn);
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count ?? 0).toBe(0);
+    expect(counters['ipfs.pin.retry.exhausted']?.count ?? 0).toBe(0);
+  });
+
+  it('retries on transient failure until success, bumps retry counter per retry', async () => {
+    let attempts = 0;
+    const fn = vi.fn(async () => {
+      attempts += 1;
+      if (attempts < 3) throw new Error('fetch failed');
+      return 'recovered';
+    });
+
+    const result = await withPinRetry(fn, isTransientPinError, [1, 1, 1]);
+    expect(result).toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count).toBe(2);
+    expect(counters['ipfs.pin.retry.exhausted']?.count ?? 0).toBe(0);
+    expect(counters['ipfs.pin.retry.permanent']?.count ?? 0).toBe(0);
+  });
+
+  it('throws after the retry budget runs out — bumps exhausted counter', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('fetch failed');
+    });
+
+    await expect(
+      withPinRetry(fn, isTransientPinError, [1, 1, 1]),
+    ).rejects.toThrow(/fetch failed/);
+    expect(fn).toHaveBeenCalledTimes(4); // 1 + 3 retries
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count).toBe(3);
+    expect(counters['ipfs.pin.retry.exhausted']?.count).toBe(1);
+  });
+
+  it('short-circuits on a permanent error — does NOT consume further retries', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('HTTP 400 Bad Request from https://gw.test');
+    });
+
+    await expect(
+      withPinRetry(fn, isTransientPinError, [1, 1, 1]),
+    ).rejects.toThrow(/HTTP 400/);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count ?? 0).toBe(0);
+    expect(counters['ipfs.pin.retry.permanent']?.count).toBe(1);
+    expect(counters['ipfs.pin.retry.exhausted']?.count ?? 0).toBe(0);
+  });
+
+  it('uses the default backoff schedule when no explicit one is passed', async () => {
+    // Default is [100, 500, 2000] — too slow to run as a real timing
+    // test, so spy on setTimeout to observe the requested delays
+    // without actually waiting.
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((cb: TimerHandler) => {
+        if (typeof cb === 'function') cb();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+    const fn = vi.fn(async () => {
+      throw new Error('fetch failed');
+    });
+
+    await expect(withPinRetry(fn)).rejects.toThrow();
+    // 3 retry backoffs in the default schedule.
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(3);
+    const delays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+    expect(delays).toEqual([100, 500, 2000]);
+
+    setTimeoutSpy.mockRestore();
+  });
+});
+
+describe('Issue #369 — pinToIpfs end-to-end retry', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    __stopAutoDumpForTest();
+    __setPerfEnabledForTest(true);
+    dumpAndReset();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    __setPerfEnabledForTest(false);
+    __stopAutoDumpForTest();
+    vi.restoreAllMocks();
+  });
+
+  it('succeeds on the third attempt when the first two fail transient', async () => {
+    let calls = 0;
+    globalThis.fetch = (async (_url: RequestInfo | URL): Promise<Response> => {
+      calls += 1;
+      if (calls < 3) {
+        throw new Error('fetch failed');
+      }
+      // Kubo's `/api/v0/dag/put` returns `{"Cid":{"/":"bafkrei…"}}`.
+      // The returned CID is intentionally ignored by pinToIpfs (it
+      // computes its own from the bytes). Any plausible string works.
+      return new Response(JSON.stringify({ Cid: { '/': 'bafkreiignored' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    // Use tiny backoffs via vi.useFakeTimers? Simpler — spy on setTimeout
+    // to fire immediately.
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((cb: TimerHandler) => {
+        if (typeof cb === 'function') cb();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+    const data = new TextEncoder().encode('hello pin retry');
+    const result = await pinToIpfs(['https://gw1.test'], data);
+    expect(result).toMatch(/^baf/);
+    // 2 transient-failing pins + 1 successful pin + 1 sidecar
+    // fire-and-forget submit on success = 4 fetch calls. The sidecar
+    // submit is unconditional after a successful pin (see
+    // `submitToSidecarBestEffort`); it never fires on a failure.
+    expect(calls).toBe(4);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count).toBe(2);
+    expect(counters['ipfs.pin.retry.exhausted']?.count ?? 0).toBe(0);
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('throws after 4 attempts all-transient on the configured gateways', async () => {
+    let calls = 0;
+    globalThis.fetch = (async (_url: RequestInfo | URL): Promise<Response> => {
+      calls += 1;
+      throw new Error('fetch failed');
+    }) as typeof fetch;
+
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((cb: TimerHandler) => {
+        if (typeof cb === 'function') cb();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+    const data = new TextEncoder().encode('hello pin exhaust');
+    await expect(pinToIpfs(['https://gw1.test'], data)).rejects.toThrow(/IPFS pin failed/);
+    // 1 attempt × 1 gateway + 3 retries × 1 gateway = 4 fetch calls.
+    expect(calls).toBe(4);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count).toBe(3);
+    expect(counters['ipfs.pin.retry.exhausted']?.count).toBe(1);
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('permanent failure (HTTP 400) does NOT consume retries', async () => {
+    let calls = 0;
+    globalThis.fetch = (async (_url: RequestInfo | URL): Promise<Response> => {
+      calls += 1;
+      return new Response('bad', { status: 400, statusText: 'Bad Request' });
+    }) as typeof fetch;
+
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((cb: TimerHandler) => {
+        if (typeof cb === 'function') cb();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+    const data = new TextEncoder().encode('hello pin perm');
+    await expect(pinToIpfs(['https://gw1.test'], data)).rejects.toThrow(/HTTP 400/);
+    // 1 attempt only — permanent failure short-circuits.
+    expect(calls).toBe(1);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count ?? 0).toBe(0);
+    expect(counters['ipfs.pin.retry.permanent']?.count).toBe(1);
+    expect(counters['ipfs.pin.retry.exhausted']?.count ?? 0).toBe(0);
+
+    setTimeoutSpy.mockRestore();
+  });
+});

--- a/tests/unit/profile/lifecycle-manager-pointer-poll.test.ts
+++ b/tests/unit/profile/lifecycle-manager-pointer-poll.test.ts
@@ -369,6 +369,16 @@ describe('LifecycleManager periodic pointer poll (Path 2 safety net)', () => {
     const lifecycle = getLifecycle(provider);
     expect(lifecycle.pointerPollTimer).not.toBeNull();
 
+    // Issue #369 — the apply-snapshot path schedules a flush whose
+    // CAR-pin now sits behind `withPinRetry` (retry-with-backoff on
+    // transient pin failures). Under `vi.useFakeTimers()` the retry's
+    // setTimeout-based backoff doesn't fire on its own, so the
+    // shutdown's flush would block forever waiting for retries. Switch
+    // to real timers for teardown so the retries drain promptly — the
+    // assertions above already cover the test's intent (applier was
+    // invoked with the new snapshot CID); the shutdown is only here to
+    // satisfy the test's resource-cleanup discipline.
+    vi.useRealTimers();
     await provider.shutdown();
   });
 


### PR DESCRIPTION
## Summary

Two of the three improvements from #369. The third (expanding \`DEFAULT_IPFS_GATEWAYS\` from a single primary to operator-provided fallbacks) is intentionally out of scope here — that's a deployment / infrastructure decision the SDK can't make unilaterally; operators wire additional gateways via the \`SPHERE_IPFS_GATEWAY\` env override or the \`ipfsGateways\` config field the loop already iterates.

## 1. Retry-with-backoff for transient pin failures

\`withPinRetry\` + \`isTransientPinError\` wrap the existing gateway-iteration loop in \`pinToIpfs\` and \`pinSingleBlock\`. Up to 4 attempts total (1 initial + 3 retries) with 100 / 500 / 2000 ms backoff between them — 2.6 s of accumulated backoff before exhaustion, well inside any operation's deadline budget.

The classifier distinguishes transient (retry) from permanent (short-circuit):

- **Transient:** \`fetch()\` throws (network blip, \`ECONNRESET\`, \`ETIMEDOUT\`, \`EAI_AGAIN\`, \`AbortError\`, \`TimeoutError\`), HTTP 5xx (gateway-side overload), HTTP 429 (explicit rate-limit signal).
- **Permanent:** HTTP 4xx other than 429 (bad request, unauthorized, not found, payload too large) — these are deterministic client-side failures and never clear on retry.
- **Lenient default:** unrecognised error shapes are treated as transient. The bounded backoff schedule caps the cost.

The HTTP-status match scans the message for \`HTTP NNN\` anywhere (not just the prefix) so a wrapped failure (e.g. \`ProfileError("IPFS pin failed on all gateways: HTTP 400 ...")\`) still classifies on the inner status rather than falling through to the lenient default. This makes #369 a no-op when every gateway returns a real 4xx — the budget is preserved for actual transient situations.

New perf counters:
- \`ipfs.pin.retry.attempt\` — bumped before each backoff sleep.
- \`ipfs.pin.retry.exhausted\` — bumped when all retries fail transient.
- \`ipfs.pin.retry.permanent\` — bumped on a permanent short-circuit.

## 2. Lower DEFAULT_PIN_CONCURRENCY 10 → 5

The Unicity kubo container caps at \`MAX_PINS_PER_SECOND=100\`. With 10 concurrent slots × ~10 pin/s/slot the SDK peaked at ~100 pin/s and routinely brushed the limit on bursts, producing intermittent \`IPFS dag/put failed on all gateways for <CID>: fetch failed\` surface errors that the soak couldn't reproduce on demand because the gateway worked ~99% of the time when tested directly.

5 concurrent slots stay comfortably under the cap (~50 pin/s peak) while still parallelizing meaningfully — the 250-block migration CAR pays ~5 s instead of ~2.5 s, but with substantially fewer rate-limit-induced retry storms. Combined with the retry wrap, a single ~1% transient block failure across a 250-block CAR is now mathematically a non-event.

## Tests

\`tests/unit/profile/ipfs-client-pin-retry-369.test.ts\` (new) — **14 cases**:
- Classifier across the failure-mode matrix (5xx / 429 / 4xx / fetch errors / AbortError / unrecognised shapes).
- \`withPinRetry\` retry / backoff / counter semantics.
- End-to-end \`pinToIpfs\` proves the wrap is in the right place: succeeds on third attempt after two transient failures, exhausts at 4 attempts when all-transient, HTTP 400 short-circuits to 1 attempt only.

\`tests/unit/profile/ipfs-client-parallel-pin.test.ts\` — pre-existing abort-propagation tests that intentionally trigger a single block failure switched from HTTP 500 (now classified transient and retried) to HTTP 400 (still classified permanent and short-circuits), preserving the original test intent under the new retry-with-backoff wrap.

\`tests/unit/profile/lifecycle-manager-pointer-poll.test.ts\` — the "returns a NEW snapshot CID → applier is invoked, re-arms" case runs under \`vi.useFakeTimers()\`, then triggers a flush whose CAR-pin retry hangs on fake-timer setTimeouts. Switched to \`vi.useRealTimers()\` for the teardown shutdown so the retries drain promptly — the test's assertions all complete BEFORE the shutdown call; the real-timer switch only affects resource-cleanup discipline. Elapsed wall-clock grows from 15 ms to ~5.5 s due to the real retry backoffs; acceptable for a single integration case.

## Validation

- [x] \`npm run typecheck\` — clean
- [x] Targeted lint clean on the 4 changed files
- [x] \`npx vitest run\` — **8816 passed | 13 skipped | 0 failed** across 539 test files

## Acceptance criteria (per issue)

- [x] Single transient gateway failure no longer aborts a CAR pin — wrapped by \`withPinRetry\`, 3 retries with backoff.
- [ ] Soak passing rate ≥ 95% across 10 consecutive runs — soak A/B is a separate run after this lands; happy to attach numbers in a follow-up comment.
- [ ] §D.1 wall-clock comparable to baseline (~98 s) without rate-limit-induced retry storms — measured in same follow-up.

## Refs

- Closes #369
- Sibling perf-track PRs: #373 (issue #367, Rule-4 gate), #374 (issue #366, recoverLatest cache), #375 (issue #368, global clear gate). All four close gaps from PR #365's dropped items and adjacent surfaces.