### PR TITLE
fix(transport)(sphere-sdk#442): gate mux relay sub until module handlers register

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -3829,6 +3829,20 @@ export class Sphere {
 
     const emitEvent = this.emitEvent.bind(this);
 
+    // Issue #442 — suppress the mux subscription BEFORE addAddress so the
+    // relay filter is NOT rebuilt with the new pubkey until this address's
+    // modules finish loading. The mux is already armed from the primary
+    // address's `initializeModules()`, so without this hop the upcoming
+    // `addAddress(...)` would auto-call `updateSubscriptions()` and the
+    // relay would immediately start streaming events for the new pubkey
+    // into adapters whose handlers haven't registered yet — same race as
+    // the primary path. The primary address's existing wallet/chat sub
+    // continues delivering through the suppression window (suppress is a
+    // gate on FUTURE updates, not a tear-down).
+    if (this._transportMux) {
+      this._transportMux.suppressSubscriptions();
+    }
+
     // Ensure transport mux exists for non-primary addresses
     const adapter = await this.ensureTransportMux(index, identity);
 
@@ -4138,6 +4152,21 @@ export class Sphere {
       }
     }
 
+    // Issue #442 — arm the mux now that the new address's modules have
+    // registered their handlers. Rebuilds the relay filter to include the
+    // new pubkey alongside any previously-tracked addresses. See the
+    // matching suppress call earlier in this method.
+    if (this._transportMux) {
+      try {
+        await this._transportMux.armSubscriptions();
+      } catch (err) {
+        logger.warn(
+          'Sphere',
+          `[#442] mux armSubscriptions failed in initializeAddressModules (continuing — address ${index} will receive no events until reconnect): ${safeErrorMessage(err)}`,
+        );
+      }
+    }
+
     const moduleSet: AddressModuleSet = {
       index,
       identity,
@@ -4317,6 +4346,17 @@ export class Sphere {
           ? () => nostrTransport.getNostrClient()
           : undefined,
       });
+
+      // Issue #442 — suppress mux subscriptions BEFORE connect so the
+      // relay subscription is NOT opened until armSubscriptions() runs
+      // after every module's `load()` returns. Without this, DMs replayed
+      // by the relay between `mux.connect()` and `swap.load()` register
+      // their `communications.onDirectMessage(...)` handler land in the
+      // CommunicationsModule inbox (via the comms-owned onMessage handler
+      // that DOES register early) but never reach SwapModule's
+      // `swap_proposal:` parser — breaking cross-process swap flows
+      // (sphere-sdk#437). Mirrors the #423 fix for the non-mux path.
+      this._transportMux.suppressSubscriptions();
 
       // Connect the mux
       await this._transportMux.connect();
@@ -7714,6 +7754,27 @@ export class Sphere {
         'Sphere',
         `[#423] armSubscriptions failed (continuing — auto-arm fallback will retry): ${safeErrorMessage(err)}`,
       );
+    }
+
+    // Issue #442 — arm the MUX's relay subscription. Mirrors the #423 arm
+    // above but for the mux path (which the #423 fix explicitly leaves as
+    // a no-op — see the comment in the #423 block above for the
+    // "suppressSubscriptions on the outer provider, mux owns event routing"
+    // architecture). Without this, the mux's `updateSubscriptions()` never
+    // runs after `ensureTransportMux()` suppressed it pre-connect, and the
+    // wallet receives no DMs / token transfers / payment requests at all
+    // (worse than the original bug — total event blackout instead of
+    // late-handler drops). Always paired with the suppress call in
+    // `ensureTransportMux`.
+    if (this._transportMux) {
+      try {
+        await this._transportMux.armSubscriptions();
+      } catch (err) {
+        logger.warn(
+          'Sphere',
+          `[#442] mux armSubscriptions failed (continuing — wallet will receive no events until reconnect): ${safeErrorMessage(err)}`,
+        );
+      }
     }
   }
 

