### PR TITLE
test: regression guards for the network-drop bug class (Phase 1)

### DIFF
--- a/tests/unit/constants/networks.consistency.test.ts
+++ b/tests/unit/constants/networks.consistency.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Per-network completeness + consistency gate.
+ *
+ * For EVERY network in NETWORKS this asserts the config is complete and
+ * self-consistent. This is the CI gate that blocks a broken/half-baked network
+ * (especially mainnet) from shipping silently on testnet data — e.g. a mainnet
+ * that still points at the testnet (v1) token registry, or has no embedded
+ * trust base.
+ *
+ * Currently-incomplete networks (mainnet, dev — not yet onboarded, see plan
+ * Phase 4) are wrapped, per failing check, in vitest's it.fails(): those checks
+ * are EXPECTED to fail today. The moment someone makes such a check pass (by
+ * onboarding the network for real), its it.fails starts failing — because the
+ * body now PASSES — forcing them to flip that row to a real it(). This keeps the
+ * gap visible AND self-correcting instead of silently green.
+ *
+ * Note: it.fails() requires the body to actually throw, so the it/it.fails
+ * choice is made PER (network, check) — a network may have some checks already
+ * passing (real it) and others still failing (it.fails). See EXPECTED_FAILURES.
+ *
+ * Do NOT weaken these assertions to make mainnet/dev pass, and do NOT skip them.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { NETWORKS } from '../../../constants';
+import type { NetworkType } from '../../../constants';
+import { getEmbeddedTrustBase } from '../../../impl/shared/trustbase-loader';
+
+/** v1 testnet token registry — only testnet itself may legitimately point here. */
+const V1_TESTNET_REGISTRY_FILE = 'unicity-ids.testnet.json';
+
+/**
+ * Known expected trust-base networkId per network. mainnet's real id is unknown
+ * until it exists; dev currently aliases testnet, so neither is pinned here.
+ */
+const EXPECTED_NETWORK_ID: Partial<Record<NetworkType, number>> = {
+  testnet: 3,
+  testnet2: 4,
+};
+
+/** The consistency checks performed for each network. */
+type Check = 'urls' | 'registry' | 'trustbase';
+
+/**
+ * (network, check) pairs that are EXPECTED-TO-FAIL until that network is
+ * onboarded (plan Phase 4); flip the entry to a real it() — i.e. remove it from
+ * this set — when its registry + trustbase are real.
+ *
+ * Verified against constants.ts / assets/trustbase.ts as of this writing:
+ *  - mainnet.tokenRegistryUrl === TOKEN_REGISTRY_URL (the v1 testnet.json)  → 'registry' fails
+ *  - TRUSTBASE_MAINNET === null                                            → 'trustbase' fails
+ *    (mainnet 'urls' already passes: all URL fields are truthy today.)
+ *  - dev.tokenRegistryUrl === TOKEN_REGISTRY_URL (the v1 testnet.json)      → 'registry' fails
+ *    (dev 'urls' and 'trustbase' already pass: TRUSTBASE_DEV aliases testnet,
+ *     and dev has no pinned expected networkId.)
+ */
+const EXPECTED_FAILURES = new Set<`${NetworkType}:${Check}`>([
+  'mainnet:registry',
+  'mainnet:trustbase',
+  'dev:registry',
+]);
+
+describe.each(Object.keys(NETWORKS) as NetworkType[])('network "%s" config', (net) => {
+  const config = NETWORKS[net];
+  // Pick it() vs it.fails() per check, so each known gap stays tracked and
+  // self-correcting without masking the checks that already pass.
+  const test = (check: Check) =>
+    EXPECTED_FAILURES.has(`${net}:${check}`) ? it.fails : it;
+
+  test('urls')('has all required URL fields present and truthy', () => {
+    expect(config.tokenRegistryUrl).toBeTruthy();
+    expect(config.aggregatorUrl).toBeTruthy();
+    expect(config.electrumUrl).toBeTruthy();
+    expect(config.nostrRelays.length).toBeGreaterThan(0);
+    expect(config.groupRelays.length).toBeGreaterThan(0);
+  });
+
+  test('registry')(
+    'registry URL names this network (no cross-network reuse of v1 testnet registry)',
+    () => {
+      if (net !== 'testnet') {
+        expect(config.tokenRegistryUrl).not.toContain(V1_TESTNET_REGISTRY_FILE);
+      }
+    },
+  );
+
+  test('trustbase')('has a non-null embedded trust base with matching networkId', () => {
+    const trustBase = getEmbeddedTrustBase(net);
+    expect(trustBase).not.toBeNull();
+
+    const expectedId = EXPECTED_NETWORK_ID[net];
+    if (expectedId !== undefined) {
+      expect((trustBase as { networkId: number }).networkId).toBe(expectedId);
+    }
+  });
+});

