### PR TITLE
Track A: make split output order an explicit contract

### DIFF
--- a/tests/unit/token-engine/engine-contract.ts
+++ b/tests/unit/token-engine/engine-contract.ts
@@ -142,6 +142,9 @@ export function runEngineContract(name: string, makeEngine: () => ITokenEngine):
           { recipientPubkey: e.getIdentity().chainPubkey, coinId: COIN, amount: 4n },
         ],
       });
+      // Outputs are index-aligned with the requested outputs (positional contract).
+      expect(e.balanceOf(outputs[0], COIN)).toBe(6n);
+      expect(e.balanceOf(outputs[1], COIN)).toBe(4n);
       expect(e.readMemo(outputs[0])).toEqual(memo);
       expect(e.readMemo(outputs[1])).toBeNull();
     });

--- a/token-engine/types.ts
+++ b/token-engine/types.ts
@@ -137,8 +137,13 @@ export interface SplitParams {
 
 // ── results ───────────────────────────────────────────────────────────────────
 
-/** Result of a split: one minted token per requested output, in input order. */
 export interface SplitResult {
+  /**
+   * One minted token per requested output, **index-aligned with
+   * `SplitParams.outputs`** — `outputs[i]` is the token for `params.outputs[i]`
+   * (so a payee/change split can rely on positional order). Guaranteed by both
+   * the real engine and FakeTokenEngine.
+   */
   readonly outputs: readonly SphereToken[];
 }
 


### PR DESCRIPTION
Formalizes that SplitResult.outputs is index-aligned with SplitParams.outputs (a Track B caller depends on outputs[0]=payee / outputs[1]=change). Engines already guarantee it; this documents it on the port + locks it with a positional assertion in the shared contract suite. 67 token-engine tests green; tsc + eslint clean.