### PR TITLE
feat: mint + store the v2 UnicityIdToken at nametag registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,25 @@ consumed exclusively through the `token-engine/` port. Consequences:
   still point at v1-era aggregators — wallet operations there fail loudly until
   those gateways are cut over to the v2 protocol.
 - **`AccountingModuleDependencies.trustBase` removed** (the engine owns trust);
-  `accounting.importInvoice` accepts the v2 invoice blob (hex string).
+  `accounting.importInvoice` accepts the v2 invoice blob (hex string);
+  `CreateInvoiceResult.token` is now that hex blob `string` (was the v1
+  `TxfToken` object type).
+- **Oracle interface gains three REQUIRED members** the v2 engine is built
+  from: `getTrustBaseJson()`, `getAggregatorUrl()`, `getApiKey()` — custom
+  `OracleProvider` implementations must provide them.
+- **Send-failure money-safety:** finished-but-undelivered transfer blobs are
+  journaled (`PENDING_V2_DELIVERIES`) and replayed on `load()`; sources
+  certified on-chain during a failed send become terminal `'spent'` (never
+  restored to `'confirmed'`); tokens stuck `'transferring'` after a crash are
+  reconciled against the network on `load()`.
+- **Unicity ID on-chain claim is minted + stored at nametag registration**
+  (`registerNametag`, init/load recovery, address switch): a self-issued v2
+  `UnicityIdToken` saved as `NametagData { format: 'v2-cbor', token: <hex> }`
+  (`NametagData.token` widened to `object | string`). Best-effort + idempotent —
+  a gateway outage never fails registration; runtime name resolution stays
+  Nostr-binding-only. On networks without a v2 oracle config a warn is logged
+  on each load. New exports: `createUnicityIdMinter`, `IUnicityIdMinter`,
+  `UnicityIdMintResult` (token-engine).
 
 ### Added
 - **`cacheMessages` option for CommunicationsModule** — `communications: { cacheMessages: false }` in `SphereInitOptions` disables DM caching in memory and storage. Messages still flow through `onDirectMessage()` handlers and `message:dm` events, but are never stored. Useful for anonymous/ephemeral agents (e.g. LLM bots) that only need streaming DM reception. `sendDM()` still works but doesn't cache the sent message. Deduplication is skipped when caching is disabled.

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -3385,10 +3385,16 @@ export class Sphere {
   private ensureUnicityIdTokenStored(): void {
     const name = this._identity?.nametag;
     if (!name) return;
+    // Capture the address-bound collaborators NOW: the mint below is a
+    // multi-second network round-trip, and switchToAddress() swaps
+    // this._payments/this._identity synchronously — a late re-read would store
+    // address A's token into address B's nametag list.
+    const payments = this._payments;
+    const privateKey = this._identity?.privateKey;
     void (async () => {
       try {
         // Already stored for this address? (v2 entries carry the CBOR hex string.)
-        const existing = this._payments
+        const existing = payments
           .getNametags()
           .find((n) => n.name === name && n.format === 'v2-cbor' && typeof n.token === 'string');
         if (existing) return;
@@ -3400,7 +3406,6 @@ export class Sphere {
         };
         const trustBaseJson = oracle.getTrustBaseJson?.() ?? null;
         const aggregatorUrl = oracle.getAggregatorUrl?.();
-        const privateKey = this._identity?.privateKey;
         if (!trustBaseJson || !aggregatorUrl || !privateKey) {
           logger.warn('Sphere', `Unicity ID token for @${name} not minted (no v2 oracle config) — retried on next load`);
           return;
@@ -3413,7 +3418,7 @@ export class Sphere {
           trustBaseJson,
         });
         const result = await minter.mintUnicityIdToken(name);
-        await this._payments.setNametag({
+        await payments.setNametag({
           name,
           token: result.tokenCborHex,
           timestamp: Date.now(),

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -119,7 +119,7 @@ import {
   isSQLiteDatabase,
   isWalletDatEncrypted,
 } from '../serialization/wallet-dat';
-import { createSphereTokenEngine, deriveDirectAddress, type ITokenEngine } from '../token-engine';
+import { createSphereTokenEngine, createUnicityIdMinter, deriveDirectAddress, type ITokenEngine } from '../token-engine';
 import { normalizeNametag, isPhoneNumber } from '@unicitylabs/nostr-js-sdk';
 
 export function isValidNametag(nametag: string): boolean {
@@ -884,6 +884,9 @@ export class Sphere {
       // Now publish identity binding (with recovered nametag if found)
       progress?.({ step: 'syncing_identity', message: 'Publishing identity...' });
       await sphere.syncIdentityWithTransport();
+      // Re-mint + store the on-chain Unicity ID claim if it is missing
+      // (best-effort, idempotent — no-op without a nametag).
+      sphere.ensureUnicityIdTokenStored();
     }
 
     // Auto-discover previously used HD addresses
@@ -1093,6 +1096,9 @@ export class Sphere {
       // Publish identity binding (with recovered nametag if found)
       progress?.({ step: 'syncing_identity', message: 'Publishing identity...' });
       await sphere.syncIdentityWithTransport();
+      // Re-mint + store the on-chain Unicity ID claim if it is missing
+      // (best-effort, idempotent — no-op without a nametag).
+      sphere.ensureUnicityIdTokenStored();
     }
 
     // Mark wallet as created only after successful initialization
@@ -2393,8 +2399,9 @@ export class Sphere {
       await this.syncIdentityWithTransport();
     }
 
-    // If a new nametag was registered on switch, persist the cache and emit. D5: there is no
-    // on-chain nametag token to mint — the Nostr binding (published in registerNametag) is the record.
+    // If a new nametag was registered on switch, persist the cache and emit. The Nostr
+    // binding stays the registration record (D5); the on-chain UnicityIdToken claim is
+    // additionally minted + stored below, best-effort.
     if (newNametag) {
       await this.persistAddressNametags();
 
@@ -2403,6 +2410,10 @@ export class Sphere {
         addressIndex: index,
       });
     }
+
+    // Mint + store the on-chain Unicity ID claim for this address if missing
+    // (covers both a newly registered and a recovered nametag; no-op otherwise).
+    this.ensureUnicityIdTokenStored();
   }
 
   /**
@@ -3356,6 +3367,64 @@ export class Sphere {
       addressIndex: this._currentAddressIndex,
     });
     logger.debug('Sphere', `Unicity ID registered for address ${this._currentAddressIndex}:`, cleanNametag);
+
+    // Mint + store the on-chain claim (best-effort, never blocks registration).
+    this.ensureUnicityIdTokenStored();
+  }
+
+  /**
+   * Best-effort: mint + store the self-issued v2 UnicityIdToken for the current
+   * address's nametag. The on-chain claim is kept minted + stored at creation
+   * (as the v1 nametag mint did), while RUNTIME name resolution stays
+   * Nostr-binding-only per D5 — the token is not consumed anywhere yet.
+   *
+   * Fire-and-forget: a gateway outage or missing v2 oracle config never fails
+   * registration/load; the mint is deterministic per (name, address key), so a
+   * later load re-mints the identical token (lost-storage recovery).
+   */
+  private ensureUnicityIdTokenStored(): void {
+    const name = this._identity?.nametag;
+    if (!name) return;
+    void (async () => {
+      try {
+        // Already stored for this address? (v2 entries carry the CBOR hex string.)
+        const existing = this._payments
+          .getNametags()
+          .find((n) => n.name === name && n.format === 'v2-cbor' && typeof n.token === 'string');
+        if (existing) return;
+
+        const oracle = this._oracle as {
+          getTrustBaseJson?: () => unknown;
+          getAggregatorUrl?: () => string;
+          getApiKey?: () => string | undefined;
+        };
+        const trustBaseJson = oracle.getTrustBaseJson?.() ?? null;
+        const aggregatorUrl = oracle.getAggregatorUrl?.();
+        const privateKey = this._identity?.privateKey;
+        if (!trustBaseJson || !aggregatorUrl || !privateKey) {
+          logger.warn('Sphere', `Unicity ID token for @${name} not minted (no v2 oracle config) — retried on next load`);
+          return;
+        }
+
+        const minter = createUnicityIdMinter({
+          aggregatorUrl,
+          apiKey: oracle.getApiKey?.(),
+          privateKey: hexToBytes(privateKey),
+          trustBaseJson,
+        });
+        const result = await minter.mintUnicityIdToken(name);
+        await this._payments.setNametag({
+          name,
+          token: result.tokenCborHex,
+          timestamp: Date.now(),
+          format: 'v2-cbor',
+          version: '2.0',
+        });
+        logger.debug('Sphere', `Unicity ID token minted + stored for @${name} (${result.tokenId.slice(0, 12)}...)`);
+      } catch (err) {
+        logger.warn('Sphere', `Unicity ID token mint failed for @${name} (non-fatal, retried on next load):`, err);
+      }
+    })();
   }
 
   /**

--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -1079,16 +1079,12 @@ export class AccountingModule {
       // ------------------------------------------------------------------
       // Step 15: Return result
       // ------------------------------------------------------------------
-      // v1: the TxfToken JSON (round-trips from sdkData). v2: the engine blob hex
-      // (the transmittable form; the v2 importInvoice path decodes it).
-      const txfToken: TxfToken = engine
-        ? (sdkData as unknown as TxfToken)
-        : (JSON.parse(sdkData) as TxfToken);
-
       return {
         success: true,
         invoiceId,
-        token: txfToken,
+        // The transmittable v2 invoice blob (hex) — feed it to importInvoice
+        // on the receiving side.
+        token: sdkData,
         terms,
       };
     } catch (err) {
@@ -1153,8 +1149,19 @@ export class AccountingModule {
     // v2: `token` is the engine blob (hex). The proof chain (engine.verify)
     // binds the genesis data (= the invoice terms) to the on-chain commitment.
     // The data token's type is established at mint (mintDataToken), so no
-    // separate type check.
-    const sphereToken = await engine.decodeToken(decodeTokenBlob(hexToBytes(token as unknown as string)));
+    // separate type check. Decode failures (non-hex strings — incl. v1 TXF
+    // JSON strings — base64, truncated or non-blob CBOR) surface as the
+    // documented INVOICE_INVALID_DATA instead of raw noble/CBOR errors.
+    let sphereToken;
+    try {
+      sphereToken = await engine.decodeToken(decodeTokenBlob(hexToBytes(token as unknown as string)));
+    } catch (err) {
+      throw new SphereError(
+        'Invoice import failed: token is not a valid v2 invoice blob (legacy v1 TXF strings are not supported — ask the issuer for a v2 invoice blob).',
+        'INVOICE_INVALID_DATA',
+        err instanceof Error ? err : undefined,
+      );
+    }
     const verifyResult = await engine.verify(sphereToken);
     if (!verifyResult.ok) {
       throw new SphereError('Invoice import failed: inclusion proof is invalid.', 'INVOICE_INVALID_PROOF');

--- a/modules/accounting/types.ts
+++ b/modules/accounting/types.ts
@@ -393,8 +393,11 @@ export interface CreateInvoiceResult {
   readonly success: boolean;
   /** Invoice token ID (if successful) */
   readonly invoiceId?: string;
-  /** Invoice token in TXF format (if successful) */
-  readonly token?: TxfToken;
+  /**
+   * The transmittable v2 invoice blob, hex-encoded (if successful) — pass it
+   * to `importInvoice` on the receiving side.
+   */
+  readonly token?: string;
   /** Parsed invoice terms (if successful) */
   readonly terms?: InvoiceTerms;
   /** Error message (if failed) */

--- a/tests/e2e/token-engine.testnet2.e2e.test.ts
+++ b/tests/e2e/token-engine.testnet2.e2e.test.ts
@@ -95,4 +95,35 @@ describe.runIf(!!API_KEY)('token-engine e2e — live testnet2 (networkId 4)', ()
     expect(engine.tokenId(restored)).toBe(engine.tokenId(minted));
     expect(engine.balanceOf(restored, COIN)).toBe(250n);
   });
+
+  it('mints a self-issued Unicity ID token, idempotently, and round-trips its CBOR', async () => {
+    const { createUnicityIdMinter } = await import('../../token-engine/unicity-id');
+    const { UnicityIdToken, HexConverter, RootTrustBase, PredicateVerifierService } =
+      await import('../../token-engine/sdk');
+
+    const trustBaseJson = await (await fetch(TRUSTBASE_URL)).json();
+    const privateKey = SigningService.generatePrivateKey();
+    const minter = createUnicityIdMinter({ aggregatorUrl: GATEWAY, apiKey: API_KEY, privateKey, trustBaseJson });
+
+    // Random name per run (the testnet is persistent; the mint is deterministic
+    // per (name, key), so a fixed name + fresh key is also fine — random keeps logs tidy).
+    const name = `e2e-${Math.random().toString(36).slice(2, 10)}`;
+
+    const first = await minter.mintUnicityIdToken(name);
+    expect(first.tokenId).toMatch(/^[0-9a-f]{64}$/);
+
+    // Idempotent re-mint: identical bytes (the lost-storage recovery path).
+    const second = await minter.mintUnicityIdToken(name);
+    expect(second.tokenCborHex).toBe(first.tokenCborHex);
+
+    // Stored form round-trips and verifies against the live trust base with the self issuer pin.
+    const token = await UnicityIdToken.fromCBOR(HexConverter.decode(first.tokenCborHex));
+    const trustBase = RootTrustBase.fromJSON(trustBaseJson);
+    const verdict = await token.verify(
+      trustBase,
+      PredicateVerifierService.create(),
+      new SigningService(privateKey).publicKey,
+    );
+    expect(String(verdict.status)).toBe('OK');
+  });
 });

--- a/tests/unit/core/Sphere.unicity-id-mint.test.ts
+++ b/tests/unit/core/Sphere.unicity-id-mint.test.ts
@@ -1,0 +1,182 @@
+/**
+ * registerNametag mints + stores the self-issued v2 UnicityIdToken (best-effort).
+ *
+ * The Nostr binding remains the registration act and the uniqueness guard (D5);
+ * the on-chain claim is ADDITIONALLY minted via token-engine/unicity-id and
+ * stored as NametagData { format: 'v2-cbor', token: <hex CBOR> } — unused at
+ * runtime, kept for the future. A mint failure must never fail registration.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ProviderStatus } from '../../../types';
+import { TEST_NETWORK } from '../../test-network';
+
+const mintUnicityIdToken = vi.fn();
+
+vi.mock('../../../token-engine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../token-engine')>();
+  return {
+    ...actual,
+    createUnicityIdMinter: vi.fn(() => ({ mintUnicityIdToken })),
+  };
+});
+
+// Import AFTER the mock so Sphere picks up the mocked factory.
+import { Sphere } from '../../../core/Sphere';
+import { createUnicityIdMinter } from '../../../token-engine';
+import { FileStorageProvider } from '../../../impl/nodejs/storage/FileStorageProvider';
+import { FileTokenStorageProvider } from '../../../impl/nodejs/storage/FileTokenStorageProvider';
+import type { TransportProvider, OracleProvider } from '../../../index';
+
+const TEST_DIR = path.join(__dirname, '.test-unicity-id-mint');
+const DATA_DIR = path.join(TEST_DIR, 'data');
+const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+
+const FAKE_CBOR_HEX = 'd9988b8401aa';
+const FAKE_TOKEN_ID = 'ab'.repeat(32);
+
+function createMockTransport(): TransportProvider {
+  return {
+    id: 'mock-transport', name: 'Mock Transport', type: 'p2p' as const, description: 'Mock',
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn().mockResolvedValue('transfer-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('request-id'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('response-id'),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    subscribeToBroadcast: vi.fn().mockReturnValue(() => {}),
+    publishBroadcast: vi.fn().mockResolvedValue('broadcast-id'),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+    resolveNametag: vi.fn().mockResolvedValue(null),
+    publishIdentityBinding: vi.fn().mockResolvedValue(true),
+    recoverNametag: vi.fn().mockResolvedValue(null),
+  } as TransportProvider;
+}
+
+/** Oracle WITH the v2 config surface — the minter prerequisites. */
+function createV2Oracle(): OracleProvider {
+  return {
+    id: 'mock-oracle', name: 'Mock Oracle', type: 'aggregator' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    getTrustBaseJson: vi.fn().mockReturnValue({ networkId: 2 }),
+    getAggregatorUrl: vi.fn().mockReturnValue('https://gateway.example'),
+    getApiKey: vi.fn().mockReturnValue(undefined),
+  } as unknown as OracleProvider;
+}
+
+function cleanTestDir(): void {
+  if (fs.existsSync(TEST_DIR)) {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  }
+}
+
+async function initSphere() {
+  const storage = new FileStorageProvider({ dataDir: DATA_DIR });
+  const tokenStorage = new FileTokenStorageProvider({ tokensDir: TOKENS_DIR });
+  const { sphere } = await Sphere.init({
+    storage,
+    transport: createMockTransport(),
+    oracle: createV2Oracle(),
+    tokenStorage,
+    network: TEST_NETWORK,
+    autoGenerate: true,
+  });
+  return sphere;
+}
+
+describe('Sphere — Unicity ID token mint at registration (v2, best-effort)', () => {
+  beforeEach(() => {
+    cleanTestDir();
+    if (Sphere.getInstance()) {
+      (Sphere as unknown as { instance: null }).instance = null;
+    }
+    vi.mocked(createUnicityIdMinter).mockClear();
+    mintUnicityIdToken.mockReset();
+    mintUnicityIdToken.mockResolvedValue({ tokenCborHex: FAKE_CBOR_HEX, tokenId: FAKE_TOKEN_ID });
+  });
+
+  afterEach(() => {
+    (Sphere as unknown as { instance: null }).instance = null;
+    cleanTestDir();
+  });
+
+  it('registerNametag mints and stores a v2-cbor NametagData entry', async () => {
+    const sphere = await initSphere();
+
+    await sphere.registerNametag('alice');
+
+    await vi.waitFor(() => {
+      const entry = sphere.payments.getNametags().find((n) => n.name === 'alice');
+      expect(entry).toBeDefined();
+      expect(entry!.format).toBe('v2-cbor');
+      expect(entry!.token).toBe(FAKE_CBOR_HEX);
+      expect(entry!.version).toBe('2.0');
+    });
+    expect(mintUnicityIdToken).toHaveBeenCalledWith('alice');
+    // Registration itself stayed binding-first.
+    expect(sphere.identity!.nametag).toBe('alice');
+
+    await sphere.destroy();
+  });
+
+  it('a mint failure does NOT fail registration (best-effort)', async () => {
+    mintUnicityIdToken.mockRejectedValue(new Error('gateway down'));
+    const sphere = await initSphere();
+
+    await expect(sphere.registerNametag('bob')).resolves.toBeUndefined();
+    expect(sphere.identity!.nametag).toBe('bob');
+
+    await vi.waitFor(() => expect(mintUnicityIdToken).toHaveBeenCalled());
+    expect(sphere.payments.getNametags().find((n) => n.name === 'bob')).toBeUndefined();
+
+    await sphere.destroy();
+  });
+
+  it('is idempotent — a stored v2-cbor entry is not re-minted', async () => {
+    const sphere = await initSphere();
+    await sphere.registerNametag('carol');
+    await vi.waitFor(() => {
+      expect(sphere.payments.getNametags().find((n) => n.name === 'carol')).toBeDefined();
+    });
+    mintUnicityIdToken.mockClear();
+
+    // Re-run the best-effort hook directly (as load()/postSwitchSync do).
+    (sphere as unknown as { ensureUnicityIdTokenStored(): void }).ensureUnicityIdTokenStored();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mintUnicityIdToken).not.toHaveBeenCalled();
+
+    await sphere.destroy();
+  });
+
+  it('legacy v1 object entries are left untouched (no re-mint storm, new entry added)', async () => {
+    const sphere = await initSphere();
+    await sphere.registerNametag('dave');
+    await vi.waitFor(() => {
+      expect(sphere.payments.getNametags().find((n) => n.name === 'dave')).toBeDefined();
+    });
+
+    // A legacy v1 entry (object token) must survive verbatim next to the v2 entry.
+    const legacy = { name: 'old', token: { genesis: {} }, timestamp: 1, format: 'txf', version: '2.0' };
+    await sphere.payments.setNametag(legacy);
+    const all = sphere.payments.getNametags();
+    expect(all.find((n) => n.name === 'old')?.token).toEqual({ genesis: {} });
+    expect(all.find((n) => n.name === 'dave')?.format).toBe('v2-cbor');
+
+    await sphere.destroy();
+  });
+});

--- a/tests/unit/token-engine/unicity-id-mint.test.ts
+++ b/tests/unit/token-engine/unicity-id-mint.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Self-issued Unicity ID (nametag) token mint — token-engine/unicity-id.ts —
+ * over the in-memory TestAggregatorClient (same harness as the real engine).
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  PredicateVerifierService,
+  SigningService,
+  StateTransitionClient,
+  UnicityId,
+  UnicityIdToken,
+  HexConverter,
+} from '../../../token-engine/sdk';
+import {
+  createUnicityIdMinterFromDeps,
+  type UnicityIdMinterDeps,
+} from '../../../token-engine/unicity-id';
+import { TestAggregatorClient } from './support/TestAggregatorClient';
+
+function createHarness(privateKey?: Uint8Array): { deps: UnicityIdMinterDeps; aggregator: TestAggregatorClient } {
+  const aggregator = TestAggregatorClient.create();
+  const deps: UnicityIdMinterDeps = {
+    client: new StateTransitionClient(aggregator),
+    trustBase: aggregator.rootTrustBase,
+    predicateVerifier: PredicateVerifierService.create(),
+    signingService: new SigningService(privateKey ?? SigningService.generatePrivateKey()),
+  };
+  return { deps, aggregator };
+}
+
+describe('UnicityIdMinter (self-issued, in-memory aggregator)', () => {
+  it('mints a UnicityIdToken whose id derives from the name', async () => {
+    const { deps } = createHarness();
+    const minter = createUnicityIdMinterFromDeps(deps);
+
+    const result = await minter.mintUnicityIdToken('alice');
+
+    expect(result.tokenId).toMatch(/^[0-9a-f]{64}$/);
+    const expectedId = await new UnicityId('alice').toTokenId();
+    expect(result.tokenId).toBe(HexConverter.encode(expectedId.bytes));
+  }, 15000);
+
+  it('the stored CBOR round-trips and verifies against the trust base (issuer = self)', async () => {
+    const { deps } = createHarness();
+    const minter = createUnicityIdMinterFromDeps(deps);
+
+    const { tokenCborHex } = await minter.mintUnicityIdToken('bob');
+
+    const token = await UnicityIdToken.fromCBOR(HexConverter.decode(tokenCborHex));
+    const verdict = await token.verify(deps.trustBase, deps.predicateVerifier, deps.signingService.publicKey);
+    expect(verdict.status).toBeDefined();
+    // UnicityIdToken.mint already verified the genesis on the local-mint path;
+    // re-verifying with the issuer pin (our own key) must also pass.
+    expect(String(verdict.status)).toBe('OK');
+  }, 15000);
+
+  it('re-mint of the same name by the same wallet is idempotent (same bytes)', async () => {
+    const key = SigningService.generatePrivateKey();
+    const { deps } = createHarness(key);
+    const minter = createUnicityIdMinterFromDeps(deps);
+
+    const first = await minter.mintUnicityIdToken('carol');
+    const second = await minter.mintUnicityIdToken('carol');
+
+    expect(second.tokenId).toBe(first.tokenId);
+    expect(second.tokenCborHex).toBe(first.tokenCborHex);
+  }, 15000);
+
+  it('different names yield different token ids; same name from different wallets coexists (per-issuer uniqueness)', async () => {
+    const { deps: a } = createHarness();
+    const { deps: b } = createHarness();
+    const minterA = createUnicityIdMinterFromDeps(a);
+    const minterB = createUnicityIdMinterFromDeps(b);
+
+    const alice = await minterA.mintUnicityIdToken('alice');
+    const dave = await minterA.mintUnicityIdToken('dave');
+    expect(dave.tokenId).not.toBe(alice.tokenId);
+
+    // Self-issued claims are per-issuer: another wallet can mint the same name
+    // on-chain (different lock script → different StateId). Global uniqueness
+    // stays with the Nostr binding — documented behavior, locked here.
+    const aliceB = await minterB.mintUnicityIdToken('alice');
+    expect(aliceB.tokenId).toBe(alice.tokenId); // same name → same token id
+    expect(aliceB.tokenCborHex).not.toBe(alice.tokenCborHex); // different issuer/owner
+  }, 15000);
+});

--- a/token-engine/identity.ts
+++ b/token-engine/identity.ts
@@ -20,8 +20,13 @@
 
 import { CborSerializer, DataHasher, HashAlgorithm, HexConverter } from './sdk';
 
-/** Unicity L3 token type used for identity-address derivation (immutable). */
-const UNICITY_TOKEN_TYPE_HEX = 'f8aa13834268d29355ff12183066f0cb902003629bbc5eb9ef0efbe397867509';
+/**
+ * Unicity L3 token type used for identity-address derivation (immutable).
+ * Also pinned as the fixed token type of self-issued Unicity ID tokens
+ * (token-engine/unicity-id.ts) — the same constant the v1 nametag mint used,
+ * keeping the mint deterministic per (name, wallet key).
+ */
+export const UNICITY_TOKEN_TYPE_HEX = 'f8aa13834268d29355ff12183066f0cb902003629bbc5eb9ef0efbe397867509';
 /** v1 `SigningService.algorithm` for secp256k1. */
 const SIGNING_ALGORITHM = 'secp256k1';
 /** v1 `EmbeddedPredicateType.UNMASKED`. */

--- a/token-engine/index.ts
+++ b/token-engine/index.ts
@@ -40,3 +40,9 @@ export { deriveDirectAddress } from './identity';
 
 // The concrete adapter factory (A4) — the public way to obtain an ITokenEngine.
 export { createSphereTokenEngine } from './factory';
+
+// Self-issued Unicity ID (nametag) token mint — the v2 analog of the v1
+// nametag mint, stored at registration but unused at runtime (D5 + user
+// decision 2026-06-10; see unicity-id.ts header).
+export { createUnicityIdMinter } from './unicity-id';
+export type { IUnicityIdMinter, UnicityIdMintResult } from './unicity-id';

--- a/token-engine/sdk.ts
+++ b/token-engine/sdk.ts
@@ -74,6 +74,12 @@ export { SplitMintJustificationVerifier } from '@unicitylabs/state-transition-sd
 export { VerificationStatus } from '@unicitylabs/state-transition-sdk/lib/verification/VerificationStatus.js';
 export { VerificationResult } from '@unicitylabs/state-transition-sdk/lib/verification/VerificationResult.js';
 
+// ── unicity-id (nametag) ────────────────────────────────────────────────────
+export { UnicityId } from '@unicitylabs/state-transition-sdk/lib/unicity-id/UnicityId.js';
+export { UnicityIdMintTransaction } from '@unicitylabs/state-transition-sdk/lib/unicity-id/UnicityIdMintTransaction.js';
+export { CertifiedUnicityIdMintTransaction } from '@unicitylabs/state-transition-sdk/lib/unicity-id/CertifiedUnicityIdMintTransaction.js';
+export { UnicityIdToken } from '@unicitylabs/state-transition-sdk/lib/unicity-id/UnicityIdToken.js';
+
 // ── util ────────────────────────────────────────────────────────────────────
 export { HexConverter } from '@unicitylabs/state-transition-sdk/lib/util/HexConverter.js';
 export { BigintConverter } from '@unicitylabs/state-transition-sdk/lib/util/BigintConverter.js';

--- a/token-engine/unicity-id.ts
+++ b/token-engine/unicity-id.ts
@@ -1,0 +1,155 @@
+/**
+ * token-engine/unicity-id.ts — self-issued v2 UnicityIdToken mint (the v2 analog
+ * of the v1 nametag-token mint).
+ *
+ * User decision 2026-06-10: the on-chain Unicity ID claim is minted AND STORED
+ * again at nametag registration (it was retired with v1 in Track B / D5), but it
+ * is NOT used at runtime — name resolution stays Nostr-binding-only, receive
+ * stays SignaturePredicate(chainPubkey), and no PROXY semantics return. The
+ * token is kept for the future (e.g. an issuer/verification model).
+ *
+ * Trust model: SELF-ISSUED. The wallet's own key is the issuer lock script, the
+ * recipient AND the target predicate (the v2 local-mint path — the issuer pin is
+ * only meaningful when verifying third-party tokens). Because the issuer lock
+ * script is part of the StateId, on-chain uniqueness is per-issuer only; GLOBAL
+ * name uniqueness remains the Nostr first-seen-wins binding's job (unchanged).
+ *
+ * Determinism / idempotency: tokenId = SHA256(CBOR["NAMETAG_", null, name]),
+ * tokenType is pinned (UNICITY_TOKEN_TYPE_HEX), and all predicates derive from
+ * the wallet key — the whole mint transaction is reproducible byte-for-byte, so
+ * a re-mint (e.g. after the token was lost from local storage) re-certifies the
+ * same state and yields the identical token (the v1 REQUEST_ID_EXISTS recovery
+ * analog).
+ */
+
+import { SphereError } from '../core/errors';
+import { logger } from '../core/logger';
+import {
+  AggregatorClient,
+  CertificationData,
+  CertificationStatus,
+  HexConverter,
+  PredicateVerifierService,
+  RootTrustBase,
+  SignaturePredicate,
+  SignaturePredicateUnlockScript,
+  SigningService,
+  StateTransitionClient,
+  TokenType,
+  UnicityId,
+  UnicityIdMintTransaction,
+  UnicityIdToken,
+  waitInclusionProof,
+} from './sdk';
+import { UNICITY_TOKEN_TYPE_HEX } from './identity';
+import type { EngineConfig, EngineOpOptions } from './engine';
+
+export interface UnicityIdMintResult {
+  /** UnicityIdToken CBOR, hex-encoded — the storable form (UnicityIdToken.fromCBOR round-trips it). */
+  readonly tokenCborHex: string;
+  /** 64-char hex token id, derived from the name (stable across re-mints). */
+  readonly tokenId: string;
+}
+
+/** Self-issued Unicity ID (nametag) token minter. */
+export interface IUnicityIdMinter {
+  /**
+   * Mint (or idempotently re-certify) the UnicityIdToken for `name`,
+   * self-issued by this wallet's key. Network-bound: submits the certification
+   * request and waits for the inclusion proof.
+   */
+  mintUnicityIdToken(name: string, options?: EngineOpOptions): Promise<UnicityIdMintResult>;
+}
+
+class SelfIssuedUnicityIdMinter implements IUnicityIdMinter {
+  public constructor(
+    private readonly client: StateTransitionClient,
+    private readonly trustBase: RootTrustBase,
+    private readonly predicateVerifier: PredicateVerifierService,
+    private readonly signingService: SigningService,
+  ) {}
+
+  public async mintUnicityIdToken(name: string, options?: EngineOpOptions): Promise<UnicityIdMintResult> {
+    const unicityId = new UnicityId(name);
+    const self = SignaturePredicate.fromSigningService(this.signingService);
+
+    // Deterministic per (name, wallet key): pinned token type, self predicates.
+    const mintTx = await UnicityIdMintTransaction.create(
+      self, // issuer lock script (self-issued)
+      self, // recipient — locks the minted token state to this wallet
+      unicityId,
+      new TokenType(HexConverter.decode(UNICITY_TOKEN_TYPE_HEX)),
+      self, // target predicate the unicity id resolves to
+    );
+
+    const certificationData = await CertificationData.fromTransaction(
+      mintTx,
+      await SignaturePredicateUnlockScript.create(mintTx, this.signingService),
+    );
+
+    const response = await this.client.submitCertificationRequest(certificationData);
+    if (response.status !== CertificationStatus.SUCCESS) {
+      // The transaction is deterministic: when this wallet minted the name
+      // before, its certification is already on-chain and the proof below
+      // still verifies (idempotent re-mint). Any genuine failure surfaces as
+      // a proof-wait timeout/verification error instead.
+      logger.warn(
+        'UnicityIdMinter',
+        `Certification request returned ${response.status} for "@${name}" — attempting proof recovery (idempotent re-mint).`,
+      );
+    }
+
+    try {
+      const proof = await waitInclusionProof(
+        this.client,
+        this.trustBase,
+        this.predicateVerifier,
+        mintTx,
+        options?.signal,
+      );
+      const certified = await mintTx.toCertifiedTransaction(this.trustBase, this.predicateVerifier, proof);
+      const token = await UnicityIdToken.mint(this.trustBase, this.predicateVerifier, certified);
+      return {
+        tokenCborHex: HexConverter.encode(token.toCBOR()),
+        tokenId: HexConverter.encode(token.id.bytes),
+      };
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new SphereError(
+        `Unicity ID mint failed for "@${name}": ${detail}` +
+          (response.status !== CertificationStatus.SUCCESS ? ` (certification status: ${response.status})` : ''),
+        'AGGREGATOR_ERROR',
+      );
+    }
+  }
+}
+
+/** SDK objects the minter operates with (test seam; mirrors EngineDeps). */
+export interface UnicityIdMinterDeps {
+  readonly client: StateTransitionClient;
+  readonly trustBase: RootTrustBase;
+  readonly predicateVerifier: PredicateVerifierService;
+  readonly signingService: SigningService;
+}
+
+/** Build the minter from pre-constructed SDK objects (tests / shared wiring). */
+export function createUnicityIdMinterFromDeps(deps: UnicityIdMinterDeps): IUnicityIdMinter {
+  return new SelfIssuedUnicityIdMinter(deps.client, deps.trustBase, deps.predicateVerifier, deps.signingService);
+}
+
+/**
+ * Build the self-issued Unicity ID minter from the same config the token engine
+ * uses (trust base JSON + gateway URL + API key + wallet key).
+ */
+export function createUnicityIdMinter(config: EngineConfig): IUnicityIdMinter {
+  if (config.trustBaseJson == null) {
+    throw new SphereError('Unicity ID minter requires a trust base (trustBaseJson)', 'INVALID_CONFIG');
+  }
+  const trustBase = RootTrustBase.fromJSON(config.trustBaseJson);
+  return new SelfIssuedUnicityIdMinter(
+    new StateTransitionClient(new AggregatorClient(config.aggregatorUrl, config.apiKey ?? null)),
+    trustBase,
+    PredicateVerifierService.create(),
+    new SigningService(config.privateKey),
+  );
+}

--- a/types/txf.ts
+++ b/types/txf.ts
@@ -113,10 +113,16 @@ export interface TxfIntegrity {
 
 /**
  * Nametag data (one per identity)
+ *
+ * `token` shape by `format`:
+ * - `'v2-cbor'`: hex-encoded v2 UnicityIdToken CBOR (string) — the self-issued
+ *   on-chain claim minted at registration (stored, unused at runtime).
+ * - legacy `'txf'`: the v1 nametag token JSON (object) — inert since the v1
+ *   cutover, still round-tripped through storage untouched.
  */
 export interface NametagData {
   name: string;
-  token: object;
+  token: object | string;
   timestamp: number;
   format: string;
   version: string;


### PR DESCRIPTION
## What

PR 3 of 3 (stacked on #480). Restores the v1 "mint the nametag token at creation and store it" behavior on the v2 SDK, per the 2026-06-10 decision — while keeping the D5 runtime model untouched (name resolution stays Nostr-binding-only, receive stays `SignaturePredicate(chainPubkey)`, no PROXY semantics return). The token is stored for the future, not consumed anywhere yet.

- **`token-engine/unicity-id.ts`** — `createUnicityIdMinter(EngineConfig)`: self-issued v2 `UnicityIdToken` mint (issuer lock script = recipient = target predicate = the wallet key; the v2 local-mint path). Deterministic per (name, key): pinned `UNICITY_TOKEN_TYPE_HEX` (the same constant the v1 nametag mint used), `tokenId = SHA256(CBOR["NAMETAG_", null, name])`. Re-mints are byte-identical — the v1 `REQUEST_ID_EXISTS` recovery analog (a non-SUCCESS certification falls through to proof recovery).
- **Sphere wiring** — `ensureUnicityIdTokenStored()` fires at `registerNametag`, the load/create nametag-recovery paths, and `postSwitchSync` (per-address), mirroring where the v1 `NametagMinter` was wired. Best-effort: a gateway outage never fails registration; the deterministic mint re-certifies the identical token on a later load (lost-storage recovery). Stored via `payments.setNametag` as `NametagData { format: 'v2-cbor', token: <hex CBOR> }` in the existing `_nametags` storage; legacy v1 `txf` object entries stay untouched.
- `NametagData.token` widened to `object | string`.

## Trust-model note (differs from v1, documented in code)

Self-issued claims are **per-issuer** on-chain: the issuer lock script is part of the StateId, so another wallet can mint the same name with its own key. GLOBAL name uniqueness remains the Nostr first-seen-wins binding (unchanged, per D5). A globally-unique on-chain claim would require the v2 issuer model (`UnicityIdPredicateVerifier` + a pinned issuer key), which does not exist in the ecosystem yet.

## Tests

- `tests/unit/token-engine/unicity-id-mint.test.ts` — 4 tests on the in-memory aggregator: name-derived tokenId, CBOR round-trip + issuer-pin verify, idempotent re-mint (same bytes), per-issuer coexistence.
- `tests/unit/core/Sphere.unicity-id-mint.test.ts` — 4 tests: registration stores the v2-cbor entry; mint failure does NOT fail registration; idempotent skip when stored; legacy v1 entries untouched.
- **Live testnet2 e2e green**: real mint on the live aggregator, idempotent re-mint byte-identical, CBOR round-trip, verify against the live trust base.
