### PR TITLE
fix(profile): stabilize pin-count assertion in OrbitDB-write-failure retry test

### DIFF
--- a/tests/unit/profile/profile-token-storage-provider.test.ts
+++ b/tests/unit/profile/profile-token-storage-provider.test.ts
@@ -1605,8 +1605,30 @@ describe('ProfileTokenStorageProvider', () => {
       await provider.save(txfData);
       await waitForFlushSettled(provider, 10000);
 
-      // Two saves → two pins (fresh-pin invariant).
-      expect(pinCallCount).toBe(2);
+      // Two saves → two pin OPERATIONS (fresh-pin invariant: each save()
+      // must invalidate `lastPinnedCid`, forcing a fresh `pinCarBlocksToIpfs`
+      // call rather than reusing the prior CID). The lower bound enforces
+      // that invariant — `pinCallCount < 2` would mean save#2 reused
+      // save#1's cached CID and skipped the pin entirely.
+      //
+      // Why the upper bound is 3, not 2 (CI flake fix):
+      // `pinSingleBlockOnce` is wrapped in `withPinRetry` (issue #369),
+      // which retries each per-block `/api/v0/dag/put` call on transient
+      // failures (fetch ECONNRESET, AbortError, HTTP 5xx, 429). Under
+      // CI load — concurrent vitest workers, slow undici fetch
+      // resolution, GC pauses — a single transient blip during one of
+      // the two legitimate pin operations triggers a retry that bumps
+      // the HTTP call count by one without changing the underlying pin
+      // OPERATION count. The retry path is intentional (a 250-block CAR
+      // with 1% per-block transient rate would otherwise cascade to ~92%
+      // pin-failure without retries) and lands the same idempotent CID,
+      // so the SUT remains correct.
+      //
+      // A pinCallCount of 4+ would mean BOTH pins retried, or save#2
+      // hit the cached-CID path AND something added a third pin —
+      // either would be a real regression worth investigating.
+      expect(pinCallCount).toBeGreaterThanOrEqual(2);
+      expect(pinCallCount).toBeLessThanOrEqual(3);
 
       // Bundle ref must exist after the successful retry.
       const bundleKeys = Array.from(db._store.keys()).filter((k) =>


### PR DESCRIPTION
## Summary
Pre-existing CI-only flake in `tests/unit/profile/profile-token-storage-provider.test.ts:1609` (`save() after OrbitDB-write failure re-pins`). Surfaced on the #423 PR (#428) and #419 PR (#422) CI runs.

## Root cause
The test mock counts `/api/v0/dag/put` HTTP calls, but `pinSingleBlockOnce` is wrapped in `withPinRetry` (`profile/ipfs-client.ts`, issue #369) with `[100, 500, 2000]` ms backoffs. Under CI load — concurrent vitest workers, slow undici fetch resolution, GC pauses — a single transient pin failure (ECONNRESET, AbortError, HTTP 5xx, 429) during one of the two legitimate pin operations triggers a retry that bumps HTTP-call count by one without changing the underlying pin OPERATION count. Retry is intentional, idempotent (same CID), and correct.

## Fix
Relax `expect(pinCallCount).toBe(2)` to a bounded range `[2, 3]` with a 22-line Why-comment explaining the bound — the SUT is correct, the assertion was overly strict for the production retry behavior.

## Test plan
- [x] 10/10 in isolation
- [x] Full file 36/36 pass
- [x] Full profile suite 2340 tests pass
- [x] Typecheck + lint clean
- [x] Repro-with-injected-transient (synthetic fetch fail) → unmodified test fails `expected 3 to be 2`; fixed test passes