### PR TITLE
fix(swap)(sphere-sdk#445): lazy-load terminal swaps from storage in getSwapStatus

### DIFF
--- a/modules/swap/SwapModule.ts
+++ b/modules/swap/SwapModule.ts
@@ -819,9 +819,17 @@ export class SwapModule {
    * the in-memory working set.
    *
    * Returns null when:
-   *   - the id is not in {@link terminalSwapIds} (truly unknown — guards
-   *     against fetching arbitrary keys, including unrelated namespaces
-   *     that happen to share the {@code swap:} prefix on misuse).
+   *   - the id is NOT in {@link terminalSwapIds} — the gate restricts
+   *     storage reads to ids the module has previously observed as
+   *     terminal (either at {@link loadFromStorage} time or via an
+   *     in-process transition). Note that this set is sticky for the
+   *     process lifetime: ids that {@link loadFromStorage} added before
+   *     deciding to PURGE the storage record (TTL-expired entries) stay
+   *     in the set — that is intentional, so DM-driven replays cannot
+   *     resurrect a closed swap. For purged ids the helper still
+   *     returns null because the subsequent storage read finds no
+   *     record, so the caller's {@code SWAP_NOT_FOUND} surface is
+   *     unchanged. \"Gate true, no record\" is a normal, expected case.
    *   - the storage read or JSON parse fails.
    *   - the persisted record lacks a {@code swap} field.
    *
@@ -2198,6 +2206,7 @@ export class SwapModule {
     this.ensureReady();
 
     let swap = this.swaps.get(swapId);
+    let isLazyLoadedTerminal = false;
     if (!swap) {
       // Terminal swaps are deliberately omitted from `this.swaps` at
       // load time (see `loadFromStorage`) to keep memory bounded — a
@@ -2213,12 +2222,30 @@ export class SwapModule {
         throw new SphereError(`Swap not found: ${swapId}`, 'SWAP_NOT_FOUND');
       }
       swap = terminalSwap;
+      isLazyLoadedTerminal = true;
     }
 
     // Determine whether to query the escrow for the latest state.
     // If options.queryEscrow is explicitly set, use that; otherwise default to
     // true for active swaps and false for terminal swaps.
-    const shouldQuery = options?.queryEscrow ?? !isTerminalProgress(swap.progress);
+    //
+    // EXCEPT: for a lazy-loaded terminal swap (not in `this.swaps`), we
+    // unconditionally skip the escrow DM even when the caller explicitly
+    // requested `queryEscrow: true`. The downstream `status_result` DM
+    // handler resolves the swap via `this.swaps.get` — it has no path
+    // for lazy-loading from storage — so the response from escrow
+    // would be silently dropped on arrival. Firing the DM under
+    // those conditions is a footgun (network noise, escrow load, no
+    // observable effect for the caller); refuse it explicitly instead.
+    const shouldQuery = !isLazyLoadedTerminal
+      && (options?.queryEscrow ?? !isTerminalProgress(swap.progress));
+
+    if (isLazyLoadedTerminal && options?.queryEscrow === true) {
+      logger.debug(
+        LOG_TAG,
+        `getSwapStatus(${swapId}): queryEscrow ignored — swap is lazy-loaded from storage and the status_result handler cannot reach it. Re-issue the call after the swap is brought back into the active working set.`,
+      );
+    }
 
     if (shouldQuery) {
       // Fire-and-forget: resolve escrow address and send status DM.

--- a/modules/swap/SwapModule.ts
+++ b/modules/swap/SwapModule.ts
@@ -813,6 +813,53 @@ export class SwapModule {
   }
 
   /**
+   * Lazy-load a terminal swap record from per-swap storage. Used by
+   * {@link getSwapStatus} after a cache miss on {@link swaps} — see the
+   * comment there for why terminal swaps are deliberately kept out of
+   * the in-memory working set.
+   *
+   * Returns null when:
+   *   - the id is not in {@link terminalSwapIds} (truly unknown — guards
+   *     against fetching arbitrary keys, including unrelated namespaces
+   *     that happen to share the {@code swap:} prefix on misuse).
+   *   - the storage read or JSON parse fails.
+   *   - the persisted record lacks a {@code swap} field.
+   *
+   * The loaded record is NOT inserted into {@link swaps} — callers that
+   * need repeated access should hold the returned ref. Keeping the
+   * terminal working set out of memory preserves the bound that
+   * {@link loadFromStorage} establishes ({@code terminalPurgeTtlMs}
+   * window × cardinality), which can be hundreds of swaps for a heavy
+   * wallet.
+   */
+  private async loadTerminalSwapFromStorage(swapId: string): Promise<SwapRef | null> {
+    if (!this.terminalSwapIds.has(swapId)) return null;
+    const deps = this.deps;
+    if (!deps) return null;
+
+    const addressId = deps.identity.directAddress
+      ? deps.identity.directAddress
+      : deps.identity.chainPubkey;
+    const swapKey = getAddressStorageKey(
+      addressId,
+      `${STORAGE_KEYS_ADDRESS.SWAP_RECORD_PREFIX}${swapId}`,
+    );
+
+    try {
+      const raw = await deps.storage.get(swapKey);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as SwapStorageData;
+      if (parsed.version > 1) {
+        logger.warn(LOG_TAG, `Terminal swap ${swapId} has version ${parsed.version}, expected 1. Attempting best-effort load.`);
+      }
+      return parsed.swap ?? null;
+    } catch (err) {
+      logger.warn(LOG_TAG, `Failed to load terminal swap ${swapId} from storage:`, err);
+      return null;
+    }
+  }
+
+  /**
    * Remove a single swap from storage (per-swap key) and update the index.
    */
   private async removeSwapFromStorage(swapId: string): Promise<void> {
@@ -2150,9 +2197,22 @@ export class SwapModule {
     this.ensureNotDestroyed();
     this.ensureReady();
 
-    const swap = this.swaps.get(swapId);
+    let swap = this.swaps.get(swapId);
     if (!swap) {
-      throw new SphereError(`Swap not found: ${swapId}`, 'SWAP_NOT_FOUND');
+      // Terminal swaps are deliberately omitted from `this.swaps` at
+      // load time (see `loadFromStorage`) to keep memory bounded — a
+      // long-lived wallet can accumulate hundreds of terminal entries
+      // inside the `terminalPurgeTtlMs` window. `getSwapStatus` is the
+      // one public surface where callers legitimately want to query a
+      // terminal swap (e.g. a soak verification that the swap reached
+      // `completed` after a fresh-CLI restart), so fall through to
+      // storage on demand. The loaded record is NOT inserted into
+      // `this.swaps` — that map stays the active-swap working set.
+      const terminalSwap = await this.loadTerminalSwapFromStorage(swapId);
+      if (!terminalSwap) {
+        throw new SphereError(`Swap not found: ${swapId}`, 'SWAP_NOT_FOUND');
+      }
+      swap = terminalSwap;
     }
 
     // Determine whether to query the escrow for the latest state.

--- a/tests/unit/modules/SwapModule.status.test.ts
+++ b/tests/unit/modules/SwapModule.status.test.ts
@@ -332,6 +332,35 @@ describe('SwapModule — getSwapStatus / getSwaps', () => {
     });
   });
 
+  it('UT-SWAP-STATUS-013: queryEscrow=true on a lazy-loaded terminal swap is refused (DM would be dropped)', async () => {
+    // The downstream `status_result` DM handler resolves the swap via
+    // `this.swaps.get` — it has no path for lazy-loading from storage,
+    // so an escrow response to a lazy-loaded swap is silently dropped
+    // on arrival. `getSwapStatus` must therefore refuse the DM in the
+    // first place, even when the caller explicitly opted in. This test
+    // pins that contract.
+    const ref = createTestSwapRef({ progress: 'completed' });
+    const addressId = mocks.identity.directAddress!;
+    const storageKey = `${addressId}_swap:${ref.swapId}`;
+    mocks.storage._data.set(
+      storageKey,
+      JSON.stringify({ version: 1, swap: ref }),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (module as any).terminalSwapIds.add(ref.swapId);
+
+    // Caller explicitly asks for an escrow query. The lazy-load path
+    // logs a debug line and skips the DM.
+    const result = await module.getSwapStatus(ref.swapId, { queryEscrow: true });
+
+    expect(result.swapId).toBe(ref.swapId);
+    // Give the fire-and-forget chain a tick to settle so a regression
+    // that DID send the DM has a chance to be observed by the mock.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mocks.communications.sendDM).not.toHaveBeenCalled();
+    expect(mocks.resolve).not.toHaveBeenCalled();
+  });
+
   it('UT-SWAP-STATUS-012: lazy-load prefers the in-memory entry when both exist (no double-read)', async () => {
     // If a swap is in `this.swaps` AND in storage (e.g. an active swap
     // that just transitioned to terminal in this process), the in-

--- a/tests/unit/modules/SwapModule.status.test.ts
+++ b/tests/unit/modules/SwapModule.status.test.ts
@@ -251,4 +251,107 @@ describe('SwapModule — getSwapStatus / getSwaps', () => {
     expect(results).toEqual([]);
     expect(results).toHaveLength(0);
   });
+
+  // --------------------------------------------------------------------------
+  // UT-SWAP-STATUS-009 / -010 / -011: terminal-swap lazy load from storage
+  //
+  // `loadFromStorage` deliberately keeps terminal swap records OUT of
+  // `this.swaps` to bound memory across the terminalPurgeTtlMs window
+  // (default 7 days), but `getSwapStatus` is the one public surface where
+  // callers legitimately want to query a terminal swap — soak verifications
+  // re-open the CLI after a swap reaches `completed` and run `sphere swap
+  // status $id` to confirm the terminal state. Without the lazy-load
+  // fallback that call throws SWAP_NOT_FOUND even though the record is
+  // sitting in storage.
+  // --------------------------------------------------------------------------
+
+  it('UT-SWAP-STATUS-009: getSwapStatus lazy-loads a terminal swap from storage on cache miss', async () => {
+    // Set up: a completed swap that is in terminalSwapIds + storage, but NOT
+    // in `this.swaps` (matches the post-loadFromStorage state for terminal
+    // entries within the purge TTL window).
+    const ref = createTestSwapRef({ progress: 'completed' });
+    const addressId = mocks.identity.directAddress!;
+    const storageKey = `${addressId}_swap:${ref.swapId}`;
+    mocks.storage._data.set(
+      storageKey,
+      JSON.stringify({ version: 1, swap: ref }),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (module as any).terminalSwapIds.add(ref.swapId);
+
+    const result = await module.getSwapStatus(ref.swapId);
+
+    expect(result.swapId).toBe(ref.swapId);
+    expect(result.progress).toBe('completed');
+    expect(result.deal).toEqual(ref.deal);
+
+    // The lazy load must NOT poison `this.swaps` — the memory bound that
+    // loadFromStorage establishes for the active set has to survive a
+    // status query against an arbitrary terminal entry. Subsequent
+    // queries re-read from storage; that's the trade-off.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((module as any).swaps.has(ref.swapId)).toBe(false);
+  });
+
+  it('UT-SWAP-STATUS-010: lazy-load returns SWAP_NOT_FOUND when id is not in terminalSwapIds', async () => {
+    // Guard: even when a record happens to be in storage under the same
+    // key shape, lazy-load MUST gate on terminalSwapIds membership.
+    // Otherwise getSwapStatus could be coerced into reading arbitrary
+    // storage keys (e.g. a stale record from a previous session that
+    // was never accepted) and resurrecting them as if they were
+    // terminal.
+    const ref = createTestSwapRef({ progress: 'completed' });
+    const addressId = mocks.identity.directAddress!;
+    const storageKey = `${addressId}_swap:${ref.swapId}`;
+    mocks.storage._data.set(
+      storageKey,
+      JSON.stringify({ version: 1, swap: ref }),
+    );
+    // Deliberately do NOT add to terminalSwapIds.
+
+    await expect(module.getSwapStatus(ref.swapId)).rejects.toMatchObject({
+      code: 'SWAP_NOT_FOUND',
+    });
+  });
+
+  it('UT-SWAP-STATUS-011: lazy-load is resilient to storage corruption — falls back to SWAP_NOT_FOUND', async () => {
+    // If the persisted record is malformed JSON or missing the `swap`
+    // field, the lazy load must not throw — it should degrade to
+    // SWAP_NOT_FOUND so the caller gets the same surface as a
+    // truly-unknown id. Avoids a corrupted record poisoning the
+    // module's bootstrap path.
+    const swapId = 'corrupted_terminal_' + '0'.repeat(48);
+    const addressId = mocks.identity.directAddress!;
+    const storageKey = `${addressId}_swap:${swapId}`;
+    mocks.storage._data.set(storageKey, '{this is not valid json');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (module as any).terminalSwapIds.add(swapId);
+
+    await expect(module.getSwapStatus(swapId)).rejects.toMatchObject({
+      code: 'SWAP_NOT_FOUND',
+    });
+  });
+
+  it('UT-SWAP-STATUS-012: lazy-load prefers the in-memory entry when both exist (no double-read)', async () => {
+    // If a swap is in `this.swaps` AND in storage (e.g. an active swap
+    // that just transitioned to terminal in this process), the in-
+    // memory ref wins. The storage-read path must not fire.
+    const ref = createTestSwapRef({ progress: 'announced' });
+    injectSwapRef(module, ref);
+
+    // Sabotage storage with a stale record so the test fails loudly
+    // if the lazy-load path runs by mistake.
+    const addressId = mocks.identity.directAddress!;
+    const storageKey = `${addressId}_swap:${ref.swapId}`;
+    mocks.storage._data.set(
+      storageKey,
+      JSON.stringify({
+        version: 1,
+        swap: { ...ref, progress: 'completed' },
+      }),
+    );
+
+    const result = await module.getSwapStatus(ref.swapId);
+    expect(result.progress).toBe('announced');
+  });
 });


### PR DESCRIPTION
## Summary

Closes #445. Companion to #443 (mux subscription gate, issue #442) — together they unblock the swap-roundtrip soak from sphere-sdk#437.

`loadFromStorage` deliberately parks terminal swap entries in `_storedTerminalEntries` (the index) instead of `this.swaps` (the working set) to bound memory across the `terminalPurgeTtlMs` window — a 7-day default that can accumulate hundreds of records on a heavy wallet. `getSwapStatus` only checked `this.swaps`, so any post-CLI-restart `sphere swap status $id` against a `completed` swap threw `SWAP_NOT_FOUND` even though the record was sitting on disk one async hop away.

That bug surfaced on the manual swap-roundtrip soak's section-9 verification (`sphere swap status` after the swap reached `completed`): every soak run failed the terminal-state check despite the swap actually completing cleanly.

## Change

- `loadTerminalSwapFromStorage(swapId)` — new private helper that reads the per-swap storage key only when `swapId` is in `terminalSwapIds`. Returns null on cache miss, malformed JSON, or missing `swap` field — every failure path collapses to the same `SWAP_NOT_FOUND` surface the existing caller already expects, so a corrupted record cannot poison bootstrap or coerce the lookup into reading arbitrary keys.
- `getSwapStatus` — falls through to the lazy load on `this.swaps.get` miss. The loaded record is NOT inserted into `this.swaps`: the memory bound that `loadFromStorage` establishes has to survive arbitrary status queries against the terminal working set. Subsequent queries re-read from storage; that is the trade-off, and it matches the original design intent.

## Test plan

- [x] Four new invariants in `tests/unit/modules/SwapModule.status.test.ts`:
  - **UT-009** — lazy-load happens on cache miss and returns the persisted ref without inserting into `this.swaps`.
  - **UT-010** — `terminalSwapIds` is the access gate; arbitrary `swap:` keys are not readable through `getSwapStatus`.
  - **UT-011** — corrupted JSON degrades to `SWAP_NOT_FOUND` without throwing.
  - **UT-012** — the in-memory entry wins when both exist; the storage path does not fire.
- [x] All 9017 unit tests still pass (16 skipped).
- [x] Live testnet soak section-9 verification (`alice progress: completed`, `bob progress: completed`) passes after a fresh-CLI restart against a real swap that reached terminal state.