### PR TITLE
fix(registry): forward network through init→create/load + per-network cache (testnet2 icons/mint)

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -275,6 +275,10 @@ export interface SphereImportOptions {
   derivationMode?: DerivationMode;
   /** Optional nametag to register for this wallet (e.g., 'alice' for @alice). Token is auto-minted. */
   nametag?: string;
+  /** Network this wallet runs on — drives TokenRegistry config. Without it, import
+   *  falls back to NETWORKS.testnet and a non-testnet wallet loads the wrong registry
+   *  (symbols resolve via baked values but icons/metadata don't) until a reload. */
+  network?: NetworkType;
   /** Storage provider instance */
   storage: StorageProvider;
   /** Optional token storage provider */
@@ -636,6 +640,7 @@ export class Sphere {
     if (walletExists) {
       // Load existing wallet
       const sphere = await Sphere.load({
+        network: options.network, // forward network so load's configureTokenRegistry uses it (not the testnet default)
         storage: options.storage,
         transport: options.transport,
         oracle: options.oracle,
@@ -676,6 +681,7 @@ export class Sphere {
 
     const sphere = await Sphere.create({
       mnemonic,
+      network: options.network, // forward network so create's configureTokenRegistry uses it (not the testnet default)
       storage: options.storage,
       transport: options.transport,
       oracle: options.oracle,
@@ -779,6 +785,15 @@ export class Sphere {
    * This method ensures the main bundle's TokenRegistry is properly configured.
    */
   private static configureTokenRegistry(storage: StorageProvider, network?: NetworkType): void {
+    if (!network) {
+      // Don't fail hard (many callers/tests omit network), but make it LOUD: a dropped
+      // network silently loads testnet (V1) — wrong registry on any non-testnet network
+      // (esp. mainnet). Every Sphere entry point should forward options.network.
+      logger.warn(
+        'Sphere',
+        'configureTokenRegistry: no network provided — defaulting to testnet. Pass options.network to avoid loading the wrong-network registry.',
+      );
+    }
     const netConfig = network ? NETWORKS[network] : NETWORKS.testnet;
     TokenRegistry.configure({ remoteUrl: netConfig.tokenRegistryUrl, storage });
   }
@@ -1005,7 +1020,13 @@ export class Sphere {
       logger.debug('Sphere', 'Storage reconnected');
     }
 
-    const groupChatConfig = Sphere.resolveGroupChatConfig(options.groupChat);
+    // Configure TokenRegistry for THIS network in the main bundle context.
+    // import() previously omitted this (unlike init/create/load), leaving the
+    // registry on a stale/default network — so imported wallets resolved tokens
+    // against the wrong-network registry (no icons) until a reload.
+    Sphere.configureTokenRegistry(options.storage, options.network);
+
+    const groupChatConfig = Sphere.resolveGroupChatConfig(options.groupChat, options.network);
     const marketConfig = Sphere.resolveMarketConfig(options.market);
     const accountingConfig = Sphere.resolveAccountingConfig(options.accounting);
     const swapConfig = Sphere.resolveSwapConfig(options.swap);

--- a/registry/TokenRegistry.ts
+++ b/registry/TokenRegistry.ts
@@ -245,6 +245,22 @@ export class TokenRegistry {
   // ===========================================================================
 
   /**
+   * Per-network cache keys. The registry cache MUST be namespaced by remoteUrl:
+   * testnet and testnet2 ship DIFFERENT coinIds for the same symbol, so a single
+   * global key let a stale testnet snapshot be served for a testnet2 request —
+   * wrong/missing icons AND self-mint resolving the wrong-network coinId. Keying
+   * by remoteUrl isolates the snapshots so a network can never read another's.
+   */
+  private cacheKeys(): { data: string; ts: string } {
+    const base = STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE;
+    const baseTs = STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE_TS;
+    // No remoteUrl configured (local-only usage): keep the legacy bare key.
+    if (!this.remoteUrl) return { data: base, ts: baseTs };
+    // Namespace by remoteUrl so testnet and testnet2 snapshots never collide.
+    return { data: `${base}:${this.remoteUrl}`, ts: `${baseTs}:${this.remoteUrl}` };
+  }
+
+  /**
    * Load definitions from StorageProvider cache.
    * Only applies if cache exists and is fresh (within refreshIntervalMs).
    */
@@ -252,9 +268,10 @@ export class TokenRegistry {
     if (!this.storage) return false;
 
     try {
+      const { data: dataKey, ts: tsKey } = this.cacheKeys();
       const [cached, cachedTs] = await Promise.all([
-        this.storage.get(STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE),
-        this.storage.get(STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE_TS),
+        this.storage.get(dataKey),
+        this.storage.get(tsKey),
       ]);
 
       if (!cached || !cachedTs) return false;
@@ -287,9 +304,10 @@ export class TokenRegistry {
     if (!this.storage) return;
 
     try {
+      const { data: dataKey, ts: tsKey } = this.cacheKeys();
       await Promise.all([
-        this.storage.set(STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE, JSON.stringify(definitions)),
-        this.storage.set(STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE_TS, String(Date.now())),
+        this.storage.set(dataKey, JSON.stringify(definitions)),
+        this.storage.set(tsKey, String(Date.now())),
       ]);
     } catch {
       // Cache save failure is non-critical

--- a/tests/unit/registry/TokenRegistry.networkResolution.test.ts
+++ b/tests/unit/registry/TokenRegistry.networkResolution.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Mechanism proof: the configured registry NETWORK determines whether a
+ * Top-Up coinId resolves (and thus whether its icon is found).
+ *
+ * Context
+ * -------
+ * Sphere.configureTokenRegistry() maps a NetworkType to a registry URL:
+ *
+ *   const netConfig = network ? NETWORKS[network] : NETWORKS.testnet;   // core/Sphere.ts:786
+ *   TokenRegistry.configure({ remoteUrl: netConfig.tokenRegistryUrl, storage });
+ *
+ * testnet and testnet2 ship DIFFERENT registry JSONs and (critically)
+ * DIFFERENT coinIds for the same symbol. So a token minted on testnet2
+ * (e.g. a Top-Up coin) cannot be resolved by the testnet registry — its
+ * icon lookup returns null.
+ *
+ * The bug: when `network` is undefined, the mapping falls back to
+ * NETWORKS.testnet instead of the actual (testnet2) network. A testnet2
+ * Top-Up coinId then never resolves and the icon is missing.
+ *
+ * This test is deterministic: the CORE assertions use a vendored fixture
+ * and constants. An OPTIONAL network probe (fetching both real JSONs)
+ * cross-checks the "different coinId per network" premise but degrades
+ * gracefully (skips) if the network is unavailable, so the suite never
+ * flakes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TokenRegistry } from '../../../registry';
+import type { TokenDefinition } from '../../../registry';
+import { NETWORKS } from '../../../constants';
+
+// =============================================================================
+// Vendored fixtures (deterministic — no network)
+// =============================================================================
+
+/**
+ * BTC coinId as it appears in the testnet registry
+ * (matches the value used in the existing TokenRegistry.test.ts).
+ */
+const BTC_COIN_ID_TESTNET = '86bc190fcf7b2d07c6078de93db803578760148b16d4431aa2f42a3241ff0daa';
+
+/**
+ * BTC coinId as minted on testnet2 — a DIFFERENT id for the SAME symbol.
+ * This stands in for a "Top-Up coin" minted on testnet2.
+ */
+const BTC_COIN_ID_TESTNET2 = '3cc412000000000000000000000000000000000000000000000000000000abcd';
+
+const BTC_TESTNET2_ICON_URL = 'https://example.com/btc-testnet2.png';
+
+/** A registry containing ONLY the testnet2 BTC definition (with icon). */
+const TESTNET2_DEFINITIONS: TokenDefinition[] = [
+  {
+    network: 'unicity:testnet2',
+    assetKind: 'fungible',
+    name: 'bitcoin',
+    symbol: 'BTC',
+    decimals: 8,
+    description: 'Bitcoin on Unicity testnet2',
+    icons: [{ url: BTC_TESTNET2_ICON_URL }],
+    id: BTC_COIN_ID_TESTNET2,
+  },
+];
+
+/** A registry containing ONLY the testnet BTC definition (with icon). */
+const TESTNET_DEFINITIONS: TokenDefinition[] = [
+  {
+    network: 'unicity:testnet',
+    assetKind: 'fungible',
+    name: 'bitcoin',
+    symbol: 'BTC',
+    decimals: 8,
+    description: 'Bitcoin on Unicity testnet',
+    icons: [{ url: 'https://example.com/btc-testnet.png' }],
+    id: BTC_COIN_ID_TESTNET,
+  },
+];
+
+/**
+ * Configure the singleton from an in-memory definitions array (no network).
+ * Mirrors how Sphere.configureTokenRegistry feeds a remoteUrl's JSON into the
+ * registry, but injected directly so the test is deterministic.
+ */
+async function configureFromDefinitions(definitions: TokenDefinition[]): Promise<void> {
+  const json = JSON.stringify(definitions);
+  const fetchSpy = (input: unknown) => Promise.resolve(new Response(json, { status: 200 }));
+  const original = globalThis.fetch;
+  globalThis.fetch = fetchSpy as typeof globalThis.fetch;
+  try {
+    TokenRegistry.configure({ remoteUrl: 'https://example.com/registry.json', autoRefresh: true });
+    await TokenRegistry.waitForReady();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('TokenRegistry network resolution (Top-Up icon mechanism)', () => {
+  beforeEach(() => {
+    TokenRegistry.resetInstance();
+  });
+
+  afterEach(() => {
+    TokenRegistry.destroy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 1. The two networks point at DIFFERENT registry URLs
+  // ---------------------------------------------------------------------------
+  it('testnet2 and testnet use DIFFERENT tokenRegistryUrl (constants.ts)', () => {
+    expect(NETWORKS.testnet2.tokenRegistryUrl).not.toBe(NETWORKS.testnet.tokenRegistryUrl);
+    // sanity: each URL names its own network file
+    expect(NETWORKS.testnet.tokenRegistryUrl).toContain('unicity-ids.testnet.json');
+    expect(NETWORKS.testnet2.tokenRegistryUrl).toContain('unicity-ids.testnet2.json');
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. configureTokenRegistry mapping: network -> NETWORKS[network].url,
+  //    and UNDEFINED network falls back to NETWORKS.testnet (the bug).
+  //    Replicated exactly from core/Sphere.ts:786.
+  // ---------------------------------------------------------------------------
+  it('maps network -> NETWORKS[network].tokenRegistryUrl, undefined falls back to testnet (the bug)', () => {
+    // EXACT logic from Sphere.configureTokenRegistry:
+    //   const netConfig = network ? NETWORKS[network] : NETWORKS.testnet;
+    const resolveUrl = (network?: keyof typeof NETWORKS): string => {
+      const netConfig = network ? NETWORKS[network] : NETWORKS.testnet;
+      return netConfig.tokenRegistryUrl;
+    };
+
+    // Correct mappings
+    expect(resolveUrl('testnet2')).toBe(NETWORKS.testnet2.tokenRegistryUrl);
+    expect(resolveUrl('testnet')).toBe(NETWORKS.testnet.tokenRegistryUrl);
+    expect(resolveUrl('mainnet')).toBe(NETWORKS.mainnet.tokenRegistryUrl);
+
+    // THE BUG: undefined network resolves to the testnet registry, NOT testnet2.
+    expect(resolveUrl(undefined)).toBe(NETWORKS.testnet.tokenRegistryUrl);
+    expect(resolveUrl(undefined)).not.toBe(NETWORKS.testnet2.tokenRegistryUrl);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. With the testnet2 registry loaded, the testnet2 BTC coinId resolves
+  //    its icon, but the testnet BTC coinId does NOT (it's a different id).
+  // ---------------------------------------------------------------------------
+  it('testnet2 registry resolves testnet2 BTC icon but NOT the testnet BTC id', async () => {
+    await configureFromDefinitions(TESTNET2_DEFINITIONS);
+    const registry = TokenRegistry.getInstance();
+
+    // testnet2 Top-Up coinId -> icon found
+    expect(registry.getIconUrl(BTC_COIN_ID_TESTNET2)).toBe(BTC_TESTNET2_ICON_URL);
+    expect(registry.isKnown(BTC_COIN_ID_TESTNET2)).toBe(true);
+
+    // testnet BTC coinId -> NOT in this registry -> no icon (the missing-icon symptom)
+    expect(registry.getIconUrl(BTC_COIN_ID_TESTNET)).toBeNull();
+    expect(registry.isKnown(BTC_COIN_ID_TESTNET)).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. The mirror image — the WRONG-NETWORK scenario that the undefined
+  //    fallback produces: a testnet registry cannot resolve a testnet2
+  //    (Top-Up) coinId, so its icon is missing.
+  // ---------------------------------------------------------------------------
+  it('testnet registry CANNOT resolve a testnet2 (Top-Up) coinId -> icon missing (reproduces the bug)', async () => {
+    await configureFromDefinitions(TESTNET_DEFINITIONS);
+    const registry = TokenRegistry.getInstance();
+
+    // testnet BTC resolves fine in the testnet registry
+    expect(registry.isKnown(BTC_COIN_ID_TESTNET)).toBe(true);
+
+    // The testnet2 Top-Up coinId is unknown here -> getIconUrl returns null.
+    // This is exactly what the user sees when network is undefined and the
+    // wrong (testnet) registry is loaded for a testnet2-minted Top-Up token.
+    expect(registry.getIconUrl(BTC_COIN_ID_TESTNET2)).toBeNull();
+    expect(registry.isKnown(BTC_COIN_ID_TESTNET2)).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. OPTIONAL network cross-check: fetch BOTH real registry JSONs and prove
+  //    they define DIFFERENT coinIds for the same symbol. Skips (does not
+  //    fail) if the network is unavailable, so the suite stays deterministic.
+  // ---------------------------------------------------------------------------
+  it('[network] real testnet vs testnet2 JSON define different coinIds for the same symbol', async () => {
+    const fetchJson = async (url: string): Promise<TokenDefinition[] | null> => {
+      try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 8000);
+        const res = await fetch(url, { signal: controller.signal });
+        clearTimeout(timer);
+        if (!res.ok) return null;
+        return (await res.json()) as TokenDefinition[];
+      } catch {
+        return null;
+      }
+    };
+
+    const [testnet, testnet2] = await Promise.all([
+      fetchJson(NETWORKS.testnet.tokenRegistryUrl),
+      fetchJson(NETWORKS.testnet2.tokenRegistryUrl),
+    ]);
+
+    if (!testnet || !testnet2) {
+      console.warn('[network] registry fetch unavailable — skipping real-JSON cross-check');
+      return; // graceful skip, keeps the deterministic core green
+    }
+
+    const idForSymbol = (defs: TokenDefinition[], symbol: string): string | undefined =>
+      defs.find((d) => d.symbol?.toUpperCase() === symbol)?.id?.toLowerCase();
+
+    // Find at least one symbol present in BOTH with a DIFFERENT id.
+    const symbols = new Set<string>();
+    for (const d of [...testnet, ...testnet2]) if (d.symbol) symbols.add(d.symbol.toUpperCase());
+
+    let foundDivergentSymbol = false;
+    for (const sym of symbols) {
+      const a = idForSymbol(testnet, sym);
+      const b = idForSymbol(testnet2, sym);
+      if (a && b && a !== b) {
+        foundDivergentSymbol = true;
+        console.info(`[network] symbol ${sym}: testnet=${a} testnet2=${b} (different)`);
+        break;
+      }
+    }
+
+    expect(foundDivergentSymbol).toBe(true);
+  });
+});

--- a/tests/unit/registry/TokenRegistry.test.ts
+++ b/tests/unit/registry/TokenRegistry.test.ts
@@ -952,13 +952,15 @@ describe('StorageProvider Cache', () => {
 
     await registry.refreshFromRemote();
 
-    // Should have called storage.set for cache and timestamp
+    // Should have called storage.set for cache and timestamp.
+    // Cache keys are namespaced by remoteUrl (per-network isolation).
+    const u = 'https://example.com/registry.json';
     expect(storage.set).toHaveBeenCalledWith(
-      STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE,
+      `${STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE}:${u}`,
       expect.any(String),
     );
     expect(storage.set).toHaveBeenCalledWith(
-      STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE_TS,
+      `${STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE_TS}:${u}`,
       expect.any(String),
     );
   });


### PR DESCRIPTION
## Root cause
testnet2 wallets minted/showed **testnet-v1 coinIds** (no icons). `Sphere.init` configured the TokenRegistry for the requested network, then delegated to `Sphere.create()`/`Sphere.load()` **without forwarding `options.network`**. Inside create/load, `configureTokenRegistry(storage, undefined)` hit `network ? NETWORKS[network] : NETWORKS.testnet` → the **v1 testnet registry**, silently reconfiguring the main-bundle singleton back to testnet. `useTopUp` then resolved testnet coinIds and minted them; testnet2's registry has different coinIds → icons never resolved. The global (non-per-network) registry cache amplified the flip.

## Fixes
- `Sphere.init` forwards `network` to **both** `Sphere.create` and `Sphere.load`.
- `Sphere.import` now calls `configureTokenRegistry(options.network)` (it didn't) and forwards `network` to `resolveGroupChatConfig`; `SphereImportOptions` gains `network?`.
- `TokenRegistry` cache is **namespaced per `remoteUrl`** (loadFromCache/saveToCache) so a testnet snapshot can't be served for a testnet2 request. No `remoteUrl` → legacy bare key (unchanged for local-only).
- `configureTokenRegistry` **warns loudly** instead of silently defaulting to testnet when network is missing.

## Test plan
- [x] `tsc` clean, `eslint` clean
- [x] `vitest` core+registry: 484/484
- [x] live: fresh wallet + Top Up on testnet2 → registry is testnet2, minted coinIds are testnet2 (`f581d3…`), icons render (verified with the reporter)

## Follow-ups (separate PRs)
- **harden-network (fail-loud):** remove silent `?? 'mainnet'`/`?? 'testnet'` in `createBrowserProviders`/`createNodeProviders`/oracle factories/`L1PaymentsModule`/trustbase loaders.
- **mainnet readiness:** own `MAINNET_TOKEN_REGISTRY_URL`, real `TRUSTBASE_MAINNET` (currently `null` → verification silently no-ops), distinct mainnet Fulcrum; `dev`→testnet2.