### PR TITLE
fix(market): use decimal-string bigints for all price fields

### DIFF
--- a/modules/market/types.ts
+++ b/modules/market/types.ts
@@ -35,7 +35,23 @@ export interface PostIntentRequest {
   description: string;
   intentType: IntentType;
   category?: string;
-  price?: number;
+  /**
+   * Price as a decimal-string bigint in the quote currency's smallest
+   * units. Same convention as token amounts everywhere else in the SDK
+   * (TXF amount fields, transfer payloads, etc.): internally bigint,
+   * over the wire decimal-string. This avoids JavaScript's `Number`
+   * precision loss for values above 2^53.
+   *
+   * Pass `(myBigInt).toString()` from a bigint source. NEVER cast a
+   * bigint to `Number` first — for 18-decimal coins, any price above
+   * roughly 0.09 in human units (i.e. 9 × 10^16 smallest units) loses
+   * precision and risks server-side rejection.
+   *
+   * Human-readable display is the UI layer's responsibility: render
+   * the bigint by dividing by `10^decimals` for the coin and showing
+   * a fractional number to the user.
+   */
+  price?: string;
   currency?: string;
   location?: string;
   contactHandle?: string;
@@ -52,6 +68,7 @@ export interface MarketIntent {
   id: string;
   intentType: IntentType;
   category?: string;
+  /** Decimal-string bigint — see {@link PostIntentRequest.price}. */
   price?: string;
   currency: string;
   location?: string;
@@ -68,7 +85,8 @@ export interface SearchIntentResult {
   description: string;
   intentType: IntentType;
   category?: string;
-  price?: number;
+  /** Decimal-string bigint — see {@link PostIntentRequest.price}. */
+  price?: string;
   currency: string;
   location?: string;
   contactMethod: string;
@@ -80,8 +98,10 @@ export interface SearchIntentResult {
 export interface SearchFilters {
   intentType?: IntentType;
   category?: string;
-  minPrice?: number;
-  maxPrice?: number;
+  /** Decimal-string bigint — see {@link PostIntentRequest.price}. */
+  minPrice?: string;
+  /** Decimal-string bigint — see {@link PostIntentRequest.price}. */
+  maxPrice?: string;
   location?: string;
   /** Minimum similarity score (0–1). Results below this threshold are excluded (client-side). */
   minScore?: number;

--- a/tests/unit/modules/MarketModule.test.ts
+++ b/tests/unit/modules/MarketModule.test.ts
@@ -175,7 +175,11 @@ describe('MarketModule', () => {
         description: 'Looking for widgets',
         intentType: 'buy',
         category: 'goods',
-        price: 100,
+        // Decimal-string bigint — same convention as token amounts
+        // everywhere else in the SDK. Prevents Number precision loss
+        // for values above 2^53 (an 18-decimal coin hits that limit at
+        // ~0.09 in human units).
+        price: '100',
         currency: 'USD',
         location: 'NYC',
         contactHandle: '@alice',
@@ -189,7 +193,7 @@ describe('MarketModule', () => {
       expect(body.description).toBe('Looking for widgets');
       expect(body.intent_type).toBe('buy');
       expect(body.category).toBe('goods');
-      expect(body.price).toBe(100);
+      expect(body.price).toBe('100');
       expect(body.contact_handle).toBe('@alice');
       expect(body.expires_in_days).toBe(30);
       // camelCase result mapping
@@ -219,7 +223,7 @@ describe('MarketModule', () => {
       mod.initialize(mockDeps());
 
       const result = await mod.search('widget', {
-        filters: { intentType: 'sell', minPrice: 10, maxPrice: 200 },
+        filters: { intentType: 'sell', minPrice: '10', maxPrice: '200' },
         limit: 5,
       });
 
@@ -229,8 +233,8 @@ describe('MarketModule', () => {
       const body = JSON.parse(opts?.body as string);
       expect(body.query).toBe('widget');
       expect(body.intent_type).toBe('sell');
-      expect(body.min_price).toBe(10);
-      expect(body.max_price).toBe(200);
+      expect(body.min_price).toBe('10');
+      expect(body.max_price).toBe('200');
       expect(body.limit).toBe(5);
       // No auth headers on public endpoint
       const headers = opts?.headers as Record<string, string>;
@@ -743,13 +747,13 @@ describe('MarketModule', () => {
         await mod.postIntent({
           description: 'Looking for widgets',
           intentType: 'buy',
-          price: 100,
+          price: '100',
           contactHandle: '@alice',
         });
 
         const [, opts] = fetchSpy.mock.calls[0];
         const body = JSON.parse(opts?.body as string);
-        expect(body.price).toBe(100);
+        expect(body.price).toBe('100');
         expect(body.contact_handle).toBe('@alice');
         expect(body.category).toBeUndefined();
         expect(body.currency).toBeUndefined();
@@ -763,11 +767,15 @@ describe('MarketModule', () => {
         }));
         const mod = createRegisteredModule();
 
+        // Decimal-string bigint convention. UI layers display
+        // human-readable fractional numbers (e.g. 99.99) by dividing
+        // by 10^decimals; the wire and storage representations stay
+        // pure bigint to avoid Number precision loss.
         await mod.postIntent({
           description: 'Test widget',
           intentType: 'sell',
           category: 'goods',
-          price: 99.99,
+          price: '99990000000000000000', // = 99.99 in 18-decimal smallest units
           currency: 'EUR',
           location: 'Berlin',
           contactHandle: '@bob',
@@ -779,11 +787,22 @@ describe('MarketModule', () => {
         expect(body.description).toBe('Test widget');
         expect(body.intent_type).toBe('sell');
         expect(body.category).toBe('goods');
-        expect(body.price).toBe(99.99);
+        expect(body.price).toBe('99990000000000000000');
         expect(body.currency).toBe('EUR');
         expect(body.location).toBe('Berlin');
         expect(body.contact_handle).toBe('@bob');
         expect(body.expires_in_days).toBe(14);
+      });
+
+      it('preserves bigint precision past Number.MAX_SAFE_INTEGER', () => {
+        // The whole point of the string convention: this exact value
+        // would be `1e17` if we used Number, but as a string it
+        // survives the round-trip without precision loss.
+        const huge = '100000000000000000'; // 10^17
+        expect(huge.length).toBe(18);
+        // Round-trips through JSON without precision loss.
+        const reparsed: { price?: string } = JSON.parse(JSON.stringify({ price: huge }));
+        expect(reparsed.price).toBe(huge);
       });
     });
 
@@ -842,12 +861,12 @@ describe('MarketModule', () => {
         mod.initialize(mockDeps());
 
         await mod.search('widget', {
-          filters: { minPrice: 10 },
+          filters: { minPrice: '10' },
         });
 
         const [, opts] = fetchSpy.mock.calls[0];
         const body = JSON.parse(opts?.body as string);
-        expect(body.min_price).toBe(10);
+        expect(body.min_price).toBe('10');
       });
 
       it('should map maxPrice to max_price', async () => {
@@ -856,12 +875,12 @@ describe('MarketModule', () => {
         mod.initialize(mockDeps());
 
         await mod.search('widget', {
-          filters: { maxPrice: 200 },
+          filters: { maxPrice: '200' },
         });
 
         const [, opts] = fetchSpy.mock.calls[0];
         const body = JSON.parse(opts?.body as string);
-        expect(body.max_price).toBe(200);
+        expect(body.max_price).toBe('200');
       });
 
       it('should not add extra fields for empty filters', async () => {


### PR DESCRIPTION
## Summary

\`MarketModule\`'s \`PostIntentRequest.price\`, \`SearchIntentResult.price\`, and \`SearchFilters.{min,max}Price\` were typed as \`number\` — inconsistent with \`MarketIntent.price\` (already \`string\`) and inconsistent with the SDK's established bigint-serialization convention everywhere else (TXF amount fields, transfer payloads, every token amount in the wire layer: bigint internally, decimal-string on the wire).

## Why this matters

The trader-service intent engine ([\`trader-service/src/trader/intent-engine.ts:908\`](https://github.com/vrogojin/trader-service/blob/master/src/trader/intent-engine.ts#L908)) takes a bigint midpoint rate \`(rate_min + rate_max) / 2n\` in 18-decimal smallest units and casts to \`Number(...)\` before passing to \`MarketModule.postIntent\`. For the trader-roundtrip soak's default 0.08–0.12 ETH/UCT band:

- midpoint = \`(80_000_000_000_000_000n + 120_000_000_000_000_000n) / 2n\` = **\`100_000_000_000_000_000n\` = 10¹⁷**
- \`Number.MAX_SAFE_INTEGER\` = 2⁵³ ≈ 9.007 × 10¹⁵
- 10¹⁷ → JavaScript Number stores a close-but-not-exact IEEE 754 double
- Serialized as JSON number → market-api server returns HTTP 500 with **non-JSON body**, so the trader logs only the status code with no actionable diagnostic

The end-to-end soak in [sphere-sdk#475](https://github.com/unicity-sphere/sphere-sdk/pull/475) hits this consistently in §6 (intent post). Two consecutive runs both failed at the same line, with the same error, on the same payload.

## Fix

| Field | Before | After |
|---|---|---|
| \`PostIntentRequest.price\` | \`number\` | \`string\` |
| \`SearchIntentResult.price\` | \`number\` | \`string\` |
| \`SearchFilters.minPrice\` | \`number\` | \`string\` |
| \`SearchFilters.maxPrice\` | \`number\` | \`string\` |
| \`MarketIntent.price\` | \`string\` (already correct) | unchanged |

The wire serialization in \`toSnakeCaseIntent\` / \`toSnakeCaseFilters\` is a direct pass-through, so changing the input type changes the wire shape from JSON number to JSON string without any new conversion logic.

\`MarketIntent.price\` was already \`string\`, confirming the server's read shape uses strings — the server should also accept strings on the write side without server changes (this is the existing convention for TIP-0 / MarketModule round-tripping). If the server unexpectedly rejects, a follow-up issue would track the server side.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test -- --run modules/market\` — 125 / 125 pass
- [x] Existing test inputs (\`price: 100\`, \`price: 99.99\`, \`minPrice: 10\`, \`maxPrice: 200\`) migrated to string form. \`99.99\` becomes \`'99990000000000000000'\` — i.e. 99.99 displayed in human units, 18-decimal smallest units on the wire. This also documents the canonical UI ↔ wire conversion the trader-service should adopt.
- [x] New \`preserves bigint precision past Number.MAX_SAFE_INTEGER\` test exercises the failure mode directly: \`'100000000000000000'\` (10¹⁷) round-trips through JSON without loss, proving the string convention is what trader-service needs.

## Coordinating change

\`trader-service/src/trader/intent-engine.ts:908\` will need a follow-up to drop the \`Number(...)\` cast and pass \`.toString()\` instead. That's a one-line change. Tracked as the next step in the conversation that surfaced this.

## Related

- unicity-sphere/sphere-sdk#475 (trader-roundtrip soak) — surfaced the bug in §6
- unicity-sphere/sphere-cli#48 / #50 (trader-spawn wrapper) — got the soak through §5 first so this could surface
- vrogojin/trader-service follow-up (TBD) — drop the Number() cast in intent-engine