### PR TITLE
chore(soak)+docs: drop #404 workaround now that #413 is merged

### DIFF
--- a/docs/DEMO-PLAYBOOK-ACCOUNTING-ROUNDTRIP.md
+++ b/docs/DEMO-PLAYBOOK-ACCOUNTING-ROUNDTRIP.md
@@ -27,19 +27,18 @@ SCENARIO B — partial-pay + bulk-refund + repeat-pay
 §9      Alice partial-pays:   `sphere invoice pay $INV2 --amount 3`
                                   alice 93 → 90,  invoice PARTIAL
 §10     Bob refunds (no args): `sphere invoice return $INV2`              ←  the payoff
-                                  bob -3 UCT (token level — invoice attribution blocked by #404)
+                                  bob -3 UCT, invoice's returnedAmount tracks the refund
 §11     Alice receives the 3 UCT refund
                                   alice 90 → 93
 §12     Alice partial-pays:   `sphere invoice pay $INV2 --amount 3`
                                   alice 93 → 90,  invoice PARTIAL
-§13     Alice covers the rest: `sphere invoice pay $INV2 --amount 4` *
+§13     Alice covers the rest: `sphere invoice pay $INV2`
+                                  (no --amount → SDK defaults to remaining = 4 UCT)
                                   alice 90 → 86,  invoice COVERED → CLOSED
 §14     Bob confirms COVERED + final balance check
                                   alice 100 → 86,  bob 100 → 114
 NET                                  alice −14 UCT,  bob +14 UCT
 ```
-
-*`--amount 4` is **explicit** because of a known SDK attribution bug (sphere-sdk #404) that prevents `--amount` defaulting to remaining from accounting for the refund. Token-level balances are correct; only the invoice's internal view miscounts. Once #404 lands, §13 becomes `sphere invoice pay $INV2` (no `--amount`).
 
 Total run time: ~6-8 minutes on a healthy testnet.
 
@@ -63,6 +62,7 @@ This playbook exercises features added across three coordinated PRs:
 | sphere-cli | PR #37 (`fix/issue-36-invoice-pay-human-units`) | `--amount` interprets as HUMAN units (matches `payments send`). Pre-PR-#37 the CLI treats `--amount 3` as 3 atoms (≈3×10⁻¹⁸ UCT) and §9 fails the balance assertion. |
 | sphere-cli | `feat/invoice-return-bulk-and-nametag` | `sphere invoice return <id>` (no flags) → calls SDK bulk-refund. Without this PR §10's one-shot form fails with "missing --recipient". |
 | sphere-sdk | PR #405 (`feat/accounting-return-all-invoice-payments`) | `AccountingModule.returnAllInvoicePayments` — the bulk-refund SDK primitive the CLI wrapper calls. Without this PR the CLI wrapper compiles but the SDK method doesn't exist. |
+| sphere-sdk | PR #413 (`fix/issue-404-masked-refund-attribution`) | Masked-predicate refund attribution recovery. Without this PR, §10's refund is correctly emitted at the token level but the SDK's invoice ledger doesn't see it — so §13's bare `sphere invoice pay $INV2` (default `--amount`) under-pays (sends 1 UCT instead of 4). |
 
 Confirm the running CLI binary includes all three:
 
@@ -73,6 +73,7 @@ sphere invoice pay --help    | grep -c "HUMAN units"          # should be 1 (pos
 # Resolve where the CLI's SDK actually lives:
 SDK_DIST="$(readlink -f /usr/local/lib/node_modules/@unicitylabs/sphere-sdk)/dist/index.js"
 grep -c "returnAllInvoicePayments" "$SDK_DIST"                # should be >= 1 (post-PR #405)
+grep -c "forwardSendersByTargetCoin" "$SDK_DIST"              # should be >= 1 (post-PR #413)
 ```
 
 If any of those return `0`, the binary on PATH is behind one of the PRs — rebuild before demoing.
@@ -388,7 +389,7 @@ sphere balance
 
 Expected — alice's `UCT: 93 (>=1 token)` (90 + 3 = 93).
 
-**Talk track:** "The refund is a real on-chain back-direction transfer. Bob's wallet sent 3 UCT to the address recorded in alice's original payment. The :B memo direction tells AccountingModule to attribute it as a refund — and that's where SDK issue #404 currently bites: when the refund itself uses a masked predicate, attribution-back-to-invoice fails. Token-level money flow is correct (everything is in alice's wallet); only the invoice's view of its own balance lags."
+**Talk track:** "The refund is a real on-chain back-direction transfer. Bob's wallet sent 3 UCT to the address recorded in alice's original payment. The :B memo direction tells AccountingModule to attribute it as a refund — and after PR #413, masked-predicate refunds are correctly attributed back to the invoice via the destinationAddress fallback in `computeInvoiceStatus`. The invoice's `returnedAmount` updates and `netCovered` drops correctly."
 
 ---
 
@@ -408,33 +409,19 @@ Expected — alice's `UCT: 90 (1 token)` (93 − 3 = 90).
 
 ---
 
-## §13 Alice covers the rest — 4 UCT (explicit, workaround for #404)
+## §13 Alice covers the rest (default `--amount`)
 
 ### T1
 
 ```bash
-sphere invoice pay "$INV2" --amount 4
+sphere invoice pay "$INV2"
 sphere payments sync
 sphere balance
 ```
 
-Expected — alice's `UCT: 86 (1 token)` (90 − 4 = 86).
+No `--amount` → the SDK reads the invoice's current state, computes `remaining = requested − netCovered = 7 − 3 = 4 UCT`, and sends that. Expected — alice's `UCT: 86 (1 token)` (90 − 4 = 86).
 
-### Why explicit `--amount 4` instead of bare `sphere invoice pay $INV2`
-
-**Ideal UX:** `sphere invoice pay $INV2` (no flag) — the SDK defaults to "remaining needed to cover the asset" and sends 4 UCT.
-
-**Today's workaround:** explicit `--amount 4` because of the masked-predicate refund-attribution bug (sphere-sdk #404).
-
-- §10's refund correctly drained bob's wallet by 3 UCT (token-level).
-- But because the refund used a masked predicate, the resulting back-direction transfer has `senderAddress: null` on-chain.
-- The SDK's `computeInvoiceStatus` requires `senderAddress === target.address` to attribute a back-direction transfer to a target. `null` fails the match → refund goes to `irrelevantTransfers` → invoice's `returnedAmount` stays 0.
-- So the SDK sees `netCovered = 6` (3 from §9 + 3 from §12) instead of the true `netCovered = 3` (3 + 3 − 3 refund).
-- Default `--amount` would compute `remaining = 7 − 6 = 1 UCT`, under-paying.
-
-Explicit `--amount 4` sidesteps the SDK's wrong remaining-calculation. Token-level deltas (alice −4, bob +4) are exact.
-
-**After #404 lands, this section becomes `sphere invoice pay $INV2` (no `--amount`) and the comment above goes away.**
+**Talk track:** "Default `--amount` works correctly post-PR #413: the SDK sees the refund recorded in §10 (netCovered correctly drops from 6 to 3 after the refund is attributed), so 'remaining' computes to the right value. Operators don't have to manually track what's been refunded."
 
 ---
 
@@ -472,7 +459,7 @@ In smallest-unit integers (UCT has 18 decimals):
 - alice: `100·10¹⁸ → 86·10¹⁸` (Δ = `−14·10¹⁸`)
 - bob:   `100·10¹⁸ → 114·10¹⁸` (Δ = `+14·10¹⁸`)
 
-Both reconcile. The 3 UCT that flowed bob→alice in §10 is real, on-chain, and accounted for at the token level even if the invoice's internal view (per #404) doesn't reflect it.
+Both reconcile. The 3 UCT that flowed bob→alice in §10 is real, on-chain, and accounted for at every level — token-level balances AND the invoice's internal ledger (per PR #413's attribution-recovery fix).
 
 ---
 
