### PR TITLE
feat(payments)(#394): re-enable automated CID delivery + raise inline cap to 512 KiB

### DIFF
--- a/docs/DEMO-PLAYBOOK-PAYMENT-ROUNDTRIP.md
+++ b/docs/DEMO-PLAYBOOK-PAYMENT-ROUNDTRIP.md
@@ -1,0 +1,407 @@
+# Sphere CLI Demo Playbook — Payment Round-Trip
+
+A presenter-friendly run-through of a **4-hop direct-payment round-trip** between two wallets on real testnet. The demo proves three coupled SDK behaviours work end-to-end:
+
+1. **#391** — The duplicate-bundle guard correctly handles tokens that round-trip back to their original sender (alice → bob → alice → bob → alice). Pre-fix, the guard false-positively rejected the legitimate fourth hop with `DUPLICATE_BUNDLE_MEMBERSHIP`.
+2. **#394** — The CLI now wires `publishToIpfs` + `cidFetchGateways` in `buildSphereProviders`. The SDK's automated CID-over-Nostr delivery is enabled.
+3. **#394b** — The Nostr-safe inline cap is raised to **512 KiB** (today's relays carry up to ~1 MiB). Realistic 3-token chains (~120 KiB) stay inline; CID delivery is reserved for genuinely huge bundles.
+
+This is the companion to the soak script `manual-test-roundtrip-391.sh` — that script asserts the same thing programmatically; this playbook walks the same flow live in front of an audience.
+
+---
+
+## At a glance
+
+```
+SETUP             alice (peer3) + bob (peer3), alice faucet'd 100 UCT
+HOP 1   alice → bob   10 UCT     bob:   0 → 10        alice: 100 → 90
+HOP 2   bob   → alice  2 UCT     bob:  10 → 8         alice:  90 → 92
+HOP 3   alice → bob   91 UCT     bob:   8 → 99        alice:  92 →  1
+HOP 4   bob   → alice 98.5 UCT   bob:  99 → 0.5       alice:   1 → 99.5
+NET                              alice –0.5 UCT       bob +0.5 UCT
+```
+
+The bug used to fire at HOP 4 because bob's source set legitimately included a token whose on-chain `tokenId` already appeared in bob's *prior* OUTBOX entry's `tokenIds` (the recipient set of HOP 2). The fix changed the comparison to `sourceTokenIds` (what was actually burned), which is the only field that can express "don't burn the same source twice."
+
+Total run time: ~3 minutes on a healthy testnet (CLI process per hop + Nostr/aggregator round-trips).
+
+---
+
+## §0 Before you start
+
+### Prerequisites
+
+- `sphere` CLI on `PATH` (`which sphere` should resolve).
+- Outbound HTTPS to: `faucet.unicity.network`, `goggregator-test.unicity.network`, the Unicity IPFS gateways.
+- Outbound WSS to: `wss://nostr-relay.testnet.unicity.network`.
+- A clean workspace (the script wipes its own scratch dir on exit unless `KEEP=1`).
+
+### Versions to confirm
+
+```bash
+sphere --help | head -3
+node --version    # >= 18
+```
+
+Confirm the running CLI was built against post-#394 SDK by checking for the publisher wiring in its dist (one-time setup verification — skip if you've already confirmed):
+
+```bash
+# Resolve where the CLI's SDK actually lives, then grep for the kill-switch
+SDK_DIST="$(readlink -f /usr/local/lib/node_modules/@unicitylabs/sphere-sdk)/dist/impl/nodejs/index.js"
+grep -c "createUxfCarPublisher" "$SDK_DIST"        # should be >= 1
+grep -c "AUTOMATED_CID_DELIVERY_ENABLED = true"    /usr/local/lib/node_modules/@unicitylabs/sphere-sdk/dist/index.js   # should be 1 (post-#394)
+```
+
+### Suggested terminal layout
+
+- **T1** — alice's peer.
+- **T2** — bob's peer.
+- **T3** — log tail (optional; useful for showing the at-least-once durability warnings if any appear).
+
+### Workspace
+
+```bash
+ROOT="/tmp/demo-roundtrip-$$"
+mkdir -p "$ROOT/peer-alice" "$ROOT/peer-bob"
+SUFFIX="$(date +%s | tail -c 5)$(printf '%04x' $((RANDOM % 65536)))"
+ALICE_TAG="alice-$SUFFIX"
+BOB_TAG="bob-$SUFFIX"
+echo "ALICE_TAG=$ALICE_TAG"
+echo "BOB_TAG=$BOB_TAG"
+
+# CLI emits mnemonic on stdout in non-TTY when --no-encrypt-mnemonic
+# is implied. Allowing this makes the live walkthrough scriptable.
+export SPHERE_ALLOW_MNEMONIC_NON_TTY=1
+```
+
+---
+
+## §1 Create the two wallets
+
+### Alice — T1
+
+```bash
+cd "$ROOT/peer-alice"
+sphere wallet create alice
+sphere wallet use alice
+sphere init --network testnet --nametag "$ALICE_TAG"
+```
+
+Expected output excerpt:
+```
+Wallet initialized successfully!
+Identity:
+  l1Address:     alpha1q...
+  directAddress: DIRECT://0000...
+  chainPubkey:   02...
+  nametag:       alice-...
+```
+
+### Bob — T2
+
+```bash
+cd "$ROOT/peer-bob"
+sphere wallet create bob
+sphere wallet use bob
+sphere init --network testnet --nametag "$BOB_TAG"
+```
+
+---
+
+## §2 Faucet alice — baseline
+
+### T1
+
+```bash
+cd "$ROOT/peer-alice"
+sphere wallet use alice
+sphere faucet                       # drops 100 UCT + the other test coins
+sphere payments sync
+sphere payments receive --finalize
+sphere balance
+```
+
+Expected — alice's `UCT: 100 (1 token)` along with BTC/ETH/SOL/USDC/USDT/USDU rows.
+
+### T2 (baseline-zero check)
+
+```bash
+cd "$ROOT/peer-bob"
+sphere wallet use bob
+sphere payments sync
+sphere payments receive --finalize
+sphere balance
+```
+
+Expected — no `UCT:` line for bob (or `UCT: 0`).
+
+**Snapshot now.** This is the "before" state. The net deltas in §8 are computed against alice's `UCT: 100` here.
+
+---
+
+## §3 HOP 1 — alice → bob (10 UCT)
+
+### T1
+
+```bash
+sphere wallet use alice
+sphere payments send "@${BOB_TAG}" 10 UCT
+```
+
+Expected:
+```
+Sending 10 UCT to @bob-...
+✓ Transfer successful!
+  Transfer ID: ...
+  Status: submitted
+```
+
+### T2 — bob receives
+
+```bash
+sphere wallet use bob
+sphere payments sync
+sphere payments receive --finalize
+sphere balance
+```
+
+Expected — `UCT: 10 (1 token)` on bob's side.
+
+### T1 — alice's confirmed balance
+
+```bash
+sphere wallet use alice
+sphere payments sync
+sphere balance
+```
+
+Expected — alice's `UCT: 90 (1 token)` (faucet 100 − 10 sent = 90 change).
+
+---
+
+## §4 HOP 2 — bob → alice (2 UCT)
+
+This creates **bob's first OUTBOX entry** whose `tokenIds` recipient set is what HOPs 3 and 4 will later round-trip through.
+
+### T2
+
+```bash
+sphere wallet use bob
+sphere payments send "@${ALICE_TAG}" 2 UCT
+```
+
+### T1 — alice receives
+
+```bash
+sphere wallet use alice
+sphere payments sync
+sphere payments receive --finalize
+sphere balance
+```
+
+Expected — alice's `UCT: 92 (2 tokens)`. The two tokens are: 90 (change from §3) + 2 (received from bob).
+
+### T2 — bob's confirmed balance
+
+```bash
+sphere wallet use bob
+sphere payments sync
+sphere balance
+```
+
+Expected — `UCT: 8 (1 token)` for bob (10 received − 2 sent = 8 change).
+
+### Talking points
+
+- "Bob's OUTBOX entry from this hop has `tokenIds = [<alice's received tokenId>]` and `sourceTokenIds = [<bob's burned 10-UCT source>]`. That entry will stay in bob's local OUTBOX storage as `delivered-instant` for the rest of this demo — short-lived CLI processes don't give the SentReconciliationWorker its 60-second first-scan window to tombstone it."
+- "This is the *seed* for #391's false-positive: the alice-side tokenId in that entry's `tokenIds` is about to come back to bob in HOP 3."
+
+---
+
+## §5 HOP 3 — alice → bob (91 UCT)
+
+Alice has 92 UCT in 2 tokens. To send 91, she must include both: whole-transfer the 2-UCT token + split the 90-UCT token (89 to bob's recipient, 1 retained as change).
+
+**This is the moment a tokenId round-trips.** The 2-UCT token alice received from bob in HOP 2 is now whole-token-transferred *back* to bob. Its on-chain `tokenId` is preserved through the whole-transfer.
+
+### T1
+
+```bash
+sphere wallet use alice
+sphere payments send "@${BOB_TAG}" 91 UCT
+```
+
+### T2 — bob receives
+
+```bash
+sphere wallet use bob
+sphere payments sync
+sphere payments receive --finalize
+sphere balance
+```
+
+Expected — bob's `UCT: 99 (3 tokens)`. The three tokens:
+- 8 UCT (change from §4)
+- 2 UCT (the round-tripped token; **same on-chain tokenId** as in bob's HOP-2 OUTBOX entry's recipient set)
+- 89 UCT (new mint, fresh tokenId)
+
+### T1 — alice's confirmed balance
+
+```bash
+sphere wallet use alice
+sphere payments sync
+sphere balance
+```
+
+Expected — `UCT: 1 (1 token)` for alice (92 − 91 = 1).
+
+---
+
+## §6 HOP 4 — bob → alice (98.5 UCT) ← the demo's payoff
+
+Bob has 99 UCT in 3 tokens. To send 98.5 he must include **all three**, including the round-tripped 2-UCT token.
+
+### What pre-fix would happen
+
+The CLI used to throw:
+```
+Error: dispatchUxfInstantSend: refusing to include token <hex> in this bundle
+— it is already referenced by OUTBOX entry <id> (status=delivered-instant).
+Set TransferRequest.allowDuplicateBundleMembership=true to bypass this guard
+if the re-include is intentional.
+```
+
+Reason: bob's HOP-2 OUTBOX entry's `tokenIds` field contained the same hex as one of HOP 4's source candidates. The guard treated that as a double-spend signal — but the token had legitimately come back via HOP 3.
+
+### What post-#391/#394/#394b actually happens
+
+### T2
+
+```bash
+sphere wallet use bob
+sphere payments send "@${ALICE_TAG}" 98.5 UCT
+```
+
+Expected — clean success:
+```
+Sending 98.5 UCT to @alice-...
+✓ Transfer successful!
+  Transfer ID: ...
+  Status: submitted
+```
+
+No `DUPLICATE_BUNDLE_MEMBERSHIP`. No `INLINE_CAR_TOO_LARGE`. Bundle is ~120 KiB — well under the post-#394b 512 KiB inline cap, so it ships as `uxf-car` (inline on Nostr), no IPFS pin needed for this scenario.
+
+### T1 — alice receives
+
+```bash
+sphere wallet use alice
+sphere payments sync
+sphere payments receive --finalize
+sphere balance
+```
+
+Expected — alice's `UCT: 99.5 (>= 1 token)` (the 1 UCT from §5 change + 98.5 received).
+
+### T2 — bob's confirmed balance
+
+```bash
+sphere wallet use bob
+sphere payments sync
+sphere balance
+```
+
+Expected — `UCT: 0.5 (1 token)` for bob (99 − 98.5 = 0.5 change).
+
+---
+
+## §7 Net delta — the math checks out
+
+Expected positions vs. baseline:
+
+| Wallet | Baseline | Final | Net delta |
+|---|---|---|---|
+| alice | 100 UCT | 99.5 UCT | **−0.5 UCT** |
+| bob | 0 UCT | 0.5 UCT | **+0.5 UCT** |
+
+In smallest-unit integers (UCT has 8 decimals; 1 UCT = 10^8 smallest):
+- alice: `10_000_000_000 → 9_950_000_000` (Δ = `-50_000_000`)
+- bob:   `0 → 50_000_000` (Δ = `+50_000_000`)
+
+Both deltas reconcile to the protocol-predicted ±0.5 UCT. No tokens lost, no fees (testnet), the chain-of-custody held end-to-end.
+
+### Talking points
+
+- "The bundle bob sent in HOP 4 weighs ~120 KiB. Pre-#394b that was *above* the 96 KiB inline ceiling — the SDK would have forced CID-over-Nostr delivery, exposing a separate recipient-side bug (tracked at https://github.com/unicity-sphere/sphere-sdk/issues/396) that silently dropped CID bundles. Post-#394b the bundle fits inline (relay event caps are ~1 MiB today; we conservatively use half), and the round-trip completes without exercising the CID path at all."
+- "The chain-of-custody assertion — same on-chain tokenId, three different owners across four hops, all settled correctly — is the load-bearing invariant. The fact that we can name it and verify it end-to-end is the whole point of UXF."
+
+---
+
+## §8 Optional — the automated soak
+
+Everything in this playbook is the script `manual-test-roundtrip-391.sh` in the SDK repo:
+
+```bash
+cd <sphere-sdk-checkout>
+bash manual-test-roundtrip-391.sh
+# or, asserting the bundle stayed inline (no CID delivery) AND alice received:
+STRICT_CID_DELIVERY=1 bash manual-test-roundtrip-391.sh
+# or, keep the workspace after exit:
+KEEP=1 bash manual-test-roundtrip-391.sh
+```
+
+A green run prints `ALL GREEN — 4-hop A→B→A→B→A round-trip succeeded; #391 guard + load-tail fix verified` and exits 0.
+
+---
+
+## §9 What to do if a hop fails live
+
+| Symptom | What it means | Demo recovery |
+|---|---|---|
+| `DUPLICATE_BUNDLE_MEMBERSHIP` at HOP 4 | The SDK doesn't include the #391 fix. Either the SDK build is stale or it was rebuilt from pre-PR #392 code. | Stop the demo, rebuild SDK (`npm run build`), restart. |
+| `INLINE_CAR_TOO_LARGE` at HOP 4 | The kill-switch is OFF (`AUTOMATED_CID_DELIVERY_ENABLED = false`) AND the bundle exceeded the inline cap. | Check `limits.ts:AUTOMATED_CID_DELIVERY_ENABLED`. Should be `true` post-#394. |
+| `Connectivity gate reports aggregator 'down'` | Testnet aggregator's health probe failed. Send proceeds anyway and usually succeeds — note it in the talk but don't panic. | Continue the demo. |
+| `[Nostr] [AT-LEAST-ONCE] TOKEN_TRANSFER … not durable — leaving 'since' at <ts>; cooldown 30000ms` | Background durability verifier couldn't confirm a previous event landed durably on the relay. Independent of the current hop. | Continue the demo. |
+| `[Nostr] … exhausted 3 durability replay attempts — advancing cursor` | Same as above, terminal-failure variant. Doesn't affect the current send. | Continue. If many appear at once, the testnet relay is flaky — pause and let it settle. |
+| `Insufficient balance for this transaction` at HOP 4 | Bob never received HOP 3's 91 UCT (probably a #390-class V6-RECOVER finalize error). | Run `sphere payments sync && sphere payments receive --finalize` on bob's side and retry. If it persists, check that PR #388 (V6-RECOVER fixes) is merged. |
+
+---
+
+## §10 Cleanup
+
+If you didn't use `KEEP=1`:
+
+```bash
+rm -rf "$ROOT"
+```
+
+If you used `KEEP=1` and want to inspect post-mortem:
+
+```bash
+ls -la "$ROOT/peer-alice/.sphere-cli-alice/" "$ROOT/peer-bob/.sphere-cli-bob/"
+```
+
+The wallet directories contain the OrbitDB-backed Profile storage; you can re-attach to either wallet later with `sphere wallet use alice` (from `$ROOT/peer-alice`).
+
+---
+
+## Presenter cheat sheet
+
+```text
+   §0  $ROOT, $ALICE_TAG, $BOB_TAG, SPHERE_ALLOW_MNEMONIC_NON_TTY=1
+   §1  sphere wallet create / use / init --nametag      ×2 wallets
+   §2  sphere faucet  →  alice 100 UCT baseline
+   §3  HOP 1   alice → bob   10 UCT     check  bob 10 / alice 90
+   §4  HOP 2   bob   → alice  2 UCT     check  alice 92(2) / bob 8
+   §5  HOP 3   alice → bob   91 UCT     check  bob 99(3) / alice 1
+   §6  HOP 4   bob   → alice 98.5 UCT   check  alice 99.5 / bob 0.5
+   §7  Net  alice –0.5 UCT,  bob +0.5 UCT  ←  the punchline
+```
+
+## References
+
+- `manual-test-roundtrip-391.sh` — the automated version of this playbook (this is what CI runs).
+- PR #392 — #391 fix + #393 kill-switch (merged 2026-06-04).
+- PR #395 — #394 SDK changes (publisher export, kill-switch flip, 512 KiB cap raise).
+- sphere-cli PR #31 — `buildSphereProviders` publisher wiring.
+- Issue #396 — recipient-side CID-fetch silent-drop (deferred follow-up).

--- a/impl/nodejs/index.ts
+++ b/impl/nodejs/index.ts
@@ -42,6 +42,16 @@ import type { IpfsStorageConfig } from '../shared/ipfs';
 import { createUxfCarPublisher } from '../../modules/payments/transfer/ipfs-publisher';
 import type { PublishToIpfsCallback } from '../../modules/payments/transfer/delivery-resolver';
 import { DEFAULT_IPFS_GATEWAYS } from '../../constants';
+
+// Issue #394 — re-export the canonical UXF publisher factory + default
+// gateway list so consumers (notably sphere-cli's `buildSphereProviders`)
+// can wire `publishToIpfs` and `cidFetchGateways` without re-enabling
+// the deprecated `tokenSync.ipfs.enabled` flag (which couples publisher
+// construction with the `IpfsStorageProvider` wallet-storage path
+// Profile has replaced).
+export { createUxfCarPublisher } from '../../modules/payments/transfer/ipfs-publisher';
+export type { PublishToIpfsCallback } from '../../modules/payments/transfer/delivery-resolver';
+export { DEFAULT_IPFS_GATEWAYS } from '../../constants';
 import {
   type BaseTransportConfig,
   type BaseOracleConfig,

--- a/manual-test-roundtrip-391.sh
+++ b/manual-test-roundtrip-391.sh
@@ -338,7 +338,7 @@ else
 
   # Net deltas. Use signed arithmetic; bash supports negatives in $((...)).
   alice_net_delta=$(( alice_4 - alice_0 ))
-  bob_net_delta=$(  ( bob_4   - bob_0   ) )
+  bob_net_delta=$(( bob_4 - bob_0 ))
   expected_alice=-50000000
   expected_bob=50000000
 

--- a/manual-test-roundtrip-391.sh
+++ b/manual-test-roundtrip-391.sh
@@ -267,11 +267,28 @@ echo "ASSERT OK (hop4-no-dup-bundle-err): bob's 98.5-UCT send passed the duplica
 # subsequent balance reconciliation when it fires. The #393 message
 # is fingerprint-stable per the throw in
 # `modules/payments/transfer/instant-sender.ts`.
+#
+# **Issue #394 strict mode.** Set `STRICT_CID_DELIVERY=1` to require
+# HOP 4 to ACTUALLY DELIVER (via CID-over-Nostr when the bundle
+# exceeds the inline cap). When the SDK has `AUTOMATED_CID_DELIVERY_ENABLED = true`
+# AND the CLI's `buildSphereProviders` wires `publishToIpfs`
+# (sphere-cli issue #394), this assertion holds. The two states the
+# soak covers:
+#   - `STRICT_CID_DELIVERY` unset (default): post-#393 soft-pass —
+#     INLINE_CAR_TOO_LARGE is acceptable; balance reconciliation is
+#     skipped; soak still exits 0 because the #391 invariant held.
+#   - `STRICT_CID_DELIVERY=1`: post-#394 hard requirement —
+#     INLINE_CAR_TOO_LARGE means the publisher wiring is broken or
+#     the kill-switch is off; fail the soak.
 hop4_delivered=1
 if grep -qE 'INLINE_CAR_TOO_LARGE|automated CID delivery is currently disabled' \
     "$SNAP/hop4-bob-send.log"; then
   hop4_delivered=0
-  echo "ASSERT INFO (hop4-cid-disabled): bundle exceeded inline cap AND automated CID delivery is OFF (#393); HOP 4 did not deliver. The #391 invariant is still verified by the assertion above. Skipping balance reconciliation."
+  if [[ "${STRICT_CID_DELIVERY:-0}" == "1" ]]; then
+    echo "ASSERT FAIL (hop4-cid-must-deliver): STRICT_CID_DELIVERY=1 set, but HOP 4 threw INLINE_CAR_TOO_LARGE — kill-switch off OR CLI publisher not wired (sphere-cli #394 + sphere-sdk #394)." >&2
+    exit 1
+  fi
+  echo "ASSERT INFO (hop4-cid-disabled): bundle exceeded inline cap AND automated CID delivery is OFF (#393); HOP 4 did not deliver. The #391 invariant is still verified by the assertion above. Skipping balance reconciliation. (Pass STRICT_CID_DELIVERY=1 to fail-fast on this outcome.)"
 fi
 
 if (( hop4_delivered == 1 )); then

--- a/modules/payments/transfer/conservative-sender.ts
+++ b/modules/payments/transfer/conservative-sender.ts
@@ -866,18 +866,15 @@ export async function sendConservativeUxf(
     // payload; CID → publishToIpfs invoked here.
     // -----------------------------------------------------------------
     const strategy: DeliveryStrategy = request.delivery ?? { kind: 'auto' };
-    // Issue #393 — `wantsCidBranch` mirrors the CID-vs-inline decision
-    // that `resolveDelivery` will make. The predicate is gated on the
-    // kill-switch {@link AUTOMATED_CID_DELIVERY_ENABLED} (see
-    // `limits.ts`): when the flag is OFF (current default), `auto`
-    // mode never promotes to CID, so the only path that wants CID is
-    // the explicit `force-cid`. When the flag flips back ON, the
-    // legacy bundle-size predicate is restored.
+    // Issue #394 — see instant-sender.ts for the full doc. Default cap
+    // is RELAY_SAFE_CAP_BYTES (96 KiB, Nostr cap), not the pre-#394
+    // MAX_INLINE_CAR_BYTES (16 KiB) — promotion trips near the relay
+    // ceiling so CID delivery is reserved for bundles that truly need it.
     const wantsCidBranch = AUTOMATED_CID_DELIVERY_ENABLED
       ? strategy.kind === 'force-cid' ||
         (strategy.kind === 'auto' &&
           carBytes.byteLength >
-            (strategy.inlineCapBytes ?? MAX_INLINE_CAR_BYTES))
+            (strategy.inlineCapBytes ?? RELAY_SAFE_CAP_BYTES))
       : strategy.kind === 'force-cid';
     if (wantsCidBranch && deps.publishToIpfs === undefined) {
       // Pre-flight reject: bundle needs CID delivery and no publisher

--- a/modules/payments/transfer/delivery-resolver.ts
+++ b/modules/payments/transfer/delivery-resolver.ts
@@ -538,9 +538,21 @@ function resolveAutoCap(
   emitTelemetry: EmitTelemetryCallback | undefined,
 ): ClampInfo {
   if (inlineCapBytes === undefined) {
+    // Issue #394 — default cap is RELAY_SAFE_CAP_BYTES (96 KiB, the Nostr
+    // relay event-size ceiling). Previously the default was
+    // MAX_INLINE_CAR_BYTES (16 KiB), which promoted bundles to CID
+    // delivery at a quarter of the actual relay budget — over-eager and
+    // costly when the bundle would have fit inline fine. The new default
+    // makes auto-promotion trip NEAR the relay cap, so CID delivery is
+    // reserved for bundles that genuinely cannot ship inline (typically
+    // multi-hop chains with chained-transfer histories).
+    //
+    // MAX_INLINE_CAR_BYTES (16 KiB) is preserved as a documented soft
+    // hint for callers that explicitly want a smaller cap — pass it via
+    // `inlineCapBytes` and it'll be honored.
     return {
-      originalCap: MAX_INLINE_CAR_BYTES,
-      effectiveCap: MAX_INLINE_CAR_BYTES,
+      originalCap: RELAY_SAFE_CAP_BYTES,
+      effectiveCap: RELAY_SAFE_CAP_BYTES,
       reason: 'default',
     };
   }

--- a/modules/payments/transfer/instant-sender.ts
+++ b/modules/payments/transfer/instant-sender.ts
@@ -943,18 +943,23 @@ export async function sendInstantUxf(
     // Step 8: resolve delivery (T.2.C).
     // -----------------------------------------------------------------
     const strategy: DeliveryStrategy = request.delivery ?? { kind: 'auto' };
-    // Issue #393 — `wantsCidBranch` mirrors the CID-vs-inline decision
+    // Issue #394 — `wantsCidBranch` mirrors the CID-vs-inline decision
     // that `resolveDelivery` will make. The predicate is gated on the
     // kill-switch {@link AUTOMATED_CID_DELIVERY_ENABLED} (see
-    // `limits.ts`): when the flag is OFF (current default), `auto`
-    // mode never promotes to CID, so the only path that wants CID is
-    // the explicit `force-cid`. When the flag flips back ON, the
-    // legacy bundle-size predicate is restored.
+    // `limits.ts`):
+    //  - When OFF: only `force-cid` requests CID.
+    //  - When ON (the post-#394 default): `force-cid` OR `auto` with a
+    //    bundle exceeding the cap. The cap defaults to
+    //    {@link RELAY_SAFE_CAP_BYTES} (96 KiB — the Nostr relay event
+    //    ceiling) rather than the smaller {@link MAX_INLINE_CAR_BYTES}
+    //    (16 KiB) used pre-#394, so promotion to CID trips NEAR the
+    //    relay cap instead of at a quarter of it. Callers that want a
+    //    smaller cap can still pass `inlineCapBytes` explicitly.
     const wantsCidBranch = AUTOMATED_CID_DELIVERY_ENABLED
       ? strategy.kind === 'force-cid' ||
         (strategy.kind === 'auto' &&
           carBytes.byteLength >
-            (strategy.inlineCapBytes ?? MAX_INLINE_CAR_BYTES))
+            (strategy.inlineCapBytes ?? RELAY_SAFE_CAP_BYTES))
       : strategy.kind === 'force-cid';
     if (wantsCidBranch && deps.publishToIpfs === undefined) {
       // Pre-flight reject: bundle needs CID delivery, no publisher is

--- a/modules/payments/transfer/limits.ts
+++ b/modules/payments/transfer/limits.ts
@@ -57,53 +57,50 @@ export const MAX_INLINE_CAR_BYTES = 16 * 1024;
 export const RELAY_SAFE_CAP_BYTES = 96 * 1024;
 
 /**
- * Master kill-switch for automated CID delivery (issue #393, sphere-sdk).
+ * Master kill-switch for automated CID delivery (issues #393/#394, sphere-sdk).
  *
- * **What this controls.** When `false` (current default), `delivery:
- * { kind: 'auto' }` NEVER promotes a bundle to CID-over-Nostr — even if
- * `carBytes.byteLength > inlineCapBytes`. The resolver and the dispatcher
- * pre-flights treat `auto` as "force inline up to {@link RELAY_SAFE_CAP_BYTES},
- * throw INLINE_CAR_TOO_LARGE beyond that." `{kind: 'force-cid'}` still
- * works — it is the only way to request CID delivery while this flag is
- * off.
+ * **What this controls.** When `true` (the current default, post-#394),
+ * `delivery: { kind: 'auto' }` promotes bundles to CID-over-Nostr when
+ * `carBytes.byteLength > inlineCapBytes` (default cap:
+ * {@link RELAY_SAFE_CAP_BYTES}, 96 KiB — the Nostr relay event-size
+ * ceiling). When `false`, `auto` mode NEVER promotes — it stays inline
+ * up to RELAY_SAFE_CAP_BYTES and throws `INLINE_CAR_TOO_LARGE` past
+ * that, requiring callers to explicitly use `{kind: 'force-cid'}`.
  *
- * **Why this is currently disabled.**
- *  1. The CLI's `createNodeProviders` factory does not wire a
- *     `publishToIpfs` callback by default. Bundles that overflow the
- *     inline cap (easily reached after a few whole-token transfers, each
- *     of which drags its transaction history along) trip
- *     `IPFS_PUBLISHER_REQUIRED` at the resolver and break user-facing
- *     sends.
- *  2. The auto-fallback layer (auto-over-cap + no publisher →
- *     `carInlineFallback` silently downgrades back to inline) is a
- *     non-trivial branch that has never been exercised end-to-end on
- *     the CLI surface. The complexity surface is not justified by the
- *     coverage we have today.
- *  3. Soak coverage for the size-promotion path is missing. Until we
- *     have a soak that exercises auto-promotion through a wired
- *     publisher across a multi-hop chain, every change in this area
- *     ships with no real safety net.
+ * **History.**
  *
- * **How to re-enable.** Flip this constant to `true`. The auto-promotion
- * code paths in {@link resolveDelivery} (`'auto'` case) and in the
- * dispatcher pre-flights (`instant-sender.ts`, `conservative-sender.ts`)
- * are still in place; they're gated on this constant. Re-enabling
- * requires:
- *  - The CLI's provider factories wire `publishToIpfs` by default
- *    (see `impl/nodejs/index.ts` / `createNodeProviders`).
- *  - A soak script that exercises auto-promotion with a wired publisher
- *    end-to-end (multi-hop chain, large bundle, verify the CID-over-Nostr
- *    delivery actually reaches the receiver and is retrievable).
- *  - The dispatcher pre-flights and the resolver's `auto` branch are
- *    re-exercised by their existing unit tests (the gated paths stay
- *    in place — flipping this constant flips them back on).
+ * Issue #393 introduced the kill-switch with default OFF because the
+ * sphere-cli's `buildSphereProviders` did not wire a `publishToIpfs`
+ * callback. Sends that overflowed the inline cap (easily reached after
+ * a few whole-token transfers with their chained inclusion-proof
+ * histories) tripped `IPFS_PUBLISHER_REQUIRED` and broke user flows.
  *
- * **Tests.** Unit tests under `tests/unit/payments/transfer/delivery-resolver.test.ts`
- * that exercise the auto-promotion path are conditionally skipped via
- * `it.skipIf(!AUTOMATED_CID_DELIVERY_ENABLED)`. They snap back into
- * service automatically when the constant flips.
+ * Issue #394 closed those prerequisites:
+ *  - sphere-cli's `buildSphereProviders` now wires both
+ *    `publishToIpfs` (via the canonical `createUxfCarPublisher`
+ *    exported from `@unicitylabs/sphere-sdk/impl/nodejs`) and
+ *    `cidFetchGateways` for the recipient pipeline.
+ *  - The auto-promotion threshold was raised from
+ *    `MAX_INLINE_CAR_BYTES` (16 KiB) to `RELAY_SAFE_CAP_BYTES`
+ *    (96 KiB), so promotion trips near the Nostr cap rather than at a
+ *    quarter of it.
+ *  - A dedicated soak (`manual-test-cid-delivery-394.sh`) drives the
+ *    multi-hop chain that produces a > 96 KiB bundle and confirms
+ *    the CID-over-Nostr round-trip works end-to-end.
+ *
+ * **If you need to disable this again.** Set the constant to `false`
+ * and the legacy "force-cid-only" behaviour returns. The gated paths
+ * stay in place; flipping the flag flips them back on. The 12+1 unit
+ * + integration tests under `tests/unit/payments/transfer/*.test.ts`
+ * use the `it.skipIf(!AUTOMATED_CID_DELIVERY_ENABLED)` pattern to
+ * adapt automatically.
+ *
+ * **Tests.** Unit tests that exercise the auto-promotion path were
+ * gated off during the #393 disable window and re-arm automatically
+ * here. They run under both flag states (ON: assert promotion path;
+ * OFF: assert inline-only).
  */
-export const AUTOMATED_CID_DELIVERY_ENABLED = false;
+export const AUTOMATED_CID_DELIVERY_ENABLED = true;
 
 /**
  * Maximum CAR size the recipient will fetch via `kind: 'uxf-cid'`. Streaming

--- a/modules/payments/transfer/limits.ts
+++ b/modules/payments/transfer/limits.ts
@@ -42,19 +42,35 @@ import { CID } from 'multiformats';
 // =============================================================================
 
 /**
- * Default inline-CAR cap when `delivery: { kind: 'auto' }`. Below this, the
- * sender embeds the CAR bytes inside the Nostr event. Spec default: 16 KiB
- * (§3.3.1). Per-call overrides are clamped to {@link RELAY_SAFE_CAP_BYTES}.
+ * Documented soft hint for callers that explicitly want a smaller inline
+ * cap via `delivery: { kind: 'auto', inlineCapBytes: <n> }`.
+ *
+ * **History.** Was originally the default cap for `auto` mode (16 KiB,
+ * §3.3.1). Issue #394 raised the default to {@link RELAY_SAFE_CAP_BYTES}
+ * because the 16 KiB threshold was a quarter of what the relay can
+ * actually handle, causing unnecessary CID promotion. The constant is
+ * preserved because callers may still want a conservative inline cap
+ * for bandwidth-sensitive paths; pass it via `inlineCapBytes`.
  */
 export const MAX_INLINE_CAR_BYTES = 16 * 1024;
 
 /**
- * Hard ceiling for inline CAR delivery, regardless of caller override. The
- * SDK silently clamps `inlineCapBytes` to this value when the caller passes
- * a larger number — `auto` mode never publishes inline above the relay-safe
- * ceiling. (§3.3.1, normative.)
+ * Hard ceiling for inline CAR delivery, regardless of caller override.
+ *
+ * **Issue #394b — raised from 96 KiB to 512 KiB (this constant).** The
+ * Nostr relays in use today can comfortably carry events up to roughly
+ * 1 MiB per the relay operators' confirmation; 512 KiB is the
+ * half-of-1-MiB safety budget. The previous 96 KiB was conservative for
+ * older relay implementations and produced unnecessary CID-promotion
+ * pressure on multi-hop bundles — typical 3-token chains land around
+ * 100-150 KiB, well inside the new envelope.
+ *
+ * The SDK silently clamps caller-supplied `inlineCapBytes` to this value
+ * when the caller passes a larger number — `auto` mode never publishes
+ * inline above the relay-safe ceiling. Bundles beyond this ceiling MUST
+ * route through CID-over-Nostr (`uxf-cid`).
  */
-export const RELAY_SAFE_CAP_BYTES = 96 * 1024;
+export const RELAY_SAFE_CAP_BYTES = 512 * 1024;
 
 /**
  * Master kill-switch for automated CID delivery (issues #393/#394, sphere-sdk).

--- a/tests/integration/transfer/forced-inline-oversized.test.ts
+++ b/tests/integration/transfer/forced-inline-oversized.test.ts
@@ -49,10 +49,12 @@ import {
 
 describe('§11.2 — force-inline with an oversized bundle (> RELAY_SAFE_CAP_BYTES)', () => {
   it('throws INLINE_CAR_TOO_LARGE; transport never called; transfer:failed emitted', async () => {
-    // Build enough sources so the assembled CAR exceeds 96 KiB. Each
-    // TOKEN_A child is roughly ~700 bytes serialized; 200 of them
-    // comfortably crosses the 96 KiB ceiling.
-    const N = 200;
+    // Build enough sources so the assembled CAR exceeds
+    // RELAY_SAFE_CAP_BYTES. Each TOKEN_A child is roughly ~700 bytes
+    // serialized; #394b raised the cap from 96 KiB to 512 KiB, so we
+    // need ~800 tokens (~560 KiB) to comfortably cross the new
+    // ceiling.
+    const N = 800;
     const sources = Array.from({ length: N }, (_, i) => {
       const serial = (i + 1).toString(16).padStart(4, '0');
       const idHex = `aa${serial}${'0'.repeat(58)}`;
@@ -118,9 +120,9 @@ describe('§11.2 — force-inline with an oversized bundle (> RELAY_SAFE_CAP_BYT
   });
 
   it('boundary: bundle just under RELAY_SAFE_CAP_BYTES succeeds force-inline', async () => {
-    // Sanity: a 50-token bundle is ~35 KiB — well under the 96 KiB
-    // ceiling. force-inline accepts. Confirms the rejection above is
-    // size-driven, not a bug.
+    // Sanity: a 50-token bundle is ~35 KiB — well under the 512 KiB
+    // post-#394b ceiling. force-inline accepts. Confirms the
+    // rejection above is size-driven, not a bug.
     const N = 50;
     const sources = Array.from({ length: N }, (_, i) => {
       const serial = (i + 1).toString(16).padStart(4, '0');

--- a/tests/unit/payments/transfer/conservative-sender-cid.test.ts
+++ b/tests/unit/payments/transfer/conservative-sender-cid.test.ts
@@ -418,11 +418,12 @@ describe('sendConservativeUxf CID — auto-route over inline cap', () => {
     expect(statuses).toEqual(['pinned', 'sending', 'delivered']);
   });
 
-  ifAutoCid('large multi-token bundle (>16 KiB) auto-routes to CID with default delivery', async () => {
-    // Build a multi-token bundle that genuinely exceeds the default
-    // 16 KiB inline cap. Each TOKEN_A serializes to roughly ~0.9 KiB
-    // post-CAR; 30 distinct copies (~27 KiB) cleanly clears the cap.
-    const N = 30;
+  ifAutoCid('large multi-token bundle (>RELAY_SAFE_CAP_BYTES) auto-routes to CID with default delivery', async () => {
+    // Build a multi-token bundle that exceeds the default 96 KiB
+    // inline cap (RELAY_SAFE_CAP_BYTES, raised from 16 KiB by issue
+    // #394). Each TOKEN_A serializes to roughly ~0.9 KiB post-CAR;
+    // 120 distinct copies (~108 KiB) cleanly clears the new cap.
+    const N = 120;
     const sources = Array.from({ length: N }, (_, i) => makeToken(`tok-${i}`, TOKEN_A));
     const commitResults = sources.map((s, i) =>
       makeCommitResult({
@@ -443,7 +444,7 @@ describe('sendConservativeUxf CID — auto-route over inline cap', () => {
     });
 
     // Default delivery (no `delivery` field) → strategy = { kind: 'auto' }
-    // → auto-route picks CID because the bundle CAR > 16 KiB.
+    // → auto-route picks CID because the bundle CAR > RELAY_SAFE_CAP_BYTES.
     await sendConservativeUxf(
       basicRequest({ amount: (1_000_000 * N).toString() }),
       makePeerInfo(),
@@ -454,11 +455,11 @@ describe('sendConservativeUxf CID — auto-route over inline cap', () => {
     expect(transport._calls).toHaveLength(1);
     const payload = transport._calls[0].payload as UxfTransferPayloadCid;
     expect(payload.kind).toBe('uxf-cid');
-    // Verify the published CAR genuinely exceeded 16 KiB (regression
+    // Verify the published CAR genuinely exceeded 96 KiB (regression
     // gate against future fixture shrinkage that would silently route
-    // through the inline branch).
+    // through the inline branch under the new RELAY_SAFE_CAP_BYTES cap).
     const carBytesArg = publishToIpfs.mock.calls[0][0];
-    expect(carBytesArg.byteLength).toBeGreaterThan(16 * 1024);
+    expect(carBytesArg.byteLength).toBeGreaterThan(96 * 1024);
   });
 });
 

--- a/tests/unit/payments/transfer/conservative-sender-cid.test.ts
+++ b/tests/unit/payments/transfer/conservative-sender-cid.test.ts
@@ -419,11 +419,14 @@ describe('sendConservativeUxf CID — auto-route over inline cap', () => {
   });
 
   ifAutoCid('large multi-token bundle (>RELAY_SAFE_CAP_BYTES) auto-routes to CID with default delivery', async () => {
-    // Build a multi-token bundle that exceeds the default 96 KiB
-    // inline cap (RELAY_SAFE_CAP_BYTES, raised from 16 KiB by issue
-    // #394). Each TOKEN_A serializes to roughly ~0.9 KiB post-CAR;
-    // 120 distinct copies (~108 KiB) cleanly clears the new cap.
-    const N = 120;
+    // Build a multi-token bundle that exceeds the default
+    // RELAY_SAFE_CAP_BYTES inline cap. Issue #394 raised this default
+    // from 16 KiB to 96 KiB; issue #394b raised it again to 512 KiB
+    // (today's Nostr relays comfortably carry up to ~1 MiB; 512 KiB
+    // is the half-of-1-MiB safety budget). Each TOKEN_A serializes to
+    // roughly ~0.9 KiB post-CAR; 640 distinct copies (~576 KiB)
+    // cleanly clears the 512 KiB cap.
+    const N = 640;
     const sources = Array.from({ length: N }, (_, i) => makeToken(`tok-${i}`, TOKEN_A));
     const commitResults = sources.map((s, i) =>
       makeCommitResult({
@@ -455,11 +458,12 @@ describe('sendConservativeUxf CID — auto-route over inline cap', () => {
     expect(transport._calls).toHaveLength(1);
     const payload = transport._calls[0].payload as UxfTransferPayloadCid;
     expect(payload.kind).toBe('uxf-cid');
-    // Verify the published CAR genuinely exceeded 96 KiB (regression
+    // Verify the published CAR genuinely exceeded 512 KiB (regression
     // gate against future fixture shrinkage that would silently route
-    // through the inline branch under the new RELAY_SAFE_CAP_BYTES cap).
+    // through the inline branch under the post-#394b RELAY_SAFE_CAP_BYTES
+    // cap).
     const carBytesArg = publishToIpfs.mock.calls[0][0];
-    expect(carBytesArg.byteLength).toBeGreaterThan(96 * 1024);
+    expect(carBytesArg.byteLength).toBeGreaterThan(512 * 1024);
   });
 });
 

--- a/tests/unit/payments/transfer/conservative-sender.test.ts
+++ b/tests/unit/payments/transfer/conservative-sender.test.ts
@@ -494,11 +494,11 @@ describe('sendConservativeUxf — auto-route to CID for oversized bundles', () =
 
 describe('sendConservativeUxf — force-inline relay-safe ceiling', () => {
   it('throws INLINE_CAR_TOO_LARGE when force-inline + oversize CAR', async () => {
-    // Build a synthetic large multi-token bundle to exceed the 96 KiB
+    // Build a synthetic large multi-token bundle to exceed
     // RELAY_SAFE_CAP_BYTES. Each TOKEN_A occupies ~0.9 KiB after CAR
-    // encoding; 120 distinct copies (~110 KiB) cleanly exceeds the
-    // 96 KiB ceiling.
-    const N = 120;
+    // encoding; 640 distinct copies (~576 KiB) cleanly exceeds the
+    // post-#394b 512 KiB ceiling (was 96 KiB pre-#394b).
+    const N = 640;
     const sources = Array.from({ length: N }, (_, i) => makeToken(`tok-${i}`, TOKEN_A));
     const commitResults = sources.map((s, i) =>
       makeCommitResult({
@@ -580,9 +580,9 @@ describe('sendConservativeUxf — CAR-inline fallback when publishToIpfs absent'
   });
 
   ifAutoCid('auto + no publisher + oversized bundle → throws IPFS_PUBLISHER_REQUIRED', async () => {
-    // Build a bundle exceeding RELAY_SAFE_CAP_BYTES (96 KiB).
-    // Each TOKEN_A fixture is ~0.9 KiB; 120 tokens ≈ 110 KiB.
-    const N = 120;
+    // Build a bundle exceeding RELAY_SAFE_CAP_BYTES (512 KiB post-#394b).
+    // Each TOKEN_A fixture is ~0.9 KiB; 640 tokens ≈ 576 KiB.
+    const N = 640;
     const sources = Array.from({ length: N }, (_, i) => makeToken(`tok-${i}`, TOKEN_A));
     const commitResults = sources.map((s, i) =>
       makeCommitResult({
@@ -602,8 +602,8 @@ describe('sendConservativeUxf — CAR-inline fallback when publishToIpfs absent'
     try {
       await sendConservativeUxf(
         // Loop1-S6 — request budget must cover the summed shipped
-        // amount across all 120 sources (each ships 1_000_000 UCT)
-        // so the new OVER_TRANSFER_GUARD doesn't trip first. The
+        // amount across all sources (each ships 1_000_000 UCT) so
+        // the new OVER_TRANSFER_GUARD doesn't trip first. The
         // test's purpose is to assert the IPFS_PUBLISHER_REQUIRED
         // pre-flight; we set the request amount to the total
         // shipped to keep the guard a no-op for this scenario.

--- a/tests/unit/payments/transfer/delivery-resolver-pin.test.ts
+++ b/tests/unit/payments/transfer/delivery-resolver-pin.test.ts
@@ -222,10 +222,12 @@ describe('resolveDelivery — CID branches preserve existing shouldPin: true con
   });
 
   ifAutoCid('auto-over-cap with publisher still returns CID with shouldPin: true', async () => {
+    // Issue #394 — default auto cap is RELAY_SAFE_CAP_BYTES (96 KiB).
+    // Bundle must clear that to route through the auto/CID branch.
     const { callback: publishToIpfs } = mockPublisher();
     const decision = await resolveDelivery({
       strategy: { kind: 'auto' },
-      carBytes: makeCarBytes(MAX_INLINE_CAR_BYTES + 1),
+      carBytes: makeCarBytes(RELAY_SAFE_CAP_BYTES + 1),
       publishToIpfs,
     });
     expect(decision.kind).toBe('cid');

--- a/tests/unit/payments/transfer/delivery-resolver.test.ts
+++ b/tests/unit/payments/transfer/delivery-resolver.test.ts
@@ -103,9 +103,9 @@ function mockTelemetry(): {
 // =============================================================================
 
 describe('resolveDelivery — auto mode, default cap', () => {
-  it('returns inline for a CAR ≤ RELAY_SAFE_CAP_BYTES (96 KiB)', async () => {
+  it('returns inline for a CAR ≤ RELAY_SAFE_CAP_BYTES', async () => {
     // Issue #394 — default cap was raised from MAX_INLINE_CAR_BYTES
-    // (16 KiB) to RELAY_SAFE_CAP_BYTES (96 KiB) so auto-promotion to
+    // (16 KiB) to RELAY_SAFE_CAP_BYTES so auto-promotion to
     // CID trips near the Nostr relay event ceiling, not at a quarter
     // of it. A CAR that's slightly larger than the OLD 16 KiB default
     // (e.g. 16 KiB + 1) now stays inline because it's still well under
@@ -131,7 +131,7 @@ describe('resolveDelivery — auto mode, default cap', () => {
     expect(publishFn).not.toHaveBeenCalled();
   });
 
-  ifAutoCid('returns CID for a CAR > RELAY_SAFE_CAP_BYTES (96 KiB)', async () => {
+  ifAutoCid('returns CID for a CAR > RELAY_SAFE_CAP_BYTES (post-#394b: 512 KiB)', async () => {
     const carBytes = makeCarBytes(RELAY_SAFE_CAP_BYTES + 1);
     const { fn: publishFn, callback: publishToIpfs } = mockPublisher('bafyhugecid');
     const decision = await resolveDelivery({
@@ -216,19 +216,25 @@ describe('resolveDelivery — auto mode, custom in-range cap', () => {
 });
 
 // =============================================================================
-// 4. `auto` mode — cap > 96 KiB (silent clamp + telemetry)
+// 4. `auto` mode — cap > RELAY_SAFE_CAP_BYTES (silent clamp + telemetry)
 // =============================================================================
 
-describe('resolveDelivery — auto mode, cap > 96 KiB clamps silently', () => {
-  it('clamps a 200 KiB cap down to 96 KiB and emits telemetry', async () => {
-    // Bundle is 64 KiB — fits under the clamped 96 KiB ceiling, so the
-    // decision is inline despite the original cap being unreasonably large.
+describe('resolveDelivery — auto mode, cap above RELAY_SAFE_CAP_BYTES clamps silently', () => {
+  // Issue #394b — RELAY_SAFE_CAP_BYTES was raised from 96 KiB to 512 KiB.
+  // Caller caps above the new ceiling get silently clamped. We use
+  // `RELAY_SAFE_CAP_BYTES * 2` (a 1 MiB cap that gets clamped to 512 KiB)
+  // and `RELAY_SAFE_CAP_BYTES + 1` (slightly over the ceiling) to drive
+  // the clamp branches regardless of the constant's exact numeric value.
+
+  it('clamps an oversized cap down to RELAY_SAFE_CAP_BYTES and emits telemetry', async () => {
+    // Bundle is small enough to fit inline under the clamped ceiling.
     const carBytes = makeCarBytes(64 * 1024);
     const { events, callback: emitTelemetry } = mockTelemetry();
     const { fn: publishFn, callback: publishToIpfs } = mockPublisher();
 
+    const oversizedCap = RELAY_SAFE_CAP_BYTES * 2;
     const decision = await resolveDelivery({
-      strategy: { kind: 'auto', inlineCapBytes: 200 * 1024 },
+      strategy: { kind: 'auto', inlineCapBytes: oversizedCap },
       carBytes,
       publishToIpfs,
       emitTelemetry,
@@ -237,7 +243,7 @@ describe('resolveDelivery — auto mode, cap > 96 KiB clamps silently', () => {
     expect(decision.kind).toBe('inline');
     if (decision.kind === 'inline') {
       expect(decision.clampInfo).toEqual({
-        originalCap: 200 * 1024,
+        originalCap: oversizedCap,
         effectiveCap: RELAY_SAFE_CAP_BYTES,
         reason: 'above-relay-cap',
       });
@@ -248,20 +254,20 @@ describe('resolveDelivery — auto mode, cap > 96 KiB clamps silently', () => {
     expect(events[0]).toEqual<ClampTelemetry>({
       type: 'inline-cap-clamped',
       clampInfo: {
-        originalCap: 200 * 1024,
+        originalCap: oversizedCap,
         effectiveCap: RELAY_SAFE_CAP_BYTES,
         reason: 'above-relay-cap',
       },
     });
   });
 
-  ifAutoCid('clamps and routes to CID when CAR exceeds the clamped 96 KiB ceiling', async () => {
+  ifAutoCid('clamps and routes to CID when CAR exceeds the clamped ceiling', async () => {
     const carBytes = makeCarBytes(RELAY_SAFE_CAP_BYTES + 1);
     const { events, callback: emitTelemetry } = mockTelemetry();
     const { fn: publishFn, callback: publishToIpfs } = mockPublisher('bafyclamped');
 
     const decision = await resolveDelivery({
-      strategy: { kind: 'auto', inlineCapBytes: 1024 * 1024 }, // 1 MiB → clamped to 96 KiB
+      strategy: { kind: 'auto', inlineCapBytes: RELAY_SAFE_CAP_BYTES * 2 },
       carBytes,
       publishToIpfs,
       emitTelemetry,
@@ -280,9 +286,10 @@ describe('resolveDelivery — auto mode, cap > 96 KiB clamps silently', () => {
   it('omitting emitTelemetry callback is non-fatal even when clamp fires', async () => {
     const carBytes = makeCarBytes(50);
     const { callback: publishToIpfs } = mockPublisher();
-    // No `emitTelemetry` field — clamp still happens silently.
+    // No `emitTelemetry` field — clamp still happens silently. Cap must
+    // exceed RELAY_SAFE_CAP_BYTES to trigger the clamp.
     const decision = await resolveDelivery({
-      strategy: { kind: 'auto', inlineCapBytes: 200 * 1024 },
+      strategy: { kind: 'auto', inlineCapBytes: RELAY_SAFE_CAP_BYTES * 2 },
       carBytes,
       publishToIpfs,
     });
@@ -298,7 +305,7 @@ describe('resolveDelivery — auto mode, cap > 96 KiB clamps silently', () => {
 // =============================================================================
 
 describe('resolveDelivery — force-inline mode', () => {
-  it('returns inline for a CAR within the 96 KiB ceiling', async () => {
+  it('returns inline for a CAR within the RELAY_SAFE_CAP_BYTES ceiling', async () => {
     const carBytes = makeCarBytes(50 * 1024);
     const { fn: publishFn, callback: publishToIpfs } = mockPublisher();
     const decision = await resolveDelivery({
@@ -315,7 +322,7 @@ describe('resolveDelivery — force-inline mode', () => {
     expect(publishFn).not.toHaveBeenCalled();
   });
 
-  it('returns inline at the exact 96 KiB boundary', async () => {
+  it('returns inline at the exact RELAY_SAFE_CAP_BYTES boundary', async () => {
     const carBytes = makeCarBytes(RELAY_SAFE_CAP_BYTES);
     const { callback: publishToIpfs } = mockPublisher();
     const decision = await resolveDelivery({
@@ -326,7 +333,7 @@ describe('resolveDelivery — force-inline mode', () => {
     expect(decision.kind).toBe('inline');
   });
 
-  it('throws INLINE_CAR_TOO_LARGE for a CAR > 96 KiB', async () => {
+  it('throws INLINE_CAR_TOO_LARGE for a CAR > RELAY_SAFE_CAP_BYTES (boundary +1)', async () => {
     const carBytes = makeCarBytes(RELAY_SAFE_CAP_BYTES + 1);
     const { callback: publishToIpfs } = mockPublisher();
     await expect(
@@ -341,8 +348,11 @@ describe('resolveDelivery — force-inline mode', () => {
     });
   });
 
-  it('throws INLINE_CAR_TOO_LARGE for a CAR substantially over the ceiling (100 KiB)', async () => {
-    const carBytes = makeCarBytes(100 * 1024);
+  it('throws INLINE_CAR_TOO_LARGE for a CAR substantially over the ceiling (2x cap)', async () => {
+    // Use a multiple of RELAY_SAFE_CAP_BYTES so this test stays valid
+    // regardless of the constant's exact numeric value (issue #394b
+    // raised it from 96 KiB to 512 KiB).
+    const carBytes = makeCarBytes(RELAY_SAFE_CAP_BYTES * 2);
     const { callback: publishToIpfs } = mockPublisher();
     await expect(
       resolveDelivery({
@@ -469,7 +479,7 @@ describe('resolveDelivery — IPFS failure propagation', () => {
 
 describe('resolveDelivery — CAR-inline fallback when publishToIpfs absent', () => {
   it('auto + no publisher + small bundle → falls back to inline (uxf-car)', async () => {
-    // Bundle > 16 KiB (CID branch) but <= RELAY_SAFE_CAP_BYTES (96 KiB).
+    // Bundle > 16 KiB (CID branch) but <= RELAY_SAFE_CAP_BYTES.
     // Without a publisher the resolver must fall back to inline delivery.
     const carBytes = makeCarBytes(MAX_INLINE_CAR_BYTES + 1);
     const decision = await resolveDelivery({

--- a/tests/unit/payments/transfer/delivery-resolver.test.ts
+++ b/tests/unit/payments/transfer/delivery-resolver.test.ts
@@ -99,12 +99,18 @@ function mockTelemetry(): {
 }
 
 // =============================================================================
-// 2. `auto` mode — default cap (16 KiB)
+// 2. `auto` mode — default cap (RELAY_SAFE_CAP_BYTES = 96 KiB, post-#394)
 // =============================================================================
 
 describe('resolveDelivery — auto mode, default cap', () => {
-  it('returns inline for a CAR ≤ 16 KiB', async () => {
-    const carBytes = makeCarBytes(MAX_INLINE_CAR_BYTES);
+  it('returns inline for a CAR ≤ RELAY_SAFE_CAP_BYTES (96 KiB)', async () => {
+    // Issue #394 — default cap was raised from MAX_INLINE_CAR_BYTES
+    // (16 KiB) to RELAY_SAFE_CAP_BYTES (96 KiB) so auto-promotion to
+    // CID trips near the Nostr relay event ceiling, not at a quarter
+    // of it. A CAR that's slightly larger than the OLD 16 KiB default
+    // (e.g. 16 KiB + 1) now stays inline because it's still well under
+    // the relay cap.
+    const carBytes = makeCarBytes(MAX_INLINE_CAR_BYTES + 1);
     const { fn: publishFn, callback: publishToIpfs } = mockPublisher();
     const decision = await resolveDelivery({
       strategy: { kind: 'auto' },
@@ -116,8 +122,8 @@ describe('resolveDelivery — auto mode, default cap', () => {
     if (decision.kind === 'inline') {
       expect(decision.carBase64).toBe(carBytesToBase64(carBytes));
       expect(decision.clampInfo).toEqual({
-        originalCap: MAX_INLINE_CAR_BYTES,
-        effectiveCap: MAX_INLINE_CAR_BYTES,
+        originalCap: RELAY_SAFE_CAP_BYTES,
+        effectiveCap: RELAY_SAFE_CAP_BYTES,
         reason: 'default',
       });
     }
@@ -125,8 +131,8 @@ describe('resolveDelivery — auto mode, default cap', () => {
     expect(publishFn).not.toHaveBeenCalled();
   });
 
-  ifAutoCid('returns CID for a CAR > 16 KiB', async () => {
-    const carBytes = makeCarBytes(MAX_INLINE_CAR_BYTES + 1);
+  ifAutoCid('returns CID for a CAR > RELAY_SAFE_CAP_BYTES (96 KiB)', async () => {
+    const carBytes = makeCarBytes(RELAY_SAFE_CAP_BYTES + 1);
     const { fn: publishFn, callback: publishToIpfs } = mockPublisher('bafyhugecid');
     const decision = await resolveDelivery({
       strategy: { kind: 'auto' },
@@ -143,9 +149,9 @@ describe('resolveDelivery — auto mode, default cap', () => {
     expect(publishFn).toHaveBeenCalledWith(carBytes);
   });
 
-  it('returns inline at the exact 16 KiB boundary', async () => {
+  it('returns inline at the exact RELAY_SAFE_CAP_BYTES boundary', async () => {
     // Boundary check: ≤ is inline, > is CID.
-    const carBytes = makeCarBytes(MAX_INLINE_CAR_BYTES);
+    const carBytes = makeCarBytes(RELAY_SAFE_CAP_BYTES);
     const { callback: publishToIpfs } = mockPublisher();
     const decision = await resolveDelivery({
       strategy: { kind: 'auto' },
@@ -440,7 +446,9 @@ describe('resolveDelivery — force-cid mode', () => {
 
 describe('resolveDelivery — IPFS failure propagation', () => {
   ifAutoCid('propagates publishToIpfs rejection from auto/CID branch', async () => {
-    const carBytes = makeCarBytes(MAX_INLINE_CAR_BYTES + 1); // routes to CID
+    // Bundle must exceed the new default cap (RELAY_SAFE_CAP_BYTES,
+    // 96 KiB post-#394) to route through the auto/CID branch.
+    const carBytes = makeCarBytes(RELAY_SAFE_CAP_BYTES + 1);
     const error = new Error('pin failed');
     const publishToIpfs: PublishToIpfsCallback = async () => {
       throw error;

--- a/tests/unit/payments/transfer/limits.test.ts
+++ b/tests/unit/payments/transfer/limits.test.ts
@@ -35,8 +35,11 @@ describe('UXF transfer limits — constant values', () => {
     expect(MAX_INLINE_CAR_BYTES).toBe(16 * 1024);
   });
 
-  it('RELAY_SAFE_CAP_BYTES === 96 KiB', () => {
-    expect(RELAY_SAFE_CAP_BYTES).toBe(96 * 1024);
+  it('RELAY_SAFE_CAP_BYTES === 512 KiB (post-#394b)', () => {
+    // Issue #394b — raised from 96 KiB to 512 KiB. Today's Nostr
+    // relays carry events up to ~1 MiB comfortably; 512 KiB is the
+    // half-of-1-MiB safety budget.
+    expect(RELAY_SAFE_CAP_BYTES).toBe(512 * 1024);
   });
 
   it('MAX_FETCHED_CAR_BYTES === 32 MiB', () => {

--- a/tests/unit/payments/transfer/§3.3.1-invalid-inline-cap.test.ts
+++ b/tests/unit/payments/transfer/§3.3.1-invalid-inline-cap.test.ts
@@ -203,16 +203,21 @@ describe('§3.3.1 INVALID_INLINE_CAP — in-range caps pass through', () => {
 // =============================================================================
 
 describe('§3.3.1 INVALID_INLINE_CAP — oversized cap silently clamps (does NOT throw)', () => {
-  it('inlineCapBytes: 200000 (> 96 KiB) → silent clamp + telemetry, NO throw', async () => {
+  it('inlineCapBytes: 2 × RELAY_SAFE_CAP_BYTES → silent clamp + telemetry, NO throw', async () => {
     // The dual case to the undersized-reject branch: oversized values are
     // CLAMPED, not rejected. This contrast is the heart of W12 — without
     // this asymmetry, callers couldn't tell which behavior they're getting
     // for a given out-of-range input. The deterministic spec is:
     //   - undersized → throw INVALID_INLINE_CAP
     //   - oversized  → silent clamp to RELAY_SAFE_CAP_BYTES + telemetry
+    //
+    // Issue #394b — RELAY_SAFE_CAP_BYTES was raised from 96 KiB to
+    // 512 KiB. We express the oversized cap as 2× the constant so this
+    // test stays valid regardless of the constant's exact value.
+    const oversizedCap = RELAY_SAFE_CAP_BYTES * 2;
     let telemetryFired = 0;
     const result = await resolveDelivery({
-      strategy: { kind: 'auto', inlineCapBytes: 200_000 },
+      strategy: { kind: 'auto', inlineCapBytes: oversizedCap },
       carBytes: minimalCar,
       publishToIpfs: noopPublisher,
       emitTelemetry: () => {
@@ -220,11 +225,11 @@ describe('§3.3.1 INVALID_INLINE_CAP — oversized cap silently clamps (does NOT
       },
     });
 
-    // Decision: inline (CAR is 2 bytes, well under the clamped 96 KiB).
+    // Decision: inline (CAR is 2 bytes, well under the clamped ceiling).
     expect(result.kind).toBe('inline');
     if (result.kind === 'inline') {
       expect(result.clampInfo).toEqual({
-        originalCap: 200_000,
+        originalCap: oversizedCap,
         effectiveCap: RELAY_SAFE_CAP_BYTES,
         reason: 'above-relay-cap',
       });


### PR DESCRIPTION
Closes #394.

## What

Three coupled changes that, together, let the CLI complete multi-hop round-trips with realistic bundle sizes:

1. **Re-export `createUxfCarPublisher` + `PublishToIpfsCallback` + `DEFAULT_IPFS_GATEWAYS`** from `impl/nodejs/index.ts`. Consumers (notably sphere-cli's `buildSphereProviders`) can now wire `publishToIpfs` and `cidFetchGateways` directly without re-enabling the deprecated `tokenSync.ipfs.enabled` flag (which would also activate the IPNS-based `IpfsStorageProvider` — Profile has replaced wallet token storage, but the UXF transfer publisher is a separate concern that survived the deprecation).

2. **Raise the auto-promotion threshold from `MAX_INLINE_CAR_BYTES` (16 KiB) to `RELAY_SAFE_CAP_BYTES`.** `delivery-resolver.ts` `resolveAutoCap` and both dispatcher pre-flights (`instant-sender.ts`, `conservative-sender.ts`) move their fallback for `inlineCapBytes` from the 16 KiB default to the relay-safe ceiling. Promotion to CID-over-Nostr now trips NEAR the actual Nostr relay event ceiling, not at a quarter of it. Bundles in the 16–RELAY_SAFE_CAP_BYTES range stay inline instead of being unnecessarily CID-pinned.

3. **Flip the kill-switch on.** `AUTOMATED_CID_DELIVERY_ENABLED = true` in `modules/payments/transfer/limits.ts`. The 16+ tests previously gated via `it.skipIf(!AUTOMATED_CID_DELIVERY_ENABLED)` re-arm automatically.

4. **#394b — raise `RELAY_SAFE_CAP_BYTES` from 96 KiB to 512 KiB.** Today's Nostr relays comfortably carry events up to ~1 MiB; 512 KiB is the half-of-1-MiB safety budget. The previous 96 KiB was conservative for older relay implementations and produced unnecessary CID-promotion pressure on multi-hop bundles (typical 3-token chains land around 100–150 KiB — well inside the new envelope).

`MAX_INLINE_CAR_BYTES` (16 KiB) is preserved as a documented soft hint for callers that explicitly want a smaller inline cap via `inlineCapBytes`.

## Verification

- **Unit:** 8290/8295 pass + 5 skipped (3 disabled-state tests under the inverse flag gate; 2 #391 load-tail).
- **Integration transfer:** 81/81 pass.
- **End-to-end soak** (`manual-test-roundtrip-391.sh` with `STRICT_CID_DELIVERY=1`) against testnet — 4-hop A→B→A→B→A:
  - HOP 4 cleared the duplicate-bundle guard (#391 invariant verified).
  - Bundle (≈121 KB) stayed inline under the new 512 KiB ceiling.
  - Alice received normally; balance reconciliation passed (`alice -0.5 UCT, bob +0.5 UCT`).
  - No `DUPLICATE_BUNDLE_MEMBERSHIP`, no `INLINE_CAR_TOO_LARGE` anywhere.
  - **ALL GREEN, exit 0.**

## Coupling

Pairs with sphere-cli PR `feat/issue-394-cli-publish-to-ipfs-v2`, which wires the now-exported `createUxfCarPublisher` into `buildSphereProviders`. The two can land in any order, but the soak above only passes when both are in effect.

## Test plan

- [x] Unit suite
- [x] Integration transfer
- [x] End-to-end soak with `STRICT_CID_DELIVERY=1`
- [ ] One follow-up issue to file separately: investigate the recipient-side CID-fetch silent-drop observed when bundles genuinely exceed 512 KiB. That code path is now exercised in production only by very large multi-hop bundles, which the soak doesn't currently produce. Not a blocker for this PR.
