### PR TITLE
fix(payments): V6-RECOVER #387/#389/#390 — durable invalid + root-cause source-state reconstruction

### DIFF
--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -223,7 +223,7 @@ normalize_snapshot() {
     -e '/^  IPFS: \+[0-9]+ added, -[0-9]+ removed$/d' \
     -e '/^Syncing\.\.\.$/d' \
     -e '/^  Ready\.$/d' \
-    -e 's/ \(\+ [0-9]+ unconfirmed\)//' \
+    -e 's/ \(\+ [0-9.]+ unconfirmed\)//' \
     -e 's/ \[[0-9]+\+[0-9]+ tokens\]//' \
     -e 's/ \([0-9]+ tokens?\)//' \
     -e 's/ \(1 token\)//'
@@ -256,11 +256,30 @@ assert_no_unconfirmed_after_finalize() {
     echo "ASSERT FAIL ($label): missing snapshot file: $snapshot" >&2
     return 1
   fi
-  if grep -q '(+ [1-9][0-9]* unconfirmed)' "$snapshot"; then
+  # Issue #389 finding #2 — match decimal amounts, not just integers.
+  # Real CLI output is e.g. `UCT: 100.000000000011 (2 tokens)` and a
+  # 10-satoshi V6-RECOVER pollution renders as `(+ 0.0000001 unconfirmed)`
+  # which the old `[1-9][0-9]*` ASCII-integer pattern silently missed.
+  #
+  # We deliberately avoid awk's `+ 0` numeric coercion (which would
+  # cast the matched amount through an IEEE-754 double and silently
+  # lose precision for any token whose smallest-unit count exceeds
+  # 2^53). The SDK aggregates balances as bigint throughout (see
+  # `aggregateTokens`); the soak gate must respect that. Instead we
+  # match by pattern: the amount must contain at least one non-zero
+  # digit somewhere in its [0-9.]* run. This is a pure
+  # string/character-class check — no numeric conversion, valid at
+  # arbitrary precision.
+  local pat='\(\+ [0-9.]*[1-9][0-9.]* unconfirmed\)'
+  if grep -qE "$pat" "$snapshot"; then
     echo "ASSERT FAIL ($label): unconfirmed tokens present after receive --finalize" >&2
     echo "  Issue #387 — V6-RECOVER permanent-mismatch should durably mark the token invalid." >&2
     echo "  Snapshot: $snapshot" >&2
-    grep -n 'unconfirmed' "$snapshot" >&2 || true
+    # Issue #389 finding #14 — diagnostic line MUST mirror the gate's
+    # decimal-aware pattern so operators see the same lines the gate
+    # tripped on, not unrelated 'unconfirmed' noise (e.g. log strings
+    # containing the word 'unconfirmed' outside the balance-line shape).
+    grep -nE "$pat" "$snapshot" >&2 || true
     return 1
   fi
   echo "ASSERT OK ($label): no unconfirmed tokens in post-finalize snapshot"
@@ -482,6 +501,58 @@ EOF
     echo "T9 OK: assert_no_unconfirmed_after_finalize gate semantics correct"
   else
     echo "T9 FAIL: gate semantics broken (clean rc=$rc1 expected 0; polluted rc=$rc2 expected non-0)" >&2
+    rc=1
+  fi
+
+  # ---- T10 (#389 #2): decimal-amount pollution must trip the gate ----
+  # Real CLI output uses decimal amounts (e.g. `UCT: 100.000000000011`),
+  # so a 10-satoshi V6-RECOVER pollution renders as `(+ 0.0000001
+  # unconfirmed)`. The pre-#389 ASCII-integer pattern silently passed
+  # exactly the shape it was designed to catch. T10 locks this in.
+  cat > "$a" <<'EOF'
+UCT: 100.000000000011 (2 tokens)
+EOF
+  cat > "$b" <<'EOF'
+UCT: 100.000000000011 (+ 0.0000001 unconfirmed) [2+1 tokens]
+EOF
+  cat > "$tmpdir/c.txt" <<'EOF'
+UCT: 100 (+ 0.0 unconfirmed) [2+1 tokens]
+EOF
+  cat > "$tmpdir/d.txt" <<'EOF'
+UCT: 100 (+ 0 unconfirmed) [2+1 tokens]
+EOF
+  local rc3=0 rc4=0 rc5=0 rc6=0
+  assert_no_unconfirmed_after_finalize "T10-clean-decimal"   "$a" >/dev/null 2>&1 || rc3=$?
+  assert_no_unconfirmed_after_finalize "T10-decimal-poll"    "$b" >/dev/null 2>&1 || rc4=$?
+  assert_no_unconfirmed_after_finalize "T10-zero-decimal-ok" "$tmpdir/c.txt" >/dev/null 2>&1 || rc5=$?
+  assert_no_unconfirmed_after_finalize "T10-zero-int-ok"     "$tmpdir/d.txt" >/dev/null 2>&1 || rc6=$?
+  if (( rc3 == 0 )) && (( rc4 != 0 )) && (( rc5 == 0 )) && (( rc6 == 0 )); then
+    echo "T10 OK: decimal-amount unconfirmed pollution detected (clean+zero-only snapshots accepted)"
+  else
+    echo "T10 FAIL: decimal-amount gate broken (clean-decimal=$rc3 expect 0; decimal-poll=$rc4 expect non-0; zero-decimal=$rc5 expect 0; zero-int=$rc6 expect 0)" >&2
+    rc=1
+  fi
+
+  # ---- T11 (#389 #3): normalize_snapshot must strip decimal unconfirmed
+  # clauses too. Otherwise diff-based gates either false-pass (both
+  # sides keep the same unstripped clause) or false-fail (one side
+  # synced more), instead of measuring the intended confirmed-only
+  # equivalence.
+  cat > "$a" <<'EOF'
+L3 Balance:
+UCT: 100.000000000011 (2 tokens)
+EOF
+  cat > "$b" <<'EOF'
+L3 Balance:
+UCT: 100.000000000011 (+ 0.0000001 unconfirmed) [2+1 tokens]
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T11 OK: normalize_snapshot strips decimal (+N.M unconfirmed) clause"
+  else
+    echo "T11 FAIL: normalize_snapshot left decimal (+N.M unconfirmed) clause unstripped" >&2
+    diff -u "$na" "$nb" >&2 || true
     rc=1
   fi
 

--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -222,7 +222,48 @@ normalize_snapshot() {
     -e '/^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z\] /d' \
     -e '/^  IPFS: \+[0-9]+ added, -[0-9]+ removed$/d' \
     -e '/^Syncing\.\.\.$/d' \
-    -e '/^  Ready\.$/d'
+    -e '/^  Ready\.$/d' \
+    -e 's/ \(\+ [0-9]+ unconfirmed\)//' \
+    -e 's/ \[[0-9]+\+[0-9]+ tokens\]//' \
+    -e 's/ \([0-9]+ tokens?\)//' \
+    -e 's/ \(1 token\)//'
+}
+# Issue #387 — confirmed-balance-only diff. The two `s/.../...` rules
+# above strip the optional `(+ N unconfirmed)` and `[X+Y tokens]`
+# clauses, plus the `(N tokens)` suffix that appears for fully-
+# confirmed entries. After normalization, each balance line is
+# reduced to `COIN: amount` (e.g. `UCT: 42`) — diff comparisons
+# therefore measure CONFIRMED balance equality only. Unconfirmed
+# pollution (the exact #387 failure mode) is caught by the dedicated
+# `assert_no_unconfirmed_after_finalize` gate below, NOT by the
+# byte-comparison diff (which would mask it equally on both sides).
+#
+# Issue #387 gate — fail the soak if any `sphere balance` snapshot
+# captured after `sphere payments receive --finalize` contains a
+# `(+ N unconfirmed)` clause with N>=1. Per #387's reproduction, a
+# V6-RECOVER permanent-mismatch verdict that doesn't durably mark
+# the token invalid surfaces as persistent unconfirmed UCT pollution
+# across multiple receive --finalize calls. The diff-based gates
+# never caught this because the pollution was equal on both sides
+# of the diff (same wallet, same stuck event).
+#
+# A finalize that "drained successfully" MUST leave zero unconfirmed
+# tokens — anything in the snapshot at that point is a regression of
+# the durable-invalid contract.
+assert_no_unconfirmed_after_finalize() {
+  local label="$1" snapshot="$2"
+  if [[ ! -f "$snapshot" ]]; then
+    echo "ASSERT FAIL ($label): missing snapshot file: $snapshot" >&2
+    return 1
+  fi
+  if grep -q '(+ [1-9][0-9]* unconfirmed)' "$snapshot"; then
+    echo "ASSERT FAIL ($label): unconfirmed tokens present after receive --finalize" >&2
+    echo "  Issue #387 — V6-RECOVER permanent-mismatch should durably mark the token invalid." >&2
+    echo "  Snapshot: $snapshot" >&2
+    grep -n 'unconfirmed' "$snapshot" >&2 || true
+    return 1
+  fi
+  echo "ASSERT OK ($label): no unconfirmed tokens in post-finalize snapshot"
 }
 
 assert_diff_empty() {
@@ -400,6 +441,50 @@ EOF
     rc=1
   fi
 
+  # ---- T8 (#387): confirmed-only diff masks (+N unconfirmed) ----
+  # Two snapshots with identical confirmed amounts but different
+  # unconfirmed clauses MUST compare equal after normalize. Without
+  # this, diff-based gates would flag every transient sync race as
+  # a regression.
+  cat > "$a" <<'EOF'
+L3 Balance:
+ETH: 42 (1 token)
+UCT: 100 (3 tokens)
+EOF
+  cat > "$b" <<'EOF'
+L3 Balance:
+ETH: 42 (1 token)
+UCT: 100 (+ 5 unconfirmed) [3+1 tokens]
+EOF
+  normalize_snapshot "$a" > "$na"
+  normalize_snapshot "$b" > "$nb"
+  if diff -u "$na" "$nb" >/dev/null; then
+    echo "T8 OK: confirmed-only normalize masks (+N unconfirmed) clause"
+  else
+    echo "T8 FAIL: confirmed-only normalize did not mask unconfirmed clause" >&2
+    diff -u "$na" "$nb" >&2 || true
+    rc=1
+  fi
+
+  # ---- T9 (#387): assert_no_unconfirmed_after_finalize semantics ----
+  # Gate must FAIL on (+N unconfirmed) with N>=1, PASS on clean
+  # snapshots.
+  cat > "$a" <<'EOF'
+UCT: 100 (3 tokens)
+EOF
+  cat > "$b" <<'EOF'
+UCT: 0 (+ 16 unconfirmed) [0+3 tokens]
+EOF
+  local rc1=0 rc2=0
+  assert_no_unconfirmed_after_finalize "T9-clean"    "$a" >/dev/null 2>&1 || rc1=$?
+  assert_no_unconfirmed_after_finalize "T9-polluted" "$b" >/dev/null 2>&1 || rc2=$?
+  if (( rc1 == 0 )) && (( rc2 != 0 )); then
+    echo "T9 OK: assert_no_unconfirmed_after_finalize gate semantics correct"
+  else
+    echo "T9 FAIL: gate semantics broken (clean rc=$rc1 expected 0; polluted rc=$rc2 expected non-0)" >&2
+    rc=1
+  fi
+
   rm -rf "$tmpdir"
   if (( rc == 0 )); then
     echo "=== normalize_snapshot self-tests: ALL PASS ==="
@@ -553,6 +638,11 @@ sphere payments receive --finalize         2>&1 | tee "$SNAP/peer2-alice-receive
 sphere balance                             > "$SNAP/peer2-alice-initial.txt"
 cat "$SNAP/peer2-alice-initial.txt"
 
+# Issue #387 — post-finalize MUST have zero unconfirmed tokens.
+assert_no_unconfirmed_after_finalize \
+  "alice-peer2-initial-post-finalize" \
+  "$SNAP/peer2-alice-initial.txt"
+
 # Peer1 snapshot for diffing
 ( cd "$PEER1" && sphere wallet use alice && sphere balance ) > "$SNAP/peer1-alice-initial.txt"
 
@@ -572,6 +662,11 @@ sphere payments sync                       2>&1 | tee "$SNAP/peer2-bob-sync.log"
 sphere payments receive --finalize         2>&1 | tee "$SNAP/peer2-bob-receive.log"
 sphere balance                             > "$SNAP/peer2-bob-initial.txt"
 cat "$SNAP/peer2-bob-initial.txt"
+
+# Issue #387 — post-finalize MUST have zero unconfirmed tokens.
+assert_no_unconfirmed_after_finalize \
+  "bob-peer2-initial-post-finalize" \
+  "$SNAP/peer2-bob-initial.txt"
 
 # ---------------------------------------------------------------------------
 # §B — Daemons on peer2
@@ -652,6 +747,14 @@ sphere payments sync       2>&1 | tee "$SNAP/peer1-bob-pre-pay-sync.log"
 # `invoice_delivery:` DM channel (handled by AccountingModule, not
 # the payments pipeline) — included here purely for hygiene.
 sphere payments receive --finalize 2>&1 | tee "$SNAP/peer1-bob-pre-pay-receive.log"
+sphere balance                     > "$SNAP/peer1-bob-pre-pay-balance.txt"
+# Issue #387 — bob's wallet MUST NOT carry any unconfirmed UCT into the
+# invoice payment, otherwise the V6-RECOVER permanent-mismatch pollution
+# would surface inside the invoice payment flow (spend planner sees a
+# phantom unconfirmed source it can never actually consume).
+assert_no_unconfirmed_after_finalize \
+  "bob-pre-pay-post-finalize" \
+  "$SNAP/peer1-bob-pre-pay-balance.txt"
 sphere invoice pay "$INV"  2>&1 | tee "$SNAP/peer1-invoice-pay.log"
 sphere payments sync       2>&1 | tee "$SNAP/peer1-invoice-pay-sync.log"
 
@@ -773,6 +876,14 @@ sphere balance                      > "$SNAP/alice-after.txt"
 sphere payments tokens              > "$SNAP/alice-tokens-after.txt"
 sphere invoice list --state COVERED > "$SNAP/alice-invoices-after.txt"
 
+# Issue #387 — recovery completes when ALL finalizable receives are
+# resolved AND nothing remains stranded as unconfirmed. A stranded
+# V6-RECOVER permanent-mismatch token would survive
+# `receive --finalize` as `(+ N unconfirmed)` despite being unspendable.
+assert_no_unconfirmed_after_finalize \
+  "alice-peer1-post-recovery" \
+  "$SNAP/alice-after.txt"
+
 # Peer1 bob
 sphere wallet use bob
 sphere init --network testnet --no-nostr --mnemonic "$BOB_MNEMONIC"
@@ -781,6 +892,11 @@ sphere payments receive --finalize
 sphere balance                      > "$SNAP/bob-after.txt"
 sphere payments tokens              > "$SNAP/bob-tokens-after.txt"
 sphere invoice list --state COVERED > "$SNAP/bob-invoices-after.txt"
+
+# Issue #387 — same gate for bob.
+assert_no_unconfirmed_after_finalize \
+  "bob-peer1-post-recovery" \
+  "$SNAP/bob-after.txt"
 
 # Peer2-alice
 cd "$PEER2_ALICE"

--- a/manual-test-simple-send.sh
+++ b/manual-test-simple-send.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+#
+# Simple alice→bob 10 UCT send + receive + finalize verification.
+#
+# Verifies: bob's CONFIRMED UCT balance goes UP by exactly 10 UCT
+# (in smallest units: 1_000_000_000) and alice's CONFIRMED UCT
+# balance goes DOWN by exactly 10 UCT, after Bob runs
+# `payments receive --finalize`.
+#
+# Integer-only verification: balances are compared at the smallest-unit
+# (satoshi/integer) layer extracted from the CLI's decimal-formatted
+# output. NO float coercion.
+
+set -euo pipefail
+
+# ---- workspace ----
+ROOT="${SIMPLE_SEND_TEST_DIR:-/tmp/simple-send-test-$$}"
+SNAP="$ROOT/snapshots"
+mkdir -p "$SNAP"
+
+# Nametag constraint: lowercase alphanumeric / underscore / hyphen,
+# 3–20 chars. The soak uses a compact 4-digit epoch tail + 4-hex
+# random to keep `alice-${SUFFIX}` under cap. Mirror that exactly.
+SUFFIX="${SUFFIX:-$(date +%s | tail -c 5)$(printf '%04x' $((RANDOM % 65536)))}"
+ALICE_TAG="alice-$SUFFIX"
+BOB_TAG="bob-$SUFFIX"
+echo "ALICE_TAG=$ALICE_TAG"
+echo "BOB_TAG=$BOB_TAG"
+
+PEER_ALICE="$ROOT/alice-peer"
+PEER_BOB="$ROOT/bob-peer"
+mkdir -p "$PEER_ALICE" "$PEER_BOB"
+
+# Allow non-TTY mnemonic capture (CLI emits mnemonic on stdout in non-TTY when --no-encrypt-mnemonic).
+export SPHERE_ALLOW_MNEMONIC_NON_TTY=1
+
+cleanup() {
+  local rc=$?
+  if [[ "${KEEP:-0}" != "1" ]]; then
+    rm -rf "$ROOT" 2>/dev/null || true
+  else
+    echo "=== KEEP=1: workspace preserved at $ROOT ==="
+  fi
+  return "$rc"
+}
+trap cleanup EXIT INT TERM
+
+banner() {
+  echo
+  echo "================================================================"
+  echo "$@"
+  echo "================================================================"
+}
+
+# ---------------------------------------------------------------------------
+# Section 1 — Create alice
+# ---------------------------------------------------------------------------
+banner "Section 1: Create alice wallet (testnet)"
+
+cd "$PEER_ALICE"
+sphere wallet create alice
+sphere wallet use alice
+sphere init --network testnet --nametag "$ALICE_TAG" 2>&1 | tee "$SNAP/alice-init.log"
+
+# ---------------------------------------------------------------------------
+# Section 2 — Create bob
+# ---------------------------------------------------------------------------
+banner "Section 2: Create bob wallet (testnet)"
+
+cd "$PEER_BOB"
+sphere wallet create bob
+sphere wallet use bob
+sphere init --network testnet --nametag "$BOB_TAG" 2>&1 | tee "$SNAP/bob-init.log"
+
+# ---------------------------------------------------------------------------
+# Section 3 — Top up alice via faucet
+# ---------------------------------------------------------------------------
+banner "Section 3: Top up alice"
+
+cd "$PEER_ALICE"
+sphere wallet use alice
+sphere faucet         2>&1 | tee "$SNAP/alice-faucet.log"
+sphere payments sync  2>&1 | tee "$SNAP/alice-sync.log"
+
+# Receive + finalize any incoming from the faucet so the baseline is CONFIRMED.
+sphere payments receive --finalize 2>&1 | tee "$SNAP/alice-faucet-receive.log"
+sphere balance | tee "$SNAP/alice-balance-before.txt"
+
+# ---------------------------------------------------------------------------
+# Section 4 — Baseline bob (zero)
+# ---------------------------------------------------------------------------
+banner "Section 4: Baseline bob (expected zero UCT)"
+
+cd "$PEER_BOB"
+sphere wallet use bob
+sphere payments sync  2>&1 | tee "$SNAP/bob-sync.log"
+sphere payments receive --finalize 2>&1 | tee "$SNAP/bob-baseline-receive.log"
+sphere balance | tee "$SNAP/bob-balance-before.txt"
+
+# ---------------------------------------------------------------------------
+# Section 5 — Alice sends 10 UCT to bob (instant)
+# ---------------------------------------------------------------------------
+banner "Section 5: alice → @${BOB_TAG} (10 UCT, instant)"
+
+cd "$PEER_ALICE"
+sphere wallet use alice
+sphere payments send "@${BOB_TAG}" 10 UCT 2>&1 | tee "$SNAP/alice-send.log"
+
+# ---------------------------------------------------------------------------
+# Section 6 — Bob receives + finalizes
+# ---------------------------------------------------------------------------
+banner "Section 6: bob payments receive --finalize"
+
+cd "$PEER_BOB"
+sphere wallet use bob
+sphere payments sync 2>&1 | tee "$SNAP/bob-sync-after.log"
+sphere payments receive --finalize 2>&1 | tee "$SNAP/bob-receive.log"
+
+# ---------------------------------------------------------------------------
+# Section 7 — Snapshot final balances
+# ---------------------------------------------------------------------------
+banner "Section 7: Snapshot final balances"
+
+cd "$PEER_BOB"
+sphere balance | tee "$SNAP/bob-balance-after.txt"
+
+cd "$PEER_ALICE"
+sphere wallet use alice
+sphere payments sync 2>&1 | tee "$SNAP/alice-sync-after.log"
+sphere balance | tee "$SNAP/alice-balance-after.txt"
+
+# ---------------------------------------------------------------------------
+# Section 8 — Verify delta (integer-only)
+# ---------------------------------------------------------------------------
+banner "Section 8: Verify exact ±10 UCT CONFIRMED delta"
+
+# UCT has 8 decimals → 10 UCT = 1_000_000_000 smallest units.
+# Extract `UCT: <amount>` lines, normalize to smallest units WITHOUT
+# float coercion: split on `.`, left-pad fractional part to 8 chars,
+# concatenate, strip leading zeros.
+#
+# Why no `awk amt+0` / `bc`? Because per the SDK's bigint-only
+# aggregation rule, any conversion through a numeric type capped at
+# IEEE-754 double silently loses precision for amounts above ~9e15.
+# We work in strings throughout, then compare integers via shell
+# arithmetic only when both sides comfortably fit in a 64-bit signed
+# integer (10 UCT is 10^10 — well within bounds).
+
+extract_uct_confirmed_smallest_units() {
+  # Reads a `sphere balance` snapshot from stdin; emits the CONFIRMED
+  # UCT amount as a smallest-unit integer string. Lines we recognize:
+  #   `UCT: 100.000000000000 (1 token)`              -- fully confirmed
+  #   `UCT: 100 (+ 5 unconfirmed) [1+1 tokens]`      -- partial
+  #   `UCT: 100.5 (1 token)`                         -- short fractional
+  # We deliberately ignore the `(+ N unconfirmed)` clause — only
+  # CONFIRMED counts here.
+  local line decimal int_part frac_part
+  line=$(grep -E '^UCT:' || true)
+  if [[ -z "$line" ]]; then
+    echo "0"
+    return
+  fi
+  # Strip optional `(+N unconfirmed) [...]` and `(N tokens)` clauses.
+  decimal=$(echo "$line" | sed -E -e 's/^UCT:[[:space:]]+//' -e 's/[[:space:]]+\(.+$//')
+  if [[ "$decimal" == *.* ]]; then
+    int_part="${decimal%.*}"
+    frac_part="${decimal#*.}"
+  else
+    int_part="$decimal"
+    frac_part=""
+  fi
+  # Pad fractional part to exactly 8 chars (UCT decimals = 8).
+  while (( ${#frac_part} < 8 )); do frac_part="${frac_part}0"; done
+  if (( ${#frac_part} > 8 )); then
+    echo "ERROR: UCT fractional part >8 digits ($decimal)" >&2
+    return 1
+  fi
+  # Concatenate and strip leading zeros (preserve at least one digit).
+  local combined="${int_part}${frac_part}"
+  combined=$(echo "$combined" | sed -E 's/^0+//')
+  [[ -z "$combined" ]] && combined="0"
+  echo "$combined"
+}
+
+alice_before=$(extract_uct_confirmed_smallest_units < "$SNAP/alice-balance-before.txt")
+alice_after=$( extract_uct_confirmed_smallest_units < "$SNAP/alice-balance-after.txt")
+bob_before=$(  extract_uct_confirmed_smallest_units < "$SNAP/bob-balance-before.txt")
+bob_after=$(   extract_uct_confirmed_smallest_units < "$SNAP/bob-balance-after.txt")
+
+echo "alice CONFIRMED before: $alice_before  (smallest units)"
+echo "alice CONFIRMED after:  $alice_after   (smallest units)"
+echo "bob   CONFIRMED before: $bob_before    (smallest units)"
+echo "bob   CONFIRMED after:  $bob_after     (smallest units)"
+
+# Expected delta: 10 UCT = 10 * 10^8 = 1_000_000_000 smallest units.
+expected_delta=1000000000
+
+alice_delta=$(( alice_before - alice_after ))
+bob_delta=$(( bob_after - bob_before ))
+
+echo
+echo "alice delta (before - after): $alice_delta"
+echo "bob   delta (after - before): $bob_delta"
+echo "expected:                     $expected_delta  (10 UCT × 10^8)"
+
+rc=0
+if (( alice_delta == expected_delta )); then
+  echo "ASSERT OK (alice-confirmed-drop-10-UCT): alice dropped exactly 10 UCT confirmed"
+else
+  echo "ASSERT FAIL (alice-confirmed-drop-10-UCT): expected delta $expected_delta, got $alice_delta" >&2
+  rc=1
+fi
+
+if (( bob_delta == expected_delta )); then
+  echo "ASSERT OK (bob-confirmed-rise-10-UCT): bob rose exactly 10 UCT confirmed"
+else
+  echo "ASSERT FAIL (bob-confirmed-rise-10-UCT): expected delta $expected_delta, got $bob_delta" >&2
+  rc=1
+fi
+
+# Also assert there's no unconfirmed UCT residue on either side after
+# finalize — the #389 #2 decimal-aware gate.
+check_no_unconfirmed() {
+  local label="$1" snapshot="$2"
+  local pat='\(\+ [0-9.]*[1-9][0-9.]* unconfirmed\)'
+  if grep -qE "$pat" "$snapshot"; then
+    echo "ASSERT FAIL ($label): non-zero unconfirmed residue in post-finalize snapshot" >&2
+    grep -nE "$pat" "$snapshot" >&2 || true
+    return 1
+  fi
+  echo "ASSERT OK ($label): no unconfirmed residue post-finalize"
+}
+
+check_no_unconfirmed "alice-balance-after" "$SNAP/alice-balance-after.txt" || rc=1
+check_no_unconfirmed "bob-balance-after"   "$SNAP/bob-balance-after.txt"   || rc=1
+
+echo
+if (( rc == 0 )); then
+  banner "ALL GREEN — alice -10 UCT, bob +10 UCT, both CONFIRMED, no residue"
+else
+  banner "FAIL — see ASSERT FAIL lines above"
+fi
+exit "$rc"

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1717,6 +1717,14 @@ export class PaymentsModule {
   private resolveUnconfirmedTimer: ReturnType<typeof setInterval> | null = null;
   private static readonly RESOLVE_UNCONFIRMED_INTERVAL_MS = 10_000; // Retry every 10s
 
+  // Issue #389 finding #11 — best-effort retry for `saveV6RecoverPermanent`
+  // when the initial persist throws. Exponential backoff capped at
+  // `V6_RECOVER_PERM_SAVE_MAX_ATTEMPTS`. Cleared on destroy / address switch.
+  private v6RecoverPermSaveRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private v6RecoverPermSaveRetryAttempts = 0;
+  private static readonly V6_RECOVER_PERM_SAVE_RETRY_BASE_MS = 2_000;
+  private static readonly V6_RECOVER_PERM_SAVE_MAX_ATTEMPTS = 5;
+
   // Guard: ensure load() completes before processing incoming bundles
   private loadedPromise: Promise<void> | null = null;
   private loaded = false;
@@ -2012,6 +2020,9 @@ export class PaymentsModule {
     this.stopProofPolling();
     this.proofPollingJobs.clear();
     this.stopResolveUnconfirmedPolling();
+    // Issue #389 finding #11 — kill any pending V6-RECOVER save retry
+    // so it doesn't fire into the new address's storage context.
+    this.stopV6RecoverPermanentSaveRetry();
     this.unsubscribeStorageEvents();
 
     // Cancel pending payment response resolvers
@@ -3703,23 +3714,26 @@ export class PaymentsModule {
         logger.debug('Payments', '[PROXY-CACHE] primeProxyAddressCache failed:', err);
       }
 
-      // Restore proof-polling jobs (#144 L1). Must run AFTER the active
-      // token map is populated so we can resolve persisted
-      // (genesisTokenId, stateHash) pairs to in-memory `Token.id`s — and
-      // BEFORE `resolveUnconfirmed` fires so newly-restored jobs are part
-      // of the same accounting.
-      try {
-        await this.restoreProofPollingJobs();
-      } catch (err) {
-        logger.error('Payments', '[V6-RESTORE] Failed to restore proof-polling jobs:', err);
-      }
-
-      // Issue #378 (#275 P4) — hydrate the V6-RECOVER permanent-verdict
-      // ledger BEFORE `recoverStrandedReceivedTokens` runs so the scan
-      // below sees the marker and skips already-failed tokens. Without
-      // this ordering, a cold-start would re-register every previously-
-      // permanent token for another round of probe + finalize work —
-      // exactly the redundant-polling pattern this commit eliminates.
+      // Issue #389 finding #6 — hydrate the V6-RECOVER permanent-verdict
+      // ledger BEFORE `restoreProofPollingJobs` so re-registered polling
+      // jobs (each carrying a `finalizeReceivedToken` callback) cannot
+      // race the ledger-load and overwrite a ledgered token's
+      // `'invalid'` status with `'confirmed'` on the next proof arrival.
+      //
+      // This also preserves the original #378 invariant: the ledger
+      // hydrates BEFORE `recoverStrandedReceivedTokens` (further down)
+      // so its scan sees the marker and skips already-failed tokens
+      // rather than re-registering them for another probe+finalize
+      // round.
+      //
+      // The previous ordering was: `restoreProofPollingJobs` →
+      // `restoreV6RecoverPermanent`. That ordering left a cold-start
+      // race window in which a polling tick firing between these two
+      // calls would call `finalizeReceivedToken` on a token whose
+      // ledger entry had not yet hydrated, defeating the persistent-
+      // verdict design. The companion `isV6RecoverPermanentToken`
+      // guard inside `finalizeReceivedToken` itself is the belt; this
+      // reorder is the suspenders.
       try {
         await this.restoreV6RecoverPermanent();
       } catch (err) {
@@ -3728,6 +3742,21 @@ export class PaymentsModule {
           '[V6-RECOVER-PERM] Failed to restore permanent-verdict ledger:',
           err,
         );
+      }
+
+      // Restore proof-polling jobs (#144 L1). Must run AFTER the active
+      // token map is populated so we can resolve persisted
+      // (genesisTokenId, stateHash) pairs to in-memory `Token.id`s,
+      // AFTER `restoreV6RecoverPermanent` (so ledgered tokens are
+      // already patched to `'invalid'` and the job-restore loop's
+      // `existingToken.status === 'confirmed'` short-circuit is not the
+      // only line of defense — see also #389 #6 above), and BEFORE
+      // `resolveUnconfirmed` fires so newly-restored jobs are part of
+      // the same accounting.
+      try {
+        await this.restoreProofPollingJobs();
+      } catch (err) {
+        logger.error('Payments', '[V6-RESTORE] Failed to restore proof-polling jobs:', err);
       }
 
       // Recover stranded V6-direct receives (#144 L3 migration). Walks
@@ -5400,6 +5429,8 @@ export class PaymentsModule {
 
     // Stop V5 resolve-unconfirmed retry polling
     this.stopResolveUnconfirmedPolling();
+    // Issue #389 finding #11 — kill any pending V6-RECOVER save retry.
+    this.stopV6RecoverPermanentSaveRetry();
 
     // Clear pending response resolvers
     for (const [, resolver] of this.pendingResponseResolvers) {
@@ -7872,13 +7903,22 @@ export class PaymentsModule {
       if (this.v6RecoverPermanent.size > 0) {
         const clearedCount = this.v6RecoverPermanent.size;
         this.v6RecoverPermanent.clear();
-        this.saveV6RecoverPermanent().catch((persistErr) =>
-          logger.debug(
+        // Issue #389 finding #11 — escalate save failures here too.
+        // The forced-retry clear path is less load-bearing than the
+        // verdict-stamp path (the worst outcome of a missed clear is
+        // a stale ledger that re-applies on next load — recoverable
+        // by another forced retry), but it still warrants a retry
+        // schedule so transient storage hiccups don't leave the
+        // operator with a confusing stale ledger entry across
+        // restart.
+        this.saveV6RecoverPermanent().catch((persistErr) => {
+          logger.error(
             'Payments',
             `[V6-RECOVER-PERM] saveV6RecoverPermanent after forced-retry clear failed:`,
             persistErr,
-          ),
-        );
+          );
+          this.scheduleV6RecoverPermanentSaveRetry();
+        });
         logger.debug(
           'Payments',
           `[V6-RECOVER-PERM] Cleared ${clearedCount} permanent-verdict entries for forced retry`,
@@ -8290,7 +8330,31 @@ export class PaymentsModule {
    * @returns Array of matching {@link Token} objects (synchronous).
    */
   getTokens(filter?: { coinId?: string; status?: TokenStatus }): Token[] {
-    let tokens = Array.from(this.tokens.values());
+    // Issue #389 finding #9 — present-status accuracy across the
+    // cold-start window. `loadFromStorageData` calls
+    // `applyV6RecoverPermanentInvalidStatus` AT ITS END, but every
+    // sync() reload re-derives `Token.status` from TXF transactions
+    // (`determineTokenStatus` only emits `'pending'`/`'confirmed'`).
+    // Between the re-derive and the apply, the in-memory tokens map
+    // briefly holds ledgered tokens at `'pending'`. AccountingModule,
+    // SwapModule, and any direct API consumer reading `getTokens`
+    // during that window would observe an unspendable token as
+    // `'pending'` — the precise lie #387 closed. Patch on read,
+    // returning a synthesized view rather than mutating the map (which
+    // would race the next save). The hot path is unaffected: when the
+    // ledger is empty (the common case), `isV6RecoverPermanentToken`
+    // short-circuits before the array walk.
+    const ledgerActive = this.v6RecoverPermanent.size > 0;
+    let tokens: Token[] = ledgerActive
+      ? Array.from(this.tokens.entries(), ([id, t]) =>
+          t.status !== 'invalid' &&
+          t.status !== 'spent' &&
+          t.status !== 'transferring' &&
+          this.isV6RecoverPermanentToken(t, id)
+            ? { ...t, status: 'invalid' as TokenStatus }
+            : t,
+        )
+      : Array.from(this.tokens.values());
 
     if (filter?.coinId) {
       tokens = tokens.filter((t) => t.coinId === filter.coinId);
@@ -8766,8 +8830,21 @@ export class PaymentsModule {
     // #144: include 'pending' status too — V6-direct receives flip from
     // 'submitted' to 'pending' after save→load and would never re-engage
     // the periodic retry otherwise.
-    const hasUnconfirmed = Array.from(this.tokens.values()).some(
-      (t) => t.status === 'submitted' || t.status === 'pending',
+    //
+    // Issue #389 finding #8 — symmetry with `hasUnconfirmedOrInflight`
+    // (which already consults the ledger). Without the ledger check
+    // here, a cold-start window where `loadFromStorageData` has run
+    // but `restoreV6RecoverPermanent`'s ledger hydrate or
+    // `applyV6RecoverPermanentInvalidStatus` patch has not yet
+    // completed would see ledgered tokens as `'pending'` and arm the
+    // periodic retry timer for them — burning a `resolveUnconfirmed`
+    // cycle every interval until they're patched. The pre-#389
+    // load() ordering fix makes this window narrow; the guard here
+    // closes it entirely.
+    const hasUnconfirmed = Array.from(this.tokens.entries()).some(
+      ([id, t]) =>
+        (t.status === 'submitted' || t.status === 'pending') &&
+        !this.isV6RecoverPermanentToken(t, id),
     );
     if (!hasUnconfirmed) {
       logger.debug('Payments', '[V5-RESOLVE] scheduleResolveUnconfirmed: no submitted/pending tokens, not starting timer');
@@ -8793,6 +8870,70 @@ export class PaymentsModule {
       clearInterval(this.resolveUnconfirmedTimer);
       this.resolveUnconfirmedTimer = null;
     }
+  }
+
+  /**
+   * Issue #389 finding #11 — best-effort retry scheduler for
+   * `saveV6RecoverPermanent` failures.
+   *
+   * The ledger is load-bearing for balance correctness across restart;
+   * a single persist failure (transient storage hiccup, IndexedDB
+   * transaction rejected, file lock contention) would otherwise lose the
+   * verdict on process exit. This retries with exponential backoff
+   * (2s × 2^attempt) capped at `V6_RECOVER_PERM_SAVE_MAX_ATTEMPTS`. Each
+   * successful save resets the attempt counter. After exhaustion we
+   * stop retrying — the next legitimate verdict path (or the next call
+   * site that hits `saveV6RecoverPermanent` directly) will re-trigger.
+   */
+  private scheduleV6RecoverPermanentSaveRetry(): void {
+    if (this.v6RecoverPermSaveRetryTimer) return;
+    if (
+      this.v6RecoverPermSaveRetryAttempts >=
+      PaymentsModule.V6_RECOVER_PERM_SAVE_MAX_ATTEMPTS
+    ) {
+      logger.error(
+        'Payments',
+        `[V6-RECOVER-PERM] save retry attempts exhausted (` +
+          `${this.v6RecoverPermSaveRetryAttempts} attempts). Verdict is in ` +
+          `memory only; restart will lose it. Operator intervention required.`,
+      );
+      return;
+    }
+    const attempt = this.v6RecoverPermSaveRetryAttempts;
+    // 2s, 4s, 8s, 16s, 32s
+    const delayMs =
+      PaymentsModule.V6_RECOVER_PERM_SAVE_RETRY_BASE_MS * Math.pow(2, attempt);
+    this.v6RecoverPermSaveRetryTimer = setTimeout(async () => {
+      this.v6RecoverPermSaveRetryTimer = null;
+      this.v6RecoverPermSaveRetryAttempts += 1;
+      try {
+        await this.saveV6RecoverPermanent();
+        // Success — reset counter so the next legitimate failure starts
+        // fresh from a 2s delay.
+        this.v6RecoverPermSaveRetryAttempts = 0;
+        logger.debug(
+          'Payments',
+          `[V6-RECOVER-PERM] save retry succeeded after ` +
+            `${attempt + 1} attempt(s)`,
+        );
+      } catch (err) {
+        logger.error(
+          'Payments',
+          `[V6-RECOVER-PERM] save retry attempt ${attempt + 1} failed:`,
+          err,
+        );
+        // Schedule the next attempt up to the cap.
+        this.scheduleV6RecoverPermanentSaveRetry();
+      }
+    }, delayMs);
+  }
+
+  private stopV6RecoverPermanentSaveRetry(): void {
+    if (this.v6RecoverPermSaveRetryTimer) {
+      clearTimeout(this.v6RecoverPermSaveRetryTimer);
+      this.v6RecoverPermSaveRetryTimer = null;
+    }
+    this.v6RecoverPermSaveRetryAttempts = 0;
   }
 
   // ===========================================================================
@@ -9907,14 +10048,35 @@ export class PaymentsModule {
         // verdict (e.g. CLI completion) cannot lose the entry. The
         // ledger is now load-bearing for balance correctness — we can
         // no longer afford fire-and-forget here.
+        //
+        // Issue #389 finding #11 — if the persist fails (storage
+        // unavailable, disk full, IndexedDB transaction rejected),
+        // the verdict survives only in memory. On CLI exit the
+        // verdict is lost; the next session re-runs the full
+        // V6-RECOVER probe + 60s drain timeout cycle. Bump the log
+        // level to `error` so observability surfaces it (operators
+        // grep for `[V6-RECOVER-PERM]` ERROR lines), and schedule a
+        // best-effort retry on a short backoff so a transient storage
+        // hiccup self-heals before the next session's load(). The
+        // in-memory `'invalid'` status from step 1 above still
+        // protects the current session's balance.
+        //
+        // We deliberately do NOT emit `transfer:operator-alert` here
+        // — that event surface is constrained to the §5.4
+        // `DispositionReason` enum (14 values, snapshot-tested) which
+        // is a transfer-disposition contract, not a generic operator
+        // channel. A storage-side failure does not fit any of the
+        // existing codes and adding a new one requires an ADR.
         try {
           await this.saveV6RecoverPermanent();
         } catch (persistErr) {
-          logger.warn(
+          logger.error(
             'Payments',
-            `[V6-RECOVER-PERM] saveV6RecoverPermanent after permanent-fail mark failed:`,
+            `[V6-RECOVER-PERM] saveV6RecoverPermanent after permanent-fail mark failed (in-memory verdict ` +
+              `for ${tokenId.slice(0, 12)} is correct, but will be lost on restart):`,
             persistErr,
           );
+          this.scheduleV6RecoverPermanentSaveRetry();
         }
 
         // 2. Remove the proof-polling job and persist the change.
@@ -10648,12 +10810,23 @@ export class PaymentsModule {
     // recovery scans see the correct status immediately. We must NOT
     // reject the addToken (returning false would block the Nostr
     // at-least-once cursor from advancing, causing perpetual replay).
+    //
+    // Issue #389 finding #4 — patch the status IN PLACE on the caller's
+    // reference, not via spread-into-new-object. Callers commonly read
+    // `incoming` after the addToken call to populate event payloads
+    // (e.g. `emitEvent('transfer:incoming', { tokens: [incoming] })`).
+    // The spread version of this guard rebound a local but left the
+    // caller's reference with the pre-patch `status: 'pending'`, so the
+    // event payload claimed the token was incoming as spendable while
+    // the map held it as `'invalid'`. AccountingModule's
+    // `_handleTokenChange` and UI listeners then drew the wrong status.
     if (this.isV6RecoverPermanentToken(token)) {
       logger.debug(
         'Payments',
         `[V6-RECOVER-PERM] Incoming token ${(incomingTokenId ?? token.id).slice(0, 12)}... matches permanent verdict — persisting as 'invalid'`,
       );
-      token = { ...token, status: 'invalid', updatedAt: Date.now() };
+      token.status = 'invalid';
+      token.updatedAt = Date.now();
     }
 
     // Add the new token state
@@ -10705,6 +10878,24 @@ export class PaymentsModule {
 
     const incomingTokenId = extractTokenIdFromSdkData(token.sdkData);
     let found = false;
+
+    // Issue #389 finding #5 — mirror `addToken`'s V6-RECOVER permanent
+    // ledger consult. A finalization worker or future internal caller
+    // could otherwise hand updateToken a `'confirmed'` (or any non-
+    // invalid) status and silently overwrite the durable `'invalid'`
+    // verdict — the very regression #387 closed for the load path,
+    // re-introduced through a different door. Patching in place
+    // (matching #389 finding #4 in addToken) keeps the caller's
+    // reference honest for event payloads downstream of this call.
+    if (this.isV6RecoverPermanentToken(token)) {
+      logger.debug(
+        'Payments',
+        `[V6-RECOVER-PERM] updateToken on ${(incomingTokenId ?? token.id).slice(0, 12)}... ` +
+          `intersects permanent-verdict ledger — coercing status to 'invalid'`,
+      );
+      token.status = 'invalid';
+      token.updatedAt = Date.now();
+    }
 
     // Find by genesis tokenId first
     let oldId: string | undefined;
@@ -12082,6 +12273,25 @@ export class PaymentsModule {
     const invalid: Token[] = [];
 
     for (const token of this.tokens.values()) {
+      // Issue #389 finding #7 — short-circuit ledgered tokens. The
+      // V6-RECOVER permanent-verdict ledger is authoritative: the
+      // wallet has decided structurally / by-recipient-mismatch that
+      // it cannot finalize this token. Re-asking the aggregator about
+      // it is wasted round-trips (and, worse, can return `valid=true`
+      // for a token the wallet permanently rejected — a
+      // `validate()` caller would then see a "valid" entry in the
+      // returned array that the rest of the SDK would refuse to
+      // spend). Route ledgered tokens straight to `invalid` so the
+      // returned partition reflects on-wallet reality.
+      if (this.isV6RecoverPermanentToken(token)) {
+        if (token.status !== 'invalid') {
+          token.status = 'invalid';
+        }
+        this.parsedTokenCache.delete(token.id);
+        invalid.push(token);
+        continue;
+      }
+
       const result = await this.deps!.oracle.validateToken(token.sdkData);
 
       if (result.valid && !result.spent) {
@@ -15427,6 +15637,40 @@ export class PaymentsModule {
         return;
       }
 
+      // Issue #389 finding #1 — the V6-RECOVER permanent ledger is
+      // authoritative for "this wallet cannot finalize this token".
+      // If a previous session stamped this tokenId as permanent (HD-
+      // index recovery exhausted / structural failure), a restored
+      // proof-polling job from `restoreProofPollingJobs` (or a stale
+      // in-memory job left over from before the verdict landed) would
+      // otherwise call into this method, succeed in fetching a proof,
+      // and overwrite the durable `'invalid'` status with `'confirmed'`
+      // — exactly the regression #387 closed. The `restoreV6RecoverPermanent`-
+      // before-`restoreProofPollingJobs` ordering fix on `load()` closes
+      // the cold-start race for fresh jobs, but a process that picks up
+      // a job mid-flight, or a future caller that bypasses the load
+      // ordering, would still hit this method. The ledger consult here
+      // is the belt to that braces.
+      if (this.isV6RecoverPermanentToken(token, tokenId)) {
+        logger.debug(
+          'Payments',
+          `[V6-RECOVER-PERM] Skipping finalize for ${tokenId.slice(0, 12)}... ` +
+            `— token is on the permanent-verdict ledger; status stays 'invalid'`,
+        );
+        // Best-effort cleanup of the polling job so subsequent ticks
+        // don't keep firing this no-op path.
+        if (this.proofPollingJobs.delete(tokenId)) {
+          this.saveProofPollingJobs().catch((persistErr) =>
+            logger.debug(
+              'Payments',
+              `[V6-RECOVER-PERM] saveProofPollingJobs after ledger-skip failed:`,
+              persistErr,
+            ),
+          );
+        }
+        return;
+      }
+
       // Get proof from aggregator
       const commitment = await TransferCommitment.fromJSON(commitmentInput);
       if (!this.deps!.oracle.waitForProofSdk) {
@@ -17065,6 +17309,23 @@ export class PaymentsModule {
         continue;
       }
 
+      // Issue #389 finding #6 — V6-RECOVER permanent ledger short-circuit.
+      // With the new load() ordering, `restoreV6RecoverPermanent` ran
+      // before this method, so the ledger is hydrated and we can skip
+      // job re-registration for any token whose canonical id was
+      // permanently rejected. Without this guard, the job would be
+      // re-registered, fire on the next proof, hit the
+      // `finalizeReceivedToken` ledger guard, and no-op — wasted work
+      // but not incorrect. The early skip here keeps load() O(restored)
+      // instead of O(restored + permanent).
+      if (existingToken && this.isV6RecoverPermanentToken(existingToken, memoryTokenId)) {
+        logger.debug(
+          'Payments',
+          `[V6-RESTORE] Token ${memoryTokenId.slice(0, 12)} on permanent-verdict ledger, skipping job`,
+        );
+        continue;
+      }
+
       // Steelman FIX G (#144): cumulative-attempts cap. If this token
       // has already burned through MAX_CUMULATIVE_ATTEMPTS across
       // prior process lifetimes, mark it invalid and skip restoration.
@@ -17273,10 +17534,35 @@ export class PaymentsModule {
     if (this.v6RecoverPermanent.size === 0) return 0;
     let patched = 0;
     for (const [mapKey, token] of this.tokens) {
-      if (token.status === 'invalid' || token.status === 'spent') continue;
+      // Issue #389 finding #10 — `'transferring'` indicates an in-flight
+      // send: an outbound commit was submitted and the recipient state
+      // is in the process of being claimed by the sender. Flipping that
+      // status to `'invalid'` would abort the in-flight send mid-way,
+      // a strictly worse outcome than letting the send complete (which
+      // it will, since the ledger only applies to RECEIVED tokens — a
+      // ledgered token can never be in `'transferring'` for our wallet
+      // in well-formed practice). Treat `'transferring'` as a terminal-
+      // for-this-cycle state the same way `'invalid'` and `'spent'`
+      // are.
+      if (
+        token.status === 'invalid' ||
+        token.status === 'spent' ||
+        token.status === 'transferring'
+      ) {
+        continue;
+      }
       if (!this.isV6RecoverPermanentToken(token, mapKey)) continue;
       token.status = 'invalid';
-      token.updatedAt = Date.now();
+      // Issue #389 finding #13 — do NOT bump `updatedAt` here.
+      // `determineTokenStatus` re-derives status to `'pending'` on every
+      // TXF reload (see also #387 root cause), so this patch runs on
+      // every load() and every sync() cycle. Bumping `updatedAt` would
+      // pollute the "last meaningful change" signal that downstream
+      // observers (AccountingModule, history projection, UI sort) read
+      // — they would see a perpetual stream of bogus "this token just
+      // changed" events even though only the load-time status re-derive
+      // happened. The status flip itself is the only signal that
+      // matters; readers that care about that observe it directly.
       this.tokens.set(mapKey, token);
       patched += 1;
     }

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -7947,12 +7947,17 @@ export class PaymentsModule {
     // exhausted" / "structural failure" — no retry semantically
     // recovers it); polling it on every `sphere balance` is wasted
     // wall-clock that historically stacked to ~60s per command.
+    // Issue #387 — canonical-id-first lookup. The ledger is keyed by
+    // canonical genesis tokenId; the map iteration key matches that
+    // immediately after `loadFromStorageData` but can be a randomUUID
+    // immediately after `addToken`. Use the helper so both forms
+    // resolve correctly.
     const hasUnconfirmedOrInflight = (): boolean =>
       this.inflightReceiveCount > 0 ||
       Array.from(this.tokens.entries()).some(
         ([tokenId, t]) =>
           (t.status === 'submitted' || t.status === 'pending') &&
-          !this.v6RecoverPermanent.has(tokenId),
+          !this.isV6RecoverPermanentToken(t, tokenId),
       );
 
     // Drain ingest worker pool first (UXF v1 path, defense in depth).
@@ -8181,6 +8186,18 @@ export class PaymentsModule {
     for (const token of this.tokens.values()) {
       // Skip spent and invalid tokens; transferring tokens remain visible
       if (token.status === 'spent' || token.status === 'invalid') continue;
+      // Issue #387 — defense in depth: any token whose tokenId carries
+      // a permanent V6-RECOVER verdict is unspendable by this wallet
+      // (HD-index recovery exhausted / structural failure). Even if a
+      // TXF round-trip stripped its `'invalid'` status, the persistent
+      // ledger is the authoritative verdict source and must be honored
+      // here so balance NEVER includes unspendable tokens. The
+      // `applyV6RecoverPermanentInvalidStatus` patch from
+      // `loadFromStorageData` makes this filter normally redundant —
+      // belt-and-braces against any future caller mutating status
+      // independently or any code path that bypasses load (e.g. a
+      // direct `tokens.set()` in tests).
+      if (this.isV6RecoverPermanentToken(token)) continue;
       // Issue #282 Residual #3 — skip invoice tokens and any residual
       // empty-coinId entries. Invoices carry zero amount and have no
       // place in a balance summary; an empty coinId is a defensive
@@ -9412,7 +9429,13 @@ export class PaymentsModule {
       // ever changing the verdict. Skip until an operator explicitly
       // forces a retry via `payments receive --finalize` (which clears
       // the ledger).
-      if (this.v6RecoverPermanent.has(tokenId)) continue;
+      //
+      // Issue #387 — use canonical-id-first lookup. The ledger is keyed
+      // by canonical genesis tokenId; the map iteration key matches
+      // that immediately after `loadFromStorageData` but `addToken` from
+      // a Nostr replay can re-key under a `crypto.randomUUID`. The
+      // `isV6RecoverPermanentToken` helper handles both forms.
+      if (this.isV6RecoverPermanentToken(token, tokenId)) continue;
       if (this.parsePendingFinalization(token.sdkData)) continue;
       if (!this.isReceivedLegacyPending(token)) continue;
 
@@ -9863,17 +9886,36 @@ export class PaymentsModule {
         // status-merge semantics) restore the original 'submitted'
         // status. The persistent ledger key is independent of the
         // token bytes and so survives those round-trips deterministically.
-        this.v6RecoverPermanent.set(tokenId, {
+        //
+        // Issue #387 — confirmed: `determineTokenStatus` only emits
+        // {pending, confirmed} from TXF; the in-memory `'invalid'`
+        // write at step 1 above is LOST on the next load. The ledger
+        // is now the SOLE durable representation of the verdict, and
+        // `loadFromStorageData` → `applyV6RecoverPermanentInvalidStatus`
+        // re-derives the `'invalid'` status from the ledger after
+        // every load + sync. Use the canonical genesis tokenId
+        // (extracted from `sdkData`) as the ledger key so the value
+        // is stable across `addToken` UUID re-keying — it always
+        // equals the storage-derived map key post-load.
+        const ledgerKey =
+          (token && extractTokenIdFromSdkData(token.sdkData)) ?? tokenId;
+        this.v6RecoverPermanent.set(ledgerKey, {
           reason: classLabel,
           ts: Date.now(),
         });
-        this.saveV6RecoverPermanent().catch((persistErr) =>
-          logger.debug(
+        // Await persistence so a process exit immediately after the
+        // verdict (e.g. CLI completion) cannot lose the entry. The
+        // ledger is now load-bearing for balance correctness — we can
+        // no longer afford fire-and-forget here.
+        try {
+          await this.saveV6RecoverPermanent();
+        } catch (persistErr) {
+          logger.warn(
             'Payments',
             `[V6-RECOVER-PERM] saveV6RecoverPermanent after permanent-fail mark failed:`,
             persistErr,
-          ),
-        );
+          );
+        }
 
         // 2. Remove the proof-polling job and persist the change.
         this.proofPollingJobs.delete(tokenId);
@@ -10596,6 +10638,22 @@ export class PaymentsModule {
           }
         }
       }
+    }
+
+    // Issue #387 — Nostr at-least-once replay can re-deliver a token
+    // whose canonical tokenId already carries a permanent V6-RECOVER
+    // verdict (HD-index recovery exhausted / structural failure). The
+    // ledger is the authoritative source; mark the incoming entry as
+    // `'invalid'` BEFORE inserting into `this.tokens` so balance and
+    // recovery scans see the correct status immediately. We must NOT
+    // reject the addToken (returning false would block the Nostr
+    // at-least-once cursor from advancing, causing perpetual replay).
+    if (this.isV6RecoverPermanentToken(token)) {
+      logger.debug(
+        'Payments',
+        `[V6-RECOVER-PERM] Incoming token ${(incomingTokenId ?? token.id).slice(0, 12)}... matches permanent verdict — persisting as 'invalid'`,
+      );
+      token = { ...token, status: 'invalid', updatedAt: Date.now() };
     }
 
     // Add the new token state
@@ -16781,6 +16839,17 @@ export class PaymentsModule {
     if (incomingHasNametags || this.nametags.length === 0) {
       this.nametags = parsed.nametags;
     }
+
+    // Issue #387 — every TXF round-trip through `parseTxfStorageData →
+    // txfToToken → determineTokenStatus` rewrites token status from
+    // {transactions, inclusionProof} only; the application-level
+    // `'invalid'` verdict (set by `finalizeStrandedReceivedToken` after
+    // a V6-RECOVER permanent-fail) is lost. Re-apply the persistent
+    // `v6RecoverPermanent` ledger to the freshly-loaded tokens so the
+    // verdict survives initial load AND every subsequent `sync()`
+    // (which calls back into `loadFromStorageData`). No-op when the
+    // ledger is empty.
+    this.applyV6RecoverPermanentInvalidStatus();
   }
 
   // ===========================================================================
@@ -17162,6 +17231,85 @@ export class PaymentsModule {
         `[V6-RECOVER-PERM] Restored ${restored} permanent-verdict entries from storage`,
       );
     }
+
+    // Issue #387 — re-apply the permanent verdict to any in-memory token
+    // whose status was reset to 'pending' by the TXF round-trip during
+    // `loadFromStorageData` (`determineTokenStatus` only knows the
+    // `pending`/`confirmed` shapes — the application-level `'invalid'`
+    // verdict is lost on every reload). The ledger is the authoritative
+    // source for V6-RECOVER permanent verdicts; patching the in-memory
+    // status here makes `aggregateTokens` (which already filters
+    // `'invalid'`) and every downstream status consumer correct without
+    // requiring a new format-version on the persisted TXF.
+    this.applyV6RecoverPermanentInvalidStatus();
+  }
+
+  /**
+   * Issue #387 — apply the persistent V6-RECOVER permanent-verdict ledger
+   * to in-memory tokens by setting their status to `'invalid'`.
+   *
+   * Called from:
+   *   - `restoreV6RecoverPermanent` after the ledger is hydrated on cold
+   *     start (handles the initial load where the ledger arrives after
+   *     `loadFromStorageData` already populated `this.tokens`).
+   *   - `loadFromStorageData` after every TXF reload (handles the
+   *     `sync()` path that re-parses storage with the ledger already in
+   *     memory; the TXF round-trip strips the previously-applied
+   *     `'invalid'` status because `determineTokenStatus` re-derives
+   *     from transactions/inclusionProofs only).
+   *
+   * Lookup is canonical-id-first: extracts the genesis tokenId from
+   * `sdkData` and checks the ledger. Falls back to the map key (which
+   * post-load equals the canonical tokenId; pre-load can be a
+   * crypto.randomUUID from `addToken`).
+   *
+   * Does NOT call `save()` — the next ordinary save consolidates the
+   * patched in-memory state to TXF. Avoiding save here keeps the load
+   * path O(n) and avoids re-entering the storage write pipeline.
+   *
+   * Returns the number of tokens whose status was patched (for tests).
+   */
+  private applyV6RecoverPermanentInvalidStatus(): number {
+    if (this.v6RecoverPermanent.size === 0) return 0;
+    let patched = 0;
+    for (const [mapKey, token] of this.tokens) {
+      if (token.status === 'invalid' || token.status === 'spent') continue;
+      if (!this.isV6RecoverPermanentToken(token, mapKey)) continue;
+      token.status = 'invalid';
+      token.updatedAt = Date.now();
+      this.tokens.set(mapKey, token);
+      patched += 1;
+    }
+    if (patched > 0) {
+      logger.debug(
+        'Payments',
+        `[V6-RECOVER-PERM] Patched ${patched} in-memory token(s) to status='invalid' from ledger`,
+      );
+    }
+    return patched;
+  }
+
+  /**
+   * Issue #387 — predicate: is this token's canonical (or fallback) id in
+   * the V6-RECOVER permanent-verdict ledger?
+   *
+   * Canonical-id-first: pulls the genesis tokenId from `sdkData` and
+   * checks the ledger. Falls back to `mapKey` (when available) so that a
+   * token whose `sdkData` is non-parseable (unlikely but defensible) is
+   * still classifiable when the caller knows the map key.
+   *
+   * Returns `false` cheaply when the ledger is empty — the hot
+   * `aggregateTokens` loop only pays the extraction cost when there is
+   * at least one ledgered verdict.
+   */
+  private isV6RecoverPermanentToken(token: Token, mapKey?: string): boolean {
+    if (this.v6RecoverPermanent.size === 0) return false;
+    const canonical = extractTokenIdFromSdkData(token.sdkData);
+    if (canonical && this.v6RecoverPermanent.has(canonical)) return true;
+    if (mapKey && mapKey !== canonical && this.v6RecoverPermanent.has(mapKey)) {
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -9623,8 +9623,25 @@ export class PaymentsModule {
         // the same shape `assembleAtState(tokenId, txCount - 1)` produces
         // for the UXF path. `SdkToken.fromJSON` only accepts source tokens
         // whose transactions all have inclusionProofs.
+        //
+        // Issue #390 — also reset `state` to the transfer's `sourceState`
+        // (the sender's mint state). The top-level `parsed.state` was
+        // written by the ingestion path with the RECIPIENT's predicate so
+        // the on-disk shape advertises bob as the owner once finalize
+        // completes. But the SOURCE token (state N-1) used by
+        // `Token.update` → `transaction.verify` → `verifyRecipient` must
+        // expose the SENDER's predicate so the
+        // `expectedRecipient == previousTransaction.recipient`
+        // invariant holds (alice's mint state predicate ⇒ alice's
+        // directAddress, which equals genesis.data.recipient). Without
+        // this fix, every fresh-send V6-RECOVER path failed permanently
+        // with "Recipient address mismatch" and the receiver lost the
+        // value (#387/#388/#389 only stamped the durable verdict —
+        // they did NOT fix this construction). Mirrors the correct
+        // pattern in `tryLocalFinalizeUnconfirmed` (~line 10249).
         const sourceTokenJsonObj = {
           ...parsed,
+          state: (lastTxJson.data as { sourceState?: unknown }).sourceState,
           transactions: txs.slice(0, -1),
         };
         const sourceTokenJson = JSON.stringify(sourceTokenJsonObj);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicitylabs/sphere-sdk",
-  "version": "0.8.0",
+  "version": "0.0.a1",
   "description": "Modular TypeScript SDK for Unicity wallet operations",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/tests/integration/payments/v6-recover-invalid-status-387.test.ts
+++ b/tests/integration/payments/v6-recover-invalid-status-387.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Issue #387 — V6-RECOVER permanent-mismatch durable invalid status (e2e)
+ *
+ * Integration coverage for the full module lifecycle of the fix:
+ *   1. Session A: PaymentsModule classifies a stranded V6 receive as
+ *      permanent (HD-index recovery exhausted). The verdict is stamped
+ *      in the persistent `v6RecoverPermanent` ledger AND the in-memory
+ *      token is set to `'invalid'`.
+ *   2. Persistence boundary: the underlying TXF format
+ *      (`determineTokenStatus`) only encodes pending/confirmed — the
+ *      'invalid' status is LOST on every TXF reload. The ledger is the
+ *      authoritative survivor.
+ *   3. Session B: fresh PaymentsModule, same storage. `module.load()`
+ *      runs `loadFromStorageData` (recreating the token as 'pending')
+ *      then `restoreV6RecoverPermanent` (hydrating the ledger and
+ *      re-applying 'invalid'). End state: token is 'invalid', balance
+ *      excludes it, recover scan returns 0.
+ *   4. Sync replay: `loadFromStorageData` called again (simulating a
+ *      sync flush) must still leave the token at 'invalid' via the
+ *      end-of-load patch.
+ *
+ * This file exercises the PUBLIC `module.load()` entry point and the
+ * end-to-end interaction between `loadFromStorageData`,
+ * `restoreV6RecoverPermanent`, `aggregateTokens`, and
+ * `recoverStrandedReceivedTokens` — the surface the bug actually
+ * spanned per the issue's reproduction recipe.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createPaymentsModule,
+  type PaymentsModule as PaymentsModuleType,
+} from '../../../modules/payments/PaymentsModule';
+import type {
+  FullIdentity,
+  Token,
+  TxfStorageDataBase,
+} from '../../../types';
+import type { StorageProvider } from '../../../storage';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type { TokenStorageProvider } from '../../../storage/storage-provider';
+import { STORAGE_KEYS_ADDRESS } from '../../../constants';
+
+// =============================================================================
+// SDK / network stubs — defensive only. The tests exercise PaymentsModule's
+// own state-management surface (load, save, balance, recover); no SDK paths
+// are actually hit since the stranded token's predicate doesn't bind.
+// =============================================================================
+
+vi.mock('../../../l1/network', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  isWebSocketConnected: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../../registry', () => ({
+  TokenRegistry: {
+    getInstance: () => ({
+      getDefinition: () => ({ symbol: 'UCT', name: 'Test', decimals: 8 }),
+      getIconUrl: () => null,
+    }),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const CANONICAL_TOKEN_ID = '59af0b9edda59e655a6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e';
+const UCT_COIN_ID = '455ad8720656b08e8dbd5bac1f3c73eeea5431565f6c1c3af742b1aa12d41d89';
+
+function makeIdentity(): FullIdentity {
+  return {
+    chainPubkey: '02' + 'a'.repeat(64),
+    l1Address: 'alpha1test',
+    directAddress: 'DIRECT://test',
+    privateKey: 'a'.repeat(64),
+  };
+}
+
+interface InMemoryStorage extends StorageProvider {
+  _store: Map<string, string>;
+}
+
+function makeStorage(initial?: Map<string, string>): InMemoryStorage {
+  const store = initial ?? new Map<string, string>();
+  return {
+    _store: store,
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { store.set(k, v); }),
+    remove: vi.fn(async (k: string) => { store.delete(k); }),
+    delete: vi.fn(async (k: string) => { store.delete(k); }),
+    clear: vi.fn(async () => { store.clear(); }),
+    has: vi.fn(async (k: string) => store.has(k)),
+    keys: vi.fn(async () => [...store.keys()]),
+  } as unknown as InMemoryStorage;
+}
+
+function makeTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn(),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue(null),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    fetchPendingEvents: vi.fn().mockResolvedValue(undefined),
+    publishNametag: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TransportProvider;
+}
+
+function makeOracle(): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    getStateTransitionClient: vi.fn().mockReturnValue(null),
+    waitForProofSdk: vi.fn(),
+  } as unknown as OracleProvider;
+}
+
+/** Build the stranded-V6-receive TXF shape that `parseTxfStorageData`
+ * will turn into a Token whose `determineTokenStatus` reads as
+ * `'pending'` (no inclusionProof on last tx) and whose
+ * `isReceivedLegacyPending` returns true (recipient matches the wallet's
+ * directAddress so the balance-model invariant keeps it in the active
+ * map rather than archiving).
+ */
+function makeStrandedTxf(tokenId: string): Record<string, unknown> {
+  return {
+    genesis: {
+      data: {
+        tokenId,
+        tokenType: 'genesis-type-hex',
+        coinData: [[UCT_COIN_ID, '10']],
+      },
+    },
+    state: {
+      predicate: { type: 'masked', publicKey: '03' + 'b'.repeat(64) },
+    },
+    transactions: [
+      {
+        data: {
+          sourceState: {
+            predicate: { type: 'unmasked', publicKey: '02' + 'c'.repeat(64) },
+          },
+          recipient: 'DIRECT://test',
+        },
+        inclusionProof: null,
+      },
+    ],
+  };
+}
+
+function makeTxfStorageData(tokenId: string): TxfStorageDataBase {
+  return {
+    _meta: {
+      formatVersion: '2.0',
+      address: 'alpha1test',
+      timestamp: Date.now(),
+    },
+    [`_${tokenId}`]: makeStrandedTxf(tokenId),
+  } as unknown as TxfStorageDataBase;
+}
+
+interface InMemoryTokenStorageProvider extends TokenStorageProvider<TxfStorageDataBase> {
+  setData(data: TxfStorageDataBase): void;
+  getData(): TxfStorageDataBase | null;
+}
+
+function makeTokenStorageProvider(initial?: TxfStorageDataBase): InMemoryTokenStorageProvider {
+  let data: TxfStorageDataBase | null = initial ?? null;
+  return {
+    id: 'mock-token-storage',
+    name: 'Mock TXF Storage',
+    type: 'local',
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected'),
+    setIdentity: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(true),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn(async (d: TxfStorageDataBase) => {
+      data = d;
+      return { success: true };
+    }),
+    load: vi.fn(async () => ({ success: true, data })),
+    sync: vi.fn(async (d: TxfStorageDataBase) => ({
+      success: true,
+      merged: d,
+      added: 0,
+      removed: 0,
+    })),
+    setData(d: TxfStorageDataBase) { data = d; },
+    getData() { return data; },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+interface ModuleInternals {
+  v6RecoverPermanent: Map<string, { reason: string; ts: number }>;
+  tokens: Map<string, Token>;
+  loadFromStorageData: (data: TxfStorageDataBase) => void;
+  recoverStrandedReceivedTokens: () => Promise<number>;
+}
+
+function asInternals(m: PaymentsModuleType): ModuleInternals {
+  return m as unknown as ModuleInternals;
+}
+
+function makeModuleWithProviders(
+  storage: StorageProvider,
+  tokenStorage: InMemoryTokenStorageProvider,
+): PaymentsModuleType {
+  const module = createPaymentsModule();
+  module.initialize({
+    identity: makeIdentity(),
+    storage,
+    transport: makeTransport(),
+    oracle: makeOracle(),
+    emitEvent: vi.fn(),
+    tokenStorageProviders: new Map([['mock', tokenStorage]]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+  return module;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Issue #387 — V6-RECOVER permanent-mismatch e2e (load + balance + recover)', () => {
+  let storage: InMemoryStorage;
+  let tokenStorage: InMemoryTokenStorageProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storage = makeStorage();
+    tokenStorage = makeTokenStorageProvider();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+  });
+
+  it('Session B (post-restart): load() restores ledger AND patches in-memory status to invalid', async () => {
+    // ARRANGE — pretend Session A: ledger persisted; stranded token
+    // saved to TXF with no encoded status (TXF carries only pending/
+    // confirmed via transactions/inclusionProofs).
+    storage._store.set(
+      STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT,
+      JSON.stringify([
+        {
+          tokenId: CANONICAL_TOKEN_ID,
+          reason: 'permanent recipient-address mismatch (HD-index recovery exhausted)',
+          ts: 1_700_000_000_000,
+        },
+      ]),
+    );
+    tokenStorage.setData(makeTxfStorageData(CANONICAL_TOKEN_ID));
+
+    // ACT — Session B: fresh module, same storage, full load().
+    const module = makeModuleWithProviders(storage, tokenStorage);
+    await module.load();
+
+    // ASSERT — the in-memory token reflects the ledger's permanent verdict.
+    const internal = asInternals(module);
+    const restored = internal.tokens.get(CANONICAL_TOKEN_ID);
+    expect(restored).toBeDefined();
+    expect(restored!.status).toBe('invalid');
+
+    // Balance excludes the polluted token (the core user-facing bug).
+    const balance = module.getBalance();
+    const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+    if (uct) {
+      expect(uct.confirmedAmount).toBe('0');
+      expect(uct.unconfirmedAmount).toBe('0');
+      expect(uct.confirmedTokenCount).toBe(0);
+      expect(uct.unconfirmedTokenCount).toBe(0);
+    } else {
+      expect(uct).toBeUndefined();
+    }
+
+    // Recover scan short-circuits.
+    const recovered = await internal.recoverStrandedReceivedTokens();
+    expect(recovered).toBe(0);
+  });
+
+  it('Sync replay: subsequent loadFromStorageData (simulating a sync flush) keeps the token invalid', async () => {
+    // ARRANGE — Session B already-loaded state.
+    storage._store.set(
+      STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT,
+      JSON.stringify([
+        {
+          tokenId: CANONICAL_TOKEN_ID,
+          reason: 'permanent structural failure',
+          ts: 1,
+        },
+      ]),
+    );
+    tokenStorage.setData(makeTxfStorageData(CANONICAL_TOKEN_ID));
+
+    const module = makeModuleWithProviders(storage, tokenStorage);
+    await module.load();
+    const internal = asInternals(module);
+    expect(internal.tokens.get(CANONICAL_TOKEN_ID)?.status).toBe('invalid');
+
+    // ACT — simulate sync() calling loadFromStorageData again with the
+    // same TXF (the storage layer has nothing new to report, just a
+    // re-parse). Without the end-of-load patch, this would clobber
+    // 'invalid' back to 'pending'.
+    internal.loadFromStorageData(makeTxfStorageData(CANONICAL_TOKEN_ID));
+
+    // ASSERT — status MUST survive.
+    expect(internal.tokens.get(CANONICAL_TOKEN_ID)?.status).toBe('invalid');
+
+    // Balance still correct.
+    const balance = module.getBalance();
+    const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+    if (uct) {
+      expect(uct.confirmedAmount).toBe('0');
+      expect(uct.unconfirmedAmount).toBe('0');
+    } else {
+      expect(uct).toBeUndefined();
+    }
+  });
+
+  it('AC1 (issue #387): status="invalid" survives load() across multiple sequential restarts', async () => {
+    // Boot, then re-boot, then re-boot — three sessions each pulling
+    // the same storage state. Every session must report 'invalid'.
+    storage._store.set(
+      STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT,
+      JSON.stringify([
+        { tokenId: CANONICAL_TOKEN_ID, reason: 'test', ts: 1 },
+      ]),
+    );
+    tokenStorage.setData(makeTxfStorageData(CANONICAL_TOKEN_ID));
+
+    for (let i = 0; i < 3; i += 1) {
+      const module = makeModuleWithProviders(storage, tokenStorage);
+      await module.load();
+      const internal = asInternals(module);
+      expect(internal.tokens.get(CANONICAL_TOKEN_ID)?.status).toBe('invalid');
+      const balance = module.getBalance();
+      const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+      const unconfirmed = uct ? BigInt(uct.unconfirmedAmount) : 0n;
+      expect(unconfirmed).toBe(0n);
+    }
+  });
+
+  it('Non-ledgered token of the same coin continues to surface in balance', async () => {
+    // Sanity: the fix must not over-trigger. A wholly unrelated
+    // confirmed UCT token at a different canonical id MUST still
+    // contribute to confirmed balance.
+    storage._store.set(
+      STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT,
+      JSON.stringify([
+        { tokenId: CANONICAL_TOKEN_ID, reason: 'permanent structural failure', ts: 1 },
+      ]),
+    );
+
+    // TXF carrying TWO tokens: the polluted one + a healthy unrelated one.
+    const healthyTokenId = 'd'.repeat(64);
+    const healthyTxf = {
+      genesis: {
+        data: {
+          tokenId: healthyTokenId,
+          tokenType: 'genesis-type-hex',
+          coinData: [[UCT_COIN_ID, '7']],
+        },
+      },
+      state: { predicate: { type: 'masked', publicKey: '03' + 'b'.repeat(64) } },
+      // No transactions → determineTokenStatus returns 'confirmed'.
+      transactions: [],
+    };
+    tokenStorage.setData({
+      _meta: { formatVersion: '2.0', address: 'alpha1test', timestamp: Date.now() },
+      [`_${CANONICAL_TOKEN_ID}`]: makeStrandedTxf(CANONICAL_TOKEN_ID),
+      [`_${healthyTokenId}`]: healthyTxf,
+    } as unknown as TxfStorageDataBase);
+
+    const module = makeModuleWithProviders(storage, tokenStorage);
+    await module.load();
+    const internal = asInternals(module);
+
+    expect(internal.tokens.get(CANONICAL_TOKEN_ID)?.status).toBe('invalid');
+    // The healthy token's predicate doesn't match the wallet's chainPubkey
+    // either, but it has no transactions → `latestStatePredicateMatchesWallet`
+    // checks rely on identity match logic; the simplest place to land
+    // here is checking that the polluted side is filtered out at minimum.
+    const balance = module.getBalance();
+    const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+    const unconfirmed = uct ? BigInt(uct.unconfirmedAmount) : 0n;
+    // The polluted 10 UCT MUST NOT appear in unconfirmed.
+    expect(unconfirmed).toBe(0n);
+  });
+});

--- a/tests/integration/payments/v6-recover-invalid-status-387.test.ts
+++ b/tests/integration/payments/v6-recover-invalid-status-387.test.ts
@@ -363,6 +363,17 @@ describe('Issue #387 — V6-RECOVER permanent-mismatch e2e (load + balance + rec
     );
 
     // TXF carrying TWO tokens: the polluted one + a healthy unrelated one.
+    // The healthy token's state predicate MUST bind to the wallet's
+    // chainPubkey — `loadFromStorageData` archives any active token whose
+    // latest state predicate doesn't bind AND that has no finalization
+    // plan (the balance-model invariant from #144). The wallet identity
+    // sets `chainPubkey = '02' + 'a'.repeat(64)`; we use that same value
+    // in an unmasked predicate so `latestStatePredicateMatchesWallet`
+    // returns true and the token stays in the active map.
+    //
+    // `determineTokenStatus` returns 'confirmed' for a token with no
+    // transactions, so a genesis-only token at a non-ledgered canonical
+    // id with a wallet-bound predicate MUST land in `confirmedAmount`.
     const healthyTokenId = 'd'.repeat(64);
     const healthyTxf = {
       genesis: {
@@ -372,7 +383,7 @@ describe('Issue #387 — V6-RECOVER permanent-mismatch e2e (load + balance + rec
           coinData: [[UCT_COIN_ID, '7']],
         },
       },
-      state: { predicate: { type: 'masked', publicKey: '03' + 'b'.repeat(64) } },
+      state: { predicate: { type: 'unmasked', publicKey: '02' + 'a'.repeat(64) } },
       // No transactions → determineTokenStatus returns 'confirmed'.
       transactions: [],
     };
@@ -386,15 +397,86 @@ describe('Issue #387 — V6-RECOVER permanent-mismatch e2e (load + balance + rec
     await module.load();
     const internal = asInternals(module);
 
+    // Polluted side is filtered.
     expect(internal.tokens.get(CANONICAL_TOKEN_ID)?.status).toBe('invalid');
-    // The healthy token's predicate doesn't match the wallet's chainPubkey
-    // either, but it has no transactions → `latestStatePredicateMatchesWallet`
-    // checks rely on identity match logic; the simplest place to land
-    // here is checking that the polluted side is filtered out at minimum.
+    // Healthy side is preserved as 'confirmed' — `isV6RecoverPermanentToken`
+    // matches by canonical id (`healthyTokenId` ≠ `CANONICAL_TOKEN_ID`),
+    // so the ledger filter must not touch it.
+    expect(internal.tokens.get(healthyTokenId)?.status).toBe('confirmed');
+
     const balance = module.getBalance();
     const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
-    const unconfirmed = uct ? BigInt(uct.unconfirmedAmount) : 0n;
-    // The polluted 10 UCT MUST NOT appear in unconfirmed.
-    expect(unconfirmed).toBe(0n);
+    expect(uct).toBeDefined();
+    // Issue #389 finding #12 — explicit positive assertion. The pre-#389
+    // test only checked `unconfirmedAmount === 0` which would silently
+    // pass an over-broad ledger filter regression that ALSO excluded
+    // the healthy token. Lock in the 7-UCT confirmed balance so future
+    // refactors can't quietly drop the healthy side.
+    expect(uct!.confirmedAmount).toBe('7');
+    expect(uct!.unconfirmedAmount).toBe('0');
+    expect(uct!.confirmedTokenCount).toBe(1);
+    expect(uct!.unconfirmedTokenCount).toBe(0);
+    expect(uct!.totalAmount).toBe('7');
+  });
+
+  // ===========================================================================
+  // Issue #389 finding #15 — backward compatibility with #378 ledger payloads.
+  // ===========================================================================
+  //
+  // #378 stamped entries under the map iteration key, which post-
+  // `loadFromStorageData` is the canonical genesis tokenId — i.e. for
+  // every in-practice path the two coincide. #388 made the canonical-id
+  // lookup explicit via `isV6RecoverPermanentToken`. We lock in that a
+  // ledger payload produced by the #378 stamping path continues to
+  // function correctly when loaded by the #388 + #389 logic:
+  //  - tokens at the canonical id are flipped to 'invalid'
+  //  - balance excludes them
+  //  - the recover scan short-circuits
+  // This is the "zero migration risk" check from finding #15.
+  it('#389 #15: legacy #378-shaped ledger payload (canonical-id key) drives #388 lookup correctly', async () => {
+    // #378 produced ledger entries with the SAME shape as #388/#389
+    // (`{ tokenId, reason, ts }`), keyed by the canonical genesis
+    // tokenId post-load. We simulate that exact payload here and
+    // assert all three #389 lookup paths agree on it.
+    const legacyShapedLedger = JSON.stringify([
+      {
+        tokenId: CANONICAL_TOKEN_ID, // canonical genesis id, as #378 wrote
+        reason: 'permanent recipient-address mismatch (HD-index recovery exhausted)',
+        ts: 1_700_000_000_000,
+      },
+    ]);
+    storage._store.set(STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT, legacyShapedLedger);
+    tokenStorage.setData(makeTxfStorageData(CANONICAL_TOKEN_ID));
+
+    const module = makeModuleWithProviders(storage, tokenStorage);
+    await module.load();
+    const internal = asInternals(module);
+
+    // 1) Token is correctly classified.
+    const restored = internal.tokens.get(CANONICAL_TOKEN_ID);
+    expect(restored).toBeDefined();
+    expect(restored!.status).toBe('invalid');
+
+    // 2) Balance excludes it (the #388 `aggregateTokens` filter).
+    const balance = module.getBalance();
+    const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+    if (uct) {
+      expect(uct.confirmedAmount).toBe('0');
+      expect(uct.unconfirmedAmount).toBe('0');
+    } else {
+      expect(uct).toBeUndefined();
+    }
+
+    // 3) Recover scan short-circuits.
+    const recovered = await internal.recoverStrandedReceivedTokens();
+    expect(recovered).toBe(0);
+
+    // 4) `getTokens()` returns the token but reports its status as
+    //    'invalid' via the #389 #9 lazy filter — important for any
+    //    direct API consumer (AccountingModule, SwapModule, CLI).
+    const all = module.getTokens();
+    const observed = all.find((t) => t.id === CANONICAL_TOKEN_ID);
+    expect(observed).toBeDefined();
+    expect(observed!.status).toBe('invalid');
   });
 });

--- a/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
+++ b/tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts
@@ -657,6 +657,92 @@ describe('#144 L3 — balance-model invariant + stranded recovery', () => {
     expect(sourceParsed.transactions).toHaveLength(1);
   });
 
+  // ---------------------------------------------------------------------------
+  // Issue #390 — source-state reconstruction invariant
+  //
+  // The pre-#390 reconstruction in recoverStrandedReceivedTokens did:
+  //     { ...parsed, transactions: txs.slice(0, -1) }
+  // which left the top-level `state` field pointing at the RECIPIENT's
+  // predicate (written by `saveCommitmentOnlyToken` for instant receives
+  // so the on-disk shape advertises us as the owner once finalize
+  // completes). Token.update → transaction.verify(trustBase, this) →
+  // this.verifyRecipient() reads state.predicate.getReference().toAddress()
+  // and compares it to genesis.data.recipient — those don't match for a
+  // freshly-minted recipient token (genesis recipient = sender's
+  // directAddress; state.predicate.publicKey = recipient's pubkey ⇒
+  // recipient's directAddress). The SDK throws
+  // `VerificationError('Recipient address mismatch')` and V6-RECOVER
+  // stamps the durable permanent-invalid verdict. The fix replaces
+  // `state` with the transfer's `sourceState` (= sender's mint state)
+  // so verifyRecipient on the source-at-state-N-1 sees consistent
+  // (state.predicate ⇒ genesis.recipient).
+  // ---------------------------------------------------------------------------
+  it('recoverStrandedReceivedTokens rewrites sourceTokenJson.state to the transfer sourceState (#390)', async () => {
+    const recipientStatePredicateMarker = '<<RECIPIENT-STATE-MARKER>>';
+    const senderSourceStatePredicateMarker = '<<SENDER-SOURCE-STATE-MARKER>>';
+
+    // Build sdkData where:
+    //   - top-level state.predicate carries the RECIPIENT marker (the
+    //     ingestion-path write that #390 regresses through).
+    //   - transactions[-1].data.sourceState.predicate carries the SENDER
+    //     marker (the transfer's source state — what verifyRecipient
+    //     on the source-at-state-N-1 must see).
+    // The mocked TransferTransactionData.fromJSON ignores `lastTxJson.data`
+    // contents (returns a stub), so the JSON shape only needs to expose
+    // `data.sourceState.predicate` for the reconstruction code to read.
+    const sdkData = JSON.stringify({
+      version: '2.0',
+      genesis: {
+        data: { tokenId: GENESIS_TOKEN_ID, tokenType: 'coinType', coinData: [['UCT_HEX', '100']] },
+        inclusionProof: { authenticator: { stateHash: 'genesisHash' } },
+      },
+      state: {
+        data: '',
+        predicate: recipientStatePredicateMarker,
+      },
+      transactions: [
+        {
+          inclusionProof: null,
+          data: {
+            recipient: { address: OUR_DIRECT, scheme: 'DIRECT' },
+            salt: '0x33',
+            sourceState: {
+              data: null,
+              predicate: senderSourceStatePredicateMarker,
+            },
+          },
+        },
+      ],
+      _integrity: { genesisDataJSONHash: '0000' + '0'.repeat(60), currentStateHash: STATE_HASH },
+    });
+
+    const token: Token = {
+      id: GENESIS_TOKEN_ID,
+      coinId: 'UCT_HEX',
+      symbol: 'UCT',
+      amount: '100',
+      status: 'pending',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    internals(module).tokens.set(token.id, token);
+
+    const recovered = await internals(module).recoverStrandedReceivedTokens();
+    expect(recovered).toBe(1);
+
+    const job = internals(module).proofPollingJobs.get(GENESIS_TOKEN_ID);
+    expect(job).toBeDefined();
+    const sourceParsed = JSON.parse(job?.sourceTokenJson ?? '{}');
+    // Source token at state N-1 — last tx stripped.
+    expect(sourceParsed.transactions).toHaveLength(0);
+    // CRITICAL #390 invariant: the source token's state MUST come from
+    // the transfer's sourceState (sender's mint state), NOT the
+    // top-level state on the saved sdkData (recipient's predicate).
+    expect(sourceParsed.state?.predicate).toBe(senderSourceStatePredicateMarker);
+    expect(sourceParsed.state?.predicate).not.toBe(recipientStatePredicateMarker);
+  });
+
   it('recoverStrandedReceivedTokens skips tokens that already have a polling job', async () => {
     const sdkData = makeV6DirectReceiveSdkData();
     const token: Token = {

--- a/tests/unit/modules/PaymentsModule.v6-recover-invalid-status-387.test.ts
+++ b/tests/unit/modules/PaymentsModule.v6-recover-invalid-status-387.test.ts
@@ -1,0 +1,588 @@
+/**
+ * Issue #387 — V6-RECOVER permanent-mismatch must durably mark token invalid.
+ *
+ * When `finalizeStrandedReceivedToken` classifies a stranded receive as
+ * permanent (HD-index recovery exhausted / structural failure), the
+ * tokenId is added to the persistent `v6RecoverPermanent` ledger AND
+ * the in-memory token is set to `status='invalid'`. The bug: the TXF
+ * round-trip through `parseTxfStorageData → txfToToken →
+ * determineTokenStatus` only knows `pending`/`confirmed`, so the
+ * `'invalid'` status is silently reverted to `'pending'` on every
+ * `loadFromStorageData`. The polluted token then surfaces in
+ * `getBalance()` as unconfirmed UCT despite being unspendable.
+ *
+ * This file pins the contract:
+ *   1. `applyV6RecoverPermanentInvalidStatus()` patches in-memory
+ *      tokens whose canonical id is in the ledger to `'invalid'`.
+ *   2. `loadFromStorageData()` re-applies the ledger after every TXF
+ *      reload, so the status survives a load() round-trip even though
+ *      the underlying TXF can only encode `pending`/`confirmed`.
+ *   3. `restoreV6RecoverPermanent()` also applies the ledger after
+ *      hydrating it on initial load.
+ *   4. `aggregateTokens()` (and therefore `getBalance()`) skips tokens
+ *      whose canonical id is in the ledger — defense in depth.
+ *   5. `addToken()` from a Nostr at-least-once replay sets the
+ *      incoming token's status to `'invalid'` when the canonical id is
+ *      in the ledger.
+ *   6. Ledger lookup is canonical-id-first: extracts the genesis
+ *      tokenId from sdkData so a `crypto.randomUUID`-keyed `addToken`
+ *      entry still resolves correctly.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPaymentsModule } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity, Token } from '../../../types';
+import type { StorageProvider } from '../../../storage';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import { STORAGE_KEYS_ADDRESS } from '../../../constants';
+
+// =============================================================================
+// SDK / network mocks — defensive only. The tests poke the internal map
+// directly and exercise the pure status / filter logic; no SDK paths are
+// actually hit.
+// =============================================================================
+
+vi.mock('../../../l1/network', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  isWebSocketConnected: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../../registry', () => ({
+  TokenRegistry: {
+    getInstance: () => ({
+      getDefinition: () => ({ symbol: 'UCT', name: 'Test', decimals: 8 }),
+      getIconUrl: () => null,
+    }),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const CANONICAL_TOKEN_ID = '59af0b9edda59e655a6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e';
+const UCT_COIN_ID = '455ad8720656b08e8dbd5bac1f3c73eeea5431565f6c1c3af742b1aa12d41d89';
+
+function makeIdentity(): FullIdentity {
+  return {
+    chainPubkey: '02' + 'a'.repeat(64),
+    l1Address: 'alpha1test',
+    directAddress: 'DIRECT://test',
+    privateKey: 'a'.repeat(64),
+  };
+}
+
+interface InMemoryStorage extends StorageProvider {
+  _store: Map<string, string>;
+}
+
+function makeStorage(): InMemoryStorage {
+  const store = new Map<string, string>();
+  return {
+    _store: store,
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { store.set(k, v); }),
+    remove: vi.fn(async (k: string) => { store.delete(k); }),
+    delete: vi.fn(async (k: string) => { store.delete(k); }),
+    clear: vi.fn(async () => { store.clear(); }),
+    has: vi.fn(async (k: string) => store.has(k)),
+    keys: vi.fn(async () => [...store.keys()]),
+  } as unknown as InMemoryStorage;
+}
+
+function makeTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn(),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue(null),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    fetchPendingEvents: vi.fn().mockResolvedValue(undefined),
+    publishNametag: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TransportProvider;
+}
+
+function makeOracle(): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    getStateTransitionClient: vi.fn().mockReturnValue(null),
+    waitForProofSdk: vi.fn(),
+  } as unknown as OracleProvider;
+}
+
+function setupModule(storage: StorageProvider): ReturnType<typeof createPaymentsModule> {
+  const module = createPaymentsModule();
+  module.initialize({
+    identity: makeIdentity(),
+    storage,
+    transport: makeTransport(),
+    oracle: makeOracle(),
+    emitEvent: vi.fn(),
+  });
+  // Bypass the lazy-load gate so the internal map is directly addressable.
+  (module as unknown as { loaded: boolean }).loaded = true;
+  (module as unknown as { loadedPromise: Promise<void> | null }).loadedPromise = null;
+  return module;
+}
+
+/**
+ * Build a minimal stranded-V6-receive Token whose sdkData carries the
+ * canonical tokenId and at least one transaction without an
+ * inclusionProof — the shape that `determineTokenStatus` reads as
+ * `'pending'`.
+ *
+ * The status field on the returned Token is the application-level
+ * verdict (e.g. `'invalid'`); independent of what
+ * `determineTokenStatus` would derive from the TXF transactions. This
+ * matches the production divergence — exactly the surface the fix
+ * has to resolve.
+ */
+function makeStrandedTxf(tokenId: string): Record<string, unknown> {
+  return {
+    genesis: {
+      data: {
+        tokenId,
+        tokenType: 'genesis-type-hex',
+        coinData: [[UCT_COIN_ID, '10']],
+      },
+    },
+    state: {
+      predicate: { type: 'masked', publicKey: '03' + 'b'.repeat(64) },
+    },
+    // A single transaction with NO inclusionProof and a recipient
+    // matching the wallet's directAddress — the stranded V6-direct
+    // receive shape. `determineTokenStatus` reads no-proof as
+    // `'pending'` on every reload; `isReceivedLegacyPending` reads the
+    // directAddress match as "has a finalization plan", which keeps
+    // the token in the active map (instead of the archive) per
+    // `loadFromStorageData`'s balance-model invariant.
+    transactions: [
+      {
+        data: {
+          sourceState: { predicate: { type: 'unmasked', publicKey: '02' + 'c'.repeat(64) } },
+          recipient: 'DIRECT://test',
+        },
+        inclusionProof: null,
+      },
+    ],
+  };
+}
+
+function makeStrandedToken(
+  tokenId: string,
+  status: Token['status'] = 'pending',
+  mapId?: string,
+): Token {
+  return {
+    id: mapId ?? tokenId,
+    coinId: UCT_COIN_ID,
+    symbol: 'UCT',
+    name: 'Test',
+    decimals: 8,
+    amount: '10',
+    status,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    sdkData: JSON.stringify(makeStrandedTxf(tokenId)),
+  };
+}
+
+interface ModuleInternals {
+  v6RecoverPermanent: Map<string, { reason: string; ts: number }>;
+  tokens: Map<string, Token>;
+  applyV6RecoverPermanentInvalidStatus: () => number;
+  isV6RecoverPermanentToken: (token: Token, mapKey?: string) => boolean;
+  restoreV6RecoverPermanent: () => Promise<void>;
+  loadFromStorageData: (data: unknown) => void;
+}
+
+function asInternals(module: ReturnType<typeof createPaymentsModule>): ModuleInternals {
+  return module as unknown as ModuleInternals;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Issue #387 — V6-RECOVER permanent-mismatch durable invalid status', () => {
+  let storage: InMemoryStorage;
+  let module: ReturnType<typeof createPaymentsModule>;
+  let internal: ModuleInternals;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storage = makeStorage();
+    module = setupModule(storage);
+    internal = asInternals(module);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // applyV6RecoverPermanentInvalidStatus — pure mechanics
+  // ---------------------------------------------------------------------------
+
+  describe('applyV6RecoverPermanentInvalidStatus()', () => {
+    it('flips matching pending tokens to invalid', () => {
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, {
+        reason: 'permanent recipient-address mismatch (HD-index recovery exhausted)',
+        ts: 1_700_000_000_000,
+      });
+
+      const patched = internal.applyV6RecoverPermanentInvalidStatus();
+      expect(patched).toBe(1);
+      expect(internal.tokens.get(t.id)?.status).toBe('invalid');
+    });
+
+    it('is a no-op when the ledger is empty (hot path)', () => {
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      internal.tokens.set(t.id, t);
+
+      const patched = internal.applyV6RecoverPermanentInvalidStatus();
+      expect(patched).toBe(0);
+      expect(internal.tokens.get(t.id)?.status).toBe('pending');
+    });
+
+    it('leaves confirmed tokens alone (different tokenId, same ledger)', () => {
+      const stranded = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      // A wholly unrelated confirmed token — must NOT be touched even
+      // though the ledger is non-empty.
+      const goodId = 'b'.repeat(64);
+      const good = makeStrandedToken(goodId, 'confirmed');
+      internal.tokens.set(stranded.id, stranded);
+      internal.tokens.set(good.id, good);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, {
+        reason: 'permanent structural failure',
+        ts: 1,
+      });
+
+      internal.applyV6RecoverPermanentInvalidStatus();
+      expect(internal.tokens.get(stranded.id)?.status).toBe('invalid');
+      expect(internal.tokens.get(good.id)?.status).toBe('confirmed');
+    });
+
+    it('does not re-touch tokens already marked invalid (idempotent)', () => {
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'invalid');
+      const originalUpdatedAt = t.updatedAt;
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+
+      const patched = internal.applyV6RecoverPermanentInvalidStatus();
+      expect(patched).toBe(0);
+      expect(internal.tokens.get(t.id)?.updatedAt).toBe(originalUpdatedAt);
+    });
+
+    it('skips spent tokens (terminal state)', () => {
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'spent');
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+
+      const patched = internal.applyV6RecoverPermanentInvalidStatus();
+      expect(patched).toBe(0);
+      expect(internal.tokens.get(t.id)?.status).toBe('spent');
+    });
+
+    it('resolves canonical-id-first when the map key is a UUID', () => {
+      // Simulates the Nostr-replay shape: addToken assigned a fresh
+      // UUID as `token.id`, but `sdkData` still carries the canonical
+      // genesis tokenId. Lookup MUST resolve via sdkData.
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending', 'uuid-1234-not-canonical');
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+
+      const patched = internal.applyV6RecoverPermanentInvalidStatus();
+      expect(patched).toBe(1);
+      expect(internal.tokens.get('uuid-1234-not-canonical')?.status).toBe('invalid');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // aggregateTokens / getBalance — balance MUST exclude ledgered tokens
+  // ---------------------------------------------------------------------------
+
+  describe('getBalance() / aggregateTokens()', () => {
+    it('excludes amount of a ledgered token from confirmed AND unconfirmed totals', () => {
+      const stranded = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      internal.tokens.set(stranded.id, stranded);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+
+      // No applyV6RecoverPermanentInvalidStatus() call here — this
+      // tests the defense-in-depth filter inside aggregateTokens.
+      const balance = module.getBalance();
+      const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+      // Either no UCT entry at all (no other UCT tokens) or zero
+      // contribution from the ledgered one. The polluted token MUST
+      // NOT show up in either confirmed or unconfirmed.
+      if (uct) {
+        expect(uct.confirmedAmount).toBe('0');
+        expect(uct.unconfirmedAmount).toBe('0');
+        expect(uct.tokenCount).toBe(0);
+      } else {
+        expect(uct).toBeUndefined();
+      }
+    });
+
+    it('still includes a non-ledgered token of the same coin', () => {
+      const stranded = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      const goodId = 'd'.repeat(64);
+      const good = makeStrandedToken(goodId, 'confirmed');
+      internal.tokens.set(stranded.id, stranded);
+      internal.tokens.set(good.id, good);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+
+      const balance = module.getBalance();
+      const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+      expect(uct).toBeDefined();
+      // The good (10 UCT) is confirmed; the polluted entry is filtered out.
+      expect(uct!.confirmedAmount).toBe('10');
+      expect(uct!.unconfirmedAmount).toBe('0');
+      expect(uct!.tokenCount).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // restoreV6RecoverPermanent — initial-load ordering: ledger arrives AFTER
+  // loadFromStorageData and must still patch the in-memory token map.
+  // ---------------------------------------------------------------------------
+
+  describe('restoreV6RecoverPermanent()', () => {
+    it('applies invalid status to in-memory tokens after hydration', async () => {
+      // Simulate the initial-load order in PaymentsModule.load():
+      //   1. loadFromStorageData (re-creates tokens at status='pending')
+      //   2. restoreV6RecoverPermanent (hydrates ledger from storage)
+      // Step 2 MUST patch tokens placed by step 1.
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      internal.tokens.set(t.id, t);
+      storage._store.set(
+        STORAGE_KEYS_ADDRESS.V6_RECOVER_PERMANENT,
+        JSON.stringify([
+          {
+            tokenId: CANONICAL_TOKEN_ID,
+            reason: 'permanent recipient-address mismatch (HD-index recovery exhausted)',
+            ts: 1_700_000_000_000,
+          },
+        ]),
+      );
+
+      await internal.restoreV6RecoverPermanent();
+      expect(internal.tokens.get(t.id)?.status).toBe('invalid');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // loadFromStorageData — TXF round-trip must NOT strip the verdict.
+  // ---------------------------------------------------------------------------
+
+  describe('loadFromStorageData() preserves the ledger verdict across TXF round-trip', () => {
+    it('re-applies invalid status to tokens whose status was reset to pending by determineTokenStatus', () => {
+      // Pre-seed: ledger has the verdict already in memory (e.g. after
+      // a prior restoreV6RecoverPermanent).
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, {
+        reason: 'permanent recipient-address mismatch (HD-index recovery exhausted)',
+        ts: 1_700_000_000_000,
+      });
+
+      // Simulate sync() calling loadFromStorageData with a TXF payload
+      // that contains the stranded token. parseTxfStorageData →
+      // txfToToken → determineTokenStatus will materialize the in-memory
+      // token at status='pending' (the TXF can't encode 'invalid'), so
+      // the post-load patch MUST flip it back to 'invalid'.
+      const txfPayload = {
+        _meta: {
+          formatVersion: '2.0',
+          address: 'alpha1test',
+          timestamp: Date.now(),
+        },
+        [`_${CANONICAL_TOKEN_ID}`]: makeStrandedTxf(CANONICAL_TOKEN_ID),
+      };
+
+      internal.loadFromStorageData(txfPayload);
+
+      // After the load, the in-memory token MUST be 'invalid'.
+      const loadedToken = internal.tokens.get(CANONICAL_TOKEN_ID);
+      expect(loadedToken).toBeDefined();
+      expect(loadedToken!.status).toBe('invalid');
+
+      // And the balance MUST exclude it — both the status filter and
+      // the belt-and-braces ledger filter agree.
+      const balance = module.getBalance();
+      const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+      if (uct) {
+        expect(uct.confirmedAmount).toBe('0');
+        expect(uct.unconfirmedAmount).toBe('0');
+      } else {
+        expect(uct).toBeUndefined();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addToken — Nostr at-least-once replay must respect the ledger
+  // ---------------------------------------------------------------------------
+
+  describe('addToken() honors the ledger on Nostr at-least-once replay', () => {
+    it('marks a replayed token as invalid before insertion', async () => {
+      // Stamp the ledger first — simulating a prior session that
+      // classified the token as permanently invalid.
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, {
+        reason: 'permanent recipient-address mismatch (HD-index recovery exhausted)',
+        ts: 1_700_000_000_000,
+      });
+
+      // Build an incoming token shaped exactly as the Nostr replay
+      // would deliver it: status='pending', sdkData carries canonical
+      // tokenId. addToken sees the ledger match and persists 'invalid'.
+      const incoming = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending', 'uuid-fresh-from-nostr');
+      const ok = await module.addToken(incoming);
+      expect(ok).toBe(true);
+
+      const stored = internal.tokens.get('uuid-fresh-from-nostr');
+      expect(stored).toBeDefined();
+      expect(stored!.status).toBe('invalid');
+
+      // Balance still correct.
+      const balance = module.getBalance();
+      const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+      if (uct) {
+        expect(uct.unconfirmedAmount).toBe('0');
+      } else {
+        expect(uct).toBeUndefined();
+      }
+    });
+
+    it('does NOT reject the addToken (cursor advancement)', async () => {
+      // If addToken returned false for a ledger match, handleIncomingTransfer
+      // would refuse to advance the Nostr at-least-once cursor, causing
+      // perpetual replay. Verify we accept the write while marking invalid.
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+      const incoming = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      const ok = await module.addToken(incoming);
+      expect(ok).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Full acceptance criteria from issue #387
+  // ---------------------------------------------------------------------------
+
+  describe('Acceptance criteria', () => {
+    it('AC1: invalid status survives a CLI restart (storage round-trip)', async () => {
+      // Session A: stamp the ledger and place the token at 'invalid'.
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'invalid');
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, {
+        reason: 'permanent recipient-address mismatch (HD-index recovery exhausted)',
+        ts: 1_700_000_000_000,
+      });
+      const saveLedger = internal as unknown as {
+        saveV6RecoverPermanent: () => Promise<void>;
+      };
+      await saveLedger.saveV6RecoverPermanent();
+
+      // Session B: brand-new module instance, same storage.
+      const module2 = setupModule(storage);
+      const internal2 = asInternals(module2);
+
+      // Simulate the load() ordering: loadFromStorageData first (with
+      // the same token shape as the TXF would yield), then
+      // restoreV6RecoverPermanent.
+      const txfPayload = {
+        _meta: { formatVersion: '2.0', address: 'alpha1test', timestamp: Date.now() },
+        [`_${CANONICAL_TOKEN_ID}`]: JSON.parse(t.sdkData!),
+      };
+      internal2.loadFromStorageData(txfPayload);
+      // Right after loadFromStorageData (and before
+      // restoreV6RecoverPermanent), the in-memory token is BACK to
+      // 'pending' because determineTokenStatus only knows
+      // pending/confirmed. This is the exact failure mode.
+      expect(internal2.tokens.get(CANONICAL_TOKEN_ID)?.status).toBe('pending');
+
+      // restoreV6RecoverPermanent then re-applies the ledger.
+      await internal2.restoreV6RecoverPermanent();
+      expect(internal2.tokens.get(CANONICAL_TOKEN_ID)?.status).toBe('invalid');
+    });
+
+    it('AC2: getBalance() excludes the amount in both confirmed AND unconfirmed', () => {
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+
+      const balance = module.getBalance();
+      const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+      if (uct) {
+        expect(uct.confirmedAmount).toBe('0');
+        expect(uct.unconfirmedAmount).toBe('0');
+        expect(uct.confirmedTokenCount).toBe(0);
+        expect(uct.unconfirmedTokenCount).toBe(0);
+      } else {
+        expect(uct).toBeUndefined();
+      }
+    });
+
+    it('AC3: recoverStrandedReceivedTokens does not re-attempt finalization on T', async () => {
+      // Stamp the ledger and place a token that would otherwise look
+      // like a recoverable stranded receive.
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, {
+        reason: 'permanent recipient-address mismatch (HD-index recovery exhausted)',
+        ts: 1,
+      });
+
+      // Call recoverStrandedReceivedTokens — it MUST short-circuit and
+      // return 0 (no jobs registered).
+      const recoverFn = (
+        internal as unknown as { recoverStrandedReceivedTokens: () => Promise<number> }
+      ).recoverStrandedReceivedTokens;
+      const registered = await recoverFn.call(internal);
+      expect(registered).toBe(0);
+    });
+
+    it('AC4 (regression): full round-trip — load, sync, balance, recover all agree', async () => {
+      // End-to-end: stamp the ledger, simulate a sync() that re-runs
+      // loadFromStorageData, then verify status, balance, and recover
+      // all reflect the verdict consistently.
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, {
+        reason: 'permanent recipient-address mismatch (HD-index recovery exhausted)',
+        ts: 1,
+      });
+
+      // Pretend a sync flush arrived with the same TXF.
+      const txfPayload = {
+        _meta: { formatVersion: '2.0', address: 'alpha1test', timestamp: Date.now() },
+        [`_${CANONICAL_TOKEN_ID}`]: makeStrandedTxf(CANONICAL_TOKEN_ID),
+      };
+      internal.loadFromStorageData(txfPayload);
+
+      // (a) Status reflects ledger.
+      expect(internal.tokens.get(CANONICAL_TOKEN_ID)?.status).toBe('invalid');
+
+      // (b) Balance excludes the polluted token.
+      const balance = module.getBalance();
+      const uct = balance.find((a) => a.coinId === UCT_COIN_ID);
+      if (uct) {
+        expect(uct.confirmedAmount).toBe('0');
+        expect(uct.unconfirmedAmount).toBe('0');
+      } else {
+        expect(uct).toBeUndefined();
+      }
+
+      // (c) Recover scan short-circuits.
+      const recoverFn = (
+        internal as unknown as { recoverStrandedReceivedTokens: () => Promise<number> }
+      ).recoverStrandedReceivedTokens;
+      const registered = await recoverFn.call(internal);
+      expect(registered).toBe(0);
+    });
+  });
+});

--- a/tests/unit/modules/PaymentsModule.v6-recover-invalid-status-387.test.ts
+++ b/tests/unit/modules/PaymentsModule.v6-recover-invalid-status-387.test.ts
@@ -548,6 +548,147 @@ describe('Issue #387 — V6-RECOVER permanent-mismatch durable invalid status', 
       expect(registered).toBe(0);
     });
 
+    // -------------------------------------------------------------------------
+    // Issue #389 review-follow-up regressions (PR #388 hardening).
+    // -------------------------------------------------------------------------
+
+    it('#389 #1: finalizeReceivedToken skips status write for a ledgered token', async () => {
+      // Stamp the ledger BEFORE the in-memory token would otherwise
+      // be marked confirmed by a stale proof-polling callback.
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, {
+        reason: 'permanent recipient-address mismatch (HD-index recovery exhausted)',
+        ts: 1,
+      });
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'invalid');
+      internal.tokens.set(t.id, t);
+
+      // Pretend a polling job was registered (we manipulate the
+      // private map directly so the cleanup branch can be exercised).
+      const pollJobs = (internal as unknown as {
+        proofPollingJobs: Map<string, unknown>;
+      }).proofPollingJobs;
+      pollJobs.set(t.id, {} as unknown);
+
+      // Call finalizeReceivedToken directly. Without the #389 #1
+      // guard, this method would build `{ ...token, status: 'confirmed' }`
+      // and clobber the ledgered 'invalid' verdict. With the guard,
+      // it must short-circuit and leave the token at 'invalid'.
+      const fin = (internal as unknown as {
+        finalizeReceivedToken: (
+          tokenId: string,
+          src: unknown,
+          commit: unknown,
+        ) => Promise<void>;
+      }).finalizeReceivedToken;
+      await fin.call(internal, t.id, {}, {});
+
+      expect(internal.tokens.get(t.id)?.status).toBe('invalid');
+      // Polling job cleanup runs (best-effort).
+      expect(pollJobs.has(t.id)).toBe(false);
+    });
+
+    it('#389 #4: addToken patches caller reference IN PLACE (event payloads see invalid)', async () => {
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+      // The caller hangs on to `incoming` and reads its status AFTER
+      // addToken returns (mirrors handleIncomingTransfer's pattern).
+      const incoming = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending', 'uuid-caller-ref');
+      expect(incoming.status).toBe('pending');
+      await module.addToken(incoming);
+      // The caller's own reference now reflects the patch — not just
+      // the entry inside `this.tokens`. Without in-place mutation,
+      // `incoming.status` would still read 'pending' here.
+      expect(incoming.status).toBe('invalid');
+      expect(internal.tokens.get('uuid-caller-ref')?.status).toBe('invalid');
+    });
+
+    it('#389 #5: updateToken coerces incoming non-invalid status to invalid when ledgered', async () => {
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+      // A pre-existing entry that addToken seeded as 'invalid'.
+      const existing = makeStrandedToken(CANONICAL_TOKEN_ID, 'invalid');
+      internal.tokens.set(existing.id, existing);
+
+      // A future caller hands updateToken the same token but at
+      // 'confirmed' — pretending to finalize. The ledger guard must
+      // coerce it back to 'invalid' BEFORE the map.set.
+      const incoming = makeStrandedToken(CANONICAL_TOKEN_ID, 'confirmed');
+      await module.updateToken(incoming);
+      expect(incoming.status).toBe('invalid');
+      expect(internal.tokens.get(incoming.id)?.status).toBe('invalid');
+    });
+
+    it('#389 #8: scheduleResolveUnconfirmed does NOT arm the timer when only ledgered tokens are pending', () => {
+      // Place a ledgered token at 'pending' (still un-patched — the
+      // cold-start window). Without the #389 #8 guard, the some()
+      // predicate matches and the timer is armed.
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+
+      const schedule = (internal as unknown as {
+        scheduleResolveUnconfirmed: () => void;
+      }).scheduleResolveUnconfirmed;
+      // Sanity: timer is not running before.
+      const timerSlot = internal as unknown as {
+        resolveUnconfirmedTimer: unknown;
+      };
+      timerSlot.resolveUnconfirmedTimer = null;
+
+      schedule.call(internal);
+      // With the guard, the predicate finds nothing and returns early.
+      expect(timerSlot.resolveUnconfirmedTimer).toBeNull();
+    });
+
+    it('#389 #9: getTokens() returns invalid-view for ledgered tokens even pre-patch', () => {
+      // Place a ledgered token at 'pending' BEFORE
+      // applyV6RecoverPermanentInvalidStatus has been called — the
+      // cold-start race window the lazy filter closes.
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'pending');
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+
+      // The in-memory entry is still 'pending' (we deliberately did
+      // NOT call applyV6RecoverPermanentInvalidStatus).
+      expect(internal.tokens.get(t.id)?.status).toBe('pending');
+
+      // But getTokens() returns the patched view.
+      const all = module.getTokens();
+      const observed = all.find((tk) => tk.id === t.id);
+      expect(observed).toBeDefined();
+      expect(observed!.status).toBe('invalid');
+    });
+
+    it('#389 #10: applyV6RecoverPermanentInvalidStatus skips transferring (in-flight send safety)', () => {
+      // A token mid-send: status='transferring' indicates an outbound
+      // commit is in-flight. The ledger MUST NOT flip it — that would
+      // abort the send.
+      const t = makeStrandedToken(CANONICAL_TOKEN_ID, 'transferring');
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+
+      const patched = internal.applyV6RecoverPermanentInvalidStatus();
+      expect(patched).toBe(0);
+      expect(internal.tokens.get(t.id)?.status).toBe('transferring');
+    });
+
+    it('#389 #13: applyV6RecoverPermanentInvalidStatus does NOT bump updatedAt', () => {
+      const ORIGINAL_TS = 1_700_000_000_000;
+      const t: Token = {
+        ...makeStrandedToken(CANONICAL_TOKEN_ID, 'pending'),
+        updatedAt: ORIGINAL_TS,
+      };
+      internal.tokens.set(t.id, t);
+      internal.v6RecoverPermanent.set(CANONICAL_TOKEN_ID, { reason: 'x', ts: 1 });
+
+      internal.applyV6RecoverPermanentInvalidStatus();
+
+      const patched = internal.tokens.get(t.id);
+      expect(patched).toBeDefined();
+      expect(patched!.status).toBe('invalid');
+      // The status flip alone is the signal; updatedAt is reserved
+      // for genuine downstream-meaningful changes.
+      expect(patched!.updatedAt).toBe(ORIGINAL_TS);
+    });
+
     it('AC4 (regression): full round-trip — load, sync, balance, recover all agree', async () => {
       // End-to-end: stamp the ledger, simulate a sync() that re-runs
       // loadFromStorageData, then verify status, balance, and recover


### PR DESCRIPTION
Closes #387, closes #389, closes #390.

This PR grew from a single-issue fix for #387 into a 3-issue V6-RECOVER hardening bundle. The original #387 work made the permanent-invalid verdict survive restart; the #389 follow-up tightened ledger discipline; and #390 finally fixed the *root cause* — the malformed source-token reconstruction that was producing the spurious "Recipient address mismatch" verdicts in the first place. Bundling keeps the chain of fixes deployable as a unit (each builds on the previous).

## Commits

| SHA | Issue | Summary |
|-----|-------|---------|
| `a9e6242` | #387 | Durable V6-RECOVER `'invalid'` status across reload; balance excludes ledger; soak gate. |
| `bc28737` | #389 | PR #388 review follow-up — V6-RECOVER ledger discipline + decimal-aware soak gate. |
| `e47da61` | #390 | Manual repro (`manual-test-simple-send.sh`) — deterministically reproduces the root-cause failure in ~30 s. |
| `2f9a690` | #390 | Root-cause fix — `recoverStrandedReceivedTokens` rebuilds source-token state from `lastTxJson.data.sourceState` (was: kept top-level recipient-predicate state). |
| `b8b526d` | release | Version bump to `0.0.a1` for downstream testing. |

---

## #387 — Durable V6-RECOVER invalid status (original PR scope)

### Summary

- `v6RecoverPermanent` ledger is now authoritative for balance + recovery (was: silently lost on TXF round-trip).
- `aggregateTokens`, `addToken`, `loadFromStorageData`, `restoreV6RecoverPermanent`, and the V6-RECOVER stamping site all consult / re-apply the ledger via a canonical-id-first lookup helper.
- 16 unit tests + 4 integration tests, both files fail without the fix.
- Soak script gains `assert_no_unconfirmed_after_finalize` gate + confirmed-only balance diff. Testnet soak: ALL GREEN, 779 s.

### Why the bug existed

`txfToToken → determineTokenStatus` re-derives `Token.status` from the TXF transactions array only — `'invalid'` is never encoded. The in-memory `'invalid'` write that `finalizeStrandedReceivedToken` makes after a V6-RECOVER permanent-fail was silently downgraded back to `'pending'` on the next `loadFromStorageData`. `aggregateTokens` then included the unspendable token in unconfirmed UCT.

The `v6RecoverPermanent` ledger added in #378 *was* the right defense-in-depth, but it was only consulted by `recoverStrandedReceivedTokens` and the drain predicate — never by balance aggregation or the Nostr at-least-once re-ingest path. So the verdict survived restart on disk but the polluted balance kept resurfacing.

### What the fix does

1. **New helper** `applyV6RecoverPermanentInvalidStatus()` patches in-memory tokens to `'invalid'` based on the ledger.
2. **Called at end of `loadFromStorageData`** — survives initial load AND every `sync()` reload.
3. **Called at end of `restoreV6RecoverPermanent`** — handles cold-start ordering (ledger arrives after tokens).
4. **`aggregateTokens` belt-and-braces filter** — balance NEVER includes a ledgered token.
5. **`addToken` ledger-aware ingest** — Nostr at-least-once replay persists incoming token as `'invalid'` (still returns `true` so cursor advances; rejecting would cause perpetual replay).
6. **Canonical-id-first lookup** — new `isV6RecoverPermanentToken(token, mapKey?)` extracts canonical genesis tokenId from `sdkData` with map-key fallback (handles UUID-keyed `addToken` entries).
7. **`finalizeStrandedReceivedToken`** keys the ledger by canonical genesis tokenId (was: map key — ambiguous post-replay) and awaits the save (was: fire-and-forget).

---

## #389 — PR #388 review follow-up: ledger discipline + decimal-aware soak gate

Bundled hardening from the review of the #387 commit:

- Tighter ledger guards on the V6-RECOVER stamping site (no fire-and-forget on the persist).
- Decimal-aware unconfirmed-residue gate in `manual-test-full-recovery.sh` so any non-zero fractional UCT residue post-finalize fails the soak — previously the gate's integer-only regex passed `0.0000001` silently.

---

## #390 — Root cause: source-token state-reconstruction bug

### Symptom

`sphere payments send <amount> UCT @<recipient>` on two freshly-created testnet wallets produced a token whose recipient predicate appeared not to bind to the recipient's HD signers. Bob's `payments receive --finalize` hit `VerificationError: Recipient address mismatch` and #387 stamped the durable permanent-invalid verdict. End-to-end: alice -10 UCT confirmed, bob +0 UCT — funds effectively lost. The PR #388 soak (`manual-test-full-recovery.sh`) passed end-to-end because §D exercises the invoice-payment path; the direct-send path (`sphere payments send`) was broken on every fresh send.

### Root cause (NOT what the issue body hypothesised)

The send path was correct — alice resolved `@bob` to bob's published `directAddress` and minted a transfer commitment targeting it. The bug was in **bob's V6-RECOVER recovery path**, specifically in `recoverStrandedReceivedTokens` (~line 9626 pre-fix):

```typescript
const sourceTokenJsonObj = {
  ...parsed,
  transactions: txs.slice(0, -1),     // strip the last unfinalized tx
};
```

This rebuilt the source-at-state-N-1 by spreading the persisted `parsed` JSON and stripping the last transaction. But it **kept the top-level `state` field unchanged.** For instant-mode receives, the ingestion path (`saveCommitmentOnlyToken` and the UXF receive at line 2807) writes `state.predicate = recipient_predicate` so the on-disk shape advertises bob as owner once finalize completes. The source token used by `Token.update → transaction.verify → verifyRecipient` therefore exposed `state.predicate.publicKey = bob` while `genesis.data.recipient = alice's directAddress` — the SDK unconditionally returned `'Recipient address mismatch'`.

#387/#388/#389 only stamped the durable verdict — they did NOT fix this construction. #390 is the actual root cause.

### Fix

Replace `state` with `lastTxJson.data.sourceState` (= alice's mint state, the sender's predicate at state N-1):

```typescript
const sourceTokenJsonObj = {
  ...parsed,
  state: (lastTxJson.data as { sourceState?: unknown }).sourceState,  // ← #390
  transactions: txs.slice(0, -1),
};
```

Mirrors the correct pattern already in `tryLocalFinalizeUnconfirmed` (~line 10249) and the UXF assembly path (~line 16284).

### Regression coverage

- **Unit:** `PaymentsModule.proof-polling-persistence.test.ts` — *"recoverStrandedReceivedTokens rewrites sourceTokenJson.state to the transfer sourceState (#390)"* — pins the invariant by inserting distinct markers in the top-level state vs the last-tx `sourceState` and asserting the registered proof-polling job's `sourceTokenJson` carries the SENDER's marker. Fails without the fix.
- **E2E:** `manual-test-simple-send.sh` (committed in `e47da61`, ~30 s against testnet). Pre-fix reliably `ASSERT FAIL (bob-confirmed-rise-10-UCT)`; post-fix all 4 ASSERT OK.

---

## Test plan

- [x] `npx vitest run tests/unit/modules/` → 1804 pass (0 fail; pre-existing flake on AccountingModule invoice-payment-attribution reproduced once across two runs, unrelated to this PR)
- [x] `npx vitest run tests/unit/modules/PaymentsModule.proof-polling-persistence.test.ts` → 29 pass (includes new #390 regression test)
- [x] `npx vitest run tests/unit/modules/PaymentsModule.v6-recover-invalid-status-387.test.ts` → 23 pass
- [x] `npx vitest run tests/unit/modules/PaymentsModule.v6-recover-permanent-378.test.ts` → 5 pass
- [x] **Manual repro (`manual-test-simple-send.sh`)** → ALL GREEN — alice -10 UCT, bob +10 UCT, both CONFIRMED, no residue
- [x] `manual-test-full-recovery.sh` soak — ALL GREEN at 513 s, 14 ASSERT OK (per #389 verification)

## Acceptance criteria (#390)

- [x] A fresh alice → fresh bob `sphere payments send 10 UCT @bob` followed by `sphere payments receive --finalize` on bob's side leaves bob with **+10 UCT CONFIRMED** and **0 unconfirmed**, NO V6-RECOVER permanent-verdict fires.
- [x] Alice's CONFIRMED balance drops by exactly 10 UCT (smallest-unit integer comparison — no float coercion).
- [x] Manual reproduction (`manual-test-simple-send.sh`) gates an end-to-end clean run.
- [x] Regression unit test pinning the source-state reconstruction invariant.