### PR TITLE
fix(swap)(sphere-sdk#447): include terminal swaps in resolveSwapId/getSwaps and write-side error codes

### DIFF
--- a/core/errors.ts
+++ b/core/errors.ts
@@ -175,6 +175,23 @@ export type SphereErrorCode =
    * thrown error's message text spells this out.
    */
   | 'SWAP_PEER_NO_TRANSPORT'
+  // Issue #447 — terminal-swap blindness fixes.
+  // `SWAP_ALREADY_TERMINAL` is thrown by write-side methods (acceptSwap,
+  // cancelSwap, deposit, rejectSwap, verifyPayout) when the swap exists
+  // but is already in a terminal state (completed/cancelled/failed).
+  // Previously these surfaces threw `SWAP_NOT_FOUND` because terminal
+  // swaps are deliberately kept out of the in-memory working set — that
+  // was inconsistent with `getSwapStatus`, which now lazy-loads
+  // terminal swaps and reports their state. Callers that previously
+  // caught `SWAP_NOT_FOUND` to detect "cannot mutate this swap" should
+  // also catch `SWAP_ALREADY_TERMINAL`.
+  //
+  // `SWAP_AMBIGUOUS_PREFIX` distinguishes the "prefix matches multiple
+  // swaps" case from the "no match" case in `resolveSwapId`. Previously
+  // both surfaces shared `SWAP_NOT_FOUND` which made it impossible for
+  // callers to give the user a "use more characters" hint.
+  | 'SWAP_ALREADY_TERMINAL'
+  | 'SWAP_AMBIGUOUS_PREFIX'
   // UXF transfer protocol error codes (T.1.D — bundle envelope decode failures).
   // The protocol surfaces three structurally-distinct failure modes that callers
   // and the receive worker must distinguish:

--- a/modules/swap/SwapModule.ts
+++ b/modules/swap/SwapModule.ts
@@ -908,6 +908,67 @@ export class SwapModule {
   }
 
   /**
+   * Issue #447: write-side helper for `acceptSwap`, `cancelSwap`,
+   * `deposit`, `rejectSwap`, and `verifyPayout`.
+   *
+   * Resolves a swap id to its in-memory SwapRef using the same lookup
+   * order as {@link getSwapStatus} (cache → terminal lazy-load), then
+   * enforces that the result is in a non-terminal state. Write
+   * operations against a terminal swap are never valid — the local
+   * state machine and the escrow are both done with the swap.
+   *
+   * Why this matters: PR #446 made `getSwapStatus` lazy-load terminal
+   * entries from storage and report their state, but
+   * `acceptSwap`/`cancelSwap`/etc. still did a bare `this.swaps.get()`
+   * which returned `undefined` for terminal ids. The result was an
+   * inconsistent operator surface — `swap status <id>` said "completed"
+   * while `swap cancel <id>` said "not found". This helper unifies the
+   * lookup and surfaces a clear `SWAP_ALREADY_TERMINAL` instead of the
+   * misleading `SWAP_NOT_FOUND`.
+   *
+   * @throws {SphereError} `SWAP_NOT_FOUND` if the id is not in the
+   *   working set and not in the terminal index.
+   * @throws {SphereError} `SWAP_ALREADY_TERMINAL` if the id resolves
+   *   to a terminal swap. The error message includes the terminal
+   *   state and the calling operation name (for UX clarity).
+   */
+  private async requireSwap(swapId: string, operation: string): Promise<SwapRef> {
+    const live = this.swaps.get(swapId);
+    if (live) {
+      // Return the live ref AS-IS — even if it's transiently terminal
+      // (a state transition happens before removal from the working
+      // set). The caller's existing state-machine guards
+      // (SWAP_ALREADY_COMPLETED / SWAP_ALREADY_CANCELLED /
+      // SWAP_WRONG_STATE) preserve the legacy fine-grained error codes
+      // for in-memory swaps. The SWAP_ALREADY_TERMINAL surface added by
+      // Issue #447 specifically replaces the misleading SWAP_NOT_FOUND
+      // that was thrown when a terminal swap was no longer in memory
+      // because loadFromStorage had already excluded it from the
+      // working set.
+      return live;
+    }
+
+    // Cache miss — try the terminal index. If the id is in
+    // _storedTerminalEntries or terminalSwapIds, the swap has been seen
+    // as terminal in this session and should NOT silently appear to the
+    // caller as "not found".
+    const terminalSwap = await this.loadTerminalSwapFromStorage(swapId);
+    if (terminalSwap) {
+      throw new SphereError(
+        `Swap ${swapId} is in terminal state '${terminalSwap.progress}'; ${operation} is not valid`,
+        'SWAP_ALREADY_TERMINAL',
+      );
+    }
+
+    // No in-memory entry, no lazy-loadable terminal record. Even if
+    // terminalSwapIds contains the id (e.g. the storage record was
+    // purged but the gate set is sticky), the caller has no usable
+    // record to act on — surface SWAP_NOT_FOUND. This matches the
+    // legacy contract for write-side "swap really doesn't exist".
+    throw new SphereError(`Swap not found: ${swapId}`, 'SWAP_NOT_FOUND');
+  }
+
+  /**
    * Remove a single swap from storage (per-swap key) and update the index.
    */
   private async removeSwapFromStorage(swapId: string): Promise<void> {
@@ -1321,6 +1382,9 @@ export class SwapModule {
    *
    * @param swapId - The swap ID to accept.
    * @throws {SphereError} `SWAP_NOT_FOUND` if swap does not exist.
+   * @throws {SphereError} `SWAP_ALREADY_TERMINAL` if the swap is already
+   *   in a terminal state (Issue #447 — consistent with `getSwapStatus`,
+   *   which lazy-loads terminal swaps and reports their state).
    * @throws {SphereError} `SWAP_WRONG_STATE` if swap is not in 'proposed' state.
    */
   async acceptSwap(swapId: string): Promise<void> {
@@ -1328,11 +1392,11 @@ export class SwapModule {
     this.ensureReady();
     const deps = this.deps!;
 
-    // Step 2: Look up swap
-    const swap = this.swaps.get(swapId);
-    if (!swap) {
-      throw new SphereError(`Swap not found: ${swapId}`, 'SWAP_NOT_FOUND');
-    }
+    // Step 2: Look up swap (Issue #447: requireSwap returns the live ref
+    // or throws SWAP_NOT_FOUND / SWAP_ALREADY_TERMINAL — never returns a
+    // terminal swap, so downstream state checks see only non-terminal
+    // progress values).
+    const swap = await this.requireSwap(swapId, 'acceptSwap');
     // Fast-path checks before gate (re-checked inside gate for TOCTOU safety)
     if (swap.progress !== 'proposed') {
       throw new SphereError(
@@ -1606,6 +1670,8 @@ export class SwapModule {
    * @param swapId - The swap ID to reject.
    * @param reason - Optional human-readable reason for rejection.
    * @throws {SphereError} `SWAP_NOT_FOUND` if swap does not exist.
+   * @throws {SphereError} `SWAP_ALREADY_TERMINAL` if the swap is already
+   *   in a terminal state (Issue #447).
    * @throws {SphereError} `SWAP_WRONG_STATE` if swap is not in 'proposed' state.
    */
   async rejectSwap(swapId: string, reason?: string): Promise<void> {
@@ -1613,13 +1679,17 @@ export class SwapModule {
     this.ensureReady();
     const deps = this.deps!;
 
-    // Step 2: Look up swap
-    const swap = this.swaps.get(swapId);
-    if (!swap) {
-      throw new SphereError(`Swap not found: ${swapId}`, 'SWAP_NOT_FOUND');
-    }
+    // Step 2: Look up swap. requireSwap returns the live in-memory ref
+    // when present, OR throws SWAP_ALREADY_TERMINAL for a lazy-loadable
+    // terminal swap, OR throws SWAP_NOT_FOUND otherwise (Issue #447).
+    // The fine-grained SWAP_ALREADY_COMPLETED / SWAP_ALREADY_CANCELLED
+    // codes below still apply to LIVE swaps that transitioned to
+    // terminal within this process — requireSwap intentionally returns
+    // those rather than throwing, to preserve the legacy contract for
+    // the in-memory case.
+    const swap = await this.requireSwap(swapId, 'rejectSwap');
 
-    // Allow rejection at any pre-payout state
+    // Allow rejection at any pre-payout state.
     if (swap.progress === 'concluding') {
       throw new SphereError('Cannot reject: payouts are already in progress', 'SWAP_WRONG_STATE');
     }
@@ -1699,6 +1769,8 @@ export class SwapModule {
    * @param swapId - The swap ID to deposit for.
    * @returns The transfer result from payInvoice().
    * @throws {SphereError} `SWAP_NOT_FOUND` if swap does not exist.
+   * @throws {SphereError} `SWAP_ALREADY_TERMINAL` if the swap is already
+   *   in a terminal state (Issue #447).
    * @throws {SphereError} `SWAP_WRONG_STATE` if swap is not in 'announced' state.
    * @throws {SphereError} `SWAP_DEPOSIT_FAILED` if payment fails.
    */
@@ -1707,11 +1779,10 @@ export class SwapModule {
     this.ensureReady();
     const deps = this.deps!;
 
-    // Look up swap
-    const swap = this.swaps.get(swapId);
-    if (!swap) {
-      throw new SphereError(`Swap ${swapId} not found`, 'SWAP_NOT_FOUND');
-    }
+    // Look up swap (Issue #447: requireSwap throws SWAP_ALREADY_TERMINAL
+    // for a lazy-loadable terminal swap, distinguishing it from the
+    // legacy SWAP_NOT_FOUND).
+    const swap = await this.requireSwap(swapId, 'deposit');
 
     // Verify progress is 'announced'
     if (swap.progress !== 'announced') {
@@ -1870,6 +1941,11 @@ export class SwapModule {
    * @param swapId - The swap ID to verify.
    * @returns true if payout is verified, false otherwise.
    * @throws {SphereError} `SWAP_NOT_FOUND` if swap does not exist.
+   * @throws {SphereError} `SWAP_ALREADY_TERMINAL` if the swap is already
+   *   in a terminal state (Issue #447). Note: a LIVE swap that is already
+   *   `completed` with `payoutVerified === true` short-circuits inside the
+   *   gate (idempotent re-verify); this code only surfaces for terminal
+   *   swaps no longer in the working set.
    * @throws {SphereError} `SWAP_PAYOUT_VERIFICATION_FAILED` on verification failure.
    */
   async verifyPayout(swapId: string): Promise<boolean> {
@@ -1877,11 +1953,11 @@ export class SwapModule {
     this.ensureReady();
     const deps = this.deps!;
 
-    // Look up swap (pre-gate fast check)
-    const swap = this.swaps.get(swapId);
-    if (!swap) {
-      throw new SphereError(`Swap ${swapId} not found`, 'SWAP_NOT_FOUND');
-    }
+    // Look up swap (pre-gate fast check). Issue #447: requireSwap throws
+    // SWAP_ALREADY_TERMINAL for lazy-loadable terminal swaps. Live swaps
+    // that are completed remain handled by the gate-internal idempotency
+    // branch below — they already passed verifyPayout once.
+    const swap = await this.requireSwap(swapId, 'verifyPayout');
 
     if (!swap.payoutInvoiceId) {
       throw new SphereError('Payout invoice not yet received', 'SWAP_WRONG_STATE');
@@ -2326,9 +2402,66 @@ export class SwapModule {
   }
 
   /**
+   * Materialize a stub SwapRef from a SwapIndexEntry. Used by
+   * {@link getSwaps} when `includeTerminal: true` — terminal entries
+   * stay out of the in-memory working set, so we synthesize a minimal
+   * SwapRef from the lightweight index entry rather than paying a
+   * storage read per terminal swap.
+   *
+   * The stub carries only `swapId`, `progress`, `role`, `createdAt`,
+   * `updatedAt` (aliased to createdAt — index entries don't track
+   * updatedAt) and `payoutVerified: false`. `deal` and `manifest` are
+   * empty placeholders — callers needing the full record must resolve
+   * each id via {@link getSwapStatus} (which lazy-loads from storage).
+   *
+   * This is sufficient for `sphere swap list` to render id, role,
+   * progress, and createdAt rows.
+   */
+  private materializeStubSwapRef(entry: SwapIndexEntry): SwapRef {
+    const stubDeal: SwapDeal = {
+      partyA: '',
+      partyB: '',
+      partyACurrency: '',
+      partyAAmount: '0',
+      partyBCurrency: '',
+      partyBAmount: '0',
+      timeout: 0,
+    };
+    const stubManifest: SwapManifest = {
+      swap_id: entry.swapId,
+      party_a_address: '',
+      party_b_address: '',
+      party_a_currency_to_change: '',
+      party_a_value_to_change: '0',
+      party_b_currency_to_change: '',
+      party_b_value_to_change: '0',
+      timeout: 0,
+      salt: '',
+    };
+    return {
+      swapId: entry.swapId,
+      deal: stubDeal,
+      manifest: stubManifest,
+      role: entry.role,
+      progress: entry.progress,
+      payoutVerified: false,
+      createdAt: entry.createdAt,
+      updatedAt: entry.createdAt,
+    };
+  }
+
+  /**
    * List swaps with optional filtering.
    *
-   * @param filter - Optional filter by progress, role, or excludeTerminal.
+   * By default returns only the in-memory working set, which excludes
+   * terminal swaps preserved in the storage index (see Issue #447).
+   * Pass `includeTerminal: true` to also surface stub SwapRefs for
+   * terminal entries — those stubs carry only id/role/progress/
+   * createdAt (see {@link materializeStubSwapRef}); call
+   * {@link getSwapStatus} per id to lazy-load the full record.
+   *
+   * @param filter - Optional filter by progress, role, excludeTerminal,
+   *   or includeTerminal.
    * @returns Array of SwapRef matching the filter.
    */
   getSwaps(filter?: GetSwapsFilter): SwapRef[] {
@@ -2336,6 +2469,19 @@ export class SwapModule {
     this.ensureReady();
 
     let results = Array.from(this.swaps.values());
+
+    // Issue #447: optionally surface terminal entries that were loaded
+    // from the swap index but are NOT in `this.swaps`. Dedup against
+    // ids already in the working set — a live swap can transiently
+    // appear in both during the terminal transition.
+    if (filter?.includeTerminal) {
+      const liveIds = new Set<string>();
+      for (const s of results) liveIds.add(s.swapId);
+      for (const entry of this._storedTerminalEntries) {
+        if (liveIds.has(entry.swapId)) continue;
+        results.push(this.materializeStubSwapRef(entry));
+      }
+    }
 
     if (filter?.progress) {
       const allowed = Array.isArray(filter.progress)
@@ -2364,17 +2510,22 @@ export class SwapModule {
    *
    * @param swapId - The swap ID to cancel.
    * @throws {SphereError} `SWAP_NOT_FOUND` if swap does not exist.
-   * @throws {SphereError} `SWAP_ALREADY_COMPLETED` if swap is already completed.
-   * @throws {SphereError} `SWAP_ALREADY_CANCELLED` if swap is already cancelled.
+   * @throws {SphereError} `SWAP_ALREADY_TERMINAL` if the swap is already
+   *   in a terminal state and was lazy-loaded from storage (Issue #447).
+   * @throws {SphereError} `SWAP_ALREADY_COMPLETED` if a LIVE swap is already
+   *   completed.
+   * @throws {SphereError} `SWAP_ALREADY_CANCELLED` if a LIVE swap is already
+   *   cancelled.
    */
   async cancelSwap(swapId: string): Promise<void> {
     this.ensureNotDestroyed();
     this.ensureReady();
 
-    const swap = this.swaps.get(swapId);
-    if (!swap) {
-      throw new SphereError(`Swap not found: ${swapId}`, 'SWAP_NOT_FOUND');
-    }
+    // Issue #447: requireSwap routes terminal-but-not-in-memory swaps
+    // through SWAP_ALREADY_TERMINAL. LIVE swaps that are transiently
+    // in terminal state still flow through the legacy
+    // SWAP_ALREADY_COMPLETED / SWAP_ALREADY_CANCELLED branches below.
+    const swap = await this.requireSwap(swapId, 'cancelSwap');
 
     // Fast-path checks before gate (TOCTOU-safe: re-checked inside gate)
     if (swap.progress === 'concluding') {
@@ -2444,12 +2595,27 @@ export class SwapModule {
 
   /**
    * Resolve a swap ID from a full 64-char hex string or a unique prefix (min 4 chars).
-   * Matches against all known swaps (active + terminal in current session).
+   * Matches against ALL known swap ids — both the active in-memory working
+   * set ({@link swaps}) and the terminal index loaded from storage
+   * ({@link _storedTerminalEntries}).
+   *
+   * Issue #447: terminal swaps deliberately stay out of `this.swaps` to
+   * bound the in-memory working set across the {@link terminalPurgeTtlMs}
+   * window. Before this fix, `resolveSwapId` only scanned `this.swaps`,
+   * so a prefix lookup against a terminal swap (e.g. `sphere swap status
+   * <prefix>` after the swap reached `completed`) threw `SWAP_NOT_FOUND`
+   * from the resolver before {@link getSwapStatus}' lazy-load could
+   * even run. The fix is to consult `_storedTerminalEntries` for prefix
+   * matches — those entries already carry enough metadata
+   * ({@link SwapIndexEntry}) for the prefix match without needing a
+   * storage read.
    *
    * @param idOrPrefix - Full swap ID or unique hex prefix (min 4 chars).
    * @returns The full 64-char swap ID.
-   * @throws {SphereError} `SWAP_NOT_FOUND` if no match or ambiguous prefix.
    * @throws {SphereError} `SWAP_INVALID_DEAL` if prefix is too short or not hex.
+   * @throws {SphereError} `SWAP_NOT_FOUND` if no live OR terminal entry matches.
+   * @throws {SphereError} `SWAP_AMBIGUOUS_PREFIX` if multiple entries match
+   *   the prefix across live + terminal (use more characters).
    */
   resolveSwapId(idOrPrefix: string): string {
     const trimmed = idOrPrefix.trim();
@@ -2466,19 +2632,31 @@ export class SwapModule {
     }
 
     const lower = trimmed.toLowerCase();
-    const matched = this.getSwaps().filter(s => s.swapId.startsWith(lower));
 
-    if (matched.length === 0) {
+    // Collect candidate IDs from live + terminal index. Use a Set to
+    // dedupe (a swap can briefly appear in both — e.g. when a live swap
+    // transitions to terminal in this process, it's added to
+    // _storedTerminalEntries before being removed from `this.swaps`).
+    const matched = new Set<string>();
+    for (const swap of this.swaps.values()) {
+      if (swap.swapId.startsWith(lower)) matched.add(swap.swapId);
+    }
+    for (const entry of this._storedTerminalEntries) {
+      if (entry.swapId.startsWith(lower)) matched.add(entry.swapId);
+    }
+
+    if (matched.size === 0) {
       throw new SphereError(`No swap found matching prefix: ${trimmed}`, 'SWAP_NOT_FOUND');
     }
-    if (matched.length > 1) {
+    if (matched.size > 1) {
       throw new SphereError(
-        `Ambiguous prefix "${trimmed}" matches ${matched.length} swaps. Use more characters.`,
-        'SWAP_NOT_FOUND',
+        `Ambiguous prefix "${trimmed}" matches ${matched.size} swaps. Use more characters.`,
+        'SWAP_AMBIGUOUS_PREFIX',
       );
     }
 
-    return matched[0].swapId;
+    // Set has size 1 — get the single value.
+    return matched.values().next().value as string;
   }
 
   // T2.4: IMPLEMENTATION END

--- a/modules/swap/types.ts
+++ b/modules/swap/types.ts
@@ -488,6 +488,28 @@ export interface GetSwapsFilter {
   readonly role?: SwapRole;
   /** When true, exclude swaps where progress is 'completed', 'cancelled', or 'failed' */
   readonly excludeTerminal?: boolean;
+  /**
+   * Issue #447 — When true, also include terminal swaps that are present in
+   * the persisted swap index but not in the in-memory working set. This is
+   * the working-set complement of {@link excludeTerminal}: by default
+   * `getSwaps()` only returns swaps cached in {@link SwapModule.swaps},
+   * which excludes terminal entries that {@link SwapModule.loadFromStorage}
+   * deliberately kept out of memory to bound the active set.
+   *
+   * Terminal entries returned via this path are STUB SwapRefs materialized
+   * from the lightweight {@link SwapIndexEntry} (swapId/progress/role/
+   * createdAt only) — `deal`, `manifest`, and most other fields will be
+   * empty placeholders. Callers needing the full record should resolve
+   * each id via {@link SwapModule.getSwapStatus} (which lazy-loads from
+   * storage). Sufficient for `sphere swap list` to show id, role,
+   * progress, and createdAt.
+   *
+   * Has no effect when combined with `excludeTerminal: true` — terminal
+   * entries are filtered out either way.
+   *
+   * Default: `false` (preserves existing list behavior).
+   */
+  readonly includeTerminal?: boolean;
 }
 
 // =============================================================================

--- a/tests/unit/modules/SwapModule.terminal-blindness.test.ts
+++ b/tests/unit/modules/SwapModule.terminal-blindness.test.ts
@@ -1,0 +1,411 @@
+/**
+ * SwapModule.terminal-blindness.test.ts
+ *
+ * Issue #447: SwapModule terminal-swap blindness in resolveSwapId,
+ * getSwaps, and write-side methods.
+ *
+ * PR #446 (closing #445) added lazy-load for terminal swaps in
+ * `getSwapStatus` only. Three other surfaces still treated terminal
+ * swaps as unknown until this PR:
+ *
+ *   1. `resolveSwapId(prefix)` — iterated `this.swaps.values()` only,
+ *      so `sphere swap status <prefix>` against a terminal swap threw
+ *      SWAP_NOT_FOUND from the prefix-resolver before `getSwapStatus`
+ *      ever ran.
+ *   2. `getSwaps(filter)` — `Array.from(this.swaps.values())` only,
+ *      with no way to surface terminal entries even via
+ *      `excludeTerminal: false`.
+ *   3. Write-side methods (`acceptSwap`, `cancelSwap`, `deposit`,
+ *      `rejectSwap`, `verifyPayout`) — bare `this.swaps.get()`, so
+ *      `cancelSwap` against a terminal id said "not found" while
+ *      `getSwapStatus` against the same id said "completed".
+ *
+ * These tests pin the post-fix contract:
+ *   - `resolveSwapId` consults `_storedTerminalEntries` for prefix
+ *     matches.
+ *   - `getSwaps({ includeTerminal: true })` materializes stub
+ *     SwapRefs from the terminal index entries.
+ *   - Write-side methods throw `SWAP_ALREADY_TERMINAL` (new code) for
+ *     terminal swaps that lazy-load from storage, distinguishing them
+ *     from truly-unknown ids that still throw `SWAP_NOT_FOUND`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createTestSwapModule,
+  createTestSwapRef,
+  injectSwapRef,
+  type TestSwapModuleMocks,
+} from './swap-test-helpers.js';
+import type { SwapModule } from '../../../modules/swap/index.js';
+import type { SwapIndexEntry } from '../../../modules/swap/types.js';
+
+describe('SwapModule — terminal-swap blindness (Issue #447)', () => {
+  let module: SwapModule;
+  let mocks: TestSwapModuleMocks;
+
+  beforeEach(async () => {
+    const ctx = createTestSwapModule();
+    module = ctx.module;
+    mocks = ctx.mocks;
+    await module.load();
+  });
+
+  // Helper: seed a terminal index entry plus its storage record. This
+  // mirrors the post-loadFromStorage state where terminal swaps within
+  // the purge TTL are tracked in `_storedTerminalEntries` and remain
+  // readable from storage, but are deliberately absent from `this.swaps`.
+  function seedTerminalSwap(progress: 'completed' | 'cancelled' | 'failed', swapIdOverride?: string): { swapId: string; ref: ReturnType<typeof createTestSwapRef> } {
+    const ref = createTestSwapRef({
+      progress,
+      ...(swapIdOverride ? { swapId: swapIdOverride } : {}),
+    });
+    const addressId = mocks.identity.directAddress!;
+    const storageKey = `${addressId}_swap:${ref.swapId}`;
+    mocks.storage._data.set(
+      storageKey,
+      JSON.stringify({ version: 1, swap: ref }),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const m = module as any;
+    m.terminalSwapIds.add(ref.swapId);
+    const entry: SwapIndexEntry = {
+      swapId: ref.swapId,
+      progress,
+      role: ref.role,
+      createdAt: ref.createdAt,
+    };
+    m._storedTerminalEntries.push(entry);
+    return { swapId: ref.swapId, ref };
+  }
+
+  // ==========================================================================
+  // resolveSwapId — surface (1)
+  // ==========================================================================
+
+  describe('resolveSwapId', () => {
+    it('finds a terminal swap by prefix from _storedTerminalEntries', () => {
+      const { swapId } = seedTerminalSwap('completed');
+      const prefix = swapId.slice(0, 8);
+
+      const resolved = module.resolveSwapId(prefix);
+
+      expect(resolved).toBe(swapId);
+    });
+
+    it('still finds a live swap by prefix (no regression)', () => {
+      const ref = createTestSwapRef({ progress: 'announced' });
+      injectSwapRef(module, ref);
+      const prefix = ref.swapId.slice(0, 8);
+
+      const resolved = module.resolveSwapId(prefix);
+
+      expect(resolved).toBe(ref.swapId);
+    });
+
+    it('throws SWAP_AMBIGUOUS_PREFIX when prefix matches a live AND a terminal swap', () => {
+      // Force matching prefixes: terminal id starts with the live id's
+      // first 8 chars. We construct a synthetic 64-hex terminal id that
+      // shares the live ref's leading 8 chars but differs later.
+      const liveRef = createTestSwapRef({ progress: 'announced' });
+      injectSwapRef(module, liveRef);
+      const sharedPrefix = liveRef.swapId.slice(0, 8);
+      const terminalId = sharedPrefix + 'f'.repeat(56);
+      // Make sure the synthetic id differs from the live id.
+      expect(terminalId).not.toBe(liveRef.swapId);
+      seedTerminalSwap('completed', terminalId);
+
+      expect(() => module.resolveSwapId(sharedPrefix)).toThrowError(
+        expect.objectContaining({ code: 'SWAP_AMBIGUOUS_PREFIX' }),
+      );
+    });
+
+    it('throws SWAP_AMBIGUOUS_PREFIX when prefix matches two terminal swaps', () => {
+      // Two synthetic terminal ids sharing leading 8 hex chars.
+      const a = 'cafebabe' + '1'.repeat(56);
+      const b = 'cafebabe' + '2'.repeat(56);
+      seedTerminalSwap('completed', a);
+      seedTerminalSwap('cancelled', b);
+
+      expect(() => module.resolveSwapId('cafebabe')).toThrowError(
+        expect.objectContaining({ code: 'SWAP_AMBIGUOUS_PREFIX' }),
+      );
+    });
+
+    it('still throws SWAP_NOT_FOUND when prefix matches nothing', () => {
+      // No swaps live, no swaps terminal — prefix lookup must miss.
+      expect(() => module.resolveSwapId('deadbeef')).toThrowError(
+        expect.objectContaining({ code: 'SWAP_NOT_FOUND' }),
+      );
+    });
+
+    it('dedupes a swap that briefly appears in both live and terminal index', () => {
+      // During a terminal transition the same id can be present in
+      // `this.swaps` AND in `_storedTerminalEntries` (the latter is
+      // appended before the former is removed). The prefix lookup must
+      // treat that as ONE match, not ambiguous.
+      const ref = createTestSwapRef({ progress: 'completed' });
+      injectSwapRef(module, ref);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const m = module as any;
+      m._storedTerminalEntries.push({
+        swapId: ref.swapId,
+        progress: 'completed' as const,
+        role: ref.role,
+        createdAt: ref.createdAt,
+      });
+
+      const resolved = module.resolveSwapId(ref.swapId.slice(0, 8));
+      expect(resolved).toBe(ref.swapId);
+    });
+
+    it('full 64-char hex id is returned as-is without scanning', () => {
+      // Sanity: no swaps anywhere, full hex id round-trips.
+      const fullId = 'a'.repeat(64);
+      expect(module.resolveSwapId(fullId)).toBe(fullId);
+    });
+
+    it('rejects prefixes shorter than 4 hex chars with SWAP_INVALID_DEAL', () => {
+      expect(() => module.resolveSwapId('abc')).toThrowError(
+        expect.objectContaining({ code: 'SWAP_INVALID_DEAL' }),
+      );
+    });
+  });
+
+  // ==========================================================================
+  // getSwaps — surface (2)
+  // ==========================================================================
+
+  describe('getSwaps with includeTerminal', () => {
+    it('default behavior (no filter) still excludes terminal entries — no regression', () => {
+      const live = createTestSwapRef({ progress: 'announced' });
+      injectSwapRef(module, live);
+      seedTerminalSwap('completed');
+
+      const results = module.getSwaps();
+
+      expect(results).toHaveLength(1);
+      expect(results[0].swapId).toBe(live.swapId);
+    });
+
+    it('includeTerminal: false (explicit) matches default behavior', () => {
+      const live = createTestSwapRef({ progress: 'announced' });
+      injectSwapRef(module, live);
+      seedTerminalSwap('completed');
+
+      const results = module.getSwaps({ includeTerminal: false });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].swapId).toBe(live.swapId);
+    });
+
+    it('includeTerminal: true surfaces terminal entries as stub SwapRefs', () => {
+      const live = createTestSwapRef({ progress: 'announced' });
+      injectSwapRef(module, live);
+      const { swapId: termId } = seedTerminalSwap('completed');
+
+      const results = module.getSwaps({ includeTerminal: true });
+
+      expect(results).toHaveLength(2);
+      const termResult = results.find(s => s.swapId === termId);
+      expect(termResult).toBeDefined();
+      expect(termResult!.progress).toBe('completed');
+      expect(termResult!.role).toBe('proposer');
+      // Stub: deal/manifest are placeholders; manifest.swap_id is preserved.
+      expect(termResult!.manifest.swap_id).toBe(termId);
+      expect(termResult!.deal.partyA).toBe('');
+      expect(termResult!.manifest.party_a_address).toBe('');
+    });
+
+    it('includeTerminal: true + excludeTerminal: true filters out terminal — excludeTerminal wins', () => {
+      const live = createTestSwapRef({ progress: 'announced' });
+      injectSwapRef(module, live);
+      seedTerminalSwap('completed');
+
+      const results = module.getSwaps({
+        includeTerminal: true,
+        excludeTerminal: true,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].swapId).toBe(live.swapId);
+    });
+
+    it('includeTerminal: true + progress filter narrows correctly across live + terminal', () => {
+      const live = createTestSwapRef({ progress: 'announced' });
+      injectSwapRef(module, live);
+      const { swapId: completedId } = seedTerminalSwap('completed');
+      seedTerminalSwap('cancelled', 'feed' + '0'.repeat(60));
+
+      const results = module.getSwaps({
+        includeTerminal: true,
+        progress: 'completed',
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].swapId).toBe(completedId);
+    });
+
+    it('includeTerminal: true + role filter applies to stub entries too', () => {
+      const live = createTestSwapRef({ progress: 'announced', role: 'proposer' });
+      injectSwapRef(module, live);
+      // Terminal entry with acceptor role.
+      const ref = createTestSwapRef({ progress: 'completed', role: 'acceptor' });
+      const addressId = mocks.identity.directAddress!;
+      mocks.storage._data.set(
+        `${addressId}_swap:${ref.swapId}`,
+        JSON.stringify({ version: 1, swap: ref }),
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const m = module as any;
+      m.terminalSwapIds.add(ref.swapId);
+      m._storedTerminalEntries.push({
+        swapId: ref.swapId,
+        progress: 'completed' as const,
+        role: 'acceptor' as const,
+        createdAt: ref.createdAt,
+      });
+
+      const results = module.getSwaps({
+        includeTerminal: true,
+        role: 'acceptor',
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].swapId).toBe(ref.swapId);
+      expect(results[0].role).toBe('acceptor');
+    });
+
+    it('dedupes when same id appears in both live working set and terminal index', () => {
+      const ref = createTestSwapRef({ progress: 'completed' });
+      injectSwapRef(module, ref);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const m = module as any;
+      m._storedTerminalEntries.push({
+        swapId: ref.swapId,
+        progress: 'completed' as const,
+        role: ref.role,
+        createdAt: ref.createdAt,
+      });
+
+      const results = module.getSwaps({ includeTerminal: true });
+
+      // Should appear ONCE — the live entry wins over the stub.
+      expect(results).toHaveLength(1);
+      // The live entry has a real deal, the stub has an empty one. We
+      // expect the live entry to be returned.
+      expect(results[0].deal.partyACurrency).not.toBe('');
+    });
+  });
+
+  // ==========================================================================
+  // Write-side methods — surface (3)
+  // ==========================================================================
+
+  describe('write-side: SWAP_ALREADY_TERMINAL for terminal swaps loaded from storage', () => {
+    it('cancelSwap on a lazy-loadable terminal swap throws SWAP_ALREADY_TERMINAL (not SWAP_NOT_FOUND)', async () => {
+      const { swapId } = seedTerminalSwap('completed');
+
+      await expect(module.cancelSwap(swapId)).rejects.toMatchObject({
+        code: 'SWAP_ALREADY_TERMINAL',
+      });
+    });
+
+    it('acceptSwap on a lazy-loadable terminal swap throws SWAP_ALREADY_TERMINAL', async () => {
+      const { swapId } = seedTerminalSwap('completed');
+
+      await expect(module.acceptSwap(swapId)).rejects.toMatchObject({
+        code: 'SWAP_ALREADY_TERMINAL',
+      });
+    });
+
+    it('rejectSwap on a lazy-loadable terminal swap throws SWAP_ALREADY_TERMINAL', async () => {
+      const { swapId } = seedTerminalSwap('completed');
+
+      await expect(module.rejectSwap(swapId, 'late reject')).rejects.toMatchObject({
+        code: 'SWAP_ALREADY_TERMINAL',
+      });
+    });
+
+    it('deposit on a lazy-loadable terminal swap throws SWAP_ALREADY_TERMINAL', async () => {
+      const { swapId } = seedTerminalSwap('completed');
+
+      await expect(module.deposit(swapId)).rejects.toMatchObject({
+        code: 'SWAP_ALREADY_TERMINAL',
+      });
+    });
+
+    it('verifyPayout on a lazy-loadable terminal swap throws SWAP_ALREADY_TERMINAL', async () => {
+      const { swapId } = seedTerminalSwap('cancelled');
+
+      await expect(module.verifyPayout(swapId)).rejects.toMatchObject({
+        code: 'SWAP_ALREADY_TERMINAL',
+      });
+    });
+  });
+
+  describe('write-side: SWAP_NOT_FOUND preserved for genuinely-unknown ids', () => {
+    it('cancelSwap on an unknown id still throws SWAP_NOT_FOUND', async () => {
+      const unknownId = 'f'.repeat(64);
+      await expect(module.cancelSwap(unknownId)).rejects.toMatchObject({
+        code: 'SWAP_NOT_FOUND',
+      });
+    });
+
+    it('acceptSwap on an unknown id still throws SWAP_NOT_FOUND', async () => {
+      const unknownId = 'f'.repeat(64);
+      await expect(module.acceptSwap(unknownId)).rejects.toMatchObject({
+        code: 'SWAP_NOT_FOUND',
+      });
+    });
+
+    it('rejectSwap on an unknown id still throws SWAP_NOT_FOUND', async () => {
+      const unknownId = 'f'.repeat(64);
+      await expect(module.rejectSwap(unknownId)).rejects.toMatchObject({
+        code: 'SWAP_NOT_FOUND',
+      });
+    });
+
+    it('deposit on an unknown id still throws SWAP_NOT_FOUND', async () => {
+      const unknownId = 'f'.repeat(64);
+      await expect(module.deposit(unknownId)).rejects.toMatchObject({
+        code: 'SWAP_NOT_FOUND',
+      });
+    });
+  });
+
+  describe('write-side: legacy fine-grained codes preserved for LIVE terminal swaps', () => {
+    // When a swap is still in `this.swaps` but has transitioned to a
+    // terminal state (the brief window before it's removed from the
+    // working set), the legacy SWAP_ALREADY_COMPLETED /
+    // SWAP_ALREADY_CANCELLED codes still apply. SWAP_ALREADY_TERMINAL
+    // is reserved for terminal swaps that had to be lazy-loaded from
+    // storage.
+    it('cancelSwap on a LIVE completed swap throws SWAP_ALREADY_COMPLETED (not SWAP_ALREADY_TERMINAL)', async () => {
+      const ref = createTestSwapRef({ progress: 'completed' });
+      injectSwapRef(module, ref);
+
+      await expect(module.cancelSwap(ref.swapId)).rejects.toMatchObject({
+        code: 'SWAP_ALREADY_COMPLETED',
+      });
+    });
+
+    it('cancelSwap on a LIVE cancelled swap throws SWAP_ALREADY_CANCELLED', async () => {
+      const ref = createTestSwapRef({ progress: 'cancelled' });
+      injectSwapRef(module, ref);
+
+      await expect(module.cancelSwap(ref.swapId)).rejects.toMatchObject({
+        code: 'SWAP_ALREADY_CANCELLED',
+      });
+    });
+
+    it('rejectSwap on a LIVE completed swap throws SWAP_ALREADY_COMPLETED', async () => {
+      const ref = createTestSwapRef({ progress: 'completed' });
+      injectSwapRef(module, ref);
+
+      await expect(module.rejectSwap(ref.swapId)).rejects.toMatchObject({
+        code: 'SWAP_ALREADY_COMPLETED',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Issue [#447](https://github.com/unicity-sphere/sphere-sdk/issues/447) — completes the terminal-swap lazy-load coverage that PR [#446](https://github.com/unicity-sphere/sphere-sdk/pull/446) (closing [#445](https://github.com/unicity-sphere/sphere-sdk/issues/445)) only applied to `getSwapStatus`. Three other public surfaces still treated terminal swaps as unknown because they iterated only `this.swaps` — `loadFromStorage` deliberately keeps terminal entries out of the working set to bound memory across the `terminalPurgeTtlMs` window (default 7 days).

### Three surfaces fixed

1. **`resolveSwapId(prefix)`** — now scans `_storedTerminalEntries` in addition to `this.swaps`. A `sphere swap status <prefix>` call against a terminal swap no longer dies at the prefix-resolver before `getSwapStatus`' lazy-load can run. The `SwapIndexEntry` already carries enough metadata (`swapId`/`progress`/`role`/`createdAt`) for the prefix match — no extra storage read.

2. **`getSwaps(filter)`** — gains `includeTerminal: boolean` (default `false`, preserving existing CLI list behavior). When `true`, terminal entries from `_storedTerminalEntries` are materialized as stub `SwapRef`s (id/role/progress/createdAt + placeholder deal/manifest). Callers needing the full record can resolve each id via `getSwapStatus` (which lazy-loads).

3. **Write-side methods** (`acceptSwap`, `cancelSwap`, `deposit`, `rejectSwap`, `verifyPayout`) — now route through a new private `requireSwap()` helper that mirrors the `getSwapStatus` cache-then-lazy-load fan-out. For terminal swaps that lazy-load from storage, it throws the new `SWAP_ALREADY_TERMINAL` code instead of the misleading `SWAP_NOT_FOUND`. The previous behavior — `getSwapStatus` says "completed" while `cancelSwap` says "not found" — is gone.

### New error codes

- **`SWAP_ALREADY_TERMINAL`** — thrown by write-side methods when the swap exists in the terminal index and lazy-loads successfully, but is in a terminal state (`completed`/`cancelled`/`failed`). Distinguishes "swap is done, you can't mutate it" from "I don't know this swap at all".
- **`SWAP_AMBIGUOUS_PREFIX`** — thrown by `resolveSwapId` when a prefix matches multiple ids across live + terminal. Previously `SWAP_NOT_FOUND` was reused for both no-match and ambiguous-match, so callers had no way to give the user a "use more characters" hint.

### Backward compatibility

- `GetSwapsFilter.includeTerminal` is additive and defaults to `false` — no behavioral change for existing `getSwaps` callers.
- Write-side methods now throw `SWAP_ALREADY_TERMINAL` instead of `SWAP_NOT_FOUND` for the terminal-swap case. Callers that catch `SWAP_NOT_FOUND` to detect "cannot mutate" should also catch `SWAP_ALREADY_TERMINAL`. (Searched `sphere-cli` for `SWAP_NOT_FOUND` catch sites — none found; the CLI surfaces SDK errors directly without code-specific branching, so the new code flows through cleanly.)
- **Important nuance:** `requireSwap` deliberately returns *live* terminal swaps (those still in `this.swaps`) as-is rather than throwing `SWAP_ALREADY_TERMINAL`. The caller's existing state-machine guards (`SWAP_ALREADY_COMPLETED` / `SWAP_ALREADY_CANCELLED` / `SWAP_WRONG_STATE`) preserve the legacy fine-grained codes for in-memory swaps. `SWAP_ALREADY_TERMINAL` is reserved specifically for the lazy-load case where the swap is no longer in the working set.

### File changes

- `core/errors.ts` — added `SWAP_ALREADY_TERMINAL` and `SWAP_AMBIGUOUS_PREFIX`.
- `modules/swap/types.ts` — added `GetSwapsFilter.includeTerminal`.
- `modules/swap/SwapModule.ts` — added `requireSwap()` and `materializeStubSwapRef()` private helpers; updated `resolveSwapId`, `getSwaps`, `acceptSwap`, `cancelSwap`, `deposit`, `rejectSwap`, `verifyPayout`.
- `tests/unit/modules/SwapModule.terminal-blindness.test.ts` — 27 new tests covering all three surfaces (prefix resolution, list filter, write-side error codes including legacy-code preservation for live swaps).

## Test plan

- [x] `npx vitest run tests/unit/modules/Swap*` — 292 tests passing (265 existing + 27 new).
- [x] `npx tsup` — clean build, all DTS bundles generated.
- [x] `npx eslint modules/swap/ tests/unit/modules/SwapModule.terminal-blindness.test.ts` — clean (6 pre-existing unused-import warnings unrelated to this change).
- [x] Sanity-ran `tests/unit/core/Sphere*` alongside swap tests — 483 tests passing, no cross-module regressions.

## Refs

- Closes #447
- Builds on #446 (terminal lazy-load for `getSwapStatus`)
- Original issue #445