### PR TITLE
fix(network): fail-loud on missing network — no silent testnet/mainnet defaults (Phase 2)

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -10,13 +10,14 @@
  *
  * const storage = createLocalStorageProvider();
  * const transport = createNostrTransportProvider();
- * const oracle = createUnicityAggregatorProvider({ url: '/rpc' });
+ * const oracle = createUnicityAggregatorProvider({ url: '/rpc', network: 'testnet2' });
  *
  * // Option 1: Unified init (recommended)
  * const { sphere, created, generatedMnemonic } = await Sphere.init({
  *   storage,
  *   transport,
  *   oracle,
+ *   network: 'testnet2', // required: selects registry/trustbase/aggregator
  *   mnemonic: 'your twelve words...', // optional - will load if wallet exists
  *   autoGenerate: true, // generate new mnemonic if needed
  * });
@@ -27,9 +28,9 @@
  *
  * // Option 2: Manual create/load
  * if (await Sphere.exists(storage)) {
- *   const sphere = await Sphere.load({ storage, transport, oracle });
+ *   const sphere = await Sphere.load({ storage, transport, oracle, network: 'testnet2' });
  * } else {
- *   const sphere = await Sphere.create({ mnemonic, storage, transport, oracle });
+ *   const sphere = await Sphere.create({ mnemonic, storage, transport, oracle, network: 'testnet2' });
  * }
  *
  * // Use the wallet
@@ -721,14 +722,16 @@ export class Sphere {
     network?: NetworkType,
   ): GroupChatModuleConfig | undefined {
     if (!config) return undefined;
+    // Fail loud: relays differ per network — never silently default to mainnet.
+    if (!network) {
+      throw new SphereError('network is required to resolve group chat relays.', 'INVALID_CONFIG');
+    }
     if (config === true) {
-      const netConfig = network ? NETWORKS[network] : NETWORKS.mainnet;
-      return { relays: [...netConfig.groupRelays] };
+      return { relays: [...NETWORKS[network].groupRelays] };
     }
     // If relays not specified, fill from network defaults
     if (!config.relays || config.relays.length === 0) {
-      const netConfig = network ? NETWORKS[network] : NETWORKS.mainnet;
-      return { ...config, relays: [...netConfig.groupRelays] };
+      return { ...config, relays: [...NETWORKS[network].groupRelays] };
     }
     return config;
   }
