### PR TITLE
test(soak): adapt to canonical CLI UX (sphere-cli #32 + #35)

### DIFF
--- a/manual-test-accounting-roundtrip.sh
+++ b/manual-test-accounting-roundtrip.sh
@@ -185,7 +185,10 @@ banner "Section 3: Bob creates a 7 UCT invoice (human-friendly --asset)"
 
 cd "$PEER_BOB"
 sphere wallet use bob
-sphere invoice create --target "@${BOB_TAG}" --asset "7 UCT" --memo "Accounting demo invoice — 7 UCT" \
+# Canonical UX (sphere-cli #32): `--asset <amount> <coin>` is two
+# positional tokens (no quoted compound form). `--json` opts back into
+# the machine-readable output the grep below expects.
+sphere invoice create --target "@${BOB_TAG}" --asset 7 UCT --memo "Accounting demo invoice — 7 UCT" --json \
   2>&1 | tee "$SNAP/bob-invoice-create.log"
 
 INV="$(grep -Eo '"invoiceId":[[:space:]]*"[^"]+"' "$SNAP/bob-invoice-create.log" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
@@ -209,7 +212,7 @@ sphere balance | tee "$SNAP/bob-balance-1.txt"
 # ---------------------------------------------------------------------------
 banner "Section 4: Bob delivers invoice to @${ALICE_TAG}"
 
-sphere invoice deliver "$INV" --to "@${ALICE_TAG}" 2>&1 | tee "$SNAP/bob-invoice-deliver.log"
+sphere invoice deliver "$INV" --to "@${ALICE_TAG}" --json 2>&1 | tee "$SNAP/bob-invoice-deliver.log"
 grep -qE '"sent":[[:space:]]*1' "$SNAP/bob-invoice-deliver.log" \
   || { echo "ASSERT FAIL (deliver-acked): expected 'sent: 1' in deliver response" >&2; exit 1; }
 echo "ASSERT OK (deliver-acked): invoice delivery DM sent"
@@ -312,7 +315,7 @@ rc=0
 # in AccountingModule) walks COVERED → CLOSED in a single step once all
 # targets are fully paid — both indicate the payment was attributed to
 # the invoice correctly.
-if grep -qE '("state"[[:space:]]*:[[:space:]]*"(COVERED|CLOSED)"|State:[[:space:]]*(COVERED|CLOSED)|state:[[:space:]]*(COVERED|CLOSED))' \
+if grep -qiE '("state"[[:space:]]*:[[:space:]]*"(COVERED|CLOSED)"|state[[:space:]]*:[[:space:]]*(COVERED|CLOSED))' \
     "$SNAP/bob-invoice-status.log"; then
   echo "ASSERT OK (invoice-covered): bob's invoice transitioned to COVERED or CLOSED"
 else

--- a/manual-test-full-recovery.sh
+++ b/manual-test-full-recovery.sh
@@ -139,14 +139,14 @@ wait_for_invoice_visible() {
   : > "$output_file"
   while (( elapsed < timeout )); do
     if sphere invoice status "$invoice" > "$output_file" 2>&1; then
-      if ! grep -q 'No invoice found' "$output_file"; then
+      if ! grep -q -i 'no invoice found' "$output_file"; then
         cat "$output_file"
         return 0
       fi
       # Found a "No invoice" — transient. Retry after sleep.
     else
       rc=$?
-      if ! grep -q 'No invoice found' "$output_file"; then
+      if ! grep -q -i 'no invoice found' "$output_file"; then
         # CLI failed for a non-transient reason (e.g. DB lock, network
         # config). Surface immediately so the soak fails informatively.
         cat "$output_file" >&2
@@ -786,7 +786,10 @@ sphere wallet use alice
 # `invoice deliver` in §C.1b via `--to`, because the invoice's only
 # target is self and `deliver`'s default ("every non-self target")
 # would yield zero recipients.
-sphere invoice create --target "@$ALICE_TAG" --asset "11 UCT" --memo "Full-recovery test invoice" \
+# Canonical UX (sphere-cli #32): `--asset <amount> <coin>` is two
+# positional tokens (no quoted compound form). `--json` opts back into
+# the machine-readable output the grep below expects.
+sphere invoice create --target "@$ALICE_TAG" --asset 11 UCT --memo "Full-recovery test invoice" --json \
   2>&1 | tee "$SNAP/peer1-invoice-create.log"
 
 INV="$(grep -Eo '"invoiceId":[[:space:]]*"[^"]+"' "$SNAP/peer1-invoice-create.log" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"


### PR DESCRIPTION
Three soak scripts in this repo consume sphere-cli output. After sphere-cli landed PR #33 (canonical UX) and PR #35 (invoice human-unit semantics), the soaks need to:

1. Drop the legacy quoted compound form `--asset "<amount> <coin>"` → use two positional tokens `--asset <amount> <coin>`.
2. Add `--json` to invocations whose stdout is grepped in JSON form (sphere-cli now defaults to a human-friendly labelled block).
3. Allow whitespace before the colon when grepping the new human format (`state[[:space:]]*:[[:space:]]*…`).
4. Use case-insensitive grep on `failWithHelp` error messages (which lowercase their prose: `Error: no invoice found matching prefix: …`).

## What this PR changes

**`manual-test-accounting-roundtrip.sh`**
- `--asset "7 UCT"` → `--asset 7 UCT` and added `--json` to `invoice create`.
- Added `--json` to `invoice deliver` so the `"sent": 1` assertion still matches.
- `invoice-covered` regex: allow whitespace before colon + `grep -i`, dropped the redundant `State:` branch.

**`manual-test-full-recovery.sh`**
- `--asset "11 UCT"` → `--asset 11 UCT --json`.
- `wait_for_invoice_visible`: `grep -q 'No invoice found'` → `grep -q -i 'no invoice found'` for the lowercased `failWithHelp` message.

**`manual-test-roundtrip-391.sh`**
- No change required (positional `<recipient> <amount> <coin>` was already canonical).

## What this PR does NOT change

- The invoice amount semantic (`--asset 7 UCT` = 7 whole UCT, not 7 atoms). That fix lives in sphere-cli PR #35; the soak's existing assertion `expected 7000000000000000000` was correct all along.
- The deliver/ingest pipeline. sphere-sdk's PR #400 / #397 (route invoice delivery through TOKEN_TRANSFER) already routed it correctly; the receiver side just needed a sphere-cli that pins a post-#397 SDK (sphere-cli PR #35).

## Test plan

End-to-end run against real testnet, all three soaks:

```
$ /tmp/soak-runs/run-all.sh
  PASS  roundtrip-391           (193s)
  PASS  accounting-roundtrip    (118s)
  PASS  full-recovery           (513s)
```