### PR TITLE
perf: combined 6-PR stack — CAR batching, Rule-4 provenance, pointer cache, clear suppression, pin retry, V6-RECOVER ledger

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -185,6 +185,24 @@ export const STORAGE_KEYS_ADDRESS = {
    * sourceTokenJson) to re-fire `finalizeReceivedToken` on next load().
    */
   PROOF_POLLING_JOBS: 'proof_polling_jobs',
+  /**
+   * Issue #378 (#275 P4) — persistent ledger of V6-RECOVER permanent
+   * verdicts. When `finalizeStrandedReceivedToken` hits
+   * `permanent recipient-address mismatch (HD-index recovery exhausted)`
+   * or `permanent structural failure`, the tokenId is recorded here
+   * with the verdict reason + timestamp.
+   *
+   * Read by `drainPendingFinalizations` (and the V6-RECOVER stranded
+   * scan at `handleStrandedReceive`) so subsequent `sphere balance` /
+   * `sphere payments receive` invocations skip the 60s drain timeout
+   * for already-failed tokens.
+   *
+   * Cleared by `Sphere.clear()` (full wallet wipe) and by an explicit
+   * `payments receive --finalize` (operator-forced retry — gives the
+   * token one more shot at finalization in case the HD-index window
+   * has since widened).
+   */
+  V6_RECOVER_PERMANENT: 'v6_recover_permanent',
   // Swap storage keys
   /** Per-swap key: swap:{swapId} */
   SWAP_RECORD_PREFIX: 'swap:',

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -75,6 +75,7 @@ import {
   LOCAL_EPOCH_RESET_REASON_KEY,
 } from '../profile/pointer-wiring';
 import { EPOCH_RESET_REASON_MAX_BYTES } from '../profile/profile-lean-snapshot';
