### PR TITLE
fix(payments): verify incoming v2 transfers + engine-aware validate()

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -5499,6 +5499,19 @@ export class PaymentsModule {
       return;
     }
 
+    // Security: the sender hands us a FINISHED token — verify it cryptographically
+    // and confirm its final state is actually locked to this wallet before it
+    // enters the balance. Both checks are local (trust base + predicate bytes).
+    const verdict = await engine.verify(token);
+    if (!verdict.ok) {
+      logger.warn('Payments', `V2 transfer rejected: verification failed (${verdict.reason ?? 'unknown'})`);
+      return;
+    }
+    if (!engine.isOwnedBy(token, engine.getIdentity().chainPubkey)) {
+      logger.warn('Payments', 'V2 transfer rejected: token not addressed to this wallet');
+      return;
+    }
+
     // Dedup by genesis-stable id (a re-delivered identical token is ignored).
     const id = `v2_${engine.tokenId(token)}`;
     if (this.tokens.has(id)) {

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -5070,7 +5070,30 @@ export class PaymentsModule {
     const valid: Token[] = [];
     const invalid: Token[] = [];
 
+    const engine = this.deps?.tokenEngine;
     for (const token of this.tokens.values()) {
+      // v2 blob tokens are verified via the engine (local proof check + on-chain
+      // spent-status); the oracle's validateToken only understands v1 TXF.
+      if (engine && token.sdkData && looksLikeTokenBlob(token.sdkData)) {
+        try {
+          const sphereToken = await engine.decodeToken(decodeTokenBlob(hexToBytes(token.sdkData)));
+          const verdict = await engine.verify(sphereToken);
+          const spent = verdict.ok ? await engine.isSpent(sphereToken) : false;
+          if (verdict.ok && !spent) {
+            valid.push(token);
+          } else {
+            token.status = 'invalid';
+            this.parsedTokenCache.delete(token.id);
+            invalid.push(token);
+          }
+        } catch (err) {
+          // Transient failure (decode/network) — do NOT invalidate funds on an
+          // outage; skip this token for this run.
+          logger.warn('Payments', `validate: engine check failed for ${token.id}, skipping:`, err);
+        }
+        continue;
+      }
+
       const result = await this.deps!.oracle.validateToken(token.sdkData);
 
       if (result.valid && !result.spent) {

--- a/tests/unit/modules/PaymentsModule.v2-receive.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-receive.test.ts
@@ -22,7 +22,7 @@ import type { V2TransferPayload } from '../../../types/v2-transfer';
 const FAKE_PRIVATE_KEY = 'a'.repeat(64);
 const FAKE_PUBKEY = '02' + 'b'.repeat(64);
 const SENDER_TRANSPORT_PUBKEY = 'cc'.repeat(32);
-const RECIPIENT = new Uint8Array([0x02, ...new Array<number>(32).fill(7)]); // 33 bytes
+const FOREIGN_PUBKEY = new Uint8Array([0x02, ...new Array<number>(32).fill(7)]); // 33 bytes, NOT this wallet
 const UCT = '11'.repeat(32); // v2 coin ids are lowercase hex
 const BOB_CHAIN_PUBKEY = '02' + 'ee'.repeat(32); // recipient's 33-byte chain pubkey (hex)
 
@@ -123,8 +123,9 @@ function setup(engine = new FakeTokenEngine()) {
 
 async function v2Payload(
   engine: FakeTokenEngine, coinId: string, amount: bigint, memo?: string,
+  recipientPubkey: Uint8Array = engine.getIdentity().chainPubkey,
 ): Promise<V2TransferPayload> {
-  const st = await engine.mint({ recipientPubkey: RECIPIENT, value: { assets: [{ coinId, amount }] } });
+  const st = await engine.mint({ recipientPubkey, value: { assets: [{ coinId, amount }] } });
   return { type: 'V2_TRANSFER', version: '2.0', tokenBlob: bytesToHex(encodeTokenBlob(engine.encodeToken(st))), memo };
 }
 
@@ -175,6 +176,28 @@ describe('handleV2Transfer — v2 receiver (B1)', () => {
 
     expect(module.getTokens()).toHaveLength(1);
   });
+
+  it('rejects a token that fails engine verification (not stored, no event)', async () => {
+    class RejectingEngine extends FakeTokenEngine {
+      public override verify() {
+        return Promise.resolve({ ok: false, reason: 'NOT_AUTHENTICATED' });
+      }
+    }
+    const { module, engine, emitEvent } = setup(new RejectingEngine());
+    await deliver(module, await v2Payload(engine as FakeTokenEngine, UCT, 100n));
+
+    expect(module.getTokens()).toHaveLength(0);
+    expect(emitEvent.mock.calls.find((c: any[]) => c[0] === 'transfer:incoming')).toBeUndefined();
+    expect(module.getHistory().filter((h) => h.type === 'RECEIVED')).toHaveLength(0);
+  });
+
+  it('rejects a token whose final state is owned by a FOREIGN pubkey (not stored)', async () => {
+    const { module, engine, emitEvent } = setup();
+    await deliver(module, await v2Payload(engine, UCT, 100n, undefined, FOREIGN_PUBKEY));
+
+    expect(module.getTokens()).toHaveLength(0);
+    expect(emitEvent.mock.calls.find((c: any[]) => c[0] === 'transfer:incoming')).toBeUndefined();
+  });
 });
 
 describe('send — v2 engine path, whole-token (B1)', () => {
@@ -208,9 +231,10 @@ describe('send — v2 engine path, whole-token (B1)', () => {
     await deliver(module, await v2Payload(engine, UCT, 100n));
     await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
 
-    // Feed the emitted V2_TRANSFER into a fresh recipient wallet (same engine fixture).
+    // Feed the emitted V2_TRANSFER into a fresh recipient wallet (bob's identity,
+    // matching the transferred token's new owner predicate).
     const sentPayload = (transport.sendTokenTransfer as any).mock.calls[0][1];
-    const recipient = setup(engine);
+    const recipient = setup(new FakeTokenEngine({ chainPubkey: hexToBytes(BOB_CHAIN_PUBKEY) }));
     await deliver(recipient.module, sentPayload);
 
     expect(recipient.module.getTokens()).toHaveLength(1);
@@ -231,10 +255,10 @@ describe('send — v2 engine path, whole-token (B1)', () => {
     expect(tokens[0].amount).toBe('700');
     expect(tokens[0].status).toBe('confirmed');
 
-    // Recipient's V2_TRANSFER decodes to a 300 token.
+    // Recipient's V2_TRANSFER decodes to a 300 token (bob's wallet owns it).
     const sentPayload = (transport.sendTokenTransfer as any).mock.calls[0][1];
     expect(sentPayload.type).toBe('V2_TRANSFER');
-    const recipient = setup(engine);
+    const recipient = setup(new FakeTokenEngine({ chainPubkey: hexToBytes(BOB_CHAIN_PUBKEY) }));
     await deliver(recipient.module, sentPayload);
     expect(recipient.module.getTokens()[0].amount).toBe('300');
   });

--- a/tests/unit/modules/PaymentsModule.v2-validate.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-validate.test.ts
@@ -1,0 +1,187 @@
+/**
+ * validate() — engine branch for v2 blob tokens.
+ *
+ * v2 blob tokens are verified via the engine (verify + isSpent); legacy v1 TXF
+ * JSON tokens keep going through oracle.validateToken. Transient engine
+ * failures must NOT mark a token invalid (fund-visibility safety) — the token
+ * is skipped for that run. Clean harness (NO SDK vi.mock), mirrors
+ * PaymentsModule.v2-receive.test.ts.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createPaymentsModule, type PaymentsModuleDependencies } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity, Token } from '../../../types';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../../storage';
+import { FakeTokenEngine } from '../token-engine/FakeTokenEngine';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import { bytesToHex } from '../../../core/crypto';
+
+const FAKE_PRIVATE_KEY = 'a'.repeat(64);
+const FAKE_PUBKEY = '02' + 'b'.repeat(64);
+const UCT = '11'.repeat(32);
+
+function mockIdentity(): FullIdentity {
+  return {
+    chainPubkey: FAKE_PUBKEY, l1Address: 'alpha1x', directAddress: 'DIRECT://x',
+    privateKey: FAKE_PRIVATE_KEY, transportPubkey: 'dd'.repeat(32),
+  };
+}
+
+function mockStorage(): StorageProvider {
+  const s = new Map<string, string>();
+  return {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+}
+
+function mockHistoryStore() {
+  const entries = new Map<string, HistoryRecord>();
+  return {
+    addHistoryEntry: vi.fn(async (e: HistoryRecord) => { entries.set(e.dedupKey, e); }),
+    getHistoryEntries: vi.fn(async () => [...entries.values()]),
+    hasHistoryEntry: vi.fn(async (k: string) => entries.has(k)),
+    clearHistory: vi.fn(async () => entries.clear()),
+    importHistoryEntries: vi.fn(async () => 0),
+  };
+}
+
+function mockTokenStorage(): TokenStorageProvider<TxfStorageDataBase> {
+  return {
+    id: 'ts', name: 'ts', type: 'local',
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(true), shutdown: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue({ success: true, timestamp: 0 }),
+    load: vi.fn().mockResolvedValue({ success: false, source: 'local', timestamp: 0 }),
+    sync: vi.fn().mockResolvedValue({ success: true, added: 0, removed: 0, conflicts: 0 }),
+    ...mockHistoryStore(),
+  } as unknown as TokenStorageProvider<TxfStorageDataBase>;
+}
+
+function mockTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    isDevMode: () => false,
+  } as unknown as OracleProvider;
+}
+
+function setup(engine = new FakeTokenEngine()) {
+  const tsp = new Map<string, TokenStorageProvider<TxfStorageDataBase>>();
+  tsp.set('local', mockTokenStorage());
+  const oracle = mockOracle();
+  const deps: PaymentsModuleDependencies = {
+    identity: mockIdentity(), storage: mockStorage(), tokenStorageProviders: tsp,
+    transport: mockTransport(), oracle, emitEvent: vi.fn(), tokenEngine: engine,
+  };
+  const module = createPaymentsModule({ debug: false });
+  module.initialize(deps);
+  return { module, engine, oracle };
+}
+
+/** Mint a v2 token to the engine's own identity and store it as a confirmed UI token. */
+async function storeV2Token(
+  module: ReturnType<typeof setup>['module'], engine: FakeTokenEngine, amount: bigint,
+): Promise<Token> {
+  const st = await engine.mint({
+    recipientPubkey: engine.getIdentity().chainPubkey,
+    value: { assets: [{ coinId: UCT, amount }] },
+  });
+  const token: Token = {
+    id: `v2_${engine.tokenId(st)}`, coinId: UCT, symbol: 'UCT', name: 'UCT', decimals: 0,
+    amount: amount.toString(), status: 'confirmed', createdAt: Date.now(), updatedAt: Date.now(),
+    sdkData: bytesToHex(encodeTokenBlob(engine.encodeToken(st))),
+  };
+  await module.addToken(token);
+  return token;
+}
+
+/** Store a legacy v1 TXF JSON token (engine cannot decode it). */
+async function storeLegacyToken(module: ReturnType<typeof setup>['module']): Promise<Token> {
+  const txf = {
+    genesis: { data: { tokenId: 'aa'.repeat(34) } },
+    state: { hash: 'bb'.repeat(32) },
+  };
+  const token: Token = {
+    id: 'legacy_1', coinId: UCT, symbol: 'UCT', name: 'UCT', decimals: 0,
+    amount: '50', status: 'confirmed', createdAt: Date.now(), updatedAt: Date.now(),
+    sdkData: JSON.stringify(txf),
+  };
+  await module.addToken(token);
+  return token;
+}
+
+describe('validate() — v2 engine branch', () => {
+  it('classifies a verified, unspent v2 blob token as valid (status unchanged)', async () => {
+    const { module, engine } = setup();
+    const token = await storeV2Token(module, engine, 100n);
+
+    const { valid, invalid } = await module.validate();
+
+    expect(valid.map((t) => t.id)).toContain(token.id);
+    expect(invalid).toHaveLength(0);
+    expect(module.getTokens()[0].status).toBe('confirmed');
+  });
+
+  it('marks a v2 token failing engine verification as invalid', async () => {
+    const { module, engine } = setup();
+    const token = await storeV2Token(module, engine, 100n);
+    vi.spyOn(engine, 'verify').mockResolvedValue({ ok: false, reason: 'NOT_AUTHENTICATED' });
+
+    const { valid, invalid } = await module.validate();
+
+    expect(valid).toHaveLength(0);
+    expect(invalid.map((t) => t.id)).toContain(token.id);
+    expect(invalid[0].status).toBe('invalid');
+  });
+
+  it('marks a spent v2 token as invalid', async () => {
+    const { module, engine } = setup();
+    const token = await storeV2Token(module, engine, 100n);
+    vi.spyOn(engine, 'isSpent').mockResolvedValue(true);
+
+    const { invalid } = await module.validate();
+
+    expect(invalid.map((t) => t.id)).toContain(token.id);
+  });
+
+  it('skips (does NOT invalidate) a v2 token on a transient engine failure', async () => {
+    const { module, engine } = setup();
+    const token = await storeV2Token(module, engine, 100n);
+    vi.spyOn(engine, 'isSpent').mockRejectedValue(new Error('network down'));
+
+    const { valid, invalid } = await module.validate();
+
+    expect(valid).toHaveLength(0);
+    expect(invalid).toHaveLength(0);
+    expect(module.getTokens().find((t) => t.id === token.id)?.status).toBe('confirmed');
+  });
+
+  it('routes legacy v1 TXF JSON tokens through oracle.validateToken', async () => {
+    const { module, oracle } = setup();
+    const token = await storeLegacyToken(module);
+
+    const { valid } = await module.validate();
+
+    expect(oracle.validateToken).toHaveBeenCalledWith(token.sdkData);
+    expect(valid.map((t) => t.id)).toContain(token.id);
+  });
+});

--- a/tests/unit/token-engine/FakeTokenEngine.ts
+++ b/tests/unit/token-engine/FakeTokenEngine.ts
@@ -183,6 +183,12 @@ export class FakeTokenEngine implements ITokenEngine {
     return Promise.resolve(this.spent.has(this.idOf(token)));
   }
 
+  public isOwnedBy(token: SphereToken, pubkey: Uint8Array): boolean {
+    const owner = decodeFakeState(token.blob.token).owner;
+    if (owner.length !== pubkey.length) return false;
+    return owner.every((b, i) => b === pubkey[i]);
+  }
+
   public encodeToken(token: SphereToken): TokenBlob {
     return token.blob;
   }

--- a/tests/unit/token-engine/engine-contract.ts
+++ b/tests/unit/token-engine/engine-contract.ts
@@ -123,6 +123,17 @@ export function runEngineContract(name: string, makeEngine: () => ITokenEngine):
       expect(e.tokenId(again)).toBe(e.tokenId(t));
     });
 
+    it('isOwnedBy matches the current state owner and follows transfers', async () => {
+      const e = makeEngine();
+      const mine = e.getIdentity().chainPubkey;
+      const src = await mintSelf(e, 5n);
+      expect(e.isOwnedBy(src, mine)).toBe(true);
+      expect(e.isOwnedBy(src, PK_B)).toBe(false);
+      const recv = await e.transfer({ token: src, recipientPubkey: PK_B });
+      expect(e.isOwnedBy(recv, PK_B)).toBe(true);
+      expect(e.isOwnedBy(recv, mine)).toBe(false);
+    });
+
     it('carries an opaque on-chain memo on a whole-token transfer (readMemo)', async () => {
       const e = makeEngine();
       const src = await mintSelf(e, 1n);

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -300,6 +300,12 @@ export class SphereTokenEngine implements ITokenEngine {
     return result.status === VerificationStatus.OK ? { ok: true } : { ok: false, reason: String(result.status) };
   }
 
+  public isOwnedBy(token: SphereToken, pubkey: Uint8Array): boolean {
+    const owner = token.sdkToken.latestTransaction.recipient;
+    const claimed = EncodedPredicate.fromPredicate(SignaturePredicate.create(pubkey));
+    return EncodedPredicate.equals(owner, claimed);
+  }
+
   public async isSpent(token: SphereToken, _options?: EngineOpOptions): Promise<boolean> {
     // The token's current state id = what a future transfer would spend. Derive it via a
     // probe transfer (never submitted) — StateId depends only on the source's lock script
@@ -337,9 +343,7 @@ export class SphereTokenEngine implements ITokenEngine {
 
   /** Fail fast if this engine's key does not own the token's current state. */
   private assertOwned(token: SphereToken): void {
-    const owner = token.sdkToken.latestTransaction.recipient;
-    const mine = EncodedPredicate.fromPredicate(SignaturePredicate.create(this.deps.signingService.publicKey));
-    if (!EncodedPredicate.equals(owner, mine)) {
+    if (!this.isOwnedBy(token, this.deps.signingService.publicKey)) {
       throw new SphereError('Cannot transfer a token not owned by this engine identity', 'VALIDATION_ERROR');
     }
   }

--- a/token-engine/engine.ts
+++ b/token-engine/engine.ts
@@ -93,6 +93,12 @@ export interface ITokenEngine {
   verify(token: SphereToken, options?: EngineOpOptions): Promise<EngineVerifyResult>;
   /** Whether the token's current state has already been spent on the network. */
   isSpent(token: SphereToken, options?: EngineOpOptions): Promise<boolean>;
+  /**
+   * Whether the token's CURRENT state is locked to `SignaturePredicate(pubkey)`.
+   * Local + synchronous (predicate byte-compare, no network). The receive path
+   * uses it to reject tokens that are not actually addressed to this wallet.
+   */
+  isOwnedBy(token: SphereToken, pubkey: Uint8Array): boolean;
 
   // ── serialization ──────────────────────────────────────────────────────────
   /** Serialize a token for storage/transport. Synchronous. */


### PR DESCRIPTION
## What

Hardens the v2 receive path ahead of the v1 cutover (PR 1 of 3):

1. **`ITokenEngine.isOwnedBy(token, pubkey)`** — new port method (local, synchronous predicate compare). Implemented in `SphereTokenEngine` (refactored out of `assertOwned`) and `FakeTokenEngine`; covered by the shared engine contract suite, so both implementations are held to the same spec.
2. **`handleV2Transfer` now rejects unverified/foreign tokens.** Previously ANY decodable blob was stored as confirmed balance — no `engine.verify`, no check that the final state is locked to this wallet. The v1 receive arms (deleted in the next PR) were the only verifying receive paths. Both checks are local (trust base + predicate bytes), so no availability risk.
3. **`validate()` gets an engine branch.** v2 blob tokens are verified via `engine.verify` + `engine.isSpent`; previously they fell into `oracle.validateToken` (v1 TXF-first) and risked being marked `invalid`. Transient engine failures skip the token instead of invalidating funds. Legacy v1 TXF tokens keep the oracle path unchanged.

## Why now

Deleting the v1 receive/finalization stack without this change would leave the wallet storing arbitrary decodable blobs as balance with no verification anywhere on the receive path.

## Tests

- New `isOwnedBy` contract test (runs against BOTH FakeTokenEngine and SphereTokenEngine).
- `PaymentsModule.v2-receive.test.ts`: +2 rejection cases; fixtures now mint to the engine identity (matches real transfer semantics).
- New `PaymentsModule.v2-validate.test.ts` (5 cases: valid, verify-fail, spent, transient-failure skip, legacy oracle routing).
- typecheck clean; lint no new errors; unit suite green (4-6 known Windows EPERM FileStorageProvider flakes, reproduced identically on the base branch).