### PR TITLE
Track A: Σ4 slice 1 — vendor DIRECT:// derivation (v1-free, golden-locked ×5)

### DIFF
--- a/tests/e2e/token-engine.testnet2.e2e.test.ts
+++ b/tests/e2e/token-engine.testnet2.e2e.test.ts
@@ -67,7 +67,9 @@ describe.runIf(!!API_KEY)('token-engine e2e — live testnet2 (networkId 4)', ()
     const engine = await makeEngine();
     const self = engine.getIdentity().chainPubkey;
     const data = new TextEncoder().encode(JSON.stringify({ inv: 'sphere-e2e' }));
-    const salt = new Uint8Array(32).fill(9);
+    // Unique salt per run: the salt → a stable tokenId, so a fixed salt would collide
+    // with a previous run's token on the persistent testnet (TRANSACTION_HASH_MISMATCH).
+    const salt = crypto.getRandomValues(new Uint8Array(32));
 
     const t = await engine.mintDataToken({ recipientPubkey: self, data, salt });
     expect(engine.readValue(t)).toBeNull();

--- a/tests/unit/token-engine/identity.test.ts
+++ b/tests/unit/token-engine/identity.test.ts
@@ -8,30 +8,35 @@ function hex(h: string): Uint8Array {
   return bytes;
 }
 
-// Fixed reference pubkeys (compressed secp256k1): the generator G and k=2.
-const PUBKEY_G = hex('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798');
-const PUBKEY_2 = hex('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5');
-
-// GOLDEN VECTOR — locks the legacy DIRECT:// derivation byte-for-byte (recorded
-// from the v1 UnmaskedPredicateReference path). Quest XP is keyed on this
-// address (Path A); if it ever changes, users silently lose XP. At final v1
-// removal, the vendored byte-exact recipe MUST still reproduce this value.
-const GOLDEN_G = 'DIRECT://00001386dc2547e656f7041444e3ef3772f374305551724ef9fe86cf004a118d917dd4192a29';
+// GOLDEN VECTORS — lock the legacy DIRECT:// derivation byte-for-byte, recorded
+// from the v1 UnmaskedPredicateReference path for fixed compressed secp256k1
+// pubkeys (k = 1..5). Quest XP is keyed on this address (Path A); if it ever
+// changes, users silently lose XP. At final v1 removal the vendored byte-exact
+// recipe MUST still reproduce EVERY one of these (one vector is too weak to
+// catch a subtly-wrong reimplementation).
+const GOLDEN: ReadonlyArray<readonly [pubkey: string, address: string]> = [
+  ['0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 'DIRECT://00001386dc2547e656f7041444e3ef3772f374305551724ef9fe86cf004a118d917dd4192a29'],
+  ['02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5', 'DIRECT://00008c78a0ae2467f58cc704161707d0a830a5876dd7afc04c57f1118b4315b661d503a6b643'],
+  ['02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9', 'DIRECT://0000fc62fc14511ed96fdbd081b73d6ac4188dd6d5ef995b43fb82ea45fcd75726af0e6a98cf'],
+  ['02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13', 'DIRECT://00001f218f10059b25fe6dc244573fdf58e97d14c013d1c2a9285aaf15ee57bd586132586630'],
+  ['022f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4', 'DIRECT://000053984f8e9a7c56f94fae7ecd31c625f0602b9b5105d19edd9af7ca51f359c3205e93f43a'],
+];
 
 describe('deriveDirectAddress (legacy DIRECT:// — Path A)', () => {
-  it('matches the golden vector for a fixed pubkey (XP-invariant lock)', async () => {
-    expect(await deriveDirectAddress(PUBKEY_G)).toBe(GOLDEN_G);
+  it.each(GOLDEN)('matches the golden vector for pubkey %s (XP-invariant lock)', async (pubkey, address) => {
+    expect(await deriveDirectAddress(hex(pubkey))).toBe(address);
   });
 
   it('is deterministic (same pubkey → same address)', async () => {
-    expect(await deriveDirectAddress(PUBKEY_G)).toBe(await deriveDirectAddress(PUBKEY_G));
+    const pk = hex(GOLDEN[0][0]);
+    expect(await deriveDirectAddress(pk)).toBe(await deriveDirectAddress(pk));
   });
 
   it('produces a DIRECT:// address', async () => {
-    expect(await deriveDirectAddress(PUBKEY_G)).toMatch(/^DIRECT:\/\//);
+    expect(await deriveDirectAddress(hex(GOLDEN[0][0]))).toMatch(/^DIRECT:\/\//);
   });
 
   it('different pubkeys → different addresses', async () => {
-    expect(await deriveDirectAddress(PUBKEY_G)).not.toBe(await deriveDirectAddress(PUBKEY_2));
+    expect(await deriveDirectAddress(hex(GOLDEN[0][0]))).not.toBe(await deriveDirectAddress(hex(GOLDEN[1][0])));
   });
 });

--- a/tests/unit/token-engine/wallet-address-invariant.test.ts
+++ b/tests/unit/token-engine/wallet-address-invariant.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPublicKey, sha256, hexToBytes } from '../../../core/crypto';
+import { deriveDirectAddress } from '../../../token-engine/identity';
+
+/**
+ * Wallet-level XP-invariant lock. The wallet's DIRECT:// address is
+ * `deriveDirectAddress(getPublicKey(SHA256(privateKey)))` (core/Sphere
+ * deriveL3PredicateAddress). These golden addresses were recorded from the v1
+ * path and confirmed byte-identical to the vendored derivation, for several
+ * wallet private keys. Quest XP is keyed on this address — it must never change.
+ */
+const WALLET_GOLDEN: ReadonlyArray<readonly [privateKey: string, address: string]> = [
+  ['0000000000000000000000000000000000000000000000000000000000000001', 'DIRECT://0000b97b4a83dc3fe636d4f21dbfe4c93149e07367539a059a9c8e64ad7d9fdc30644eaaf64b'],
+  ['7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f', 'DIRECT://0000c6fcb02e86386b35d20908185da2752d9b94bf1222bcb602ca838323c3d35d6f0ee90e9a'],
+  ['a3f1c2d4e5b6978012345678abcdefabcdef0123456789abcdef0123456789ab', 'DIRECT://0000c3f1e98c5d61ef26abaeae052f5726c91dbe33f65af22f5e404ba2b2f9e6ee97cbf6c452'],
+  ['deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef0', 'DIRECT://0000b6b71b6b7003700f2b758c5f824ab51758a4a2833534a4f1d8b47d34da62fec2105b0aa3'],
+];
+
+describe('wallet DIRECT:// address (full derivation — XP invariant)', () => {
+  it.each(WALLET_GOLDEN)('matches the golden wallet address for key %s', async (privateKey, address) => {
+    const walletPubkey = hexToBytes(getPublicKey(sha256(privateKey, 'hex')));
+    expect(await deriveDirectAddress(walletPubkey)).toBe(address);
+  });
+});

--- a/token-engine/identity.ts
+++ b/token-engine/identity.ts
@@ -1,27 +1,35 @@
 /**
  * token-engine/identity.ts — legacy `DIRECT://` identity address (Path A, A6).
  *
- * Reproduces the wallet's stable L3 identity address EXACTLY as the existing
- * core/Sphere.deriveL3PredicateAddress does, but as ONE shared, pubkey-based
- * helper. Quest XP is keyed on this address, so it MUST stay byte-identical
- * across the migration — the golden-vector test locks it.
+ * Reproduces the wallet's stable L3 identity address EXACTLY as the v1
+ * `UnmaskedPredicateReference` → `DirectAddress` path did, but VENDORED (no v1 SDK
+ * import) so the v1 dependency can be removed at the final cut-over. Quest XP is
+ * keyed on this address, so it MUST stay byte-identical — the multi-vector
+ * golden test (identity.test.ts) locks it.
  *
- * It reuses the SAME v1 primitive the wallet has always used
- * (`UnmaskedPredicateReference`) — not a reimplementation. v1 is the only thing
- * here outside the v2 engine boundary; at the final v1 removal this single call
- * is swapped for a vendored, byte-exact recipe (still golden-locked). The
- * address is a pure function of the compressed secp256k1 public key (plus the
- * fixed Unicity token type, the `secp256k1` algorithm and SHA-256).
+ * The recipe (recovered from v1 `UnmaskedPredicateReference.create` + `DirectAddress.create`):
+ *   ref     = SHA-256( CBOR[ bstr([UNMASKED]), bstr(tokenType.toCBOR()),
+ *                            tstr("secp256k1"), uint(SHA256), bstr(publicKey) ] )
+ *   imprint = 0x0000 ‖ ref                    (SHA-256 DataHash imprint)
+ *   address = "DIRECT://" ‖ hex(imprint) ‖ hex( SHA-256(imprint)[0:4] )
+ *
+ * The CBOR + SHA-256 are standard, so v2's CborSerializer/DataHasher produce
+ * byte-identical output; the v1 enum values (UNMASKED=0, HashAlgorithm.SHA256=0)
+ * and the SHA-256 imprint prefix (0x0000) are pinned as constants.
  */
 
-import { HashAlgorithm } from '@unicitylabs/state-transition-sdk/lib/hash/HashAlgorithm';
-import { UnmaskedPredicateReference } from '@unicitylabs/state-transition-sdk/lib/predicate/embedded/UnmaskedPredicateReference';
-import { TokenType } from '@unicitylabs/state-transition-sdk/lib/token/TokenType';
+import { CborSerializer, DataHasher, HashAlgorithm, HexConverter } from './sdk';
 
 /** Unicity L3 token type used for identity-address derivation (immutable). */
 const UNICITY_TOKEN_TYPE_HEX = 'f8aa13834268d29355ff12183066f0cb902003629bbc5eb9ef0efbe397867509';
-/** Value of v1 `SigningService.algorithm` for secp256k1 (verified against the SDK). */
+/** v1 `SigningService.algorithm` for secp256k1. */
 const SIGNING_ALGORITHM = 'secp256k1';
+/** v1 `EmbeddedPredicateType.UNMASKED`. */
+const EMBEDDED_PREDICATE_UNMASKED = 0;
+/** v1 `HashAlgorithm.SHA256` (as encoded in the reference CBOR). */
+const HASH_ALGORITHM_SHA256 = 0n;
+/** v1 SHA-256 `DataHash` imprint algorithm tag (2-byte big-endian). */
+const SHA256_IMPRINT_PREFIX = new Uint8Array([0x00, 0x00]);
 
 function hexToBytes(hex: string): Uint8Array {
   const bytes = new Uint8Array(hex.length / 2);
@@ -31,17 +39,30 @@ function hexToBytes(hex: string): Uint8Array {
   return bytes;
 }
 
+function sha256(data: Uint8Array): Promise<Uint8Array> {
+  return new DataHasher(HashAlgorithm.SHA256)
+    .update(data)
+    .digest()
+    .then((h) => h.data);
+}
+
 /**
  * Derive the legacy `DIRECT://` identity address for a compressed (33-byte)
- * secp256k1 public key. Deterministic; stable across the migration (Path A).
+ * secp256k1 public key. Deterministic; byte-identical to the v1 path (Path A).
  */
 export async function deriveDirectAddress(publicKey: Uint8Array): Promise<string> {
-  const tokenType = new TokenType(hexToBytes(UNICITY_TOKEN_TYPE_HEX));
-  const reference = await UnmaskedPredicateReference.create(
-    tokenType,
-    SIGNING_ALGORITHM,
-    publicKey,
-    HashAlgorithm.SHA256,
+  const tokenTypeCbor = CborSerializer.encodeByteString(hexToBytes(UNICITY_TOKEN_TYPE_HEX)); // v1 TokenType.toCBOR()
+  const reference = CborSerializer.encodeArray(
+    CborSerializer.encodeByteString(new Uint8Array([EMBEDDED_PREDICATE_UNMASKED])),
+    CborSerializer.encodeByteString(tokenTypeCbor),
+    CborSerializer.encodeTextString(SIGNING_ALGORITHM),
+    CborSerializer.encodeUnsignedInteger(HASH_ALGORITHM_SHA256),
+    CborSerializer.encodeByteString(publicKey),
   );
-  return (await reference.toAddress()).toString();
+
+  const refHash = await sha256(reference);
+  const imprint = new Uint8Array([...SHA256_IMPRINT_PREFIX, ...refHash]);
+  const checksum = (await sha256(imprint)).slice(0, 4);
+
+  return `DIRECT://${HexConverter.encode(imprint)}${HexConverter.encode(checksum)}`;
 }


### PR DESCRIPTION
First Σ4 cut-over slice: removes the only v1 SDK import in token-engine/ by vendoring the XP-critical DIRECT:// derivation byte-exact (v2 has no UnmaskedPredicateReference). De-risked by locking FIVE real-v1 golden vectors (was one); the vendored recipe reproduces all five. tsc + eslint + 72 token-engine tests green. **XP-critical — please review the byte-exact recipe** (token-engine/identity.ts). Remaining cut-over slices (module v1-fallback removal, oracle, drop v1 dep+alias, ESLint strict, txf v1 retirement) follow.