### PR TITLE
feat(accounting)(#401): wire publishUxfBundle into OUTBOX/SENT + recovery exhaustion event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,7 @@ Typed RPC layer for dApp ↔ wallet communication. Full guide: [`docs/CONNECT.md
 | `transfer:retention-warning` | `{ sentId, nostrEventId, bundleCid, tokenIds, recipientTransportPubkey, detectedAt }` | Relay no longer retains the Nostr TOKEN_TRANSFER event for a SENT entry |
 | `transfer:retention-republish-rearmed` | `{ sentId, nostrEventId, bundleCid, tokenIds, recipientTransportPubkey, fromStatus, toStatus, rearmedAt }` | Verifier transitioned a live OUTBOX entry back to `'sending'` so the recovery worker republishes |
 | `transfer:retention-republish-skipped` | `{ sentId, nostrEventId, bundleCid, reason, observedStatus?, errorMessage?, detectedAt }` | Retention re-publish could not be initiated (`reason ∈ no-outbox-writer / entry-tombstoned-or-missing / wrong-status / transition-failed`) |
+| `transfer:recovery-republish-exhausted` | `{ outboxId, bundleCid, tokenIds, mode, recipient, lastError, exhaustedAt }` | SendingRecoveryWorker exhausted `maxRetries` (default 3) and transitioned OUTBOX entry to `'failed-transient'`. Issue #401 — AccountingModule listens and re-emits `invoice:deliver-failed { reason: 'non-durable' }` when `tokenIds` contains a tracked invoice |
 
 See [QUICKSTART-BROWSER.md](docs/QUICKSTART-BROWSER.md) and [QUICKSTART-NODEJS.md](docs/QUICKSTART-NODEJS.md) for detailed guides. Operator runbooks for the send-pipeline events live at [docs/uxf/RUNBOOK-SEND-PIPELINE.md](docs/uxf/RUNBOOK-SEND-PIPELINE.md).
 

--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -5330,12 +5330,47 @@ export class AccountingModule {
       }
     });
 
+    // Issue #401 — surface SendingRecoveryWorker exhaustion as
+    // `invoice:deliver-failed { reason: 'non-durable' }` when the
+    // exhausted OUTBOX entry carried an invoice token. The token-id
+    // lookup against `invoiceTermsCache` is the same predicate that
+    // `_handleTokenChange` uses to recognize an incoming invoice; if
+    // the cache hasn't picked the invoice up yet (race with sync) we
+    // skip — non-invoice exhaustions stay silent here on purpose, the
+    // `'transfer:recovery-republish-exhausted'` event is the generic
+    // operator surface for those.
+    const unsubRecoveryExhausted = deps.on(
+      'transfer:recovery-republish-exhausted',
+      (payload: SphereEventMap['transfer:recovery-republish-exhausted']) => {
+        if (this.destroyed) return;
+        try {
+          const invoiceTokenId = payload.tokenIds.find((id) =>
+            this.invoiceTermsCache.has(id),
+          );
+          if (invoiceTokenId === undefined) return;
+          deps.emitEvent('invoice:deliver-failed', {
+            invoiceId: invoiceTokenId,
+            recipient: payload.recipient,
+            reason: 'non-durable',
+            errorMessage: payload.lastError,
+          });
+        } catch (err) {
+          logger.warn(
+            LOG_TAG,
+            'Error handling transfer:recovery-republish-exhausted event:',
+            err,
+          );
+        }
+      },
+    );
+
     this.unsubscribePayments = [
       unsubIncoming,
       unsubConfirmed,
       unsubHistory,
       unsubTokenChange,
       unsubSyncCompleted,
+      unsubRecoveryExhausted,
     ];
   }
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -6547,6 +6547,69 @@ export class PaymentsModule {
       };
     }
 
