### PR TITLE
perf(profile/ipfs): adaptive cold-cache for sidecar probes — kill 404 console storm

### DIFF
--- a/profile/ipfs-client.ts
+++ b/profile/ipfs-client.ts
@@ -427,6 +427,80 @@ const SIDECAR_SUBMIT_TIMEOUT_MS = 5_000;
 const SIDECAR_READ_TIMEOUT_MS = 500;
 
 /**
+ * Per-gateway adaptive cold-cache state. The sidecar correctly GCs
+ * blobs after they're promoted to Kubo (see ipfs-storage's
+ * `instant_pin_cache._reconcile_once`), so for any wallet load that
+ * walks an *old* Profile bundle the steady-state outcome is 404 on
+ * every block. With N blocks in a Profile snapshot that produces N
+ * console-visible failed fetches (Chrome auto-logs every non-2xx
+ * `fetch()` even when the JS swallows the result), drowning real
+ * signal.
+ *
+ * Strategy: track consecutive misses per gateway. After
+ * {@link SIDECAR_COLD_MISS_THRESHOLD} misses in a row, mark the
+ * gateway "sidecar cold" for {@link SIDECAR_COLD_DURATION_MS}.
+ * During the cold window both {@link tryReadFromSidecar} and
+ * {@link submitToSidecarBestEffort} short-circuit before issuing the
+ * HTTP request — eliminating the console noise while preserving the
+ * cross-device fast path: a single hit (or a successful submit,
+ * which usually means a sibling device just published) resets the
+ * counter, and after the cooldown a single re-probe re-arms the
+ * fast path automatically.
+ *
+ * 3 / 60 s is intentionally conservative — we want to keep probing
+ * during cross-device bursts (where hits are likely), and only cool
+ * off when the gateway looks genuinely empty for this wallet's
+ * working set.
+ */
+const SIDECAR_COLD_MISS_THRESHOLD = 3;
+const SIDECAR_COLD_DURATION_MS = 60_000;
+
+interface SidecarColdState {
+  consecutiveMisses: number;
+  coldUntil: number; // epoch ms; 0 means not cold
+}
+
+const sidecarColdState = new Map<string, SidecarColdState>();
+
+function getSidecarColdState(gateway: string): SidecarColdState {
+  const key = normalizeGatewayKey(gateway);
+  let state = sidecarColdState.get(key);
+  if (!state) {
+    state = { consecutiveMisses: 0, coldUntil: 0 };
+    sidecarColdState.set(key, state);
+  }
+  return state;
+}
+
+function isSidecarCold(gateway: string): boolean {
+  const state = sidecarColdState.get(normalizeGatewayKey(gateway));
+  if (!state) return false;
+  return state.coldUntil > Date.now();
+}
+
+function recordSidecarMiss(gateway: string): void {
+  const state = getSidecarColdState(gateway);
+  state.consecutiveMisses += 1;
+  if (state.consecutiveMisses >= SIDECAR_COLD_MISS_THRESHOLD) {
+    state.coldUntil = Date.now() + SIDECAR_COLD_DURATION_MS;
+  }
+}
+
+function recordSidecarHit(gateway: string): void {
+  const state = getSidecarColdState(gateway);
+  state.consecutiveMisses = 0;
+  state.coldUntil = 0;
+}
+
+/**
+ * Test-only helper to reset the cold-cache between tests. Production
+ * code does not call this — the state self-heals via the cooldown.
+ */
+export function _resetSidecarColdState(): void {
+  sidecarColdState.clear();
+}
+
+/**
  * Fire-and-forget POST the raw bytes that hash to `cid` to the
  * gateway's instant-pin sidecar (`/sidecar/submit?cid=<cid>`). Lets
  * cross-device readers fetch `cid` immediately after pin, before
@@ -457,6 +531,12 @@ function submitToSidecarBestEffort(
   if (typeof cid !== 'string' || cid.length === 0) return;
   if (!(bytes instanceof Uint8Array) || bytes.length === 0) return;
   if (bytes.length > SIDECAR_SUBMIT_MAX_BYTES) return;
+  // Cold-cache short-circuit: if this gateway has consistently failed
+  // recent sidecar interactions, skip the POST entirely. The primary
+  // pin path is the source of truth; this skip only loses the
+  // cross-device fast-path acceleration for the cooldown window. See
+  // SIDECAR_COLD_* doc for the rationale.
+  if (isSidecarCold(gateway)) return;
   const url =
     `${gateway.replace(/\/$/, '')}/sidecar/submit?cid=${encodeURIComponent(cid)}`;
   // Detached fire-and-forget. The .catch swallows any rejection so
@@ -475,12 +555,18 @@ function submitToSidecarBestEffort(
       // into how often sphere-sdk publishes actually populate the
       // cache vs how often they get 503-back-pressured or 4xx-rejected.
       if (!response.ok) {
+        // 404 = sidecar not deployed on this gateway → count as miss.
+        // 503 = cache_full back-pressure → not a "cold" signal, the
+        //       sidecar is alive and rejecting under load. Don't count.
+        // 413 = oversize → also not "cold"; don't count.
+        if (response.status === 404) recordSidecarMiss(gateway);
         logger.debug(
           'IPFS-Sidecar',
           `submit ${cid.slice(0, 16)} → HTTP ${response.status} ` +
           `(${response.statusText}) on ${gateway}`,
         );
       } else {
+        recordSidecarHit(gateway);
         logger.debug(
           'IPFS-Sidecar',
           `submit ${cid.slice(0, 16)} → 200 on ${gateway}`,
@@ -493,7 +579,9 @@ function submitToSidecarBestEffort(
     .catch(() => {
       // Network error, timeout, gateway-without-sidecar (404 → ok=false
       // above), or AbortError. All silently dropped — the primary pin
-      // already succeeded; this is pure optimization.
+      // already succeeded; this is pure optimization. Network/timeout
+      // counts as a miss for cooldown purposes.
+      recordSidecarMiss(gateway);
     });
 }
 
@@ -527,6 +615,12 @@ async function tryReadFromSidecar(
 ): Promise<Uint8Array | null> {
   if (typeof gateway !== 'string' || gateway.length === 0) return null;
   if (typeof cid !== 'string' || cid.length === 0) return null;
+  // Cold-cache short-circuit: skip the probe if this gateway has 404'd
+  // SIDECAR_COLD_MISS_THRESHOLD times in a row. The normal multi-gateway
+  // `/api/v0/block/get` path is unaffected — this only skips the
+  // cross-device fast-path optimization during the cooldown window.
+  // See SIDECAR_COLD_* doc above for the noise rationale.
+  if (isSidecarCold(gateway)) return null;
   try {
     const url =
       `${gateway.replace(/\/$/, '')}/sidecar/blob?cid=${encodeURIComponent(cid)}`;
@@ -539,6 +633,7 @@ async function tryReadFromSidecar(
       // 404 (cache miss / sidecar disabled) is the common case; drain
       // and return null so caller falls through to the normal fetch.
       response.body?.cancel?.().catch(() => { /* ignore */ });