--- a/tests/unit/core/Sphere.network-delegation.test.ts
+++ b/tests/unit/core/Sphere.network-delegation.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression guard: Sphere.init({ network }) must configure the TokenRegistry
+ * for THAT network through BOTH delegations — Sphere.create() (fresh wallet)
+ * and Sphere.load() (existing wallet).
+ *
+ * Background: a bug had Sphere.init() configure the registry for the requested
+ * network, then call create()/load() WITHOUT forwarding options.network. Inside
+ * those, configureTokenRegistry(storage, undefined) fell back to NETWORKS.testnet
+ * and silently re-pointed the registry at the testnet (v1) URL — so testnet2
+ * wallets fetched the wrong-network registry (testnet coinIds, no icons).
+ *
+ * These tests use a fetch spy to record which registry URL the SDK actually
+ * fetched. If the network forwarding regresses, the second configure (inside
+ * create/load) re-points remoteUrl at testnet, the testnet URL gets fetched,
+ * and these assertions fail. Do NOT weaken the assertions to make them pass —
+ * a failure here means the production fix regressed.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TokenRegistry } from '../../../registry';
+import { NETWORKS } from '../../../constants';
+import { Sphere } from '../../../core/Sphere';
+import { makeMockProviders } from './support/mock-providers';
+
+// Mock L1 network module so init() never reaches Fulcrum (mirrors other core tests).
+vi.mock('../../../l1/network', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  isWebSocketConnected: vi.fn().mockReturnValue(false),
+}));
+
+/**
+ * Install a fetch spy that records every requested URL and returns a minimal,
+ * valid token-definitions response ('[]' with HTTP 200) so refreshFromRemote()
+ * succeeds. Returns the array the spy appends URLs to.
+ */
+function stubFetchRecording(): string[] {
+  const fetched: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = typeof input === 'string' ? input : String((input as { url?: string })?.url ?? input);
+      fetched.push(url);
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => [],
+        text: async () => '[]',
+      } as unknown as Response;
+    }),
+  );
+  return fetched;
+}
+
+describe('Sphere.init network → TokenRegistry delegation (regression guard)', () => {
+  beforeEach(() => {
+    // Fresh registry singleton per test so a prior test's remoteUrl can't leak.
+    TokenRegistry.resetInstance();
+    if (Sphere.getInstance()) {
+      (Sphere as unknown as { instance: null }).instance = null;
+    }
+  });
+
+  afterEach(async () => {
+    if (Sphere.getInstance()) {
+      try { await Sphere.getInstance()!.destroy(); } catch { /* ignore */ }
+    }
+    (Sphere as unknown as { instance: null }).instance = null;
+    TokenRegistry.destroy();
+    vi.unstubAllGlobals();
+  });
+
+  it('Test A: fresh wallet (create path) fetches testnet2 registry, not testnet', async () => {
+    const fetched = stubFetchRecording();
+    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: false });
+
+    const { sphere, created } = await Sphere.init({
+      storage,
+      transport,
+      oracle,
+      l1,
+      network: 'testnet2',
+      autoGenerate: true,
+    });
+
+    // Sanity: this went through the create branch.
+    expect(created).toBe(true);
+    expect(sphere).toBeDefined();
+
+    // Ensure the registry's initial remote load (the fetch) has resolved.
+    await TokenRegistry.waitForReady();
+
+    const registryFetches = fetched.filter((u) => u.includes('unicity-ids'));
+    expect(registryFetches.length).toBeGreaterThan(0);
+    expect(registryFetches).toContain(NETWORKS.testnet2.tokenRegistryUrl);
+    expect(registryFetches).not.toContain(NETWORKS.testnet.tokenRegistryUrl);
+  });
+
+  it('Test B: existing wallet (load path) fetches testnet2 registry, not testnet', async () => {
+    const fetched = stubFetchRecording();
+    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: true });
+
+    const { sphere, created } = await Sphere.init({
+      storage,
+      transport,
+      oracle,
+      l1,
+      network: 'testnet2',
+    });
+
+    // Sanity: this went through the load branch.
+    expect(created).toBe(false);
+    expect(sphere).toBeDefined();
+
+    await TokenRegistry.waitForReady();
+
+    const registryFetches = fetched.filter((u) => u.includes('unicity-ids'));
+    expect(registryFetches.length).toBeGreaterThan(0);
+    expect(registryFetches).toContain(NETWORKS.testnet2.tokenRegistryUrl);
+    expect(registryFetches).not.toContain(NETWORKS.testnet.tokenRegistryUrl);
+  });
+});

