### PR TITLE
fix(accounting)(#404): attribute null-sender back-direction refunds via destinationAddress fallback

### DIFF
--- a/modules/accounting/balance-computer.ts
+++ b/modules/accounting/balance-computer.ts
@@ -362,6 +362,50 @@ export function computeInvoiceStatus(
   let allConfirmed = true; // will be set to false on first unconfirmed
 
   // ---------------------------------------------------------------------------
+  // Pre-pass — index forward senders by (targetAddress, coinId) for null-sender
+  // back-direction recovery (issue #404).
+  //
+  // Back-direction transfers (B / RC / RX) normally route via
+  // `entry.senderAddress === target.address`: the refunder IS the target.
+  // When the refund itself uses a masked predicate, `entry.senderAddress` is
+  // null on-chain (the sender identity is unresolvable from a one-time
+  // masked address) and the straightforward match fails — pre-fix, the
+  // entry was bucketed as `unknown_address_and_asset` and the invoice's
+  // `returnedAmount` stayed stuck at zero. Bob's wallet would also miss its
+  // OWN refund, because the recording path uses the on-chain payload, not
+  // wallet identity (see issue #404 §"Root cause").
+  //
+  // The recovery: build an index of every (target, coin) → {senderAddress}
+  // pair we've seen from forward payments. If a null-sender back-direction
+  // transfer's (destinationAddress, coinId) matches exactly one such target,
+  // route it there. Ambiguity (multiple targets match) leaves the entry as
+  // irrelevant — preserving the spec's "only attribute when we know" stance.
+  // ---------------------------------------------------------------------------
+  const forwardSendersByTargetCoin = new Map<string, Map<string, Set<string>>>();
+  for (const entry of entries) {
+    if (isReturnDirection(entry.paymentDirection)) continue;
+    if (!targetIndexMap.has(entry.destinationAddress)) continue;
+    if (entry.senderAddress === null) continue;
+    // Use refundAddress if present (matches the per-sender keying rule used
+    // by senderBalances) — falling back to senderAddress preserves the
+    // legacy lookup behaviour for entries without a refund address.
+    const effectiveSender =
+      ('refundAddress' in entry && (entry as { refundAddress?: string | null }).refundAddress)
+        || entry.senderAddress;
+    let perCoin = forwardSendersByTargetCoin.get(entry.destinationAddress);
+    if (!perCoin) {
+      perCoin = new Map();
+      forwardSendersByTargetCoin.set(entry.destinationAddress, perCoin);
+    }
+    let senderSet = perCoin.get(entry.coinId);
+    if (!senderSet) {
+      senderSet = new Set();
+      perCoin.set(entry.coinId, senderSet);
+    }
+    senderSet.add(effectiveSender);
+  }
+
+  // ---------------------------------------------------------------------------
   // Process each entry
   // ---------------------------------------------------------------------------
   for (const entry of entries) {
@@ -406,9 +450,28 @@ export function computeInvoiceStatus(
         matchedTargetAddress = entry.destinationAddress;
       }
     } else {
-      // Return: sender is the target (return flows from target)
+      // Return: sender is the target (return flows from target).
       if (entry.senderAddress !== null && targetIndexMap.has(entry.senderAddress)) {
         matchedTargetAddress = entry.senderAddress;
+      } else if (entry.senderAddress === null) {
+        // Issue #404 — masked-predicate refund recovery. When a back-direction
+        // transfer comes from a target via a masked predicate, on-chain
+        // senderAddress is null. Fall back to matching against the forward-
+        // sender index built in the pre-pass: if exactly one target had this
+        // destinationAddress as a recorded sender on this coinId, route there.
+        const candidateTargets: string[] = [];
+        for (const [targetAddr, perCoin] of forwardSendersByTargetCoin) {
+          const senderSet = perCoin.get(entry.coinId);
+          if (senderSet && senderSet.has(entry.destinationAddress)) {
+            candidateTargets.push(targetAddr);
+          }
+        }
+        if (candidateTargets.length === 1) {
+          matchedTargetAddress = candidateTargets[0]!;
+        }
+        // Zero or multiple candidates → leave matchedTargetAddress null;
+        // the entry falls through to the irrelevantTransfers path with
+        // reason='unknown_address_and_asset' as before.
       }
     }
 

--- a/tests/unit/modules/AccountingModule.surplus.test.ts
+++ b/tests/unit/modules/AccountingModule.surplus.test.ts
@@ -963,3 +963,118 @@ describe('AccountingModule.surplus.test - freezeBalances() surplus assignment', 
     expect(frozenCoin.frozenSenderBalances[0]!.netBalance).toBe(expectedSurplus);
   });
 });
