### PR TITLE
feat(network): required NetworkConfig + startup consistency assertion (Phase 3)

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -331,6 +331,22 @@ export const DEFAULT_GROUP_RELAYS = [
   'wss://sphere-relay.unicity.network',
 ] as const;
 
+/**
+ * Complete configuration for one network. Every field is required, so adding a
+ * network (or a field) that is missing any of these is a COMPILE error at the
+ * NETWORKS literal below (via `satisfies`) — a half-configured network can never
+ * be defined silently.
+ */
+export interface NetworkConfig {
+  readonly name: string;
+  readonly aggregatorUrl: string;
+  readonly nostrRelays: readonly string[];
+  readonly ipfsGateways: readonly string[];
+  readonly electrumUrl: string;
+  readonly groupRelays: readonly string[];
+  readonly tokenRegistryUrl: string;
+}
+
 /** Network configurations */
 export const NETWORKS = {
   mainnet: {
@@ -371,10 +387,9 @@ export const NETWORKS = {
     groupRelays: DEFAULT_GROUP_RELAYS,
     tokenRegistryUrl: TOKEN_REGISTRY_URL,
   },
-} as const;
+} as const satisfies Record<string, NetworkConfig>;
 
 export type NetworkType = keyof typeof NETWORKS;
-export type NetworkConfig = (typeof NETWORKS)[NetworkType];
 
 // =============================================================================
 // Timeouts & Limits

--- a/impl/browser/index.ts
+++ b/impl/browser/index.ts
@@ -29,6 +29,7 @@ export type {
 
 import { logger as sdkLogger } from '../../core/logger';
 import { SphereError } from '../../core/errors';
+import { assertNetworkConsistency } from '../shared/network';
 import { createIndexedDBStorageProvider, type IndexedDBStorageProviderConfig, createIndexedDBTokenStorageProvider } from './storage';
 import { createNostrTransportProvider } from './transport';
 import { createUnicityAggregatorProvider } from './oracle';
@@ -368,6 +369,9 @@ export function createBrowserProviders(config?: BrowserProvidersConfig): Browser
     throw new SphereError('createBrowserProviders: config.network is required.', 'INVALID_CONFIG');
   }
   const network = config.network;
+  // Refuse provably-broken networks (e.g. a null/mismatched trust base would
+  // silently accept unverified tokens) before building any provider.
+  assertNetworkConsistency(network);
 
   // Configure global logger: top-level debug enables all, per-provider overrides are additive.
   // Only override global debug flag when explicitly provided — don't reset a previously-configured value.

--- a/impl/nodejs/index.ts
+++ b/impl/nodejs/index.ts
@@ -26,6 +26,7 @@ export type {
 
 import { logger as sdkLogger } from '../../core/logger';
 import { SphereError } from '../../core/errors';
+import { assertNetworkConsistency } from '../shared/network';
 import { createFileStorageProvider, createFileTokenStorageProvider } from './storage';
 import { createNostrTransportProvider } from './transport';
 import { createUnicityAggregatorProvider } from './oracle';
@@ -206,6 +207,9 @@ export function createNodeProviders(config?: NodeProvidersConfig): NodeProviders
     throw new SphereError('createNodeProviders: config.network is required.', 'INVALID_CONFIG');
   }
   const network = config.network;
+  // Refuse provably-broken networks (e.g. a null/mismatched trust base would
+  // silently accept unverified tokens) before building any provider.
+  assertNetworkConsistency(network);
 
   // Configure global logger: top-level debug enables all, per-provider overrides are additive
   const globalDebug = config?.debug ?? false;

--- a/impl/shared/network.ts
+++ b/impl/shared/network.ts
@@ -1,0 +1,62 @@
+/**
+ * Centralized network-config resolution + a startup consistency assertion.
+ *
+ * Principle: resolve a network's full configuration in ONE place, and refuse to
+ * run a network whose configuration is provably broken (e.g. a null or mismatched
+ * trust base would silently accept unverified tokens — a funds risk).
+ */
+
+import { NETWORKS, type NetworkType, type NetworkConfig } from '../../constants';
+import { getEmbeddedTrustBase } from './trustbase-loader';
+import { SphereError } from '../../core/errors';
+
+/**
+ * Known trust-base networkId per network. The embedded trust base for a network
+ * MUST carry this id; a mismatch means the wrong trust base is wired to a network
+ * (e.g. the testnet trust base under testnet2), which would verify tokens against
+ * the wrong chain. mainnet/dev have no pinned id yet (mainnet is not onboarded).
+ */
+const EXPECTED_NETWORK_ID: Partial<Record<NetworkType, number>> = {
+  testnet: 3,
+  testnet2: 4,
+};
+
+export interface ResolvedNetworkConfig {
+  readonly network: NetworkType;
+  readonly config: NetworkConfig;
+  readonly trustBase: unknown | null;
+  readonly networkId: number | undefined;
+}
+
+/** Resolve a network's full config + embedded trust base in one place. */
+export function resolveNetworkConfig(network: NetworkType): ResolvedNetworkConfig {
+  const config = NETWORKS[network];
+  const trustBase = getEmbeddedTrustBase(network);
+  const networkId = (trustBase as { networkId?: number } | null)?.networkId;
+  return { network, config, trustBase, networkId };
+}
+
+/**
+ * Fail loud if a network is unsafe to run. Conservative on purpose: it rejects
+ * only provably-broken configs, so currently-valid networks (testnet/testnet2/dev)
+ * keep working while mainnet — which has no embedded trust base — is blocked until
+ * onboarded (otherwise it would silently accept unverified tokens). The stricter
+ * hygiene checks (e.g. no cross-network registry reuse) live in the per-network CI
+ * test, not at runtime, so they can't break a valid deployment.
+ */
+export function assertNetworkConsistency(network: NetworkType): void {
+  const { trustBase, networkId } = resolveNetworkConfig(network);
+  if (trustBase == null) {
+    throw new SphereError(
+      `Network "${network}" has no embedded trust base — refusing to run (tokens would be unverified).`,
+      'INVALID_CONFIG',
+    );
+  }
+  const expected = EXPECTED_NETWORK_ID[network];
+  if (expected !== undefined && networkId !== expected) {
+    throw new SphereError(
+      `Network "${network}" trust base networkId ${networkId} does not match expected ${expected} (wrong trust base wired to this network).`,
+      'INVALID_CONFIG',
+    );
+  }
+}