--- a/tests/unit/core/support/mock-providers.ts
+++ b/tests/unit/core/support/mock-providers.ts
@@ -1,0 +1,191 @@
+/**
+ * Reusable mock provider factory for Sphere core unit tests.
+ *
+ * The concrete mock bodies (storage / transport / oracle / token storage) are
+ * copied verbatim from tests/unit/core/Sphere.status.test.ts so behavior matches
+ * the long-standing harness those tests rely on. The only addition is the
+ * `walletExists` knob, which seeds the exact storage key Sphere.exists() reads
+ * (STORAGE_KEYS_GLOBAL.MNEMONIC) so a test can drive Sphere.init()'s
+ * create-vs-load branch.
+ */
+
+import { vi } from 'vitest';
+import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../../storage';
+import type { TransportProvider } from '../../../../transport';
+import type { OracleProvider } from '../../../../oracle';
+import type { ProviderStatus } from '../../../../types';
+import { STORAGE_KEYS_GLOBAL } from '../../../../constants';
+
+/**
+ * A valid BIP39 test mnemonic (well-known abandon×11 + about vector). Stored as
+ * plaintext under STORAGE_KEYS_GLOBAL.MNEMONIC so Sphere.exists() returns true
+ * and Sphere.load() can decrypt it (decrypt() passes through valid BIP39 when no
+ * password is set).
+ */
+export const TEST_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+// =============================================================================
+// Mock Factories (copied verbatim from Sphere.status.test.ts)
+// =============================================================================
+
+function createMockStorage(): StorageProvider {
+  const data = new Map<string, string>();
+  return {
+    id: 'mock-storage',
+    name: 'Mock Storage',
+    type: 'local' as const,
+    setIdentity: vi.fn(),
+    get: vi.fn(async (key: string) => data.get(key) ?? null),
+    set: vi.fn(async (key: string, value: string) => { data.set(key, value); }),
+    remove: vi.fn(async (key: string) => { data.delete(key); }),
+    has: vi.fn(async (key: string) => data.has(key)),
+    keys: vi.fn(async () => Array.from(data.keys())),
+    clear: vi.fn(async () => { data.clear(); }),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+    isConnected: vi.fn(() => true),
+    getStatus: vi.fn((): ProviderStatus => 'connected'),
+    saveTrackedAddresses: vi.fn(async () => {}),
+    loadTrackedAddresses: vi.fn(async () => []),
+    // Expose the backing map so callers can seed wallet-existence keys.
+    _data: data,
+  } as unknown as StorageProvider & { _data: Map<string, string> };
+}
+
+function createMockTransport(): TransportProvider {
+  const eventCallbacks = new Set<(event: unknown) => void>();
+  return {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn().mockResolvedValue('transfer-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('request-id'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('response-id'),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    publishIdentityBinding: vi.fn().mockResolvedValue(true),
+    recoverNametag: vi.fn().mockResolvedValue(null),
+    resolve: vi.fn().mockResolvedValue(null),
+    onEvent: vi.fn((callback: (event: unknown) => void) => {
+      eventCallbacks.add(callback);
+      return () => eventCallbacks.delete(callback);
+    }),
+    // Expose for testing: simulate transport events
+    _simulateEvent: (event: unknown) => {
+      for (const cb of eventCallbacks) cb(event);
+    },
+    // Relay methods for metadata
+    getRelays: vi.fn(() => ['wss://relay1.test', 'wss://relay2.test']),
+    getConnectedRelays: vi.fn(() => ['wss://relay1.test']),
+  } as unknown as TransportProvider & { _simulateEvent: (e: unknown) => void };
+}
+
+function createMockOracle(): OracleProvider {
+  const eventCallbacks = new Set<(event: unknown) => void>();
+  return {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'network' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    submitCommitment: vi.fn().mockResolvedValue({ requestId: 'test-id' }),
+    getProof: vi.fn().mockResolvedValue(null),
+    waitForProof: vi.fn().mockResolvedValue({ proof: 'mock' }),
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    onEvent: vi.fn((callback: (event: unknown) => void) => {
+      eventCallbacks.add(callback);
+      return () => eventCallbacks.delete(callback);
+    }),
+    _simulateEvent: (event: unknown) => {
+      for (const cb of eventCallbacks) cb(event);
+    },
+  } as unknown as OracleProvider & { _simulateEvent: (e: unknown) => void };
+}
+
+function createMockTokenStorage(id: string, name: string): TokenStorageProvider<TxfStorageDataBase> {
+  return {
+    id,
+    name,
+    type: 'cloud' as const,
+    setIdentity: vi.fn(),
+    initialize: vi.fn(async () => true),
+    shutdown: vi.fn(async () => {}),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+    isConnected: vi.fn(() => true),
+    getStatus: vi.fn((): ProviderStatus => 'connected'),
+    load: vi.fn(async () => ({
+      success: true,
+      data: { _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: Date.now() } },
+      source: 'local' as const,
+      timestamp: Date.now(),
+    })),
+    save: vi.fn(async () => ({ success: true, timestamp: Date.now() })),
+    sync: vi.fn(async (localData: TxfStorageDataBase) => ({
+      success: true,
+      merged: localData,
+      added: 0,
+      removed: 0,
+      conflicts: 0,
+    })),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+  };
+}
+
+// =============================================================================
+// Combined factory
+// =============================================================================
+
+export interface MockProviders {
+  storage: StorageProvider & { _data: Map<string, string> };
+  transport: TransportProvider & { _simulateEvent: (e: unknown) => void };
+  oracle: OracleProvider & { _simulateEvent: (e: unknown) => void };
+  tokenStorage: TokenStorageProvider<TxfStorageDataBase>;
+  /** L1 disabled so tests don't reach Fulcrum. */
+  l1: null;
+}
+
+export interface MakeMockProvidersOptions {
+  /**
+   * When true, seeds storage so Sphere.exists() returns true — Sphere.init()
+   * takes the load branch. When false (default), storage is empty so init()
+   * takes the create branch.
+   */
+  walletExists?: boolean;
+}
+
+/**
+ * Build a fresh set of mock providers for a Sphere core test.
+ *
+ * @param options.walletExists - Seed the wallet-existence storage key so
+ *   Sphere.init() loads instead of creates. Sphere.exists() checks
+ *   STORAGE_KEYS_GLOBAL.MNEMONIC (then MASTER_KEY); we seed MNEMONIC with a
+ *   valid plaintext BIP39 mnemonic so both exists() and load()'s decrypt pass.
+ */
+export function makeMockProviders(options: MakeMockProvidersOptions = {}): MockProviders {
+  const storage = createMockStorage() as StorageProvider & { _data: Map<string, string> };
+
+  if (options.walletExists) {
+    storage._data.set(STORAGE_KEYS_GLOBAL.MNEMONIC, TEST_MNEMONIC);
+  }
+
+  return {
+    storage,
+    transport: createMockTransport() as TransportProvider & { _simulateEvent: (e: unknown) => void },
+    oracle: createMockOracle() as OracleProvider & { _simulateEvent: (e: unknown) => void },
+    tokenStorage: createMockTokenStorage('indexeddb-tokens', 'IndexedDB'),
+    l1: null,
+  };
+}


