### PR TITLE
Track A: audit fixes — inject v2 engine on all address paths

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -445,6 +445,8 @@ export interface AddressModuleSet {
   market: MarketModule | null;
   transportAdapter: AddressTransportAdapter | null;
   tokenStorageProviders: Map<string, TokenStorageProvider<TxfStorageDataBase>>;
+  /** v2 token engine for THIS address (bound to its signing key). */
+  tokenEngine: ITokenEngine | undefined;
   initialized: boolean;
 }
 
@@ -2294,7 +2296,8 @@ export class Sphere {
         moduleSet.identity = newIdentity;
         // Use per-address transport if available
         const addressTransport: TransportProvider = moduleSet.transportAdapter ?? this._transport;
-        // Re-initialize with updated identity (nametag change)
+        // Re-initialize with updated identity (nametag change). The signing key is
+        // unchanged (only the nametag label), so reuse this address's token engine.
         moduleSet.payments.initialize({
           identity: newIdentity,
           storage: this._storage,
@@ -2304,6 +2307,7 @@ export class Sphere {
           emitEvent: this.emitEvent.bind(this),
           chainCode: this._masterKey?.chainCode || undefined,
           price: this._priceProvider ?? undefined,
+          tokenEngine: moduleSet.tokenEngine,
         });
       }
     }
