### PR TITLE
Track A: A5 — persist v2 token blobs through storage build/parse

### DIFF
--- a/serialization/txf-serializer.ts
+++ b/serialization/txf-serializer.ts
@@ -242,6 +242,36 @@ export function txfToToken(tokenId: string, txf: TxfToken): Token {
 // Storage Data Building
 // =============================================================================
 
+// =============================================================================
+// v2 token blob storage (opaque CBOR blob in sdkData, not v1 JSON TXF)
+// =============================================================================
+
+/** True when sdkData is an even-length lowercase-hex CBOR blob (a v2 token), not JSON TXF. */
+function isV2TokenBlob(sdkData: string | undefined): sdkData is string {
+  return (
+    typeof sdkData === 'string' &&
+    sdkData.length >= 2 &&
+    sdkData.length % 2 === 0 &&
+    sdkData[0] !== '{' &&
+    /^[0-9a-f]+$/i.test(sdkData)
+  );
+}
+
+/** Genesis token id for a v2 token's storage key (`v2_` is the UI-id prefix convention). */
+function v2TokenId(token: Token): string {
+  return token.id.startsWith('v2_') ? token.id.slice(3) : token.id;
+}
+
+/** A v2 storage entry is the UI token record itself (blob sdkData, no v1 `genesis`). */
+function isV2TokenEntry(entry: unknown): entry is Token {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    !('genesis' in entry) &&
+    isV2TokenBlob((entry as Token).sdkData)
+  );
+}
+
 /**
  * Build TXF storage data from tokens and metadata
  */
@@ -290,12 +320,18 @@ export async function buildTxfStorageData(
     (storageData as TxfStorageData & { _history: HistoryRecord[] })._history = options.historyEntries;
   }
 
-  // Add active tokens
+  // Add active tokens. v2 tokens carry an opaque hex blob in sdkData (not JSON TXF),
+  // so tokenToTxf returns null for them — store the UI token record directly under
+  // its genesis token id (the v2 storage entry).
   for (const token of tokens) {
     const txf = tokenToTxf(token);
     if (txf) {
       const actualTokenId = txf.genesis.data.tokenId;
       storageData[keyFromTokenId(actualTokenId)] = txf;
+    } else if (isV2TokenBlob(token.sdkData)) {
+      // The v2 entry (a UI token record) lives in the token slot; parse reads it back
+      // via isV2TokenEntry. Cast because TxfStorageData's value union predates v2.
+      storageData[keyFromTokenId(v2TokenId(token))] = token as unknown as TxfToken;
     }
   }
 
@@ -466,6 +502,9 @@ export function parseTxfStorageData(data: unknown): ParsedStorageData {
         if (txfToken?.genesis?.data?.tokenId) {
           const token = txfToToken(tokenId, txfToken);
           result.tokens.push(token);
+        } else if (isV2TokenEntry(storageData[key])) {
+          // v2 storage entry — the UI token record (opaque blob in sdkData).
+          result.tokens.push(storageData[key] as Token);
         }
       } catch (err) {
         result.validationErrors.push(`Token ${tokenId}: ${err}`);

--- a/tests/unit/serialization/txf-serializer.v2.test.ts
+++ b/tests/unit/serialization/txf-serializer.v2.test.ts
@@ -1,0 +1,62 @@
+/**
+ * A5 — v2 token blob storage round-trip.
+ *
+ * v2 tokens persist as an opaque hex CBOR blob in `sdkData` (not the v1 JSON TXF).
+ * These tests pin that build → parse round-trips a v2 token. (RED before A5: the
+ * legacy build path JSON.parses sdkData and silently drops v2 tokens.)
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { bytesToHex } from '../../../core/crypto';
+import { buildTxfStorageData, parseTxfStorageData } from '../../../serialization/txf-serializer';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import type { Token } from '../../../types';
+import { createTestEngine } from '../token-engine/test-engine';
+
+const COIN = 'a'.repeat(64);
+const META = { version: 1, address: 'DIRECT://test', ipnsName: 'k51-test' };
+
+async function makeV2Token(amount = 100n): Promise<Token> {
+  const engine = createTestEngine();
+  const sphereToken = await engine.mint({
+    recipientPubkey: engine.getIdentity().chainPubkey,
+    value: { assets: [{ coinId: COIN, amount }] },
+  });
+  const sdkData = bytesToHex(encodeTokenBlob(engine.encodeToken(sphereToken)));
+  return {
+    id: `v2_${engine.tokenId(sphereToken)}`,
+    coinId: COIN,
+    symbol: 'TST',
+    name: 'Test',
+    decimals: 8,
+    amount: amount.toString(),
+    status: 'confirmed',
+    createdAt: 1,
+    updatedAt: 1,
+    sdkData,
+  };
+}
+
+describe('TXF storage — v2 token blob round-trip', () => {
+  it('persists and restores a v2 token through build/parse', async () => {
+    const token = await makeV2Token();
+    const doc = await buildTxfStorageData([token], META);
+    const parsed = parseTxfStorageData(doc);
+
+    expect(parsed.tokens).toHaveLength(1);
+    expect(parsed.tokens[0].sdkData).toBe(token.sdkData);
+    expect(parsed.tokens[0].coinId).toBe(COIN);
+    expect(parsed.tokens[0].amount).toBe('100');
+  });
+
+  it('round-trips multiple v2 tokens', async () => {
+    const a = await makeV2Token(10n);
+    const b = await makeV2Token(20n);
+    const doc = await buildTxfStorageData([a, b], META);
+    const parsed = parseTxfStorageData(doc);
+
+    expect(parsed.tokens).toHaveLength(2);
+    expect(new Set(parsed.tokens.map((t) => t.sdkData))).toEqual(new Set([a.sdkData, b.sdkData]));
+  });
+});


### PR DESCRIPTION
Fixes the v2 storage gap: a v2 token's sdkData is an opaque hex CBOR blob (not v1 JSON TXF), so buildTxfStorageData's JSON.parse returned null and the token was silently dropped from save. Now v2 tokens persist as their UI token record under keyFromTokenId(genesis id), and parse reads them straight back. Additive — v1 TXF path untouched (existing tests green); storage providers + ipfs merge unchanged (opaque dict). New round-trip test (was RED). serialization 108 + modules 1217 tests green; tsc + eslint clean. v1 retirement + loud-reject + archived/forked v2 are the final Σ4 cutover.