+    // Issue #401 — best-effort local IPFS pin for the inline branch.
+    // Mirrors `instant-sender.ts` Step 8.5: the SendingRecoveryWorker's
+    // default republish callback ALWAYS converts to `'uxf-cid'` (PR #189
+    // OUTBOX-SEND-FOLLOWUPS item #2), so the bundle CID MUST be fetchable
+    // for republish to succeed end-to-end. The CID-branch caller already
+    // pinned (AccountingModule line ~1515); the inline branch needs an
+    // equivalent best-effort pin here so a retention drop on inline-CAR
+    // invoices can still recover.
+    //
+    // Fire-and-forget — pin failure MUST NOT block the wire publish.
+    // Idempotent at the IPFS layer (content-addressed; re-pin is a no-op).
+    if (!params.publishViaIpfsCid && this.deps!.publishToIpfs !== undefined) {
+      const publish = this.deps!.publishToIpfs;
+      const carBytes = params.carBytes;
+      void Promise.resolve()
+        .then(() => publish(carBytes))
+        .catch((pinErr) => {
+          const message =
+            pinErr instanceof Error ? pinErr.message : String(pinErr);
+          logger.warn(
+            'Payments',
+            `publishUxfBundle: best-effort inline-CAR pin failed (Issue #401) — ` +
+              `wire send unaffected; retention re-publish via SendingRecoveryWorker ` +
+              `will publish 'uxf-cid' shape but receivers can't decode without the pin. ` +
+              `bundleCid=${params.bundleCid} cause=${message}`,
+          );
+        });
+    }
+
+    // Issue #401 — OUTBOX wiring. Write a `'sending'` entry BEFORE the
+    // transport publish so the SendingRecoveryWorker picks the entry up
+    // if the publish crashes between this line and the ack write below.
+    // Skip if no OUTBOX writer is installed (legacy/in-memory wallets,
+    // bootstrap-only paths) — the existing fire-and-publish behavior
+    // remains correct for those callers.
+    const outboxWriter = this._outboxWriter;
+    const deliveryMethod: 'cid-over-nostr' | 'car-over-nostr' =
+      params.publishViaIpfsCid ? 'cid-over-nostr' : 'car-over-nostr';
+    const outboxId = crypto.randomUUID();
+    if (outboxWriter !== null) {
+      const createdAt = Date.now();
+      await outboxWriter.write({
+        id: outboxId,
+        bundleCid: params.bundleCid,
+        tokenIds,
+        deliveryMethod,
+        recipient: params.recipient,
+        recipientTransportPubkey,
+        ...(peerInfo?.nametag !== undefined
+          ? { recipientNametag: peerInfo.nametag }
+          : {}),
+        mode: 'instant',
+        status: 'sending',
+        outstandingRequestIds: [],
+        completedRequestIds: [],
+        ...(params.memo !== undefined ? { memo: params.memo } : {}),
+        createdAt,
+        updatedAt: createdAt,
+        submitRetryCount: 0,
+        proofErrorCount: 0,
+      });
+    }
+
     // Publish via TOKEN_TRANSFER (kind 31113) — same wire kind as
     // ordinary token transfers, so the receiver's existing ingest
     // pool + at-least-once gate cover this delivery for free.
@@ -6558,10 +6621,61 @@ export class PaymentsModule {
       );
     } catch (cause) {
       const message = cause instanceof Error ? cause.message : String(cause);
+      // The OUTBOX entry remains live at `'sending'`. The
+      // SendingRecoveryWorker scans `'sending'` entries past
+      // `stuckThresholdMs` (default 60s) and re-publishes via its
+      // generic `'uxf-cid'` callback (PaymentsModule line ~2199).
       throw new SphereError(
         `publishUxfBundle: transport.sendTokenTransfer failed: ${message}`,
         'TRANSPORT_ERROR',
         cause,
+      );
+    }
+
+    // Transition `'sending' → 'delivered'` once the relay ack lands.
+    // Choosing the conservative-mode arc (NOT `'delivered-instant'`):
+    // invoice bundles carry their own genesis proofs from the payee
+    // and have no aggregator commitments to poll, so there's nothing
+    // for the FinalizationWorker to do. `'delivered'` is the correct
+    // resting state — the NostrPersistenceVerifier scans SENT past
+    // `verifyDelayMs` and, on retention drop, rearms the OUTBOX entry
+    // back to `'sending'` for the recovery worker to republish.
+    if (outboxWriter !== null) {
+      await outboxWriter.update(outboxId, (prev) => ({
+        ...prev,
+        status: 'delivered',
+        nostrEventId,
+        updatedAt: Date.now(),
+      }));
+      // Mirror the dispatcher's pattern (PaymentsModule line ~14569):
+      // the OUTBOX `update` itself does not write SENT — that lives
+      // in the orchestrator's `outbox.write` hook for normal sends.
+      // For `publishUxfBundle` (no orchestrator), the SENT write is
+      // an inline follow-up. The verifier reads the SENT ledger so
+      // this step is what makes retention monitoring work for free.
+      await this.writeSentEntryFromOutbox(
+        {
+          id: outboxId,
+          bundleCid: params.bundleCid,
+          tokenIds,
+          deliveryMethod,
+          recipient: params.recipient,
+          recipientTransportPubkey,
+          ...(peerInfo?.nametag !== undefined
+            ? { recipientNametag: peerInfo.nametag }
+            : {}),
+          mode: 'instant',
+          status: 'delivered',
+          outstandingRequestIds: [],
+          completedRequestIds: [],
+          ...(params.memo !== undefined ? { memo: params.memo } : {}),
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          submitRetryCount: 0,
+          proofErrorCount: 0,
+          nostrEventId,
+        },
+        'publishUxfBundle',
       );
     }
 

