### PR TITLE
test(integration): per-test TEST_DIR for 7 remaining flake-prone test files

### DIFF
--- a/tests/integration/history-sync.test.ts
+++ b/tests/integration/history-sync.test.ts
@@ -15,6 +15,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { Sphere } from '../../core/Sphere';
 import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
@@ -40,9 +41,16 @@ vi.mock('../../l1/network', () => ({
 // Test directories
 // =============================================================================
 
-const TEST_DIR = path.join(__dirname, '.test-history-sync');
-const DEVICE_A_DIR = path.join(TEST_DIR, 'device-a');
-const DEVICE_B_DIR = path.join(TEST_DIR, 'device-b');
+// Per-test unique directory under tmpfs (see commit 9bf3e90 and PR #432).
+let TEST_DIR = '';
+let DEVICE_A_DIR = '';
+let DEVICE_B_DIR = '';
+
+function freshTestDirs(): void {
+  TEST_DIR = path.join(os.tmpdir(), `sphere-history-sync-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
+  DEVICE_A_DIR = path.join(TEST_DIR, 'device-a');
+  DEVICE_B_DIR = path.join(TEST_DIR, 'device-b');
+}
 
 // =============================================================================
 // Mock providers
@@ -161,7 +169,7 @@ describe('History sync integration (multi-device)', () => {
   let sharedIpfsState: { data: TxfStorageDataBase | null };
 
   beforeEach(() => {
-    cleanTestDir();
+    freshTestDirs();
     sharedIpfsState = { data: null };
     if (Sphere.getInstance()) {
       (Sphere as unknown as { instance: null }).instance = null;

--- a/tests/integration/market-module.test.ts
+++ b/tests/integration/market-module.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { Sphere } from '../../core/Sphere';
 import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
@@ -24,9 +25,16 @@ import type { ProviderStatus } from '../../types';
 // Test directories
 // =============================================================================
 
-const TEST_DIR = path.join(__dirname, '.test-market-module');
-const DATA_DIR = path.join(TEST_DIR, 'data');
-const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+// Per-test unique directory under tmpfs (see commit 9bf3e90 and PR #432).
+let TEST_DIR = '';
+let DATA_DIR = '';
+let TOKENS_DIR = '';
+
+function freshTestDirs(): void {
+  TEST_DIR = path.join(os.tmpdir(), `sphere-market-module-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
+  DATA_DIR = path.join(TEST_DIR, 'data');
+  TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+}
 
 // =============================================================================
 // Mock providers
@@ -97,7 +105,7 @@ function ensureTestDirs(): void {
 
 describe('MarketModule integration with Sphere', () => {
   beforeEach(() => {
-    cleanupTestDir();
+    freshTestDirs();
     ensureTestDirs();
     vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
       new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } })

--- a/tests/integration/nametag-overwrite-guard.test.ts
+++ b/tests/integration/nametag-overwrite-guard.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { Sphere } from '../../core/Sphere';
 import { mockMintNametagSuccess } from '../helpers/mockMintNametag';
@@ -27,9 +28,16 @@ import type { ProviderStatus } from '../../types';
 // Test directories
 // =============================================================================
 
-const TEST_DIR = path.join(__dirname, '.test-nametag-overwrite-guard');
-const DATA_DIR = path.join(TEST_DIR, 'data');
-const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+// Per-test unique directory under tmpfs (see commit 9bf3e90 and PR #432).
+let TEST_DIR = '';
+let DATA_DIR = '';
+let TOKENS_DIR = '';
+
+function freshTestDirs(): void {
+  TEST_DIR = path.join(os.tmpdir(), `sphere-nametag-overwrite-guard-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
+  DATA_DIR = path.join(TEST_DIR, 'data');
+  TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+}
 
 // =============================================================================
 // Simulated relay state
@@ -165,7 +173,7 @@ describe('Nametag overwrite guard (syncIdentityWithTransport)', () => {
   let mintSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    cleanTestDir();
+    freshTestDirs();
     clearRelay();
     if (Sphere.getInstance()) {
       (Sphere as unknown as { instance: null }).instance = null;

--- a/tests/integration/operator-escape-hatch-bootstrap.test.ts
+++ b/tests/integration/operator-escape-hatch-bootstrap.test.ts
@@ -37,6 +37,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { vi } from 'vitest';
 import { Sphere } from '../../core/Sphere';
@@ -50,9 +51,16 @@ import type { ProviderStatus } from '../../types';
 // Test directories
 // =============================================================================
 
-const TEST_DIR = path.join(__dirname, '.test-operator-escape-hatch-bootstrap');
-const DATA_DIR = path.join(TEST_DIR, 'data');
-const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+// Per-test unique directory under tmpfs (see commit 9bf3e90 and PR #432).
+let TEST_DIR = '';
+let DATA_DIR = '';
+let TOKENS_DIR = '';
+
+function freshTestDirs(): void {
+  TEST_DIR = path.join(os.tmpdir(), `sphere-operator-escape-hatch-bootstrap-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
+  DATA_DIR = path.join(TEST_DIR, 'data');
+  TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+}
 
 // =============================================================================
 // Mock providers
@@ -130,7 +138,7 @@ function cleanTestDir(): void {
 
 describe('Round 7 (FIX 1): operator escape-hatch bootstrap wiring', () => {
   beforeEach(async () => {
-    cleanTestDir();
+    freshTestDirs();
     if (Sphere.getInstance()) {
       try { await Sphere.getInstance()!.destroy(); } catch { /* ignore */ }
     }

--- a/tests/integration/provider-disable-sync.test.ts
+++ b/tests/integration/provider-disable-sync.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { Sphere } from '../../core/Sphere';
 import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
@@ -28,9 +29,16 @@ vi.mock('../../l1/network', () => ({
 // Test directories
 // =============================================================================
 
-const TEST_DIR = path.join(__dirname, '.test-provider-disable-sync');
-const DATA_DIR = path.join(TEST_DIR, 'data');
-const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+// Per-test unique directory under tmpfs (see commit 9bf3e90 and PR #432).
+let TEST_DIR = '';
+let DATA_DIR = '';
+let TOKENS_DIR = '';
+
+function freshTestDirs(): void {
+  TEST_DIR = path.join(os.tmpdir(), `sphere-provider-disable-sync-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
+  DATA_DIR = path.join(TEST_DIR, 'data');
+  TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+}
 
 // =============================================================================
 // Mock providers
@@ -130,7 +138,7 @@ describe('Provider disable/enable integration', () => {
   let tokenStorageMock: TokenStorageProvider<TxfStorageDataBase>;
 
   beforeEach(async () => {
-    cleanTestDir();
+    freshTestDirs();
     if (Sphere.getInstance()) {
       try { await Sphere.getInstance()!.destroy(); } catch { /* ignore */ }
     }

--- a/tests/integration/tracked-addresses.test.ts
+++ b/tests/integration/tracked-addresses.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { Sphere } from '../../core/Sphere';
 import { mockMintNametagSuccess } from '../helpers/mockMintNametag';
@@ -26,9 +27,16 @@ import { vi } from 'vitest';
 // Test directories
 // =============================================================================
 
-const TEST_DIR = path.join(__dirname, '.test-tracked-addresses');
-const DATA_DIR = path.join(TEST_DIR, 'data');
-const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+// Per-test unique directory under tmpfs (see commit 9bf3e90 and PR #432).
+let TEST_DIR = '';
+let DATA_DIR = '';
+let TOKENS_DIR = '';
+
+function freshTestDirs(): void {
+  TEST_DIR = path.join(os.tmpdir(), `sphere-tracked-addresses-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
+  DATA_DIR = path.join(TEST_DIR, 'data');
+  TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+}
 
 // =============================================================================
 // Mock providers
@@ -125,7 +133,7 @@ describe('Tracked addresses integration', () => {
     // (from a prior test that didn't await its own destroy) flush
     // before we delete the directory. cleanTestDir is sync rm.
     await new Promise((r) => setImmediate(r));
-    cleanTestDir();
+    freshTestDirs();
     clearNostrRelay();
     // Defense against full-suite-only race: a prior test's async
     // storage write can land in DATA_DIR after cleanTestDir() ran

--- a/tests/integration/wallet-clear.test.ts
+++ b/tests/integration/wallet-clear.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { Sphere } from '../../core/Sphere';
 import { mockMintNametagSuccess } from '../helpers/mockMintNametag';
@@ -26,9 +27,17 @@ import { vi } from 'vitest';
 // Test directories
 // =============================================================================
 
-const TEST_DIR = path.join(__dirname, '.test-wallet-clear');
-const DATA_DIR = path.join(TEST_DIR, 'data');
-const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+// Per-test unique directory under tmpfs to eliminate full-suite-only
+// FS race (see commit 9bf3e90 and PR #432).
+let TEST_DIR = '';
+let DATA_DIR = '';
+let TOKENS_DIR = '';
+
+function freshTestDirs(): void {
+  TEST_DIR = path.join(os.tmpdir(), `sphere-wallet-clear-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
+  DATA_DIR = path.join(TEST_DIR, 'data');
+  TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+}
 
 // =============================================================================
 // Mock providers
@@ -146,7 +155,7 @@ describe('Sphere.clear() integration', () => {
   let mintSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    cleanTestDir();
+    freshTestDirs();
     clearNostrRelay();
     // Reset Sphere singleton
     if (Sphere.getInstance()) {


### PR DESCRIPTION
## Summary
Follow-up to PR #432. Same flake class (`Wallet already exists` from `Sphere.create()` under parallel-worker load) was surfaced on PR #326's CI in `wallet-clear.test.ts`. Six other integration test files share the same shared-TEST_DIR pattern and are equally exposed — fixing them all proactively.

## Root cause
Mirror of commit 9bf3e90 and PR #432: shared `path.join(__dirname, '.test-X')` plus `cleanTestDir()` in beforeEach/afterEach races with FileStorageProvider's proper-lockfile path. `Sphere.exists()` can see a partially-saved wallet.json from a prior test → `Sphere.create()` throws.

## Fix
Mirrors 9bf3e90/#432: each beforeEach generates a fresh per-test TEST_DIR under `os.tmpdir()` with `Date.now()` + random suffix. afterEach still runs `cleanTestDir()` to keep tmpdir from growing.

## Files
- `tests/integration/wallet-clear.test.ts` (the one that surfaced this)
- `tests/integration/provider-disable-sync.test.ts`
- `tests/integration/operator-escape-hatch-bootstrap.test.ts`
- `tests/integration/history-sync.test.ts` (custom DEVICE_A/B_DIR)
- `tests/integration/tracked-addresses.test.ts`
- `tests/integration/market-module.test.ts` (custom cleanupTestDir)
- `tests/integration/nametag-overwrite-guard.test.ts`

## Test plan
- [x] Full integration suite: 486/486 pass, 9 skipped
- [x] Typecheck clean