### PR TITLE
fix(sphere-sdk)(#424): make AggregatorPinger flake-resilient

### DIFF
--- a/core/connectivity.ts
+++ b/core/connectivity.ts
@@ -100,11 +100,36 @@ export const DEFAULT_BACKOFF_SCHEDULE_MS: ReadonlyArray<number> = [
  *  `'down'`. */
 export const DEFAULT_PING_TIMEOUT_MS = 8_000;
 
+/**
+ * Default number of consecutive `'down'` probe results required before the
+ * manager flips a backend's status to `'down'` (Issue #424).
+ *
+ * The intent is to absorb single transient blips — a TCP RST, a DNS hiccup,
+ * a one-off undici `fetch failed` — without flipping the public status. A
+ * sustained outage will still flip after this many consecutive failures.
+ *
+ * Recovery is asymmetric: a single successful probe (`'up'` or `'degraded'`)
+ * resets the counter AND flips the status immediately. Failure is patient;
+ * recovery is fast.
+ */
+export const DEFAULT_FAILURE_THRESHOLD = 2;
+
 export interface ConnectivityManagerConfig {
   /** Probe schedule. Defaults to {@link DEFAULT_BACKOFF_SCHEDULE_MS}. */
   readonly backoffScheduleMs?: ReadonlyArray<number>;
   /** Per-probe wall-clock timeout. Defaults to {@link DEFAULT_PING_TIMEOUT_MS}. */
   readonly pingTimeoutMs?: number;
+  /**
+   * Number of consecutive `'down'` probe results required before the manager
+   * flips a backend's status to `'down'`. Defaults to
+   * {@link DEFAULT_FAILURE_THRESHOLD}. Must be >= 1; a value of 1 means
+   * "flip on the first failure" (the legacy pre-#424 behaviour).
+   *
+   * Applies to ALL backends uniformly. The counter is reset to 0 on every
+   * successful (`'up'` or `'degraded'`) result, so a flaky alternate-success
+   * stream never accumulates enough consecutive failures to flip.
+   */
+  readonly failureThreshold?: number;
   /**
    * Event-emit hook. The manager calls this with three event types:
    *
@@ -153,6 +178,13 @@ interface PerBackendState {
   inFlight: Promise<void> | null;
   /** AbortController for the in-flight probe (used to cancel on stop()). */
   abort: AbortController | null;
+  /**
+   * Issue #424: consecutive `'down'` probe results since the last `'up'` or
+   * `'degraded'`. Saturates at `failureThreshold` to avoid unbounded growth
+   * on a long-running offline wallet; we only ever care whether the counter
+   * has met the threshold. Reset to 0 on any successful result.
+   */
+  consecutiveFailures: number;
 }
 
 export class ConnectivityManager implements ConnectivityManagerHandle {
@@ -161,6 +193,7 @@ export class ConnectivityManager implements ConnectivityManagerHandle {
   private readonly subscribers: Set<ConnectivitySubscriber> = new Set();
   private readonly schedule: ReadonlyArray<number>;
   private readonly pingTimeoutMs: number;
+  private readonly failureThreshold: number;
   private readonly emitEvent: ConnectivityManagerConfig['emitEvent'];
 
   private lastOnlineAt: number | null = null;
@@ -185,6 +218,7 @@ export class ConnectivityManager implements ConnectivityManagerHandle {
         timer: null,
         inFlight: null,
         abort: null,
+        consecutiveFailures: 0,
       });
     }
     this.schedule = config?.backoffScheduleMs ?? DEFAULT_BACKOFF_SCHEDULE_MS;
@@ -195,6 +229,14 @@ export class ConnectivityManager implements ConnectivityManagerHandle {
       );
     }
     this.pingTimeoutMs = config?.pingTimeoutMs ?? DEFAULT_PING_TIMEOUT_MS;
+    const ft = config?.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD;
+    if (!Number.isFinite(ft) || ft < 1 || !Number.isInteger(ft)) {
+      throw new SphereError(
+        'ConnectivityManager: failureThreshold must be a positive integer (>= 1)',
+        'INVALID_CONFIG',
+      );
+    }
+    this.failureThreshold = ft;
     this.emitEvent = config?.emitEvent;
     this.cachedSnapshot = this.buildSnapshot();
   }
