### PR TITLE
docs(sphere-sdk#456): document escrow DIRECT address fallback for nametag resolution

### DIFF
--- a/docs/DEMO-PLAYBOOK-SWAP-ROUNDTRIP.md
+++ b/docs/DEMO-PLAYBOOK-SWAP-ROUNDTRIP.md
@@ -56,7 +56,7 @@ Total run time:
 - `sphere` CLI on `PATH` (`which sphere` should resolve).
 - Outbound HTTPS to: `faucet.unicity.network`, `goggregator-test.unicity.network`, Unicity IPFS gateways.
 - Outbound WSS to: `wss://nostr-relay.testnet.unicity.network`.
-- An escrow service reachable on the same testnet relay set as the wallets. The default is `@escrow-testnet`; override with `--escrow @your-escrow` or `--escrow DIRECT://…` on `swap propose`.
+- An escrow service reachable on the same testnet relay set as the wallets. The canonical default is `@escrow-testnet`; override with `--escrow @your-escrow` or `--escrow DIRECT://…` on `swap propose`. If the nametag does not resolve (see [Troubleshooting](#troubleshooting-escrow-nametag-resolution) below — tracked in sphere-sdk#456), fall back to the escrow's raw DIRECT address: `DIRECT://00007968fa28648e4670438bf1f3c936296e84ff46dd5ebb2e34e20092e780b652da2d3d695b`.
 - A clean workspace (the script wipes its own scratch dir on exit unless `KEEP=1`).
 
 ### Dependency check (one-time setup)
@@ -95,7 +95,11 @@ BOB_TAG="bob-$SUFFIX"
 echo "ALICE_TAG=$ALICE_TAG"
 echo "BOB_TAG=$BOB_TAG"
 
-# Default escrow. Override if your environment uses a different one.
+# Default escrow address. Canonical form is the @escrow-testnet nametag.
+# If the nametag fails to resolve (see Troubleshooting below — tracked in
+# sphere-sdk#456), set ESCROW to the escrow's raw DIRECT address before
+# running the playbook, e.g.:
+#   ESCROW="DIRECT://00007968fa28648e4670438bf1f3c936296e84ff46dd5ebb2e34e20092e780b652da2d3d695b"
 ESCROW="${ESCROW:-@escrow-testnet}"
 echo "ESCROW=$ESCROW"
 
@@ -535,7 +539,7 @@ sphere balance | diff -q /tmp/alice-pre-C.txt -    # exit 0
 
 | Symptom | What it means | Demo recovery |
 |---|---|---|
-| `swap propose: --escrow <addr>` resolution fails | The escrow nametag doesn't resolve on the relay set. | Use a DIRECT://… form: ask the escrow operator for its direct address. |
+| `swap propose: --escrow <addr>` resolution fails | The escrow nametag doesn't resolve on the relay set. | Use a `DIRECT://…` form — see [Troubleshooting: escrow nametag resolution](#troubleshooting-escrow-nametag-resolution) for the production testnet escrow's DIRECT address (sphere-sdk#456). |
 | `Escrow ping failed` from `sphere swap ping $ESCROW` (sanity check) | The escrow service is unreachable. | Restart the escrow container or point at a different one via `ESCROW=…`. |
 | Proposal never appears in bob's `swap list` after 90s | Either the relay is slow, or alice's wallet exited before the gift-wrap was actually published. | Run `sphere payments sync` on alice's peer to flush. If still empty after another 60s, restart from §3. |
 | `swap accept --deposit` errors with "Swap did not reach 'announced' state" | The escrow didn't reply to the announce. Either escrow is down, or its nametag binding doesn't include bob's relay. | Skip `--deposit`, run `sphere swap accept` (no `--deposit`) and check `sphere swap status $SWAP_ID --query-escrow` to query the escrow directly. |
@@ -545,6 +549,24 @@ sphere balance | diff -q /tmp/alice-pre-C.txt -    # exit 0
 | `swap reject` exits 1 with "Cannot reject: 'swap reject' is acceptor-only" | You ran it on the proposer side (probably switched terminals by mistake). | Run `sphere swap cancel $SWAP_ID` instead — it's the proposer's analog. |
 | `swap cancel` exits 1 with "Cannot cancel: payouts are already in progress" | The swap is already at `concluding` — the escrow is mid-payout and there's no safe way to abort. | Wait for the swap to finish naturally (either `completed` or escrow timeout → `cancelled`). |
 | `[Nostr] [AT-LEAST-ONCE] TOKEN_TRANSFER … not durable — leaving 'since' at <ts>` | Background durability verifier couldn't confirm a previous event landed durably on the relay. Independent of the current step. | Continue the demo. |
+
+### Troubleshooting: escrow nametag resolution
+
+If `sphere swap ping @escrow-testnet` (or any `swap` command using `--escrow @escrow-testnet`) fails with a resolution error like `Could not resolve recipient: @escrow-testnet`, the escrow daemon's nametag binding event is not currently published on the testnet relay. This is tracked in **sphere-sdk#456**.
+
+**Workaround — use the escrow's raw DIRECT address:**
+
+```bash
+# Override the playbook default
+ESCROW="DIRECT://00007968fa28648e4670438bf1f3c936296e84ff46dd5ebb2e34e20092e780b652da2d3d695b"
+
+# Verify it's reachable
+sphere swap ping "$ESCROW"
+```
+
+All `swap propose / accept --deposit / deposit / wait` commands continue to work — the escrow uses the same routing for both forms. The DIRECT address above is the production testnet escrow service's actual address; only the human-readable nametag binding is missing.
+
+**For escrow operators:** the canonical fix is to (re-)run wallet init on the production escrow host with `SPHERE_NAMETAG=escrow-testnet` set in the environment so the binding event is republished to the relay, and to periodically re-publish the binding (well inside relay retention) so a relay rotation cannot silently disable the documented address.
 
 ---
 

--- a/docs/QUICKSTART-CLI.md
+++ b/docs/QUICKSTART-CLI.md
@@ -1225,7 +1225,7 @@ The swap module enables trustless two-party token swaps via an escrow service. B
 - Two wallet profiles set up (or two terminals with different data directories)
 - Both wallets initialized with nametags
 - Tokens available for the swap
-- An escrow service address (e.g., `@escrow-testnet` on testnet)
+- An escrow service address (e.g., `@escrow-testnet` on testnet, or its raw `DIRECT://…` form if the nametag is not currently resolvable — see [Troubleshooting](#troubleshooting-escrow-address) below)
 
 > **Note:** The swap module requires the Accounting module (for invoice-based deposits) and the Communications module (for DM negotiation). Both are included by default.
 
@@ -1356,6 +1356,21 @@ npm run cli -- swap-list --role acceptor
 # Show all swaps including completed/cancelled/failed (default hides terminal)
 npm run cli -- swap-list --all
 ```
+
+### Troubleshooting: escrow address
+
+If `swap-propose --escrow @escrow-testnet` fails with `Could not resolve recipient: @escrow-testnet`, the testnet escrow daemon's nametag binding event is not currently published on the relay (tracked in sphere-sdk#456). Fall back to the escrow's raw `DIRECT://…` address:
+
+```bash
+npm run cli -- swap-propose \
+  --to @bob \
+  --offer "1000000 UCT" \
+  --want "500000 USDU" \
+  --escrow DIRECT://00007968fa28648e4670438bf1f3c936296e84ff46dd5ebb2e34e20092e780b652da2d3d695b \
+  --timeout 3600
+```
+
+The escrow services both forms transparently. Once the operator republishes the `escrow-testnet` nametag binding, `@escrow-testnet` becomes usable again — keep DIRECT form as a fallback, not as the canonical reference.
 
 ### Cancellation and Timeouts
 

--- a/manual-test-swap-roundtrip.sh
+++ b/manual-test-swap-roundtrip.sh
@@ -47,6 +47,18 @@
 #
 # Requires `sphere` on PATH, outbound HTTPS+WSS to testnet, and a
 # reachable escrow service.
+#
+# Escrow nametag resolution fallback (sphere-sdk#456):
+#   If the @escrow-testnet nametag does not resolve on the testnet
+#   relay (the §2.5 `sphere swap ping` pre-flight will fail with
+#   `Could not resolve recipient`), re-run with the escrow's raw
+#   DIRECT address. The production testnet escrow currently lives at:
+#
+#     ESCROW="DIRECT://00007968fa28648e4670438bf1f3c936296e84ff46dd5ebb2e34e20092e780b652da2d3d695b" \
+#       bash manual-test-swap-roundtrip.sh
+#
+#   The nametag remains the canonical reference — switch back once
+#   the operator republishes the binding event.
 
 set -euo pipefail
 
@@ -216,6 +228,12 @@ sphere wallet use alice
 if ! sphere swap ping "$ESCROW" 2>&1 | tee "$SNAP/alice-escrow-ping.log"; then
   echo "ASSERT FAIL (escrow-unreachable): $ESCROW did not respond to swap ping" >&2
   echo "Hint: set ESCROW=<addr> to point at a different escrow service." >&2
+  if [[ "$ESCROW" == "@escrow-testnet" ]]; then
+    echo "Hint (sphere-sdk#456): the @escrow-testnet nametag binding may be" >&2
+    echo "  missing on the testnet relay. Re-run with the DIRECT-address fallback:" >&2
+    echo "  ESCROW=\"DIRECT://00007968fa28648e4670438bf1f3c936296e84ff46dd5ebb2e34e20092e780b652da2d3d695b\" \\" >&2
+    echo "    bash manual-test-swap-roundtrip.sh" >&2
+  fi
   exit 1
 fi
 echo "ASSERT OK (escrow-reachable): $ESCROW responded"


### PR DESCRIPTION
## Summary

Issue #456: `@escrow-testnet` does not currently resolve on the testnet relay, blocking the swap soak. Investigation (below) shows the production testnet escrow operator never published the `escrow-testnet` nametag binding — the local escrow-service checkout at `/home/vrogojin/escrow-service` is running under a different nametag (`test-escrow-v3`) and a different DIRECT address than the production deployment, so this is a deployment-side gap, not a relay TTL issue.

While the operator republishes the binding, this PR makes the DIRECT-address fallback a first-class documented escape hatch — without abandoning `@escrow-testnet` as the canonical reference.

### Changes

- **`docs/DEMO-PLAYBOOK-SWAP-ROUNDTRIP.md`**
  - §0 prerequisites and §0 Workspace `ESCROW=` shell-var comment now mention the DIRECT fallback (default value unchanged at `@escrow-testnet`).
  - New `### Troubleshooting: escrow nametag resolution` subsection between §11 and §12, with copy-pasteable override, verification step, and an operator-action note.
  - §11 failure-table row for `--escrow` resolution failure cross-links to the new troubleshooting subsection.

- **`docs/QUICKSTART-CLI.md`**
  - §11 prerequisites bullet for "escrow service address" mentions the DIRECT fallback.
  - New `### Troubleshooting: escrow address` subsection in §11 with a worked `swap-propose --escrow DIRECT://…` example.

- **`manual-test-swap-roundtrip.sh`**
  - Header block documents the fallback override (sphere-sdk#456) and the canonical re-run invocation.
  - §2.5 escrow-ping pre-flight emits a targeted hint pointing at the DIRECT-form re-run command when `ESCROW=@escrow-testnet` and the ping fails.

### What was NOT done

- `@escrow-testnet` references **kept** in `docs/SWAP-SPEC.md`, `docs/API.md`, `docs/QUICKSTART-BROWSER.md`, `docs/QUICKSTART-NODEJS.md`, and the §0 / §11 default values — once the operator republishes the binding, the canonical nametag becomes usable again.
- No SDK / code-path changes — this is a doc + soak-script fallback only.

## Verification of escrow-service deployment state

Performed against `/home/vrogojin/escrow-service`:

```
$ grep -rn "escrow-testnet" /home/vrogojin/escrow-service/
(no matches)

$ grep -rn "00007968" /home/vrogojin/escrow-service/
(no matches — production DIRECT address is not baked into local repo)

$ cat /home/vrogojin/escrow-service/.env | grep SPHERE_NAMETAG
SPHERE_NAMETAG=test-escrow-v3

$ cat /home/vrogojin/escrow-service/.sphere-escrow/tokens/DIRECT_000014_af3e4f/nametags.json | jq -r '.[].name'
test-escrow-v3
```

Local escrow's DIRECT address is `DIRECT://0000142a02a50bc99e0ace77552a9dbd7be51c4658414fc4c25cd479733f6ca45208d5af3e4f`. The DIRECT address that the soak's WORKING workaround uses (`DIRECT://00007968...`) is a different keypair — confirming the production testnet escrow is **not** this local checkout. Operator action documented in the issue comment.

Init path in `src/scripts/init-wallet.ts` confirms `SPHERE_NAMETAG` env var → `sphere.registerNametag()` on first init (no re-publish on subsequent boots), which matches what we'd expect for the "binding event aged out" symptom.

## Test plan

- [x] `git grep '@escrow-testnet' docs/` still shows the nametag as the canonical reference in API.md / QUICKSTART-BROWSER.md / QUICKSTART-NODEJS.md / SWAP-SPEC.md / playbook §0 default / playbook example output.
- [x] `bash -n manual-test-swap-roundtrip.sh` parses cleanly (syntax check).
- [x] Playbook anchor `#troubleshooting-escrow-nametag-resolution` exists and links resolve.
- [ ] Operator-side: once `@escrow-testnet` re-publishes, run the playbook with default `ESCROW=@escrow-testnet` to confirm the canonical path is restored.

Closes-blocker-for: #456