+
+// ============================================================================
+// Issue #404 — masked-predicate refund attribution recovery
+//
+// When a target refunds an attributed payment using a masked predicate, the
+// resulting back-direction transfer has `senderAddress: null` on-chain (the
+// per-send masked address is unresolvable). Pre-fix, computeInvoiceStatus
+// matched back-direction transfers by `entry.senderAddress === target.address`
+// — null fails the match → the entry went to irrelevantTransfers with
+// `reason: 'unknown_address_and_asset'` and the invoice's `returnedAmount`
+// stayed stuck at zero.
+//
+// The fix indexes forward-payment senders per (target, coin) in a pre-pass,
+// then routes null-sender back-direction transfers by matching their
+// `destinationAddress` against the index. Exactly-one-match attributes;
+// zero/multiple leaves the entry irrelevant.
+// ============================================================================
+
+describe('issue #404 — masked-refund attribution recovery', () => {
+  const TARGET = 'DIRECT://bob_target_addr';
+  const ALICE_MASKED = 'DIRECT://alice_one_time_predicate';
+  const REQUESTED = '7000000000000000000'; // 7 UCT
+
+  it('attributes a null-sender back-direction transfer when destination matches a single forward sender', () => {
+    const terms = createTerms(TARGET, 'UCT', REQUESTED);
+    const forwardEntry = createForwardTransfer(
+      'tx-forward', ALICE_MASKED, TARGET, 'UCT', '3000000000000000000',
+    );
+    // Bob's refund via masked predicate — senderAddress null, destination is
+    // alice's recorded per-send address.
+    const backEntry = createReturnTransfer(
+      'tx-back', /* senderAddress */ 'placeholder', ALICE_MASKED, 'UCT', '3000000000000000000',
+    );
+    (backEntry as { senderAddress: string | null }).senderAddress = null;
+
+    const status = computeInvoiceStatus('invoice-404', terms, [forwardEntry, backEntry], null, new Set());
+
+    // Refund routed back to the invoice — returnedAmount equals the refund.
+    expect(status.targets[0]!.coinAssets[0]!.returnedAmount).toBe('3000000000000000000');
+    // Net covered drops to zero (forward minus return).
+    expect(status.targets[0]!.coinAssets[0]!.netCoveredAmount).toBe('0');
+    // Invoice goes back to OPEN (no net payment after the refund).
+    expect(status.state).toBe('OPEN');
+    // No irrelevant transfers — the back entry was attributed.
+    expect(status.irrelevantTransfers).toHaveLength(0);
+  });
+
+  it('leaves a null-sender back-direction transfer irrelevant when destination matches no forward sender', () => {
+    const terms = createTerms(TARGET, 'UCT', REQUESTED);
+    const forwardEntry = createForwardTransfer(
+      'tx-forward', ALICE_MASKED, TARGET, 'UCT', '3000000000000000000',
+    );
+    // Back transfer going to an address that was NEVER a forward sender.
+    const backEntry = createReturnTransfer(
+      'tx-back', 'placeholder', 'DIRECT://some_other_address', 'UCT', '1000000000000000000',
+    );
+    (backEntry as { senderAddress: string | null }).senderAddress = null;
+
+    const status = computeInvoiceStatus('invoice-404', terms, [forwardEntry, backEntry], null, new Set());
+
+    // Refund not attributed — net covered = forward amount (3 UCT), no return recorded.
+    expect(status.targets[0]!.coinAssets[0]!.returnedAmount).toBe('0');
+    expect(status.targets[0]!.coinAssets[0]!.netCoveredAmount).toBe('3000000000000000000');
+    // Back entry recorded as irrelevant.
+    expect(status.irrelevantTransfers).toHaveLength(1);
+    expect(status.irrelevantTransfers[0]!.transferId).toBe('tx-back');
+  });
+
+  it('leaves a null-sender back-direction transfer irrelevant when multiple targets have matching senders (ambiguous)', () => {
+    // Multi-target invoice where the same masked predicate appears as a
+    // forward sender on TWO targets for the same coin. A back-direction
+    // transfer toward that predicate is ambiguous: which target refunded it?
+    // The recovery declines to guess and leaves it irrelevant.
+    const TARGET_2 = 'DIRECT://carol_target_addr';
+    const terms: InvoiceTerms = {
+      createdAt: Date.now(),
+      targets: [
+        { address: TARGET,   assets: [{ coin: ['UCT', REQUESTED] }] },
+        { address: TARGET_2, assets: [{ coin: ['UCT', REQUESTED] }] },
+      ],
+    };
+    const forwardEntry1 = createForwardTransfer('tx-fwd-1', ALICE_MASKED, TARGET,   'UCT', '3000000000000000000');
+    const forwardEntry2 = createForwardTransfer('tx-fwd-2', ALICE_MASKED, TARGET_2, 'UCT', '3000000000000000000');
+    const backEntry = createReturnTransfer('tx-back', 'placeholder', ALICE_MASKED, 'UCT', '3000000000000000000');
+    (backEntry as { senderAddress: string | null }).senderAddress = null;
+
+    const status = computeInvoiceStatus('invoice-404', terms, [forwardEntry1, forwardEntry2, backEntry], null, new Set());
+
+    // Neither target picks up the refund — disambiguation is impossible.
+    expect(status.targets[0]!.coinAssets[0]!.returnedAmount).toBe('0');
+    expect(status.targets[1]!.coinAssets[0]!.returnedAmount).toBe('0');
+    expect(status.irrelevantTransfers).toHaveLength(1);
+    expect(status.irrelevantTransfers[0]!.transferId).toBe('tx-back');
+  });
+
+  it('preserves the existing match path for non-null senderAddress (no regression)', () => {
+    // Sanity: when senderAddress IS set on a back-direction transfer (the
+    // pre-#404 happy path), matching by senderAddress === target.address
+    // still works.
+    const terms = createTerms(TARGET, 'UCT', REQUESTED);
+    const forwardEntry = createForwardTransfer(
+      'tx-forward', ALICE_MASKED, TARGET, 'UCT', '3000000000000000000',
+    );
+    // Back transfer with proper senderAddress set (target's address).
+    const backEntry = createReturnTransfer(
+      'tx-back', TARGET, ALICE_MASKED, 'UCT', '3000000000000000000',
+    );
+
+    const status = computeInvoiceStatus('invoice-404', terms, [forwardEntry, backEntry], null, new Set());
+
+    expect(status.targets[0]!.coinAssets[0]!.returnedAmount).toBe('3000000000000000000');
+    expect(status.targets[0]!.coinAssets[0]!.netCoveredAmount).toBe('0');
+    expect(status.irrelevantTransfers).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #404 — refunds sent via masked predicate were not attributed back to the invoice, because the per-target router required `entry.senderAddress` to exactly equal a target address. Masked-predicate sends record `senderAddress: null` on-chain (per-send one-time address is unresolvable), so the match failed and the back-direction transfer was bucketed as `irrelevantTransfers.unknown_address_and_asset`.

Downstream impact: `payInvoice`'s default-amount computation (`remaining = requested − netCovered`) under-paid on the next attempt because `netCovered` was overstated by the refunded amount.

## Fix

Two surgical changes in `modules/accounting/balance-computer.ts`:

1. **Pre-pass** — build an index of forward-payment senders per `(targetAddress, coinId)`:
   ```ts
   forwardSendersByTargetCoin: Map<target, Map<coinId, Set<sender>>>
   ```
   Uses `refundAddress ?? senderAddress` for the per-sender key (matches `senderBalances[].senderAddress`).

2. **Extended back-direction match** — when `entry.senderAddress` is null, look up `(entry.destinationAddress, entry.coinId)` in the index:
   - exactly one target matches → attribute to that target
   - zero / multiple matches → leave as irrelevant (spec's "only attribute when we know" stance)

The existing happy path (non-null `senderAddress`) is unchanged — this is purely additive.

## Tests

4 new tests in `tests/unit/modules/AccountingModule.surplus.test.ts`:
- null-sender back-transfer attributed when destination matches one forward sender (canonical refund case)
- null-sender back-transfer stays irrelevant when destination matches no forward sender
- null-sender back-transfer stays irrelevant under multi-target ambiguity
- non-null `senderAddress` preserves existing match path (no regression)

Full accounting suite: **446/446 pass** (was 442 — 4 new tests). No regressions.

## Why receiver-side rather than sender-side

The bug was originally surfaced from bob's own wallet view of his own refund — so a sender-side fix (set `senderAddress` from wallet identity when the wallet originates the transfer) would have worked for bob. But any OTHER party viewing the invoice (alice, an auditor, an escrow service) legitimately doesn't know the on-chain sender from the masked-predicate envelope and would mis-attribute the same way. The receiver-side recovery handles all viewers uniformly.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/unit/modules/AccountingModule.surplus.test.ts` — 29/29 pass (was 25)
- [x] `npx vitest run tests/unit/modules/AccountingModule.` — 446/446 pass (was 442)
- [ ] After merge: re-run `manual-test-accounting-roundtrip.sh` end-to-end with §13 reverted to bare `sphere invoice pay \$INV2` (no `--amount`) — verify default-amount path now computes `remaining = 4` correctly. The §13 workaround revert is a follow-up commit on the soak file.

## Related
- #404 — original bug report
- #405 — `returnAllInvoicePayments` (merged) — was unblocked by this PR's underlying primitive
- #406 — accounting soak (merged) — carries the §13 workaround that this PR enables removing