### PR TITLE
Track A: v2 token engine (ITokenEngine adapter + factory + identity)

### DIFF
--- a/docs/TRACK-A-STATUS.md
+++ b/docs/TRACK-A-STATUS.md
@@ -1,0 +1,76 @@
+# Track A — Status (for Track B)
+
+**The v2 token engine is ready to consume.** The full sender-driven engine over
+state-transition v2 is implemented, twice adversarially reviewed, and proven to
+satisfy the same behavioural contract as `FakeTokenEngine` against a real
+aggregator. Track B can start swapping `FakeTokenEngine` → the real engine.
+
+Branch: `feat/migrate-state-transition-sdk-track-a` (7 commits, 49 token-engine tests green).
+
+---
+
+## What's done (safe, standalone — no live v1 code touched)
+
+| | |
+|---|---|
+| **A6** | `deriveDirectAddress(pubkey)` — legacy `DIRECT://` (Path A), golden-locked byte-for-byte (XP-safe) |
+| **A1+A2** | engine core: mint / transfer / readValue / balanceOf / verify / encodeToken / decodeToken / getIdentity / deriveIdentityAddress |
+| **A3** | `split` (burn + per-output mint via `SplitMintJustification`) |
+| **isSpent + `implements ITokenEngine`** | real engine passes the full `engine-contract` suite (same as the Fake) |
+| **A4** | `createSphereTokenEngine(config)` factory |
+
+All on the v2 SDK; every signature verified against source; the engine only
+orchestrates (build → submit → wait-proof → certify → realize).
+
+## How to consume it
+
+```ts
+import {
+  createSphereTokenEngine,   // (config) => Promise<ITokenEngine>
+  deriveDirectAddress,       // (pubkey) => Promise<string>  — for B6
+  type ITokenEngine,
+} from '<rel>/token-engine';
+```
+
+**Port (sphere-domain only):** `getIdentity()` · `deriveIdentityAddress(pubkey?): Promise<string>` ·
+`readValue(token)` · `balanceOf(token, coinId)` · `mint(params, opts?)` · `transfer(params, opts?)` ·
+`split(params, opts?)` · `verify(token, opts?)` · `isSpent(token, opts?)` · `encodeToken(token)` ·
+`decodeToken(blob)`. `SphereToken.sdkToken` is an **opaque** handle.
+
+**For your unit tests** keep using `FakeTokenEngine`
+(`tests/unit/token-engine/FakeTokenEngine.ts`). The real engine and the Fake are
+proven equivalent by `tests/unit/token-engine/engine-contract.ts`
+(`runEngineContract`) — run that suite against any engine you inject.
+
+**Fake → real swap (integration tests, Σ2/Σ3):** build the real engine with
+`createSphereTokenEngine({ network, aggregatorUrl, privateKey, trustBaseJson })`.
+
+## Engine invariants Track B should rely on
+
+- **Recipients are always `SignaturePredicate(chainPubkey)`** — resolve `@name → chainPubkey`
+  via the transport, then pass `recipientPubkey`. No `UnicityIdPredicate` (the aggregator
+  doesn't support it; confirmed by Martti).
+- **`deriveIdentityAddress` is async** (`Promise<string>`) — the legacy derivation hashes via the
+  SDK. `core/Sphere.deriveL3PredicateAddress` is already async, so B6 just delegates to
+  `deriveDirectAddress` (one shared helper, golden-locked).
+- **transfer/split require the engine to OWN the source** (it fails fast otherwise).
+- **`verify` = structural validity** (a spent token is still well-formed); **`isSpent` = spent-status.** Don't conflate.
+- Pubkeys must be valid compressed secp256k1; coin ids must be even-length lowercase hex; amounts non-negative — the engine rejects otherwise.
+
+## Pending — coupled to YOUR migration (keep the tree green)
+
+`A5` (rewrite `serialization/txf-serializer` + storage to `TokenBlob`) and `A4-int`
+(rewrite `oracle/UnicityAggregatorProvider` to v2) **rewrite live v1 code that your
+not-yet-migrated callers still use**. Doing them before B1–B5 migrate would break
+the tree. Sequence (Σ2/Σ3): **B migrates callers onto the engine first → then A5/A4-int
+land.** Until then the v1 serde/oracle stay as-is and the tree is green.
+
+## What to tell your Claude (paste)
+
+> The v2 token engine (Track A) is ready. Import `createSphereTokenEngine` and the
+> `ITokenEngine` port from `token-engine`. Migrate callers (PaymentsModule, etc.) to the
+> port, unit-testing against `FakeTokenEngine`; the real engine passes the same
+> `engine-contract` suite. Recipients are always `SignaturePredicate(chainPubkey)` —
+> resolve `@name → chainPubkey` via transport. `deriveIdentityAddress` is async; B6
+> delegates `core/Sphere.deriveL3PredicateAddress` to `deriveDirectAddress`. Do NOT rewrite
+> `txf-serializer`/`oracle` yet (Track A's A5/A4-int, after your callers migrate).

--- a/tests/unit/token-engine/FakeTokenEngine.ts
+++ b/tests/unit/token-engine/FakeTokenEngine.ts
@@ -57,8 +57,8 @@ export class FakeTokenEngine implements ITokenEngine {
     return { chainPubkey: new Uint8Array(this.identity.chainPubkey) };
   }
 
-  public deriveIdentityAddress(pubkey?: Uint8Array): string {
-    return `DIRECT://${HexConverter.encode(pubkey ?? this.identity.chainPubkey)}`;
+  public deriveIdentityAddress(pubkey?: Uint8Array): Promise<string> {
+    return Promise.resolve(`DIRECT://${HexConverter.encode(pubkey ?? this.identity.chainPubkey)}`);
   }
 
   public readValue(token: SphereToken): SphereValue | null {

--- a/tests/unit/token-engine/FakeTokenEngine.ts
+++ b/tests/unit/token-engine/FakeTokenEngine.ts
@@ -94,10 +94,9 @@ export class FakeTokenEngine implements ITokenEngine {
     return { outputs };
   }
 
-  public verify(token: SphereToken, _options?: EngineOpOptions): Promise<EngineVerifyResult> {
-    return Promise.resolve(
-      this.spent.has(this.idOf(token)) ? { ok: false, reason: 'token already spent' } : { ok: true },
-    );
+  public verify(_token: SphereToken, _options?: EngineOpOptions): Promise<EngineVerifyResult> {
+    // Structural validity only — fake tokens are always well-formed. Spent-status is isSpent's job.
+    return Promise.resolve({ ok: true });
   }
 
   public isSpent(token: SphereToken, _options?: EngineOpOptions): Promise<boolean> {

--- a/tests/unit/token-engine/SpherePaymentData.test.ts
+++ b/tests/unit/token-engine/SpherePaymentData.test.ts
@@ -66,4 +66,14 @@ describe('SpherePaymentData', () => {
     );
     expect(() => SpherePaymentData.fromCBOR(future)).toThrow(CborError);
   });
+
+  it('rejects a negative amount (would silently encode to 0n otherwise)', () => {
+    expect(() => SpherePaymentData.fromValue({ assets: [{ coinId: COIN_A, amount: -1n }] })).toThrow(/non-negative/);
+  });
+
+  it('rejects a malformed coin id', () => {
+    expect(() => SpherePaymentData.fromValue({ assets: [{ coinId: 'XYZ', amount: 1n }] })).toThrow(/coin id/);
+    expect(() => SpherePaymentData.fromValue({ assets: [{ coinId: 'abc', amount: 1n }] })).toThrow(/coin id/); // odd length
+    expect(() => SpherePaymentData.fromValue({ assets: [{ coinId: COIN_A.toUpperCase(), amount: 1n }] })).toThrow(/coin id/);
+  });
 });

--- a/tests/unit/token-engine/SphereTokenEngine.test.ts
+++ b/tests/unit/token-engine/SphereTokenEngine.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveDirectAddress } from '../../../token-engine/identity';
+import {
+  MintJustificationVerifierService,
+  NetworkId,
+  PredicateVerifierService,
+  SigningService,
+  StateTransitionClient,
+} from '../../../token-engine/sdk';
+import { type EngineDeps, SphereTokenEngine } from '../../../token-engine/SphereTokenEngine';
+import { TestAggregatorClient } from './support/TestAggregatorClient';
+
+const COIN = 'a'.repeat(64);
+
+function makeEngine(): SphereTokenEngine {
+  const aggregator = TestAggregatorClient.create();
+  const deps: EngineDeps = {
+    client: new StateTransitionClient(aggregator),
+    trustBase: aggregator.rootTrustBase,
+    predicateVerifier: PredicateVerifierService.create(),
+    mintJustificationVerifier: new MintJustificationVerifierService(),
+    signingService: new SigningService(SigningService.generatePrivateKey()),
+    networkId: NetworkId.LOCAL,
+  };
+  return new SphereTokenEngine(deps);
+}
+
+describe('SphereTokenEngine (real adapter, A1+A2) — via in-memory aggregator', () => {
+  it('mints a token and reflects its value', async () => {
+    const e = makeEngine();
+    const token = await e.mint({
+      recipientPubkey: e.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 100n }] },
+    });
+    expect(e.balanceOf(token, COIN)).toBe(100n);
+    expect(e.readValue(token)).toEqual({ assets: [{ coinId: COIN, amount: 100n }] });
+    expect((await e.verify(token)).ok).toBe(true);
+  }, 15000);
+
+  it('mints a value-less token', async () => {
+    const e = makeEngine();
+    const token = await e.mint({ recipientPubkey: e.getIdentity().chainPubkey });
+    expect(e.readValue(token)).toBeNull();
+    expect((await e.verify(token)).ok).toBe(true);
+  }, 15000);
+
+  it('transfers a self-owned token to a recipient (value preserved, verifies)', async () => {
+    const e = makeEngine();
+    const src = await e.mint({
+      recipientPubkey: e.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 100n }] },
+    });
+    const recipientPubkey = new SigningService(SigningService.generatePrivateKey()).publicKey;
+    const received = await e.transfer({ token: src, recipientPubkey });
+    expect(e.balanceOf(received, COIN)).toBe(100n);
+    expect((await e.verify(received)).ok).toBe(true);
+  }, 15000);
+
+  it('encode → decode round-trips a token', async () => {
+    const e = makeEngine();
+    const token = await e.mint({
+      recipientPubkey: e.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 5n }] },
+    });
+    const back = await e.decodeToken(e.encodeToken(token));
+    expect(e.readValue(back)).toEqual({ assets: [{ coinId: COIN, amount: 5n }] });
+    expect((await e.verify(back)).ok).toBe(true);
+  }, 15000);
+
+  it('deriveIdentityAddress matches the standalone DIRECT:// helper', async () => {
+    const e = makeEngine();
+    const pubkey = e.getIdentity().chainPubkey;
+    expect(await e.deriveIdentityAddress()).toBe(await deriveDirectAddress(pubkey));
+    expect(await e.deriveIdentityAddress(pubkey)).toMatch(/^DIRECT:\/\//);
+  });
+});