--- a/tests/unit/impl/shared/network.test.ts
+++ b/tests/unit/impl/shared/network.test.ts
@@ -1,0 +1,41 @@
+/**
+ * resolveNetworkConfig + assertNetworkConsistency.
+ *
+ * The assertion is the startup safety net for the mainnet-readiness scaffolding:
+ * it refuses to run a network whose trust base is null or mismatched (which would
+ * silently accept unverified tokens — a funds risk), while leaving currently-valid
+ * networks working.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveNetworkConfig, assertNetworkConsistency } from '../../../../impl/shared/network';
+import { createBrowserProviders } from '../../../../impl/browser';
+
+describe('resolveNetworkConfig', () => {
+  it('resolves a complete testnet2 config (own registry, trust base, networkId 4)', () => {
+    const r = resolveNetworkConfig('testnet2');
+    expect(r.config.tokenRegistryUrl).toContain('unicity-ids.testnet2.json');
+    expect(r.trustBase).not.toBeNull();
+    expect(r.networkId).toBe(4);
+  });
+
+  it('resolves networkId 3 for testnet', () => {
+    expect(resolveNetworkConfig('testnet').networkId).toBe(3);
+  });
+});
+
+describe('assertNetworkConsistency', () => {
+  it('passes for testnet / testnet2 / dev (non-null trust base, matching networkId)', () => {
+    expect(() => assertNetworkConsistency('testnet')).not.toThrow();
+    expect(() => assertNetworkConsistency('testnet2')).not.toThrow();
+    expect(() => assertNetworkConsistency('dev')).not.toThrow();
+  });
+
+  it('throws for mainnet — no embedded trust base (would accept unverified tokens)', () => {
+    expect(() => assertNetworkConsistency('mainnet')).toThrow(/trust base/i);
+  });
+
+  it('is wired into createBrowserProviders — mainnet is refused at provider construction', () => {
+    expect(() => createBrowserProviders({ network: 'mainnet' })).toThrow(/trust base/i);
+  });
+});


### PR DESCRIPTION
Phase 3 of the network-config-safety plan — the scaffolding that makes onboarding a new network (mainnet) **config-only and safe**: a half-configured network fails at compile time, and a network with a null/mismatched trust base fails loud at runtime instead of silently accepting unverified tokens.

## Changes
- **`NetworkConfig` is now a required interface + `NETWORKS … as const satisfies Record<string, NetworkConfig>`.** A network (or field) missing any required field is a **compile error** at the `NETWORKS` literal, while `as const` literal types are preserved (no ripple). *Verified: dropping a field → `TS2741: Property … is missing … required in 'NetworkConfig'`.*
- **`impl/shared/network.ts` (new):**
  - `resolveNetworkConfig(network)` — resolves a network's full config + embedded trust base + `networkId` in one place (Principle 1: resolve once).
  - `assertNetworkConsistency(network)` — **conservative** fail-loud: throws only when the trust base is `null` (e.g. mainnet — not onboarded; would otherwise accept unverified tokens) or its `networkId` ≠ the expected id (wrong trust base wired to a network). testnet/testnet2/dev keep working.
- **`createBrowserProviders` / `createNodeProviders`** call `assertNetworkConsistency(network)` right after the required-network check, so the standard consumer path refuses a broken network at provider construction. Placed in **impl** (not core) to avoid a `core → impl` dependency cycle (the trust base lives in `impl/shared`).
- Stricter hygiene (no cross-network registry reuse) stays a **CI test** (Phase 1's per-network gate), not a runtime throw, so it can't break a valid deployment.

## Verification
- [x] `tsc --noEmit` → exit 0; teeth-checked that `satisfies` rejects a missing field
- [x] new `tests/unit/impl/shared/network.test.ts` (5/5): testnet2/testnet/dev pass, mainnet throws, wired into `createBrowserProviders`
- [x] full `npx vitest run` → 2861 passed; only 2 failures are the known **Windows-only** `EPERM rename` flake (Linux CI clean)
- [x] `eslint` clean

Follow-up: the bigger finance-critical phases — Phase 6 (per-network storage isolation) and Phase 7 (invalid-token guard). Mainnet onboarding (Phase 4) is deferred; this assertion now guarantees a half-baked mainnet can't run.