### PR TITLE
Track A: engine hardening (edge-case tests)

### DIFF
--- a/tests/unit/token-engine/SphereTokenEngine.hardening.test.ts
+++ b/tests/unit/token-engine/SphereTokenEngine.hardening.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { NetworkId } from '../../../token-engine/sdk';
+import { createTestEngine, freshPubkey } from './test-engine';
+
+const COIN_A = 'a'.repeat(64);
+const COIN_B = 'b'.repeat(64);
+const COIN_C = 'c'.repeat(64);
+
+// Edge cases hardening the real engine (token-engine territory only).
+describe('SphereTokenEngine — hardening / edge cases', () => {
+  it('mints a multi-coin token; balanceOf is per-coin', async () => {
+    const e = createTestEngine();
+    const token = await e.mint({
+      recipientPubkey: e.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN_A, amount: 100n }, { coinId: COIN_B, amount: 50n }] },
+    });
+    expect(e.balanceOf(token, COIN_A)).toBe(100n);
+    expect(e.balanceOf(token, COIN_B)).toBe(50n);
+    expect(e.balanceOf(token, COIN_C)).toBe(0n);
+    expect(e.readValue(token)).toEqual({
+      assets: [{ coinId: COIN_A, amount: 100n }, { coinId: COIN_B, amount: 50n }],
+    });
+  }, 15000);
+
+  it('round-trips a very large amount (no precision loss)', async () => {
+    const e = createTestEngine();
+    const amount = 2n ** 200n;
+    const token = await e.mint({ recipientPubkey: e.getIdentity().chainPubkey, value: { assets: [{ coinId: COIN_A, amount }] } });
+    expect(e.balanceOf(token, COIN_A)).toBe(amount);
+    const back = await e.decodeToken(e.encodeToken(token));
+    expect(e.balanceOf(back, COIN_A)).toBe(amount);
+  }, 15000);
+
+  it('refuses to transfer a token the engine does not own (fail fast)', async () => {
+    const e = createTestEngine();
+    const foreign = await e.mint({ recipientPubkey: freshPubkey(), value: { assets: [{ coinId: COIN_A, amount: 1n }] } });
+    await expect(e.transfer({ token: foreign, recipientPubkey: freshPubkey() })).rejects.toThrow(/own/i);
+  }, 15000);
+
+  it('rejects a transfer to an invalid recipient public key', async () => {
+    const e = createTestEngine();
+    const own = await e.mint({ recipientPubkey: e.getIdentity().chainPubkey, value: { assets: [{ coinId: COIN_A, amount: 1n }] } });
+    await expect(e.transfer({ token: own, recipientPubkey: new Uint8Array(33).fill(0xb2) })).rejects.toThrow();
+  }, 15000);
+
+  it('rejects decoding a token minted on a different network', async () => {
+    const local = createTestEngine(); // NetworkId.LOCAL
+    const blob = local.encodeToken(
+      await local.mint({ recipientPubkey: local.getIdentity().chainPubkey, value: { assets: [{ coinId: COIN_A, amount: 1n }] } }),
+    );
+    const otherNetwork = createTestEngine({ networkId: NetworkId.TESTNET });
+    await expect(otherNetwork.decodeToken(blob)).rejects.toThrow(/network/i);
+  }, 15000);
+
+  it('splits into three value-conserving outputs', async () => {
+    const e = createTestEngine();
+    const self = e.getIdentity().chainPubkey;
+    const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN_A, amount: 100n }] } });
+    const { outputs } = await e.split({
+      token: src,
+      outputs: [
+        { recipientPubkey: self, coinId: COIN_A, amount: 30n },
+        { recipientPubkey: freshPubkey(), coinId: COIN_A, amount: 30n },
+        { recipientPubkey: freshPubkey(), coinId: COIN_A, amount: 40n },
+      ],
+    });
+    expect(outputs).toHaveLength(3);
+    expect(outputs.reduce((sum, o) => sum + e.balanceOf(o, COIN_A), 0n)).toBe(100n);
+  }, 30000);
+
+  it('rejects minting a negative or malformed value', async () => {
+    const e = createTestEngine();
+    const self = e.getIdentity().chainPubkey;
+    await expect(e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN_A, amount: -1n }] } })).rejects.toThrow();
+    await expect(e.mint({ recipientPubkey: self, value: { assets: [{ coinId: 'nothex', amount: 1n }] } })).rejects.toThrow();
+  }, 15000);
+});