@@ -505,7 +492,8 @@ A green run prints `ALL GREEN — round-trip + partial-pay + bulk-return + repea
 | `Connectivity gate reports aggregator 'down'` | Testnet aggregator's health probe failed. Send proceeds anyway and usually succeeds — note it in the talk but don't panic. | Continue the demo. |
 | `[Nostr] [AT-LEAST-ONCE] TOKEN_TRANSFER … not durable — leaving 'since' at <ts>; cooldown 30000ms` | Background durability verifier couldn't confirm a previous event landed durably on the relay. Independent of the current step. | Continue the demo. |
 | Alice's balance lags after refund in §11 | The back-direction transfer hasn't fully propagated yet — Nostr fan-out + IPFS pin can take 10-30s on a slow testnet. | Retry `sphere payments sync && sphere payments receive --finalize` once or twice before failing. |
-| Invoice state stays at PARTIAL after §13 | If you used the workaround `--amount 4`, the SDK's view shows surplus (because the refund isn't attributed). State should still be COVERED (netCovered >= requested) — if it shows PARTIAL the SDK build is missing something. | Inspect `sphere invoice status $INV2 --json` and check whether `coveredAmount` matches expectation. |
+| §13 default `--amount` sends 1 UCT instead of 4 | The SDK build predates PR #413 (masked-predicate refund attribution). The refund in §10 isn't being attributed back to the invoice, so the SDK overestimates netCovered. | Bump SDK to post-#413, OR fall back to explicit `--amount 4` for the duration of the demo. |
+| Invoice state stays at PARTIAL after §13 | Either the demo is running with the legacy default-amount under-pay (above row), or `coveredAmount` is incorrect for a different reason. | Inspect `sphere invoice status $INV2 --json` — `coveredAmount` should equal 7 UCT and `netCovered` should equal 7 UCT after §13. |
 
 ---
 
@@ -547,7 +535,7 @@ The wallet directories contain the OrbitDB-backed Profile storage; re-attach to 
    §10 sphere invoice return $INV2                ← bob refunds (NO FLAGS) ← payoff
    §11 alice receives the refund
    §12 sphere invoice pay $INV2 --amount 3        ← alice partial-pay again
-   §13 sphere invoice pay $INV2 --amount 4 *      ← alice covers rest (* #404 workaround)
+   §13 sphere invoice pay $INV2                   ← alice covers rest (default --amount)
    §14 bob confirms COVERED
    NET (over A+B):  alice -14, bob +14   ✓
 ```
