### PR TITLE
feat(config): require injected aggregator apiKey (drop hardcoded default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,13 @@
-# sphere-sdk e2e configuration — copy to `.env` (gitignored) and fill in.
+# sphere-sdk e2e configuration — copy to `.env` (gitignored).
 # Used by `npm run test:e2e`. The token-engine testnet2 e2e is SKIPPED unless
-# TESTNET2_API_KEY is set, so this file is safe to leave blank.
+# TESTNET2_API_KEY is set; it is pre-filled below because the testnet2 key is not a secret.
 
 # Unicity testnet2 v2 gateway (state-transition aggregator).
 TESTNET2_GATEWAY=https://gateway.testnet2.unicity.network
 
-# Gateway API key — SECRET. Never commit a real key (.env is gitignored).
-# Ask the aggregator team for one.
-TESTNET2_API_KEY=
+# testnet2 gateway API key — NOT a secret: testnet2 keys are safe to commit here and in docs.
+# A MAINNET key, by contrast, IS a secret — keep it only in your deploy env, never in this file.
+TESTNET2_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
 
 # Root trust base JSON URL. Declares the network id (testnet2 = 4); the engine
 # takes its NetworkId from here.

--- a/constants.ts
+++ b/constants.ts
@@ -238,8 +238,6 @@ export const TEST_AGGREGATOR_URL = 'https://goggregator-test.unicity.network' as
 /** Default aggregator request timeout (ms) */
 export const DEFAULT_AGGREGATOR_TIMEOUT = 30000;
 
-/** Default API key for aggregator authentication */
-export const DEFAULT_AGGREGATOR_API_KEY = 'sk_06365a9c44654841a366068bcfc68986' as const;
 
 // =============================================================================
 // IPFS Defaults

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -50,6 +50,34 @@ const providers = createNodeProviders({
 });
 ```
 
+### Aggregator API key
+
+The SDK does **not** ship a default aggregator API key. Pass it explicitly via
+`oracle.apiKey` when creating providers:
+
+```typescript
+createBrowserProviders({
+  network: 'testnet',
+  oracle: {
+    url: 'https://gateway.testnet2.unicity.network',
+    apiKey: import.meta.env.VITE_AGGREGATOR_API_KEY, // browser: build-time env
+    // trustBaseUrl: '<testnet2 trustbase url>',
+  },
+});
+```
+
+The SDK itself reads no environment variables (it runs in browsers too) — your app injects the
+key from its own environment (`import.meta.env.*` in Vite apps, `process.env.*` in node/bots).
+
+- **testnet / testnet2 keys are NOT secret** — safe to commit in `.env.example` and show in docs.
+- **mainnet keys ARE secret** — keep them only in your deploy environment, never committed. Note
+  that a browser app bundles `VITE_*` vars into shipped JS, so a key delivered that way is visible
+  to clients; for a truly secret mainnet key, proxy aggregator calls through a backend (the browser
+  then passes `oracle.url = <proxy>` and no key) or use per-user gateway auth.
+
+If no `apiKey` is provided, the v2 token engine still constructs, but its gateway requests are
+unauthenticated and the SDK logs a `TokenEngine` warning.
+
 ### Initialize Wallet
 
 ```typescript

--- a/impl/shared/resolvers.ts
+++ b/impl/shared/resolvers.ts
@@ -3,7 +3,7 @@
  * Utility functions for resolving provider configurations with extend/override pattern
  */
 
-import { NETWORKS, DEFAULT_AGGREGATOR_API_KEY, type NetworkType, type NetworkConfig } from '../../constants';
+import { NETWORKS, type NetworkType, type NetworkConfig } from '../../constants';
 import type {
   BaseTransportConfig,
   BaseOracleConfig,
@@ -110,7 +110,7 @@ export function resolveOracleConfig(
 
   return {
     url: config?.url ?? networkConfig.aggregatorUrl,
-    apiKey: config?.apiKey ?? DEFAULT_AGGREGATOR_API_KEY,
+    apiKey: config?.apiKey,
     timeout: config?.timeout,
     skipVerification: config?.skipVerification,
     debug: config?.debug,

--- a/tests/unit/impl/shared/resolvers.test.ts
+++ b/tests/unit/impl/shared/resolvers.test.ts
@@ -180,12 +180,17 @@ describe('resolveOracleConfig', () => {
       expect(result.trustBasePath).toBe('./trustbase.json');
     });
 
-    it('should use default API key when not specified', () => {
+    it('should NOT set an API key when not specified (no bundled default)', () => {
       const result = resolveOracleConfig('testnet');
-      // Default API key is set in constants for trustbase authentication
-      expect(result.apiKey).toBe('sk_06365a9c44654841a366068bcfc68986');
+      // The SDK no longer ships a default key — consumers inject config.oracle.apiKey from env.
+      expect(result.apiKey).toBeUndefined();
       expect(result.timeout).toBeUndefined();
       expect(result.skipVerification).toBeUndefined();
+    });
+
+    it('should pass through an explicitly provided API key', () => {
+      const result = resolveOracleConfig('testnet', { apiKey: 'sk_custom' });
+      expect(result.apiKey).toBe('sk_custom');
     });
   });
 });

--- a/tests/unit/token-engine/factory.test.ts
+++ b/tests/unit/token-engine/factory.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createSphereTokenEngine } from '../../../token-engine/factory';
 import { SigningService } from '../../../token-engine/sdk';
+import { logger } from '../../../core/logger';
 
 // Minimal single-node trust base (sigKey = a valid compressed pubkey). Parses fine;
 // no network is touched (AggregatorClient connects lazily, on the first request).
@@ -39,6 +40,30 @@ describe('createSphereTokenEngine', () => {
     });
     // Construction succeeds: NetworkId.fromId(4) is valid; no enum entry needed.
     expect(engine.getIdentity().chainPubkey).toBeInstanceOf(Uint8Array);
+  });
+
+  it('warns when constructed without an apiKey', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    await createSphereTokenEngine({
+      aggregatorUrl: 'http://localhost:3000',
+      privateKey: SigningService.generatePrivateKey(),
+      trustBaseJson: TRUST_BASE_JSON,
+    });
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls.some((c) => String(c[1]).includes('apiKey'))).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('does NOT warn when an apiKey is provided', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    await createSphereTokenEngine({
+      aggregatorUrl: 'http://localhost:3000',
+      apiKey: 'sk_provided',
+      privateKey: SigningService.generatePrivateKey(),
+      trustBaseJson: TRUST_BASE_JSON,
+    });
+    expect(warn.mock.calls.some((c) => String(c[1]).includes('apiKey'))).toBe(false);
+    warn.mockRestore();
   });
 
   it('rejects a config without a trust base', async () => {

--- a/token-engine/factory.ts
+++ b/token-engine/factory.ts
@@ -14,6 +14,7 @@
  */
 
 import { SphereError } from '../core/errors';
+import { logger } from '../core/logger';
 import {
   AggregatorClient,
   MintJustificationVerifierService,
@@ -30,6 +31,13 @@ import type { EngineConfig, ITokenEngine } from './engine';
 export async function createSphereTokenEngine(config: EngineConfig): Promise<ITokenEngine> {
   if (config.trustBaseJson == null) {
     throw new SphereError('Engine config requires a trust base (trustBaseJson)', 'INVALID_CONFIG');
+  }
+
+  if (!config.apiKey) {
+    logger.warn(
+      'TokenEngine',
+      'No aggregator apiKey — pass config.oracle.apiKey (testnet2 value in .env.example; mainnet from a secret env var). Gateway requests will be unauthenticated.',
+    );
   }
 
   const trustBase = RootTrustBase.fromJSON(config.trustBaseJson);


### PR DESCRIPTION
## Summary

The SDK no longer ships a hardcoded aggregator API key. Consumers inject `config.oracle.apiKey` from their own environment (the SDK reads no env — it runs in browsers too).

- **Remove `DEFAULT_AGGREGATOR_API_KEY`** from `constants.ts`; `resolveOracleConfig` no longer substitutes a default (`apiKey: config?.apiKey`). Previously this single seam silently applied a bundled testnet key to **every** network — including mainnet.
- **`createSphereTokenEngine` warns** (clear `TokenEngine` log) when built without an apiKey — gateway requests would otherwise be unauthenticated (the v2 `AggregatorClient` only sends `X-API-Key` when a key is present). Warn-and-proceed, not throw, since the legacy v1 fallback still exists.
- **`.env.example`**: fill in the non-secret testnet2 key; document that a mainnet key is a secret (deploy env only, never committed).
- **`docs/INTEGRATION.md`**: new "Aggregator API key" section — injection policy, testnet keys non-secret vs mainnet secret, and the browser-bundle/proxy caveat.

## Scope

`sphere-sdk` only. Deferred to the separate apps-migration task: wiring `sphere`/bots to inject the key, a `testnet2` `NETWORKS` preset, and switching the wallet "Top Up" from faucet to v2 self-mint. Legacy v1 e2e tests keep their self-contained hardcoded testnet gateway/trustbase/key (they are removed at the v1 cutover, so a second `TESTNET_*` env convention was intentionally avoided).

## Test Plan

- [x] `npx vitest run` — full unit suite green (2829 tests)
- [x] New unit coverage: `resolveOracleConfig` returns `undefined` apiKey when not provided + passes through when provided; `createSphereTokenEngine` warns iff no apiKey
- [x] `eslint` clean on all changed files (3 repo-wide lint errors are pre-existing in `modules/swap/SwapModule.ts` + `tests/e2e/swap-continuous.test.ts`, untouched here)
- [ ] testnet2 e2e (gated on `TESTNET2_API_KEY`) — run on CI/Linux

> Note: local `npm run build` DTS phase segfaults on Windows+node22.14 (known pre-existing trap); build verified on CI/Linux.