### PR TITLE
fix(profile)(sphere-sdk#419): pin OpLog blocks at depth=0 + emit one-shot Helia config snapshot

### DIFF
--- a/profile/helia-blockstore-pin-shim.ts
+++ b/profile/helia-blockstore-pin-shim.ts
@@ -57,15 +57,30 @@
 import { logger } from '../core/logger';
 import { incr, observeMs } from '../core/perf-counters.js';
 
-/** Minimal structural shape of the Helia v6+ pins API. */
+/**
+ * Minimal structural shape of the Helia v6+ pins API.
+ *
+ * The shim always passes `{ depth: 0 }` so Helia pins each block as a
+ * leaf without walking referenced descendants — see issue #419 + the
+ * "Why depth: 0" doc-comment on {@link installHeliaBlockstorePinShim}.
+ */
 export interface HeliaPinsLike {
   /**
-   * Pin a CID so the block (and its references) survive Helia GC.
+   * Pin a CID so the block survives Helia GC.
+   *
    * Helia v6 returns an `AsyncIterable<CID>` that yields each pinned
-   * descendant. The shim consumes the iterable so the pin is actually
-   * applied (Helia computes the pin set lazily on iteration).
+   * descendant (one CID per depth-0 add when called with `{ depth: 0 }`).
+   * The shim consumes the iterable so the pin is actually applied —
+   * Helia computes the pin set lazily on iteration.
+   *
+   * `options` is forwarded verbatim; the only field the shim sets is
+   * `depth`. Other fields (metadata, AbortSignal) are not used today
+   * but the structural shape allows future call sites to pass them.
    */
-  add(cid: unknown, options?: unknown): AsyncIterable<unknown> | Promise<unknown>;
+  add(
+    cid: unknown,
+    options?: { readonly depth?: number; readonly metadata?: unknown; readonly signal?: unknown },
+  ): AsyncIterable<unknown> | Promise<unknown>;
 }
 
 /** Minimal structural shape of the Helia v6+ blockstore. */
@@ -142,6 +157,17 @@ export function installHeliaBlockstorePinShim(
   let pinFailed = 0;
   let pinSkipped = 0;
   const pinnedCids = new Set<string>();
+
+  // Issue #419 follow-up — capture a one-shot Helia config snapshot the
+  // first time `pins.add` raises a non-"Already pinned" failure. Many
+  // pin failures look identical in the warn-log; the snapshot tells an
+  // operator at a glance whether they're looking at an HTTP-only Helia
+  // (no libp2p), a libp2p-with-bootstraps wallet that can't reach its
+  // peers, or an unfamiliar blockstore/pins surface. Captured at install
+  // time (cheap, runs once) and emitted lazily on the first failure so
+  // a healthy session never logs the snapshot at all.
+  const heliaConfigSnapshot = snapshotHeliaConfig(helia);
+  let firstFailureSnapshotEmitted = false;
 
   const handle: PinShimHandle = {
     getCounters: () => ({ pinAttempted, pinSucceeded, pinFailed, pinSkipped }),
@@ -325,7 +351,36 @@ export function installHeliaBlockstorePinShim(
     incr('helia.pins.add.calls');
     const __pStart = performance.now();
     try {
-      const result = pinsApi.add(cid);
+      // Pin as a LEAF: `{ depth: 0 }` tells Helia to pin this block
+      // alone without walking the DAG of referenced descendants.
+      //
+      // Why this matters (issue #419):
+      //   `@helia/utils`'s `Pins.add` defaults to `depth: Infinity`,
+      //   meaning every pin call decodes the block, follows every CID
+      //   link, and recursively pins descendants. Each descendant load
+      //   goes through `blockstore.get(cid)`, which (in online mode)
+      //   falls through to Bitswap when the block isn't already on
+      //   disk — and throws "Failed to load block for <child cid>"
+      //   when Bitswap can't satisfy it either.
+      //
+      //   Every OpLog block this shim pins references its parent
+      //   block. Every CAR block pinned via `putBlockToLocalHelia`
+      //   (issue #236) references its children. Recursive descent
+      //   makes the FIRST pin try to load the WHOLE chain — most of
+      //   which isn't local yet (e.g., the genesis OpLog block from a
+      //   different session, or a CAR child that hasn't been put yet
+      //   because the worker pool ordered the puts arbitrarily).
+      //
+      //   The shim's contract is "pin individual blocks at write
+      //   time". Recursive walks contradict that contract and produce
+      //   the floods of `helia.pins.add failed for X: Failed to load
+      //   block for Y` warnings observed in issue #419. Switching to
+      //   `depth: 0` aligns Helia's behaviour with the contract: each
+      //   pin call pins exactly the block whose put just succeeded.
+      //   The DAG remains fully pinned across calls because every
+      //   block in it is the subject of its own `put` (and therefore
+      //   its own pin).
+      const result = pinsApi.add(cid, { depth: 0 });
       // Helia v6 returns AsyncIterable<CID>; older / test stubs may
       // return a thenable. Drain both shapes.
       if (
@@ -377,11 +432,96 @@ export function installHeliaBlockstorePinShim(
         'ProfilePinShim',
         `helia.pins.add failed for ${cidStr.slice(0, 16)}…: ${msg}`,
       );
+      // Issue #419 — emit the captured Helia config snapshot exactly
+      // once across the install lifetime. Tells the operator at a
+      // glance which Helia shape is in use (HTTP-only vs libp2p,
+      // blockstore type, pins implementation) so a flurry of identical
+      // pin-failure warnings doesn't bury the actual diagnostic signal.
+      if (!firstFailureSnapshotEmitted) {
+        firstFailureSnapshotEmitted = true;
+        logger.warn(
+          'ProfilePinShim',
+          `first pin failure — helia config snapshot: ${heliaConfigSnapshot}`,
+        );
+      }
       incr('helia.pins.add.failed');
       observeMs('helia.pins.add.failedMs', performance.now() - __pStart);
       return 'failed';
     }
   }
+}
+
+/**
+ * Capture a compact, one-line description of the Helia instance the
+ * shim has been bound to. Emitted lazily by {@link installHeliaBlockstorePinShim}
+ * on the first observed pin failure (issue #419).
+ *
+ * Fields:
+ *   - `blockstore`: blockstore class name (e.g., `FsBlockstore`,
+ *     `MemoryBlockstore`, `IDBBlockstore`). A failed pin against an
+ *     `FsBlockstore` points at on-disk corruption / fd exhaustion; a
+ *     failure against `MemoryBlockstore` points at a test stub.
+ *   - `pins`: pins implementation class name (real Helia is
+ *     `DefaultPins`; tests stub this).
+ *   - `libp2p`: `present`, `absent`, or `unknown`. `absent` is the
+ *     HTTP-only Helia config introduced in issue #266 — when present
+ *     the failure may be a Bitswap walk that couldn't reach a peer.
+ *   - `peerCount`: number of libp2p peers known to be connected (or
+ *     `unknown` when libp2p is absent). A peer count of 0 with libp2p
+ *     present signals isolation — Helia's Bitswap descendant walks
+ *     have no chance of succeeding.
+ *
+ * Defensive: every field falls back to `unknown` on any access error.
+ * Never throws — the caller emits this from a warn branch and must
+ * not amplify a logging path's cost into a control-flow problem.
+ */
+function snapshotHeliaConfig(helia: HeliaWithPinsLike): string {
+  const safeClassName = (value: unknown): string => {
+    if (value === null || value === undefined) return 'absent';
+    try {
+      const ctor = (value as { constructor?: { name?: unknown } }).constructor;
+      const name = ctor?.name;
+      return typeof name === 'string' && name.length > 0 ? name : 'unknown';
+    } catch {
+      return 'unknown';
+    }
+  };
+  let blockstoreName = 'unknown';
+  let pinsName = 'unknown';
+  let libp2pState: 'present' | 'absent' | 'unknown' = 'absent';
+  let peerCount: number | 'unknown' = 'unknown';
+  try {
+    blockstoreName = safeClassName(helia.blockstore);
+  } catch {
+    /* ignore */
+  }
+  try {
+    pinsName = safeClassName(helia.pins);
+  } catch {
+    /* ignore */
+  }
+  try {
+    const libp2p = (helia as unknown as { libp2p?: unknown }).libp2p;
+    if (libp2p === null || libp2p === undefined) {
+      libp2pState = 'absent';
+    } else {
+      libp2pState = 'present';
+      try {
+        const peers = (libp2p as { getPeers?: () => ReadonlyArray<unknown> }).getPeers?.();
+        if (Array.isArray(peers)) {
+          peerCount = peers.length;
+        }
+      } catch {
+        /* peer-count lookup is best-effort; libp2p shape varies */
+      }
+    }
+  } catch {
+    libp2pState = 'unknown';
+  }
+  return (
+    `blockstore=${blockstoreName} pins=${pinsName} ` +
+    `libp2p=${libp2pState} peerCount=${peerCount}`
+  );
 }
 
 /**

--- a/tests/unit/profile/helia-blockstore-pin-shim.test.ts
+++ b/tests/unit/profile/helia-blockstore-pin-shim.test.ts
@@ -17,6 +17,7 @@ import {
   requestPersistentStorage,
   type HeliaWithPinsLike,
 } from '../../../profile/helia-blockstore-pin-shim';
+import { logger } from '../../../core/logger';
 
 // ---------------------------------------------------------------------------
 // Mock helpers
@@ -228,6 +229,235 @@ describe('installHeliaBlockstorePinShim', () => {
     expect(counters.pinFailed).toBe(0);
   });
 
+  // -------------------------------------------------------------------------
+  // Issue #419 — pin shim must pass `{ depth: 0 }` so Helia does NOT
+  // walk descendants. Default `pins.add` is `depth: Infinity`, which
+  // makes Helia decode each pinned block and walk its CID-link
+  // descendants. Descendants that aren't yet on disk fall through to
+  // Bitswap and time out — the failure surfaces as
+  // `helia.pins.add failed for X: Failed to load block for Y` warnings
+  // (X != Y). The shim's contract is "pin individual leaf blocks at
+  // write time"; depth: 0 aligns Helia with that contract.
+  // -------------------------------------------------------------------------
+
+  it('invokes pins.add with { depth: 0 } so Helia does NOT walk descendants', async () => {
+    const optionsSeen: unknown[] = [];
+    const blockstore = makeBlockstore('ok');
+    const pinsApi = {
+      add(cid: unknown, options?: unknown): AsyncIterable<unknown> {
+        optionsSeen.push(options);
+        return (async function* () {
+          yield cid;
+        })();
+      },
+    };
+    const helia: HeliaWithPinsLike = {
+      blockstore: blockstore.bs,
+      pins: pinsApi,
+    };
+    installHeliaBlockstorePinShim(helia);
+
+    await helia.blockstore!.put!('bafyDEPTH', new Uint8Array([1]));
+    await flushAsync();
+
+    expect(optionsSeen.length).toBe(1);
+    expect(optionsSeen[0]).toMatchObject({ depth: 0 });
+  });
+
+  it('survives a Helia stub that throws when asked to walk descendants', async () => {
+    // Simulate Helia v6's real behaviour without depth: 0 — `pins.add`
+    // walks the DAG, fails to load a referenced descendant, and throws
+    // "Failed to load block for <child cid>". With our depth: 0 fix the
+    // PRODUCTION Helia would not even attempt the walk, but a strict
+    // stub helps us verify the shim's failure path stays well-behaved
+    // (counters increment correctly, warn fires, put never throws).
+    const blockstore = makeBlockstore('ok');
+    const pinsApi = {
+      add(_cid: unknown, _options?: unknown): AsyncIterable<unknown> {
+        return (async function* () {
+          throw new Error('Failed to load block for bafy_descendant');
+           
+          yield _cid;
+        })();
+      },
+    };
+    const helia: HeliaWithPinsLike = {
+      blockstore: blockstore.bs,
+      pins: pinsApi,
+    };
+    const handle = installHeliaBlockstorePinShim(helia);
+
+    // Put MUST resolve cleanly even though pin descends-and-fails.
+    await expect(
+      helia.blockstore!.put!('bafyROOT', new Uint8Array([1])),
+    ).resolves.toBeUndefined();
+    await flushAsync();
+
+    const counters = handle.getCounters();
+    expect(counters.pinAttempted).toBe(1);
+    expect(counters.pinSucceeded).toBe(0);
+    expect(counters.pinFailed).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #419 — one-shot Helia config snapshot on FIRST pin failure.
+  // Each subsequent failure must NOT re-emit the snapshot (otherwise it
+  // floods the log just like the bare "Failed to load block" warnings
+  // it's supposed to disambiguate).
+  // -------------------------------------------------------------------------
+
+  it('emits a Helia config snapshot exactly ONCE across many pin failures', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    try {
+      const blockstore = makeBlockstore('ok');
+      const pinsApi = {
+        add(_cid: unknown, _options?: unknown): AsyncIterable<unknown> {
+          return (async function* () {
+            throw new Error('Failed to load block for bafy_descendant');
+             
+            yield _cid;
+          })();
+        },
+      };
+      const helia: HeliaWithPinsLike = {
+        blockstore: blockstore.bs,
+        pins: pinsApi,
+      };
+      installHeliaBlockstorePinShim(helia);
+
+      for (let i = 0; i < 5; i++) {
+        await helia.blockstore!.put!(`bafyDUMP${i}`, new Uint8Array([i]));
+      }
+      await flushAsync();
+
+      // Per-failure warn fires 5×; snapshot fires once.
+      const snapshotLogs = warnSpy.mock.calls.filter((call) => {
+        const msg = call[1];
+        return typeof msg === 'string' && msg.includes('helia config snapshot');
+      });
+      expect(snapshotLogs.length).toBe(1);
+
+      // The snapshot line should mention the structural fields we
+      // promised in the doc-comment: blockstore, pins, libp2p,
+      // peerCount. Failure to include them makes the diagnostic
+      // surface less useful in production triage.
+      const snapshotMsg = snapshotLogs[0][1] as string;
+      expect(snapshotMsg).toMatch(/blockstore=/);
+      expect(snapshotMsg).toMatch(/pins=/);
+      expect(snapshotMsg).toMatch(/libp2p=(present|absent|unknown)/);
+      expect(snapshotMsg).toMatch(/peerCount=/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does NOT emit a config snapshot when "Already pinned" is the only failure surface', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    try {
+      const blockstore = makeBlockstore('ok');
+      const pinsApi = {
+        add(_cid: unknown, _options?: unknown): AsyncIterable<unknown> {
+          return (async function* () {
+            throw new Error('Already pinned');
+             
+            yield _cid;
+          })();
+        },
+      };
+      const helia: HeliaWithPinsLike = {
+        blockstore: blockstore.bs,
+        pins: pinsApi,
+      };
+      installHeliaBlockstorePinShim(helia);
+
+      await helia.blockstore!.put!('bafyDUP', new Uint8Array([1]));
+      await flushAsync();
+
+      const snapshotLogs = warnSpy.mock.calls.filter((call) => {
+        const msg = call[1];
+        return typeof msg === 'string' && msg.includes('helia config snapshot');
+      });
+      // "Already pinned" classifies as success — the failure branch
+      // never runs, and the snapshot stays silent.
+      expect(snapshotLogs.length).toBe(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('reflects an HTTP-only Helia (no libp2p) in the snapshot', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    try {
+      const blockstore = makeBlockstore('ok');
+      const pinsApi = {
+        add(_cid: unknown, _options?: unknown): AsyncIterable<unknown> {
+          return (async function* () {
+            throw new Error('something broke');
+             
+            yield _cid;
+          })();
+        },
+      };
+      // Helia handle WITHOUT a libp2p field — issue #266 HTTP-only mode.
+      const helia: HeliaWithPinsLike = {
+        blockstore: blockstore.bs,
+        pins: pinsApi,
+      };
+      installHeliaBlockstorePinShim(helia);
+
+      await helia.blockstore!.put!('bafyHTTP', new Uint8Array([1]));
+      await flushAsync();
+
+      const snapshotMsg = warnSpy.mock.calls.find((call) => {
+        const msg = call[1];
+        return typeof msg === 'string' && msg.includes('helia config snapshot');
+      })?.[1] as string | undefined;
+      expect(snapshotMsg).toBeTruthy();
+      expect(snapshotMsg!).toMatch(/libp2p=absent/);
+      expect(snapshotMsg!).toMatch(/peerCount=unknown/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('reflects a libp2p-equipped Helia (with peers) in the snapshot', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    try {
+      const blockstore = makeBlockstore('ok');
+      const pinsApi = {
+        add(_cid: unknown, _options?: unknown): AsyncIterable<unknown> {
+          return (async function* () {
+            throw new Error('something broke');
+             
+            yield _cid;
+          })();
+        },
+      };
+      const heliaWithLibp2p = {
+        blockstore: blockstore.bs,
+        pins: pinsApi,
+        libp2p: {
+          getPeers: () => ['peer1', 'peer2', 'peer3'],
+        },
+      };
+      installHeliaBlockstorePinShim(heliaWithLibp2p as unknown as HeliaWithPinsLike);
+
+      await (heliaWithLibp2p.blockstore as { put: (cid: unknown, val: unknown) => Promise<void> })
+        .put('bafyP2P', new Uint8Array([1]));
+      await flushAsync();
+
+      const snapshotMsg = warnSpy.mock.calls.find((call) => {
+        const msg = call[1];
+        return typeof msg === 'string' && msg.includes('helia config snapshot');
+      })?.[1] as string | undefined;
+      expect(snapshotMsg).toBeTruthy();
+      expect(snapshotMsg!).toMatch(/libp2p=present/);
+      expect(snapshotMsg!).toMatch(/peerCount=3/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('treats "Already pinned" from helia.pins.add as success (no warn)', async () => {
     // Custom pins API: throws "Already pinned" — simulates the helia
     // pin-tracker survived state where the in-memory Set was cleared
@@ -236,7 +466,7 @@ describe('installHeliaBlockstorePinShim', () => {
       add(cid: unknown): AsyncIterable<unknown> {
         return (async function* () {
           throw new Error('Already pinned');
-          // eslint-disable-next-line @typescript-eslint/no-unreachable
+           
           yield cid;
         })();
       },


### PR DESCRIPTION
## Summary

Closes #419.

- `helia.pins.add(cid)` defaults to `depth: Infinity`. Helia decodes the pinned block, follows every CID link, and recursively pins descendants. Each descendant load falls through to `blockstore.get(cid)` → Bitswap → `Failed to load block for <child cid>` when neither local nor a peer can serve it.
- The pin shim's contract is *"pin individual blocks at write time"*. Recursive descent contradicts that contract — every OpLog block references its parent; every CAR block written via `putBlockToLocalHelia` (#236) references its children — so the first pin tries to walk the whole chain even though only the current block is guaranteed to be local.
- Result on the #419 testnet repro: floods of `[ProfilePinShim] helia.pins.add failed for X: Failed to load block for Y` warnings where X ≠ Y (because Y is a descendant of X). See `tests/e2e/profile-sync.test.ts` → `ProfileTokenStorageProvider pins real tokens to a CAR and recovers them on a fresh load`.

This PR:
1. Passes `{ depth: 0 }` to `pinsApi.add(cid, …)` so each pin is a leaf — matches the shim's contract. The DAG remains fully pinned across calls because every block is the subject of its own `put` (and pin).
2. Captures a one-shot Helia config snapshot (`blockstore=… pins=… libp2p=… peerCount=…`) at install time and emits it lazily on the first non-"Already pinned" failure. Operators triaging a pin-failure burst now get a single diagnostic line that distinguishes HTTP-only Helia (#266) from an isolated libp2p node from a test stub.
3. Extends `tests/unit/profile/helia-blockstore-pin-shim.test.ts` with 5 new cases covering both behaviours.

## Test plan

- [x] `npx vitest run tests/unit/profile/helia-blockstore-pin-shim.test.ts` — 19/19 pass.
- [x] `npx vitest run tests/unit/profile/` — 2346/2346 pass.
- [x] Full `npx vitest run` — 8935 pass, 16 skipped, 551 files.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint profile/helia-blockstore-pin-shim.ts tests/unit/profile/helia-blockstore-pin-shim.test.ts` — clean.
- [ ] Soak: re-run `tests/e2e/profile-sync.test.ts → ProfileTokenStorageProvider pins real tokens…` against real testnet to confirm the pin-warning floods disappear. *Requires `npm run test:e2e` infra; see #419 reproduction steps.*

## Out of scope

- The triage in #419 lists 3 candidate causes. This PR addresses the primary cause (recursive pin walks); the gateway-lag and verify-gate paths (#234 / #268) are unchanged.
- The actual cross-device 0-token recovery surface (the test's `toBeGreaterThanOrEqual(MIN_CONFIRMED)` assertion) depends on HTTP-pin durability + aggregator pointer fetch, not on this shim. If the pin-warning storm was the test's only signal noise, the soak should pass now; if a deeper HTTP propagation issue remains, the new one-shot snapshot will help triage it.

## Related

- sphere-sdk #234, #239, #240 — Helia v6 + FsBlockstore + per-flush shutdown gate
- sphere-sdk #266 — HTTP-only IPFS default
- sphere-sdk #268 — flush-durability verify gate
- sphere-sdk #311 — original pin-shim landed