@@ -558,7 +546,7 @@ The wallet directories contain the OrbitDB-backed Profile storage; re-attach to 
 
 - `manual-test-accounting-roundtrip.sh` — the automated version of this playbook.
 - sphere-sdk PR #405 — `AccountingModule.returnAllInvoicePayments`.
-- sphere-sdk issue #404 — masked-predicate refund attribution bug (workaround at §13 until merged).
+- sphere-sdk PR #413 — masked-predicate refund attribution fix (closes #404). Enables §13's default-`--amount` form.
 - sphere-cli PR #37 (`fix/issue-36-invoice-pay-human-units`) — `invoice pay --amount` human units.
 - sphere-cli branch `feat/invoice-return-bulk-and-nametag` — `sphere invoice return <id>` (no flags) and `--recipient @nametag` resolution.
 - [`DEMO-PLAYBOOK-PAYMENT-ROUNDTRIP.md`](DEMO-PLAYBOOK-PAYMENT-ROUNDTRIP.md) — companion demo for the direct-payment round-trip (#391 guard).

--- a/manual-test-accounting-roundtrip.sh
+++ b/manual-test-accounting-roundtrip.sh
@@ -570,38 +570,24 @@ echo "alice partial-2 delta:       $partial_2_delta  (expected $expected_3_uct)"
 echo "ASSERT OK (alice-partial-2-minus-3): alice partial-paid exactly 3 UCT (second time)"
 
 # ===========================================================================
-# Section 13 — Alice covers the rest (4 UCT, explicit --amount)
+# Section 13 — Alice covers the rest (no --amount → SDK defaults to remaining)
 #
-# IDEAL UX: `sphere invoice pay $INV2` (no --amount → SDK defaults to
-# remaining = 7 - netCovered).
+# Per PayInvoiceParams.amount doc: "defaults to remaining needed to cover
+# the asset". After §10's bulk refund AND §12's second partial-pay, the
+# invoice's netCovered is 3 UCT (the §12 payment; §9's payment was refunded
+# in §10). The SDK computes remaining = 7 - 3 = 4 UCT and sends that.
 #
-# WORKAROUND today: explicit `--amount 4` because of a known SDK bug
-# (filed as sphere-sdk #TODO):
-#
-#   When bob's §10 refund used a masked predicate (the default), the
-#   resulting back-direction transfer has `senderAddress: null` on-chain.
-#   `computeInvoiceStatus` (balance-computer.ts ~line 408-413) only
-#   matches back-direction transfers when `senderAddress` exactly equals
-#   a target address — null fails the match and the refund goes to
-#   `irrelevantTransfers` instead of being attributed to the invoice.
-#
-#   As a result:
-#     - The SDK's view of INV2 shows `coveredAmount = 3 + 3 = 6`,
-#       `returnedAmount = 0` (refund not seen), `netCovered = 6`.
-#     - Default --amount in payInvoice computes `remaining = 7 - 6 = 1`,
-#       sending only 1 UCT instead of the 4 we actually need.
-#     - Token-level balances are CORRECT (bob -3 on refund send, alice
-#       +3 on refund receive) — this is purely an invoice-attribution
-#       miss inside AccountingModule, not a payment failure.
-#
-# Once the SDK bug is fixed, this section becomes `sphere invoice pay
-# $INV2` (no --amount). The final balance assertions in §14 are
-# computed against EXPLICIT amounts so they don't depend on the SDK's
-# remaining-calculation correctness.
+# This used to require an explicit `--amount 4` workaround because of
+# sphere-sdk #404 (masked-predicate refund attribution): the §10 refund's
+# back-direction transfer had `senderAddress: null` on-chain, so the
+# balance-computer's per-target matcher classified it as irrelevant and
+# the invoice's `returnedAmount` stayed stuck at zero. PR #413 fixed that
+# with a destinationAddress-fallback recovery, and §13 can now use the
+# canonical default-amount form.
 # ===========================================================================
-banner "Section 13: Alice covers the rest of invoice #2 — 4 UCT (explicit, SDK-bug workaround)"
+banner "Section 13: Alice covers the rest of invoice #2 (default --amount = remaining)"
 
-sphere invoice pay "$INV2" --amount 4 2>&1 | tee "$SNAP/alice-invoice-pay2-final.log"
+sphere invoice pay "$INV2" 2>&1 | tee "$SNAP/alice-invoice-pay2-final.log"
 sphere payments sync 2>&1 | tee "$SNAP/alice-post-final-sync.log"
 sphere balance | tee "$SNAP/alice-balance-final.txt"
 


### PR DESCRIPTION
## Summary

Reverts the accounting soak's §13 `--amount 4` workaround back to the canonical bare `sphere invoice pay \$INV2` (no flag → SDK defaults to remaining). With PR #413 merged, the SDK correctly attributes masked-predicate refunds, so the default-amount path computes `remaining` correctly post-refund.

Also updates `docs/DEMO-PLAYBOOK-ACCOUNTING-ROUNDTRIP.md` to match.

## Changes

- `manual-test-accounting-roundtrip.sh` §13 — bare `sphere invoice pay \$INV2`, comment updated to reference #413 instead of documenting the workaround.
- `docs/DEMO-PLAYBOOK-ACCOUNTING-ROUNDTRIP.md` — at-a-glance flow loses the asterisk, §13 terminal block uses bare form, §11 talk track flips, §0 dependency-check table adds a row for PR #413, failure-recovery row flips, presenter cheat sheet and references updated.

## Verification

Live testnet end-to-end with sphere-sdk @ post-#413 main and sphere-cli @ post-#39 main:

```
ALL GREEN — round-trip + partial-pay + bulk-return + repeat-pay scenario succeeded
```

The decisive assertion `alice-partial-3-minus-4` (alice's UCT delta in §13 = exactly 4 UCT) passes — bare `sphere invoice pay \$INV2` sends the right amount.

## Related
- #404 — original bug (closed by #413)
- #413 — the SDK fix
- #406 — the soak that introduced the §13 workaround