--- a/tests/unit/token-engine/SphereTokenEngine.test.ts
+++ b/tests/unit/token-engine/SphereTokenEngine.test.ts
@@ -1,47 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
 import { deriveDirectAddress } from '../../../token-engine/identity';
-import {
-  MintJustificationVerifierService,
-  NetworkId,
-  PredicateVerifierService,
-  SigningService,
-  SplitMintJustificationVerifier,
-  StateTransitionClient,
-} from '../../../token-engine/sdk';
-import { decodeSpherePaymentData } from '../../../token-engine/SpherePaymentData';
-import { type EngineDeps, SphereTokenEngine } from '../../../token-engine/SphereTokenEngine';
 import { runEngineContract } from './engine-contract';
-import { TestAggregatorClient } from './support/TestAggregatorClient';
+import { createTestEngine, freshPubkey } from './test-engine';
 
 const COIN = 'a'.repeat(64);
 
-function makeEngine(): SphereTokenEngine {
-  const aggregator = TestAggregatorClient.create();
-  const trustBase = aggregator.rootTrustBase;
-  const predicateVerifier = PredicateVerifierService.create();
-  const mintJustificationVerifier = new MintJustificationVerifierService();
-  // Required for split-output tokens to verify (their genesis carries a SplitMintJustification).
-  mintJustificationVerifier.register(
-    new SplitMintJustificationVerifier(trustBase, predicateVerifier, decodeSpherePaymentData),
-  );
-  const deps: EngineDeps = {
-    client: new StateTransitionClient(aggregator),
-    trustBase,
-    predicateVerifier,
-    mintJustificationVerifier,
-    signingService: new SigningService(SigningService.generatePrivateKey()),
-    networkId: NetworkId.LOCAL,
-  };
-  return new SphereTokenEngine(deps);
-}
-
 // The real adapter must satisfy the same behavioural contract as FakeTokenEngine.
