### PR TITLE
fix(transport)(sphere-sdk#464): mux dispatch await gap

### DIFF
--- a/tests/e2e/uxf-bundle-cross-instance-import-223.test.ts
+++ b/tests/e2e/uxf-bundle-cross-instance-import-223.test.ts
@@ -267,7 +267,7 @@ function captureSentPayloads(sphere: Sphere): {
  * Injection bypasses Nostr decryption + relay subscription entirely
  * while still walking the production `handleIncomingTransfer` pipeline.
  */
-function injectTokenTransfer(sphere: Sphere, transfer: IncomingTokenTransfer): void {
+async function injectTokenTransfer(sphere: Sphere, transfer: IncomingTokenTransfer): Promise<void> {
   const sphereAny = sphere as unknown as {
     _transportMux: MultiAddressTransportMux | null;
     _currentAddressIndex: number;
@@ -278,7 +278,8 @@ function injectTokenTransfer(sphere: Sphere, transfer: IncomingTokenTransfer): v
   if (!adapter) {
     throw new Error('Bob #2 has no Mux adapter — cannot inject token transfer');
   }
-  adapter.dispatchTokenTransfer(transfer);
+  // Issue #464 — dispatch is now async and awaits handler durability.
+  await adapter.dispatchTokenTransfer(transfer);
 }
 
 // =============================================================================
@@ -444,7 +445,7 @@ describe.skipIf(SKIP)(
           `[#223-iso] injecting synthetic event into bob #2 mux adapter — ` +
           `sender=${aliceTransportPubkey.slice(0, 16)}…`,
         );
-        injectTokenTransfer(bobReloaded, synthetic);
+        await injectTokenTransfer(bobReloaded, synthetic);
 
         // Poll Bob #2 balance. `dispatchTokenTransfer` invokes the
         // registered handler (PaymentsModule.handleIncomingTransfer)

--- a/tests/unit/transport/MultiAddressTransportMux.dispatch-await.test.ts
+++ b/tests/unit/transport/MultiAddressTransportMux.dispatch-await.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for the mux dispatch await-gap fix (#464).
+ *
+ * Issue #464 — `MuxAdapter.dispatchTokenTransfer` (and siblings) discarded
+ * the async handler's returned Promise, so any caller that awaited
+ * dispatch saw it resolve BEFORE `handleIncomingTransfer` (an async
+ * function in PaymentsModule) finished writing the token to storage.
+ * The next caller step (`PaymentsModule.load()`) then raced against
+ * the in-flight `addToken` write and roughly half the time observed
+ * empty storage. Single-coin faucet flakiness (#455 root cause).
+ *
+ * The fix:
+ *  - `dispatch*` methods are now `async` and `await Promise.allSettled(...)`
+ *    over every handler invocation. Per-handler fault isolation is
+ *    preserved (one rejection does not block the others).
+ *  - Late drain inside `on*(handler)` is tracked via `inFlightDrains`
+ *    and exposed through `flushPendingDrains()`. The mux's
+ *    `fetchPendingEvents` flushes drains across all adapters before
+ *    returning.
+ *
+ * These tests prove the await-gap is closed by constructing a controllable
+ * async handler (gated by an external promise) and asserting that dispatch
+ * does NOT resolve until the handler resolves.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AddressTransportAdapter, MultiAddressTransportMux } from '../../../transport/MultiAddressTransportMux';
+import type {
+  IncomingTokenTransfer,
+  IncomingPaymentRequest,
+  IncomingPaymentRequestResponse,
+  IncomingMessage,
+} from '../../../transport/transport-provider';
+import type { FullIdentity } from '../../../types';
+
+const STUB_IDENTITY: FullIdentity = {
+  chainPubkey: '02' + 'ab'.repeat(32),
+  l1Address: 'alpha1stub',
+  directAddress: 'DIRECT://stub',
+  transportPubkey: 'cc'.repeat(32),
+  privateKey: 'dd'.repeat(32),
+};
+
+function newAdapter(): AddressTransportAdapter {
+  const muxStub = {} as unknown as MultiAddressTransportMux;
+  return new AddressTransportAdapter(muxStub, 0, STUB_IDENTITY, null);
+}
+
+function makeTransfer(id: string): IncomingTokenTransfer {
+  return {
+    id,
+    senderTransportPubkey: 'ee'.repeat(32),
+    payload: { kind: 'token-transfer' } as unknown as IncomingTokenTransfer['payload'],
+    timestamp: 1779443013_000,
+  };
+}
+
+function makePaymentRequest(id: string): IncomingPaymentRequest {
+  return {
+    id,
+    senderTransportPubkey: 'ee'.repeat(32),
+    request: { requestId: id, amount: '1000000', coinId: 'UCT' },
+    timestamp: 1779443013_000,
+  };
+}
+
+function makePaymentResponse(id: string): IncomingPaymentRequestResponse {
+  return {
+    id,
+    responderTransportPubkey: 'ee'.repeat(32),
+    response: { requestId: id, responseType: 'accepted' },
+    timestamp: 1779443013_000,
+  };
+}
+
+function makeMessage(id: string): IncomingMessage {
+  return {
+    id,
+    senderTransportPubkey: 'ee'.repeat(32),
+    content: 'hello',
+    timestamp: 1779443013_000,
+    encrypted: false,
+  };
+}
+
+/**
+ * Build a controllable gate: a promise that resolves only when the
+ * `release` function is called. Used to pause an async handler in
+ * mid-flight so the test can assert that callers awaiting the dispatch
+ * are still pending.
+ */
+function gate(): { wait: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const wait = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { wait, release };
+}
+
+/**
+ * Helper: race `promise` against a microtask-boundary check. Returns
+ * `true` if `promise` is still pending after the microtask queue
+ * drains, `false` if it resolved.
+ *
+ * `await new Promise(setImmediate)` / `setTimeout(0)` would also work
+ * but `queueMicrotask` is the closest deterministic boundary in
+ * Vitest.
+ */
+async function isStillPending(p: Promise<unknown>): Promise<boolean> {
+  const sentinel = Symbol('pending');
+  const result = await Promise.race([
+    p.then(() => 'resolved' as const),
+    new Promise<typeof sentinel>((resolve) => setImmediate(() => resolve(sentinel))),
+  ]);
+  return result === sentinel;
+}
+
+describe('AddressTransportAdapter — dispatch await-gap (#464)', () => {
+  // ===========================================================================
+  // dispatchTokenTransfer — the critical async-handler site
+  // ===========================================================================
+
+  it('dispatchTokenTransfer awaits an async handler before resolving', async () => {
+    const adapter = newAdapter();
+    const recorded: string[] = [];
+    const handlerGate = gate();
+
+    adapter.onTokenTransfer(async (transfer) => {
+      await handlerGate.wait;
+      recorded.push(transfer.id);
+    });
+
+    const dispatchPromise = adapter.dispatchTokenTransfer(makeTransfer('event-1'));
+
+    // The dispatch must STILL be pending while the handler is mid-flight.
+    expect(await isStillPending(dispatchPromise)).toBe(true);
+    expect(recorded).toEqual([]);
+
+    // Release the handler; dispatch should now resolve.
+    handlerGate.release();
+    await dispatchPromise;
+    expect(recorded).toEqual(['event-1']);
+  });
+
+  it('dispatchTokenTransfer surfaces handler completion to the upstream awaiter (the #464 bug shape)', async () => {
+    // This mirrors the call shape in `MultiAddressTransportMux.handleTokenTransfer`:
+    // an `await entry.adapter.dispatchTokenTransfer(transfer)` followed by
+    // a state read that must observe the handler's side-effects.
+    const adapter = newAdapter();
+    const storage: string[] = [];
+
+    adapter.onTokenTransfer(async (transfer) => {
+      // Simulate the storage write that `PaymentsModule.handleIncomingTransfer`
+      // performs (async, microtask-yielding).
+      await Promise.resolve();
+      await Promise.resolve();
+      storage.push(transfer.id);
+    });
+
+    // Simulate the buggy pre-fix call shape that DID NOT await:
+    //   `entry.adapter.dispatchTokenTransfer(transfer);` (fire-and-forget)
+    // ↓
+    //   `read storage immediately` → race
+    //
+    // With the #464 fix, the upstream caller can simply `await` the
+    // dispatch and observe a consistent state.
+    await adapter.dispatchTokenTransfer(makeTransfer('event-1'));
+    expect(storage).toEqual(['event-1']);
+  });
+
+  it('dispatchTokenTransfer with Promise.allSettled isolates handler exceptions', async () => {
+    const adapter = newAdapter();
+    const recorded: string[] = [];
+
+    // Throwing handler (sync throw)
+    adapter.onTokenTransfer(() => { throw new Error('boom-sync'); });
+
+    // Rejecting handler (async rejection — this is the case the pre-#464
+    // try/catch could NOT catch).
+    adapter.onTokenTransfer(async () => {
+      throw new Error('boom-async');
+    });
+
+    // Healthy handler — must still run despite the two failures above.
+    adapter.onTokenTransfer((transfer) => { recorded.push(transfer.id); });
+
+    // No throw, no rejection — `Promise.allSettled` swallows both
+    // rejections internally; the dispatcher logs and proceeds.
+    await expect(adapter.dispatchTokenTransfer(makeTransfer('event-1'))).resolves.toBeUndefined();
+    expect(recorded).toEqual(['event-1']);
+  });
+
+  // ===========================================================================
+  // Sibling dispatchers — same await contract for forward compat.
+  // ===========================================================================
+
+  it('dispatchMessage awaits async message handlers', async () => {
+    const adapter = newAdapter();
+    const recorded: string[] = [];
+    const handlerGate = gate();
+
+    adapter.onMessage(async (msg) => {
+      await handlerGate.wait;
+      recorded.push(msg.id);
+    });
+
+    const dispatchPromise = adapter.dispatchMessage(makeMessage('msg-1'));
+    expect(await isStillPending(dispatchPromise)).toBe(true);
+    handlerGate.release();
+    await dispatchPromise;
+    expect(recorded).toEqual(['msg-1']);
+  });
+
+  it('dispatchPaymentRequest awaits async handlers', async () => {
+    const adapter = newAdapter();
+    const recorded: string[] = [];
+    const handlerGate = gate();
+
+    adapter.onPaymentRequest(async (req) => {
+      await handlerGate.wait;
+      recorded.push(req.id);
+    });
+
+    const dispatchPromise = adapter.dispatchPaymentRequest(makePaymentRequest('req-1'));
+    expect(await isStillPending(dispatchPromise)).toBe(true);
+    handlerGate.release();
+    await dispatchPromise;
+    expect(recorded).toEqual(['req-1']);
+  });
+
+  it('dispatchPaymentRequestResponse awaits async handlers', async () => {
+    const adapter = newAdapter();
+    const recorded: string[] = [];
+    const handlerGate = gate();
+
+    adapter.onPaymentRequestResponse(async (rsp) => {
+      await handlerGate.wait;
+      recorded.push(rsp.id);
+    });
+
+    const dispatchPromise = adapter.dispatchPaymentRequestResponse(makePaymentResponse('rsp-1'));
+    expect(await isStillPending(dispatchPromise)).toBe(true);
+    handlerGate.release();
+    await dispatchPromise;
+    expect(recorded).toEqual(['rsp-1']);
+  });
+
+  // ===========================================================================
+  // Late drain — `onTokenTransfer` registration triggers drain of buffered
+  // events. `flushPendingDrains()` exposes the drain promise so callers can
+  // await it. This is the second arm of the #464 fix (mux's
+  // `fetchPendingEvents` calls it).
+  // ===========================================================================
+
+  it('flushPendingDrains awaits the late-drain promise (drain triggered by handler registration)', async () => {
+    const adapter = newAdapter();
+    const recorded: string[] = [];
+    const handlerGate = gate();
+
+    // Two events buffered with no handler attached.
+    await adapter.dispatchTokenTransfer(makeTransfer('event-1'));
+    await adapter.dispatchTokenTransfer(makeTransfer('event-2'));
+
+    // Register an async handler — drain starts as a tracked promise.
+    adapter.onTokenTransfer(async (transfer) => {
+      await handlerGate.wait;
+      recorded.push(transfer.id);
+    });
+
+    const flushPromise = adapter.flushPendingDrains();
+
+    // Drain handler is gated — flush must still be pending.
+    expect(await isStillPending(flushPromise)).toBe(true);
+    expect(recorded).toEqual([]);
+
+    handlerGate.release();
+    await flushPromise;
+    // Drain processes buffered events in arrival order.
+    expect(recorded).toEqual(['event-1', 'event-2']);
+  });
+
+  it('flushPendingDrains is a no-op when no drains are in flight', async () => {
+    const adapter = newAdapter();
+    await expect(adapter.flushPendingDrains()).resolves.toBeUndefined();
+
+    // Register handler with no buffered events — no drain promise is tracked.
+    adapter.onTokenTransfer(() => { /* no-op */ });
+    await expect(adapter.flushPendingDrains()).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/transport/MultiAddressTransportMux.pending-queue-223.test.ts
+++ b/tests/unit/transport/MultiAddressTransportMux.pending-queue-223.test.ts
@@ -80,51 +80,60 @@ describe('AddressTransportAdapter — pending-queue race fix (#223)', () => {
   // ---------------------------------------------------------------------------
   // TOKEN_TRANSFER — the bug-report scenario
   // ---------------------------------------------------------------------------
+  //
+  // Issue #464 update — `dispatchTokenTransfer` is now `async` and `await`s
+  // every handler invocation via `Promise.allSettled`. The drain triggered
+  // by late `onTokenTransfer` registration is also async-aware (tracked
+  // via `flushPendingDrains`). Tests below await accordingly.
 
-  it('queues token transfers dispatched before any handler is registered', () => {
+  it('queues token transfers dispatched before any handler is registered', async () => {
     const adapter = newAdapter();
     const received: IncomingTokenTransfer[] = [];
 
     // The Mux dispatches BEFORE PaymentsModule.initialize subscribes —
     // exactly the cross-process race in issue #223.
-    adapter.dispatchTokenTransfer(makeTransfer('event-1'));
-    adapter.dispatchTokenTransfer(makeTransfer('event-2'));
+    await adapter.dispatchTokenTransfer(makeTransfer('event-1'));
+    await adapter.dispatchTokenTransfer(makeTransfer('event-2'));
 
     // Handler registered late. Pre-fix this returned nothing; with the
-    // pending queue the two events are drained in arrival order.
+    // pending queue the two events are drained in arrival order. Drain
+    // is async post-#464 — we await `flushPendingDrains` for ordering.
     adapter.onTokenTransfer((t) => { received.push(t); });
+    await adapter.flushPendingDrains();
 
     expect(received.map((t) => t.id)).toEqual(['event-1', 'event-2']);
   });
 
-  it('does not double-deliver: queue is drained exactly once on first subscribe', () => {
+  it('does not double-deliver: queue is drained exactly once on first subscribe', async () => {
     const adapter = newAdapter();
     const firstHandler: IncomingTokenTransfer[] = [];
     const secondHandler: IncomingTokenTransfer[] = [];
 
-    adapter.dispatchTokenTransfer(makeTransfer('event-1'));
+    await adapter.dispatchTokenTransfer(makeTransfer('event-1'));
     adapter.onTokenTransfer((t) => { firstHandler.push(t); });
+    await adapter.flushPendingDrains();
 
     // A second handler subscribed AFTER drain must NOT see the already-
     // delivered events. The queue is cleared on the first drain.
     adapter.onTokenTransfer((t) => { secondHandler.push(t); });
+    await adapter.flushPendingDrains();
 
     expect(firstHandler).toHaveLength(1);
     expect(secondHandler).toHaveLength(0);
   });
 
-  it('dispatches synchronously when a handler is already registered (no queue side-effect)', () => {
+  it('dispatches via await when a handler is already registered (no queue side-effect)', async () => {
     const adapter = newAdapter();
     const received: IncomingTokenTransfer[] = [];
     adapter.onTokenTransfer((t) => { received.push(t); });
 
-    adapter.dispatchTokenTransfer(makeTransfer('event-1'));
-    adapter.dispatchTokenTransfer(makeTransfer('event-2'));
+    await adapter.dispatchTokenTransfer(makeTransfer('event-1'));
+    await adapter.dispatchTokenTransfer(makeTransfer('event-2'));
 
     expect(received.map((t) => t.id)).toEqual(['event-1', 'event-2']);
   });
 
-  it('fans out queued transfers to every currently-registered handler on drain', () => {
+  it('fans out queued transfers to every currently-registered handler on drain', async () => {
     // Edge case: two handlers register before the first dispatch.
     // The pending queue is empty at that point; this just guards against
     // accidental behavioural drift in the multi-handler path.
@@ -134,27 +143,28 @@ describe('AddressTransportAdapter — pending-queue race fix (#223)', () => {
     adapter.onTokenTransfer((t) => { a.push(t); });
     adapter.onTokenTransfer((t) => { b.push(t); });
 
-    adapter.dispatchTokenTransfer(makeTransfer('event-1'));
+    await adapter.dispatchTokenTransfer(makeTransfer('event-1'));
 
     expect(a).toHaveLength(1);
     expect(b).toHaveLength(1);
   });
 
-  it('a throwing drain handler does not block delivery to later subscribers', () => {
+  it('a throwing drain handler does not block delivery to later subscribers', async () => {
     // Defensive: errors inside the drained handler must not poison the
     // adapter's state. The queue is cleared before drain so a throw
     // can't re-queue the events.
     const adapter = newAdapter();
-    adapter.dispatchTokenTransfer(makeTransfer('event-1'));
+    await adapter.dispatchTokenTransfer(makeTransfer('event-1'));
 
     adapter.onTokenTransfer(() => { throw new Error('boom'); });
+    await adapter.flushPendingDrains();
 
     const received: IncomingTokenTransfer[] = [];
-    adapter.dispatchTokenTransfer(makeTransfer('event-2'));
+    await adapter.dispatchTokenTransfer(makeTransfer('event-2'));
     // event-2 must fan out; the first handler will throw again but the
     // second handler must still be invoked.
     adapter.onTokenTransfer((t) => { received.push(t); });
-    adapter.dispatchTokenTransfer(makeTransfer('event-3'));
+    await adapter.dispatchTokenTransfer(makeTransfer('event-3'));
 
     // event-3 dispatched while two handlers are live (throwing + capturing).
     expect(received.map((t) => t.id)).toEqual(['event-3']);
@@ -164,12 +174,13 @@ describe('AddressTransportAdapter — pending-queue race fix (#223)', () => {
   // PAYMENT_REQUEST — same race shape, fixed symmetrically
   // ---------------------------------------------------------------------------
 
-  it('queues payment requests dispatched before any handler is registered', () => {
+  it('queues payment requests dispatched before any handler is registered', async () => {
     const adapter = newAdapter();
     const received: IncomingPaymentRequest[] = [];
-    adapter.dispatchPaymentRequest(makePaymentRequest('req-1'));
-    adapter.dispatchPaymentRequest(makePaymentRequest('req-2'));
+    await adapter.dispatchPaymentRequest(makePaymentRequest('req-1'));
+    await adapter.dispatchPaymentRequest(makePaymentRequest('req-2'));
     adapter.onPaymentRequest((r) => { received.push(r); });
+    await adapter.flushPendingDrains();
     expect(received.map((r) => r.id)).toEqual(['req-1', 'req-2']);
   });
 
@@ -177,12 +188,13 @@ describe('AddressTransportAdapter — pending-queue race fix (#223)', () => {
   // PAYMENT_REQUEST_RESPONSE — same race shape, fixed symmetrically
   // ---------------------------------------------------------------------------
 
-  it('queues payment request responses dispatched before any handler is registered', () => {
+  it('queues payment request responses dispatched before any handler is registered', async () => {
     const adapter = newAdapter();
     const received: IncomingPaymentRequestResponse[] = [];
-    adapter.dispatchPaymentRequestResponse(makePaymentResponse('rsp-1'));
-    adapter.dispatchPaymentRequestResponse(makePaymentResponse('rsp-2'));
+    await adapter.dispatchPaymentRequestResponse(makePaymentResponse('rsp-1'));
+    await adapter.dispatchPaymentRequestResponse(makePaymentResponse('rsp-2'));
     adapter.onPaymentRequestResponse((r) => { received.push(r); });
+    await adapter.flushPendingDrains();
     expect(received.map((r) => r.id)).toEqual(['rsp-1', 'rsp-2']);
   });
 });

--- a/transport/MultiAddressTransportMux.ts
+++ b/transport/MultiAddressTransportMux.ts
@@ -811,6 +811,17 @@ export class MultiAddressTransportMux {
       await this.handleEvent(event);
     }
 
+    // Issue #464 — flush any drain promises tracked by adapters during this
+    // call. `dispatch*` already awaits handler completion for events
+    // delivered through `handleEvent`, but if a late handler registration
+    // occurred concurrently (its drain runs as a tracked async IIFE),
+    // we must also wait for that drain to settle before returning so
+    // the caller's next `load()` / state read sees a consistent view.
+    for (const entry of this.addresses.values()) {
+      try { await entry.adapter.flushPendingDrains(); }
+      catch (e) { logger.debug('Mux', 'flushPendingDrains error:', e); }
+    }
+
     logger.debug('Mux', `fetchPendingEvents: processed ${events.length} events`);
   }
 
@@ -1196,7 +1207,8 @@ export class MultiAddressTransportMux {
                 encrypted: true,
                 isSelfWrap: true,
               };
-              entry.adapter.dispatchMessage(message);
+              // Issue #464 — await dispatch so handler durability propagates.
+              await entry.adapter.dispatchMessage(message);
               return;
             }
           } catch {
@@ -1214,7 +1226,7 @@ export class MultiAddressTransportMux {
               messageEventId: pm.replyToEventId,
               timestamp: pm.timestamp * 1000,
             };
-            entry.adapter.dispatchReadReceipt(receipt);
+            await entry.adapter.dispatchReadReceipt(receipt);
           }
           return;
         }
@@ -1228,7 +1240,7 @@ export class MultiAddressTransportMux {
             senderNametag = parsed.senderNametag || undefined;
             expiresIn = parsed.expiresIn ?? 30000;
           } catch { /* defaults */ }
-          entry.adapter.dispatchComposingIndicator({
+          await entry.adapter.dispatchComposingIndicator({
             senderPubkey: pm.senderPubkey,
             senderNametag,
             expiresIn,
@@ -1245,7 +1257,7 @@ export class MultiAddressTransportMux {
               messageEventId: parsed.messageEventId,
               timestamp: pm.timestamp * 1000,
             };
-            entry.adapter.dispatchReadReceipt(receipt);
+            await entry.adapter.dispatchReadReceipt(receipt);
             return;
           }
           if (parsed?.type === 'typing') {
@@ -1254,11 +1266,11 @@ export class MultiAddressTransportMux {
               senderNametag: parsed.senderNametag,
               timestamp: pm.timestamp * 1000,
             };
-            entry.adapter.dispatchTypingIndicator(indicator);
+            await entry.adapter.dispatchTypingIndicator(indicator);
             return;
           }
           if (parsed?.senderNametag !== undefined && parsed?.expiresIn !== undefined && !parsed?.text) {
-            entry.adapter.dispatchComposingIndicator({
+            await entry.adapter.dispatchComposingIndicator({
               senderPubkey: pm.senderPubkey,
               senderNametag: parsed.senderNametag || undefined,
               expiresIn: parsed.expiresIn ?? 30000,
@@ -1289,7 +1301,7 @@ export class MultiAddressTransportMux {
           encrypted: true,
         };
 
-        entry.adapter.dispatchMessage(message);
+        await entry.adapter.dispatchMessage(message);
         return; // Successfully routed, stop trying other addresses
       } catch {
         // Decryption failed for this address — try next
@@ -1340,7 +1352,13 @@ export class MultiAddressTransportMux {
         timestamp: event.created_at * 1000,
       };
 
-      entry.adapter.dispatchTokenTransfer(transfer);
+      // Issue #464 — await dispatch so handler durability propagates upstream.
+      // The async handler (`PaymentsModule.handleIncomingTransfer`) must
+      // complete its storage write before `dispatchWalletEvent` returns,
+      // otherwise `fetchPendingEvents` resolves mid-write and the caller's
+      // next `load()` reads stale storage. Single-coin faucet flakiness
+      // (#455 → #464 root-cause) lived in this gap.
+      await entry.adapter.dispatchTokenTransfer(transfer);
     } catch (err) {
       logger.debug('Mux', `Token transfer decrypt failed for address ${entry.index}:`, (err as Error)?.message?.slice(0, 50));
     }
@@ -1365,7 +1383,8 @@ export class MultiAddressTransportMux {
         timestamp: event.created_at * 1000,
       };
 
-      entry.adapter.dispatchPaymentRequest(request);
+      // Issue #464 — await dispatch (see dispatchTokenTransfer above).
+      await entry.adapter.dispatchPaymentRequest(request);
     } catch (err) {
       logger.debug('Mux', `Payment request decrypt failed for address ${entry.index}:`, (err as Error)?.message?.slice(0, 50));
     }
@@ -1388,7 +1407,8 @@ export class MultiAddressTransportMux {
         timestamp: event.created_at * 1000,
       };
 
-      entry.adapter.dispatchPaymentRequestResponse(response);
+      // Issue #464 — await dispatch (see dispatchTokenTransfer above).
+      await entry.adapter.dispatchPaymentRequestResponse(response);
     } catch (err) {
       logger.debug('Mux', `Payment response decrypt failed for address ${entry.index}:`, (err as Error)?.message?.slice(0, 50));
     }
@@ -1929,6 +1949,19 @@ export class AddressTransportAdapter implements TransportProvider {
   private pendingPaymentRequestResponses: IncomingPaymentRequestResponse[] = [];
   private chatEoseHandlers: Array<() => void> = [];
 
+  // Issue #464 — drain promise tracker. When `onTokenTransfer` (or sibling
+  // `on*` registrations) drains its pending buffer, it does so via an async
+  // handler. Pre-#464 the drain iterated synchronously and dropped the
+  // returned Promise — a future `dispatchTokenTransfer` or
+  // `fetchPendingEvents` could resolve while drained-event writes were
+  // still in flight. We track every drain as a Promise here so that any
+  // ordering-sensitive caller (in particular `dispatchTokenTransfer` and
+  // the mux's `fetchPendingEvents`) can `await flushPendingDrains()`
+  // before observing storage state. `Promise.allSettled` keeps fault
+  // isolation across handlers and across drains. Completed drains are
+  // pruned lazily inside `flushPendingDrains`.
+  private inFlightDrains: Set<Promise<unknown>> = new Set();
+
   constructor(
     mux: MultiAddressTransportMux,
     addressIndex: number,
@@ -2080,16 +2113,53 @@ export class AddressTransportAdapter implements TransportProvider {
   // ===========================================================================
   // Subscription handlers — per-address
   // ===========================================================================
+  //
+  // Issue #464 — drain path. The `on*(handler)` registration returns the
+  // unsubscribe function synchronously (legacy contract), but the actual
+  // drain of any buffered events runs asynchronously and is tracked in
+  // `inFlightDrains`. `flushPendingDrains()` / `dispatchTokenTransfer`
+  // (and siblings) await those tracked promises before observing storage
+  // state, so a caller that does `onTokenTransfer(h); await flushPendingDrains()`
+  // sees the drain settled.
+  //
+  // The drain buffer is snapshotted and cleared atomically before the
+  // async fan-out — events arriving during the drain take the live
+  // dispatch path (`transferHandlers.size > 0` is true now) and won't
+  // double-buffer.
+
+  /**
+   * Track an async drain so ordering-sensitive callers can await it.
+   * Auto-removes itself on settle.
+   */
+  private trackDrain(p: Promise<unknown>): void {
+    this.inFlightDrains.add(p);
+    p.finally(() => { this.inFlightDrains.delete(p); }).catch(() => { /* tracked */ });
+  }
+
+  /**
+   * Await all in-flight drains for this adapter. Used by the mux's
+   * `fetchPendingEvents` to guarantee that a `receive()` call sees the
+   * effects of any drain triggered by handler registration during init.
+   */
+  async flushPendingDrains(): Promise<void> {
+    if (this.inFlightDrains.size === 0) return;
+    // Snapshot — new drains added during settle won't block this call.
+    const snapshot = Array.from(this.inFlightDrains);
+    await Promise.allSettled(snapshot);
+  }
 
   onMessage(handler: MessageHandler): () => void {
     this.messageHandlers.add(handler);
-    // Flush pending
+    // Flush pending — async drain tracked for `flushPendingDrains`.
     if (this.pendingMessages.length > 0) {
       const pending = this.pendingMessages;
       this.pendingMessages = [];
-      for (const msg of pending) {
-        try { handler(msg); } catch { /* ignore */ }
-      }
+      this.trackDrain((async () => {
+        for (const msg of pending) {
+          try { await handler(msg); }
+          catch (e) { logger.debug('MuxAdapter', 'Pending message drain error:', e); }
+        }
+      })());
     }
     return () => this.messageHandlers.delete(handler);
   }
@@ -2097,12 +2167,16 @@ export class AddressTransportAdapter implements TransportProvider {
   onTokenTransfer(handler: TokenTransferHandler): () => void {
     this.transferHandlers.add(handler);
     // Issue #223 — drain pending transfers queued before any handler existed.
+    // Issue #464 — drain is async-aware and tracked via `inFlightDrains`.
     if (this.pendingTransfers.length > 0) {
       const pending = this.pendingTransfers;
       this.pendingTransfers = [];
-      for (const transfer of pending) {
-        try { handler(transfer); } catch (e) { logger.debug('MuxAdapter', 'Pending transfer drain error:', e); }
-      }
+      this.trackDrain((async () => {
+        for (const transfer of pending) {
+          try { await handler(transfer); }
+          catch (e) { logger.debug('MuxAdapter', 'Pending transfer drain error:', e); }
+        }
+      })());
     }
     return () => this.transferHandlers.delete(handler);
   }
@@ -2113,9 +2187,12 @@ export class AddressTransportAdapter implements TransportProvider {
     if (this.pendingPaymentRequests.length > 0) {
       const pending = this.pendingPaymentRequests;
       this.pendingPaymentRequests = [];
-      for (const request of pending) {
-        try { handler(request); } catch (e) { logger.debug('MuxAdapter', 'Pending payment request drain error:', e); }
-      }
+      this.trackDrain((async () => {
+        for (const request of pending) {
+          try { await handler(request); }
+          catch (e) { logger.debug('MuxAdapter', 'Pending payment request drain error:', e); }
+        }
+      })());
     }
     return () => this.paymentRequestHandlers.delete(handler);
   }
@@ -2126,9 +2203,12 @@ export class AddressTransportAdapter implements TransportProvider {
     if (this.pendingPaymentRequestResponses.length > 0) {
       const pending = this.pendingPaymentRequestResponses;
       this.pendingPaymentRequestResponses = [];
-      for (const response of pending) {
-        try { handler(response); } catch (e) { logger.debug('MuxAdapter', 'Pending payment response drain error:', e); }
-      }
+      this.trackDrain((async () => {
+        for (const response of pending) {
+          try { await handler(response); }
+          catch (e) { logger.debug('MuxAdapter', 'Pending payment response drain error:', e); }
+        }
+      })());
     }
     return () => this.paymentRequestResponseHandlers.delete(handler);
   }
@@ -2272,18 +2352,48 @@ export class AddressTransportAdapter implements TransportProvider {
   // ===========================================================================
   // Dispatch methods — called by MultiAddressTransportMux to route events
   // ===========================================================================
+  //
+  // Issue #464 — dispatch contract MUST propagate handler durability.
+  //
+  // PaymentsModule.handleIncomingTransfer is async; before #464 the
+  // dispatcher iterated handlers synchronously (`handler(transfer);`),
+  // discarded the returned Promise, and returned. The synchronous
+  // `try/catch` only caught synchronous throws — async rejections silently
+  // resolved into unhandled-rejection territory. Worse, the caller of
+  // `dispatchTokenTransfer` (in particular `fetchPendingEvents` via
+  // `handleTokenTransfer`) saw the dispatch return immediately and
+  // happily resolved its outer Promise BEFORE the handler had finished
+  // writing the token to storage. The next caller step (typically
+  // `PaymentsModule.load()`) then raced against an in-flight `addToken`
+  // and roughly half the time observed empty storage.
+  //
+  // Fix: every dispatch method is now `async` and uses `Promise.allSettled`
+  // to await every handler invocation before resolving. The
+  // `allSettled` (not `Promise.all`) choice preserves the per-handler
+  // fault-isolation guarantee — a rejection in one handler must not
+  // prevent the remaining handlers from running. Sync handlers (e.g.
+  // `MessageHandler` returns `void`) `await` to a no-op via microtask;
+  // the per-dispatch cost is one microtask which is negligible relative
+  // to the handler workload.
+  //
+  // Upstream call sites (`handleTokenTransfer`, `handlePaymentRequest`,
+  // gift-wrap path) MUST `await` the dispatch — see those methods
+  // above for the awaited calls.
 
-  dispatchMessage(message: IncomingMessage): void {
+  async dispatchMessage(message: IncomingMessage): Promise<void> {
     if (this.messageHandlers.size === 0) {
       this.pendingMessages.push(message);
       return;
     }
-    for (const handler of this.messageHandlers) {
-      try { handler(message); } catch (e) { logger.debug('MuxAdapter', 'Message handler error:', e); }
-    }
+    await Promise.allSettled(
+      Array.from(this.messageHandlers).map(async (h) => {
+        try { await h(message); }
+        catch (e) { logger.debug('MuxAdapter', 'Message handler error:', e); }
+      }),
+    );
   }
 
-  dispatchTokenTransfer(transfer: IncomingTokenTransfer): void {
+  async dispatchTokenTransfer(transfer: IncomingTokenTransfer): Promise<void> {
     // Issue #223 — queue if no handler is registered yet. The relay can push
     // events between mux.addAddress (which subscribes) and PaymentsModule.
     // initialize (which calls onTokenTransfer); without the queue this fires
@@ -2293,54 +2403,78 @@ export class AddressTransportAdapter implements TransportProvider {
       this.pendingTransfers.push(transfer);
       return;
     }
-    for (const handler of this.transferHandlers) {
-      try { handler(transfer); } catch (e) { logger.debug('MuxAdapter', 'Transfer handler error:', e); }
-    }
+    // Issue #464 — the CRITICAL site. PaymentsModule.handleIncomingTransfer
+    // is `async`; awaiting here closes the gap between `fetchPendingEvents`
+    // resolving and the handler's storage write completing.
+    await Promise.allSettled(
+      Array.from(this.transferHandlers).map(async (h) => {
+        try { await h(transfer); }
+        catch (e) { logger.debug('MuxAdapter', 'Transfer handler error:', e); }
+      }),
+    );
   }
 
-  dispatchPaymentRequest(request: IncomingPaymentRequest): void {
+  async dispatchPaymentRequest(request: IncomingPaymentRequest): Promise<void> {
     if (this.paymentRequestHandlers.size === 0) {
       this.pendingPaymentRequests.push(request);
       return;
     }
-    for (const handler of this.paymentRequestHandlers) {
-      try { handler(request); } catch (e) { logger.debug('MuxAdapter', 'Payment request handler error:', e); }
-    }
+    await Promise.allSettled(
+      Array.from(this.paymentRequestHandlers).map(async (h) => {
+        try { await h(request); }
+        catch (e) { logger.debug('MuxAdapter', 'Payment request handler error:', e); }
+      }),
+    );
   }
 
-  dispatchPaymentRequestResponse(response: IncomingPaymentRequestResponse): void {
+  async dispatchPaymentRequestResponse(response: IncomingPaymentRequestResponse): Promise<void> {
     if (this.paymentRequestResponseHandlers.size === 0) {
       this.pendingPaymentRequestResponses.push(response);
       return;
     }
-    for (const handler of this.paymentRequestResponseHandlers) {
-      try { handler(response); } catch (e) { logger.debug('MuxAdapter', 'Payment response handler error:', e); }
-    }
+    await Promise.allSettled(
+      Array.from(this.paymentRequestResponseHandlers).map(async (h) => {
+        try { await h(response); }
+        catch (e) { logger.debug('MuxAdapter', 'Payment response handler error:', e); }
+      }),
+    );
   }
 
-  dispatchReadReceipt(receipt: IncomingReadReceipt): void {
-    for (const handler of this.readReceiptHandlers) {
-      try { handler(receipt); } catch (e) { logger.debug('MuxAdapter', 'Read receipt handler error:', e); }
-    }
+  async dispatchReadReceipt(receipt: IncomingReadReceipt): Promise<void> {
+    await Promise.allSettled(
+      Array.from(this.readReceiptHandlers).map(async (h) => {
+        try { await h(receipt); }
+        catch (e) { logger.debug('MuxAdapter', 'Read receipt handler error:', e); }
+      }),
+    );
   }
 
-  dispatchTypingIndicator(indicator: IncomingTypingIndicator): void {
-    for (const handler of this.typingIndicatorHandlers) {
-      try { handler(indicator); } catch (e) { logger.debug('MuxAdapter', 'Typing handler error:', e); }
-    }
+  async dispatchTypingIndicator(indicator: IncomingTypingIndicator): Promise<void> {
+    await Promise.allSettled(
+      Array.from(this.typingIndicatorHandlers).map(async (h) => {
+        try { await h(indicator); }
+        catch (e) { logger.debug('MuxAdapter', 'Typing handler error:', e); }
+      }),
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  dispatchComposingIndicator(indicator: any): void {
-    for (const handler of this.composingHandlers) {
-      try { handler(indicator); } catch (e) { logger.debug('MuxAdapter', 'Composing handler error:', e); }
-    }
+  async dispatchComposingIndicator(indicator: any): Promise<void> {
+    await Promise.allSettled(
+      Array.from(this.composingHandlers).map(async (h) => {
+        try { await h(indicator); }
+        catch (e) { logger.debug('MuxAdapter', 'Composing handler error:', e); }
+      }),
+    );
   }
 
-  dispatchInstantSplitBundle(bundle: IncomingInstantSplitBundle): void {
-    for (const handler of this.instantSplitBundleHandlers) {
-      try { handler(bundle); } catch (e) { logger.debug('MuxAdapter', 'Instant split handler error:', e); }
-    }
+  async dispatchInstantSplitBundle(bundle: IncomingInstantSplitBundle): Promise<void> {
+    await Promise.allSettled(
+      Array.from(this.instantSplitBundleHandlers).map(async (h) => {
+        try { await h(bundle); }
+        catch (e) { logger.debug('MuxAdapter', 'Instant split handler error:', e); }
+      }),
+    );
   }
 
   emitTransportEvent(event: TransportEvent): void {


### PR DESCRIPTION
## Summary

Closes #464. `AddressTransportAdapter.dispatchTokenTransfer` (and siblings) iterated over registered handlers synchronously, called `handler(transfer)` and discarded the returned Promise. `PaymentsModule.handleIncomingTransfer` is `async`, so the dispatch returned (and `MultiAddressTransportMux.handleTokenTransfer`'s caller chain — ultimately `fetchPendingEvents`) resolved BEFORE the handler finished writing the token to storage. The next caller step (`PaymentsModule.load()` inside `payments.receive()`) then raced against the in-flight `addToken` write and roughly half the time observed empty storage. This was the real root cause behind the single-coin faucet flakiness investigated in #455.

Bulk faucet (#391) masked the bug: 7 events serialize through OrbitDB's write lock and the per-event microtasks usually all finish before the follow-up `load()` reads. The race is masked there, not fixed.

## Fix choice — Option A (minimal-surface async dispatch contract)

Picked Option A over Option B (explicit drain) per the issue's recommendation. The bulk path's parallelism comes from `fetchPendingEvents`'s upstream `Promise.all` over multiple events, not from per-dispatch parallelism. Option A keeps the contract uniform with no caller-side bookkeeping. If a future soak shows meaningful bulk-path regression, switching to Option B is a non-breaking refinement.

- Every `dispatch*` method on `AddressTransportAdapter` is now `async` and `await Promise.allSettled(...)` over each handler invocation. `Promise.allSettled` preserves per-handler fault isolation — a rejection in one handler does not block the others (do NOT short-circuit to `Promise.all`).
- Upstream callers in `MultiAddressTransportMux` (`handleTokenTransfer`, `handlePaymentRequest`, `handlePaymentRequestResponse`, gift-wrap routing) now `await` the dispatch. The chain `fetchPendingEvents → handleEvent → dispatchWalletEvent → handleTokenTransfer → dispatchTokenTransfer → handler` is fully awaited end-to-end.

## Sibling dispatch sites swept

All in `transport/MultiAddressTransportMux.ts`:
- `dispatchTokenTransfer` (THE #464 site — async handler `PaymentsModule.handleIncomingTransfer`)
- `dispatchMessage`
- `dispatchPaymentRequest`
- `dispatchPaymentRequestResponse`
- `dispatchReadReceipt`
- `dispatchTypingIndicator`
- `dispatchComposingIndicator`
- `dispatchInstantSplitBundle`

All upstream call sites in the same file updated to `await`.

## Late-drain hardening (the second arm of #464)

`onTokenTransfer(handler)` (and siblings) used to drain `pendingTransfers` by calling `handler(transfer)` synchronously — same shape as the dispatch bug. Drains are now tracked as Promises in `inFlightDrains` and exposed via `flushPendingDrains()`. The mux's `fetchPendingEvents` calls `flushPendingDrains()` on every adapter before returning, so a late-registered handler's buffered drain is fully observed by the caller's next state read.

## Tests

**New unit tests** — `tests/unit/transport/MultiAddressTransportMux.dispatch-await.test.ts` (8 tests). Prove dispatch does NOT resolve until the async handler resolves (gated via controllable Promise). Cover `dispatchTokenTransfer`, `dispatchMessage`, `dispatchPaymentRequest`, `dispatchPaymentRequestResponse`, late-drain flush, and async-rejection isolation.

**Updated tests:**
- `tests/unit/transport/MultiAddressTransportMux.pending-queue-223.test.ts` — converted to async; all 7 tests await dispatch and `flushPendingDrains()` where they previously relied on sync drain.
- `tests/e2e/uxf-bundle-cross-instance-import-223.test.ts` — `injectTokenTransfer` is now async, call site awaits.

**Test results:**
- `tests/unit` — 8418 passed, 5 skipped (zero regressions)
- `tests/unit/transport` — 196 passed
- `tests/unit/modules/PaymentsModule` — 479 passed
- `tests/unit/core` — 650 passed
- Build (`npx tsup`) clean
- Lint (`npx eslint`) — zero new errors or warnings

## Soak results

**Single-coin send (the bug's primary symptom):**
- 3/3 consecutive PASS via `manual-test-simple-send.sh` (alice→bob 10 UCT send + receive + finalize, exact ±10 UCT confirmed delta verified, no unconfirmed residue).

**Bulk path no-regression:**
- `manual-test-roundtrip-391.sh` (4-hop A→B→A→B→A round-trip, ASSERT OK on net deltas, no DUPLICATE_BUNDLE_MEMBERSHIP, no unconfirmed residue) — PASS.
- `manual-test-accounting-roundtrip.sh` (invoice round-trip + partial-pay + bulk-return + repeat-pay) — PASS.

Single-coin faucet flakiness (the original #455 symptom) is fully resolved with 3 consecutive clean runs.

## Test plan

- [x] `npx vitest run tests/unit` — 8418 pass
- [x] `npx vitest run tests/unit/transport` — 196 pass
- [x] `npx vitest run tests/unit/modules/PaymentsModule` — 479 pass
- [x] `npx vitest run tests/unit/core` — 650 pass
- [x] `npx tsup` — build success
- [x] `npx eslint transport/ modules/payments/ tests/unit/transport/` — clean
- [x] `manual-test-simple-send.sh` — 3/3 consecutive PASS
- [x] `manual-test-roundtrip-391.sh` — PASS (no regression)
- [x] `manual-test-accounting-roundtrip.sh` — PASS (no regression)