### PR TITLE
fix(profile)(sphere-sdk#450): bound pre-shutdown publish-retry spin

### DIFF
--- a/profile/aggregator-pointer/discover-algorithm.ts
+++ b/profile/aggregator-pointer/discover-algorithm.ts
@@ -354,9 +354,31 @@ async function findLatestValidVersionInner(
       // the throw below propagates immediately but a probe that's
       // mid-RPC continues to the wire and consumes resources.
       armDeadlineAbort();
+      // Issue #450 diagnostic fix: distinguish "deadline already past
+      // at start" from "deadline expired during discovery". Previously
+      // the message always read "after Nms" where N was elapsed since
+      // the local start, even when the caller-supplied
+      // `discoveryDeadlineMs` was already in the past (in which case N
+      // is ≈0 and the message looks like an instant aggregator
+      // failure). The reconcile-algorithm's shared 5-minute budget
+      // (see reconcile-algorithm.ts:RECONCILE_WALL_CLOCK_BUDGET_MS)
+      // makes this scenario routine: when the initial discovery +
+      // publish exhaust the budget, the conflict rediscovery inherits
+      // an expired deadline and trips this check on its first probe.
+      // Without distinguishing the two cases, operators chasing
+      // pre-shutdown loops cannot tell whether the publish path is
+      // hitting a real aggregator stall or an exhausted retry budget.
+      const elapsed = Date.now() - discoveryStartMs;
+      const initialBudgetMs = discoveryDeadlineMs - discoveryStartMs;
+      const message =
+        initialBudgetMs <= 0
+          ? `Discovery deadline was already ${-initialBudgetMs}ms in the past at start ` +
+            `(discoveryDeadlineMs=${discoveryDeadlineMs}, discoveryStartMs=${discoveryStartMs}); ` +
+            `caller-supplied deadline had already expired before discovery began.`
+          : `Discovery exceeded wall-clock deadline after ${elapsed}ms (budget=${initialBudgetMs}ms).`;
       throw new AggregatorPointerError(
         AggregatorPointerErrorCode.RETRY_EXHAUSTED,
-        `Discovery exceeded wall-clock deadline after ${Date.now() - discoveryStartMs}ms.`,
+        message,
         { currentLocalVersion },
       );
     }

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -159,6 +159,34 @@ const POINTER_READBACK_POLL_MS = 500;
 const PENDING_PUBLISH_RETRY_INTERVAL_MS = 1_000;
 
 /**
+ * Issue #450 — stuck-progress threshold for
+ * {@link LifecycleManager.awaitPendingPublishCleared}. When N
+ * consecutive iterations of the pre-shutdown retry loop observe the
+ * SAME `pendingPublishCid` + SAME error code, treat the failure as
+ * stable and bail rather than burn the rest of the shutdown deadline.
+ *
+ * Why this exists: under contended-testnet conditions, each retry can
+ * burn the reconcile algorithm's shared 5-minute wall-clock budget
+ * (see `reconcile-algorithm.ts:RECONCILE_WALL_CLOCK_BUDGET_MS`). In
+ * the §D.1 hang reported in issue #450, the loop spun for ~6 hours at
+ * ~150% CPU before SIGTERM rescued the host. Detecting that the
+ * failure is stable and giving up cleanly hands the work to the
+ * cold-start retry path on next boot (the `pendingPublishCid` marker
+ * is preserved across the bail).
+ *
+ * Threshold = 3 balances responsiveness against false positives:
+ *   - 1 single failure could be a transient blip.
+ *   - 2 still gives the underlying lag one chance to clear.
+ *   - 3 confirms the failure pattern is stable.
+ *
+ * Combined with `PENDING_PUBLISH_RETRY_INTERVAL_MS`, the worst-case
+ * loop runtime drops from "deadline" to roughly
+ * `3 × (per-attempt cost + sleep) ≈ 3 × (5 min budget + 1s)`,
+ * bounded by `awaitRemoteDurability`'s deadline regardless.
+ */
+const STUCK_PENDING_PUBLISH_THRESHOLD = 3;
+
+/**
  * Issue #239 — discriminated identifier for the durability leg that
  * tripped the shutdown deadline. Surfaced via the
  * `shutdown:verification-timeout` event so operators see which path
@@ -822,8 +850,17 @@ export class LifecycleManager {
     signal: AbortSignal,
     reason: string | undefined,
   ): Promise<void> {
+    const loopStartedAt = Date.now();
     let lastError: string | undefined;
     let lastCid: string | null = this.host.getPendingPublishCid();
+    // Issue #450 stuck-progress detection: track the most recent
+    // (cid, errorKey) tuple and how many CONSECUTIVE iterations have
+    // observed it. When the count crosses `STUCK_PENDING_PUBLISH_THRESHOLD`,
+    // emit `storage:pending-publish-stuck` and bail so cold-start
+    // recovery on next boot handles the publish via the preserved
+    // marker. See the constant's doc-comment for rationale.
+    let lastFailureKey: string | null = null;
+    let consecutiveSameFailures = 0;
 
     while (Date.now() < deadline && !signal.aborted) {
       const pending = this.host.getPendingPublishCid();
@@ -847,6 +884,49 @@ export class LifecycleManager {
         lastError = result.code ?? (result.transient ? 'TRANSIENT' : 'PERMANENT');
       } catch (err) {
         lastError = err instanceof Error ? err.message : String(err);
+      }
+
+      // Issue #450: update the stuck-progress counter. Key combines
+      // CID and error so a NEW pending CID or DIFFERENT failure code
+      // resets the counter (we only bail on STABLE failure patterns).
+      const failureKey = `${pending}|${lastError ?? 'unknown'}`;
+      if (failureKey === lastFailureKey) {
+        consecutiveSameFailures += 1;
+      } else {
+        consecutiveSameFailures = 1;
+        lastFailureKey = failureKey;
+      }
+      if (consecutiveSameFailures >= STUCK_PENDING_PUBLISH_THRESHOLD) {
+        const elapsedMs = Date.now() - loopStartedAt;
+        this.host.log(
+          `Shutdown durability: pending-publish appears stuck for ` +
+            `cid=${pending} after ${consecutiveSameFailures} consecutive ` +
+            `identical failures (lastError=${lastError ?? 'unknown'}, ` +
+            `elapsedMs=${elapsedMs}). Bailing — cold-start retry on ` +
+            `next boot will handle via preserved pendingPublishCid marker.`,
+        );
+        this.host.emitEvent({
+          type: 'storage:pending-publish-stuck',
+          timestamp: Date.now(),
+          data: {
+            cid: pending,
+            consecutiveFailures: consecutiveSameFailures,
+            lastError,
+            elapsedMs,
+            reason,
+          },
+          code: lastError,
+        });
+        // Also surface the existing verification-timeout signal so
+        // operator dashboards routing on `shutdown:verification-timeout`
+        // continue to receive this leg's terminal outcome.
+        this.emitVerificationTimeout({
+          leg: 'pending-publish-retry',
+          cidsInQuestion: [pending],
+          lastError,
+          reason,
+        });
+        return;
       }
 
       if (signal.aborted || Date.now() >= deadline) break;

--- a/profile/profile-token-storage/lifecycle-manager.ts
+++ b/profile/profile-token-storage/lifecycle-manager.ts
@@ -883,7 +883,21 @@ export class LifecycleManager {
         // so we re-check at the top of the next loop iteration.
         lastError = result.code ?? (result.transient ? 'TRANSIENT' : 'PERMANENT');
       } catch (err) {
-        lastError = err instanceof Error ? err.message : String(err);
+        // Issue #450 hardening: prefer a typed `.code` over the raw
+        // message so the stuck-detection failureKey stays stable
+        // iteration-over-iteration. Without this, a typed error whose
+        // message embeds a varying value (e.g. elapsed-ms) would
+        // produce a different key every loop and the counter would
+        // never reach the threshold. In practice
+        // `publishAggregatorPointerBestEffort` converts every internal
+        // throw to a structured result before returning, so the catch
+        // arm is currently dead code — this is defense-in-depth
+        // against future regressions that let a typed error escape.
+        const errCode =
+          err && typeof (err as { code?: unknown }).code === 'string'
+            ? (err as { code: string }).code
+            : undefined;
+        lastError = errCode ?? (err instanceof Error ? err.message : String(err));
       }
 
       // Issue #450: update the stuck-progress counter. Key combines

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -651,7 +651,38 @@ export type StorageEventType =
    * identifying data, but telemetry pipelines that forward these events
    * upstream SHOULD scrub or aggregate per their privacy policy.
    */
-  | 'storage:blocked-auto-cleared';
+  | 'storage:blocked-auto-cleared'
+  /**
+   * Issue #450 — emitted by `LifecycleManager.awaitPendingPublishCleared`
+   * when N consecutive iterations of the pre-shutdown retry loop have
+   * failed against the SAME `pendingPublishCid` with the SAME error
+   * code. Surfaces stable failure modes (e.g. contended-testnet
+   * aggregator + exhausted reconcile budget) so operators see the
+   * "stuck" signal instead of the loop spinning silently against the
+   * shutdown deadline while the daemon burns CPU.
+   *
+   * `data` carries:
+   *   - `cid: string`                     the pending publish CID that
+   *                                        could not be cleared.
+   *   - `consecutiveFailures: number`     count of identical-key
+   *                                        failures observed before
+   *                                        bailing.
+   *   - `lastError?: string`              the error code or message
+   *                                        observed on each failure
+   *                                        (same value across the run).
+   *   - `elapsedMs: number`               wall-clock ms spent in the
+   *                                        retry loop before bailing.
+   *   - `reason?: string`                 free-form context propagated
+   *                                        from `ShutdownOptions.reason`.
+   *
+   * Informational only — shutdown continues. The `pendingPublishCid`
+   * marker is preserved so the next process boot retries the publish
+   * via the cold-start recovery path. Distinct from
+   * `shutdown:verification-timeout` (deadline-exceeded), which still
+   * fires on this leg AFTER the stuck event so existing dashboards
+   * continue to receive the timeout signal as well.
+   */
+  | 'storage:pending-publish-stuck';
 
 export interface StorageEvent {
   type: StorageEventType;

--- a/tests/unit/profile/lifecycle-manager-pending-publish-stuck-450.test.ts
+++ b/tests/unit/profile/lifecycle-manager-pending-publish-stuck-450.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for Issue #450 — pre-shutdown `awaitPendingPublishCleared`
+ * stuck-progress detection.
+ *
+ * Before the fix: the retry loop in
+ * `LifecycleManager.awaitPendingPublishCleared` had no awareness of
+ * stable failure modes. Under contended-testnet conditions every
+ * iteration could burn the reconcile algorithm's shared 5-minute
+ * wall-clock budget against the same `pendingPublishCid` and the same
+ * error code; the soak report observed the loop spinning at ~150% CPU
+ * for 6+ hours before SIGTERM rescued the host.
+ *
+ * The fix:
+ *   - tracks the most recent `(cid, errorCode)` tuple per iteration
+ *   - emits `storage:pending-publish-stuck` after N consecutive
+ *     identical failures (threshold = 3)
+ *   - bails the loop and preserves the `pendingPublishCid` marker so
+ *     cold-start recovery on next boot retries the publish.
+ *
+ * These tests assert:
+ *   - The bail event fires with the expected payload after exactly N
+ *     stable failures (no spurious early fire, no late fire).
+ *   - The verification-timeout event still fires alongside the stuck
+ *     event so existing dashboards routing on
+ *     `shutdown:verification-timeout` continue to receive the leg's
+ *     terminal outcome.
+ *   - The bail short-circuits well before the verification deadline.
+ *   - The `pendingPublishCid` marker is preserved across the bail.
+ *   - When the failure code CHANGES between iterations, the counter
+ *     resets and the stuck event does NOT fire (we only treat STABLE
+ *     failure patterns as terminal).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ProfileDatabase,
+  OrbitDbConfig,
+} from '../../../profile/types';
+import type { FullIdentity } from '../../../types';
+import { ProfileTokenStorageProvider } from '../../../profile/profile-token-storage-provider';
+import type { ProfilePointerLayer } from '../../../profile/aggregator-pointer';
+import { CID } from 'multiformats/cid';
+import * as raw from 'multiformats/codecs/raw';
+import { create as createMultihash } from 'multiformats/hashes/digest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import type { StorageEvent } from '../../../storage/storage-provider';
+
+const TEST_PRIVATE_KEY =
+  'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const TEST_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'aa'.repeat(32),
+  l1Address: 'alpha1testaddress',
+  directAddress: 'DIRECT://AABBCCDDEEFF112233445566778899AABBCCDDEEFF',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+const GATEWAY = 'https://gateway-a.test';
+
+function makeCid(seed: string): string {
+  const bytes = new TextEncoder().encode(seed);
+  return CID.createV1(raw.code, createMultihash(0x12, sha256(bytes))).toString();
+}
+
+const PENDING_CID = makeCid('issue-450-pending');
+
+function createMockDb(): ProfileDatabase {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async connect(_config: OrbitDbConfig) {},
+    async put(key: string, value: Uint8Array) {
+      store.set(key, value);
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async del(key: string) {
+      store.delete(key);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as ProfileDatabase;
+}
+
+function createMockLocalCache(): {
+  storage: {
+    get: (k: string) => Promise<string | null>;
+    set: (k: string, v: string) => Promise<void>;
+    remove: (k: string) => Promise<void>;
+    clear: () => Promise<void>;
+  };
+} {
+  const store = new Map<string, string>();
+  return {
+    storage: {
+      async get(k: string) {
+        return store.get(k) ?? null;
+      },
+      async set(k: string, v: string) {
+        store.set(k, v);
+      },
+      async remove(k: string) {
+        store.delete(k);
+      },
+      async clear() {
+        store.clear();
+      },
+    },
+  };
+}
+
+/**
+ * Build a stub pointer layer whose `publish()` always throws a
+ * caller-controlled error. Each invocation increments a counter so
+ * tests can assert how many times the publish path was exercised.
+ */
+function stuckPointer(opts: {
+  errorForCall: (callIndex: number) => Error;
+}): { pointer: ProfilePointerLayer; callCount: () => number } {
+  let calls = 0;
+  return {
+    callCount: () => calls,
+    pointer: {
+      async recoverLatest() {
+        return null;
+      },
+      async publish() {
+        const idx = calls;
+        calls += 1;
+        throw opts.errorForCall(idx);
+      },
+    } as unknown as ProfilePointerLayer,
+  };
+}
+
+interface TestHandle {
+  provider: ProfileTokenStorageProvider;
+  events: StorageEvent[];
+  setPendingPublishCid(c: string | null): void;
+  getPendingPublishCid(): string | null;
+}
+
+async function createTestHandle(pointer: ProfilePointerLayer): Promise<TestHandle> {
+  const db = createMockDb();
+  const localCache = createMockLocalCache();
+  const provider = new ProfileTokenStorageProvider(
+    db,
+    new Uint8Array(32).fill(0x11),
+    [GATEWAY],
+    {
+      config: {
+        orbitDb: { privateKey: TEST_PRIVATE_KEY },
+        ipnsSnapshot: false,
+      },
+      addressId: 'test',
+      encrypt: true,
+      getPointerLayer: () => pointer,
+    },
+    localCache.storage as unknown as never,
+  );
+  provider.setIdentity(TEST_IDENTITY);
+  await provider.initialize();
+
+  const events: StorageEvent[] = [];
+  provider.onEvent?.((e) => events.push(e));
+
+  const internal = provider as unknown as {
+    pendingPublishCid: string | null;
+  };
+
+  return {
+    provider,
+    events,
+    setPendingPublishCid: (c) => {
+      internal.pendingPublishCid = c;
+    },
+    getPendingPublishCid: () => internal.pendingPublishCid,
+  };
+}
+
+describe('LifecycleManager.awaitPendingPublishCleared — stuck-progress detection (#450)', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits storage:pending-publish-stuck after 3 identical (cid, code) failures and bails', async () => {
+    const stableErr = (): Error => {
+      const e = new Error('Discovery exceeded wall-clock deadline after 0ms.') as Error & {
+        code?: string;
+      };
+      e.code = 'AGGREGATOR_POINTER_RETRY_EXHAUSTED';
+      return e;
+    };
+    const { pointer, callCount } = stuckPointer({ errorForCall: () => stableErr() });
+    const handle = await createTestHandle(pointer);
+
+    // Pre-stamp the marker so `awaitPendingPublishCleared` has work to do.
+    handle.setPendingPublishCid(PENDING_CID);
+
+    // 10s deadline gives the loop ample time to spin past 3 retries
+    // (each at 1s cadence) if the fix were not in place. We assert
+    // below that shutdown completes WELL under that budget.
+    const t0 = Date.now();
+    await handle.provider.shutdown({
+      verificationDeadlineMs: 10_000,
+      reason: 'unit-test-stuck',
+    });
+    const elapsedMs = Date.now() - t0;
+
+    const stuckEvents = handle.events.filter(
+      (e) => e.type === 'storage:pending-publish-stuck',
+    );
+    expect(stuckEvents).toHaveLength(1);
+
+    const payload = stuckEvents[0].data as {
+      cid: string;
+      consecutiveFailures: number;
+      lastError?: string;
+      elapsedMs: number;
+      reason?: string;
+    };
+    expect(payload.cid).toBe(PENDING_CID);
+    expect(payload.consecutiveFailures).toBe(3);
+    expect(payload.lastError).toBe('AGGREGATOR_POINTER_RETRY_EXHAUSTED');
+    expect(payload.reason).toBe('unit-test-stuck');
+    expect(stuckEvents[0].code).toBe('AGGREGATOR_POINTER_RETRY_EXHAUSTED');
+
+    // Companion verification-timeout signal still fires for legacy
+    // dashboards routing on that event.
+    const timeouts = handle.events.filter(
+      (e) =>
+        e.type === 'shutdown:verification-timeout' &&
+        (e.data as { leg?: string } | undefined)?.leg === 'pending-publish-retry',
+    );
+    expect(timeouts).toHaveLength(1);
+    expect((timeouts[0].data as { cidsInQuestion: string[] }).cidsInQuestion).toContain(
+      PENDING_CID,
+    );
+
+    // The pending marker is PRESERVED across the bail so cold-start
+    // recovery can retry the publish on next boot.
+    expect(handle.getPendingPublishCid()).toBe(PENDING_CID);
+
+    // The bail short-circuits well under the 10s verification deadline.
+    // 3 retries × 1s cadence ≈ 3s of sleeps; allow generous headroom.
+    expect(elapsedMs).toBeLessThan(7_000);
+
+    // `pointer.publish` was called exactly 3 times — the bail prevented
+    // a 4th retry that the old code would have attempted.
+    expect(callCount()).toBe(3);
+  }, 15_000);
+
+  it('does NOT fire the stuck event when failure codes rotate (counter resets)', async () => {
+    // Each call alternates between two codes — every iteration looks
+    // DIFFERENT than the previous, so `consecutiveSameFailures` never
+    // reaches 3.
+    const rotateErr = (idx: number): Error => {
+      const e = new Error(`rotating failure ${idx}`) as Error & { code?: string };
+      e.code = idx % 2 === 0 ? 'CODE_A' : 'CODE_B';
+      return e;
+    };
+    const { pointer, callCount } = stuckPointer({ errorForCall: rotateErr });
+    const handle = await createTestHandle(pointer);
+    handle.setPendingPublishCid(PENDING_CID);
+
+    // Short deadline keeps the test fast; we only care that NO stuck
+    // event fires — the verification-timeout will fire on deadline
+    // expiry, which is fine.
+    await handle.provider.shutdown({
+      verificationDeadlineMs: 3_500,
+      reason: 'unit-test-rotating',
+    });
+
+    const stuckEvents = handle.events.filter(
+      (e) => e.type === 'storage:pending-publish-stuck',
+    );
+    expect(stuckEvents).toHaveLength(0);
+
+    // Marker preserved (no successful publish).
+    expect(handle.getPendingPublishCid()).toBe(PENDING_CID);
+
+    // `pointer.publish` was called more than 3 times — the rotating
+    // code prevented the stuck-detection short-circuit.
+    expect(callCount()).toBeGreaterThan(3);
+  }, 10_000);
+});