--- a/modules/payments/transfer/sending-recovery-worker.ts
+++ b/modules/payments/transfer/sending-recovery-worker.ts
@@ -369,9 +369,11 @@ export class SendingRecoveryWorker {
     cause: unknown,
   ): Promise<void> {
     const message = errMessage(cause);
+    let didTransition = false;
     try {
       await this.deps.outbox.update(entry.id, (prev) => {
         if (prev.status !== 'sending') return prev;
+        didTransition = true;
         return {
           ...prev,
           status: 'failed-transient',
@@ -384,6 +386,22 @@ export class SendingRecoveryWorker {
         bundleCid: entry.bundleCid,
         lastError: message,
       });
+      // Issue #401 — emit a terminal-failure signal so subscribers
+      // (AccountingModule re-emits `'invoice:deliver-failed' { reason:
+      // 'non-durable' }`) can surface the failure to operators. Gate
+      // on the CAS to avoid firing on concurrent-advance no-ops, same
+      // pattern as `transitionToDelivered`'s `didTransition` guard.
+      if (didTransition) {
+        this.deps.emit('transfer:recovery-republish-exhausted', {
+          outboxId: entry.id,
+          bundleCid: entry.bundleCid,
+          tokenIds: entry.tokenIds,
+          mode: entry.mode,
+          recipient: entry.recipient,
+          lastError: message,
+          exhaustedAt: this.now(),
+        });
+      }
     } catch (err) {
       this.warn('failed-transient transition failed', {
         outboxId: entry.id,

--- a/tests/unit/modules/AccountingModule.invoiceDelivery.test.ts
+++ b/tests/unit/modules/AccountingModule.invoiceDelivery.test.ts
@@ -548,6 +548,65 @@ describe('AccountingModule.deliverInvoice — failure modes', () => {
       }),
     );
   });
+
+  it('UT-DELIVER-105 (#401): re-emits invoice:deliver-failed with reason "non-durable" when SendingRecoveryWorker exhausts on a delivered invoice', async () => {
+    // Mint and "deliver" an invoice so it lives in invoiceTermsCache —
+    // this is the predicate AccountingModule uses to decide whether a
+    // recovery-republish-exhausted event belongs to it.
+    const { invoiceId } = await mintRealInvoice();
+    await module.deliverInvoice(invoiceId);
+
+    const emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    emitEvent.mockClear();
+
+    // Fire the new SendingRecoveryWorker exhaustion event through the
+    // mock payments emit pipe (deps.on routes subscriptions to this).
+    // tokenIds includes the invoice id so AccountingModule recognizes
+    // it as one of its own and re-emits the focused failure.
+    mocks.payments._emit('transfer:recovery-republish-exhausted', {
+      outboxId: 'outbox-fake',
+      bundleCid: 'bafy-fake',
+      tokenIds: [invoiceId],
+      mode: 'instant',
+      recipient: REMOTE_BOB,
+      lastError: 'relay down for 90s',
+      exhaustedAt: Date.now(),
+    });
+
+    expect(emitEvent).toHaveBeenCalledWith(
+      'invoice:deliver-failed',
+      expect.objectContaining({
+        invoiceId,
+        recipient: REMOTE_BOB,
+        reason: 'non-durable',
+        errorMessage: expect.stringContaining('relay down'),
+      }),
+    );
+  });
+
+  it('UT-DELIVER-106 (#401): does NOT re-emit invoice:deliver-failed when exhausted entry is unrelated to any tracked invoice', async () => {
+    await mintRealInvoice();
+
+    const emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    emitEvent.mockClear();
+
+    // tokenIds carries an id that is NOT in invoiceTermsCache — the
+    // exhaustion is for an ordinary token transfer, not an invoice.
+    mocks.payments._emit('transfer:recovery-republish-exhausted', {
+      outboxId: 'outbox-fake',
+      bundleCid: 'bafy-fake',
+      tokenIds: ['deadbeef'.repeat(8)],
+      mode: 'instant',
+      recipient: REMOTE_BOB,
+      lastError: 'relay down',
+      exhaustedAt: Date.now(),
+    });
+
+    expect(emitEvent).not.toHaveBeenCalledWith(
+      'invoice:deliver-failed',
+      expect.objectContaining({ reason: 'non-durable' }),
+    );
+  });
 });
 
 // =============================================================================

--- a/tests/unit/payments/publish-uxf-bundle-outbox-wiring.test.ts
+++ b/tests/unit/payments/publish-uxf-bundle-outbox-wiring.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Issue #401 — publishUxfBundle OUTBOX/SENT wiring.
+ *
+ * Pins the contract added in PR #400 follow-up: when a wallet has the
+ * OUTBOX writer + SENT ledger writer installed (the default path after
+ * `Sphere.init`), every call to `PaymentsModule.publishUxfBundle`:
+ *
+ *   1. Writes an OUTBOX entry at status `'sending'` BEFORE the transport
+ *      publish (the SendingRecoveryWorker's pickup point if the publish
+ *      crashes between this line and the ack write).
+ *   2. After the transport ack, transitions the entry to status
+ *      `'delivered'` (NOT `'delivered-instant'` — invoice bundles carry
+ *      their own genesis proofs and have no aggregator commitments to
+ *      finalize) and captures the relay's `nostrEventId`.
+ *   3. Writes a SENT ledger entry mirroring the OUTBOX terminal-success
+ *      state so the `NostrPersistenceVerifier` scan picks it up on the
+ *      next cycle and emits retention-warning / rearm events if the
+ *      relay drops the event.
+ *
+ * Failure-path contract:
+ *   4. If `transport.sendTokenTransfer` throws, the OUTBOX entry STAYS at
+ *      `'sending'` (no transition fires, no SENT write) so the recovery
+ *      worker picks it up on its next scan cycle.
+ *
+ * Skip-path contract:
+ *   5. If no OUTBOX writer is installed (legacy/in-memory wallets,
+ *      bootstrap-only paths), `publishUxfBundle` reverts to the
+ *      fire-and-publish behavior — no OUTBOX/SENT writes occur. The
+ *      existing fire-and-publish callers (some unit-test fixtures) must
+ *      keep working.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { PaymentsModule } from '../../../modules/payments/PaymentsModule';
+import type { OutboxWriter } from '../../../profile/outbox-writer';
+import type { SentLedgerWriter } from '../../../profile/sent-ledger-writer';
+import type { FullIdentity } from '../../../types';
+import type { UxfTransferOutboxEntry } from '../../../types/uxf-outbox';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function stubIdentity(): FullIdentity {
+  return {
+    chainPubkey: '02' + 'aa'.repeat(32),
+    l1Address: 'alpha1test',
+    directAddress: 'DIRECT://test',
+    privateKey: 'bb'.repeat(32),
+  };
+}
+
+function stubDeps(transport: any) {
+  return {
+    identity: stubIdentity(),
+    storage: {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+      has: vi.fn(async () => false),
+      list: vi.fn(async () => []),
+      isConnected: () => true,
+      connect: async () => undefined,
+      disconnect: async () => undefined,
+      setIdentity: () => undefined,
+      clear: async () => undefined,
+    } as any,
+    transport,
+    oracle: {
+      verifyToken: vi.fn(),
+      submitTransaction: vi.fn(),
+    } as any,
+    emitEvent: vi.fn(),
+  };
+}
+
+interface FakeOutboxFixture {
+  readonly writer: Pick<OutboxWriter, 'write' | 'update' | 'readAllNew'>;
+  readonly entries: Map<string, UxfTransferOutboxEntry>;
+  readonly writeOrder: string[];
+  readonly transitionOrder: Array<{ from: string; to: string }>;
+}
+
+function makeFakeOutbox(): FakeOutboxFixture {
+  const entries = new Map<string, UxfTransferOutboxEntry>();
+  const writeOrder: string[] = [];
+  const transitionOrder: Array<{ from: string; to: string }> = [];
+  return {
+    writer: {
+      async write(input: any): Promise<UxfTransferOutboxEntry> {
+        const stamped: UxfTransferOutboxEntry = {
+          _schemaVersion: 'uxf-1',
+          lamport: (entries.get(input.id)?.lamport ?? 0) + 1,
+          ...input,
+        };
+        entries.set(stamped.id, stamped);
+        writeOrder.push(`write:${stamped.status}`);
+        return stamped;
+      },
+      async update(
+        id: string,
+        mutator: (prev: UxfTransferOutboxEntry) => UxfTransferOutboxEntry,
+      ): Promise<UxfTransferOutboxEntry> {
+        const prev = entries.get(id);
+        if (!prev) throw new Error(`OutboxWriter.update: no entry "${id}"`);
+        const next = mutator(prev);
+        if (next.status !== prev.status) {
+          transitionOrder.push({ from: prev.status, to: next.status });
+        }
+        const bumped = { ...next, lamport: prev.lamport + 1 };
+        entries.set(id, bumped);
+        writeOrder.push(`update:${bumped.status}`);
+        return bumped;
+      },
+      async readAllNew(): Promise<UxfTransferOutboxEntry[]> {
+        return Array.from(entries.values());
+      },
+    },
+    entries,
+    writeOrder,
+    transitionOrder,
+  };
+}
+
+interface FakeSentFixture {
+  readonly writer: Pick<SentLedgerWriter, 'write'>;
+  readonly writes: Array<Record<string, unknown>>;
+}
+
+function makeFakeSentLedger(): FakeSentFixture {
+  const writes: Array<Record<string, unknown>> = [];
+  return {
+    writer: {
+      async write(input: any): Promise<any> {
+        writes.push(input);
+        return { ...input, _schemaVersion: 'uxf-1', lamport: 1 };
+      },
+    },
+    writes,
+  };
+}
+
+function makeFakeTransport(opts: {
+  readonly sendResult?: string;
+  readonly sendError?: Error;
+}) {
+  const sendTokenTransfer = vi.fn(async () => {
+    if (opts.sendError) throw opts.sendError;
+    return opts.sendResult ?? 'mock-event-id-abc123';
+  });
+  return {
+    sendTokenTransfer,
+    resolve: vi.fn(async () => null),
+    subscribe: vi.fn(() => () => undefined),
+    onTokenTransfer: vi.fn(() => () => undefined),
+    onPaymentRequest: vi.fn(() => () => undefined),
+    onPaymentRequestResponse: vi.fn(() => () => undefined),
+  };
+}
+
+function buildModuleWithWriters(opts: {
+  readonly sendResult?: string;
+  readonly sendError?: Error;
+}): {
+  module: PaymentsModule;
+  outbox: FakeOutboxFixture;
+  sent: FakeSentFixture;
+  transport: ReturnType<typeof makeFakeTransport>;
+} {
+  const module = new PaymentsModule({ features: { senderUxf: true } });
+  const transport = makeFakeTransport({
+    ...(opts.sendResult !== undefined ? { sendResult: opts.sendResult } : {}),
+    ...(opts.sendError !== undefined ? { sendError: opts.sendError } : {}),
+  });
+  module.initialize(stubDeps(transport) as any);
+  const outbox = makeFakeOutbox();
+  const sent = makeFakeSentLedger();
+  module.installOutboxWriter(outbox.writer as unknown as OutboxWriter);
+  module.installSentLedgerWriter(sent.writer as unknown as SentLedgerWriter);
+  return { module, outbox, sent, transport };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Issue #401 — publishUxfBundle OUTBOX/SENT wiring', () => {
+  // 33-byte compressed chain pubkey passed as `recipient`. PaymentsModule's
+  // `resolveTransportPubkey` strips the leading parity byte and binds the
+  // 32-byte x-coordinate as the transport pubkey, mirroring the
+  // single-identity model documented in `core/Sphere.ts`.
+  const RECIPIENT_CHAIN_PUBKEY = '02' + 'cc'.repeat(32);
+  const RECIPIENT_TRANSPORT_PUBKEY = 'cc'.repeat(32);
+  const CAR_BYTES = new Uint8Array([0xa1, 0xa2, 0xa3]);
+  const BUNDLE_CID = 'bafkreigh2akiscaildc' + 'q'.repeat(32);
+
+  it('writes OUTBOX in "sending" BEFORE transport publish, transitions to "delivered" after ack', async () => {
+    const { module, outbox, transport } = buildModuleWithWriters({
+      sendResult: 'event-id-aaaa',
+    });
+
+    const result = await module.publishUxfBundle({
+      recipient: RECIPIENT_CHAIN_PUBKEY,
+      bundleCid: BUNDLE_CID,
+      tokenIds: ['invoice-token-id'],
+      carBytes: CAR_BYTES,
+      memo: 'Order #42',
+    });
+
+    expect(result.nostrEventId).toBe('event-id-aaaa');
+    expect(result.recipientTransportPubkey).toBe(RECIPIENT_TRANSPORT_PUBKEY);
+    expect(transport.sendTokenTransfer).toHaveBeenCalledTimes(1);
+
+    // Sequence: OUTBOX 'sending' write THEN transport.sendTokenTransfer
+    // THEN OUTBOX 'delivered' transition. The 'sending' write must
+    // observably precede the transport call (recovery-worker pickup
+    // point on crash).
+    expect(outbox.writeOrder).toEqual([
+      'write:sending',
+      'update:delivered',
+    ]);
+    expect(outbox.transitionOrder).toEqual([
+      { from: 'sending', to: 'delivered' },
+    ]);
+  });
+
+  it('captured OUTBOX entry has mode=instant, outstandingRequestIds=[], nostrEventId set after delivery', async () => {
+    const { module, outbox } = buildModuleWithWriters({
+      sendResult: 'event-id-bbbb',
+    });
+
+    await module.publishUxfBundle({
+      recipient: RECIPIENT_CHAIN_PUBKEY,
+      bundleCid: BUNDLE_CID,
+      tokenIds: ['invoice-token-1'],
+      carBytes: CAR_BYTES,
+    });
+
+    expect(outbox.entries.size).toBe(1);
+    const entry = Array.from(outbox.entries.values())[0]!;
+    expect(entry).toMatchObject({
+      _schemaVersion: 'uxf-1',
+      bundleCid: BUNDLE_CID,
+      tokenIds: ['invoice-token-1'],
+      deliveryMethod: 'car-over-nostr',
+      recipient: RECIPIENT_CHAIN_PUBKEY,
+      recipientTransportPubkey: RECIPIENT_TRANSPORT_PUBKEY,
+      mode: 'instant',
+      status: 'delivered',
+      outstandingRequestIds: [],
+      completedRequestIds: [],
+      nostrEventId: 'event-id-bbbb',
+    });
+  });
+
+  it('publishViaIpfsCid=true sets deliveryMethod="cid-over-nostr" on the OUTBOX entry', async () => {
+    const { module, outbox } = buildModuleWithWriters({});
+
+    await module.publishUxfBundle({
+      recipient: RECIPIENT_CHAIN_PUBKEY,
+      bundleCid: BUNDLE_CID,
+      tokenIds: ['invoice-token-id'],
+      carBytes: CAR_BYTES,
+      publishViaIpfsCid: true,
+    });
+
+    const entry = Array.from(outbox.entries.values())[0]!;
+    expect(entry.deliveryMethod).toBe('cid-over-nostr');
+  });
+
+  it('writes SENT ledger entry with nostrEventId after the OUTBOX terminal-success transition', async () => {
+    const { module, sent } = buildModuleWithWriters({
+      sendResult: 'event-id-cccc',
+    });
+
+    await module.publishUxfBundle({
+      recipient: RECIPIENT_CHAIN_PUBKEY,
+      bundleCid: BUNDLE_CID,
+      tokenIds: ['invoice-token-id'],
+      carBytes: CAR_BYTES,
+    });
+
+    expect(sent.writes).toHaveLength(1);
+    expect(sent.writes[0]).toMatchObject({
+      bundleCid: BUNDLE_CID,
+      tokenIds: ['invoice-token-id'],
+      recipientTransportPubkey: RECIPIENT_TRANSPORT_PUBKEY,
+      recipient: RECIPIENT_CHAIN_PUBKEY,
+      deliveryMethod: 'car-over-nostr',
+      mode: 'instant',
+      nostrEventId: 'event-id-cccc',
+    });
+    expect(typeof sent.writes[0]!.sentAt).toBe('number');
+  });
+
+  it('on transport.sendTokenTransfer failure, OUTBOX entry STAYS at "sending" (recovery-worker pickup)', async () => {
+    const { module, outbox, sent } = buildModuleWithWriters({
+      sendError: new Error('relay offline'),
+    });
+
+    await expect(
+      module.publishUxfBundle({
+        recipient: RECIPIENT_CHAIN_PUBKEY,
+        bundleCid: BUNDLE_CID,
+        tokenIds: ['invoice-token-id'],
+        carBytes: CAR_BYTES,
+      }),
+    ).rejects.toThrow(/relay offline/);
+
+    // OUTBOX entry was written at 'sending' but NEVER transitioned —
+    // SendingRecoveryWorker.scanCycle() picks it up on its next pass.
+    expect(outbox.entries.size).toBe(1);
+    const entry = Array.from(outbox.entries.values())[0]!;
+    expect(entry.status).toBe('sending');
+    expect(outbox.transitionOrder).toEqual([]);
+    // No SENT write fires on failure (verifier owns retention duty only
+    // AFTER the entry transitions through 'delivered').
+    expect(sent.writes).toHaveLength(0);
+  });
+
+  it('skips OUTBOX writes entirely when no writer is installed (legacy/in-memory wallets)', async () => {
+    const module = new PaymentsModule({ features: { senderUxf: true } });
+    const transport = makeFakeTransport({ sendResult: 'event-id-dddd' });
+    module.initialize(stubDeps(transport) as any);
+    // NB: no installOutboxWriter / installSentLedgerWriter calls.
+
+    const result = await module.publishUxfBundle({
+      recipient: RECIPIENT_CHAIN_PUBKEY,
+      bundleCid: BUNDLE_CID,
+      tokenIds: ['invoice-token-id'],
+      carBytes: CAR_BYTES,
+    });
+
+    expect(result.nostrEventId).toBe('event-id-dddd');
+    expect(transport.sendTokenTransfer).toHaveBeenCalledTimes(1);
+    // Survives without writers — fire-and-publish path stays correct
+    // for legacy/in-memory consumers that don't have crash-safety.
+  });
+});

