### PR TITLE
feat(payments): v2 self-mint / top-up

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -4730,8 +4730,8 @@ export class PaymentsModule {
     if (amount <= 0n) {
       return { success: false, error: 'Mint amount must be greater than zero' };
     }
-    if (!/^([0-9a-fA-F]{2})+$/.test(coinIdHex)) {
-      return { success: false, error: `Invalid coin id (expected even-length hex): ${coinIdHex}` };
+    if (!/^([0-9a-f]{2})+$/.test(coinIdHex)) {
+      return { success: false, error: `Invalid coin id (expected even-length lowercase hex): ${coinIdHex}` };
     }
 
     try {

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1312,22 +1312,7 @@ export class PaymentsModule {
           });
           await handToRecipient(outputs[0]);
 
-          const changeToken = outputs[1];
-          const changeBlob = bytesToHex(encodeTokenBlob(engine.encodeToken(changeToken)));
-          const changeInfo = await parseTokenInfo(changeBlob, engine);
-          const registry = TokenRegistry.getInstance();
-          await this.addToken({
-            id: `v2_${engine.tokenId(changeToken)}`,
-            coinId: changeInfo.coinId,
-            symbol: registry.getSymbol(changeInfo.coinId) || changeInfo.symbol,
-            name: registry.getName(changeInfo.coinId) || changeInfo.name,
-            decimals: registry.getDecimals(changeInfo.coinId) ?? changeInfo.decimals,
-            amount: changeInfo.amount,
-            status: 'confirmed',
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-            sdkData: changeBlob,
-          });
+          await this.storeEngineToken(engine, outputs[1]); // change token, confirmed
 
           result.tokenTransfers.push({ sourceTokenId: splitPlan.tokenToSplit.uiToken.id, method: 'split' });
           await this.removeToken(splitPlan.tokenToSplit.uiToken.id, result.id);
@@ -4594,12 +4579,48 @@ export class PaymentsModule {
    *   when converting from human values).
    * @returns Result with the resulting wallet Token and its on-chain id.
    */
+
+  /**
+   * Persist a realized v2 engine token as a confirmed wallet Token and return it.
+   * Single source of truth for "engine SphereToken -> stored UI Token": serialize
+   * with the wallet blob codec, derive coin/amount via parseTokenInfo, apply
+   * registry overrides, key it v2_<genesis-stable tokenId>, and addToken. Reused
+   * by self-mint, the send change-token path, and the v2 receive path.
+   */
+  private async storeEngineToken(engine: ITokenEngine, token: SphereToken): Promise<Token> {
+    const sdkData = bytesToHex(encodeTokenBlob(engine.encodeToken(token)));
+    const info = await parseTokenInfo(sdkData, engine);
+    const registry = TokenRegistry.getInstance();
+    const uiToken: Token = {
+      id: `v2_${engine.tokenId(token)}`,
+      coinId: info.coinId,
+      symbol: registry.getSymbol(info.coinId) || info.symbol,
+      name: registry.getName(info.coinId) || info.name,
+      decimals: registry.getDecimals(info.coinId) ?? info.decimals,
+      amount: info.amount,
+      status: 'confirmed',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    await this.addToken(uiToken);
+    return uiToken;
+  }
+
   async mintFungibleToken(
     coinIdHex: string,
     amount: bigint,
   ): Promise<{ success: true; token: Token; tokenId: string } | { success: false; error: string }> {
     this.ensureInitialized();
 
+    // v2 engine present -> self-mint via the engine (no faucet, no v1 round-trip).
+    // Same if/else shape as send(): engine path when present, else v1 fallback.
+    const engine = this.deps?.tokenEngine;
+    if (engine) {
+      return this.mintFungibleTokenV2(engine, coinIdHex, amount);
+    }
+
+    // V1-FALLBACK (removable on v2 cutover): the whole body below goes when v1 is cut.
     const stClient = this.deps!.oracle.getStateTransitionClient?.() as StateTransitionClient | undefined;
     if (!stClient) {
       return { success: false, error: 'State transition client not available' };
@@ -4717,6 +4738,36 @@ export class PaymentsModule {
     }
   }
 
+  /**
+   * v2 engine self-mint (no faucet): build a FINISHED token via engine.mint and
+   * store it (storeEngineToken) as a confirmed wallet token — no commitment /
+   * inclusion-proof / finalization round-trip. Lets a fresh wallet be topped up
+   * on networks where the v1 mint path is unavailable (e.g. testnet2).
+   */
+  private async mintFungibleTokenV2(
+    engine: ITokenEngine,
+    coinIdHex: string,
+    amount: bigint,
+  ): Promise<{ success: true; token: Token; tokenId: string } | { success: false; error: string }> {
+    if (amount <= 0n) {
+      return { success: false, error: 'Mint amount must be greater than zero' };
+    }
+    if (!/^[0-9a-fA-F]+$/.test(coinIdHex)) {
+      return { success: false, error: `Invalid coin id (expected hex): ${coinIdHex}` };
+    }
+
+    try {
+      const minted = await engine.mint({
+        recipientPubkey: engine.getIdentity().chainPubkey,
+        value: { assets: [{ coinId: coinIdHex, amount }] },
+      });
+      const uiToken = await this.storeEngineToken(engine, minted);
+      return { success: true, token: uiToken, tokenId: engine.tokenId(minted) };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { success: false, error: `V2 mint failed: ${msg}` };
+    }
+  }
 
   // ===========================================================================
   // Public API - Sync & Validate
@@ -5469,22 +5520,7 @@ export class PaymentsModule {
       return;
     }
 
-    const info = await parseTokenInfo(payload.tokenBlob, engine);
-    const registry = TokenRegistry.getInstance();
-    const uiToken: Token = {
-      id,
-      coinId: info.coinId,
-      symbol: registry.getSymbol(info.coinId) || info.symbol,
-      name: registry.getName(info.coinId) || info.name,
-      decimals: registry.getDecimals(info.coinId) ?? info.decimals,
-      amount: info.amount,
-      status: 'confirmed',
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-      sdkData: payload.tokenBlob,
-    };
-
-    await this.addToken(uiToken);
+    const uiToken = await this.storeEngineToken(engine, token);
     const senderInfo = await this.resolveSenderInfo(senderPubkey);
 
     this.deps!.emitEvent('transfer:incoming', {
@@ -5498,8 +5534,8 @@ export class PaymentsModule {
 
     await this.addToHistory({
       type: 'RECEIVED',
-      amount: info.amount,
-      coinId: info.coinId,
+      amount: uiToken.amount,
+      coinId: uiToken.coinId,
       symbol: uiToken.symbol,
       timestamp: Date.now(),
       senderPubkey,

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -4552,61 +4552,11 @@ export class PaymentsModule {
 
 
   /**
-   * Mint a fungible token directly to this wallet (genesis mint).
-   *
-   * Useful for test setups that need to seed a wallet with specific token
-   * balances WITHOUT depending on the testnet faucet HTTP service. The
-   * resulting token has the canonical CoinId bytes (passed in `coinIdHex`)
-   * — when those bytes match a registered symbol in the TokenRegistry,
-   * the token shows up under the symbol's name (e.g. "UCT"). There is no
-   * cryptographic restriction on which key may issue a given CoinId; the
-   * aggregator records the mint regardless of issuer identity.
-   *
-   * The flow:
-   *   1. Generate a random TokenId.
-   *   2. Build TokenCoinData with [(coinId, amount)].
-   *   3. Build MintTransactionData with recipient = self (UnmaskedPredicate
-   *      from this wallet's signing service).
-   *   4. Submit MintCommitment to the aggregator.
-   *   5. Wait for the inclusion proof.
-   *   6. Construct an SDK Token via Token.mint().
-   *   7. Convert to wallet Token format and call addToken().
-   *
-   * @param coinIdHex - 64-char lowercase hex CoinId. Must match the bytes
-   *   used by the registered symbol if you want the wallet to recognize
-   *   the token as that symbol (e.g. UCT's coinId from the public registry).
-   * @param amount - Amount in smallest units (multiply by 10^decimals
-   *   when converting from human values).
-   * @returns Result with the resulting wallet Token and its on-chain id.
+   * Self-mint fungible tokens to this wallet (no faucet). When a v2 token engine
+   * is present, mints via the engine (engine.mint, no commitment round-trip);
+   * otherwise falls back to the legacy v1 mint flow. Returns the stored token and
+   * its genesis-stable id, or an error result.
    */
-
-  /**
-   * Persist a realized v2 engine token as a confirmed wallet Token and return it.
-   * Single source of truth for "engine SphereToken -> stored UI Token": serialize
-   * with the wallet blob codec, derive coin/amount via parseTokenInfo, apply
-   * registry overrides, key it v2_<genesis-stable tokenId>, and addToken. Reused
-   * by self-mint, the send change-token path, and the v2 receive path.
-   */
-  private async storeEngineToken(engine: ITokenEngine, token: SphereToken): Promise<Token> {
-    const sdkData = bytesToHex(encodeTokenBlob(engine.encodeToken(token)));
-    const info = await parseTokenInfo(sdkData, engine);
-    const registry = TokenRegistry.getInstance();
-    const uiToken: Token = {
-      id: `v2_${engine.tokenId(token)}`,
-      coinId: info.coinId,
-      symbol: registry.getSymbol(info.coinId) || info.symbol,
-      name: registry.getName(info.coinId) || info.name,
-      decimals: registry.getDecimals(info.coinId) ?? info.decimals,
-      amount: info.amount,
-      status: 'confirmed',
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-      sdkData,
-    };
-    await this.addToken(uiToken);
-    return uiToken;
-  }
-
   async mintFungibleToken(
     coinIdHex: string,
     amount: bigint,
@@ -4739,6 +4689,34 @@ export class PaymentsModule {
   }
 
   /**
+   * Persist a realized v2 engine token as a confirmed wallet Token and return it.
+   * Single source of truth for "engine SphereToken -> stored UI Token": serialize
+   * with the wallet blob codec, derive coin/amount via parseTokenInfo, apply
+   * registry overrides, key it v2_<genesis-stable tokenId>, and addToken. Reused
+   * by self-mint, the send change-token path, and the v2 receive path.
+   */
+  private async storeEngineToken(engine: ITokenEngine, token: SphereToken): Promise<Token> {
+    // Re-encode from the decoded blob; byte-identical to the wire blob (canonical CBOR).
+    const sdkData = bytesToHex(encodeTokenBlob(engine.encodeToken(token)));
+    const info = await parseTokenInfo(sdkData, engine);
+    const registry = TokenRegistry.getInstance();
+    const uiToken: Token = {
+      id: `v2_${engine.tokenId(token)}`,
+      coinId: info.coinId,
+      symbol: registry.getSymbol(info.coinId) || info.symbol,
+      name: registry.getName(info.coinId) || info.name,
+      decimals: registry.getDecimals(info.coinId) ?? info.decimals,
+      amount: info.amount,
+      status: 'confirmed',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sdkData,
+    };
+    await this.addToken(uiToken);
+    return uiToken;
+  }
+
+  /**
    * v2 engine self-mint (no faucet): build a FINISHED token via engine.mint and
    * store it (storeEngineToken) as a confirmed wallet token — no commitment /
    * inclusion-proof / finalization round-trip. Lets a fresh wallet be topped up
@@ -4752,8 +4730,8 @@ export class PaymentsModule {
     if (amount <= 0n) {
       return { success: false, error: 'Mint amount must be greater than zero' };
     }
-    if (!/^[0-9a-fA-F]+$/.test(coinIdHex)) {
-      return { success: false, error: `Invalid coin id (expected hex): ${coinIdHex}` };
+    if (!/^([0-9a-fA-F]{2})+$/.test(coinIdHex)) {
+      return { success: false, error: `Invalid coin id (expected even-length hex): ${coinIdHex}` };
     }
 
     try {

--- a/tests/e2e/token-engine.testnet2.e2e.test.ts
+++ b/tests/e2e/token-engine.testnet2.e2e.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, it } from 'vitest';
 
 import { createSphereTokenEngine } from '../../token-engine/factory';
 import { SigningService } from '../../token-engine/sdk';
+import { decodeTokenBlob, encodeTokenBlob } from '../../token-engine/token-blob';
+import { bytesToHex, hexToBytes } from '../../core/crypto';
 
 const GATEWAY = process.env.TESTNET2_GATEWAY ?? 'https://gateway.testnet2.unicity.network';
 const API_KEY = process.env.TESTNET2_API_KEY;
@@ -75,5 +77,22 @@ describe.runIf(!!API_KEY)('token-engine e2e — live testnet2 (networkId 4)', ()
     expect(engine.readValue(t)).toBeNull();
     expect(engine.readTokenData(t)).toEqual(data);
     expect(engine.tokenId(t)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('self-mints a top-up token to own identity and round-trips its stored blob', async () => {
+    const engine = await makeEngine();
+    const self = engine.getIdentity().chainPubkey;
+
+    // Self-mint (the top-up primitive PaymentsModule.mintFungibleToken uses).
+    const minted = await engine.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 250n }] } });
+    expect(engine.balanceOf(minted, COIN)).toBe(250n);
+    expect((await engine.verify(minted)).ok).toBe(true);
+    expect(await engine.isSpent(minted)).toBe(false);
+
+    // Exactly the wallet's storage codec: blob hex -> decode -> balance preserved.
+    const sdkData = bytesToHex(encodeTokenBlob(engine.encodeToken(minted)));
+    const restored = await engine.decodeToken(decodeTokenBlob(hexToBytes(sdkData)));
+    expect(engine.tokenId(restored)).toBe(engine.tokenId(minted));
+    expect(engine.balanceOf(restored, COIN)).toBe(250n);
   });
 });

--- a/tests/unit/modules/PaymentsModule.v2-mint.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-mint.test.ts
@@ -16,6 +16,12 @@ import { FakeTokenEngine } from '../token-engine/FakeTokenEngine';
 import { decodeTokenBlob } from '../../../token-engine/token-blob';
 import { hexToBytes } from '../../../core/crypto';
 
+class ThrowingMintEngine extends FakeTokenEngine {
+  mint(): Promise<never> {
+    return Promise.reject(new Error('boom'));
+  }
+}
+
 const FAKE_PRIVATE_KEY = 'a'.repeat(64);
 const FAKE_PUBKEY = '02' + 'b'.repeat(64);
 const UCT = '11'.repeat(32); // v2 coin ids are lowercase hex
@@ -23,7 +29,7 @@ const UCT = '11'.repeat(32); // v2 coin ids are lowercase hex
 function mockIdentity(): FullIdentity {
   return {
     chainPubkey: FAKE_PUBKEY, l1Address: 'alpha1x', directAddress: 'DIRECT://x',
-    privateKey: FAKE_PRIVATE_KEY, transportPubkey: 'dd'.repeat(32),
+    privateKey: FAKE_PRIVATE_KEY,
   };
 }
 
@@ -123,6 +129,9 @@ describe('mintFungibleToken — v2 engine self-mint (top-up)', () => {
     expect(tokens[0].coinId).toBe(UCT);
     expect(tokens[0].amount).toBe('500');
     expect(tokens[0].status).toBe('confirmed');
+    // Registry-fallback: unregistered coin — symbol = first 6 chars uppercased, name = full coinId
+    expect(tokens[0].symbol).toBe('111111');
+    expect(tokens[0].name).toBe(UCT);
   });
 
   it('stores a blob that decodes back to the requested value (engine.balanceOf)', async () => {
@@ -158,6 +167,27 @@ describe('mintFungibleToken — v2 engine self-mint (top-up)', () => {
     const res = await module.mintFungibleToken('abc', 100n);
 
     expect(res.success).toBe(false);
+    expect(module.getTokens()).toHaveLength(0);
+  });
+
+  it('rejects an uppercase hex coin id without minting', async () => {
+    const { module } = setup();
+    const res = await module.mintFungibleToken('AB'.repeat(32), 100n);
+
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.error).toContain('lowercase');
+    expect(module.getTokens()).toHaveLength(0);
+  });
+
+  it('returns a V2 mint failed error and stores nothing when engine.mint throws', async () => {
+    const { module } = setup({ engine: new ThrowingMintEngine() });
+    const res = await module.mintFungibleToken(UCT, 100n);
+
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.error).toContain('V2 mint failed');
+    expect(res.error).toContain('boom');
     expect(module.getTokens()).toHaveLength(0);
   });
 });

--- a/tests/unit/modules/PaymentsModule.v2-mint.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-mint.test.ts
@@ -152,6 +152,14 @@ describe('mintFungibleToken — v2 engine self-mint (top-up)', () => {
     expect(res.success).toBe(false);
     expect(module.getTokens()).toHaveLength(0);
   });
+
+  it('rejects an odd-length hex coin id without minting', async () => {
+    const { module } = setup();
+    const res = await module.mintFungibleToken('abc', 100n);
+
+    expect(res.success).toBe(false);
+    expect(module.getTokens()).toHaveLength(0);
+  });
 });
 
 describe('mintFungibleToken — v1 fallback when no engine', () => {

--- a/tests/unit/modules/PaymentsModule.v2-mint.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-mint.test.ts
@@ -1,0 +1,167 @@
+/**
+ * v2 self-mint / top-up — mintFungibleToken engine branch (feat/v2-self-mint-topup).
+ *
+ * When a token engine is present, mintFungibleToken self-mints a FINISHED v2 token
+ * via engine.mint and stores it as a confirmed wallet token (id v2_<id>), with no
+ * commitment / inclusion-proof round-trip. Without an engine it falls back to the
+ * legacy v1 path. Clean harness (NO SDK vi.mock) so FakeTokenEngine runs end-to-end.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createPaymentsModule, type PaymentsModuleDependencies } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity } from '../../../types';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../../storage';
+import { FakeTokenEngine } from '../token-engine/FakeTokenEngine';
+import { decodeTokenBlob } from '../../../token-engine/token-blob';
+import { hexToBytes } from '../../../core/crypto';
+
+const FAKE_PRIVATE_KEY = 'a'.repeat(64);
+const FAKE_PUBKEY = '02' + 'b'.repeat(64);
+const UCT = '11'.repeat(32); // v2 coin ids are lowercase hex
+
+function mockIdentity(): FullIdentity {
+  return {
+    chainPubkey: FAKE_PUBKEY, l1Address: 'alpha1x', directAddress: 'DIRECT://x',
+    privateKey: FAKE_PRIVATE_KEY, transportPubkey: 'dd'.repeat(32),
+  };
+}
+
+function mockStorage(): StorageProvider {
+  const s = new Map<string, string>();
+  return {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+}
+
+function mockHistoryStore() {
+  const entries = new Map<string, HistoryRecord>();
+  return {
+    addHistoryEntry: vi.fn(async (e: HistoryRecord) => { entries.set(e.dedupKey, e); }),
+    getHistoryEntries: vi.fn(async () => [...entries.values()]),
+    hasHistoryEntry: vi.fn(async (k: string) => entries.has(k)),
+    clearHistory: vi.fn(async () => entries.clear()),
+    importHistoryEntries: vi.fn(async () => 0),
+  };
+}
+
+function mockTokenStorage(): TokenStorageProvider<TxfStorageDataBase> {
+  return {
+    id: 'ts', name: 'ts', type: 'local',
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(true), shutdown: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue({ success: true, timestamp: 0 }),
+    load: vi.fn().mockResolvedValue({ success: false, source: 'local', timestamp: 0 }),
+    sync: vi.fn().mockResolvedValue({ success: true, added: 0, removed: 0, conflicts: 0 }),
+    ...mockHistoryStore(),
+  } as unknown as TokenStorageProvider<TxfStorageDataBase>;
+}
+
+function mockTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue(null),
+    resolveNametagInfo: vi.fn().mockResolvedValue(null),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn(), isConnected: () => true,
+    publishNametag: vi.fn().mockResolvedValue(undefined),
+    sendPaymentRequest: vi.fn().mockResolvedValue(undefined),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(withStClient: boolean): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    // When withStClient is false the v1 mint path bails with a deterministic error,
+    // which is what the "no engine -> v1 fallback" test asserts on.
+    getStateTransitionClient: vi.fn().mockReturnValue(withStClient ? {} : undefined),
+    getTrustBase: vi.fn().mockReturnValue(withStClient ? {} : undefined),
+    isDevMode: () => false,
+    waitForProofSdk: vi.fn().mockResolvedValue({ proof: 'mock' }),
+  } as unknown as OracleProvider;
+}
+
+function setup(opts: { engine?: FakeTokenEngine | null; withStClient?: boolean } = {}) {
+  const engine = opts.engine === undefined ? new FakeTokenEngine() : opts.engine;
+  const tsp = new Map<string, TokenStorageProvider<TxfStorageDataBase>>();
+  tsp.set('local', mockTokenStorage());
+  const emitEvent = vi.fn();
+  const deps: PaymentsModuleDependencies = {
+    identity: mockIdentity(), storage: mockStorage(), tokenStorageProviders: tsp,
+    transport: mockTransport(), oracle: mockOracle(opts.withStClient ?? true), emitEvent,
+    ...(engine ? { tokenEngine: engine } : {}),
+  };
+  const module = createPaymentsModule({ debug: false });
+  module.initialize(deps);
+  return { module, engine, emitEvent };
+}
+
+describe('mintFungibleToken — v2 engine self-mint (top-up)', () => {
+  it('self-mints a confirmed v2 token and stores it', async () => {
+    const { module } = setup();
+    const res = await module.mintFungibleToken(UCT, 500n);
+
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.tokenId).toMatch(/^[0-9a-f]{64}$/);
+
+    const tokens = module.getTokens();
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].id).toBe(`v2_${res.tokenId}`);
+    expect(tokens[0].coinId).toBe(UCT);
+    expect(tokens[0].amount).toBe('500');
+    expect(tokens[0].status).toBe('confirmed');
+  });
+
+  it('stores a blob that decodes back to the requested value (engine.balanceOf)', async () => {
+    const { module, engine } = setup();
+    const res = await module.mintFungibleToken(UCT, 750n);
+
+    expect(res.success).toBe(true);
+    if (!res.success || !engine) return;
+
+    const stored = module.getTokens()[0];
+    const token = await engine.decodeToken(decodeTokenBlob(hexToBytes(stored.sdkData!)));
+    expect(engine.balanceOf(token, UCT)).toBe(750n);
+  });
+
+  it('rejects a non-positive amount without minting', async () => {
+    const { module } = setup();
+    const res = await module.mintFungibleToken(UCT, 0n);
+
+    expect(res.success).toBe(false);
+    expect(module.getTokens()).toHaveLength(0);
+  });
+
+  it('rejects a non-hex coin id without minting', async () => {
+    const { module } = setup();
+    const res = await module.mintFungibleToken('not-hex', 100n);
+
+    expect(res.success).toBe(false);
+    expect(module.getTokens()).toHaveLength(0);
+  });
+});
+
+describe('mintFungibleToken — v1 fallback when no engine', () => {
+  it('takes the v1 path and surfaces the v1 unavailability error', async () => {
+    const { module } = setup({ engine: null, withStClient: false });
+    const res = await module.mintFungibleToken(UCT, 100n);
+
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.error).toContain('State transition client not available');
+    expect(module.getTokens()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a v2 engine self-mint path to `PaymentsModule.mintFungibleToken`: when a token engine is present it self-mints a finished v2 token via `engine.mint` (no faucet, no commitment/inclusion-proof round-trip); otherwise it falls back to the unchanged legacy v1 mint flow. Signature and return type are unchanged.
- Extracts a shared private `storeEngineToken(engine, token)` helper (serialize blob → `parseTokenInfo` → registry overrides → `addToken`, keyed `v2_<tokenId>`) and refactors the two pre-existing duplicate storage sites (the `send` change-token path and `handleV2Transfer`) onto it — removing duplication, behaviour-preserving.
- Keeps the anti-corruption boundary intact: no direct `state-transition-sdk` import is added; all v2 access stays behind the `ITokenEngine` port. The v1 fallback is marked `V1-FALLBACK` so it can be removed mechanically once v2 is confirmed stable.

This unblocks testing v2 payments in the sphere app: a fresh testnet2 wallet is empty (no faucet, v1 mint doesn't work on testnet2), so a v2 funding path is the prerequisite to exercising send/split.

## Test Plan
- [x] Unit (`tests/unit/modules/PaymentsModule.v2-mint.test.ts`, FakeTokenEngine): self-mint stores a confirmed `v2_` token with correct coinId/amount; stored blob decodes back to the requested value; non-positive amount rejected; non-hex / odd-length hex coinId rejected; no-engine → v1 fallback error.
- [x] `PaymentsModule.v2-receive.test.ts` still green (proves the `storeEngineToken` refactor is behaviour-preserving).
- [x] Full unit suite green (1299 tests, modules + token-engine); `npm run typecheck` clean.
- [ ] e2e (`tests/e2e/token-engine.testnet2.e2e.test.ts`, gated by `TESTNET2_API_KEY`): live self-mint → serialize → decode → balance round-trip. Run locally with credentials.

## Follow-up
- Dev-publish `0.8.0-dev.1` from this branch (auto `@dev` dist-tag) so the sphere app can consume it and wire a top-up trigger.