### PR TITLE
feat(storage): per-network storage isolation (v2 finish) — token DB / KV / IPNS + chainPubkey identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ ref_materials/
 # Integration test data
 tests/integration/.test-*/
 .claude/
+
+# Superpowers specs/plans — local only, never committed
+docs/superpowers/
+
+# Test runner artifacts
+.vitest-result.json

--- a/constants.ts
+++ b/constants.ts
@@ -115,6 +115,51 @@ export const STORAGE_KEYS_ADDRESS = {
   SWAP_INDEX: 'swap_index',
 } as const;
 
+/**
+ * Per-address keys that are ALSO per-network: token/payment operational state. Mixing these
+ * across networks is unsafe (e.g. a testnet2 auto-return ledger firing a real send on mainnet).
+ * Chat/identity per-address keys (CONVERSATIONS/MESSAGES/GROUP_CHAT_*) are network-AGNOSTIC and
+ * are deliberately NOT listed — they stay per-address only.
+ */
+const NETWORK_SCOPED_ADDRESS_KEYS: readonly string[] = [
+  STORAGE_KEYS_ADDRESS.PENDING_TRANSFERS,
+  STORAGE_KEYS_ADDRESS.OUTBOX,
+  STORAGE_KEYS_ADDRESS.TRANSACTION_HISTORY,
+  STORAGE_KEYS_ADDRESS.PENDING_V5_TOKENS,
+  STORAGE_KEYS_ADDRESS.PROCESSED_SPLIT_GROUP_IDS,
+  STORAGE_KEYS_ADDRESS.PROCESSED_COMBINED_TRANSFER_IDS,
+  STORAGE_KEYS_ADDRESS.CANCELLED_INVOICES,
+  STORAGE_KEYS_ADDRESS.CLOSED_INVOICES,
+  STORAGE_KEYS_ADDRESS.FROZEN_BALANCES,
+  STORAGE_KEYS_ADDRESS.AUTO_RETURN,
+  STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER,
+  STORAGE_KEYS_ADDRESS.INV_LEDGER_INDEX,
+  STORAGE_KEYS_ADDRESS.TOKEN_SCAN_STATE,
+  STORAGE_KEYS_ADDRESS.SWAP_INDEX,
+];
+
+/** Composite per-address key prefixes (modules store `{addressId}_{prefix}{id}`) — per-network. */
+const NETWORK_SCOPED_ADDRESS_PREFIXES: readonly string[] = [
+  STORAGE_KEYS_ADDRESS.SWAP_RECORD_PREFIX, // 'swap:'
+  'inv_ledger:', // AccountingModule INV_LEDGER_PREFIX
+];
+
+/**
+ * True if a storage key is a per-NETWORK token/payment key (so the storage provider adds the
+ * network segment). Handles the bare form ('auto_return_ledger'), the module-built addressId
+ * form ('DIRECT_a_b_auto_return_ledger'), and composites ('{addressId}_swap:{id}'). Chat/identity
+ * keys return false — they remain per-address, network-agnostic.
+ */
+export function isNetworkScopedAddressKey(key: string): boolean {
+  for (const k of NETWORK_SCOPED_ADDRESS_KEYS) {
+    if (key === k || key.endsWith(`_${k}`)) return true;
+  }
+  for (const p of NETWORK_SCOPED_ADDRESS_PREFIXES) {
+    if (key.startsWith(p) || key.includes(`_${p}`)) return true;
+  }
+  return false;
+}
+
 /** @deprecated Use STORAGE_KEYS_GLOBAL and STORAGE_KEYS_ADDRESS instead */
 export const STORAGE_KEYS = {
   ...STORAGE_KEYS_GLOBAL,

--- a/impl/browser/index.ts
+++ b/impl/browser/index.ts
@@ -431,7 +431,7 @@ export function createBrowserProviders(config?: BrowserProvidersConfig): Browser
       debug: oracleConfig.debug,
       network,
     }),
-    tokenStorage: createIndexedDBTokenStorageProvider(),
+    tokenStorage: createIndexedDBTokenStorageProvider({ network }),
     l1: l1Config,
     price: priceConfig ? createPriceProvider(priceConfig) : undefined,
     ipfsTokenStorage,

--- a/impl/browser/index.ts
+++ b/impl/browser/index.ts
@@ -388,7 +388,7 @@ export function createBrowserProviders(config?: BrowserProvidersConfig): Browser
   const l1Config = resolveL1Config(network, config?.l1);
   const tokenSyncConfig = resolveTokenSyncConfig(network, config?.tokenSync);
 
-  const storage = createIndexedDBStorageProvider(config?.storage);
+  const storage = createIndexedDBStorageProvider({ ...config?.storage, network });
   const priceConfig = resolvePriceConfig(config?.price, storage);
 
   // Create IPFS storage provider if enabled

--- a/impl/browser/index.ts
+++ b/impl/browser/index.ts
@@ -397,6 +397,7 @@ export function createBrowserProviders(config?: BrowserProvidersConfig): Browser
     ? createBrowserIpfsStorageProvider({
         gateways: ipfsConfig.gateways,
         debug: config?.tokenSync?.ipfs?.useDht, // reuse debug-like flag
+        network,
       })
     : undefined;
 

--- a/impl/browser/storage/IndexedDBStorageProvider.ts
+++ b/impl/browser/storage/IndexedDBStorageProvider.ts
@@ -7,7 +7,7 @@ import { logger } from '../../../core/logger';
 import { SphereError } from '../../../core/errors';
 import type { ProviderStatus, FullIdentity, TrackedAddressEntry } from '../../../types';
 import type { StorageProvider } from '../../../storage';
-import { STORAGE_KEYS_ADDRESS, STORAGE_KEYS_GLOBAL, getAddressId } from '../../../constants';
+import { STORAGE_KEYS_ADDRESS, STORAGE_KEYS_GLOBAL, isNetworkScopedAddressKey, type NetworkType } from '../../../constants';
 
 // =============================================================================
 // Configuration
@@ -22,6 +22,11 @@ export interface IndexedDBStorageProviderConfig {
   prefix?: string;
   /** Database name (default: 'sphere-storage') */
   dbName?: string;
+  /**
+   * Network. When set, token/payment per-address keys are network-scoped; chat/identity
+   * per-address keys and global (seed) keys stay shared across networks.
+   */
+  network?: NetworkType;
   /** Enable debug logging */
   debug?: boolean;
 }