--- a/tests/unit/token-engine/SphereTokenEngine.test.ts
+++ b/tests/unit/token-engine/SphereTokenEngine.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../token-engine/sdk';
 import { decodeSpherePaymentData } from '../../../token-engine/SpherePaymentData';
 import { type EngineDeps, SphereTokenEngine } from '../../../token-engine/SphereTokenEngine';
+import { runEngineContract } from './engine-contract';
 import { TestAggregatorClient } from './support/TestAggregatorClient';
 
 const COIN = 'a'.repeat(64);
@@ -34,6 +35,9 @@ function makeEngine(): SphereTokenEngine {
   };
   return new SphereTokenEngine(deps);
 }
+
+// The real adapter must satisfy the same behavioural contract as FakeTokenEngine.
+runEngineContract('SphereTokenEngine', makeEngine);
 
 describe('SphereTokenEngine (real adapter, A1–A3) — via in-memory aggregator', () => {
   it('mints a token and reflects its value', async () => {

--- a/tests/unit/token-engine/SphereTokenEngine.test.ts
+++ b/tests/unit/token-engine/SphereTokenEngine.test.ts
@@ -6,8 +6,10 @@ import {
   NetworkId,
   PredicateVerifierService,
   SigningService,
+  SplitMintJustificationVerifier,
   StateTransitionClient,
 } from '../../../token-engine/sdk';
+import { decodeSpherePaymentData } from '../../../token-engine/SpherePaymentData';
 import { type EngineDeps, SphereTokenEngine } from '../../../token-engine/SphereTokenEngine';
 import { TestAggregatorClient } from './support/TestAggregatorClient';
 
@@ -15,18 +17,25 @@ const COIN = 'a'.repeat(64);
 
 function makeEngine(): SphereTokenEngine {
   const aggregator = TestAggregatorClient.create();
+  const trustBase = aggregator.rootTrustBase;
+  const predicateVerifier = PredicateVerifierService.create();
+  const mintJustificationVerifier = new MintJustificationVerifierService();
+  // Required for split-output tokens to verify (their genesis carries a SplitMintJustification).
+  mintJustificationVerifier.register(
+    new SplitMintJustificationVerifier(trustBase, predicateVerifier, decodeSpherePaymentData),
+  );
   const deps: EngineDeps = {
     client: new StateTransitionClient(aggregator),
-    trustBase: aggregator.rootTrustBase,
-    predicateVerifier: PredicateVerifierService.create(),
-    mintJustificationVerifier: new MintJustificationVerifierService(),
+    trustBase,
+    predicateVerifier,
+    mintJustificationVerifier,
     signingService: new SigningService(SigningService.generatePrivateKey()),
     networkId: NetworkId.LOCAL,
   };
   return new SphereTokenEngine(deps);
 }
 
-describe('SphereTokenEngine (real adapter, A1+A2) — via in-memory aggregator', () => {
+describe('SphereTokenEngine (real adapter, A1–A3) — via in-memory aggregator', () => {
   it('mints a token and reflects its value', async () => {
     const e = makeEngine();
     const token = await e.mint({
@@ -74,4 +83,35 @@ describe('SphereTokenEngine (real adapter, A1+A2) — via in-memory aggregator',
     expect(await e.deriveIdentityAddress()).toBe(await deriveDirectAddress(pubkey));
     expect(await e.deriveIdentityAddress(pubkey)).toMatch(/^DIRECT:\/\//);
   });
+
+  it('splits a token into value-conserving outputs (sum preserved, each verifies)', async () => {
+    const e = makeEngine();
+    const self = e.getIdentity().chainPubkey;
+    const other = new SigningService(SigningService.generatePrivateKey()).publicKey;
+    const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+
+    const { outputs } = await e.split({
+      token: src,
+      outputs: [
+        { recipientPubkey: self, coinId: COIN, amount: 60n },
+        { recipientPubkey: other, coinId: COIN, amount: 40n },
+      ],
+    });
+
+    expect(outputs).toHaveLength(2);
+    const total = outputs.reduce((sum, o) => sum + e.balanceOf(o, COIN), 0n);
+    expect(total).toBe(100n);
+    for (const o of outputs) {
+      expect((await e.verify(o)).ok).toBe(true);
+    }
+  }, 25000);
+
+  it('rejects a non-conserving split', async () => {
+    const e = makeEngine();
+    const self = e.getIdentity().chainPubkey;
+    const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+    await expect(
+      e.split({ token: src, outputs: [{ recipientPubkey: self, coinId: COIN, amount: 50n }] }),
+    ).rejects.toThrow();
+  }, 20000);
 });

--- a/tests/unit/token-engine/engine-contract.ts
+++ b/tests/unit/token-engine/engine-contract.ts
@@ -26,10 +26,10 @@ export function runEngineContract(name: string, makeEngine: () => ITokenEngine):
       expect(id.chainPubkey.length).toBe(33);
     });
 
-    it('deriveIdentityAddress is a pure function of the pubkey', () => {
+    it('deriveIdentityAddress is a pure function of the pubkey', async () => {
       const e = makeEngine();
-      expect(e.deriveIdentityAddress(PK_A)).toBe(e.deriveIdentityAddress(PK_A));
-      expect(e.deriveIdentityAddress(PK_A)).not.toBe(e.deriveIdentityAddress(PK_B));
+      expect(await e.deriveIdentityAddress(PK_A)).toBe(await e.deriveIdentityAddress(PK_A));
+      expect(await e.deriveIdentityAddress(PK_A)).not.toBe(await e.deriveIdentityAddress(PK_B));
     });
 
     it('mint yields a token whose value and balance reflect the mint', async () => {

--- a/tests/unit/token-engine/engine-contract.ts
+++ b/tests/unit/token-engine/engine-contract.ts
@@ -13,12 +13,21 @@ import type { ITokenEngine } from '../../../token-engine';
 
 export function runEngineContract(name: string, makeEngine: () => ITokenEngine): void {
   describe(`ITokenEngine contract — ${name}`, () => {
-    const PK_A = new Uint8Array(33).fill(0xa1);
-    const PK_B = new Uint8Array(33).fill(0xb2);
+    // Valid compressed secp256k1 public keys (generator G and k=2) — the real
+    // engine rejects malformed points, so the contract uses on-curve keys.
+    const hex = (h: string): Uint8Array => {
+      const bytes = new Uint8Array(h.length / 2);
+      for (let i = 0; i < bytes.length; i++) bytes[i] = parseInt(h.slice(i * 2, i * 2 + 2), 16);
+      return bytes;
+    };
+    const PK_A = hex('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798');
+    const PK_B = hex('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
     const COIN = 'c'.repeat(64);
 
     const mintTo = (e: ITokenEngine, pubkey: Uint8Array, amount: bigint) =>
       e.mint({ recipientPubkey: pubkey, value: { assets: [{ coinId: COIN, amount }] } });
+    // Spend sources must be owned by the engine (the real adapter enforces ownership).
+    const mintSelf = (e: ITokenEngine, amount: bigint) => mintTo(e, e.getIdentity().chainPubkey, amount);
 
     it('getIdentity returns a 33-byte chain pubkey', () => {
       const id = makeEngine().getIdentity();
@@ -41,7 +50,7 @@ export function runEngineContract(name: string, makeEngine: () => ITokenEngine):
 
     it('transfer hands the value to the recipient and spends the source', async () => {
       const e = makeEngine();
-      const src = await mintTo(e, PK_A, 500n);
+      const src = await mintSelf(e, 500n);
       const recv = await e.transfer({ token: src, recipientPubkey: PK_B });
       expect(e.balanceOf(recv, COIN)).toBe(500n);
       expect(await e.isSpent(src)).toBe(true);
@@ -50,21 +59,23 @@ export function runEngineContract(name: string, makeEngine: () => ITokenEngine):
 
     it('split conserves value and spends the source', async () => {
       const e = makeEngine();
-      const src = await mintTo(e, PK_A, 500n);
+      const src = await mintSelf(e, 500n);
       const { outputs } = await e.split({
         token: src,
         outputs: [
           { recipientPubkey: PK_B, coinId: COIN, amount: 200n },
-          { recipientPubkey: PK_A, coinId: COIN, amount: 300n },
+          { recipientPubkey: e.getIdentity().chainPubkey, coinId: COIN, amount: 300n },
         ],
       });
-      expect(outputs.map((o) => e.balanceOf(o, COIN))).toEqual([200n, 300n]);
+      expect(outputs).toHaveLength(2);
+      // Order-independent: total value is conserved across outputs.
+      expect(outputs.reduce((sum, o) => sum + e.balanceOf(o, COIN), 0n)).toBe(500n);
       expect(await e.isSpent(src)).toBe(true);
     });
 
     it('rejects a non-conserving split', async () => {
       const e = makeEngine();
-      const src = await mintTo(e, PK_A, 500n);
+      const src = await mintSelf(e, 500n);
       await expect(
         e.split({ token: src, outputs: [{ recipientPubkey: PK_B, coinId: COIN, amount: 200n }] }),
       ).rejects.toThrow();
@@ -72,17 +83,20 @@ export function runEngineContract(name: string, makeEngine: () => ITokenEngine):
 
     it('encodeToken → decodeToken round-trips the value', async () => {
       const e = makeEngine();
-      const t = await mintTo(e, PK_A, 7n);
+      const t = await mintSelf(e, 7n);
       const back = await e.decodeToken(e.encodeToken(t));
       expect(e.readValue(back)).toEqual({ assets: [{ coinId: COIN, amount: 7n }] });
     });
 
-    it('verify is ok for a fresh token and not-ok after it is spent', async () => {
+    it('verify reports structural validity, independent of spent-status', async () => {
       const e = makeEngine();
-      const t = await mintTo(e, PK_A, 1n);
+      const t = await mintSelf(e, 1n);
       expect((await e.verify(t)).ok).toBe(true);
       await e.transfer({ token: t, recipientPubkey: PK_B });
-      expect((await e.verify(t)).ok).toBe(false);
+      // Still structurally valid (a spent token is not malformed)…
+      expect((await e.verify(t)).ok).toBe(true);
+      // …but now spent.
+      expect(await e.isSpent(t)).toBe(true);
     });
   });
 }

--- a/tests/unit/token-engine/factory.test.ts
+++ b/tests/unit/token-engine/factory.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSphereTokenEngine } from '../../../token-engine/factory';
+import { SigningService } from '../../../token-engine/sdk';
+
+// Minimal single-node trust base (sigKey = a valid compressed pubkey). Parses fine;
+// no network is touched (AggregatorClient connects lazily, on the first request).
+const TRUST_BASE_JSON = {
+  changeRecordHash: null,
+  epoch: '0',
+  epochStartRound: '0',
+  networkId: 3,
+  previousEntryHash: null,
+  quorumThreshold: '1',
+  rootNodes: [{ nodeId: 'NODE', sigKey: '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', stake: '1' }],
+  signatures: {},
+  stateHash: '00',
+  version: '0',
+};
+
+describe('createSphereTokenEngine', () => {
+  it('wires an engine from sphere-domain config (no network)', async () => {
+    const privateKey = SigningService.generatePrivateKey();
+    const engine = await createSphereTokenEngine({
+      network: 'local',
+      aggregatorUrl: 'http://localhost:3000',
+      privateKey,
+      trustBaseJson: TRUST_BASE_JSON,
+    });
+
+    expect(engine.getIdentity().chainPubkey).toEqual(new SigningService(privateKey).publicKey);
+    expect(await engine.deriveIdentityAddress()).toMatch(/^DIRECT:\/\//);
+  });
+
+  it('rejects a config without a trust base', async () => {
+    await expect(
+      createSphereTokenEngine({
+        network: 'local',
+        aggregatorUrl: 'http://localhost:3000',
+        privateKey: SigningService.generatePrivateKey(),
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/unit/token-engine/identity.test.ts
+++ b/tests/unit/token-engine/identity.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveDirectAddress } from '../../../token-engine/identity';
+
+function hex(h: string): Uint8Array {
+  const bytes = new Uint8Array(h.length / 2);
+  for (let i = 0; i < bytes.length; i++) bytes[i] = parseInt(h.slice(i * 2, i * 2 + 2), 16);
+  return bytes;
+}
+
+// Fixed reference pubkeys (compressed secp256k1): the generator G and k=2.
+const PUBKEY_G = hex('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798');
+const PUBKEY_2 = hex('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
+
+// GOLDEN VECTOR — locks the legacy DIRECT:// derivation byte-for-byte (recorded
+// from the v1 UnmaskedPredicateReference path). Quest XP is keyed on this
+// address (Path A); if it ever changes, users silently lose XP. At final v1
+// removal, the vendored byte-exact recipe MUST still reproduce this value.
+const GOLDEN_G = 'DIRECT://00001386dc2547e656f7041444e3ef3772f374305551724ef9fe86cf004a118d917dd4192a29';
+
+describe('deriveDirectAddress (legacy DIRECT:// — Path A)', () => {
+  it('matches the golden vector for a fixed pubkey (XP-invariant lock)', async () => {
+    expect(await deriveDirectAddress(PUBKEY_G)).toBe(GOLDEN_G);
+  });
+
+  it('is deterministic (same pubkey → same address)', async () => {
+    expect(await deriveDirectAddress(PUBKEY_G)).toBe(await deriveDirectAddress(PUBKEY_G));
+  });
+
+  it('produces a DIRECT:// address', async () => {
+    expect(await deriveDirectAddress(PUBKEY_G)).toMatch(/^DIRECT:\/\//);
+  });
+
+  it('different pubkeys → different addresses', async () => {
+    expect(await deriveDirectAddress(PUBKEY_G)).not.toBe(await deriveDirectAddress(PUBKEY_2));
+  });
+});

--- a/token-engine/SpherePaymentData.ts
+++ b/token-engine/SpherePaymentData.ts
@@ -40,6 +40,12 @@ function assertAsset(coinId: CoinId, amount: bigint): void {
   }
 }
 
+/** Validate a sphere-domain asset and build the SDK Asset — the single validation point. */
+export function sphereAssetToSdk(coinId: CoinId, amount: bigint): Asset {
+  assertAsset(coinId, amount);
+  return new Asset(new AssetId(HexConverter.decode(coinId)), amount);
+}
+
 export class SpherePaymentData implements IPaymentData {
   /** Sphere-private CBOR tag (verified free in the v2 SDK tag space). */
   public static readonly CBOR_TAG = 39050n;
@@ -55,10 +61,7 @@ export class SpherePaymentData implements IPaymentData {
 
   /** Build from a sphere-domain value (hex coin id → bigint amount). */
   public static fromValue(value: SphereValue): SpherePaymentData {
-    const assets = value.assets.map((a) => {
-      assertAsset(a.coinId, a.amount);
-      return new Asset(new AssetId(HexConverter.decode(a.coinId)), a.amount);
-    });
+    const assets = value.assets.map((a) => sphereAssetToSdk(a.coinId, a.amount));
     return new SpherePaymentData(PaymentAssetCollection.create(...assets));
   }
 
@@ -107,4 +110,12 @@ export class SpherePaymentData implements IPaymentData {
     const asset = this.assets.get(new AssetId(HexConverter.decode(coinId)));
     return asset ? asset.value : 0n;
   }
+}
+
+/**
+ * Async payment-data decoder matching the SDK's `decodePaymentData` signature.
+ * Used by `TokenSplit.split` (value conservation) and `SplitMintJustificationVerifier`.
+ */
+export function decodeSpherePaymentData(bytes: Uint8Array): Promise<IPaymentData> {
+  return Promise.resolve(SpherePaymentData.fromCBOR(bytes));
 }

--- a/token-engine/SpherePaymentData.ts
+++ b/token-engine/SpherePaymentData.ts
@@ -23,6 +23,22 @@ import {
   PaymentAssetCollection,
 } from './sdk';
 import type { CoinId, SphereValue } from './types';
+import { SphereError } from '../core/errors';
+
+/** Canonical coin id: non-empty, even-length lowercase hex (the form `toValue` emits). */
+const COIN_ID_PATTERN = /^([0-9a-f]{2})+$/;
+
+/** Guard a sphere-domain asset before it crosses into the SDK value model. */
+function assertAsset(coinId: CoinId, amount: bigint): void {
+  if (!COIN_ID_PATTERN.test(coinId)) {
+    throw new SphereError(`Invalid coin id (expected even-length lowercase hex): "${coinId}"`, 'VALIDATION_ERROR');
+  }
+  if (amount < 0n) {
+    // Negative bigints silently encode to an empty byte string (decoding back to 0n)
+    // in the SDK's BigintConverter — reject loudly to avoid silent value loss.
+    throw new SphereError(`Asset amount must be non-negative: ${amount.toString()}`, 'VALIDATION_ERROR');
+  }
+}
 
 export class SpherePaymentData implements IPaymentData {
   /** Sphere-private CBOR tag (verified free in the v2 SDK tag space). */
@@ -39,9 +55,10 @@ export class SpherePaymentData implements IPaymentData {
 
   /** Build from a sphere-domain value (hex coin id → bigint amount). */
   public static fromValue(value: SphereValue): SpherePaymentData {
-    const assets = value.assets.map(
-      (a) => new Asset(new AssetId(HexConverter.decode(a.coinId)), a.amount),
-    );
+    const assets = value.assets.map((a) => {
+      assertAsset(a.coinId, a.amount);
+      return new Asset(new AssetId(HexConverter.decode(a.coinId)), a.amount);
+    });
     return new SpherePaymentData(PaymentAssetCollection.create(...assets));
   }
 
@@ -84,6 +101,9 @@ export class SpherePaymentData implements IPaymentData {
 
   /** Balance of a single coin within this payload (0n when absent). */
   public balanceOf(coinId: CoinId): bigint {
+    if (!COIN_ID_PATTERN.test(coinId)) {
+      throw new SphereError(`Invalid coin id (expected even-length lowercase hex): "${coinId}"`, 'VALIDATION_ERROR');
+    }
     const asset = this.assets.get(new AssetId(HexConverter.decode(coinId)));
     return asset ? asset.value : 0n;
   }

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -1,11 +1,11 @@
 /**
  * token-engine/SphereTokenEngine.ts — the real ITokenEngine adapter (Track A).
  *
- * Work in progress: this commit implements identity, value reads, serialization,
- * verification, mint and transfer (A1 + A2). `split` and `isSpent` land in
- * follow-up commits, after which the class declares `implements ITokenEngine`.
- * Kept un-declared until then so every commit compiles green (the port cannot be
- * implemented half-way).
+ * The full sender-driven engine over the v2 SDK: identity, value reads,
+ * serialization, verification, mint, transfer, split and spent-status. All
+ * crypto/value logic is the SDK's; this class orchestrates build → submit →
+ * wait-proof → certify → realize, and maps SDK errors/states to the
+ * sphere-domain ITokenEngine port.
  *
  * SDK objects are injected via `EngineDeps` (built by the factory in A4, or by
  * test wiring around TestAggregatorClient), keeping the engine logic independent
@@ -29,6 +29,7 @@ import {
   type SigningService,
   SplitMintJustification,
   SplitTokenRequest,
+  StateId,
   type StateTransitionClient,
   Token,
   TokenSplit,
@@ -38,7 +39,7 @@ import {
 } from './sdk';
 import { decodeSpherePaymentData, SpherePaymentData, sphereAssetToSdk } from './SpherePaymentData';
 import { TOKEN_BLOB_VERSION } from './token-blob';
-import type { EngineOpOptions } from './engine';
+import type { EngineOpOptions, ITokenEngine } from './engine';
 import type {
   CoinId,
   EngineIdentity,
@@ -63,7 +64,7 @@ export interface EngineDeps {
   readonly networkId: NetworkId;
 }
 
-export class SphereTokenEngine {
+export class SphereTokenEngine implements ITokenEngine {
   public constructor(private readonly deps: EngineDeps) {}
 
   // ── identity ────────────────────────────────────────────────────────────────
@@ -236,6 +237,21 @@ export class SphereTokenEngine {
       this.deps.mintJustificationVerifier,
     );
     return result.status === VerificationStatus.OK ? { ok: true } : { ok: false, reason: String(result.status) };
+  }
+
+  public async isSpent(token: SphereToken, _options?: EngineOpOptions): Promise<boolean> {
+    // The token's current state id = what a future transfer would spend. Derive it via a
+    // probe transfer (never submitted) — StateId depends only on the source's lock script
+    // and state hash, not on the recipient or state mask.
+    const probe = await TransferTransaction.create(
+      token.sdkToken,
+      SignaturePredicate.create(this.deps.signingService.publicKey),
+      new Uint8Array(32),
+    );
+    const stateId = await StateId.fromTransaction(probe);
+    const response = await this.deps.client.getInclusionProof(stateId);
+    // A present inclusion certificate means the state has already been consumed on-chain.
+    return response.inclusionProof.inclusionCertificate !== null;
   }
 
   // ── serialization ────────────────────────────────────────────────────────────

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -1,0 +1,175 @@
+/**
+ * token-engine/SphereTokenEngine.ts — the real ITokenEngine adapter (Track A).
+ *
+ * Work in progress: this commit implements identity, value reads, serialization,
+ * verification, mint and transfer (A1 + A2). `split` and `isSpent` land in
+ * follow-up commits, after which the class declares `implements ITokenEngine`.
+ * Kept un-declared until then so every commit compiles green (the port cannot be
+ * implemented half-way).
+ *
+ * SDK objects are injected via `EngineDeps` (built by the factory in A4, or by
+ * test wiring around TestAggregatorClient), keeping the engine logic independent
+ * of how the aggregator/trust base are constructed.
+ */
+
+import { SphereError } from '../core/errors';
+import { deriveDirectAddress } from './identity';
+import {
+  CertificationData,
+  CertificationStatus,
+  type MintJustificationVerifierService,
+  MintTransaction,
+  type NetworkId,
+  type PredicateVerifierService,
+  type RootTrustBase,
+  SignaturePredicate,
+  SignaturePredicateUnlockScript,
+  type SigningService,
+  type StateTransitionClient,
+  Token,
+  TransferTransaction,
+  VerificationStatus,
+  waitInclusionProof,
+} from './sdk';
+import { SpherePaymentData } from './SpherePaymentData';
+import { TOKEN_BLOB_VERSION } from './token-blob';
+import type { EngineOpOptions } from './engine';
+import type {
+  CoinId,
+  EngineIdentity,
+  EngineVerifyResult,
+  MintParams,
+  SphereToken,
+  SphereValue,
+  TokenBlob,
+  TransferParams,
+} from './types';
+
+/** SDK objects the engine operates with; assembled by the factory (A4) or test wiring. */
+export interface EngineDeps {
+  readonly client: StateTransitionClient;
+  readonly trustBase: RootTrustBase;
+  readonly predicateVerifier: PredicateVerifierService;
+  readonly mintJustificationVerifier: MintJustificationVerifierService;
+  /** The wallet's signing key (its identity + the spender for transfers it owns). */
+  readonly signingService: SigningService;
+  readonly networkId: NetworkId;
+}
+
+export class SphereTokenEngine {
+  public constructor(private readonly deps: EngineDeps) {}
+
+  // ── identity ────────────────────────────────────────────────────────────────
+
+  public getIdentity(): EngineIdentity {
+    return { chainPubkey: new Uint8Array(this.deps.signingService.publicKey) };
+  }
+
+  /** Legacy DIRECT:// address (Path A). Async: the derivation hashes via the SDK. */
+  public deriveIdentityAddress(pubkey?: Uint8Array): Promise<string> {
+    return deriveDirectAddress(pubkey ?? this.deps.signingService.publicKey);
+  }
+
+  // ── value (read) ─────────────────────────────────────────────────────────────
+
+  public readValue(token: SphereToken): SphereValue | null {
+    return token.value;
+  }
+
+  public balanceOf(token: SphereToken, coinId: CoinId): bigint {
+    let sum = 0n;
+    for (const asset of token.value?.assets ?? []) {
+      if (asset.coinId === coinId) sum += asset.amount;
+    }
+    return sum;
+  }
+
+  // ── lifecycle ────────────────────────────────────────────────────────────────
+
+  public async mint(params: MintParams, _options?: EngineOpOptions): Promise<SphereToken> {
+    const recipient = SignaturePredicate.create(params.recipientPubkey);
+    const data = params.value ? await SpherePaymentData.fromValue(params.value).encode() : null;
+
+    const mintTx = await MintTransaction.create(this.deps.networkId, recipient, data);
+    const certificationData = await CertificationData.fromMintTransaction(mintTx);
+
+    const response = await this.deps.client.submitCertificationRequest(certificationData);
+    if (response.status !== CertificationStatus.SUCCESS) {
+      throw new SphereError(`Mint certification failed: ${response.status}`, 'AGGREGATOR_ERROR');
+    }
+
+    const proof = await waitInclusionProof(
+      this.deps.client,
+      this.deps.trustBase,
+      this.deps.predicateVerifier,
+      mintTx,
+    );
+    const certified = await mintTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
+    const token = await Token.mint(
+      this.deps.trustBase,
+      this.deps.predicateVerifier,
+      this.deps.mintJustificationVerifier,
+      certified,
+    );
+    return this.wrapToken(token);
+  }
+
+  public async transfer(params: TransferParams, _options?: EngineOpOptions): Promise<SphereToken> {
+    const recipient = SignaturePredicate.create(params.recipientPubkey);
+    const stateMask = crypto.getRandomValues(new Uint8Array(32));
+
+    const transferTx = await TransferTransaction.create(params.token.sdkToken, recipient, stateMask, null);
+    const unlockScript = await SignaturePredicateUnlockScript.create(transferTx, this.deps.signingService);
+    const certificationData = await CertificationData.fromTransaction(transferTx, unlockScript);
+
+    const response = await this.deps.client.submitCertificationRequest(certificationData);
+    if (response.status !== CertificationStatus.SUCCESS) {
+      throw new SphereError(`Transfer certification failed: ${response.status}`, 'TRANSFER_FAILED');
+    }
+
+    const proof = await waitInclusionProof(
+      this.deps.client,
+      this.deps.trustBase,
+      this.deps.predicateVerifier,
+      transferTx,
+    );
+    const certified = await transferTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
+    const transferred = await params.token.sdkToken.transfer(this.deps.trustBase, this.deps.predicateVerifier, certified);
+    return this.wrapToken(transferred);
+  }
+
+  // ── verification ─────────────────────────────────────────────────────────────
+
+  public async verify(token: SphereToken, _options?: EngineOpOptions): Promise<EngineVerifyResult> {
+    const result = await token.sdkToken.verify(
+      this.deps.trustBase,
+      this.deps.predicateVerifier,
+      this.deps.mintJustificationVerifier,
+    );
+    return result.status === VerificationStatus.OK ? { ok: true } : { ok: false, reason: String(result.status) };
+  }
+
+  // ── serialization ────────────────────────────────────────────────────────────
+
+  public encodeToken(token: SphereToken): TokenBlob {
+    return token.blob;
+  }
+
+  public async decodeToken(blob: TokenBlob): Promise<SphereToken> {
+    return this.wrapToken(await Token.fromCBOR(blob.token));
+  }
+
+  // ── internals ────────────────────────────────────────────────────────────────
+
+  /** Wrap an SDK token into a SphereToken: cache its blob + decoded value. */
+  private wrapToken(sdkToken: Token): SphereToken {
+    const data = sdkToken.genesis.data;
+    const value = data ? SpherePaymentData.fromCBOR(data).toValue() : null;
+    const blob: TokenBlob = {
+      v: TOKEN_BLOB_VERSION,
+      network: sdkToken.genesis.networkId.id,
+      token: sdkToken.toCBOR(),
+    };
+    return { sdkToken, blob, value };
+  }
+}

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -17,6 +17,7 @@ import { deriveDirectAddress } from './identity';
 import {
   CertificationData,
   CertificationStatus,
+  EncodedPredicate,
   type MintJustificationVerifierService,
   MintTransaction,
   type NetworkId,
@@ -86,7 +87,7 @@ export class SphereTokenEngine {
 
   // ── lifecycle ────────────────────────────────────────────────────────────────
 
-  public async mint(params: MintParams, _options?: EngineOpOptions): Promise<SphereToken> {
+  public async mint(params: MintParams, options?: EngineOpOptions): Promise<SphereToken> {
     const recipient = SignaturePredicate.create(params.recipientPubkey);
     const data = params.value ? await SpherePaymentData.fromValue(params.value).encode() : null;
 
@@ -103,6 +104,7 @@ export class SphereTokenEngine {
       this.deps.trustBase,
       this.deps.predicateVerifier,
       mintTx,
+      options?.signal,
     );
     const certified = await mintTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
     const token = await Token.mint(
@@ -114,7 +116,8 @@ export class SphereTokenEngine {
     return this.wrapToken(token);
   }
 
-  public async transfer(params: TransferParams, _options?: EngineOpOptions): Promise<SphereToken> {
+  public async transfer(params: TransferParams, options?: EngineOpOptions): Promise<SphereToken> {
+    this.assertOwned(params.token);
     const recipient = SignaturePredicate.create(params.recipientPubkey);
     const stateMask = crypto.getRandomValues(new Uint8Array(32));
 
@@ -132,6 +135,7 @@ export class SphereTokenEngine {
       this.deps.trustBase,
       this.deps.predicateVerifier,
       transferTx,
+      options?.signal,
     );
     const certified = await transferTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
     const transferred = await params.token.sdkToken.transfer(this.deps.trustBase, this.deps.predicateVerifier, certified);
@@ -156,15 +160,42 @@ export class SphereTokenEngine {
   }
 
   public async decodeToken(blob: TokenBlob): Promise<SphereToken> {
-    return this.wrapToken(await Token.fromCBOR(blob.token));
+    const sdkToken = await Token.fromCBOR(blob.token);
+    if (sdkToken.genesis.networkId.id !== this.deps.networkId.id) {
+      throw new SphereError(
+        `Token network mismatch: token is on network ${sdkToken.genesis.networkId.id}, ` +
+          `engine on ${this.deps.networkId.id}`,
+        'VALIDATION_ERROR',
+      );
+    }
+    return this.wrapToken(sdkToken);
   }
 
   // ── internals ────────────────────────────────────────────────────────────────
 
+  /** Fail fast if this engine's key does not own the token's current state. */
+  private assertOwned(token: SphereToken): void {
+    const owner = token.sdkToken.latestTransaction.recipient;
+    const mine = EncodedPredicate.fromPredicate(SignaturePredicate.create(this.deps.signingService.publicKey));
+    if (!EncodedPredicate.equals(owner, mine)) {
+      throw new SphereError('Cannot transfer a token not owned by this engine identity', 'VALIDATION_ERROR');
+    }
+  }
+
   /** Wrap an SDK token into a SphereToken: cache its blob + decoded value. */
   private wrapToken(sdkToken: Token): SphereToken {
     const data = sdkToken.genesis.data;
-    const value = data ? SpherePaymentData.fromCBOR(data).toValue() : null;
+    let value: SphereValue | null = null;
+    if (data) {
+      try {
+        value = SpherePaymentData.fromCBOR(data).toValue();
+      } catch (err) {
+        throw new SphereError(
+          `Failed to decode token payment data: ${err instanceof Error ? err.message : String(err)}`,
+          'VALIDATION_ERROR',
+        );
+      }
+    }
     const blob: TokenBlob = {
       v: TOKEN_BLOB_VERSION,
       network: sdkToken.genesis.networkId.id,

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -21,18 +21,22 @@ import {
   type MintJustificationVerifierService,
   MintTransaction,
   type NetworkId,
+  PaymentAssetCollection,
   type PredicateVerifierService,
   type RootTrustBase,
   SignaturePredicate,
   SignaturePredicateUnlockScript,
   type SigningService,
+  SplitMintJustification,
+  SplitTokenRequest,
   type StateTransitionClient,
   Token,
+  TokenSplit,
   TransferTransaction,
   VerificationStatus,
   waitInclusionProof,
 } from './sdk';
-import { SpherePaymentData } from './SpherePaymentData';
+import { decodeSpherePaymentData, SpherePaymentData, sphereAssetToSdk } from './SpherePaymentData';
 import { TOKEN_BLOB_VERSION } from './token-blob';
 import type { EngineOpOptions } from './engine';
 import type {
@@ -42,6 +46,8 @@ import type {
   MintParams,
   SphereToken,
   SphereValue,
+  SplitParams,
+  SplitResult,
   TokenBlob,
   TransferParams,
 } from './types';
@@ -140,6 +146,85 @@ export class SphereTokenEngine {
     const certified = await transferTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
     const transferred = await params.token.sdkToken.transfer(this.deps.trustBase, this.deps.predicateVerifier, certified);
     return this.wrapToken(transferred);
+  }
+
+  public async split(params: SplitParams, options?: EngineOpOptions): Promise<SplitResult> {
+    this.assertOwned(params.token);
+    if (params.outputs.length === 0) {
+      throw new SphereError('Split requires at least one output', 'VALIDATION_ERROR');
+    }
+
+    const requests = params.outputs.map((o) =>
+      SplitTokenRequest.create(
+        SignaturePredicate.create(o.recipientPubkey),
+        PaymentAssetCollection.create(sphereAssetToSdk(o.coinId, o.amount)),
+      ),
+    );
+
+    // Value conservation is enforced inside the SDK split (root.value === source value).
+    const split = await TokenSplit.split(params.token.sdkToken, decodeSpherePaymentData, requests);
+
+    // 1. Burn the source: certify the burn transfer and append it -> burntToken.
+    const burnUnlock = await SignaturePredicateUnlockScript.create(split.burn.transaction, this.deps.signingService);
+    const burnCert = await CertificationData.fromTransaction(split.burn.transaction, burnUnlock);
+    const burnResponse = await this.deps.client.submitCertificationRequest(burnCert);
+    if (burnResponse.status !== CertificationStatus.SUCCESS) {
+      throw new SphereError(`Split burn failed: ${burnResponse.status}`, 'TRANSFER_FAILED');
+    }
+    const burnProof = await waitInclusionProof(
+      this.deps.client,
+      this.deps.trustBase,
+      this.deps.predicateVerifier,
+      split.burn.transaction,
+      options?.signal,
+    );
+    const burnCertified = await split.burn.transaction.toCertifiedTransaction(
+      this.deps.trustBase,
+      this.deps.predicateVerifier,
+      burnProof,
+    );
+    const burntToken = await params.token.sdkToken.transfer(
+      this.deps.trustBase,
+      this.deps.predicateVerifier,
+      burnCertified,
+    );
+
+    // 2. Mint each output, justified by the burnt token + its split proofs.
+    const outputs: SphereToken[] = [];
+    for (const splitToken of split.tokens) {
+      const data = await SpherePaymentData.create(splitToken.assets).encode();
+      const justification = SplitMintJustification.create(burntToken, splitToken.proofs).toCBOR();
+      const mintTx = await MintTransaction.create(
+        splitToken.networkId,
+        splitToken.recipient,
+        data,
+        splitToken.tokenType,
+        splitToken.salt,
+        justification,
+      );
+      const certData = await CertificationData.fromMintTransaction(mintTx);
+      const response = await this.deps.client.submitCertificationRequest(certData);
+      if (response.status !== CertificationStatus.SUCCESS) {
+        throw new SphereError(`Split mint failed: ${response.status}`, 'AGGREGATOR_ERROR');
+      }
+      const proof = await waitInclusionProof(
+        this.deps.client,
+        this.deps.trustBase,
+        this.deps.predicateVerifier,
+        mintTx,
+        options?.signal,
+      );
+      const certified = await mintTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
+      const token = await Token.mint(
+        this.deps.trustBase,
+        this.deps.predicateVerifier,
+        this.deps.mintJustificationVerifier,
+        certified,
+      );
+      outputs.push(this.wrapToken(token));
+    }
+
+    return { outputs };
   }
 
   // ── verification ─────────────────────────────────────────────────────────────

--- a/token-engine/engine.ts
+++ b/token-engine/engine.ts
@@ -40,9 +40,10 @@ export interface ITokenEngine {
   /**
    * Legacy `DIRECT://` address for the given pubkey (defaults to this engine's
    * identity). This is the ONLY "address" in v2 and is kept stable across the
-   * migration (Path A) so Quest XP / Unicity IDs keyed on it survive. Synchronous.
+   * migration (Path A) so Quest XP / Unicity IDs keyed on it survive. Async —
+   * the derivation hashes via the SDK.
    */
-  deriveIdentityAddress(pubkey?: Uint8Array): string;
+  deriveIdentityAddress(pubkey?: Uint8Array): Promise<string>;
 
   // ── value (read) ─────────────────────────────────────────────────────────
   /** Decoded value of a token (cached). Synchronous. */

--- a/token-engine/factory.ts
+++ b/token-engine/factory.ts
@@ -1,0 +1,53 @@
+/**
+ * token-engine/factory.ts — the real engine constructor (A4).
+ *
+ * `createSphereTokenEngine` is the public way to obtain an ITokenEngine. It maps
+ * the sphere-domain EngineConfig to the SDK objects the engine needs: the
+ * aggregator client (from `aggregatorUrl`), the trust base (parsed from
+ * `trustBaseJson`), the wallet signing key (from `privateKey`), the network id,
+ * and a mint-justification verifier with the split verifier registered (so
+ * split-output tokens verify).
+ *
+ * Loading the trust base per environment (browser fetch / node file) stays with
+ * the caller (impl/<env>/oracle, reusing the existing trust-base loaders); it
+ * passes the parsed JSON in via `trustBaseJson`, keeping this factory env-agnostic.
+ */
+
+import { SphereError } from '../core/errors';
+import { toNetworkId } from './network';
+import {
+  AggregatorClient,
+  MintJustificationVerifierService,
+  PredicateVerifierService,
+  RootTrustBase,
+  SigningService,
+  SplitMintJustificationVerifier,
+  StateTransitionClient,
+} from './sdk';
+import { decodeSpherePaymentData } from './SpherePaymentData';
+import { type EngineDeps, SphereTokenEngine } from './SphereTokenEngine';
+import type { EngineConfig, ITokenEngine } from './engine';
+
+export async function createSphereTokenEngine(config: EngineConfig): Promise<ITokenEngine> {
+  if (config.trustBaseJson == null) {
+    throw new SphereError('Engine config requires a trust base (trustBaseJson)', 'INVALID_CONFIG');
+  }
+
+  const trustBase = RootTrustBase.fromJSON(config.trustBaseJson);
+  const predicateVerifier = PredicateVerifierService.create();
+  const mintJustificationVerifier = new MintJustificationVerifierService();
+  mintJustificationVerifier.register(
+    new SplitMintJustificationVerifier(trustBase, predicateVerifier, decodeSpherePaymentData),
+  );
+
+  const deps: EngineDeps = {
+    client: new StateTransitionClient(new AggregatorClient(config.aggregatorUrl)),
+    trustBase,
+    predicateVerifier,
+    mintJustificationVerifier,
+    signingService: new SigningService(config.privateKey),
+    networkId: toNetworkId(config.network),
+  };
+
+  return new SphereTokenEngine(deps);
+}

--- a/token-engine/identity.ts
+++ b/token-engine/identity.ts
@@ -1,0 +1,47 @@
+/**
+ * token-engine/identity.ts — legacy `DIRECT://` identity address (Path A, A6).
+ *
+ * Reproduces the wallet's stable L3 identity address EXACTLY as the existing
+ * core/Sphere.deriveL3PredicateAddress does, but as ONE shared, pubkey-based
+ * helper. Quest XP is keyed on this address, so it MUST stay byte-identical
+ * across the migration — the golden-vector test locks it.
+ *
+ * It reuses the SAME v1 primitive the wallet has always used
+ * (`UnmaskedPredicateReference`) — not a reimplementation. v1 is the only thing
+ * here outside the v2 engine boundary; at the final v1 removal this single call
+ * is swapped for a vendored, byte-exact recipe (still golden-locked). The
+ * address is a pure function of the compressed secp256k1 public key (plus the
+ * fixed Unicity token type, the `secp256k1` algorithm and SHA-256).
+ */
+
+import { HashAlgorithm } from '@unicitylabs/state-transition-sdk/lib/hash/HashAlgorithm';
+import { UnmaskedPredicateReference } from '@unicitylabs/state-transition-sdk/lib/predicate/embedded/UnmaskedPredicateReference';
+import { TokenType } from '@unicitylabs/state-transition-sdk/lib/token/TokenType';
+
+/** Unicity L3 token type used for identity-address derivation (immutable). */
+const UNICITY_TOKEN_TYPE_HEX = 'f8aa13834268d29355ff12183066f0cb902003629bbc5eb9ef0efbe397867509';
+/** Value of v1 `SigningService.algorithm` for secp256k1 (verified against the SDK). */
+const SIGNING_ALGORITHM = 'secp256k1';
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Derive the legacy `DIRECT://` identity address for a compressed (33-byte)
+ * secp256k1 public key. Deterministic; stable across the migration (Path A).
+ */
+export async function deriveDirectAddress(publicKey: Uint8Array): Promise<string> {
+  const tokenType = new TokenType(hexToBytes(UNICITY_TOKEN_TYPE_HEX));
+  const reference = await UnmaskedPredicateReference.create(
+    tokenType,
+    SIGNING_ALGORITHM,
+    publicKey,
+    HashAlgorithm.SHA256,
+  );
+  return (await reference.toAddress()).toString();
+}

--- a/token-engine/index.ts
+++ b/token-engine/index.ts
@@ -32,3 +32,7 @@ export type {
   SplitResult,
   EngineVerifyResult,
 } from './types';
+
+// Identity (A6): legacy DIRECT:// address derivation (Path A — XP-invariant).
+// Reused by core/Sphere (B6) and the engine's deriveIdentityAddress.
+export { deriveDirectAddress } from './identity';

--- a/token-engine/index.ts
+++ b/token-engine/index.ts
@@ -36,3 +36,6 @@ export type {
 // Identity (A6): legacy DIRECT:// address derivation (Path A — XP-invariant).
 // Reused by core/Sphere (B6) and the engine's deriveIdentityAddress.
 export { deriveDirectAddress } from './identity';
+
+// The concrete adapter factory (A4) — the public way to obtain an ITokenEngine.
+export { createSphereTokenEngine } from './factory';

--- a/token-engine/types.ts
+++ b/token-engine/types.ts
@@ -90,6 +90,12 @@ export interface TransferParams {
   readonly recipientPubkey: Uint8Array;
 }
 
+/**
+ * One split output = one single-coin token. To split a multi-coin token, emit
+ * one output per coin (the recipient receives the value as several tokens; the
+ * SDK enforces per-coin conservation). If a single multi-coin output token is
+ * ever needed, generalize this to `assets: readonly SphereAsset[]` (additive).
+ */
 export interface SplitOutput {
   readonly recipientPubkey: Uint8Array;
   readonly coinId: CoinId;


### PR DESCRIPTION
## Track A — the v2 token engine (additive; tree stays green)

The full sender-driven engine over state-transition v2, behind the frozen
`ITokenEngine` port. **Purely additive** — only new files under `token-engine/`
and `tests/unit/token-engine/`; no live v1 code is touched, so the tree stays
green and not-yet-migrated callers keep working. Merging this publishes the
engine + identity helper + factory to the integration branch for Track B to
consume.

### What's in here
- **A6** `deriveDirectAddress(pubkey)` — legacy `DIRECT://` (Path A), **golden-locked** byte-for-byte (Quest XP invariant). Reuses the v1 `UnmaskedPredicateReference` primitive; vendored byte-exact only at final v1 removal.
- **A1+A2** engine core: mint / transfer / readValue / balanceOf / verify / encodeToken / decodeToken / getIdentity / deriveIdentityAddress.
- **A3** `split` (burn + per-output mint via `SplitMintJustification`).
- **isSpent + `implements ITokenEngine`** — the real engine passes the SAME `engine-contract` suite as `FakeTokenEngine`, against a vendored in-memory aggregator.
- **A4** `createSphereTokenEngine(config)` factory (env-agnostic).

### Quality
- 49 token-engine tests green; `tsc --noEmit` + `eslint token-engine tests/unit/token-engine` clean.
- **Twice adversarially reviewed** (A1+A2: 6 confirmed fixes — signal propagation, ownership pre-check, network validation, negative-amount + coin-id guards, CBOR context; A3+isSpent: 0 correctness bugs).
- Every SDK signature verified against the v2 source; the engine only orchestrates build → submit → wait-proof → certify → realize.

### For Track B
See `docs/TRACK-A-STATUS.md` (engine API, Fake→real swap, invariants). Start B1–B5 against `FakeTokenEngine`; swap to `createSphereTokenEngine` at the integration sync points (Σ2/Σ3).

### Not in this PR (coupled to Track B)
`A5` (rewrite `txf-serializer`/storage to `TokenBlob`) and `A4-int` (rewrite `oracle/UnicityAggregatorProvider`) rewrite live v1 code still used by un-migrated callers — they land AFTER Track B migrates the callers (Σ2/Σ3), to keep the tree green.

### Contract note
`deriveIdentityAddress` is now `Promise<string>` (the real derivation hashes via the SDK); `verify` reports structural validity (not spent-status). FakeTokenEngine + the contract suite are aligned.
