### PR TITLE
fix(swap)(sphere-sdk#457): fail-fast on missing transportPubkey

### DIFF
--- a/core/errors.ts
+++ b/core/errors.ts
@@ -155,6 +155,26 @@ export type SphereErrorCode =
   | 'SWAP_ALREADY_INITIALIZED'
   | 'SWAP_MODULE_DESTROYED'
   | 'SWAP_NOT_INITIALIZED'
+  /**
+   * Issue #457 — counterparty / escrow peer resolved but the binding lacks a
+   * `transportPubkey`. The acceptor's wallet subscribes to NIP-17 events on
+   * the transport pubkey ONLY; previously the swap module silently fell
+   * back to `chainPubkey`, sealing the DM to a key the receiver never
+   * subscribes to. Result: the proposal vanishes with no error, no event,
+   * no warning — indistinguishable from a healthy proposal whose acceptor
+   * is offline.
+   *
+   * Fail-fast at all three sites in `modules/swap/SwapModule.ts`:
+   *  - `proposeSwap` counterparty resolution (line ~1133)
+   *  - `proposeSwap` escrow peer resolution (line ~1190)
+   *  - `getSwapStatus` escrow status-DM send (line ~2260)
+   *
+   * Surfaces when the resolved binding is partially propagated. The fix
+   * for the operator is to retry once `init` propagation finishes —
+   * usually seconds later, sometimes minutes if the relay is laggy. The
+   * thrown error's message text spells this out.
+   */
+  | 'SWAP_PEER_NO_TRANSPORT'
   // UXF transfer protocol error codes (T.1.D — bundle envelope decode failures).
   // The protocol surfaces three structurally-distinct failure modes that callers
   // and the receive worker must distinguish:

--- a/modules/swap/SwapModule.ts
+++ b/modules/swap/SwapModule.ts
@@ -91,6 +91,46 @@ const DEFAULT_TERMINAL_PURGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 /** Grace period added to local timeout over escrow timeout: 30 seconds. */
 const LOCAL_TIMEOUT_GRACE_MS = 30_000;
 
+/**
+ * Issue #457 — assert the resolved peer binding includes a usable
+ * `transportPubkey`, and return it.
+ *
+ * Background: NIP-17 swap DMs are sealed to the recipient's `transportPubkey`
+ * — that is the ONLY key the acceptor's wallet subscribes to. Before this
+ * helper, three call sites silently fell back to `chainPubkey` via the
+ * `??` operator (counterparty resolve, escrow resolve, status-DM send).
+ * When a binding event was partially propagated (missing `transportPubkey`),
+ * the DM would be sealed to a key the receiver does NOT subscribe to —
+ * indistinguishable from a healthy proposal whose acceptor is offline.
+ *
+ * The fix is fail-fast: throw a typed `SWAP_PEER_NO_TRANSPORT` error that
+ * spells out the recommended remediation (retry after binding propagation
+ * completes). At the fire-and-forget status-DM site (line ~2260) the
+ * `.catch` already logs the error rather than propagating it to the
+ * caller — but a logged warn is dramatically better than a silent black
+ * hole.
+ */
+function requireTransportPubkey(
+  peer: { readonly transportPubkey?: string; readonly nametag?: string; readonly directAddress?: string },
+  context: string,
+): string {
+  if (peer.transportPubkey) {
+    return peer.transportPubkey;
+  }
+  const peerLabel = peer.nametag
+    ? `@${peer.nametag}`
+    : peer.directAddress
+      ? peer.directAddress
+      : '<unknown>';
+  throw new SphereError(
+    `Cannot send swap DM to ${peerLabel} (${context}): the resolved binding has no transportPubkey. `
+      + `This usually means the peer's identity binding event has not finished propagating across the relay. `
+      + `Retry once the recipient has been online long enough for their binding to publish — typically a few seconds, occasionally minutes on a laggy relay. `
+      + `Falling back to the chain pubkey would silently black-hole the DM: the recipient's wallet subscribes to NIP-17 on the transport pubkey only.`,
+    'SWAP_PEER_NO_TRANSPORT',
+  );
+}
+
 export class SwapModule {
   // =========================================================================
   // Private fields
@@ -1130,7 +1170,11 @@ export class SwapModule {
     }
     const role = 'proposer' as const;
     const counterpartyPeer = matchesPartyA ? peerB : peerA;
-    const counterpartyPubkey = counterpartyPeer.transportPubkey ?? counterpartyPeer.chainPubkey;
+    // Issue #457 — refuse to fall back to `chainPubkey`. The acceptor's wallet
+    // subscribes to NIP-17 on the transport pubkey only; a fallback DM would
+    // be sealed to a key the receiver never reads, silently dropping the
+    // proposal. Surface a typed SWAP_PEER_NO_TRANSPORT error instead.
+    const counterpartyPubkey = requireTransportPubkey(counterpartyPeer, 'proposeSwap counterparty');
     const counterpartyNametag = counterpartyPeer.nametag;
 
     // Step 6: Check pending swap limit
@@ -1187,7 +1231,11 @@ export class SwapModule {
       progress: 'proposed',
       counterpartyPubkey,
       counterpartyNametag,
-      escrowPubkey: escrowPeer.transportPubkey ?? escrowPeer.chainPubkey,
+      // Issue #457 — refuse to fall back to `chainPubkey` for the escrow
+      // either. Subsequent escrow DMs (announce / status query / cancel)
+      // would silently black-hole on a chain-pubkey send. Same fail-fast
+      // contract as the counterparty resolve above.
+      escrowPubkey: requireTransportPubkey(escrowPeer, 'proposeSwap escrow'),
       escrowDirectAddress: escrowPeer.directAddress,
       payoutVerified: false,
       createdAt: now,
@@ -2257,7 +2305,14 @@ export class SwapModule {
           .then((peer) => {
             if (peer) {
               const statusDM = buildStatusQueryDM(swapId);
-              return deps.communications.sendDM(peer.transportPubkey ?? peer.chainPubkey, statusDM).then(() => undefined);
+              // Issue #457 — refuse to fall back to `chainPubkey` here too.
+              // The escrow won't see a status query sealed to its chain
+              // pubkey, so silently sending to that key is a black-hole.
+              // The `.catch` below logs the SWAP_PEER_NO_TRANSPORT throw,
+              // which is dramatically better than a silent drop because
+              // operators see the actionable warning in their logs.
+              const escrowPubkey = requireTransportPubkey(peer, `getSwapStatus status query for swap ${swapId}`);
+              return deps.communications.sendDM(escrowPubkey, statusDM).then(() => undefined);
             }
           })
           .catch((err) => {

--- a/tests/unit/modules/SwapModule.transport-pubkey.test.ts
+++ b/tests/unit/modules/SwapModule.transport-pubkey.test.ts
@@ -1,0 +1,192 @@
+/**
+ * SwapModule.transport-pubkey.test.ts
+ *
+ * Issue #457 — fail-fast when a resolved counterparty / escrow peer is
+ * missing `transportPubkey`. The pre-fix code silently fell back to
+ * `chainPubkey`, sealing NIP-17 DMs to a key the receiver's wallet does
+ * NOT subscribe to. Now the three sites in `modules/swap/SwapModule.ts`
+ * throw a typed `SWAP_PEER_NO_TRANSPORT` `SphereError`.
+ *
+ * Covers all three call sites:
+ *   1. `proposeSwap` counterparty resolution (rejects the proposeSwap call)
+ *   2. `proposeSwap` escrow peer resolution (rejects the proposeSwap call)
+ *   3. `getSwapStatus` escrow status-DM send (fire-and-forget — the throw
+ *      is caught and logged by the existing `.catch`, but the failing
+ *      `sendDM` call is observably skipped)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createTestSwapModule,
+  createTestSwapDeal,
+  createTestSwapRef,
+  injectSwapRef,
+  DEFAULT_TEST_PARTY_B_ADDRESS,
+  DEFAULT_TEST_PARTY_B_PUBKEY,
+  DEFAULT_TEST_ESCROW_PUBKEY,
+  DEFAULT_TEST_ESCROW_ADDRESS,
+  SphereError,
+} from './swap-test-helpers.js';
+import type { SwapModule } from '../../../modules/swap/index.js';
+import type { TestSwapModuleMocks } from './swap-test-helpers.js';
+import type { PeerInfo } from '../../../transport/transport-provider.js';
+
+describe('SwapModule — Issue #457 fail-fast on missing transportPubkey', () => {
+  let module: SwapModule;
+  let mocks: TestSwapModuleMocks;
+
+  beforeEach(async () => {
+    const ctx = createTestSwapModule();
+    module = ctx.module;
+    mocks = ctx.mocks;
+    await module.load();
+  });
+
+  afterEach(async () => {
+    try {
+      await module.destroy();
+    } catch {
+      // ignore double-destroy
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Site #1: proposeSwap — counterparty resolve
+  // ---------------------------------------------------------------------------
+
+  it('rejects proposeSwap with SWAP_PEER_NO_TRANSPORT when counterparty peer binding has no transportPubkey', async () => {
+    // Mutate the resolve mock so partyB (the counterparty) resolves to a
+    // PeerInfo whose `transportPubkey` is undefined. This simulates the
+    // §457 partial-propagation scenario.
+    const incompleteBinding: PeerInfo = {
+      chainPubkey: DEFAULT_TEST_PARTY_B_PUBKEY,
+      directAddress: DEFAULT_TEST_PARTY_B_ADDRESS,
+      transportPubkey: undefined as unknown as string, // partially propagated binding
+      l1Address: 'alpha1partybbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      nametag: 'bob-demo06',
+      timestamp: Date.now(),
+    };
+    mocks.resolve._peers.set(DEFAULT_TEST_PARTY_B_ADDRESS, incompleteBinding);
+    mocks.resolve._peers.set(DEFAULT_TEST_PARTY_B_PUBKEY, incompleteBinding);
+    mocks.resolve._peers.set('@bob-demo06', incompleteBinding);
+
+    const deal = createTestSwapDeal({ partyB: '@bob-demo06' });
+
+    await expect(module.proposeSwap(deal)).rejects.toMatchObject({
+      code: 'SWAP_PEER_NO_TRANSPORT',
+    });
+
+    // No DM should have been sent — the throw fires before sendDM.
+    expect(mocks.communications.sendDM).not.toHaveBeenCalled();
+
+    // The thrown error MUST be a SphereError with actionable text.
+    let captured: unknown = null;
+    try {
+      await module.proposeSwap(deal);
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(SphereError);
+    expect((captured as SphereError).code).toBe('SWAP_PEER_NO_TRANSPORT');
+    // Message must mention the binding-propagation cause + remediation.
+    expect((captured as Error).message).toMatch(/binding/i);
+    expect((captured as Error).message).toMatch(/propagat/i);
+    // Peer identification (nametag preferred) should appear so operators
+    // can tell WHICH peer was incomplete.
+    expect((captured as Error).message).toMatch(/@bob-demo06/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Site #2: proposeSwap — escrow resolve
+  // ---------------------------------------------------------------------------
+
+  it('rejects proposeSwap with SWAP_PEER_NO_TRANSPORT when escrow peer binding has no transportPubkey', async () => {
+    // Counterparty resolves fine; the escrow itself has incomplete binding.
+    const escrowIncomplete: PeerInfo = {
+      chainPubkey: DEFAULT_TEST_ESCROW_PUBKEY,
+      directAddress: DEFAULT_TEST_ESCROW_ADDRESS,
+      transportPubkey: undefined as unknown as string,
+      l1Address: 'alpha1escroweeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      nametag: 'escrow',
+      timestamp: Date.now(),
+    };
+    mocks.resolve._peers.set(DEFAULT_TEST_ESCROW_ADDRESS, escrowIncomplete);
+    mocks.resolve._peers.set(DEFAULT_TEST_ESCROW_PUBKEY, escrowIncomplete);
+    mocks.resolve._peers.set('@escrow', escrowIncomplete);
+
+    const deal = createTestSwapDeal();
+
+    await expect(module.proposeSwap(deal)).rejects.toMatchObject({
+      code: 'SWAP_PEER_NO_TRANSPORT',
+    });
+
+    // No counterparty DM should have escaped either — the proposeSwap
+    // function builds the SwapRef AFTER counterparty resolve, and the
+    // escrow throw fires before counterparty DM dispatch. (The fix order
+    // is: counterparty.transportPubkey check, then SwapRef construction
+    // which includes the escrow check.)
+    expect(mocks.communications.sendDM).not.toHaveBeenCalled();
+
+    let captured: unknown = null;
+    try {
+      await module.proposeSwap(deal);
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(SphereError);
+    expect((captured as SphereError).code).toBe('SWAP_PEER_NO_TRANSPORT');
+    // Context label should identify this as the escrow site.
+    expect((captured as Error).message).toMatch(/escrow/i);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Site #3: getSwapStatus — fire-and-forget status DM
+  // ---------------------------------------------------------------------------
+
+  it('skips (does not silently fall back) the status DM when escrow peer is missing transportPubkey in getSwapStatus', async () => {
+    // Seed an active swap so getSwapStatus has something to query.
+    const ref = createTestSwapRef({ progress: 'awaiting_counter' });
+    injectSwapRef(module, ref);
+
+    // Now mutate the escrow binding to be incomplete (after injection so
+    // the SwapRef itself isn't affected).
+    const escrowIncomplete: PeerInfo = {
+      chainPubkey: DEFAULT_TEST_ESCROW_PUBKEY,
+      directAddress: DEFAULT_TEST_ESCROW_ADDRESS,
+      transportPubkey: undefined as unknown as string,
+      l1Address: 'alpha1escroweeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      nametag: 'escrow',
+      timestamp: Date.now(),
+    };
+    mocks.resolve._peers.set(DEFAULT_TEST_ESCROW_ADDRESS, escrowIncomplete);
+    mocks.resolve._peers.set(DEFAULT_TEST_ESCROW_PUBKEY, escrowIncomplete);
+    mocks.resolve._peers.set('@escrow', escrowIncomplete);
+
+    // getSwapStatus is fire-and-forget for the status DM; the call itself
+    // must STILL return a SwapRef without throwing.
+    const result = await module.getSwapStatus(ref.swapId, { queryEscrow: true });
+    expect(result.swapId).toBe(ref.swapId);
+
+    // Give the fire-and-forget promise a microtask flush to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The pre-fix code would have called sendDM with the escrow's
+    // chainPubkey (silent black-hole). With the fix, sendDM must NEVER
+    // have been called.
+    expect(mocks.communications.sendDM).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Regression check: happy path (transportPubkey present) still works.
+  // ---------------------------------------------------------------------------
+
+  it('proposeSwap continues to work when transportPubkey IS present on both peers', async () => {
+    // Default mock peers already include transportPubkey, so this should
+    // just succeed.
+    const deal = createTestSwapDeal();
+    const result = await module.proposeSwap(deal);
+    expect(result.swapId).toMatch(/^[0-9a-f]{64}$/);
+    expect(mocks.communications.sendDM).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Three sites in `modules/swap/SwapModule.ts` used `peer.transportPubkey ?? peer.chainPubkey` to address swap DMs. When a resolved binding is partially propagated (transportPubkey not yet observed on the relay), that fallback seals the NIP-17 DM to a key the receiver's wallet does NOT subscribe to. The proposer sees `status: proposed`; the acceptor sees nothing. No error, no event, no warning — indistinguishable from a healthy proposal whose acceptor is offline.

Demo session **2026-06-09** reproduced this live: first `sphere swap propose --to bob-demo06` silently dropped; a retry 5 minutes later (same wallet, same relay — propagation completed) landed normally.

Closes #457.

## The fix

A new `requireTransportPubkey(peer, context)` helper throws a typed `SWAP_PEER_NO_TRANSPORT` `SphereError` with actionable text that:
- identifies the peer (`@nametag` preferred, DIRECT address as fallback)
- explains the binding-propagation cause
- recommends retrying once the recipient has been online long enough for their binding to publish
- spells out why a chainPubkey fallback would silently black-hole the DM

## Three call sites converted

| Site | Location | Behaviour change |
|------|----------|------------------|
| `proposeSwap` counterparty resolve | `SwapModule.ts:~1133` | Rejects the call with `SWAP_PEER_NO_TRANSPORT` before any DM dispatch |
| `proposeSwap` escrow peer resolve | `SwapModule.ts:~1190` | Rejects the call with `SWAP_PEER_NO_TRANSPORT` before SwapRef construction completes |
| `getSwapStatus` status-DM send | `SwapModule.ts:~2260` | Fire-and-forget — the throw is caught by the existing `.catch` and logged as `warn`. Dramatically better than silent black-hole: operators see actionable text in their logs. |

## Files changed

- `core/errors.ts` — adds `SWAP_PEER_NO_TRANSPORT` to `SphereErrorCode`, with a doc-comment explaining why.
- `modules/swap/SwapModule.ts` — adds `requireTransportPubkey()` helper and updates all three sites.
- `tests/unit/modules/SwapModule.transport-pubkey.test.ts` — 4 new tests covering all three sites + happy-path regression check.

## Test plan

- [x] `npx vitest run tests/unit/modules/SwapModule.transport-pubkey.test.ts` — 4/4 pass
- [x] `npx vitest run tests/unit/modules/Swap*` — 269/269 pass (no regressions)
- [x] `npx eslint modules/swap/SwapModule.ts core/errors.ts tests/unit/modules/SwapModule.transport-pubkey.test.ts` — 0 errors (pre-existing SwapModule.ts unused-import warnings only)
- [x] `npx tsc --noEmit` — clean
- [x] `npx tsup` — build success