--- a/tests/unit/transport/MultiAddressTransportMux.subscribeGate442.test.ts
+++ b/tests/unit/transport/MultiAddressTransportMux.subscribeGate442.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the relay-subscription gate on MultiAddressTransportMux (#442).
+ *
+ * Issue #442 (cross-process Nostr delivery gap) — `ensureTransportMux()`
+ * called `mux.connect()` and `mux.addAddress()` BEFORE non-critical
+ * modules (SwapModule, AccountingModule, GroupChatModule, MarketModule)
+ * registered their `communications.onDirectMessage(...)` fan-out
+ * subscribers. Any DM replayed by the relay between the subscription open
+ * and the late module loads landed in CommunicationsModule's inbox (its
+ * own `onMessage` registered early) but never reached the late-
+ * registering DM consumers — `sphere dm history` showed the message but
+ * `sphere swap list` returned "No swaps found".
+ *
+ * The fix mirrors `NostrTransportProvider`'s #423 gate: a
+ * `suppressSubscriptions` / `armSubscriptions` pair on the mux that
+ * decouples the WebSocket open from the relay-subscription open. Sphere
+ * bootstrap suppresses BEFORE `connect()`, runs every module's `load()`,
+ * then arms — guaranteeing every late subscriber is wired before events
+ * start streaming.
+ *
+ * These tests pin the gate semantics with a mocked SDK so the regression
+ * cannot reappear:
+ *   - Default-armed (backward compat for direct-construction consumers).
+ *   - Suppressed mux: connect + addAddress is a relay-subscription no-op.
+ *   - armSubscriptions opens the relay subscription with every tracked
+ *     pubkey.
+ *   - Idempotent / always-rebuild on arm so the multi-address switch path
+ *     can re-call `armSubscriptions` to fold the newly-added pubkey into
+ *     the filter without losing the gate's protection.
+ *   - Suppressed updateSubscriptions does NOT tear down existing
+ *     subscriptions — primary's active filter keeps delivering events
+ *     during the gate window.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockSubscribe = vi.fn().mockReturnValue('mock-sub-id');
+const mockUnsubscribe = vi.fn();
+const mockConnect = vi.fn().mockResolvedValue(undefined);
+const mockDisconnect = vi.fn();
+const mockIsConnected = vi.fn().mockReturnValue(true);
+const mockGetConnectedRelays = vi.fn().mockReturnValue(new Set(['wss://relay1.test']));
+const mockAddConnectionListener = vi.fn();
+const mockRemoveConnectionListener = vi.fn();
+const mockPublishEvent = vi.fn().mockResolvedValue('mock-event-id');
+
+const NostrClientCtor = vi.fn().mockImplementation(() => ({
+  connect: mockConnect,
+  disconnect: mockDisconnect,
+  isConnected: mockIsConnected,
+  getConnectedRelays: mockGetConnectedRelays,
+  subscribe: mockSubscribe,
+  unsubscribe: mockUnsubscribe,
+  publishEvent: mockPublishEvent,
+  addConnectionListener: mockAddConnectionListener,
+  removeConnectionListener: mockRemoveConnectionListener,
+}));
+
+vi.mock('@unicitylabs/nostr-js-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/nostr-js-sdk')>();
+  return {
+    ...actual,
+    NostrClient: NostrClientCtor,
+  };
+});
+
+const { MultiAddressTransportMux } = await import('../../../transport/MultiAddressTransportMux');
+
+const TEST_IDENTITY_0 = {
+  chainPubkey: '02' + 'ab'.repeat(32),
+  l1Address: 'alpha1testaddr0',
+  directAddress: 'DIRECT://test0',
+  transportPubkey: 'cc'.repeat(32),
+  privateKey: 'dd'.repeat(32),
+};
+
+const TEST_IDENTITY_1 = {
+  chainPubkey: '02' + 'cd'.repeat(32),
+  l1Address: 'alpha1testaddr1',
+  directAddress: 'DIRECT://test1',
+  transportPubkey: '11'.repeat(32),
+  // secp256k1 private keys must be in [1..N-1]; 'ff'.repeat(32) is above N.
+  // 22.. is a safe low-bit constant.
+  privateKey: '22'.repeat(32),
+};
+
+function newMux() {
+  return new MultiAddressTransportMux({
+    relays: ['wss://relay1.test'],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    createWebSocket: (() => {}) as any,
+    timeout: 100,
+    autoReconnect: false,
+  });
+}
+
+describe('MultiAddressTransportMux — subscription gate (#442)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+    mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay1.test']));
+    mockSubscribe.mockReturnValue('mock-sub-id');
+  });
+
+  it('default-armed: connect + addAddress opens the relay subscription (backward compat)', async () => {
+    // Direct-construction consumers (tests, custom hosts) that never call
+    // suppressSubscriptions must see the same behavior as pre-#442:
+    // connect + addAddress immediately opens wallet + chat subs.
+    const mux = newMux();
+    expect(mux.isSubscriptionsArmed()).toBe(true);
+
+    await mux.connect();
+    await mux.addAddress(0, TEST_IDENTITY_0);
+
+    // updateSubscriptions ran inside addAddress because isConnected was
+    // true and the gate was open. Two subscribes — wallet filter + chat
+    // (gift-wrap) filter.
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('suppressed: connect + addAddress does NOT call subscribe', async () => {
+    const mux = newMux();
+    mux.suppressSubscriptions();
+    expect(mux.isSubscriptionsArmed()).toBe(false);
+
+    await mux.connect();
+    await mux.addAddress(0, TEST_IDENTITY_0);
+
+    // The gate short-circuited updateSubscriptions inside addAddress.
+    // No relay subscribes — events cannot flow yet.
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('armSubscriptions after suppress opens the relay subscription with the tracked pubkey', async () => {
+    const mux = newMux();
+    mux.suppressSubscriptions();
+
+    await mux.connect();
+    await mux.addAddress(0, TEST_IDENTITY_0);
+    expect(mockSubscribe).not.toHaveBeenCalled();
+
+    await mux.armSubscriptions();
+
+    expect(mux.isSubscriptionsArmed()).toBe(true);
+    // Both wallet and chat filters open exactly once. updateSubscriptions
+    // ran with all (one) tracked pubkey.
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('armSubscriptions always rebuilds (idempotent in effect, supports multi-address switch)', async () => {
+    // The multi-address switch path re-arms the mux after suppressing it
+    // around addAddress(N). Re-arm must rebuild the filter to include the
+    // newly-added pubkey — calling armSubscriptions a second time cannot
+    // be a no-op.
+    const mux = newMux();
+    mux.suppressSubscriptions();
+
+    await mux.connect();
+    await mux.addAddress(0, TEST_IDENTITY_0);
+    await mux.armSubscriptions();
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+
+    // Multi-address switch: suppress, addAddress(1), arm.
+    mockSubscribe.mockClear();
+    mockUnsubscribe.mockClear();
+    mux.suppressSubscriptions();
+    await mux.addAddress(1, TEST_IDENTITY_1);
+    // While suppressed, addAddress's auto-update no-oped.
+    expect(mockSubscribe).not.toHaveBeenCalled();
+
+    await mux.armSubscriptions();
+    // Now the rebuild ran: 2 unsubscribes (old wallet + old chat IDs) +
+    // 2 subscribes (new wallet + new chat with both pubkeys in the filter).
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(2);
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('suppressSubscriptions does NOT tear down active subscriptions', async () => {
+    // The multi-address-switch invariant: primary's active wallet/chat
+    // subs MUST keep delivering events through the suppression window.
+    // suppress sets the gate; it does not unsubscribe.
+    const mux = newMux();
+
+    await mux.connect();
+    await mux.addAddress(0, TEST_IDENTITY_0);
+    // Pre-suppression baseline: subs were opened.
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+    mockSubscribe.mockClear();
+    mockUnsubscribe.mockClear();
+
+    mux.suppressSubscriptions();
+
+    // No unsubscribes triggered by the gate flip.
+    expect(mockUnsubscribe).not.toHaveBeenCalled();
+    // And no new subscribes either.
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('suppressed updateSubscriptions does NOT tear down stale IDs (no event blackout)', async () => {
+    // Regression guard: a naive "early-return after unsubscribe" version
+    // of the gate would tear down the active subs without rebuilding,
+    // dropping incoming events for already-tracked addresses. The gate
+    // MUST short-circuit BEFORE the stale-ID unsubscribe.
+    const mux = newMux();
+
+    await mux.connect();
+    await mux.addAddress(0, TEST_IDENTITY_0);
+    mockUnsubscribe.mockClear();
+    mockSubscribe.mockClear();
+
+    // Now suppress + force a new updateSubscriptions trigger (addAddress on
+    // a different index re-enters updateSubscriptions).
+    mux.suppressSubscriptions();
+    await mux.addAddress(1, TEST_IDENTITY_1);
+
+    // No relay traffic at all — gate fires before the unsubscribe of the
+    // stale wallet/chat IDs.
+    expect(mockUnsubscribe).not.toHaveBeenCalled();
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('armSubscriptions before connect does NOT open subs (deferred until connect)', async () => {
+    // Pre-connect arming is allowed (the flag is sticky). connect() opens
+    // the WebSocket; updateSubscriptions runs inside connect()'s tail only
+    // when there are tracked addresses. Without any address, no subscribe.
+    const mux = newMux();
+    mux.suppressSubscriptions();
+    await mux.armSubscriptions();
+    // No connect yet → no subscribe.
+    expect(mockSubscribe).not.toHaveBeenCalled();
+
+    // Connect with no addresses tracked → still no subscribe.
+    await mux.connect();
+    expect(mockSubscribe).not.toHaveBeenCalled();
+
+    // Add an address → updateSubscriptions opens the relay sub.
+    await mux.addAddress(0, TEST_IDENTITY_0);
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('AddressTransportAdapter exposes the gate API and delegates to the mux', async () => {
+    const mux = newMux();
+    mux.suppressSubscriptions();
+    await mux.connect();
+    const adapter = await mux.addAddress(0, TEST_IDENTITY_0);
+
+    expect(adapter.isSubscriptionsArmed()).toBe(false);
+    expect(mockSubscribe).not.toHaveBeenCalled();
+
+    // Adapter delegates to the underlying mux — arming through the adapter
+    // opens the relay sub for every tracked address.
+    await adapter.armSubscriptions();
+    expect(mux.isSubscriptionsArmed()).toBe(true);
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+
+    // Re-suppress through the adapter — the gate closes for future
+    // updateSubscriptions triggers (e.g., reconnect-driven re-subs).
+    adapter.suppressSubscriptions();
+    expect(mux.isSubscriptionsArmed()).toBe(false);
+  });
+});

--- a/transport/MultiAddressTransportMux.ts
+++ b/transport/MultiAddressTransportMux.ts
@@ -205,6 +205,23 @@ export class MultiAddressTransportMux {
   // re-establish subscriptions it shouldn't have.
   private connectionListener: ConnectionEventListener | null = null;
 
+  // Issue #442 — gate the relay subscription open until all module DM
+  // handlers (CommunicationsModule + late-registering fan-out subscribers:
+  // SwapModule, AccountingModule, GroupChatModule, MarketModule) have
+  // attached. Default-armed for backward compat with consumers that build
+  // a Mux directly without going through Sphere bootstrap; Sphere
+  // explicitly calls {@link suppressSubscriptions} before
+  // {@link connect} so the gate opens on the explicit
+  // {@link armSubscriptions} call after every module's `load()` returns.
+  //
+  // When suppressed, {@link updateSubscriptions} short-circuits before
+  // touching the relay (no unsubscribe of stale IDs, no resubscribe). The
+  // mux still tracks addresses, but the relay sub stays in its previous
+  // state — closed for a freshly-connected Mux, or the prior address
+  // filter for the multi-address-switch path (primary keeps receiving
+  // events through the existing sub during the gate window).
+  private subscriptionsArmed = true;
+
   constructor(config: MultiAddressTransportMuxConfig) {
     this.identityPrivateKey = config.identityPrivateKey;
     this.config = {
@@ -493,6 +510,79 @@ export class MultiAddressTransportMux {
     return this.status === 'connected' && this.nostrClient?.isConnected() === true;
   }
 
+  // ===========================================================================
+  // Issue #442 — Subscription gate (mirror of NostrTransportProvider's #423
+  // gate, but for the mux path which #423 left uncovered).
+  //
+  // Pre-#442: `ensureTransportMux()` opened the WebSocket and immediately
+  // called `updateSubscriptions()` (via `connect()` / `addAddress()`), so
+  // the relay started replaying events BEFORE Sphere's module loads
+  // registered their handlers. Events that arrived before
+  // `SwapModule.load()` ran its `communications.onDirectMessage(...)` were
+  // routed through `CommunicationsModule.handleIncomingMessage` (which
+  // persisted to inbox) but missed the late-registering fan-out
+  // subscribers entirely — so a `swap_proposal:` DM landed in `sphere dm
+  // history` but `sphere swap list` returned "No swaps found".
+  //
+  // The gate decouples WebSocket open from relay-subscription open. Sphere
+  // bootstrap suppresses BEFORE `connect()`, runs all module loads, then
+  // arms — guaranteeing every onDirectMessage subscriber is wired before
+  // the relay starts streaming.
+  // ===========================================================================
+
+  /**
+   * Suppress the relay subscription so {@link updateSubscriptions} becomes a
+   * no-op. The WebSocket stays open (so resolve / sendDM still work), but no
+   * new wallet / chat filter is registered with the relay. Active filters
+   * registered before suppression are NOT torn down — they continue
+   * delivering events for the still-tracked pubkeys.
+   *
+   * Idempotent. Sticky until {@link armSubscriptions} is called.
+   *
+   * Used by:
+   *   - `Sphere.ensureTransportMux` BEFORE `connect()` on first
+   *     creation, so the initial address's `addAddress(...)` auto-update
+   *     no-ops until module handlers register.
+   *   - `Sphere.initializeAddressModules` BEFORE adding a non-primary
+   *     address, so the relay filter is not rebuilt with the new pubkey
+   *     until the new address's modules finish loading. (The primary
+   *     address's active filter keeps delivering events through the
+   *     suppression window — we explicitly do NOT unsubscribe here.)
+   */
+  suppressSubscriptions(): void {
+    if (!this.subscriptionsArmed) return;
+    this.subscriptionsArmed = false;
+    logger.debug('Mux', '[#442] Subscriptions suppressed — updateSubscriptions deferred until armSubscriptions()');
+  }
+
+  /**
+   * Arm the relay subscription. Sets armed=true and (when connected with
+   * at least one tracked address) rebuilds the wallet / chat filters via
+   * {@link updateSubscriptions}. Always rebuilds so multi-address switch
+   * paths can use this as the "open relay sub for the newly-added pubkey
+   * now that its modules have loaded" trigger — `armSubscriptions()` after
+   * a previous `armSubscriptions()` is NOT a no-op when new addresses have
+   * been registered in between.
+   *
+   * Safe to call before {@link connect}; the gate stays open, and connect
+   * will subscribe inline when it reaches its tail (existing behaviour).
+   *
+   * Returns once `updateSubscriptions` resolves so callers can await an
+   * established subscription before proceeding.
+   */
+  async armSubscriptions(): Promise<void> {
+    this.subscriptionsArmed = true;
+    if (this.isConnected() && this.addresses.size > 0) {
+      await this.updateSubscriptions();
+    }
+    logger.debug('Mux', '[#442] Subscriptions armed');
+  }
+
+  /** For tests and operator inspection. */
+  isSubscriptionsArmed(): boolean {
+    return this.subscriptionsArmed;
+  }
+
   /**
    * Build the connection listener used by both {@link connect} and
    * {@link rebindToSharedClient}.
@@ -775,6 +865,18 @@ export class MultiAddressTransportMux {
    */
   private async updateSubscriptions(): Promise<void> {
     if (!this.nostrClient) return;
+
+    // Issue #442 — Subscription gate. When suppressed (Sphere bootstrap
+    // before module loads complete, or the multi-address switch window)
+    // skip the relay update entirely. Critically, this MUST short-circuit
+    // BEFORE the stale-ID unsubscribe below — otherwise a suppress that
+    // lands between two updateSubscriptions calls would tear down the
+    // active sub without rebuilding it, dropping incoming events for the
+    // already-tracked addresses.
+    if (!this.subscriptionsArmed) {
+      logger.debug('Mux', '[#442] updateSubscriptions deferred — subscriptions not armed');
+      return;
+    }
 
     // Issue #275 — hydrate persistent dedup BEFORE EOSE replay arrives.
     // The first CLI command of a new process otherwise re-walks the
@@ -2119,6 +2221,30 @@ export class AddressTransportAdapter implements TransportProvider {
     // walks the same handleEvent dispatch chain (mux-level dedup prevents
     // double-processing with the live subscription).
     await this.mux.fetchPendingEvents();
+  }
+
+  /**
+   * Issue #442 — delegate to the underlying mux. Exposed on the adapter so
+   * consumers holding only an `AddressTransportAdapter` reference (the
+   * `TransportProvider` returned to PaymentsModule / CommunicationsModule)
+   * can also gate subscription arming through the same API shape as
+   * `NostrTransportProvider` (issue #423).
+   *
+   * Note: the gate is mux-wide, NOT per-adapter — calling
+   * `armSubscriptions` on one adapter opens the relay sub for every tracked
+   * address. Sphere bootstrap is the only intended caller; module code
+   * should not touch this.
+   */
+  suppressSubscriptions(): void {
+    this.mux.suppressSubscriptions();
+  }
+
+  async armSubscriptions(): Promise<void> {
+    await this.mux.armSubscriptions();
+  }
+
+  isSubscriptionsArmed(): boolean {
+    return this.mux.isSubscriptionsArmed();
   }
 
   onChatReady(handler: () => void): () => void {

--- a/transport/MultiAddressTransportMux.ts
+++ b/transport/MultiAddressTransportMux.ts
@@ -638,6 +638,16 @@ export class MultiAddressTransportMux {
           this.emitEvent({ type: 'transport:connected', timestamp: Date.now() });
         }
         // Re-establish subscriptions — the relay drops them on disconnect.
+        //
+        // Issue #442 caveat: if reconnect lands inside the bootstrap
+        // suppression window (between `ensureTransportMux` and the
+        // trailing `armSubscriptions` in `initializeModules`), this
+        // call short-circuits at the gate inside `updateSubscriptions`
+        // and no rebuild fires here. That's intentional — `arm`
+        // itself calls `updateSubscriptions` unconditionally, so the
+        // explicit arm masks rebuilds dropped during the suppress
+        // window. Outside the bootstrap window the gate is open and
+        // this path behaves as before.
         this.updateSubscriptions().catch((err) => {
           logger.error('Mux', 'Failed to re-subscribe after reconnect:', err);
         });
@@ -1011,6 +1021,14 @@ export class MultiAddressTransportMux {
    * Schedule a re-subscription after a relay-initiated subscription closure.
    * Debounced: if both wallet and chat subscriptions fire onError in quick
    * succession, only one updateSubscriptions() call runs.
+   *
+   * Issue #442 caveat: if the 2 s timer ticks while the gate is
+   * suppressed (during the bootstrap window), `updateSubscriptions`
+   * short-circuits and the rebuild is dropped. The explicit
+   * `armSubscriptions` at the end of `Sphere.initializeModules`
+   * always calls `updateSubscriptions` unconditionally, so any
+   * rebuild dropped here self-heals when arm fires. Outside the
+   * bootstrap window the gate is open and this path is unaffected.
    */
   private scheduleResubscribe(): void {
     if (this.resubscribeTimer) return; // already scheduled


### PR DESCRIPTION
## Summary

Closes #442. Fixes the cross-process Nostr delivery gap that breaks swap-roundtrip flows for fresh-CLI receivers.

`ensureTransportMux()` opened the WebSocket and (via `connect()` / `addAddress()`) immediately called `updateSubscriptions()` BEFORE non-critical modules registered their DM handlers in the trailing `Promise.allSettled`. Any DM the relay replayed between subscription open and the late `swap.load()` / `accounting.load()` calls landed in CommunicationsModule's inbox (its own `onMessage` registered early via the address adapter's #223 pending-queue) but never reached the late fan-out subscribers — so a `swap_proposal:` DM showed up in `sphere dm history` while `sphere swap list` returned "No swaps found".

The #423 gate handles this for the non-mux path; this PR adds the matching gate to the mux path that #423 explicitly left as a no-op (the comment in `Sphere.initializeModules` calls this out — \"the call below is a no-op (the gate short-circuits when suppressed)\").

## Change

- `MultiAddressTransportMux`: new `suppressSubscriptions()` / `armSubscriptions()` / `isSubscriptionsArmed()` API. When suppressed, `updateSubscriptions()` short-circuits BEFORE the stale-ID unsubscribe (regression-guarded by the new \"no event blackout\" test) so the multi-address-switch path keeps delivering events through the gate window. Default-armed for backward compat with direct-construction consumers (tests, custom hosts).
- `AddressTransportAdapter`: delegate `suppressSubscriptions` / `armSubscriptions` / `isSubscriptionsArmed` to the mux for API parity with NostrTransportProvider's #423 surface.
- `Sphere.ensureTransportMux`: call `mux.suppressSubscriptions()` BEFORE `mux.connect()` so the initial `addAddress(...)` auto-update no-ops.
- `Sphere.initializeModules`: call `mux.armSubscriptions()` at the end of the method, alongside the existing #423 outer-transport arm. Without this the wallet would never open a relay sub at all — total event blackout worse than the original race.
- `Sphere.initializeAddressModules`: suppress before `addAddress` and arm after `Promise.allSettled`, covering the same race for non-primary addresses.

## Test plan

- [x] New gate tests in `tests/unit/transport/MultiAddressTransportMux.subscribeGate442.test.ts` — 8 invariants pin the contract: default-armed backward compat, suppressed no-relay-traffic, arm opens with all tracked pubkeys, always-rebuild on re-arm for multi-address switch, suppress is not a tear-down, suppressed `updateSubscriptions` stays before the stale-ID unsubscribe (no event blackout guard), pre-connect arming defers to connect time, and adapter delegates to mux.
- [x] All 9013 unit tests still pass (16 skipped).
- [x] Live testnet swap soak (`docs/uxf` repo, `manual-test-swap-roundtrip.sh`) re-run against a live agentic-hosting escrow tenant — proposal-ingest, accept+deposit, deposit, swap-wait, and balance-delta sections all pass cross-process; this is the exact flow #442's reproduction blocked.

## Notes for reviewers

The soak's terminal-state verification (\"sphere swap status \$id\" after the swap reaches `completed`) still fails on a separate, pre-existing SwapModule limitation: `loadFromStorage` parks terminal entries in `_storedTerminalEntries` but `getSwapStatus` only checks `this.swaps`. That's out of scope for #442 and worth its own issue.