--- a/tests/unit/profile/pointer/discover-algorithm.test.ts
+++ b/tests/unit/profile/pointer/discover-algorithm.test.ts
@@ -214,3 +214,86 @@ describe('computeProbeFingerprint', () => {
     expect(fp1).not.toBe(fp2);
   });
 });
+
+// Issue #450 — Discovery deadline diagnostic. Previously the
+// RETRY_EXHAUSTED message always read "after Nms" where N was elapsed
+// since the locally-captured `discoveryStartMs`. When the caller (e.g.
+// reconcile-algorithm sharing a single 5-min budget across initial
+// discovery + conflict rediscovery) supplied a `discoveryDeadlineMs`
+// that was ALREADY in the past, N was ≈0 and the message read
+// "after 0ms" — which looked like an instant aggregator failure
+// instead of an exhausted retry budget. The fix distinguishes the
+// two cases in the message.
+describe('findLatestValidVersion — deadline diagnostic (#450)', () => {
+  it('reports "deadline already past at start" when caller-supplied deadline has already expired', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const trustBase = fakeTrustBase();
+    const pastDeadline = Date.now() - 1234;
+    let caught: unknown = undefined;
+    try {
+      await findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase,
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        discoveryDeadlineMs: pastDeadline,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as { code?: string }).code).toBe(
+      AggregatorPointerErrorCode.RETRY_EXHAUSTED,
+    );
+    const msg = (caught as { message: string }).message;
+    expect(msg).toMatch(/already .*ms in the past at start/);
+    expect(msg).toMatch(/caller-supplied deadline had already expired/);
+    expect(msg).toContain(String(pastDeadline));
+  });
+
+  it('reports "exceeded wall-clock deadline after Nms (budget=Bms)" when deadline expires mid-discovery', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const trustBase = fakeTrustBase();
+    // Caller supplies a positive-budget deadline. We force expiry by
+    // pinning the deadline 5ms into the future and then having the
+    // mock client sleep past it before responding to the first probe.
+    const initialBudgetMs = 5;
+    const start = Date.now();
+    const slowClient: AggregatorClient = {
+      getInclusionProof: vi.fn(async () => {
+        await new Promise((r) => setTimeout(r, initialBudgetMs + 25));
+        return new InclusionProofResponse(
+          fakeProof(InclusionProofVerificationStatus.PATH_NOT_INCLUDED),
+        );
+      }),
+    } as unknown as AggregatorClient;
+    let caught: unknown = undefined;
+    try {
+      await findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: slowClient,
+        trustBase,
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        discoveryDeadlineMs: start + initialBudgetMs,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as { code?: string }).code).toBe(
+      AggregatorPointerErrorCode.RETRY_EXHAUSTED,
+    );
+    const msg = (caught as { message: string }).message;
+    // The "elapsed positive-budget" branch — distinct from the
+    // "already past at start" branch above.
+    expect(msg).toMatch(/exceeded wall-clock deadline after \d+ms/);
+    expect(msg).toMatch(/budget=\d+ms/);
+    expect(msg).not.toMatch(/already .*ms in the past at start/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #450.

The §D.1 soak hang in #450 was a 6+ hour, ~150% CPU spin in `LifecycleManager.awaitPendingPublishCleared`. The retry loop had no detection for stable failure modes — under contended testnet, every iteration burned the reconcile algorithm's shared 5-minute wall-clock budget against the same `pendingPublishCid` + same error code; the loop only stopped when SIGTERM rescued the host.

Two changes:

1. **Diagnostic** — `profile/aggregator-pointer/discover-algorithm.ts`: distinguish "deadline already past at start" from "deadline expired during discovery" in the `RETRY_EXHAUSTED` message. The original "after 0ms" wording hid the load-bearing fact that `reconcile-algorithm.ts`'s shared 5-min budget can be exhausted by the initial discovery, leaving conflict rediscovery with a negative budget at entry.

2. **Loop break** — `profile/profile-token-storage/lifecycle-manager.ts`: `awaitPendingPublishCleared` now tracks consecutive `(cid, code)` failures and bails after `STUCK_PENDING_PUBLISH_THRESHOLD = 3` identical fires, emitting a new `storage:pending-publish-stuck` event with `{cid, consecutiveFailures, lastError, elapsedMs, reason}`. The `pendingPublishCid` marker is preserved across the bail so the next cold start retries via the existing recovery path; the companion `shutdown:verification-timeout` event still fires so dashboards routing on the existing leg signal continue to work.

Threshold = 3 keeps the worst-case loop runtime bounded at roughly `3 × per-attempt cost` (~15 minutes vs. 6+ hours observed) and on a healthy testnet a single transient blip still gets two free retries before triggering the stuck signal.

Steelman hardening commit: the catch arm in the retry loop now prefers `err.code` over `err.message` so the stuck-detection failureKey survives future regressions where a typed error with a time-varying message escapes the inner converter (currently dead code, but the fix's own new "after Nms (budget=Bms)" wording would have been exactly that risk).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` exit 0, no new findings on touched files
- [x] `npm run test:run` — 9022 tests pass, 16 skipped (558 files)
- [x] Two new unit cases in `tests/unit/profile/pointer/discover-algorithm.test.ts` cover both branches of the discovery deadline message
- [x] New file `tests/unit/profile/lifecycle-manager-pending-publish-stuck-450.test.ts` asserts (a) stuck event fires with the right payload after exactly 3 stable failures, (b) bail short-circuits well before the verification deadline, (c) marker is preserved, (d) rotating failure codes keep the counter reset (no false-positive fire)
- [x] **`manual-test-full-recovery.sh` reproducer**: total **516s (~8.6 min), rc=0, all sections green**. §D.1 — previously the 6+ hour hang — completed in **80 seconds**. Log: `/tmp/issue-450-soak-1780996713.log`

## Limitations

- Hang only reproduces against a contended testnet; this verification run hit a healthy testnet so it exercises the §D.1 path but not the worst-case 5-min reconcile budget exhaustion. Unit tests deterministically cover the loop-break behavior.
- Fix is **reactive**: makes the symptom non-fatal (loop bails cleanly, cold-start retries on next boot). Does not address the underlying aggregator contention that produces the deterministic failure pattern — that is tracked separately under #444 and the `OUTBOX-SEND-FOLLOWUPS.md` aggregator cross-check item.

## Related
- #444 — at-least-once TOKEN_TRANSFER durability race; same contended-testnet root condition
- #234 / #239 / #268 — pointer / verify-gate deadline issues in the same lifecycle-manager area