### PR TITLE
fix(profile)(security): keep identity / seed material out of OrbitDB

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -6128,6 +6128,32 @@ export class Sphere {
         fallbackThrew = err;
       }
       if (fallbackValue !== null && fallbackValue !== undefined) {
+        // Lazy backfill — write the fallback value into primary so the
+        // next boot finds it without consulting fallback again. With
+        // the IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS fix in
+        // `profile-storage-provider.ts`, identity-key writes route to
+        // the Profile localCache (IndexedDB) only — they never reach
+        // OrbitDB / IPFS. So the backfill is the right move: it
+        // silences the per-boot "missing from primary; consulting
+        // fallbackStorage" warning for wallets that predate this fix
+        // without re-introducing the OrbitDB leak the cache-only
+        // routing closes.
+        //
+        // Best-effort: a failure to backfill is non-fatal — the read
+        // already succeeded and the caller has the value. We log at
+        // debug so operators can see why a subsequent boot still
+        // re-falls-back if the backfill kept failing.
+        try {
+          await this._storage.set(key, fallbackValue);
+        } catch (err) {
+          logger.debug(
+            'Sphere',
+            `Identity backfill of "${key}" into primary storage failed; the ` +
+              `next boot will re-consult fallback. (${
+                err instanceof Error ? err.message : String(err)
+              })`,
+          );
+        }
         return fallbackValue;
       }
       // Neither side has it. The primary error wins when both threw —

--- a/profile/index.ts
+++ b/profile/index.ts
@@ -43,6 +43,7 @@ export {
   DEFAULT_ENCRYPTION_CONFIG,
   PROFILE_KEY_MAPPING,
   CACHE_ONLY_KEYS,
+  IDENTITY_KEYS,
   IPFS_STATE_KEYS_PATTERN,
   computeAddressId,
 } from './types';

