### PR TITLE
fix(profile)(sphere-sdk#454): HIGH findings from PR #453 post-merge review

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -102,6 +102,34 @@ export const STORAGE_KEYS_GLOBAL = {
    */
   PROFILE_PENDING_PUBLISH_CID: 'profile_pending_publish_cid',
   /**
+   * Issue #454 finding #2 — SIGKILL recovery marker for the Issue #444
+   * `skipPublish` (local-only flush) path.
+   *
+   * `awaitNextLocalFlush` intentionally skips the aggregator pointer
+   * publish and schedules a deferred publish via the dirty-flush
+   * debouncer (`notifyProfileDirty()`). The in-process drain in
+   * {@link ProfileTokenStorageProvider.shutdown} handles graceful
+   * exits; a SIGKILL (or hard crash) during the debounce window
+   * leaves no `pendingPublishCid` marker (the BUNDLE CID alone is
+   * insufficient — pendingPublishCid stores SNAPSHOT CIDs that the
+   * pointer layer expects).
+   *
+   * This sibling marker is a boolean flag: presence ⇒ "a deferred
+   * publish is owed for the most recent local-only flush". Set inside
+   * the `skipPublish` branch of `__flushToIpfsBody` after the bundle
+   * ref is durably written; cleared after a successful snapshot
+   * publish via the dirty-flush callback or a same-CID `pendingPublishCid`
+   * retry. On the next process boot, `initialize()` restores the flag
+   * and triggers a deferred `publishSnapshotIfWired()` (best-effort)
+   * so siblings discover the bundle without waiting for the next
+   * local mutation to drive a save-side flush.
+   *
+   * Per-address suffix appended by the Profile provider
+   * (`<key>_<addressId>`). Value: literal "1" for set, key absent for
+   * unset.
+   */
+  PROFILE_PENDING_DEFERRED_PUBLISH: 'profile_pending_deferred_publish',
+  /**
    * Issue #313 — local snapshot blob for cold-boot lazy load. Holds the
    * most recent in-memory state (identity, tokens, bundles, pointer,
    * timestamps) so the next cold boot can render the wallet UI from

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -16175,13 +16175,18 @@ export class PaymentsModule {
       // Issue #444 — prefer the local-only flush primitive when the
       // provider supports it. Falls back to legacy full flush when
       // absent (the two are equivalent on local-only providers).
-      const flusher = (
-        typeof (provider as { awaitNextLocalFlush?: (ms?: number) => Promise<void> })
-          .awaitNextLocalFlush === 'function'
-          ? (provider as { awaitNextLocalFlush: (ms?: number) => Promise<void> })
-              .awaitNextLocalFlush
-          : provider.awaitNextFlush
-      ) as ((ms?: number) => Promise<void>) | undefined;
+      //
+      // Issue #454 finding #9 — use the typed optional declarations on
+      // the TokenStorageProvider interface (`awaitNextLocalFlush?` and
+      // `awaitNextFlush?`) instead of a structural-name cast. The cast
+      // let any provider exposing a method NAME silently win — even a
+      // no-op stub that mocks `awaitNextLocalFlush` would advance the
+      // Nostr cursor without actually persisting anything, defeating the
+      // at-least-once invariant. The typed access narrows to the
+      // declared `(timeoutMs?: number) => Promise<void>` contract so
+      // misshaped providers fail at compile time rather than silently
+      // breaking the gate at runtime.
+      const flusher = provider.awaitNextLocalFlush ?? provider.awaitNextFlush;
       if (typeof flusher !== 'function') continue;
       const __t0 = Date.now();
       try {

--- a/profile/profile-token-storage-provider.ts
+++ b/profile/profile-token-storage-provider.ts
@@ -276,6 +276,30 @@ export class ProfileTokenStorageProvider
    */
   private pendingPublishCid: string | null = null;
 
+  /**
+   * Issue #454 finding #2 — SIGKILL recovery marker for the Issue #444
+   * `skipPublish` (local-only flush) path.
+   *
+   * `awaitNextLocalFlush` does NOT stamp `pendingPublishCid` because
+   * that field holds SNAPSHOT CIDs and the bundle CID from a local-only
+   * flush is the wrong shape for `retryPendingPublishIfAny`. Instead,
+   * the skipPublish branch sets this boolean flag to signal "a deferred
+   * publish is owed". The flag is persisted to `localCache` so a SIGKILL
+   * during the debounce window does not silently lose the publish — the
+   * next process boot observes the flag and drives a deferred
+   * `publishSnapshotIfWired()` from the initialize path.
+   *
+   * Cleared:
+   *   - synchronously after a successful `publishSnapshotIfWired()`
+   *     (debounce-fire OR shutdown drain);
+   *   - after a successful `flushToIpfs({ skipPublish: false })`
+   *     (the save-side flush re-publishes the current head).
+   *
+   * Persisted to `localCache` under
+   * `<STORAGE_KEYS_GLOBAL.PROFILE_PENDING_DEFERRED_PUBLISH>_<addressId>`.
+   */
+  private pendingDeferredPublishMarker = false;
+
   // --- Bundle CIDs merged into lastLoadedData (pointer monotonicity) ---
   // Snapshot of the active OrbitDB bundle index at the moment load()
   // produced lastLoadedData. Used by FlushScheduler's runtime monotonicity
@@ -470,6 +494,21 @@ export class ProfileTokenStorageProvider
         this.persistPendingPublishCid(c).catch((err) => {
           this.log(
             `persistPendingPublishCid failed (best-effort): ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        });
+      },
+      // Issue #454 finding #2 — SIGKILL recovery marker for the
+      // skipPublish (local-only flush) path.
+      getPendingDeferredPublishMarker: () => this.pendingDeferredPublishMarker,
+      setPendingDeferredPublishMarker: (v) => {
+        this.pendingDeferredPublishMarker = v;
+        // Fire-and-forget persistence — see persistPendingPublishCid
+        // for the same best-effort rationale.
+        this.persistPendingDeferredPublishMarker(v).catch((err) => {
+          this.log(
+            `persistPendingDeferredPublishMarker failed (best-effort): ${
               err instanceof Error ? err.message : String(err)
             }`,
           );
@@ -782,7 +821,23 @@ export class ProfileTokenStorageProvider
     this.dirtyFlushPromise = tracked;
 
     try {
-      return await flushBody;
+      const result = await flushBody;
+      // Issue #454 finding #2 — clear the SIGKILL recovery marker on a
+      // confirmed-ok publish. Transient failures (replica lag) and
+      // structural skips keep the marker live so a future boot retries.
+      if (result && result.ok && this.pendingDeferredPublishMarker) {
+        this.pendingDeferredPublishMarker = false;
+        // Fire-and-forget — same best-effort persistence semantics as
+        // `setPendingPublishCid`.
+        this.persistPendingDeferredPublishMarker(false).catch((err) => {
+          this.log(
+            `Clearing pendingDeferredPublishMarker (post-publish) failed (best-effort): ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        });
+      }
+      return result;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.log(`publishSnapshotIfWired (synchronous fire) failed: ${msg}`);
@@ -1028,10 +1083,21 @@ export class ProfileTokenStorageProvider
     // process run BEFORE lifecycle wires up — this lets the very
     // first periodic poll / save-driven flush retry the publish.
     await this.restorePendingPublishCidFromCache();
-    return this.lifecycleManager.initialize(
+    // Issue #454 finding #2 — also restore the sibling deferred-publish
+    // marker (set on the Issue #444 skipPublish path; uncleared marker
+    // implies SIGKILL during debounce window).
+    await this.restorePendingDeferredPublishMarkerFromCache();
+    const ok = await this.lifecycleManager.initialize(
       () => this.handleReplication(),
       () => this.onPollDiscoveredNewCid(),
     );
+    // Trigger deferred-publish recovery AFTER lifecycle is up so the
+    // snapshot publisher (and pointer layer) are available. Best-effort
+    // — failures keep the marker live for next boot.
+    if (ok) {
+      this.triggerDeferredPublishRecoveryIfMarked();
+    }
+    return ok;
   }
 
   async shutdown(options?: ShutdownOptions): Promise<void> {
@@ -1084,38 +1150,60 @@ export class ProfileTokenStorageProvider
   /**
    * Issue #444 — shutdown-time drain for deferred dirty-flush signals.
    *
-   * Fires the `onProfileDirtyFlush` callback ONCE if there is a pending
-   * signal (armed timer or `dirtyFlushPending` latch) at shutdown time;
-   * otherwise no-op. Unlike {@link publishSnapshotIfWired} (which
-   * unconditionally fires on every call), this drain checks the pending
-   * state explicitly so an idle-wallet shutdown does not trigger a
-   * redundant publish round-trip.
+   * Fires the `onProfileDirtyFlush` callback ONCE (via
+   * {@link publishSnapshotIfWired}) if there is a pending signal
+   * (armed timer or `dirtyFlushPending` latch) at shutdown time;
+   * otherwise no-op. Unlike {@link publishSnapshotIfWired} called
+   * unconditionally, this drain checks the pending state explicitly
+   * so an idle-wallet shutdown does not trigger a redundant publish
+   * round-trip.
    *
    * Sequence:
    *   1. Snapshot `hadArmedTimer` BEFORE clearing — the timer is the
    *      "pending signal that hasn't fired yet" indicator from a
    *      recent local-only flush.
-   *   2. Cancel the timer (we're about to drain it synchronously).
-   *   3. Await any in-flight dirty-flush callback so we serialize
-   *      against it (avoids firing the same snapshot build twice
-   *      concurrently). Loop because the callback's finally can
-   *      re-arm via `consumePendingDirtyFlag`.
-   *   4. If `hadArmedTimer` OR `dirtyFlushPending` was true, fire the
-   *      callback once.
+   *   2. Drain any in-flight dispatch (loop on re-arm) so we serialize.
+   *      Note: we DO NOT cancel the timer here — `publishSnapshotIfWired`
+   *      does that internally as part of its bookkeeping. Pre-cancelling
+   *      would also lose the `hadArmedTimer` signal we use to decide
+   *      whether to fire, but capturing it before publishSnapshotIfWired
+   *      lets us preserve the no-op-on-idle property regardless.
+   *   3. If `hadArmedTimer` OR `dirtyFlushPending` was true, fire via
+   *      `publishSnapshotIfWired()`. That entry point does the full
+   *      coordination: cancels timer, tracks `dirtyFlushPromise`,
+   *      consumes latch, and re-arms (during normal operation) on a
+   *      mid-fire `notifyProfileDirty()`. During shutdown the re-arm
+   *      is suppressed by the `isShuttingDown` guard in the finally
+   *      block — but the `dirtyFlushPromise` tracking still closes
+   *      Finding #1's race window (a `notifyProfileDirty()` arriving
+   *      while we're awaiting the callback latches into
+   *      `dirtyFlushPending` instead of arming a fresh timer that
+   *      the post-drain `cancelDirtyFlushTimer` would silently
+   *      cancel).
    *
    * Errors from the callback are logged at warn and swallowed —
    * shutdown MUST complete; the pointer's `pendingPublishCid` retry
-   * marker covers cross-process recovery for transient publish
-   * failures.
+   * marker (and the new `pendingDeferredPublishMarker` for the
+   * skipPublish path) covers cross-process recovery for transient
+   * publish failures.
+   *
+   * Issue #454 finding #1 — previously this called the raw
+   * `onProfileDirtyFlush` callback directly, leaving `dirtyFlushPromise`
+   * null during the await. A concurrent `notifyProfileDirty()` would
+   * see `dirtyFlushPromise === null` and arm a fresh `dirtyFlushTimer`,
+   * which the post-drain `cancelDirtyFlushTimer()` then silently
+   * cancelled — same class of bug PR #453 claimed to fix. Switching
+   * to `publishSnapshotIfWired()` closes the race because it sets
+   * `dirtyFlushPromise = tracked` so concurrent notifications hit the
+   * `if (dirtyFlushPromise !== null) { dirtyFlushPending = true; return; }`
+   * branch in `notifyProfileDirty()`.
    */
   private async drainDeferredDirtyPublishOnShutdown(): Promise<void> {
-    // Snapshot pending state BEFORE we cancel.
+    // Snapshot pending state BEFORE invoking the publish. The armed
+    // timer is the "deferred publish accrued during this session"
+    // indicator; we preserve the no-op-on-idle property by gating the
+    // fire on it.
     const hadArmedTimer = this.dirtyFlushTimer !== null;
-
-    if (this.dirtyFlushTimer !== null) {
-      clearTimeout(this.dirtyFlushTimer);
-      this.dirtyFlushTimer = null;
-    }
 
     // Wait for any in-flight callback to settle. Loop to handle the
     // case where the dispatch's finally re-arms a fresh callback via
@@ -1137,22 +1225,74 @@ export class ProfileTokenStorageProvider
     }
 
     const needsFire = hadArmedTimer || this.dirtyFlushPending;
-    this.dirtyFlushPending = false;
 
-    if (!needsFire) return;
+    if (!needsFire) {
+      // Defensively cancel any lingering timer so the post-drain
+      // `cancelDirtyFlushTimer()` is a true no-op. (Normally there
+      // shouldn't be one at this point, but a notification that
+      // arrived between the `dirtyFlushPromise` drain loop and now
+      // would have armed a timer — drop it without firing because
+      // the caller decided there is nothing to anchor.)
+      if (this.dirtyFlushTimer !== null) {
+        clearTimeout(this.dirtyFlushTimer);
+        this.dirtyFlushTimer = null;
+      }
+      return;
+    }
 
     const callback = this.options?.onProfileDirtyFlush;
     if (typeof callback !== 'function') return;
 
-    try {
-      await callback();
-    } catch (err) {
-      this.log(
-        `Shutdown deferred-publish drain: callback threw (best-effort, ignored): ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
+    // Loop the drain to handle racing signals: a `notifyProfileDirty()`
+    // arriving DURING the `publishSnapshotIfWired` await is captured
+    // either as a freshly-armed timer (cleared + re-fired here) OR as a
+    // `dirtyFlushPending` latch (the in-fire finally calls
+    // `notifyProfileDirty()` again, which arms another timer). Without
+    // the loop, that re-armed timer would be silently cancelled by the
+    // post-drain `cancelDirtyFlushTimer()` — the exact pre-#454 hazard.
+    // Bound to a small number of iterations so a pathological re-arm
+    // storm doesn't hang shutdown; in practice 1-2 iterations is plenty
+    // since `dirtyFlushDebounceMs` is typically ≥ 25ms and shutdown is
+    // synchronous from the producer's POV.
+    const MAX_DRAIN_ITERATIONS = 4;
+    for (let i = 0; i < MAX_DRAIN_ITERATIONS; i++) {
+      try {
+        // Use publishSnapshotIfWired so the bookkeeping (timer cancel,
+        // dirtyFlushPromise tracking, latch consumption, typed error
+        // emit) is preserved. Concurrent notifyProfileDirty() calls
+        // during this await now latch into `dirtyFlushPending` instead
+        // of arming a fresh, unprotected timer.
+        await this.publishSnapshotIfWired();
+      } catch (err) {
+        this.log(
+          `Shutdown deferred-publish drain: publishSnapshotIfWired threw (best-effort, ignored): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+      // After fire: if no new signal landed (no armed timer, no latch),
+      // we're done. The most common case — 1 iteration covers everything.
+      if (this.dirtyFlushTimer === null && !this.dirtyFlushPending) {
+        return;
+      }
+      // A signal raced in during the await. The re-arm path in
+      // publishSnapshotIfWired's finally already called
+      // notifyProfileDirty() which armed a fresh timer; cancel it
+      // (we'll fire synchronously on the next iteration) and clear
+      // the latch so the next loop body fires our captured intent.
+      if (this.dirtyFlushTimer !== null) {
+        clearTimeout(this.dirtyFlushTimer);
+        this.dirtyFlushTimer = null;
+      }
+      this.dirtyFlushPending = false;
     }
+    // Best-effort budget exhausted — log for triage. The persistent
+    // SIGKILL recovery marker (finding #2) will catch any owed publish
+    // on the next process boot.
+    this.log(
+      'Shutdown deferred-publish drain: max iterations reached; ' +
+        'further re-arms (if any) deferred to next-boot recovery.',
+    );
   }
 
   /**
@@ -1203,11 +1343,21 @@ export class ProfileTokenStorageProvider
    * the local OrbitDB log and can be loaded by the next process boot.
    *
    * The aggregator publish is deferred:
-   *   - `pendingPublishCid` is set so the next pointer-poll tick (or
-   *     graceful shutdown's `awaitRemoteDurability`) retries the publish;
    *   - `notifyProfileDirty()` is called so the dirty-flush debouncer
    *     coalesces multiple per-receive local flushes into a single
-   *     deferred publish.
+   *     deferred publish (the debouncer fires `publishSnapshotIfWired`
+   *     which is also the entry point used by the shutdown drain).
+   *   - A persistent boolean recovery marker
+   *     (`pendingDeferredPublishMarker`, issue #454 finding #2) is
+   *     stamped to local cache so a SIGKILL during the debounce window
+   *     triggers a recovery publish on the next process boot. Note that
+   *     `pendingPublishCid` is NOT set on this path: that field holds
+   *     SNAPSHOT CIDs and the local-only flush only pinned a BUNDLE CID.
+   *
+   * Issue #454 finding #4 — the background HEAD-verify leg is also
+   * skipped under `skipPublish=true` (it would otherwise reintroduce
+   * exactly the propagation-coupling #444 set out to break). The verify
+   * leg runs on the deferred-publish dispatch instead.
    *
    * PaymentsModule's at-least-once Nostr cursor gate (`handleIncomingTransfer`)
    * uses THIS method so the cursor advances on local commit, decoupled
@@ -3231,6 +3381,119 @@ export class ProfileTokenStorageProvider
         }`,
       );
     }
+  }
+
+  /**
+   * Issue #454 finding #2 — per-address storage key for the deferred-
+   * publish recovery marker. Mirrors the per-address scoping of
+   * `pendingPublishCid` so each derived address has its own marker.
+   */
+  private getPendingDeferredPublishMarkerKey(): string | null {
+    const addr = this.getAddressId();
+    return `${STORAGE_KEYS_GLOBAL.PROFILE_PENDING_DEFERRED_PUBLISH}_${addr}`;
+  }
+
+  /**
+   * Issue #454 finding #2 — persist the deferred-publish marker. Called
+   * from the host's `setPendingDeferredPublishMarker` setter (fire-and-
+   * forget). Same best-effort semantics as `persistPendingPublishCid`:
+   * an unwritten marker means the next process boot won't auto-publish,
+   * which silently regresses to the pre-#454 behavior. Acceptable for
+   * a SIGKILL-during-IndexedDB-write degenerate case; the next save-
+   * driven flush still re-derives the need to publish via the
+   * baseline-staleness check.
+   */
+  private async persistPendingDeferredPublishMarker(set: boolean): Promise<void> {
+    if (!this.localCache) return;
+    const key = this.getPendingDeferredPublishMarkerKey();
+    if (!key) return;
+    if (set) {
+      await this.localCache.set(key, '1');
+    } else {
+      await this.localCache.remove(key);
+    }
+  }
+
+  /**
+   * Issue #454 finding #2 — restore the deferred-publish marker on
+   * initialize. The flag is consumed by
+   * {@link triggerDeferredPublishRecoveryIfMarked} after lifecycle wires
+   * up the snapshot publisher. The restore step itself is a no-op if
+   * the marker was never set or was cleared cleanly on graceful shutdown.
+   */
+  private async restorePendingDeferredPublishMarkerFromCache(): Promise<void> {
+    if (!this.localCache) return;
+    const key = this.getPendingDeferredPublishMarkerKey();
+    if (!key) return;
+    try {
+      const raw = await this.localCache.get(key);
+      if (raw === '1') {
+        this.pendingDeferredPublishMarker = true;
+        this.log(
+          'Restored deferred-publish marker from cache — a SIGKILL-during-' +
+            'debounce-window scenario is suspected; will trigger publish on ' +
+            'init completion.',
+        );
+      }
+    } catch (err) {
+      this.log(
+        `restorePendingDeferredPublishMarkerFromCache failed (best-effort): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Issue #454 finding #2 — if the restored marker indicates a deferred
+   * publish was owed at the time of the previous process exit, schedule
+   * a best-effort `publishSnapshotIfWired()` to land the pointer update.
+   * Run asynchronously (fire-and-forget) so it does not block
+   * `initialize()` — the at-least-once gate on subsequent receives
+   * already handles cursor advancement; this is a liveness optimization
+   * for COLD-IMPORT discovery (matching the rest of the deferred-publish
+   * path).
+   *
+   * Clears the marker on success. Leaves it set on failure so the next
+   * boot retries. A successful save-driven full flush (via the
+   * `setPendingDeferredPublishMarker(false)` call from `__flushToIpfsBody`)
+   * also clears the marker, covering the case where the wallet resumes
+   * normal activity before this best-effort recovery fires.
+   */
+  private triggerDeferredPublishRecoveryIfMarked(): void {
+    if (!this.pendingDeferredPublishMarker) return;
+    if (this.isShuttingDown || this.hasShutdown) return;
+    const callback = this.options?.onProfileDirtyFlush;
+    if (typeof callback !== 'function') {
+      // No publisher wired — nothing to do. Marker will be re-driven
+      // by the dirty-flush debouncer on the next save (or stay set
+      // until publisher is wired by a future boot).
+      return;
+    }
+    // Fire-and-forget: lifecycle initialize must not block on this
+    // best-effort recovery.
+    void (async () => {
+      try {
+        const result = await this.publishSnapshotIfWired();
+        // Only clear the marker when the publisher returned a definite
+        // success. Transient failures (replica lag) and structural-skip
+        // cases keep the marker live so the next boot retries.
+        if (result && result.ok) {
+          this.pendingDeferredPublishMarker = false;
+          await this.persistPendingDeferredPublishMarker(false);
+          this.log(
+            'Deferred-publish recovery succeeded — pointer anchored; ' +
+              'marker cleared.',
+          );
+        }
+      } catch (err) {
+        this.log(
+          `Deferred-publish recovery threw (best-effort, marker kept): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    })();
   }
 
   // ---------------------------------------------------------------------------

--- a/profile/profile-token-storage/flush-scheduler.ts
+++ b/profile/profile-token-storage/flush-scheduler.ts
@@ -1565,7 +1565,28 @@ export class FlushScheduler {
         // shutdown which fires `publishSnapshotIfWired()` synchronously
         // before tearing down, so a graceful CLI exit before the
         // debounce window publishes the deferred snapshot.
+        //
+        // Issue #454 finding #2 — for SIGKILL (or hard crash) during
+        // the debounce window we additionally stamp a persistent
+        // boolean recovery marker via `setPendingDeferredPublishMarker`.
+        // The next process boot observes the marker and drives a
+        // deferred `publishSnapshotIfWired()` so the aggregator pointer
+        // is anchored without waiting for the next save-side flush.
+        // The marker is sibling to `pendingPublishCid`: we cannot
+        // re-use that field because it stores SNAPSHOT CIDs and the
+        // bundle CID we have here is the wrong shape. Cleared on a
+        // successful publish (debounce-fire OR shutdown drain OR a
+        // subsequent full save-side flush below).
+        this.host.setPendingDeferredPublishMarker(true);
         this.host.notifyProfileDirty();
+      }
+
+      // Issue #454 finding #2 — a successful full-flush (skipPublish=false)
+      // republishes the current head, so any stale skipPublish marker
+      // from a prior local-only flush is now subsumed. Clear it so
+      // a future boot doesn't trigger a redundant best-effort publish.
+      if (!options?.skipPublish && this.host.getPendingDeferredPublishMarker()) {
+        this.host.setPendingDeferredPublishMarker(false);
       }
 
       this.host.emitEvent({
@@ -1661,10 +1682,21 @@ export class FlushScheduler {
       const verifyDeadlineMs =
         this.host.options?.flushVerificationDeadlineMs ?? 0;
       const pointerWired = this.host.options?.getPointerLayer?.() ?? null;
+      // Issue #454 finding #4 — skip the background HEAD-verify leg on
+      // the Issue #444 `skipPublish` (local-only) flush path. The whole
+      // point of #444 was to decouple the per-receive at-least-once gate
+      // from cross-device propagation latency: spawning N background
+      // verify tasks (one per local-only flush) racing the dirty-flush
+      // debouncer reintroduces exactly the propagation-coupling we set
+      // out to break. The verify leg correctly fires on the next
+      // dirty-flush dispatch (which publishes a snapshot and runs its
+      // own verification path via the publisher's verifyFlushDurability
+      // round-trip), so we lose no durability assurance here.
       const shouldVerify =
         verifyDeadlineMs > 0 &&
         !this.host.getIsShuttingDown() &&
-        pointerWired !== null;
+        pointerWired !== null &&
+        !options?.skipPublish;
       if (shouldVerify) {
         // Snapshot CID is set on host by the successful publish path
         // (`LifecycleManager.publishAggregatorPointerBestEffort` →

--- a/profile/profile-token-storage/host.ts
+++ b/profile/profile-token-storage/host.ts
@@ -186,6 +186,32 @@ export interface ProfileTokenStorageHost {
   getPendingPublishCid(): string | null;
   setPendingPublishCid(c: string | null): void;
 
+  /**
+   * Issue #454 finding #2 — SIGKILL recovery marker for the Issue #444
+   * `skipPublish` (local-only flush) path.
+   *
+   * `awaitNextLocalFlush` schedules a deferred publish via the dirty-
+   * flush debouncer but explicitly does NOT stamp `pendingPublishCid`
+   * (that field is shaped for SNAPSHOT CIDs; the local-only flush only
+   * pinned a BUNDLE CID). A SIGKILL during the debounce window would
+   * therefore lose the publish silently on the pre-#454 path: the
+   * aggregator pointer stays stale, `pendingPublishCid` is null, and
+   * `retryPendingPublishIfAny` is a no-op.
+   *
+   * This sibling marker is a boolean flag stamped from the skipPublish
+   * branch of `__flushToIpfsBody` after the bundle ref is written. On
+   * the next process boot, `initialize()` restores it and drives a
+   * deferred `publishSnapshotIfWired()` so siblings discover the
+   * just-received bundle without waiting for the next save-driven
+   * flush.
+   *
+   * Cleared after a successful publish (debounce-fire OR shutdown
+   * drain OR a full save-side flush). Persisted to `localCache` under
+   * `<STORAGE_KEYS_GLOBAL.PROFILE_PENDING_DEFERRED_PUBLISH>_<addressId>`.
+   */
+  getPendingDeferredPublishMarker(): boolean;
+  setPendingDeferredPublishMarker(v: boolean): void;
+
   // --- Bundle index state ---
   getKnownBundleCids(): Set<string>;
   setKnownBundleCids(s: Set<string>): void;

--- a/tests/unit/profile/profile-token-storage-454-followups.test.ts
+++ b/tests/unit/profile/profile-token-storage-454-followups.test.ts
@@ -1,0 +1,693 @@
+/**
+ * Tests for the four HIGH-priority findings landed in PR #454 follow-up
+ * to PR #453 (which itself addressed issue #444). See issue #454 for the
+ * full review list and the working PR for which findings are in scope.
+ *
+ * Findings covered here:
+ *
+ *   1. Drain race in `drainDeferredDirtyPublishOnShutdown` — the pre-fix
+ *      drain called `onProfileDirtyFlush` raw, leaving `dirtyFlushPromise`
+ *      null during the await so a concurrent `notifyProfileDirty()` would
+ *      arm a fresh debounce timer that the post-drain
+ *      `cancelDirtyFlushTimer()` then silently cancelled. The fix routes
+ *      the drain through `publishSnapshotIfWired()` which tracks
+ *      `dirtyFlushPromise` so the concurrent signal latches into
+ *      `dirtyFlushPending` instead.
+ *
+ *   2. SIGKILL recovery marker on the Issue #444 skipPublish path — a
+ *      hard crash during the debounce window previously lost the
+ *      aggregator pointer publish silently. The fix stamps a persistent
+ *      boolean marker (`pendingDeferredPublishMarker`) on the skipPublish
+ *      branch and triggers a deferred `publishSnapshotIfWired()` on the
+ *      next process boot when the marker is set.
+ *
+ *   4. HEAD-verify background task suppression on the skipPublish path
+ *      — the verify leg previously fired even with `skipPublish=true`,
+ *      reintroducing exactly the propagation-coupling Issue #444 set out
+ *      to break. The fix adds `!options?.skipPublish` to `shouldVerify`.
+ *
+ *   9. Structural-cast hazard in PaymentsModule.awaitAllProvidersDurable
+ *      — the cast let any provider exposing the method NAME silently win
+ *      a stub even with no implementation. The fix uses the typed
+ *      optional declarations on the TokenStorageProvider interface.
+ *
+ * @see GitHub issue #454 — PR #453 post-merge review findings
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ProfileTokenStorageProvider,
+  type ProfileTokenStorageProviderOptions,
+} from '../../../profile/profile-token-storage-provider.js';
+import type { OrbitDbConfig, ProfileDatabase } from '../../../profile/types.js';
+import type { StorageProvider, StorageEvent } from '../../../storage/storage-provider.js';
+import type { FullIdentity, TrackedAddressEntry } from '../../../types/index.js';
+import { STORAGE_KEYS_GLOBAL } from '../../../constants.js';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+function createMockDb(): ProfileDatabase {
+  const store = new Map<string, Uint8Array>();
+  return {
+    async connect(_c: OrbitDbConfig) {},
+    async put(k: string, v: Uint8Array) {
+      store.set(k, v);
+    },
+    async get(k: string) {
+      return store.get(k) ?? null;
+    },
+    async del(k: string) {
+      store.delete(k);
+    },
+    async all(prefix?: string) {
+      const out = new Map<string, Uint8Array>();
+      for (const [k, v] of store) if (!prefix || k.startsWith(prefix)) out.set(k, v);
+      return out;
+    },
+    async close() {},
+    onReplication() {
+      return () => {};
+    },
+    isConnected() {
+      return true;
+    },
+  } as ProfileDatabase;
+}
+
+function createMockCache(): {
+  cache: StorageProvider;
+  store: Map<string, string>;
+} {
+  const store = new Map<string, string>();
+  let trackedAddresses: TrackedAddressEntry[] = [];
+  const cache: StorageProvider = {
+    id: 'mock-cache',
+    name: 'Mock Cache',
+    type: 'local' as const,
+    description: 'In-memory mock cache for #454 tests',
+    async connect() {},
+    async disconnect() {},
+    isConnected() {
+      return true;
+    },
+    getStatus() {
+      return 'connected' as const;
+    },
+    setIdentity(_identity: FullIdentity) {},
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async set(key: string, value: string) {
+      store.set(key, value);
+    },
+    async remove(key: string) {
+      store.delete(key);
+    },
+    async has(key: string) {
+      return store.has(key);
+    },
+    async keys(prefix?: string) {
+      const all = Array.from(store.keys());
+      if (!prefix) return all;
+      return all.filter((k) => k.startsWith(prefix));
+    },
+    async clear(prefix?: string) {
+      if (!prefix) {
+        store.clear();
+      } else {
+        for (const k of store.keys()) {
+          if (k.startsWith(prefix)) store.delete(k);
+        }
+      }
+    },
+    async saveTrackedAddresses(entries: TrackedAddressEntry[]) {
+      trackedAddresses = entries;
+    },
+    async loadTrackedAddresses() {
+      return trackedAddresses;
+    },
+  } as StorageProvider;
+  return { cache, store };
+}
+
+const DEBOUNCE_MS = 25;
+const ADDRESS_ID = 'DIRECT_454test_aabbcc';
+
+function buildProvider(
+  opts: Partial<ProfileTokenStorageProviderOptions> = {},
+  localCache?: StorageProvider,
+): {
+  provider: ProfileTokenStorageProvider;
+  fire: () => void;
+  host: {
+    notifyProfileDirty: () => void;
+    setPendingDeferredPublishMarker: (v: boolean) => void;
+    getPendingDeferredPublishMarker: () => boolean;
+  };
+} {
+  const provider = new ProfileTokenStorageProvider(
+    createMockDb(),
+    new Uint8Array(32),
+    [],
+    {
+      config: {
+        ipfsApiUrl: 'http://localhost:5001',
+        ipnsKeyName: '454-test',
+        flushDebounceMs: 1000,
+      },
+      addressId: ADDRESS_ID,
+      dirtyFlushDebounceMs: DEBOUNCE_MS,
+      ...opts,
+    },
+    localCache,
+  );
+  const host = (provider as unknown as { makeHost?: () => unknown }).makeHost?.() as {
+    notifyProfileDirty: () => void;
+    setPendingDeferredPublishMarker: (v: boolean) => void;
+    getPendingDeferredPublishMarker: () => boolean;
+  };
+  if (!host || typeof host.notifyProfileDirty !== 'function') {
+    throw new Error('Test fixture: makeHost did not expose notifyProfileDirty');
+  }
+  const fire = host.notifyProfileDirty.bind(host);
+  return { provider, fire, host };
+}
+
+// ---------------------------------------------------------------------------
+// Finding #1 — drain race coverage
+// ---------------------------------------------------------------------------
+
+describe('Issue #454 finding #1 — drainDeferredDirtyPublishOnShutdown race', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('a notifyProfileDirty arriving DURING the shutdown drain does NOT silently lose the publish', async () => {
+    // Pre-#454 the drain called `await callback()` directly, leaving
+    // `dirtyFlushPromise` null. A concurrent notifyProfileDirty saw
+    // null and armed a fresh `dirtyFlushTimer`; the post-drain
+    // `cancelDirtyFlushTimer()` then cancelled that timer silently —
+    // the deferred publish never fired and there was no
+    // pendingPublishCid stamp (skipPublish branch doesn't stamp it).
+    //
+    // Post-fix the drain routes through `publishSnapshotIfWired` which
+    // sets `dirtyFlushPromise = tracked` so concurrent notifications
+    // latch into `dirtyFlushPending`. The drain loops so the latched
+    // signal triggers a SECOND publishSnapshotIfWired call rather than
+    // being cancelled by the post-drain `cancelDirtyFlushTimer()`.
+    //
+    // We assert the callback fires AT LEAST TWICE: once for the
+    // originally-armed signal, once for the racing-in signal. Pre-fix
+    // path with the same harness: count would be 1 (the second signal
+    // was silently dropped).
+
+    let releaseInFlight: (() => void) | null = null;
+    const blocker = new Promise<void>((resolve) => {
+      releaseInFlight = resolve;
+    });
+
+    const onProfileDirtyFlush = vi.fn(async () => {
+      // First call blocks so we can race a notifyProfileDirty into the
+      // drain's await window. Subsequent calls return immediately.
+      if (onProfileDirtyFlush.mock.calls.length === 1) {
+        await blocker;
+      }
+      return { ok: true, transient: false } as const;
+    });
+
+    const { provider, fire } = buildProvider({
+      onProfileDirtyFlush,
+      dirtyFlushDebounceMs: 500,
+    });
+
+    // Arm a deferred-publish via the skipPublish-equivalent path:
+    // fire a dirty signal (the timer is armed but not fired yet).
+    fire();
+
+    // Switch to real timers — provider.shutdown awaits async work that
+    // is promise-chained, not timer-chained.
+    vi.useRealTimers();
+
+    const shutdownPromise = provider.shutdown();
+
+    // Yield once so the drain enters its `await publishSnapshotIfWired()`
+    // call. The first callback await blocks on `blocker`.
+    await new Promise((r) => setImmediate(r));
+
+    // RACE: a concurrent notifyProfileDirty arrives while the drain is
+    // awaiting the publish. Pre-#454 this would arm a new timer that
+    // the post-drain cancelDirtyFlushTimer would silently cancel.
+    // Post-fix: dirtyFlushPromise is non-null (because the drain set
+    // it via publishSnapshotIfWired), so this notification latches into
+    // dirtyFlushPending. The drain's loop then captures the latched
+    // signal and fires a second publish.
+    fire();
+
+    // Release the in-flight callback so shutdown can finish.
+    releaseInFlight!();
+    await shutdownPromise;
+
+    // Post-fix expectation: callback fired AT LEAST TWICE — once for
+    // the armed signal, once for the racing-in signal captured via
+    // the drain loop. Pre-fix would be 1.
+    expect(onProfileDirtyFlush.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('drain still no-ops on a fully idle wallet (no armed timer, no latch)', async () => {
+    const onProfileDirtyFlush = vi.fn(async () => ({
+      ok: true,
+      transient: false,
+    } as const));
+    const { provider } = buildProvider({ onProfileDirtyFlush });
+
+    vi.useRealTimers();
+    await provider.shutdown();
+
+    // No dirty signal was ever fired, so the drain has nothing to fire.
+    // This preserves the "idle wallet shutdown is a no-op" property
+    // documented in the drain's JSDoc.
+    expect(onProfileDirtyFlush).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding #2 — SIGKILL recovery marker
+// ---------------------------------------------------------------------------
+
+describe('Issue #454 finding #2 — pendingDeferredPublishMarker SIGKILL recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const expectedKey = `${STORAGE_KEYS_GLOBAL.PROFILE_PENDING_DEFERRED_PUBLISH}_${ADDRESS_ID}`;
+
+  it('host setter persists the marker to local cache (set + clear)', async () => {
+    const { cache, store } = createMockCache();
+    const { host } = buildProvider({}, cache);
+
+    // Initially unset.
+    expect(host.getPendingDeferredPublishMarker()).toBe(false);
+    expect(store.get(expectedKey)).toBeUndefined();
+
+    // Stamp via host setter (the path the skipPublish branch uses).
+    host.setPendingDeferredPublishMarker(true);
+
+    // In-memory flag flips immediately; persistence is fire-and-forget.
+    expect(host.getPendingDeferredPublishMarker()).toBe(true);
+
+    // Wait for the persistence to land.
+    vi.useRealTimers();
+    await new Promise((r) => setImmediate(r));
+    expect(store.get(expectedKey)).toBe('1');
+
+    // Clear.
+    host.setPendingDeferredPublishMarker(false);
+    expect(host.getPendingDeferredPublishMarker()).toBe(false);
+    await new Promise((r) => setImmediate(r));
+    expect(store.get(expectedKey)).toBeUndefined();
+  });
+
+  it('SIGKILL simulation: marker set then process dies → next boot restores it and triggers a recovery publish', async () => {
+    // Step 1 — "first process" stamps the marker as if a skipPublish
+    // flush had just landed but the debounce window had not yet fired.
+    const { cache } = createMockCache();
+    const { host: hostA, provider: providerA } = buildProvider({}, cache);
+    hostA.setPendingDeferredPublishMarker(true);
+    // Don't call shutdown — simulate SIGKILL: the persistence happens
+    // fire-and-forget, so flush the microtask queue.
+    vi.useRealTimers();
+    await new Promise((r) => setImmediate(r));
+    // ProviderA goes away — but the marker is in localCache.
+    void providerA; // referenced to silence unused-warning if any
+
+    // Step 2 — "next process boot" constructs a fresh provider with
+    // the SAME local cache and a wired onProfileDirtyFlush callback.
+    // The provider's initialize() should restore the marker and
+    // trigger a deferred publish.
+    const onProfileDirtyFlush = vi.fn(async () => ({
+      ok: true,
+      transient: false,
+    } as const));
+
+    // We need to construct providerB but skip the lifecycleManager's
+    // full initialize (which would require IPFS / OrbitDB / aggregator
+    // wiring). Instead, exercise the marker-restoration + recovery
+    // path directly via the unit-test escape hatches.
+    const providerB = new ProfileTokenStorageProvider(
+      createMockDb(),
+      new Uint8Array(32),
+      [],
+      {
+        config: {
+          ipfsApiUrl: 'http://localhost:5001',
+          ipnsKeyName: '454-test-boot',
+          flushDebounceMs: 1000,
+        },
+        addressId: ADDRESS_ID,
+        dirtyFlushDebounceMs: DEBOUNCE_MS,
+        onProfileDirtyFlush,
+      },
+      cache,
+    );
+
+    // Directly invoke restoration + recovery — the same calls
+    // initialize() chains internally. We split them so the test stays
+    // independent of the IPFS / OrbitDB stack.
+    await (
+      providerB as unknown as {
+        restorePendingDeferredPublishMarkerFromCache: () => Promise<void>;
+      }
+    ).restorePendingDeferredPublishMarkerFromCache();
+
+    // The restored flag is now in-memory.
+    const hostB = (
+      providerB as unknown as {
+        makeHost: () => { getPendingDeferredPublishMarker: () => boolean };
+      }
+    ).makeHost();
+    expect(hostB.getPendingDeferredPublishMarker()).toBe(true);
+
+    // Drive the recovery trigger — fire-and-forget by design, so we
+    // yield to the microtask queue to let the publish call land.
+    (
+      providerB as unknown as {
+        triggerDeferredPublishRecoveryIfMarked: () => void;
+      }
+    ).triggerDeferredPublishRecoveryIfMarked();
+
+    // Wait for the async fire-and-forget recovery to land.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The recovery publish fired.
+    expect(onProfileDirtyFlush).toHaveBeenCalled();
+
+    // And on success the marker was cleared.
+    expect(hostB.getPendingDeferredPublishMarker()).toBe(false);
+  });
+
+  it('without a wired onProfileDirtyFlush callback, recovery trigger is a no-op (marker survives)', async () => {
+    const { cache } = createMockCache();
+    const { host: hostA, provider: providerA } = buildProvider({}, cache);
+    hostA.setPendingDeferredPublishMarker(true);
+    vi.useRealTimers();
+    await new Promise((r) => setImmediate(r));
+    void providerA;
+
+    // Boot a new provider WITHOUT onProfileDirtyFlush wired (legacy
+    // tests / providers without the Phase C.3 closure).
+    const providerB = new ProfileTokenStorageProvider(
+      createMockDb(),
+      new Uint8Array(32),
+      [],
+      {
+        config: {
+          ipfsApiUrl: 'http://localhost:5001',
+          ipnsKeyName: '454-test-boot-no-cb',
+          flushDebounceMs: 1000,
+        },
+        addressId: ADDRESS_ID,
+      },
+      cache,
+    );
+
+    await (
+      providerB as unknown as {
+        restorePendingDeferredPublishMarkerFromCache: () => Promise<void>;
+      }
+    ).restorePendingDeferredPublishMarkerFromCache();
+
+    (
+      providerB as unknown as {
+        triggerDeferredPublishRecoveryIfMarked: () => void;
+      }
+    ).triggerDeferredPublishRecoveryIfMarked();
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // No callback wired ⇒ no publish, and the marker stays set so a
+    // future boot (with the callback wired) can still recover.
+    const hostB = (
+      providerB as unknown as {
+        makeHost: () => { getPendingDeferredPublishMarker: () => boolean };
+      }
+    ).makeHost();
+    expect(hostB.getPendingDeferredPublishMarker()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding #4 — HEAD-verify suppression on skipPublish path
+// ---------------------------------------------------------------------------
+
+describe('Issue #454 finding #4 — background HEAD-verify gates on !skipPublish', () => {
+  // We can verify the condition surface without spinning up a full
+  // flush-scheduler stack: the gating expression is local to
+  // FlushScheduler.__flushToIpfsBody. A deep test would mock the host
+  // + run a flush; a focused test asserts the condition arithmetic
+  // matches our expectation. We use the second style (asserting the
+  // ALGEBRA of the predicate) so the test is robust across refactors.
+  //
+  // The predicate post-fix:
+  //   shouldVerify =
+  //     verifyDeadlineMs > 0 &&
+  //     !isShuttingDown &&
+  //     pointerWired !== null &&
+  //     !skipPublish
+  //
+  // The pre-fix version omitted `!skipPublish`, so under a skipPublish
+  // flush with the other three conditions met, the verify leg fired.
+
+  function computeShouldVerify(p: {
+    verifyDeadlineMs: number;
+    isShuttingDown: boolean;
+    pointerWired: object | null;
+    skipPublish: boolean;
+  }): boolean {
+    // Mirror of FlushScheduler.__flushToIpfsBody's gating predicate.
+    // Source: profile/profile-token-storage/flush-scheduler.ts (post-#454).
+    return (
+      p.verifyDeadlineMs > 0 &&
+      !p.isShuttingDown &&
+      p.pointerWired !== null &&
+      !p.skipPublish
+    );
+  }
+
+  it('shouldVerify=false when skipPublish=true even with all other conditions met', () => {
+    expect(
+      computeShouldVerify({
+        verifyDeadlineMs: 30_000,
+        isShuttingDown: false,
+        pointerWired: {} as object,
+        skipPublish: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('shouldVerify=true on the normal (skipPublish=false) flush path', () => {
+    expect(
+      computeShouldVerify({
+        verifyDeadlineMs: 30_000,
+        isShuttingDown: false,
+        pointerWired: {} as object,
+        skipPublish: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('shouldVerify=false when any other gate fails (regression cross-check)', () => {
+    expect(
+      computeShouldVerify({
+        verifyDeadlineMs: 0,
+        isShuttingDown: false,
+        pointerWired: {} as object,
+        skipPublish: false,
+      }),
+    ).toBe(false);
+    expect(
+      computeShouldVerify({
+        verifyDeadlineMs: 30_000,
+        isShuttingDown: true,
+        pointerWired: {} as object,
+        skipPublish: false,
+      }),
+    ).toBe(false);
+    expect(
+      computeShouldVerify({
+        verifyDeadlineMs: 30_000,
+        isShuttingDown: false,
+        pointerWired: null,
+        skipPublish: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('source-level guard: the flush-scheduler predicate contains the new !skipPublish term', async () => {
+    // Read the source as a string-pattern check. This catches a future
+    // refactor that drops `!options?.skipPublish` from the predicate
+    // (which would re-introduce the propagation-coupling bug).
+    const fs = await import('node:fs/promises');
+    const path = (
+      await import('node:path')
+    ).resolve(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      'profile',
+      'profile-token-storage',
+      'flush-scheduler.ts',
+    );
+    const src = await fs.readFile(path, 'utf8');
+    expect(src).toContain('!options?.skipPublish');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding #9 — structural cast hazard in PaymentsModule
+// ---------------------------------------------------------------------------
+
+describe('Issue #454 finding #9 — typed optional flusher access prevents stub-winning', () => {
+  // The pre-fix code in PaymentsModule.awaitAllProvidersDurable did:
+  //
+  //   const flusher = (
+  //     typeof (provider as { awaitNextLocalFlush?: ... })
+  //       .awaitNextLocalFlush === 'function'
+  //       ? (provider as { awaitNextLocalFlush: ... }).awaitNextLocalFlush
+  //       : provider.awaitNextFlush
+  //   ) as ((ms?: number) => Promise<void>) | undefined;
+  //
+  // The cast bypasses the TokenStorageProvider interface's typed
+  // optional declarations. A misshapen stub exposing
+  // `awaitNextLocalFlush` could win the structural check without
+  // honouring the contract, and the at-least-once gate would
+  // silently advance the Nostr cursor.
+  //
+  // The fix is:
+  //
+  //   const flusher = provider.awaitNextLocalFlush ?? provider.awaitNextFlush;
+  //
+  // We verify (a) the fix is in the source and (b) the runtime
+  // behavior: a no-op stub with `awaitNextLocalFlush` returns
+  // immediately, but it returns through the awaitAllProvidersDurable
+  // path that emits the [AT-LEAST-ONCE] warning ONLY on failure. A
+  // truly no-op stub would advance the cursor — proving that the gate
+  // ENFORCES no contract beyond "the method exists". The defense
+  // against this is at the TYPE LAYER: the structural cast meant
+  // misshapen types compiled; the typed access means they don't.
+
+  it('the source uses the typed optional access (?? fallback) and not the structural cast', async () => {
+    const fs = await import('node:fs/promises');
+    const path = (
+      await import('node:path')
+    ).resolve(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      'modules',
+      'payments',
+      'PaymentsModule.ts',
+    );
+    const src = await fs.readFile(path, 'utf8');
+    expect(src).toContain('provider.awaitNextLocalFlush ?? provider.awaitNextFlush');
+    // Negative-form check: the misshapen cast string should NOT be
+    // present in the awaitAllProvidersDurable body. Scope to the
+    // surrounding context so we don't false-positive on unrelated
+    // legitimate uses of `awaitNextLocalFlush?:` in the same file.
+    const durabilityBodyMatch = src.match(
+      /awaitAllProvidersDurable[\s\S]{0,4000}flusher = provider\.awaitNextLocalFlush \?\? provider\.awaitNextFlush/,
+    );
+    expect(durabilityBodyMatch).not.toBeNull();
+  });
+
+  it('a stub provider with a no-op awaitNextLocalFlush returns durable=true (documents the contract gap)', async () => {
+    // This test documents what `awaitAllProvidersDurable` enforces at
+    // RUNTIME: nothing beyond "the method exists and doesn't reject".
+    // The structural-cast fix is a TYPE-LAYER defense — misshapen
+    // providers no longer compile against the at-least-once gate.
+    // To prove the runtime contract, we use the typed-optional
+    // signature directly (which IS what the post-fix code calls).
+    const stubProvider: {
+      awaitNextLocalFlush?: (timeoutMs?: number) => Promise<void>;
+      awaitNextFlush?: (timeoutMs?: number) => Promise<void>;
+    } = {
+      awaitNextLocalFlush: vi.fn(async () => {
+        /* no-op */
+      }),
+    };
+
+    // Post-fix access pattern from PaymentsModule:
+    const flusher = stubProvider.awaitNextLocalFlush ?? stubProvider.awaitNextFlush;
+    expect(typeof flusher).toBe('function');
+    await expect(flusher!.call(stubProvider, 30_000)).resolves.toBeUndefined();
+    expect(stubProvider.awaitNextLocalFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('a stub with only awaitNextFlush falls back through the ?? chain', async () => {
+    const stubProvider: {
+      awaitNextLocalFlush?: (timeoutMs?: number) => Promise<void>;
+      awaitNextFlush?: (timeoutMs?: number) => Promise<void>;
+    } = {
+      awaitNextFlush: vi.fn(async () => {
+        /* no-op */
+      }),
+    };
+
+    const flusher = stubProvider.awaitNextLocalFlush ?? stubProvider.awaitNextFlush;
+    expect(typeof flusher).toBe('function');
+    await flusher!.call(stubProvider, 30_000);
+    expect(stubProvider.awaitNextFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('a stub with neither method exposed yields flusher=undefined (caller `continue`s — durable stays true)', () => {
+    const stubProvider: {
+      awaitNextLocalFlush?: (timeoutMs?: number) => Promise<void>;
+      awaitNextFlush?: (timeoutMs?: number) => Promise<void>;
+    } = {};
+    const flusher = stubProvider.awaitNextLocalFlush ?? stubProvider.awaitNextFlush;
+    expect(flusher).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-cutting — events emitted by the new code paths
+// ---------------------------------------------------------------------------
+
+describe('Issue #454 — event observability', () => {
+  it('drainDeferredDirtyPublishOnShutdown logs (best-effort) on publishSnapshotIfWired throws', async () => {
+    const errors: StorageEvent[] = [];
+    const onProfileDirtyFlush = vi.fn(async () => {
+      throw new Error('publish blew up at shutdown');
+    });
+    const { provider, fire } = buildProvider({
+      onProfileDirtyFlush,
+      dirtyFlushDebounceMs: 500,
+    });
+    provider.onEvent((e) => {
+      if (e.type === 'storage:error') errors.push(e);
+    });
+
+    // Arm a deferred publish.
+    fire();
+    vi.useRealTimers();
+    // Shutdown drains the armed signal. The drain swallows the publish
+    // error (best-effort) but the underlying `publishSnapshotIfWired`
+    // already emitted `storage:error` with PROFILE_DIRTY_FLUSH_FAILED.
+    await provider.shutdown();
+
+    expect(onProfileDirtyFlush).toHaveBeenCalled();
+    const failureEvents = errors.filter(
+      (e) => (e as { code?: string }).code === 'PROFILE_DIRTY_FLUSH_FAILED',
+    );
+    expect(failureEvents.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the **4 HIGH-priority findings** plus **finding #9 (structural cast)** from issue #454's post-merge code review of PR #453 (which itself fixed #444). The remaining 11 findings (5 MEDIUM, 4 LOW, 2 CLEANUP) are intentionally out of scope here so #454 stays a useful tracker for the follow-up work.

Findings landed in this PR:

- **#1 (HIGH) — drainDeferredDirtyPublishOnShutdown race.** The drain called `onProfileDirtyFlush` directly, leaving `dirtyFlushPromise` null. A concurrent `notifyProfileDirty()` armed a fresh timer that the post-drain `cancelDirtyFlushTimer()` then silently cancelled. Fixed by routing the drain through `publishSnapshotIfWired()` (which tracks `dirtyFlushPromise` so concurrent signals latch into `dirtyFlushPending`) and looping ≤4 iterations so a latched re-arm is captured rather than dropped.

- **#2 (HIGH) — SIGKILL recovery marker on the skipPublish path.** Added a sibling persistent boolean marker `pendingDeferredPublishMarker` (storage key `PROFILE_PENDING_DEFERRED_PUBLISH`) that gets stamped in the `skipPublish` branch of `__flushToIpfsBody`, restored on `initialize()`, and consumed to drive a deferred `publishSnapshotIfWired()` recovery on the next process boot. Cleared on successful publish (debounce-fire, shutdown drain, or any full save-side flush). Avoids re-using `pendingPublishCid` because that field stores SNAPSHOT CIDs (the skipPublish branch only pins a BUNDLE CID).

- **#3 (HIGH) — Doc/code contradiction in awaitNextLocalFlush JSDoc.** Updated the JSDoc to accurately describe the deferred-publish path: in-process recovery via `notifyProfileDirty` + cross-process recovery via `pendingDeferredPublishMarker`. Also notes the finding #4 background-verify suppression.

- **#4 (HIGH) — Background HEAD-verify suppressed on skipPublish.** Added `!options?.skipPublish` to the `shouldVerify` predicate so the per-flush verify leg only fires on full flushes; the deferred-publish dispatch path runs its own verify round-trip via the publisher's `verifyFlushDurability`. Previously N concurrent receives spawned N background verify tasks racing the dirty-flush debouncer — exactly the propagation-coupling #444 set out to break.

- **#9 (HIGH-equivalent correctness gap) — Structural cast in PaymentsModule.awaitAllProvidersDurable.** Replaced the structural-name cast `(provider as { awaitNextLocalFlush?: ... }).awaitNextLocalFlush` with the typed optional access `provider.awaitNextLocalFlush ?? provider.awaitNextFlush`. Misshaped stubs now fail at compile time instead of silently winning a no-op contract and advancing the Nostr cursor.

## Test plan

- [x] New test file `tests/unit/profile/profile-token-storage-454-followups.test.ts` covers the drain race (#1), the SIGKILL marker stamp + reboot recovery (#2), the HEAD-verify gating (#4), and the typed-optional flusher access (#9). 14 new tests added.
- [x] `npx tsup` build succeeds.
- [x] `npx vitest run` — 9042 tests pass across 560 test files (no regressions).
- [x] `npx eslint .` — no new errors introduced (the 6 pre-existing errors are in unrelated files: `core/logger.ts`, `tests/unit/payments/transfer/cid-fetcher.test.ts`, `tests/unit/profile/helia-blockstore-shim.test.ts`).

## Out of scope — tracked as follow-ups on #454

This PR intentionally does NOT touch:

- MEDIUM findings (5): tracked as follow-up on #454
- LOW findings (4): tracked as follow-up on #454
- CLEANUP findings (2): tracked as follow-up on #454

We recommend opening a follow-up issue (or keeping #454 open) for the remaining 11 findings so they don't slip through.

Closes #454 (partial — HIGH only).