-runEngineContract('SphereTokenEngine', makeEngine);
+runEngineContract('SphereTokenEngine', () => createTestEngine());
 
 describe('SphereTokenEngine (real adapter, A1–A3) — via in-memory aggregator', () => {
   it('mints a token and reflects its value', async () => {
-    const e = makeEngine();
+    const e = createTestEngine();
     const token = await e.mint({
       recipientPubkey: e.getIdentity().chainPubkey,
       value: { assets: [{ coinId: COIN, amount: 100n }] },
@@ -52,26 +22,26 @@ describe('SphereTokenEngine (real adapter, A1–A3) — via in-memory aggregator
   }, 15000);
 
   it('mints a value-less token', async () => {
-    const e = makeEngine();
+    const e = createTestEngine();
     const token = await e.mint({ recipientPubkey: e.getIdentity().chainPubkey });
     expect(e.readValue(token)).toBeNull();
     expect((await e.verify(token)).ok).toBe(true);
   }, 15000);
 
   it('transfers a self-owned token to a recipient (value preserved, verifies)', async () => {
-    const e = makeEngine();
+    const e = createTestEngine();
     const src = await e.mint({
       recipientPubkey: e.getIdentity().chainPubkey,
       value: { assets: [{ coinId: COIN, amount: 100n }] },
     });
-    const recipientPubkey = new SigningService(SigningService.generatePrivateKey()).publicKey;
+    const recipientPubkey = freshPubkey();
     const received = await e.transfer({ token: src, recipientPubkey });
     expect(e.balanceOf(received, COIN)).toBe(100n);
     expect((await e.verify(received)).ok).toBe(true);
   }, 15000);
 
   it('encode → decode round-trips a token', async () => {
-    const e = makeEngine();
+    const e = createTestEngine();
     const token = await e.mint({
       recipientPubkey: e.getIdentity().chainPubkey,
       value: { assets: [{ coinId: COIN, amount: 5n }] },
@@ -82,16 +52,16 @@ describe('SphereTokenEngine (real adapter, A1–A3) — via in-memory aggregator
   }, 15000);
 
   it('deriveIdentityAddress matches the standalone DIRECT:// helper', async () => {
-    const e = makeEngine();
+    const e = createTestEngine();
     const pubkey = e.getIdentity().chainPubkey;
     expect(await e.deriveIdentityAddress()).toBe(await deriveDirectAddress(pubkey));
     expect(await e.deriveIdentityAddress(pubkey)).toMatch(/^DIRECT:\/\//);
   });
 
   it('splits a token into value-conserving outputs (sum preserved, each verifies)', async () => {
-    const e = makeEngine();
+    const e = createTestEngine();
     const self = e.getIdentity().chainPubkey;
-    const other = new SigningService(SigningService.generatePrivateKey()).publicKey;
+    const other = freshPubkey();
     const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
 
     const { outputs } = await e.split({
@@ -111,7 +81,7 @@ describe('SphereTokenEngine (real adapter, A1–A3) — via in-memory aggregator
   }, 25000);
 
   it('rejects a non-conserving split', async () => {
-    const e = makeEngine();
+    const e = createTestEngine();
     const self = e.getIdentity().chainPubkey;
     const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
     await expect(

--- a/tests/unit/token-engine/test-engine.ts
+++ b/tests/unit/token-engine/test-engine.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared test harness: build a real SphereTokenEngine over the in-memory
+ * TestAggregatorClient (with the split-justification verifier registered).
+ * Used by SphereTokenEngine.test.ts + the hardening tests.
+ */
+
+import {
+  MintJustificationVerifierService,
+  NetworkId,
+  PredicateVerifierService,
+  SigningService,
+  SplitMintJustificationVerifier,
+  StateTransitionClient,
+} from '../../../token-engine/sdk';
+import { decodeSpherePaymentData } from '../../../token-engine/SpherePaymentData';
+import { type EngineDeps, SphereTokenEngine } from '../../../token-engine/SphereTokenEngine';
+import { TestAggregatorClient } from './support/TestAggregatorClient';
+
+/**
+ * Build a real engine backed by a fresh in-memory aggregator.
+ * `networkId` can be overridden to exercise cross-network guards.
+ */
+export function createTestEngine(opts: { networkId?: NetworkId } = {}): SphereTokenEngine {
+  const aggregator = TestAggregatorClient.create();
+  const trustBase = aggregator.rootTrustBase;
+  const predicateVerifier = PredicateVerifierService.create();
+  const mintJustificationVerifier = new MintJustificationVerifierService();
+  mintJustificationVerifier.register(
+    new SplitMintJustificationVerifier(trustBase, predicateVerifier, decodeSpherePaymentData),
+  );
+  const deps: EngineDeps = {
+    client: new StateTransitionClient(aggregator),
+    trustBase,
+    predicateVerifier,
+    mintJustificationVerifier,
+    signingService: new SigningService(SigningService.generatePrivateKey()),
+    networkId: opts.networkId ?? NetworkId.LOCAL,
+  };
+  return new SphereTokenEngine(deps);
+}
+
+/** A fresh, valid compressed secp256k1 public key the engine does NOT own. */
+export function freshPubkey(): Uint8Array {
+  return new SigningService(SigningService.generatePrivateKey()).publicKey;
+}


### PR DESCRIPTION
Additive edge-case tests for the v2 engine (token-engine territory only; no live v1 / Track B files). Multi-coin balanceOf, 2^200 round-trip, not-owned transfer rejection, invalid-pubkey rejection, cross-network decode rejection, 3-output split, negative/malformed mint rejection. Extracts shared createTestEngine/freshPubkey harness. 56 token-engine tests green; tsc + eslint clean.