### PR TITLE
fix(accounting)(#397): publisher-side extended-durability for invoice DMs

### DIFF
--- a/manual-test-accounting-roundtrip.sh
+++ b/manual-test-accounting-roundtrip.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+#
+# manual-test-accounting-roundtrip.sh — accounting module invoice
+# round-trip soak (real testnet, single-asset 7 UCT).
+#
+# Scenario (per the user's brief):
+#   1. Alice tops up via faucet (100 UCT + assorted others).
+#   2. Bob creates a 7 UCT invoice with himself as the payee, using
+#      the human-friendly CLI: `--target @bob --asset "7 UCT"`.
+#   3. Bob delivers the invoice to Alice via NIP-17 DM.
+#   4. Alice covers (pays) the invoice.
+#   5. Bob receives the payment; the invoice transitions to COVERED.
+#
+# What this verifies that the existing `manual-test-full-recovery.sh`
+# does NOT:
+#   - The invoice is created by the PAYEE (bob), not by the payer's
+#     surrogate (the existing soak has alice create + alice receives
+#     payment via bob's pay command).
+#   - The human-friendly CLI surface introduced in sphere-cli's
+#     invoice-create fix: `--asset "7 UCT"` instead of forcing the
+#     user to type smallest-unit integers like "7000000000000000000".
+#     The CLI handles registry decimals lookup + conversion.
+#   - Addressing via @nametag throughout — `--target @bob` is the
+#     only identity reference the script uses. No DIRECT://… is ever
+#     constructed by hand; the CLI resolves the nametag before
+#     handing the request to the SDK's accounting-module mint flow.
+#
+# Multi-asset support (e.g., "7 UCT + 2 ETH") is OUT OF SCOPE for
+# this soak per the user's direction ("If it is too complex now for
+# multiassets, lets create invoice just for 7 UCT, but the command
+# must be user-friendly"). The CLI does support `--asset "..." --asset
+# "..."` repetition; a follow-up multi-asset soak can chain that.
+#
+# Run:
+#   bash manual-test-accounting-roundtrip.sh
+#   KEEP=1 bash manual-test-accounting-roundtrip.sh    # preserve workspace
+#   ACCOUNTING_TEST_DIR=/tmp/acc bash manual-test-accounting-roundtrip.sh
+#
+# Requires the `sphere` CLI on PATH and outbound HTTPS+WSS to testnet.
+
+set -euo pipefail
+
+# ---- workspace ----
+ROOT="${ACCOUNTING_TEST_DIR:-/tmp/accounting-roundtrip-$$}"
+SNAP="$ROOT/snapshots"
+mkdir -p "$SNAP"
+
+SUFFIX="${SUFFIX:-$(date +%s | tail -c 5)$(printf '%04x' $((RANDOM % 65536)))}"
+ALICE_TAG="alice-$SUFFIX"
+BOB_TAG="bob-$SUFFIX"
+echo "ALICE_TAG=$ALICE_TAG"
+echo "BOB_TAG=$BOB_TAG"
+
+PEER_ALICE="$ROOT/alice-peer"
+PEER_BOB="$ROOT/bob-peer"
+mkdir -p "$PEER_ALICE" "$PEER_BOB"
+
+export SPHERE_ALLOW_MNEMONIC_NON_TTY=1
+
+cleanup() {
+  local rc=$?
+  if [[ "${KEEP:-0}" != "1" ]]; then
+    rm -rf "$ROOT" 2>/dev/null || true
+  else
+    echo "=== KEEP=1: workspace preserved at $ROOT ==="
+  fi
+  return "$rc"
+}
+trap cleanup EXIT INT TERM
+
+banner() {
+  echo
+  echo "================================================================"
+  echo "$@"
+  echo "================================================================"
+}
+
+# ---------------------------------------------------------------------------
+# Integer-only confirmed balance extractor.
+#
+# UCT and ETH both have 18 decimals on the production testnet registry
+# (https://raw.githubusercontent.com/unicitynetwork/unicity-ids/refs/heads/main/unicity-ids.testnet.json).
+# The extractor pads fractional parts to exactly 18 chars so the
+# resulting integer string is in smallest units. Adapted from
+# manual-test-roundtrip-391.sh's extractor (which used 8 decimals
+# for UCT under the legacy assumption; we now follow the real
+# registry).
+#
+# Args:
+#   $1 — symbol (e.g. "UCT", "ETH")
+# Stdin: contents of `sphere balance` output.
+# Stdout: confirmed balance as smallest-unit integer string.
+# ---------------------------------------------------------------------------
+extract_confirmed_smallest_units() {
+  local symbol="$1"
+  local line decimal int_part frac_part
+  line=$(grep -E "^${symbol}:" || true)
+  if [[ -z "$line" ]]; then
+    echo "0"
+    return
+  fi
+  decimal=$(echo "$line" | sed -E -e "s/^${symbol}:[[:space:]]+//" -e 's/[[:space:]]+\(.+$//')
+  if [[ "$decimal" == *.* ]]; then
+    int_part="${decimal%.*}"
+    frac_part="${decimal#*.}"
+  else
+    int_part="$decimal"
+    frac_part=""
+  fi
+  while (( ${#frac_part} < 18 )); do frac_part="${frac_part}0"; done
+  if (( ${#frac_part} > 18 )); then
+    echo "ERROR: ${symbol} fractional part >18 digits ($decimal)" >&2
+    return 1
+  fi
+  local combined="${int_part}${frac_part}"
+  combined=$(echo "$combined" | sed -E 's/^0+//')
+  [[ -z "$combined" ]] && combined="0"
+  echo "$combined"
+}
+
+# ---------------------------------------------------------------------------
+# Section 1 — Create alice + bob
+# ---------------------------------------------------------------------------
+banner "Section 1: Create alice + bob (testnet)"
+
+cd "$PEER_ALICE"
+sphere wallet create alice
+sphere wallet use alice
+sphere init --network testnet --nametag "$ALICE_TAG" 2>&1 | tee "$SNAP/alice-init.log"
+
+cd "$PEER_BOB"
+sphere wallet create bob
+sphere wallet use bob
+sphere init --network testnet --nametag "$BOB_TAG" 2>&1 | tee "$SNAP/bob-init.log"
+# Sanity — `sphere status` should print bob's nametag (mint succeeded).
+sphere status | tee "$SNAP/bob-status.log"
+grep -qE "Nametag:.*$BOB_TAG" "$SNAP/bob-status.log" \
+  || { echo "FAIL: bob's nametag '$BOB_TAG' not visible in status" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Section 2 — Faucet both wallets, capture baselines
+#
+# Why faucet bob too: minting the invoice token requires bob's wallet
+# to have a working aggregator path. Even though invoice mint doesn't
+# consume any existing payment token, fauceting bob mirrors the
+# proven pattern in manual-test-full-recovery.sh and reduces flake
+# surface (a brand-new wallet with zero on-chain history can race
+# Profile sync on first mint).
+# ---------------------------------------------------------------------------
+banner "Section 2: Faucet alice + bob; capture baselines"
+
+cd "$PEER_ALICE"
+sphere wallet use alice
+sphere faucet                       2>&1 | tee "$SNAP/alice-faucet.log"
+sphere payments sync                2>&1 | tee "$SNAP/alice-sync-1.log"
+sphere payments receive --finalize  2>&1 | tee "$SNAP/alice-faucet-receive.log"
+sphere balance | tee "$SNAP/alice-balance-0.txt"
+
+cd "$PEER_BOB"
+sphere wallet use bob
+sphere faucet                       2>&1 | tee "$SNAP/bob-faucet.log"
+sphere payments sync                2>&1 | tee "$SNAP/bob-sync-1.log"
+sphere payments receive --finalize  2>&1 | tee "$SNAP/bob-faucet-receive.log"
+sphere balance | tee "$SNAP/bob-balance-0.txt"
+
+# ---------------------------------------------------------------------------
+# Section 3 — Bob creates a 7 UCT invoice (single-asset, human-friendly)
+#
+# CLI surface (human-friendly, per sphere-cli's invoice-create fix):
+#   - `sphere invoice create --target @<nametag> --asset "7 UCT"`
+#     accepts the human-readable amount. The CLI:
+#       1) resolves `@nametag` → DIRECT:// via the transport's
+#          nametag binding events (AccountingModule.createInvoice
+#          requires DIRECT at the cryptographic-binding boundary).
+#       2) looks up the symbol's decimals via the token registry
+#          (UCT: 18 decimals on the testnet registry).
+#       3) converts "7" + decimals=18 → 7×10^18 smallest units before
+#          handing the request to the SDK.
+#   - Multi-asset is also supported (e.g. `--asset "7 UCT" --asset
+#     "2 ETH"`), but this soak deliberately uses single-asset to
+#     match the user's directive ("If it is too complex now for
+#     multiassets, lets create invoice just for 7 UCT").
+# ---------------------------------------------------------------------------
+banner "Section 3: Bob creates a 7 UCT invoice (human-friendly --asset)"
+
+cd "$PEER_BOB"
+sphere wallet use bob
+sphere invoice create --target "@${BOB_TAG}" --asset "7 UCT" --memo "Accounting demo invoice — 7 UCT" \
+  2>&1 | tee "$SNAP/bob-invoice-create.log"
+
+INV="$(grep -Eo '"invoiceId":[[:space:]]*"[^"]+"' "$SNAP/bob-invoice-create.log" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+[[ -n "$INV" ]] || { echo "FAIL: couldn't extract invoiceId" >&2; exit 1; }
+echo "INV=$INV"
+
+# Snapshot bob's balance after invoice mint. The invoice itself is a
+# new on-chain token — bob's "balance" output may or may not include
+# it depending on whether the CLI's balance formatter filters invoice
+# tokens out of the asset roll-up. For the assertions below we care
+# only about UCT/ETH deltas, not the invoice token row.
+sphere balance | tee "$SNAP/bob-balance-1.txt"
+
+# ---------------------------------------------------------------------------
+# Section 4 — Bob delivers the invoice to alice
+#
+# `sphere invoice deliver $INV --to @alice` packages the invoice into
+# a UXF bundle and ships it via NIP-17 DM (kind 14). Alice's wallet
+# auto-imports the bundle on receipt (handled inside AccountingModule,
+# not the payments pipeline).
+# ---------------------------------------------------------------------------
+banner "Section 4: Bob delivers invoice to @${ALICE_TAG}"
+
+sphere invoice deliver "$INV" --to "@${ALICE_TAG}" 2>&1 | tee "$SNAP/bob-invoice-deliver.log"
+grep -qE '"sent":[[:space:]]*1' "$SNAP/bob-invoice-deliver.log" \
+  || { echo "ASSERT FAIL (deliver-acked): expected 'sent: 1' in deliver response" >&2; exit 1; }
+echo "ASSERT OK (deliver-acked): invoice delivery DM sent"
+
+# ---------------------------------------------------------------------------
+# Section 5 — Alice covers (pays) the invoice
+#
+# A short settle gives alice's Nostr subscription time to ingest the
+# `invoice_delivery` DM and AccountingModule's importInvoice to write
+# the invoice into the local Profile store. Without it, the very next
+# `invoice pay` would race the DM arrival and could error with "No
+# invoice found matching prefix" (the same pattern noted at
+# manual-test-full-recovery.sh §C.2).
+# ---------------------------------------------------------------------------
+banner "Section 5: Alice covers the invoice"
+
+cd "$PEER_ALICE"
+sphere wallet use alice
+
+# Poll for alice's local AccountingModule to ingest bob's
+# invoice_delivery DM. Each `sphere invoice list` call boots a fresh
+# CLI process, which:
+#   1) opens a Nostr subscription with `since=<persisted_timestamp>`,
+#   2) fetches pending events (including bob's DM if it's still on
+#      the relay), routes them through CommunicationsModule, which
+#      hands invoice_delivery payloads to AccountingModule.importInvoice,
+#   3) writes the imported invoice to alice's local Profile.
+#
+# The first call ALSO advances alice's `since` cursor, so subsequent
+# calls only pick up newer events. Polling is the right shape because
+# the testnet relay's read path can lag behind writes by several
+# seconds (sometimes >10s under load) — a one-shot 5s sleep wasn't
+# enough in run #1.
+#
+# Bail out at 60s wall-clock; in practice the invoice appears within
+# 5–20s on a healthy relay.
+INV_LIST_DEADLINE=$(( $(date +%s) + 60 ))
+INV_FOUND=0
+while (( $(date +%s) < INV_LIST_DEADLINE )); do
+  sphere payments sync                2>&1 > "$SNAP/alice-pre-pay-sync.log"
+  # Fresh-list dump on every poll so the final state is captured.
+  sphere invoice list 2>&1 | tee "$SNAP/alice-invoice-list-before-pay.log" || true
+  if grep -qE "(\"invoiceId\":[[:space:]]*\"${INV}\"|^${INV:0:16})" "$SNAP/alice-invoice-list-before-pay.log"; then
+    echo "INFO: invoice $INV visible in alice's local list"
+    INV_FOUND=1
+    break
+  fi
+  echo "  invoice not yet visible — sleeping 3s and retrying…"
+  sleep 3
+done
+if (( INV_FOUND == 0 )); then
+  echo "ASSERT FAIL (invoice-ingest-timeout): alice's wallet did NOT ingest invoice $INV within 60s" >&2
+  echo "--- alice-invoice-list-before-pay.log tail ---" >&2
+  tail -20 "$SNAP/alice-invoice-list-before-pay.log" >&2 || true
+  exit 1
+fi
+sphere invoice pay "$INV" 2>&1 | tee "$SNAP/alice-invoice-pay.log"
+sphere payments sync                2>&1 | tee "$SNAP/alice-post-pay-sync.log"
+sphere balance | tee "$SNAP/alice-balance-1.txt"
+
+# ---------------------------------------------------------------------------
+# Section 6 — Bob receives, finalizes, and observes COVERED state
+# ---------------------------------------------------------------------------
+banner "Section 6: Bob receives + verifies COVERED"
+
+cd "$PEER_BOB"
+sphere wallet use bob
+sleep 5
+sphere payments sync                2>&1 | tee "$SNAP/bob-post-pay-sync.log"
+sphere payments receive --finalize  2>&1 | tee "$SNAP/bob-receive.log"
+sphere balance | tee "$SNAP/bob-balance-2.txt"
+sphere invoice status "$INV" 2>&1 | tee "$SNAP/bob-invoice-status.log"
+
+# ---------------------------------------------------------------------------
+# Section 7 — Assertions
+#
+# Three load-bearing checks:
+#   (a) bob's invoice state transitioned to COVERED (the invoice's
+#       lifecycle moved through the receipt path correctly).
+#   (b) bob's UCT and ETH balances rose by exactly the demanded
+#       amounts (no over-payment, no shortfall).
+#   (c) alice's UCT and ETH balances fell by EXACTLY the demanded
+#       amounts (no extra charges, no UCT/ETH cross-talk).
+# ---------------------------------------------------------------------------
+banner "Section 7: Verify assertions"
+
+rc=0
+
+# (a) Invoice state — the CLI's `invoice status` output includes a
+# `state: <STATE>` field; we grep tolerantly because the JSON formatter
+# may render it in any of several equivalent shapes.
+if grep -qE '("state"[[:space:]]*:[[:space:]]*"COVERED"|State:[[:space:]]*COVERED|state:[[:space:]]*COVERED)' \
+    "$SNAP/bob-invoice-status.log"; then
+  echo "ASSERT OK (invoice-covered): bob's invoice transitioned to COVERED"
+else
+  echo "ASSERT FAIL (invoice-covered): bob's invoice did not reach COVERED" >&2
+  echo "--- bob-invoice-status.log tail ---" >&2
+  tail -30 "$SNAP/bob-invoice-status.log" >&2
+  rc=1
+fi
+
+# (b) Bob's UCT balance rose by exactly 7 UCT.
+bob_uct_0=$(extract_confirmed_smallest_units UCT < "$SNAP/bob-balance-0.txt")
+bob_uct_2=$(extract_confirmed_smallest_units UCT < "$SNAP/bob-balance-2.txt")
+
+# Use python for 18-digit-decimal arithmetic — bash $(( … )) tops out
+# at 64-bit signed (~9.2e18); 7×10^18 fits but the sum 100+7 UCT in
+# smallest units would exceed it on some compositions.
+bob_uct_delta=$(python3 -c "print($bob_uct_2 - $bob_uct_0)")
+
+expected_uct=7000000000000000000
+
+echo "bob UCT baseline:  $bob_uct_0"
+echo "bob UCT final:     $bob_uct_2"
+echo "bob UCT delta:     $bob_uct_delta  (expected $expected_uct)"
+
+if [[ "$bob_uct_delta" == "$expected_uct" ]]; then
+  echo "ASSERT OK (bob-uct-delta-plus-7): bob received exactly 7 UCT"
+else
+  echo "ASSERT FAIL (bob-uct-delta-plus-7): expected $expected_uct, got $bob_uct_delta" >&2
+  rc=1
+fi
+
+# (c) Alice's UCT balance fell by exactly 7 UCT.
+alice_uct_0=$(extract_confirmed_smallest_units UCT < "$SNAP/alice-balance-0.txt")
+alice_uct_1=$(extract_confirmed_smallest_units UCT < "$SNAP/alice-balance-1.txt")
+
+alice_uct_delta=$(python3 -c "print($alice_uct_0 - $alice_uct_1)")
+
+echo "alice UCT baseline: $alice_uct_0"
+echo "alice UCT final:    $alice_uct_1"
+echo "alice UCT delta:    $alice_uct_delta  (expected $expected_uct)"
+
+if [[ "$alice_uct_delta" == "$expected_uct" ]]; then
+  echo "ASSERT OK (alice-uct-delta-minus-7): alice paid exactly 7 UCT"
+else
+  echo "ASSERT FAIL (alice-uct-delta-minus-7): expected $expected_uct, got $alice_uct_delta" >&2
+  rc=1
+fi
+
+# Cross-hop unconfirmed residue check.
+check_no_unconfirmed() {
+  local label="$1" snapshot="$2"
+  local pat='\(\+ [0-9.]*[1-9][0-9.]* unconfirmed\)'
+  if grep -qE "$pat" "$snapshot"; then
+    echo "ASSERT FAIL ($label): non-zero unconfirmed residue in post-finalize snapshot" >&2
+    grep -nE "$pat" "$snapshot" >&2 || true
+    return 1
+  fi
+  echo "ASSERT OK ($label): no unconfirmed residue post-finalize"
+}
+
+check_no_unconfirmed "alice-balance-1" "$SNAP/alice-balance-1.txt" || rc=1
+check_no_unconfirmed "bob-balance-2"   "$SNAP/bob-balance-2.txt"   || rc=1
+
+echo
+if (( rc == 0 )); then
+  banner "ALL GREEN — invoice round-trip succeeded; bob +7 UCT, alice -7 UCT, invoice COVERED"
+else
+  banner "FAIL — see ASSERT FAIL lines above"
+fi
+exit "$rc"

--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -786,7 +786,7 @@ sphere wallet use alice
 # `invoice deliver` in §C.1b via `--to`, because the invoice's only
 # target is self and `deliver`'s default ("every non-self target")
 # would yield zero recipients.
-sphere invoice create --target "@$ALICE_TAG" --asset "11000000 UCT" --memo "Full-recovery test invoice" \
+sphere invoice create --target "@$ALICE_TAG" --asset "11 UCT" --memo "Full-recovery test invoice" \
   2>&1 | tee "$SNAP/peer1-invoice-create.log"
 
 INV="$(grep -Eo '"invoiceId":[[:space:]]*"[^"]+"' "$SNAP/peer1-invoice-create.log" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"

--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -1603,10 +1603,27 @@ export class AccountingModule {
           error: cidPublishError,
         });
         failed++;
+        // Mirror the failure into a structured event so operator surfaces
+        // can react without parsing per-recipient `error` strings.
+        deps.emitEvent('invoice:deliver-failed', {
+          invoiceId,
+          recipient,
+          reason: 'transport-error',
+          errorMessage: cidPublishError,
+        });
         continue;
       }
       try {
-        await deps.communications.sendDM(recipient, dmContent);
+        // Issue #397 — invoice deliveries always request extended-
+        // durability. The publisher keeps the gift wrap live on the
+        // relay across an extended window so a short-lived recipient
+        // CLI process that subscribes anytime during the window
+        // ingests it. Throws `TRANSPORT_ERROR` if the publisher's
+        // republish budget is exhausted (relay retention shorter than
+        // the delivery window).
+        await deps.communications.sendDM(recipient, dmContent, {
+          extendedDurability: true,
+        });
         recipientResults.push({
           recipient,
           success: true,
@@ -1616,15 +1633,36 @@ export class AccountingModule {
       } catch (err) {
         // Common per-recipient failures: resolver miss (nametag not
         // registered, no binding event), transport offline, relay
-        // rejection. Surface the message so callers can present it to
-        // the user without leaking SDK internals.
+        // rejection, extended-durability budget exhausted. Surface the
+        // message so callers can present it to the user without leaking
+        // SDK internals.
+        const errorMessage = err instanceof Error ? err.message : String(err);
         recipientResults.push({
           recipient,
           success: false,
           shape: '',
-          error: err instanceof Error ? err.message : String(err),
+          error: errorMessage,
         });
         failed++;
+        // Classify the failure for the new `invoice:deliver-failed`
+        // event so consumers can branch on cause. The message-substring
+        // check is intentionally narrow: only the extended-durability
+        // exhaustion path uses the `non-durable` phrase in its
+        // SphereError message (see NostrTransportProvider.
+        // publishWithExtendedDurability). Everything else falls into
+        // `transport-error`.
+        const reason: 'non-durable' | 'transport-error' | 'unknown' =
+          /non-durable\b/i.test(errorMessage)
+            ? 'non-durable'
+            : err instanceof Error
+              ? 'transport-error'
+              : 'unknown';
+        deps.emitEvent('invoice:deliver-failed', {
+          invoiceId,
+          recipient,
+          reason,
+          errorMessage,
+        });
       }
     }
 

--- a/modules/communications/CommunicationsModule.ts
+++ b/modules/communications/CommunicationsModule.ts
@@ -16,7 +16,7 @@ import type {
   SphereEventMap,
 } from '../../types';
 import type { StorageProvider } from '../../storage';
-import type { TransportProvider, IncomingMessage, IncomingBroadcast } from '../../transport';
+import type { TransportProvider, IncomingMessage, IncomingBroadcast, SendMessageOptions } from '../../transport';
 import { STORAGE_KEYS_ADDRESS } from '../../constants';
 
 // =============================================================================
@@ -39,6 +39,22 @@ export interface CommunicationsModuleConfig {
    *  events may occur if the relay delivers the same message twice. */
   cacheMessages?: boolean;
 }
+
+// =============================================================================
+// sendDM Options
+// =============================================================================
+
+/**
+ * Options accepted by {@link CommunicationsModule.sendDM}. Forwarded
+ * verbatim to the underlying {@link TransportProvider.sendMessage}.
+ *
+ * Re-exported as a named type so consumers (callers in other modules,
+ * apps embedding the SDK) can construct option bags without reaching
+ * into the transport layer.
+ *
+ * @see SendMessageOptions
+ */
+export type SendDMOptions = SendMessageOptions;
 
 // =============================================================================
 // Pagination Types
@@ -333,16 +349,32 @@ export class CommunicationsModule {
   // ===========================================================================
 
   /**
-   * Send direct message
+   * Send direct message.
+   *
+   * @param recipient - Identifier accepted by the transport resolver
+   *   (`@nametag`, `DIRECT://...`, chain pubkey, transport pubkey).
+   * @param content - Plaintext DM payload (the transport handles NIP-17
+   *   encryption + gift-wrap framing).
+   * @param options - Optional transport publish flags. See
+   *   {@link SendDMOptions}. The default (omitted) preserves the legacy
+   *   immediate-verification behavior. Callers that need higher
+   *   delivery confidence — notably the accounting module's invoice
+   *   delivery (issue #397) — pass `{ extendedDurability: true }` to
+   *   keep the gift wrap live on the relay long enough for a short-
+   *   lived recipient CLI to subscribe and ingest it.
    */
-  async sendDM(recipient: string, content: string): Promise<DirectMessage> {
+  async sendDM(
+    recipient: string,
+    content: string,
+    options?: SendDMOptions,
+  ): Promise<DirectMessage> {
     this.ensureInitialized();
 
     // Resolve recipient
     const resolved = await this.resolveRecipient(recipient);
 
     // Send via transport
-    const eventId = await this.deps!.transport.sendMessage(resolved.pubkey, content);
+    const eventId = await this.deps!.transport.sendMessage(resolved.pubkey, content, options);
 
     // Create message record
     // isRead=false for sent messages means "not yet read by recipient".

--- a/tests/unit/modules/AccountingModule.invoiceDelivery.test.ts
+++ b/tests/unit/modules/AccountingModule.invoiceDelivery.test.ts
@@ -479,6 +479,8 @@ describe('AccountingModule.deliverInvoice — happy path (real createInvoice fix
     expect(mocks.communications.sendDM).toHaveBeenCalledWith(
       '@arbitrary-recipient',
       expect.any(String),
+      // Issue #397 — invoice deliveries always opt in to extended durability.
+      { extendedDurability: true },
     );
   });
 
@@ -567,6 +569,67 @@ describe('AccountingModule.deliverInvoice — failure modes', () => {
     expect(bobResult.error).toContain('relay offline');
     const carolResult = result.recipients.find((r) => r.recipient === REMOTE_CAROL)!;
     expect(carolResult.success).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #397 — invoice:deliver-failed event + extendedDurability opt-in
+  // -------------------------------------------------------------------------
+
+  it('UT-DELIVER-104 (#397): passes extendedDurability:true to sendDM', async () => {
+    const { invoiceId } = await mintRealInvoice();
+    mocks.communications.sendDM.mockImplementation((_recipient: string, content: string) =>
+      Promise.resolve({
+        id: 'mock-dm-' + Math.random().toString(36).slice(2),
+        senderPubkey: '02' + 'a'.repeat(64),
+        recipientPubkey: '02' + 'b'.repeat(64),
+        content,
+        timestamp: Date.now(),
+        isRead: false,
+      }),
+    );
+    await module.deliverInvoice(invoiceId);
+    // Final option-bag argument must request extended durability.
+    const lastCall = mocks.communications.sendDM.mock.calls.at(-1)!;
+    expect(lastCall[2]).toEqual({ extendedDurability: true });
+  });
+
+  it('UT-DELIVER-105 (#397): emits invoice:deliver-failed with reason "non-durable" when transport throws non-durable error', async () => {
+    const { invoiceId } = await mintRealInvoice();
+    // Mirror NostrTransportProvider.publishWithExtendedDurability's
+    // exhausted-budget error shape (substring match in deliverInvoice
+    // is on /non-durable\b/i).
+    mocks.communications.sendDM.mockRejectedValue(
+      new Error('dm event abcdef012345 non-durable at 30000ms after 3 republish attempts — relay retention shorter than delivery window'),
+    );
+    const emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    const result = await module.deliverInvoice(invoiceId);
+    expect(result.sent).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(emitEvent).toHaveBeenCalledWith(
+      'invoice:deliver-failed',
+      expect.objectContaining({
+        invoiceId,
+        recipient: REMOTE_BOB,
+        reason: 'non-durable',
+        errorMessage: expect.stringContaining('non-durable'),
+      }),
+    );
+  });
+
+  it('UT-DELIVER-106 (#397): emits invoice:deliver-failed with reason "transport-error" on generic transport error', async () => {
+    const { invoiceId } = await mintRealInvoice();
+    mocks.communications.sendDM.mockRejectedValue(new Error('relay offline'));
+    const emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    const result = await module.deliverInvoice(invoiceId);
+    expect(result.failed).toBe(1);
+    expect(emitEvent).toHaveBeenCalledWith(
+      'invoice:deliver-failed',
+      expect.objectContaining({
+        invoiceId,
+        recipient: REMOTE_BOB,
+        reason: 'transport-error',
+      }),
+    );
   });
 });
 

--- a/tests/unit/modules/CommunicationsModule.cache.test.ts
+++ b/tests/unit/modules/CommunicationsModule.cache.test.ts
@@ -166,7 +166,9 @@ describe('CommunicationsModule cacheMessages option', () => {
 
       // Transport receives x-only key (02 prefix stripped by resolver)
       const xOnlyPeer = 'b'.repeat(64);
-      expect(deps.transport.sendMessage).toHaveBeenCalledWith(xOnlyPeer, 'hi');
+      // Issue #397 — sendDM forwards an options bag to transport.sendMessage.
+      // Default callers pass nothing, so options arrives as `undefined`.
+      expect(deps.transport.sendMessage).toHaveBeenCalledWith(xOnlyPeer, 'hi', undefined);
       expect(message).toMatchObject({ content: 'hi' });
       expect(mod.getConversation(PEER_PUBKEY)).toEqual([]);
       expect(deps.storage.set).not.toHaveBeenCalled();

--- a/tests/unit/transport/NostrTransportProvider.extendedDurability397.test.ts
+++ b/tests/unit/transport/NostrTransportProvider.extendedDurability397.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Issue #397 — extended-durability publisher hold for short-lived
+ * recipient processes.
+ *
+ * Tests the new `publishWithExtendedDurability` private method on
+ * `NostrTransportProvider`. The method extends the standard
+ * `publishWithVerification` window from ~1.5 seconds to ~30 seconds by
+ * re-querying the relay at a schedule of escalating checkpoints and
+ * re-publishing the same event if it has been evicted.
+ *
+ * What this fixes (reproduced by `manual-test-accounting-roundtrip.sh`):
+ *   - testnet's single Nostr relay sometimes evicts gift wraps within
+ *     seconds of publish, well before a short-lived recipient CLI
+ *     subscribes;
+ *   - pre-fix, the publisher's `publishWithVerification` queried at
+ *     ~1.5s, observed the event still present, returned success, then
+ *     exited — and the recipient's later subscribe got nothing.
+ *
+ * The tests below exercise the method directly through reflection
+ * (mirrors the durabilityCooldown272 pattern) because routing through
+ * the public `sendMessage` path would require functional NIP-17
+ * crypto + identity setup that adds no logic coverage to this surface.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { WebSocketFactory } from '../../../transport/websocket';
+
+// =============================================================================
+// Mock NostrClient
+// =============================================================================
+
+const mockSubscribe = vi.fn();
+const mockUnsubscribe = vi.fn();
+const mockPublishEvent = vi.fn().mockResolvedValue('mock-event-id');
+const mockConnect = vi.fn().mockResolvedValue(undefined);
+const mockDisconnect = vi.fn();
+const mockIsConnected = vi.fn().mockReturnValue(true);
+const mockGetConnectedRelays = vi
+  .fn()
+  .mockReturnValue(new Set(['wss://test.relay']));
+const mockAddConnectionListener = vi.fn();
+const mockRelaysMap = new Map<string, unknown>();
+const mockStopPingTimer = vi.fn();
+
+vi.mock('@unicitylabs/nostr-js-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/nostr-js-sdk')>();
+  return {
+    ...actual,
+    NostrClient: vi.fn().mockImplementation(() => ({
+      connect: mockConnect,
+      disconnect: mockDisconnect,
+      isConnected: mockIsConnected,
+      getConnectedRelays: mockGetConnectedRelays,
+      subscribe: mockSubscribe,
+      unsubscribe: mockUnsubscribe,
+      publishEvent: mockPublishEvent,
+      addConnectionListener: mockAddConnectionListener,
+      relays: mockRelaysMap,
+      stopPingTimer: mockStopPingTimer,
+    })),
+  };
+});
+
+const { NostrTransportProvider } = await import(
+  '../../../transport/NostrTransportProvider'
+);
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function createProvider(): InstanceType<typeof NostrTransportProvider> {
+  return new NostrTransportProvider({
+    relays: ['wss://test.relay'],
+    createWebSocket: (() => {}) as unknown as WebSocketFactory,
+    timeout: 100,
+    autoReconnect: false,
+  });
+}
+
+function createMockNostrEvent() {
+  return {
+    id: 'a'.repeat(64),
+    kind: 1059, // GIFT_WRAP
+    content: 'mock encrypted content',
+    tags: [['p', 'b'.repeat(64)]],
+    pubkey: 'c'.repeat(64),
+    created_at: Math.floor(Date.now() / 1000),
+    sig: 'd'.repeat(128),
+  };
+}
+
+/**
+ * Build a `mockSubscribe` implementation that controls the verify
+ * outcome for each successive `queryEvents` call.
+ *
+ * Each entry in `verifyOutcomes` corresponds to one call to
+ * `mockSubscribe` and decides what the synthetic subscription delivers:
+ *   - `'present'` — onEvent fires with the target event, then EOSE.
+ *   - `'absent'`  — only EOSE fires (no events delivered).
+ *   - `'timeout'` — neither onEvent nor EOSE fires (queryEvents times out).
+ *
+ * The method returns a fake subId.
+ */
+function installVerifyOutcomes(
+  event: ReturnType<typeof createMockNostrEvent>,
+  verifyOutcomes: ReadonlyArray<'present' | 'absent' | 'timeout'>,
+): void {
+  let call = 0;
+  mockSubscribe.mockImplementation(
+    (_filter: unknown, callbacks: { onEvent?: (e: unknown) => void; onEndOfStoredEvents?: () => void }) => {
+      const outcome = verifyOutcomes[call] ?? 'present';
+      call++;
+      // Defer to microtask so subscribe() returns the subId before
+      // settling, matching the real nostr-js-sdk behavior.
+      queueMicrotask(() => {
+        if (outcome === 'present') {
+          callbacks.onEvent?.(event);
+          callbacks.onEndOfStoredEvents?.();
+        } else if (outcome === 'absent') {
+          callbacks.onEndOfStoredEvents?.();
+        }
+        // 'timeout' → never settle; queryEvents will hit its 8s cap.
+      });
+      return `sub-${call}`;
+    },
+  );
+}
+
+/**
+ * Drive a `publishWithExtendedDurability` promise to settlement under
+ * fake timers. Advances the timer in 1s steps until the promise either
+ * resolves or rejects, capped at a generous wall-clock budget.
+ */
+async function drivePromise<T>(
+  promise: Promise<T>,
+): Promise<{ value?: T; error?: unknown }> {
+  let value: T | undefined;
+  let error: unknown;
+  const tracked = promise.then(
+    (v) => {
+      value = v;
+    },
+    (e) => {
+      error = e;
+    },
+  );
+
+  // The schedule maxes out at 30s, plus 8s query timeouts per
+  // checkpoint. 5 minutes is a generous safety budget for the timer
+  // advance loop; we exit as soon as the promise settles.
+  for (let i = 0; i < 300; i++) {
+    await vi.advanceTimersByTimeAsync(1000);
+    if (value !== undefined || error !== undefined) break;
+  }
+  // Yield once more to flush any pending microtasks.
+  await tracked.catch(() => undefined);
+  return { value, error };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('NostrTransportProvider.publishWithExtendedDurability (#397)', () => {
+  beforeEach(() => {
+    mockPublishEvent.mockReset();
+    mockSubscribe.mockReset();
+    mockUnsubscribe.mockReset();
+    mockConnect.mockReset();
+    mockIsConnected.mockReset();
+    mockGetConnectedRelays.mockReset();
+
+    vi.useFakeTimers();
+
+    mockPublishEvent.mockResolvedValue('mock-event-id');
+    mockConnect.mockResolvedValue(undefined);
+    mockIsConnected.mockReturnValue(true);
+    mockGetConnectedRelays.mockReturnValue(new Set(['wss://test.relay']));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves without republishing when the event stays durable at every checkpoint', async () => {
+    const provider = createProvider();
+    await provider.connect();
+    const event = createMockNostrEvent();
+    // Verify call sequence: 1 from publishWithVerification + 4 from
+    // extended-durability checkpoints (3000, 8000, 18000, 30000).
+    installVerifyOutcomes(event, [
+      'present', // publishWithVerification post-publish verify
+      'present', // checkpoint 3000ms
+      'present', // checkpoint 8000ms
+      'present', // checkpoint 18000ms
+      'present', // checkpoint 30000ms
+    ]);
+
+    const { value, error } = await drivePromise(
+      (provider as unknown as { publishWithExtendedDurability: (e: unknown, l: string) => Promise<void> })
+        .publishWithExtendedDurability(event, 'dm'),
+    );
+
+    expect(error).toBeUndefined();
+    expect(value).toBeUndefined();
+    // Exactly one publish — the initial one. Zero republishes.
+    expect(mockPublishEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('republishes when the event is observed missing at a checkpoint, then succeeds on the next verify', async () => {
+    const provider = createProvider();
+    await provider.connect();
+    const event = createMockNostrEvent();
+    // Sequence:
+    //  1. publishWithVerification post-publish verify → present
+    //  2. checkpoint 3000ms → present
+    //  3. checkpoint 8000ms → ABSENT → triggers republish
+    //  4. republish's own post-publish verify → present
+    //  5. checkpoint 18000ms → present
+    //  6. checkpoint 30000ms → present
+    installVerifyOutcomes(event, [
+      'present',
+      'present',
+      'absent',
+      'present',
+      'present',
+      'present',
+    ]);
+
+    const { error } = await drivePromise(
+      (provider as unknown as { publishWithExtendedDurability: (e: unknown, l: string) => Promise<void> })
+        .publishWithExtendedDurability(event, 'dm'),
+    );
+
+    expect(error).toBeUndefined();
+    // 2 publishes: initial + 1 republish triggered at 8000ms checkpoint.
+    expect(mockPublishEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws TRANSPORT_ERROR after exhausting the republish budget', async () => {
+    const provider = createProvider();
+    await provider.connect();
+    const event = createMockNostrEvent();
+    // Sequence: post-publish verify present, then every checkpoint
+    // misses. Each miss triggers a republish + its own verify (which
+    // returns present, satisfying the inner publishWithVerification);
+    // then the next checkpoint misses again.
+    //  - call 1: post-publish verify → present
+    //  - call 2: cp 3000ms → ABSENT (republish #1 fires)
+    //  - call 3: republish #1 verify → present
+    //  - call 4: cp 8000ms → ABSENT (republish #2 fires)
+    //  - call 5: republish #2 verify → present
+    //  - call 6: cp 18000ms → ABSENT (republish #3 fires)
+    //  - call 7: republish #3 verify → present
+    //  - call 8: cp 30000ms → ABSENT (budget exhausted → throws)
+    installVerifyOutcomes(event, [
+      'present', // 1
+      'absent',  // 2 — cp 3000ms
+      'present', // 3 — republish 1 verify
+      'absent',  // 4 — cp 8000ms
+      'present', // 5 — republish 2 verify
+      'absent',  // 6 — cp 18000ms
+      'present', // 7 — republish 3 verify
+      'absent',  // 8 — cp 30000ms (budget exhausted)
+    ]);
+
+    const { error } = await drivePromise(
+      (provider as unknown as { publishWithExtendedDurability: (e: unknown, l: string) => Promise<void> })
+        .publishWithExtendedDurability(event, 'invoice_delivery'),
+    );
+
+    expect(error).toBeDefined();
+    expect((error as { code?: string }).code).toBe('TRANSPORT_ERROR');
+    expect((error as { message?: string }).message).toMatch(/non-durable/);
+    // 4 publishes: initial + 3 republishes (the budget).
+    expect(mockPublishEvent).toHaveBeenCalledTimes(4);
+  });
+
+  it('treats a verify-query disconnect throw as optimistically durable (no republish)', async () => {
+    const provider = createProvider();
+    await provider.connect();
+    const event = createMockNostrEvent();
+    // queryEvents throws SphereError 'No connected relays' if the
+    // client is not connected when the verify call fires. Simulate by
+    // returning false from isConnected the moment the second verify
+    // call is about to query the relay.
+    //
+    // Sequence:
+    //  - call 1 (publishWithVerification verify, post-publish): present
+    //  - call 2 (extended durability cp 3000ms): isConnected→false →
+    //    queryEvents throws → catch fires → continue (no republish)
+    //  - call 3 (cp 8000ms): isConnected→true again → present
+    //  - call 4 (cp 18000ms): present
+    //  - call 5 (cp 30000ms): present
+    installVerifyOutcomes(event, [
+      'present',
+      'present', // unused — the second queryEvents throws before subscribing
+      'present',
+      'present',
+      'present',
+    ]);
+    let isConnCall = 0;
+    mockIsConnected.mockImplementation(() => {
+      isConnCall++;
+      // queryEvents checks isConnected at the top. The first call is
+      // for the post-publish verify (publishWithVerification path).
+      // The second is for the cp-3000ms verify — return false here so
+      // queryEvents throws and the extended-durability catch fires.
+      if (isConnCall === 2) return false;
+      return true;
+    });
+
+    const { error } = await drivePromise(
+      (provider as unknown as { publishWithExtendedDurability: (e: unknown, l: string) => Promise<void> })
+        .publishWithExtendedDurability(event, 'dm'),
+    );
+
+    expect(error).toBeUndefined();
+    // Zero republishes — disconnect-mid-flight is optimistic.
+    expect(mockPublishEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/transport/MultiAddressTransportMux.ts
+++ b/transport/MultiAddressTransportMux.ts
@@ -55,6 +55,7 @@ import type {
   InstantSplitBundlePayload,
   InstantSplitBundleHandler,
   IncomingInstantSplitBundle,
+  SendMessageOptions,
 } from './transport-provider';
 import type { WebSocketFactory, UUIDGenerator } from './websocket';
 import { defaultUUIDGenerator } from './websocket';
@@ -1427,11 +1428,23 @@ export class MultiAddressTransportMux {
 
   /**
    * Create and publish a NIP-17 gift wrap message for a specific address.
+   *
+   * @param options - Optional publish-behavior flags:
+   *   - `extendedDurability` (issue #397): when true, hold the gift wrap
+   *     event on the relay across an extended window via repeated
+   *     verify+republish at escalating checkpoints. See
+   *     {@link NostrTransportProvider}'s sister method
+   *     `publishWithExtendedDurability` for the schedule + budget.
+   *     Throws `TRANSPORT_ERROR` if the republish budget is exhausted.
+   *
+   * Default (no options): single publish, no verification. Matches
+   * the pre-#397 behavior so existing callers do not regress.
    */
   async sendGiftWrap(
     addressIndex: number,
     recipientPubkey: string,
-    content: string
+    content: string,
+    options?: { extendedDurability?: boolean }
   ): Promise<string> {
     const entry = this.addresses.get(addressIndex);
     if (!entry) throw new SphereError('Address not registered in mux', 'NOT_INITIALIZED');
@@ -1445,9 +1458,20 @@ export class MultiAddressTransportMux {
 
     const giftWrap = NIP17.createGiftWrap(entry.keyManager, nostrRecipient, content);
     const giftWrapEvent = NostrEventClass.fromJSON(giftWrap);
-    await this.nostrClient.publishEvent(giftWrapEvent);
 
-    // Self-wrap for relay replay
+    if (options?.extendedDurability) {
+      // Issue #397 — keep the gift wrap live on the relay across an
+      // extended window so a short-lived recipient CLI process that
+      // subscribes anywhere inside the window observes the event.
+      // Pass the raw signed object — the helper rehydrates a fresh
+      // SDK Event class per publish to avoid `pendingOks` reuse.
+      await this._publishWithExtendedDurability(giftWrap, giftWrap.id, 'dm');
+    } else {
+      await this.nostrClient.publishEvent(giftWrapEvent);
+    }
+
+    // Self-wrap for relay replay (fire-and-forget; losing the self-wrap
+    // only affects local conversation-history replay, not delivery).
     const selfPubkey = entry.keyManager.getPublicKeyHex();
     const senderNametag = entry.identity.nametag;
     const selfWrapContent = JSON.stringify({
@@ -1465,6 +1489,133 @@ export class MultiAddressTransportMux {
 
     return giftWrap.id;
   }
+
+  /**
+   * Issue #397 — Mux equivalent of
+   * {@link NostrTransportProvider}.publishWithExtendedDurability. Same
+   * schedule + budget. Uses the Mux's own `_queryEventById` for the
+   * verification cycles so the relay round-trip semantics match the
+   * adjacent `createAndPublishEncryptedEvent` flow.
+   *
+   * @param event   - The pre-signed gift wrap event to publish.
+   * @param eventId - The id of `event` (cached so we don't re-extract).
+   * @param label   - Human label for log/error messages (`'dm'` etc.).
+   */
+  private async _publishWithExtendedDurability(
+    rawEvent: NostrEvent,
+    eventId: string,
+    label: string,
+  ): Promise<void> {
+    if (!this.nostrClient) throw new SphereError('Not connected', 'NOT_INITIALIZED');
+
+    // 1. Initial publish + immediate verification (~300-1500 ms after
+    //    publish). Mirrors the inner verify loop of
+    //    `createAndPublishEncryptedEvent` so behavior is consistent
+    //    across publish paths.
+    await this._publishVerified(rawEvent, eventId, label);
+
+    const checkpointsMs = MultiAddressTransportMux.EXTENDED_DURABILITY_CHECKPOINTS_MS;
+    const maxRepublishes = MultiAddressTransportMux.EXTENDED_DURABILITY_MAX_REPUBLISHES;
+    let republishes = 0;
+    let elapsedMs = 1500;
+
+    for (const checkpointMs of checkpointsMs) {
+      if (checkpointMs <= elapsedMs) continue;
+      await new Promise(r => setTimeout(r, checkpointMs - elapsedMs));
+      elapsedMs = checkpointMs;
+
+      let stillThere: boolean;
+      try {
+        stillThere = await this._queryEventById(eventId);
+      } catch {
+        logger.debug('Mux', `${label} extended-durability verify query failed at ${checkpointMs}ms — treating optimistically`);
+        continue;
+      }
+      if (stillThere) continue;
+
+      if (republishes >= maxRepublishes) {
+        throw new SphereError(
+          `${label} event ${eventId.slice(0, 12)} non-durable at ${checkpointMs}ms after ${republishes} republish attempts — relay retention shorter than delivery window`,
+          'TRANSPORT_ERROR',
+        );
+      }
+
+      logger.warn(
+        'Mux',
+        `[EXTENDED-DURABILITY] ${label} event ${eventId.slice(0, 12)} missing from relay at ${checkpointMs}ms; republishing (attempt ${republishes + 1}/${maxRepublishes})`,
+      );
+      await this._publishVerified(rawEvent, eventId, label);
+      republishes++;
+    }
+  }
+
+  /**
+   * Mux's equivalent of `NostrTransportProvider.publishWithVerification`.
+   * Publishes the event, waits for relay indexing, then queries by id;
+   * retries up to `maxAttempts` times if not observed. Throws
+   * `TRANSPORT_ERROR` if exhausted.
+   *
+   * Pulled into a helper so both `_publishWithExtendedDurability` and
+   * a future hardening of `sendGiftWrap`'s default path share the same
+   * verified-publish semantics.
+   */
+  private async _publishVerified(
+    rawEvent: NostrEvent,
+    eventId: string,
+    label: string,
+    maxAttempts = 3,
+  ): Promise<void> {
+    if (!this.nostrClient) throw new SphereError('Not connected', 'NOT_INITIALIZED');
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        // Re-create the SDK Event class per attempt — mirrors
+        // `NostrTransportProvider.publishEvent`'s defense against
+        // pendingOks-map reuse leaks across retries.
+        const sdkEvent = NostrEventClass.fromJSON(rawEvent);
+        await this.nostrClient.publishEvent(sdkEvent);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('Event rejected') && !msg.includes('rate') && !msg.includes('limit')) {
+          throw err;
+        }
+        if (attempt === maxAttempts) throw err;
+        logger.debug('Mux', `${label} publish attempt ${attempt} failed (${msg}), retrying...`);
+        await new Promise(r => setTimeout(r, 1000 * attempt));
+        continue;
+      }
+
+      await new Promise(r => setTimeout(r, 300 + Math.random() * 1200));
+      try {
+        if (await this._queryEventById(eventId)) {
+          if (attempt > 1) {
+            logger.debug('Mux', `${label} verified on relay after ${attempt} attempt(s)`);
+          }
+          return;
+        }
+      } catch {
+        if (attempt === maxAttempts) {
+          logger.debug('Mux', `${label} verification query failed — accepting as best-effort`);
+          return;
+        }
+      }
+
+      if (attempt < maxAttempts) {
+        const delay = Math.min(2000 * attempt, 10000);
+        logger.debug('Mux', `${label} not found on relay, retrying in ${delay}ms (attempt ${attempt}/${maxAttempts})...`);
+        await new Promise(r => setTimeout(r, delay));
+      } else {
+        throw new SphereError(
+          `${label} not verified on relay after ${maxAttempts} attempts — delivery failed`,
+          'TRANSPORT_ERROR',
+        );
+      }
+    }
+  }
+
+  private static readonly EXTENDED_DURABILITY_CHECKPOINTS_MS: ReadonlyArray<number> =
+    [3000, 8000, 18000, 30000];
+  private static readonly EXTENDED_DURABILITY_MAX_REPUBLISHES = 3;
 
   /**
    * Send a NIP-17 read receipt (kind 15) for a specific address.
@@ -1859,13 +2010,22 @@ export class AddressTransportAdapter implements TransportProvider {
   // Sending — delegates to mux with this address's keyManager
   // ===========================================================================
 
-  async sendMessage(recipientPubkey: string, content: string): Promise<string> {
+  async sendMessage(
+    recipientPubkey: string,
+    content: string,
+    options?: SendMessageOptions,
+  ): Promise<string> {
     const senderNametag = this.identity.nametag;
     const wrappedContent = senderNametag
       ? JSON.stringify({ senderNametag, text: content })
       : content;
 
-    return this.mux.sendGiftWrap(this.addressIndex, recipientPubkey, wrappedContent);
+    return this.mux.sendGiftWrap(
+      this.addressIndex,
+      recipientPubkey,
+      wrappedContent,
+      options,
+    );
   }
 
   async sendTokenTransfer(recipientPubkey: string, payload: TokenTransferPayload): Promise<string> {

--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -59,6 +59,7 @@ import type {
   IncomingReadReceipt,
   TypingIndicatorHandler,
   IncomingTypingIndicator,
+  SendMessageOptions,
 } from './transport-provider';
 import type { WebSocketFactory, UUIDGenerator } from './websocket';
 import { defaultUUIDGenerator } from './websocket';
@@ -733,7 +734,11 @@ export class NostrTransportProvider implements TransportProvider {
     return this.keyManager.getPublicKeyHex();
   }
 
-  async sendMessage(recipientPubkey: string, content: string): Promise<string> {
+  async sendMessage(
+    recipientPubkey: string,
+    content: string,
+    options?: SendMessageOptions,
+  ): Promise<string> {
     this.ensureReady();
 
     // NIP-17 requires 32-byte x-only pubkey; strip 02/03 prefix if present
@@ -750,10 +755,20 @@ export class NostrTransportProvider implements TransportProvider {
     // Create NIP-17 gift-wrapped message (kind 1059) for recipient
     const giftWrap = NIP17.createGiftWrap(this.keyManager!, nostrRecipient, wrappedContent);
 
-    await this.publishWithVerification(giftWrap, 3, 'dm');
+    if (options?.extendedDurability) {
+      // Issue #397 — keep the event live on the relay across an
+      // extended window so a short-lived recipient CLI that subscribes
+      // anywhere inside the window observes the event. See
+      // `publishWithExtendedDurability` for the schedule + budget.
+      await this.publishWithExtendedDurability(giftWrap, 'dm');
+    } else {
+      await this.publishWithVerification(giftWrap, 3, 'dm');
+    }
 
     // NIP-17 self-wrap: send a copy to ourselves so relay can replay sent messages.
     // Content includes recipientPubkey and originalId for dedup against the live-sent record.
+    // We do NOT extend-durability the self-wrap: it's a local-history replay copy
+    // only; losing it has no user-visible effect on the receiver's delivery.
     const selfWrapContent = JSON.stringify({
       selfWrap: true,
       originalId: giftWrap.id,
@@ -2614,6 +2629,166 @@ export class NostrTransportProvider implements TransportProvider {
       }
     }
   }
+
+  /**
+   * Issue #397 — extended-window durability verification + republish.
+   *
+   * After the initial {@link publishWithVerification} confirms the event
+   * landed on the relay (within ~1.5 s), this method continues checking
+   * relay retention at a schedule of escalating delays. If the event is
+   * observed missing at any checkpoint, the SAME event is re-published
+   * (`event.id` is content-derived so the relay treats the re-publish as
+   * idempotent and the recipient's NIP-17 unwrap pipeline dedupes by id).
+   * The republish budget is bounded; once exhausted we throw a typed
+   * `TRANSPORT_ERROR` so callers can surface the failure to operators.
+   *
+   * The motivating case (issue #397): testnet's single Nostr relay
+   * sometimes evicts gift wraps within seconds of publish, well before
+   * a short-lived recipient CLI process subscribes. The original
+   * `publishWithVerification` returned success at +1.5 s — long before
+   * the eviction window — so the publisher believed delivery succeeded
+   * and exited, leaving the recipient with nothing to fetch.
+   *
+   * The schedule below covers roughly the first ~30 s after publish.
+   * In aggregate this gives the recipient a ~30-second window during
+   * which any subscription will land on a live event. Beyond 30 s we
+   * accept that delivery requires the recipient to be online during
+   * the publisher's hold — out-of-scope channels (IPFS uxf-cid pinning,
+   * a daemon on the receiver side, or periodic re-runs of `invoice
+   * deliver` by the operator) cover the longer tail.
+   *
+   * Idempotency: the relay deduplicates by `event.id`; the recipient
+   * deduplicates by `event.id` in its incoming-message dedup. Republishes
+   * are safe to attempt multiple times.
+   *
+   * Concurrency: the verify queries reuse `queryEvents` with a tight
+   * 8 s timeout. A query timeout (resolves to empty) is treated the same
+   * as a true "no events" result — conservatively, we republish. This
+   * may over-publish under a degraded relay, but republishes are
+   * idempotent (event id is content-addressed; relay + recipient both
+   * dedupe). A *thrown* queryEvents error (disconnect mid-flight) is
+   * treated optimistically (no republish): if we cannot reach the
+   * relay at all, a republish would fail too, and the next checkpoint
+   * will retry the verify.
+   *
+   * @param event - The NostrEvent already produced by the caller. It
+   *                must be the same event published by the initial
+   *                publish; re-publishing creates the same wire bytes.
+   * @param label - Human-friendly label used in logs and error messages
+   *                (e.g. `'dm'`, `'invoice_delivery'`).
+   *
+   * @throws {SphereError} `TRANSPORT_ERROR` — final checkpoint observed
+   *   the event missing AND the republish budget is exhausted. Callers
+   *   should surface this as a delivery failure.
+   */
+  private async publishWithExtendedDurability(
+    event: NostrEvent,
+    label: string,
+  ): Promise<void> {
+    // 1. Initial publish + immediate verification (~300-1500 ms after
+    //    publish). On failure this throws; the caller's outer catch sees
+    //    the same TRANSPORT_ERROR semantics as the non-extended path.
+    await this.publishWithVerification(event, 3, label);
+
+    const checkpointsMs = NostrTransportProvider.EXTENDED_DURABILITY_CHECKPOINTS_MS;
+    const maxRepublishes = NostrTransportProvider.EXTENDED_DURABILITY_MAX_REPUBLISHES;
+
+    let republishes = 0;
+    // publishWithVerification waited 300-1500 ms before its verify query,
+    // and the query itself takes some time. We approximate the elapsed
+    // budget as 1500 ms — the schedule below skips checkpoints that
+    // would land inside that already-verified window.
+    let elapsedMs = 1500;
+
+    for (const checkpointMs of checkpointsMs) {
+      if (checkpointMs <= elapsedMs) continue;
+      const waitMs = checkpointMs - elapsedMs;
+      await new Promise(r => setTimeout(r, waitMs));
+      elapsedMs = checkpointMs;
+
+      let found: NostrEvent[];
+      try {
+        // Use a tight query timeout for the durability check — a 60 s
+        // default would dominate the schedule and stall the publisher.
+        found = await this.queryEvents({ ids: [event.id], limit: 1 }, 8000);
+      } catch {
+        // Verification query failed (transport error, relay timeout).
+        // Treat optimistically: do not republish on the basis of a
+        // verification failure — only on observed absence. The next
+        // checkpoint will retry the verify.
+        logger.debug('Nostr', `${label} extended-durability verify query failed at ${checkpointMs}ms — treating optimistically`);
+        continue;
+      }
+
+      if (found.length > 0) {
+        // Still on relay; nothing to do.
+        continue;
+      }
+
+      // Observed missing. Republish if budget allows.
+      if (republishes >= maxRepublishes) {
+        throw new SphereError(
+          `${label} event ${event.id.slice(0, 12)} non-durable at ${checkpointMs}ms after ${republishes} republish attempts — relay retention shorter than delivery window`,
+          'TRANSPORT_ERROR',
+        );
+      }
+
+      logger.warn(
+        'Nostr',
+        `[EXTENDED-DURABILITY] ${label} event ${event.id.slice(0, 12)} missing from relay at ${checkpointMs}ms; republishing (attempt ${republishes + 1}/${maxRepublishes})`,
+      );
+      try {
+        await this.publishWithVerification(event, 3, label);
+      } catch (err) {
+        // publishWithVerification exhausted its own retry budget. Surface
+        // as TRANSPORT_ERROR — the publisher cannot keep the event live.
+        throw err instanceof SphereError
+          ? err
+          : new SphereError(
+              `${label} republish at ${checkpointMs}ms failed: ${err instanceof Error ? err.message : String(err)}`,
+              'TRANSPORT_ERROR',
+              err,
+            );
+      }
+      republishes++;
+      // After republish, the relay has just verified it again; treat the
+      // freshly-verified state as the new baseline so the very next
+      // checkpoint does not immediately re-verify with no elapsed delay.
+      // (The for-loop iteration already advances `elapsedMs`; no further
+      // adjustment needed here.)
+    }
+  }
+
+  /**
+   * Issue #397 — extended-durability checkpoint schedule (ms after the
+   * initial publish, measured from `publishEvent` return).
+   *
+   * Rationale for the schedule:
+   *  - 3000 ms: catches relays that evict within the first few seconds.
+   *  - 8000 ms / 18000 ms: covers the most common "short retention"
+   *    window observed on testnet reproducers.
+   *  - 30000 ms: spans typical CLI recipient boot+subscribe latency.
+   *
+   * Beyond 30 s the publisher hold cost outweighs the marginal value:
+   * recipients that haven't subscribed in the first 30 seconds are
+   * unlikely to subscribe before a relay's longer-tail retention also
+   * elapses. Operators with stronger guarantees should run a daemon on
+   * the receiver side or use the IPFS uxf-cid delivery path.
+   */
+  private static readonly EXTENDED_DURABILITY_CHECKPOINTS_MS: ReadonlyArray<number> =
+    [3000, 8000, 18000, 30000];
+
+  /**
+   * Issue #397 — extended-durability republish budget.
+   *
+   * 3 republishes across the 4 checkpoints means the publisher can
+   * survive up to 3 separate eviction events within the 30 s window
+   * before declaring terminal failure. 4 republishes within 30 s would
+   * indicate a relay so aggressive that no in-band fix can rescue
+   * delivery — the operator must switch to a longer-retention relay or
+   * use the IPFS uxf-cid path.
+   */
+  private static readonly EXTENDED_DURABILITY_MAX_REPUBLISHES = 3;
 
   /**
    * Issue #166 P2 #3 — Verify a previously published TOKEN_TRANSFER

--- a/transport/transport-provider.ts
+++ b/transport/transport-provider.ts
@@ -23,9 +23,16 @@ export interface TransportProvider extends BaseProvider {
   /**
    * Send encrypted direct message
    * @param recipientTransportPubkey - Transport-specific pubkey for messaging
+   * @param options - Optional publish/durability behavior. See
+   *   {@link SendMessageOptions}. Backwards-compatible: callers that omit
+   *   the argument get the existing immediate-verification behavior.
    * @returns Event ID
    */
-  sendMessage(recipientTransportPubkey: string, content: string): Promise<string>;
+  sendMessage(
+    recipientTransportPubkey: string,
+    content: string,
+    options?: SendMessageOptions,
+  ): Promise<string>;
 
   /**
    * Subscribe to incoming direct messages
@@ -380,6 +387,56 @@ export interface IncomingInstantSplitBundle {
  * Handler for instant split bundles
  */
 export type InstantSplitBundleHandler = (bundle: IncomingInstantSplitBundle) => void;
+
+// =============================================================================
+// sendMessage Options
+// =============================================================================
+
+/**
+ * Options accepted by {@link TransportProvider.sendMessage}.
+ *
+ * The legacy two-argument call (no options) is preserved verbatim. New
+ * publish behaviors are opted-in via these flags so existing callers
+ * never see a behavior change without their consent.
+ *
+ * @see TransportProvider.sendMessage
+ */
+export interface SendMessageOptions {
+  /**
+   * Issue #397 — when `true`, the transport performs **extended-window
+   * durability verification** AFTER the initial publish.
+   *
+   * Background: `NostrTransportProvider.publishWithVerification` queries
+   * the relay ~300-1500 ms after publish to confirm the event was
+   * stored. That suffices for healthy relays, but on testnet (single
+   * relay, short effective retention) the event is sometimes evicted
+   * within seconds — well before a short-lived CLI recipient subscribes.
+   *
+   * Extended durability extends the verify window into the seconds-to-
+   * tens-of-seconds range: the transport re-queries the relay at a
+   * schedule of escalating checkpoints and re-publishes the same event
+   * if it is observed missing. This keeps the event live on the relay
+   * long enough for a recipient CLI that connects within the window to
+   * receive it.
+   *
+   * Contract:
+   *  - Resolves once the configured checkpoint schedule completes
+   *    without observing the event missing on the final query, OR
+   *    after a final-checkpoint republish succeeds.
+   *  - Throws {@link SphereError} with code `'TRANSPORT_ERROR'` if the
+   *    republish budget is exhausted (the event keeps being evicted).
+   *  - The caller's promise resolves substantially later than the
+   *    non-extended path — on the order of tens of seconds.
+   *
+   * Use this for one-way deliveries to short-lived recipient processes
+   * (e.g. invoice delivery). Do NOT use it for high-volume fan-outs
+   * where the per-recipient publisher hold time would multiply.
+   *
+   * Transports that do not implement extended durability MUST silently
+   * fall through to their normal publish path — the flag is advisory.
+   */
+  readonly extendedDurability?: boolean;
+}
 
 // =============================================================================
 // Message Types

--- a/types/index.ts
+++ b/types/index.ts
@@ -679,6 +679,7 @@ export type SphereEventType =
   | 'invoice:receipt_received'
   | 'invoice:cancellation_sent'
   | 'invoice:cancellation_received'
+  | 'invoice:deliver-failed'
   // Swap events
   | 'swap:proposal_received'
   | 'swap:proposed'
@@ -1527,6 +1528,37 @@ export interface SphereEventMap {
   'invoice:receipt_received': { invoiceId: string; receipt: import('../modules/accounting/types').IncomingInvoiceReceipt };
   'invoice:cancellation_sent': { invoiceId: string; sent: number; failed: number };
   'invoice:cancellation_received': { invoiceId: string; notice: import('../modules/accounting/types').IncomingCancellationNotice };
+  /**
+   * Issue #397 — fires when an invoice delivery DM could not be
+   * confirmed durable on the relay despite the publisher's extended-
+   * durability republish budget. The recipient will NOT receive the
+   * invoice over Nostr; operators should retry `deliverInvoice` (the
+   * relay may have recovered), use the IPFS uxf-cid delivery path, or
+   * deliver the invoice ID out-of-band.
+   *
+   * Payload fields:
+   *  - `invoiceId`: hex tokenId of the invoice whose delivery failed.
+   *  - `recipient`: the recipient identifier passed to `deliverInvoice`
+   *    (`@nametag`, `DIRECT://…`, etc.). NOT the resolved transport
+   *    pubkey — operator-facing.
+   *  - `reason`: classifies the failure cause:
+   *      - `'non-durable'`: the relay kept evicting the gift wrap
+   *        within the publisher's hold window.
+   *      - `'transport-error'`: the publish itself failed (relay
+   *        offline, rejected event, etc.) before durability was even
+   *        attempted.
+   *      - `'unknown'`: the SDK could not classify the error.
+   *  - `errorMessage`: short human-readable message (the SphereError
+   *    `message` field or a fallback).
+   *
+   * This is a terminal event — the SDK does not retry on its own.
+   */
+  'invoice:deliver-failed': {
+    invoiceId: string;
+    recipient: string;
+    reason: 'non-durable' | 'transport-error' | 'unknown';
+    errorMessage: string;
+  };
   // Swap event payloads
   'swap:proposal_received': { swapId: string; deal: Record<string, unknown>; senderPubkey: string; senderNametag?: string };
   'swap:proposed': { swapId: string; deal: Record<string, unknown>; recipientPubkey: string };


### PR DESCRIPTION
## Summary

Closes the publisher-side gap diagnosed in #397: invoice delivery DMs now keep the gift wrap event live on the relay across an extended verify+republish window (`~30 s`), and surface terminal non-durability via a new `invoice:deliver-failed` event instead of the silent `sent: 1` of pre-fix code.

Includes the reproducer (`manual-test-accounting-roundtrip.sh`) carried forward from `feat/soak-accounting-invoice-roundtrip` (commit `7daef57` cherry-picked).

## What the fix does

- **`SendMessageOptions { extendedDurability? }`** — new option on `TransportProvider.sendMessage` and `CommunicationsModule.sendDM`. Default (omitted) preserves legacy behavior.
- **`NostrTransportProvider.publishWithExtendedDurability`** — after the standard `publishWithVerification` lands the event, the publisher re-queries the relay at `3 s`, `8 s`, `18 s`, `30 s` and republishes the same event on observed eviction. Budget: 3 republishes; on exhaustion throws `TRANSPORT_ERROR` with `'non-durable'` in the message.
- **`MultiAddressTransportMux.sendGiftWrap`** — same extended-durability path (was previously bypassing even the standard verification — raw `publishEvent`).
- **`AccountingModule.deliverInvoice`** — passes `{ extendedDurability: true }` for every recipient; on terminal failure emits `invoice:deliver-failed { invoiceId, recipient, reason, errorMessage }` where `reason ∈ 'non-durable' | 'transport-error' | 'unknown'`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean on changed files (0 errors)
- [x] `npx vitest run` — **8915 pass, 16 skipped**
- [x] New `tests/unit/transport/NostrTransportProvider.extendedDurability397.test.ts` — 4 tests cover schedule, single-drop+recover, budget-exhaustion failure, disconnect-mid-flight optimistic path
- [x] `tests/unit/modules/AccountingModule.invoiceDelivery.test.ts` — UT-DELIVER-104/105/106 cover the extended-durability opt-in, the `non-durable` event reason, and the `transport-error` event reason

## Soak observation

`manual-test-accounting-roundtrip.sh` was run end-to-end against testnet with this branch's `dist/` wired into sphere-cli's `node_modules`. Two findings:

1. **Publisher path engages correctly.** `sphere invoice deliver` now holds for ~30 s (was ~3 s pre-fix), matching the checkpoint schedule. Bob's verify-by-id queries succeed at every checkpoint — no republish needed against this testnet relay.

2. **Soak still fails at `ASSERT FAIL (invoice-ingest-timeout)`** on the receiver side. Alice's `sphere invoice list` polling (every 3 s for 60 s) never finds the invoice. Same failure mode as the issue's `[AT-LEAST-ONCE] TOKEN_TRANSFER ... not durable` evidence for faucet transfers: the testnet relay delivers events to **open** subscriptions in real time but does **not** retain them for follow-up `(#p, since)` filter queries from newly-opened subscriptions — even when the publisher's `verifyById` confirms the event id is still indexed.

   This is the architectural limit of option 1 (publisher-side durability) as described in #397's acceptance criteria. Closing the receiver gap requires:
   - **Multi-relay publishing** — out of testnet-config scope (only one testnet relay is currently configured), but the existing `additionalRelays` knob supports it for callers that want to opt in.
   - **Recipient-side replay** (option 2 in the acceptance section) — the recipient CLI keeps a subscription open while it polls, OR resolves the invoice via an out-of-band signal.
   - **Daemon on the recipient side** — operational workaround.

   The publisher-side fix here is still load-bearing for the cases where the relay's filter-index retention DOES hold long enough to cover the gap (browsers with persistent connections, healthier mainnet relays, or any deployment with multi-relay configured), and surfaces a structured `invoice:deliver-failed` event when the publisher's hold-window republish budget is exhausted — replacing the silent `sent: 1` of pre-fix code.

## Related

- Refs: #397, #396
- Reproducer commit `7daef57` from `feat/soak-accounting-invoice-roundtrip` is cherry-picked into this branch so the soak is bundled with the fix attempt.