@@ -2425,6 +2429,9 @@ export class Sphere {
     const groupChat = this._groupChatConfig ? createGroupChatModule(this._groupChatConfig) : null;
     const market = this._marketConfig ? createMarketModule(this._marketConfig) : null;
 
+    // v2 token engine for THIS address (bound to its signing key).
+    const tokenEngine = await this.buildTokenEngine(identity);
+
     // Initialize with address-specific identity and per-address transport
     payments.initialize({
       identity,
@@ -2435,6 +2442,7 @@ export class Sphere {
       emitEvent,
       chainCode: this._masterKey?.chainCode || undefined,
       price: this._priceProvider ?? undefined,
+      tokenEngine,
     });
 
     communications.initialize({
@@ -2478,6 +2486,7 @@ export class Sphere {
           on: this.on.bind(this),
           storage: this._storage,
           communications,
+          tokenEngine,
         });
       } else {
         logger.warn('Sphere', 'Accounting module enabled but no token storage available — disabling');
@@ -2543,6 +2552,7 @@ export class Sphere {
       market,
       transportAdapter: adapter,
       tokenStorageProviders: new Map(tokenStorageProviders),
+      tokenEngine,
       initialized: true,
     };
 
@@ -4193,22 +4203,24 @@ export class Sphere {
   }
 
   /**
-   * Construct the v2 token engine for the active address from the oracle's gateway
-   * URL + trust base and this address's signing key. The trust base is the single
-   * source of truth for the network id (so any id works — e.g. testnet2 = 4 — with
-   * no enum entry). Returns undefined (modules keep their legacy path) when the
-   * oracle can't supply a trust base / url, or construction fails — a misconfigured
-   * oracle never breaks initialization.
+   * Construct the v2 token engine for a given address identity (defaults to the
+   * active one) from the oracle's gateway URL + trust base and that address's
+   * signing key. The engine is per-address — each address signs with its own key.
+   * The trust base is the single source of truth for the network id (so any id
+   * works — e.g. testnet2 = 4 — with no enum entry). Returns undefined (modules
+   * keep their legacy path) when the oracle can't supply a trust base / url, or
+   * construction fails — a misconfigured oracle never breaks initialization.
    */
-  private async buildTokenEngine(): Promise<ITokenEngine | undefined> {
+  private async buildTokenEngine(identity?: FullIdentity): Promise<ITokenEngine | undefined> {
     const oracle = this._oracle as {
       getTrustBaseJson?: () => unknown;
       getAggregatorUrl?: () => string;
       getApiKey?: () => string | undefined;
     };
+    const privateKey = (identity ?? this._identity)?.privateKey;
     const trustBaseJson = oracle.getTrustBaseJson?.() ?? null;
     const aggregatorUrl = oracle.getAggregatorUrl?.();
-    if (!trustBaseJson || !aggregatorUrl || !this._identity?.privateKey) {
+    if (!trustBaseJson || !aggregatorUrl || !privateKey) {
       logger.warn('Sphere', 'v2 token engine not constructed (oracle has no trust base / url, or no identity) — legacy path');
       return undefined;
     }
@@ -4216,7 +4228,7 @@ export class Sphere {
       return await createSphereTokenEngine({
         aggregatorUrl,
         apiKey: oracle.getApiKey?.(),
-        privateKey: hexToBytes(this._identity.privateKey),
+        privateKey: hexToBytes(privateKey),
         trustBaseJson,
       });
     } catch (err) {
@@ -4364,6 +4376,7 @@ export class Sphere {
       market: this._market,
       transportAdapter: adapter,
       tokenStorageProviders: new Map(this._tokenStorageProviders),
+      tokenEngine: this._tokenEngine,
       initialized: true,
     });
   }

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -16,7 +16,6 @@ import { SphereError } from '../core/errors';
 import { deriveDirectAddress } from './identity';
 import {
   CborDeserializer,
-  CborSerializer,
   CertificationData,
   CertificationStatus,
   EncodedPredicate,
@@ -156,9 +155,7 @@ export class SphereTokenEngine implements ITokenEngine {
     const recipient = SignaturePredicate.create(params.recipientPubkey);
     const tokenType = params.tokenType ? new TokenType(params.tokenType) : TokenType.generate();
     // A deterministic salt yields a stable, terms-derived tokenId (TokenId.fromSalt).
-    const salt = params.salt
-      ? TokenSalt.fromCBOR(CborSerializer.encodeByteString(params.salt))
-      : TokenSalt.generate();
+    const salt = params.salt ? TokenSalt.fromBytes(params.salt) : TokenSalt.generate();
 
     const mintTx = await MintTransaction.create(this.deps.networkId, recipient, params.data, tokenType, salt);
     const certificationData = await CertificationData.fromMintTransaction(mintTx);

--- a/token-engine/token-blob.ts
+++ b/token-engine/token-blob.ts
@@ -1,11 +1,12 @@
 /**
  * token-engine/token-blob.ts — storage/transport codec for a wallet token.
  *
- * A {@link TokenBlob} is `{ v, network, token }` where `token` is the v2
- * `Token.toCBOR()` bytes. This codec wraps it in a sphere-private CBOR envelope
- * so the wallet's own storage format can version independently of the SDK's
- * token CBOR. The decoded value is re-derivable from `token`, so it is NOT
- * stored here.
+ * A {@link TokenBlob} is `{ v, network, tokenId, token }` where `token` is the v2
+ * `Token.toCBOR()` bytes and `tokenId` is the genesis-stable id (stored so dedup /
+ * listing / tombstone keys need no engine call). This codec wraps it in a
+ * sphere-private CBOR envelope so the wallet's own storage format can version
+ * independently of the SDK's token CBOR. The decoded value is re-derivable from
+ * `token`, so it is NOT stored here.
  */
 
 import { CborDeserializer, CborError, CborSerializer } from './sdk';
@@ -16,7 +17,7 @@ const TOKEN_BLOB_TAG = 39051n;
 /** Current blob envelope version. */
 export const TOKEN_BLOB_VERSION = 1;
 
-/** Encode a blob as `tag(39051)[ v, network, token ]`. */
+/** Encode a blob as `tag(39051)[ v, network, tokenId, token ]`. */
 export function encodeTokenBlob(blob: TokenBlob): Uint8Array {
   return CborSerializer.encodeTag(
     TOKEN_BLOB_TAG,


### PR DESCRIPTION
Fixes from the migration audit. **Main (HIGH):** A4-int injected the token engine only in initializeModules (primary address) — secondary addresses + nametag changes silently fell back to v1. Now the engine is built per-address (its own signing key) and injected in initializeAddressModules (Payments+Accounting) + the nametag re-init + recorded on AddressModuleSet. **Low:** mintDataToken uses TokenSalt.fromBytes (byte-identical, cleaner); token-blob JSDoc corrected to 4-field envelope. Engine core unchanged (audit verified it correct). tsc + eslint clean; token-engine 76 + modules 1293 green. Integration EPERM under parallel load is pre-existing Windows file-rename flakiness, upstream of this change.