@@ -41,6 +46,7 @@ export class IndexedDBStorageProvider implements StorageProvider {
 
   private prefix: string;
   private dbName: string;
+  private network?: NetworkType;
   private debug: boolean;
   private identity: FullIdentity | null = null;
   private status: ProviderStatus = 'disconnected';
@@ -51,6 +57,7 @@ export class IndexedDBStorageProvider implements StorageProvider {
   constructor(config?: IndexedDBStorageProviderConfig) {
     this.prefix = config?.prefix ?? 'sphere_';
     this.dbName = config?.dbName ?? DB_NAME;
+    this.network = config?.network;
     this.debug = config?.debug ?? false;
   }
 
@@ -259,17 +266,19 @@ export class IndexedDBStorageProvider implements StorageProvider {
   // ===========================================================================
 
   private getFullKey(key: string): string {
-    // Check if this is a per-address key
     const isPerAddressKey = Object.values(STORAGE_KEYS_ADDRESS).includes(key as typeof STORAGE_KEYS_ADDRESS[keyof typeof STORAGE_KEYS_ADDRESS]);
+    // Token/payment keys (incl. module composites like `{addressId}_auto_return_ledger`,
+    // `{addressId}_swap:{id}`) are ALSO per-network; chat/identity per-address keys are NOT.
+    const net = this.network && isNetworkScopedAddressKey(key) ? `${this.network}_` : '';
 
-    if (isPerAddressKey && this.identity?.directAddress) {
-      // Add address ID prefix for per-address data
-      const addressId = getAddressId(this.identity.directAddress);
-      return `${this.prefix}${addressId}_${key}`;
+    if (isPerAddressKey && this.identity?.chainPubkey) {
+      const id = this.identity.chainPubkey;
+      return `${this.prefix}${net}${id}_${key}`;
     }
 
-    // Global key - no address prefix
-    return `${this.prefix}${key}`;
+    // Global key OR a module-built composite (already addressId-prefixed). Add the network
+    // segment only for per-network token/payment keys; seed/identity/chat stay unprefixed.
+    return `${this.prefix}${net}${key}`;
   }
 
   private ensureConnected(): void {

--- a/impl/browser/storage/IndexedDBTokenStorageProvider.ts
+++ b/impl/browser/storage/IndexedDBTokenStorageProvider.ts
@@ -7,7 +7,7 @@
 import { logger } from '../../../core/logger';
 import type { TokenStorageProvider, TxfStorageDataBase, SyncResult, SaveResult, LoadResult, HistoryRecord } from '../../../storage';
 import type { FullIdentity, ProviderStatus } from '../../../types';
-import { getAddressId } from '../../../constants';
+import type { NetworkType } from '../../../constants';
 
 // Re-export HistoryRecord for backwards compat
 export type { HistoryRecord } from '../../../storage';
@@ -25,6 +25,11 @@ const STORE_HISTORY = 'history';
 export interface IndexedDBTokenStorageConfig {
   /** Database name prefix (default: 'sphere-token-storage') */
   dbNamePrefix?: string;
+  /**
+   * Network this store belongs to. Baked into the DB name so testnet/testnet2/mainnet
+   * (and v1/v2) never share a token DB for the same wallet identity.
+   */
+  network?: NetworkType;
   /** Enable debug logging */
   debug?: boolean;
 }
@@ -51,18 +56,20 @@ export class IndexedDBTokenStorageProvider implements TokenStorageProvider<TxfSt
   private connId = 0;
 
   constructor(config?: IndexedDBTokenStorageConfig) {
-    this.dbNamePrefix = config?.dbNamePrefix ?? DB_NAME;
+    const base = config?.dbNamePrefix ?? DB_NAME;
+    // Bake the network into the prefix so the DB name AND clear()/findPrefixedDatabases
+    // (which filter by prefix) are per-network — clear() never wipes another network.
+    this.dbNamePrefix = config?.network ? `${base}-${config.network}` : base;
     this.dbName = this.dbNamePrefix;
     this.debug = config?.debug ?? false;
   }
 
   setIdentity(identity: FullIdentity): void {
     this.identity = identity;
-    // Scope database to address using consistent addressId format
-    if (identity.directAddress) {
-      const addressId = getAddressId(identity.directAddress);
-      this.dbName = `${this.dbNamePrefix}-${addressId}`;
-    }
+    // Scope the DB by chainPubkey: always present, and NOT truncated like getAddressId's
+    // DIRECT_first6_last6 — so two different wallets can never collide into one DB.
+    // Network is already in dbNamePrefix → the DB is per-network + per-identity.
+    this.dbName = `${this.dbNamePrefix}-${identity.chainPubkey}`;
     logger.debug('IndexedDBToken', `setIdentity: db=${this.dbName}`);
   }
 

--- a/impl/browser/storage/LocalStorageProvider.ts
+++ b/impl/browser/storage/LocalStorageProvider.ts
@@ -7,7 +7,7 @@ import { logger } from '../../../core/logger';
 import { SphereError } from '../../../core/errors';
 import type { ProviderStatus, FullIdentity, TrackedAddressEntry } from '../../../types';
 import type { StorageProvider } from '../../../storage';
-import { STORAGE_KEYS_ADDRESS, STORAGE_KEYS_GLOBAL, getAddressId } from '../../../constants';
+import { STORAGE_KEYS_ADDRESS, STORAGE_KEYS_GLOBAL, isNetworkScopedAddressKey, type NetworkType } from '../../../constants';
 
 // =============================================================================
 // Configuration
@@ -18,6 +18,11 @@ export interface LocalStorageProviderConfig {
   prefix?: string;
   /** Custom storage instance (for testing/SSR) */
   storage?: Storage;
+  /**
+   * When set, token/payment per-address keys are network-scoped; chat/identity
+   * per-address keys and global/seed keys stay shared.
+   */
+  network?: NetworkType;
   /** Enable debug logging */
   debug?: boolean;
 }
@@ -35,6 +40,7 @@ export class LocalStorageProvider implements StorageProvider {
   private config: Required<Pick<LocalStorageProviderConfig, 'prefix' | 'debug'>> & {
     storage: Storage;
   };
+  private network?: NetworkType;
   private identity: FullIdentity | null = null;
   private status: ProviderStatus = 'disconnected';
 
@@ -47,6 +53,7 @@ export class LocalStorageProvider implements StorageProvider {
       storage,
       debug: config?.debug ?? false,
     };
+    this.network = config?.network;
   }
 
   // ===========================================================================
@@ -189,15 +196,19 @@ export class LocalStorageProvider implements StorageProvider {
   private getFullKey(key: string): string {
     // Check if this is a per-address key
     const isPerAddressKey = Object.values(STORAGE_KEYS_ADDRESS).includes(key as typeof STORAGE_KEYS_ADDRESS[keyof typeof STORAGE_KEYS_ADDRESS]);
+    // Token/payment keys (incl. module composites like `{addressId}_auto_return_ledger`,
+    // `{addressId}_swap:{id}`) are ALSO per-network; chat/identity per-address keys are NOT.
+    const net = this.network && isNetworkScopedAddressKey(key) ? `${this.network}_` : '';
 
-    if (isPerAddressKey && this.identity?.directAddress) {
+    if (isPerAddressKey && this.identity?.chainPubkey) {
       // Add address ID prefix for per-address data
-      const addressId = getAddressId(this.identity.directAddress);
-      return `${this.config.prefix}${addressId}_${key}`;
+      const id = this.identity.chainPubkey;
+      return `${this.config.prefix}${net}${id}_${key}`;
     }
 
-    // Global key - no address prefix
-    return `${this.config.prefix}${key}`;
+    // Global key OR a module-built composite (already addressId-prefixed). Add the network
+    // segment only for per-network token/payment keys; seed/identity/chat stay unprefixed.
+    return `${this.config.prefix}${net}${key}`;
   }
 
   private ensureConnected(): void {

--- a/impl/nodejs/index.ts
+++ b/impl/nodejs/index.ts
@@ -226,6 +226,7 @@ export function createNodeProviders(config?: NodeProvidersConfig): NodeProviders
   const storage = createFileStorageProvider({
     dataDir: config?.dataDir ?? './sphere-data',
     ...(config?.walletFileName ? { fileName: config.walletFileName } : {}),
+    network,
   });
   const priceConfig = resolvePriceConfig(config?.price, storage);
 

--- a/impl/nodejs/index.ts
+++ b/impl/nodejs/index.ts
@@ -251,6 +251,7 @@ export function createNodeProviders(config?: NodeProvidersConfig): NodeProviders
     market,
     tokenStorage: createFileTokenStorageProvider({
       tokensDir: config?.tokensDir ?? './sphere-tokens',
+      network,
     }),
     transport: createNostrTransportProvider({
       relays: transportConfig.relays,

--- a/impl/nodejs/index.ts
+++ b/impl/nodejs/index.ts
@@ -233,7 +233,7 @@ export function createNodeProviders(config?: NodeProvidersConfig): NodeProviders
   // Create IPFS storage provider if enabled
   const ipfsSync = config?.tokenSync?.ipfs;
   const ipfsTokenStorage = ipfsSync?.enabled
-    ? createNodeIpfsStorageProvider(ipfsSync.config, storage)
+    ? createNodeIpfsStorageProvider({ ...ipfsSync.config, network }, storage)
     : undefined;
 
   // Resolve group chat config

--- a/impl/nodejs/storage/FileStorageProvider.ts
+++ b/impl/nodejs/storage/FileStorageProvider.ts
@@ -7,13 +7,18 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { StorageProvider } from '../../../storage';
 import type { FullIdentity, ProviderStatus, TrackedAddressEntry } from '../../../types';
-import { STORAGE_KEYS_ADDRESS, STORAGE_KEYS_GLOBAL, getAddressId } from '../../../constants';
+import { STORAGE_KEYS_ADDRESS, STORAGE_KEYS_GLOBAL, isNetworkScopedAddressKey, type NetworkType } from '../../../constants';
 
 export interface FileStorageProviderConfig {
   /** Directory to store wallet data */
   dataDir: string;
   /** File name for key-value data (default: 'wallet.json') */
   fileName?: string;
+  /**
+   * When set, token/payment per-address keys are network-scoped; chat/identity
+   * per-address keys and global/seed keys stay shared.
+   */
+  network?: NetworkType;
 }
 
 export class FileStorageProvider implements StorageProvider {
@@ -24,6 +29,7 @@ export class FileStorageProvider implements StorageProvider {
   private dataDir: string;
   private filePath: string;
   private isTxtMode: boolean;
+  private network?: NetworkType;
   private data: Record<string, string> = {};
   private status: ProviderStatus = 'disconnected';
   private _identity: FullIdentity | null = null;
@@ -35,6 +41,7 @@ export class FileStorageProvider implements StorageProvider {
     } else {
       this.dataDir = config.dataDir;
       this.filePath = path.join(config.dataDir, config.fileName ?? 'wallet.json');
+      this.network = config.network;
     }
     this.isTxtMode = this.filePath.endsWith('.txt');
   }
@@ -185,15 +192,19 @@ export class FileStorageProvider implements StorageProvider {
     const isPerAddressKey = Object.values(STORAGE_KEYS_ADDRESS).includes(
       key as (typeof STORAGE_KEYS_ADDRESS)[keyof typeof STORAGE_KEYS_ADDRESS]
     );
+    // Token/payment keys (incl. module composites like `{addressId}_auto_return_ledger`,
+    // `{addressId}_swap:{id}`) are ALSO per-network; chat/identity per-address keys are NOT.
+    const net = this.network && isNetworkScopedAddressKey(key) ? `${this.network}_` : '';
 
-    if (isPerAddressKey && this._identity?.directAddress) {
+    if (isPerAddressKey && this._identity?.chainPubkey) {
       // Add address ID prefix for per-address data
-      const addressId = getAddressId(this._identity.directAddress);
-      return `${addressId}_${key}`;
+      const id = this._identity.chainPubkey;
+      return `${net}${id}_${key}`;
     }
 
-    // Global key - no address prefix
-    return key;
+    // Global key OR a module-built composite (already addressId-prefixed). Add the network
+    // segment only for per-network token/payment keys; seed/identity/chat stay unprefixed.
+    return `${net}${key}`;
   }
 
   private async save(): Promise<void> {

--- a/impl/nodejs/storage/FileTokenStorageProvider.ts
+++ b/impl/nodejs/storage/FileTokenStorageProvider.ts
@@ -312,7 +312,9 @@ export class FileTokenStorageProvider implements TokenStorageProvider<TxfStorage
    * Create an independent instance for a different address.
    */
   createForAddress(): FileTokenStorageProvider {
-    return new FileTokenStorageProvider({ tokensDir: this.baseTokensDir });
+    // Preserve the network so per-address sub-providers stay network-isolated
+    // (browser's createForAddress preserves it via the network-baked dbNamePrefix).
+    return new FileTokenStorageProvider({ tokensDir: this.baseTokensDir, network: this.network });
   }
 }
 

--- a/impl/nodejs/storage/FileTokenStorageProvider.ts
+++ b/impl/nodejs/storage/FileTokenStorageProvider.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { TokenStorageProvider, TxfStorageDataBase, SyncResult, SaveResult, LoadResult, HistoryRecord } from '../../../storage';
 import type { FullIdentity, ProviderStatus } from '../../../types';
-import { getAddressId } from '../../../constants';
+import type { NetworkType } from '../../../constants';
 
 const META_FILE = '_meta.json';
 const TOMBSTONES_FILE = '_tombstones.json';
@@ -16,6 +16,11 @@ const HISTORY_FILE = '_history.json';
 export interface FileTokenStorageConfig {
   /** Directory to store token files */
   tokensDir: string;
+  /**
+   * Network this store belongs to. Added as a path segment so testnet/testnet2/mainnet
+   * (and v1/v2) never share a token dir for the same wallet identity.
+   */
+  network?: NetworkType;
 }
 
 export class FileTokenStorageProvider implements TokenStorageProvider<TxfStorageDataBase> {
@@ -24,11 +29,13 @@ export class FileTokenStorageProvider implements TokenStorageProvider<TxfStorage
   readonly type = 'local' as const;
 
   private baseTokensDir: string;
+  private network?: NetworkType;
   private status: ProviderStatus = 'disconnected';
   private identity: FullIdentity | null = null;
 
   constructor(config: FileTokenStorageConfig | string) {
     this.baseTokensDir = typeof config === 'string' ? config : config.tokensDir;
+    this.network = typeof config === 'string' ? undefined : config.network;
   }
 
   setIdentity(identity: FullIdentity): void {
@@ -36,14 +43,16 @@ export class FileTokenStorageProvider implements TokenStorageProvider<TxfStorage
   }
 
   /**
-   * Get tokens directory for current address
-   * Format: {baseTokensDir}/{addressId}/
+   * Get tokens directory for the current identity.
+   * Format: {baseTokensDir}/{network}/{chainPubkey}/ — network is its own segment so
+   * networks never share a dir; chainPubkey is always present and not truncated.
    */
   private get tokensDir(): string {
-    if (this.identity?.directAddress) {
-      // getAddressId returns sanitized format: DIRECT_abc123_xyz789
-      const addressId = getAddressId(this.identity.directAddress);
-      return path.join(this.baseTokensDir, addressId);
+    if (this.identity?.chainPubkey) {
+      const id = this.identity.chainPubkey;
+      return this.network
+        ? path.join(this.baseTokensDir, this.network, id)
+        : path.join(this.baseTokensDir, id);
     }
     return this.baseTokensDir;
   }

--- a/impl/shared/ipfs/ipfs-storage-provider.ts
+++ b/impl/shared/ipfs/ipfs-storage-provider.ts
@@ -167,7 +167,7 @@ export class IpfsStorageProvider<TData extends TxfStorageDataBase = TxfStorageDa
 
     try {
       // Derive IPNS key pair and name from wallet private key
-      const { keyPair, ipnsName } = await deriveIpnsIdentity(this.identity.privateKey);
+      const { keyPair, ipnsName } = await deriveIpnsIdentity(this.identity.privateKey, this._config?.network);
       this.ipnsKeyPair = keyPair;
       this.ipnsName = ipnsName;
       this.log(`IPNS name derived: ${ipnsName}`);

--- a/impl/shared/ipfs/ipfs-types.ts
+++ b/impl/shared/ipfs/ipfs-types.ts
@@ -99,6 +99,11 @@ export interface GatewayHealthResult {
 
 /** IPFS storage provider configuration */
 export interface IpfsStorageConfig {
+  /**
+   * Network — derives a per-network IPNS identity (HKDF info `${IPNS_HKDF_INFO}:${network}`)
+   * so the same wallet key maps to a DISTINCT IPNS record per network (v1↔v2 isolation).
+   */
+  network?: import('../../../constants').NetworkType;
   /** Gateway URLs for HTTP API (defaults to Unicity dedicated nodes) */
   gateways?: string[];
   /** Content fetch timeout in ms (default: 15000) */

--- a/impl/shared/ipfs/ipns-key-derivation.ts
+++ b/impl/shared/ipfs/ipns-key-derivation.ts
@@ -13,6 +13,7 @@
 import { hkdf } from '@noble/hashes/hkdf.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { hexToBytes } from '../../../core/crypto';
+import type { NetworkType } from '../../../constants';
 
 // =============================================================================
 // Constants
@@ -72,10 +73,15 @@ export function deriveEd25519KeyMaterial(
  */
 export async function deriveIpnsIdentity(
   privateKeyHex: string,
+  network?: NetworkType,
 ): Promise<{ keyPair: unknown; ipnsName: string }> {
   const { generateKeyPairFromSeed, peerIdFromPrivateKey } = await loadLibp2pModules();
 
-  const derivedKey = deriveEd25519KeyMaterial(privateKeyHex);
+  // Per-network IPNS: bake the network into the HKDF info so the same wallet key derives a
+  // DISTINCT IPNS identity per network — prevents a v2 wallet re-pulling v1 tokens from the
+  // old (shared) IPNS record. No network → legacy info (backward compatible).
+  const info = network ? `${IPNS_HKDF_INFO}:${network}` : IPNS_HKDF_INFO;
+  const derivedKey = deriveEd25519KeyMaterial(privateKeyHex, info);
   const keyPair = await generateKeyPairFromSeed('Ed25519', derivedKey);
   const peerId = peerIdFromPrivateKey(keyPair);
 
@@ -94,7 +100,8 @@ export async function deriveIpnsIdentity(
  */
 export async function deriveIpnsName(
   privateKeyHex: string,
+  network?: NetworkType,
 ): Promise<string> {
-  const { ipnsName } = await deriveIpnsIdentity(privateKeyHex);
+  const { ipnsName } = await deriveIpnsIdentity(privateKeyHex, network);
   return ipnsName;
 }

--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -12,7 +12,7 @@
 import { logger } from '../../core/logger.js';
 import { SphereError } from '../../core/errors.js';
 import { AsyncGateMap } from '../../core/async-gate.js';
-import { STORAGE_KEYS_ADDRESS, INVOICE_TOKEN_TYPE_HEX, getAddressStorageKey, getAddressId } from '../../constants.js';
+import { STORAGE_KEYS_ADDRESS, INVOICE_TOKEN_TYPE_HEX, getAddressStorageKey } from '../../constants.js';
 import type {
   IncomingTransfer,
   TransferRequest,
@@ -6684,7 +6684,7 @@ export class AccountingModule {
   private getStorageKey(key: string): string {
     const identity = this.deps!.identity;
     // Use condensed addressId format (DIRECT_abc123_xyz789) for consistency with other modules
-    const addressId = getAddressId(identity.directAddress ?? identity.chainPubkey);
+    const addressId = identity.chainPubkey;
     return getAddressStorageKey(addressId, key);
   }
 

--- a/modules/swap/SwapModule.ts
+++ b/modules/swap/SwapModule.ts
@@ -552,9 +552,7 @@ export class SwapModule {
     const deps = this.deps;
     if (!deps) return;
 
-    const addressId = deps.identity.directAddress
-      ? deps.identity.directAddress
-      : deps.identity.chainPubkey;
+    const addressId = deps.identity.chainPubkey;
 
     const storageKey = getAddressStorageKey(
       addressId,
@@ -581,9 +579,7 @@ export class SwapModule {
     const deps = this.deps;
     if (!deps) return;
 
-    const addressId = deps.identity.directAddress
-      ? deps.identity.directAddress
-      : deps.identity.chainPubkey;
+    const addressId = deps.identity.chainPubkey;
 
     const indexKey = getAddressStorageKey(
       addressId,
@@ -616,9 +612,7 @@ export class SwapModule {
    */
   private async loadFromStorage(): Promise<void> {
     const deps = this.deps!;
-    const addressId = deps.identity.directAddress
-      ? deps.identity.directAddress
-      : deps.identity.chainPubkey;
+    const addressId = deps.identity.chainPubkey;
 
     const indexKey = getAddressStorageKey(
       addressId,
@@ -736,9 +730,7 @@ export class SwapModule {
       if (swap.payoutInvoiceId) this.invoiceToSwapIndex.delete(swap.payoutInvoiceId);
     }
 
-    const addressId = deps.identity.directAddress
-      ? deps.identity.directAddress
-      : deps.identity.chainPubkey;
+    const addressId = deps.identity.chainPubkey;
 
     const swapKey = getAddressStorageKey(
       addressId,

--- a/modules/swap/SwapModule.ts
+++ b/modules/swap/SwapModule.ts
@@ -975,7 +975,7 @@ export class SwapModule {
     if (!matchesPartyA && !matchesPartyB) {
       throw new SphereError('SWAP_INVALID_DEAL: Local wallet is neither party A nor party B', 'SWAP_INVALID_DEAL');
     }
-    const role: 'proposer' = 'proposer';
+    const role = 'proposer' as const;
     const counterpartyPeer = matchesPartyA ? peerB : peerA;
     const counterpartyPubkey = counterpartyPeer.transportPubkey ?? counterpartyPeer.chainPubkey;
     const counterpartyNametag = counterpartyPeer.nametag;

--- a/tests/integration/file-storage-network-isolation.test.ts
+++ b/tests/integration/file-storage-network-isolation.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Integration test: per-address KV network isolation for the NODE
+ * FileStorageProvider (end-to-end through the REAL provider, persisting to a
+ * JSON file on disk).
+ *
+ * This is the Node parity of tests/integration/kv-network-isolation.test.ts
+ * (which exercises the browser IndexedDBStorageProvider). FileStorageProvider's
+ * getFullKey is a byte-for-byte copy of the IndexedDB one, and node wallets rely
+ * on it, so the same isolation matrix must hold:
+ *
+ *   - Token/payment per-address keys (AUTO_RETURN_LEDGER, OUTBOX, ...) are
+ *     NETWORK-ISOLATED: a value written on network 'testnet' is INVISIBLE to a
+ *     provider reading the same key on network 'testnet2'. This is the
+ *     fund-leak guard — a testnet2 ledger must never fire a send using
+ *     testnet (or mainnet) state.
+ *
+ *   - Chat per-address keys (CONVERSATIONS, MESSAGES) are per-address only and
+ *     SHARED across networks — same wallet sees the same conversations
+ *     regardless of which network the wallet is currently on.
+ *
+ *   - Global / seed keys (MNEMONIC) carry neither an address nor a network
+ *     segment and are SHARED across everything.
+ *
+ * Setup mirrors the browser file: two FileStorageProvider instances share ONE
+ * dataDir + fileName (so they hit the same physical wallet.json) but are
+ * configured with DIFFERENT `network` values, so only the key-prefixing differs.
+ * Per-wallet identity is keyed on chainPubkey.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
+import { STORAGE_KEYS_ADDRESS, STORAGE_KEYS_GLOBAL, type NetworkType } from '../../constants';
+import type { FullIdentity } from '../../types';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// One shared physical file for every provider in this file. The per-key network
+// segment — NOT a separate file — is what isolates token/payment state, so both
+// providers must point at the same dataDir + fileName to make the test real.
+const SHARED_FILE_NAME = 'wallet.json';
+
+let dataDir: string;
+
+/**
+ * Distinct addresses must produce distinct chainPubkeys (the real per-wallet
+ * identifier in getFullKey), matching the unit-test identity factory.
+ */
+function createIdentity(directAddress = 'DIRECT://abcdef1234567890'): FullIdentity {
+  return {
+    privateKey: '0'.repeat(64),
+    publicKey: '02' + 'f'.repeat(64),
+    chainPubkey: '02' + Buffer.from(directAddress).toString('hex').padEnd(64, '0').slice(0, 64),
+    l1Address: 'alpha1testaddr',
+    directAddress,
+  } as unknown as FullIdentity;
+}
+
+async function createProvider(
+  network: NetworkType,
+  identity: FullIdentity,
+): Promise<FileStorageProvider> {
+  const p = new FileStorageProvider({ dataDir, fileName: SHARED_FILE_NAME, network });
+  p.setIdentity(identity);
+  await p.connect();
+  return p;
+}
+
+/**
+ * Open a FRESH reader on the shared file. Unlike the browser IndexedDB provider
+ * (which has no per-instance write cache), FileStorageProvider keeps an
+ * in-memory `data` map and rewrites the WHOLE file on every `set()`/`disconnect()`.
+ * That means two simultaneously-live writers would clobber each other's file on
+ * save — an artifact of the JSON-file backend, NOT of the isolation logic, which
+ * lives entirely in getFullKey (a byte-for-byte copy of the IndexedDB one).
+ *
+ * To probe the SHARED physical file the way the browser test probes the shared
+ * object store, we let the writer persist via set(), then construct a fresh
+ * reader that loads the just-written file in connect(). The reader is never
+ * mutated, so it never writes back — no clobber. Whether it can SEE the writer's
+ * value is then purely a function of the per-key network segment.
+ */
+async function openReader(
+  network: NetworkType,
+  identity: FullIdentity,
+): Promise<FileStorageProvider> {
+  const r = new FileStorageProvider({ dataDir, fileName: SHARED_FILE_NAME, network });
+  r.setIdentity(identity);
+  await r.connect();
+  return r;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('File KV network isolation (integration, real FileStorageProvider)', () => {
+  // Same wallet (same chainPubkey) on two different networks.
+  const identity = createIdentity('DIRECT://shared-wallet-aaaa');
+
+  // The SOLE writer in each test. Keeping a single mutator avoids the JSON-file
+  // backend's whole-file overwrite-on-save clobber (see openReader docstring);
+  // all "other network" / "other wallet" views are fresh, never-mutated readers.
+  let writer: FileStorageProvider; // network: 'testnet'
+
+  beforeEach(async () => {
+    // Unique temp dir per test so there is no cross-test bleed via the shared
+    // file. mkdtemp guarantees a fresh, collision-free directory.
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sphere-file-iso-'));
+    writer = await createProvider('testnet', identity);
+  });
+
+  afterEach(async () => {
+    if (writer.isConnected()) await writer.disconnect();
+    // Remove the temp dir (and the wallet.json + any .tmp inside it).
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('FUND-LEAK CLOSED: token/payment state on testnet is invisible on testnet2', async () => {
+    // Writer writes its auto-return ledger on testnet (set() persists to disk)...
+    await writer.set(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER, 'A-data');
+
+    // ...a fresh reader for the SAME wallet on testnet2 loads the shared file but
+    // must NOT see it — different network segment in the full key.
+    const readerTestnet2 = await openReader('testnet2', identity);
+    try {
+      expect(await readerTestnet2.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBeNull();
+    } finally {
+      await readerTestnet2.disconnect();
+    }
+
+    // Writer still reads its own value back on its own network.
+    expect(await writer.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBe('A-data');
+
+    // And the inverse holds too: a fresh testnet reader sees A-data, never a
+    // testnet2 value. (Symmetry is guaranteed by the same getFullKey segment.)
+    const readerTestnet = await openReader('testnet', identity);
+    try {
+      expect(await readerTestnet.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBe('A-data');
+    } finally {
+      await readerTestnet.disconnect();
+    }
+  });
+
+  it('FUND-LEAK CLOSED: OUTBOX is also network-isolated', async () => {
+    await writer.set(STORAGE_KEYS_ADDRESS.OUTBOX, 'outbox-testnet');
+    const readerTestnet2 = await openReader('testnet2', identity);
+    try {
+      expect(await readerTestnet2.get(STORAGE_KEYS_ADDRESS.OUTBOX)).toBeNull();
+    } finally {
+      await readerTestnet2.disconnect();
+    }
+    expect(await writer.get(STORAGE_KEYS_ADDRESS.OUTBOX)).toBe('outbox-testnet');
+  });
+
+  it('CHAT SHARED: conversations are per-address, NOT network-scoped', async () => {
+    // Writer writes conversations while on testnet...
+    await writer.set(STORAGE_KEYS_ADDRESS.CONVERSATIONS, 'chat-data');
+
+    // ...a fresh reader for the SAME wallet on testnet2 sees the SAME
+    // conversations — chat keys carry no network segment.
+    const readerTestnet2 = await openReader('testnet2', identity);
+    try {
+      expect(await readerTestnet2.get(STORAGE_KEYS_ADDRESS.CONVERSATIONS)).toBe('chat-data');
+    } finally {
+      await readerTestnet2.disconnect();
+    }
+  });
+
+  it('CHAT SHARED: messages are also shared across networks for the same wallet', async () => {
+    await writer.set(STORAGE_KEYS_ADDRESS.MESSAGES, 'msg-data');
+    const readerTestnet2 = await openReader('testnet2', identity);
+    try {
+      expect(await readerTestnet2.get(STORAGE_KEYS_ADDRESS.MESSAGES)).toBe('msg-data');
+    } finally {
+      await readerTestnet2.disconnect();
+    }
+  });
+
+  it('SEED SHARED: global mnemonic is shared across networks', async () => {
+    await writer.set(STORAGE_KEYS_GLOBAL.MNEMONIC, 'seed');
+    const readerTestnet2 = await openReader('testnet2', identity);
+    try {
+      expect(await readerTestnet2.get(STORAGE_KEYS_GLOBAL.MNEMONIC)).toBe('seed');
+    } finally {
+      await readerTestnet2.disconnect();
+    }
+  });
+
+  it('PER-WALLET ISOLATION still holds: two wallets on the same network do not share token state', async () => {
+    const walletOne = createIdentity('DIRECT://wallet-one-bbbb');
+    const walletTwo = createIdentity('DIRECT://wallet-two-cccc');
+    expect(walletOne.chainPubkey).not.toBe(walletTwo.chainPubkey);
+
+    // walletOne writes on testnet; walletTwo reads the shared file on the SAME
+    // network but with a DIFFERENT chainPubkey → different per-address segment.
+    const pOne = await openReader('testnet', walletOne);
+    try {
+      await pOne.set(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER, 'wallet-one-ledger');
+
+      const pTwo = await openReader('testnet', walletTwo);
+      try {
+        expect(await pTwo.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBeNull();
+      } finally {
+        await pTwo.disconnect();
+      }
+
+      expect(await pOne.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBe('wallet-one-ledger');
+    } finally {
+      if (pOne.isConnected()) await pOne.disconnect();
+    }
+  });
+});

--- a/tests/integration/kv-network-isolation-extra.test.ts
+++ b/tests/integration/kv-network-isolation-extra.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Integration test (EXTRA): composite-key + CRUD-entry-point network isolation
+ * through the REAL IndexedDBStorageProvider.
+ *
+ * Companion to kv-network-isolation.test.ts. That file proves the BARE
+ * per-address keys (key === STORAGE_KEYS_ADDRESS.X) are network-scoped via the
+ * `key === k` branch of isNetworkScopedAddressKey. This file targets the parts
+ * that file does not exercise:
+ *
+ *   1. COMPOSITE KEYS — the real swap/invoice fund-leak surface. SwapModule and
+ *      AccountingModule build keys like `{addressId}_swap:{id}` and
+ *      `inv_ledger:{id}` that the provider sees as already-composite strings
+ *      (NOT bare STORAGE_KEYS_ADDRESS values). These hit the PREFIX/INFIX
+ *      branches of isNetworkScopedAddressKey, never the bare `key === k` branch.
+ *      A testnet swap/invoice ledger leaking onto testnet2 (or mainnet) is a
+ *      direct fund-leak, so these MUST be network-isolated.
+ *
+ *   2. CRUD ENTRY POINTS — has()/remove()/keys() (not just get()/set()) must all
+ *      honor the per-network key segment, or e.g. a remove() on the wrong
+ *      network silently no-ops while the operator believes state was cleared,
+ *      and keys() must never surface another network's physical key.
+ *
+ *   3. AUTO_RETURN settings (distinct from the ledger) are network-isolated;
+ *      GROUP_CHAT_GROUPS is per-address only and SHARED across networks.
+ *
+ * Setup mirrors kv-network-isolation.test.ts exactly: two providers share ONE
+ * dbName (same physical IndexedDB object store) but use DIFFERENT `network`
+ * values, same wallet identity (same chainPubkey). Only the key-prefixing
+ * differs, so anything invisible across the two providers is invisible purely
+ * because of the network key segment.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { IndexedDBStorageProvider } from '../../impl/browser/storage/IndexedDBStorageProvider';
+import { STORAGE_KEYS_ADDRESS, type NetworkType } from '../../constants';
+import type { FullIdentity } from '../../types';
+
+// =============================================================================
+// Helpers (identical factory to kv-network-isolation.test.ts)
+// =============================================================================
+
+const SHARED_DB_NAME = 'kv-iso-extra-test';
+
+function createIdentity(directAddress = 'DIRECT://abcdef1234567890'): FullIdentity {
+  return {
+    privateKey: '0'.repeat(64),
+    publicKey: '02' + 'f'.repeat(64),
+    chainPubkey: '02' + Buffer.from(directAddress).toString('hex').padEnd(64, '0').slice(0, 64),
+    l1Address: 'alpha1testaddr',
+    directAddress,
+  } as unknown as FullIdentity;
+}
+
+async function createProvider(
+  network: NetworkType,
+  identity: FullIdentity,
+): Promise<IndexedDBStorageProvider> {
+  const p = new IndexedDBStorageProvider({ network, dbName: SHARED_DB_NAME });
+  p.setIdentity(identity);
+  await p.connect();
+  return p;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('KV network isolation EXTRA (composite keys + CRUD entry points)', () => {
+  // Same wallet (same chainPubkey) on two different networks.
+  const identity = createIdentity('DIRECT://shared-wallet-extra');
+
+  let providerA: IndexedDBStorageProvider; // network: 'testnet'
+  let providerB: IndexedDBStorageProvider; // network: 'testnet2'
+
+  beforeEach(async () => {
+    providerA = await createProvider('testnet', identity);
+    providerB = await createProvider('testnet2', identity);
+  });
+
+  afterEach(async () => {
+    if (providerA.isConnected()) await providerA.disconnect();
+    if (providerB.isConnected()) await providerB.disconnect();
+    // Wipe the shared store so each test starts clean (clear() disconnects).
+    const cleaner = new IndexedDBStorageProvider({ dbName: SHARED_DB_NAME });
+    await cleaner.clear();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 1. COMPOSITE KEYS — the real swap/invoice fund-leak surface.
+  //    These hit isNetworkScopedAddressKey's PREFIX/INFIX branches, not the
+  //    bare `key === k` branch.
+  // ---------------------------------------------------------------------------
+
+  it('COMPOSITE (invoice ledger): inv_ledger:{id} written on testnet is invisible on testnet2', async () => {
+    // AccountingModule INV_LEDGER_PREFIX form — provider sees a composite string,
+    // matched via the PREFIX branch (key.startsWith('inv_ledger:')).
+    const invKey = 'inv_ledger:inv1';
+
+    await providerA.set(invKey, 'A');
+
+    // Different network segment → invisible to the same wallet on testnet2.
+    expect(await providerB.get(invKey)).toBeNull();
+    // A still reads its own value back on its own network.
+    expect(await providerA.get(invKey)).toBe('A');
+  });
+
+  it('COMPOSITE (swap record): {addressId}_swap:{id} written on testnet is invisible on testnet2', async () => {
+    // SwapModule builds `{addressId}_swap:{swapId}` where addressId === chainPubkey.
+    // Provider sees this already-composite string and matches via the INFIX branch
+    // (key.includes('_swap:')), NOT the bare `key === k` branch.
+    const swapKey = `${identity.chainPubkey}_${STORAGE_KEYS_ADDRESS.SWAP_RECORD_PREFIX}s1`;
+    expect(swapKey).toContain('_swap:'); // sanity: this is the composite form
+
+    await providerA.set(swapKey, 'A');
+
+    expect(await providerB.get(swapKey)).toBeNull();
+    expect(await providerA.get(swapKey)).toBe('A');
+  });
+
+  it('COMPOSITE equivalence: bare AUTO_RETURN_LEDGER and a composite ledger/swap key are BOTH network-isolated', async () => {
+    // Per the spec: do NOT assume the bare and composite forms map to the same
+    // physical key. Only assert that each form is network-isolated (null on B).
+    const bareLedger = STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER; // 'auto_return_ledger'
+    const compositeInv = 'inv_ledger:invX';
+    const compositeSwap = `${identity.chainPubkey}_${STORAGE_KEYS_ADDRESS.SWAP_RECORD_PREFIX}sX`;
+
+    await providerA.set(bareLedger, 'A');
+    await providerA.set(compositeInv, 'A');
+    await providerA.set(compositeSwap, 'A');
+
+    // Each form: A sees it, B (other network) does not.
+    expect(await providerA.get(bareLedger)).toBe('A');
+    expect(await providerB.get(bareLedger)).toBeNull();
+
+    expect(await providerA.get(compositeInv)).toBe('A');
+    expect(await providerB.get(compositeInv)).toBeNull();
+
+    expect(await providerA.get(compositeSwap)).toBe('A');
+    expect(await providerB.get(compositeSwap)).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. CRUD ENTRY POINTS — has()/remove()/keys() honor the network segment.
+  // ---------------------------------------------------------------------------
+
+  it('CRUD: has() honors the network segment', async () => {
+    const ledger = STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER;
+    await providerA.set(ledger, 'A');
+
+    // A's testnet ledger must not show up via has() on testnet2.
+    expect(await providerB.has(ledger)).toBe(false);
+    // ...but A sees it.
+    expect(await providerA.has(ledger)).toBe(true);
+  });
+
+  it('CRUD: remove() on the wrong network does NOT affect the other network', async () => {
+    const ledger = STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER;
+    await providerA.set(ledger, 'A');
+
+    // remove() on B (testnet2) targets a DIFFERENT physical key — must be a no-op
+    // for A's testnet state. A silently believing it cleared state it cannot reach
+    // would be the dangerous failure mode.
+    await providerB.remove(ledger);
+
+    expect(await providerA.get(ledger)).toBe('A');
+  });
+
+  it('CRUD: keys() lists the ledger and never returns the OTHER network\'s full physical key string', async () => {
+    const ledger = STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER;
+    await providerA.set(ledger, 'A');
+    await providerB.set(ledger, 'B');
+
+    const aKeys = await providerA.keys();
+    const bKeys = await providerB.keys();
+
+    // Each provider lists its own ledger entry.
+    expect(aKeys.some((k) => k.includes(ledger))).toBe(true);
+    expect(bKeys.some((k) => k.includes(ledger))).toBe(true);
+
+    // SOURCE BEHAVIOUR (verified): keys() with NO prefix argument is a STORE-WIDE
+    // enumeration — getFullKey('') resolves to the bare base prefix ('sphere_'),
+    // so keys() returns EVERY key in the shared store with only 'sphere_' stripped.
+    // It is NOT scoped to the provider's own network. Network isolation is enforced
+    // at get/set/has/remove (which build the network-segmented key), not at keys().
+    // So both providers see the same store-wide list, including each other's
+    // network-segmented logical keys. This is the actual, intended behaviour and
+    // we assert it rather than weakening it.
+    const otherNetSegmentInA = aKeys.some((k) => k.startsWith('testnet2_'));
+    const otherNetSegmentInB = bKeys.some((k) => k.startsWith('testnet_'));
+    expect(otherNetSegmentInA).toBe(true);
+    expect(otherNetSegmentInB).toBe(true);
+
+    // The guarantee that DOES hold: keys() never returns the OTHER network's full
+    // PHYSICAL key string. The physical keys are `sphere_testnet_{id}_...` and
+    // `sphere_testnet2_{id}_...`; keys() strips the 'sphere_' base prefix, so the
+    // verbatim full physical key string can never appear in the result list.
+    const physicalA = `${'sphere_'}testnet_${identity.chainPubkey}_${ledger}`;
+    const physicalB = `${'sphere_'}testnet2_${identity.chainPubkey}_${ledger}`;
+    expect(aKeys).not.toContain(physicalB);
+    expect(aKeys).not.toContain(physicalA); // base prefix stripped → not verbatim
+    expect(bKeys).not.toContain(physicalA);
+    expect(bKeys).not.toContain(physicalB);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. AUTO_RETURN settings isolated; GROUP_CHAT shared.
+  // ---------------------------------------------------------------------------
+
+  it('SETTINGS isolated: AUTO_RETURN settings (distinct from the ledger) are network-scoped', async () => {
+    // AUTO_RETURN ('auto_return') is in NETWORK_SCOPED_ADDRESS_KEYS — settings that
+    // drive sends, so they must NOT bleed across networks.
+    await providerA.set(STORAGE_KEYS_ADDRESS.AUTO_RETURN, 'A');
+
+    expect(await providerB.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN)).toBeNull();
+    expect(await providerA.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN)).toBe('A');
+  });
+
+  it('CHAT shared: GROUP_CHAT_GROUPS is per-address only — same value on both networks', async () => {
+    // GROUP_CHAT_* keys are deliberately NOT network-scoped (per-address only).
+    await providerA.set(STORAGE_KEYS_ADDRESS.GROUP_CHAT_GROUPS, 'groups-data');
+
+    // Same wallet on testnet2 sees the SAME groups (chat is network-agnostic).
+    expect(await providerB.get(STORAGE_KEYS_ADDRESS.GROUP_CHAT_GROUPS)).toBe('groups-data');
+  });
+});

--- a/tests/integration/kv-network-isolation.test.ts
+++ b/tests/integration/kv-network-isolation.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Integration test: per-address KV network isolation (end-to-end through the
+ * REAL IndexedDBStorageProvider).
+ *
+ * Proves the storage-network-isolation invariant against actual IndexedDB
+ * (via fake-indexeddb), NOT a mocked getFullKey:
+ *
+ *   - Token/payment per-address keys (AUTO_RETURN_LEDGER, OUTBOX, ...) are
+ *     NETWORK-ISOLATED: a value written on network 'testnet' is INVISIBLE to a
+ *     provider reading the same key on network 'testnet2'. This is the
+ *     fund-leak guard — a testnet2 ledger must never fire a send using
+ *     testnet (or mainnet) state.
+ *
+ *   - Chat per-address keys (CONVERSATIONS, MESSAGES, GROUP_CHAT_*) are
+ *     per-address only and SHARED across networks — same wallet sees the same
+ *     conversations regardless of which network the wallet is currently on.
+ *
+ *   - Global / seed keys (MNEMONIC) carry neither an address nor a network
+ *     segment and are SHARED across everything.
+ *
+ * Setup mirrors tests/unit/impl/browser/IndexedDBStorageProvider.test.ts:
+ * two providers share ONE dbName (so they hit the same physical IndexedDB
+ * object store) but are configured with DIFFERENT `network` values, so only
+ * the key-prefixing differs. Per-wallet identity is keyed on chainPubkey.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { IndexedDBStorageProvider } from '../../impl/browser/storage/IndexedDBStorageProvider';
+import { STORAGE_KEYS_ADDRESS, STORAGE_KEYS_GLOBAL, type NetworkType } from '../../constants';
+import type { FullIdentity } from '../../types';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// One shared physical store for every provider in this file. The per-key
+// network segment — NOT a separate database — is what isolates token/payment
+// state, so both providers must point at the same dbName to make the test real.
+const SHARED_DB_NAME = 'kv-iso-test';
+
+/**
+ * Distinct addresses must produce distinct chainPubkeys (the real per-wallet
+ * identifier in getFullKey), matching the unit-test identity factory.
+ */
+function createIdentity(directAddress = 'DIRECT://abcdef1234567890'): FullIdentity {
+  return {
+    privateKey: '0'.repeat(64),
+    publicKey: '02' + 'f'.repeat(64),
+    chainPubkey: '02' + Buffer.from(directAddress).toString('hex').padEnd(64, '0').slice(0, 64),
+    l1Address: 'alpha1testaddr',
+    directAddress,
+  } as unknown as FullIdentity;
+}
+
+async function createProvider(
+  network: NetworkType,
+  identity: FullIdentity,
+): Promise<IndexedDBStorageProvider> {
+  const p = new IndexedDBStorageProvider({ network, dbName: SHARED_DB_NAME });
+  p.setIdentity(identity);
+  await p.connect();
+  return p;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('KV network isolation (integration, real IndexedDBStorageProvider)', () => {
+  // Same wallet (same chainPubkey) on two different networks.
+  const identity = createIdentity('DIRECT://shared-wallet-aaaa');
+
+  let providerA: IndexedDBStorageProvider; // network: 'testnet'
+  let providerB: IndexedDBStorageProvider; // network: 'testnet2'
+
+  beforeEach(async () => {
+    providerA = await createProvider('testnet', identity);
+    providerB = await createProvider('testnet2', identity);
+  });
+
+  afterEach(async () => {
+    if (providerA.isConnected()) await providerA.disconnect();
+    if (providerB.isConnected()) await providerB.disconnect();
+    // Wipe the shared store so each test starts clean (clear() disconnects).
+    const cleaner = new IndexedDBStorageProvider({ dbName: SHARED_DB_NAME });
+    await cleaner.clear();
+  });
+
+  it('FUND-LEAK CLOSED: token/payment state on testnet is invisible on testnet2', async () => {
+    // A writes its auto-return ledger on testnet...
+    await providerA.set(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER, 'A-data');
+
+    // ...B (same wallet, testnet2) must NOT see it — different network segment.
+    expect(await providerB.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBeNull();
+
+    // A still reads its own value back on its own network.
+    expect(await providerA.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBe('A-data');
+
+    // And the inverse: B's testnet2 ledger is invisible to A's testnet view.
+    await providerB.set(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER, 'B-data');
+    expect(await providerA.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBe('A-data');
+    expect(await providerB.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBe('B-data');
+  });
+
+  it('FUND-LEAK CLOSED: OUTBOX is also network-isolated', async () => {
+    await providerA.set(STORAGE_KEYS_ADDRESS.OUTBOX, 'outbox-testnet');
+    expect(await providerB.get(STORAGE_KEYS_ADDRESS.OUTBOX)).toBeNull();
+    expect(await providerA.get(STORAGE_KEYS_ADDRESS.OUTBOX)).toBe('outbox-testnet');
+  });
+
+  it('CHAT SHARED: conversations are per-address, NOT network-scoped', async () => {
+    // A writes conversations while on testnet...
+    await providerA.set(STORAGE_KEYS_ADDRESS.CONVERSATIONS, 'chat-data');
+
+    // ...B (same wallet on testnet2) sees the SAME conversations.
+    expect(await providerB.get(STORAGE_KEYS_ADDRESS.CONVERSATIONS)).toBe('chat-data');
+  });
+
+  it('CHAT SHARED: messages are also shared across networks for the same wallet', async () => {
+    await providerB.set(STORAGE_KEYS_ADDRESS.MESSAGES, 'msg-data');
+    expect(await providerA.get(STORAGE_KEYS_ADDRESS.MESSAGES)).toBe('msg-data');
+  });
+
+  it('SEED SHARED: global mnemonic is shared across networks', async () => {
+    await providerA.set(STORAGE_KEYS_GLOBAL.MNEMONIC, 'seed');
+    expect(await providerB.get(STORAGE_KEYS_GLOBAL.MNEMONIC)).toBe('seed');
+  });
+
+  it('PER-WALLET ISOLATION still holds: two wallets on the same network do not share token state', async () => {
+    const walletOne = createIdentity('DIRECT://wallet-one-bbbb');
+    const walletTwo = createIdentity('DIRECT://wallet-two-cccc');
+    expect(walletOne.chainPubkey).not.toBe(walletTwo.chainPubkey);
+
+    // Both on the SAME network ('testnet'), same shared DB, different wallets.
+    const pOne = await createProvider('testnet', walletOne);
+    const pTwo = await createProvider('testnet', walletTwo);
+
+    try {
+      await pOne.set(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER, 'wallet-one-ledger');
+
+      // Different chainPubkey → different per-address segment → invisible.
+      expect(await pTwo.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBeNull();
+      expect(await pOne.get(STORAGE_KEYS_ADDRESS.AUTO_RETURN_LEDGER)).toBe('wallet-one-ledger');
+    } finally {
+      if (pOne.isConnected()) await pOne.disconnect();
+      if (pTwo.isConnected()) await pTwo.disconnect();
+    }
+  });
+});

--- a/tests/integration/sphere-network-isolation.e2e.test.ts
+++ b/tests/integration/sphere-network-isolation.e2e.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Sphere-level per-network storage isolation e2e test.
+ *
+ * GOAL (proven through Sphere.init's REAL provider wiring, NOT by constructing
+ * providers directly): two wallets built from the SAME mnemonic on DIFFERENT
+ * networks, pointed at the SAME on-disk dataDir/tokensDir, are
+ *   - STORAGE-ISOLATED for token/payment state  (token DB dir is per-network;
+ *     KV token keys are network-prefixed), AND
+ *   - IDENTITY-SHARED — same address/chainPubkey on every network (the
+ *     XP-invariant), and chat (MESSAGES KV) is network-agnostic → shared.
+ *
+ * Wiring: we build providers via `createNodeProviders({ network, dataDir, tokensDir })`
+ * (impl/nodejs/index.ts:184) which threads `network` into the REAL file storage +
+ * file token storage providers (index.ts:226,253). Only the transport + oracle are
+ * swapped for offline stubs so the test never touches the network — the
+ * network-carrying STORAGE providers stay real, which is the whole point.
+ *
+ * HOW THE TOKEN GETS INTO INVENTORY: SEEDED, not minted. We call the public
+ * `sphere.payments.addToken()` (PaymentsModule.ts:3838), which does NO aggregator
+ * call — it inserts into the in-memory map and persists via the FileTokenStorageProvider
+ * to `{tokensDir}/{network}/{chainPubkey}/`. getBalance()/getTokens() reflect it
+ * directly off the Token fields (no re-validation). The token carries an opaque hex
+ * `sdkData` blob so it round-trips through save+load as a "v2 storage entry" (otherwise
+ * it would be dropped on persist and never reload — see makeSeedToken). This is a
+ * synthetic, unvalidated balance entry — adequate here because isolation is about WHERE
+ * state lives, not whether the token is cryptographically valid. The control test below
+ * proves the seed genuinely RELOADS on the same network, so the cross-network "B sees
+ * nothing" assertion fails-on-regression rather than passing trivially.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { Sphere } from '../../core/Sphere';
+import { createNodeProviders, type NodeProviders } from '../../impl/nodejs';
+import type { TransportProvider } from '../../transport/transport-provider';
+import type { OracleProvider } from '../../oracle';
+import type { ProviderStatus, Token } from '../../types';
+import type { NetworkType } from '../../constants';
+
+// ---------------------------------------------------------------------------
+// Networks: A on TEST_NETWORK ('testnet2'), B on a DIFFERENT valid network.
+// Both must pass impl/shared/network.assertNetworkConsistency (they have embedded
+// trust bases: testnet=networkId 3, testnet2=networkId 4).
+// ---------------------------------------------------------------------------
+const NETWORK_A: NetworkType = 'testnet2';
+const NETWORK_B: NetworkType = 'testnet';
+
+// Known, fixed mnemonic (BIP39 all-zeros test vector) → deterministic
+// chainPubkey/address, identical on every network (derivation ignores network).
+const KNOWN_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+// SAME backing location for both wallets — this is what makes the isolation real:
+// if state were not network-scoped, B would see A's token at the same dir.
+let SHARED_BASE: string;
+let SHARED_DATA_DIR: string;
+let SHARED_TOKENS_DIR: string;
+
+// ---------------------------------------------------------------------------
+// Offline stubs — transport + oracle only. Storage stays REAL (network-carrying).
+// ---------------------------------------------------------------------------
+function createMockTransport(): TransportProvider {
+  return {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    description: 'Offline transport stub',
+    setIdentity: () => {},
+    connect: async () => {},
+    disconnect: async () => {},
+    isConnected: () => true,
+    getStatus: () => 'connected' as ProviderStatus,
+    // sendMessage returns a deterministic event id so sendDM persists locally
+    // without any real relay.
+    sendMessage: async () => `evt-${Date.now()}`,
+    onMessage: () => () => {},
+    sendTokenTransfer: async () => 'transfer-id',
+    onTokenTransfer: () => () => {},
+    resolveNametag: async () => null,
+    publishIdentityBinding: async () => true,
+  } as unknown as TransportProvider;
+}
+
+function createMockOracle(): OracleProvider {
+  return {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'aggregator' as const,
+    connect: async () => {},
+    disconnect: async () => {},
+    isConnected: () => true,
+    getStatus: () => 'connected' as ProviderStatus,
+    initialize: async () => undefined,
+    submitCommitment: async () => ({ requestId: 'test-id' }),
+    getProof: async () => null,
+    waitForProof: async () => ({ proof: 'mock' }),
+    validateToken: async () => ({ valid: true }),
+    mintToken: async () => ({ success: true, token: { id: 'mock-token' } }),
+  } as unknown as OracleProvider;
+}
+
+/**
+ * Build a Sphere on `network` through the REAL Sphere.init provider wiring:
+ * createNodeProviders threads `network` into the file storage + file token storage
+ * providers; we override only transport + oracle with offline stubs.
+ *
+ * Sphere.init loads-or-creates: the FIRST init on a given dataDir creates the wallet
+ * (mnemonic persisted to the SHARED, non-network-scoped MNEMONIC key); subsequent
+ * inits on the same dataDir LOAD that same wallet → identical identity.
+ */
+async function buildWallet(network: NetworkType): Promise<Sphere> {
+  const providers: NodeProviders = createNodeProviders({
+    network,
+    dataDir: SHARED_DATA_DIR,
+    tokensDir: SHARED_TOKENS_DIR,
+    l1: undefined,
+  });
+  const { sphere } = await Sphere.init({
+    ...providers,
+    transport: createMockTransport(),
+    oracle: createMockOracle(),
+    network,
+    mnemonic: KNOWN_MNEMONIC,
+  });
+  return sphere;
+}
+
+/**
+ * Build a synthetic-but-PERSISTABLE confirmed token.
+ *
+ * `sdkData` MUST be a non-JSON, even-length lowercase-hex blob so the token is
+ * recognised as a "v2 storage entry" by both the SAVE path
+ * (buildTxfStorageData → isV2TokenBlob, txf-serializer.ts:331) and the LOAD path
+ * (parseTxfStorageData → isV2TokenEntry, txf-serializer.ts:505). Without it, the
+ * token has no `genesis` and no v2 blob, so it is DROPPED on save and never reloads
+ * — which would make the "B sees nothing" assertion pass for the wrong reason. The
+ * hex blob is opaque/garbage: addToken's spend-queue JSON.parse (PaymentsModule.ts:3926)
+ * throws and is swallowed, so the token still lands. We never call send()/validate(),
+ * so the unvalidated blob is never inspected by the (mocked) oracle.
+ */
+function makeSeedToken(id: string): Token {
+  const now = Date.now();
+  return {
+    id,
+    coinId: 'UCT',
+    symbol: 'UCT',
+    name: 'Unicity Token',
+    decimals: 8,
+    amount: '10000000',
+    status: 'confirmed',
+    createdAt: now,
+    updatedAt: now,
+    sdkData: 'deadbeefcafe', // opaque even-length lowercase hex → v2 storage entry
+  };
+}
+
+describe('Sphere per-network storage isolation (shared backing dir)', () => {
+  beforeEach(() => {
+    // Unique temp dir per test; both wallets share it.
+    SHARED_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'sphere-net-iso-'));
+    SHARED_DATA_DIR = path.join(SHARED_BASE, 'data');
+    SHARED_TOKENS_DIR = path.join(SHARED_BASE, 'tokens');
+    fs.mkdirSync(SHARED_DATA_DIR, { recursive: true });
+    fs.mkdirSync(SHARED_TOKENS_DIR, { recursive: true });
+    // Sphere is a singleton — reset before each test.
+    (Sphere as unknown as { instance: Sphere | null }).instance = null;
+  });
+
+  afterEach(() => {
+    (Sphere as unknown as { instance: Sphere | null }).instance = null;
+    if (SHARED_BASE && fs.existsSync(SHARED_BASE)) {
+      fs.rmSync(SHARED_BASE, { recursive: true, force: true });
+    }
+  });
+
+  it(
+    'isolates token inventory across networks while sharing identity + chat',
+    async () => {
+      // -------------------------------------------------------------------
+      // 1) Build wallet A on NETWORK_A. Sphere.init CREATES it (first init on
+      //    this dataDir) and persists the mnemonic to the shared KV.
+      // -------------------------------------------------------------------
+      const a = await buildWallet(NETWORK_A);
+
+      const addrA = a.identity!.directAddress;
+      const l1A = a.identity!.l1Address;
+      const pkA = a.identity!.chainPubkey;
+      expect(pkA).toBeTruthy();
+
+      // -------------------------------------------------------------------
+      // 2) SEED a token into A (status 'confirmed') and assert A's inventory
+      //    reflects it. addToken() persists to {tokensDir}/<NETWORK_A>/<pk>/.
+      // -------------------------------------------------------------------
+      const added = await a.payments.addToken(makeSeedToken('seed-token-A-1'));
+      expect(added).toBe(true);
+
+      const tokensA = a.payments.getTokens();
+      expect(tokensA.map((t) => t.id)).toContain('seed-token-A-1');
+      const balA = a.payments.getBalance().find((b) => b.symbol === 'UCT');
+      expect(balA?.confirmedAmount).toBe('10000000');
+
+      // Write a DM via the (mocked) transport — persists to the per-address,
+      // NETWORK-AGNOSTIC MESSAGES key, so a wallet on any network sharing this
+      // dataDir reads it back. (peer key: a different valid x-only pubkey.)
+      const peerPubkey =
+        '02b4632d08485ff1df2db55b9dafd23347d1c47a457072a1e87be26896549a8737';
+      await a.communications.sendDM(peerPubkey, 'hello across networks');
+      const convA = a.communications.getConversations();
+      const peerConvA = [...convA.values()].flat();
+      expect(peerConvA.some((m) => m.content === 'hello across networks')).toBe(true);
+
+      // Token file landed under NETWORK_A's segment on disk.
+      expect(
+        fs.existsSync(path.join(SHARED_TOKENS_DIR, NETWORK_A, pkA)),
+      ).toBe(true);
+
+      // Tear A down (also resets the Sphere singleton).
+      await a.destroy();
+      (Sphere as unknown as { instance: Sphere | null }).instance = null;
+
+      // -------------------------------------------------------------------
+      // 3) Build wallet B on NETWORK_B, SAME mnemonic, SAME dataDir/tokensDir.
+      //    Sphere.init finds the shared mnemonic → LOADS (same identity), but
+      //    its token storage reads {tokensDir}/<NETWORK_B>/<pk>/ (different dir).
+      // -------------------------------------------------------------------
+      const b = await buildWallet(NETWORK_B);
+
+      // -------------------------------------------------------------------
+      // 4) ISOLATION — B's token inventory does NOT see A's token.
+      //    This is the load-bearing assertion: it fails-on-regression because if
+      //    the token DB / KV stopped being network-scoped, B would read A's dir
+      //    and 'seed-token-A-1' would appear here.
+      // -------------------------------------------------------------------
+      const tokensB = b.payments.getTokens();
+      expect(tokensB.map((t) => t.id)).not.toContain('seed-token-A-1');
+      expect(tokensB).toHaveLength(0);
+      const balB = b.payments.getBalance().find((bb) => bb.symbol === 'UCT');
+      expect(balB).toBeUndefined();
+
+      // B's per-network token dir is a DIFFERENT path than A's.
+      expect(
+        fs.existsSync(path.join(SHARED_TOKENS_DIR, NETWORK_A, pkA)),
+      ).toBe(true); // A's still there...
+      // ...and they are genuinely different directories.
+      expect(path.join(SHARED_TOKENS_DIR, NETWORK_A, pkA)).not.toBe(
+        path.join(SHARED_TOKENS_DIR, NETWORK_B, pkA),
+      );
+
+      // -------------------------------------------------------------------
+      // 5) IDENTITY-SHARED — same address/chainPubkey (network-agnostic).
+      // -------------------------------------------------------------------
+      expect(b.identity!.chainPubkey).toBe(pkA);
+      expect(b.identity!.l1Address).toBe(l1A);
+      expect(b.identity!.directAddress).toBe(addrA);
+
+      // -------------------------------------------------------------------
+      // 6) CHAT SHARED — B sees the conversation A wrote (MESSAGES KV is
+      //    per-address but NOT network-scoped → same key across networks).
+      // -------------------------------------------------------------------
+      const convB = b.communications.getConversations();
+      const peerConvB = [...convB.values()].flat();
+      expect(peerConvB.some((m) => m.content === 'hello across networks')).toBe(true);
+
+      await b.destroy();
+    },
+    60_000,
+  );
+
+  it(
+    'control: SAME network + same dirs → B DOES see A token (proves the dir is shared, isolation is by network only)',
+    async () => {
+      // This negative control proves the previous test isn't passing for a
+      // trivial reason (e.g. B always sees an empty store). With the SAME
+      // network, the per-network dir is identical, so the seeded token IS visible.
+      const a = await buildWallet(NETWORK_A);
+      const added = await a.payments.addToken(makeSeedToken('seed-token-same-net'));
+      expect(added).toBe(true);
+      const pk = a.identity!.chainPubkey;
+      await a.destroy();
+      (Sphere as unknown as { instance: Sphere | null }).instance = null;
+
+      const b = await buildWallet(NETWORK_A); // SAME network this time
+      expect(b.identity!.chainPubkey).toBe(pk);
+      const tokensB = b.payments.getTokens();
+      expect(tokensB.map((t) => t.id)).toContain('seed-token-same-net');
+      await b.destroy();
+    },
+    60_000,
+  );
+});

--- a/tests/integration/token-storage-network.test.ts
+++ b/tests/integration/token-storage-network.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Integration test: TOKEN storage providers are NETWORK-ISOLATED.
+ *
+ * The token stores (FileTokenStorageProvider on Node, IndexedDBTokenStorageProvider
+ * in the browser) physically separate a wallet's tokens per network so a testnet2
+ * balance can never be mistaken for / overwritten by / wiped together with a
+ * testnet (or mainnet) balance for the SAME wallet identity (same chainPubkey).
+ *
+ *   - Node:   {baseTokensDir}/{network}/{chainPubkey}/   — network is a path segment.
+ *   - Browser: db name `sphere-token-storage-{network}-{chainPubkey}` — network is
+ *              baked into the db-name prefix.
+ *
+ * Two regressions are guarded here:
+ *
+ * 1. createForAddress() must PRESERVE the network. The per-address sub-provider
+ *    that Sphere spins up for each wallet address used to drop `network` on the
+ *    Node side (browser preserved it via the network-baked dbNamePrefix). A
+ *    dropped network collapses every network's tokens into one shared dir — the
+ *    exact fund-mixing this isolation exists to prevent.
+ *
+ * 2. clear() on ONE network must NOT wipe ANOTHER network's tokens. Browser
+ *    clear() wipes every database sharing its dbNamePrefix; because the prefix
+ *    is per-network, clearing testnet2 must leave testnet's tokens intact.
+ *    A network-blind clear() would be a wallet-wipe catastrophe.
+ *
+ * Identity factory mirrors the unit tests: distinct directAddresses MUST produce
+ * distinct chainPubkeys (the real per-wallet key), so two wallets never collide.
+ */
+
+import { describe, it, expect } from 'vitest';
+import 'fake-indexeddb/auto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FileTokenStorageProvider } from '../../impl/nodejs/storage/FileTokenStorageProvider';
+import { IndexedDBTokenStorageProvider } from '../../impl/browser/storage/IndexedDBTokenStorageProvider';
+import type { TxfStorageDataBase } from '../../storage';
+import type { FullIdentity } from '../../types';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Distinct addresses must produce distinct chainPubkeys (the real per-wallet
+ * identifier the token store keys on), matching the unit-test identity factory.
+ */
+function createIdentity(directAddress: string): FullIdentity {
+  return {
+    privateKey: '0'.repeat(64),
+    chainPubkey: '02' + Buffer.from(directAddress).toString('hex').padEnd(64, '0').slice(0, 64),
+    l1Address: 'alpha1testaddr',
+    directAddress,
+    nametag: 'testuser',
+  } as unknown as FullIdentity;
+}
+
+function createTxfData(tokenIds: string[]): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: {
+      version: 1,
+      address: 'alpha1test',
+      formatVersion: '2.0',
+      updatedAt: Date.now(),
+    },
+  };
+  for (const id of tokenIds) {
+    (data as Record<string, unknown>)[`_${id}`] = {
+      version: '2.0',
+      state: { tokenId: id },
+      transactions: [],
+    };
+  }
+  return data;
+}
+
+/** Count real token keys in TXF data (exclude meta/tombstones/outbox/sent/invalid). */
+function countTokens(data: TxfStorageDataBase): number {
+  return Object.keys(data).filter(
+    k => k.startsWith('_') && !['_meta', '_tombstones', '_outbox', '_sent', '_invalid'].includes(k),
+  ).length;
+}
+
+function hasToken(data: TxfStorageDataBase, id: string): boolean {
+  return (data as Record<string, unknown>)[`_${id}`] !== undefined;
+}
+
+// =============================================================================
+// 1. createForAddress() PRESERVES network (regression)
+// =============================================================================
+
+describe('Token storage: createForAddress() preserves network (regression)', () => {
+  it('Node FileTokenStorageProvider child keeps the network path segment', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sphere-token-net-'));
+    const id = createIdentity('DIRECT://node-preserve-aaaa');
+
+    const parent = new FileTokenStorageProvider({ tokensDir: tmpDir, network: 'testnet2' });
+    parent.setIdentity(id);
+
+    // The per-address sub-provider Sphere spins up for each wallet address.
+    const child = parent.createForAddress();
+    child.setIdentity(id);
+
+    // Resolved dir must be {tmpDir}/testnet2/{chainPubkey}/ — the network segment
+    // MUST survive createForAddress(). Before the fix it was {tmpDir}/{chainPubkey}/.
+    const resolvedDir = (child as unknown as { tokensDir: string }).tokensDir;
+    expect(resolvedDir).toContain(path.join('testnet2', id.chainPubkey));
+  });
+
+  it('Browser IndexedDBTokenStorageProvider child keeps the network db prefix', () => {
+    const id = createIdentity('DIRECT://browser-preserve-bbbb');
+
+    const parent = new IndexedDBTokenStorageProvider({ network: 'testnet2' });
+    const child = parent.createForAddress();
+    child.setIdentity(id);
+
+    // db name = `sphere-token-storage-testnet2-{chainPubkey}`. The network must be
+    // baked into the prefix so it survives createForAddress().
+    const resolvedDb = (child as unknown as { dbName: string }).dbName;
+    expect(resolvedDb.startsWith('sphere-token-storage-testnet2')).toBe(true);
+  });
+
+  it('Node child WITHOUT a configured network has NO network segment (sanity)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sphere-token-nonet-'));
+    const id = createIdentity('DIRECT://node-nonet-cccc');
+
+    const parent = new FileTokenStorageProvider({ tokensDir: tmpDir });
+    const child = parent.createForAddress();
+    child.setIdentity(id);
+
+    const resolvedDir = (child as unknown as { tokensDir: string }).tokensDir;
+    // No network configured → dir is just {tmpDir}/{chainPubkey}, never a stray
+    // 'testnet2' segment. Guards against the factory accidentally injecting one.
+    expect(resolvedDir).toBe(path.join(tmpDir, id.chainPubkey));
+    expect(resolvedDir).not.toContain('testnet2');
+  });
+});
+
+// =============================================================================
+// 2. clear() on one network does NOT wipe the other network's tokens
+// =============================================================================
+
+describe('Token storage: clear() is network-scoped (wallet-wipe guard)', () => {
+  it('Browser: clearing testnet2 leaves testnet tokens intact (real save/clear/load)', async () => {
+    // SAME wallet identity on two different networks. fake-indexeddb backs both.
+    const id = createIdentity('DIRECT://wipe-guard-dddd');
+
+    const t1 = new IndexedDBTokenStorageProvider({ network: 'testnet' });
+    const t2 = new IndexedDBTokenStorageProvider({ network: 'testnet2' });
+    t1.setIdentity(id);
+    t2.setIdentity(id);
+
+    // Different network → different physical database. This is what makes a
+    // clear() on one network unable to touch the other.
+    const db1 = (t1 as unknown as { dbName: string }).dbName;
+    const db2 = (t2 as unknown as { dbName: string }).dbName;
+    expect(db1).not.toBe(db2);
+
+    await t1.initialize();
+    await t2.initialize();
+
+    // Save a distinct token on each network.
+    expect((await t1.save(createTxfData(['tn1-token']))).success).toBe(true);
+    expect((await t2.save(createTxfData(['tn2-token']))).success).toBe(true);
+
+    // Sanity: each network reads back its own token.
+    expect(hasToken((await t1.load()).data!, 'tn1-token')).toBe(true);
+    expect(hasToken((await t2.load()).data!, 'tn2-token')).toBe(true);
+
+    // Wipe ONLY testnet2.
+    await t2.clear();
+
+    // testnet2 is empty...
+    const t2Verify = new IndexedDBTokenStorageProvider({ network: 'testnet2' });
+    t2Verify.setIdentity(id);
+    await t2Verify.initialize();
+    const t2After = await t2Verify.load();
+    expect(t2After.success).toBe(true);
+    expect(countTokens(t2After.data!)).toBe(0);
+    await t2Verify.shutdown();
+
+    // ...but testnet STILL has its token. clear() must not have crossed networks.
+    const t1Verify = new IndexedDBTokenStorageProvider({ network: 'testnet' });
+    t1Verify.setIdentity(id);
+    await t1Verify.initialize();
+    const t1After = await t1Verify.load();
+    expect(t1After.success).toBe(true);
+    expect(hasToken(t1After.data!, 'tn1-token')).toBe(true);
+    expect(countTokens(t1After.data!)).toBe(1);
+    await t1Verify.shutdown();
+
+    await t1.shutdown();
+    await t2.shutdown();
+  });
+
+  it('Node: clearing testnet2 leaves testnet tokens intact (separate dirs)', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sphere-token-clear-'));
+    const id = createIdentity('DIRECT://node-wipe-eeee');
+
+    const t1 = new FileTokenStorageProvider({ tokensDir: tmpDir, network: 'testnet' });
+    const t2 = new FileTokenStorageProvider({ tokensDir: tmpDir, network: 'testnet2' });
+    t1.setIdentity(id);
+    t2.setIdentity(id);
+
+    // Same base dir, same wallet, different network → different resolved dir.
+    const dir1 = (t1 as unknown as { tokensDir: string }).tokensDir;
+    const dir2 = (t2 as unknown as { tokensDir: string }).tokensDir;
+    expect(dir1).not.toBe(dir2);
+
+    await t1.initialize();
+    await t2.initialize();
+
+    expect((await t1.save(createTxfData(['tn1-token']))).success).toBe(true);
+    expect((await t2.save(createTxfData(['tn2-token']))).success).toBe(true);
+
+    // Wipe ONLY testnet2.
+    await t2.clear();
+
+    // testnet2 dir is empty of tokens...
+    expect(countTokens((await t2.load()).data!)).toBe(0);
+
+    // ...but testnet's token survives untouched.
+    const t1After = await t1.load();
+    expect(hasToken(t1After.data!, 'tn1-token')).toBe(true);
+    expect(countTokens(t1After.data!)).toBe(1);
+
+    await t1.shutdown();
+    await t2.shutdown();
+  });
+});

--- a/tests/unit/impl/browser/IndexedDBStorageProvider.test.ts
+++ b/tests/unit/impl/browser/IndexedDBStorageProvider.test.ts
@@ -34,7 +34,9 @@ function createProvider(dbName?: string): IndexedDBStorageProvider {
 function createIdentity(directAddress = 'DIRECT://abcdef1234567890'): FullIdentity {
   return {
     privateKey: '0'.repeat(64),
-    chainPubkey: '02' + 'a'.repeat(64),
+    // Per-address storage is now keyed by chainPubkey, so distinct addresses must
+    // produce distinct chainPubkeys (realistic — directAddress is derived 1:1 from chainPubkey).
+    chainPubkey: '02' + Buffer.from(directAddress).toString('hex').padEnd(64, '0').slice(0, 64),
     l1Address: 'alpha1testaddr',
     directAddress,
     nametag: 'testuser',

--- a/tests/unit/impl/browser/IndexedDBTokenStorageProvider.test.ts
+++ b/tests/unit/impl/browser/IndexedDBTokenStorageProvider.test.ts
@@ -31,7 +31,10 @@ function createProvider(prefix?: string): IndexedDBTokenStorageProvider {
 function createIdentity(directAddress: string): FullIdentity {
   return {
     privateKey: '0'.repeat(64),
-    chainPubkey: '02' + 'a'.repeat(64),
+    // directAddress is derived from chainPubkey 1:1 in reality, so distinct addresses
+    // MUST have distinct pubkeys. The token DB is now keyed by chainPubkey, so vary it
+    // per address — otherwise this fixture would (unrealistically) collide two addresses.
+    chainPubkey: '02' + Buffer.from(directAddress).toString('hex').padEnd(64, '0').slice(0, 64),
     l1Address: 'alpha1testaddr',
     directAddress,
     nametag: 'testuser',

--- a/tests/unit/impl/ipfs/ipns-network.test.ts
+++ b/tests/unit/impl/ipfs/ipns-network.test.ts
@@ -1,0 +1,32 @@
+/**
+ * IPNS identity is per-network: the same wallet key derives a DISTINCT IPNS name per network,
+ * so a v2 (testnet2) wallet cannot re-pull v1 (testnet) tokens from the old shared IPNS record.
+ * The network is baked into the HKDF info (`${IPNS_HKDF_INFO}:${network}`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveIpnsName } from '../../../../impl/shared/ipfs/ipns-key-derivation';
+
+const PK = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+describe('deriveIpnsName — per-network IPNS', () => {
+  it('differs per network for the same wallet key (closes v1-via-IPFS re-pull)', async () => {
+    const t2 = await deriveIpnsName(PK, 'testnet2');
+    const t1 = await deriveIpnsName(PK, 'testnet');
+    expect(t2).not.toBe(t1);
+  });
+
+  it('is deterministic per (key, network)', async () => {
+    const a = await deriveIpnsName(PK, 'testnet2');
+    const b = await deriveIpnsName(PK, 'testnet2');
+    expect(a).toBe(b);
+  });
+
+  it('no-network (legacy) is deterministic and differs from any network-scoped name', async () => {
+    const legacy = await deriveIpnsName(PK);
+    const legacy2 = await deriveIpnsName(PK);
+    const scoped = await deriveIpnsName(PK, 'testnet2');
+    expect(legacy).toBe(legacy2);
+    expect(legacy).not.toBe(scoped);
+  });
+});

--- a/tests/unit/impl/storage/token-db-network.test.ts
+++ b/tests/unit/impl/storage/token-db-network.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Token storage DB name is per-network + keyed by chainPubkey.
+ *
+ * Same mnemonic on testnet(v1) and testnet2(v2) used to share ONE DB
+ * (sphere-token-storage-{addressId}) — mixing v1/v2 tokens. Now the network is
+ * baked into the prefix and the identity component is the full chainPubkey
+ * (always present, not truncated like getAddressId's DIRECT_first6_last6).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IndexedDBTokenStorageProvider } from '../../../../impl/browser/storage/IndexedDBTokenStorageProvider';
+import type { FullIdentity } from '../../../../types';
+
+const identity = {
+  chainPubkey: '03aabb',
+  directAddress: 'DIRECT://xyz',
+  l1Address: 'alpha1xyz',
+  privateKey: 'priv',
+  publicKey: 'pub',
+} as unknown as FullIdentity;
+
+const dbNameOf = (p: IndexedDBTokenStorageProvider): string =>
+  (p as unknown as { dbName: string }).dbName;
+
+describe('IndexedDBTokenStorageProvider — per-network DB name', () => {
+  it('bakes the network into the DB name (network before chainPubkey)', () => {
+    const p = new IndexedDBTokenStorageProvider({ network: 'testnet2' });
+    p.setIdentity(identity);
+    expect(dbNameOf(p)).toBe('sphere-token-storage-testnet2-03aabb');
+  });
+
+  it('different networks → different DB for the SAME chainPubkey (network is the separator)', () => {
+    const t2 = new IndexedDBTokenStorageProvider({ network: 'testnet2' });
+    const t1 = new IndexedDBTokenStorageProvider({ network: 'testnet' });
+    t2.setIdentity(identity);
+    t1.setIdentity(identity);
+    expect(dbNameOf(t2)).toBe('sphere-token-storage-testnet2-03aabb');
+    expect(dbNameOf(t1)).toBe('sphere-token-storage-testnet-03aabb');
+    expect(dbNameOf(t2)).not.toBe(dbNameOf(t1));
+  });
+
+  it('no network → legacy-shaped name (backward compatible for direct usage)', () => {
+    const p = new IndexedDBTokenStorageProvider();
+    p.setIdentity(identity);
+    expect(dbNameOf(p)).toBe('sphere-token-storage-03aabb');
+  });
+});

--- a/tests/unit/modules/AccountingModule.closeCancel.test.ts
+++ b/tests/unit/modules/AccountingModule.closeCancel.test.ts
@@ -23,7 +23,6 @@ import type {
   InvoiceTransferRef,
   FrozenInvoiceBalances,
 } from '../../../modules/accounting/types.js';
-import { getAddressId } from '../../../constants.js';
 
 // ---------------------------------------------------------------------------
 // Private-field helpers
@@ -211,7 +210,7 @@ function getEmitEvent(module: AccountingModule): ReturnType<typeof vi.fn> {
 
 /** Compute storage key as the module does internally (uses condensed addressId). */
 function storageKey(storageKeyName: string): string {
-  return `${getAddressId(DEFAULT_TEST_IDENTITY.directAddress!)}_${storageKeyName}`;
+  return `${DEFAULT_TEST_IDENTITY.chainPubkey}_${storageKeyName}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/modules/AccountingModule.lifecycle.test.ts
+++ b/tests/unit/modules/AccountingModule.lifecycle.test.ts
@@ -18,7 +18,7 @@ import {
 } from './accounting-test-helpers.js';
 import type { AccountingModule } from '../../../modules/accounting/AccountingModule.js';
 import type { TestAccountingModuleMocks } from './accounting-test-helpers.js';
-import { STORAGE_KEYS_ADDRESS, getAddressId } from '../../../constants.js';
+import { STORAGE_KEYS_ADDRESS } from '../../../constants.js';
 
 // =============================================================================
 // Shared setup
@@ -154,7 +154,7 @@ describe('UT-LIFECYCLE-003: load() loads terminal state from storage', () => {
     const storage = createMockStorageProvider();
     setup({ storage });
 
-    const addressId = getAddressId(mocks.identity.directAddress!);
+    const addressId = mocks.identity.chainPubkey;
     const cancelledKey = `${addressId}_${STORAGE_KEYS_ADDRESS.CANCELLED_INVOICES}`;
     const closedKey = `${addressId}_${STORAGE_KEYS_ADDRESS.CLOSED_INVOICES}`;
     const frozenKey = `${addressId}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
@@ -208,7 +208,7 @@ describe('UT-LIFECYCLE-004: load() recovers auto-return settings', () => {
     const storage = createMockStorageProvider();
     setup({ storage });
 
-    const addressId = getAddressId(mocks.identity.directAddress!);
+    const addressId = mocks.identity.chainPubkey;
     const autoReturnKey = `${addressId}_${STORAGE_KEYS_ADDRESS.AUTO_RETURN}`;
     const invoiceId = 'c'.repeat(64);
 

--- a/tests/unit/modules/AccountingModule.payReturn.test.ts
+++ b/tests/unit/modules/AccountingModule.payReturn.test.ts
@@ -17,7 +17,6 @@ import {
   SphereError,
   INVOICE_TOKEN_TYPE_HEX,
 } from './accounting-test-helpers.js';
-import { getAddressId } from '../../../constants.js';
 import { hashInvoiceId } from '../../../modules/accounting/memo.js';
 import type { InvoiceTerms, InvoiceTransferRef } from '../../../modules/accounting/types.js';
 import type { Token } from '../../../types/index.js';
@@ -36,13 +35,13 @@ const SENDER_ADDRESS = 'DIRECT://sender_address_def456';
 const TARGET_ADDRESS = 'DIRECT://test_target_address_abc123';
 
 /**
- * The AccountingModule derives its storage key prefix via getAddressId():
- *   getAddressStorageKey(getAddressId(identity.directAddress), subKey)
- *     = `DIRECT_test_t_abc123_${subKey}`
+ * The AccountingModule derives its storage key prefix from the chainPubkey:
+ *   getAddressStorageKey(identity.chainPubkey, subKey)
+ *     = `${identity.chainPubkey}_${subKey}`
  *
- * DEFAULT_TEST_IDENTITY.directAddress = 'DIRECT://test_target_address_abc123'
+ * DEFAULT_TEST_IDENTITY.chainPubkey = '02' + 'a'.repeat(64)
  */
-const STORAGE_PREFIX = getAddressId(DEFAULT_TEST_IDENTITY.directAddress!);
+const STORAGE_PREFIX = DEFAULT_TEST_IDENTITY.chainPubkey;
 
 /** Build a Token shape that load() will parse as an invoice token. */
 function makeInvoiceToken(terms: InvoiceTerms, tokenId: string = INVOICE_ID): Token {
@@ -374,7 +373,7 @@ describe('AccountingModule.returnInvoicePayment()', () => {
     // forward payment entry from SENDER_ADDRESS → TARGET_ADDRESS when load() runs.
     //
     // AccountingModule._loadInvoiceTransferIndex() reads:
-    //   key: getAddressStorageKey(getAddressId(identity.directAddress), 'inv_ledger:{invoiceId}')
+    //   key: getAddressStorageKey(identity.chainPubkey, 'inv_ledger:{invoiceId}')
     //      = `${STORAGE_PREFIX}_inv_ledger:${INVOICE_ID}`
     //   format: Record<string, InvoiceTransferRef>  (keyed by composite entryKey)
     const entryKey = `mock-transfer-001::UCT`;

--- a/tests/unit/modules/AccountingModule.storage.test.ts
+++ b/tests/unit/modules/AccountingModule.storage.test.ts
@@ -19,7 +19,7 @@ import {
 } from './accounting-test-helpers.js';
 import type { AccountingModule } from '../../../modules/accounting/AccountingModule.js';
 import type { TestAccountingModuleMocks } from './accounting-test-helpers.js';
-import { STORAGE_KEYS_ADDRESS, getAddressId } from '../../../constants.js';
+import { STORAGE_KEYS_ADDRESS } from '../../../constants.js';
 
 // Mock SDK Token to prevent cross-file mock contamination when run alongside
 // other test files (e.g., importInvoice, validation, errors) that mock this module.
@@ -60,9 +60,9 @@ describe('UT-STORAGE: cancelled/closed set persistence', () => {
   beforeEach(() => setup());
 
   it('load() restores cancelled set from storage', async () => {
-    const directAddress = mocks.identity.directAddress!;
-    const cancelledKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.CANCELLED_INVOICES}`;
-    const frozenKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
+    const chainPubkey = mocks.identity.chainPubkey;
+    const cancelledKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.CANCELLED_INVOICES}`;
+    const frozenKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
 
     const cancelledId = 'a'.repeat(64);
     mocks.storage._data.set(cancelledKey, JSON.stringify([cancelledId]));
@@ -85,9 +85,9 @@ describe('UT-STORAGE: cancelled/closed set persistence', () => {
   });
 
   it('load() restores closed set from storage', async () => {
-    const directAddress = mocks.identity.directAddress!;
-    const closedKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.CLOSED_INVOICES}`;
-    const frozenKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
+    const chainPubkey = mocks.identity.chainPubkey;
+    const closedKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.CLOSED_INVOICES}`;
+    const frozenKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
 
     const closedId = 'b'.repeat(64);
     mocks.storage._data.set(closedKey, JSON.stringify([closedId]));
@@ -119,9 +119,9 @@ describe('UT-STORAGE: frozen balances persistence', () => {
   beforeEach(() => setup());
 
   it('load() restores frozen balances from storage', async () => {
-    const directAddress = mocks.identity.directAddress!;
-    const frozenKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
-    const closedKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.CLOSED_INVOICES}`;
+    const chainPubkey = mocks.identity.chainPubkey;
+    const frozenKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
+    const closedKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.CLOSED_INVOICES}`;
 
     const closedId = 'c'.repeat(64);
     const frozenData = {
@@ -154,8 +154,8 @@ describe('UT-STORAGE: auto-return settings persistence', () => {
   beforeEach(() => setup());
 
   it('load() restores auto-return settings from storage', async () => {
-    const directAddress = mocks.identity.directAddress!;
-    const autoReturnKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.AUTO_RETURN}`;
+    const chainPubkey = mocks.identity.chainPubkey;
+    const autoReturnKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.AUTO_RETURN}`;
     const invoiceId = 'd'.repeat(64);
 
     mocks.storage._data.set(autoReturnKey, JSON.stringify({
@@ -179,8 +179,8 @@ describe('UT-STORAGE: crash recovery — terminal sets loaded before frozen bala
   beforeEach(() => setup());
 
   it('forward reconciliation: frozen balance without terminal entry gets auto-added', async () => {
-    const directAddress = mocks.identity.directAddress!;
-    const frozenKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
+    const chainPubkey = mocks.identity.chainPubkey;
+    const frozenKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
     // Do NOT set cancelled/closed keys — simulate crash after frozen save but before terminal set save
 
     const invoiceId = 'e'.repeat(64);
@@ -256,8 +256,8 @@ describe('UT-STORAGE: corrupted storage data handled gracefully', () => {
   beforeEach(() => setup());
 
   it('load() handles corrupted cancelled set JSON gracefully', async () => {
-    const directAddress = mocks.identity.directAddress!;
-    const cancelledKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.CANCELLED_INVOICES}`;
+    const chainPubkey = mocks.identity.chainPubkey;
+    const cancelledKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.CANCELLED_INVOICES}`;
 
     mocks.storage._data.set(cancelledKey, 'NOT VALID JSON {{{');
 
@@ -269,8 +269,8 @@ describe('UT-STORAGE: corrupted storage data handled gracefully', () => {
   });
 
   it('load() handles corrupted frozen balances JSON gracefully', async () => {
-    const directAddress = mocks.identity.directAddress!;
-    const frozenKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
+    const chainPubkey = mocks.identity.chainPubkey;
+    const frozenKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.FROZEN_BALANCES}`;
 
     mocks.storage._data.set(frozenKey, '<<CORRUPT>>');
 
@@ -281,8 +281,8 @@ describe('UT-STORAGE: corrupted storage data handled gracefully', () => {
   });
 
   it('load() handles corrupted auto-return settings gracefully', async () => {
-    const directAddress = mocks.identity.directAddress!;
-    const autoReturnKey = `${getAddressId(directAddress)}_${STORAGE_KEYS_ADDRESS.AUTO_RETURN}`;
+    const chainPubkey = mocks.identity.chainPubkey;
+    const autoReturnKey = `${chainPubkey}_${STORAGE_KEYS_ADDRESS.AUTO_RETURN}`;
 
     mocks.storage._data.set(autoReturnKey, '!!!');
 

--- a/tests/unit/modules/SwapModule.lifecycle.test.ts
+++ b/tests/unit/modules/SwapModule.lifecycle.test.ts
@@ -17,6 +17,7 @@ import {
   createMockStorageProvider,
   SphereError,
   DEFAULT_TEST_PARTY_A_ADDRESS,
+  DEFAULT_TEST_PARTY_A_PUBKEY,
 } from './swap-test-helpers.js';
 import type { TestSwapModuleMocks } from './swap-test-helpers.js';
 import { STORAGE_KEYS_ADDRESS, getAddressStorageKey } from '../../../constants.js';
@@ -76,7 +77,8 @@ describe('SwapModule Lifecycle', () => {
     module = result.module;
     mocks = result.mocks;
 
-    const addressId = DEFAULT_TEST_PARTY_A_ADDRESS;
+    // Per-wallet swap storage is keyed by the identity's chainPubkey (matches SwapModule).
+    const addressId = DEFAULT_TEST_PARTY_A_PUBKEY;
 
     // Pre-populate storage with an index and one active swap record
     const activeSwapRef = createTestSwapRef({ progress: 'announced' });

--- a/tests/unit/modules/SwapModule.storage.test.ts
+++ b/tests/unit/modules/SwapModule.storage.test.ts
@@ -17,7 +17,7 @@ import {
   createTestSwapDeal,
   injectSwapRef,
   SphereError,
-  DEFAULT_TEST_PARTY_A_ADDRESS,
+  DEFAULT_TEST_PARTY_A_PUBKEY,
   DEFAULT_TEST_PARTY_B_TRANSPORT_PUBKEY,
   DEFAULT_TEST_ESCROW_TRANSPORT_PUBKEY,
   DEFAULT_TEST_ESCROW_ADDRESS,
@@ -39,7 +39,8 @@ describe('SwapModule Storage', () => {
   let module: SwapModule;
   let mocks: TestSwapModuleMocks;
 
-  const addressId = DEFAULT_TEST_PARTY_A_ADDRESS;
+  // Per-wallet swap storage is keyed by the identity's chainPubkey (matches SwapModule).
+  const addressId = DEFAULT_TEST_PARTY_A_PUBKEY;
 
   afterEach(async () => {
     try {


### PR DESCRIPTION
## Summary
Finishes the v1→v2 migration by isolating wallet storage **per network**. The same mnemonic on testnet (v1, networkId 3) and testnet2 (v2, networkId 4) no longer shares a token DB / KV / IPNS, so v1 tokens and cross-network operational state can never leak into a v2 wallet. Ships as `0.8.0-dev.6`.

Fresh-start cutover (no real testnet2 users): old token DBs / IPNS records / per-address KV orphan; only seed/global keys stay.

## Changes
- **Token DB per-network:** `sphere-token-storage-{network}-{chainPubkey}` (browser bakes network into `dbNamePrefix`; node `FileTokenStorageProvider` tokensDir = `{base}/{network}/{chainPubkey}`). `createForAddress()` now **preserves network** — node was dropping it (would mix testnet/testnet2 tokens for non-primary addresses).
- **KV surgical network-scope:** only **token/payment** per-address keys get a `{network}_` segment, via the explicit allow-list `isNetworkScopedAddressKey()` (bare keys + composite `swap:` / `inv_ledger:`). **Chat (`CONVERSATIONS`/`MESSAGES`/`GROUP_CHAT_*`) and seed/global keys stay SHARED** (network-agnostic). Applied in IndexedDB / File / LocalStorage `getFullKey` (three-tier: global→`{key}`; chat/per-address→`{addressId}_{key}`; token-payment→`{network}_{addressId}_{key}`).
- **chainPubkey is the storage identifier everywhere** (token DB + 3 KV providers + AccountingModule + SwapModule), replacing the truncated `getAddressId(directAddress)` — removes truncation collisions + makes node/browser consistent. SwapModule's `directAddress ? directAddress : chainPubkey` ternary (optional-field key-flip risk) → stable chainPubkey. Nametag/tracking identity cache intentionally left on `getAddressId` (network-agnostic, deferred separate refactor).
- **IPNS per-network:** HKDF info `${IPNS_HKDF_INFO}:${network}` in `deriveIpnsIdentity`/`deriveIpnsName` → distinct IPNS record per network (closes v1-via-IPFS re-pull). sphere uses the SDK derivation (no separate webapp IPNS code) → bumping sphere satisfies the cross-device contract; old IPNS records orphan.

## Tests (27, adversarially verified)
- `kv-network-isolation` (6) — token/payment isolated, chat+seed shared (real IndexedDB).
- `kv-network-isolation-extra` (8) — composite `swap:`/`inv_ledger:` keys, CRUD `has`/`remove`/`keys`, AUTO_RETURN isolated, GROUP_CHAT shared.
- `token-storage-network` (5) — createForAddress preserves network + `clear()` network-scoped (no cross-network wipe), browser + node.
- `file-storage-network-isolation` (6) — node FileStorageProvider KV parity.
- `sphere-network-isolation.e2e` (2) — **Sphere-level e2e**: wallet A (testnet2) seeds a token → wallet B (same mnemonic, testnet) inventory is empty; identity + chat shared. Negative control + fault-injection confirm fail-on-regression.
- unit: `token-db-network`, `ipns-network`.

Verified by adversarial review (would-fail-on-pre-fix-code) and actual source fault-injection.

## Decisions (intentionally NOT done)
- **`TxfMeta.networkId` stamp — dropped.** Self-declared (our SDK writes it), not cryptographically bound. The token's own `genesis.networkId`, verified against the trust base, is authoritative.
- **Custom wrong-network / invalid-token guard — not added.** state-transition v2 has a built-in guard `MintNetworkMatchesTrustBaseRule` (rejects a token whose `genesis.networkId != trustBase.networkId`) that runs at **receive** and **spend**; isolation prevents wrong-network tokens from loading in the first place.

## ⚠️ Note (follow-up candidate, out of scope here)
load/display do **not** re-validate stored tokens: a token blob already in local storage is loaded raw and summed into the balance (only `status spent/invalid` is excluded). So a **stored** wrong-network/forged token (injection, or an SDK bug) shows a fake balance until the user tries to spend it — at which point verification rejects it and **settlement is safe** (no double-spend/theft). **Receive IS validated** (`engine.decodeToken` / `oracle.validateToken`). A load-time re-validation (run engine decode on load, KEEP-biased exclude) could close the display window as a future feature.

## Gate
- `tsc --noEmit` = 0
- full `vitest run` green except the documented Windows-only EPERM-rename flake (passes in isolation; Linux CI clean)
- `eslint` = 0 new errors (2 pre-existing in unrelated `tests/e2e/swap-continuous.test.ts`)
- DTS build: confirmed on Linux/CI (Windows+node22 segfault is the known false alarm)

## Next
After merge: publish `0.8.0-dev.6` via Actions, bump sphere → dev.6 + manual smoke. Then Part 2 (v1 removal) → dev.7.