### PR TITLE
feat(networks): add testnet2 network preset

### DIFF
--- a/assets/trustbase.ts
+++ b/assets/trustbase.ts
@@ -25,6 +25,50 @@ export const TRUSTBASE_TESTNET = {
   },
 };
 
+// Testnet2 (networkId 4) — embedded copy of bft-trustbase.testnet2.json
+export const TRUSTBASE_TESTNET2 = {
+  version: 1,
+  networkId: 4,
+  epoch: 1,
+  epochStartRound: 1,
+  rootNodes: [
+    {
+      nodeId: '16Uiu2HAm33LfAYP811b4fpW5x8qejmujuB1LFCXPGGTT6bumHrvy',
+      sigKey: '0x02b2b1daf4dee562ef5ed5b89e1e0e6cf0bf952ce3af12be6531e40f8bd1a7e682',
+      stake: 1,
+    },
+    {
+      nodeId: '16Uiu2HAmFCiccNnmDEdcBiBq5Giz5VsEUzdcL8uDe2QPTjE3ZL3M',
+      sigKey: '0x02822d7ce59d2ff4f2da4cef361d5a80a3a74c351fe61a8a2c908a54841930cee0',
+      stake: 1,
+    },
+    {
+      nodeId: '16Uiu2HAmFzgCoCdKt8y7so3w5jfgxc2FCW8p1bffHzY3L6zqc8BC',
+      sigKey: '0x0352ef027d60921e252839bea60e2f1810473fb0ad8cb89044b101aecdea5f356a',
+      stake: 1,
+    },
+    {
+      nodeId: '16Uiu2HAmU5T1TqKyKkUB3sitWb431hVFfp9nqvaLgVagQF6ywLFF',
+      sigKey: '0x02ef71c49c77ca9510ad84596522b887e4df0b3262fce80192ddcfb6276efdf901',
+      stake: 1,
+    },
+  ],
+  quorumThreshold: 3,
+  stateHash: '',
+  changeRecordHash: '',
+  previousEntryHash: '',
+  signatures: {
+    '16Uiu2HAm33LfAYP811b4fpW5x8qejmujuB1LFCXPGGTT6bumHrvy':
+      '0xe9289562b9faf283ae264ce42ef641133237bca6b7f232e1e293305f0cf994d3262cee1ca9c8de93fc5b7da1466486123b6219e5308843b8ead173472dad35e501',
+    '16Uiu2HAmFCiccNnmDEdcBiBq5Giz5VsEUzdcL8uDe2QPTjE3ZL3M':
+      '0x45e26943305c264d5dc5c3069cd5dbd2d43feb35d56d580656b80b33f4126e2a735b0c8eace0ef638128d9dbf5eb854dd9ad3ba42f9eafded60251bf7edb454501',
+    '16Uiu2HAmFzgCoCdKt8y7so3w5jfgxc2FCW8p1bffHzY3L6zqc8BC':
+      '0xe2263c1cb24b6d933ead249901c7fd83fa884d95b935a63f1489b07ea342281071cbf2117ad27be29cde9207d8d87e8b331630718d92d644faf2fccbc9dba4c000',
+    '16Uiu2HAmU5T1TqKyKkUB3sitWb431hVFfp9nqvaLgVagQF6ywLFF':
+      '0x9f28f3e3c50d4bfdaf54d7290fbbe311fffb3be2281a1d211be56818fa43d06a2e9a81925e9d365e552c8b772c99285a686de1d9fb581920be7524c7a5d467a301',
+  },
+};
+
 // Mainnet trust base (TODO: add when available)
 export const TRUSTBASE_MAINNET = null;
 

--- a/constants.ts
+++ b/constants.ts
@@ -351,6 +351,17 @@ export const NETWORKS = {
     groupRelays: DEFAULT_GROUP_RELAYS,
     tokenRegistryUrl: TOKEN_REGISTRY_URL,
   },
