### PR TITLE
fix(communications)(page-freeze): degrade CID_REF_UNREADABLE — mirror GroupChat #334

### DIFF
--- a/modules/communications/CommunicationsModule.ts
+++ b/modules/communications/CommunicationsModule.ts
@@ -249,26 +249,39 @@ export class CommunicationsModule {
    *
    * Dual-read per PROFILE-CID-REFERENCES.md §6:
    *   - If the payload is a CID ref envelope → fetch content from IPFS
-   *     via `cidRefStore`. Errors propagate with typed codes.
-   *   - If no cidRefStore is injected but a ref is found → throw typed
-   *     `ProfileError('CID_REF_UNREADABLE')`. Silent fallback would mean
-   *     silently losing all stored DMs for this address.
+   *     via `cidRefStore`. Errors degrade to empty rather than bricking load.
+   *   - If no cidRefStore is injected but a ref is found → `[CID_REF_DEGRADE]`
+   *     warn + start with empty messages. Relay re-delivery (NIP-17) will
+   *     rehydrate whatever the relay still retains. Mirrors the GroupChat
+   *     fallback added 2026-05-29 — the previous fatal throw bricked
+   *     `Sphere.load` via the shared `Promise.allSettled`, taking down every
+   *     other module's load with it.
    *   - Otherwise parse as legacy inline JSON with narrow SyntaxError catch.
    */
   private async parseMessagesPayload(data: string, keyForDiagnostic: string): Promise<DirectMessage[]> {
     const ref = CidRefStore.tryParseRef(data);
     if (ref) {
       if (!this.deps!.cidRefStore) {
-        const { ProfileError } = await import('../../profile/errors.js');
-        throw new ProfileError(
-          'CID_REF_UNREADABLE',
-          `CommunicationsModule.load: KV at ${keyForDiagnostic} contains a CID ref ` +
-            `(cid=${ref.cid}) but no cidRefStore was injected. DMs cannot be ` +
-            `restored without IPFS access. Check CommunicationsModule init — ` +
-            `is cidRefStore provided?`,
+        // Degrade rather than brick load. See note above.
+        logger.warn(
+          'Communications',
+          `[CID_REF_DEGRADE] KV at ${keyForDiagnostic} contains a CID ref ` +
+            `(cid=${ref.cid}) but no cidRefStore was injected; starting fresh. ` +
+            `Relay re-delivery will rehydrate any retained DMs.`,
         );
+        return [];
       }
-      const fetched = await this.deps!.cidRefStore.fetchJson<DirectMessage[]>(ref);
+      let fetched: DirectMessage[];
+      try {
+        fetched = await this.deps!.cidRefStore.fetchJson<DirectMessage[]>(ref);
+      } catch (err) {
+        logger.error(
+          'Communications',
+          `[MESSAGES] CID-ref fetch failed for ${keyForDiagnostic} (cid=${ref.cid}); starting fresh`,
+          err,
+        );
+        return [];
+      }
       if (!Array.isArray(fetched)) {
         logger.error(
           'Communications',

--- a/tests/unit/modules/CommunicationsModule.cidref.test.ts
+++ b/tests/unit/modules/CommunicationsModule.cidref.test.ts
@@ -313,7 +313,13 @@ describe('CommunicationsModule — DM CID-ref persistence', () => {
     expect(fakeStore.pinJson).toHaveBeenCalledTimes(1);
   });
 
-  it('throws CID_REF_UNREADABLE when ref present but cidRefStore absent', async () => {
+  it('degrades to empty messages when ref present but cidRefStore absent', async () => {
+    // Mirrors the GroupChat fallback added 2026-05-29 — when the legacy
+    // factory wires the module without a cidRefStore, the messages KV
+    // starts fresh and NIP-17 relay re-delivery rehydrates whatever the
+    // relay still retains. The previous fatal throw bricked `Sphere.load`
+    // via the shared `Promise.allSettled`, taking down every other module's
+    // load with it.
     const store = new Map<string, string>();
     const storage = createMockStorage(store);
     // No cidRefStore injected.
@@ -330,7 +336,44 @@ describe('CommunicationsModule — DM CID-ref persistence', () => {
     );
 
     mod.initialize(deps);
-    await expect(mod.load()).rejects.toThrow(/CID_REF_UNREADABLE/);
+
+    // No throw: load resolves and the messages Map is empty.
+    await expect(mod.load()).resolves.toBeUndefined();
+    expect((mod as unknown as { messages: Map<string, DirectMessage> }).messages.size).toBe(0);
+  });
+
+  it('degrades to empty messages when CID-ref fetch fails (e.g., gateway 404)', async () => {
+    // Companion to the previous test. Even with a cidRefStore wired up, the
+    // fetch can fail at runtime (offline gateway, GC'd content, network
+    // glitch). Before the 2026-06-01 fix the rejection propagated and
+    // bricked Sphere.load; now we log error and start fresh.
+    const store = new Map<string, string>();
+    const storage = createMockStorage(store);
+
+    const fakeStore = {
+      pinJson: vi.fn(),
+      fetchJson: vi.fn(async () => {
+        throw new Error('gateway 404');
+      }),
+      destroy: vi.fn(),
+    };
+    const deps = createDeps({ storage, cidRefStore: fakeStore as never });
+
+    store.set(
+      STORAGE_KEYS_ADDRESS.MESSAGES,
+      JSON.stringify({
+        v: 1,
+        cid: 'bafkreieyqvmjr6zq5adijx2kzlcfmdvexmy2i6knyj4w2pybmzxmvg6bze',
+        size: 1000,
+        ts: 1700000000000,
+      }),
+    );
+
+    mod.initialize(deps);
+
+    await expect(mod.load()).resolves.toBeUndefined();
+    expect((mod as unknown as { messages: Map<string, DirectMessage> }).messages.size).toBe(0);
+    expect(fakeStore.fetchJson).toHaveBeenCalledTimes(1);
   });
 
   it('OpLog value shrinks dramatically when CidRefStore is used', async () => {


### PR DESCRIPTION
## Summary

`CommunicationsModule.parseMessagesPayload` used to fatal-throw `ProfileError(CID_REF_UNREADABLE)` when the `messages` KV held a CID-ref envelope but the wallet was opened without a `cidRefStore` (legacy factory path). The throw propagated through `Sphere.load`'s `Promise.allSettled` as "Module load failed", taking down every other module's load with it.

Live testnet evidence (2026-06-01): https://sphere-telco-test.dyndns.org was failing wallet load entirely with this error in the console.

Mirrors the GroupChat fallback added in #334 / commit 7421386: `[CID_REF_DEGRADE]` warn + empty-state return. NIP-17 relay re-delivery rehydrates whatever the relay still retains.

## Changes

- \`modules/communications/CommunicationsModule.ts\` — \`parseMessagesPayload\` now logs warn + returns \`[]\` instead of throwing when \`cidRefStore\` is absent.
- Also wraps \`cidRefStore.fetchJson()\` in try/catch so a gateway 404/timeout no longer bricks the load either — same recovery strategy.

## Trade-off

The previous fatal-throw existed because "silent fallback would mean silently losing all stored DMs for this address." That's still true if the wallet hits this path, but a fatal throw also loses every other module's state and is strictly worse for the user. Warn + empty + relay-rehydrate retains the visibility without the load-bricking failure mode.

## Test plan

- [x] Converted \`throws CID_REF_UNREADABLE …\` → \`degrades to empty messages …\`
- [x] New test: degrades on \`cidRefStore.fetchJson()\` rejection (gateway failure)
- [x] 74/74 CommunicationsModule tests pass
- [x] tsc clean for touched files
- [x] Verified live on sphere-telco-test.dyndns.org via vendored build (sphere.telco vendor bump pending)