--- a/tests/unit/payments/transfer/sending-recovery-worker.test.ts
+++ b/tests/unit/payments/transfer/sending-recovery-worker.test.ts
@@ -300,6 +300,56 @@ describe('SendingRecoveryWorker', () => {
     expect(finalEntry?.error).toContain('relay down');
   });
 
+  it('Issue #401: emits transfer:recovery-republish-exhausted on maxRetries exhaustion (and not on intermediate failures)', async () => {
+    const stuckEntry = makeEntry({
+      id: 'outbox-exhaust',
+      bundleCid: 'bafy-exhaust',
+      tokenIds: ['invoice-token-id'],
+      mode: 'instant',
+      recipient: '@bob',
+      updatedAt: 1_000,
+    });
+    const outboxFixture = makeFakeOutbox([stuckEntry]);
+    const republish = vi
+      .fn<RepublishFn>()
+      .mockRejectedValue(new Error('relay down for 90s'));
+
+    const recorder = makeEventRecorder();
+    const worker = new SendingRecoveryWorker(
+      makeDeps({
+        outboxFixture,
+        republish,
+        nowMs: 2_000_000,
+        emit: recorder.emit,
+      }),
+      { maxRetries: 3 },
+    );
+
+    // First two cycles fail without exhaustion — no event yet.
+    await worker.runScanCycle();
+    await worker.runScanCycle();
+    expect(
+      recorder.events.filter((e) => e.type === 'transfer:recovery-republish-exhausted'),
+    ).toHaveLength(0);
+
+    // Third cycle exhausts; event fires exactly once.
+    await worker.runScanCycle();
+
+    const exhausted = recorder.events.filter(
+      (e) => e.type === 'transfer:recovery-republish-exhausted',
+    );
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0]!.data).toMatchObject({
+      outboxId: 'outbox-exhaust',
+      bundleCid: 'bafy-exhaust',
+      tokenIds: ['invoice-token-id'],
+      mode: 'instant',
+      recipient: '@bob',
+      lastError: expect.stringContaining('relay down'),
+    });
+    expect((exhausted[0]!.data as { exhaustedAt: number }).exhaustedAt).toBe(2_000_000);
+  });
+
   it('skips entries whose updatedAt is within the stuck threshold', async () => {
     const fresh = makeEntry({
       id: 'fresh',

--- a/types/index.ts
+++ b/types/index.ts
@@ -572,6 +572,7 @@ export type SphereEventType =
   | 'transfer:override-applied'
   | 'transfer:capability-warning'
   | 'transfer:recovery-republished'
+  | 'transfer:recovery-republish-exhausted'
   | 'transfer:orphan-spending-detected'
   | 'transfer:orphan-recovered'
   | 'transfer:sent-reconciliation-recovered'
@@ -1152,6 +1153,36 @@ export interface SphereEventMap {
     readonly mode: 'conservative' | 'instant' | 'txf';
     readonly targetStatus: 'delivered' | 'delivered-instant';
     readonly recoveredAt: number;
+  };
+  /**
+   * Issue #401 — SendingRecoveryWorker exhausted its per-entry retry
+   * budget (`maxRetries`, default 3 consecutive failed republish
+   * attempts) and transitioned the OUTBOX entry to `'failed-transient'`.
+   * The bundle is provably undeliverable on the current relay set.
+   *
+   * Companion signal to `'transfer:recovery-republished'` (success). This
+   * is the terminal-failure signal the recovery layer was missing — the
+   * AccountingModule subscribes to it and re-emits as
+   * `'invoice:deliver-failed' { reason: 'non-durable' }` for invoice
+   * tokenIds it owns, so operators receive a focused failure event for
+   * the at-least-once durability path.
+   *
+   * Payload fields:
+   *  - `outboxId`    — the entry that exhausted
+   *  - `bundleCid`   — content-addressed handle (for IPFS triage)
+   *  - `tokenIds`    — bundle recipients (for AccountingModule filter)
+   *  - `mode`        — entry's transfer mode at exhaustion
+   *  - `lastError`   — final failure's message (sanitized)
+   *  - `exhaustedAt` — wall-clock ms timestamp
+   */
+  'transfer:recovery-republish-exhausted': {
+    readonly outboxId: string;
+    readonly bundleCid: string;
+    readonly tokenIds: ReadonlyArray<string>;
+    readonly mode: 'conservative' | 'instant' | 'txf';
+    readonly recipient: string;
+    readonly lastError: string;
+    readonly exhaustedAt: number;
   };
   /**
    * Issue #97 — A token in `'transferring'` status (= has an


### PR DESCRIPTION
Closes #401. **Stacked on top of #400** — review/merge #400 first; this branch's base is `fix/issue-397-invoice-via-token-pipeline`.

## Summary
PR #400 routed invoice delivery through the standard TOKEN_TRANSFER pipeline but left `publishUxfBundle` as fire-and-publish. This PR threads it into the same crash-safety lifecycle ordinary token transfers already use, closing the gap #401 calls out.

## What changed

### 1. OUTBOX writes in `publishUxfBundle` (#401 items 1–2)
- Writes a `UxfTransferOutboxEntry` at status `'sending'` **before** `transport.sendTokenTransfer`. If the publish throws, the entry stays at `'sending'` → SendingRecoveryWorker picks it up on the next scan.
- After the relay ack lands, transitions the entry to `'delivered'` with the captured `nostrEventId` and inline-writes a SENT ledger entry.
- Skip-path: when no OUTBOX writer is installed, the call reverts to fire-and-publish — legacy/in-memory wallets and bootstrap-only paths keep working.

**Design call on item #2:** chose `'sending' → 'delivered'` (NOT `'delivered-instant'`). Invoice bundles carry their own genesis proofs from the payee and have no aggregator commitments to poll — `'delivered'` is the correct resting state, mirrors conservative-mode TOKEN_TRANSFER, and avoids leaking entries through the FinalizationWorker with empty `outstandingRequestIds`.

### 2. SENT ledger write (#401 item 3)
After the OUTBOX terminal-success transition, inline call to `writeSentEntryFromOutbox` (the same helper the orchestrator's `outbox.write` hook uses on line ~14569). NostrPersistenceVerifier scans the SENT ledger for retention drops automatically — no extra wiring needed. On `'missing'` outcome, the verifier rearms OUTBOX `'delivered' → 'sending'` for SendingRecoveryWorker to republish.

### 3. `transfer:recovery-republish-exhausted` event + AccountingModule re-emit (#401 item 4)
- New event emitted by `SendingRecoveryWorker.transitionToFailedTransient` when `maxRetries` (default 3) is hit. Carries `outboxId`, `bundleCid`, `tokenIds`, `mode`, `recipient`, `lastError`, `exhaustedAt`.
- AccountingModule subscribes; when an exhausted entry's `tokenIds` contain a tracked invoice, re-emits `invoice:deliver-failed { reason: 'non-durable' }`. Closes the reserved-but-unfired enum value from PR #400.

### 4. Best-effort inline-CAR IPFS pin (defensive, gap discovered during steelman)
The recovery worker's default republish callback **always** converts to `'uxf-cid'` (per PR #189 OUTBOX-SEND-FOLLOWUPS item #2). For inline-CAR invoices, this means receivers can't decode the republished bundle unless the CAR is pinned to IPFS. `publishUxfBundle` now mirrors `instant-sender.ts` Step 8.5 — fire-and-forget pin via `deps.publishToIpfs` when delivery is inline. Failure is logged but does not block the wire send (idempotent at the IPFS layer, content-addressed).

### 5. Receiver-side `uxf-cid` fetch validation (#401 item 5)
The receive path `acquireBundle` (`modules/payments/transfer/bundle-acquirer.ts`) is shared verbatim with ordinary token transfers and already covered by `tests/integration/transfer/uxf-cid-canonical-publisher.test.ts` + the broader `transfer/` test suite. AccountingModule does NOT special-case `uxf-cid` — it just observes the local tokenStorage change after `_handleTokenChange` fires. A separate forced-CID invoice soak is a low-priority follow-up; the full vitest run from this PR catches regressions in the shared path.

## Tests

- **NEW** `tests/unit/payments/publish-uxf-bundle-outbox-wiring.test.ts` (6 cases) — pins the contract:
  - OUTBOX `'sending'` write precedes transport publish
  - OUTBOX transitions to `'delivered'` with `nostrEventId` after ack
  - `mode: 'instant'`, `outstandingRequestIds: []`, `completedRequestIds: []`
  - `publishViaIpfsCid: true` → `deliveryMethod: 'cid-over-nostr'`
  - SENT ledger entry written with `nostrEventId`
  - Transport throw → entry stays at `'sending'` (no SENT write, no transition)
  - No-writer skip-path preserves fire-and-publish behavior
- **NEW case** in `sending-recovery-worker.test.ts` — asserts the exhaustion event fires exactly once at `maxRetries` (not on intermediate failures).
- **NEW cases** UT-DELIVER-105 / UT-DELIVER-106 in `AccountingModule.invoiceDelivery.test.ts` — AccountingModule re-emit: matched tokenIds → `non-durable`; unrelated tokenIds → silent.

### Full vitest run
8912 passed / 16 skipped / 1 pre-existing flake (`bundle-acquirer.test.ts` negative-LRU — passes deterministically in isolation, unrelated to this PR).

### Soak
`manual-test-accounting-roundtrip.sh` — ALL GREEN. Bob +7 UCT, alice -7 UCT, invoice COVERED.

## Test plan
- [x] Targeted unit tests pass (36/36)
- [x] Full vitest suite green (1 unrelated pre-existing flake)
- [x] Accounting roundtrip soak ALL GREEN
- [x] Typecheck clean
- [x] Documentation updated (CLAUDE.md events table)

## Out of scope
- Multi-relay configuration on testnet (orthogonal)
- Receiver-side queueing when payment arrives referencing an invoice we never saw (option 2 in #397's acceptance — separate issue if needed)
- Forced-CID invoice soak script (deferred — receiver code path is shared and well-tested)

## Related
- Closes #401
- Stacked on #400 (which closes #397)
- See `docs/uxf/OUTBOX-SEND-FOLLOWUPS.md` for the parent #166 hardening epic