### PR TITLE
Track A: engine surface — tokenId, on-chain memo, data tokens (Q1/Q2/Q3)

### DIFF
--- a/tests/unit/token-engine/FakeTokenEngine.test.ts
+++ b/tests/unit/token-engine/FakeTokenEngine.test.ts
@@ -27,10 +27,10 @@ describe('FakeTokenEngine specifics', () => {
     expect(e.getIdentity().chainPubkey[0]).toBe(0x09);
   });
 
-  it('mints a value-less token when no value is given', async () => {
+  it('mints a value-less token when no value is given (value === null, like the real engine)', async () => {
     const e = new FakeTokenEngine();
     const t = await e.mint({ recipientPubkey: PK });
-    expect(e.readValue(t)).toEqual({ assets: [] });
+    expect(e.readValue(t)).toBeNull();
     expect(e.balanceOf(t, COIN)).toBe(0n);
   });
 });

--- a/tests/unit/token-engine/FakeTokenEngine.ts
+++ b/tests/unit/token-engine/FakeTokenEngine.ts
@@ -22,7 +22,10 @@ import {
   CborDeserializer,
   CborSerializer,
   HexConverter,
+  NetworkId,
   type Token,
+  TokenId,
+  TokenSalt,
 } from '../../../token-engine/sdk';
 import type {
   CoinId,
@@ -121,8 +124,11 @@ export class FakeTokenEngine implements ITokenEngine {
   }
 
   public async mintDataToken(params: MintDataTokenParams, _options?: EngineOpOptions): Promise<SphereToken> {
-    // Deterministic salt → deterministic, terms-derived tokenId (mirrors the real engine's intent).
-    const tokenId = params.salt ? to32(params.salt) : this.nextId();
+    // Derive the tokenId EXACTLY as the real engine does (TokenId.fromSalt = SHA-256 over
+    // [salt, networkId]) so the fake is a faithful double — the id is NOT the raw salt.
+    const tokenId = params.salt
+      ? (await TokenId.fromSalt(networkIdOf(this.network), TokenSalt.fromCBOR(CborSerializer.encodeByteString(params.salt)))).bytes
+      : this.nextId();
     return this.makeToken({
       tokenId,
       stateId: this.nextId(),
@@ -260,11 +266,11 @@ function isSpherePaymentData(data: Uint8Array): boolean {
   }
 }
 
-/** Pad/truncate to 32 bytes so a (terms-derived) salt yields a stable 64-hex tokenId. */
-function to32(bytes: Uint8Array): Uint8Array {
-  const out = new Uint8Array(32);
-  out.set(bytes.subarray(0, 32));
-  return out;
+/** Map the fake's numeric network to the SDK NetworkId instance (for TokenId.fromSalt). */
+function networkIdOf(n: number): NetworkId {
+  if (n === NetworkId.MAINNET.id) return NetworkId.MAINNET;
+  if (n === NetworkId.LOCAL.id) return NetworkId.LOCAL;
+  return NetworkId.TESTNET;
 }
 
 // Opaque placeholder for SphereToken.sdkToken — callers never call methods on it.

--- a/tests/unit/token-engine/FakeTokenEngine.ts
+++ b/tests/unit/token-engine/FakeTokenEngine.ts
@@ -4,8 +4,14 @@
  * Track B develops + unit-tests callers (PaymentsModule, AccountingModule, …)
  * against the frozen ITokenEngine port using this fake, before the real adapter
  * lands. It does no network/crypto: it models token identity, value, ownership
- * transfer, value-conserving split, and spent-state in memory. Token ids are a
- * monotonic counter, so behaviour is fully deterministic.
+ * transfer, value-conserving split, data tokens, on-chain memos and spent-state
+ * in memory. Token ids are a monotonic counter (or the salt for data tokens), so
+ * behaviour is fully deterministic.
+ *
+ * Its state mirrors the real engine: a token carries raw `genesisData` (a
+ * SpherePaymentData envelope for value tokens, opaque bytes for data tokens) plus
+ * an optional `transferMemo` (the latest transfer's data). value / readMemo /
+ * readTokenData are derived exactly as the real adapter derives them.
  *
  * This is a TEST double (lives under tests/, never shipped). The real adapter
  * puts a genuine v2 Token in SphereToken.sdkToken; here it is an opaque
@@ -24,6 +30,7 @@ import type {
   EngineOpOptions,
   EngineVerifyResult,
   ITokenEngine,
+  MintDataTokenParams,
   MintParams,
   SphereToken,
   SphereValue,
@@ -36,6 +43,18 @@ import { SpherePaymentData } from '../../../token-engine/SpherePaymentData';
 import { TOKEN_BLOB_VERSION } from '../../../token-engine/token-blob';
 
 const DEFAULT_PUBKEY = new Uint8Array([0x02, ...new Array<number>(32).fill(0)]); // 33 bytes
+
+interface FakeState {
+  /** Genesis-stable identity — same across every state of the token (mirrors v2 TokenId). */
+  readonly tokenId: Uint8Array;
+  /** Per-state identity — changes on every transfer; the unit of spent-tracking. */
+  readonly stateId: Uint8Array;
+  readonly owner: Uint8Array;
+  /** Raw mint data: a SpherePaymentData envelope (value token) or opaque bytes (data token). */
+  readonly genesisData: Uint8Array | null;
+  /** The latest transfer's opaque memo, when the token was delivered by transfer. */
+  readonly transferMemo: Uint8Array | null;
+}
 
 export interface FakeEngineConfig {
   readonly chainPubkey?: Uint8Array;
@@ -61,6 +80,10 @@ export class FakeTokenEngine implements ITokenEngine {
     return Promise.resolve(`DIRECT://${HexConverter.encode(pubkey ?? this.identity.chainPubkey)}`);
   }
 
+  public tokenId(token: SphereToken): string {
+    return token.blob.tokenId;
+  }
+
   public readValue(token: SphereToken): SphereValue | null {
     return token.value;
   }
@@ -73,13 +96,53 @@ export class FakeTokenEngine implements ITokenEngine {
     return sum;
   }
 
+  public readMemo(token: SphereToken): Uint8Array | null {
+    const state = decodeFakeState(token.blob.token);
+    if (state.transferMemo) return state.transferMemo;
+    if (state.genesisData && isSpherePaymentData(state.genesisData)) {
+      return SpherePaymentData.fromCBOR(state.genesisData).memo;
+    }
+    return null;
+  }
+
+  public readTokenData(token: SphereToken): Uint8Array | null {
+    return decodeFakeState(token.blob.token).genesisData;
+  }
+
   public async mint(params: MintParams, _options?: EngineOpOptions): Promise<SphereToken> {
-    return this.makeToken(this.nextId(), params.recipientPubkey, params.value ?? { assets: [] });
+    const genesisData = params.value ? await SpherePaymentData.fromValue(params.value).encode() : null;
+    return this.makeToken({
+      tokenId: this.nextId(),
+      stateId: this.nextId(),
+      owner: params.recipientPubkey,
+      genesisData,
+      transferMemo: null,
+    });
+  }
+
+  public async mintDataToken(params: MintDataTokenParams, _options?: EngineOpOptions): Promise<SphereToken> {
+    // Deterministic salt → deterministic, terms-derived tokenId (mirrors the real engine's intent).
+    const tokenId = params.salt ? to32(params.salt) : this.nextId();
+    return this.makeToken({
+      tokenId,
+      stateId: this.nextId(),
+      owner: params.recipientPubkey,
+      genesisData: params.data,
+      transferMemo: null,
+    });
   }
 
   public async transfer(params: TransferParams, _options?: EngineOpOptions): Promise<SphereToken> {
     this.consume(params.token);
-    return this.makeToken(this.nextId(), params.recipientPubkey, params.token.value ?? { assets: [] });
+    const source = decodeFakeState(params.token.blob.token);
+    // A transfer keeps the same token (genesis + tokenId); only the state + owner change.
+    return this.makeToken({
+      tokenId: source.tokenId,
+      stateId: this.nextId(),
+      owner: params.recipientPubkey,
+      genesisData: source.genesisData,
+      transferMemo: params.data ?? null,
+    });
   }
 
   public async split(params: SplitParams, _options?: EngineOpOptions): Promise<SplitResult> {
@@ -87,8 +150,19 @@ export class FakeTokenEngine implements ITokenEngine {
     this.consume(params.token);
     const outputs: SphereToken[] = [];
     for (const o of params.outputs) {
+      // A split output is a fresh mint (new tokenId); its memo rides inside the value envelope.
+      const genesisData = await SpherePaymentData.fromValue(
+        { assets: [{ coinId: o.coinId, amount: o.amount }] },
+        o.data ?? null,
+      ).encode();
       outputs.push(
-        await this.makeToken(this.nextId(), o.recipientPubkey, { assets: [{ coinId: o.coinId, amount: o.amount }] }),
+        await this.makeToken({
+          tokenId: this.nextId(),
+          stateId: this.nextId(),
+          owner: o.recipientPubkey,
+          genesisData,
+          transferMemo: null,
+        }),
       );
     }
     return { outputs };
@@ -108,8 +182,7 @@ export class FakeTokenEngine implements ITokenEngine {
   }
 
   public decodeToken(blob: TokenBlob): Promise<SphereToken> {
-    const { value } = decodeFakeState(blob.token);
-    return Promise.resolve({ sdkToken: handleFor(blob.token), blob, value });
+    return Promise.resolve({ sdkToken: handleFor(blob.token), blob, value: valueOf(decodeFakeState(blob.token)) });
   }
 
   // ── internals ──────────────────────────────────────────────────────────────
@@ -124,14 +197,20 @@ export class FakeTokenEngine implements ITokenEngine {
     return id;
   }
 
-  private async makeToken(id: Uint8Array, owner: Uint8Array, value: SphereValue): Promise<SphereToken> {
-    const stateBytes = await encodeFakeState(id, owner, value);
-    const blob: TokenBlob = { v: TOKEN_BLOB_VERSION, network: this.network, token: stateBytes };
-    return { sdkToken: handleFor(stateBytes), blob, value };
+  private async makeToken(state: FakeState): Promise<SphereToken> {
+    const stateBytes = encodeFakeState(state);
+    const blob: TokenBlob = {
+      v: TOKEN_BLOB_VERSION,
+      network: this.network,
+      tokenId: HexConverter.encode(state.tokenId),
+      token: stateBytes,
+    };
+    return { sdkToken: handleFor(stateBytes), blob, value: valueOf(state) };
   }
 
+  /** Spent-tracking key = the per-state id (changes on every transfer). */
   private idOf(token: SphereToken): string {
-    return HexConverter.encode(decodeFakeState(token.blob.token).id);
+    return HexConverter.encode(decodeFakeState(token.blob.token).stateId);
   }
 
   private consume(token: SphereToken): void {
@@ -143,22 +222,49 @@ export class FakeTokenEngine implements ITokenEngine {
   }
 }
 
-// fake-token state: CBOR array[ id, owner, SpherePaymentData(value) ]
-async function encodeFakeState(id: Uint8Array, owner: Uint8Array, value: SphereValue): Promise<Uint8Array> {
+// fake-token state: CBOR array[ tokenId, stateId, owner, genesisData?, transferMemo? ]
+function encodeFakeState(state: FakeState): Uint8Array {
   return CborSerializer.encodeArray(
-    CborSerializer.encodeByteString(id),
-    CborSerializer.encodeByteString(owner),
-    await SpherePaymentData.fromValue(value).encode(),
+    CborSerializer.encodeByteString(state.tokenId),
+    CborSerializer.encodeByteString(state.stateId),
+    CborSerializer.encodeByteString(state.owner),
+    CborSerializer.encodeNullable(state.genesisData, CborSerializer.encodeByteString),
+    CborSerializer.encodeNullable(state.transferMemo, CborSerializer.encodeByteString),
   );
 }
 
-function decodeFakeState(bytes: Uint8Array): { id: Uint8Array; owner: Uint8Array; value: SphereValue } {
-  const [idB, ownerB, valueB] = CborDeserializer.decodeArray(bytes, 3);
+function decodeFakeState(bytes: Uint8Array): FakeState {
+  const [tokenIdB, stateIdB, ownerB, genesisB, memoB] = CborDeserializer.decodeArray(bytes, 5);
   return {
-    id: CborDeserializer.decodeByteString(idB),
+    tokenId: CborDeserializer.decodeByteString(tokenIdB),
+    stateId: CborDeserializer.decodeByteString(stateIdB),
     owner: CborDeserializer.decodeByteString(ownerB),
-    value: SpherePaymentData.fromCBOR(valueB).toValue(),
+    genesisData: CborDeserializer.decodeNullable(genesisB, CborDeserializer.decodeByteString),
+    transferMemo: CborDeserializer.decodeNullable(memoB, CborDeserializer.decodeByteString),
   };
+}
+
+/** Derive the decoded value exactly as the real adapter does (SpherePaymentData envelope only). */
+function valueOf(state: FakeState): SphereValue | null {
+  if (state.genesisData && isSpherePaymentData(state.genesisData)) {
+    return SpherePaymentData.fromCBOR(state.genesisData).toValue();
+  }
+  return null;
+}
+
+function isSpherePaymentData(data: Uint8Array): boolean {
+  try {
+    return CborDeserializer.decodeTag(data).tag === SpherePaymentData.CBOR_TAG;
+  } catch {
+    return false;
+  }
+}
+
+/** Pad/truncate to 32 bytes so a (terms-derived) salt yields a stable 64-hex tokenId. */
+function to32(bytes: Uint8Array): Uint8Array {
+  const out = new Uint8Array(32);
+  out.set(bytes.subarray(0, 32));
+  return out;
 }
 
 // Opaque placeholder for SphereToken.sdkToken — callers never call methods on it.

--- a/tests/unit/token-engine/SpherePaymentData.test.ts
+++ b/tests/unit/token-engine/SpherePaymentData.test.ts
@@ -76,9 +76,21 @@ describe('SpherePaymentData', () => {
   it('rejects an unsupported version', () => {
     const future = CborSerializer.encodeTag(
       SpherePaymentData.CBOR_TAG,
-      CborSerializer.encodeArray(CborSerializer.encodeUnsignedInteger(999n), CborSerializer.encodeArray()),
+      CborSerializer.encodeArray(
+        CborSerializer.encodeUnsignedInteger(999n),
+        CborSerializer.encodeArray(),
+        CborSerializer.encodeNullable(null, CborSerializer.encodeByteString),
+      ),
     );
     expect(() => SpherePaymentData.fromCBOR(future)).toThrow(CborError);
+  });
+
+  it('rejects an envelope with the wrong number of fields', () => {
+    const malformed = CborSerializer.encodeTag(
+      SpherePaymentData.CBOR_TAG,
+      CborSerializer.encodeArray(CborSerializer.encodeUnsignedInteger(1n), CborSerializer.encodeArray()),
+    );
+    expect(() => SpherePaymentData.fromCBOR(malformed)).toThrow(CborError);
   });
 
   it('rejects a negative amount (would silently encode to 0n otherwise)', () => {

--- a/tests/unit/token-engine/SpherePaymentData.test.ts
+++ b/tests/unit/token-engine/SpherePaymentData.test.ts
@@ -15,6 +15,20 @@ describe('SpherePaymentData', () => {
     expect(SpherePaymentData.fromCBOR(bytes).toValue()).toEqual(value);
   });
 
+  it('round-trips an opaque memo alongside the value', async () => {
+    const value: SphereValue = { assets: [{ coinId: COIN_A, amount: 1n }] };
+    const memo = new Uint8Array([7, 8, 9, 250]);
+    const bytes = await SpherePaymentData.fromValue(value, memo).encode();
+    const decoded = SpherePaymentData.fromCBOR(bytes);
+    expect(decoded.toValue()).toEqual(value);
+    expect(decoded.memo).toEqual(memo);
+  });
+
+  it('has a null memo when none is provided', async () => {
+    const bytes = await SpherePaymentData.fromValue({ assets: [{ coinId: COIN_A, amount: 1n }] }).encode();
+    expect(SpherePaymentData.fromCBOR(bytes).memo).toBeNull();
+  });
+
   it('round-trips multiple coins incl. zero and very large amounts', async () => {
     const value: SphereValue = {
       assets: [

--- a/tests/unit/token-engine/engine-contract.ts
+++ b/tests/unit/token-engine/engine-contract.ts
@@ -98,5 +98,52 @@ export function runEngineContract(name: string, makeEngine: () => ITokenEngine):
       // …but now spent.
       expect(await e.isSpent(t)).toBe(true);
     });
+
+    it('exposes a 64-char hex tokenId that is stable across a transfer', async () => {
+      const e = makeEngine();
+      const src = await mintSelf(e, 5n);
+      const id = e.tokenId(src);
+      expect(id).toMatch(/^[0-9a-f]{64}$/);
+      const recv = await e.transfer({ token: src, recipientPubkey: PK_B });
+      expect(e.tokenId(recv)).toBe(id); // same token (genesis), new state
+    });
+
+    it('mints a data token (value === null) with readable data and a salt-derived tokenId', async () => {
+      const e = makeEngine();
+      const data = new Uint8Array([1, 2, 3, 4]);
+      const tokenType = new Uint8Array(32).fill(1);
+      const salt = new Uint8Array(32).fill(7);
+      const t = await e.mintDataToken({ recipientPubkey: PK_A, data, tokenType, salt });
+      expect(e.readValue(t)).toBeNull();
+      expect(e.readTokenData(t)).toEqual(data);
+      expect(e.tokenId(t)).toMatch(/^[0-9a-f]{64}$/);
+      // tokenId is derived from (networkId, salt): the same terms-derived salt re-mints
+      // to the identical, stable tokenId (the invoice-id use case).
+      const again = await e.mintDataToken({ recipientPubkey: PK_A, data, tokenType, salt });
+      expect(e.tokenId(again)).toBe(e.tokenId(t));
+    });
+
+    it('carries an opaque on-chain memo on a whole-token transfer (readMemo)', async () => {
+      const e = makeEngine();
+      const src = await mintSelf(e, 1n);
+      const memo = new Uint8Array([9, 8, 7]);
+      const recv = await e.transfer({ token: src, recipientPubkey: PK_B, data: memo });
+      expect(e.readMemo(recv)).toEqual(memo);
+    });
+
+    it('carries an opaque on-chain memo on a split output (readMemo)', async () => {
+      const e = makeEngine();
+      const src = await mintSelf(e, 10n);
+      const memo = new Uint8Array([4, 2]);
+      const { outputs } = await e.split({
+        token: src,
+        outputs: [
+          { recipientPubkey: PK_B, coinId: COIN, amount: 6n, data: memo },
+          { recipientPubkey: e.getIdentity().chainPubkey, coinId: COIN, amount: 4n },
+        ],
+      });
+      expect(e.readMemo(outputs[0])).toEqual(memo);
+      expect(e.readMemo(outputs[1])).toBeNull();
+    });
   });
 }

--- a/tests/unit/token-engine/token-blob.test.ts
+++ b/tests/unit/token-engine/token-blob.test.ts
@@ -4,17 +4,20 @@ import { CborError, CborSerializer } from '../../../token-engine/sdk';
 import { decodeTokenBlob, encodeTokenBlob, TOKEN_BLOB_VERSION } from '../../../token-engine/token-blob';
 import type { TokenBlob } from '../../../token-engine/types';
 
+const TOKEN_ID = 'ab'.repeat(32); // 64-char hex
+
 describe('TokenBlob codec', () => {
   it('round-trips a blob through encode/decode', () => {
-    const blob: TokenBlob = { v: TOKEN_BLOB_VERSION, network: 2, token: new Uint8Array([1, 2, 3, 4]) };
+    const blob: TokenBlob = { v: TOKEN_BLOB_VERSION, network: 2, tokenId: TOKEN_ID, token: new Uint8Array([1, 2, 3, 4]) };
     expect(decodeTokenBlob(encodeTokenBlob(blob))).toEqual(blob);
   });
 
-  it('preserves raw token bytes and network exactly', () => {
+  it('preserves raw token bytes, network and tokenId exactly', () => {
     const token = new Uint8Array([0, 255, 128, 7, 42]);
-    const back = decodeTokenBlob(encodeTokenBlob({ v: TOKEN_BLOB_VERSION, network: 1, token }));
+    const back = decodeTokenBlob(encodeTokenBlob({ v: TOKEN_BLOB_VERSION, network: 1, tokenId: TOKEN_ID, token }));
     expect(back.token).toEqual(token);
     expect(back.network).toBe(1);
+    expect(back.tokenId).toBe(TOKEN_ID);
   });
 
   it('rejects bytes with the wrong CBOR tag', () => {
@@ -28,6 +31,7 @@ describe('TokenBlob codec', () => {
       CborSerializer.encodeArray(
         CborSerializer.encodeUnsignedInteger(999n),
         CborSerializer.encodeUnsignedInteger(2n),
+        CborSerializer.encodeTextString(TOKEN_ID),
         CborSerializer.encodeByteString(new Uint8Array([1])),
       ),
     );

--- a/token-engine/SpherePaymentData.ts
+++ b/token-engine/SpherePaymentData.ts
@@ -79,12 +79,14 @@ export class SpherePaymentData implements IPaymentData {
     if (tag.tag !== SpherePaymentData.CBOR_TAG) {
       throw new CborError(`Invalid SpherePaymentData tag: ${tag.tag}`);
     }
-    const fields = CborDeserializer.decodeArray(tag.data);
+    // Strict structure: exactly [version, assets, memo] (matches encode + the SDK's
+    // fixed-shape decoders). Extra/missing fields are corruption, not tolerated.
+    const fields = CborDeserializer.decodeArray(tag.data, 3);
     const version = CborDeserializer.decodeUnsignedInteger(fields[0]);
     if (version !== SpherePaymentData.VERSION) {
       throw new CborError(`Unsupported SpherePaymentData version: ${version}`);
     }
-    const memo = fields.length > 2 ? CborDeserializer.decodeNullable(fields[2], CborDeserializer.decodeByteString) : null;
+    const memo = CborDeserializer.decodeNullable(fields[2], CborDeserializer.decodeByteString);
     return new SpherePaymentData(PaymentAssetCollection.fromCBOR(fields[1]), memo);
   }
 

--- a/token-engine/SpherePaymentData.ts
+++ b/token-engine/SpherePaymentData.ts
@@ -52,17 +52,25 @@ export class SpherePaymentData implements IPaymentData {
   /** Envelope version; bump when the structure changes. */
   public static readonly VERSION = 1n;
 
-  private constructor(public readonly assets: PaymentAssetCollection) {}
+  private constructor(
+    public readonly assets: PaymentAssetCollection,
+    private readonly _memo: Uint8Array | null = null,
+  ) {}
 
-  /** Wrap an existing SDK asset collection. */
-  public static create(assets: PaymentAssetCollection): SpherePaymentData {
-    return new SpherePaymentData(assets);
+  /** Opaque, app-defined memo carried alongside the value (e.g. invoice attribution). */
+  public get memo(): Uint8Array | null {
+    return this._memo ? new Uint8Array(this._memo) : null;
   }
 
-  /** Build from a sphere-domain value (hex coin id → bigint amount). */
-  public static fromValue(value: SphereValue): SpherePaymentData {
+  /** Wrap an existing SDK asset collection (+ optional opaque memo). */
+  public static create(assets: PaymentAssetCollection, memo: Uint8Array | null = null): SpherePaymentData {
+    return new SpherePaymentData(assets, memo);
+  }
+
+  /** Build from a sphere-domain value (hex coin id → bigint amount) + optional opaque memo. */
+  public static fromValue(value: SphereValue, memo: Uint8Array | null = null): SpherePaymentData {
     const assets = value.assets.map((a) => sphereAssetToSdk(a.coinId, a.amount));
-    return new SpherePaymentData(PaymentAssetCollection.create(...assets));
+    return new SpherePaymentData(PaymentAssetCollection.create(...assets), memo);
   }
 
   /** Decode from the CBOR envelope produced by {@link encode}. */
@@ -71,15 +79,16 @@ export class SpherePaymentData implements IPaymentData {
     if (tag.tag !== SpherePaymentData.CBOR_TAG) {
       throw new CborError(`Invalid SpherePaymentData tag: ${tag.tag}`);
     }
-    const fields = CborDeserializer.decodeArray(tag.data, 2);
+    const fields = CborDeserializer.decodeArray(tag.data);
     const version = CborDeserializer.decodeUnsignedInteger(fields[0]);
     if (version !== SpherePaymentData.VERSION) {
       throw new CborError(`Unsupported SpherePaymentData version: ${version}`);
     }
-    return new SpherePaymentData(PaymentAssetCollection.fromCBOR(fields[1]));
+    const memo = fields.length > 2 ? CborDeserializer.decodeNullable(fields[2], CborDeserializer.decodeByteString) : null;
+    return new SpherePaymentData(PaymentAssetCollection.fromCBOR(fields[1]), memo);
   }
 
-  /** Deterministic, versioned, tagged CBOR: `tag(39050)[ version, assets ]`. */
+  /** Deterministic, versioned, tagged CBOR: `tag(39050)[ version, assets, memo? ]`. */
   public encode(): Promise<Uint8Array> {
     return Promise.resolve(
       CborSerializer.encodeTag(
@@ -87,6 +96,7 @@ export class SpherePaymentData implements IPaymentData {
         CborSerializer.encodeArray(
           CborSerializer.encodeUnsignedInteger(SpherePaymentData.VERSION),
           this.assets.toCBOR(),
+          CborSerializer.encodeNullable(this._memo, CborSerializer.encodeByteString),
         ),
       ),
     );

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -15,9 +15,12 @@
 import { SphereError } from '../core/errors';
 import { deriveDirectAddress } from './identity';
 import {
+  CborDeserializer,
+  CborSerializer,
   CertificationData,
   CertificationStatus,
   EncodedPredicate,
+  HexConverter,
   type MintJustificationVerifierService,
   MintTransaction,
   type NetworkId,
@@ -32,7 +35,9 @@ import {
   StateId,
   type StateTransitionClient,
   Token,
+  TokenSalt,
   TokenSplit,
+  TokenType,
   TransferTransaction,
   VerificationStatus,
   waitInclusionProof,
@@ -44,6 +49,7 @@ import type {
   CoinId,
   EngineIdentity,
   EngineVerifyResult,
+  MintDataTokenParams,
   MintParams,
   SphereToken,
   SphereValue,
@@ -92,6 +98,29 @@ export class SphereTokenEngine implements ITokenEngine {
     return sum;
   }
 
+  public tokenId(token: SphereToken): string {
+    return token.blob.tokenId;
+  }
+
+  public readMemo(token: SphereToken): Uint8Array | null {
+    const sdkToken = token.sdkToken;
+    // A transferred token delivers its memo on the latest transfer.
+    if (sdkToken.transactions.length > 0) {
+      return sdkToken.latestTransaction.data;
+    }
+    // A minted output (e.g. a split output) carries the memo in its value envelope.
+    const data = sdkToken.genesis.data;
+    if (data && this.isSpherePaymentData(data)) {
+      return SpherePaymentData.fromCBOR(data).memo;
+    }
+    return null;
+  }
+
+  public readTokenData(token: SphereToken): Uint8Array | null {
+    const data = token.sdkToken.genesis.data;
+    return data ? new Uint8Array(data) : null;
+  }
+
   // ── lifecycle ────────────────────────────────────────────────────────────────
 
   public async mint(params: MintParams, options?: EngineOpOptions): Promise<SphereToken> {
@@ -123,12 +152,45 @@ export class SphereTokenEngine implements ITokenEngine {
     return this.wrapToken(token);
   }
 
+  public async mintDataToken(params: MintDataTokenParams, options?: EngineOpOptions): Promise<SphereToken> {
+    const recipient = SignaturePredicate.create(params.recipientPubkey);
+    const tokenType = params.tokenType ? new TokenType(params.tokenType) : TokenType.generate();
+    // A deterministic salt yields a stable, terms-derived tokenId (TokenId.fromSalt).
+    const salt = params.salt
+      ? TokenSalt.fromCBOR(CborSerializer.encodeByteString(params.salt))
+      : TokenSalt.generate();
+
+    const mintTx = await MintTransaction.create(this.deps.networkId, recipient, params.data, tokenType, salt);
+    const certificationData = await CertificationData.fromMintTransaction(mintTx);
+
+    const response = await this.deps.client.submitCertificationRequest(certificationData);
+    if (response.status !== CertificationStatus.SUCCESS) {
+      throw new SphereError(`Data-token mint failed: ${response.status}`, 'AGGREGATOR_ERROR');
+    }
+
+    const proof = await waitInclusionProof(
+      this.deps.client,
+      this.deps.trustBase,
+      this.deps.predicateVerifier,
+      mintTx,
+      options?.signal,
+    );
+    const certified = await mintTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
+    const token = await Token.mint(
+      this.deps.trustBase,
+      this.deps.predicateVerifier,
+      this.deps.mintJustificationVerifier,
+      certified,
+    );
+    return this.wrapToken(token);
+  }
+
   public async transfer(params: TransferParams, options?: EngineOpOptions): Promise<SphereToken> {
     this.assertOwned(params.token);
     const recipient = SignaturePredicate.create(params.recipientPubkey);
     const stateMask = crypto.getRandomValues(new Uint8Array(32));
 
-    const transferTx = await TransferTransaction.create(params.token.sdkToken, recipient, stateMask, null);
+    const transferTx = await TransferTransaction.create(params.token.sdkToken, recipient, stateMask, params.data ?? null);
     const unlockScript = await SignaturePredicateUnlockScript.create(transferTx, this.deps.signingService);
     const certificationData = await CertificationData.fromTransaction(transferTx, unlockScript);
 
@@ -192,8 +254,10 @@ export class SphereTokenEngine implements ITokenEngine {
 
     // 2. Mint each output, justified by the burnt token + its split proofs.
     const outputs: SphereToken[] = [];
-    for (const splitToken of split.tokens) {
-      const data = await SpherePaymentData.create(splitToken.assets).encode();
+    for (let i = 0; i < split.tokens.length; i++) {
+      const splitToken = split.tokens[i];
+      // split.tokens preserves requests order, so the per-output memo maps by index.
+      const data = await SpherePaymentData.create(splitToken.assets, params.outputs[i].data ?? null).encode();
       const justification = SplitMintJustification.create(burntToken, splitToken.proofs).toCBOR();
       const mintTx = await MintTransaction.create(
         splitToken.networkId,
@@ -283,11 +347,13 @@ export class SphereTokenEngine implements ITokenEngine {
     }
   }
 
-  /** Wrap an SDK token into a SphereToken: cache its blob + decoded value. */
+  /** Wrap an SDK token into a SphereToken: cache its blob (incl. stable tokenId) + decoded value. */
   private wrapToken(sdkToken: Token): SphereToken {
     const data = sdkToken.genesis.data;
     let value: SphereValue | null = null;
-    if (data) {
+    // Only value tokens carry a SpherePaymentData envelope; data tokens (e.g. invoices)
+    // leave value === null. A corrupt value envelope still errors loudly.
+    if (data && this.isSpherePaymentData(data)) {
       try {
         value = SpherePaymentData.fromCBOR(data).toValue();
       } catch (err) {
@@ -300,8 +366,18 @@ export class SphereTokenEngine implements ITokenEngine {
     const blob: TokenBlob = {
       v: TOKEN_BLOB_VERSION,
       network: sdkToken.genesis.networkId.id,
+      tokenId: HexConverter.encode(sdkToken.id.bytes),
       token: sdkToken.toCBOR(),
     };
     return { sdkToken, blob, value };
+  }
+
+  /** True if the bytes are a SpherePaymentData envelope (value token) vs a raw data token. */
+  private isSpherePaymentData(data: Uint8Array): boolean {
+    try {
+      return CborDeserializer.decodeTag(data).tag === SpherePaymentData.CBOR_TAG;
+    } catch {
+      return false;
+    }
   }
 }

--- a/token-engine/engine.ts
+++ b/token-engine/engine.ts
@@ -59,7 +59,10 @@ export interface ITokenEngine {
   /**
    * The opaque on-chain memo delivered with this token: the latest transfer's
    * data for a transferred token, else the memo in a minted output's value
-   * envelope (split). `null` when there is none. Synchronous.
+   * envelope (split). Returns `null` when there is no memo — including for data
+   * tokens (no value envelope; use `readTokenData`) and memo-less value tokens.
+   * To tell a data token from a value token, check `readValue` (null ⇒
+   * data/value-less token). Synchronous.
    */
   readMemo(token: SphereToken): Uint8Array | null;
   /** Raw genesis data of a token (e.g. a data-token's terms). `null` when absent. Synchronous. */

--- a/token-engine/engine.ts
+++ b/token-engine/engine.ts
@@ -15,6 +15,7 @@ import type {
   TokenBlob,
   SphereNetwork,
   MintParams,
+  MintDataTokenParams,
   TransferParams,
   SplitParams,
   SplitResult,
@@ -46,10 +47,23 @@ export interface ITokenEngine {
   deriveIdentityAddress(pubkey?: Uint8Array): Promise<string>;
 
   // ── value (read) ─────────────────────────────────────────────────────────
+  /**
+   * Genesis-stable token id — 64-char lowercase hex of the v2 TokenId (same
+   * across every state). Use for dedup / history / tombstone keys. Synchronous.
+   */
+  tokenId(token: SphereToken): string;
   /** Decoded value of a token (cached). Synchronous. */
   readValue(token: SphereToken): SphereValue | null;
   /** Balance of a single coin within a token. Synchronous. */
   balanceOf(token: SphereToken, coinId: CoinId): bigint;
+  /**
+   * The opaque on-chain memo delivered with this token: the latest transfer's
+   * data for a transferred token, else the memo in a minted output's value
+   * envelope (split). `null` when there is none. Synchronous.
+   */
+  readMemo(token: SphereToken): Uint8Array | null;
+  /** Raw genesis data of a token (e.g. a data-token's terms). `null` when absent. Synchronous. */
+  readTokenData(token: SphereToken): Uint8Array | null;
 
   // ── lifecycle (sender-driven: build → submit → wait → certify → realize) ──
   /**
@@ -61,6 +75,12 @@ export interface ITokenEngine {
    * Unicity-ID/nametag mint is a distinct identity surface (see migration plan §4.4).
    */
   mint(params: MintParams, options?: EngineOpOptions): Promise<SphereToken>;
+  /**
+   * Mint a NON-value (data) token: opaque `data` + custom `tokenType` + deterministic
+   * `salt` → a stable, terms-derived `tokenId`. The result has `value === null`;
+   * read its bytes via `readTokenData`. (Used e.g. for on-chain invoice tokens.)
+   */
+  mintDataToken(params: MintDataTokenParams, options?: EngineOpOptions): Promise<SphereToken>;
   /** Spend a token wholesale to a recipient pubkey; returns the recipient's finished token. */
   transfer(params: TransferParams, options?: EngineOpOptions): Promise<SphereToken>;
   /** Split a token into N value-conserving outputs (burn source + internally mint each output). */

--- a/token-engine/index.ts
+++ b/token-engine/index.ts
@@ -26,6 +26,7 @@ export type {
   TokenBlob,
   SphereToken,
   MintParams,
+  MintDataTokenParams,
   TransferParams,
   SplitOutput,
   SplitParams,

--- a/token-engine/token-blob.ts
+++ b/token-engine/token-blob.ts
@@ -23,6 +23,7 @@ export function encodeTokenBlob(blob: TokenBlob): Uint8Array {
     CborSerializer.encodeArray(
       CborSerializer.encodeUnsignedInteger(BigInt(blob.v)),
       CborSerializer.encodeUnsignedInteger(BigInt(blob.network)),
+      CborSerializer.encodeTextString(blob.tokenId),
       CborSerializer.encodeByteString(blob.token),
     ),
   );
@@ -34,7 +35,7 @@ export function decodeTokenBlob(bytes: Uint8Array): TokenBlob {
   if (tag.tag !== TOKEN_BLOB_TAG) {
     throw new CborError(`Invalid TokenBlob tag: ${tag.tag}`);
   }
-  const fields = CborDeserializer.decodeArray(tag.data, 3);
+  const fields = CborDeserializer.decodeArray(tag.data, 4);
   const v = Number(CborDeserializer.decodeUnsignedInteger(fields[0]));
   if (v !== TOKEN_BLOB_VERSION) {
     throw new CborError(`Unsupported TokenBlob version: ${v}`);
@@ -42,6 +43,7 @@ export function decodeTokenBlob(bytes: Uint8Array): TokenBlob {
   return {
     v,
     network: Number(CborDeserializer.decodeUnsignedInteger(fields[1])),
-    token: CborDeserializer.decodeByteString(fields[2]),
+    tokenId: CborDeserializer.decodeTextString(fields[2]),
+    token: CborDeserializer.decodeByteString(fields[3]),
   };
 }

--- a/token-engine/types.ts
+++ b/token-engine/types.ts
@@ -57,6 +57,12 @@ export interface TokenBlob {
   readonly v: number;
   /** NetworkId.id the token belongs to (mainnet=1 / testnet=2 / local=3). */
   readonly network: number;
+  /**
+   * Genesis-stable token id — 64-char lowercase hex of the v2 `TokenId.bytes`
+   * (same across every state of the token). Stored on the blob so dedup / listing
+   * / tombstone keys need no engine call. `createTokenStateKey = ${tokenId}_${hash}`.
+   */
+  readonly tokenId: string;
   /** CBOR bytes of the v2 Token (`Token.toCBOR()`). */
   readonly token: Uint8Array;
 }
@@ -83,11 +89,29 @@ export interface MintParams {
   readonly value?: SphereValue | null;
 }
 
+/**
+ * Mint a NON-value (data) token: arbitrary opaque `data` (e.g. serialized invoice
+ * terms), a custom `tokenType`, and a deterministic `salt` → a stable,
+ * terms-derived `tokenId`. The minted token has `value === null` (it carries data,
+ * not coins); read the bytes back with `readTokenData`.
+ */
+export interface MintDataTokenParams {
+  readonly recipientPubkey: Uint8Array;
+  /** Opaque token payload (the engine does not interpret it). */
+  readonly data: Uint8Array;
+  /** Token type bytes; defaults to a random type when omitted. */
+  readonly tokenType?: Uint8Array;
+  /** Salt bytes; deterministic salt → deterministic (terms-derived) tokenId. */
+  readonly salt?: Uint8Array;
+}
+
 export interface TransferParams {
   /** The token to spend (must be owned by this engine's identity). */
   readonly token: SphereToken;
   /** Recipient's 33-byte compressed chain pubkey. */
   readonly recipientPubkey: Uint8Array;
+  /** Optional opaque on-chain memo carried on the transfer (read back via `readMemo`). */
+  readonly data?: Uint8Array;
 }
 
 /**
@@ -100,6 +124,8 @@ export interface SplitOutput {
   readonly recipientPubkey: Uint8Array;
   readonly coinId: CoinId;
   readonly amount: bigint;
+  /** Optional opaque memo carried in this output's value envelope (read back via `readMemo`). */
+  readonly data?: Uint8Array;
 }
 
 export interface SplitParams {


### PR DESCRIPTION
## Track A — engine surface for caller migration (Q1/Q2/Q3)

Closes Track B's blocking engine-surface questions. **Additive** — ITokenEngine port
+ real engine + FakeTokenEngine; no live v1 code touched, so it merges cleanly with
Track B's in-flight caller work. The shared `engine-contract` suite exercises every
new method against BOTH the fake and the real engine.

### Q1 — genesis-stable tokenId
- `TokenBlob.tokenId` — 64-char lowercase hex of the v2 `TokenId.bytes`, populated in
  `encodeToken` (travels with stored blobs → dedup/listing/tombstone need no engine call).
- `tokenId(token)` on the port; stable across transfers (it's the genesis identity).
- `createTokenStateKey = ${tokenId64}_${SHA256(blob.token)}`.

### Q2 — opaque on-chain memo (read path = BOTH)
- `TransferParams.data` → on the transfer (whole-token payments).
- `SplitOutput.data` → in the output's SpherePaymentData envelope (split-minted payee output).
- `readMemo(token)` → latest transfer data, else the value-envelope memo. Raw opaque bytes; the engine assigns no semantics.

### Q3 — data-token mint (on-chain invoices)
- `mintDataToken({recipientPubkey, data, tokenType?, salt?})` → arbitrary data + custom
  type + deterministic salt ⇒ stable, terms-derived `tokenId` (`TokenId.fromSalt`).
- `wrapToken` distinguishes value vs data tokens by the SpherePaymentData CBOR tag —
  data tokens get `value === null` (a corrupt value envelope still errors).
- `readTokenData(token)` → raw genesis data.
- tokenId is **64-char** (not the v1 68-char imprint) — retarget INVOICE_ID_REGEX / hash index.

### Notes
- `SpherePaymentData` envelope extended to `tag(39050)[ version, assets, memo? ]` (decode is length-tolerant).
- `FakeTokenEngine` mirrors the real adapter (genesisData + transferMemo; tokenId vs per-state spent id split, so tokenId is stable across transfer).
- 66 token-engine tests green; tsc + eslint clean.

Track B: the Fake now has the full surface — wire B1-core (tokenId from blob) and B2 (mintDataToken + readMemo).