### PR DESCRIPTION
Phase 1 of the network-config-safety plan — the tests that would have caught the wrong-network bug.

## What
- **`Sphere.init` → registry delegation guard** (`tests/unit/core/Sphere.network-delegation.test.ts`): asserts `Sphere.init({network:'testnet2'})` loads the testnet2 registry — never testnet — through BOTH the create (fresh wallet) and load (existing wallet) paths. This is the exact regression that shipped: `init` dropped `network` when delegating to create/load → registry silently fell back to testnet → testnet2 wallets minted testnet coinIds with no icons. Verified to FAIL if either forward regresses.
- **Per-network completeness + consistency gate** (`tests/unit/constants/networks.consistency.test.ts`): for every `NETWORKS` entry asserts required URL fields, that the registry URL names its own network (no testnet.json reuse), and a non-null embedded trustbase with matching `networkId`. `mainnet`/`dev` are incomplete today (registry=testnet.json, `TRUSTBASE_MAINNET=null`) → those specific checks are `it.fails()` (expected-to-fail) so CI stays green AND the gap is self-correcting: onboarding the network makes its `it.fails` fail-because-it-passed, forcing a flip to a real `it`.
- New reusable `tests/unit/core/support/mock-providers.ts` (extracted verbatim from `Sphere.status.test.ts`).

## Tests
- [x] `vitest` core+constants: all green (delegation 2/2, consistency 12/12, status 59/59).
- [x] `tsc --noEmit` clean; `eslint` clean. No production code touched.

Plan: `docs/superpowers/plans/2026-06-09-network-config-safety.md` (local). Follow-ups: Phase 2 fail-loud, Phase 3 required NetworkConfig+assertion, Phase 6 storage isolation, Phase 7 invalid-token guard.