### PR TITLE
test(integration): per-test TEST_DIR for nametag-normalization to fix full-suite flake

### DIFF
--- a/tests/integration/nametag-normalization.test.ts
+++ b/tests/integration/nametag-normalization.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { Sphere } from '../../core/Sphere';
 import { mockMintNametagSuccess } from '../helpers/mockMintNametag';
@@ -23,9 +24,18 @@ import { vi } from 'vitest';
 // Test directories
 // =============================================================================
 
-const TEST_DIR = path.join(__dirname, '.test-nametag-normalization');
-const DATA_DIR = path.join(TEST_DIR, 'data');
-const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+// Per-test unique directory under tmpfs to eliminate full-suite-only
+// FS race between cleanTestDir() and the next test's Sphere.init →
+// Sphere.exists (see commit 9bf3e90 for the prior Sphere.* fix).
+let TEST_DIR = '';
+let DATA_DIR = '';
+let TOKENS_DIR = '';
+
+function freshTestDirs(): void {
+  TEST_DIR = path.join(os.tmpdir(), `sphere-nametag-normalization-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
+  DATA_DIR = path.join(TEST_DIR, 'data');
+  TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+}
 
 // =============================================================================
 // Mock providers
@@ -110,7 +120,7 @@ describe('Nametag normalization integration', () => {
   let mintSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    cleanTestDir();
+    freshTestDirs();
     nostrRelayNametags.clear();
     if (Sphere.getInstance()) {
       (Sphere as unknown as { instance: null }).instance = null;


### PR DESCRIPTION
## Summary
Pre-existing intermittent failure in `tests/integration/nametag-normalization.test.ts` during full-suite runs (passes in isolation). Surfaced on the #423 PR full local unit-suite run.

## Root cause
Same root cause as commit 9bf3e90 (which fixed the same flake in two `Sphere.*` unit-test files): the shared `path.join(__dirname, '.test-nametag-normalization')` directory plus `cleanTestDir()` in `beforeEach`/`afterEach` races with `FileStorageProvider`'s proper-lockfile path under parallel-worker CPU load. `Sphere.exists()` can see a partially-saved `wallet.json` from a prior test, causing `Sphere.create()` to throw or `Sphere.load()` to read inconsistent state.

## Fix
Mirrors 9bf3e90: each `beforeEach` generates a fresh per-test `TEST_DIR` under `os.tmpdir()` with `Date.now()` + random suffix. tmpfs gives no fsync / no cross-process lock contention, and the unique path guarantees zero FS interaction between tests in the same file. `afterEach` still runs `cleanTestDir()` to keep tmpdir from growing.

## Test plan
- [x] File in isolation: 7/7 pass
- [x] Full integration suite: 486/486 pass (no regression)