### PR TITLE
Track A: A4-int — construct + inject v2 engine in Sphere (networkId from trust base)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# sphere-sdk e2e configuration — copy to `.env` (gitignored) and fill in.
+# Used by `npm run test:e2e`. The token-engine testnet2 e2e is SKIPPED unless
+# TESTNET2_API_KEY is set, so this file is safe to leave blank.
+
+# Unicity testnet2 v2 gateway (state-transition aggregator).
+TESTNET2_GATEWAY=https://gateway.testnet2.unicity.network
+
+# Gateway API key — SECRET. Never commit a real key (.env is gitignored).
+# Ask the aggregator team for one.
+TESTNET2_API_KEY=
+
+# Root trust base JSON URL. Declares the network id (testnet2 = 4); the engine
+# takes its NetworkId from here.
+TESTNET2_TRUSTBASE_URL=https://raw.githubusercontent.com/unicitynetwork/unicity-ids/main/bft-trustbase.testnet2.json

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -118,7 +118,7 @@ import {
   isSQLiteDatabase,
   isWalletDatEncrypted,
 } from '../serialization/wallet-dat';
-import { deriveDirectAddress } from '../token-engine';
+import { createSphereTokenEngine, deriveDirectAddress, type ITokenEngine } from '../token-engine';
 import { normalizeNametag, isPhoneNumber } from '@unicitylabs/nostr-js-sdk';
 
 export function isValidNametag(nametag: string): boolean {
@@ -480,6 +480,8 @@ export class Sphere {
   private _transport: TransportProvider;
   private _oracle: OracleProvider;
   private _priceProvider: PriceProvider | null;
+  /** v2 token engine (built per active address from the oracle); injected into modules. */
+  private _tokenEngine: ITokenEngine | undefined;
 
   // Modules (single-instance — backward compat, delegates to active address)
   private _payments: PaymentsModule;
@@ -4190,6 +4192,40 @@ export class Sphere {
     this._lastProviderConnected.clear();
   }
 
+  /**
+   * Construct the v2 token engine for the active address from the oracle's gateway
+   * URL + trust base and this address's signing key. The trust base is the single
+   * source of truth for the network id (so any id works — e.g. testnet2 = 4 — with
+   * no enum entry). Returns undefined (modules keep their legacy path) when the
+   * oracle can't supply a trust base / url, or construction fails — a misconfigured
+   * oracle never breaks initialization.
+   */
+  private async buildTokenEngine(): Promise<ITokenEngine | undefined> {
+    const oracle = this._oracle as {
+      getTrustBaseJson?: () => unknown;
+      getAggregatorUrl?: () => string;
+    };
+    const trustBaseJson = oracle.getTrustBaseJson?.() ?? null;
+    const aggregatorUrl = oracle.getAggregatorUrl?.();
+    if (!trustBaseJson || !aggregatorUrl || !this._identity?.privateKey) {
+      logger.warn('Sphere', 'v2 token engine not constructed (oracle has no trust base / url, or no identity) — legacy path');
+      return undefined;
+    }
+    try {
+      return await createSphereTokenEngine({
+        aggregatorUrl,
+        privateKey: hexToBytes(this._identity.privateKey),
+        trustBaseJson,
+      });
+    } catch (err) {
+      logger.warn(
+        'Sphere',
+        `Failed to construct v2 token engine — modules use the legacy path: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
   private async initializeModules(): Promise<void> {
     const emitEvent = this.emitEvent.bind(this);
 
@@ -4197,6 +4233,11 @@ export class Sphere {
     // from the start. The original transport stays connected for resolve operations.
     const adapter = await this.ensureTransportMux(this._currentAddressIndex, this._identity!);
     const moduleTransport: TransportProvider = adapter ?? this._transport;
+
+    // Build the v2 token engine for this active address (from the oracle's gateway +
+    // trust base + this address's key). Injected into the caller modules below.
+    this._tokenEngine = await this.buildTokenEngine();
+    const tokenEngine = this._tokenEngine;
 
     this._payments.initialize({
       identity: this._identity!,
@@ -4209,6 +4250,7 @@ export class Sphere {
       chainCode: this._masterKey?.chainCode || undefined,
       price: this._priceProvider ?? undefined,
       disabledProviderIds: this._disabledProviders,
+      tokenEngine,
     });
 
     this._communications.initialize({
@@ -4252,6 +4294,7 @@ export class Sphere {
           on: this.on.bind(this),
           storage: this._storage,
           communications: this._communications,
+          tokenEngine,
         });
       } else {
         logger.warn('Sphere', 'Accounting module enabled but no token storage available — disabling');

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -4204,6 +4204,7 @@ export class Sphere {
     const oracle = this._oracle as {
       getTrustBaseJson?: () => unknown;
       getAggregatorUrl?: () => string;
+      getApiKey?: () => string | undefined;
     };
     const trustBaseJson = oracle.getTrustBaseJson?.() ?? null;
     const aggregatorUrl = oracle.getAggregatorUrl?.();
@@ -4214,6 +4215,7 @@ export class Sphere {
     try {
       return await createSphereTokenEngine({
         aggregatorUrl,
+        apiKey: oracle.getApiKey?.(),
         privateKey: hexToBytes(this._identity.privateKey),
         trustBaseJson,
       });

--- a/oracle/UnicityAggregatorProvider.ts
+++ b/oracle/UnicityAggregatorProvider.ts
@@ -123,10 +123,22 @@ export class UnicityAggregatorProvider implements OracleProvider {
   private aggregatorClient: AggregatorClient | null = null;
   private stateTransitionClient: StateTransitionClient | null = null;
   private trustBase: RootTrustBase | null = null;
+  /** Raw trust-base JSON as loaded (kept so the v2 token engine can re-parse it). */
+  private trustBaseJson: unknown | null = null;
 
   /** Get the current trust base */
   getTrustBase(): RootTrustBase | null {
     return this.trustBase;
+  }
+
+  /** Raw trust-base JSON (for constructing the v2 token engine); null if loaded as an object. */
+  getTrustBaseJson(): unknown | null {
+    return this.trustBaseJson;
+  }
+
+  /** The aggregator URL this provider is configured against. */
+  getAggregatorUrl(): string {
+    return this.config.url;
   }
 
   /** Get the state transition client */
@@ -203,6 +215,7 @@ export class UnicityAggregatorProvider implements OracleProvider {
       try {
         const trustBaseJson = await this.config.trustBaseLoader.load();
         if (trustBaseJson) {
+          this.trustBaseJson = trustBaseJson;
           this.trustBase = RootTrustBase.fromJSON(trustBaseJson);
         }
       } catch (error) {

--- a/oracle/UnicityAggregatorProvider.ts
+++ b/oracle/UnicityAggregatorProvider.ts
@@ -141,6 +141,11 @@ export class UnicityAggregatorProvider implements OracleProvider {
     return this.config.url;
   }
 
+  /** The gateway API key (for the v2 token engine); undefined when none is configured. */
+  getApiKey(): string | undefined {
+    return this.config.apiKey || undefined;
+  }
+
   /** Get the state transition client */
   getStateTransitionClient(): StateTransitionClient | null {
     return this.stateTransitionClient;

--- a/tests/e2e/token-engine.testnet2.e2e.test.ts
+++ b/tests/e2e/token-engine.testnet2.e2e.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Σ3 — live testnet2 e2e for the v2 token engine.
+ *
+ * Runs the real sender-driven flows (mint / transfer / split / data-token) against
+ * the LIVE testnet2 v2 aggregator. Skipped unless TESTNET2_API_KEY is set, so it
+ * never runs in CI / normal `npm run test:e2e` without credentials.
+ *
+ * Run locally: fill `.env` (see .env.example) then `npm run test:e2e`.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createSphereTokenEngine } from '../../token-engine/factory';
+import { SigningService } from '../../token-engine/sdk';
+
+const GATEWAY = process.env.TESTNET2_GATEWAY ?? 'https://gateway.testnet2.unicity.network';
+const API_KEY = process.env.TESTNET2_API_KEY;
+const TRUSTBASE_URL =
+  process.env.TESTNET2_TRUSTBASE_URL ??
+  'https://raw.githubusercontent.com/unicitynetwork/unicity-ids/main/bft-trustbase.testnet2.json';
+
+const COIN = 'a'.repeat(64);
+
+async function makeEngine() {
+  const trustBaseJson = await (await fetch(TRUSTBASE_URL)).json();
+  const privateKey = SigningService.generatePrivateKey();
+  return createSphereTokenEngine({ aggregatorUrl: GATEWAY, apiKey: API_KEY, privateKey, trustBaseJson });
+}
+
+// Live network — only runs when an API key is present.
+describe.runIf(!!API_KEY)('token-engine e2e — live testnet2 (networkId 4)', () => {
+  it('mints, transfers, verifies and detects spend against the live aggregator', async () => {
+    const engine = await makeEngine();
+    const self = engine.getIdentity().chainPubkey;
+
+    const minted = await engine.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+    expect(engine.balanceOf(minted, COIN)).toBe(100n);
+    expect((await engine.verify(minted)).ok).toBe(true);
+    expect(await engine.isSpent(minted)).toBe(false);
+
+    const recipient = new SigningService(SigningService.generatePrivateKey()).publicKey;
+    const sent = await engine.transfer({ token: minted, recipientPubkey: recipient });
+    expect(engine.balanceOf(sent, COIN)).toBe(100n);
+    expect(engine.tokenId(sent)).toBe(engine.tokenId(minted)); // genesis-stable across transfer
+    expect(await engine.isSpent(minted)).toBe(true);
+  });
+
+  it('splits a token into value-conserving outputs against the live aggregator', async () => {
+    const engine = await makeEngine();
+    const self = engine.getIdentity().chainPubkey;
+    const src = await engine.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+
+    const other = new SigningService(SigningService.generatePrivateKey()).publicKey;
+    const { outputs } = await engine.split({
+      token: src,
+      outputs: [
+        { recipientPubkey: other, coinId: COIN, amount: 60n },
+        { recipientPubkey: self, coinId: COIN, amount: 40n },
+      ],
+    });
+    expect(outputs).toHaveLength(2);
+    expect(outputs.reduce((sum, o) => sum + engine.balanceOf(o, COIN), 0n)).toBe(100n);
+    expect(await engine.isSpent(src)).toBe(true);
+  });
+
+  it('mints a data token (invoice-style) and reads its bytes back', async () => {
+    const engine = await makeEngine();
+    const self = engine.getIdentity().chainPubkey;
+    const data = new TextEncoder().encode(JSON.stringify({ inv: 'sphere-e2e' }));
+    const salt = new Uint8Array(32).fill(9);
+
+    const t = await engine.mintDataToken({ recipientPubkey: self, data, salt });
+    expect(engine.readValue(t)).toBeNull();
+    expect(engine.readTokenData(t)).toEqual(data);
+    expect(engine.tokenId(t)).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/tests/unit/token-engine/factory.test.ts
+++ b/tests/unit/token-engine/factory.test.ts
@@ -22,7 +22,6 @@ describe('createSphereTokenEngine', () => {
   it('wires an engine from sphere-domain config (no network)', async () => {
     const privateKey = SigningService.generatePrivateKey();
     const engine = await createSphereTokenEngine({
-      network: 'local',
       aggregatorUrl: 'http://localhost:3000',
       privateKey,
       trustBaseJson: TRUST_BASE_JSON,
@@ -32,12 +31,22 @@ describe('createSphereTokenEngine', () => {
     expect(await engine.deriveIdentityAddress()).toMatch(/^DIRECT:\/\//);
   });
 
+  it('takes the network id from the trust base — non-standard ids work (e.g. testnet2 = 4)', async () => {
+    const engine = await createSphereTokenEngine({
+      aggregatorUrl: 'http://localhost:3000',
+      privateKey: SigningService.generatePrivateKey(),
+      trustBaseJson: { ...TRUST_BASE_JSON, networkId: 4 },
+    });
+    // Construction succeeds: NetworkId.fromId(4) is valid; no enum entry needed.
+    expect(engine.getIdentity().chainPubkey).toBeInstanceOf(Uint8Array);
+  });
+
   it('rejects a config without a trust base', async () => {
     await expect(
       createSphereTokenEngine({
-        network: 'local',
         aggregatorUrl: 'http://localhost:3000',
         privateKey: SigningService.generatePrivateKey(),
+        trustBaseJson: null,
       }),
     ).rejects.toThrow();
   });

--- a/token-engine/engine.ts
+++ b/token-engine/engine.ts
@@ -13,7 +13,6 @@ import type {
   SphereValue,
   SphereToken,
   TokenBlob,
-  SphereNetwork,
   MintParams,
   MintDataTokenParams,
   TransferParams,
@@ -111,18 +110,17 @@ export interface ITokenEngine {
  * this shape may gain fields there without affecting the ITokenEngine contract.
  */
 export interface EngineConfig {
-  /** Target network; selects NetworkId and the default trust base. */
-  readonly network: SphereNetwork;
   /** Aggregator (gateway) base URL the StateTransitionClient talks to. */
   readonly aggregatorUrl: string;
   /** Wallet signing key (secp256k1 private scalar, 32 bytes). Held inside the engine only. */
   readonly privateKey: Uint8Array;
   /**
-   * Optional explicit root-trust-base JSON. When omitted, the factory uses the
-   * built-in default for `network`. Typed `unknown` to keep SDK types out of
-   * the public surface (the factory parses it internally).
+   * Root-trust-base JSON. The single source of truth for the network — the engine's
+   * NetworkId is taken from it (`RootTrustBase.networkId` via `NetworkId.fromId`), so
+   * any network id works (e.g. testnet2 = 4) with no enum entry. Typed `unknown` to
+   * keep SDK types off the public surface (the factory parses it internally).
    */
-  readonly trustBaseJson?: unknown;
+  readonly trustBaseJson: unknown;
   /** Inclusion-proof poll cadence in ms (engine owns the await policy; Spike S1). */
   readonly proofPollIntervalMs?: number;
   /** Inclusion-proof overall timeout in ms (0/undefined = no engine-side cap). */

--- a/token-engine/engine.ts
+++ b/token-engine/engine.ts
@@ -112,6 +112,8 @@ export interface ITokenEngine {
 export interface EngineConfig {
   /** Aggregator (gateway) base URL the StateTransitionClient talks to. */
   readonly aggregatorUrl: string;
+  /** Optional gateway API key (some gateways, e.g. testnet2, require it for auth). */
+  readonly apiKey?: string;
   /** Wallet signing key (secp256k1 private scalar, 32 bytes). Held inside the engine only. */
   readonly privateKey: Uint8Array;
   /**

--- a/token-engine/factory.ts
+++ b/token-engine/factory.ts
@@ -14,7 +14,6 @@
  */
 
 import { SphereError } from '../core/errors';
-import { toNetworkId } from './network';
 import {
   AggregatorClient,
   MintJustificationVerifierService,
@@ -46,7 +45,9 @@ export async function createSphereTokenEngine(config: EngineConfig): Promise<ITo
     predicateVerifier,
     mintJustificationVerifier,
     signingService: new SigningService(config.privateKey),
-    networkId: toNetworkId(config.network),
+    // The trust base is the single source of truth for the network id (it carries
+    // NetworkId.fromId, so any id works — e.g. testnet2 = 4 — with no enum entry).
+    networkId: trustBase.networkId,
   };
 
   return new SphereTokenEngine(deps);

--- a/token-engine/factory.ts
+++ b/token-engine/factory.ts
@@ -40,7 +40,7 @@ export async function createSphereTokenEngine(config: EngineConfig): Promise<ITo
   );
 
   const deps: EngineDeps = {
-    client: new StateTransitionClient(new AggregatorClient(config.aggregatorUrl)),
+    client: new StateTransitionClient(new AggregatorClient(config.aggregatorUrl, config.apiKey ?? null)),
     trustBase,
     predicateVerifier,
     mintJustificationVerifier,

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig } from 'vitest/config';
 
+// Load .env (gitignored) so e2e runs can pick up secrets (e.g. TESTNET2_API_KEY)
+// without exporting them by hand. No-op when .env is absent (CI relies on shell env).
+try {
+  process.loadEnvFile();
+} catch {
+  /* no .env file — rely on the ambient shell environment */
+}
+
 export default defineConfig({
   test: {
     globals: true,


### PR DESCRIPTION
## Track A — A4-int: construct + inject the v2 engine in Sphere

Wires the v2 token engine into the wallet. `Sphere` now builds the engine per active
address and injects it as `tokenEngine` into the Payments + Accounting deps — flipping
the dual-path callers (Track B) onto the engine. Clean cutover: mainnet doesn't exist
yet, no back-compat, v1 fallback becomes dead code (removed later with A5).

### Changes
- **oracle/UnicityAggregatorProvider**: `getAggregatorUrl()` + `getTrustBaseJson()` (keeps the raw trust-base JSON so the engine can re-parse it into a v2 RootTrustBase).
- **core/Sphere.buildTokenEngine()**: `createSphereTokenEngine` from the oracle's gateway URL + trust base + this address's signing key; injected into both module deps. Graceful — returns `undefined` (modules keep their legacy path) if the oracle lacks a trust base / url, so init never breaks.

### networkId from the trust base (testnet2 = 4)
The factory now takes `networkId` from `trustBase.networkId` (the trust base is the single source of truth; `RootTrustBase` carries `NetworkId.fromId`, so **any** id works with no enum entry). This fixes **testnet2 (networkId = 4)** — confirmed against the live trust base — and matches the aggregator team's "take network id from trustbase" fix. `EngineConfig` drops `network`; `trustBaseJson` is now required.

### Verification
- Full suite **2808/2808** green; `tsc` + `eslint` clean.
- `factory.test.ts` adds a case asserting a non-standard id (4) is accepted.

Note: `toNetworkId`/`network.ts` are now unused by the factory (left in place; separate cleanup). Next: Σ3 real testnet2 e2e against the wired engine, then A5 (finalize sdkData as the v2 blob, retire txf-serializer).
