### PR TITLE
fix(sphere-sdk)(#423): gate Nostr subscription on handler readiness

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -7645,6 +7645,50 @@ export class Sphere {
         `Failed to wire connectivity gate into PaymentsModule (sends will not gate on OFFLINE): ${safeErrorMessage(err)}`,
       );
     }
+
+    // Issue #423 — arm the Nostr transport's subscription gate now that all
+    // modules have registered their handlers (either directly on the outer
+    // provider in the non-mux path, or on the MultiAddressTransportMux's
+    // per-address adapter in the mux path).
+    //
+    // Pre-#423: `transport.connect()` opened the relay subscription inline,
+    // BEFORE PaymentsModule / CommunicationsModule / AccountingModule /
+    // SwapModule registered their `onTokenTransfer` / `onMessage` /
+    // `onPaymentRequest` / `onPaymentRequestResponse` handlers. In the mux
+    // path the outer provider never gets handlers at all (they live on the
+    // mux adapter), so the outer subscription would route every TOKEN_TRANSFER
+    // through the defensive `pendingTransfers` buffer and pin `lastEventTs`
+    // — surfacing as the persistent `[AT-LEAST-ONCE] TOKEN_TRANSFER ... not
+    // durable` warn storm in soak logs.
+    //
+    // For the mux path: `ensureTransportMux()` already called
+    // `suppressSubscriptions()` on the outer provider, so the `armSubscriptions`
+    // call below is a no-op (the gate short-circuits when suppressed). The
+    // mux owns event routing and is independent.
+    //
+    // For the non-mux path: this is where the outer provider's subscription
+    // actually opens. Idempotent — safe to re-call across `initializeModules`
+    // re-runs (the gate is sticky).
+    //
+    // Duck-typed: legacy/test transports may not expose `armSubscriptions`.
+    // No-op in that case — those transports never had the gated behavior.
+    try {
+      const transportWithArm = this._transport as unknown as {
+        armSubscriptions?: () => Promise<void>;
+      };
+      if (typeof transportWithArm.armSubscriptions === 'function') {
+        await transportWithArm.armSubscriptions();
+      }
+    } catch (err) {
+      // Non-fatal — if arming throws (e.g., transient relay error during the
+      // first subscribe), the auto-arm fallback inside the next `on*` handler
+      // registration still covers us. Better to log and continue than to
+      // brick init.
+      logger.warn(
+        'Sphere',
+        `[#423] armSubscriptions failed (continuing — auto-arm fallback will retry): ${safeErrorMessage(err)}`,
+      );
+    }
   }
 
   /**

--- a/tests/unit/transport/NostrTransportProvider.chatReady.test.ts
+++ b/tests/unit/transport/NostrTransportProvider.chatReady.test.ts
@@ -127,6 +127,8 @@ describe('NostrTransportProvider — onChatReady()', () => {
     // Connect + setIdentity triggers subscribeToEvents internally
     await provider.connect();
     await provider.setIdentity(TEST_IDENTITY);
+    // Issue #423 — arm the gate so subscribeToEvents() runs in test setup
+    await provider.armSubscriptions();
 
     // Verify subscriptions were created
     expect(subscribeCalls.length).toBeGreaterThan(0);
@@ -146,6 +148,8 @@ describe('NostrTransportProvider — onChatReady()', () => {
     // Connect and trigger EOSE
     await provider.connect();
     await provider.setIdentity(TEST_IDENTITY);
+    // Issue #423 — arm the gate so subscribeToEvents() runs in test setup
+    await provider.armSubscriptions();
     triggerChatEose();
 
     // Late handler — should fire immediately since EOSE already happened
@@ -164,6 +168,8 @@ describe('NostrTransportProvider — onChatReady()', () => {
 
     await provider.connect();
     await provider.setIdentity(TEST_IDENTITY);
+    // Issue #423 — arm the gate so subscribeToEvents() runs in test setup
+    await provider.armSubscriptions();
     triggerChatEose();
 
     expect(handler1).toHaveBeenCalledTimes(1);
@@ -175,6 +181,8 @@ describe('NostrTransportProvider — onChatReady()', () => {
 
     await provider.connect();
     await provider.setIdentity(TEST_IDENTITY);
+    // Issue #423 — arm the gate so subscribeToEvents() runs in test setup
+    await provider.armSubscriptions();
     triggerChatEose();
 
     // Verify late handler fires immediately
@@ -201,6 +209,8 @@ describe('NostrTransportProvider — onChatReady()', () => {
 
     await provider.connect();
     await provider.setIdentity(TEST_IDENTITY);
+    // Issue #423 — arm the gate so subscribeToEvents() runs in test setup
+    await provider.armSubscriptions();
 
     expect(() => triggerChatEose()).not.toThrow();
     expect(goodHandler).toHaveBeenCalledTimes(1);
@@ -214,6 +224,8 @@ describe('NostrTransportProvider — onChatReady()', () => {
 
     await provider.connect();
     await provider.setIdentity(TEST_IDENTITY);
+    // Issue #423 — arm the gate so subscribeToEvents() runs in test setup
+    await provider.armSubscriptions();
 
     triggerChatEose();
     triggerChatEose(); // Second EOSE — no-op
@@ -226,6 +238,8 @@ describe('NostrTransportProvider — onChatReady()', () => {
 
     await provider.connect();
     await provider.setIdentity(TEST_IDENTITY);
+    // Issue #423 — arm the gate so subscribeToEvents() runs in test setup
+    await provider.armSubscriptions();
     triggerChatEose();
 
     const handler = vi.fn();

--- a/tests/unit/transport/NostrTransportProvider.subscribeGate423.test.ts
+++ b/tests/unit/transport/NostrTransportProvider.subscribeGate423.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Issue #423 — Nostr subscription handler-readiness gate
+ *
+ * Pre-#423: `transport.connect()` (and `setIdentity()` when already
+ * connected) called `subscribeToEvents()` inline, opening the relay
+ * subscription BEFORE any caller registered handlers. In the mux path
+ * the outer NostrTransportProvider never gets handlers attached (they
+ * live on the `AddressTransportAdapter` instead), so the outer
+ * subscription would route every TOKEN_TRANSFER through the defensive
+ * `pendingTransfers` buffer and pin `lastEventTs` — surfacing as the
+ * persistent `[AT-LEAST-ONCE] TOKEN_TRANSFER ... not durable` warn
+ * storm.
+ *
+ * Fix: defer `subscribeToEvents()` until ARMED. Two arming surfaces:
+ *   1. Explicit `armSubscriptions()` — Sphere bootstrap uses this after
+ *      every module's `initialize()` has registered its handlers.
+ *   2. First `on*` handler registration — backward-compat for consumers
+ *      that don't know about the explicit API.
+ *
+ * These tests exercise the public surface:
+ *   - `connect()` does NOT subscribe before arming.
+ *   - `armSubscriptions()` opens the subscription exactly once.
+ *   - Idempotent re-arm is a no-op.
+ *   - Reconnect after disconnect re-subscribes because the gate stays
+ *     sticky.
+ *   - Suppression (mux takeover) defeats arming (no relay sub opens).
+ *   - Auto-arm-on-handler-register opens the sub for direct consumers.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { WebSocketFactory } from '../../../transport/websocket';
+import type { FullIdentity } from '../../../types';
+
+// =============================================================================
+// Mock NostrClient — record every subscribe() call so we can count them.
+// =============================================================================
+
+const mockSubscribe = vi.fn().mockReturnValue('mock-sub-id');
+const mockUnsubscribe = vi.fn();
+const mockPublishEvent = vi.fn().mockResolvedValue('mock-event-id');
+const mockConnect = vi.fn().mockResolvedValue(undefined);
+const mockDisconnect = vi.fn();
+const mockIsConnected = vi.fn().mockReturnValue(true);
+const mockGetConnectedRelays = vi
+  .fn()
+  .mockReturnValue(new Set(['wss://relay.test']));
+const mockAddConnectionListener = vi.fn();
+const mockRelaysMap = new Map<string, unknown>();
+const mockStopPingTimer = vi.fn();
+
+vi.mock('@unicitylabs/nostr-js-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/nostr-js-sdk')>();
+  return {
+    ...actual,
+    NostrClient: vi.fn().mockImplementation(() => ({
+      connect: mockConnect,
+      disconnect: mockDisconnect,
+      isConnected: mockIsConnected,
+      getConnectedRelays: mockGetConnectedRelays,
+      subscribe: mockSubscribe,
+      unsubscribe: mockUnsubscribe,
+      publishEvent: mockPublishEvent,
+      addConnectionListener: mockAddConnectionListener,
+      relays: mockRelaysMap,
+      stopPingTimer: mockStopPingTimer,
+    })),
+  };
+});
+
+const { NostrTransportProvider } = await import(
+  '../../../transport/NostrTransportProvider'
+);
+
+// =============================================================================
+// Test setup
+// =============================================================================
+
+// Real-looking 64-hex private key — strictHexToBytes is strict, so the stub
+// identity must use valid hex. The key derives a deterministic nostr pubkey
+// which subscribe() embeds in the filter; we don't assert the value, only
+// the call count and the fact that subscribe() WAS called.
+const STUB_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'ab'.repeat(32),
+  l1Address: 'alpha1stub',
+  directAddress: 'DIRECT://stub',
+  privateKey: 'cd'.repeat(32),
+};
+
+function createProvider() {
+  return new NostrTransportProvider({
+    relays: ['wss://relay.test'],
+    createWebSocket: (() => {}) as unknown as WebSocketFactory,
+    timeout: 100,
+    autoReconnect: false,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsConnected.mockReturnValue(true);
+  mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay.test']));
+  // Each subscribe() call gets a unique ID so the unsubscribe-on-rearm
+  // logic in subscribeToEvents (clearing prior IDs) does the right thing.
+  let counter = 0;
+  mockSubscribe.mockImplementation(() => `mock-sub-${counter++}`);
+});
+
+// =============================================================================
+// Gate behavior
+// =============================================================================
+
+describe('NostrTransportProvider — handler-readiness subscription gate (#423)', () => {
+  it('does NOT subscribe to relay events on connect() until armed', async () => {
+    const provider = createProvider();
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+
+    // Pre-#423 this would be 2 (wallet + chat subscriptions). With the gate
+    // closed, subscribe() must NOT have been called.
+    expect(mockSubscribe).not.toHaveBeenCalled();
+    expect(provider.isSubscriptionsArmed()).toBe(false);
+  });
+
+  it('armSubscriptions() opens the relay subscription exactly once', async () => {
+    const provider = createProvider();
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+    expect(mockSubscribe).not.toHaveBeenCalled();
+
+    await provider.armSubscriptions();
+    // subscribeToEvents() creates two subscriptions: wallet + chat.
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+    expect(provider.isSubscriptionsArmed()).toBe(true);
+  });
+
+  it('armSubscriptions() is idempotent — re-arming is a no-op', async () => {
+    const provider = createProvider();
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+    await provider.armSubscriptions();
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+
+    await provider.armSubscriptions();
+    await provider.armSubscriptions();
+    // No further subscribe calls — the gate is sticky.
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('armSubscriptions() before connect() defers subscribe until connect() runs', async () => {
+    const provider = createProvider();
+    await provider.armSubscriptions();
+    // No connection yet — nothing to subscribe to.
+    expect(mockSubscribe).not.toHaveBeenCalled();
+    expect(provider.isSubscriptionsArmed()).toBe(true);
+
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+    // Now that we're connected AND armed, subscribe runs.
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('registering onTokenTransfer auto-arms the gate', async () => {
+    const provider = createProvider();
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+    expect(mockSubscribe).not.toHaveBeenCalled();
+    expect(provider.isSubscriptionsArmed()).toBe(false);
+
+    const unsubscribe = provider.onTokenTransfer(async () => true);
+    // Auto-arm fires immediately; subscribe is fire-and-forget so yield.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(provider.isSubscriptionsArmed()).toBe(true);
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it('registering onMessage auto-arms the gate', async () => {
+    const provider = createProvider();
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+
+    const unsubscribe = provider.onMessage(() => undefined);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(provider.isSubscriptionsArmed()).toBe(true);
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it('registering onPaymentRequest auto-arms the gate', async () => {
+    const provider = createProvider();
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+
+    const unsubscribe = provider.onPaymentRequest(() => undefined);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(provider.isSubscriptionsArmed()).toBe(true);
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it('registering onPaymentRequestResponse auto-arms the gate', async () => {
+    const provider = createProvider();
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+
+    const unsubscribe = provider.onPaymentRequestResponse(() => undefined);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(provider.isSubscriptionsArmed()).toBe(true);
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it('multiple handler registrations only subscribe once', async () => {
+    const provider = createProvider();
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+
+    provider.onTokenTransfer(async () => true);
+    provider.onMessage(() => undefined);
+    provider.onPaymentRequest(() => undefined);
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Still exactly 2 subscriptions (wallet + chat). The gate is sticky.
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('suppressSubscriptions() defeats arming — no subscribe opens', async () => {
+    const provider = createProvider();
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+    // Mux scenario: suppress BEFORE handlers register.
+    provider.suppressSubscriptions();
+
+    // Even an explicit arm + handler registration must not open a sub.
+    await provider.armSubscriptions();
+    provider.onTokenTransfer(async () => true);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Reconnect interaction
+// =============================================================================
+
+describe('NostrTransportProvider — gate + reconnect (#423)', () => {
+  it('reconnect after disconnect re-subscribes because gate is sticky', async () => {
+    const provider = createProvider();
+    await provider.setIdentity(STUB_IDENTITY);
+    await provider.connect();
+    await provider.armSubscriptions();
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+
+    // Disconnect — clears subscription IDs but the arm flag is sticky.
+    await provider.disconnect();
+    // Sticky: the gate state survives a disconnect/reconnect cycle.
+    expect(provider.isSubscriptionsArmed()).toBe(true);
+
+    // Reconnect → subscribeToEvents runs again because still armed.
+    await provider.connect();
+    // 2 from initial connect, 2 from reconnect = 4.
+    expect(mockSubscribe).toHaveBeenCalledTimes(4);
+  });
+});

--- a/tests/unit/transport/NostrTransportProvider.test.ts
+++ b/tests/unit/transport/NostrTransportProvider.test.ts
@@ -104,6 +104,8 @@ describe('NostrTransportProvider', () => {
       mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay1.test', 'wss://relay2.test']));
       const provider = createProvider(['wss://relay1.test', 'wss://relay2.test']);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
 
       const connected = provider.getConnectedRelays();
       expect(connected).toContain('wss://relay1.test');
@@ -115,6 +117,8 @@ describe('NostrTransportProvider', () => {
       mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay1.test']));
       const provider = createProvider(['wss://relay1.test', 'wss://relay2.test']);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
 
       const connected = provider.getConnectedRelays();
       expect(connected).toContain('wss://relay1.test');
@@ -144,6 +148,8 @@ describe('NostrTransportProvider', () => {
       mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay1.test']));
       const provider = createProvider(['wss://relay1.test']);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       expect(provider.isRelayConnected('wss://relay1.test')).toBe(true);
     });
 
@@ -151,6 +157,8 @@ describe('NostrTransportProvider', () => {
       mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay2.test']));
       const provider = createProvider(['wss://relay1.test', 'wss://relay2.test']);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       expect(provider.isRelayConnected('wss://relay1.test')).toBe(false);
       expect(provider.isRelayConnected('wss://relay2.test')).toBe(true);
     });
@@ -173,6 +181,8 @@ describe('NostrTransportProvider', () => {
       mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay1.test', 'wss://relay2.test']));
       const provider = createProvider(['wss://relay1.test']);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
 
       const result = await provider.addRelay('wss://relay2.test');
       expect(result).toBe(true);
@@ -183,6 +193,8 @@ describe('NostrTransportProvider', () => {
       mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay1.test']));
       const provider = createProvider(['wss://relay1.test']);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
 
       // Mock connect failure for the new relay
       mockConnect.mockRejectedValueOnce(new Error('Connection failed'));
@@ -211,6 +223,8 @@ describe('NostrTransportProvider', () => {
       mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay1.test', 'wss://relay2.test']));
       const provider = createProvider(['wss://relay1.test', 'wss://relay2.test']);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
 
       expect(provider.isRelayConnected('wss://relay2.test')).toBe(true);
 
@@ -226,6 +240,8 @@ describe('NostrTransportProvider', () => {
       mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay1.test']));
       const provider = createProvider(['wss://relay1.test']);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
 
       // After removing, mock that no relays are connected
       mockIsConnected.mockReturnValue(false);
@@ -248,6 +264,8 @@ describe('NostrTransportProvider', () => {
     it('stops application-level ping timers on every relay', async () => {
       const provider = createProvider(['wss://relay1.test', 'wss://relay2.test']);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       // Pre-flight: provider should not have called stopPingTimer at connect time.
       expect(mockStopPingTimer).not.toHaveBeenCalled();
 
@@ -297,6 +315,10 @@ describe('Reconnect re-subscription', () => {
 
     await provider.connect();
 
+    // Issue #423 — auto-arm to preserve pre-gate test semantics
+
+    await provider.armSubscriptions();
+
     // Capture the connection listener registered during connect()
     expect(mockAddConnectionListener).toHaveBeenCalled();
     const listener = mockAddConnectionListener.mock.calls[0][0];
@@ -318,6 +340,8 @@ describe('Reconnect re-subscription', () => {
 
     // Connect without identity
     await provider.connect();
+    // Issue #423 — auto-arm to preserve pre-gate test semantics
+    await provider.armSubscriptions();
 
     const listener = mockAddConnectionListener.mock.calls[0][0];
 
@@ -422,6 +446,10 @@ describe('Event subscription pubkey format', () => {
 
     await provider.connect();
 
+    // Issue #423 — auto-arm to preserve pre-gate test semantics
+
+    await provider.armSubscriptions();
+
     // Wait for subscription to be sent
     await new Promise(resolve => setTimeout(resolve, 50));
 
@@ -459,6 +487,10 @@ describe('Event subscription pubkey format', () => {
     });
 
     await provider.connect();
+
+    // Issue #423 — auto-arm to preserve pre-gate test semantics
+
+    await provider.armSubscriptions();
     await new Promise(resolve => setTimeout(resolve, 50));
 
     // Should create two subscriptions: wallet and chat
@@ -617,6 +649,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       expect(mockSubscribe).toHaveBeenCalled();
@@ -635,6 +669,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       expect(mockSubscribe).toHaveBeenCalled();
@@ -655,6 +691,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       expect(mockSubscribe).toHaveBeenCalled();
@@ -670,6 +708,8 @@ describe('Last event timestamp persistence', () => {
 
       const now = Math.floor(Date.now() / 1000);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       expect(mockSubscribe).toHaveBeenCalled();
@@ -694,6 +734,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Two subscriptions: wallet and DM (chat)
@@ -715,6 +757,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Four reads: persistent dedup events (#275) + persistent cooldowns (#275)
@@ -742,6 +786,8 @@ describe('Last event timestamp persistence', () => {
       provider.setFallbackSince(fallbackTs);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       expect(mockSubscribe).toHaveBeenCalled();
@@ -761,6 +807,8 @@ describe('Last event timestamp persistence', () => {
       provider.setFallbackSince(1690000000); // Earlier than stored
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       expect(mockSubscribe).toHaveBeenCalled();
@@ -780,6 +828,8 @@ describe('Last event timestamp persistence', () => {
       provider.setFallbackSince(fallbackTs);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // First subscription should use fallback
@@ -810,6 +860,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Reset mock to only track calls from handleEvent
@@ -850,6 +902,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       mockStorage.set.mockClear();
@@ -880,6 +934,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       mockStorage.set.mockClear();
@@ -912,6 +968,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       mockStorage.set.mockClear();
@@ -953,6 +1011,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       mockStorage.get.mockClear();
@@ -986,6 +1046,8 @@ describe('Last event timestamp persistence', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       mockStorage.set.mockClear();
@@ -1056,6 +1118,8 @@ describe('Issue #275 — persistent dedup', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Fire one of the hydrated event IDs through the handler
@@ -1099,6 +1163,8 @@ describe('Issue #275 — persistent dedup', () => {
       setIdentity(provider);
       // Should not throw — corrupt data degrades to "start fresh".
       await expect(provider.connect()).resolves.toBeUndefined();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
       expect(mockSubscribe).toHaveBeenCalled();
     });
@@ -1117,6 +1183,8 @@ describe('Issue #275 — persistent dedup', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await expect(provider.connect()).resolves.toBeUndefined();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Subsequent event with same id should be processed (not deduped).
@@ -1155,6 +1223,8 @@ describe('Issue #275 — persistent dedup', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Direct map inspection — the cooldown should have been hydrated
@@ -1192,6 +1262,8 @@ describe('Issue #275 — persistent dedup', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Inspect the private field to verify the drop happened.
@@ -1214,6 +1286,8 @@ describe('Issue #275 — persistent dedup', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       mockStorage.set.mockClear();
@@ -1250,6 +1324,8 @@ describe('Issue #275 — persistent dedup', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       mockStorage.set.mockClear();
@@ -1290,6 +1366,8 @@ describe('Issue #275 — persistent dedup', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
       mockStorage.set.mockClear();
 
@@ -1319,6 +1397,8 @@ describe('Issue #275 — persistent dedup', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Pre-populate the set to exactly the cap by reaching into the
@@ -1351,6 +1431,8 @@ describe('Issue #275 — persistent dedup', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       const callbacks = mockSubscribe.mock.calls[0][1];
@@ -1389,6 +1471,8 @@ describe('Issue #275 — persistent dedup', () => {
       const provider = createProviderWithStorage(mockStorage);
       setIdentity(provider);
       await provider.connect();
+      // Issue #423 — auto-arm to preserve pre-gate test semantics
+      await provider.armSubscriptions();
       await new Promise(resolve => setTimeout(resolve, 50));
 
       const callbacks = mockSubscribe.mock.calls[0][1];

--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -366,6 +366,44 @@ export class NostrTransportProvider implements TransportProvider {
   // Flag to prevent re-subscription after suppressSubscriptions()
   private _subscriptionsSuppressed = false;
 
+  // ---------------------------------------------------------------------------
+  // Issue #423 — handler-readiness gate
+  //
+  // Pre-#423: connect()/setIdentity() called subscribeToEvents() inline, opening
+  // the relay subscription BEFORE any caller had registered handlers via
+  // onTokenTransfer/onMessage/etc. When Sphere uses the MultiAddressTransportMux
+  // path, handlers are registered on the MUX ADAPTER, not on this outer
+  // provider — so the outer subscription would fire TOKEN_TRANSFER events at
+  // an empty handler set, route them through the defensive `pendingTransfers`
+  // buffer, and pin `lastEventTs` (issues #223 / #247). That produced the
+  // "[AT-LEAST-ONCE] TOKEN_TRANSFER ... not durable" warn storm in soak logs.
+  //
+  // Fix: defer subscribeToEvents() until ARMED. Three ways to arm:
+  //   1. Explicit `armSubscriptions()` call — Sphere uses this after wiring
+  //      all modules (the bootstrap-time path).
+  //   2. First `on*` handler registration — backward compatibility for
+  //      consumers that register handlers directly on this provider (the
+  //      non-mux path) without knowing about the gate.
+  //   3. `suppressSubscriptions()` — mux is taking over; the gate becomes
+  //      irrelevant because we won't subscribe anyway.
+  //
+  // `pendingArm` records that connect/setIdentity wanted to subscribe but the
+  // gate was closed. When the gate opens (via #1 or #2), we drain the pending
+  // arm. Reconnect-after-disconnect re-checks armed state so a relay reconnect
+  // before arming does not bypass the gate. The state is "sticky": once armed,
+  // re-arming is a no-op and subscriptions stay live for the rest of the
+  // session.
+  //
+  // The `pendingTransfers` buffer (around line 2298) becomes effectively dead
+  // code in the common Sphere paths now — events can no longer arrive before
+  // a handler is wired. It is kept as defense-in-depth and STILL warns at the
+  // `[AT-LEAST-ONCE] not durable` site, because if it ever fires post-#423,
+  // something genuinely unexpected is happening (e.g., a backfill burst that
+  // outraces the handler-attach sequence) and an operator should see it.
+  // ---------------------------------------------------------------------------
+  private subscriptionsArmed = false;
+  private pendingArm = false;
+
   // ===========================================================================
   // BaseProvider Implementation
   // ===========================================================================
@@ -428,7 +466,11 @@ export class NostrTransportProvider implements TransportProvider {
           logger.debug('Nostr', 'NostrClient reconnected to relay:', url);
           this.emitEvent({ type: 'transport:connected', timestamp: Date.now() });
           // Re-establish subscriptions — the relay drops them on disconnect.
-          this.subscribeToEvents().catch((err) => {
+          // Issue #423: gated on the readiness arm. If the original session
+          // was never armed (e.g., mux took over before any direct handler
+          // registered), the re-subscribe path is a no-op until something
+          // arms us. Once armed, reconnects re-subscribe automatically.
+          this.maybeSubscribe().catch((err) => {
             logger.error('Nostr', 'Failed to re-subscribe after reconnect:', err);
           });
           // The reconnected socket starts a fresh ping timer; under
@@ -458,9 +500,15 @@ export class NostrTransportProvider implements TransportProvider {
       this.emitEvent({ type: 'transport:connected', timestamp: Date.now() });
       logger.debug('Nostr', 'Connected to', this.nostrClient.getConnectedRelays().size, 'relays');
 
-      // Set up subscriptions
+      // Set up subscriptions — gated on the handler-readiness arm (#423).
+      // When the gate is closed, record `pendingArm` so `armSubscriptions()`
+      // can drain it once handlers are wired. Without the gate, a relay event
+      // could land before any consumer registered a handler (the pre-Mux race
+      // in the Sphere bootstrap), and the outer transport would route through
+      // the `pendingTransfers` defensive buffer, emit the "not durable" warn,
+      // and pin `lastEventTs`.
       if (this.identity) {
-        await this.subscribeToEvents();
+        await this.maybeSubscribe();
       }
     } catch (error) {
       this.status = 'error';
@@ -700,7 +748,12 @@ export class NostrTransportProvider implements TransportProvider {
           )), this.config.timeout)
         ),
       ]);
-      await this.subscribeToEvents();
+      // Issue #423 — gate on handler-readiness arm. The previous identity may
+      // have armed subscriptions already, in which case `maybeSubscribe()`
+      // proceeds. Otherwise it records `pendingArm` so the next arming call
+      // (`armSubscriptions()` or first handler registration) opens the
+      // subscription against the new identity.
+      await this.maybeSubscribe();
       // The fresh NostrClient started its own ping timers on connect.
       // If subscriptions were suppressed (mux owns event routing), the
       // bare client should not ping — see suppressSubscriptions() docstring.
@@ -709,8 +762,8 @@ export class NostrTransportProvider implements TransportProvider {
       }
       oldClient.disconnect();
     } else if (this.isConnected()) {
-      // Already connected with right key, just subscribe
-      await this.subscribeToEvents();
+      // Already connected with right key, just subscribe (gated; #423).
+      await this.maybeSubscribe();
     }
   }
 
@@ -778,6 +831,10 @@ export class NostrTransportProvider implements TransportProvider {
 
   onMessage(handler: MessageHandler): () => void {
     this.messageHandlers.add(handler);
+    // Issue #423 — auto-arm the readiness gate so the relay subscription
+    // opens once a handler exists (backward compat for consumers that
+    // don't call `armSubscriptions()` explicitly).
+    this.autoArmOnHandlerRegistration();
 
     // Flush any messages that arrived before this handler was registered
     if (this.pendingMessages.length > 0) {
@@ -859,13 +916,22 @@ export class NostrTransportProvider implements TransportProvider {
 
   onTokenTransfer(handler: TokenTransferHandler): () => void {
     this.transferHandlers.add(handler);
+    // Issue #423 — auto-arm the readiness gate. Subscription opens here
+    // for direct-on-outer-provider consumers; for the mux path the gate
+    // is suppressed and no subscription opens on the outer provider.
+    this.autoArmOnHandlerRegistration();
 
     // Issue #247 — drain any TOKEN_TRANSFER events that arrived BEFORE
-    // this handler was registered (the pre-Mux window race documented
-    // in `handleTokenTransfer`). Buffer is snapshotted and cleared
-    // atomically before the (async) handler calls — events arriving
-    // during the drain take the live path (`transferHandlers.size > 0`
-    // is true now) and won't double-buffer.
+    // this handler was registered. With #423 in place the gate prevents
+    // subscriptions from opening before handlers attach, so this drain
+    // should be effectively dead code in the Sphere bootstrap path. It
+    // is retained as defense-in-depth (no-op when the buffer is empty)
+    // for any pathological case the gate cannot cover.
+    //
+    // Buffer is snapshotted and cleared atomically before the (async)
+    // handler calls — events arriving during the drain take the live
+    // path (`transferHandlers.size > 0` is true now) and won't
+    // double-buffer.
     //
     // Per-event durability propagation: if the handler returns truthy
     // (or undefined), advance `lastEventTs` so the event doesn't
@@ -958,6 +1024,7 @@ export class NostrTransportProvider implements TransportProvider {
 
   onPaymentRequest(handler: PaymentRequestHandler): () => void {
     this.paymentRequestHandlers.add(handler);
+    this.autoArmOnHandlerRegistration(); // Issue #423
     return () => this.paymentRequestHandlers.delete(handler);
   }
 
@@ -998,6 +1065,7 @@ export class NostrTransportProvider implements TransportProvider {
 
   onPaymentRequestResponse(handler: PaymentRequestResponseHandler): () => void {
     this.paymentRequestResponseHandlers.add(handler);
+    this.autoArmOnHandlerRegistration(); // Issue #423
     return () => this.paymentRequestResponseHandlers.delete(handler);
   }
 
@@ -1020,6 +1088,7 @@ export class NostrTransportProvider implements TransportProvider {
 
   onReadReceipt(handler: ReadReceiptHandler): () => void {
     this.readReceiptHandlers.add(handler);
+    this.autoArmOnHandlerRegistration(); // Issue #423
     return () => this.readReceiptHandlers.delete(handler);
   }
 
@@ -1044,6 +1113,7 @@ export class NostrTransportProvider implements TransportProvider {
 
   onTypingIndicator(handler: TypingIndicatorHandler): () => void {
     this.typingIndicatorHandlers.add(handler);
+    this.autoArmOnHandlerRegistration(); // Issue #423
     return () => this.typingIndicatorHandlers.delete(handler);
   }
 
@@ -1065,6 +1135,7 @@ export class NostrTransportProvider implements TransportProvider {
 
   onComposing(handler: ComposingHandler): () => void {
     this.composingHandlers.add(handler);
+    this.autoArmOnHandlerRegistration(); // Issue #423
     return () => this.composingHandlers.delete(handler);
   }
 
@@ -2831,6 +2902,94 @@ export class NostrTransportProvider implements TransportProvider {
   // Chat EOSE handlers — fired once when relay finishes delivering stored DMs
   private chatEoseHandlers: Array<() => void> = [];
   private chatEoseFired = false;
+
+  // ---------------------------------------------------------------------------
+  // Issue #423 — handler-readiness gate (public + helpers)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Issue #423 — explicitly arm subscriptions. Call this AFTER all message
+   * handlers (`onTokenTransfer`, `onMessage`, `onPaymentRequest`, etc.) have
+   * been registered on this provider, so relay events arrive at fully-wired
+   * handlers and do NOT fall into the defensive `pendingTransfers` buffer
+   * that triggers the "[AT-LEAST-ONCE] not durable" warn.
+   *
+   * Idempotent: subsequent calls are no-ops once subscriptions are armed.
+   * Safe to call before `connect()` — the arming state is recorded and the
+   * next `connect()` will open the subscription as part of its normal flow.
+   * Safe to call multiple times during a single session: re-arming is a no-op.
+   *
+   * Sphere bootstrap calls this from `initializeModules()` after every
+   * module's `initialize()` has run (handlers attached). The mux path does
+   * NOT need to call this — `suppressSubscriptions()` skips the auto-arm
+   * because the outer provider's subscription is irrelevant when the mux
+   * owns event routing.
+   *
+   * The gate is sticky: armed → stays armed for the lifetime of this
+   * instance. Reconnects re-subscribe automatically once armed. A subsequent
+   * call to `disconnect()` resets the arming state so a fresh `connect()`
+   * cycle goes through the gate again — this matches the existing contract
+   * where `disconnect()` tears down all session state.
+   */
+  async armSubscriptions(): Promise<void> {
+    if (this.subscriptionsArmed) return;
+    this.subscriptionsArmed = true;
+    logger.debug('Nostr', '[#423] Subscriptions armed — opening relay subscription if connected');
+    await this.maybeSubscribe();
+  }
+
+  /** Issue #423 — for tests and operator inspection. */
+  isSubscriptionsArmed(): boolean {
+    return this.subscriptionsArmed;
+  }
+
+  /**
+   * Issue #423 — gated wrapper around `subscribeToEvents()`. Called from
+   * connect()/setIdentity()/reconnect/armSubscriptions/on*-handler-register.
+   *
+   * Behavior:
+   *   - If suppressed (mux took over): no-op (mux owns subscriptions).
+   *   - If armed: proceed to `subscribeToEvents()` — opens the relay
+   *     subscription on the underlying NostrClient.
+   *   - Otherwise: record `pendingArm = true` and bail. The next call from
+   *     a gate-opening surface (armSubscriptions / on*-register) will
+   *     proceed.
+   */
+  private async maybeSubscribe(): Promise<void> {
+    if (this._subscriptionsSuppressed) return;
+    if (!this.subscriptionsArmed) {
+      this.pendingArm = true;
+      logger.debug(
+        'Nostr',
+        '[#423] subscribe deferred — handler-readiness gate closed (waiting for armSubscriptions or first handler)',
+      );
+      return;
+    }
+    this.pendingArm = false;
+    await this.subscribeToEvents();
+  }
+
+  /**
+   * Issue #423 — auto-arm on first handler registration. Called from each
+   * `on*` registration method as a backward-compat fallback for consumers
+   * that do not know about the explicit `armSubscriptions()` API.
+   *
+   * No-op once already armed or suppressed. Fire-and-forget: the underlying
+   * subscribe is async but `on*` methods are synchronous in their existing
+   * contract, so we don't await here.
+   */
+  private autoArmOnHandlerRegistration(): void {
+    if (this.subscriptionsArmed) return;
+    if (this._subscriptionsSuppressed) return;
+    this.subscriptionsArmed = true;
+    logger.debug(
+      'Nostr',
+      '[#423] Subscriptions auto-armed on first handler registration',
+    );
+    this.maybeSubscribe().catch((err) => {
+      logger.error('Nostr', '[#423] auto-arm subscribe failed:', err);
+    });
+  }
 
   private async subscribeToEvents(): Promise<void> {
     logger.debug('Nostr', 'subscribeToEvents called, identity:', !!this.identity, 'keyManager:', !!this.keyManager, 'nostrClient:', !!this.nostrClient);


### PR DESCRIPTION
## Summary
Closes #423.

Defers `NostrTransportProvider.subscribeToEvents()` until subscriptions are explicitly armed, either via the new `armSubscriptions()` method (Sphere calls this at the end of `initializeModules()` once every module has registered its handlers) or via auto-arm on the first `on*`-handler registration (backward-compat for direct consumers).

Eliminates the pre-Mux race that surfaced during the #419 soak as the persistent `[AT-LEAST-ONCE] TOKEN_TRANSFER … not durable` warn storm: events can no longer arrive on the outer provider before a handler exists. The defensive `pendingTransfers` buffer is retained as defense-in-depth.

## Architectural choice
Option A — transport-owned readiness gate. Tracks `subscriptionsArmed` / `pendingArm` state and routes `connect()` / `setIdentity()` / `onReconnected` through the gate. Auto-arms on first handler registration to preserve backward compatibility for direct consumers (sphere app, sphere-cli, etc.) that don't know about the explicit API.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx eslint` — clean for modified files
- [x] `npx vitest run tests/unit/transport/` — 180/180 pass
- [x] `npx vitest run tests/unit/core/Sphere*` — 188/188 pass
- [ ] CI: full unit suite
- [ ] CI: e2e soak
- [ ] Soak: monitor for `[AT-LEAST-ONCE] TOKEN_TRANSFER … not durable` warn — should be silent in the common case

## Tests added
- 11 new gate-behavior cases in `tests/unit/transport/NostrTransportProvider.subscribeGate423.test.ts`:
  - Gate closed by default after `connect()`
  - Explicit-arm opens subscription exactly once
  - Idempotent re-arm
  - Arm-before-connect defers correctly
  - Auto-arm on each of `onTokenTransfer` / `onMessage` / `onPaymentRequest` / `onPaymentRequestResponse`
  - Multi-handler register only subscribes once
  - `suppressSubscriptions()` defeats arming
  - Reconnect after disconnect re-subscribes (gate is sticky)

Existing transport tests updated to call `armSubscriptions()` after `connect()` to preserve pre-gate semantics (37 mechanical sites + 2 manual fixes).