### PR TITLE
fix(uxf)(sphere-sdk#437): soak section 10 poison-pill scan aborts on clean runs

### DIFF
--- a/manual-test-swap-roundtrip.sh
+++ b/manual-test-swap-roundtrip.sh
@@ -447,11 +447,18 @@ assert_grep "bob-status-completed" 'progress[[:space:]]*:[[:space:]]*completed' 
 # ---------------------------------------------------------------------------
 banner "Section 10: Poison-pill scan across all logs"
 
-POISON_HITS=$(grep -cE "SERIALIZATION_ERROR|VERIFICATION_FAILED|DUPLICATE_BUNDLE_MEMBERSHIP" \
-  "$SNAP"/*.log 2>/dev/null | grep -vE ':0$' | wc -l)
-if [[ "$POISON_HITS" -gt 0 ]]; then
+# Use `grep -l` (list filenames with matches). The old `grep -c | grep -v ':0$'`
+# pipeline tripped `set -euo pipefail` on a clean run: the inner `grep -v`
+# exits 1 when every file is `:0` (no matches), pipefail propagates, and
+# the command substitution aborts the script before we ever print
+# "ASSERT OK". `|| true` keeps the pipeline non-fatal on no-matches —
+# emptiness is the success case here, not an error.
+POISON_FILES=$(grep -lE "SERIALIZATION_ERROR|VERIFICATION_FAILED|DUPLICATE_BUNDLE_MEMBERSHIP" \
+  "$SNAP"/*.log 2>/dev/null || true)
+if [[ -n "$POISON_FILES" ]]; then
+  POISON_HITS=$(printf '%s\n' "$POISON_FILES" | wc -l)
   echo "ASSERT FAIL (poison-pill): found $POISON_HITS log(s) with poison-pill errors" >&2
-  grep -lE "SERIALIZATION_ERROR|VERIFICATION_FAILED|DUPLICATE_BUNDLE_MEMBERSHIP" "$SNAP"/*.log >&2 || true
+  printf '%s\n' "$POISON_FILES" >&2
   rc=1
 else
   echo "ASSERT OK (poison-pill-clean): no SERIALIZATION_ERROR / VERIFICATION_FAILED / DUPLICATE_BUNDLE_MEMBERSHIP across any log"


### PR DESCRIPTION
## Summary

The Section 10 (cross-hop poison-pill scan) in `manual-test-swap-roundtrip.sh` aborts every successful soak run before printing its assertion, surfacing as a confusing `EXITCODE=1` with no `ASSERT OK` line — even though the underlying swap round-trip completed cleanly.

## Root cause

The old pipeline:

```bash
POISON_HITS=$(grep -cE "..." "$SNAP"/*.log 2>/dev/null | grep -vE ':0$' | wc -l)
```

Under `set -euo pipefail`:

1. `grep -c pattern files` emits `file:N` per file, exit 0 if any matched, exit 1 if no file matched.
2. When all files are clean (the success case), every line is `file:0`; the inner `grep -v ':0$'` filters them all out and exits 1.
3. `pipefail` propagates the exit-1 from the middle command.
4. The command substitution `$(...)` inherits the non-zero exit.
5. `set -e` aborts the script BEFORE the `if/else` branch can print `ASSERT OK (poison-pill-clean)`.

Net effect: every green soak run looks indistinguishable from a real poison-pill hit (script aborts at the Section 10 banner). Surfaced during the swap-roundtrip verification of sphere-sdk #443 + #446.

## Fix

Replace count-parsing with `grep -l` (list filenames with matches), wrapped in `|| true` so the no-matches exit (1) is captured as the empty-string success case the assertion expects:

```bash
POISON_FILES=$(grep -lE "..." "$SNAP"/*.log 2>/dev/null || true)
if [[ -n "$POISON_FILES" ]]; then
  POISON_HITS=$(printf '%s\n' "$POISON_FILES" | wc -l)
  echo "ASSERT FAIL (poison-pill): found $POISON_HITS log(s)" >&2
  printf '%s\n' "$POISON_FILES" >&2
  rc=1
else
  echo "ASSERT OK (poison-pill-clean): no SERIALIZATION_ERROR / VERIFICATION_FAILED / DUPLICATE_BUNDLE_MEMBERSHIP across any log"
fi
```

## Test plan

- [x] Standalone bash test (clean input + seeded poisoned input):
  - All-clean → `ASSERT OK (poison-pill-clean)`, rc unchanged.
  - Seeded `SERIALIZATION_ERROR` → `ASSERT FAIL (poison-pill): found 1 log(s)` with filename printed, `rc=2`.
- [x] Full live-testnet swap-roundtrip soak (Scenario A) — first run to actually print **ALL GREEN — swap round-trip succeeded** with `EXITCODE=0`. Every assertion through §10 passes.

## Related

- sphere-sdk#437 — swap-roundtrip soak (introduced the script).
- sphere-sdk#443 (#442) + sphere-sdk#446 (#445) — SDK fixes the soak now verifies green end-to-end.