--- a/profile/migration.ts
+++ b/profile/migration.ts
@@ -30,7 +30,12 @@ import type {
 import type { ProfileStorageProvider } from './profile-storage-provider.js';
 import type { ProfileTokenStorageProvider } from './profile-token-storage-provider.js';
 import type { ProfileDatabase, MigrationPhase, MigrationResult } from './types.js';
-import { PROFILE_KEY_MAPPING, CACHE_ONLY_KEYS, IPFS_STATE_KEYS_PATTERN } from './types.js';
+import {
+  PROFILE_KEY_MAPPING,
+  CACHE_ONLY_KEYS,
+  IDENTITY_KEYS,
+  IPFS_STATE_KEYS_PATTERN,
+} from './types.js';
 import { ProfileError } from './errors.js';
 import { STORAGE_PREFIX } from '../constants.js';
 import {
@@ -135,6 +140,17 @@ const DEFAULT_IPFS_API_URL = 'https://ipfs.unicity.network';
 interface TransformedData {
   /** Profile-format key-value pairs (global + per-address). */
   readonly profileKeys: Map<string, string>;
+  /**
+   * Identity / seed material legacy keys (`mnemonic`, `master_key`, ...).
+   * These NEVER touch OrbitDB — they are written to ProfileStorageProvider
+   * via `storage.set(LEGACY_KEY, value)`, which short-circuits at the
+   * `cacheOnly` step (CACHE_ONLY_KEYS contains IDENTITY_KEYS). Tracked
+   * separately so they:
+   *   (a) skip the read-back sanity check (no OrbitDB record exists);
+   *   (b) make a future audit grep ("is identity material ever pushed
+   *       to OrbitDB?") return zero hits.
+   */
+  readonly identityKeys: Map<string, string>;
   /** TXF storage data (tokens + operational state) from legacy TokenStorageProvider. */
   readonly txfData: TxfStorageDataBase | null;
   /** Token IDs extracted from TXF data (for sanity check). */
@@ -335,7 +351,7 @@ export class ProfileMigration {
 
       const result: MigrationResult = {
         success: true,
-        keysMigrated: transformed.profileKeys.size,
+        keysMigrated: transformed.profileKeys.size + transformed.identityKeys.size,
         tokensMigrated: transformed.tokenIds.size,
         addressesMigrated: countAddresses(transformed),
         durationMs: Date.now() - startTime,
@@ -351,7 +367,8 @@ export class ProfileMigration {
 
       return {
         success: false,
-        keysMigrated: transformed?.profileKeys.size ?? 0,
+        keysMigrated:
+          (transformed?.profileKeys.size ?? 0) + (transformed?.identityKeys.size ?? 0),
         tokensMigrated: transformed?.tokenIds.size ?? 0,
         addressesMigrated: transformed !== null ? countAddresses(transformed) : 0,
         durationMs: Date.now() - startTime,
@@ -441,6 +458,7 @@ export class ProfileMigration {
     this.log('Step 2: TRANSFORM LOCAL');
 
     const profileKeys = new Map<string, string>();
+    const identityKeys = new Map<string, string>();
     const tokenIds = new Set<string>();
     let historyCount = 0;
     let conversationCount = 0;
@@ -471,6 +489,18 @@ export class ProfileMigration {
       // Read the value
       const value = await legacyStorage.get(rawKey);
       if (value === null) continue;
+
+      // Identity / seed material — divert to a separate map. These MUST
+      // NOT be mapped to their `identity.*` Profile key (which would
+      // try to write them to OrbitDB and trip the IDENTITY_KEYS guard
+      // in ProfileStorageProvider.set). Instead, persist them via the
+      // LEGACY key — ProfileStorageProvider treats them as cache-only
+      // (CACHE_ONLY_KEYS), so the write lands in the Profile localCache
+      // only and never replicates.
+      if (IDENTITY_KEYS.has(stripped)) {
+        identityKeys.set(stripped, value);
+        continue;
+      }
 
       // Map to Profile key name
       const profileKey = mapLegacyKeyToProfileKey(stripped);
@@ -561,6 +591,7 @@ export class ProfileMigration {
 
     return {
       profileKeys,
+      identityKeys,
       txfData,
       tokenIds,
       historyCount,
@@ -608,6 +639,28 @@ export class ProfileMigration {
       }
     }
     this.log(`Wrote ${keysWritten} profile keys`);
+
+    // Identity / seed material — write via the LEGACY key name so
+    // ProfileStorageProvider's `translateKey` reports `cacheOnly: true`
+    // and the write short-circuits at the localCache step (no OrbitDB
+    // entry, no IPFS replication). The defense-in-depth assertion in
+    // `ProfileStorageProvider.set` would fail-closed if anything routed
+    // an `identity.*` Profile key through here instead.
+    let identityKeysWritten = 0;
+    for (const [legacyKey, value] of data.identityKeys) {
+      try {
+        await storage.set(legacyKey, value);
+        identityKeysWritten++;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new ProfileError(
+          'MIGRATION_FAILED',
+          `Failed to write identity key '${legacyKey}': ${msg}`,
+          err,
+        );
+      }
+    }
+    this.log(`Wrote ${identityKeysWritten} identity keys (cache-only, never OrbitDB)`);
 
     // Save TXF data via ProfileTokenStorageProvider
     // (builds UXF bundle, encrypts CAR, pins to IPFS, adds bundle ref to OrbitDB)

--- a/profile/profile-storage-provider.ts
+++ b/profile/profile-storage-provider.ts
@@ -19,6 +19,7 @@ import {
   type ProfileStorageProviderOptions,
   PROFILE_KEY_MAPPING,
   CACHE_ONLY_KEYS,
+  IDENTITY_KEYS,
   IPFS_STATE_KEYS_PATTERN,
   computeAddressId,
 } from './types';
@@ -1601,34 +1602,52 @@ export class ProfileStorageProvider implements StorageProvider {
    * SHOULD use `setEntry()` (see below) which accepts an explicit type.
    */
   async set(key: string, value: string, opts?: { entryType?: OpLogEntryType }): Promise<void> {
-    // C1 fail-closed gate (Audit #333):
+    // Audit #333 C1 — identity / seed material MUST NOT replicate via
+    // OrbitDB/IPFS. The defense is two-layer:
     //
-    // The actual attack surface is the OrbitDB write path: the audit's
-    // described scenario is "the seed replicated to third-party IPFS
-    // gateways in cleartext". Local-cache writes are NOT replicated to
-    // IPFS — they live in the device's IndexedDB / FileStorage same
-    // as legacy. The primary defense is therefore the `encrypt()`
-    // throw further down: when `encryptionEnabled === true` and no
-    // key is derived, the OrbitDB write is rejected at the
-    // `writeEnvelope` boundary.
+    //   (1) The IDENTITY_KEYS set in `profile/types.ts` is folded into
+    //       `CACHE_ONLY_KEYS`, so `translateKey()` returns
+    //       `cacheOnly: true` for `mnemonic`, `master_key`, `chain_code`,
+    //       `derivation_path`, `base_path`, `derivation_mode`,
+    //       `wallet_source`, and `current_address_index`. The write
+    //       short-circuits at step 2 below (localCache only).
+    //
+    //   (2) The post-translation assertion below — belt-and-suspenders.
+    //       If a future refactor adds an identity-shaped Profile key
+    //       (anything translating to `identity.*`) but forgets to also
+    //       add it to CACHE_ONLY_KEYS, the assertion throws here rather
+    //       than silently pinning the encrypted seed to IPFS.
     //
     // Sphere.create() legitimately calls `set('mnemonic', ...)` during
     // Phase A (localCache attached, OrbitDB not yet attached because
-    // identity has not been derived YET — the mnemonic is the INPUT
-    // to identity derivation). Pre-fix-fix the C1 gate fired here too
-    // aggressively and broke that flow. The encrypt() throw remains
-    // the catch-all for the actual IPFS-leak window.
+    // identity has not been derived YET — the mnemonic is the INPUT to
+    // identity derivation). Step 2 keeps the localCache write working;
+    // step 3 never fires for these keys.
     //
-    // Identity-class keys (`mnemonic`, `master_key`, ...) intentionally
-    // flow through `localCache.set()` below — that is how the wallet
-    // has always persisted the seed locally. Audit #333 C1 only ever
-    // cared about the OrbitDB replication path.
+    // The earlier "encrypt() throw is the catch-all" reasoning is
+    // insufficient: `encrypt()` only throws *before* the key is derived.
+    // Any post-Phase-A rewrite would otherwise have encrypted the seed
+    // and pushed it onto the OpLog. The cache-only classification closes
+    // that hole completely.
 
     const translated = translateKey(key, this.addressId);
 
     // Excluded keys — silently drop
     if (translated.excluded) {
       return;
+    }
+
+    // Defense in depth: identity-shaped translations MUST be cache-only.
+    // This catches refactor regressions where someone introduces a new
+    // `identity.*` mapping but forgets the CACHE_ONLY_KEYS entry.
+    if (translated.profileKey.startsWith('identity.') && !translated.cacheOnly) {
+      throw new ProfileError(
+        'PROFILE_NOT_INITIALIZED',
+        `Refusing to write identity-shaped Profile key "${translated.profileKey}" ` +
+          `to OrbitDB: seed material must NEVER replicate. Add the legacy key ` +
+          `"${key}" to CACHE_ONLY_KEYS in profile/types.ts. ` +
+          `See IDENTITY_KEYS for the canonical list.`,
+      );
     }
 
     // 1. Always write to local cache

--- a/profile/types.ts
+++ b/profile/types.ts
@@ -939,15 +939,70 @@ export const PROFILE_KEY_MAPPING: ProfileKeyMap = {
 
 /**
  * Keys that are stored ONLY in the local cache, never written to OrbitDB.
- * These are regenerated from external APIs and are not replicated.
+ *
+ * Two distinct reasons land a key here:
+ *
+ * 1. **External-API caches** (`token_registry_*`, `price_*`) — regenerated
+ *    from network calls; replicating wastes OpLog bytes and stale entries
+ *    on one device can poison a cross-device read.
+ *
+ * 2. **Identity / seed material** (the IDENTITY_KEYS block) —
+ *    *security boundary*. OrbitDB content is replicated to IPFS (the
+ *    snapshot CAR is pinned by the user's own pin gateway *and*, in
+ *    practice, observable by any peer the pubsub topic reaches). Even
+ *    when wrapped by the password-derived `encrypt()`, distributing the
+ *    encrypted seed lowers the threat model from "attacker must
+ *    compromise the device" to "attacker must brute-force a password
+ *    against an IPFS-pinned ciphertext". The seed MUST stay
+ *    device-local; the only legitimate cross-device transport for the
+ *    seed is the user's own BIP-39 mnemonic backup. Audit #333 C1 was
+ *    interpreted as "encrypt before OrbitDB write" — that defense holds
+ *    only during Phase A (no key derived → `encrypt()` throws); any
+ *    post-Phase-A rewrite of an identity key would otherwise succeed
+ *    encrypted and leak. Mark them cache-only so the write short-
+ *    circuits at the localCache step in `ProfileStorageProvider.set()`.
  *
  * See PROFILE-ARCHITECTURE.md Section 2.1 "Cache-only keys".
  */
 export const CACHE_ONLY_KEYS: ReadonlySet<string> = new Set([
+  // External-API caches (regenerated from network)
   'token_registry_cache',
   'token_registry_cache_ts',
   'price_cache',
   'price_cache_ts',
+
+  // Identity / seed material — NEVER replicate via OrbitDB/IPFS.
+  // Keep this list in sync with IDENTITY_KEYS below.
+  'mnemonic',
+  'master_key',
+  'chain_code',
+  'derivation_path',
+  'base_path',
+  'derivation_mode',
+  'wallet_source',
+  // `current_address_index` is the active HD slot pointer. Could be cross-
+  // device synced in principle, but on a fresh-device boot the address-
+  // discovery walker re-derives it from the mnemonic anyway; keeping it
+  // device-local removes one more identity-shaped key from the OpLog.
+  'current_address_index',
+]);
+
+/**
+ * The identity / seed-material keys. Listed separately so other modules
+ * (migration, audits, tests) can refer to "the identity class" without
+ * coupling to the full CACHE_ONLY_KEYS list.
+ *
+ * Every key here MUST also appear in CACHE_ONLY_KEYS.
+ */
+export const IDENTITY_KEYS: ReadonlySet<string> = new Set([
+  'mnemonic',
+  'master_key',
+  'chain_code',
+  'derivation_path',
+  'base_path',
+  'derivation_mode',
+  'wallet_source',
+  'current_address_index',
 ]);
 
 /**

--- a/tests/unit/core/Sphere.identity-fallback-backfill.test.ts
+++ b/tests/unit/core/Sphere.identity-fallback-backfill.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for the identity-key lazy backfill behaviour in
+ * `Sphere.loadIdentityFromStorage` → `readIdentityKey`.
+ *
+ * Symptom motivating the fix (2026-06-02): wallets that existed BEFORE
+ * the `IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS` fix still have their seed
+ * material in the legacy IndexedDB (configured as Sphere's
+ * `fallbackStorage`). On every boot the Profile-mode primary read
+ * returns `null` for every identity key, the helper consults the
+ * fallback, succeeds, and the wallet boots — but emits one
+ * `[Sphere] Identity read for "<key>" missing from primary storage`
+ * warning per identity key on every single boot.
+ *
+ * Fix: when the fallback read succeeds, also write the value back to
+ * the primary. With `IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS`, that write
+ * lands in the Profile localCache (IndexedDB) only — it never
+ * reaches OrbitDB / IPFS. The next boot finds the value in the
+ * primary on the first read; no fallback consult, no warning.
+ *
+ * The backfill must be best-effort: if the primary `set` throws, the
+ * read already succeeded and the caller has the value — we must not
+ * regress the load just because the backfill failed.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Sphere } from '../../../core/Sphere';
+import { STORAGE_KEYS_GLOBAL } from '../../../constants';
+import type { StorageProvider } from '../../../storage';
+import type { ProviderStatus } from '../../../types';
+
+function createMockStorage(
+  seed: Map<string, string> = new Map(),
+): StorageProvider & { _store: Map<string, string> } {
+  const data = new Map(seed);
+  return {
+    id: 'mock-storage',
+    name: 'Mock Storage',
+    type: 'local' as const,
+    _store: data,
+    setIdentity: vi.fn(),
+    get: vi.fn(async (key: string) => data.get(key) ?? null),
+    set: vi.fn(async (key: string, value: string) => {
+      data.set(key, value);
+    }),
+    remove: vi.fn(async (key: string) => {
+      data.delete(key);
+    }),
+    has: vi.fn(async (key: string) => data.has(key)),
+    keys: vi.fn(async () => Array.from(data.keys())),
+    clear: vi.fn(async () => {
+      data.clear();
+    }),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+    isConnected: vi.fn(() => true),
+    getStatus: vi.fn((): ProviderStatus => 'connected'),
+    saveTrackedAddresses: vi.fn(async () => {}),
+    loadTrackedAddresses: vi.fn(async () => []),
+  } as StorageProvider & { _store: Map<string, string> };
+}
+
+describe('Sphere — identity-key fallback backfill', () => {
+  it('writes fallback values back into primary so subsequent boots skip the fallback consult', async () => {
+    // Primary satisfies `Sphere.exists` via MNEMONIC alone — modelling
+    // the real-world scenario where a wallet predates the Profile
+    // refactor: SOME identity material is in the Profile localCache
+    // (or, via legacy migration markers, was already partially
+    // backfilled), but other identity keys are still ONLY in the
+    // legacy fallback. The backfill path runs for every identity key
+    // the primary doesn't yet have.
+    const primary = createMockStorage(
+      new Map<string, string>([
+        // MNEMONIC present in primary so Sphere.exists returns true.
+        [STORAGE_KEYS_GLOBAL.MNEMONIC, 'v2:primary-mnemonic'],
+      ]),
+    );
+    const fallback = createMockStorage(
+      new Map<string, string>([
+        [STORAGE_KEYS_GLOBAL.MNEMONIC, 'v2:fallback-mnemonic'],
+        [STORAGE_KEYS_GLOBAL.MASTER_KEY, 'v2:fallback-masterkey'],
+        [STORAGE_KEYS_GLOBAL.CHAIN_CODE, 'cafebabe'],
+        [STORAGE_KEYS_GLOBAL.DERIVATION_PATH, "m/44'/0'/0'/0/0"],
+        [STORAGE_KEYS_GLOBAL.BASE_PATH, "m/44'/0'/0'/0"],
+        [STORAGE_KEYS_GLOBAL.DERIVATION_MODE, 'mnemonic'],
+        [STORAGE_KEYS_GLOBAL.WALLET_SOURCE, 'mnemonic'],
+        [STORAGE_KEYS_GLOBAL.CURRENT_ADDRESS_INDEX, '0'],
+      ]),
+    );
+
+    // Sphere.load WILL throw downstream of readIdentityKey — the
+    // ciphertexts here aren't real v2 envelopes so decryption fails.
+    // What matters for THIS test is whether the backfill happens
+    // BEFORE the throw.
+    try {
+      await Sphere.load({ storage: primary, fallbackStorage: fallback });
+    } catch {
+      // Expected — see comment above.
+    }
+
+    // For each identity key the primary lacks, the loader should
+    // have backfilled the fallback value. MNEMONIC is in primary so
+    // it should NOT be backfilled; the rest should.
+    const setCalls = (primary.set as ReturnType<typeof vi.fn>).mock.calls;
+    const setKeys = setCalls.map(([k]) => k as string);
+
+    expect(setKeys).not.toContain(STORAGE_KEYS_GLOBAL.MNEMONIC);
+    expect(setKeys).toContain(STORAGE_KEYS_GLOBAL.MASTER_KEY);
+    expect(setKeys).toContain(STORAGE_KEYS_GLOBAL.CHAIN_CODE);
+    expect(setKeys).toContain(STORAGE_KEYS_GLOBAL.DERIVATION_PATH);
+
+    // The values written must match the fallback values verbatim.
+    const masterKeyWrite = setCalls.find(
+      ([k]) => k === STORAGE_KEYS_GLOBAL.MASTER_KEY,
+    );
+    expect(masterKeyWrite?.[1]).toBe('v2:fallback-masterkey');
+
+    const chainCodeWrite = setCalls.find(
+      ([k]) => k === STORAGE_KEYS_GLOBAL.CHAIN_CODE,
+    );
+    expect(chainCodeWrite?.[1]).toBe('cafebabe');
+  });
+
+  it('backfill failure does NOT regress the wallet load (best-effort write)', async () => {
+    // Primary's set() throws on every call (e.g., quota exhaustion,
+    // contention, etc.). The fallback read still succeeds; readIdentityKey
+    // must return the fallback value to the caller, not bubble the
+    // backfill error.
+    const primary = createMockStorage(
+      new Map<string, string>([
+        // Satisfy Sphere.exists.
+        [STORAGE_KEYS_GLOBAL.MNEMONIC, 'v2:primary-mnemonic'],
+      ]),
+    );
+    primary.set = vi.fn(async () => {
+      throw new Error('quota exceeded');
+    });
+    const fallback = createMockStorage(
+      new Map<string, string>([
+        [STORAGE_KEYS_GLOBAL.MASTER_KEY, 'fallback-value'],
+      ]),
+    );
+
+    // We don't care about Sphere.load succeeding here — only that the
+    // failing backfill didn't surface as an error at the readIdentityKey
+    // boundary. Verify by asserting primary.set was attempted (proving
+    // the code path ran).
+    let thrownMessage: string | null = null;
+    try {
+      await Sphere.load({ storage: primary, fallbackStorage: fallback });
+    } catch (err) {
+      thrownMessage = err instanceof Error ? err.message : String(err);
+    }
+
+    // Whatever downstream threw, it must NOT be 'quota exceeded' —
+    // the backfill error was swallowed (best-effort) and the original
+    // load-path error surfaced instead.
+    if (thrownMessage !== null) {
+      expect(thrownMessage).not.toContain('quota exceeded');
+    }
+
+    // primary.set was attempted for MASTER_KEY (the backfill) —
+    // proving the fallback path was taken and the backfill code ran.
+    const setCalls = (primary.set as ReturnType<typeof vi.fn>).mock.calls;
+    const masterKeyAttempt = setCalls.find(
+      ([k]) => k === STORAGE_KEYS_GLOBAL.MASTER_KEY,
+    );
+    expect(masterKeyAttempt).toBeDefined();
+  });
+
+  it('no fallback consult when primary already holds the value (no backfill triggered)', async () => {
+    // The post-backfill steady state. On the second boot, primary has
+    // the identity keys; fallback is never consulted; primary.set is
+    // never called from readIdentityKey for these keys.
+    const primary = createMockStorage(
+      new Map<string, string>([
+        [STORAGE_KEYS_GLOBAL.MNEMONIC, 'v2:already-here'],
+        [STORAGE_KEYS_GLOBAL.MASTER_KEY, 'v2:already-here-too'],
+        [STORAGE_KEYS_GLOBAL.CHAIN_CODE, 'cafebabe'],
+        [STORAGE_KEYS_GLOBAL.DERIVATION_PATH, "m/44'/0'/0'/0/0"],
+        [STORAGE_KEYS_GLOBAL.BASE_PATH, "m/44'/0'/0'/0"],
+        [STORAGE_KEYS_GLOBAL.DERIVATION_MODE, 'mnemonic'],
+        [STORAGE_KEYS_GLOBAL.WALLET_SOURCE, 'mnemonic'],
+        [STORAGE_KEYS_GLOBAL.CURRENT_ADDRESS_INDEX, '0'],
+      ]),
+    );
+    const fallback = createMockStorage(new Map());
+
+    try {
+      await Sphere.load({ storage: primary, fallbackStorage: fallback });
+    } catch {
+      // Decryption / downstream errors expected — irrelevant to this test.
+    }
+
+    // Fallback.get was never called for an identity key — we never
+    // needed to consult it. (Other components might query fallback for
+    // unrelated keys; this test only enforces identity-key behaviour.)
+    const fallbackGetCalls = (fallback.get as ReturnType<typeof vi.fn>).mock
+      .calls;
+    const identityKeysAccessedFromFallback = fallbackGetCalls.filter(([k]) =>
+      [
+        STORAGE_KEYS_GLOBAL.MNEMONIC,
+        STORAGE_KEYS_GLOBAL.MASTER_KEY,
+        STORAGE_KEYS_GLOBAL.CHAIN_CODE,
+        STORAGE_KEYS_GLOBAL.DERIVATION_PATH,
+        STORAGE_KEYS_GLOBAL.BASE_PATH,
+        STORAGE_KEYS_GLOBAL.DERIVATION_MODE,
+        STORAGE_KEYS_GLOBAL.WALLET_SOURCE,
+        STORAGE_KEYS_GLOBAL.CURRENT_ADDRESS_INDEX,
+      ].includes(k as string),
+    );
+    expect(identityKeysAccessedFromFallback).toEqual([]);
+
+    // And we did NOT re-write to primary for these keys via the
+    // backfill path (primary.set may have been called by other paths
+    // like finalizeWalletCreation — filter to identity keys only).
+    const primarySetCalls = (primary.set as ReturnType<typeof vi.fn>).mock
+      .calls;
+    const identityBackfills = primarySetCalls.filter(([k]) =>
+      [
+        STORAGE_KEYS_GLOBAL.MNEMONIC,
+        STORAGE_KEYS_GLOBAL.MASTER_KEY,
+        STORAGE_KEYS_GLOBAL.CHAIN_CODE,
+        STORAGE_KEYS_GLOBAL.DERIVATION_PATH,
+        STORAGE_KEYS_GLOBAL.BASE_PATH,
+        STORAGE_KEYS_GLOBAL.DERIVATION_MODE,
+        STORAGE_KEYS_GLOBAL.WALLET_SOURCE,
+        STORAGE_KEYS_GLOBAL.CURRENT_ADDRESS_INDEX,
+      ].includes(k as string),
+    );
+    expect(identityBackfills).toEqual([]);
+  });
+});

--- a/tests/unit/profile/integration.test.ts
+++ b/tests/unit/profile/integration.test.ts
@@ -231,9 +231,11 @@ describe('Profile Integration', () => {
       storageA.setIdentity(TEST_IDENTITY);
       await mockDb.connect({} as any);
 
-      // Access internal connection state
+      // Use a non-identity key — `mnemonic`/`master_key` are
+      // cache-only post the IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS fix and
+      // never reach OrbitDB.
       (storageA as any).dbStatus = "attached";
-      await storageA.set('mnemonic', 'encrypt me');
+      await storageA.set('wallet_exists', 'encrypt me');
 
       // Provider B reads from the same OrbitDB with fresh cache
       const cacheB = createMockCacheStorage();
@@ -244,8 +246,8 @@ describe('Profile Integration', () => {
       storageB.setIdentity(TEST_IDENTITY);
       (storageB as any).dbStatus = "attached";
 
-      // Clear cache so it falls through to OrbitDB
-      const value = await storageB.get('mnemonic');
+      // Cache cold → falls through to OrbitDB.
+      const value = await storageB.get('wallet_exists');
       expect(value).toBe('encrypt me');
     });
   });
@@ -255,7 +257,11 @@ describe('Profile Integration', () => {
   // ---------------------------------------------------------------------------
 
   describe('multi-device simulation', () => {
-    it('two providers sharing OrbitDB see data from both', async () => {
+    it('two providers sharing OrbitDB see data from both (non-identity keys only)', async () => {
+      // Note: identity / seed material is intentionally NOT cross-device
+      // synced — `mnemonic` / `master_key` etc. are cache-only post the
+      // IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS fix, and the user moves them
+      // between devices via BIP-39 mnemonic backup, not OrbitDB.
       const sharedDb = createMockProfileDatabase();
       await sharedDb.connect({} as any);
 
@@ -267,7 +273,7 @@ describe('Profile Integration', () => {
       });
       storageA.setIdentity(TEST_IDENTITY);
       (storageA as any).dbStatus = "attached";
-      await storageA.set('mnemonic', 'shared secret');
+      await storageA.set('wallet_exists', 'shared marker');
 
       // Provider B
       const cacheB = createMockCacheStorage();
@@ -279,8 +285,8 @@ describe('Profile Integration', () => {
       (storageB as any).dbStatus = "attached";
 
       // B should see A's data via OrbitDB fallback
-      const value = await storageB.get('mnemonic');
-      expect(value).toBe('shared secret');
+      const value = await storageB.get('wallet_exists');
+      expect(value).toBe('shared marker');
     });
   });
 
@@ -369,9 +375,16 @@ describe('Profile Integration', () => {
       expect(result.tokensMigrated).toBe(2);
       expect(result.keysMigrated).toBeGreaterThan(0);
 
-      // Verify profile has identity keys
-      expect(profileStore.has('identity.mnemonic')).toBe(true);
-      expect(profileStore.get('identity.mnemonic')).toBe('abandon abandon abandon');
+      // Verify identity keys live in the Profile localCache under
+      // their LEGACY name (not the `identity.*` Profile key). The
+      // migration writes them as cache-only — they must not appear
+      // under `identity.*` because OrbitDB replicates that namespace.
+      // This mock profileStorage doesn't distinguish localCache vs
+      // OrbitDB, so we just verify the legacy key is present and the
+      // identity.* key is NOT.
+      expect(profileStore.has('identity.mnemonic')).toBe(false);
+      expect(profileStore.has('mnemonic')).toBe(true);
+      expect(profileStore.get('mnemonic')).toBe('abandon abandon abandon');
     });
 
     it('post-migration cleanup removes legacy data', async () => {

--- a/tests/unit/profile/migration-c2-flush-before-cleanup.test.ts
+++ b/tests/unit/profile/migration-c2-flush-before-cleanup.test.ts
@@ -430,8 +430,15 @@ describe('Audit #333 C2 — migration cleanup-before-flush', () => {
         expect(key).toMatch(/^migration\./);
       }
 
-      // Profile side has the token data + identity keys.
-      expect(profileStorage._store.has('identity.mnemonic')).toBe(true);
+      // Profile side has the token data + identity keys. Post the
+      // IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS fix, identity material is
+      // written via its LEGACY key name (`mnemonic`), not the
+      // `identity.mnemonic` profile key — so the OrbitDB-replicated
+      // namespace stays clean. The mock profileStorage doesn't model
+      // localCache vs OrbitDB separately, so we just check the legacy
+      // key landed and the `identity.*` profile key did NOT.
+      expect(profileStorage._store.has('identity.mnemonic')).toBe(false);
+      expect(profileStorage._store.has('mnemonic')).toBe(true);
       expect(profileTokenStorage._savedData).toEqual(SAMPLE_TXF);
     });
 

--- a/tests/unit/profile/migration.test.ts
+++ b/tests/unit/profile/migration.test.ts
@@ -394,6 +394,7 @@ describe('ProfileMigration', () => {
     it('catches missing profile key', async () => {
       const legacyStorage = createMockLegacyStorage({
         wallet_exists: 'true',
+        address_nametags: '{"alice":1}',
         mnemonic: 'secret',
       });
 
@@ -401,12 +402,16 @@ describe('ProfileMigration', () => {
 
       // Profile storage where set() works but get() returns null for
       // a specific key during sanity check (simulates data loss in OrbitDB).
+      // We target `addresses.nametags` — a non-identity profile key that
+      // DOES go through the OrbitDB-backed sanity-check path. (Identity
+      // keys are now diverted to a separate cache-only path and the
+      // sanity check intentionally skips them per CACHE_ONLY_KEYS.)
       const store = new Map<string, string>();
       let verifyingPhase = false;
       const profileStorage = {
         async get(key: string) {
-          // During verifying phase, pretend 'identity.mnemonic' is missing
-          if (verifyingPhase && key === 'identity.mnemonic') return null;
+          // During verifying phase, pretend 'addresses.nametags' is missing
+          if (verifyingPhase && key === 'addresses.nametags') return null;
           return store.get(key) ?? null;
         },
         async set(key: string, value: string) {

--- a/tests/unit/profile/profile-storage-provider-c1-plaintext-seed.test.ts
+++ b/tests/unit/profile/profile-storage-provider-c1-plaintext-seed.test.ts
@@ -206,16 +206,13 @@ describe('Audit #333 C1 — plaintext-seed window', () => {
       expect(cache._store.get('wallet_exists')).toBe('true');
     });
 
-    it('encrypt() also throws on identity-class writes in the danger window', async () => {
-      const { provider, db } = buildDangerWindowProvider();
-      // dbStatus='attached' + profileEncryptionKey=null is the
-      // audit's exact dangerous scenario. Even though the localCache
-      // write succeeds first (legacy behaviour), the OrbitDB write
-      // is rejected at the encrypt() boundary — the mnemonic does
-      // NOT reach OrbitDB, and therefore does NOT replicate to IPFS.
-      await expect(provider.set('mnemonic', 'plaintext-seed-bytes'))
-        .rejects.toMatchObject({ code: 'PROFILE_NOT_INITIALIZED' });
-      // OrbitDB store is empty — the audit's described leak is blocked.
+    it('identity-class writes in the danger window never reach OrbitDB (cache-only short-circuit precedes encrypt())', async () => {
+      // Post IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS: identity writes resolve
+      // to localCache only, so `encrypt()` is never invoked and `set()`
+      // does not throw. The OrbitDB store stays empty regardless.
+      const { provider, db, cache } = buildDangerWindowProvider();
+      await provider.set('mnemonic', 'plaintext-seed-bytes');
+      expect(cache._store.get('mnemonic')).toBe('plaintext-seed-bytes');
       expect(db._store.size).toBe(0);
     });
 
@@ -237,13 +234,31 @@ describe('Audit #333 C1 — plaintext-seed window', () => {
         .rejects.toMatchObject({ code: 'PROFILE_NOT_INITIALIZED' });
     });
 
-    it('after setIdentity, writes succeed and land ENCRYPTED in OrbitDB', async () => {
-      const { provider, db } = buildDangerWindowProvider();
+    it('after setIdentity, identity-class writes STILL never reach OrbitDB (cache-only)', async () => {
+      // Post-IDENTITY_KEYS-cache-only fix: even with a valid encryption
+      // key, `mnemonic` / `master_key` / etc. are cache-only by the
+      // `CACHE_ONLY_KEYS` set in profile/types.ts. The set() short-
+      // circuits at the localCache step. This closes the seed-leak
+      // window completely — encrypt()-throw was only a Phase-A defense.
+      const { provider, db, cache } = buildDangerWindowProvider();
       provider.setIdentity(TEST_IDENTITY);
       await provider.set('mnemonic', 'abandon abandon abandon');
-      const stored = db._store.get('identity.mnemonic');
+      expect(cache._store.get('mnemonic')).toBe('abandon abandon abandon');
+      // No OrbitDB entry at any identity.* key.
+      expect(db._store.get('identity.mnemonic')).toBeUndefined();
+      expect([...db._store.keys()].filter((k) => k.startsWith('identity.'))).toEqual([]);
+    });
+
+    it('after setIdentity, non-identity writes still land ENCRYPTED in OrbitDB (control)', async () => {
+      // Sanity: the cache-only routing is scoped to IDENTITY_KEYS, not
+      // a side effect of any other refactor. A non-identity key like
+      // `address_nametags` still flows through writeEnvelope→encrypt.
+      const { provider, db } = buildDangerWindowProvider();
+      provider.setIdentity(TEST_IDENTITY);
+      await provider.set('address_nametags', '{"a":1}');
+      const stored = db._store.get('addresses.nametags');
       expect(stored).toBeDefined();
-      expect(new TextDecoder().decode(stored!)).not.toBe('abandon abandon abandon');
+      expect(new TextDecoder().decode(stored!)).not.toBe('{"a":1}');
     });
   });
 
@@ -252,24 +267,23 @@ describe('Audit #333 C1 — plaintext-seed window', () => {
   // -------------------------------------------------------------------------
 
   describe('boot-order regression — IPFS replication leak is closed', () => {
-    it('the audit\'s scenario (OrbitDB attached + no setIdentity + set mnemonic) is REJECTED at the OrbitDB boundary', async () => {
-      // The audit's exact described attack: provider in the dangerous
-      // window, writes the seed via set('mnemonic', ...). Pre-fix the
-      // encrypt() fallback would return raw UTF-8 bytes and the
-      // mnemonic would land in OrbitDB → replicate to IPFS. Post-fix
-      // the encrypt() throws and the OrbitDB store stays empty.
+    it('the audit\'s scenario (OrbitDB attached + no setIdentity + set mnemonic) is blocked by the cache-only routing; post-setIdentity it is STILL blocked', async () => {
+      // Pre-fix the encrypt() fallback returned raw UTF-8 bytes and the
+      // mnemonic landed in OrbitDB. The C1 fix made encrypt() throw in
+      // the danger window; this present fix (IDENTITY_KEYS ⊂
+      // CACHE_ONLY_KEYS) makes the cache-only routing skip OrbitDB
+      // *entirely* — both before and after a valid encryption key is
+      // attached.
       const { provider, db } = buildDangerWindowProvider();
-      await expect(provider.set('mnemonic', 'twelve word phrase'))
-        .rejects.toMatchObject({ code: 'PROFILE_NOT_INITIALIZED' });
-      expect([...db._store.keys()]).not.toContain('identity.mnemonic');
-
-      // Recovery: after setIdentity, the write succeeds and lands
-      // ENCRYPTED (not plaintext) in OrbitDB.
-      provider.setIdentity(TEST_IDENTITY);
       await provider.set('mnemonic', 'twelve word phrase');
-      const stored = db._store.get('identity.mnemonic');
-      expect(stored).toBeDefined();
-      expect(new TextDecoder().decode(stored!)).not.toBe('twelve word phrase');
+      expect([...db._store.keys()]).not.toContain('identity.mnemonic');
+      expect(db._store.size).toBe(0);
+
+      // Post-setIdentity: the seed STILL never lands in OrbitDB.
+      provider.setIdentity(TEST_IDENTITY);
+      await provider.set('mnemonic', 'twelve word phrase v2');
+      expect(db._store.get('identity.mnemonic')).toBeUndefined();
+      expect([...db._store.keys()].filter((k) => k.startsWith('identity.'))).toEqual([]);
     });
 
     it('the legitimate Sphere.create flow (Phase A → setIdentity → Phase B) WORKS end-to-end', async () => {

--- a/tests/unit/profile/profile-storage-provider-identity-keys-cache-only.test.ts
+++ b/tests/unit/profile/profile-storage-provider-identity-keys-cache-only.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for the IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS routing in
+ * `ProfileStorageProvider.set`.
+ *
+ * Background
+ * ----------
+ * The pre-fix C1 defense was an `encrypt()` throw in
+ * `writeEnvelope`: when `encryptionEnabled === true` but no encryption
+ * key has been derived yet (Phase A, pre-setIdentity), the OrbitDB
+ * write is rejected. After setIdentity, however, identity keys
+ * (`mnemonic`, `master_key`, `chain_code`, `derivation_path`, ...)
+ * would be encrypted and written to OrbitDB → replicated to IPFS via
+ * the snapshot CAR pin path. Even encrypted, this lowers the threat
+ * model from "attacker must compromise the device" to "attacker must
+ * brute-force a password against an IPFS-pinned ciphertext", which is
+ * a strictly weaker guarantee than what users expect of seed material.
+ *
+ * Fix
+ * ---
+ * Add the legacy identity keys to `CACHE_ONLY_KEYS` (via the new
+ * `IDENTITY_KEYS` set in `profile/types.ts`). `translateKey()` returns
+ * `cacheOnly: true` for them; `set()` short-circuits at the localCache
+ * step and never reaches `writeEnvelope`. A defense-in-depth assertion
+ * in `set()` fail-closes if any future refactor adds an `identity.*`
+ * Profile key without also putting its legacy alias into
+ * `CACHE_ONLY_KEYS`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ProfileDatabase, OrbitDbConfig } from '../../../profile/types';
+import {
+  IDENTITY_KEYS,
+  CACHE_ONLY_KEYS,
+  PROFILE_KEY_MAPPING,
+} from '../../../profile/types';
+import type { StorageProvider } from '../../../storage/storage-provider';
+import type { FullIdentity, TrackedAddressEntry } from '../../../types';
+import { ProfileStorageProvider } from '../../../profile/profile-storage-provider';
+
+// ---------------------------------------------------------------------------
+// Mocks (self-contained — independent of the broader test file so any
+// future re-shuffle does not affect this regression surface).
+// ---------------------------------------------------------------------------
+
+function createMockDb(): ProfileDatabase & { _store: Map<string, Uint8Array> } {
+  const store = new Map<string, Uint8Array>();
+  let connected = true;
+  return {
+    _store: store,
+    async connect(_config: OrbitDbConfig) {
+      connected = true;
+    },
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) {
+        if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      }
+      return out;
+    },
+    async close() {
+      connected = false;
+    },
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return connected;
+    },
+  } as ProfileDatabase & { _store: Map<string, Uint8Array> };
+}
+
+function createMockCache(): StorageProvider & { _store: Map<string, string> } {
+  const store = new Map<string, string>();
+  let tracked: TrackedAddressEntry[] = [];
+  return {
+    id: 'mock-cache',
+    name: 'Mock Cache',
+    type: 'local' as const,
+    description: 'In-memory mock cache',
+    _store: store,
+    async connect() {},
+    async disconnect() {},
+    isConnected() {
+      return true;
+    },
+    getStatus() {
+      return 'connected' as const;
+    },
+    setIdentity(_id: FullIdentity) {},
+    async get(k: string) {
+      return store.get(k) ?? null;
+    },
+    async set(k: string, v: string) {
+      store.set(k, v);
+    },
+    async remove(k: string) {
+      store.delete(k);
+    },
+    async has(k: string) {
+      return store.has(k);
+    },
+    async keys(prefix?: string) {
+      const all = [...store.keys()];
+      return prefix ? all.filter((k) => k.startsWith(prefix)) : all;
+    },
+    async clear(prefix?: string) {
+      if (!prefix) {
+        store.clear();
+        return;
+      }
+      for (const k of store.keys()) if (k.startsWith(prefix)) store.delete(k);
+    },
+    async saveTrackedAddresses(entries: TrackedAddressEntry[]) {
+      tracked = entries;
+    },
+    async loadTrackedAddresses() {
+      return tracked;
+    },
+  } as StorageProvider & { _store: Map<string, string> };
+}
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+function buildPostIdentityProvider(opts?: { encrypt?: boolean }) {
+  const db = createMockDb();
+  const cache = createMockCache();
+  const provider = new ProfileStorageProvider(cache, db, {
+    config: { orbitDb: { privateKey: TEST_PRIVATE_KEY } },
+    encrypt: opts?.encrypt ?? true,
+  });
+  provider.setIdentity(TEST_IDENTITY);
+  // Mark OrbitDB attached — this is the dangerous post-Phase-A state
+  // where the older `encrypt()` defense no longer fires.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (provider as any).dbStatus = 'attached';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (provider as any).status = 'connected';
+  return { provider, db, cache };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS — seed material never reaches OrbitDB', () => {
+  it('IDENTITY_KEYS contract: every identity key is also in CACHE_ONLY_KEYS', () => {
+    for (const key of IDENTITY_KEYS) {
+      expect(CACHE_ONLY_KEYS.has(key)).toBe(true);
+    }
+  });
+
+  it('IDENTITY_KEYS contract: covers every legacy → Profile `identity.*` mapping', () => {
+    // If a new identity-shaped Profile key is added to PROFILE_KEY_MAPPING
+    // without updating IDENTITY_KEYS / CACHE_ONLY_KEYS, this test fails
+    // immediately — the contract that the seed never leaves the device
+    // is enforced at the schema level, not just the runtime.
+    const identityLegacyKeys = Object.entries(
+      PROFILE_KEY_MAPPING as Record<string, { profileKey: string }>,
+    )
+      .filter(([, v]) => v.profileKey.startsWith('identity.'))
+      .map(([k]) => k);
+    for (const k of identityLegacyKeys) {
+      expect(
+        IDENTITY_KEYS.has(k),
+        `Legacy key "${k}" maps to "${
+          (PROFILE_KEY_MAPPING as Record<string, { profileKey: string }>)[k].profileKey
+        }" (identity.*) but is missing from IDENTITY_KEYS — this would allow seed material to be replicated via OrbitDB. Add it to IDENTITY_KEYS and CACHE_ONLY_KEYS in profile/types.ts.`,
+      ).toBe(true);
+    }
+  });
+
+  it.each([
+    'mnemonic',
+    'master_key',
+    'chain_code',
+    'derivation_path',
+    'base_path',
+    'derivation_mode',
+    'wallet_source',
+    'current_address_index',
+  ])(
+    'set("%s", ...) writes to localCache only — OrbitDB stays empty',
+    async (legacyKey) => {
+      const { provider, db, cache } = buildPostIdentityProvider();
+      await provider.set(legacyKey, 'sensitive-seed-material');
+      // localCache populated under the legacy key (where the consumer
+      // — Sphere.loadIdentityFromStorage — looks for it).
+      expect(cache._store.get(legacyKey)).toBe('sensitive-seed-material');
+      // OrbitDB completely untouched.
+      expect(db._store.size).toBe(0);
+      expect([...db._store.keys()].filter((k) => k.startsWith('identity.'))).toEqual(
+        [],
+      );
+    },
+  );
+
+  it('round-trip: identity write + read returns the original value via localCache', async () => {
+    const { provider, db } = buildPostIdentityProvider();
+    await provider.set('master_key', 'encrypted-master-bytes-hex');
+    const fetched = await provider.get('master_key');
+    expect(fetched).toBe('encrypted-master-bytes-hex');
+    // And still no OrbitDB write.
+    expect(db._store.size).toBe(0);
+  });
+
+  it('defense-in-depth: a synthetic identity.* write rejected with a clear error', async () => {
+    // Drive the post-translation assertion by calling set() with a key
+    // that has no entry in PROFILE_KEY_MAPPING and translates verbatim
+    // to a synthetic `identity.*` profileKey. This simulates a future
+    // refactor where someone introduces a new identity field but forgets
+    // to update CACHE_ONLY_KEYS.
+    const { provider } = buildPostIdentityProvider();
+    await expect(provider.set('identity.someNewSecret', 'value')).rejects.toThrow(
+      /Refusing to write identity-shaped Profile key/i,
+    );
+  });
+
+  it('control: non-identity write still flows through writeEnvelope to OrbitDB', async () => {
+    const { provider, db } = buildPostIdentityProvider();
+    await provider.set('address_nametags', '{"alice":1}');
+    // The mapped profile key is `addresses.nametags`. Verify it is
+    // present in OrbitDB and that the wire bytes are ciphertext, not
+    // the raw UTF-8 payload.
+    const wire = db._store.get('addresses.nametags');
+    expect(wire).toBeDefined();
+    expect(new TextDecoder().decode(wire!)).not.toBe('{"alice":1}');
+  });
+});

--- a/tests/unit/profile/profile-storage-provider-issue-311.test.ts
+++ b/tests/unit/profile/profile-storage-provider-issue-311.test.ts
@@ -197,16 +197,18 @@ describe('Issue #311 — critical-block-evicted notifier', () => {
       fired.push({ cid: info.cid, key: info.key, attemptedAt: info.attemptedAt });
     });
 
-    // `mnemonic` translates to the profile key `identity.mnemonic`. The
+    // `wallet_exists` translates to the profile key `wallet_exists`. The
     // adapter's `get(...)` throws our crafted error → readEnvelopePayload
     // detects the LoadBlockFailed signature and fires the notifier.
-    await expect(provider.getEncryptedRaw('mnemonic')).rejects.toThrow(
+    // (Using a non-identity key — `mnemonic` is cache-only post the
+    // IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS fix and would not reach `db.get`.)
+    await expect(provider.getEncryptedRaw('wallet_exists')).rejects.toThrow(
       /Failed to load block/,
     );
 
     expect(fired.length).toBe(1);
     expect(fired[0].cid).toBe(MISSING_CID);
-    expect(fired[0].key).toBe('identity.mnemonic');
+    expect(fired[0].key).toBe('wallet_exists');
     expect(typeof fired[0].attemptedAt).toBe('number');
     expect(fired[0].attemptedAt).toBeGreaterThan(0);
   });
@@ -218,7 +220,7 @@ describe('Issue #311 — critical-block-evicted notifier', () => {
       if (info.cid !== null) fired.push(info.cid);
     });
 
-    await expect(provider.getEncryptedRaw('mnemonic')).rejects.toBeDefined();
+    await expect(provider.getEncryptedRaw('wallet_exists')).rejects.toBeDefined();
 
     expect(fired).toEqual([MISSING_CID]);
   });
@@ -231,7 +233,7 @@ describe('Issue #311 — critical-block-evicted notifier', () => {
     });
 
     for (let i = 0; i < 5; i++) {
-      await expect(provider.getEncryptedRaw('mnemonic')).rejects.toBeDefined();
+      await expect(provider.getEncryptedRaw('wallet_exists')).rejects.toBeDefined();
     }
     expect(count).toBe(1);
   });
@@ -243,7 +245,7 @@ describe('Issue #311 — critical-block-evicted notifier', () => {
     });
     // The original "Failed to load block" error must still surface to
     // the caller — the observability hook is best-effort, not a sink.
-    await expect(provider.getEncryptedRaw('mnemonic')).rejects.toThrow(
+    await expect(provider.getEncryptedRaw('wallet_exists')).rejects.toThrow(
       /Failed to load block/,
     );
   });
@@ -256,7 +258,7 @@ describe('Issue #311 — critical-block-evicted notifier', () => {
       fired += 1;
     });
     // The key is absent, so getEncryptedRaw resolves to null cleanly.
-    const result = await provider.getEncryptedRaw('mnemonic');
+    const result = await provider.getEncryptedRaw('wallet_exists');
     expect(result).toBeNull();
     expect(fired).toBe(0);
   });

--- a/tests/unit/profile/profile-storage-provider.test.ts
+++ b/tests/unit/profile/profile-storage-provider.test.ts
@@ -184,9 +184,16 @@ describe('ProfileStorageProvider', () => {
   // =========================================================================
 
   describe('key translation', () => {
-    it("global key 'mnemonic' maps to 'identity.mnemonic'", async () => {
+    it("global key 'mnemonic' maps to 'identity.mnemonic' (translation lookup only — write is cache-only)", async () => {
+      // PROFILE_KEY_MAPPING still maps `mnemonic` → `identity.mnemonic`,
+      // but `mnemonic` is now in CACHE_ONLY_KEYS (identity / seed
+      // material) — the set() write does NOT reach OrbitDB. Verify the
+      // mapping via the cache instead.
       await provider.set('mnemonic', 'test-mnemonic');
-      expect(db._store.has('identity.mnemonic')).toBe(true);
+      expect(db._store.has('identity.mnemonic')).toBe(false);
+      // Cache holds it under the legacy key (same key that
+      // ProfileStorageProvider.get() will look up).
+      expect(cache._store.get('mnemonic')).toBe('test-mnemonic');
     });
 
     it("global key 'wallet_exists' maps to 'wallet_exists'", async () => {
@@ -303,18 +310,22 @@ describe('ProfileStorageProvider', () => {
       expect(result).toBe('secret');
     });
 
-    it('get falls back to OrbitDB on cache miss', async () => {
-      // Write encrypted value directly to OrbitDB (bypassing provider)
+    it('get falls back to OrbitDB on cache miss (non-identity keys only)', async () => {
+      // Use a non-identity key. Identity keys are cache-only post the
+      // IDENTITY_KEYS ⊂ CACHE_ONLY_KEYS fix; get() short-circuits to
+      // null on cache miss for them. `address_nametags` flows through
+      // the legacy translate-encrypt-write path so cache-fallback to
+      // OrbitDB is still exercised here.
       const encKey = deriveProfileEncryptionKey(hexToBytes(TEST_PRIVATE_KEY));
       const encrypted = await encryptString(encKey, 'from-orbit');
-      db._store.set('identity.mnemonic', encrypted);
+      db._store.set('addresses.nametags', encrypted);
 
       // Cache is empty, so get should fall back to OrbitDB
-      const result = await provider.get('mnemonic');
+      const result = await provider.get('address_nametags');
       expect(result).toBe('from-orbit');
 
       // Also should have populated cache
-      expect(cache._store.get('mnemonic')).toBe('from-orbit');
+      expect(cache._store.get('address_nametags')).toBe('from-orbit');
     });
 
     it('get returns null when neither cache nor OrbitDB has the key', async () => {
@@ -473,11 +484,14 @@ describe('ProfileStorageProvider', () => {
       // Verify cache received the identity
       expect(cacheSpy).toHaveBeenCalledWith(TEST_IDENTITY);
 
-      // Verify encryption key was derived (set a value and check it is encrypted in OrbitDB)
+      // Verify encryption key was derived. Use a NON-identity key
+      // (`address_nametags` → `addresses.nametags`) — `mnemonic` is
+      // cache-only post IDENTITY_KEYS-cache-only fix and would not
+      // reach the encrypt path.
       (newProvider as any).dbStatus = 'attached';
       (newProvider as any).status = 'connected';
-      await newProvider.set('mnemonic', 'test');
-      const stored = db._store.get('identity.mnemonic');
+      await newProvider.set('address_nametags', 'test');
+      const stored = db._store.get('addresses.nametags');
       expect(stored).toBeDefined();
       // The stored value should be encrypted (not raw UTF-8)
       const rawText = new TextDecoder().decode(stored!);
@@ -1011,9 +1025,12 @@ describe('ProfileStorageProvider', () => {
       (provider as unknown as { dbStatus: string }).dbStatus = 'attached';
       (provider as unknown as { status: string }).status = 'connected';
 
-      await provider.set('mnemonic', 'test-mnemonic');
+      // `wallet_exists` is a non-identity, non-cache-only global key —
+      // suitable for exercising the OrbitDB envelope write path.
+      // (`mnemonic` is now cache-only and would not reach OrbitDB.)
+      await provider.set('wallet_exists', 'true');
 
-      const setWrite = entryWrites.find((w) => w.key === 'identity.mnemonic');
+      const setWrite = entryWrites.find((w) => w.key === 'wallet_exists');
       expect(setWrite).toBeDefined();
       expect(setWrite!.type).toBe('cache_index');
       expect(setWrite!.originated).toBe('system');
@@ -1028,8 +1045,8 @@ describe('ProfileStorageProvider', () => {
       (provider as unknown as { dbStatus: string }).dbStatus = 'attached';
       (provider as unknown as { status: string }).status = 'connected';
 
-      await provider.setEntry('mnemonic', 'val', 'token_send');
-      const write = entryWrites.find((w) => w.key === 'identity.mnemonic');
+      await provider.setEntry('wallet_exists', 'val', 'token_send');
+      const write = entryWrites.find((w) => w.key === 'wallet_exists');
       expect(write!.type).toBe('token_send');
       expect(write!.originated).toBe('user');
     });
@@ -1062,10 +1079,10 @@ describe('ProfileStorageProvider', () => {
       (provider as unknown as { dbStatus: string }).dbStatus = 'attached';
       (provider as unknown as { status: string }).status = 'connected';
 
-      await provider.set('mnemonic', 'test-value');
+      await provider.set('wallet_exists', 'test-value');
       // Clear local cache so read hits OrbitDB.
       cache._store.clear();
-      const read = await provider.get('mnemonic');
+      const read = await provider.get('wallet_exists');
       expect(read).toBe('test-value');
     });
 
@@ -1078,8 +1095,8 @@ describe('ProfileStorageProvider', () => {
       (provider as unknown as { dbStatus: string }).dbStatus = 'attached';
       (provider as unknown as { status: string }).status = 'connected';
 
-      await provider.set('mnemonic', 'val');
-      const bytes = store.get('identity.mnemonic');
+      await provider.set('wallet_exists', 'val');
+      const bytes = store.get('wallet_exists');
       expect(bytes).toBeDefined();
 
       const { decodeEntry, OPLOG_ENTRY_SCHEMA_VERSION } = await import('../../../profile/oplog-entry');
@@ -1100,12 +1117,12 @@ describe('ProfileStorageProvider', () => {
       (provider as unknown as { dbStatus: string }).dbStatus = 'attached';
       (provider as unknown as { status: string }).status = 'connected';
 
-      await provider.set('mnemonic', 'legacy-value');
+      await provider.set('wallet_exists', 'legacy-value');
       // The raw store contains encrypted bytes (not envelope CBOR).
       expect(db._store.size).toBeGreaterThan(0);
       // Read round-trips via the legacy path.
       cache._store.clear();
-      const read = await provider.get('mnemonic');
+      const read = await provider.get('wallet_exists');
       expect(read).toBe('legacy-value');
     });
 
@@ -1128,7 +1145,7 @@ describe('ProfileStorageProvider', () => {
       (provider as unknown as { dbStatus: string }).dbStatus = 'attached';
       (provider as unknown as { status: string }).status = 'connected';
 
-      await expect(provider.set('mnemonic', 'val')).rejects.toMatchObject({
+      await expect(provider.set('wallet_exists', 'val')).rejects.toMatchObject({
         code: 'PROFILE_NOT_INITIALIZED',
       });
     });
@@ -1143,7 +1160,7 @@ describe('ProfileStorageProvider', () => {
       (provider as unknown as { dbStatus: string }).dbStatus = 'attached';
       (provider as unknown as { status: string }).status = 'connected';
 
-      await expect(provider.set('mnemonic', 'val')).rejects.toMatchObject({
+      await expect(provider.set('wallet_exists', 'val')).rejects.toMatchObject({
         code: 'PROFILE_NOT_INITIALIZED',
       });
     });
@@ -1170,7 +1187,9 @@ describe('ProfileStorageProvider', () => {
     });
 
     it('does NOT warn for small payloads (<8 KiB)', async () => {
-      await provider.set('mnemonic', 'a small value');
+      // Drive the OrbitDB encrypt path via a non-identity key.
+      // (`mnemonic` is cache-only and never hits the size-guarded path.)
+      await provider.set('wallet_exists', 'a small value');
       // Any unrelated warnings from setup are fine; assert none mention PAYLOAD-SIZE.
       const payloadWarnings = warnSpy.mock.calls.filter(
         (args: unknown[]) => typeof args[1] === 'string' && (args[1] as string).includes('[PAYLOAD-SIZE]'),
@@ -1181,7 +1200,7 @@ describe('ProfileStorageProvider', () => {
     it('warns when encrypted payload exceeds 8 KiB soft threshold', async () => {
       // Plaintext ~10 KiB (encrypted will be ~10 KiB + ~28 B AES-GCM overhead).
       const fatValue = 'x'.repeat(10 * 1024);
-      await provider.set('mnemonic', fatValue);
+      await provider.set('wallet_exists', fatValue);
 
       const payloadWarnings = warnSpy.mock.calls.filter(
         (args: unknown[]) => typeof args[1] === 'string' && (args[1] as string).includes('[PAYLOAD-SIZE]'),
@@ -1193,21 +1212,21 @@ describe('ProfileStorageProvider', () => {
       const fatValue = 'y'.repeat(10 * 1024);
       // `token_send` is a canonical user-action type from originated-tag.ts —
       // using it here ensures the test documents a realistic call shape.
-      await provider.setEntry('mnemonic', fatValue, 'token_send');
+      await provider.setEntry('wallet_exists', fatValue, 'token_send');
 
       const payloadWarnings = warnSpy.mock.calls.filter(
         (args: unknown[]) => typeof args[1] === 'string' && (args[1] as string).includes('[PAYLOAD-SIZE]'),
       );
       expect(payloadWarnings.length).toBeGreaterThanOrEqual(1);
       const warnMsg = payloadWarnings[0]![1] as string;
-      expect(warnMsg).toContain('key=identity.mnemonic');
+      expect(warnMsg).toContain('key=wallet_exists');
       expect(warnMsg).toContain('type=token_send');
       expect(warnMsg).toMatch(/size=\d+/);
     });
 
     it('warning does NOT contain payload content (privacy — size is already a fingerprint)', async () => {
       const sensitive = 'SECRET_MARKER_' + 'z'.repeat(10 * 1024);
-      await provider.set('mnemonic', sensitive);
+      await provider.set('wallet_exists', sensitive);
 
       const payloadWarnings = warnSpy.mock.calls.filter(
         (args: unknown[]) => typeof args[1] === 'string' && (args[1] as string).includes('[PAYLOAD-SIZE]'),
@@ -1220,9 +1239,9 @@ describe('ProfileStorageProvider', () => {
 
     it('write still succeeds despite warning (non-fatal)', async () => {
       const fatValue = 'q'.repeat(10 * 1024);
-      await expect(provider.set('mnemonic', fatValue)).resolves.toBeUndefined();
+      await expect(provider.set('wallet_exists', fatValue)).resolves.toBeUndefined();
       // Round-trip: we can still read it back.
-      const roundTrip = await provider.get('mnemonic');
+      const roundTrip = await provider.get('wallet_exists');
       expect(roundTrip).toBe(fatValue);
     });
 
@@ -1231,8 +1250,8 @@ describe('ProfileStorageProvider', () => {
       // see that a write site is CHRONICALLY oversized, not just the first
       // occurrence.
       const fatValue = 'p'.repeat(10 * 1024);
-      await provider.set('mnemonic', fatValue);
-      await provider.set('mnemonic', fatValue + '-v2');
+      await provider.set('wallet_exists', fatValue);
+      await provider.set('wallet_exists', fatValue + '-v2');
 
       const payloadWarnings = warnSpy.mock.calls.filter(
         (args: unknown[]) => typeof args[1] === 'string' && (args[1] as string).includes('[PAYLOAD-SIZE]'),
@@ -1263,20 +1282,20 @@ describe('ProfileStorageProvider', () => {
     });
 
     it('warning does NOT redact static keys with short suffixes', async () => {
-      // `identity.mnemonic` has no dynamic suffix to redact; the key should
+      // `wallet_exists` has no dynamic suffix to redact; the key should
       // appear as-is so operators can see exactly which static site is
       // oversized.
       const fatValue = 's'.repeat(10 * 1024);
-      await provider.set('mnemonic', fatValue);
+      await provider.set('wallet_exists', fatValue);
 
       const payloadWarnings = warnSpy.mock.calls.filter(
         (args: unknown[]) => typeof args[1] === 'string' && (args[1] as string).includes('[PAYLOAD-SIZE]'),
       );
       expect(payloadWarnings.length).toBeGreaterThanOrEqual(1);
       const warnMsg = payloadWarnings[0]![1] as string;
-      expect(warnMsg).toContain('key=identity.mnemonic');
+      expect(warnMsg).toContain('key=wallet_exists');
       // No redaction marker for static keys.
-      expect(warnMsg).not.toContain('identity.mnem…');
+      expect(warnMsg).not.toContain('wallet_exi…');
     });
   });
 
@@ -1361,16 +1380,16 @@ describe('ProfileStorageProvider', () => {
       const { provider, db } = await buildEnvelopeProvider();
       // Step 1 — write a legitimate envelope at the key so the bookkeeping
       // is consistent with a real write path.
-      await provider.set('mnemonic', 'original plaintext');
+      await provider.set('wallet_exists', 'original plaintext');
       // Step 2 — corrupt the stored bytes to force the envelope decoder
       // to throw `invalid minor (30) for major 3` — the production
       // signature from the issue-280 production logs.
-      db._store.set('identity.mnemonic', invalidCborBytes());
+      db._store.set('wallet_exists', invalidCborBytes());
       // Step 3 — `getEncryptedRaw` exercises `readEnvelopePayload`. With
       // the Issue #280 fix the call returns the raw bytes (base64-
       // encoded) instead of propagating the decode error up to the
       // lean-snapshot builder where it would be silently skipped.
-      const encryptedRaw = await provider.getEncryptedRaw('mnemonic');
+      const encryptedRaw = await provider.getEncryptedRaw('wallet_exists');
       expect(encryptedRaw).not.toBeNull();
       const decodedBytes = Buffer.from(encryptedRaw!, 'base64');
       // The raw bytes returned match the corrupted bytes verbatim —
@@ -1381,26 +1400,26 @@ describe('ProfileStorageProvider', () => {
 
     it('envelope-fallback notifier fires with the key + error message', async () => {
       const { provider, db } = await buildEnvelopeProvider();
-      await provider.set('mnemonic', 'value');
-      db._store.set('identity.mnemonic', invalidCborBytes());
+      await provider.set('wallet_exists', 'value');
+      db._store.set('wallet_exists', invalidCborBytes());
 
       const fired: Array<{ key: string; errorMessage: string }> = [];
       provider.setEnvelopeFallbackNotifier((info) => {
         fired.push({ key: info.key, errorMessage: info.errorMessage });
       });
 
-      await provider.getEncryptedRaw('mnemonic');
+      await provider.getEncryptedRaw('wallet_exists');
 
       expect(fired.length).toBe(1);
-      expect(fired[0].key).toBe('identity.mnemonic');
+      expect(fired[0].key).toBe('wallet_exists');
       expect(fired[0].errorMessage).toContain('invalid minor');
       expect(fired[0].errorMessage).toContain('major 3');
     });
 
     it('notifier is dedup-ed: same (key, error) fires only once', async () => {
       const { provider, db } = await buildEnvelopeProvider();
-      await provider.set('mnemonic', 'v');
-      db._store.set('identity.mnemonic', invalidCborBytes());
+      await provider.set('wallet_exists', 'v');
+      db._store.set('wallet_exists', invalidCborBytes());
 
       let count = 0;
       provider.setEnvelopeFallbackNotifier(() => {
@@ -1408,18 +1427,18 @@ describe('ProfileStorageProvider', () => {
       });
 
       // Read 4 times — same key, same error, same dedup signature.
-      await provider.getEncryptedRaw('mnemonic');
-      await provider.getEncryptedRaw('mnemonic');
-      await provider.getEncryptedRaw('mnemonic');
-      await provider.getEncryptedRaw('mnemonic');
+      await provider.getEncryptedRaw('wallet_exists');
+      await provider.getEncryptedRaw('wallet_exists');
+      await provider.getEncryptedRaw('wallet_exists');
+      await provider.getEncryptedRaw('wallet_exists');
 
       expect(count).toBe(1);
     });
 
     it('notifier exception does NOT break the read path (best-effort signal)', async () => {
       const { provider, db } = await buildEnvelopeProvider();
-      await provider.set('mnemonic', 'v');
-      db._store.set('identity.mnemonic', invalidCborBytes());
+      await provider.set('wallet_exists', 'v');
+      db._store.set('wallet_exists', invalidCborBytes());
 
       provider.setEnvelopeFallbackNotifier(() => {
         throw new Error('notifier exploded');
@@ -1428,7 +1447,7 @@ describe('ProfileStorageProvider', () => {
       // Despite the notifier throwing, the read still returns the raw
       // bytes — the corruption visibility hook MUST NOT regress the
       // primary data path.
-      const encryptedRaw = await provider.getEncryptedRaw('mnemonic');
+      const encryptedRaw = await provider.getEncryptedRaw('wallet_exists');
       expect(encryptedRaw).not.toBeNull();
     });
 
@@ -1443,8 +1462,8 @@ describe('ProfileStorageProvider', () => {
       // operator triage is already required and the cap (1024) is well
       // above any legitimate single-instance corruption surface).
       const { provider, db } = await buildEnvelopeProvider();
-      await provider.set('mnemonic', 'v');
-      db._store.set('identity.mnemonic', invalidCborBytes());
+      await provider.set('wallet_exists', 'v');
+      db._store.set('wallet_exists', invalidCborBytes());
 
       // Pre-populate the dedup set to the cap via direct private-state
       // access. This is the only practical way to exercise the cap
@@ -1467,14 +1486,14 @@ describe('ProfileStorageProvider', () => {
         fired += 1;
       });
 
-      // Read multiple times — the (identity.mnemonic, invalid-minor-30)
+      // Read multiple times — the (wallet_exists, invalid-minor-30)
       // pair has NOT been added to the set (it's not in the pre-populated
       // filler entries), so pre-fix this would fire on every read. Post-
       // fix, at-cap early-return means the notifier fires ZERO times.
-      await provider.getEncryptedRaw('mnemonic');
-      await provider.getEncryptedRaw('mnemonic');
-      await provider.getEncryptedRaw('mnemonic');
-      await provider.getEncryptedRaw('mnemonic');
+      await provider.getEncryptedRaw('wallet_exists');
+      await provider.getEncryptedRaw('wallet_exists');
+      await provider.getEncryptedRaw('wallet_exists');
+      await provider.getEncryptedRaw('wallet_exists');
 
       expect(fired).toBe(0);
     });
@@ -1488,10 +1507,10 @@ describe('ProfileStorageProvider', () => {
       // error message text. Verify the dedupKey shape by inspecting
       // the populated set.
       const { provider, db } = await buildEnvelopeProvider();
-      await provider.set('mnemonic', 'v');
-      db._store.set('identity.mnemonic', invalidCborBytes());
+      await provider.set('wallet_exists', 'v');
+      db._store.set('wallet_exists', invalidCborBytes());
 
-      await provider.getEncryptedRaw('mnemonic');
+      await provider.getEncryptedRaw('wallet_exists');
 
       const seen = (provider as unknown as {
         envelopeFallbackSeen: Set<string>;
@@ -1501,12 +1520,12 @@ describe('ProfileStorageProvider', () => {
       // The dedup key includes the separator; key bytes precede it,
       // error text follows.
       expect(onlyKey).toContain('\x1f');
-      expect(onlyKey.startsWith('identity.mnemonic\x1f')).toBe(true);
+      expect(onlyKey.startsWith('wallet_exists\x1f')).toBe(true);
     });
 
     it('clean envelope round-trip does NOT fire the notifier', async () => {
       const { provider } = await buildEnvelopeProvider();
-      await provider.set('mnemonic', 'v');
+      await provider.set('wallet_exists', 'v');
       // No corruption — read should succeed via the envelope path.
 
       let fired = 0;
@@ -1514,8 +1533,8 @@ describe('ProfileStorageProvider', () => {
         fired += 1;
       });
 
-      await provider.get('mnemonic');
-      await provider.getEncryptedRaw('mnemonic');
+      await provider.get('wallet_exists');
+      await provider.getEncryptedRaw('wallet_exists');
       expect(fired).toBe(0);
     });
 


### PR DESCRIPTION
## Summary

Audit #333 C1 was closed at the `encrypt()` boundary: when the OrbitDB write path was reachable but no encryption key had been derived (Phase A), `encrypt()` threw and the write was rejected. **That defense only holds before `setIdentity`.** After identity is attached, any subsequent write of `mnemonic` / `master_key` / `chain_code` / `derivation_path` / `base_path` / `derivation_mode` / `wallet_source` / `current_address_index` would have been encrypted and written to OrbitDB → replicated to IPFS via the snapshot CAR pin path.

Even encrypted, distributing the seed lowers the threat model from "attacker must compromise the device" to "attacker must brute-force a password against an IPFS-pinned ciphertext" — strictly weaker than what users expect of seed material. The only legitimate cross-device transport for the seed is the user's own BIP-39 mnemonic backup.

This was visible in the browser console at https://sphere-telco-test.dyndns.org as

```
[Sphere] Identity read for "master_key" missing from primary storage; consulting fallbackStorage (legacy cached identity).
[Sphere] Identity read for "chain_code" missing from primary storage; consulting fallbackStorage (legacy cached identity).
[Sphere] Identity read for "derivation_path" missing from primary storage; consulting fallbackStorage (legacy cached identity).
[Sphere] Identity read for "current_address_index" missing from primary storage; consulting fallbackStorage (legacy cached identity).
```

— the *symptom* was the fallback consult, but the *root concern* the user flagged was that the architecture had Profile-mode writes routing identity keys to OrbitDB at all.

## Fix

Two-layer defense:

**Layer 1 — Cache-only routing** (`profile/types.ts`)
- New `IDENTITY_KEYS` set names the identity / seed-material legacy keys explicitly.
- `CACHE_ONLY_KEYS` is widened to fold in `IDENTITY_KEYS`. After `translateKey()`, identity writes return `cacheOnly: true`; the `set()` flow short-circuits at the localCache step and never reaches `writeEnvelope()`.

**Layer 2 — Defense-in-depth assertion** (`profile/profile-storage-provider.ts`)
- A post-translation assertion in `set()` fail-closes if any future refactor adds an identity-shaped Profile key (`identity.*`) without putting its legacy alias into `CACHE_ONLY_KEYS`. The error message points at the right file to fix.

**Migration update** (`profile/migration.ts`)
- Identity keys are diverted at read time into a separate `identityKeys` map and persisted at the LEGACY key name (so the cache-only routing kicks in). This keeps the legacy-import path working — `Sphere.loadIdentityFromStorage` reads `_storage.get('master_key')` against the Profile localCache and finds it under the same legacy name it always lived at — without routing any encrypted seed bytes through the OrbitDB OpLog.

## Tests

**New** — `profile-storage-provider-identity-keys-cache-only.test.ts` (13 tests):
- Schema-level contract: every key in IDENTITY_KEYS is also in CACHE_ONLY_KEYS, and every `identity.*` mapping in PROFILE_KEY_MAPPING has its legacy alias in IDENTITY_KEYS. This catches future refactors at test time, not at runtime.
- Parametrised assertion that `set('<identity-key>', ...)` writes to localCache and leaves OrbitDB empty for every key in IDENTITY_KEYS.
- Defense-in-depth assertion fires on a synthetic `identity.*` profile key with no CACHE_ONLY_KEYS entry.
- Round-trip via localCache returns the value (boot path still works).
- Control: a non-identity write still flows through writeEnvelope.

**Updated** — `profile-storage-provider-c1-plaintext-seed.test.ts`: assertions that asserted the OLD behaviour ("after setIdentity, mnemonic lands ENCRYPTED in OrbitDB") were captured the older still-leaky behaviour. Now verifies the seed never lands in OrbitDB at any point.

**Updated** — `profile-storage-provider.test.ts`, `integration.test.ts`, `migration.test.ts`, `migration-c2-flush-before-cleanup.test.ts`, `profile-storage-provider-issue-311.test.ts`: tests that used `'mnemonic'` as a generic test fixture for the OrbitDB write/read path now swap to `'wallet_exists'` (non-identity, non-cache-only). Migration assertions verify the legacy key landed in Profile localCache, NOT under `identity.*`.

Full suite: 8889 passing (1 unrelated flake in `AccountingModule.invoiceDelivery.test.ts:762` that passes in isolation; same flake as observed on `main`).

## Behaviour change consumers should know about

- Cross-device "wallet exists by virtue of `identity.*` being replicated" no longer works — `Sphere.exists()` on a fresh device returns false until the user imports the mnemonic, which is the correct UX for a non-replicating seed. The `has('wallet_exists')` fallback in `ProfileStorageProvider` still scans for legacy `identity.*` keys, so wallets created BEFORE this PR (which still have those entries in OrbitDB) keep working unchanged.
- Identity material in legacy IndexedDB is migrated to the Profile localCache (IndexedDB, same device). The user-facing experience is unchanged.

## Test plan

- [x] `npx vitest run tests/unit/profile/` — all profile tests pass.
- [x] Full suite: 8889 / 8903 passing (1 flake in `AccountingModule.invoiceDelivery.test.ts`, unrelated).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx tsup` — clean.
- [ ] Deploy to https://sphere-telco-test.dyndns.org via vendor-bump in sphere.telco and verify the `[Sphere] Identity read for "master_key" missing from primary storage` warnings stop appearing for **new** Profile-mode wallets. (Existing legacy-migrated wallets will still consult fallback — that's correct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)