+      recordSidecarMiss(gateway);
       return null;
     }
     // Sniff content-type — a gateway that doesn't run the sidecar
@@ -551,10 +646,17 @@ async function tryReadFromSidecar(
       !ct.startsWith('application/vnd.ipld')
     ) {
       response.body?.cancel?.().catch(() => { /* ignore */ });
+      // Wrong content-type = same operational signal as a miss
+      // (gateway returning HTML/JSON catch-all means no sidecar).
+      recordSidecarMiss(gateway);
       return null;
     }
     const buf = await response.arrayBuffer();
-    if (buf.byteLength === 0) return null;
+    if (buf.byteLength === 0) {
+      recordSidecarMiss(gateway);
+      return null;
+    }
+    recordSidecarHit(gateway);
     logger.debug(
       'IPFS-Sidecar',
       `read hit ${cid.slice(0, 16)} (${buf.byteLength} bytes) on ${gateway}`,
@@ -563,6 +665,7 @@ async function tryReadFromSidecar(
   } catch {
     // Timeout, network error, abort — all treated as a miss. The
     // caller's normal-path fetch is the source of truth.
+    recordSidecarMiss(gateway);
     return null;
   }
 }

--- a/tests/unit/profile/ipfs-client-sidecar-cold-cache.test.ts
+++ b/tests/unit/profile/ipfs-client-sidecar-cold-cache.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for the sidecar per-gateway adaptive cold-cache in
+ * `profile/ipfs-client.ts`.
+ *
+ * Symptom motivating the cache (2026-06-01): a steady-state wallet load
+ * walks an old Profile bundle, probing the sidecar for every block. Each
+ * block has been promoted out of the sidecar (the sidecar correctly GCs
+ * after `block_stat` confirms availability in Kubo), so every probe 404s.
+ * Chrome auto-logs every non-2xx `fetch()` to the console even when the
+ * JS swallows the result — producing ~100 visible failed-fetch lines per
+ * load.
+ *
+ * Fix: after SIDECAR_COLD_MISS_THRESHOLD (3) consecutive 404s on a
+ * gateway, both `tryReadFromSidecar` and `submitToSidecarBestEffort`
+ * short-circuit *before* issuing the fetch, for SIDECAR_COLD_DURATION_MS
+ * (60 s). A successful hit (or a 200 submit) resets the counter and
+ * re-arms the fast path immediately.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { create as createDigest } from 'multiformats/hashes/digest';
+
+import {
+  pinToIpfs,
+  fetchFromIpfs,
+  _resetSidecarColdState,
+} from '../../../profile/ipfs-client';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function cidForBytes(bytes: Uint8Array): string {
+  return CID.createV1(raw.code, createDigest(0x12, sha256(bytes))).toString();
+}
+
+interface RecordedFetch {
+  readonly url: string;
+  readonly method: string;
+}
+
+interface MockHandlers {
+  pinHandler?: () => Response | Promise<Response>;
+  sidecarSubmitHandler?: () => Response | Promise<Response>;
+  sidecarBlobHandler?: () => Response | Promise<Response>;
+  blockGetHandler?: () => Response | Promise<Response>;
+}
+
+function installFetchMock(handlers: MockHandlers): {
+  recorded: RecordedFetch[];
+  restore: () => void;
+} {
+  const recorded: RecordedFetch[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : (input as { url?: string }).url ?? String(input);
+    const method = (init?.method ?? 'GET').toUpperCase();
+    recorded.push({ url, method });
+
+    if (url.includes('/sidecar/submit')) {
+      return (handlers.sidecarSubmitHandler ?? (() => new Response(null, { status: 404 })))();
+    }
+    if (url.includes('/sidecar/blob')) {
+      return (handlers.sidecarBlobHandler ?? (() => new Response(null, { status: 404 })))();
+    }
+    if (url.includes('/api/v0/dag/put')) {
+      return (
+        handlers.pinHandler ??
+        (() => new Response(JSON.stringify({ Cid: { '/': 'bafkqaaa' } }), { status: 200 }))
+      )();
+    }
+    if (url.includes('/api/v0/block/get')) {
+      return (handlers.blockGetHandler ?? (() => new Response(null, { status: 404 })))();
+    }
+    return new Response(null, { status: 404 });
+  }) as typeof fetch;
+
+  return {
+    recorded,
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+const GATEWAY = 'https://gw.example.test';
+const THRESHOLD = 3; // matches SIDECAR_COLD_MISS_THRESHOLD
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sidecar cold-cache (2026-06-01 noise reduction)', () => {
+  beforeEach(() => {
+    _resetSidecarColdState();
+  });
+
+  afterEach(() => {
+    _resetSidecarColdState();
+  });
+
+  // -------------------------------------------------------------------------
+  // Submit path
+  // -------------------------------------------------------------------------
+
+  it('submit: short-circuits after N consecutive 404s on the gateway', async () => {
+    // All submits 404. After THRESHOLD 404s the gateway is marked cold and
+    // subsequent submits skip the fetch entirely.
+    const { recorded, restore } = installFetchMock({
+      sidecarSubmitHandler: () => new Response(null, { status: 404 }),
+    });
+    try {
+      for (let i = 0; i < THRESHOLD + 5; i++) {
+        const bytes = new TextEncoder().encode(`payload-${i}`);
+        await pinToIpfs([GATEWAY], bytes);
+        // Detach: submit is fire-and-forget. Yield so its .then() runs and
+        // the cold-state update lands before the next iteration.
+        await new Promise((r) => setTimeout(r, 5));
+      }
+
+      const submitCalls = recorded.filter((r) => r.url.includes('/sidecar/submit'));
+      // Exactly THRESHOLD submits issued; the rest short-circuited.
+      expect(submitCalls.length).toBe(THRESHOLD);
+    } finally {
+      restore();
+    }
+  });
+
+  it('submit: 200 hit resets the counter so cold-state never trips', async () => {
+    // Alternate hit/miss/miss — the counter resets on each hit and we
+    // never accumulate THRESHOLD misses in a row.
+    let n = 0;
+    const { recorded, restore } = installFetchMock({
+      sidecarSubmitHandler: () => {
+        const ok = n % 3 === 0;
+        n += 1;
+        return new Response(null, { status: ok ? 200 : 404 });
+      },
+    });
+    try {
+      for (let i = 0; i < 9; i++) {
+        const bytes = new TextEncoder().encode(`payload-${i}`);
+        await pinToIpfs([GATEWAY], bytes);
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      const submitCalls = recorded.filter((r) => r.url.includes('/sidecar/submit'));
+      // All 9 submits issued — counter never reached threshold thanks to
+      // the periodic 200 reset.
+      expect(submitCalls.length).toBe(9);
+    } finally {
+      restore();
+    }
+  });
+
+  it('submit: 503/413 do NOT count as cold misses (sidecar is alive under load)', async () => {
+    // 503 = cache_full back-pressure (sidecar healthy, rejecting load).
+    // We must NOT cool down the gateway in this case — the next pin may
+    // succeed and we want to keep the fast path enabled.
+    const { recorded, restore } = installFetchMock({
+      sidecarSubmitHandler: () => new Response(null, { status: 503 }),
+    });
+    try {
+      for (let i = 0; i < THRESHOLD + 3; i++) {
+        const bytes = new TextEncoder().encode(`payload-${i}`);
+        await pinToIpfs([GATEWAY], bytes);
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      const submitCalls = recorded.filter((r) => r.url.includes('/sidecar/submit'));
+      // All issued — 503 didn't trip the cold cache.
+      expect(submitCalls.length).toBe(THRESHOLD + 3);
+    } finally {
+      restore();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Read path
+  // -------------------------------------------------------------------------
+
+  it('read: short-circuits after N consecutive 404s on the gateway', async () => {
+    // All sidecar reads 404; the underlying block/get also 404s. We just
+    // want to confirm /sidecar/blob is queried <=THRESHOLD times across
+    // many fetches.
+    const { recorded, restore } = installFetchMock({
+      sidecarBlobHandler: () => new Response(null, { status: 404 }),
+      blockGetHandler: () => new Response(null, { status: 404 }),
+    });
+    try {
+      for (let i = 0; i < THRESHOLD + 5; i++) {
+        const bytes = new TextEncoder().encode(`read-payload-${i}`);
+        const cid = cidForBytes(bytes);
+        // Each fetch will fail (no real backing store), but the test only
+        // cares about the sidecar probe count.
+        try {
+          await fetchFromIpfs([GATEWAY], cid);
+        } catch {
+          /* expected — no real bytes */
+        }
+      }
+      const sidecarReads = recorded.filter((r) => r.url.includes('/sidecar/blob'));
+      expect(sidecarReads.length).toBe(THRESHOLD);
+    } finally {
+      restore();
+    }
+  });
+
+  it('read: a hit resets the counter', async () => {
+    // First 2 misses, then a real hit, then 3 more misses. The hit at
+    // index 2 resets the counter, so we should see all 6 sidecar probes
+    // (none short-circuited).
+    let n = 0;
+    const { recorded, restore } = installFetchMock({
+      sidecarBlobHandler: () => {
+        const idx = n;
+        n += 1;
+        if (idx === 2) {
+          // Return real bytes that hash to a CID we know.
+          const hit = new TextEncoder().encode('hit-bytes');
+          return new Response(hit as BlobPart, {
+            status: 200,
+            headers: { 'Content-Type': 'application/octet-stream' },
+          });
+        }
+        return new Response(null, { status: 404 });
+      },
+      blockGetHandler: () => new Response(null, { status: 404 }),
+    });
+    try {
+      // Build the CID that the hit returns, so the verifier passes on idx=2.
+      const hitBytes = new TextEncoder().encode('hit-bytes');
+      const hitCid = cidForBytes(hitBytes);
+
+      for (let i = 0; i < 6; i++) {
+        // Use hitCid every time so the verifyCidMatchesBytes check passes
+        // on the one iteration that the mock returns hit-bytes.
+        try {
+          await fetchFromIpfs([GATEWAY], hitCid);
+        } catch {
+          /* expected for the miss iterations */
+        }
+      }
+      const sidecarReads = recorded.filter((r) => r.url.includes('/sidecar/blob'));
+      // No short-circuit: the hit at iteration 2 cleared the counter,
+      // and we never accumulated 3 consecutive misses afterward.
+      expect(sidecarReads.length).toBe(6);
+    } finally {
+      restore();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Cooldown duration
+  // -------------------------------------------------------------------------
+
+  it('re-arms after the cooldown window expires', async () => {
+    // Stub Date.now directly rather than via vi.useFakeTimers — the latter
+    // also patches setTimeout, which conflicts with the AbortSignal.timeout
+    // used inside fetch. We only need to control the cold-state clock.
+    let nowMs = 1_000_000_000_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+
+    const { recorded, restore } = installFetchMock({
+      sidecarBlobHandler: () => new Response(null, { status: 404 }),
+      blockGetHandler: () => new Response(null, { status: 404 }),
+    });
+    try {
+      // Burst N misses to enter cold state.
+      for (let i = 0; i < THRESHOLD; i++) {
+        const bytes = new TextEncoder().encode(`payload-${i}`);
+        try {
+          await fetchFromIpfs([GATEWAY], cidForBytes(bytes));
+        } catch {
+          /* expected */
+        }
+      }
+      const beforeCooldown = recorded.filter((r) => r.url.includes('/sidecar/blob')).length;
+      expect(beforeCooldown).toBe(THRESHOLD);
+
+      // One more attempt while cold — should be short-circuited.
+      try {
+        await fetchFromIpfs([GATEWAY], cidForBytes(new TextEncoder().encode('coldcheck')));
+      } catch {
+        /* expected */
+      }
+      const duringCooldown = recorded.filter((r) => r.url.includes('/sidecar/blob')).length;
+      expect(duringCooldown).toBe(THRESHOLD); // no new sidecar fetch
+
+      // Advance the cold-state clock past the 60 s cooldown.
+      nowMs += 61_000;
+
+      // Now a new probe should fire (coldUntil has passed). On 404, it
+      // re-enters cold state — but the probe itself counts as one new
+      // sidecar fetch.
+      try {
+        await fetchFromIpfs([GATEWAY], cidForBytes(new TextEncoder().encode('rearm')));
+      } catch {
+        /* expected */
+      }
+      const afterCooldown = recorded.filter((r) => r.url.includes('/sidecar/blob')).length;
+      expect(afterCooldown).toBe(THRESHOLD + 1);
+    } finally {
+      restore();
+      nowSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Live testnet deploy 2026-06-01 logs ~100 visible failed-fetch errors per wallet load:
\`\`\`
GET https://unicity-ipfs1.dyndns.org/sidecar/blob?cid=… 404
\`\`\`

The SDK is already silent on 404 (\`tryReadFromSidecar\` returns null without logging), but Chrome auto-logs every non-2xx \`fetch()\`. With ~100 blocks in a typical Profile snapshot the noise drowns real signal.

**Root cause is by design:** the sidecar correctly GCs blobs once promoted to Kubo (\`instant_pin_cache._reconcile_once\` unlinks the disk blob after \`block_stat\` confirms in-kubo). So for any wallet load that walks an *old* Profile bundle every probe 404s — verified by curling the same CIDs and getting 200 from the same gateway's \`/ipfs/\` endpoint.

## Fix

Per-gateway adaptive cold-cache. After \`SIDECAR_COLD_MISS_THRESHOLD\` (3) consecutive 404s on a gateway, both \`tryReadFromSidecar\` and \`submitToSidecarBestEffort\` short-circuit *before* issuing the fetch for \`SIDECAR_COLD_DURATION_MS\` (60 s). A successful hit (or 200 submit) resets the counter and re-arms the fast path immediately.

**Cross-device fast path preserved:** a single hit re-enables probing for the rest of the session. Steady-state cold gateways collapse from ~100 misses to ~3 misses + 1 re-probe per minute.

**503 / 413 do NOT count as cold misses** — the sidecar is alive in those cases (cache_full back-pressure / oversize), just refusing this particular submit. We must keep probing.

## Test plan

- [x] submit: short-circuits after N consecutive 404s
- [x] submit: 200 hit resets the counter
- [x] submit: 503 does NOT count as a cold miss
- [x] read: short-circuits after N consecutive 404s
- [x] read: hit resets the counter
- [x] re-arms after the cooldown window expires
- [x] 6/6 new tests pass
- [x] 40/40 other ipfs-client tests pass (2 pre-existing \`@ipld/car\` dep failures verified on bare main)
- [x] Verified live on sphere-telco-test.dyndns.org via vendored build