+  testnet2: {
+    name: 'Testnet2',
+    // v2 state-transition gateway (networkId 4 comes from the trust base). apiKey is env-injected.
+    aggregatorUrl: 'https://gateway.testnet2.unicity.network',
+    nostrRelays: TEST_NOSTR_RELAYS, // reuse testnet infra (shared relays/ipfs/electrum)
+    ipfsGateways: DEFAULT_IPFS_GATEWAYS,
+    electrumUrl: TEST_ELECTRUM_URL,
+    groupRelays: DEFAULT_GROUP_RELAYS,
+    tokenRegistryUrl:
+      'https://raw.githubusercontent.com/unicitynetwork/unicity-ids/refs/heads/main/unicity-ids.testnet2.json',
+  },
   dev: {
     name: 'Development',
     aggregatorUrl: DEV_AGGREGATOR_URL,

--- a/impl/shared/trustbase-loader.ts
+++ b/impl/shared/trustbase-loader.ts
@@ -3,7 +3,7 @@
  * Common embedded trustbase data and base loader
  */
 
-import { TRUSTBASE_TESTNET, TRUSTBASE_MAINNET, TRUSTBASE_DEV } from '../../assets/trustbase';
+import { TRUSTBASE_TESTNET, TRUSTBASE_TESTNET2, TRUSTBASE_MAINNET, TRUSTBASE_DEV } from '../../assets/trustbase';
 import type { NetworkType } from '../../constants';
 
 export interface TrustBaseLoader {
@@ -19,6 +19,8 @@ export function getEmbeddedTrustBase(network: NetworkType): unknown | null {
       return TRUSTBASE_MAINNET;
     case 'testnet':
       return TRUSTBASE_TESTNET;
+    case 'testnet2':
+      return TRUSTBASE_TESTNET2;
     case 'dev':
       return TRUSTBASE_DEV;
     default:

--- a/tests/unit/impl/shared/testnet2-preset.test.ts
+++ b/tests/unit/impl/shared/testnet2-preset.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { getNetworkConfig } from '../../../../impl/shared/resolvers';
+import { getEmbeddedTrustBase } from '../../../../impl/shared/trustbase-loader';
+
+describe('testnet2 network preset', () => {
+  it('NETWORKS.testnet2 points at the testnet2 gateway + registry', () => {
+    const cfg = getNetworkConfig('testnet2');
+    expect(cfg.aggregatorUrl).toBe('https://gateway.testnet2.unicity.network');
+    expect(cfg.tokenRegistryUrl).toContain('unicity-ids.testnet2.json');
+  });
+
+  it('embeds a testnet2 trust base with networkId 4', () => {
+    const tb = getEmbeddedTrustBase('testnet2') as { networkId?: number } | null;
+    expect(tb).not.toBeNull();
+    expect(tb?.networkId).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **testnet2** as a first-class network in the SDK, so consumers reach the v2 state-transition gateway with `network: 'testnet2'` + an injected `oracle.apiKey` (no hacky oracle override, no `trustBaseUrl` plumbing). Completes the #440 policy — network URLs/trust base are public presets, the apiKey is env-injected. testnet2 was the only live network without a preset.

- `assets/trustbase.ts` — embed `TRUSTBASE_TESTNET2` (verbatim `bft-trustbase.testnet2.json`, networkId 4).
- `impl/shared/trustbase-loader.ts` — `getEmbeddedTrustBase` handles `'testnet2'`.
- `constants.ts` — `NETWORKS.testnet2` (gateway `gateway.testnet2.unicity.network`, `unicity-ids.testnet2.json` registry, testnet relays/ipfs/electrum reused). `NetworkType` gains `'testnet2'` automatically.

Flow verified end-to-end: `createBrowserProviders({ network: 'testnet2' })` → `resolveOracleConfig` (gateway URL) + `createUnicityAggregatorProvider(network)` → `BrowserTrustBaseLoader('testnet2')` → `getEmbeddedTrustBase('testnet2')` → networkId 4.

## Why

Unblocks the sphere v2 migration (`feat/sdk-migration-v2`): sphere will set `network: 'testnet2'` + `oracle: { apiKey }`.

## Test Plan

- [x] New unit test `tests/unit/impl/shared/testnet2-preset.test.ts` (gateway/registry + embedded trustbase networkId 4)
- [x] `npx tsc --noEmit` clean (adding `'testnet2'` to `NetworkType` breaks no exhaustive switch)
- [x] `impl/shared` unit suite green (289)
- [x] `eslint` clean on changed files
- [ ] DTS build verified on CI/Linux (local Windows DTS phase hits the known node22 segfault trap; JS bundles + tsc are green)