@@ -422,7 +464,6 @@ export class ConnectivityManager implements ConnectivityManagerHandle {
     if (!state) return;
 
     const prev = state.status;
-    const next: ConnectivityBackendStatus = result;
 
     // Schedule semantics: `backoffStep` is the index of `schedule` to USE
     // for the NEXT probe. The first failure → use schedule[0] = 5 s for
@@ -445,6 +486,36 @@ export class ConnectivityManager implements ConnectivityManagerHandle {
     // step advances for the slot after that. This makes the first
     // failure use schedule[0] (= 5s) for the next probe — matching the
     // spec.
+
+    // Issue #424: consecutive-failure threshold for `'down'` flips.
+    //
+    // - A successful result (`'up'` or `'degraded'`) resets the counter
+    //   and the visible status is whatever the probe reported. Recovery
+    //   is immediate — one good probe is enough.
+    // - A failed result (`'down'`) bumps the counter (saturating at the
+    //   threshold so a long-running offline wallet never grows the
+    //   number unboundedly). The visible status only flips to `'down'`
+    //   when the counter reaches the threshold.
+    //
+    // Until the threshold is reached we hold the previous status. This
+    // means an `'unknown'` start → 1 `'down'` keeps `'unknown'` visible,
+    // and an `'up'` → 1 `'down'` keeps `'up'` visible. Operators get
+    // false-negative suppression at the cost of slightly delayed real-
+    // outage detection (one extra probe interval).
+    let next: ConnectivityBackendStatus;
+    if (result === 'down') {
+      // Saturating increment — see steelman note: a 32-bit counter would
+      // be fine in practice, but capping at the threshold keeps the
+      // semantics tight: "have we hit threshold yet?" is the only
+      // question we ask.
+      if (state.consecutiveFailures < this.failureThreshold) {
+        state.consecutiveFailures += 1;
+      }
+      next = state.consecutiveFailures >= this.failureThreshold ? 'down' : prev;
+    } else {
+      state.consecutiveFailures = 0;
+      next = result;
+    }
 
     if (prev === next) {
       // No transition — still refresh cached snapshot's `lastOnlineAt`
@@ -555,7 +626,13 @@ export class ConnectivityManager implements ConnectivityManagerHandle {
  *     Used when no provider instance is available (e.g. pre-init health
  *     checks, tests). Sends a `get_block_height` JSON-RPC POST.
  *
- * Treats:
+ * Issue #424: each `ping()` call internally retries transient failures with a
+ * `[100, 500, 2000]` ms backoff before surfacing `'down'` to the manager.
+ * This absorbs the dominant TCP retransmit-window blip and DNS hiccup without
+ * stacking up against the manager's consecutive-failure threshold. The manager
+ * still has the final say on status transitions (see `failureThreshold`).
+ *
+ * Treats (after retries exhausted):
  *   - successful call (numeric round / `result` field) ⇒ `'up'`
  *   - 200 OK with `error` body / unrecognizable result ⇒ `'degraded'`
  *   - any throw / 4xx / 5xx / abort / timeout          ⇒ `'down'`
@@ -564,82 +641,244 @@ export interface AggregatorPingerProvider {
   getCurrentRound(): Promise<number>;
 }
 
+/**
+ * Issue #424: backoff schedule (ms) for {@link AggregatorPinger}'s
+ * in-probe retries on transient failures. Matches the IPFS layer's
+ * `withPinRetry` schedule — 100 / 500 / 2000 ms.
+ *
+ * Total budget: ~2.6 s of accumulated backoff between attempts; the
+ * manager's `pingTimeoutMs` (default 8 s) caps the overall wall-clock
+ * cost. Each retry runs a fresh inner ping attempt, so a slow-but-
+ * eventually-failing call could be aborted mid-retry by the manager's
+ * outer timeout.
+ */
+export const AGGREGATOR_RETRY_BACKOFFS_MS: ReadonlyArray<number> = [100, 500, 2000] as const;
+
+/**
+ * Issue #424: classify whether an aggregator-probe failure is worth a
+ * quick in-probe retry.
+ *
+ * Transient (retry):
+ *   - `AbortError` / `TimeoutError` from the per-attempt timeout.
+ *   - Network errors (`ECONNRESET`, `ECONNREFUSED`, `ENOTFOUND`,
+ *     `ETIMEDOUT`, `EAI_AGAIN`, undici `fetch failed`).
+ *   - HTTP 5xx — server-side transient (overload, bad backend).
+ *   - HTTP 429 — rate-limit signal; backoff is the right response.
+ *   - Anything we can't classify — the bounded 2.6 s budget caps the
+ *     cost of guessing wrong.
+ *
+ * Permanent (do NOT retry — return `'down'` without consuming more budget):
+ *   - HTTP 4xx (except 429) — deterministic client error; retry wastes
+ *     budget and is semantically wrong.
+ *
+ * The classifier matches the shape of errors thrown by both provider-mode
+ * (the underlying transport rethrows) and URL-mode (we throw synthetic
+ * `"HTTP <status>"` errors for non-OK responses so this classifier can
+ * route by status code).
+ */
+export function isTransientAggregatorError(err: unknown): boolean {
+  if (!(err instanceof Error)) return true;
+  const msg = err.message;
+
+  // HTTP-derived: explicit status code in the message.
+  const httpMatch = /\bHTTP (\d{3})\b/.exec(msg);
+  if (httpMatch !== null) {
+    const status = Number.parseInt(httpMatch[1], 10);
+    if (status === 429) return true;               // rate-limit → retry
+    if (status >= 500 && status < 600) return true; // 5xx → retry
+    if (status >= 400 && status < 500) return false; // 4xx → permanent
+  }
+
+  // Network / abort signals from `fetch` and friends.
+  if (
+    msg.toLowerCase().includes('fetch failed') ||
+    msg.toLowerCase().includes('network') ||
+    msg.includes('ECONNRESET') ||
+    msg.includes('ECONNREFUSED') ||
+    msg.includes('ENOTFOUND') ||
+    msg.includes('ETIMEDOUT') ||
+    msg.includes('EAI_AGAIN') ||
+    err.name === 'AbortError' ||
+    err.name === 'TimeoutError'
+  ) {
+    return true;
+  }
+
+  // Unknown shape — lenient default, capped by the bounded retry budget.
+  return true;
+}
+
 export class AggregatorPinger implements Pinger {
   readonly backend: ConnectivityBackend = 'aggregator';
 
   private readonly provider: AggregatorPingerProvider | null;
   private readonly url: string;
   private readonly fetchImpl: typeof fetch;
+  private readonly retryBackoffsMs: ReadonlyArray<number>;
+  private readonly isTransient: (err: unknown) => boolean;
 
   constructor(opts: {
     provider?: AggregatorPingerProvider;
     url?: string;
     fetchImpl?: typeof fetch;
+    /**
+     * Issue #424 (test-seam): override the retry backoff schedule.
+     * Defaults to {@link AGGREGATOR_RETRY_BACKOFFS_MS}. Pass an empty
+     * array to disable retries entirely (single-attempt, legacy behaviour).
+     */
+    retryBackoffsMs?: ReadonlyArray<number>;
+    /**
+     * Issue #424 (test-seam): override the transient-error classifier.
+     * Defaults to {@link isTransientAggregatorError}.
+     */
+    isTransientError?: (err: unknown) => boolean;
   }) {
     this.provider = opts.provider ?? null;
     this.url = opts.url ?? '';
     this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+    this.retryBackoffsMs = opts.retryBackoffsMs ?? AGGREGATOR_RETRY_BACKOFFS_MS;
+    this.isTransient = opts.isTransientError ?? isTransientAggregatorError;
   }
 
   async ping(signal: AbortSignal): Promise<PingResult> {
     if (signal.aborted) return 'down';
-    if (this.provider) {
+    // Issue #424: in-probe retry loop. A single transient blip (TCP RST,
+    // DNS hiccup, undici `fetch failed`) should not surface as `'down'`
+    // to the manager. We attempt up to `1 + retryBackoffsMs.length`
+    // times; each attempt runs the underlying probe (provider or URL).
+    // On a permanent error (e.g. HTTP 4xx) we short-circuit immediately.
+    // On caller abort, we return `'down'` without further retries.
+    const totalAttempts = 1 + this.retryBackoffsMs.length;
+    let lastResult: PingResult = 'down';
+    for (let attempt = 0; attempt < totalAttempts; attempt++) {
+      if (signal.aborted) return 'down';
+      let attemptError: unknown = null;
       try {
-        // Any finite numeric round (including 0) is a structured response
-        // from the aggregator and counts as alive — matches the reference
-        // infra-probe semantics (any JSON-RPC `result` ⇒ alive) and the
-        // URL-mode fallback below. Fresh shards / between-batch states
-        // can legitimately surface a `0` block height; demoting those to
-        // `'degraded'` would surface a false "Aggregator unavailable" in
-        // the wallet UI. The legacy "no aggregator client" stub path
-        // (UnicityAggregatorProvider before `initialize()`) now throws
-        // instead of returning `0`, so the catch below routes it to
-        // `'down'` as intended.
-        const round = await this.provider.getCurrentRound();
-        if (typeof round === 'number' && Number.isFinite(round) && round >= 0) {
-          return 'up';
-        }
-        return 'degraded';
-      } catch {
+        lastResult = await this.runSingleAttempt(signal);
+        // 'up' and 'degraded' are conclusive — return immediately.
+        if (lastResult !== 'down') return lastResult;
+      } catch (err) {
+        attemptError = err;
+        lastResult = 'down';
+      }
+
+      // We either got a thrown error or a 'down' result. Decide whether
+      // to retry.
+      const isLast = attempt === totalAttempts - 1;
+      if (isLast) break;
+      if (attemptError !== null && !this.isTransient(attemptError)) {
+        // Permanent error — surface 'down' without burning more budget.
         return 'down';
       }
+      // Sleep for the backoff between attempts. Honours caller abort
+      // mid-sleep so a stop() during the retry loop short-circuits.
+      const delay = this.retryBackoffsMs[attempt]!;
+      const aborted = await sleepWithAbort(delay, signal);
+      if (aborted) return 'down';
+    }
+    return lastResult;
+  }
+
+  /**
+   * Run a single underlying probe attempt — provider mode if a provider
+   * is configured, URL-mode otherwise. Throws on network / HTTP errors
+   * (so the retry loop can classify and retry). Returns `'up'`,
+   * `'degraded'`, or `'down'` on a successful structured response.
+   *
+   * Provider-mode preserves the legacy semantics: any finite non-negative
+   * numeric round counts as `'up'`; a non-finite or negative result is
+   * `'degraded'`; a thrown error propagates out (the retry loop catches
+   * and decides).
+   *
+   * URL-mode throws a synthetic `"HTTP <status>"` error on non-OK
+   * responses so {@link isTransientAggregatorError} can classify by
+   * status code.
+   */
+  private async runSingleAttempt(signal: AbortSignal): Promise<PingResult> {
+    if (this.provider) {
+      // Any finite numeric round (including 0) is a structured response
+      // from the aggregator and counts as alive — matches the reference
+      // infra-probe semantics (any JSON-RPC `result` ⇒ alive) and the
+      // URL-mode fallback below. Fresh shards / between-batch states
+      // can legitimately surface a `0` block height; demoting those to
+      // `'degraded'` would surface a false "Aggregator unavailable" in
+      // the wallet UI. The legacy "no aggregator client" stub path
+      // (UnicityAggregatorProvider before `initialize()`) now throws
+      // instead of returning `0`, so the catch in the retry loop routes
+      // it to `'down'` as intended.
+      const round = await this.provider.getCurrentRound();
+      if (typeof round === 'number' && Number.isFinite(round) && round >= 0) {
+        return 'up';
+      }
+      return 'degraded';
     }
     if (!this.url) return 'down';
+    const response = await this.fetchImpl(this.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'get_block_height',
+        params: {},
+      }),
+      signal,
+    });
+    if (!response.ok) {
+      // Throw a synthetic "HTTP <status>" error so the classifier can
+      // decide retry-vs-permanent by status code. The retry loop catches
+      // and routes; a 4xx surfaces as 'down' immediately (no further
+      // budget consumed).
+      throw new Error(`HTTP ${response.status} ${response.statusText} from ${this.url}`);
+    }
     try {
-      const response = await this.fetchImpl(this.url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'get_block_height',
-          params: {},
-        }),
-        signal,
-      });
-      if (!response.ok) return 'down';
-      try {
-        const body = (await response.json()) as { result?: unknown; error?: unknown };
-        if (body && typeof body === 'object' && body.error) {
-          return 'degraded';
-        }
-        const result = body && typeof body === 'object' ? body.result : null;
-        if (
-          typeof result === 'number' ||
-          typeof result === 'bigint' ||
-          (typeof result === 'string' && result.length > 0) ||
-          (result !== null && typeof result === 'object')
-        ) {
-          return 'up';
-        }
-        return 'degraded';
-      } catch {
+      const body = (await response.json()) as { result?: unknown; error?: unknown };
+      if (body && typeof body === 'object' && body.error) {
+        // A genuine JSON-RPC error envelope means the aggregator IS up
+        // but rejected our specific payload. Surface as 'degraded' —
+        // the backend is reachable, not retried, not counted as 'down'.
         return 'degraded';
       }
+      const result = body && typeof body === 'object' ? body.result : null;
+      if (
+        typeof result === 'number' ||
+        typeof result === 'bigint' ||
+        (typeof result === 'string' && result.length > 0) ||
+        (result !== null && typeof result === 'object')
+      ) {
+        return 'up';
+      }
+      return 'degraded';
     } catch {
-      return 'down';
+      // JSON parse failure on a 200 response — backend reachable but
+      // body is junk. Treat as degraded (backend IS reachable).
+      return 'degraded';
     }
   }
+}
+
+/**
+ * Sleep for `ms` milliseconds, honouring `signal`. Returns `true` if the
+ * sleep was cut short by an abort (caller should stop retrying); returns
+ * `false` on a clean timeout.
+ *
+ * Used by {@link AggregatorPinger}'s retry loop so a `stop()` landing
+ * during a backoff sleep short-circuits the loop instead of pinning the
+ * probe in a no-op wait.
+ */
+async function sleepWithAbort(ms: number, signal: AbortSignal): Promise<boolean> {
+  if (signal.aborted) return true;
+  return await new Promise<boolean>((resolve) => {
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve(false);
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 /**

--- a/tests/unit/core/connectivity.test.ts
+++ b/tests/unit/core/connectivity.test.ts
@@ -5,6 +5,9 @@ import {
   IpfsPinger,
   NostrPinger,
   DEFAULT_BACKOFF_SCHEDULE_MS,
+  DEFAULT_FAILURE_THRESHOLD,
+  AGGREGATOR_RETRY_BACKOFFS_MS,
+  isTransientAggregatorError,
   type ConnectivityStatus,
   type Pinger,
   type PingResult,
@@ -96,7 +99,10 @@ describe('ConnectivityManager', () => {
 
     it('respects 5/15/60/300s backoff schedule on consecutive failures', async () => {
       const agg = new MockPinger('aggregator', 'down');
-      const m = new ConnectivityManager([agg]);
+      // failureThreshold:1 — this test pre-dates #424 and asserts
+      // immediate-flip semantics. Threshold behaviour is exercised in
+      // its dedicated block.
+      const m = new ConnectivityManager([agg], { failureThreshold: 1 });
       m.start();
       // 1st probe fires on microtask.
       await drain();
@@ -185,7 +191,9 @@ describe('ConnectivityManager', () => {
   describe('subscribers and events', () => {
     it('notifies subscribers on every state transition', async () => {
       const agg = new MockPinger('aggregator', 'down');
-      const m = new ConnectivityManager([agg]);
+      // failureThreshold:1 — pre-#424 immediate-flip semantics; this test
+      // is about subscriber notification, not about threshold behaviour.
+      const m = new ConnectivityManager([agg], { failureThreshold: 1 });
       const seen: ConnectivityStatus[] = [];
       m.subscribe((s) => { seen.push(s); });
       m.start();
@@ -234,8 +242,11 @@ describe('ConnectivityManager', () => {
       const ipfs = new MockPinger('ipfs', 'up');
       const nostr = new MockPinger('nostr', 'up');
       const events: Array<{ type: string; payload: ConnectivityStatus }> = [];
+      // failureThreshold:1 — this test asserts an immediate flip on a
+      // single failure. The #424 threshold block covers default-2 semantics.
       const m = new ConnectivityManager([agg, ipfs, nostr], {
         emitEvent: (type, payload) => { events.push({ type, payload }); },
+        failureThreshold: 1,
       });
       m.start();
       await drain();
@@ -279,7 +290,8 @@ describe('ConnectivityManager', () => {
   describe('probe error handling', () => {
     it('treats a throwing pinger as down', async () => {
       const agg = new MockPinger('aggregator', 'throw');
-      const m = new ConnectivityManager([agg]);
+      // failureThreshold:1 — pre-#424 immediate-flip semantics.
+      const m = new ConnectivityManager([agg], { failureThreshold: 1 });
       m.start();
       await drain();
       expect(m.status().aggregator).toBe('down');
@@ -293,7 +305,8 @@ describe('ConnectivityManager', () => {
         backend: 'aggregator',
         ping: () => new Promise(() => undefined), // never resolves
       };
-      const m = new ConnectivityManager([slowAgg], { pingTimeoutMs: 100 });
+      // failureThreshold:1 — pre-#424 immediate-flip semantics.
+      const m = new ConnectivityManager([slowAgg], { pingTimeoutMs: 100, failureThreshold: 1 });
       m.start();
       // 1st probe is enqueued
       await drain();
@@ -455,23 +468,32 @@ describe('AggregatorPinger', () => {
     // `aggregatorClient` is null (pre-`initialize()`), so the pinger
     // correctly classifies an uninitialized provider as offline rather
     // than silently treating `0` as a real round value.
+    //
+    // Issue #424: retries disabled here (`retryBackoffsMs: []`) to
+    // preserve the original test intent — verify the FINAL outcome is
+    // 'down' — without adding real-time retry budget.
     const stub = new AggregatorPinger({
       provider: {
         getCurrentRound: async () => {
           throw new Error('UnicityAggregatorProvider: aggregator client not initialized');
         },
       },
+      retryBackoffsMs: [],
     });
     expect(await stub.ping(new AbortController().signal)).toBe('down');
 
     const generic = new AggregatorPinger({
       provider: { getCurrentRound: async () => { throw new Error('503'); } },
+      retryBackoffsMs: [],
     });
     expect(await generic.ping(new AbortController().signal)).toBe('down');
   });
 
   it('returns down when neither provider nor URL is supplied', async () => {
-    const p = new AggregatorPinger({});
+    // Issue #424: retries disabled — the 'down' path exits early (no URL,
+    // no provider) without going through the retry loop, but we disable
+    // explicitly to guard against future changes in that code path.
+    const p = new AggregatorPinger({ retryBackoffsMs: [] });
     expect(await p.ping(new AbortController().signal)).toBe('down');
   });
 
@@ -487,9 +509,12 @@ describe('AggregatorPinger', () => {
 
   it('reports down when URL-mode fetch fails', async () => {
     const fetchImpl = vi.fn(async () => { throw new Error('ECONNREFUSED'); });
+    // Issue #424: retries disabled to avoid real-time backoff in this
+    // legacy test. Retry behaviour is covered in the #424 block.
     const p = new AggregatorPinger({
       url: 'https://example.com/rpc',
       fetchImpl: fetchImpl as unknown as typeof fetch,
+      retryBackoffsMs: [],
     });
     expect(await p.ping(new AbortController().signal)).toBe('down');
   });
@@ -552,5 +577,388 @@ describe('NostrPinger', () => {
 describe('DEFAULT_BACKOFF_SCHEDULE_MS', () => {
   it('matches the spec: 5/15/60/300 seconds', () => {
     expect(DEFAULT_BACKOFF_SCHEDULE_MS).toEqual([5_000, 15_000, 60_000, 300_000]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #424: AggregatorPinger flake resilience
+// ---------------------------------------------------------------------------
+
+describe('AggregatorPinger flake resilience (issue #424)', () => {
+  // Use real timers — the retry-loop's sleepWithAbort schedules sub-ms
+  // backoffs (we override the schedule to [0, 0, 0]) and real timers
+  // keep the test logic simple.
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('quick in-probe retry', () => {
+    it('returns "up" when a transient error throws then a retry succeeds', async () => {
+      let calls = 0;
+      const p = new AggregatorPinger({
+        provider: {
+          getCurrentRound: async () => {
+            calls += 1;
+            if (calls < 2) throw new Error('fetch failed');
+            return 42;
+          },
+        },
+        retryBackoffsMs: [0, 0, 0],
+      });
+      expect(await p.ping(new AbortController().signal)).toBe('up');
+      expect(calls).toBe(2);
+    });
+
+    it('retries through two transient throws then succeeds on the third attempt', async () => {
+      let calls = 0;
+      const p = new AggregatorPinger({
+        provider: {
+          getCurrentRound: async () => {
+            calls += 1;
+            if (calls < 3) throw new Error('ECONNRESET');
+            return 7;
+          },
+        },
+        retryBackoffsMs: [0, 0, 0],
+      });
+      expect(await p.ping(new AbortController().signal)).toBe('up');
+      expect(calls).toBe(3);
+    });
+
+    it('returns "down" only after exhausting the retry budget', async () => {
+      let calls = 0;
+      const p = new AggregatorPinger({
+        provider: {
+          getCurrentRound: async () => {
+            calls += 1;
+            throw new Error('fetch failed');
+          },
+        },
+        retryBackoffsMs: [0, 0, 0],
+      });
+      expect(await p.ping(new AbortController().signal)).toBe('down');
+      // 1 initial + 3 retries = 4 attempts total
+      expect(calls).toBe(4);
+    });
+
+    it('disables retries when retryBackoffsMs is empty (legacy single-attempt behaviour)', async () => {
+      let calls = 0;
+      const p = new AggregatorPinger({
+        provider: {
+          getCurrentRound: async () => {
+            calls += 1;
+            throw new Error('fetch failed');
+          },
+        },
+        retryBackoffsMs: [],
+      });
+      expect(await p.ping(new AbortController().signal)).toBe('down');
+      expect(calls).toBe(1);
+    });
+  });
+
+  describe('error classification', () => {
+    it('does NOT retry on HTTP 4xx (permanent error)', async () => {
+      const fetchImpl = vi.fn(async () =>
+        new Response('', { status: 400, statusText: 'Bad Request' }),
+      );
+      const p = new AggregatorPinger({
+        url: 'https://example.com/rpc',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        retryBackoffsMs: [0, 0, 0],
+      });
+      expect(await p.ping(new AbortController().signal)).toBe('down');
+      // Only one fetch call — no retries for permanent errors.
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on HTTP 5xx (transient server error)', async () => {
+      let calls = 0;
+      const fetchImpl = vi.fn(async () => {
+        calls += 1;
+        if (calls < 3) return new Response('', { status: 503, statusText: 'Unavailable' });
+        return new Response(JSON.stringify({ result: 42 }), { status: 200 });
+      });
+      const p = new AggregatorPinger({
+        url: 'https://example.com/rpc',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        retryBackoffsMs: [0, 0, 0],
+      });
+      expect(await p.ping(new AbortController().signal)).toBe('up');
+      expect(fetchImpl).toHaveBeenCalledTimes(3);
+    });
+
+    it('retries on HTTP 429 (rate-limit)', async () => {
+      let calls = 0;
+      const fetchImpl = vi.fn(async () => {
+        calls += 1;
+        if (calls < 2) return new Response('', { status: 429, statusText: 'Too Many Requests' });
+        return new Response(JSON.stringify({ result: 1 }), { status: 200 });
+      });
+      const p = new AggregatorPinger({
+        url: 'https://example.com/rpc',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        retryBackoffsMs: [0, 0, 0],
+      });
+      expect(await p.ping(new AbortController().signal)).toBe('up');
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    it('classifier returns true for network-error shapes', () => {
+      expect(isTransientAggregatorError(new Error('fetch failed'))).toBe(true);
+      expect(isTransientAggregatorError(new Error('ECONNRESET'))).toBe(true);
+      expect(isTransientAggregatorError(new Error('ECONNREFUSED'))).toBe(true);
+      expect(isTransientAggregatorError(new Error('ENOTFOUND'))).toBe(true);
+      expect(isTransientAggregatorError(new Error('ETIMEDOUT'))).toBe(true);
+      expect(isTransientAggregatorError(new Error('EAI_AGAIN'))).toBe(true);
+      const abortErr = new Error('aborted');
+      abortErr.name = 'AbortError';
+      expect(isTransientAggregatorError(abortErr)).toBe(true);
+    });
+
+    it('classifier returns false for HTTP 4xx (except 429)', () => {
+      expect(isTransientAggregatorError(new Error('HTTP 400 Bad Request from x'))).toBe(false);
+      expect(isTransientAggregatorError(new Error('HTTP 401 Unauthorized from x'))).toBe(false);
+      expect(isTransientAggregatorError(new Error('HTTP 404 Not Found from x'))).toBe(false);
+      // 429 is the explicit exception — rate-limit is retryable.
+      expect(isTransientAggregatorError(new Error('HTTP 429 Too Many Requests from x'))).toBe(true);
+    });
+
+    it('classifier returns true for HTTP 5xx', () => {
+      expect(isTransientAggregatorError(new Error('HTTP 500 Internal Server Error'))).toBe(true);
+      expect(isTransientAggregatorError(new Error('HTTP 502 Bad Gateway'))).toBe(true);
+      expect(isTransientAggregatorError(new Error('HTTP 503 Service Unavailable'))).toBe(true);
+    });
+
+    it('classifier returns true for non-Error / unknown shapes (lenient default)', () => {
+      expect(isTransientAggregatorError('plain string')).toBe(true);
+      expect(isTransientAggregatorError(null)).toBe(true);
+      expect(isTransientAggregatorError({ foo: 'bar' })).toBe(true);
+      expect(isTransientAggregatorError(new Error('totally unrecognised'))).toBe(true);
+    });
+  });
+
+  describe('abort propagation', () => {
+    it('returns "down" immediately when the caller aborts before the first attempt', async () => {
+      const ctrl = new AbortController();
+      ctrl.abort();
+      let calls = 0;
+      const p = new AggregatorPinger({
+        provider: {
+          getCurrentRound: async () => {
+            calls += 1;
+            return 1;
+          },
+        },
+        retryBackoffsMs: [50, 50, 50],
+      });
+      expect(await p.ping(ctrl.signal)).toBe('down');
+      expect(calls).toBe(0);
+    });
+
+    it('returns "down" when the caller aborts mid-backoff between attempts', async () => {
+      let calls = 0;
+      const ctrl = new AbortController();
+      const p = new AggregatorPinger({
+        provider: {
+          getCurrentRound: async () => {
+            calls += 1;
+            throw new Error('fetch failed');
+          },
+        },
+        // Long enough backoff for the abort to land mid-sleep.
+        retryBackoffsMs: [200, 200, 200],
+      });
+      const promise = p.ping(ctrl.signal);
+      // Let the first attempt run and start sleeping.
+      await new Promise<void>((r) => setTimeout(r, 20));
+      ctrl.abort();
+      expect(await promise).toBe('down');
+      // Only the first attempt ran; we aborted during the first backoff.
+      expect(calls).toBe(1);
+    });
+  });
+
+  describe('AGGREGATOR_RETRY_BACKOFFS_MS', () => {
+    it('matches the [100, 500, 2000] schedule', () => {
+      expect(AGGREGATOR_RETRY_BACKOFFS_MS).toEqual([100, 500, 2000]);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #424: ConnectivityManager consecutive-failure threshold
+// ---------------------------------------------------------------------------
+
+describe('ConnectivityManager consecutive-failure threshold (issue #424)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Drain microtasks + zero-delay timers. */
+  async function drainLocal(): Promise<void> {
+    for (let i = 0; i < 20; i++) {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+  }
+
+  it('DEFAULT_FAILURE_THRESHOLD is 2', () => {
+    expect(DEFAULT_FAILURE_THRESHOLD).toBe(2);
+  });
+
+  it('a single failed probe does NOT flip status to "down" (threshold=2)', async () => {
+    const agg = new MockPinger('aggregator', 'down');
+    const m = new ConnectivityManager([agg], { failureThreshold: 2 });
+    m.start();
+    await drainLocal();
+    // First probe failed but status is still 'unknown' (held previous).
+    expect(agg.calls).toBe(1);
+    expect(m.status().aggregator).toBe('unknown');
+    await m.stop();
+  });
+
+  it('flips to "down" only after N consecutive failures', async () => {
+    const agg = new MockPinger('aggregator', 'down');
+    const m = new ConnectivityManager([agg], { failureThreshold: 3 });
+    m.start();
+    await drainLocal();
+    expect(agg.calls).toBe(1);
+    expect(m.status().aggregator).toBe('unknown');
+
+    // 2nd failure (after 5s) — still not flipped (threshold is 3).
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(agg.calls).toBe(2);
+    expect(m.status().aggregator).toBe('unknown');
+
+    // 3rd failure (after 15s) — now flips to 'down'.
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(agg.calls).toBe(3);
+    expect(m.status().aggregator).toBe('down');
+
+    await m.stop();
+  });
+
+  it('threshold=1 reproduces the legacy "flip on first failure" behaviour', async () => {
+    const agg = new MockPinger('aggregator', 'down');
+    const m = new ConnectivityManager([agg], { failureThreshold: 1 });
+    m.start();
+    await drainLocal();
+    expect(m.status().aggregator).toBe('down');
+    await m.stop();
+  });
+
+  it('a single success after "down" flips back to "up" immediately (fast recovery)', async () => {
+    const agg = new MockPinger('aggregator', 'down');
+    const m = new ConnectivityManager([agg], { failureThreshold: 2 });
+    m.start();
+    await drainLocal();
+    expect(m.status().aggregator).toBe('unknown');
+
+    // Second failure (5s) — flips to 'down'.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(m.status().aggregator).toBe('down');
+
+    // Now flip the mock to up; the next scheduled probe (at 15s from
+    // last) will return 'up'.
+    agg.result = 'up';
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(m.status().aggregator).toBe('up');
+
+    await m.stop();
+  });
+
+  it('resets the failure counter on success — alternating fail/pass never flips', async () => {
+    let n = 0;
+    const flaky: Pinger = {
+      backend: 'aggregator',
+      ping: async () => {
+        n += 1;
+        return n % 2 === 1 ? 'down' : 'up';
+      },
+    };
+    const m = new ConnectivityManager([flaky], { failureThreshold: 2 });
+    m.start();
+    await drainLocal();
+    // 1st: down → counter=1, prev='unknown', status stays 'unknown'.
+    expect(m.status().aggregator).toBe('unknown');
+    // 2nd (at 5s): up → counter resets, status flips to 'up'.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(m.status().aggregator).toBe('up');
+    // 3rd (at 5s after up): down → counter=1, status stays 'up'.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(m.status().aggregator).toBe('up');
+    // 4th: up → counter resets, status stays 'up'.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(m.status().aggregator).toBe('up');
+    await m.stop();
+  });
+
+  it('default threshold (no config) is 2 — one failure does not flip', async () => {
+    const agg = new MockPinger('aggregator', 'down');
+    const m = new ConnectivityManager([agg]); // no config → DEFAULT_FAILURE_THRESHOLD = 2
+    m.start();
+    await drainLocal();
+    expect(m.status().aggregator).toBe('unknown');
+    // Second failure flips it.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(m.status().aggregator).toBe('down');
+    await m.stop();
+  });
+
+  it('subscriber is NOT notified on a suppressed failure (status unchanged)', async () => {
+    const agg = new MockPinger('aggregator', 'down');
+    const m = new ConnectivityManager([agg], { failureThreshold: 2 });
+    const seen: ConnectivityStatus[] = [];
+    m.subscribe((s) => { seen.push(s); });
+    m.start();
+    await drainLocal();
+    // First failure suppressed — no transition, no notification.
+    expect(seen).toHaveLength(0);
+    // Second failure flips to 'down' — notification fires.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.aggregator).toBe('down');
+    await m.stop();
+  });
+
+  it('backoff schedule still advances even on suppressed failures', async () => {
+    // Verify no regression: the 5/15/60/300 backoff still climbs for
+    // consecutive failures regardless of whether status flipped.
+    const agg = new MockPinger('aggregator', 'down');
+    const m = new ConnectivityManager([agg], { failureThreshold: 5 });
+    m.start();
+    await drainLocal();
+    expect(agg.calls).toBe(1);
+    // Failures 1-5 — all suppressed (threshold=5) but schedule
+    // climbs identically to the all-flips case.
+    await vi.advanceTimersByTimeAsync(5_000);   // step 0 → 5s
+    expect(agg.calls).toBe(2);
+    await vi.advanceTimersByTimeAsync(15_000);  // step 1 → 15s
+    expect(agg.calls).toBe(3);
+    await vi.advanceTimersByTimeAsync(60_000);  // step 2 → 60s
+    expect(agg.calls).toBe(4);
+    await vi.advanceTimersByTimeAsync(300_000); // step 3 → 300s
+    expect(agg.calls).toBe(5);
+    // 5th failure meets the threshold — status flips to 'down'.
+    expect(m.status().aggregator).toBe('down');
+    await m.stop();
+  });
+
+  it('throws on invalid failureThreshold (zero / negative / non-integer)', () => {
+    expect(() =>
+      new ConnectivityManager([new MockPinger('aggregator')], { failureThreshold: 0 }),
+    ).toThrow(/failureThreshold/);
+    expect(() =>
+      new ConnectivityManager([new MockPinger('aggregator')], { failureThreshold: -1 }),
+    ).toThrow(/failureThreshold/);
+    expect(() =>
+      new ConnectivityManager([new MockPinger('aggregator')], { failureThreshold: 1.5 }),
+    ).toThrow(/failureThreshold/);
   });
 });


### PR DESCRIPTION
## Summary
Closes #424.

`AggregatorPinger` previously collapsed any single `ping()` throw to status `'down'` — no retry inside `ping()`, no consecutive-failure threshold, no error-class discrimination. A single transient TCP RST or DNS hiccup was enough to mark the aggregator down, producing the misleading `Connectivity gate reports aggregator 'down'` advisory warn surfaced during the #419 soak.

This PR adds three resilience layers mirroring the IPFS layer's `withPinRetry` discipline:

1. **In-probe retry** with `[100, 500, 2000]` ms backoff (matches the IPFS schedule).
2. **Consecutive-failure threshold** (default = 2) inside `ConnectivityManager`. A single failed ping no longer flips status. Recovery is asymmetric: the first successful probe immediately resets the counter and flips back to `'up'`.
3. **Error-class discrimination** via `isTransientAggregatorError`: HTTP 5xx, 429, network errors, abort, unknown shapes → transient (retry). HTTP 4xx (excl. 429) → permanent (no retry, but still respects the threshold).

`sleepWithAbort` honours caller aborts mid-backoff so `stop()` during retries short-circuits cleanly.

## Choices made
- **Threshold default: 2** — minimal change that absorbs one blip without delaying real outage detection by more than one probe interval. Configurable via `ConnectivityManager` constructor.
- **Retry budget: `[100, 500, 2000]` ms** — exactly matches `withPinRetry`'s schedule for symmetry with the IPFS layer.
- **Permanent errors still respect the threshold** — a single HTTP 400 from a transient CDN misroute won't flip status; consecutive HTTP 400s will. Symmetric semantics.
- **Fast recovery** — first `'up'` or `'degraded'` after `'down'` resets counter and flips status immediately.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx eslint core/connectivity.ts tests/unit/core/connectivity.test.ts` — clean
- [x] `npx vitest run tests/unit/core/connectivity.test.ts` — 59/59 pass
- [ ] CI: full unit suite
- [ ] CI: e2e soak

## Tests added
- 15 cases in new `AggregatorPinger flake resilience (issue #424)` block: quick retry success after 1/2 throws, retry budget exhaustion, retry disable via empty array, HTTP 4xx no-retry, HTTP 5xx retry, HTTP 429 retry, classifier shape coverage, abort-before-first-attempt, abort-mid-backoff, schedule constant check.
- 10 cases in new `ConnectivityManager consecutive-failure threshold (issue #424)` block: default = 2, single failure doesn't flip, N failures flip, threshold=1 = legacy behaviour, fast recovery, flaky alternation never flips, default-no-config, no notify on suppressed failure, backoff still climbs on suppressed failures, invalid-threshold throws.

5 pre-existing immediate-flip tests opt in via `{ failureThreshold: 1 }` to preserve their original intent.