+import { beginGlobalClear, endGlobalClear } from '../profile/global-clear-gate';
 import type {
   ShutdownOptions,
   StorageProvider,
@@ -1730,82 +1731,105 @@ export class Sphere {
     const fallbackTokenStorage =
       'get' in storageOrOptions ? undefined : storageOrOptions.fallbackTokenStorage;
 
-    // 1. Destroy Sphere instance — flushes pending IPFS writes (saves good
-    //    state), then closes all connections. Awaited so IPFS completes
-    //    before we delete databases.
-    if (Sphere.instance) {
-      logger.debug('Sphere', 'Destroying Sphere instance...');
-      await Sphere.instance.destroy();
-      logger.debug('Sphere', 'Sphere instance destroyed');
-    }
-
-    // 2. Clear L1 vesting cache
-    logger.debug('Sphere', 'Clearing L1 vesting cache...');
-    await vestingClassifier.destroy();
-
-    // 3. Yield to let IndexedDB finalize pending transactions after close().
-    //    db.close() is synchronous but the connection isn't fully released
-    //    until all in-flight transactions complete.
-    logger.debug('Sphere', 'Yielding 50ms for IDB transaction settlement...');
-    await new Promise((r) => setTimeout(r, 50));
-
-    // 4. Delete token databases (sphere-token-storage-*)
-    if (tokenStorage?.clear) {
-      logger.debug('Sphere', 'Clearing token storage...');
-      try {
-        await tokenStorage.clear();
-        logger.debug('Sphere', 'Token storage cleared');
-      } catch (err) {
-        logger.warn('Sphere', 'Token storage clear failed:', err);
-      }
-    } else {
-      logger.debug('Sphere', 'No token storage provider to clear');
-    }
-
-    // 4b. Issue #330 — also wipe the read-only fallback token storage
-    // (legacy IndexedDB from before Profile migration). Without this,
-    // a user who calls `clear()` to start over with the same mnemonic
-    // would see pre-clear tokens resurrected via the fallback wiring.
-    // This violates the "clear means clear" invariant and is a real
-    // data-integrity hazard, not just UX confusion.
+    // Issue #368 — bracket the destructive body with the process-wide
+    // global-clear gate. While the bracket is held, every
+    // `ProfileTokenStorageProvider._applySnapshotIfWiredImpl` call in
+    // this process early-returns and bumps
+    // `profile.applySnapshot.suppressedDuringGlobalClear`. Closes the
+    // multi-wallet gap left by the per-instance `isClearing` latch:
+    // sibling wallets' periodic pointer-polls must not seed snapshot
+    // state mid-batch while another wallet's `clear()` is in flight.
     //
-    // Idempotent and best-effort: a missing `clear` method (older
-    // legacy providers) or an exception is logged but does not block
-    // the rest of the cleanup. The fallback was never written to by
-    // this SDK; the bytes here are pre-migration legacy data.
-    if (fallbackTokenStorage?.clear) {
-      logger.debug('Sphere', 'Clearing fallback (legacy) token storage...');
-      try {
-        if (
-          typeof fallbackTokenStorage.isConnected === 'function' &&
-          !fallbackTokenStorage.isConnected() &&
-          typeof fallbackTokenStorage.connect === 'function'
-        ) {
-          await fallbackTokenStorage.connect();
-        }
-        await fallbackTokenStorage.clear();
-        logger.debug('Sphere', 'Fallback token storage cleared');
-      } catch (err) {
-        logger.warn('Sphere', 'Fallback token storage clear failed:', err);
+    // The bracket nests safely (reference-counted), so an orchestrator
+    // wrapping its own sequence of `Sphere.clear()` calls in a higher-
+    // level bracket sees both layers compose. `endGlobalClear()` is
+    // no-op-safe at depth 0, so a stray double-end is harmless.
+    beginGlobalClear();
+    try {
+      // 1. Destroy Sphere instance — flushes pending IPFS writes (saves good
+      //    state), then closes all connections. Awaited so IPFS completes
+      //    before we delete databases.
+      if (Sphere.instance) {
+        logger.debug('Sphere', 'Destroying Sphere instance...');
+        await Sphere.instance.destroy();
+        logger.debug('Sphere', 'Sphere instance destroyed');
       }
-    }
 
-    // 5. Delete KV database (sphere-storage)
-    logger.debug('Sphere', 'Clearing KV storage...');
-    if (!storage.isConnected()) {
-      try {
-        await storage.connect();
-      } catch {
-        // May fail if database was already deleted — that's fine
+      // 2. Clear L1 vesting cache
+      logger.debug('Sphere', 'Clearing L1 vesting cache...');
+      await vestingClassifier.destroy();
+
+      // 3. Yield to let IndexedDB finalize pending transactions after close().
+      //    db.close() is synchronous but the connection isn't fully released
+      //    until all in-flight transactions complete.
+      logger.debug('Sphere', 'Yielding 50ms for IDB transaction settlement...');
+      await new Promise((r) => setTimeout(r, 50));
+
+      // 4. Delete token databases (sphere-token-storage-*)
+      if (tokenStorage?.clear) {
+        logger.debug('Sphere', 'Clearing token storage...');
+        try {
+          await tokenStorage.clear();
+          logger.debug('Sphere', 'Token storage cleared');
+        } catch (err) {
+          logger.warn('Sphere', 'Token storage clear failed:', err);
+        }
+      } else {
+        logger.debug('Sphere', 'No token storage provider to clear');
       }
+
+      // 4b. Issue #330 — also wipe the read-only fallback token storage
+      // (legacy IndexedDB from before Profile migration). Without this,
+      // a user who calls `clear()` to start over with the same mnemonic
+      // would see pre-clear tokens resurrected via the fallback wiring.
+      // This violates the "clear means clear" invariant and is a real
+      // data-integrity hazard, not just UX confusion.
+      //
+      // Idempotent and best-effort: a missing `clear` method (older
+      // legacy providers) or an exception is logged but does not block
+      // the rest of the cleanup. The fallback was never written to by
+      // this SDK; the bytes here are pre-migration legacy data.
+      if (fallbackTokenStorage?.clear) {
+        logger.debug('Sphere', 'Clearing fallback (legacy) token storage...');
+        try {
+          if (
+            typeof fallbackTokenStorage.isConnected === 'function' &&
+            !fallbackTokenStorage.isConnected() &&
+            typeof fallbackTokenStorage.connect === 'function'
+          ) {
+            await fallbackTokenStorage.connect();
+          }
+          await fallbackTokenStorage.clear();
+          logger.debug('Sphere', 'Fallback token storage cleared');
+        } catch (err) {
+          logger.warn('Sphere', 'Fallback token storage clear failed:', err);
+        }
+      }
+
+      // 5. Delete KV database (sphere-storage)
+      logger.debug('Sphere', 'Clearing KV storage...');
+      if (!storage.isConnected()) {
+        try {
+          await storage.connect();
+        } catch {
+          // May fail if database was already deleted — that's fine
+        }
+      }
+      if (storage.isConnected()) {
+        await storage.clear();
+        logger.debug('Sphere', 'KV storage cleared');
+      } else {
+        logger.debug('Sphere', 'KV storage not connected, skipping');
+      }
+      logger.debug('Sphere', 'Done');
+    } finally {
+      // Issue #368 — release the global-clear bracket. Reached even on
+      // a destructive failure inside the try body so a partial clear
+      // never leaves the gate stuck closed (which would silently
+      // disable applySnapshot dispatch for the rest of the process
+      // lifetime).
+      endGlobalClear();
     }
-    if (storage.isConnected()) {
-      await storage.clear();
-      logger.debug('Sphere', 'KV storage cleared');
-    } else {
-      logger.debug('Sphere', 'KV storage not connected, skipping');
-    }
-    logger.debug('Sphere', 'Done');
   }
 
   /**

--- a/core/perf-counters.ts
+++ b/core/perf-counters.ts
@@ -1,0 +1,261 @@
+/**
+ * core/perf-counters.ts — opt-in runtime measurement hooks.
+ *
+ * Created in response to GH issue #363 (post-mortem of #360). The
+ * lesson from #360: do NOT propose perf fixes from static analysis.
+ * Measure first, fix second. This module exists so that the next
+ * investigator can capture real numbers from the hot paths the #360
+ * findings called out but never instrumented.
+ *
+ * ## Activation
+ *
+ * Zero overhead when off. Enabled by either of:
+ *
+ *   - `process.env.SPHERE_PERF=1` at process start (Node), OR
+ *   - `localStorage.SPHERE_PERF=1` (browser)
+ *
+ * When enabled, the module:
+ *
+ *   1. Records counter / timer samples taken via {@link incr},
+ *      {@link observeMs}, and {@link time}.
+ *   2. Dumps a snapshot of all counters every
+ *      `SPHERE_PERF_DUMP_MS` (default 5000 ms) via
+ *      `logger.info('perf', { snapshot })`.
+ *   3. Clears the snapshot after each dump so the numbers reflect the
+ *      most recent window, not cumulative since start.
+ *
+ * ## API
+ *
+ *   - `incr(name, n=1)` — bump a counter.
+ *   - `observeMs(name, ms)` — record a timing sample (ms).
+ *   - `time(name, fn)` — wrap an async function; records its wall-clock.
+ *   - `snapshot()` — return current counters without clearing.
+ *   - `dumpAndReset()` — emit + clear (called periodically when enabled).
+ *
+ * All calls are guarded by `PERF_ENABLED` and bail out cheap when off
+ * (one boolean check + early return; no allocations, no time reads).
+ *
+ * ## Why no histograms / no p99
+ *
+ * Keep it minimal. The first profile-driven investigation needs
+ * count + total + max, not a HDR histogram. If a future investigation
+ * needs percentiles, swap the storage at that point. We are recovering
+ * from the over-engineering of #360 — do not repeat that here.
+ *
+ * @module core/perf-counters
+ */
+
+import { logger } from './logger.js';
+
+// =============================================================================
+// Activation
+// =============================================================================
+
+function detectEnabled(): boolean {
+  try {
+    if (typeof process !== 'undefined' && process?.env) {
+      if (process.env.SPHERE_PERF === '1') return true;
+    }
+  } catch {
+    /* ignore — browser ESM */
+  }
+  try {
+    if (typeof localStorage !== 'undefined') {
+      if (localStorage.getItem('SPHERE_PERF') === '1') return true;
+    }
+  } catch {
+    /* ignore — sandboxed iframe / private mode */
+  }
+  return false;
+}
+
+/**
+ * Cached at module load. We deliberately do NOT re-read the env on
+ * every call — the gating must be cheap. To flip the flag for an
+ * in-flight test, call `__setPerfEnabledForTest`.
+ */
+let PERF_ENABLED: boolean = detectEnabled();
+
+function detectDumpIntervalMs(): number {
+  try {
+    if (typeof process !== 'undefined' && process?.env?.SPHERE_PERF_DUMP_MS) {
+      const n = Number(process.env.SPHERE_PERF_DUMP_MS);
+      if (Number.isFinite(n) && n > 0) return Math.max(100, Math.floor(n));
+    }
+  } catch {
+    /* ignore */
+  }
+  return 5_000;
+}
+
+// =============================================================================
+// Storage
+// =============================================================================
+
+interface CounterCell {
+  count: number;
+  totalMs: number;
+  maxMs: number;
+}
+
+const counters = new Map<string, CounterCell>();
+
+function getCell(name: string): CounterCell {
+  let c = counters.get(name);
+  if (c === undefined) {
+    c = { count: 0, totalMs: 0, maxMs: 0 };
+    counters.set(name, c);
+  }
+  return c;
+}
+
+// =============================================================================
+// API
+// =============================================================================
+
+/**
+ * Bump a counter by `n` (default 1). No-op when perf is disabled.
+ */
+export function incr(name: string, n: number = 1): void {
+  if (!PERF_ENABLED) return;
+  const c = getCell(name);
+  c.count += n;
+}
+
+/**
+ * Record one timing sample (milliseconds). No-op when perf is disabled.
+ *
+ * Negative or non-finite values are silently clamped to 0 — caller
+ * mistakes (e.g., subtracting `Date.now()` across a clock skip) must
+ * not corrupt the counter state.
+ */
+export function observeMs(name: string, ms: number): void {
+  if (!PERF_ENABLED) return;
+  const v = Number.isFinite(ms) && ms > 0 ? ms : 0;
+  const c = getCell(name);
+  c.count += 1;
+  c.totalMs += v;
+  if (v > c.maxMs) c.maxMs = v;
+}
+
+/**
+ * Wrap a function and record its wall-clock. No-op overhead is one
+ * boolean check + the function call. When enabled, adds a single
+ * `performance.now()` pair around the call.
+ *
+ * Errors propagate; the timing is still recorded (so a failing
+ * subsystem still shows up in the snapshot).
+ */
+export async function time<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  if (!PERF_ENABLED) return fn();
+  const t0 = performance.now();
+  try {
+    return await fn();
+  } finally {
+    observeMs(name, performance.now() - t0);
+  }
+}
+
+/**
+ * Sync wrapper variant. Same semantics as `time` for synchronous
+ * functions.
+ */
+export function timeSync<T>(name: string, fn: () => T): T {
+  if (!PERF_ENABLED) return fn();
+  const t0 = performance.now();
+  try {
+    return fn();
+  } finally {
+    observeMs(name, performance.now() - t0);
+  }
+}
+
+/**
+ * Read-only view of the current counters. Returns an empty object
+ * when perf is disabled. Does NOT clear.
+ */
+export function snapshot(): Record<
+  string,
+  { count: number; totalMs: number; avgMs: number; maxMs: number }
+> {
+  const out: Record<
+    string,
+    { count: number; totalMs: number; avgMs: number; maxMs: number }
+  > = {};
+  for (const [name, c] of counters) {
+    out[name] = {
+      count: c.count,
+      totalMs: Math.round(c.totalMs * 1000) / 1000,
+      avgMs: c.count > 0 ? Math.round((c.totalMs / c.count) * 1000) / 1000 : 0,
+      maxMs: Math.round(c.maxMs * 1000) / 1000,
+    };
+  }
+  return out;
+}
+
+/**
+ * Emit the current counters via `logger.info('perf', ...)` and clear.
+ * Intended to be called by the auto-dump timer; safe to call manually
+ * for tests.
+ */
+export function dumpAndReset(): void {
+  if (!PERF_ENABLED) return;
+  if (counters.size === 0) return;
+  const snap = snapshot();
+  counters.clear();
+  logger.info('perf', `[perf-counters] snapshot:`, snap);
+}
+
+// =============================================================================
+// Auto-dump timer
+// =============================================================================
+
+let dumpTimer: ReturnType<typeof setInterval> | null = null;
+
+function startAutoDump(): void {
+  if (dumpTimer !== null) return;
+  if (!PERF_ENABLED) return;
+  const ms = detectDumpIntervalMs();
+  dumpTimer = setInterval(() => {
+    try {
+      dumpAndReset();
+    } catch {
+      /* never let the dump path throw into the event loop */
+    }
+  }, ms);
+  // Don't keep the event loop alive just for the dump timer.
+  if (typeof (dumpTimer as { unref?: () => void }).unref === 'function') {
+    (dumpTimer as { unref?: () => void }).unref!();
+  }
+}
+
+/**
+ * Stop the auto-dump timer (test cleanup; not for production).
+ */
+export function __stopAutoDumpForTest(): void {
+  if (dumpTimer !== null) {
+    clearInterval(dumpTimer);
+    dumpTimer = null;
+  }
+}
+
+/**
+ * Toggle PERF_ENABLED at runtime. Tests only. In production the flag
+ * is read once at module load.
+ */
+export function __setPerfEnabledForTest(value: boolean): void {
+  PERF_ENABLED = value;
+  if (value) startAutoDump();
+  else __stopAutoDumpForTest();
+}
+
+/**
+ * Public: is perf measurement currently on? Useful for callers that
+ * want to skip building expensive instrumentation payloads when off.
+ */
+export function isPerfEnabled(): boolean {
+  return PERF_ENABLED;
+}
+
+// Boot the auto-dump if env enables it at module load.
+startAutoDump();

--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -174,17 +174,55 @@ wait_for_invoice_visible() {
 #     output captured when the CLI runs in verbose mode. Wall-clock
 #     timestamps + monotonic counters (event IDs, bundle counts) make
 #     these lines pure noise for state comparison.
+#   - "[perf-counters] snapshot: { ... }" — MULTI-LINE perf dump emitted
+#     by core/perf-counters.ts on a setInterval when SPHERE_PERF=1. The
+#     opening line is timestamped (and would be stripped by the ISO rule
+#     below), but the continuation lines and the bare closing `}` at
+#     column 0 survive a per-line sed filter and produce spurious
+#     diffs between otherwise-equal snapshots. Issue #364 Item #6.
 #
 # Filtering operates on a temp file the caller hands to diff, leaving
 # the original snapshot untouched for forensics.
+#
+# Implementation note: the awk pass runs FIRST so it can detect the
+# opening `[perf-counters] snapshot: {` line even when that line is
+# timestamped (and would otherwise be eaten by the ISO sed rule before
+# awk gets to see it). The awk state machine drops every line from
+# the opening through the matching closing `}` at column 0 inclusive.
 normalize_snapshot() {
   # shellcheck disable=SC2016
-  sed -E \
+  awk '
+    BEGIN { in_perf = 0 }
+    {
+      if (in_perf) {
+        # Closing brace of the perf-block — always at column 0 because
+        # Node util.inspect renders the top-level } unindented.
+        if ($0 ~ /^\}[[:space:]]*$/) {
+          in_perf = 0
+        }
+        next
+      }
+      # Detect opening of a perf-counters snapshot block. Substring
+      # match works for both timestamped ("[ISO] [INFO ] [perf] ...")
+      # and untimestamped ("[perf] ...") logger output.
+      if (index($0, "[perf-counters] snapshot:") > 0) {
+        # Single-line snapshot (1-counter case): line ends with "}".
+        # Drop and stay outside block mode.
+        if ($0 ~ /\}[[:space:]]*$/) {
+          next
+        }
+        # Multi-line snapshot: line ends with "{". Drop and enter
+        # block mode so subsequent continuation lines are dropped too.
+        in_perf = 1
+        next
+      }
+      print
+    }
+  ' "$1" | sed -E \
     -e '/^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z\] /d' \
     -e '/^  IPFS: \+[0-9]+ added, -[0-9]+ removed$/d' \
     -e '/^Syncing\.\.\.$/d' \
-    -e '/^  Ready\.$/d' \
-    "$1"
+    -e '/^  Ready\.$/d'
 }
 
 assert_diff_empty() {
@@ -201,6 +239,182 @@ assert_diff_empty() {
     return 1
   fi
 }
+
+# ---------------------------------------------------------------------------
+# Optional self-test for normalize_snapshot()
+#
+# Run with: RUN_NORMALIZE_TESTS=1 bash manual-test-full-recovery.sh
+#
+# Pipes synthetic snapshots that EQUAL each other modulo `[perf-counters]
+# snapshot:` blocks through normalize_snapshot() and asserts the diff is
+# empty. Protects against regressions of the #364 Item #6 fix where the
+# multi-line perf dump contaminates byte comparisons between
+# logically-equivalent `sphere status` / `sphere balance` outputs.
+#
+# Exits 0 on pass, non-zero on fail. Bypasses the teardown trap.
+# ---------------------------------------------------------------------------
+
+run_normalize_self_tests() {
+  local tmpdir a b na nb rc=0
+  tmpdir="$(mktemp -d -t normalize-tests.XXXXXX)"
+  a="$tmpdir/a.txt"
+  b="$tmpdir/b.txt"
+  na="$tmpdir/a.norm"
+  nb="$tmpdir/b.norm"
+
+  echo "=== normalize_snapshot self-tests ==="
+
+  # ---- T1: multi-line perf block (untimestamped) ----
+  cat > "$a" <<'EOF'
+Balance: 11 UCT
+Tokens: 3
+EOF
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[perf] [perf-counters] snapshot: {
+  'profile.applySnapshot': { count: 42, totalMs: 123.4, avgMs: 2.9, maxMs: 9.8 },
+  'aggregator.fetch': { count: 7, totalMs: 12.3, avgMs: 1.7, maxMs: 4.5 }
+}
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T1 OK: multi-line untimestamped perf block stripped"
+  else
+    echo "T1 FAIL: multi-line untimestamped perf block leaked" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T2: multi-line perf block (timestamped opening) ----
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[2026-05-31T12:34:56.789Z] [INFO ] [perf] [perf-counters] snapshot: {
+  'profile.applySnapshot': { count: 42, totalMs: 123.4, avgMs: 2.9, maxMs: 9.8 },
+  'aggregator.fetch': { count: 7, totalMs: 12.3, avgMs: 1.7, maxMs: 4.5 }
+}
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T2 OK: timestamped-opening perf block stripped"
+  else
+    echo "T2 FAIL: timestamped-opening perf block leaked" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T3: single-line perf block (1-counter case) ----
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[perf] [perf-counters] snapshot: { a: { count: 1, totalMs: 2, avgMs: 2, maxMs: 2 } }
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T3 OK: single-line perf block stripped"
+  else
+    echo "T3 FAIL: single-line perf block leaked" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T4: multiple consecutive perf blocks ----
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[perf] [perf-counters] snapshot: {
+  'a.b.c': { count: 1, totalMs: 2, avgMs: 2, maxMs: 2 },
+  'd.e.f': { count: 3, totalMs: 4, avgMs: 4, maxMs: 4 }
+}
+[perf] [perf-counters] snapshot: {
+  'g.h.i': { count: 5, totalMs: 6, avgMs: 6, maxMs: 6 }
+}
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T4 OK: multiple consecutive perf blocks stripped"
+  else
+    echo "T4 FAIL: multiple consecutive perf blocks leaked" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T5: existing strips still work (ISO + IPFS + Syncing + Ready) ----
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[2026-05-31T12:34:56.789Z] [INFO ] [Sphere] something happened
+  IPFS: +3 added, -1 removed
+Syncing...
+  Ready.
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T5 OK: legacy strips intact"
+  else
+    echo "T5 FAIL: legacy strips broken" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T6: counter name containing '}' must not exit perf block early ----
+  # Defensive: counter names in our codebase are dot-paths, but a future
+  # operator-style counter could contain literal braces. We trust the
+  # column-0 anchor of the closing `}` per Node util.inspect formatting.
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+[perf] [perf-counters] snapshot: {
+  'odd}name': { count: 1, totalMs: 2, avgMs: 2, maxMs: 2 },
+  'other': { count: 3, totalMs: 4, avgMs: 4, maxMs: 4 }
+}
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T6 OK: indented '}' inside counter name does not exit block"
+  else
+    echo "T6 FAIL: indented '}' inside counter name exited block early" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T7: no perf block — identical inputs stay identical ----
+  cat > "$b" <<'EOF'
+Balance: 11 UCT
+Tokens: 3
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T7 OK: identity passthrough"
+  else
+    echo "T7 FAIL: passthrough corrupted equal inputs" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  rm -rf "$tmpdir"
+  if (( rc == 0 )); then
+    echo "=== normalize_snapshot self-tests: ALL PASS ==="
+  else
+    echo "=== normalize_snapshot self-tests: FAILED ===" >&2
+  fi
+  return "$rc"
+}
+
+if [[ "${RUN_NORMALIZE_TESTS:-}" == "1" ]]; then
+  run_normalize_self_tests
+  # Bypass teardown trap — nothing was created.
+  trap - EXIT INT TERM
+  exit $?
+fi
 
 # Wall-clock anchor + per-section elapsed. SECTION_T0 is set the first
 # time `banner` is invoked; SECTION_LAST_TS tracks the previous banner so

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1673,6 +1673,27 @@ export class PaymentsModule {
 
   // NOSTR-FIRST proof polling (background proof verification)
   private proofPollingJobs: Map<string, ProofPollingJob> = new Map();
+
+  /**
+   * Issue #378 (#275 P4) — persistent ledger of V6-RECOVER permanent
+   * verdicts. Keyed by in-memory `Token.id`; value carries the verdict
+   * label + timestamp the recovery code stamped at the time the
+   * permanent classification was determined.
+   *
+   * Read by `drainPendingFinalizations` (and the stranded-token
+   * registration scan in `recoverStrandedReceivedTokens`) so a
+   * subsequent `sphere balance` / `sphere payments receive`
+   * invocation does NOT re-pay the 60s drain timeout polling a token
+   * whose V6-RECOVER verdict is already known to be unrecoverable.
+   *
+   * Hydrated by `restoreV6RecoverPermanent()` on `load()` so the
+   * verdict survives process restart. Cleared by `Sphere.clear()`
+   * (full wallet wipe — the underlying KV key goes with it) and by
+   * `payments receive --finalize` (operator-forced retry: clears the
+   * map so the recovery path runs one more time in case the HD-index
+   * recovery window has since widened).
+   */
+  private v6RecoverPermanent: Map<string, { reason: string; ts: number }> = new Map();
   /**
    * Lowercase hex of the signing-service publicKey used by
    * `UnmaskedPredicate.create` / `MaskedPredicate.create`. Lazily
@@ -3691,6 +3712,22 @@ export class PaymentsModule {
         await this.restoreProofPollingJobs();
       } catch (err) {
         logger.error('Payments', '[V6-RESTORE] Failed to restore proof-polling jobs:', err);
+      }
+
+      // Issue #378 (#275 P4) — hydrate the V6-RECOVER permanent-verdict
+      // ledger BEFORE `recoverStrandedReceivedTokens` runs so the scan
+      // below sees the marker and skips already-failed tokens. Without
+      // this ordering, a cold-start would re-register every previously-
+      // permanent token for another round of probe + finalize work —
+      // exactly the redundant-polling pattern this commit eliminates.
+      try {
+        await this.restoreV6RecoverPermanent();
+      } catch (err) {
+        logger.error(
+          'Payments',
+          '[V6-RECOVER-PERM] Failed to restore permanent-verdict ledger:',
+          err,
+        );
       }
 
       // Recover stranded V6-direct receives (#144 L3 migration). Walks
@@ -7819,6 +7856,34 @@ export class PaymentsModule {
     const result: ReceiveResult = { transfers: received };
 
     if (opts.finalize) {
+      // Issue #378 (#275 P4) — `receive({ finalize: true })` is the
+      // operator-forced retry path. Clear the persistent permanent-
+      // verdict ledger so any token previously classified as
+      // unrecoverable gets one more shot at finalization. The
+      // recovery scan that runs below (via `drainPendingFinalizations`
+      // → `resolveUnconfirmed`) will re-derive the verdict from
+      // first principles; if the underlying condition genuinely
+      // hasn't cleared (HD index still doesn't cover the recipient,
+      // structural shape still broken) the ledger is re-stamped on
+      // the next round and subsequent non-forced calls short-circuit
+      // again. The empty-map clear is best-effort — a save failure
+      // logs and proceeds; the in-memory clear has already taken
+      // effect for this drain.
+      if (this.v6RecoverPermanent.size > 0) {
+        const clearedCount = this.v6RecoverPermanent.size;
+        this.v6RecoverPermanent.clear();
+        this.saveV6RecoverPermanent().catch((persistErr) =>
+          logger.debug(
+            'Payments',
+            `[V6-RECOVER-PERM] saveV6RecoverPermanent after forced-retry clear failed:`,
+            persistErr,
+          ),
+        );
+        logger.debug(
+          'Payments',
+          `[V6-RECOVER-PERM] Cleared ${clearedCount} permanent-verdict entries for forced retry`,
+        );
+      }
       const drain = await this.drainPendingFinalizations({
         timeoutMs: opts.timeout ?? 60_000,
         pollIntervalMs: opts.pollInterval ?? 2_000,
@@ -7874,10 +7939,20 @@ export class PaymentsModule {
     // that haven't yet reached `addToken` (their tokens are not in
     // `this.tokens` yet, so the status scan below would miss them).
     // See `inflightReceiveCount` doc for why.
+    //
+    // Issue #378 (#275 P4) — a token whose tokenId is in the persistent
+    // `v6RecoverPermanent` ledger is intentionally EXCLUDED from the
+    // drain predicate even if its status reverted to 'submitted' /
+    // 'pending'. The V6-RECOVER verdict is final ("HD-index recovery
+    // exhausted" / "structural failure" — no retry semantically
+    // recovers it); polling it on every `sphere balance` is wasted
+    // wall-clock that historically stacked to ~60s per command.
     const hasUnconfirmedOrInflight = (): boolean =>
       this.inflightReceiveCount > 0 ||
-      Array.from(this.tokens.values()).some(
-        (t) => t.status === 'submitted' || t.status === 'pending',
+      Array.from(this.tokens.entries()).some(
+        ([tokenId, t]) =>
+          (t.status === 'submitted' || t.status === 'pending') &&
+          !this.v6RecoverPermanent.has(tokenId),
       );
 
     // Drain ingest worker pool first (UXF v1 path, defense in depth).
@@ -9329,6 +9404,15 @@ export class PaymentsModule {
     for (const [tokenId, token] of this.tokens) {
       if (token.status !== 'pending') continue;
       if (this.proofPollingJobs.has(tokenId)) continue;
+      // Issue #378 (#275 P4) — a tokenId already in the persistent
+      // permanent-verdict ledger has been classified as un-recoverable
+      // (HD-index recovery exhausted or structural failure). Re-running
+      // the recovery scan against it on every cold start would pay
+      // multi-second probe + finalize costs per stranded token without
+      // ever changing the verdict. Skip until an operator explicitly
+      // forces a retry via `payments receive --finalize` (which clears
+      // the ledger).
+      if (this.v6RecoverPermanent.has(tokenId)) continue;
       if (this.parsePendingFinalization(token.sdkData)) continue;
       if (!this.isReceivedLegacyPending(token)) continue;
 
@@ -9767,6 +9851,29 @@ export class PaymentsModule {
             logger.warn('Payments', `[V6-RECOVER] Failed to persist invalid status for ${tokenId.slice(0, 12)}:`, saveErr);
           }
         }
+
+        // 1a. Issue #378 (#275 P4) — record the verdict in the
+        // persistent ledger so subsequent `drainPendingFinalizations`
+        // and `recoverStrandedReceivedTokens` scans short-circuit
+        // this tokenId in <100ms instead of repeating the V6-RECOVER
+        // probe + the 60s drain timeout. Defense-in-depth above the
+        // status='invalid' write at step 1: a load() that re-ingests
+        // the source TXF bytes from disk would re-derive the in-memory
+        // token map and could (depending on the storage layer's
+        // status-merge semantics) restore the original 'submitted'
+        // status. The persistent ledger key is independent of the
+        // token bytes and so survives those round-trips deterministically.
+        this.v6RecoverPermanent.set(tokenId, {
+          reason: classLabel,
+          ts: Date.now(),
+        });
+        this.saveV6RecoverPermanent().catch((persistErr) =>
+          logger.debug(
+            'Payments',
+            `[V6-RECOVER-PERM] saveV6RecoverPermanent after permanent-fail mark failed:`,
+            persistErr,
+          ),
+        );
 
         // 2. Remove the proof-polling job and persist the change.
         this.proofPollingJobs.delete(tokenId);
@@ -16958,6 +17065,102 @@ export class PaymentsModule {
         `[V6-RESTORE] Restored ${restored} proof-polling job(s) from storage`
       );
       this.startProofPolling();
+    }
+  }
+
+  // ===========================================================================
+  // Issue #378 (#275 P4) — V6-RECOVER permanent-verdict persistence
+  // ===========================================================================
+
+  /**
+   * Persist the `v6RecoverPermanent` map to storage so the verdict
+   * survives process restart. Fire-and-forget at call sites — failures
+   * are logged via the caller's catch arm; the next call re-attempts.
+   *
+   * Empty map → `storage.remove()` so a stale list does not survive
+   * (mirrors `saveProofPollingJobs` exactly).
+   */
+  private async saveV6RecoverPermanent(): Promise<void> {
+    const entries = Array.from(this.v6RecoverPermanent.entries()).map(
+      ([tokenId, v]) => ({ tokenId, reason: v.reason, ts: v.ts }),
+    );
+
+    if (entries.length === 0) {
+      const storage = this.deps!.storage;
+      const removeFn = (storage as { remove?: (k: string) => Promise<void> }).remove;
+      if (typeof removeFn === 'function') {
+        await removeFn.call(storage, STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT);
+      } else {
+        await this.setStorageEntry(
+          STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT,
+          '[]',
+          'cache_index',
+        );
+      }
+      return;
+    }
+
+    await this.setStorageEntry(
+      STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT,
+      JSON.stringify(entries),
+      'cache_index',
+    );
+  }
+
+  /**
+   * Restore the `v6RecoverPermanent` map from storage. Called from
+   * `load()` AFTER `loadFromStorageData` populates `this.tokens`.
+   *
+   * Malformed entries are silently skipped — a single stray entry must
+   * not block legitimate verdicts. A wholly-malformed payload is logged
+   * once and the map starts empty.
+   */
+  private async restoreV6RecoverPermanent(): Promise<void> {
+    const data = await this.deps!.storage.get(
+      STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT,
+    );
+    if (!data) return;
+
+    let entries: Array<{ tokenId: string; reason: string; ts: number }>;
+    try {
+      const parsed = JSON.parse(data);
+      if (!Array.isArray(parsed)) {
+        logger.error(
+          'Payments',
+          '[V6-RECOVER-PERM] Persisted ledger is not an array; clearing',
+        );
+        return;
+      }
+      entries = parsed as Array<{ tokenId: string; reason: string; ts: number }>;
+    } catch (err) {
+      logger.error(
+        'Payments',
+        '[V6-RECOVER-PERM] Failed to parse persisted ledger:',
+        err,
+      );
+      return;
+    }
+
+    let restored = 0;
+    for (const e of entries) {
+      if (
+        typeof e?.tokenId !== 'string' ||
+        e.tokenId.length === 0 ||
+        typeof e.reason !== 'string' ||
+        typeof e.ts !== 'number' ||
+        !Number.isFinite(e.ts)
+      ) {
+        continue;
+      }
+      this.v6RecoverPermanent.set(e.tokenId, { reason: e.reason, ts: e.ts });
+      restored += 1;
+    }
+
+    if (restored > 0) {
+      logger.debug(
+        'Payments',
+        `[V6-RECOVER-PERM] Restored ${restored} permanent-verdict entries from storage`,
+      );
     }
   }
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -17127,7 +17127,7 @@ export class PaymentsModule {
       if (!Array.isArray(parsed)) {
         logger.error(
           'Payments',
-          '[V6-RECOVER-PERM] Persisted ledger is not an array; clearing',
+          '[V6-RECOVER-PERM] Persisted ledger is not an array; ignoring (in-memory ledger preserved)',
         );
         return;
       }

--- a/oracle/UnicityAggregatorProvider.ts
+++ b/oracle/UnicityAggregatorProvider.ts
@@ -11,6 +11,7 @@
  */
 
 import { logger } from '../core/logger';
+import { incr, time } from '../core/perf-counters';
 import type { ProviderStatus } from '../types';
 import type {
   OracleProvider,
@@ -298,6 +299,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
    * Accepts either an SDK TransferCommitment or a simple commitment object.
    */
   async submitCommitment(commitment: TransferCommitment | SdkTransferCommitment): Promise<SubmitResult> {
+    return time('aggregator.submitCommitment', () => this._submitCommitmentImpl(commitment));
+  }
+  private async _submitCommitmentImpl(commitment: TransferCommitment | SdkTransferCommitment): Promise<SubmitResult> {
     this.ensureConnected();
 
     try {
@@ -358,6 +362,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
    * @param commitment - SDK MintCommitment instance
    */
   async submitMintCommitment(commitment: SdkMintCommitment): Promise<SubmitResult> {
+    return time('aggregator.submitMintCommitment', () => this._submitMintCommitmentImpl(commitment));
+  }
+  private async _submitMintCommitmentImpl(commitment: SdkMintCommitment): Promise<SubmitResult> {
     this.ensureConnected();
 
     try {
@@ -405,6 +412,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async getProof(requestId: string): Promise<InclusionProof | null> {
+    return time('aggregator.getProof', () => this._getProofImpl(requestId));
+  }
+  private async _getProofImpl(requestId: string): Promise<InclusionProof | null> {
     this.ensureConnected();
 
     try {
@@ -495,6 +505,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async waitForProof(requestId: string, options?: WaitOptions): Promise<InclusionProof> {
+    return time('aggregator.waitForProof', () => this._waitForProofImpl(requestId, options));
+  }
+  private async _waitForProofImpl(requestId: string, options?: WaitOptions): Promise<InclusionProof> {
     const timeout = options?.timeout ?? this.config.timeout;
     const pollInterval = options?.pollInterval ?? TIMEOUTS.PROOF_POLL_INTERVAL;
     const startTime = Date.now();
@@ -520,6 +533,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async validateToken(tokenData: unknown): Promise<ValidationResult> {
+    return time('aggregator.validateToken', () => this._validateTokenImpl(tokenData));
+  }
+  private async _validateTokenImpl(tokenData: unknown): Promise<ValidationResult> {
     this.ensureConnected();
 
     // Issue #245 #5 — parse the SDK token ONCE so we can reuse it for
@@ -641,6 +657,12 @@ export class UnicityAggregatorProvider implements OracleProvider {
    */
   async waitForProofSdk(
     commitment: SdkTransferCommitment | SdkMintCommitment,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    return time('aggregator.waitForProofSdk', () => this._waitForProofSdkImpl(commitment, signal));
+  }
+  private async _waitForProofSdkImpl(
+    commitment: SdkTransferCommitment | SdkMintCommitment,
     signal?: AbortSignal
   ): Promise<unknown> {
     this.ensureConnected();
@@ -681,6 +703,13 @@ export class UnicityAggregatorProvider implements OracleProvider {
   private static INCLUSION_PROOF_CACHE_MAX = 1024;
 
   async verifyInclusionProof(input: {
+    proofJson: unknown;
+    transactionHash: string;
+    proofHash?: string;
+  }): Promise<boolean> {
+    return time('aggregator.verifyInclusionProof', () => this._verifyInclusionProofImpl(input));
+  }
+  private async _verifyInclusionProofImpl(input: {
     proofJson: unknown;
     transactionHash: string;
     proofHash?: string;
@@ -806,6 +835,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async isSpent(publicKey: string, stateHash: string): Promise<boolean> {
+    return time('aggregator.isSpent', () => this._isSpentImpl(publicKey, stateHash));
+  }
+  private async _isSpentImpl(publicKey: string, stateHash: string): Promise<boolean> {
     // Cache key binds publicKey + stateHash. A given stateHash may
     // be commit-checked under multiple pubkeys in a multi-address
     // wallet; we MUST NOT cross-pollinate cache hits between keys.
@@ -924,6 +956,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async getTokenState(tokenId: string): Promise<TokenState | null> {
+    return time('aggregator.getTokenState', () => this._getTokenStateImpl(tokenId));
+  }
+  private async _getTokenStateImpl(tokenId: string): Promise<TokenState | null> {
     this.ensureConnected();
 
     try {
@@ -947,6 +982,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async getCurrentRound(): Promise<number> {
+    return time('aggregator.getCurrentRound', () => this._getCurrentRoundImpl());
+  }
+  private async _getCurrentRoundImpl(): Promise<number> {
     if (!this.aggregatorClient) {
       // Defensive: aggregator client is constructed in `initialize()`. If
       // `getCurrentRound()` is called before `initialize()` (or after a
@@ -965,6 +1003,9 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   async mint(params: MintParams): Promise<MintResult> {
+    return time('aggregator.mint', () => this._mintImpl(params));
+  }
+  private async _mintImpl(params: MintParams): Promise<MintResult> {
     this.ensureConnected();
 
     try {
@@ -1002,38 +1043,42 @@ export class UnicityAggregatorProvider implements OracleProvider {
   // ===========================================================================
 
   private async rpcCall<T>(method: string, params: unknown): Promise<T> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.config.timeout);
+    return time(`aggregator.rpc.${method}`, async () => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), this.config.timeout);
 
-    try {
-      const response = await fetch(this.config.url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: Date.now(),
-          method,
-          params,
-        }),
-        signal: controller.signal,
-      });
+      try {
+        const response = await fetch(this.config.url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: Date.now(),
+            method,
+            params,
+          }),
+          signal: controller.signal,
+        });
 
-      if (!response.ok) {
-        throw new SphereError(`HTTP ${response.status}: ${response.statusText}`, 'AGGREGATOR_ERROR');
+        if (!response.ok) {
+          incr(`aggregator.rpc.${method}.http_error`);
+          throw new SphereError(`HTTP ${response.status}: ${response.statusText}`, 'AGGREGATOR_ERROR');
+        }
+
+        const result = await response.json();
+
+        if (result.error) {
+          incr(`aggregator.rpc.${method}.rpc_error`);
+          throw new SphereError(result.error.message ?? 'RPC error', 'AGGREGATOR_ERROR');
+        }
+
+        return (result.result ?? {}) as T;
+      } finally {
+        clearTimeout(timeout);
       }
-
-      const result = await response.json();
-
-      if (result.error) {
-        throw new SphereError(result.error.message ?? 'RPC error', 'AGGREGATOR_ERROR');
-      }
-
-      return (result.result ?? {}) as T;
-    } finally {
-      clearTimeout(timeout);
-    }
+    });
   }
 
   // ===========================================================================

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -575,6 +575,31 @@ export class ProfilePointerLayer {
       resolveRemoteCid: this.#init.resolveRemoteCid,
       abortSignal,
     });
+    // Issue #366 — invalidate the recoverLatest head cache after a
+    // successful publish. The cache's pre-#366 design assumed the
+    // aggregator view was the only source of pointer-version change
+    // observable to this layer; a local publish that commits a new
+    // version (`reconcileAndPublish` returns without throwing) breaks
+    // that assumption. Downstream readers — chiefly the read-back loop
+    // at `LifecycleManager.awaitAggregatorPointerReadBack`, but also
+    // any caller polling after a flush — must see the freshly-committed
+    // version, not the cached pre-publish view served for the rest of
+    // the TTL window. The §D.4 wall-clock degradation observed in PR
+    // #365's A/B (243s → 467s when the cache was enabled) traced
+    // directly to this gap: the read-back loop spent the cache TTL
+    // re-asserting a stale answer.
+    //
+    // Cleared inside the `#publishInner` body (post-publish, pre-
+    // return) so EVERY successful publish path invalidates — including
+    // the fast-path that skips Step B (`result.attemptsUsed === 0`).
+    // The in-flight slot is NOT touched here: a concurrent recover
+    // that's already awaiting `#inFlightRecover` will still receive
+    // that round-trip's result. A NEW recover after this point starts
+    // fresh.
+    if (this.#cachedRecover !== null) {
+      incr('pointerLayer.recoverLatest.cacheInvalidatedOnPublish');
+      this.#cachedRecover = null;
+    }
     // Issue #264 steelman fix: only overwrite the probe history when
     // the publish actually ran a discovery walkback. The fast-path
     // (#263, attempts === 0) skips Step B and returns

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -60,7 +60,7 @@ import type { PointerMutex } from './mutex-lock.js';
 import { reconcileAndPublish, type FetchAndJoinCallback } from './reconcile-algorithm.js';
 import type { PointerSigner } from './signing.js';
 import type { BlockedState, PointerVersion } from './types.js';
-import { time } from '../../core/perf-counters.js';
+import { incr, time } from '../../core/perf-counters.js';
 
 // ── Constructor input ──────────────────────────────────────────────────────
 
@@ -121,6 +121,35 @@ export interface ProfilePointerLayerInit {
   ) => Promise<number | undefined>;
   /** Configuration (capabilities). */
   readonly config?: PointerLayerConfig;
+  /**
+   * Issue #364 Item #1 — TTL (ms) for the `recoverLatest()` head cache.
+   *
+   * A short cache eliminates the read-back tight-loop's redundant
+   * aggregator round-trips: the §D.4 recovery soak observed 108
+   * recoverLatest calls in 123 s (0.88/s), driven by the
+   * `awaitAggregatorPointerReadBack` loop polling every 500 ms while
+   * the per-call cost averages 250 ms. With this cache, only the first
+   * call in each TTL window hits the aggregator; subsequent calls
+   * within the window return the cached value in sub-millisecond time
+   * and bump the `pointerLayer.recoverLatest.cacheHit` counter.
+   *
+   * Concurrent callers that arrive while a call is in flight attach to
+   * the in-flight promise (`pointerLayer.recoverLatest.inFlightDedup`)
+   * rather than launching a parallel aggregator round-trip.
+   *
+   * Default: 10_000 (10 s). Trade-off rationale:
+   *   - The read-back loop's 500 ms poll cadence over a typical 30 s
+   *     shutdown-durability deadline drops from 60 calls to 3.
+   *   - The periodic pointer poll's 30-90 s cadence is unaffected
+   *     (each poll exceeds the TTL).
+   *   - New pointer versions are still observed within 10 s, which is
+   *     well inside the worst-case aggregator read-replica lag this
+   *     loop is designed to absorb.
+   *
+   * Set `0` to disable the cache entirely (every call hits the
+   * aggregator — restores pre-#364 behavior).
+   */
+  readonly recoverLatestCacheTtlMs?: number;
 }
 
 // ── Public result types ────────────────────────────────────────────────────
@@ -227,6 +256,21 @@ export class ProfilePointerLayer {
   // immediately after shutdown starts.
   #shuttingDown = false;
 
+  // ── Issue #364 Item #1 — recoverLatest head cache ──────────────────────
+  // Cached most-recent result of recoverLatest() with a short TTL.
+  // Subsequent calls within the TTL return the cached value, eliminating
+  // the read-back tight-loop's redundant aggregator round-trips.
+  // Cleared on shutdown(); concurrent callers attach to #inFlightRecover.
+  readonly #recoverCacheTtlMs: number;
+  #cachedRecover: {
+    readonly result: RecoverResult | RecoverAllUnfetchableResult | null;
+    readonly expiresAt: number;
+  } | null = null;
+  // In-flight dedup: when set, a concurrent recoverLatest awaits this
+  // promise instead of launching a parallel aggregator round-trip.
+  // Cleared in finally after settle (success or failure).
+  #inFlightRecover: Promise<RecoverResult | RecoverAllUnfetchableResult | null> | null = null;
+
   constructor(init: ProfilePointerLayerInit) {
     this.#init = init;
     // Steelman² remediation: extract just the known boolean fields
@@ -259,6 +303,17 @@ export class ProfilePointerLayer {
       enablePointerWinBroadcasts:
         suppliedConfig.enablePointerWinBroadcasts === true,
     });
+
+    // Issue #364 Item #1 — clamp the recoverLatest cache TTL. A non-
+    // finite / negative value disables the cache (treated as 0). The
+    // upper bound (60s) prevents pathological misconfigurations from
+    // pinning a stale aggregator view for arbitrarily long.
+    const rawTtl = init.recoverLatestCacheTtlMs;
+    const ttlCandidate =
+      typeof rawTtl === 'number' && Number.isFinite(rawTtl) && rawTtl >= 0
+        ? rawTtl
+        : 10_000;
+    this.#recoverCacheTtlMs = Math.min(ttlCandidate, 60_000);
   }
 
   /**
@@ -459,6 +514,11 @@ export class ProfilePointerLayer {
     // shutdown cycle. The fingerprint API is not safe to call after
     // shutdown anyway (#assertNotShuttingDown gates it).
     this.#lastProbeVersions = [];
+    // Issue #364 Item #1 — clear the recoverLatest cache so a future
+    // re-init reading a fresh aggregator view never observes stale
+    // bytes. The in-flight slot is cleared by the operation's own
+    // finally arm during the drain above.
+    this.#cachedRecover = null;
   }
 
   // ── publish ──────────────────────────────────────────────────────────────
@@ -567,9 +627,73 @@ export class ProfilePointerLayer {
   async recoverLatest(opts?: {
     abortSignal?: AbortSignal;
   }): Promise<RecoverResult | RecoverAllUnfetchableResult | null> {
-    return time('pointerLayer.recoverLatest', () => {
+    return time('pointerLayer.recoverLatest', async () => {
       this.#assertNotShuttingDown('recoverLatest');
-      return this.#tracked(this.#recoverLatestInner(opts?.abortSignal));
+      // Issue #364 Item #1 — cache-first path. The cache sits INSIDE
+      // the `time()` wrapper so hit/miss latencies both count toward
+      // the aggregate cost recorded in `pointerLayer.recoverLatest`.
+      // Cache hits are sub-millisecond, which shows up in the counter
+      // snapshot as a dramatic drop in totalMs/avgMs without changing
+      // the call count semantic (every public call is counted once).
+      const abortSignal = opts?.abortSignal;
+      if (abortSignal?.aborted) {
+        const err = new Error('recoverLatest aborted by caller');
+        err.name = 'AbortError';
+        throw err;
+      }
+      // Cache hit: serve from #cachedRecover when within TTL. The
+      // cached value is shared across callers — this is sound because
+      // RecoverResult / RecoverAllUnfetchableResult / null are
+      // immutable value types from the caller's perspective.
+      if (this.#recoverCacheTtlMs > 0 && this.#cachedRecover !== null) {
+        if (Date.now() < this.#cachedRecover.expiresAt) {
+          incr('pointerLayer.recoverLatest.cacheHit');
+          return this.#cachedRecover.result;
+        }
+        // TTL expired — fall through to a fresh aggregator round-trip.
+        incr('pointerLayer.recoverLatest.cacheStale');
+        this.#cachedRecover = null;
+      }
+      // In-flight dedup: a concurrent caller already triggered the
+      // aggregator call. Attach to the same promise instead of
+      // launching a parallel round-trip. The attached caller does NOT
+      // share the upstream call's abort signal — aborting one waiter
+      // must not cancel the request for the others (we've already
+      // checked our own signal above).
+      if (this.#inFlightRecover !== null) {
+        incr('pointerLayer.recoverLatest.inFlightDedup');
+        return this.#inFlightRecover;
+      }
+      // cacheMiss is only meaningful when caching is enabled. With
+      // TTL=0 (cache disabled) every call is structurally a miss and
+      // emitting the counter would conflate the two modes.
+      if (this.#recoverCacheTtlMs > 0) {
+        incr('pointerLayer.recoverLatest.cacheMiss');
+      }
+      const inner = this.#tracked(this.#recoverLatestInner(abortSignal));
+      this.#inFlightRecover = inner;
+      try {
+        const result = await inner;
+        // Populate the cache only when the TTL is enabled. A fresh
+        // shutdown() between launch and settle clears #cachedRecover
+        // below; we still record the result on the local variable so
+        // any awaiting callers receive it consistently.
+        if (this.#recoverCacheTtlMs > 0 && !this.#shuttingDown) {
+          this.#cachedRecover = {
+            result,
+            expiresAt: Date.now() + this.#recoverCacheTtlMs,
+          };
+        }
+        return result;
+      } finally {
+        // Always clear the in-flight slot, even on failure — the next
+        // call should retry the aggregator rather than re-throwing the
+        // cached rejection (which would defeat the read-back retry
+        // loop's recovery semantics).
+        if (this.#inFlightRecover === inner) {
+          this.#inFlightRecover = null;
+        }
+      }
     });
   }
 

--- a/profile/aggregator-pointer/ProfilePointerLayer.ts
+++ b/profile/aggregator-pointer/ProfilePointerLayer.ts
@@ -60,6 +60,7 @@ import type { PointerMutex } from './mutex-lock.js';
 import { reconcileAndPublish, type FetchAndJoinCallback } from './reconcile-algorithm.js';
 import type { PointerSigner } from './signing.js';
 import type { BlockedState, PointerVersion } from './types.js';
+import { time } from '../../core/perf-counters.js';
 
 // ── Constructor input ──────────────────────────────────────────────────────
 
@@ -566,8 +567,10 @@ export class ProfilePointerLayer {
   async recoverLatest(opts?: {
     abortSignal?: AbortSignal;
   }): Promise<RecoverResult | RecoverAllUnfetchableResult | null> {
-    this.#assertNotShuttingDown('recoverLatest');
-    return this.#tracked(this.#recoverLatestInner(opts?.abortSignal));
+    return time('pointerLayer.recoverLatest', () => {
+      this.#assertNotShuttingDown('recoverLatest');
+      return this.#tracked(this.#recoverLatestInner(opts?.abortSignal));
+    });
   }
 
   async #recoverLatestInner(
@@ -699,8 +702,10 @@ export class ProfilePointerLayer {
     walkbackLimit?: number,
     opts?: { abortSignal?: AbortSignal },
   ): Promise<DiscoverResult> {
-    this.#assertNotShuttingDown('discoverLatestVersion');
-    return this.#tracked(this.#discoverLatestVersionInner(walkbackLimit, opts?.abortSignal));
+    return time('pointerLayer.discoverLatestVersion', () => {
+      this.#assertNotShuttingDown('discoverLatestVersion');
+      return this.#tracked(this.#discoverLatestVersionInner(walkbackLimit, opts?.abortSignal));
+    });
   }
 
   async #discoverLatestVersionInner(
@@ -1127,20 +1132,23 @@ export class ProfilePointerLayer {
 
   /** Low-level probe for a single version — H2 OR-predicate. */
   async probe(v: PointerVersion): Promise<boolean> {
-    this.#assertNotShuttingDown('probe');
-    return this.#tracked(probeVersion({
-      v,
-      keyMaterial: this.#init.keyMaterial,
-      signer: this.#init.signer,
-      aggregatorClient: this.#init.aggregatorClient,
-      trustBase: this.#init.trustBase,
-    }));
+    return time('pointerLayer.probe', () => {
+      this.#assertNotShuttingDown('probe');
+      return this.#tracked(probeVersion({
+        v,
+        keyMaterial: this.#init.keyMaterial,
+        signer: this.#init.signer,
+        aggregatorClient: this.#init.aggregatorClient,
+        trustBase: this.#init.trustBase,
+      }));
+    });
   }
 
   /** Low-level classifyVersion. */
   async classify(v: PointerVersion): Promise<'VALID' | 'SEMANTICALLY_INVALID' | 'PROOF_TRANSIENT' | 'CAR_TRANSIENT'> {
-    this.#assertNotShuttingDown('classify');
-    return this.#tracked(classifyVersion({
+    return time('pointerLayer.classify', () => {
+      this.#assertNotShuttingDown('classify');
+      return this.#tracked(classifyVersion({
       v,
       keyMaterial: this.#init.keyMaterial,
       signer: this.#init.signer,
@@ -1149,5 +1157,6 @@ export class ProfilePointerLayer {
       decodeCid: this.#init.decodeCid,
       fetchCar: this.#init.fetchCar,
     }));
+    });
   }
 }

--- a/profile/aggregator-pointer/discover-algorithm.ts
+++ b/profile/aggregator-pointer/discover-algorithm.ts
@@ -136,6 +136,7 @@ import {
   VERSION_MAX,
 } from './constants.js';
 import { AggregatorPointerError, AggregatorPointerErrorCode } from './errors.js';
+import { time } from '../../core/perf-counters.js';
 import type { PointerKeyMaterial } from './key-derivation.js';
 import type { PointerSigner } from './signing.js';
 import type { PointerVersion } from './types.js';
@@ -280,6 +281,9 @@ export interface DiscoverResult {
 // ── findLatestValidVersion ─────────────────────────────────────────────────
 
 export async function findLatestValidVersion(input: DiscoverInput): Promise<DiscoverResult> {
+  return time('pointerLayer.findLatestValidVersion', () => _findLatestValidVersionImpl(input));
+}
+async function _findLatestValidVersionImpl(input: DiscoverInput): Promise<DiscoverResult> {
   // Wave G.4: small wrapper that ensures the external-abort listener
   // is removed on every exit path (success, throw, abort). Without
   // this, a long-lived caller signal would leak a closure-reference

--- a/profile/factory.ts
+++ b/profile/factory.ts
@@ -30,6 +30,7 @@ import {
   type LeanProfileSnapshot,
 } from './profile-lean-snapshot';
 import { fetchFromIpfs, pinCarBlocksToIpfs } from './ipfs-client';
+import { time, incr, observeMs } from '../core/perf-counters';
 import {
   LOCAL_EPOCH_FLOOR_KEY,
   LOCAL_EPOCH_RESET_REASON_KEY,
@@ -817,6 +818,8 @@ export function createProfileProviders(
   // object is built. The provider's late-binding setter resolves this
   // ordering cleanly.
   tokenStorage.setApplySnapshotCallback(async (cidString) => {
+    incr('applySnapshotCb.calls');
+    const __cbStart = performance.now();
     // `dag/put` (used by `pinCarBlocksToIpfs`) stored each CAR block
     // under its canonical CID, so `block/get(rootCid)` returns the
     // dag-cbor encoded root block bytes (NOT a CAR envelope).
@@ -835,19 +838,19 @@ export function createProfileProviders(
     // accessor as the bundle load path: cross-process snapshot apply
     // becomes deterministic, cross-device apply falls back to HTTP.
     const helia = db.getHelia?.();
-    const rootBlockBytes = await fetchFromIpfs(
-      ipfsGateways,
-      cidString,
-      undefined,
-      undefined,
-      helia,
+    const rootBlockBytes = await time('applySnapshotCb.fetchRootMs', () =>
+      fetchFromIpfs(ipfsGateways, cidString, undefined, undefined, helia),
     );
-    const snapshot = await parseLeanProfileSnapshotFromRootBlock(
-      rootBlockBytes,
-      (subBlockCid) =>
-        fetchFromIpfs(ipfsGateways, subBlockCid, undefined, undefined, helia),
+    const snapshot = await time('applySnapshotCb.parseSnapshotMs', () =>
+      parseLeanProfileSnapshotFromRootBlock(
+        rootBlockBytes,
+        (subBlockCid) =>
+          fetchFromIpfs(ipfsGateways, subBlockCid, undefined, undefined, helia),
+      ),
     );
-    return dispatchParsedSnapshot(snapshot);
+    const result = await time('applySnapshotCb.dispatchMs', () => dispatchParsedSnapshot(snapshot));
+    observeMs('applySnapshotCb.totalMs', performance.now() - __cbStart);
+    return result;
   });
 
   return { storage, tokenStorage };

--- a/profile/factory.ts
+++ b/profile/factory.ts
@@ -370,10 +370,12 @@ export interface ProfileSnapshotApplyDeps {
 export function runProfileSnapshotApply(
   snapshot: LeanProfileSnapshot,
   deps: ProfileSnapshotApplyDeps,
+  sourcePointerCid?: string,
 ): Promise<ApplySnapshotResult> {
   return runProfileSnapshotJoin(snapshot, {
     writersFor: deps.writersFor,
     bundleIndex: deps.getBundleIndex(),
+    sourcePointerCid,
     log: deps.log,
   });
 }
@@ -704,6 +706,7 @@ export function createProfileProviders(
   // instances (the adapter is a thin handle over `db` + key).
   const dispatchParsedSnapshot = (
     snapshot: LeanProfileSnapshot,
+    sourcePointerCid?: string,
   ): Promise<ApplySnapshotResult> =>
     runProfileSnapshotApply(snapshot, {
       writersFor: (addressId) => {
@@ -792,9 +795,11 @@ export function createProfileProviders(
         return writers;
       },
       getBundleIndex: () => tokenStorage.getBundleIndex(),
-    });
+    }, sourcePointerCid);
 
-  storage.setSnapshotApplier((snapshot) => dispatchParsedSnapshot(snapshot));
+  storage.setSnapshotApplier((snapshot, sourcePointerCid) =>
+    dispatchParsedSnapshot(snapshot, sourcePointerCid),
+  );
 
   // Item #15 Phase E follow-up — install the pull-side dispatcher for
   // the periodic-poll / cold-start recovery paths. Symmetric to
@@ -848,7 +853,7 @@ export function createProfileProviders(
           fetchFromIpfs(ipfsGateways, subBlockCid, undefined, undefined, helia),
       ),
     );
-    const result = await time('applySnapshotCb.dispatchMs', () => dispatchParsedSnapshot(snapshot));
+    const result = await time('applySnapshotCb.dispatchMs', () => dispatchParsedSnapshot(snapshot, cidString));
     observeMs('applySnapshotCb.totalMs', performance.now() - __cbStart);
     return result;
   });

--- a/profile/global-clear-gate.ts
+++ b/profile/global-clear-gate.ts
@@ -1,0 +1,95 @@
+/**
+ * profile/global-clear-gate.ts — process-wide gate consulted by
+ * `ProfileTokenStorageProvider._applySnapshotIfWiredImpl` to suppress
+ * snapshot dispatch during multi-wallet `Sphere.clear()` sequences.
+ *
+ * # Why a separate module
+ *
+ * Item #2 (issue #364) ships the per-instance `isClearing` latch on
+ * `ProfileTokenStorageProvider`. It correctly suppresses
+ * `applySnapshotIfWired` for THE provider whose `clear()` is in flight.
+ * It does NOT cover the multi-wallet workflow where `Sphere.clear()` is
+ * invoked sequentially across several wallets in the same process (or
+ * where multi-wallet apps like sphere.telco have many providers running
+ * concurrently): while wallet A is being cleared, wallets B/C/D's
+ * periodic pointer-polls keep firing `applySnapshotIfWired` against
+ * state that is about to be wiped when their own `clear()` runs next.
+ *
+ * Putting the state on `ProfileTokenStorageProvider` as a class-static
+ * would couple `core/Sphere.ts` directly to the provider class. A small
+ * dedicated module keeps the dependency direction clean: both
+ * `core/Sphere.ts` and `profile/profile-token-storage-provider.ts`
+ * import this leaf module.
+ *
+ * # Semantics
+ *
+ *   - Reference counted, not boolean. Multiple orchestrators (a batch
+ *     wrapper AND the per-call `Sphere.clear()` body) may bracket the
+ *     same range; both increments and the matching decrements compose.
+ *   - {@link endGlobalClear} is no-op-safe when the depth is already 0
+ *     so a stray double-end can't push the counter negative.
+ *   - Process-scoped — there is one counter per JS realm. Cross-process
+ *     coordination is not in scope (each process is its own clear; the
+ *     filesystem/IndexedDB locks already serialize cross-process
+ *     wallet wipes).
+ *
+ * # Usage
+ *
+ * ```ts
+ * import { beginGlobalClear, endGlobalClear } from './global-clear-gate';
+ *
+ * beginGlobalClear();
+ * try {
+ *   // existing destructive sequence …
+ * } finally {
+ *   endGlobalClear();
+ * }
+ * ```
+ *
+ * @module profile/global-clear-gate
+ * @see profile/profile-token-storage-provider.ts:_applySnapshotIfWiredImpl
+ * @see core/Sphere.ts:Sphere.clear
+ */
+
+let depth = 0;
+
+/**
+ * Increment the process-wide global-clear depth. MUST be paired with
+ * {@link endGlobalClear} in a `try/finally`. Idempotent on the
+ * increment side — nesting composes.
+ */
+export function beginGlobalClear(): void {
+  depth += 1;
+}
+
+/**
+ * Decrement the process-wide global-clear depth. No-op-safe when the
+ * depth is already 0 — a stray extra-end is harmless rather than
+ * negative-going corruption.
+ */
+export function endGlobalClear(): void {
+  if (depth > 0) {
+    depth -= 1;
+  }
+}
+
+/**
+ * Read the current process-wide global-clear depth. Returns `true`
+ * whenever at least one orchestrator currently holds the bracket.
+ * Exposed for tests and operator surfaces; production callers should
+ * use {@link beginGlobalClear} / {@link endGlobalClear} rather than
+ * polling.
+ */
+export function isGlobalClearActive(): boolean {
+  return depth > 0;
+}
+
+/**
+ * Test-only — reset the counter to 0. Other production paths must NOT
+ * call this; the begin/end protocol is the public contract. Tests
+ * occasionally need a hard reset to recover from a failure that left
+ * a bracket unclosed.
+ */
+export function __resetGlobalClearForTest(): void {
+  depth = 0;
+}

--- a/profile/helia-blockstore-pin-shim.ts
+++ b/profile/helia-blockstore-pin-shim.ts
@@ -55,6 +55,7 @@
  */
 
 import { logger } from '../core/logger';
+import { incr, observeMs } from '../core/perf-counters.js';
 
 /** Minimal structural shape of the Helia v6+ pins API. */
 export interface HeliaPinsLike {
@@ -237,25 +238,34 @@ export function installHeliaBlockstorePinShim(
       source: AsyncIterable<{ cid: unknown; block: unknown }>,
       options?: unknown,
     ): AsyncIterable<unknown> {
+      incr('helia.blockstore.putMany.calls');
+      const __pmStart = performance.now();
       const upstream = originalPutMany(source, options);
       // Return an async generator that pins each yielded CID before
       // forwarding it. Pin is fire-and-forget per CID so a slow pin
       // doesn't stall the iterator chain.
       return (async function* pinningPutManyGen() {
-        for await (const yieldedCid of upstream) {
-          pinAttempted++;
-          // Pin in the background; the put is already complete by
-          // the time the iterator yielded the CID.
-          schedulePin(yieldedCid, pins, Promise.resolve())
-            .then((outcome) => {
-              if (outcome === 'pinned') pinSucceeded++;
-              else if (outcome === 'skipped') pinSkipped++;
-              else pinFailed++;
-            })
-            .catch(() => {
-              pinFailed++;
-            });
-          yield yieldedCid;
+        let itemCount = 0;
+        try {
+          for await (const yieldedCid of upstream) {
+            itemCount++;
+            pinAttempted++;
+            // Pin in the background; the put is already complete by
+            // the time the iterator yielded the CID.
+            schedulePin(yieldedCid, pins, Promise.resolve())
+              .then((outcome) => {
+                if (outcome === 'pinned') pinSucceeded++;
+                else if (outcome === 'skipped') pinSkipped++;
+                else pinFailed++;
+              })
+              .catch(() => {
+                pinFailed++;
+              });
+            yield yieldedCid;
+          }
+        } finally {
+          incr('helia.blockstore.putMany.items', itemCount);
+          observeMs('helia.blockstore.putMany.totalMs', performance.now() - __pmStart);
         }
       })();
     };
@@ -308,9 +318,12 @@ export function installHeliaBlockstorePinShim(
     // DevTools). The Set is the authoritative in-session tracker
     // populated below on success.
     if (pinnedCids.has(cidStr)) {
+      incr('helia.pins.add.cached');
       return 'pinned';
     }
 
+    incr('helia.pins.add.calls');
+    const __pStart = performance.now();
     try {
       const result = pinsApi.add(cid);
       // Helia v6 returns AsyncIterable<CID>; older / test stubs may
@@ -338,6 +351,7 @@ export function installHeliaBlockstorePinShim(
       // throwaway array — so the push did nothing. The actual
       // persistence is `pinnedCids.add(cidStr)` below.
       pinnedCids.add(cidStr);
+      observeMs('helia.pins.add.successMs', performance.now() - __pStart);
       return 'pinned';
     } catch (err) {
       // "Already pinned" is NOT a failure — Helia rejects re-adds with
@@ -351,6 +365,8 @@ export function installHeliaBlockstorePinShim(
       const msg = err instanceof Error ? err.message : String(err);
       if (/already pinned/i.test(msg)) {
         pinnedCids.add(cidStr);
+        incr('helia.pins.add.alreadyPinned');
+        observeMs('helia.pins.add.alreadyPinnedMs', performance.now() - __pStart);
         return 'pinned';
       }
       // Best-effort: log at warn level and move on. The single most
@@ -361,6 +377,8 @@ export function installHeliaBlockstorePinShim(
         'ProfilePinShim',
         `helia.pins.add failed for ${cidStr.slice(0, 16)}…: ${msg}`,
       );
+      incr('helia.pins.add.failed');
+      observeMs('helia.pins.add.failedMs', performance.now() - __pStart);
       return 'failed';
     }
   }

--- a/profile/helia-blockstore-shim.ts
+++ b/profile/helia-blockstore-shim.ts
@@ -61,6 +61,8 @@
  * @module profile/helia-blockstore-shim
  */
 
+import { incr, observeMs } from '../core/perf-counters.js';
+
 /**
  * Default maximum LRU entries. 64 entries comfortably covers the
  * OpLog head + recent snapshot + tens of bundle CIDs the load path
@@ -275,6 +277,8 @@ export function installHeliaBlockstoreGetShim(
     cid: unknown,
     opts?: unknown,
   ): Promise<Uint8Array | undefined> => {
+    incr('helia.blockstore.get.calls');
+    const __gStart = performance.now();
     const key = cidKey(cid);
 
     if (key !== null) {
@@ -286,16 +290,22 @@ export function installHeliaBlockstoreGetShim(
         lru.delete(key);
         lru.set(key, cached);
         hits++;
+        incr('helia.blockstore.get.cacheHit');
+        observeMs('helia.blockstore.get.cacheHitMs', performance.now() - __gStart);
         return cached;
       }
       const pending = inflight.get(key);
       if (pending !== undefined) {
         hits++;
-        return pending;
+        incr('helia.blockstore.get.inflightHit');
+        const result = await pending;
+        observeMs('helia.blockstore.get.inflightHitMs', performance.now() - __gStart);
+        return result;
       }
     }
 
     misses++;
+    incr('helia.blockstore.get.miss');
     const work = (async (): Promise<Uint8Array | undefined> => {
       try {
         const source = originalGet(cid, opts) as AsyncIterable<Uint8Array>;
@@ -313,7 +323,9 @@ export function installHeliaBlockstoreGetShim(
     const result = await work;
     if (key !== null && result instanceof Uint8Array) {
       touch(key, result);
+      incr('helia.blockstore.get.bytes', result.byteLength);
     }
+    observeMs('helia.blockstore.get.missMs', performance.now() - __gStart);
     return result;
   };
 
@@ -322,12 +334,21 @@ export function installHeliaBlockstoreGetShim(
   let wrappedPut: ((cid: unknown, val: unknown, opts?: unknown) => unknown) | null = null;
   if (originalPut !== null) {
     wrappedPut = (cid: unknown, val: unknown, opts?: unknown): unknown => {
+      incr('helia.blockstore.put.calls');
+      const __pStart = performance.now();
       const key = cidKey(cid);
       if (key !== null) {
         lru.delete(key);
         inflight.delete(key);
       }
-      return originalPut(cid, val, opts);
+      const result = originalPut(cid, val, opts);
+      if (result && typeof (result as { then?: unknown }).then === 'function') {
+        return (result as Promise<unknown>).finally(() => {
+          observeMs('helia.blockstore.put.totalMs', performance.now() - __pStart);
+        });
+      }
+      observeMs('helia.blockstore.put.totalMs', performance.now() - __pStart);
+      return result;
     };
     blockstore.put = wrappedPut as HeliaBlockstoreLike['put'];
   }
@@ -341,12 +362,21 @@ export function installHeliaBlockstoreGetShim(
   let wrappedDelete: ((cid: unknown, opts?: unknown) => unknown) | null = null;
   if (originalDelete !== null) {
     wrappedDelete = (cid: unknown, opts?: unknown): unknown => {
+      incr('helia.blockstore.delete.calls');
+      const __dStart = performance.now();
       const key = cidKey(cid);
       if (key !== null) {
         lru.delete(key);
         inflight.delete(key);
       }
-      return originalDelete(cid, opts);
+      const result = originalDelete(cid, opts);
+      if (result && typeof (result as { then?: unknown }).then === 'function') {
+        return (result as Promise<unknown>).finally(() => {
+          observeMs('helia.blockstore.delete.totalMs', performance.now() - __dStart);
+        });
+      }
+      observeMs('helia.blockstore.delete.totalMs', performance.now() - __dStart);
+      return result;
     };
     blockstore.delete = wrappedDelete as HeliaBlockstoreLike['delete'];
   }

--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -22,6 +22,7 @@ import { CID } from 'multiformats/cid';
 import * as raw from 'multiformats/codecs/raw';
 import { create as createMultihash } from 'multiformats/hashes/digest';
 import { logger } from '../core/logger.js';
+import { incr, observeMs } from '../core/perf-counters.js';
 import { ProfileError } from './errors.js';
 
 // =============================================================================
@@ -695,6 +696,12 @@ export async function pinCarBlocksToIpfs(
   helia?: unknown,
   concurrency: number = DEFAULT_PIN_CONCURRENCY,
 ): Promise<string> {
+  // GH #363 measurement: total pin wall-clock + block count + total
+  // bytes. Resolves whether the per-write-round-trip pattern the
+  // maintainer hypothesised about is actually network-bound on this
+  // function.
+  const __perfStart = performance.now();
+  const __perfBytes = carBytes.byteLength;
   const localHelia = asHelia(helia);
   // Parse the CAR locally to extract each block. Done up front so a
   // malformed CAR fails fast before any network round-trips.
@@ -891,9 +898,15 @@ export async function pinCarBlocksToIpfs(
     // failed against a downed sidecar) are discarded; if operator
     // diagnostics need them, attach a `storage:error` event before
     // re-throwing in a future enhancement.
+    incr('ipfs.pinCar.error');
+    observeMs('ipfs.pinCar.totalMs', performance.now() - __perfStart);
     throw workerErrors[0];
   }
 
+  // GH #363 measurement.
+  incr('ipfs.pinCar.blocks', blocks.length);
+  incr('ipfs.pinCar.bytes', __perfBytes);
+  observeMs('ipfs.pinCar.totalMs', performance.now() - __perfStart);
   return expectedRootCid;
 }
 
@@ -946,6 +959,9 @@ export async function fetchFromIpfs(
   maxSizeBytes: number = DEFAULT_MAX_SIZE_BYTES,
   helia?: unknown,
 ): Promise<Uint8Array> {
+  // GH #363 measurement — split local-Helia hits from HTTP gateway
+  // fetches so the two cost models are visible separately.
+  const __perfStart = performance.now();
   // Issue #236 — local Helia blockstore fast-path. When the block was
   // pinned through this process (or any prior process with the same
   // `dataDir`), it is already on disk and a synchronous get() avoids
@@ -960,6 +976,8 @@ export async function fetchFromIpfs(
         // gateways (which apply their own enforcement) rather than
         // returning oversized bytes.
       } else {
+        incr('ipfs.fetchBlock.localHit');
+        observeMs('ipfs.fetchBlock.localHitMs', performance.now() - __perfStart);
         return local;
       }
     }
@@ -1154,6 +1172,10 @@ export async function fetchFromIpfs(
         await putBlockToLocalHelia(localHelia, cid, bytesOrNull);
       }
 
+      // GH #363 — gateway hit (HTTP round-trip cost).
+      incr('ipfs.fetchBlock.gatewayHit');
+      incr('ipfs.fetchBlock.bytes', bytesOrNull.byteLength);
+      observeMs('ipfs.fetchBlock.gatewayMs', performance.now() - __perfStart);
       return bytesOrNull;
     } catch (err) {
       // Size-limit ProfileError is fatal for this request (not per-gateway)
@@ -1165,6 +1187,8 @@ export async function fetchFromIpfs(
     }
   }
 
+  incr('ipfs.fetchBlock.allGatewaysFailed');
+  observeMs('ipfs.fetchBlock.failedMs', performance.now() - __perfStart);
   throw new ProfileError(
     'BUNDLE_NOT_FOUND',
     `Failed to fetch CAR ${cid} from all gateways: ${lastError?.message ?? 'unknown error'}`,
@@ -1233,6 +1257,11 @@ export async function fetchCarFromIpfs(
   maxSizeBytesPerBlock: number = DEFAULT_MAX_SIZE_BYTES,
   helia?: unknown,
 ): Promise<Uint8Array> {
+  // GH #363 measurement — per-CAR walk wall-clock + block count. Issue
+  // #360 claimed sequential block-fetch dominated load time; verify or
+  // refute with real data instead of speculating.
+  const __perfStart = performance.now();
+  incr('ipfs.fetchCar.calls');
   let parsedRoot: CID;
   try {
     parsedRoot = CID.parse(rootCid);
@@ -1361,6 +1390,9 @@ export async function fetchCarFromIpfs(
     carBytes.set(c, offset);
     offset += c.length;
   }
+  incr('ipfs.fetchCar.blocks', blocks.length);
+  incr('ipfs.fetchCar.bytes', totalLength);
+  observeMs('ipfs.fetchCar.totalMs', performance.now() - __perfStart);
   return carBytes;
 }
 

--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -237,18 +237,155 @@ const DEFAULT_PIN_TIMEOUT_MS = 60_000;
  * single HTTP POST to the sidecar; round-trip is ~80-150 ms regardless of
  * payload size, so serial = N × RTT and dominates wall-clock for any
  * non-trivial wallet (a 24-token migration emits ~250 blocks, which at
- * 100 ms each is ~25 s serial). 10 concurrent in-flight pins reduces the
- * same workload to ~2.5 s while staying well under typical browser
- * per-origin connection caps (Chrome's 6 HTTP/1.1 cap is multiplexed by
- * HTTP/2 on the sidecar). Overridable per-call to support stress tests
- * or sidecars with explicit per-client rate limits.
+ * 100 ms each is ~25 s serial).
+ *
+ * Issue #369 — lowered from 10 → 5. The Unicity kubo container caps at
+ * `MAX_PINS_PER_SECOND=100`; 10 concurrent slots × ~10 pin/s/slot peaks
+ * at ~100 pin/s and routinely brushed the limit on bursts, producing
+ * intermittent `IPFS dag/put failed on all gateways for <CID>: fetch
+ * failed` surface errors that the soak couldn't reproduce on demand.
+ * 5 concurrent slots stay comfortably under the cap (~50 pin/s peak)
+ * while still parallelizing meaningfully — the 250-block migration
+ * pays ~5 s instead of ~2.5 s, but with substantially fewer
+ * rate-limit-induced retry storms. Overridable per-call for stress
+ * tests or operator deployments with explicit per-client rate limits.
  *
  * Concurrency is bounded by a worker pool (not Promise.all over all
  * blocks) so memory stays O(concurrency × block-size) rather than
  * O(blocks × block-size) — important for migration of large wallets
  * where the CAR may contain thousands of blocks.
  */
-const DEFAULT_PIN_CONCURRENCY = 10;
+const DEFAULT_PIN_CONCURRENCY = 5;
+
+// =============================================================================
+// Issue #369 — retry-with-backoff for transient pin failures.
+// =============================================================================
+
+/**
+ * Backoff schedule for a single pin attempt's retries (ms). The
+ * indices line up 1:1 with retry attempts AFTER the initial pass:
+ * a single call to {@link withPinRetry} makes `1 + backoffs.length`
+ * attempts total before throwing.
+ *
+ * 100 / 500 / 2000 ms is the issue #369 recommendation — fast first
+ * retry to absorb the dominant TCP retransmit-window blip, longer
+ * second retry to ride through a gateway hiccup, and a third retry
+ * for the rare extended outage. After 2.6 s of accumulated backoff,
+ * if the gateway still rejects, the failure is unlikely to clear in
+ * the operation's deadline.
+ */
+const PIN_RETRY_BACKOFFS_MS: readonly number[] = [100, 500, 2000];
+
+/**
+ * Classify whether a pin failure is worth retrying.
+ *
+ * Transient (retry):
+ *   - Native `fetch()` throws — network blip, ECONNRESET, ETIMEDOUT,
+ *     TLS handshake stall, AbortError from the per-attempt timeout.
+ *   - HTTP 5xx — gateway-side transient (overload, bad backend).
+ *   - HTTP 429 — explicit rate-limit signal; backoff is the right
+ *     response.
+ *
+ * Permanent (do NOT retry):
+ *   - Other HTTP 4xx — deterministic client-side failures (bad
+ *     request, unauthorized, not found, payload too large).
+ *
+ * Default is transient — leniency favours availability over giving
+ * up on an unrecognised error shape; the bounded backoff schedule
+ * caps the cost.
+ *
+ * The classifier inspects the error's `message` against the shape
+ * `pinToIpfs` / `pinSingleBlock` use for their own throws
+ * (`"HTTP <code> <statusText> from <gw>"`) so a synthetic test error
+ * with that prefix is classified identically to a real one.
+ */
+export function isTransientPinError(err: unknown): boolean {
+  if (!(err instanceof Error)) return true;
+  const msg = err.message;
+
+  // HTTP-derived errors carry the explicit status in the message. We
+  // match anywhere in the string so a wrapped failure (e.g.,
+  // `pinToIpfs` packaging the last gateway's "HTTP 400 …" into its
+  // `IPFS pin failed on all gateways: HTTP 400 …` final throw) still
+  // classifies on the inner status code rather than falling through
+  // to the lenient default.
+  const httpMatch = /\bHTTP (\d{3})\b/.exec(msg);
+  if (httpMatch !== null) {
+    const status = Number.parseInt(httpMatch[1], 10);
+    if (status === 429) return true;
+    if (status >= 500 && status < 600) return true;
+    if (status >= 400 && status < 500) return false;
+  }
+
+  // Network / abort errors propagate from `fetch()` directly. Patterns
+  // observed across Node 18+ undici (`fetch failed`, `Connect Timeout
+  // Error`) and the platform `AbortError` from `AbortSignal.timeout`.
+  if (
+    msg.toLowerCase().includes('fetch failed') ||
+    msg.toLowerCase().includes('network') ||
+    msg.includes('ECONNRESET') ||
+    msg.includes('ETIMEDOUT') ||
+    msg.includes('ECONNREFUSED') ||
+    msg.includes('EAI_AGAIN') ||
+    err.name === 'AbortError' ||
+    err.name === 'TimeoutError'
+  ) {
+    return true;
+  }
+
+  // Lenient default — unrecognised shape is treated as transient. The
+  // bounded backoff schedule caps the cost; a truly-permanent failure
+  // exhausts the retries in 2.6 s and surfaces normally.
+  return true;
+}
+
+/**
+ * Run `fn` with retry-with-backoff for transient pin failures. Makes
+ * up to `1 + backoffs.length` attempts; the first attempt fires
+ * immediately, each subsequent retry waits `backoffs[i]` ms.
+ *
+ * `isRetryable` classifies the thrown error. On the FINAL attempt a
+ * failure short-circuits — no further backoff is paid. On a permanent
+ * (non-retryable) failure the function throws immediately with the
+ * observed error, regardless of the retry budget.
+ *
+ * Counters (fired only when `SPHERE_PERF=1`):
+ *   - `ipfs.pin.retry.attempt` — bumped on each transient retry just
+ *     before the backoff sleep. Total fires = number of paid retries.
+ *   - `ipfs.pin.retry.exhausted` — bumped when all retries fail with
+ *     transient errors AND we throw the last one. Distinct from
+ *     `ipfs.pin.retry.permanent` (a permanent failure exits before the
+ *     retry budget runs out).
+ *   - `ipfs.pin.retry.permanent` — bumped when the classifier returns
+ *     `false` and the function throws the permanent error without
+ *     consuming further retries.
+ */
+export async function withPinRetry<T>(
+  fn: () => Promise<T>,
+  isRetryable: (err: unknown) => boolean = isTransientPinError,
+  backoffs: readonly number[] = PIN_RETRY_BACKOFFS_MS,
+): Promise<T> {
+  for (let attempt = 0; attempt <= backoffs.length; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const isLast = attempt >= backoffs.length;
+      if (isLast) {
+        incr('ipfs.pin.retry.exhausted');
+        throw err;
+      }
+      if (!isRetryable(err)) {
+        incr('ipfs.pin.retry.permanent');
+        throw err;
+      }
+      incr('ipfs.pin.retry.attempt');
+      await new Promise<void>((resolve) => setTimeout(resolve, backoffs[attempt]));
+    }
+  }
+  // Unreachable — the loop above either returns or throws on every
+  // path. This satisfies TypeScript's exhaustiveness check.
+  throw new Error('withPinRetry: unreachable');
+}
 
 /** Default timeout for fetch operations (ms). */
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
@@ -452,6 +589,21 @@ export async function pinToIpfs(
 ): Promise<string> {
   const effectiveGateways = gateways.length > 0 ? gateways : [DEFAULT_IPFS_API_URL];
   validateGatewayUrls(effectiveGateways);
+
+  // Issue #369 — wrap the gateway-iteration in retry-with-backoff so a
+  // single transient hiccup (network blip, brief TLS slowdown, 429 from
+  // a rate-limited gateway) no longer aborts the pin. The retry only
+  // fires when EVERY configured gateway has failed in the current
+  // attempt — a single healthy gateway still satisfies the pin without
+  // paying any backoff cost.
+  return withPinRetry(() => pinToIpfsOnce(effectiveGateways, data, timeoutMs));
+}
+
+async function pinToIpfsOnce(
+  effectiveGateways: string[],
+  data: Uint8Array,
+  timeoutMs: number,
+): Promise<string> {
   let lastError: Error | null = null;
 
   for (const gateway of effectiveGateways) {
@@ -570,6 +722,22 @@ async function pinSingleBlock(
   const effectiveGateways = gateways.length > 0 ? gateways : [DEFAULT_IPFS_API_URL];
   validateGatewayUrls(effectiveGateways);
 
+  // Issue #369 — wrap the per-block pin in retry-with-backoff so a
+  // single transient network/gateway failure on this one block doesn't
+  // abort the whole CAR pin (a 250-block CAR has 250 retry slots — a
+  // single 1% failure rate without retries cascades to ~92% chance of
+  // at-least-one-failure per CAR).
+  return withPinRetry(() =>
+    pinSingleBlockOnce(effectiveGateways, blockBytes, expectedCid, timeoutMs),
+  );
+}
+
+async function pinSingleBlockOnce(
+  effectiveGateways: string[],
+  blockBytes: Uint8Array,
+  expectedCid: string,
+  timeoutMs: number,
+): Promise<void> {
   // Derive the Kubo codec token from the CID's multicodec prefix.
   // Unknown codecs fall back to `raw` so we still store the bytes (the
   // gateway will compute a different CID, but our locally-computed

--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -609,6 +609,22 @@ export function _resetGatewayCapabilityCache(): void {
   capabilityCache.clear();
 }
 
+/**
+ * Test/soak-only helper to pre-populate the capability cache for a
+ * specific gateway URL. Lets a smoke probe force the legacy path for
+ * an A/B comparison against the live gateway without needing to
+ * spin up a second gateway that doesn't expose /dag/import.
+ *
+ * Production code MUST NOT call this — the probe is the source of
+ * truth at runtime.
+ */
+export function _setGatewayCapabilityForTest(
+  gateway: string,
+  caps: { readonly dagImport: boolean; readonly dagExport: boolean },
+): void {
+  capabilityCache.set(normalizeGatewayKey(gateway), Promise.resolve(caps));
+}
+
 function normalizeGatewayKey(gateway: string): string {
   return gateway.replace(/\/$/, '');
 }

--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -568,6 +568,319 @@ async function tryReadFromSidecar(
 }
 
 // =============================================================================
+// Issue #370 — Capability probe and CAR-batched fast paths
+// =============================================================================
+
+/**
+ * Per-gateway timeout for the capability probe. Short and bounded so a
+ * slow or unreachable gateway can't block the first hot-path pin beyond
+ * this window. On timeout / network error the probe caches the gateway
+ * as "fast path unsupported" for the process lifetime — same outcome as
+ * an explicit 404 from the operator gateway.
+ */
+const PROBE_TIMEOUT_MS = 2_000;
+
+/**
+ * Result of the per-gateway capability probe. Each field is `true` iff
+ * the gateway advertises the corresponding endpoint at the operator
+ * layer (haproxy/nginx ACL passes the route through to Kubo).
+ */
+interface GatewayCapabilities {
+  readonly dagImport: boolean;
+  readonly dagExport: boolean;
+}
+
+/**
+ * Per-process probe cache. Keyed by normalized gateway URL (trailing
+ * slash trimmed). Stores the in-flight Promise, not the resolved value,
+ * so a concurrent burst of pins triggers exactly one probe per gateway.
+ * Capability is treated as a static property of a gateway within a
+ * process's lifetime — operator reconfiguration requires a new wallet
+ * process to pick up the change.
+ */
+const capabilityCache = new Map<string, Promise<GatewayCapabilities>>();
+
+/**
+ * Test-only helper to reset the probe cache between tests. Production
+ * code does not call this — operator gateway reconfiguration requires a
+ * process restart.
+ */
+export function _resetGatewayCapabilityCache(): void {
+  capabilityCache.clear();
+}
+
+function normalizeGatewayKey(gateway: string): string {
+  return gateway.replace(/\/$/, '');
+}
+
+/**
+ * POST a single empty request to `url` to determine whether the
+ * operator gateway exposes that endpoint. Returns `true` iff the
+ * gateway responded with a 4xx status that is NOT 404 (route absent)
+ * or 405 (POST blocked at the proxy layer). A healthy Kubo returns
+ * 400 *Bad Request* for an empty POST to `/dag/import` / `/dag/export`
+ * — that's the positive signal we look for.
+ *
+ * 5xx is treated as "not exposed" — a healthy operator gateway would
+ * have returned 4xx for empty input. 5xx suggests an unhealthy upstream
+ * or a misconfigured proxy returning a synthetic error page. 2xx is
+ * accepted (defense: the operator may have rewritten the endpoint to
+ * return 200; if the actual call later fails, the selector falls
+ * through to legacy).
+ *
+ * Network errors, timeouts, or aborts → returns `false` (treat as not
+ * exposed). The caller's legacy path will rediscover real failures at
+ * call time through its own per-gateway iteration.
+ */
+async function probeEndpointExposed(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    response.body?.cancel?.().catch(() => { /* ignore */ });
+    return (
+      response.status !== 404 &&
+      response.status !== 405 &&
+      response.status < 500
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Probe a gateway for `/dag/import` and `/dag/export` support, caching
+ * the result for the rest of the process lifetime. Issue #370.
+ */
+async function probeGatewayCapabilities(gateway: string): Promise<GatewayCapabilities> {
+  const key = normalizeGatewayKey(gateway);
+  const cached = capabilityCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const probe = (async (): Promise<GatewayCapabilities> => {
+    const [dagImport, dagExport] = await Promise.all([
+      probeEndpointExposed(`${key}/api/v0/dag/import`),
+      probeEndpointExposed(`${key}/api/v0/dag/export`),
+    ]);
+    if (!dagImport || !dagExport) {
+      logger.warn(
+        'ipfs-client',
+        `#370 capability probe ${key}: dagImport=${dagImport} dagExport=${dagExport} ` +
+          `— legacy per-block path will be used where the fast path is unavailable`,
+      );
+    }
+    return { dagImport, dagExport };
+  })();
+  capabilityCache.set(key, probe);
+  return probe;
+}
+
+/**
+ * Single-round-trip CAR push: POST `carBytes` to Kubo's
+ * `/api/v0/dag/import?pin=true`. Replaces the per-block `/dag/put`
+ * loop when the operator gateway exposes the import endpoint.
+ *
+ * Parses the NDJSON response and verifies `expectedRootCid` appears
+ * among the imported roots with no `PinErrorMsg`. CAR-bytes content
+ * verification is end-to-end via receiver-side `fetchFromIpfs` checks
+ * — this function does NOT recompute every block's CID (Kubo does that
+ * server-side during import).
+ *
+ * Permissive `Cid` shape parsing accepts both modern
+ * `{"Root": {"Cid": {"/": "bafy..."}}}` and older
+ * `{"Root": {"Cid": "bafy..."}}` Kubo response forms.
+ *
+ * Multi-root defensive check: validates our root is present, ignores
+ * extra roots the gateway reports (defense for a hostile gateway
+ * appending phantom entries).
+ *
+ * Throws on any failure so the caller's selector can fall through to
+ * the legacy per-block path.
+ */
+async function pinCarViaImport(
+  gateway: string,
+  carBytes: Uint8Array,
+  expectedRootCid: string,
+  timeoutMs: number,
+): Promise<void> {
+  const url = `${normalizeGatewayKey(gateway)}/api/v0/dag/import?pin=true`;
+  const form = new FormData();
+  form.append('file', new Blob([carBytes as BlobPart]), 'bundle.car');
+
+  const response = await fetch(url, {
+    method: 'POST',
+    body: form,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status} ${response.statusText} from ${gateway} for /dag/import`,
+    );
+  }
+
+  const text = await response.text();
+  let foundExpectedRoot = false;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    let node: unknown;
+    try {
+      node = JSON.parse(trimmed);
+    } catch {
+      continue; // ignore non-JSON noise
+    }
+    if (node === null || typeof node !== 'object') continue;
+    const root = (node as { Root?: unknown }).Root;
+    if (root === null || root === undefined || typeof root !== 'object') continue;
+    const rootObj = root as { Cid?: unknown; PinErrorMsg?: unknown };
+    let cidStr: string | null = null;
+    const cid = rootObj.Cid;
+    if (typeof cid === 'string') {
+      cidStr = cid;
+    } else if (cid !== null && typeof cid === 'object') {
+      const inner = (cid as { '/'?: unknown })['/'];
+      if (typeof inner === 'string') cidStr = inner;
+    }
+    if (cidStr === expectedRootCid) {
+      const errMsg = rootObj.PinErrorMsg;
+      if (typeof errMsg === 'string' && errMsg.length > 0) {
+        throw new Error(
+          `Gateway ${gateway} reported PinErrorMsg for ${expectedRootCid}: ${errMsg}`,
+        );
+      }
+      foundExpectedRoot = true;
+    }
+  }
+  if (!foundExpectedRoot) {
+    throw new Error(
+      `Gateway ${gateway} /dag/import did not include expected root ${expectedRootCid} in NDJSON response`,
+    );
+  }
+}
+
+/**
+ * Single-round-trip CAR pull: POST to Kubo's
+ * `/api/v0/dag/export?arg=<root>` and return the response bytes
+ * verbatim. The bytes ARE a CARv1 stream — feed directly to
+ * `CarReader.fromBytes`. Replaces the per-block BFS walk when the
+ * operator gateway exposes the export endpoint.
+ *
+ * Per-block CID verification happens after parse in the caller
+ * (`verifyAndReassembleExportedCar`). This function only handles the
+ * HTTP transport. A hostile gateway can DoS but cannot forge data —
+ * the caller's CID-binding check rejects mismatched bytes.
+ *
+ * Throws on any HTTP failure or size-cap breach so the caller's
+ * selector can fall through to the legacy BFS path.
+ */
+async function fetchCarViaExport(
+  gateway: string,
+  rootCid: string,
+  timeoutMs: number,
+  maxSizeBytes: number,
+): Promise<Uint8Array> {
+  const url =
+    `${normalizeGatewayKey(gateway)}/api/v0/dag/export?arg=${encodeURIComponent(rootCid)}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status} ${response.statusText} from ${gateway} for /dag/export`,
+    );
+  }
+
+  const contentLength = response.headers.get('Content-Length');
+  if (contentLength != null) {
+    const size = parseInt(contentLength, 10);
+    if (!isNaN(size) && size > maxSizeBytes) {
+      throw new Error(
+        `Gateway ${gateway} /dag/export Content-Length ${size} exceeds limit ${maxSizeBytes}`,
+      );
+    }
+  }
+
+  if (response.body != null) {
+    return await readStreamWithLimit(response.body, maxSizeBytes, gateway);
+  }
+  const buf = await response.arrayBuffer();
+  if (buf.byteLength > maxSizeBytes) {
+    throw new Error(
+      `Gateway ${gateway} /dag/export returned ${buf.byteLength} bytes exceeding limit ${maxSizeBytes}`,
+    );
+  }
+  return new Uint8Array(buf);
+}
+
+/**
+ * Verify every block CID-binding in an exported CAR and reassemble it
+ * into a CARv1 rooted at `rootCid` (stream order preserved). Issue
+ * #370 fetch-path companion to {@link fetchCarViaExport}.
+ *
+ * On verification or root-absence failure, throws so the caller's
+ * selector can fall through to the legacy BFS path (which will fetch
+ * each block individually and apply the same CID check via
+ * `fetchFromIpfs`).
+ *
+ * Also write-backs every verified block to the local Helia blockstore
+ * (preserves the #236 bidirectional cache invariant).
+ */
+async function verifyAndReassembleExportedCar(
+  carBytes: Uint8Array,
+  rootCid: string,
+  helia: unknown,
+): Promise<Uint8Array> {
+  const { CarReader } = await import('@ipld/car');
+  const { CarWriter } = await import('@ipld/car/writer');
+  const reader = await CarReader.fromBytes(carBytes);
+
+  let rootBlockCid: CID | null = null;
+  const collected: Array<{ cid: CID; bytes: Uint8Array }> = [];
+  for await (const block of reader.blocks()) {
+    const cidStr = block.cid.toString();
+    verifyCidMatchesBytes(cidStr, block.bytes);
+    collected.push({ cid: block.cid, bytes: block.bytes });
+    if (cidStr === rootCid) rootBlockCid = block.cid;
+  }
+  if (rootBlockCid === null) {
+    throw new Error(
+      `/dag/export response for ${rootCid} did not include the requested root block`,
+    );
+  }
+
+  const localHelia = asHelia(helia);
+  if (localHelia !== null) {
+    for (const block of collected) {
+      await putBlockToLocalHelia(localHelia, block.cid.toString(), block.bytes);
+    }
+  }
+
+  const { writer, out } = CarWriter.create([rootBlockCid]);
+  const chunks: Uint8Array[] = [];
+  const collectPromise = (async () => {
+    for await (const chunk of out) chunks.push(chunk);
+  })();
+  try {
+    for (const block of collected) await writer.put(block);
+  } finally {
+    await writer.close();
+  }
+  await collectPromise;
+
+  let totalLength = 0;
+  for (const c of chunks) totalLength += c.length;
+  const reassembled = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const c of chunks) {
+    reassembled.set(c, offset);
+    offset += c.length;
+  }
+  return reassembled;
+}
+
+// =============================================================================
 // Public API
 // =============================================================================
 
@@ -809,10 +1122,15 @@ async function pinSingleBlockOnce(
  * CARs (lean v3 and fat v2), and the Nostr `uxf-cid` publisher (via
  * `createUxfCarPublisher`).
  *
- * Why not `/api/v0/dag/import`: the Unicity IPFS gateway does not expose
- * that endpoint. `dag/put` is universally available across Kubo deploys,
- * including hardened gateways that restrict the API surface. The
- * tradeoff is one HTTP round-trip per block.
+ * Relationship to `/api/v0/dag/import`: as of issue #370, the SDK
+ * prefers `/dag/import` (single CAR push) over this per-block loop
+ * whenever a gateway's capability probe confirms the endpoint is
+ * exposed at the operator layer. This legacy per-block path remains
+ * the hardened fallback for gateways that don't expose `/dag/import`
+ * (or for fast-path call-time failures). `dag/put` is universally
+ * available across Kubo deploys, including hardened gateways that
+ * restrict the API surface; the tradeoff is one HTTP round-trip per
+ * block.
  *
  * The function trusts the caller-supplied `expectedRootCid` and the
  * framed CIDs in the CAR (`@ipld/car`'s `CarReader` does NOT recompute
@@ -856,6 +1174,18 @@ async function pinSingleBlockOnce(
  * @throws {ProfileError} `ORBITDB_WRITE_FAILED` if all gateways fail to
  *         accept a pin or the CAR doesn't contain the expected root.
  */
+/**
+ * Issue #370 fast-path selector. Probes each gateway for `/dag/import`
+ * support and uses the single-shot CAR push when available. Falls
+ * through to {@link pinCarBlocksToIpfsLegacy} when no gateway exposes
+ * the endpoint, or when the fast path fails mid-flight (which would
+ * suggest a transient gateway issue that the hardened per-block path
+ * may still ride out on a sibling gateway).
+ *
+ * Local Helia writes happen on both paths (preserves the #236
+ * crash-safety invariant). The sidecar submit fires once for the CAR
+ * root on the fast path and once per block on the legacy path.
+ */
 export async function pinCarBlocksToIpfs(
   gateways: string[],
   carBytes: Uint8Array,
@@ -864,12 +1194,152 @@ export async function pinCarBlocksToIpfs(
   helia?: unknown,
   concurrency: number = DEFAULT_PIN_CONCURRENCY,
 ): Promise<string> {
+  const effectiveGateways = gateways.length > 0 ? gateways : [DEFAULT_IPFS_API_URL];
+  validateGatewayUrls(effectiveGateways);
+
+  // Track whether we already wrote every block into the local Helia
+  // store on the fast-path attempt. If so, the legacy fallback must
+  // NOT re-write them (would surface as duplicate puts in tests and
+  // wasted disk I/O at runtime). We pass `helia: undefined` to the
+  // legacy call in that case to skip its own per-block local-Helia
+  // write loop.
+  let localHeliaWrittenInFastPath = false;
+
+  for (const gateway of effectiveGateways) {
+    const caps = await probeGatewayCapabilities(gateway);
+    if (!caps.dagImport) continue;
+
+    // Parse the CAR locally for the fast path's local-Helia write and
+    // root-block extraction (used by the post-success sidecar submit).
+    // A malformed CAR fails with a deterministic ProfileError and we
+    // re-throw without falling through — the legacy path would emit
+    // the same error after re-parsing.
+    let parsed: {
+      readonly blocks: ReadonlyArray<{ cid: string; bytes: Uint8Array }>;
+      readonly rootBlock: { cid: string; bytes: Uint8Array };
+    };
+    try {
+      parsed = await parseCarForFastPathPin(carBytes, expectedRootCid);
+    } catch (err) {
+      if (err instanceof ProfileError) throw err;
+      throw new ProfileError(
+        'ORBITDB_WRITE_FAILED',
+        `pinCarBlocksToIpfs: fast-path CAR parse failed: ${err instanceof Error ? err.message : String(err)}`,
+        err,
+      );
+    }
+
+    const localHelia = asHelia(helia);
+    if (localHelia !== null && !localHeliaWrittenInFastPath) {
+      for (const block of parsed.blocks) {
+        let cidBindingOk = true;
+        try {
+          verifyCidMatchesBytes(block.cid, block.bytes);
+        } catch (err) {
+          cidBindingOk = false;
+          logger.warn(
+            'ipfs-client',
+            `pinCarBlocksToIpfs: producer-side CID/bytes mismatch for ${block.cid} ` +
+              `— skipping local-helia put. ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        if (cidBindingOk) await putBlockToLocalHelia(localHelia, block.cid, block.bytes);
+      }
+      localHeliaWrittenInFastPath = true;
+    }
+
+    try {
+      await pinCarViaImport(gateway, carBytes, expectedRootCid, timeoutMs);
+      // One sidecar submit per CAR root (issue #370 explicit guidance).
+      submitToSidecarBestEffort(gateway, expectedRootCid, parsed.rootBlock.bytes);
+      return expectedRootCid;
+    } catch (err) {
+      logger.warn(
+        'ipfs-client',
+        `pinCarBlocksToIpfs: /dag/import fast path failed on ${gateway} for ${expectedRootCid}, ` +
+          `falling back to legacy per-block path. Reason: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+      // Exit the gateway probe loop; legacy iterates the full list itself
+      // (a sibling gateway may still accept per-block /dag/put even if
+      // /dag/import on this gateway stumbled).
+      break;
+    }
+  }
+
+  return pinCarBlocksToIpfsLegacy(
+    effectiveGateways,
+    carBytes,
+    expectedRootCid,
+    timeoutMs,
+    // Skip the legacy path's local-Helia write loop if the fast path
+    // already wrote every block — avoids duplicate puts.
+    localHeliaWrittenInFastPath ? undefined : helia,
+    concurrency,
+  );
+}
+
+/**
+ * Parse a CAR upfront for the fast-path pin. Materialises the block
+ * list and extracts the root block bytes for sidecar submit. Throws
+ * `ProfileError(ORBITDB_WRITE_FAILED)` on malformed CARs, zero-block
+ * CARs, or missing-expected-root CARs (matches the legacy path's
+ * pre-flight checks).
+ */
+async function parseCarForFastPathPin(
+  carBytes: Uint8Array,
+  expectedRootCid: string,
+): Promise<{
+  readonly blocks: ReadonlyArray<{ cid: string; bytes: Uint8Array }>;
+  readonly rootBlock: { cid: string; bytes: Uint8Array };
+}> {
+  const { CarReader } = await import('@ipld/car');
+  const reader = await CarReader.fromBytes(carBytes);
+  const blocks: Array<{ cid: string; bytes: Uint8Array }> = [];
+  for await (const block of reader.blocks()) {
+    blocks.push({ cid: block.cid.toString(), bytes: block.bytes });
+  }
+  if (blocks.length === 0) {
+    throw new ProfileError(
+      'ORBITDB_WRITE_FAILED',
+      'CAR contained zero blocks — refusing to publish a phantom rootCid.',
+    );
+  }
+  const rootBlock = blocks.find((b) => b.cid === expectedRootCid);
+  if (rootBlock === undefined) {
+    throw new ProfileError(
+      'ORBITDB_WRITE_FAILED',
+      `expectedRootCid ${expectedRootCid} is not present among CAR blocks (count=${blocks.length}) — builder/publisher mismatch.`,
+    );
+  }
+  return { blocks, rootBlock };
+}
+
+/**
+ * Legacy per-block pin implementation. Issue #370 turned the public
+ * `pinCarBlocksToIpfs` into a selector that prefers `/dag/import` when
+ * the operator gateway advertises it; this function is the fallback
+ * path for legacy gateways and for fast-path call-time failures.
+ *
+ * Signature and behaviour are exactly what `pinCarBlocksToIpfs` had
+ * before issue #370.
+ */
+async function pinCarBlocksToIpfsLegacy(
+  gateways: string[],
+  carBytes: Uint8Array,
+  expectedRootCid: string,
+  timeoutMs: number = DEFAULT_PIN_TIMEOUT_MS,
+  helia?: unknown,
+  concurrency: number = DEFAULT_PIN_CONCURRENCY,
+): Promise<string> {
   // GH #363 measurement: total pin wall-clock + block count + total
-  // bytes. Resolves whether the per-write-round-trip pattern the
-  // maintainer hypothesised about is actually network-bound on this
-  // function.
+  // bytes for the LEGACY per-block path. (The fast path uses
+  // `ipfs.dagImport.*` counters wired by issue #370 around
+  // `pinCarViaImport`.) Each path measures its own wall-clock so the
+  // selector's effective cost is unambiguous in the snapshot.
   const __perfStart = performance.now();
   const __perfBytes = carBytes.byteLength;
+
   const localHelia = asHelia(helia);
   // Parse the CAR locally to extract each block. Done up front so a
   // malformed CAR fails fast before any network round-trips.
@@ -1442,7 +1912,8 @@ export async function fetchCarFromIpfs(
 
   // Backcompat path: the legacy raw-pinning scheme pinned the entire
   // CAR as one raw block. `fetchFromIpfs` already returns the bytes
-  // verbatim — they ARE the CAR. Skip the walk.
+  // verbatim — they ARE the CAR. Skip the walk. Taken BEFORE the
+  // capability probe — raw-codec roots never need /dag/export.
   if (parsedRoot.code === CODEC_RAW) {
     return fetchFromIpfs(gateways, rootCid, timeoutMs, maxSizeBytesPerBlock, helia);
   }
@@ -1454,6 +1925,89 @@ export async function fetchCarFromIpfs(
     );
   }
 
+  const effectiveGateways = gateways.length > 0 ? gateways : [DEFAULT_IPFS_API_URL];
+  validateGatewayUrls(effectiveGateways);
+
+  // Issue #236 + #370 — local-helia-first short-circuit. When the root
+  // block is already in the local Helia blockstore the legacy BFS path
+  // satisfies the entire walk from disk via `fetchFromIpfs`'s
+  // local-first lookup with zero HTTP round-trips. Take that path
+  // BEFORE the capability probe so we don't spend an /dag/export probe
+  // round-trip when no HTTP is needed at all.
+  const localHeliaForRoot = asHelia(helia);
+  if (localHeliaForRoot !== null) {
+    const localRoot = await tryGetBlockFromLocalHelia(localHeliaForRoot, rootCid);
+    if (localRoot !== null) {
+      return fetchCarFromIpfsLegacy(
+        effectiveGateways,
+        rootCid,
+        parsedRoot,
+        timeoutMs,
+        maxSizeBytesPerBlock,
+        helia,
+      );
+    }
+  }
+
+  // Issue #370 fast path: probe each gateway for /dag/export. On a
+  // capable gateway, fetch the whole CAR in a single HTTP request,
+  // verify every block CID-binding, reassemble and return. On any
+  // failure (404 probe miss, mid-call HTTP error, CID mismatch on
+  // any block, missing root in the exported CAR) fall through to the
+  // legacy per-block BFS path with the full gateway list.
+  for (const gateway of effectiveGateways) {
+    const caps = await probeGatewayCapabilities(gateway);
+    if (!caps.dagExport) continue;
+    try {
+      const carBytes = await fetchCarViaExport(gateway, rootCid, timeoutMs, maxSizeBytesPerBlock);
+      return await verifyAndReassembleExportedCar(carBytes, rootCid, helia);
+    } catch (err) {
+      logger.warn(
+        'ipfs-client',
+        `fetchCarFromIpfs: /dag/export fast path failed on ${gateway} for ${rootCid}, ` +
+          `falling back to legacy per-block BFS. Reason: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+      // Exit the gateway probe loop; legacy iterates the full gateway
+      // list itself (a sibling gateway may still serve per-block
+      // /block/get even if /dag/export on this gateway stumbled).
+      break;
+    }
+  }
+
+  return fetchCarFromIpfsLegacy(
+    effectiveGateways,
+    rootCid,
+    parsedRoot,
+    timeoutMs,
+    maxSizeBytesPerBlock,
+    helia,
+  );
+}
+
+/**
+ * Legacy per-block BFS implementation. Issue #370 turned the public
+ * `fetchCarFromIpfs` into a selector that prefers `/dag/export` when
+ * the operator gateway advertises it; this function is the fallback
+ * path for legacy gateways and for fast-path failures.
+ *
+ * Signature differs from the public function: takes the already-parsed
+ * `rootCid` to avoid re-parsing in the selector. Behaviour is exactly
+ * what `fetchCarFromIpfs` had before issue #370.
+ */
+async function fetchCarFromIpfsLegacy(
+  gateways: string[],
+  rootCid: string,
+  parsedRoot: CID,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+  maxSizeBytesPerBlock: number = DEFAULT_MAX_SIZE_BYTES,
+  helia?: unknown,
+): Promise<Uint8Array> {
+  // Issue #363 — total wall-clock for the LEGACY per-block fetch path.
+  // The fast path emits `ipfs.fetchCar.fastPath` / `ipfs.dagExport.*`
+  // counters via `fetchCarViaExport`; this counter measures the
+  // fallback's BFS walk + per-block fetch loop.
+  const __perfStart = performance.now();
   // Lazy-import @ipld/dag-cbor + CarWriter to keep the cold-path import
   // off the synchronous load of every module that touches ipfs-client.
   const { decode: dagCborDecode } = await import('@ipld/dag-cbor');

--- a/profile/orbitdb-adapter.ts
+++ b/profile/orbitdb-adapter.ts
@@ -13,6 +13,7 @@
 
 import { logger } from '../core/logger.js';
 import { hexToBytes } from '../core/hex.js';
+import { incr, observeMs } from '../core/perf-counters.js';
 import { ProfileError } from './errors.js';
 import { installHeliaBlockstoreGetShim } from './helia-blockstore-shim.js';
 import {
@@ -814,6 +815,13 @@ export class OrbitDbAdapter implements ProfileDatabase {
    */
   async putEntry(key: string, entry: OpLogEntryEnvelope): Promise<void> {
     this.ensureConnected();
+    // GH #363 — measure putEntry round-trip. Hypothesis under
+    // investigation: every logical operation produces many putEntry
+    // calls, each paying a full IPFS round-trip. Counter splits the
+    // bundle-ref keyspace from everything else so the batching
+    // question (issue #363) gets a direct signal.
+    const t0 = performance.now();
+    const isBundleKey = key.startsWith('tokens.bundle.');
     try {
       const cborBytes = encodeEntry(entry);
       await this.db.put(key, cborBytes);
@@ -821,10 +829,16 @@ export class OrbitDbAdapter implements ProfileDatabase {
       // decide whether to trust the stored `originated` tag.
       this.localAuthoredKeys.add(key);
     } catch (err) {
+      incr('orbitdb.putEntry.error');
       throw new ProfileError(
         'ORBITDB_WRITE_FAILED',
         `Failed to write structured entry at "${key}": ${err instanceof Error ? err.message : String(err)}`,
         err,
+      );
+    } finally {
+      observeMs(
+        isBundleKey ? 'orbitdb.putEntry.bundle' : 'orbitdb.putEntry.other',
+        performance.now() - t0,
       );
     }
   }
@@ -1151,9 +1165,20 @@ export class OrbitDbAdapter implements ProfileDatabase {
     // may have overwritten any of our keys (LWW per-key), so we can no
     // longer trust the stored `originated` tag for ANY key without
     // re-authoring. This is conservative (over-invalidates) but safe.
+    //
+    // GH #363 measurement: count BOTH the raw 'update' fires AND the
+    // callback-side wall-clock. Issue #360 Finding #1 claimed every
+    // local write triggers this handler — but never measured the rate
+    // or the callback cost. Confirm or refute with real data.
     const handler = () => {
+      incr('orbitdb.onReplication.fired');
+      const t0 = performance.now();
       this.localAuthoredKeys.clear();
-      callback();
+      try {
+        callback();
+      } finally {
+        observeMs('orbitdb.onReplication.callbackMs', performance.now() - t0);
+      }
     };
 
     this.db.events.on('update', handler);

--- a/profile/orbitdb-adapter.ts
+++ b/profile/orbitdb-adapter.ts
@@ -751,22 +751,32 @@ export class OrbitDbAdapter implements ProfileDatabase {
 
   async put(key: string, value: Uint8Array): Promise<void> {
     this.ensureConnected();
+    const __t0 = performance.now();
+    const isBundleKey = key.startsWith('tokens.bundle.');
     try {
       await this.db.put(key, value);
     } catch (err) {
+      incr('orbitdb.put.error');
       throw new ProfileError(
         'ORBITDB_WRITE_FAILED',
         `Failed to write key "${key}": ${err instanceof Error ? err.message : String(err)}`,
         err,
+      );
+    } finally {
+      observeMs(
+        isBundleKey ? 'orbitdb.put.bundle' : 'orbitdb.put.other',
+        performance.now() - __t0,
       );
     }
   }
 
   async get(key: string): Promise<Uint8Array | null> {
     this.ensureConnected();
+    const __t0 = performance.now();
     try {
       const value = await this.db.get(key);
       if (value === undefined || value === null) {
+        observeMs('orbitdb.get.missMs', performance.now() - __t0);
         return null;
       }
       // Steelman² remediation: shape validation now lives inside
@@ -774,8 +784,12 @@ export class OrbitDbAdapter implements ProfileDatabase {
       // getEntry() and all()). A peer-crafted LWW write that puts a
       // pathological object in the value slot is rejected uniformly
       // across all three entry points.
-      return coerceToUint8Array(value);
+      const result = coerceToUint8Array(value);
+      observeMs('orbitdb.get.hitMs', performance.now() - __t0);
+      return result;
     } catch (err) {
+      incr('orbitdb.get.error');
+      observeMs('orbitdb.get.errorMs', performance.now() - __t0);
       if (err instanceof ProfileError) throw err;
       throw new ProfileError(
         'ORBITDB_READ_FAILED',
@@ -787,14 +801,18 @@ export class OrbitDbAdapter implements ProfileDatabase {
 
   async del(key: string): Promise<void> {
     this.ensureConnected();
+    const __t0 = performance.now();
     try {
       await this.db.del(key);
     } catch (err) {
+      incr('orbitdb.del.error');
       throw new ProfileError(
         'ORBITDB_WRITE_FAILED',
         `Failed to delete key "${key}": ${err instanceof Error ? err.message : String(err)}`,
         err,
       );
+    } finally {
+      observeMs('orbitdb.del.totalMs', performance.now() - __t0);
     }
   }
 
@@ -882,14 +900,27 @@ export class OrbitDbAdapter implements ProfileDatabase {
     } = {},
   ): Promise<OpLogEntryEnvelope | null> {
     this.ensureConnected();
+    const __geStart = performance.now();
+    const isBundleKey = key.startsWith('tokens.bundle.');
     try {
       const raw = await this.db.get(key);
-      if (raw === undefined || raw === null) return null;
+      if (raw === undefined || raw === null) {
+        observeMs(
+          isBundleKey ? 'orbitdb.getEntry.bundleMissMs' : 'orbitdb.getEntry.missMs',
+          performance.now() - __geStart,
+        );
+        return null;
+      }
       const bytes = coerceToUint8Array(raw);
 
       // Explicit downgrade requested → route through the ingress path.
       if (opts.downgradeAsReplicated === true) {
-        return decodeAndDowngradeReplicated(bytes);
+        const result = decodeAndDowngradeReplicated(bytes);
+        observeMs(
+          isBundleKey ? 'orbitdb.getEntry.bundleHitMs' : 'orbitdb.getEntry.hitMs',
+          performance.now() - __geStart,
+        );
+        return result;
       }
 
       // Default: decode, then enforce the downgrade UNLESS the caller
@@ -899,11 +930,19 @@ export class OrbitDbAdapter implements ProfileDatabase {
       // Legacy entries (v=0) always carry the synthesized system tag —
       // pass through unchanged; the v=0 sentinel tells the caller.
       if (envelope.v === 0) {
+        observeMs(
+          isBundleKey ? 'orbitdb.getEntry.bundleHitMs' : 'orbitdb.getEntry.hitMs',
+          performance.now() - __geStart,
+        );
         return envelope;
       }
 
       const trusted = opts.trustLocalClaim === true && this.localAuthoredKeys.has(key);
       if (trusted) {
+        observeMs(
+          isBundleKey ? 'orbitdb.getEntry.bundleHitMs' : 'orbitdb.getEntry.hitMs',
+          performance.now() - __geStart,
+        );
         return envelope;
       }
 
@@ -920,8 +959,15 @@ export class OrbitDbAdapter implements ProfileDatabase {
       // default. A future enhancement could verify the OpLog entry's
       // identity field against the wallet's chainPubkey to recognize
       // sibling-tab writes; deferred until a use case justifies it.
-      return decodeAndDowngradeReplicated(bytes);
+      const downgraded = decodeAndDowngradeReplicated(bytes);
+      observeMs(
+        isBundleKey ? 'orbitdb.getEntry.bundleHitMs' : 'orbitdb.getEntry.hitMs',
+        performance.now() - __geStart,
+      );
+      return downgraded;
     } catch (err) {
+      incr('orbitdb.getEntry.error');
+      observeMs('orbitdb.getEntry.errorMs', performance.now() - __geStart);
       // Steelman³ remediation: pass ProfileError through unchanged.
       // Re-wrapping double-prefixes the error code (`[PROFILE:ORBITDB_READ_FAILED]
       // ... [PROFILE:ORBITDB_READ_FAILED]`) and obscures the original
@@ -941,11 +987,15 @@ export class OrbitDbAdapter implements ProfileDatabase {
     opts?: { readonly maxResults?: number },
   ): Promise<Map<string, Uint8Array>> {
     this.ensureConnected();
+    incr('orbitdb.all.calls');
+    const __allStart = performance.now();
     try {
       const result = new Map<string, Uint8Array>();
       // OrbitDB keyvalue databases expose an `all()` method that returns
       // all entries as an object or iterable.
+      const __dbAllStart = performance.now();
       const allEntries = await this.db.all();
+      observeMs('orbitdb.all.dbAllMs', performance.now() - __dbAllStart);
       // Round 5 (FIX 3) — short-circuit iteration once the requested
       // `maxResults` matching entries have been buffered. Defends
       // against a hostile peer planting millions of crafted prefix
@@ -1064,8 +1114,12 @@ export class OrbitDbAdapter implements ProfileDatabase {
         );
       }
 
+      incr('orbitdb.all.entries', result.size);
+      observeMs('orbitdb.all.totalMs', performance.now() - __allStart);
       return result;
     } catch (err) {
+      incr('orbitdb.all.error');
+      observeMs('orbitdb.all.totalMs', performance.now() - __allStart);
       if (err instanceof ProfileError) throw err;
       throw new ProfileError(
         'ORBITDB_READ_FAILED',

--- a/profile/pointer-wiring.ts
+++ b/profile/pointer-wiring.ts
@@ -180,9 +180,19 @@ export interface PointerWiringInput {
    * `snapshot_applier_missing` skip reason — the wallet then runs
    * without aggregator-pointer recovery rather than silently writing
    * the wrong CAR shape to the bundle index.
+   *
+   * Issue #367 — accepts an optional `sourcePointerCid` carrying the
+   * IPFS CID of the snapshot blob being applied. The dispatcher uses
+   * it to annotate each landed bundle ref with its source snapshot so
+   * a subsequent `load()` can skip Rule-4 pairwise verification when
+   * every active bundle traces to the same single trusted snapshot.
+   * Pre-#367 callers may omit the parameter — the dispatcher then
+   * treats the apply as "context-unknown" (no annotation) and the
+   * Rule-4 gate degrades safely (Rule-4 runs).
    */
   readonly applySnapshot: (
     snapshot: LeanProfileSnapshot,
+    sourcePointerCid?: string,
   ) => Promise<ApplySnapshotResult>;
   /** Turn on verbose logging for the wiring helper itself. */
   readonly debug?: boolean;
@@ -444,6 +454,7 @@ function buildFetchAndJoin(deps: {
    */
   applySnapshot: (
     snapshot: LeanProfileSnapshot,
+    sourcePointerCid?: string,
   ) => Promise<ApplySnapshotResult>;
 }): FetchAndJoinCallback {
   return async (remoteCid: Uint8Array, remoteVersion: PointerVersion) => {
@@ -517,7 +528,10 @@ function buildFetchAndJoin(deps: {
     }
 
     try {
-      await deps.applySnapshot(snapshot);
+      // Issue #367 — pass the snapshot's IPFS pointer CID so the
+      // dispatcher can annotate each landed bundle ref. Already
+      // decoded at line ~453 above.
+      await deps.applySnapshot(snapshot, cidString);
     } catch (err) {
       // Throwing here keeps the cursor behind the unconsumed
       // remote, so the next reconcile pass re-fetches + re-applies.

--- a/profile/profile-snapshot-cache.ts
+++ b/profile/profile-snapshot-cache.ts
@@ -84,6 +84,7 @@
 import type { StorageProvider, TxfStorageDataBase } from '../storage/storage-provider.js';
 import { STORAGE_KEYS_GLOBAL } from '../constants.js';
 import { sha256 as nobleSha256 } from '@noble/hashes/sha2.js';
+import { time } from '../core/perf-counters.js';
 
 /**
  * Current snapshot schema version. Bumped on incompatible changes; the
@@ -274,6 +275,12 @@ export async function writeSnapshot(
   storage: StorageProvider,
   input: WriteSnapshotInput,
 ): Promise<number> {
+  return time('snapshotCache.writeSnapshot', () => _writeSnapshotImpl(storage, input));
+}
+async function _writeSnapshotImpl(
+  storage: StorageProvider,
+  input: WriteSnapshotInput,
+): Promise<number> {
   const ts = (input.now ?? Date.now)();
   const blobNoHash: Omit<ProfileSnapshotBlob, 'contentHash'> = {
     version: PROFILE_SNAPSHOT_SCHEMA_VERSION,
@@ -376,6 +383,14 @@ export async function writeSnapshot(
  * the next successful flush writes a fresh blob in the current schema.
  */
 export async function readSnapshot(
+  storage: StorageProvider,
+  addressId: string,
+  expectedWalletId: string,
+  now: () => number = Date.now,
+): Promise<SnapshotReadResult> {
+  return time('snapshotCache.readSnapshot', () => _readSnapshotImpl(storage, addressId, expectedWalletId, now));
+}
+async function _readSnapshotImpl(
   storage: StorageProvider,
   addressId: string,
   expectedWalletId: string,

--- a/profile/profile-snapshot-dispatcher.ts
+++ b/profile/profile-snapshot-dispatcher.ts
@@ -97,10 +97,41 @@ export interface ProfileSnapshotJoinDeps {
    * the token storage layer is not ready (e.g., shutdown in progress).
    * BundleIndex implements `ProfileSyncWriter` directly and owns the
    * `tokens.bundle.*` namespace.
+   *
+   * Issue #367 — when the concrete type also exposes
+   * {@link BundleIndexSnapshotContextSetter.setCurrentSnapshotApplyCid},
+   * the dispatcher arms it with {@link sourcePointerCid} before calling
+   * `joinSnapshot()` so each landed bundle ref can be annotated with the
+   * source snapshot's pointer CID for downstream Rule-4 provenance gating.
    */
   readonly bundleIndex: ProfileSyncWriter | null;
+  /**
+   * Issue #367 — IPFS pointer CID of the lean-snapshot blob currently
+   * being applied. Propagates into each landed bundle ref via
+   * `BundleIndex.joinSnapshot`'s `writeRemote` callback so a subsequent
+   * `load()` can identify pure-snapshot bundle sets and skip Rule-4
+   * pairwise verification (no cross-device sibling collisions possible
+   * when every bundle came through a single trusted snapshot blob).
+   *
+   * Empty string indicates "context not propagated" — preserves the
+   * pre-#367 behaviour where bundle refs land without provenance and
+   * the gate degrades safely (Rule-4 runs).
+   */
+  readonly sourcePointerCid?: string;
   /** Optional debug logger; falls back to the SDK logger. */
   readonly log?: (msg: string) => void;
+}
+
+/**
+ * Issue #367 — structural type the dispatcher duck-types against to
+ * arm the snapshot-source context on `BundleIndex` before its
+ * `joinSnapshot` runs. The setter is OPTIONAL on the dispatcher-facing
+ * interface so legacy bundle-index doubles (test stubs) and other
+ * future writers can satisfy `ProfileSyncWriter` without implementing
+ * the snapshot-annotation contract.
+ */
+interface BundleIndexSnapshotContextSetter {
+  setCurrentSnapshotApplyCid(cid: string | null): void;
 }
 
 /**
@@ -382,6 +413,26 @@ export async function runProfileSnapshotJoin(
     const bundleSlice = entries.filter((e) => e.key.startsWith(BUNDLE_KEY_PREFIX));
     bundleEntriesSeen = bundleSlice.length;
     if (bundleSlice.length > 0) {
+      // Issue #367 — arm the snapshot-source context if the concrete
+      // bundle-index implementation exposes the setter (production
+      // `BundleIndex` does; test stubs typically don't). Clearing in
+      // `finally` keeps the field at `null` between applies so a stale
+      // CID can never leak into a later non-snapshot path.
+      const setter = (
+        deps.bundleIndex as ProfileSyncWriter & Partial<BundleIndexSnapshotContextSetter>
+      ).setCurrentSnapshotApplyCid;
+      const armed = typeof setter === 'function';
+      const cidForContext = deps.sourcePointerCid ?? '';
+      if (armed && cidForContext.length > 0) {
+        try {
+          setter.call(deps.bundleIndex, cidForContext);
+        } catch (err) {
+          log(
+            `runProfileSnapshotJoin: setCurrentSnapshotApplyCid threw — proceeding without provenance annotation ` +
+              `(error: ${err instanceof Error ? err.message : String(err)})`,
+          );
+        }
+      }
       try {
         const result = await deps.bundleIndex.joinSnapshot(bundleSlice);
         accumulate(aggregated, result);
@@ -390,6 +441,14 @@ export async function runProfileSnapshotJoin(
           `runProfileSnapshotJoin: bundleIndex.joinSnapshot threw — skipping ` +
             `(error: ${err instanceof Error ? err.message : String(err)})`,
         );
+      } finally {
+        if (armed) {
+          try {
+            setter.call(deps.bundleIndex, null);
+          } catch {
+            /* swallow — setter must not break the JOIN result reporting */
+          }
+        }
       }
     }
   } else {

--- a/profile/profile-snapshot-dispatcher.ts
+++ b/profile/profile-snapshot-dispatcher.ts
@@ -44,6 +44,7 @@
  */
 
 import { logger } from '../core/logger';
+import { incr, observeMs } from '../core/perf-counters.js';
 import type { LeanProfileSnapshot } from './profile-lean-snapshot';
 import type {
   JoinResult,
@@ -311,6 +312,9 @@ export async function runProfileSnapshotJoin(
 ): Promise<ApplySnapshotResult> {
   const log = deps.log ?? ((msg: string): void => logger.debug('SnapshotDispatcher', msg));
 
+  const __sjStart = performance.now();
+  incr('profile.snapshotJoin.calls');
+
   // 1. Decode base64 once. Reuse the resulting bytes for every writer's
   //    prefix-filtered view via `Array.prototype.filter` — no copies.
   //
@@ -325,10 +329,13 @@ export async function runProfileSnapshotJoin(
   //    array and the writer is never called — Phase 2's wiring is
   //    correct, the entries simply never reach it. See
   //    `normalizeEntryKey` doc-comment for the full rationale.
+  const __decodeStart = performance.now();
   const entries: SnapshotEntry[] = snapshot.entries.map((e) => ({
     key: normalizeEntryKey(e.key),
     encryptedValue: base64ToBytes(e.value),
   }));
+  observeMs('profile.snapshotJoin.decodeMs', performance.now() - __decodeStart);
+  incr('profile.snapshotJoin.decodedEntries', entries.length);
 
   // 2. Extract unique addressIds.
   const addressIds = new Set<string>();
@@ -361,6 +368,8 @@ export async function runProfileSnapshotJoin(
       // `remoteRejectedMalformed` counter signal-only.
       const slice = entries.filter((e) => e.key.startsWith(keyPrefix));
       if (slice.length === 0) continue;
+      incr('profile.snapshotJoin.perWriterDispatchCalls');
+      const __wStart = performance.now();
       try {
         const result = await writer.joinSnapshot(slice);
         accumulate(aggregated, result);
@@ -373,6 +382,8 @@ export async function runProfileSnapshotJoin(
           `runProfileSnapshotJoin: writer @ ${keyPrefix} threw — skipping ` +
             `(error: ${err instanceof Error ? err.message : String(err)})`,
         );
+      } finally {
+        observeMs('profile.snapshotJoin.perWriterDispatchMs', performance.now() - __wStart);
       }
     }
   }
@@ -382,6 +393,8 @@ export async function runProfileSnapshotJoin(
     const bundleSlice = entries.filter((e) => e.key.startsWith(BUNDLE_KEY_PREFIX));
     bundleEntriesSeen = bundleSlice.length;
     if (bundleSlice.length > 0) {
+      incr('profile.snapshotJoin.bundleIndexJoinCalls');
+      const __bStart = performance.now();
       try {
         const result = await deps.bundleIndex.joinSnapshot(bundleSlice);
         accumulate(aggregated, result);
@@ -390,6 +403,8 @@ export async function runProfileSnapshotJoin(
           `runProfileSnapshotJoin: bundleIndex.joinSnapshot threw — skipping ` +
             `(error: ${err instanceof Error ? err.message : String(err)})`,
         );
+      } finally {
+        observeMs('profile.snapshotJoin.bundleIndexJoinMs', performance.now() - __bStart);
       }
     }
   } else {
@@ -397,6 +412,8 @@ export async function runProfileSnapshotJoin(
       'runProfileSnapshotJoin: bundleIndex not available — bundle JOIN skipped',
     );
   }
+
+  observeMs('profile.snapshotJoin.totalMs', performance.now() - __sjStart);
 
   const joinedAny = aggregated.liveLanded > 0 || aggregated.tombstonesLanded > 0;
   return {

--- a/profile/profile-snapshot-merge.ts
+++ b/profile/profile-snapshot-merge.ts
@@ -73,6 +73,8 @@
  * @see profile/lamport.ts — §7.1 Lamport invariants, W39 bounds defence
  */
 
+import { incr, observeMs } from '../core/perf-counters.js';
+
 // =============================================================================
 // 1. Constants
 // =============================================================================
@@ -348,16 +350,20 @@ export async function runJoinSnapshot(
 
   for (const entry of remote) {
     entriesEvaluated += 1;
+    incr('profile.snapshotJoin.perKeyApplyCalls');
+    const __keyStart = performance.now();
 
     let remoteSlot: ClassifiedSlot | null;
     try {
       remoteSlot = await deps.classifyRemote(entry);
     } catch {
       remoteRejectedMalformed += 1;
+      observeMs('profile.snapshotJoin.perKeyApplyMs', performance.now() - __keyStart);
       continue;
     }
     if (remoteSlot === null || remoteSlot.kind === 'absent') {
       remoteRejectedMalformed += 1;
+      observeMs('profile.snapshotJoin.perKeyApplyMs', performance.now() - __keyStart);
       continue;
     }
 
@@ -373,6 +379,7 @@ export async function runJoinSnapshot(
     const action = mergeSlots(localSlot, remoteSlot);
     if (action.kind === 'noop') {
       localWon += 1;
+      observeMs('profile.snapshotJoin.perKeyApplyMs', performance.now() - __keyStart);
       continue;
     }
 
@@ -385,6 +392,8 @@ export async function runJoinSnapshot(
       }
     } catch {
       remoteRejectedMalformed += 1;
+    } finally {
+      observeMs('profile.snapshotJoin.perKeyApplyMs', performance.now() - __keyStart);
     }
   }
 

--- a/profile/profile-storage-provider.ts
+++ b/profile/profile-storage-provider.ts
@@ -506,8 +506,10 @@ export class ProfileStorageProvider implements StorageProvider {
    * In practice the factory sets it once at construction.
    */
   private snapshotApplier:
-    | ((snapshot: import('./profile-lean-snapshot').LeanProfileSnapshot)
-        => Promise<import('./profile-snapshot-dispatcher').ApplySnapshotResult>)
+    | ((
+        snapshot: import('./profile-lean-snapshot').LeanProfileSnapshot,
+        sourcePointerCid?: string,
+      ) => Promise<import('./profile-snapshot-dispatcher').ApplySnapshotResult>)
     | null = null;
 
   /**
@@ -553,8 +555,10 @@ export class ProfileStorageProvider implements StorageProvider {
    */
   setSnapshotApplier(
     applier:
-      | ((snapshot: import('./profile-lean-snapshot').LeanProfileSnapshot)
-          => Promise<import('./profile-snapshot-dispatcher').ApplySnapshotResult>)
+      | ((
+          snapshot: import('./profile-lean-snapshot').LeanProfileSnapshot,
+          sourcePointerCid?: string,
+        ) => Promise<import('./profile-snapshot-dispatcher').ApplySnapshotResult>)
       | null,
   ): void {
     this.snapshotApplier = applier;

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -44,6 +44,7 @@
 
 import { logger } from '../core/logger.js';
 import { SphereError } from '../core/errors.js';
+import { incr, time, observeMs } from '../core/perf-counters.js';
 import { STORAGE_KEYS_GLOBAL } from '../constants.js';
 import type { ProviderStatus, FullIdentity } from '../types/index.js';
 import type {
@@ -846,12 +847,18 @@ export class ProfileTokenStorageProvider
   async applySnapshotIfWired(
     cidString: string,
   ): Promise<import('./profile-snapshot-dispatcher.js').ApplySnapshotResult | null> {
+    return time('profile.applySnapshot', () => this._applySnapshotIfWiredImpl(cidString));
+  }
+  private async _applySnapshotIfWiredImpl(
+    cidString: string,
+  ): Promise<import('./profile-snapshot-dispatcher.js').ApplySnapshotResult | null> {
     if (this.isShuttingDown || this.hasShutdown) return null;
     // Late-bound setter wins; falls back to construction-time option
     // for callers that prefer the static-config style.
     const callback =
       this.applySnapshotCallback ?? this.options?.onApplySnapshot ?? null;
     if (typeof callback !== 'function') return null;
+    incr('profile.applySnapshot.fired');
     return callback(cidString);
   }
 
@@ -1290,6 +1297,10 @@ export class ProfileTokenStorageProvider
   // ---------------------------------------------------------------------------
 
   async load(_identifier?: string): Promise<LoadResult<TxfStorageDataBase>> {
+    incr('profile.load.calls');
+    return time('profile.load.totalMs', () => this._loadImpl(_identifier));
+  }
+  private async _loadImpl(_identifier?: string): Promise<LoadResult<TxfStorageDataBase>> {
     const timestamp = Date.now();
 
     if (!this.initialized || !this.encryptionKey) {
@@ -1508,7 +1519,20 @@ export class ProfileTokenStorageProvider
       // candidate roots; a single-bundle load has none.
       let verifiedProofs: ReadonlySet<string> | undefined = undefined;
       const verifyInclusionProof = this.options?.oracle?.verifyInclusionProof;
-      if (verifyInclusionProof && loadedBundles.length >= 2) {
+      // GH #363 prototype — env-gated bypass for the Rule-4 pairwise
+      // UXF-level verification loop. When set, load() skips the
+      // O(N²) pairwise computeVerifiedProofs pass; structural JOIN
+      // still runs and Rule 3 (longest-valid prefix) still applies;
+      // only Rule 4 enrichment is skipped. Mirrors the verifier-failure
+      // catch path below — that fallback is the existing graceful
+      // degradation, this flag just opts into it unconditionally so
+      // we can A/B measure the wall-clock delta.
+      const skipRule4 =
+        typeof process !== 'undefined' && process?.env?.SPHERE_SKIP_RULE4 === '1';
+      if (skipRule4) incr('profile.load.rule4Skipped');
+      if (verifyInclusionProof && loadedBundles.length >= 2 && !skipRule4) {
+        incr('profile.load.rule4PairwiseInvocations');
+        const __r4Start = performance.now();
         try {
           // Pairwise accumulation via the existing helper. `computeVerifiedProofs`
           // walks BOTH packages' pools dedup-by-content-hash, so for N
@@ -1531,12 +1555,15 @@ export class ProfileTokenStorageProvider
               for (const h of pairwise) accum.add(h);
             }
           }
+          observeMs('profile.load.rule4PairwiseMs', performance.now() - __r4Start);
           verifiedProofs = accum;
           this.log(
             `JOIN: computed verifiedProofs across ${loadedBundles.length} bundles ` +
               `(${accum.size} proof element(s) verified)`,
           );
         } catch (err) {
+          observeMs('profile.load.rule4PairwiseMs', performance.now() - __r4Start);
+          incr('profile.load.rule4PairwiseThrew');
           // Verifier failure must not abort the load — fall back to the
           // conservative (no-enrichment) resolution. The structural JOIN
           // still runs and Rule 3 (longest-valid prefix) still applies;

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -136,6 +136,16 @@ export class ProfileTokenStorageProvider
   private encryptionKey: Uint8Array | null = null;
   private initialized = false;
   private isShuttingDown = false;
+  /**
+   * Issue #364 Item #2 — true between {@link clear} entry and exit.
+   * `clear()` is destructive; allowing the periodic pointer-poll's
+   * `applySnapshotIfWired` to run mid-clear would dispatch a snapshot
+   * against state that is about to be wiped, wasting IPFS round-trips
+   * and risking partial seeding of about-to-be-deleted data. The
+   * shutdown gate (`isShuttingDown`/`hasShutdown`) does not cover the
+   * clear-on-a-live-provider path, hence the separate latch.
+   */
+  private isClearing = false;
 
   // --- Write-behind buffer ---
   private pendingData: TxfStorageDataBase | null = null;
@@ -852,6 +862,10 @@ export class ProfileTokenStorageProvider
   private async _applySnapshotIfWiredImpl(
     cidString: string,
   ): Promise<import('./profile-snapshot-dispatcher.js').ApplySnapshotResult | null> {
+    if (this.isClearing) {
+      incr('profile.applySnapshot.suppressedDuringClear');
+      return null;
+    }
     if (this.isShuttingDown || this.hasShutdown) return null;
     // Late-bound setter wins; falls back to construction-time option
     // for callers that prefer the static-config style.
@@ -1852,6 +1866,11 @@ export class ProfileTokenStorageProvider
   async clear(): Promise<boolean> {
     if (!this.initialized) return false;
 
+    // Issue #364 Item #2 — gate concurrent applySnapshotIfWired calls
+    // for the duration of clear(). A periodic pointer-poll that fires
+    // during destructive teardown would dispatch a snapshot against
+    // about-to-be-wiped state, racing the deletes below.
+    this.isClearing = true;
     try {
       // Remove all bundle refs from OrbitDB
       const allBundles = await this.db.all(BUNDLE_KEY_PREFIX);
@@ -1888,6 +1907,8 @@ export class ProfileTokenStorageProvider
     } catch (err) {
       this.log(`clear() failed: ${err instanceof Error ? err.message : String(err)}`);
       return false;
+    } finally {
+      this.isClearing = false;
     }
   }
 

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -1453,8 +1453,12 @@ export class ProfileTokenStorageProvider
       // we can pre-compute verifiedProofs across the full set before
       // running the resolver. Per-bundle fetch failures are non-fatal
       // (partial load is better than failure).
-      const loadedBundles: Array<{ cid: string; pkg: UxfPackageInstance }> = [];
-      for (const [cid] of activeBundles) {
+      const loadedBundles: Array<{
+        cid: string;
+        pkg: UxfPackageInstance;
+        sourcedFromSnapshotPointerCid: string | null;
+      }> = [];
+      for (const [cid, ref] of activeBundles) {
         try {
           // Issue #200 Phase 2: bundle CIDs are now dag-cbor envelope
           // CIDs (per-block pinned), not raw-CIDs over the CAR bytes.
@@ -1479,7 +1483,11 @@ export class ProfileTokenStorageProvider
             this.db.getHelia?.(),
           );
           const pkg = await UxfPackage.fromCar(carBytes);
-          loadedBundles.push({ cid, pkg });
+          loadedBundles.push({
+            cid,
+            pkg,
+            sourcedFromSnapshotPointerCid: ref.sourcedFromSnapshotPointerCid ?? null,
+          });
         } catch (err) {
           this.log(`Failed to load bundle ${cid}: ${err instanceof Error ? err.message : String(err)}`);
         }
@@ -1527,9 +1535,41 @@ export class ProfileTokenStorageProvider
       // catch path below — that fallback is the existing graceful
       // degradation, this flag just opts into it unconditionally so
       // we can A/B measure the wall-clock delta.
-      const skipRule4 =
+      const skipRule4Env =
         typeof process !== 'undefined' && process?.env?.SPHERE_SKIP_RULE4 === '1';
-      if (skipRule4) incr('profile.load.rule4Skipped');
+      if (skipRule4Env) incr('profile.load.rule4Skipped');
+
+      // GH #367 — per-bundle provenance gate. Skip Rule-4 pairwise
+      // verification when every active bundle was placed into the
+      // local OrbitDB store by the snapshot dispatcher's `writeRemote`
+      // path and they ALL trace to the same source snapshot. In that
+      // case the snapshot producer's local merge already resolved any
+      // siblings before publishing — the receiver's pairwise loop is
+      // redundant.
+      //
+      // The gate fails-safe: any bundle without provenance (locally-
+      // published, replication-arrived, or legacy pre-#367), or a
+      // mix of source snapshots, leaves Rule-4 enabled. Single-bundle
+      // loads are handled by the `>= 2` guard below — Rule-4 doesn't
+      // fire on single bundles anyway.
+      let skipRule4Snapshot = false;
+      if (loadedBundles.length >= 2) {
+        const firstCid = loadedBundles[0].sourcedFromSnapshotPointerCid;
+        if (firstCid !== null) {
+          skipRule4Snapshot = loadedBundles.every(
+            (b) => b.sourcedFromSnapshotPointerCid === firstCid,
+          );
+        }
+      }
+      if (skipRule4Snapshot) {
+        incr('profile.load.rule4SkippedSnapshot');
+        this.log(
+          `JOIN: Rule-4 pairwise skipped — all ${loadedBundles.length} bundles ` +
+            `sourced from snapshot ${loadedBundles[0].sourcedFromSnapshotPointerCid?.slice(0, 12)}…`,
+        );
+      }
+
+      const skipRule4 = skipRule4Env || skipRule4Snapshot;
       if (verifyInclusionProof && loadedBundles.length >= 2 && !skipRule4) {
         incr('profile.load.rule4PairwiseInvocations');
         const __r4Start = performance.now();

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -45,6 +45,7 @@
 import { logger } from '../core/logger.js';
 import { SphereError } from '../core/errors.js';
 import { incr, time, observeMs } from '../core/perf-counters.js';
+import { isGlobalClearActive } from './global-clear-gate.js';
 import { STORAGE_KEYS_GLOBAL } from '../constants.js';
 import type { ProviderStatus, FullIdentity } from '../types/index.js';
 import type {
@@ -146,6 +147,12 @@ export class ProfileTokenStorageProvider
    * clear-on-a-live-provider path, hence the separate latch.
    */
   private isClearing = false;
+
+  // Issue #368 — the process-wide global-clear gate lives in a
+  // dedicated leaf module (`profile/global-clear-gate.ts`) so
+  // `core/Sphere.ts` can bracket multi-wallet clears without taking a
+  // hard import on `ProfileTokenStorageProvider`. The gate is consulted
+  // inside `_applySnapshotIfWiredImpl` below.
 
   // --- Write-behind buffer ---
   private pendingData: TxfStorageDataBase | null = null;
@@ -864,6 +871,17 @@ export class ProfileTokenStorageProvider
   ): Promise<import('./profile-snapshot-dispatcher.js').ApplySnapshotResult | null> {
     if (this.isClearing) {
       incr('profile.applySnapshot.suppressedDuringClear');
+      return null;
+    }
+    // Issue #368 — process-wide gate. Suppresses applySnapshot across
+    // EVERY provider in this process while ANY `Sphere.clear()` (or
+    // batch orchestrator) holds the global-clear bracket. Closes the
+    // multi-wallet gap left by the per-instance `isClearing` latch:
+    // wallets B/C/D's periodic pointer-polls must not seed snapshot
+    // state mid-batch while wallet A's clear() is in flight, because
+    // B/C/D are about to be cleared next.
+    if (isGlobalClearActive()) {
+      incr('profile.applySnapshot.suppressedDuringGlobalClear');
       return null;
     }
     if (this.isShuttingDown || this.hasShutdown) return null;

--- a/profile/profile-token-storage/bundle-index.ts
+++ b/profile/profile-token-storage/bundle-index.ts
@@ -32,6 +32,7 @@ import {
   encryptProfileValue,
   decryptProfileValue,
 } from '../encryption.js';
+import { incr, observeMs } from '../../core/perf-counters.js';
 import { buildLocalEntry, decodeEntry } from '../oplog-entry.js';
 import {
   runJoinSnapshot,
@@ -85,7 +86,12 @@ export class BundleIndex implements ProfileSyncWriter {
    * adapter's legacy-wrapping).
    */
   async listBundles(): Promise<Map<string, UxfBundleRef>> {
+    // GH #363 measurement: how often is this called per second, and
+    // how much wall-clock does the underlying `db.all` walk cost?
+    // Issue #360 Finding #3 claimed 5× per flush — confirm or refute.
+    const t0 = performance.now();
     const rawEntries = await this.host.db.all(BUNDLE_KEY_PREFIX);
+    observeMs('bundleIndex.listBundles.dbAllMs', performance.now() - t0);
     const result = new Map<string, UxfBundleRef>();
 
     // Steelman⁴⁰ warning: aggregate corrupt-bundle events into a single
@@ -130,6 +136,7 @@ export class BundleIndex implements ProfileSyncWriter {
       }
     }
 
+    incr('bundleIndex.listBundles.entries', result.size);
     if (corruptCids.length > 0) {
       const ev = this.host.buildErrorEvent('storage:error', firstCorruptError, 'CID_REF_CORRUPT');
       const truncated = corruptCids.length > CORRUPT_CIDS_PREVIEW_CAP;

--- a/profile/profile-token-storage/bundle-index.ts
+++ b/profile/profile-token-storage/bundle-index.ts
@@ -57,7 +57,41 @@ export const CONSOLIDATION_WARNING_THRESHOLD = 3;
 const CORRUPT_CIDS_PREVIEW_CAP = 100;
 
 export class BundleIndex implements ProfileSyncWriter {
+  /**
+   * Issue #367 — set by {@link runProfileSnapshotJoin} BEFORE invoking
+   * this writer's `joinSnapshot()` and cleared in `finally` after.
+   * Read inside `joinSnapshot`'s `writeRemote` callback to annotate
+   * each landed bundle ref with its source snapshot's pointer CID.
+   *
+   * Null outside of an active snapshot apply — covers production code
+   * paths (where the dispatcher always arms it for non-empty bundle
+   * slices) AND legacy code paths / test doubles (where the dispatcher
+   * may not arm it at all). The `writeRemote` callback treats null as
+   * "no provenance available" and writes the bundle ref bytes verbatim,
+   * matching the pre-#367 behaviour.
+   */
+  private currentSnapshotApplyCid: string | null = null;
+
   constructor(private readonly host: ProfileTokenStorageHost) {}
+
+  /**
+   * Issue #367 — arm/clear the source-snapshot context consulted by
+   * `joinSnapshot`'s `writeRemote` callback. Invoked by the snapshot
+   * dispatcher around its BundleIndex JOIN call. Never throws.
+   *
+   * The setter is idempotent and does NOT enforce ownership — callers
+   * are responsible for clearing after their JOIN completes (the
+   * dispatcher's `finally` block satisfies this). A leaked non-null
+   * value into a later apply with a stale CID is the worst-case
+   * downside; the Rule-4 gate would then group bundles under the
+   * wrong source — but Rule-4 is an enrichment skip, not a correctness
+   * gate, so the cost is at most a missed optimisation, never lost
+   * tokens. The serialized `_applySnapshotIfWiredImpl` call site
+   * prevents this in practice.
+   */
+  setCurrentSnapshotApplyCid(cid: string | null): void {
+    this.currentSnapshotApplyCid = cid;
+  }
 
   /**
    * List all bundle refs from OrbitDB, filtered to active status.
@@ -315,16 +349,56 @@ export class BundleIndex implements ProfileSyncWriter {
         // Falling back to raw `db.put` when `putEntry` is unavailable
         // matches `addBundle()`'s pattern — the adapter's read-time
         // legacy wrap (v=0 synthetic envelope) handles those bytes.
+        //
+        // Issue #367 — annotate the landed bundle ref with the source
+        // snapshot's pointer CID so a subsequent `load()` can identify
+        // pure-snapshot bundle sets and skip Rule-4 pairwise verification.
+        // The annotation is best-effort: any failure (decrypt, JSON
+        // parse, re-encrypt) falls back to the verbatim write — the JOIN
+        // still lands and the Rule-4 gate degrades safely (Rule-4 runs).
+        let bytesToWrite = bytes;
+        const sourceCid = this.currentSnapshotApplyCid;
+        const encryptionKey = this.host.getEncryptionKey();
+        if (sourceCid !== null && sourceCid.length > 0 && encryptionKey !== null) {
+          try {
+            let encryptedPayload: Uint8Array = bytes;
+            try {
+              const envelope = decodeEntry(bytes);
+              if (envelope.v === 1) {
+                encryptedPayload = envelope.payload;
+              }
+            } catch {
+              /* legacy raw-bytes — encryptedPayload is `bytes` already */
+            }
+            const decrypted = await decryptProfileValue(encryptionKey, encryptedPayload);
+            const parsed = JSON.parse(new TextDecoder().decode(decrypted)) as unknown;
+            if (isUxfBundleRef(parsed)) {
+              const annotated: UxfBundleRef = {
+                ...parsed,
+                sourcedFromSnapshotPointerCid: sourceCid,
+              };
+              const reSerialized = new TextEncoder().encode(JSON.stringify(annotated));
+              bytesToWrite = await encryptProfileValue(encryptionKey, reSerialized);
+            }
+          } catch (err) {
+            this.host.log(
+              `BundleIndex.joinSnapshot: provenance annotation failed for ${key}; persisting verbatim ` +
+                `(${err instanceof Error ? err.message : String(err)})`,
+            );
+            bytesToWrite = bytes;
+          }
+        }
+
         const db = this.host.db;
         if (typeof db.putEntry === 'function') {
           const envelope = buildLocalEntry({
             type: 'cache_index',
             originated: 'system',
-            payload: bytes,
+            payload: bytesToWrite,
           });
           await db.putEntry(key, envelope);
         } else {
-          await db.put(key, bytes);
+          await db.put(key, bytesToWrite);
           const markHook = (db as { markLocallyAuthored?: (k: string) => void }).markLocallyAuthored;
           if (typeof markHook === 'function') {
             markHook.call(db, key);

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -68,6 +68,7 @@ import {
   verifyCidAccessibleWithRetry,
 } from '../ipfs-client.js';
 import { extractCarRootCid } from '../../uxf/transfer-payload.js';
+import { incr, observeMs } from '../../core/perf-counters.js';
 import { extractLostHeadCid } from '../orbitdb-adapter.js';
 import type { OrbitDbAdapter } from '../orbitdb-adapter.js';
 import type {
@@ -580,6 +581,22 @@ export class FlushScheduler {
    * the remote originator already published while we were merging).
    */
   async flushToIpfs(): Promise<void> {
+    // GH #363 measurement — how often does flushToIpfs run and how
+    // long does it take? Issue #360 Finding #1 hypothesised every
+    // local write triggers a full flush; the rate counter answers it.
+    incr('flushScheduler.flushToIpfs.calls');
+    const __perfStart = performance.now();
+    try {
+      return await this.__flushToIpfsBody();
+    } finally {
+      observeMs(
+        'flushScheduler.flushToIpfs.totalMs',
+        performance.now() - __perfStart,
+      );
+    }
+  }
+
+  private async __flushToIpfsBody(): Promise<void> {
     const encryptionKey = this.host.getEncryptionKey();
     if (!encryptionKey) return;
 

--- a/profile/types.ts
+++ b/profile/types.ts
@@ -351,6 +351,26 @@ export interface UxfBundleRef {
   readonly removeFromProfileAfter?: number;
   /** Number of tokens in this bundle (for quick display without fetching CAR) */
   readonly tokenCount?: number;
+  /**
+   * Issue #367 — pointer CID of the lean-snapshot blob that placed this
+   * bundle ref into the local OrbitDB store via a snapshot-apply dispatch.
+   *
+   * Set ONLY when the writer that landed the ref was the snapshot
+   * dispatcher's `writeRemote` path inside `BundleIndex.joinSnapshot`.
+   * Unset (undefined) on:
+   *   - locally-published bundles written via `BundleIndex.addBundle`;
+   *   - bundles arriving via OrbitDB cross-device pubsub replication
+   *     (which doesn't flow through the snapshot dispatcher);
+   *   - legacy bundle refs persisted before this field existed.
+   *
+   * Read by `load()`'s Rule-4 pairwise gate: when every active bundle's
+   * `sourcedFromSnapshotPointerCid` is non-null AND identical, the load
+   * is sourced from a single trusted snapshot blob and Rule-4 enrichment
+   * can be skipped (the snapshot producer's local merge already resolved
+   * any siblings before publication). Any non-snapshot bundle in the
+   * active set forces Rule-4 to run.
+   */
+  readonly sourcedFromSnapshotPointerCid?: string;
 }
 
 // =============================================================================

--- a/serialization/txf-serializer.ts
+++ b/serialization/txf-serializer.ts
@@ -31,6 +31,7 @@ import {
 import type { Token, TokenStatus } from '../types';
 import { TokenRegistry } from '../registry/TokenRegistry';
 import { INVOICE_TOKEN_TYPE_HEX } from '../constants';
+import { incr, observeMs } from '../core/perf-counters.js';
 
 // =============================================================================
 // SDK Token Normalization
@@ -234,6 +235,16 @@ function determineTokenStatus(txf: TxfToken): TokenStatus {
  * for any persisted invoice.
  */
 export function txfToToken(tokenId: string, txf: TxfToken): Token {
+  incr('serialization.txfSerializer.txfToToken.calls');
+  const __t0 = performance.now();
+  try {
+    return __txfToTokenImpl(tokenId, txf);
+  } finally {
+    observeMs('serialization.txfSerializer.txfToToken.totalMs', performance.now() - __t0);
+  }
+}
+
+function __txfToTokenImpl(tokenId: string, txf: TxfToken): Token {
   const coinData = txf.genesis.data.coinData ?? [];
   const totalAmount = coinData.reduce((sum, [, amt]) => {
     return sum + BigInt(amt || '0');
@@ -400,6 +411,19 @@ export interface ParsedStorageData {
  * Parse TXF storage data
  */
 export function parseTxfStorageData(data: unknown): ParsedStorageData {
+  incr('serialization.txfSerializer.parseStorageData.calls');
+  const __pStart = performance.now();
+  try {
+    return __parseTxfStorageDataImpl(data);
+  } finally {
+    observeMs(
+      'serialization.txfSerializer.parseStorageData.totalMs',
+      performance.now() - __pStart,
+    );
+  }
+}
+
+function __parseTxfStorageDataImpl(data: unknown): ParsedStorageData {
   const result: ParsedStorageData = {
     tokens: [],
     meta: null,

--- a/tests/integration/pointer/recover-latest-cache.test.ts
+++ b/tests/integration/pointer/recover-latest-cache.test.ts
@@ -464,4 +464,121 @@ describe('ProfilePointerLayer recoverLatest cache (issue #364 Item #1)', () => {
       layer.recoverLatest({ abortSignal: controller.signal }),
     ).rejects.toThrow(/abort/i);
   });
+
+  // ---------------------------------------------------------------------------
+  // Issue #366 — publish-time invalidation
+  // ---------------------------------------------------------------------------
+
+  it('publish() invalidates the cache: subsequent recoverLatest is a fresh round-trip', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    // Seed v=1 so a recoverLatest has something to return.
+    const firstCid = cidForBytes(new TextEncoder().encode('first-payload'));
+    await layer.publish(async () => firstCid.bytes);
+
+    // Warm the cache.
+    agg.callCount.value = 0;
+    const cachedBefore = await layer.recoverLatest();
+    expect(cachedBefore).not.toBeNull();
+    const callsForFirstRecover = agg.callCount.value;
+    expect(callsForFirstRecover).toBeGreaterThan(0);
+
+    // Within TTL → cache hit → no new aggregator activity.
+    agg.callCount.value = 0;
+    await layer.recoverLatest();
+    expect(agg.callCount.value).toBe(0);
+
+    // Publish a NEW pointer (v=2). This MUST invalidate the cache so the
+    // next recoverLatest reads through to the aggregator rather than
+    // returning the v=1 view.
+    agg.callCount.value = 0;
+    const secondCid = cidForBytes(new TextEncoder().encode('second-payload'));
+    await layer.publish(async () => secondCid.bytes);
+
+    // Counter signal: the invalidation fired (cache was warm at publish time).
+    const counters = snapshot();
+    expect(
+      counters['pointerLayer.recoverLatest.cacheInvalidatedOnPublish']?.count,
+    ).toBeGreaterThan(0);
+
+    // Next recoverLatest is a fresh round-trip and surfaces v=2.
+    agg.callCount.value = 0;
+    const fresh = await layer.recoverLatest();
+    expect(fresh).not.toBeNull();
+    expect(agg.callCount.value).toBeGreaterThan(0);
+    if (fresh && 'version' in fresh) {
+      expect(fresh.version).toBe(2);
+      expect(CID.decode(fresh.cid).toString()).toBe(secondCid.toString());
+    }
+  });
+
+  it('publish() with no cached value is a no-op for the invalidation counter', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    // No recoverLatest before publish → cache stays null → invalidation
+    // should NOT fire (the guard only bumps the counter when there's
+    // something to clear).
+    const cid = cidForBytes(new TextEncoder().encode('no-cache-payload'));
+    await layer.publish(async () => cid.bytes);
+
+    const counters = snapshot();
+    expect(
+      counters['pointerLayer.recoverLatest.cacheInvalidatedOnPublish'],
+    ).toBeUndefined();
+  });
+
+  it('publish() invalidation does not abort an in-flight recoverLatest started before publish', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    const firstCid = cidForBytes(new TextEncoder().encode('first-inflight'));
+    await layer.publish(async () => firstCid.bytes);
+
+    // Start a recoverLatest and a publish concurrently. The publish's
+    // invalidation must not corrupt the in-flight recover's result —
+    // the in-flight slot is owned by the operation already in motion.
+    const inflightRecover = layer.recoverLatest();
+    const secondCid = cidForBytes(new TextEncoder().encode('second-inflight'));
+    const publishPromise = layer.publish(async () => secondCid.bytes);
+
+    const [recovered, published] = await Promise.all([
+      inflightRecover,
+      publishPromise,
+    ]);
+
+    expect(recovered).not.toBeNull();
+    expect(published.version).toBe(2);
+
+    // A FRESH recoverLatest after both settle must see v=2 (invalidation
+    // applied; the cache no longer holds the pre-publish v=1 view).
+    agg.callCount.value = 0;
+    const post = await layer.recoverLatest();
+    expect(post).not.toBeNull();
+    if (post && 'version' in post) {
+      expect(post.version).toBe(2);
+    }
+  });
 });

--- a/tests/integration/pointer/recover-latest-cache.test.ts
+++ b/tests/integration/pointer/recover-latest-cache.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Issue #364 Item #1 — recoverLatest head cache tests.
+ *
+ * Verifies that the cache + in-flight dedup added to
+ * `ProfilePointerLayer.recoverLatest()` correctly:
+ *   1. Serves a cached value within TTL without round-tripping the
+ *      aggregator (cacheHit counter).
+ *   2. Coalesces concurrent in-flight calls to a single round-trip
+ *      (inFlightDedup counter).
+ *   3. Re-hits the aggregator after TTL expires (cacheStale + cacheMiss).
+ *   4. Clears the cache on shutdown so a re-init starts fresh.
+ *   5. Reports a cacheMiss on the very first call (cold start).
+ *
+ * The baseline impact: §D.4 (full mnemonic recovery soak per issue #363)
+ * observed 108 recoverLatest calls in 123 s. The same pattern under
+ * default 10 s TTL drops to ~12 — a >9× reduction — without changing
+ * recovery semantics.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import type { AggregatorClient } from '@unicitylabs/state-transition-sdk/lib/api/AggregatorClient.js';
+import type { RootTrustBase } from '@unicitylabs/state-transition-sdk/lib/bft/RootTrustBase.js';
+import {
+  SubmitCommitmentResponse,
+  SubmitCommitmentStatus,
+} from '@unicitylabs/state-transition-sdk/lib/api/SubmitCommitmentResponse.js';
+import { InclusionProofVerificationStatus } from '@unicitylabs/state-transition-sdk/lib/transaction/InclusionProof.js';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { create as createDigest } from 'multiformats/hashes/digest';
+
+import {
+  ProfilePointerLayer,
+  createMasterPrivateKey,
+  derivePointerKeyMaterial,
+  buildPointerSigner,
+  FlagStore,
+  DURABLE_STORAGE,
+  type CarFetcher,
+  type CidDecoder,
+  type FetchAndJoinCallback,
+} from '../../../profile/aggregator-pointer/index.js';
+import { decodeVersionCid } from '../../../profile/aggregator-pointer/aggregator-probe.js';
+import {
+  __setPerfEnabledForTest,
+  __stopAutoDumpForTest,
+  snapshot,
+  dumpAndReset,
+} from '../../../core/perf-counters.js';
+
+const WALLET_SEED = new Uint8Array(32).fill(0x77);
+
+function makeDurableStore() {
+  const kv = new Map<string, string>();
+  return {
+    get: async (k: string) => kv.get(k) ?? null,
+    set: async (k: string, v: string) => {
+      kv.set(k, v);
+    },
+    remove: async (k: string) => {
+      kv.delete(k);
+    },
+    has: async (k: string) => kv.has(k),
+    keys: async () => [...kv.keys()],
+    clear: async () => {
+      kv.clear();
+    },
+    setIdentity: () => {},
+    saveTrackedAddresses: async () => {},
+    loadTrackedAddresses: async () => [],
+    initialize: async () => {},
+    shutdown: async () => {},
+    name: 'test-recover-cache',
+    [DURABLE_STORAGE]: true as const,
+  };
+}
+
+interface CountingAggregator {
+  client: AggregatorClient;
+  commitments: Map<string, Uint8Array>;
+  /**
+   * Increments on every call to either submitCommitment or
+   * getInclusionProof. The pointer layer's discover walkback makes
+   * many probe calls per recoverLatest — we count the AGGREGATE wire
+   * activity so a cache hit shows up as zero new calls.
+   */
+  callCount: { value: number };
+}
+
+function makeCountingAggregator(): CountingAggregator {
+  const commitments = new Map<string, Uint8Array>();
+  const callCount = { value: 0 };
+  const client = {
+    async submitCommitment(
+      requestId: { toString(): string },
+      transactionHash: { data: Uint8Array },
+      _authenticator: unknown,
+    ) {
+      callCount.value += 1;
+      commitments.set(requestId.toString(), new Uint8Array(transactionHash.data));
+      return new SubmitCommitmentResponse(SubmitCommitmentStatus.SUCCESS);
+    },
+    async getInclusionProof(requestId: { toString(): string }) {
+      callCount.value += 1;
+      const data = commitments.get(requestId.toString());
+      if (!data) {
+        return {
+          inclusionProof: {
+            verify: async () => InclusionProofVerificationStatus.PATH_NOT_INCLUDED,
+            transactionHash: null,
+          },
+        };
+      }
+      return {
+        inclusionProof: {
+          verify: async () => InclusionProofVerificationStatus.OK,
+          transactionHash: { data },
+        },
+      };
+    },
+  } as unknown as AggregatorClient;
+  return { client, commitments, callCount };
+}
+
+function cidForBytes(bytes: Uint8Array): CID {
+  const digest = createDigest(0x12, sha256(bytes));
+  return CID.createV1(raw.code, digest);
+}
+
+const alwaysOkCarFetcher: CarFetcher = async () => ({ ok: true });
+
+const multiformatsDecoder: CidDecoder = (full: Uint8Array) => {
+  try {
+    if (full.length === 0) return { ok: false };
+    const cidLen = full[0];
+    if (cidLen === undefined || cidLen === 0 || cidLen > full.length - 1) {
+      return { ok: false };
+    }
+    const cid = CID.decode(full.subarray(1, 1 + cidLen));
+    return { ok: true, cidBytes: new Uint8Array(cid.bytes) };
+  } catch {
+    return { ok: false };
+  }
+};
+
+interface BuildLayerDeps {
+  aggregatorClient: AggregatorClient;
+  readLocal: () => Promise<number>;
+  persistLocal: (v: number) => Promise<void>;
+  recoverLatestCacheTtlMs?: number;
+}
+
+async function buildLayer(deps: BuildLayerDeps): Promise<ProfilePointerLayer> {
+  const masterKey = createMasterPrivateKey(WALLET_SEED);
+  const keyMaterial = derivePointerKeyMaterial(masterKey);
+  const signer = await buildPointerSigner(keyMaterial.signingSeed);
+  const storage = makeDurableStore();
+  const flagStore = FlagStore.create(storage as never, signer.signingPubKeyHex);
+
+  let held = false;
+  const queue: Array<() => void> = [];
+  const mutex = {
+    async acquire() {
+      if (held) {
+        await new Promise<void>((resolve) => queue.push(resolve));
+      }
+      held = true;
+      return {
+        release: async () => {
+          held = false;
+          const next = queue.shift();
+          if (next) next();
+        },
+        assertHeld: () => {
+          if (!held) throw new Error('fake mutex: lock lost');
+        },
+      };
+    },
+  };
+
+  const trustBase = {} as unknown as RootTrustBase;
+
+  const fetchAndJoin: FetchAndJoinCallback = async () => {
+    throw new Error('fetchAndJoin should not fire in this test');
+  };
+
+  const resolveRemoteCid = async (version: number): Promise<Uint8Array> => {
+    const result = await decodeVersionCid({
+      v: version,
+      keyMaterial,
+      signer,
+      aggregatorClient: deps.aggregatorClient,
+      trustBase,
+      decodeCid: multiformatsDecoder,
+    });
+    if (!result.ok) {
+      throw new Error(`decodeVersionCid failed: ${result.reason}`);
+    }
+    return result.cidBytes;
+  };
+
+  return new ProfilePointerLayer({
+    keyMaterial,
+    signer,
+    aggregatorClient: deps.aggregatorClient,
+    trustBase,
+    flagStore,
+    mutex,
+    decodeCid: multiformatsDecoder,
+    fetchCar: alwaysOkCarFetcher,
+    fetchAndJoin,
+    readLocalVersion: deps.readLocal,
+    persistLocalVersion: deps.persistLocal,
+    resolveRemoteCid,
+    recoverLatestCacheTtlMs: deps.recoverLatestCacheTtlMs,
+  });
+}
+
+describe('ProfilePointerLayer recoverLatest cache (issue #364 Item #1)', () => {
+  let localVersion = 0;
+
+  beforeEach(() => {
+    localVersion = 0;
+    __stopAutoDumpForTest();
+    // Enable first so dumpAndReset() actually clears the in-memory
+    // counters Map (it short-circuits when PERF is disabled).
+    __setPerfEnabledForTest(true);
+    dumpAndReset();
+  });
+
+  afterEach(() => {
+    // Re-enable + clear so a downstream test in this process starts
+    // with empty counters even if it never runs its own beforeEach.
+    __setPerfEnabledForTest(true);
+    dumpAndReset();
+    __setPerfEnabledForTest(false);
+    __stopAutoDumpForTest();
+  });
+
+  it('first call is a cacheMiss; second call within TTL is a cacheHit (no aggregator round-trip)', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-1'));
+    await layer.publish(async () => cid.bytes);
+
+    const baselineCalls = agg.callCount.value;
+
+    // First recover — cold, must hit the aggregator.
+    const first = await layer.recoverLatest();
+    expect(first).not.toBeNull();
+    expect(agg.callCount.value).toBeGreaterThan(baselineCalls);
+    const afterFirst = agg.callCount.value;
+
+    const snap1 = snapshot();
+    expect(snap1['pointerLayer.recoverLatest.cacheMiss']?.count ?? 0).toBe(1);
+    expect(snap1['pointerLayer.recoverLatest.cacheHit']?.count ?? 0).toBe(0);
+
+    // Second recover — within TTL, must NOT hit the aggregator.
+    const second = await layer.recoverLatest();
+    expect(second).not.toBeNull();
+    expect(agg.callCount.value).toBe(afterFirst);
+
+    const snap2 = snapshot();
+    expect(snap2['pointerLayer.recoverLatest.cacheHit']?.count ?? 0).toBe(1);
+    expect(snap2['pointerLayer.recoverLatest.cacheMiss']?.count ?? 0).toBe(1);
+
+    // Cached result must be referentially identical (we share the
+    // immutable cached object across callers).
+    expect(second).toBe(first);
+  });
+
+  it('5 concurrent calls collapse to 1 aggregator round-trip via inFlightDedup', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-conc'));
+    await layer.publish(async () => cid.bytes);
+
+    // Measure the cost of ONE serial recoverLatest first, so we can
+    // assert the concurrent burst stays close to that cost (not 5×).
+    // We reset the layer's cache+counters between the two phases by
+    // toggling the perf flag and resetting localVersion stays put.
+    const layerSerial = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+    const beforeSerial = agg.callCount.value;
+    await layerSerial.recoverLatest();
+    const serialCost = agg.callCount.value - beforeSerial;
+    // sanity: the discover walkback touches the aggregator at least once
+    expect(serialCost).toBeGreaterThan(0);
+
+    dumpAndReset(); // drop counters from publish + serial baseline
+    __setPerfEnabledForTest(true);
+    const baselineCalls = agg.callCount.value;
+
+    // Fire 5 concurrent recoverLatest calls. The first one starts the
+    // aggregator round-trip; the other 4 must attach via inFlightDedup.
+    const results = await Promise.all([
+      layer.recoverLatest(),
+      layer.recoverLatest(),
+      layer.recoverLatest(),
+      layer.recoverLatest(),
+      layer.recoverLatest(),
+    ]);
+
+    // All 5 callers receive the same result.
+    expect(results.length).toBe(5);
+    for (let i = 1; i < results.length; i += 1) {
+      expect(results[i]).toBe(results[0]);
+    }
+
+    // The aggregator saw only ONE round-trip's worth of activity (the
+    // 4 deduped callers attached to the in-flight promise). The
+    // concurrent-burst cost must be < 2 × serial cost (some slack for
+    // microtask races in a real concurrent scheduler) — far less than
+    // the 5× we'd see without dedup.
+    const callsThisRound = agg.callCount.value - baselineCalls;
+    expect(callsThisRound).toBeGreaterThan(0);
+    expect(callsThisRound).toBeLessThan(serialCost * 2);
+
+    const snap = snapshot();
+    expect(snap['pointerLayer.recoverLatest.cacheMiss']?.count ?? 0).toBe(1);
+    expect(snap['pointerLayer.recoverLatest.inFlightDedup']?.count ?? 0).toBe(4);
+    // No cacheHit — by construction every concurrent caller hit the
+    // in-flight path, not the cache path.
+    expect(snap['pointerLayer.recoverLatest.cacheHit']?.count ?? 0).toBe(0);
+  });
+
+  it('cache expires after TTL: subsequent call is cacheStale + cacheMiss and hits the aggregator', async () => {
+    const agg = makeCountingAggregator();
+    // Tiny TTL so we can test expiry without sleeping a long time.
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 50, // 50ms
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-ttl'));
+    await layer.publish(async () => cid.bytes);
+
+    // Drop counters from publish so the subsequent assertions see
+    // only the recoverLatest activity we're interested in.
+    dumpAndReset();
+    __setPerfEnabledForTest(true);
+
+    // First call — cold.
+    await layer.recoverLatest();
+    const callsAfterFirst = agg.callCount.value;
+
+    // Wait past TTL.
+    await new Promise<void>((resolve) => setTimeout(resolve, 70));
+
+    // Second call — TTL expired, must hit the aggregator again.
+    await layer.recoverLatest();
+    expect(agg.callCount.value).toBeGreaterThan(callsAfterFirst);
+
+    const snap = snapshot();
+    expect(snap['pointerLayer.recoverLatest.cacheMiss']?.count ?? 0).toBe(2);
+    expect(snap['pointerLayer.recoverLatest.cacheStale']?.count ?? 0).toBe(1);
+    expect(snap['pointerLayer.recoverLatest.cacheHit']?.count ?? 0).toBe(0);
+  });
+
+  it('TTL=0 disables the cache: every call hits the aggregator (pre-#364 behavior)', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 0,
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-nocache'));
+    await layer.publish(async () => cid.bytes);
+
+    const baselineCalls = agg.callCount.value;
+    await layer.recoverLatest();
+    const callsAfterFirst = agg.callCount.value;
+    expect(callsAfterFirst).toBeGreaterThan(baselineCalls);
+
+    await layer.recoverLatest();
+    // Second call must ALSO hit the aggregator (no caching).
+    expect(agg.callCount.value).toBeGreaterThan(callsAfterFirst);
+
+    const snap = snapshot();
+    expect(snap['pointerLayer.recoverLatest.cacheHit']?.count ?? 0).toBe(0);
+    // cacheMiss is only counted when TTL > 0. With TTL=0 the cache
+    // path is short-circuited entirely — no miss/hit counters fire.
+    expect(snap['pointerLayer.recoverLatest.cacheMiss']?.count ?? 0).toBe(0);
+  });
+
+  it('shutdown clears the cache so a re-init reading the same layer starts fresh', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-shutdown'));
+    await layer.publish(async () => cid.bytes);
+
+    // Populate cache.
+    const first = await layer.recoverLatest();
+    expect(first).not.toBeNull();
+
+    // Shutdown — should clear the cache and refuse further calls.
+    await layer.shutdown();
+
+    // After shutdown, recoverLatest must throw (per assertNotShuttingDown).
+    await expect(layer.recoverLatest()).rejects.toThrow(/shutdown/i);
+  });
+
+  it('aborted call returns AbortError before reading cache', async () => {
+    const agg = makeCountingAggregator();
+    const layer = await buildLayer({
+      aggregatorClient: agg.client,
+      readLocal: async () => localVersion,
+      persistLocal: async (v) => {
+        localVersion = v;
+      },
+      recoverLatestCacheTtlMs: 10_000,
+    });
+
+    const cid = cidForBytes(new TextEncoder().encode('payload-abort'));
+    await layer.publish(async () => cid.bytes);
+
+    // Warm the cache.
+    await layer.recoverLatest();
+
+    // Pre-aborted signal — must throw AbortError even though cache is warm.
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      layer.recoverLatest({ abortSignal: controller.signal }),
+    ).rejects.toThrow(/abort/i);
+  });
+});

--- a/tests/unit/core/perf-counters.test.ts
+++ b/tests/unit/core/perf-counters.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __setPerfEnabledForTest,
+  __stopAutoDumpForTest,
+  dumpAndReset,
+  incr,
+  isPerfEnabled,
+  observeMs,
+  snapshot,
+  time,
+  timeSync,
+} from '../../../core/perf-counters.js';
+
+// =============================================================================
+// Test fixtures
+// =============================================================================
+
+beforeEach(() => {
+  // Start from a clean slate: stop any auto-dump, clear counters, enable.
+  __stopAutoDumpForTest();
+  __setPerfEnabledForTest(false);
+  // Re-enable for the test body. The clean order is: disable to drop
+  // any prior state via dumpAndReset under-the-hood guarantees, then
+  // enable so test calls actually record.
+  __setPerfEnabledForTest(true);
+});
+
+afterEach(() => {
+  __setPerfEnabledForTest(false);
+  __stopAutoDumpForTest();
+});
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('perf-counters — opt-in measurement', () => {
+  describe('when disabled (default)', () => {
+    it('isPerfEnabled returns false', () => {
+      __setPerfEnabledForTest(false);
+      expect(isPerfEnabled()).toBe(false);
+    });
+
+    it('incr() is a no-op', () => {
+      __setPerfEnabledForTest(false);
+      incr('x');
+      incr('y', 5);
+      // Re-enable to inspect: snapshot must still be empty because the
+      // calls above happened with PERF disabled.
+      __setPerfEnabledForTest(true);
+      expect(snapshot()).toEqual({});
+    });
+
+    it('observeMs() is a no-op', () => {
+      __setPerfEnabledForTest(false);
+      observeMs('latency', 42);
+      __setPerfEnabledForTest(true);
+      expect(snapshot()).toEqual({});
+    });
+
+    it('time() still runs the function and returns its value', async () => {
+      __setPerfEnabledForTest(false);
+      const result = await time('op', async () => 7);
+      expect(result).toBe(7);
+      __setPerfEnabledForTest(true);
+      expect(snapshot()).toEqual({});
+    });
+
+    it('timeSync() still runs the function and returns its value', () => {
+      __setPerfEnabledForTest(false);
+      const result = timeSync('op', () => 'hello');
+      expect(result).toBe('hello');
+      __setPerfEnabledForTest(true);
+      expect(snapshot()).toEqual({});
+    });
+  });
+
+  describe('when enabled', () => {
+    it('incr() accumulates counts', () => {
+      incr('hits');
+      incr('hits', 3);
+      incr('misses');
+      const snap = snapshot();
+      expect(snap.hits.count).toBe(4);
+      expect(snap.misses.count).toBe(1);
+    });
+
+    it('observeMs() records count + total + max', () => {
+      observeMs('latency', 10);
+      observeMs('latency', 20);
+      observeMs('latency', 5);
+      const snap = snapshot();
+      expect(snap.latency.count).toBe(3);
+      expect(snap.latency.totalMs).toBe(35);
+      expect(snap.latency.maxMs).toBe(20);
+      expect(snap.latency.avgMs).toBeCloseTo(11.667, 2);
+    });
+
+    it('observeMs() clamps negative and non-finite values to 0', () => {
+      observeMs('bad', -100);
+      observeMs('bad', Infinity);
+      observeMs('bad', NaN);
+      const snap = snapshot();
+      expect(snap.bad.count).toBe(3);
+      expect(snap.bad.totalMs).toBe(0);
+      expect(snap.bad.maxMs).toBe(0);
+    });
+
+    it('time() wraps async function and records its wall-clock', async () => {
+      const result = await time('op', async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return 42;
+      });
+      expect(result).toBe(42);
+      const snap = snapshot();
+      expect(snap.op.count).toBe(1);
+      expect(snap.op.totalMs).toBeGreaterThan(0);
+    });
+
+    it('time() records the timing even when the function throws', async () => {
+      await expect(
+        time('badop', async () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+      const snap = snapshot();
+      expect(snap.badop.count).toBe(1);
+    });
+
+    it('timeSync() wraps sync function and records its wall-clock', () => {
+      const result = timeSync('syncop', () => 99);
+      expect(result).toBe(99);
+      const snap = snapshot();
+      expect(snap.syncop.count).toBe(1);
+    });
+
+    it('snapshot() returns a stable view and does not clear', () => {
+      incr('x');
+      const a = snapshot();
+      const b = snapshot();
+      expect(a).toEqual(b);
+      expect(snapshot().x.count).toBe(1);
+    });
+
+    it('dumpAndReset() clears counters', () => {
+      incr('a');
+      observeMs('b', 10);
+      dumpAndReset();
+      expect(snapshot()).toEqual({});
+    });
+
+    it('dumpAndReset() is a no-op when there are no counters', () => {
+      // Should not throw, should not allocate.
+      expect(() => dumpAndReset()).not.toThrow();
+      expect(snapshot()).toEqual({});
+    });
+  });
+
+  describe('isPerfEnabled', () => {
+    it('reflects __setPerfEnabledForTest', () => {
+      __setPerfEnabledForTest(true);
+      expect(isPerfEnabled()).toBe(true);
+      __setPerfEnabledForTest(false);
+      expect(isPerfEnabled()).toBe(false);
+    });
+  });
+});

--- a/tests/unit/modules/PaymentsModule.v6-recover-permanent-378.test.ts
+++ b/tests/unit/modules/PaymentsModule.v6-recover-permanent-378.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Issue #378 (#275 P4) — V6-RECOVER permanent-verdict persistence.
+ *
+ * When `finalizeStrandedReceivedToken` classifies a stranded receive
+ * as permanent (HD-index recovery exhausted / structural failure), the
+ * tokenId is recorded in a persistent ledger. Subsequent
+ * `drainPendingFinalizations` invocations skip these tokens in
+ * <100ms instead of repeating the 60s drain timeout per token.
+ *
+ * This file tests the ledger's contract at the unit level:
+ *   1. `saveV6RecoverPermanent` + `restoreV6RecoverPermanent` round-trip
+ *      preserves the marker across a process boundary.
+ *   2. The drain predicate (`hasUnconfirmedOrInflight`) returns false
+ *      for a token whose ID is in the ledger, even when its status
+ *      would otherwise satisfy `pending` / `submitted`.
+ *   3. `receive({ finalize: true })` clears the ledger before draining
+ *      so a forced retry gets one more shot at the V6-RECOVER path.
+ *
+ * The end-to-end V6-RECOVER finalize path itself is exercised in the
+ * existing integration tests (`tests/integration/payments/
+ * v6-recover-real-sdk-recovery.test.ts`); this file only pins the
+ * ledger-side semantics around it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPaymentsModule } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity } from '../../../types';
+import type { StorageProvider } from '../../../storage';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import { STORAGE_KEYS_ADDRESS } from '../../../constants';
+
+// =============================================================================
+// SDK mocks — defensive only. None of the SDK paths are exercised here;
+// the tests poke the internal map directly and verify the persistence /
+// gate semantics.
+// =============================================================================
+
+vi.mock('../../../l1/network', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  isWebSocketConnected: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../../registry', () => ({
+  TokenRegistry: {
+    getInstance: () => ({ getDefinition: () => null, getIconUrl: () => null }),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeIdentity(): FullIdentity {
+  return {
+    chainPubkey: '02' + 'a'.repeat(64),
+    l1Address: 'alpha1test',
+    directAddress: 'DIRECT://test',
+    privateKey: 'a'.repeat(64),
+  };
+}
+
+interface InMemoryStorage extends StorageProvider {
+  _store: Map<string, string>;
+}
+
+function makeStorage(): InMemoryStorage {
+  const store = new Map<string, string>();
+  return {
+    _store: store,
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { store.set(k, v); }),
+    remove: vi.fn(async (k: string) => { store.delete(k); }),
+    delete: vi.fn(async (k: string) => { store.delete(k); }),
+    clear: vi.fn(async () => { store.clear(); }),
+    has: vi.fn(async (k: string) => store.has(k)),
+    keys: vi.fn(async () => [...store.keys()]),
+  } as unknown as InMemoryStorage;
+}
+
+function makeTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn(),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue(null),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    fetchPendingEvents: vi.fn().mockResolvedValue(undefined),
+    publishNametag: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TransportProvider;
+}
+
+function makeOracle(): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    getStateTransitionClient: vi.fn().mockReturnValue(null),
+    waitForProofSdk: vi.fn(),
+  } as unknown as OracleProvider;
+}
+
+function setupModule(storage: StorageProvider): ReturnType<typeof createPaymentsModule> {
+  const module = createPaymentsModule();
+  module.initialize({
+    identity: makeIdentity(),
+    storage,
+    transport: makeTransport(),
+    oracle: makeOracle(),
+    emitEvent: vi.fn(),
+  });
+  // Bypass the lazy-load gate so the internal map is directly addressable.
+  (module as unknown as { loaded: boolean }).loaded = true;
+  (module as unknown as { loadedPromise: Promise<void> | null }).loadedPromise = null;
+  return module;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Issue #378 — V6-RECOVER permanent-verdict persistence', () => {
+  let storage: InMemoryStorage;
+  let module: ReturnType<typeof createPaymentsModule>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storage = makeStorage();
+    module = setupModule(storage);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('save+restore preserves the ledger across a process boundary', async () => {
+    const internal = module as unknown as {
+      v6RecoverPermanent: Map<string, { reason: string; ts: number }>;
+      saveV6RecoverPermanent: () => Promise<void>;
+    };
+
+    // Stamp two verdicts and persist.
+    internal.v6RecoverPermanent.set('token-a', { reason: 'permanent recipient-address mismatch', ts: 1_700_000_000_000 });
+    internal.v6RecoverPermanent.set('token-b', { reason: 'permanent structural failure', ts: 1_700_000_000_001 });
+    await internal.saveV6RecoverPermanent();
+
+    // Storage round-trip — fresh module reads the same storage.
+    const raw = storage._store.get(STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)).toEqual([
+      { tokenId: 'token-a', reason: 'permanent recipient-address mismatch', ts: 1_700_000_000_000 },
+      { tokenId: 'token-b', reason: 'permanent structural failure', ts: 1_700_000_000_001 },
+    ]);
+
+    // Simulate a new process: fresh module, same storage, restore.
+    const module2 = setupModule(storage);
+    const internal2 = module2 as unknown as {
+      v6RecoverPermanent: Map<string, { reason: string; ts: number }>;
+      restoreV6RecoverPermanent: () => Promise<void>;
+    };
+    expect(internal2.v6RecoverPermanent.size).toBe(0);
+    await internal2.restoreV6RecoverPermanent();
+    expect(internal2.v6RecoverPermanent.size).toBe(2);
+    expect(internal2.v6RecoverPermanent.get('token-a')).toEqual({
+      reason: 'permanent recipient-address mismatch',
+      ts: 1_700_000_000_000,
+    });
+    expect(internal2.v6RecoverPermanent.get('token-b')).toEqual({
+      reason: 'permanent structural failure',
+      ts: 1_700_000_000_001,
+    });
+  });
+
+  it('empty ledger save clears the storage key (no stale list survives)', async () => {
+    const internal = module as unknown as {
+      v6RecoverPermanent: Map<string, { reason: string; ts: number }>;
+      saveV6RecoverPermanent: () => Promise<void>;
+    };
+
+    // Seed an entry and persist.
+    internal.v6RecoverPermanent.set('token-x', { reason: 'permanent structural failure', ts: 1 });
+    await internal.saveV6RecoverPermanent();
+    expect(storage._store.has(STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT)).toBe(true);
+
+    // Clear in-memory and persist — storage key should be removed.
+    internal.v6RecoverPermanent.clear();
+    await internal.saveV6RecoverPermanent();
+    expect(storage._store.has(STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT)).toBe(false);
+  });
+
+  it('restoreV6RecoverPermanent tolerates malformed entries (single-entry resilience)', async () => {
+    // Plant a payload with a mix of valid + malformed entries.
+    storage._store.set(
+      STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT,
+      JSON.stringify([
+        { tokenId: 'good-1', reason: 'permanent structural failure', ts: 1_000 },
+        { tokenId: '', reason: 'empty-id should skip', ts: 2_000 },
+        { tokenId: 'no-reason', ts: 3_000 },
+        { tokenId: 'good-2', reason: 'permanent recipient-address mismatch', ts: 4_000 },
+        { tokenId: 'nan-ts', reason: 'NaN ts should skip', ts: Number.NaN },
+      ]),
+    );
+
+    const internal = module as unknown as {
+      v6RecoverPermanent: Map<string, { reason: string; ts: number }>;
+      restoreV6RecoverPermanent: () => Promise<void>;
+    };
+    await internal.restoreV6RecoverPermanent();
+
+    // Only the two well-formed entries survive.
+    expect(internal.v6RecoverPermanent.size).toBe(2);
+    expect(internal.v6RecoverPermanent.has('good-1')).toBe(true);
+    expect(internal.v6RecoverPermanent.has('good-2')).toBe(true);
+    expect(internal.v6RecoverPermanent.has('')).toBe(false);
+    expect(internal.v6RecoverPermanent.has('no-reason')).toBe(false);
+    expect(internal.v6RecoverPermanent.has('nan-ts')).toBe(false);
+  });
+
+  it('restoreV6RecoverPermanent on missing storage key is a no-op', async () => {
+    const internal = module as unknown as {
+      v6RecoverPermanent: Map<string, { reason: string; ts: number }>;
+      restoreV6RecoverPermanent: () => Promise<void>;
+    };
+    expect(internal.v6RecoverPermanent.size).toBe(0);
+    await internal.restoreV6RecoverPermanent();
+    expect(internal.v6RecoverPermanent.size).toBe(0);
+  });
+
+  it('restoreV6RecoverPermanent on non-array payload clears nothing and logs', async () => {
+    storage._store.set(
+      STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT,
+      JSON.stringify({ shape: 'object instead of array' }),
+    );
+    const internal = module as unknown as {
+      v6RecoverPermanent: Map<string, { reason: string; ts: number }>;
+      restoreV6RecoverPermanent: () => Promise<void>;
+    };
+    internal.v6RecoverPermanent.set('pre-existing', { reason: 'should-not-be-touched', ts: 1 });
+    await internal.restoreV6RecoverPermanent();
+    // Pre-existing in-memory state is preserved; malformed payload is logged.
+    expect(internal.v6RecoverPermanent.size).toBe(1);
+    expect(internal.v6RecoverPermanent.has('pre-existing')).toBe(true);
+  });
+});

--- a/tests/unit/profile/global-clear-gate-368.test.ts
+++ b/tests/unit/profile/global-clear-gate-368.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Issue #368 — process-wide `applySnapshot` suppression during
+ * multi-wallet `Sphere.clear()` batches.
+ *
+ * Item #2 (issue #364, sibling PR #365) added the per-instance
+ * `isClearing` latch on `ProfileTokenStorageProvider`. It correctly
+ * suppresses `applySnapshotIfWired` for THE provider whose `clear()`
+ * is in flight but leaves a gap when `Sphere.clear()` is invoked
+ * sequentially across several wallets in the same process (or when
+ * multi-wallet apps run many providers concurrently): while wallet A's
+ * `clear()` is running, wallets B/C/D's periodic pointer-polls keep
+ * firing `applySnapshotIfWired` against state that is about to be
+ * wiped next.
+ *
+ * The fix is a process-wide reference-counted gate
+ * (`profile/global-clear-gate.ts`) consulted by
+ * `_applySnapshotIfWiredImpl` AFTER the per-instance latch. While the
+ * gate is held (depth > 0), every provider in the process suppresses
+ * snapshot dispatch and bumps
+ * `profile.applySnapshot.suppressedDuringGlobalClear`.
+ *
+ * This test file pins the gate's semantics in isolation — it does NOT
+ * exercise the full `Sphere.clear()` body (that's covered by the
+ * Item #2 file). It verifies:
+ *
+ *   - depth tracking composes (begin / end nest);
+ *   - end is no-op-safe at depth 0;
+ *   - a HELD gate suppresses applySnapshot even when isClearing=false;
+ *   - the counter `profile.applySnapshot.suppressedDuringGlobalClear`
+ *     fires the expected number of times;
+ *   - after the gate releases, applySnapshot proceeds normally.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import type { ApplySnapshotResult } from '../../../profile/profile-snapshot-dispatcher';
+import {
+  beginGlobalClear,
+  endGlobalClear,
+  isGlobalClearActive,
+  __resetGlobalClearForTest,
+} from '../../../profile/global-clear-gate';
+import {
+  __setPerfEnabledForTest,
+  __stopAutoDumpForTest,
+  dumpAndReset,
+  snapshot,
+} from '../../../core/perf-counters.js';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1test',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+function createMockDb(): ProfileDatabase {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as ProfileDatabase;
+}
+
+function makeApplyResult(): ApplySnapshotResult {
+  return {
+    joinedAny: true,
+    addressesSeen: 1,
+    bundleEntriesSeen: 0,
+    counters: {
+      entriesEvaluated: 1,
+      liveLanded: 1,
+      tombstonesLanded: 0,
+      localWon: 0,
+      remoteRejectedMalformed: 0,
+    },
+  };
+}
+
+function createProvider(addressId: string): ProfileTokenStorageProvider {
+  const provider = new ProfileTokenStorageProvider(
+    createMockDb(),
+    new Uint8Array(32).fill(0x11),
+    ['https://mock-ipfs.test'],
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId,
+      encrypt: true,
+    },
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  return provider;
+}
+
+describe('Issue #368 — process-wide global-clear gate', () => {
+  beforeEach(() => {
+    __stopAutoDumpForTest();
+    __setPerfEnabledForTest(true);
+    dumpAndReset();
+    __resetGlobalClearForTest();
+  });
+
+  afterEach(() => {
+    __setPerfEnabledForTest(false);
+    __stopAutoDumpForTest();
+    __resetGlobalClearForTest();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Counter semantics
+  // ---------------------------------------------------------------------------
+
+  it('begin / end track depth and isGlobalClearActive() returns true while held', () => {
+    expect(isGlobalClearActive()).toBe(false);
+    beginGlobalClear();
+    expect(isGlobalClearActive()).toBe(true);
+    endGlobalClear();
+    expect(isGlobalClearActive()).toBe(false);
+  });
+
+  it('depth nests: two begins require two ends to release', () => {
+    beginGlobalClear();
+    beginGlobalClear();
+    expect(isGlobalClearActive()).toBe(true);
+    endGlobalClear();
+    expect(isGlobalClearActive()).toBe(true);
+    endGlobalClear();
+    expect(isGlobalClearActive()).toBe(false);
+  });
+
+  it('endGlobalClear is no-op-safe at depth 0 — a stray double-end cannot go negative', () => {
+    expect(isGlobalClearActive()).toBe(false);
+    endGlobalClear();
+    endGlobalClear();
+    expect(isGlobalClearActive()).toBe(false);
+
+    // Subsequent begin still moves the gate to 1 cleanly.
+    beginGlobalClear();
+    expect(isGlobalClearActive()).toBe(true);
+    endGlobalClear();
+    expect(isGlobalClearActive()).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Gate effect on applySnapshotIfWired
+  // ---------------------------------------------------------------------------
+
+  it('held gate suppresses applySnapshotIfWired across an UNRELATED provider (isClearing=false)', async () => {
+    // Two providers: A is "being cleared" via the bracket; B is a
+    // sibling whose periodic-poll fires while A is mid-clear. The
+    // per-instance `isClearing` latch on B is unset.
+    const providerA = createProvider('addrA');
+    const providerB = createProvider('addrB');
+    const applierA = vi.fn(async () => makeApplyResult());
+    const applierB = vi.fn(async () => makeApplyResult());
+    providerA.setApplySnapshotCallback(applierA);
+    providerB.setApplySnapshotCallback(applierB);
+    await providerA.initialize();
+    await providerB.initialize();
+
+    beginGlobalClear();
+    try {
+      const a = await providerA.applySnapshotIfWired('bafy-A');
+      const b = await providerB.applySnapshotIfWired('bafy-B');
+      expect(a).toBeNull();
+      expect(b).toBeNull();
+      expect(applierA).not.toHaveBeenCalled();
+      expect(applierB).not.toHaveBeenCalled();
+    } finally {
+      endGlobalClear();
+    }
+  });
+
+  it('bumps profile.applySnapshot.suppressedDuringGlobalClear exactly once per gated call', async () => {
+    const provider = createProvider('addr');
+    const applier = vi.fn(async () => makeApplyResult());
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    beginGlobalClear();
+    try {
+      await provider.applySnapshotIfWired('bafy-1');
+      await provider.applySnapshotIfWired('bafy-2');
+      await provider.applySnapshotIfWired('bafy-3');
+    } finally {
+      endGlobalClear();
+    }
+
+    const counters = snapshot();
+    expect(
+      counters['profile.applySnapshot.suppressedDuringGlobalClear']?.count,
+    ).toBe(3);
+    expect(counters['profile.applySnapshot.fired']?.count ?? 0).toBe(0);
+    expect(applier).not.toHaveBeenCalled();
+  });
+
+  it('per-instance isClearing takes precedence over the global gate', async () => {
+    // When BOTH latches would gate, the per-instance one fires first
+    // (it's checked earlier in `_applySnapshotIfWiredImpl`). This pins
+    // the ordering so counters stay attributable.
+    const provider = createProvider('addr');
+    const applier = vi.fn(async () => makeApplyResult());
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    (provider as unknown as { isClearing: boolean }).isClearing = true;
+    beginGlobalClear();
+    try {
+      await provider.applySnapshotIfWired('bafy-1');
+    } finally {
+      endGlobalClear();
+      (provider as unknown as { isClearing: boolean }).isClearing = false;
+    }
+
+    const counters = snapshot();
+    expect(counters['profile.applySnapshot.suppressedDuringClear']?.count).toBe(1);
+    // Global gate stayed quiet (the per-instance branch returned first).
+    expect(
+      counters['profile.applySnapshot.suppressedDuringGlobalClear']?.count ?? 0,
+    ).toBe(0);
+  });
+
+  it('after the gate releases, applySnapshot proceeds normally', async () => {
+    const provider = createProvider('addr');
+    const applier = vi.fn(async () => makeApplyResult());
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    beginGlobalClear();
+    const blocked = await provider.applySnapshotIfWired('bafy-blocked');
+    expect(blocked).toBeNull();
+    endGlobalClear();
+
+    const allowed = await provider.applySnapshotIfWired('bafy-allowed');
+    expect(allowed).not.toBeNull();
+    expect(applier).toHaveBeenCalledTimes(1);
+    expect(applier).toHaveBeenCalledWith('bafy-allowed');
+  });
+});

--- a/tests/unit/profile/ipfs-client-dag-export.test.ts
+++ b/tests/unit/profile/ipfs-client-dag-export.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Issue #370 — `fetchCarFromIpfs` `/dag/export` fast-path tests.
+ *
+ * Verifies the selector layer added in issue #370 on the read side:
+ *   - Probe-driven fast path: a single `/dag/export` POST replaces the
+ *     per-block `/api/v0/block/get` BFS walk, returns CAR bytes that the
+ *     selector parses + verifies block-by-block + reassembles.
+ *   - Per-block CID verification: a gateway returning a CAR with one
+ *     mismatched block triggers fallback to legacy BFS (defense-in-depth
+ *     against gateway tampering).
+ *   - Missing-root defensive check: a CAR returned by /dag/export that
+ *     does not contain the requested root triggers fallback.
+ *   - Probe-miss fallback: gateway returning 404 from probe → legacy BFS
+ *     walks `/api/v0/block/get`.
+ *   - Byte-for-byte equivalence: fast-path output and legacy BFS output
+ *     reassemble identical CAR bytes for the same input fixture.
+ *
+ * @module tests/unit/profile/ipfs-client-dag-export
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { CID } from 'multiformats/cid';
+import { create as createDigest } from 'multiformats/hashes/digest';
+import { encode as dagCborEncode } from '@ipld/dag-cbor';
+import { CarReader } from '@ipld/car';
+import {
+  fetchCarFromIpfs,
+  _resetGatewayCapabilityCache,
+} from '../../../profile/ipfs-client';
+import { makeFakeUxfCar } from './_helpers/fake-uxf-car.js';
+
+// ---------------------------------------------------------------------------
+// Fetch mock builders
+// ---------------------------------------------------------------------------
+
+interface ExportMockOptions {
+  readonly probeStatus: number;
+  /** Bytes to return on /api/v0/dag/export call. */
+  readonly exportBytes?: Uint8Array;
+  /** Status to return on /api/v0/dag/export call (default 200). */
+  readonly exportStatus?: number;
+  /** Blocks map for legacy /api/v0/block/get fallback path. */
+  readonly blocks?: Map<string, Uint8Array>;
+}
+
+interface MockHandle {
+  readonly restore: () => void;
+  readonly exportCalls: () => number;
+  readonly blockGetCalls: () => number;
+}
+
+function installMock(opts: ExportMockOptions): MockHandle {
+  const original = globalThis.fetch;
+  const counts = { exportCalls: 0, blockGetCalls: 0 };
+
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : (input as { url?: string }).url ?? String(input);
+
+    // Probe: a POST to /api/v0/dag/import or /api/v0/dag/export with no
+    // body. The real fast-path /dag/export has `arg=<cid>` in the query.
+    const isProbe =
+      (url.endsWith('/api/v0/dag/import') || url.endsWith('/api/v0/dag/export')) &&
+      init?.body === undefined;
+    if (isProbe) {
+      return new Response('', { status: opts.probeStatus });
+    }
+
+    if (url.includes('/api/v0/dag/export?')) {
+      counts.exportCalls += 1;
+      const status = opts.exportStatus ?? 200;
+      if (status !== 200) {
+        return new Response('forced failure', { status });
+      }
+      if (opts.exportBytes === undefined) {
+        return new Response('no bytes configured', { status: 500 });
+      }
+      return new Response(opts.exportBytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/vnd.ipld.car' },
+      });
+    }
+
+    if (url.includes('/api/v0/block/get?arg=')) {
+      counts.blockGetCalls += 1;
+      const match = url.match(/\/api\/v0\/block\/get\?arg=([^&]+)/);
+      if (!match) return new Response('missing arg', { status: 400 });
+      const cid = decodeURIComponent(match[1]!);
+      const bytes = opts.blocks?.get(cid);
+      if (!bytes) return new Response('miss', { status: 404 });
+      return new Response(bytes, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      });
+    }
+
+    if (url.includes('/sidecar/blob') || url.includes('/sidecar/submit')) {
+      return new Response('', { status: 404 });
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  return {
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    exportCalls: () => counts.exportCalls,
+    blockGetCalls: () => counts.blockGetCalls,
+  };
+}
+
+/** Extract every block from a CAR into a map for the legacy mock. */
+async function carToBlockMap(carBytes: Uint8Array): Promise<Map<string, Uint8Array>> {
+  const reader = await CarReader.fromBytes(carBytes);
+  const out = new Map<string, Uint8Array>();
+  for await (const block of reader.blocks()) {
+    out.set(block.cid.toString(), block.bytes);
+  }
+  return out;
+}
+
+/** Hand-build a CAR whose root is dag-cbor with a single block. */
+async function makeMinimalDagCborCar(): Promise<Uint8Array> {
+  const { CarWriter } = await import('@ipld/car');
+  const payload = { issue: 370, kind: 'minimal-dag-cbor' };
+  const bytes = dagCborEncode(payload);
+  const cid = CID.createV1(0x71, createDigest(0x12, sha256(bytes)));
+  const { writer, out } = CarWriter.create([cid]);
+  const collect = (async () => {
+    const chunks: Uint8Array[] = [];
+    for await (const c of out) chunks.push(c);
+    return chunks;
+  })();
+  await writer.put({ cid, bytes });
+  await writer.close();
+  const chunks = await collect;
+  const total = chunks.reduce((a, c) => a + c.length, 0);
+  const buf = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    buf.set(c, offset);
+    offset += c.length;
+  }
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Issue #370 — fetchCarFromIpfs /dag/export fast path', () => {
+  let mock: MockHandle | null = null;
+
+  beforeEach(() => {
+    _resetGatewayCapabilityCache();
+  });
+
+  afterEach(() => {
+    if (mock !== null) {
+      mock.restore();
+      mock = null;
+    }
+  });
+
+  it('happy path: single /dag/export call replaces per-block BFS', async () => {
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'fast-1' }, { id: 'fast-2' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+
+    mock = installMock({ probeStatus: 400, exportBytes: carBytes });
+    const out = await fetchCarFromIpfs(['https://gw-fast.test'], rootCid);
+
+    // Single export call, zero per-block fetches.
+    expect(mock.exportCalls()).toBe(1);
+    expect(mock.blockGetCalls()).toBe(0);
+
+    // Output is a valid CAR with the same root.
+    const outReader = await CarReader.fromBytes(out);
+    const outRoots = await outReader.getRoots();
+    expect(outRoots[0]!.toString()).toBe(rootCid);
+
+    // Every source block is present.
+    const sourceCids = new Set<string>();
+    const r2 = await CarReader.fromBytes(carBytes);
+    for await (const b of r2.blocks()) sourceCids.add(b.cid.toString());
+    const outCids = new Set<string>();
+    const r3 = await CarReader.fromBytes(out);
+    for await (const b of r3.blocks()) outCids.add(b.cid.toString());
+    expect(outCids).toEqual(sourceCids);
+  });
+
+  it('falls back to legacy BFS when probe returns 404', async () => {
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'legacy' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+    const blocks = await carToBlockMap(carBytes);
+
+    mock = installMock({ probeStatus: 404, blocks });
+    const out = await fetchCarFromIpfs(['https://gw-no-export.test'], rootCid);
+
+    expect(mock.exportCalls()).toBe(0);
+    expect(mock.blockGetCalls()).toBeGreaterThan(0);
+
+    const outReader = await CarReader.fromBytes(out);
+    const outRoots = await outReader.getRoots();
+    expect(outRoots[0]!.toString()).toBe(rootCid);
+  });
+
+  it('falls back to legacy BFS when fast-path /dag/export returns 500', async () => {
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'mid-failure' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+    const blocks = await carToBlockMap(carBytes);
+
+    mock = installMock({ probeStatus: 400, exportStatus: 500, blocks });
+    const out = await fetchCarFromIpfs(['https://gw-export-500.test'], rootCid);
+
+    expect(mock.exportCalls()).toBe(1);
+    expect(mock.blockGetCalls()).toBeGreaterThan(0);
+    const outReader = await CarReader.fromBytes(out);
+    const outRoots = await outReader.getRoots();
+    expect(outRoots[0]!.toString()).toBe(rootCid);
+  });
+
+  it('falls back to legacy BFS when /dag/export response omits the requested root', async () => {
+    const truthful = await makeFakeUxfCar({ tokens: [{ id: 'truthful' }] });
+    const truthfulReader = await CarReader.fromBytes(truthful);
+    const truthfulRoots = await truthfulReader.getRoots();
+    const truthfulRoot = truthfulRoots[0]!.toString();
+    const truthfulBlocks = await carToBlockMap(truthful);
+
+    // Build a different CAR that claims a different root — the gateway
+    // returns this in response to a request for the truthful root.
+    const phantom = await makeMinimalDagCborCar();
+
+    mock = installMock({ probeStatus: 400, exportBytes: phantom, blocks: truthfulBlocks });
+    const out = await fetchCarFromIpfs(
+      ['https://gw-wrong-root.test'],
+      truthfulRoot,
+    );
+
+    expect(mock.exportCalls()).toBe(1);
+    expect(mock.blockGetCalls()).toBeGreaterThan(0);
+    const outReader = await CarReader.fromBytes(out);
+    const outRoots = await outReader.getRoots();
+    expect(outRoots[0]!.toString()).toBe(truthfulRoot);
+  });
+
+  it('falls back to legacy BFS when /dag/export response contains a CID-binding-violating block', async () => {
+    // Use the legitimate CAR's root and structure, but corrupt one block's
+    // bytes in the served stream so per-block sha256 check fails. The
+    // legacy BFS will then succeed (because its mock serves honest bytes).
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'corrupted' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+    const blocks = await carToBlockMap(carBytes);
+
+    // Build a corrupt CAR by reassembling with one block's bytes mutated.
+    const { CarWriter } = await import('@ipld/car');
+    const allBlocks: Array<{ cid: CID; bytes: Uint8Array }> = [];
+    for await (const b of (await CarReader.fromBytes(carBytes)).blocks()) {
+      allBlocks.push({ cid: b.cid, bytes: b.bytes });
+    }
+    // Corrupt a non-root block. Mutate the last byte of the last block.
+    const target = allBlocks[allBlocks.length - 1]!;
+    const corrupted = new Uint8Array(target.bytes);
+    corrupted[corrupted.length - 1] = corrupted[corrupted.length - 1]! ^ 0xff;
+    allBlocks[allBlocks.length - 1] = { cid: target.cid, bytes: corrupted };
+
+    const { writer, out } = CarWriter.create([roots[0]!]);
+    const collect = (async () => {
+      const chunks: Uint8Array[] = [];
+      for await (const c of out) chunks.push(c);
+      return chunks;
+    })();
+    for (const b of allBlocks) await writer.put(b);
+    await writer.close();
+    const chunks = await collect;
+    const total = chunks.reduce((a, c) => a + c.length, 0);
+    const corruptCar = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      corruptCar.set(c, offset);
+      offset += c.length;
+    }
+
+    mock = installMock({ probeStatus: 400, exportBytes: corruptCar, blocks });
+    const reassembled = await fetchCarFromIpfs(
+      ['https://gw-corrupt.test'],
+      rootCid,
+    );
+    // Fast path attempted then failed CID-binding → fell through to legacy BFS.
+    expect(mock.exportCalls()).toBe(1);
+    expect(mock.blockGetCalls()).toBeGreaterThan(0);
+    const r = await CarReader.fromBytes(reassembled);
+    const r2 = await r.getRoots();
+    expect(r2[0]!.toString()).toBe(rootCid);
+  });
+
+  it('byte-for-byte equivalence: fast-path output and legacy BFS produce identical CAR block sets', async () => {
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'eq-1' }, { id: 'eq-2' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+    const blocks = await carToBlockMap(carBytes);
+
+    // Run 1: fast path.
+    mock = installMock({ probeStatus: 400, exportBytes: carBytes, blocks });
+    const fastOut = await fetchCarFromIpfs(['https://gw-eq-fast.test'], rootCid);
+    mock.restore();
+    mock = null;
+    _resetGatewayCapabilityCache();
+
+    // Run 2: legacy path (probe miss).
+    mock = installMock({ probeStatus: 404, blocks });
+    const legacyOut = await fetchCarFromIpfs(['https://gw-eq-legacy.test'], rootCid);
+
+    // Equivalence: same root + same block set. The two paths reassemble
+    // the CAR independently (fast-path uses verifyAndReassembleExportedCar,
+    // legacy uses the BFS reassembly); CAR-wire bytes may differ in block
+    // ordering, but root and block-set MUST match.
+    const fastReader = await CarReader.fromBytes(fastOut);
+    const legacyReader = await CarReader.fromBytes(legacyOut);
+    const fastRoots = await fastReader.getRoots();
+    const legacyRoots = await legacyReader.getRoots();
+    expect(fastRoots[0]!.toString()).toBe(rootCid);
+    expect(legacyRoots[0]!.toString()).toBe(rootCid);
+
+    const fastCids = new Set<string>();
+    for await (const b of fastReader.blocks()) fastCids.add(b.cid.toString());
+    const legacyCids = new Set<string>();
+    for await (const b of legacyReader.blocks()) legacyCids.add(b.cid.toString());
+    expect(fastCids).toEqual(legacyCids);
+    expect(fastCids.size).toBe(blocks.size);
+  });
+
+  it('probe cache: same gateway probed exactly once across multiple fetches', async () => {
+    const carBytes = await makeFakeUxfCar({ tokens: [{ id: 'cache' }] });
+    const reader = await CarReader.fromBytes(carBytes);
+    const roots = await reader.getRoots();
+    const rootCid = roots[0]!.toString();
+
+    let probeHits = 0;
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : (input as { url?: string }).url ?? String(input);
+      const isProbe =
+        (url.endsWith('/api/v0/dag/import') || url.endsWith('/api/v0/dag/export')) &&
+        init?.body === undefined;
+      if (isProbe) {
+        probeHits += 1;
+        return new Response('', { status: 400 });
+      }
+      if (url.includes('/api/v0/dag/export?')) {
+        return new Response(carBytes, {
+          status: 200,
+          headers: { 'Content-Type': 'application/vnd.ipld.car' },
+        });
+      }
+      return new Response('not found', { status: 404 });
+    }) as typeof globalThis.fetch;
+
+    try {
+      for (let i = 0; i < 3; i++) {
+        await fetchCarFromIpfs(['https://gw-fetch-cache.test'], rootCid);
+      }
+      // Two endpoints probed (import + export), each exactly once across
+      // the three fetches.
+      expect(probeHits).toBe(2);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/tests/unit/profile/ipfs-client-dag-import.test.ts
+++ b/tests/unit/profile/ipfs-client-dag-import.test.ts
@@ -1,0 +1,555 @@
+/**
+ * Issue #370 — `pinCarBlocksToIpfs` `/dag/import` fast-path tests.
+ *
+ * Verifies the selector layer added in issue #370:
+ *   - Capability probe semantics (200/400/404/405/500/timeout/network-error)
+ *   - Probe cache: a gateway is probed exactly once across many pins
+ *   - Fast-path happy case: single `/dag/import` POST replaces the per-block
+ *     `/dag/put` loop, NDJSON response parsed for expected-root presence
+ *   - Multi-root defensive check: the gateway reporting extra roots does not
+ *     fail; the gateway omitting our root does
+ *   - Fallback on probe-miss (gateway returns 404 from probe): legacy
+ *     per-block path runs against `/dag/put`
+ *   - Fallback on per-call HTTP failure (probe says capable but actual
+ *     `/dag/import` call returns 500): legacy per-block path runs
+ *   - Legacy path local-Helia writes are skipped when the fast path already
+ *     wrote them (no duplicate puts)
+ *
+ * The legacy path's per-block correctness is covered by
+ * `tests/unit/profile/ipfs-client-parallel-pin.test.ts` — this file only
+ * verifies the dispatch + fast-path layer.
+ *
+ * @module tests/unit/profile/ipfs-client-dag-import
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { create as createDigest } from 'multiformats/hashes/digest';
+
+import {
+  pinCarBlocksToIpfs,
+  _resetGatewayCapabilityCache,
+} from '../../../profile/ipfs-client';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async function buildCar(
+  blocks: Array<{ cid: CID; bytes: Uint8Array }>,
+): Promise<Uint8Array> {
+  const { CarWriter } = await import('@ipld/car');
+  const { writer, out } = CarWriter.create([blocks[0]!.cid]);
+  const collect = (async () => {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of out) chunks.push(chunk);
+    return chunks;
+  })();
+  for (const block of blocks) await writer.put(block);
+  await writer.close();
+  const chunks = await collect;
+  const total = chunks.reduce((a, c) => a + c.length, 0);
+  const buf = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    buf.set(c, offset);
+    offset += c.length;
+  }
+  return buf;
+}
+
+function makeRawBlocks(n: number): Array<{ cid: CID; bytes: Uint8Array }> {
+  const out: Array<{ cid: CID; bytes: Uint8Array }> = [];
+  for (let i = 0; i < n; i++) {
+    const bytes = new TextEncoder().encode(`#370-import-block-${i}`);
+    out.push({
+      cid: CID.createV1(raw.code, createDigest(0x12, sha256(bytes))),
+      bytes,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock builders
+// ---------------------------------------------------------------------------
+
+interface ProbeMockOptions {
+  /** Status returned for probe POST to /api/v0/dag/import. */
+  readonly importProbeStatus: number;
+  /** Status returned for probe POST to /api/v0/dag/export. Default mirrors import. */
+  readonly exportProbeStatus?: number;
+  /** When true, the probe rejects with a network error instead of responding. */
+  readonly probeNetworkError?: boolean;
+  /** When true, the probe never resolves (forces timeout). */
+  readonly probeHang?: boolean;
+}
+
+interface FastPathMockOptions extends ProbeMockOptions {
+  /**
+   * NDJSON lines to return on `/api/v0/dag/import` (one per line). When
+   * omitted defaults to a single-root envelope with the supplied
+   * `expectedRootCid`.
+   */
+  readonly importNdjson?: (expectedRootCid: string) => string;
+  /** Status for /api/v0/dag/import call (default 200). */
+  readonly importStatus?: number;
+  /** Status for /api/v0/dag/put fallback (default 200, returns minimal JSON). */
+  readonly dagPutStatus?: number;
+}
+
+interface MockHandle {
+  readonly restore: () => void;
+  readonly importProbeHits: () => number;
+  readonly exportProbeHits: () => number;
+  readonly importCalls: () => number;
+  readonly dagPutCalls: () => number;
+}
+
+function installMock(opts: FastPathMockOptions, gatewayBase: string): MockHandle {
+  const original = globalThis.fetch;
+  const counts = {
+    importProbeHits: 0,
+    exportProbeHits: 0,
+    importCalls: 0,
+    dagPutCalls: 0,
+  };
+
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : (input as { url?: string }).url ?? String(input);
+
+    const isProbe =
+      (url.endsWith('/api/v0/dag/import') || url.endsWith('/api/v0/dag/export')) &&
+      // A probe has no body; the real fast-path call has a FormData body.
+      init?.body === undefined;
+
+    if (isProbe) {
+      if (opts.probeHang === true) {
+        return await new Promise(() => {
+          /* hang */
+        });
+      }
+      if (opts.probeNetworkError === true) {
+        throw new Error('probe-network-error');
+      }
+      if (url.endsWith('/api/v0/dag/import')) {
+        counts.importProbeHits += 1;
+        return new Response('', { status: opts.importProbeStatus });
+      }
+      counts.exportProbeHits += 1;
+      return new Response('', {
+        status: opts.exportProbeStatus ?? opts.importProbeStatus,
+      });
+    }
+
+    if (url.includes('/api/v0/dag/import?')) {
+      counts.importCalls += 1;
+      const status = opts.importStatus ?? 200;
+      if (status !== 200) {
+        return new Response('forced failure', { status });
+      }
+      const ndjson = (opts.importNdjson ?? defaultImportNdjson)(
+        currentExpectedRoot ?? '',
+      );
+      return new Response(ndjson, { status: 200 });
+    }
+
+    if (url.includes('/api/v0/dag/put')) {
+      counts.dagPutCalls += 1;
+      return new Response(JSON.stringify({ Cid: { '/': 'ignored' } }), {
+        status: opts.dagPutStatus ?? 200,
+      });
+    }
+
+    if (url.includes('/sidecar/submit') || url.includes('/sidecar/blob')) {
+      return new Response('', { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  // Defensive: silence the unused-warning if the caller doesn't use gatewayBase.
+  void gatewayBase;
+
+  return {
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    importProbeHits: () => counts.importProbeHits,
+    exportProbeHits: () => counts.exportProbeHits,
+    importCalls: () => counts.importCalls,
+    dagPutCalls: () => counts.dagPutCalls,
+  };
+}
+
+/**
+ * Default NDJSON: single Root envelope with the expected CID and no
+ * PinErrorMsg. Models the modern Kubo shape (`Cid: {"/": "..."}`).
+ */
+function defaultImportNdjson(expectedRootCid: string): string {
+  return (
+    JSON.stringify({
+      Root: { Cid: { '/': expectedRootCid }, PinErrorMsg: '' },
+    }) + '\n'
+  );
+}
+
+// Thin global so the mock can include the expected root in NDJSON output
+// without the caller having to pass it through every layer.
+let currentExpectedRoot: string | null = null;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Issue #370 — pinCarBlocksToIpfs /dag/import fast path', () => {
+  let mock: MockHandle | null = null;
+
+  beforeEach(() => {
+    _resetGatewayCapabilityCache();
+  });
+
+  afterEach(() => {
+    if (mock !== null) {
+      mock.restore();
+      mock = null;
+    }
+    currentExpectedRoot = null;
+  });
+
+  describe('capability probe', () => {
+    it('treats 400 (healthy Kubo on empty body) as "exposed" → fast path runs', async () => {
+      const blocks = makeRawBlocks(4);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-probe-400.test';
+
+      mock = installMock({ importProbeStatus: 400 }, gateway);
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+      expect(mock.importCalls()).toBe(1);
+      expect(mock.dagPutCalls()).toBe(0);
+    });
+
+    it('treats 404 as "not exposed" → falls through to legacy per-block', async () => {
+      const blocks = makeRawBlocks(3);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-probe-404.test';
+
+      mock = installMock({ importProbeStatus: 404 }, gateway);
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+      expect(mock.importCalls()).toBe(0);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+
+    it('treats 405 as "not exposed" → falls through to legacy per-block', async () => {
+      const blocks = makeRawBlocks(2);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-probe-405.test';
+
+      mock = installMock({ importProbeStatus: 405 }, gateway);
+      await pinCarBlocksToIpfs([gateway], carBytes, expectedRoot);
+      expect(mock.importCalls()).toBe(0);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+
+    it('treats 500 as "not exposed" → falls through to legacy per-block', async () => {
+      const blocks = makeRawBlocks(2);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-probe-500.test';
+
+      mock = installMock({ importProbeStatus: 500 }, gateway);
+      await pinCarBlocksToIpfs([gateway], carBytes, expectedRoot);
+      expect(mock.importCalls()).toBe(0);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+
+    it('treats network error as "not exposed" → falls through to legacy per-block', async () => {
+      const blocks = makeRawBlocks(2);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-probe-neterr.test';
+
+      mock = installMock(
+        { importProbeStatus: 0, probeNetworkError: true },
+        gateway,
+      );
+      await pinCarBlocksToIpfs([gateway], carBytes, expectedRoot);
+      expect(mock.importCalls()).toBe(0);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+  });
+
+  describe('probe cache', () => {
+    it('probes the same gateway exactly once across multiple pins', async () => {
+      const expectedCalls = 3;
+      const gateway = 'https://gw-probe-cache.test';
+      mock = installMock({ importProbeStatus: 400 }, gateway);
+
+      for (let i = 0; i < expectedCalls; i++) {
+        const blocks = makeRawBlocks(1);
+        const carBytes = await buildCar(blocks);
+        const expectedRoot = blocks[0]!.cid.toString();
+        currentExpectedRoot = expectedRoot;
+        await pinCarBlocksToIpfs([gateway], carBytes, expectedRoot);
+      }
+      expect(mock.importProbeHits()).toBe(1);
+      expect(mock.exportProbeHits()).toBe(1);
+      expect(mock.importCalls()).toBe(expectedCalls);
+    });
+  });
+
+  describe('NDJSON response parsing', () => {
+    it('accepts modern shape {"Root":{"Cid":{"/":"<cid>"}}}', async () => {
+      const blocks = makeRawBlocks(1);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-ndjson-modern.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: (root) =>
+            JSON.stringify({ Root: { Cid: { '/': root }, PinErrorMsg: '' } }) +
+            '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+    });
+
+    it('accepts older shape {"Root":{"Cid":"<cid>"}} (bare string Cid)', async () => {
+      const blocks = makeRawBlocks(1);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-ndjson-old.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: (root) =>
+            JSON.stringify({ Root: { Cid: root, PinErrorMsg: '' } }) + '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+    });
+
+    it('skips Stats lines and other non-Root envelopes', async () => {
+      const blocks = makeRawBlocks(1);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-ndjson-mixed.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: (root) =>
+            [
+              JSON.stringify({ Stats: { BlockCount: 1 } }),
+              JSON.stringify({ Root: { Cid: { '/': root } } }),
+              JSON.stringify({ Stats: { BlockBytesCount: 64 } }),
+              '   ', // whitespace-only line
+              '{not json',
+            ].join('\n') + '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+    });
+
+    it('multi-root defensive check: tolerates extra Root entries beyond our expected root', async () => {
+      const blocks = makeRawBlocks(1);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      const phantomRoot = CID.createV1(
+        raw.code,
+        createDigest(0x12, sha256(new TextEncoder().encode('phantom'))),
+      ).toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-multi-root.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: (root) =>
+            [
+              JSON.stringify({ Root: { Cid: { '/': root } } }),
+              JSON.stringify({ Root: { Cid: { '/': phantomRoot } } }),
+            ].join('\n') + '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+    });
+
+    it('falls back to legacy when NDJSON response omits the expected root', async () => {
+      const blocks = makeRawBlocks(2);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      const wrongRoot = CID.createV1(
+        raw.code,
+        createDigest(0x12, sha256(new TextEncoder().encode('not-our-root'))),
+      ).toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-missing-root.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: () =>
+            JSON.stringify({ Root: { Cid: { '/': wrongRoot } } }) + '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+      // Fast path was attempted, then fell through to legacy per-block.
+      expect(mock.importCalls()).toBe(1);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+
+    it('falls back to legacy when NDJSON Root reports a non-empty PinErrorMsg', async () => {
+      const blocks = makeRawBlocks(2);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-pin-error.test';
+
+      mock = installMock(
+        {
+          importProbeStatus: 400,
+          importNdjson: (root) =>
+            JSON.stringify({
+              Root: { Cid: { '/': root }, PinErrorMsg: 'block too large' },
+            }) + '\n',
+        },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+      expect(mock.importCalls()).toBe(1);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+  });
+
+  describe('fallback on per-call HTTP failure', () => {
+    it('falls back to legacy when fast-path /dag/import returns 500', async () => {
+      const blocks = makeRawBlocks(3);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-500-onlyimport.test';
+
+      mock = installMock(
+        { importProbeStatus: 400, importStatus: 500 },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+      );
+      expect(returned).toBe(expectedRoot);
+      expect(mock.importCalls()).toBe(1);
+      expect(mock.dagPutCalls()).toBe(blocks.length);
+    });
+  });
+
+  describe('local-Helia write deduplication', () => {
+    it('does not duplicate local-Helia puts when fast path runs then legacy fallback runs', async () => {
+      const blocks = makeRawBlocks(4);
+      const carBytes = await buildCar(blocks);
+      const expectedRoot = blocks[0]!.cid.toString();
+      currentExpectedRoot = expectedRoot;
+      const gateway = 'https://gw-helia-dedup.test';
+
+      const heliaPuts: string[] = [];
+      const fakeHelia = {
+        blockstore: {
+          get: () => {
+            throw new Error('not supposed to read');
+          },
+          put: async (cid: { toString(): string }) => {
+            heliaPuts.push(cid.toString());
+          },
+        },
+      };
+
+      // Force fast path to attempt then fail (import status 500) so legacy
+      // runs after the fast-path local-helia write phase.
+      mock = installMock(
+        { importProbeStatus: 400, importStatus: 500 },
+        gateway,
+      );
+      const returned = await pinCarBlocksToIpfs(
+        [gateway],
+        carBytes,
+        expectedRoot,
+        30_000,
+        fakeHelia,
+      );
+      expect(returned).toBe(expectedRoot);
+      // Every block written exactly ONCE — the fast-path phase wrote them
+      // and the legacy phase was told to skip its own write loop via
+      // helia=undefined.
+      const expectedCids = blocks.map((b) => b.cid.toString()).sort();
+      expect(heliaPuts.sort()).toEqual(expectedCids);
+    });
+  });
+});

--- a/tests/unit/profile/ipfs-client-parallel-pin.test.ts
+++ b/tests/unit/profile/ipfs-client-parallel-pin.test.ts
@@ -183,7 +183,14 @@ function installConcurrencyMock(
         }
         await new Promise((r) => setTimeout(r, delayMs));
         if (tracker.failNthBlock !== null && myIdx === tracker.failNthBlock) {
-          return new Response('forced failure', { status: 500 });
+          // Issue #369 — HTTP 400 is classified as a PERMANENT failure
+          // by `isTransientPinError`, so `withPinRetry` short-circuits
+          // the retry budget and surfaces the error immediately. This
+          // preserves the original test intent of these abort-propagation
+          // scenarios (single failure → abort the whole CAR pin) under
+          // the new retry-with-backoff wrap; transient codes (5xx, 429,
+          // network errors) would now be retried instead.
+          return new Response('forced failure', { status: 400 });
         }
         return new Response(JSON.stringify({ Cid: { '/': 'ignored' } }), {
           status: 200,
@@ -356,7 +363,7 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
         undefined,
         4,
       ),
-    ).rejects.toThrow(/ORBITDB_WRITE_FAILED|dag\/put failed|HTTP 500/);
+    ).rejects.toThrow(/ORBITDB_WRITE_FAILED|dag\/put failed|HTTP 400/);
   });
 
   it('order-independent: pins arrive in any order, every index processed exactly once', async () => {
@@ -415,7 +422,7 @@ describe('pinCarBlocksToIpfs — bounded-concurrency worker pool', () => {
           undefined,
           4,
         ),
-      ).rejects.toThrow(/ORBITDB_WRITE_FAILED|HTTP 500/);
+      ).rejects.toThrow(/ORBITDB_WRITE_FAILED|HTTP 400/);
       // Give the peer workers enough time to finish their in-flight
       // pin POSTs and any post-throw microtask processing.
       await new Promise((r) => setTimeout(r, 150));

--- a/tests/unit/profile/ipfs-client-pin-retry-369.test.ts
+++ b/tests/unit/profile/ipfs-client-pin-retry-369.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Issue #369 — retry-with-backoff for transient IPFS pin failures.
+ *
+ * The SDK's pin path (`pinToIpfs`, `pinSingleBlock`) historically did
+ * a single `fetch()` per gateway with NO retry on transient errors
+ * (network blip, brief TLS slowdown, rate-limit 429). The observed
+ * surface error was `IPFS dag/put failed on all gateways for <CID>:
+ * fetch failed`, not reproducible on demand because the gateway worked
+ * ~99% of the time when tested directly. A single 1% per-block error
+ * rate cascades to ~92% chance of at-least-one-failure across a
+ * 250-block migration CAR.
+ *
+ * This test file covers:
+ *
+ *   - `isTransientPinError` classifier across the failure-mode matrix
+ *     the pin path actually produces (HTTP-status strings, fetch
+ *     throws, AbortError).
+ *   - `withPinRetry` retry / backoff / counter semantics.
+ *   - End-to-end: `pinToIpfs` succeeds on the third attempt when the
+ *     first two transient-fail (proves the wrap is in the right
+ *     place).
+ *   - Permanent failures (HTTP 4xx other than 429) short-circuit the
+ *     retry budget.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isTransientPinError, withPinRetry, pinToIpfs } from '../../../profile/ipfs-client';
+import {
+  __setPerfEnabledForTest,
+  __stopAutoDumpForTest,
+  dumpAndReset,
+  snapshot,
+} from '../../../core/perf-counters.js';
+
+describe('Issue #369 — isTransientPinError classifier', () => {
+  it('classifies HTTP 5xx as transient', () => {
+    expect(isTransientPinError(new Error('HTTP 500 Internal Server Error from https://gw.test'))).toBe(true);
+    expect(isTransientPinError(new Error('HTTP 502 Bad Gateway from https://gw.test'))).toBe(true);
+    expect(isTransientPinError(new Error('HTTP 503 Service Unavailable from https://gw.test'))).toBe(true);
+  });
+
+  it('classifies HTTP 429 (rate limit) as transient', () => {
+    expect(isTransientPinError(new Error('HTTP 429 Too Many Requests from https://gw.test'))).toBe(true);
+  });
+
+  it('classifies other HTTP 4xx as permanent', () => {
+    expect(isTransientPinError(new Error('HTTP 400 Bad Request from https://gw.test'))).toBe(false);
+    expect(isTransientPinError(new Error('HTTP 401 Unauthorized from https://gw.test'))).toBe(false);
+    expect(isTransientPinError(new Error('HTTP 403 Forbidden from https://gw.test'))).toBe(false);
+    expect(isTransientPinError(new Error('HTTP 404 Not Found from https://gw.test'))).toBe(false);
+    expect(isTransientPinError(new Error('HTTP 413 Payload Too Large from https://gw.test'))).toBe(false);
+  });
+
+  it('classifies fetch network errors as transient', () => {
+    expect(isTransientPinError(new Error('fetch failed'))).toBe(true);
+    expect(isTransientPinError(new Error('Network request failed'))).toBe(true);
+    expect(isTransientPinError(new Error('connect ECONNRESET 1.2.3.4:443'))).toBe(true);
+    expect(isTransientPinError(new Error('connect ETIMEDOUT 1.2.3.4:443'))).toBe(true);
+    expect(isTransientPinError(new Error('connect ECONNREFUSED 1.2.3.4:443'))).toBe(true);
+    expect(isTransientPinError(new Error('getaddrinfo EAI_AGAIN gw.test'))).toBe(true);
+  });
+
+  it('classifies AbortError / TimeoutError by Error.name', () => {
+    const abort = new Error('aborted');
+    abort.name = 'AbortError';
+    expect(isTransientPinError(abort)).toBe(true);
+
+    const timeout = new Error('timed out');
+    timeout.name = 'TimeoutError';
+    expect(isTransientPinError(timeout)).toBe(true);
+  });
+
+  it('classifies non-Error throws and unrecognised shapes as transient (lenient default)', () => {
+    expect(isTransientPinError('a bare string')).toBe(true);
+    expect(isTransientPinError({ shape: 'weird' })).toBe(true);
+    expect(isTransientPinError(new Error('something else entirely'))).toBe(true);
+  });
+});
+
+describe('Issue #369 — withPinRetry', () => {
+  beforeEach(() => {
+    __stopAutoDumpForTest();
+    __setPerfEnabledForTest(true);
+    dumpAndReset();
+  });
+
+  afterEach(() => {
+    __setPerfEnabledForTest(false);
+    __stopAutoDumpForTest();
+  });
+
+  it('returns the value on the first successful attempt — no retries paid', async () => {
+    const fn = vi.fn(async () => 'ok');
+    const result = await withPinRetry(fn);
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count ?? 0).toBe(0);
+    expect(counters['ipfs.pin.retry.exhausted']?.count ?? 0).toBe(0);
+  });
+
+  it('retries on transient failure until success, bumps retry counter per retry', async () => {
+    let attempts = 0;
+    const fn = vi.fn(async () => {
+      attempts += 1;
+      if (attempts < 3) throw new Error('fetch failed');
+      return 'recovered';
+    });
+
+    const result = await withPinRetry(fn, isTransientPinError, [1, 1, 1]);
+    expect(result).toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count).toBe(2);
+    expect(counters['ipfs.pin.retry.exhausted']?.count ?? 0).toBe(0);
+    expect(counters['ipfs.pin.retry.permanent']?.count ?? 0).toBe(0);
+  });
+
+  it('throws after the retry budget runs out — bumps exhausted counter', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('fetch failed');
+    });
+
+    await expect(
+      withPinRetry(fn, isTransientPinError, [1, 1, 1]),
+    ).rejects.toThrow(/fetch failed/);
+    expect(fn).toHaveBeenCalledTimes(4); // 1 + 3 retries
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count).toBe(3);
+    expect(counters['ipfs.pin.retry.exhausted']?.count).toBe(1);
+  });
+
+  it('short-circuits on a permanent error — does NOT consume further retries', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('HTTP 400 Bad Request from https://gw.test');
+    });
+
+    await expect(
+      withPinRetry(fn, isTransientPinError, [1, 1, 1]),
+    ).rejects.toThrow(/HTTP 400/);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count ?? 0).toBe(0);
+    expect(counters['ipfs.pin.retry.permanent']?.count).toBe(1);
+    expect(counters['ipfs.pin.retry.exhausted']?.count ?? 0).toBe(0);
+  });
+
+  it('uses the default backoff schedule when no explicit one is passed', async () => {
+    // Default is [100, 500, 2000] — too slow to run as a real timing
+    // test, so spy on setTimeout to observe the requested delays
+    // without actually waiting.
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((cb: TimerHandler) => {
+        if (typeof cb === 'function') cb();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+    const fn = vi.fn(async () => {
+      throw new Error('fetch failed');
+    });
+
+    await expect(withPinRetry(fn)).rejects.toThrow();
+    // 3 retry backoffs in the default schedule.
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(3);
+    const delays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+    expect(delays).toEqual([100, 500, 2000]);
+
+    setTimeoutSpy.mockRestore();
+  });
+});
+
+describe('Issue #369 — pinToIpfs end-to-end retry', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    __stopAutoDumpForTest();
+    __setPerfEnabledForTest(true);
+    dumpAndReset();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    __setPerfEnabledForTest(false);
+    __stopAutoDumpForTest();
+    vi.restoreAllMocks();
+  });
+
+  it('succeeds on the third attempt when the first two fail transient', async () => {
+    let calls = 0;
+    globalThis.fetch = (async (_url: RequestInfo | URL): Promise<Response> => {
+      calls += 1;
+      if (calls < 3) {
+        throw new Error('fetch failed');
+      }
+      // Kubo's `/api/v0/dag/put` returns `{"Cid":{"/":"bafkrei…"}}`.
+      // The returned CID is intentionally ignored by pinToIpfs (it
+      // computes its own from the bytes). Any plausible string works.
+      return new Response(JSON.stringify({ Cid: { '/': 'bafkreiignored' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    // Use tiny backoffs via vi.useFakeTimers? Simpler — spy on setTimeout
+    // to fire immediately.
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((cb: TimerHandler) => {
+        if (typeof cb === 'function') cb();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+    const data = new TextEncoder().encode('hello pin retry');
+    const result = await pinToIpfs(['https://gw1.test'], data);
+    expect(result).toMatch(/^baf/);
+    // 2 transient-failing pins + 1 successful pin + 1 sidecar
+    // fire-and-forget submit on success = 4 fetch calls. The sidecar
+    // submit is unconditional after a successful pin (see
+    // `submitToSidecarBestEffort`); it never fires on a failure.
+    expect(calls).toBe(4);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count).toBe(2);
+    expect(counters['ipfs.pin.retry.exhausted']?.count ?? 0).toBe(0);
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('throws after 4 attempts all-transient on the configured gateways', async () => {
+    let calls = 0;
+    globalThis.fetch = (async (_url: RequestInfo | URL): Promise<Response> => {
+      calls += 1;
+      throw new Error('fetch failed');
+    }) as typeof fetch;
+
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((cb: TimerHandler) => {
+        if (typeof cb === 'function') cb();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+    const data = new TextEncoder().encode('hello pin exhaust');
+    await expect(pinToIpfs(['https://gw1.test'], data)).rejects.toThrow(/IPFS pin failed/);
+    // 1 attempt × 1 gateway + 3 retries × 1 gateway = 4 fetch calls.
+    expect(calls).toBe(4);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count).toBe(3);
+    expect(counters['ipfs.pin.retry.exhausted']?.count).toBe(1);
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('permanent failure (HTTP 400) does NOT consume retries', async () => {
+    let calls = 0;
+    globalThis.fetch = (async (_url: RequestInfo | URL): Promise<Response> => {
+      calls += 1;
+      return new Response('bad', { status: 400, statusText: 'Bad Request' });
+    }) as typeof fetch;
+
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((cb: TimerHandler) => {
+        if (typeof cb === 'function') cb();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+    const data = new TextEncoder().encode('hello pin perm');
+    await expect(pinToIpfs(['https://gw1.test'], data)).rejects.toThrow(/HTTP 400/);
+    // 1 attempt only — permanent failure short-circuits.
+    expect(calls).toBe(1);
+
+    const counters = snapshot();
+    expect(counters['ipfs.pin.retry.attempt']?.count ?? 0).toBe(0);
+    expect(counters['ipfs.pin.retry.permanent']?.count).toBe(1);
+    expect(counters['ipfs.pin.retry.exhausted']?.count ?? 0).toBe(0);
+
+    setTimeoutSpy.mockRestore();
+  });
+});

--- a/tests/unit/profile/lifecycle-manager-pointer-poll.test.ts
+++ b/tests/unit/profile/lifecycle-manager-pointer-poll.test.ts
@@ -369,6 +369,16 @@ describe('LifecycleManager periodic pointer poll (Path 2 safety net)', () => {
     const lifecycle = getLifecycle(provider);
     expect(lifecycle.pointerPollTimer).not.toBeNull();
 
+    // Issue #369 — the apply-snapshot path schedules a flush whose
+    // CAR-pin now sits behind `withPinRetry` (retry-with-backoff on
+    // transient pin failures). Under `vi.useFakeTimers()` the retry's
+    // setTimeout-based backoff doesn't fire on its own, so the
+    // shutdown's flush would block forever waiting for retries. Switch
+    // to real timers for teardown so the retries drain promptly — the
+    // assertions above already cover the test's intent (applier was
+    // invoked with the new snapshot CID); the shutdown is only here to
+    // satisfy the test's resource-cleanup discipline.
+    vi.useRealTimers();
     await provider.shutdown();
   });
 

--- a/tests/unit/profile/load-rule4-snapshot-gate.test.ts
+++ b/tests/unit/profile/load-rule4-snapshot-gate.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Issue #367 — per-bundle provenance gate for Rule-4 pairwise verification.
+ *
+ * The provider's `_loadImpl` skips the O(N²) `computeVerifiedProofs`
+ * pairwise loop when every active bundle was placed into the local
+ * OrbitDB store by the snapshot dispatcher's `writeRemote` path AND they
+ * all trace to the same source snapshot. Snapshot-sourced means the
+ * `UxfBundleRef.sourcedFromSnapshotPointerCid` field is set on every
+ * loaded bundle to the same non-null value. Any non-snapshot bundle in
+ * the active set, or a mix of source snapshots, leaves Rule-4 enabled.
+ *
+ * This file pins the gate at the `load()` layer using planted refs.
+ * The crypto/persistence paths are exercised in the existing
+ * `load-rule4-wiring.test.ts`; here we only assert the gate's decision
+ * matrix.
+ *
+ * Cases:
+ *   - All bundles share one snapshot CID → skip (computeVerifiedProofs NOT called).
+ *   - All bundles are local (field absent) → no skip.
+ *   - Mixed bundles (some snapshot, some local) → no skip.
+ *   - Bundles span two different snapshot CIDs → no skip.
+ *   - Single-bundle snapshot-sourced load → no skip path is irrelevant
+ *     (the `>= 2` guard in the gate prevents the pairwise loop anyway).
+ *
+ * Strategy mirrors `load-rule4-wiring.test.ts`:
+ *   - In-memory MockProfileDb with planted encrypted bundle refs.
+ *   - Spy on `UxfPackage.prototype.computeVerifiedProofs` and
+ *     `UxfPackage.prototype.merge` to observe Rule-4 invocation.
+ *   - Stub the CAR fetch so the actual bundle bytes are irrelevant —
+ *     we only care about the gate's decision.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+  UxfBundleRef,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import type { OracleProvider } from '../../../oracle';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import {
+  deriveProfileEncryptionKey,
+  encryptProfileValue,
+} from '../../../profile/encryption';
+import { UxfPackage } from '../../../uxf/UxfPackage';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+const EXPECTED_ADDRESS_ID = 'DIRECT_aabbcc_ddeeff';
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+const BUNDLE_KEY_PREFIX = 'tokens.bundle.';
+
+const SNAPSHOT_CID_A = 'bafyreigh2akiscaildc6zdrgwqjevvw2tbifg6vkv7gh2akiscaildc6zda';
+const SNAPSHOT_CID_B = 'bafyreigh2akiscaildc6zdrgwqjevvw2tbifg6vkv7gh2akiscaildc6zdb';
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function getEncryptionKey(): Uint8Array {
+  return deriveProfileEncryptionKey(hexToBytes(TEST_PRIVATE_KEY));
+}
+
+interface MockProfileDb extends ProfileDatabase {
+  _store: Map<string, Uint8Array>;
+}
+
+function createMockDb(): MockProfileDb {
+  const store = new Map<string, Uint8Array>();
+  return {
+    _store: store,
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as MockProfileDb;
+}
+
+async function plantBundleInOrbit(
+  db: MockProfileDb,
+  cid: string,
+  ref: UxfBundleRef,
+): Promise<void> {
+  const encKey = getEncryptionKey();
+  db._store.set(
+    `${BUNDLE_KEY_PREFIX}${cid}`,
+    await encryptProfileValue(
+      encKey,
+      new TextEncoder().encode(JSON.stringify(ref)),
+    ),
+  );
+}
+
+async function buildEmptyBundle(seed: string): Promise<{ cid: string; carBytes: Uint8Array }> {
+  const pkg = UxfPackage.create({ description: seed });
+  const carBytes = await pkg.toCar();
+  const { CID } = await import('multiformats/cid');
+  const { sha256 } = await import('@noble/hashes/sha2.js');
+  const raw = await import('multiformats/codecs/raw');
+  const { create: createDigest } = await import('multiformats/hashes/digest');
+  const cid = CID.createV1(raw.code, createDigest(0x12, sha256(carBytes))).toString();
+  return { cid, carBytes };
+}
+
+const originalFetch = globalThis.fetch;
+function installCarFetchMock(carBytesByCid: Map<string, Uint8Array>): void {
+  globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const ipfsMatch = url.match(/\/ipfs\/([^/?]+)/);
+    const blockMatch = url.match(/\/api\/v0\/block\/get\?arg=([^&]+)/);
+    const cid = ipfsMatch
+      ? ipfsMatch[1]
+      : blockMatch
+        ? decodeURIComponent(blockMatch[1]!)
+        : null;
+    if (cid && carBytesByCid.has(cid)) {
+      return new Response(carBytesByCid.get(cid), { status: 200 });
+    }
+    return new Response('', { status: 404 });
+  }) as typeof fetch;
+}
+
+function createProvider(
+  db: MockProfileDb,
+  oracle?: OracleProvider,
+): ProfileTokenStorageProvider {
+  const provider = new ProfileTokenStorageProvider(
+    db,
+    getEncryptionKey(),
+    ['https://mock-ipfs.test'],
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId: EXPECTED_ADDRESS_ID,
+      encrypt: true,
+      oracle,
+    },
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  return provider;
+}
+
+function stubOracle(verify: ReturnType<typeof vi.fn>): OracleProvider {
+  return {
+    verifyInclusionProof: verify,
+  } as unknown as OracleProvider;
+}
+
+describe('ProfileTokenStorageProvider.load — Issue #367 Rule-4 snapshot gate', () => {
+  let db: MockProfileDb;
+
+  beforeEach(() => {
+    db = createMockDb();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('skips Rule-4 when all loaded bundles share the same snapshot pointer CID', async () => {
+    const computeSpy = vi
+      .spyOn(UxfPackage.prototype, 'computeVerifiedProofs')
+      .mockResolvedValue(new Set<string>());
+    const mergeSpy = vi.spyOn(UxfPackage.prototype, 'merge');
+
+    const verifier = vi.fn(async () => true);
+    const provider = createProvider(db, stubOracle(verifier));
+    await provider.initialize();
+
+    const bundleA = await buildEmptyBundle('A');
+    const bundleB = await buildEmptyBundle('B');
+    await plantBundleInOrbit(db, bundleA.cid, {
+      cid: bundleA.cid,
+      status: 'active',
+      createdAt: 1000,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_A,
+    });
+    await plantBundleInOrbit(db, bundleB.cid, {
+      cid: bundleB.cid,
+      status: 'active',
+      createdAt: 1001,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_A,
+    });
+
+    installCarFetchMock(
+      new Map<string, Uint8Array>([
+        [bundleA.cid, bundleA.carBytes],
+        [bundleB.cid, bundleB.carBytes],
+      ]),
+    );
+
+    const result = await provider.load();
+    expect(result.success).toBe(true);
+
+    // Gate fired → pairwise loop skipped.
+    expect(computeSpy).not.toHaveBeenCalled();
+    // Merge calls SHOULD NOT carry verifiedProofs in this branch
+    // (the catch arm that also skips Rule-4 enriches with an empty
+    // set; the gate skip path leaves verifiedProofs undefined).
+    const callWithVerified = mergeSpy.mock.calls.find((args) => {
+      const opts = args[1] as { verifiedProofs?: ReadonlySet<string> } | undefined;
+      return opts !== undefined && opts.verifiedProofs !== undefined;
+    });
+    expect(callWithVerified).toBeUndefined();
+
+    await provider.shutdown();
+  });
+
+  it('does NOT skip Rule-4 when bundles have no provenance (locally-published)', async () => {
+    const computeSpy = vi
+      .spyOn(UxfPackage.prototype, 'computeVerifiedProofs')
+      .mockResolvedValue(new Set<string>());
+    vi.spyOn(UxfPackage.prototype, 'merge');
+
+    const verifier = vi.fn(async () => true);
+    const provider = createProvider(db, stubOracle(verifier));
+    await provider.initialize();
+
+    const bundleA = await buildEmptyBundle('A');
+    const bundleB = await buildEmptyBundle('B');
+    // No sourcedFromSnapshotPointerCid → locally-published bundles.
+    await plantBundleInOrbit(db, bundleA.cid, {
+      cid: bundleA.cid,
+      status: 'active',
+      createdAt: 1000,
+    });
+    await plantBundleInOrbit(db, bundleB.cid, {
+      cid: bundleB.cid,
+      status: 'active',
+      createdAt: 1001,
+    });
+
+    installCarFetchMock(
+      new Map<string, Uint8Array>([
+        [bundleA.cid, bundleA.carBytes],
+        [bundleB.cid, bundleB.carBytes],
+      ]),
+    );
+
+    const result = await provider.load();
+    expect(result.success).toBe(true);
+    // Gate did NOT fire → pairwise loop ran.
+    expect(computeSpy).toHaveBeenCalled();
+
+    await provider.shutdown();
+  });
+
+  it('does NOT skip Rule-4 on a mix of snapshot-sourced and local bundles', async () => {
+    const computeSpy = vi
+      .spyOn(UxfPackage.prototype, 'computeVerifiedProofs')
+      .mockResolvedValue(new Set<string>());
+
+    const verifier = vi.fn(async () => true);
+    const provider = createProvider(db, stubOracle(verifier));
+    await provider.initialize();
+
+    const bundleA = await buildEmptyBundle('A');
+    const bundleB = await buildEmptyBundle('B');
+    // A is snapshot-sourced.
+    await plantBundleInOrbit(db, bundleA.cid, {
+      cid: bundleA.cid,
+      status: 'active',
+      createdAt: 1000,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_A,
+    });
+    // B is locally-published (no annotation).
+    await plantBundleInOrbit(db, bundleB.cid, {
+      cid: bundleB.cid,
+      status: 'active',
+      createdAt: 1001,
+    });
+
+    installCarFetchMock(
+      new Map<string, Uint8Array>([
+        [bundleA.cid, bundleA.carBytes],
+        [bundleB.cid, bundleB.carBytes],
+      ]),
+    );
+
+    const result = await provider.load();
+    expect(result.success).toBe(true);
+    // Mixed provenance → conservative gate keeps Rule-4 on.
+    expect(computeSpy).toHaveBeenCalled();
+
+    await provider.shutdown();
+  });
+
+  it('does NOT skip Rule-4 when bundles span two different snapshot CIDs', async () => {
+    const computeSpy = vi
+      .spyOn(UxfPackage.prototype, 'computeVerifiedProofs')
+      .mockResolvedValue(new Set<string>());
+
+    const verifier = vi.fn(async () => true);
+    const provider = createProvider(db, stubOracle(verifier));
+    await provider.initialize();
+
+    const bundleA = await buildEmptyBundle('A');
+    const bundleB = await buildEmptyBundle('B');
+    await plantBundleInOrbit(db, bundleA.cid, {
+      cid: bundleA.cid,
+      status: 'active',
+      createdAt: 1000,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_A,
+    });
+    await plantBundleInOrbit(db, bundleB.cid, {
+      cid: bundleB.cid,
+      status: 'active',
+      createdAt: 1001,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_B,
+    });
+
+    installCarFetchMock(
+      new Map<string, Uint8Array>([
+        [bundleA.cid, bundleA.carBytes],
+        [bundleB.cid, bundleB.carBytes],
+      ]),
+    );
+
+    const result = await provider.load();
+    expect(result.success).toBe(true);
+    // Two distinct snapshots → JOIN across them is exactly when
+    // Rule-4 is needed. Gate must NOT fire.
+    expect(computeSpy).toHaveBeenCalled();
+
+    await provider.shutdown();
+  });
+
+  it('single-bundle snapshot-sourced load — pairwise loop is structurally skipped (gate is moot)', async () => {
+    const computeSpy = vi
+      .spyOn(UxfPackage.prototype, 'computeVerifiedProofs')
+      .mockResolvedValue(new Set<string>());
+
+    const verifier = vi.fn(async () => true);
+    const provider = createProvider(db, stubOracle(verifier));
+    await provider.initialize();
+
+    const bundle = await buildEmptyBundle('only');
+    await plantBundleInOrbit(db, bundle.cid, {
+      cid: bundle.cid,
+      status: 'active',
+      createdAt: 1000,
+      sourcedFromSnapshotPointerCid: SNAPSHOT_CID_A,
+    });
+
+    installCarFetchMock(new Map<string, Uint8Array>([[bundle.cid, bundle.carBytes]]));
+
+    const result = await provider.load();
+    expect(result.success).toBe(true);
+    // Single-bundle: the `loadedBundles.length >= 2` guard short-
+    // circuits the pairwise loop independently of the gate.
+    expect(computeSpy).not.toHaveBeenCalled();
+
+    await provider.shutdown();
+  });
+});

--- a/tests/unit/profile/profile-token-storage-clear-suppress-apply-snapshot-364.test.ts
+++ b/tests/unit/profile/profile-token-storage-clear-suppress-apply-snapshot-364.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Issue #364 Item #2 — Suppress `applySnapshotIfWired` invocations
+ * during {@link ProfileTokenStorageProvider.clear}.
+ *
+ * Trace (from issue #363 §D.3 baseline): the periodic pointer-poll
+ * fires during `Sphere.clear()` teardown. `pointerLayer.recoverLatest()`
+ * returns a CID; `applySnapshotIfWired(cid)` runs the wired callback,
+ * which fetches the CAR, parses it as a lean snapshot, and dispatches
+ * a per-writer JOIN against state that is about to be wiped. 23
+ * invocations were observed in a 41 s clear-all-wallets phase, wasting
+ * IPFS round-trips and racing the destructive deletes.
+ *
+ * The fix is a per-provider `isClearing` latch checked by
+ * `_applySnapshotIfWiredImpl`. Set at the top of `clear()`, unset on
+ * completion; a concurrent applySnapshot returns null and bumps
+ * `profile.applySnapshot.suppressedDuringClear`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import type { ApplySnapshotResult } from '../../../profile/profile-snapshot-dispatcher';
+import {
+  __setPerfEnabledForTest,
+  __stopAutoDumpForTest,
+  dumpAndReset,
+  snapshot,
+} from '../../../core/perf-counters.js';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1test',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+function createMockDb(): ProfileDatabase {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as ProfileDatabase;
+}
+
+function makeApplyResult(joinedAny = false): ApplySnapshotResult {
+  return {
+    joinedAny,
+    addressesSeen: joinedAny ? 1 : 0,
+    bundleEntriesSeen: 0,
+    counters: {
+      entriesEvaluated: joinedAny ? 1 : 0,
+      liveLanded: joinedAny ? 1 : 0,
+      tombstonesLanded: 0,
+      localWon: 0,
+      remoteRejectedMalformed: 0,
+    },
+  };
+}
+
+function createProvider(): ProfileTokenStorageProvider {
+  const provider = new ProfileTokenStorageProvider(
+    createMockDb(),
+    new Uint8Array(32).fill(0x11),
+    ['https://mock-ipfs.test'],
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId: 'test',
+      encrypt: true,
+    },
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  return provider;
+}
+
+describe('Issue #364 Item #2 — applySnapshot suppression during clear()', () => {
+  beforeEach(() => {
+    __stopAutoDumpForTest();
+    __setPerfEnabledForTest(true);
+    // Drop any cross-test residue from the shared counter map.
+    dumpAndReset();
+  });
+
+  afterEach(() => {
+    __setPerfEnabledForTest(false);
+    __stopAutoDumpForTest();
+  });
+
+  it('applySnapshotIfWired() called during clear() returns null without invoking callback', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    // Spy on db.all so we can intercept mid-clear and fire an
+    // applySnapshotIfWired race during the await chain inside clear().
+    const db = (provider as unknown as { db: ProfileDatabase }).db;
+    const realAll = db.all.bind(db);
+    let raceResult: ApplySnapshotResult | null | undefined;
+    let allCalls = 0;
+    db.all = (async (prefix?: string) => {
+      allCalls += 1;
+      if (allCalls === 1) {
+        // Fire the race BEFORE returning from db.all() — the clear()
+        // method is awaiting us, so isClearing is already true.
+        raceResult = await provider.applySnapshotIfWired('bafy-snapshot-cid');
+      }
+      return realAll(prefix);
+    }) as ProfileDatabase['all'];
+
+    const ok = await provider.clear();
+    expect(ok).toBe(true);
+
+    expect(raceResult).toBeNull();
+    expect(applier).not.toHaveBeenCalled();
+  });
+
+  it('bumps profile.applySnapshot.suppressedDuringClear when the gate trips', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    const db = (provider as unknown as { db: ProfileDatabase }).db;
+    const realAll = db.all.bind(db);
+    let allCalls = 0;
+    db.all = (async (prefix?: string) => {
+      allCalls += 1;
+      if (allCalls === 1) {
+        await provider.applySnapshotIfWired('bafy-cid-1');
+        await provider.applySnapshotIfWired('bafy-cid-2');
+      }
+      return realAll(prefix);
+    }) as ProfileDatabase['all'];
+
+    await provider.clear();
+
+    const counters = snapshot();
+    expect(counters['profile.applySnapshot.suppressedDuringClear']?.count).toBe(2);
+    expect(counters['profile.applySnapshot.fired']?.count ?? 0).toBe(0);
+    expect(applier).not.toHaveBeenCalled();
+  });
+
+  it('applySnapshotIfWired() works normally after clear() completes', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    const ok = await provider.clear();
+    expect(ok).toBe(true);
+
+    // Gate has been unset in finally — a fresh call should proceed.
+    const result = await provider.applySnapshotIfWired('bafy-after-clear');
+    expect(result).not.toBeNull();
+    expect(applier).toHaveBeenCalledTimes(1);
+    expect(applier).toHaveBeenCalledWith('bafy-after-clear');
+  });
+
+  it('unsets isClearing even when clear() throws mid-way', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    // Force db.all to reject so clear() takes the catch branch.
+    const db = (provider as unknown as { db: ProfileDatabase }).db;
+    db.all = (async () => {
+      throw new Error('synthetic db.all failure');
+    }) as ProfileDatabase['all'];
+
+    const ok = await provider.clear();
+    expect(ok).toBe(false);
+
+    // Latch released in `finally`; a subsequent applySnapshot should
+    // dispatch normally.
+    const result = await provider.applySnapshotIfWired('bafy-after-failed-clear');
+    expect(result).not.toBeNull();
+    expect(applier).toHaveBeenCalledTimes(1);
+  });
+
+  it('isClearing gate takes precedence over shutdown gate', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+    await provider.initialize();
+
+    // Force the isClearing latch directly to simulate an in-flight clear.
+    (provider as unknown as { isClearing: boolean }).isClearing = true;
+    try {
+      const result = await provider.applySnapshotIfWired('bafy-cid');
+      expect(result).toBeNull();
+      expect(applier).not.toHaveBeenCalled();
+
+      const counters = snapshot();
+      expect(
+        counters['profile.applySnapshot.suppressedDuringClear']?.count,
+      ).toBeGreaterThanOrEqual(1);
+    } finally {
+      (provider as unknown as { isClearing: boolean }).isClearing = false;
+    }
+  });
+
+  it('returns false (without setting isClearing) when provider not initialized', async () => {
+    const provider = createProvider();
+    const applier = vi.fn(async () => makeApplyResult(true));
+    provider.setApplySnapshotCallback(applier);
+
+    // Skip initialize() — clear() should short-circuit.
+    const ok = await provider.clear();
+    expect(ok).toBe(false);
+
+    // Gate must be in the un-set state — applySnapshot proceeds normally.
+    const result = await provider.applySnapshotIfWired('bafy-cid');
+    expect(result).not.toBeNull();
+    expect(applier).toHaveBeenCalledTimes(1);
+  });
+});

--- a/uxf/UxfPackage.ts
+++ b/uxf/UxfPackage.ts
@@ -30,6 +30,7 @@ import type {
   TokenRootChildren,
   GenesisChildren,
 } from './types.js';
+import { incr, observeMs } from '../core/perf-counters.js';
 import { STRATEGY_LATEST } from './types.js';
 import { UxfError } from './errors.js';
 import { computeElementHash } from './hash.js';
@@ -348,6 +349,15 @@ export class UxfPackage {
       proofHash?: string;
     }) => Promise<boolean>,
   ): Promise<Set<string>> {
+    // GH #363 measurement. Issue #360 Finding #2 claimed this is
+    // O(B²·P) sequential and dominates load latency; verify on real
+    // data before any future optimisation. Counters split:
+    //   .calls       — invocations
+    //   .verifyCalls — verifier RPCs actually made
+    //   .verifyOk    — verifier returned true
+    //   .totalMs     — outer wall-clock per call
+    incr('uxf.computeVerifiedProofs.calls');
+    const __perfStart = performance.now();
     const verified = new Set<string>();
     const ELEMENT_TYPE_INCLUSION_PROOF = 'inclusion-proof' as const;
     // Pool from both packages — same proof element may appear in
@@ -367,16 +377,24 @@ export class UxfPackage {
         continue;
       }
       try {
+        incr('uxf.computeVerifiedProofs.verifyCalls');
+        const __vStart = performance.now();
         const ok = await verifier({
           proofJson,
           transactionHash: txHashImprintHex,
           proofHash: hash,
         });
-        if (ok) verified.add(hash);
+        observeMs('uxf.computeVerifiedProofs.verifyMs', performance.now() - __vStart);
+        if (ok) {
+          incr('uxf.computeVerifiedProofs.verifyOk');
+          verified.add(hash);
+        }
       } catch {
         /* verifier failure → not verified, conservative */
+        incr('uxf.computeVerifiedProofs.verifyThrew');
       }
     }
+    observeMs('uxf.computeVerifiedProofs.totalMs', performance.now() - __perfStart);
     return verified;
   }
 

--- a/uxf/UxfPackage.ts
+++ b/uxf/UxfPackage.ts
@@ -562,6 +562,8 @@ export function ingest(
   token: unknown,
   opts?: { updatedAt?: number },
 ): void {
+  incr('uxf.ingest.calls');
+  const __iStart = performance.now();
   const pool = wrapPool(pkg);
   const rootHash = deconstructToken(pool, token);
   syncPool(pkg, pool);
@@ -583,6 +585,7 @@ export function ingest(
 
   // Update secondary indexes
   updateIndexesForToken(pkg, tokenId, rootHash);
+  observeMs('uxf.ingest.totalMs', performance.now() - __iStart);
 }
 
 /**
@@ -611,10 +614,15 @@ export function ingestAll(
   opts?: { updatedAt?: number },
 ): void {
   if (tokens.length === 0) return;
+  incr('uxf.ingestAll.calls');
+  incr('uxf.ingestAll.tokens', tokens.length);
+  const __iaStart = performance.now();
   const pool = wrapPool(pkg);
   const newTokens: Array<{ tokenId: string; rootHash: ContentHash }> = [];
   for (const token of tokens) {
+    const __dStart = performance.now();
     const rootHash = deconstructToken(pool, token);
+    observeMs('uxf.ingestAll.perTokenDeconstructMs', performance.now() - __dStart);
     const rootElement = pool.get(rootHash)!;
     const rootContent = rootElement.content as unknown as TokenRootContent;
     newTokens.push({ tokenId: rootContent.tokenId, rootHash });
@@ -703,11 +711,13 @@ export function ingestAll(
     } catch {
       /* best-effort — pool integrity already compromised, throw the original error */
     }
+    observeMs('uxf.ingestAll.totalMs', performance.now() - __iaStart);
     throw err;
   }
   // Stamp envelope updatedAt; caller can lock for determinism.
   (pkg.envelope as { updatedAt: number }).updatedAt =
     opts?.updatedAt ?? Math.floor(Date.now() / 1000);
+  observeMs('uxf.ingestAll.totalMs', performance.now() - __iaStart);
 }
 
 /**
@@ -718,8 +728,13 @@ export function assemble(
   tokenId: string,
   strategy: InstanceSelectionStrategy = STRATEGY_LATEST,
 ): unknown {
-  const pool = wrapPool(pkg);
-  return assembleToken(pool, pkg.manifest, tokenId, pkg.instanceChains, strategy);
+  incr('uxf.assemble.calls');
+  const __aStart = performance.now();
+  try {
+    return assembleToken(wrapPool(pkg), pkg.manifest, tokenId, pkg.instanceChains, strategy);
+  } finally {
+    observeMs('uxf.assemble.totalMs', performance.now() - __aStart);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Bundle of 6 perf PRs + #365 baseline, validated by A/B/C/D soak runs against a quiet IPFS gateway. D vs A baseline: **-252s (-34.1%)**.

| PR | Issue | Target |
|---|---|---|
| #371 | #370 | CAR-batching `/dag/import` + `/dag/export` |
| #373 | #367 | Per-bundle provenance gate for Rule-4 skip |
| #374 | #366 | `recoverLatest` cache with publish-time invalidation |
| #375 | #368 | Process-wide `applySnapshot` suppression during `Sphere.clear` |
| #376 | #369 | Pin retry-with-backoff + lower `DEFAULT_PIN_CONCURRENCY` |
| #379 | #378 | Persist V6-RECOVER permanent verdict; short-circuit drain |
| #365 | #364 | Items #2+#3+#6 — clear-time suppression, attribution counters, test-harness perf-block strip |

## A/B/C/D soak — 1-iter each, same gateway

| Section | A (PR #365 only) | B (+4 perf PRs) | C (+#370) | **D (+#379)** |
|---|---:|---:|---:|---:|
| §C.2 Bob pays | 106 s | 36 s | 32 s | **33 s** |
| §C.4 Peer2 view | 81 s | 35 s | 31 s | **25 s** ← best |
| §D.1 Pre-clear snapshots | 106 s | 71 s | 83 s | **63 s** ← best |
| §D.3 `sphere clear` | 38 s | 33 s | 31 s | 31 s |
| §D.4 IPFS-only recovery | 240 s | 182 s | 202 s | **185 s** |
| §E Invoice ledger preserved | 26 s | 19 s | 19 s | 19 s |
| **TOTAL** | **740 s** | **516 s** | **527 s** | **488 s** |

## Diff

36 files changed, +5,677 / -178. Surface area:
- New module: `profile/global-clear-gate.ts` (process-wide depth counter for clear suppression)
- Extended: `profile/ipfs-client.ts` (CAR import/export, pin retry/backoff)
- Extended: `profile/aggregator-pointer/ProfilePointerLayer.ts` (recoverLatest cache)
- Extended: `modules/payments/PaymentsModule.ts` (V6-RECOVER permanent ledger)
- Tests: 4 new test files (1,289 lines) for new modules + cache behavior

## Review

Adversarial code review by `code-reviewer` agent: **OK with follow-ups**, no BLOCKERs. Findings filed as follow-up issue (linked below).

## Test plan

- [x] Local build passes (`npx tsup`)
- [ ] Local test suite passes (`npx vitest run`) — running
- [ ] CI on this PR passes
- [x] D-soak validates real-world perf gain (-34.1% vs baseline)
- [x] All §D.5 + §E assertions passed on D-soak
- [x] Zero `helia.pins.add failed` events on D-soak

## Follow-ups (filed separately, not blocking this merge)

- recoverLatest cache: publish-during-in-flight race could write stale to cache (HIGH)
- Fast-path CAR import has no retry budget — single transient falls through to slow path (HIGH)
- `Sphere.clear()` global-gate test for throw-safety (MEDIUM)
- See follow-up issue for full list

## Component PRs to close as bundled

#371, #373, #374, #375, #376, #379, #365