@@ -785,17 +788,15 @@ export class Sphere {
    * This method ensures the main bundle's TokenRegistry is properly configured.
    */
   private static configureTokenRegistry(storage: StorageProvider, network?: NetworkType): void {
+    // Fail loud: a dropped/missing network would silently load the wrong-network
+    // registry (testnet vs mainnet). Every Sphere entry point must forward options.network.
     if (!network) {
-      // Don't fail hard (many callers/tests omit network), but make it LOUD: a dropped
-      // network silently loads testnet (V1) — wrong registry on any non-testnet network
-      // (esp. mainnet). Every Sphere entry point should forward options.network.
-      logger.warn(
-        'Sphere',
-        'configureTokenRegistry: no network provided — defaulting to testnet. Pass options.network to avoid loading the wrong-network registry.',
+      throw new SphereError(
+        'network is required to configure the TokenRegistry. Every Sphere entry point must forward options.network.',
+        'INVALID_CONFIG',
       );
     }
-    const netConfig = network ? NETWORKS[network] : NETWORKS.testnet;
-    TokenRegistry.configure({ remoteUrl: netConfig.tokenRegistryUrl, storage });
+    TokenRegistry.configure({ remoteUrl: NETWORKS[network].tokenRegistryUrl, storage });
   }
 
   /**

--- a/impl/browser/index.ts
+++ b/impl/browser/index.ts
@@ -28,6 +28,7 @@ export type {
 // =============================================================================
 
 import { logger as sdkLogger } from '../../core/logger';
+import { SphereError } from '../../core/errors';
 import { createIndexedDBStorageProvider, type IndexedDBStorageProviderConfig, createIndexedDBTokenStorageProvider } from './storage';
 import { createNostrTransportProvider } from './transport';
 import { createUnicityAggregatorProvider } from './oracle';
@@ -362,7 +363,11 @@ function resolveTokenSyncConfig(
  * ```
  */
 export function createBrowserProviders(config?: BrowserProvidersConfig): BrowserProviders {
-  const network = config?.network ?? 'mainnet';
+  // Fail loud: a missing network would silently load the wrong-network providers.
+  if (!config?.network) {
+    throw new SphereError('createBrowserProviders: config.network is required.', 'INVALID_CONFIG');
+  }
+  const network = config.network;
 
   // Configure global logger: top-level debug enables all, per-provider overrides are additive.
   // Only override global debug flag when explicitly provided — don't reset a previously-configured value.

--- a/impl/browser/oracle/index.ts
+++ b/impl/browser/oracle/index.ts
@@ -10,6 +10,7 @@ import {
 import type { TrustBaseLoader } from '../../../oracle/oracle-provider';
 import { BaseTrustBaseLoader } from '../../shared/trustbase-loader';
 import type { NetworkType } from '../../../constants';
+import { SphereError } from '../../../core/errors';
 
 // Re-export shared types and classes
 export {
@@ -31,9 +32,24 @@ export type { TrustBaseLoader } from '../../../oracle/oracle-provider';
 export class BrowserTrustBaseLoader extends BaseTrustBaseLoader {
   private url?: string;
 
-  constructor(networkOrUrl: NetworkType | string = 'testnet') {
+  /**
+   * @param networkOrUrl - a NetworkType, or a URL to fetch the trust base from
+   * @param fallbackNetwork - network used for the embedded fallback when a URL is
+   *   supplied (and the fetch fails). Required when networkOrUrl is a URL — we must
+   *   never silently fall back to testnet on a different network.
+   */
+  constructor(networkOrUrl?: NetworkType | string, fallbackNetwork?: NetworkType) {
+    if (!networkOrUrl) {
+      throw new SphereError('BrowserTrustBaseLoader: network or trustBaseUrl is required.', 'INVALID_CONFIG');
+    }
     if (networkOrUrl.startsWith('/') || networkOrUrl.startsWith('http')) {
-      super('testnet');
+      if (!fallbackNetwork) {
+        throw new SphereError(
+          'BrowserTrustBaseLoader: fallbackNetwork is required when a trustBaseUrl is supplied.',
+          'INVALID_CONFIG',
+        );
+      }
+      super(fallbackNetwork);
       this.url = networkOrUrl;
     } else {
       super(networkOrUrl as NetworkType);
@@ -58,8 +74,11 @@ export class BrowserTrustBaseLoader extends BaseTrustBaseLoader {
 /**
  * Create browser TrustBase loader
  */
-export function createBrowserTrustBaseLoader(networkOrUrl?: NetworkType | string): TrustBaseLoader {
-  return new BrowserTrustBaseLoader(networkOrUrl);
+export function createBrowserTrustBaseLoader(
+  networkOrUrl?: NetworkType | string,
+  fallbackNetwork?: NetworkType,
+): TrustBaseLoader {
+  return new BrowserTrustBaseLoader(networkOrUrl, fallbackNetwork);
 }
 
 // =============================================================================
@@ -76,9 +95,17 @@ export function createUnicityAggregatorProvider(
   }
 ): UnicityAggregatorProvider {
   const { trustBaseUrl, network, ...restConfig } = config;
+  // Fail loud: without a network we cannot pick the right embedded trust base.
+  if (!trustBaseUrl && !network) {
+    throw new SphereError(
+      'createUnicityAggregatorProvider: network or trustBaseUrl required.',
+      'INVALID_CONFIG',
+    );
+  }
   return new UnicityAggregatorProvider({
     ...restConfig,
-    trustBaseLoader: createBrowserTrustBaseLoader(trustBaseUrl ?? network ?? 'testnet'),
+    // When a URL is supplied, `network` (if any) is the embedded-fallback network.
+    trustBaseLoader: createBrowserTrustBaseLoader(trustBaseUrl ?? network, network),
   });
 }
 

--- a/impl/nodejs/index.ts
+++ b/impl/nodejs/index.ts
@@ -25,6 +25,7 @@ export type {
 // =============================================================================
 
 import { logger as sdkLogger } from '../../core/logger';
+import { SphereError } from '../../core/errors';
 import { createFileStorageProvider, createFileTokenStorageProvider } from './storage';
 import { createNostrTransportProvider } from './transport';
 import { createUnicityAggregatorProvider } from './oracle';
@@ -200,7 +201,11 @@ export function createNodeProviders(config?: NodeProvidersConfig): NodeProviders
     }
   }
 
-  const network = config?.network ?? 'mainnet';
+  // Fail loud: a missing network would silently load the wrong-network providers.
+  if (!config?.network) {
+    throw new SphereError('createNodeProviders: config.network is required.', 'INVALID_CONFIG');
+  }
+  const network = config.network;
 
   // Configure global logger: top-level debug enables all, per-provider overrides are additive
   const globalDebug = config?.debug ?? false;

--- a/impl/nodejs/oracle/index.ts
+++ b/impl/nodejs/oracle/index.ts
@@ -11,6 +11,7 @@ import {
 import type { TrustBaseLoader } from '../../../oracle/oracle-provider';
 import { BaseTrustBaseLoader } from '../../shared/trustbase-loader';
 import type { NetworkType } from '../../../constants';
+import { SphereError } from '../../../core/errors';
 
 // Re-export shared types and classes
 export {
@@ -32,11 +33,23 @@ export type { TrustBaseLoader } from '../../../oracle/oracle-provider';
 export class NodeTrustBaseLoader extends BaseTrustBaseLoader {
   private filePath?: string;
 
-  constructor(filePathOrNetwork?: string | NetworkType) {
+  /**
+   * @param filePathOrNetwork - a NetworkType, or a file path to load the trust base from
+   * @param fallbackNetwork - network used for the embedded fallback when a file path is
+   *   supplied (and the file is missing/unreadable). Required when filePathOrNetwork is a
+   *   path — we must never silently fall back to testnet on a different network.
+   */
+  constructor(filePathOrNetwork?: string | NetworkType, fallbackNetwork?: NetworkType) {
     if (!filePathOrNetwork) {
-      super('testnet');
+      throw new SphereError('NodeTrustBaseLoader: network or trustBasePath is required.', 'INVALID_CONFIG');
     } else if (filePathOrNetwork.includes('/') || filePathOrNetwork.includes('.')) {
-      super('testnet');
+      if (!fallbackNetwork) {
+        throw new SphereError(
+          'NodeTrustBaseLoader: fallbackNetwork is required when a trustBasePath is supplied.',
+          'INVALID_CONFIG',
+        );
+      }
+      super(fallbackNetwork);
       this.filePath = filePathOrNetwork;
     } else {
       super(filePathOrNetwork as NetworkType);
@@ -61,8 +74,11 @@ export class NodeTrustBaseLoader extends BaseTrustBaseLoader {
 /**
  * Create Node.js TrustBase loader
  */
-export function createNodeTrustBaseLoader(filePathOrNetwork?: string | NetworkType): TrustBaseLoader {
-  return new NodeTrustBaseLoader(filePathOrNetwork);
+export function createNodeTrustBaseLoader(
+  filePathOrNetwork?: string | NetworkType,
+  fallbackNetwork?: NetworkType,
+): TrustBaseLoader {
+  return new NodeTrustBaseLoader(filePathOrNetwork, fallbackNetwork);
 }
 
 // =============================================================================
@@ -79,9 +95,17 @@ export function createUnicityAggregatorProvider(
   }
 ): UnicityAggregatorProvider {
   const { trustBasePath, network, ...restConfig } = config;
+  // Fail loud: without a network we cannot pick the right embedded trust base.
+  if (!trustBasePath && !network) {
+    throw new SphereError(
+      'createUnicityAggregatorProvider: network or trustBaseUrl required.',
+      'INVALID_CONFIG',
+    );
+  }
   return new UnicityAggregatorProvider({
     ...restConfig,
-    trustBaseLoader: createNodeTrustBaseLoader(trustBasePath ?? network ?? 'testnet'),
+    // When a path is supplied, `network` (if any) is the embedded-fallback network.
+    trustBaseLoader: createNodeTrustBaseLoader(trustBasePath ?? network, network),
   });
 }
 

--- a/impl/shared/trustbase-loader.ts
+++ b/impl/shared/trustbase-loader.ts
@@ -5,6 +5,7 @@
 
 import { TRUSTBASE_TESTNET, TRUSTBASE_TESTNET2, TRUSTBASE_MAINNET, TRUSTBASE_DEV } from '../../assets/trustbase';
 import type { NetworkType } from '../../constants';
+import { SphereError } from '../../core/errors';
 
 export interface TrustBaseLoader {
   load(): Promise<unknown | null>;
@@ -24,7 +25,8 @@ export function getEmbeddedTrustBase(network: NetworkType): unknown | null {
     case 'dev':
       return TRUSTBASE_DEV;
     default:
-      return TRUSTBASE_TESTNET;
+      // Fail loud: an unknown network must not silently resolve to the testnet trust base.
+      throw new SphereError(`getEmbeddedTrustBase: unknown network "${network}"`, 'INVALID_CONFIG');
   }
 }
 

--- a/tests/unit/core/Sphere.registerNametag.test.ts
+++ b/tests/unit/core/Sphere.registerNametag.test.ts
@@ -100,6 +100,7 @@ describe('Sphere.registerNametag() — Nostr-binding only (D5, no on-chain mint)
       transport,
       oracle,
       tokenStorage,
+      network: 'testnet2',
       autoGenerate: true,
     });
 
@@ -133,6 +134,7 @@ describe('Sphere.registerNametag() — Nostr-binding only (D5, no on-chain mint)
       transport,
       oracle,
       tokenStorage,
+      network: 'testnet2',
       autoGenerate: true,
     });
 

--- a/tests/unit/core/Sphere.status.test.ts
+++ b/tests/unit/core/Sphere.status.test.ts
@@ -171,6 +171,7 @@ describe('Sphere Status & Provider Management', () => {
       transport: transport as unknown as TransportProvider,
       oracle: oracle as unknown as OracleProvider,
       tokenStorage,
+      network: 'testnet2',
       autoGenerate: true,
     };
     if (options?.l1) {

--- a/tests/unit/core/network-fail-loud.test.ts
+++ b/tests/unit/core/network-fail-loud.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Fail-loud network requirement tests.
+ *
+ * Production wallet code must NEVER silently default the network to a hardcoded
+ * value: a dropped/missing network would silently load the wrong (testnet vs
+ * mainnet) registry/trustbase/aggregator. Every such site must throw
+ * SphereError('INVALID_CONFIG') instead.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SphereError } from '../../../core/errors';
+import { createBrowserProviders } from '../../../impl/browser';
+import { createNodeProviders } from '../../../impl/nodejs';
+import {
+  createUnicityAggregatorProvider as createBrowserAggregator,
+} from '../../../impl/browser/oracle';
+import {
+  createUnicityAggregatorProvider as createNodeAggregator,
+} from '../../../impl/nodejs/oracle';
+import { getEmbeddedTrustBase } from '../../../impl/shared/trustbase-loader';
+
+describe('fail-loud: network required (no silent defaults)', () => {
+  describe('createBrowserProviders', () => {
+    it('throws when network is omitted', () => {
+      // @ts-expect-error network is required
+      expect(() => createBrowserProviders({})).toThrow(/network/i);
+      // @ts-expect-error network is required
+      expect(() => createBrowserProviders({})).toThrow(SphereError);
+    });
+
+    it('throws when config is omitted entirely', () => {
+      expect(() => createBrowserProviders()).toThrow(/network/i);
+    });
+  });
+
+  describe('createNodeProviders', () => {
+    it('throws when network is omitted', () => {
+      // @ts-expect-error network is required
+      expect(() => createNodeProviders({})).toThrow(/network/i);
+      // @ts-expect-error network is required
+      expect(() => createNodeProviders({})).toThrow(SphereError);
+    });
+
+    it('throws when config is omitted entirely', () => {
+      expect(() => createNodeProviders()).toThrow(/network/i);
+    });
+  });
+
+  describe('createUnicityAggregatorProvider (browser)', () => {
+    it('throws when neither network nor trustBaseUrl is provided', () => {
+      expect(() => createBrowserAggregator({ url: 'https://x' })).toThrow(/network|trustBaseUrl/i);
+      expect(() => createBrowserAggregator({ url: 'https://x' })).toThrow(SphereError);
+    });
+  });
+
+  describe('createUnicityAggregatorProvider (node)', () => {
+    it('throws when neither network nor trustBasePath is provided', () => {
+      expect(() => createNodeAggregator({ url: 'https://x' })).toThrow(/network|trustBaseUrl/i);
+      expect(() => createNodeAggregator({ url: 'https://x' })).toThrow(SphereError);
+    });
+  });
+
+  describe('getEmbeddedTrustBase', () => {
+    it('throws on unknown network instead of silently returning testnet', () => {
+      // @ts-expect-error intentionally passing an invalid network
+      expect(() => getEmbeddedTrustBase('bogus')).toThrow(/unknown network/i);
+      // @ts-expect-error intentionally passing an invalid network
+      expect(() => getEmbeddedTrustBase('bogus')).toThrow(SphereError);
+    });
+
+    it('returns embedded data for a known network', () => {
+      expect(getEmbeddedTrustBase('testnet2')).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Phase 2 of the network-config-safety plan. Every silent network fallback becomes a thrown `SphereError('INVALID_CONFIG')`, so a dropped/missing network crashes immediately instead of silently loading the wrong-network registry/trustbase/aggregator (the root cause class behind the testnet2 icon/mint bug).

## Production changes (L3 network axis)
- `core/Sphere.ts` `configureTokenRegistry`: throw on `!network` (was warn + default testnet).
- `core/Sphere.ts` `resolveGroupChatConfig`: require network (was `: NETWORKS.mainnet`); `groupChat:false/undefined` still early-returns (no throw).
- `createBrowserProviders` / `createNodeProviders`: throw on `!config.network` (was `?? 'mainnet'`).
- Oracle factories + `BrowserTrustBaseLoader`/`NodeTrustBaseLoader`: require network/trustBaseUrl (dropped `?? 'testnet'` + hardcoded `super('testnet')`).
- `getEmbeddedTrustBase`: default case throws on unknown network (was silent `return TRUSTBASE_TESTNET`).
- JSDoc examples updated to pass the now-required `network`.

## Deliberately NOT touched: L1
`L1PaymentsModule` was reverted out of this PR. Its `network` field is **dead code** today (L1 addresses are always `alpha`-prefixed — Sphere.ts:2720/2757/4025/4081; fee fixed at 10_000 — l1/tx.ts:17; endpoint = `electrumUrl` defaulting to `DEFAULT_ELECTRUM_URL`). L1 is a **separate axis** (`'mainnet'|'testnet'`, not the L3 `NetworkType`) and optional (`l1:null`). A throw for a field that controls nothing is validation theater; an earlier draft of this branch wrongly required it and then "fixed" ~30 tests by passing `testnet2` to L1 (a non-existent L1 network) — that contamination was fully reverted. L1 is left exactly as-is until/unless its network becomes load-bearing.

## Verification
- [x] Full unit suite **2665/2665** green
- [x] `tsc --noEmit` clean; `eslint` clean on all changed production files
- [x] `grep` confirms **zero** `testnet2`-on-L1 anywhere
- [x] New `tests/unit/core/network-fail-loud.test.ts` asserts the throws; broken `Sphere.status`/`Sphere.registerNametag` init helpers fixed by passing `network:'testnet2'` (correct L3 axis)
- [ ] DTS build to be confirmed on Linux/CI (Windows+node22 DTS segfault is a known false alarm)

Audited via a two-pass (review + adversarial) workflow before landing — confirmed all 11 throws use INVALID_CONFIG, none break the `l1:null` / oracle-with-url / `groupChat:false` paths, and no silent defaults remain.

Plan: `docs/superpowers/plans/2026-06-09-network-config-safety.md`. Follow-up: Phase 3 (required NetworkConfig type + resolveNetworkConfig + startup consistency assertion). Known gap (separate): tests are not type-checked (`tsconfig` excludes `*.test.ts`) — a tests-typecheck CI gate would have caught the testnet2-on-L1; tracked for a follow-up.