### PR TITLE
docs: refresh all documentation for the v2 engine cutover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,15 +23,21 @@ import { Sphere } from '@unicitylabs/sphere-sdk';
 import { createBrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
 // For Node.js: import { createNodeProviders } from '@unicitylabs/sphere-sdk/impl/nodejs';
 
-// 1. Create providers (all services configured automatically by network)
-const providers = createBrowserProviders({ network: 'testnet' });
-// Node.js: createNodeProviders({ network: 'testnet', dataDir: './wallet', tokensDir: './tokens' })
+// 1. Create providers. `network` is REQUIRED (throws INVALID_CONFIG otherwise).
+//    There is NO bundled gateway API key — inject it via oracle.apiKey.
+//    The testnet2 key is NOT a secret (see .env.example); a mainnet key IS.
+const providers = createBrowserProviders({
+  network: 'testnet', // alias of testnet2 — the v2 gateway network
+  oracle: { apiKey: 'sk_...' },
+});
+// Node.js: createNodeProviders({ network: 'testnet', oracle: { apiKey: 'sk_...' },
+//                                dataDir: './sphere-data', tokensDir: './sphere-tokens' })
 
 // 2. Init wallet (creates new OR loads existing — single entry point)
 const { sphere, created, generatedMnemonic } = await Sphere.init({
   ...providers,
   autoGenerate: true,   // Generate mnemonic if no wallet exists
-  nametag: 'alice',     // Optional: register @alice for receiving payments
+  nametag: 'alice',     // Optional: register @alice (only on create)
   password: 'secret',   // Optional: encrypt mnemonic (plaintext if omitted)
   accounting: true,     // Enable accounting/invoicing module
   swap: true,           // Enable token swap module
@@ -46,40 +52,46 @@ if (created && generatedMnemonic) {
 const identity = sphere.identity!;
 console.log('L3 address:', identity.directAddress);  // DIRECT://... (primary)
 console.log('L1 address:', identity.l1Address);      // alpha1...
-console.log('Nametag:', identity.nametag);            // alice
+console.log('Unicity ID:', identity.nametag);        // alice
 
 // 4. Check tokens and balance
 const assets = await sphere.payments.getAssets();
-// [{ coinId, symbol, totalAmount, tokenCount, priceUsd, fiatValueUsd, change24h }]
+// Asset[]: { coinId, symbol, totalAmount, tokenCount, confirmedAmount,
+//            unconfirmedAmount, priceUsd, fiatValueUsd, change24h, ... }
 
-const balances = sphere.payments.getBalance();        // Asset[] with confirmed/unconfirmed breakdown
+const balances = sphere.payments.getBalance();           // Asset[] (sync, from loaded tokens)
 const totalUsd = await sphere.payments.getFiatBalance(); // number | null (null if no PriceProvider)
 
-const tokens = sphere.payments.getTokens();           // individual Token[]
-const uctOnly = sphere.payments.getTokens({ coinId: 'UCT' }); // filter by coin
+const tokens = sphere.payments.getTokens();              // individual Token[]
+const filtered = sphere.payments.getTokens({ coinId: '...' }); // filter by coin
 
-// 5. Send tokens (L3)
+// 5. Send tokens (L3) — v2 engine path. Requires the token engine (v2 oracle
+//    config) and a recipient with a PUBLISHED chain pubkey; fails loudly otherwise.
 const result = await sphere.payments.send({
   recipient: '@bob',           // @nametag, DIRECT://..., chain pubkey (02...), or alpha1...
   amount: '1000000',           // in smallest unit (string)
-  coinId: 'UCT',              // token coin ID
-  memo: 'Payment for coffee', // optional
-  // transferMode: 'instant',      // default — fast, receiver resolves proofs
-  // transferMode: 'conservative', // slower — sender collects all proofs first
+  coinId: 'UCT',               // coin ID (64-hex canonical; short symbols resolved via registry)
+  memo: 'Payment for coffee',  // optional
 });
 // result: { id, status, tokens, tokenTransfers, error? }
-// status: 'pending' | 'submitted' | 'delivered' | 'completed' | 'failed'
+// status: 'pending' | 'submitted' | 'confirmed' | 'delivered' | 'completed' | 'failed'
 
-// 6. Receive tokens (explicit one-shot query + optional finalization)
+// 6. Receive tokens (explicit one-shot fetch). v2 transfers arrive as FINISHED
+//    tokens — stored confirmed immediately, no finalization phase.
+//    The old { finalize, timeout, pollInterval } options are deprecated no-ops.
 const { transfers } = await sphere.payments.receive();
-await sphere.payments.receive({ finalize: true }); // also resolve unconfirmed V5 tokens
 
 // Listen for incoming transfers
 sphere.on('transfer:incoming', (transfer) => {
   console.log(`From: ${transfer.senderNametag}, Tokens: ${transfer.tokens.length}`);
 });
 
-// 7. L1 operations (enabled by default, lazy Fulcrum connection)
+// 7. Self-mint fungible tokens (no faucet — engine.mint to own pubkey)
+//    coinId must be even-length lowercase hex (the canonical v2 AssetId form)
+const mint = await sphere.payments.mintFungibleToken(coinIdHex, 1000000n);
+// { success: true, token, tokenId } | { success: false, error }
+
+// 8. L1 operations (enabled by default, lazy Fulcrum connection)
 const l1Balance = await sphere.payments.l1!.getBalance();
 // { confirmed, unconfirmed, vested, unvested, total } — all strings in satoshis
 
@@ -87,23 +99,22 @@ const l1Result = await sphere.payments.l1!.send({
   to: 'alpha1...', amount: '100000', feeRate: 5,
 });
 
-// 8. Sync with remote storage (IPFS etc.)
+// 9. Sync with remote storage (IPFS etc.)
 const syncResult = await sphere.payments.sync(); // { added, removed }
 
-// 9. Transaction history
-const history = sphere.payments.getHistory();
-// [{ type, amount, coinId, symbol, timestamp, recipientNametag, senderPubkey }]
+// 10. Transaction history
+const history = sphere.payments.getHistory(); // TransactionHistoryEntry[]
 
-// 10. Peer resolution (nametag → addresses)
+// 11. Peer resolution (Unicity ID → addresses)
 const peer = await sphere.resolve('@bob');
-// { chainPubkey, directAddress, l1Address, nametag, transportPubkey }
+// PeerInfo | null: { nametag?, transportPubkey, chainPubkey, l1Address, directAddress, timestamp }
 
-// 11. Multi-address
+// 12. Multi-address
 await sphere.switchToAddress(1);
 await sphere.registerNametag('alice2');
 const addresses = sphere.getActiveAddresses(); // TrackedAddress[]
 
-// 12. Payment requests
+// 13. Payment requests
 const reqResult = await sphere.payments.sendPaymentRequest('@bob', {
   amount: '1000000', coinId: 'UCT', message: 'Pay for order #1234',
 });
@@ -114,19 +125,25 @@ sphere.payments.onPaymentRequest((req) => {
   sphere.payments.payPaymentRequest(req.id);  // or rejectPaymentRequest()
 });
 
-// 12a. Invoicing (requires accounting: true in init)
-const invoice = await sphere.accounting.createInvoice({
+// 13a. Invoicing (requires accounting: true in init; sphere.accounting is nullable)
+const invoice = await sphere.accounting!.createInvoice({
   targets: [{ address: identity.directAddress!, assets: [{ coin: ['UCT', '1000000'] }] }],
   memo: 'Order #1234',
 });
+// invoice.token is the transmittable v2 invoice blob (hex STRING) — pass it to
+// importInvoice on the receiving side:
+//   const terms = await sphere.accounting!.importInvoice(invoice.token!);
 
-// 12b. Token swaps (requires swap: true in init)
-const swap = await sphere.swap.proposeSwap({
-  give: { currency: 'UCT', amount: '1000000' },
-  receive: { currency: 'USDU', amount: '500000' },
-}, { recipient: '@bob', escrowAddress: 'DIRECT://escrow...' });
+// 13b. Token swaps (requires swap: true in init; sphere.swap is nullable)
+const swap = await sphere.swap!.proposeSwap({
+  partyA: '@alice', partyB: '@bob',
+  partyACurrency: 'UCT',  partyAAmount: '1000000',
+  partyBCurrency: 'USDU', partyBAmount: '500000',
+  timeout: 3600,                       // seconds, [60, 86400]
+  escrowAddress: 'DIRECT://escrow...', // or SwapModuleConfig.defaultEscrowAddress
+}, { message: 'wanna trade?' });
 
-// 13. Cleanup
+// 14. Cleanup
 await sphere.destroy();
 ```
 
@@ -143,13 +160,15 @@ Typed RPC layer for dApp ↔ wallet communication. Full guide: [`docs/CONNECT.md
 
 **Transports:** `PostMessageTransport` (iframe/popup), `ExtensionTransport` (browser extension), `WebSocketTransport` (Node.js).
 
-**Queries:** `sphere_getIdentity`, `sphere_getBalance`, `sphere_getFiatBalance`, `sphere_l1GetBalance`, `sphere_getAssets`, `sphere_getTokens`, `sphere_getHistory`, `sphere_l1GetHistory`, `sphere_resolve`.
+**Queries (18):** `sphere_getIdentity`, `sphere_getBalance`, `sphere_getAssets`, `sphere_getFiatBalance`, `sphere_getTokens`, `sphere_getHistory`, `sphere_l1GetBalance`, `sphere_l1GetHistory`, `sphere_resolve`, `sphere_subscribe`, `sphere_unsubscribe`, `sphere_disconnect`, `sphere_getConversations`, `sphere_getMessages`, `sphere_getDMUnreadCount`, `sphere_markAsRead`, `sphere_getInvoices`, `sphere_getInvoiceStatus`.
 
-**Intents:** `send`, `l1_send`, `dm`, `payment_request`, `receive`, `sign_message`.
+**Intents (15):** `send`, `l1_send`, `dm`, `payment_request`, `receive`, `sign_message`, `create_invoice`, `close_invoice`, `cancel_invoice`, `pay_invoice`, `return_invoice_payment`, `import_invoice`, `send_invoice_receipts`, `send_cancellation_notices`, `set_auto_return`.
 
-**Permissions:** `identity:read`, `balance:read`, `history:read`, `assets:read`, `intent:send`, `intent:l1_send`, `intent:dm`, `intent:payment_request`, `intent:receive`, `intent:sign_message`.
+**Permission scopes (16):** `identity:read`, `balance:read`, `tokens:read`, `history:read`, `l1:read`, `events:subscribe`, `resolve:peer`, `transfer:request`, `l1:transfer`, `dm:request`, `dm:read`, `dm:manage`, `payment:request`, `sign:request`, `invoice:read`, `invoice:write`.
 
 **Silent mode:** `new ConnectClient({ ..., silent: true })` — fast-check approved list without UI popup.
+
+**Wallet-pushed events:** `WALLET_EVENTS.LOCKED` (`wallet:locked`), `WALLET_EVENTS.IDENTITY_CHANGED` (`identity:changed`) — pushed by the host without subscription.
 
 ---
 
@@ -160,60 +179,67 @@ Typed RPC layer for dApp ↔ wallet communication. Full guide: [`docs/CONNECT.md
 | Storage | IndexedDB (`IndexedDBStorageProvider`) | File-based JSON (`FileStorageProvider`) |
 | Token Storage | IndexedDB per-address | File-based per-address |
 | Transport (Nostr) | Native WebSocket | `ws` package (install separately) |
-| Oracle (Aggregator) | Included with API key | Included with API key |
+| Oracle (network config) | Embedded trust base per network; API key injected via `oracle.apiKey` | Same (+ optional `trustBasePath` file) |
 | L1 (ALPHA blockchain) | Enabled, lazy Fulcrum connect | Enabled, lazy Fulcrum connect |
 | L1 Vesting Cache | IndexedDB (`SphereVestingCacheV5`) | Memory-only (no persistence) |
 | Price (CoinGecko) | Optional (`price` config) | Optional (`price` config) |
-| Token Registry | Remote fetch + localStorage cache | Remote fetch + file cache |
-| IPFS sync | Built-in (HTTP) | Built-in (HTTP) |
+| Token Registry | Remote fetch + persistent cache | Remote fetch + file cache |
+| IPFS sync | Opt-in (`tokenSync.ipfs.enabled`) | Opt-in |
 
 ### Key API Methods Reference
 
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `Sphere.init(options)` | `{ sphere, created, generatedMnemonic? }` | Create or load wallet |
-| `Sphere.exists(storage)` | `boolean` | Check if wallet exists |
+| `Sphere.exists(storage)` | `Promise<boolean>` | Check if wallet exists |
 | `Sphere.clear({ storage, tokenStorage? })` | `void` | Delete all wallet data |
 | `Sphere.import(options)` | `Sphere` | Import from mnemonic/masterKey |
-| `sphere.payments.getAssets(coinId?)` | `Asset[]` | Get assets grouped by coin |
-| `sphere.payments.getBalance()` | `number \| null` | Total USD value |
+| `sphere.payments.getAssets(coinId?)` | `Promise<Asset[]>` | Assets grouped by coin |
+| `sphere.payments.getBalance(coinId?)` | `Asset[]` | Synchronous balance from loaded tokens |
+| `sphere.payments.getFiatBalance()` | `Promise<number \| null>` | Total USD value |
 | `sphere.payments.getTokens(filter?)` | `Token[]` | Get individual tokens |
-| `sphere.payments.send(request)` | `TransferResult` | Send L3 tokens |
+| `sphere.payments.send(request)` | `Promise<TransferResult>` | Send L3 tokens (engine-only path) |
+| `sphere.payments.receive(options?)` | `Promise<ReceiveResult>` | One-shot fetch of pending transfers (options deprecated no-ops) |
+| `sphere.payments.mintFungibleToken(coinIdHex, amount)` | `{ success, token?, tokenId?, error? }` | Self-mint via engine (no faucet) |
 | `sphere.payments.sync()` | `{ added, removed }` | Sync with remote storage |
-| `sphere.payments.validate()` | `{ valid, invalid }` | Validate against aggregator |
+| `sphere.payments.validate()` | `{ valid, invalid }` | Verify tokens (engine for v2 blobs, legacy RPC for v1 TXF) |
 | `sphere.payments.getHistory()` | `TransactionHistoryEntry[]` | Transaction history |
 | `sphere.payments.l1.getBalance()` | `L1Balance` | L1 balance (strings in sats) |
 | `sphere.payments.l1.send(request)` | `L1SendResult` | Send L1 transaction |
 | `sphere.payments.l1.getHistory(limit?)` | `L1Transaction[]` | L1 tx history |
 | `sphere.resolve(identifier)` | `PeerInfo \| null` | Resolve @nametag/address/pubkey |
-| `sphere.communications.resolvePeerNametag(pubkey)` | `string \| undefined` | Resolve peer nametag via transport |
-| `sphere.registerNametag(name)` | `void` | Register nametag (mints on-chain) |
-| `sphere.switchToAddress(index)` | `void` | Switch HD address |
+| `sphere.communications.resolvePeerNametag(pubkey)` | `string \| undefined` | Resolve peer Unicity ID via transport |
+| `sphere.registerNametag(name)` | `void` | Register Unicity ID (Nostr binding + best-effort v2 token mint) |
+| `sphere.signMessage(message)` | `string` | Sign with wallet key (secp256k1 ECDSA) |
+| `sphere.switchToAddress(index, options?)` | `void` | Switch HD address |
 | `sphere.getActiveAddresses()` | `TrackedAddress[]` | Non-hidden tracked addresses |
 | `sphere.on(event, handler)` | `() => void` (unsubscribe) | Subscribe to events |
-| `sphere.accounting.createInvoice(request)` | `CreateInvoiceResult` | Mint a new invoice token |
-| `sphere.accounting.importInvoice(token)` | `InvoiceTerms` | Import a received invoice TXF token |
+| `sphere.accounting.createInvoice(request)` | `CreateInvoiceResult` | Mint a v2 invoice data token (`token` = hex blob string) |
+| `sphere.accounting.importInvoice(tokenBlobHex)` | `InvoiceTerms` | Import a received v2 invoice blob (v1 TXF rejected) |
 | `sphere.accounting.getInvoiceStatus(invoiceId)` | `InvoiceStatus` | Full status with per-target balances |
 | `sphere.accounting.payInvoice(invoiceId, params)` | `TransferResult` | Send payment referencing an invoice |
-| `sphere.accounting.closeInvoice(invoiceId)` | `void` | Explicitly close (terminal state) |
-| `sphere.accounting.cancelInvoice(invoiceId)` | `void` | Cancel and optionally auto-return |
+| `sphere.accounting.closeInvoice(invoiceId, options?)` | `void` | Explicitly close (terminal state) |
+| `sphere.accounting.cancelInvoice(invoiceId, options?)` | `void` | Cancel and optionally auto-return |
 | `sphere.swap.proposeSwap(deal, options?)` | `SwapProposalResult` | Propose a token swap |
 | `sphere.swap.acceptSwap(swapId)` | `void` | Accept a swap proposal |
 | `sphere.swap.deposit(swapId)` | `TransferResult` | Deposit into a swap |
 | `sphere.swap.getSwaps(filter?)` | `SwapRef[]` | List swaps with filter |
 
+Note: `sphere.accounting`, `sphere.swap`, `sphere.groupChat`, `sphere.market` are
+nullable getters — `null` unless the module was enabled in init options.
+
 ### Key Events
 
 | Event | Payload | When |
 |-------|---------|------|
-| `transfer:incoming` | `{ senderPubkey, senderNametag?, tokens, receivedAt }` | Received tokens via Nostr |
+| `transfer:incoming` | `IncomingTransfer` (`{ senderPubkey, senderNametag?, tokens, receivedAt }`) | Received tokens via Nostr |
 | `transfer:confirmed` | `TransferResult` | Outgoing transfer confirmed |
 | `transfer:failed` | `TransferResult` | Outgoing transfer failed |
-| `identity:changed` | `{ l1Address, directAddress, chainPubkey, nametag, addressIndex }` | Address switch |
-| `nametag:registered` | `{ nametag, addressIndex }` | Nametag registered |
-| `nametag:recovered` | `{ nametag }` | Nametag recovered from Nostr on import |
+| `identity:changed` | `{ l1Address, directAddress?, chainPubkey, nametag?, addressIndex }` | Address switch |
+| `nametag:registered` | `{ nametag, addressIndex }` | Unicity ID registered |
+| `nametag:recovered` | `{ nametag }` | Unicity ID recovered from Nostr on import |
 | `address:activated` | `{ address: TrackedAddress }` | New address tracked |
-| `sync:provider` | `{ providerId, success, added, removed }` | Per-provider sync result |
+| `sync:provider` | `{ providerId, success, added?, removed?, error? }` | Per-provider sync result |
 | `payment_request:incoming` | `IncomingPaymentRequest` | Received payment request |
 | `invoice:created` | `{ invoiceId, confirmed }` | Invoice token minted or imported |
 | `invoice:payment` | `{ invoiceId, transfer, paymentDirection, confirmed }` | Payment attributed to invoice |
@@ -233,108 +259,120 @@ See [QUICKSTART-BROWSER.md](docs/QUICKSTART-BROWSER.md) and [QUICKSTART-NODEJS.m
 ## Project Overview
 
 **Sphere SDK** (`@unicitylabs/sphere-sdk`) is a modular TypeScript SDK for Unicity wallet operations supporting:
-- **L1 (ALPHA blockchain)** - UTXO-based blockchain transactions via Electrum
-- **L3 (Unicity state transition network)** - Token transfers with state proofs via Aggregator
+- **L1 (ALPHA blockchain)** - UTXO-based blockchain transactions via Electrum (Fulcrum)
+- **L3 (Unicity state transition network)** - Token transfers via the **v2 state-transition SDK**, consumed exclusively through the `token-engine/` port
 
-**Version:** 0.6.14
+**Version:** 0.8.0-dev.6 (post v1-cutover; see CHANGELOG `[Unreleased]`)
 **License:** MIT
-**Target:** Node.js >= 18.0.0, Browser (ESM/CJS)
+**Target:** Node.js >= 22.0.0, Browser (ESM/CJS)
+**CLI:** moved out to `@unicity-sphere/cli` (`npm run cli` only prints a pointer)
 
 ## Directory Structure
 
 ```
 sphere-sdk/
 ├── core/                    # Core wallet and crypto utilities
-│   ├── Sphere.ts           # Main wallet class (72KB) - entry point
-│   ├── crypto.ts           # BIP39/BIP32, secp256k1, hashing
+│   ├── Sphere.ts           # Main wallet class (~165KB) - entry point
+│   ├── address.ts          # DIRECT:// address parsing/validation
+│   ├── crypto.ts           # BIP39/BIP32, secp256k1, hashing, message signing
 │   ├── bech32.ts           # Address encoding/decoding
-│   ├── encryption.ts       # AES encryption utilities
+│   ├── encryption.ts       # AES/Argon2+ChaCha20 encryption utilities
+│   ├── errors.ts           # SphereError + SphereErrorCode
+│   ├── logger.ts           # Centralized logger singleton
 │   ├── currency.ts         # Amount formatting/conversion
+│   ├── scan.ts / discover.ts # HD address scanning/discovery
+│   ├── network-health.ts   # checkNetworkHealth()
 │   └── utils.ts            # Base58, patterns, UUID, helpers
 │
+├── token-engine/            # ⭐ Anti-corruption layer over the v2 state-transition SDK
+│   ├── engine.ts           # ITokenEngine port (frozen contract) + EngineConfig
+│   ├── types.ts            # Sphere-domain types: SphereToken, TokenBlob, Mint/Transfer/SplitParams
+│   ├── factory.ts          # createSphereTokenEngine(config)
+│   ├── SphereTokenEngine.ts # The real adapter (engine implementation)
+│   ├── SpherePaymentData.ts # Value envelope codec (coins inside v2 tokens)
+│   ├── token-blob.ts       # TokenBlob CBOR encode/decode
+│   ├── identity.ts         # deriveDirectAddress() — vendored v1-identical DIRECT:// derivation
+│   ├── unicity-id.ts       # createUnicityIdMinter() — self-issued v2 UnicityIdToken mint
+│   ├── network.ts          # SphereNetwork ↔ SDK NetworkId mapping
+│   └── sdk.ts              # ⚠️ THE ONLY file allowed to import @unicitylabs/state-transition-sdk
+│
 ├── types/                   # TypeScript type definitions
-│   ├── index.ts            # Main types (Identity, Token, Transfer, etc.)
-│   └── txf.ts              # Token eXchange Format types
+│   ├── index.ts            # Main types (Identity, Token, Transfer, events, etc.)
+│   ├── txf.ts              # Token eXchange Format types (legacy v1 storage) + NametagData
+│   └── v2-transfer.ts      # V2TransferPayload — the only supported transfer wire format
 │
 ├── modules/                 # Feature modules
 │   ├── payments/
-│   │   ├── PaymentsModule.ts      # L3 token operations (88KB)
+│   │   ├── PaymentsModule.ts      # L3 token operations (~139KB)
 │   │   ├── L1PaymentsModule.ts    # ALPHA blockchain operations
-│   │   ├── TokenSplitCalculator.ts
-│   │   ├── TokenSplitExecutor.ts
-│   │   └── NametagMinter.ts       # On-chain nametag minting
+│   │   ├── SpendQueue.ts          # Concurrent-send queueing (waits for change tokens)
+│   │   ├── TokenSplitCalculator.ts # Split planning
+│   │   └── TokenReservationLedger.ts # Token reservations for concurrent sends
 │   ├── accounting/
-│   │   ├── AccountingModule.ts    # Invoice lifecycle and payment attribution
+│   │   ├── AccountingModule.ts    # Invoice lifecycle and payment attribution (~268KB)
 │   │   ├── types.ts               # InvoiceTerms, InvoiceStatus, etc.
 │   │   ├── balance-computer.ts    # Per-target status computation
 │   │   ├── auto-return.ts         # Automatic refund management
 │   │   ├── memo.ts                # Invoice memo encoding + hashInvoiceId
 │   │   └── serialization.ts       # Canonical invoice serialization
 │   ├── swap/
-│   │   ├── SwapModule.ts          # P2P token swap lifecycle
+│   │   ├── SwapModule.ts          # P2P token swap lifecycle (~169KB)
 │   │   ├── dm-protocol.ts         # NIP-17 swap DM message protocol
 │   │   ├── escrow-client.ts       # Escrow service interaction
 │   │   ├── manifest.ts            # Swap manifest signing/verification
 │   │   └── state-machine.ts       # Swap progress transitions
-│   ├── groupchat/
-│   │   ├── GroupChatModule.ts     # NIP-29 group chat (relay-based)
-│   │   ├── types.ts               # GroupData, GroupMessageData, etc.
-│   │   └── index.ts               # Barrel exports + factory
-│   └── communications/
-│       └── CommunicationsModule.ts # DMs and broadcasts
+│   ├── groupchat/                 # NIP-29 group chat (relay-based)
+│   ├── market/                    # Market intents
+│   └── communications/            # DMs and broadcasts
 │
-├── transport/               # P2P messaging abstraction
-│   ├── transport-provider.ts      # TransportProvider interface
-│   └── NostrTransportProvider.ts  # Nostr implementation
-│
+├── transport/               # P2P messaging abstraction (NostrTransportProvider)
 ├── storage/                 # Data persistence abstraction
-│   └── token-storage-provider.ts  # TokenStorageProvider interface
-│
-├── oracle/                  # Token validation (Aggregator)
-│   └── oracle-provider.ts         # OracleProvider interface
-│
-├── price/                   # Token market prices
-│   ├── price-provider.ts          # PriceProvider interface
-│   ├── CoinGeckoPriceProvider.ts  # CoinGecko implementation
-│   └── index.ts                   # Barrel exports + factory
+├── oracle/                  # Network-config provider for the token engine
+│   ├── oracle-provider.ts         # OracleProvider interface
+│   └── UnicityAggregatorProvider.ts # Default implementation
+├── price/                   # Token market prices (CoinGeckoPriceProvider)
+├── registry/                # Token metadata registry (remote fetch + cache singleton)
+├── validation/              # TokenValidator
+├── serialization/           # TXF + legacy wallet file parsing (.txt / .dat)
+├── connect/                 # Sphere Connect protocol (client/, host/, protocol, permissions)
+├── l1/                      # ALPHA blockchain utilities (address, tx, vesting, ...)
+├── assets/                  # Embedded trust bases per network (trustbase.ts)
 │
 ├── impl/                    # Platform-specific implementations
-│   ├── browser/            # IndexedDB storage (kv + tokens), browser IPFS factory
-│   ├── nodejs/             # FileStorage, FileTokenStorage, Node.js IPFS factory
-│   └── shared/             # Common config, resolvers, and IPFS provider
-│       └── ipfs/           # Cross-platform IPFS/IPNS storage (HTTP-based)
+│   ├── browser/            # IndexedDB storage, browser oracle/transport/IPFS, connect
+│   ├── nodejs/             # FileStorage, Node oracle/transport/IPFS, connect
+│   └── shared/             # Config resolvers, network consistency checks, trust-base loaders, IPFS
 │
-├── l1/                      # ALPHA blockchain utilities
-│   ├── address.ts          # Address generation
-│   ├── tx.ts               # Transaction construction
-│   ├── vesting.ts          # Vesting classification
-│   └── ...
-│
-├── registry/                # Token metadata registry
-│   └── TokenRegistry.ts    # Remote fetch + cache singleton
-│
-├── validation/              # Token validation
-│   └── TokenValidator.ts
-│
-├── serialization/           # Legacy format parsing
-│   ├── txf-serializer.ts   # TXF format
-│   ├── wallet-text.ts      # .txt backup format
-│   └── wallet-dat.ts       # SQLite .dat format
-│
-├── tests/                   # Test suite (Vitest)
-│   ├── unit/               # Unit tests
-│   └── integration/        # Integration tests
-│
-├── docs/                    # Documentation
-│   ├── API.md              # API reference
-│   └── INTEGRATION.md      # Integration guide
-│
+├── tests/                   # Test suite (Vitest): unit/, integration/, e2e/, relay/, fixtures/
+├── docs/                    # Documentation (CONNECT.md, QUICKSTART-*, ACCOUNTING-*, SWAP-*, ...)
 ├── index.ts                 # Main SDK entry point
-├── constants.ts             # Global constants and defaults
+├── constants.ts             # Global constants, NETWORKS, storage keys
 └── package.json
 ```
 
 ## Architecture
+
+### Token Engine (v2) — the only L3 money path
+
+The legacy v1 `@unicitylabs/state-transition-sdk@1.6.1-rc` engine is **removed**.
+The canonical package name resolves to the **v2 SDK, pinned `2.0.0-rc.6027e82`**.
+
+- The SDK is imported in exactly ONE file: `token-engine/sdk.ts`. An ESLint
+  `no-restricted-imports` rule blocks any other import of
+  `@unicitylabs/state-transition-sdk` — everything else codes against the
+  `ITokenEngine` port and sphere-domain types from `token-engine/`.
+- `ITokenEngine` operations: `getIdentity`, `deriveIdentityAddress`, `tokenId`,
+  `readValue`, `balanceOf`, `readMemo`, `readTokenData`, `mint`, `mintDataToken`,
+  `transfer`, `split`, `verify`, `isSpent`, `isOwnedBy`, `encodeToken`, `decodeToken`.
+- `Sphere` builds the engine from the oracle's config surface
+  (`getTrustBaseJson()` / `getAggregatorUrl()` / `getApiKey()`) via
+  `createSphereTokenEngine(EngineConfig)`. The trust base JSON is the single
+  source of truth for the network id (`RootTrustBase.networkId`, e.g. testnet2 = 4).
+- `SphereToken.sdkToken` is an OPAQUE handle — callers store it and hand it back
+  to the engine, never call methods on it.
+- **The engine is mandatory for money movement**: `send()`, `mintFungibleToken()`,
+  `accounting.createInvoice()/importInvoice()` fail loudly (`AGGREGATOR_ERROR` /
+  invoice errors) when the oracle does not supply a v2 trust base + gateway URL.
 
 ### Single Identity Model
 L1 and L3 share the same secp256k1 key pair:
@@ -350,6 +388,11 @@ mnemonic → master key → BIP32 derivation → identity
                         └─────────────────────────────────────────────┘
 ```
 
+The `DIRECT://` address is derived by `token-engine/identity.ts`
+(`deriveDirectAddress`) — a vendored, byte-identical reproduction of the v1
+derivation. It MUST stay stable: external systems (Quest XP) key user identity
+on it.
+
 ### Key Types
 
 ```typescript
@@ -358,7 +401,7 @@ interface Identity {
   l1Address: string;        // L1 bech32 address (alpha1...)
   directAddress?: string;   // L3 DIRECT address
   ipnsName?: string;        // IPFS/IPNS identifier
-  nametag?: string;         // Human-readable alias (@username)
+  nametag?: string;         // Unicity ID (@username)
 }
 
 interface FullIdentity extends Identity {
@@ -368,29 +411,32 @@ interface FullIdentity extends Identity {
 interface TransferRequest {
   recipient: string;        // @nametag, DIRECT://..., chain pubkey, alpha1...
   amount: string;           // Amount in smallest unit
-  coinId: string;           // Token coin ID (e.g., 'UCT')
+  coinId: string;           // Coin ID (64-hex canonical; short symbols resolved via registry)
   memo?: string;            // Optional message
+  // addressMode / transferMode still exist on the type but are IGNORED —
+  // there is a single engine send path (no PROXY, no instant/conservative branches).
 }
 
 interface TransferResult {
   readonly id: string;
-  status: 'pending' | 'submitted' | 'delivered' | 'completed' | 'failed';
+  status: 'pending' | 'submitted' | 'confirmed' | 'delivered' | 'completed' | 'failed';
   readonly tokens: Token[];
-  txHash?: string;
+  readonly tokenTransfers: TokenTransferDetail[];
   error?: string;
 }
 
-// Tracked address (returned by getActiveAddresses(), etc.)
-interface TrackedAddress {
-  index: number;            // HD derivation index
-  addressId: string;        // "DIRECT_abc123_xyz789"
-  l1Address: string;        // alpha1...
-  directAddress: string;    // DIRECT://...
-  chainPubkey: string;      // 33-byte compressed pubkey
-  nametag?: string;         // primary nametag (without @)
-  hidden: boolean;          // manual hide flag for UI
-  createdAt: number;        // ms timestamp
-  updatedAt: number;        // ms timestamp
+// token-engine sphere-domain types
+interface TokenBlob {
+  v: number;        // blob format version (sphere storage migrations)
+  network: number;  // NetworkId.id
+  tokenId: string;  // genesis-stable 64-hex id (same across all states)
+  token: Uint8Array; // CBOR of the v2 Token
+}
+
+interface SphereToken {
+  sdkToken: Token;          // OPAQUE v2 SDK handle — never touch outside token-engine/
+  blob: TokenBlob;          // serializable form
+  value: SphereValue | null; // decoded { assets: [{ coinId, amount: bigint }] }
 }
 ```
 
@@ -399,24 +445,42 @@ Abstract interfaces for platform independence:
 
 | Provider | Interface | Implementations |
 |----------|-----------|-----------------|
-| Storage | `StorageProvider` | IndexedDBStorageProvider (browser default), LocalStorageProvider (browser legacy), FileStorageProvider (Node.js) |
+| Storage | `StorageProvider` | IndexedDBStorageProvider (browser), FileStorageProvider (Node.js) |
 | TokenStorage | `TokenStorageProvider` | IndexedDBTokenStorageProvider, FileTokenStorageProvider, IpfsStorageProvider |
 | Transport | `TransportProvider` | NostrTransportProvider |
 | Oracle | `OracleProvider` | UnicityAggregatorProvider |
 | Price | `PriceProvider` | CoinGeckoPriceProvider |
 
-### Network Configuration
+**Oracle is a thin network-config provider** (post v1-cutover). Its surface:
+- `initialize(trustBaseJson?)` — loads trust base via the platform loader unless passed explicitly
+- `getTrustBaseJson()` / `getAggregatorUrl()` / `getApiKey()` — REQUIRED members; the v2 engine is built from exactly these three
+- `validateToken(tokenData)` — best-effort legacy JSON-RPC check for v1 TXF tokens only (display path); v2 blobs are verified via the engine
 
-| Network | Aggregator | Nostr Relay | Electrum |
-|---------|------------|-------------|----------|
-| mainnet | aggregator.unicity.network | relay.unicity.network | fulcrum.alpha.unicity.network |
-| testnet | goggregator-test.unicity.network | nostr-relay.testnet.unicity.network | fulcrum.alpha.testnet.unicity.network |
-| dev | dev-aggregator.dyndns.org | nostr-relay.testnet.unicity.network | fulcrum.alpha.testnet.unicity.network |
+Custom `OracleProvider` implementations MUST provide the three config accessors.
+
+### Network Configuration (`constants.ts` → `NETWORKS`)
+
+| Network | Aggregator/Gateway | Status |
+|---------|--------------------|--------|
+| `testnet` | `https://gateway.testnet2.unicity.network` | ⭐ **Alias of testnet2** (v2 gateway, trust-base networkId 4, testnet2 token registry) |
+| `testnet2` | `https://gateway.testnet2.unicity.network` | Same config as `testnet` |
+| `mainnet` | `aggregator.unicity.network/rpc` | v1-era; **no embedded trust base** — provider factories refuse it (`INVALID_CONFIG`) |
+| `dev` | `dev-aggregator.dyndns.org/rpc` | v1-era aggregator — wallet operations fail loudly (`AGGREGATOR_ERROR`) until cut over |
+
+All networks share Nostr relays (`nostr-relay.testnet.unicity.network` for test
+nets), IPFS gateways, Fulcrum electrum and group relays per `NETWORKS`.
+`assertNetworkConsistency()` (impl/shared/network.ts) refuses provably-broken
+networks at provider creation (null or networkId-mismatched trust base).
+
+**API key:** there is NO bundled default. Consumers inject `oracle.apiKey`
+(plumbed through `createBrowserProviders`/`createNodeProviders` →
+`UnicityAggregatorProvider` → engine). The testnet2 key is non-secret and
+pre-filled in `.env.example`; a mainnet key is a secret.
 
 ## Common Commands
 
 ```bash
-# Build (ESM + CJS via tsup)
+# Build (ESM + CJS via tsup, multiple entry points)
 npm run build
 
 # Test (watch mode)
@@ -425,6 +489,12 @@ npm test
 # Test (single run)
 npm run test:run
 
+# E2E tests (live testnet2; needs .env with TESTNET2_API_KEY — see .env.example)
+npm run test:e2e
+
+# Relay integration tests (Docker testcontainers, or RELAY_URL=...)
+npm run test:relay
+
 # Lint
 npm run lint
 
@@ -432,204 +502,180 @@ npm run lint
 npm run typecheck
 ```
 
+⚠️ **Windows note:** the tsup DTS build is known to segfault on Windows +
+Node 22.x. This is a local toolchain trap, NOT a real break — CI (Linux) is
+authoritative for build success.
+
 ## Key Concepts
 
+### v1 → v2 Cutover (what changed)
+- **Removed:** `payments.sendInstant()`, `payments.resolveUnconfirmed()`,
+  instant-split/payment-session wire types (`types/instant-split`,
+  `types/payment-session`), `NametagMinter`, `TokenSplitExecutor`, oracle
+  commitment/proof/mint methods (`submitCommitment`, `getProof`, `waitForProof`,
+  `isSpent`, `getTokenState`, `getCurrentRound`, `mint`, SDK client accessors).
+- **Wire format:** the only supported transfer payload is `V2_TRANSFER`
+  (`{ type: 'V2_TRANSFER', version: '2.0', tokenBlob, memo? }` — a FINISHED v2
+  token blob, hex of CBOR(TokenBlob)). Incoming v1 payloads (V5/V6
+  instant-split, NOSTR-FIRST, `{sourceToken, transferTx}`, plain token JSON) are
+  dropped with an explicit error log — peers must run a >=0.8 wallet.
+- **Stored v1 TXF tokens** stay visible (parsed as JSON for display) but are
+  unspendable; orphaned pending-V5 tokens are terminalized to `invalid` on load.
+
+### Send Pipeline (v2, money-safety)
+- `send()` requires the token engine AND a recipient with a published chain
+  pubkey (`INVALID_RECIPIENT` otherwise). Transfers lock to
+  `SignaturePredicate(recipient chainPubkey)`.
+- Spend planning goes through `SpendQueue` + `TokenReservationLedger`
+  (synchronous critical section; concurrent sends queue for change tokens
+  instead of failing).
+- The engine `transfer`/`split` produces a FINISHED token for the recipient.
+  The moment it is certified on-chain (source already spent), the blob is
+  journaled in `PENDING_V2_DELIVERIES` storage and only removed after
+  successful transport delivery — `load()` replays undelivered blobs, so a
+  crash or transport failure never loses the recipient's token.
+- **Failure restore semantics:** source tokens whose spend was certified
+  on-chain during a failed send become terminal `'spent'` — never restored to
+  `'confirmed'`. Tokens stuck `'transferring'` after a crash are reconciled
+  against the network on `load()`.
+
+### Receive & Verification (v2)
+- v2 transfers arrive as finished tokens: decode + verify + store, no
+  commitment/proof/finalization round-trip. `receive()` is a one-shot fetch;
+  its old finalization options are deprecated no-ops.
+- **Incoming transfers are verified before entering the balance:**
+  `engine.verify` (full trust-base proof check) + `engine.isOwnedBy(token,
+  own chainPubkey)` — tokens that fail verification or are not addressed to
+  this wallet are rejected (warn log). Dedup by genesis-stable tokenId.
+- `validate()` checks v2 blob tokens via the engine (`verify` + `isSpent`);
+  legacy v1 TXF tokens fall back to the oracle's `validateToken` RPC.
+  Transient engine failures skip the token (never invalidate funds on an outage).
+
+### Minting
+- `payments.mintFungibleToken(coinIdHex, amount: bigint)` = **engine self-mint**
+  (v2 standalone mint to the wallet's own pubkey, no faucet, no commitment
+  round-trip). Lets a fresh wallet top up on testnet2.
+- `engine.mintDataToken` mints NON-value (data) tokens — used for invoices.
+
+### Unicity IDs (nametags)
+- Human-readable aliases (e.g., `@alice`) for receiving payments.
+- **Registration = publishing the Nostr identity binding** (name ↔ chainPubkey,
+  first-seen-wins is the global uniqueness guard). Runtime name resolution is
+  Nostr-binding-only; receive is always `SignaturePredicate(chainPubkey)`;
+  there is **no PROXY addressing anywhere**.
+- `registerNametag()` ALSO best-effort mints + stores a **self-issued v2
+  `UnicityIdToken`** (`token-engine/unicity-id.ts`, `createUnicityIdMinter`),
+  saved as `NametagData { format: 'v2-cbor', token: <CBOR hex string> }`. The
+  mint is deterministic per (name, wallet key) → idempotent re-mint recovers a
+  lost token; a gateway outage never fails registration (retried on next load).
+  The stored token is unused at runtime (kept for a future issuer/verification
+  model). `NametagMinter` / `mintNametag` DO NOT EXIST anymore.
+- Recovered from Nostr when importing a wallet; each HD address can have its own.
+
+### Accounting / Invoicing
+- **Invoice IS a v2 data token** minted via `engine.mintDataToken` (terms in the
+  token's data, deterministic salt → stable terms-derived tokenId).
+- `CreateInvoiceResult.token` is the transmittable **hex blob string**;
+  `importInvoice` takes that hex string (legacy v1 TXF invoices are rejected
+  with an explicit error). No trust-base dependency in
+  `AccountingModuleDependencies` — the engine owns trust.
+- State machine: `OPEN -> PARTIAL -> COVERED -> CLOSED` (or `CANCELLED`,
+  `EXPIRED`). Terminal states freeze balances.
+- Privacy: on-chain memos embed `SHA-256(invoiceId)`; recipients verify by
+  re-hashing (legacy raw-ID memos still resolve via `resolveInvoiceRef()`).
+- Auto-return refunds payments to closed/cancelled invoices with a dedup ledger.
+
+### Token Swaps
+- `SwapModule` (`sphere.swap`) orchestrates P2P swaps via an escrow service.
+- Protocol v2: signed manifests with Unicity-ID binding proofs; all messages via
+  NIP-17 encrypted DMs; deposits are payments of escrow-created invoices;
+  payout verified locally via `verifyPayout()`.
+- State machine: `proposed -> accepted -> announced -> depositing -> concluding
+  -> completed` (or `cancelled`/`failed`).
+
 ### L1 Payments (Enabled by Default)
-- L1 module (`sphere.payments.l1`) is created automatically
-- Fulcrum WebSocket connection is **lazy** — deferred until first L1 operation
-- Set `l1: null` in `PaymentsModuleConfig` to explicitly disable
-- `importFromJSON()` and `importFromLegacyFile()` accept `l1` config option
-- **Vesting cache**: `VestingClassifier` uses IndexedDB (`SphereVestingCacheV5`) in browser for persistent UTXO→coinbase tracing cache. In Node.js, falls back to memory-only cache (re-fetched from network each session)
-
-### Nametags
-- Human-readable aliases (e.g., `@alice`) for receiving payments
-- Registered via Nostr relay events (NIP-04 encrypted)
-- Can be recovered from Nostr when importing wallet
-- Each derived HD address can have its own nametag
-
-**When nametag token is minted on-chain:**
-- `Sphere.init({ nametag: 'alice' })` → mints via `registerNametag()`
-- `sphere.registerNametag('alice')` → mints token
-- CLI: `npm run cli -- init --nametag alice` → mints token
-- CLI: `npm run cli -- nametag alice` → mints token
-
-**When NO minting happens:**
-- `Sphere.init({ autoGenerate: true })` without nametag → only creates wallet
-- CLI: `npm run cli -- init` → only creates wallet
-
-**Requirements for minting:**
-- Oracle (Aggregator) provider - included by default with `createBrowserProviders()` / `createNodeProviders()`
-- API key - embedded by default for testnet/mainnet
-
-### L3 Transfers
-- Use `DirectAddress` (not PROXY) for transfers
-- Finalization required to generate local state for tracking
-- Recipient resolved via unified `transport.resolve(identifier)` → returns `PeerInfo`
+- L1 module (`sphere.payments.l1`) is created automatically; Fulcrum WebSocket
+  connection is **lazy** — deferred until first L1 operation.
+- Set `l1: null` in init options to disable L1 entirely.
+- **Vesting cache:** IndexedDB (`SphereVestingCacheV5`) in browser; memory-only in Node.js.
 
 ### Peer Resolution
-- `sphere.resolve(identifier)` / `transport.resolve(identifier)` — unified lookup
-- Accepts: `@nametag`, `DIRECT://...`, `PROXY://...`, `alpha1...`, chain pubkey (`02`/`03` prefix), transport pubkey (64-hex)
-- Returns `PeerInfo` with all address formats, or `null` if not found
-- Identity binding event published on `init()`/`load()` — wallet discoverable without nametag
-
-### DM Nametag Resolution
-- In DMs, peer nametag can come from two sources:
-  1. **Message-embedded**: `senderNametag` field in `DirectMessage` (set by sender in NIP-17 JSON payload)
-  2. **Transport fallback**: `CommunicationsModule.resolvePeerNametag(pubkey)` — live lookup via `transport.resolveTransportPubkeyInfo()` against Nostr relay binding events
-- `ConnectHost.GET_CONVERSATIONS` automatically falls back to transport resolution when no nametag found in messages
-- Consumers using the SDK directly (e.g., agentsphere) should call `resolvePeerNametag()` for conversations missing nametags
-- Resolution is best-effort: errors are silently caught, returns `undefined` on failure
-
-### Transport vs Chain Pubkeys
-- `chainPubkey`: 33-byte compressed secp256k1 for L3 chain operations
-- `transportPubkey`: Derived key for transport messaging (HKDF from private key)
-- Identity binding events include both for cross-resolution
+- `sphere.resolve(identifier)` — unified lookup via transport.
+- Accepts: `@nametag`, `DIRECT://...`, `alpha1...`, chain pubkey (`02`/`03`),
+  transport pubkey (64-hex). Returns `PeerInfo` or `null`.
+- Identity binding event published on init/load — wallet discoverable without a Unicity ID.
 
 ### Token Registry (Remote + Cached)
-- `TokenRegistry` is a singleton that provides token metadata (symbol, name, decimals, icons) by coin ID
-- **No bundled data** — starts empty, data comes from remote URL + persistent cache
-- Configured in two places due to tsup bundle duplication (see below):
-  - By `createBrowserProviders()` / `createNodeProviders()` — configures the impl bundle's singleton
-  - By `Sphere.init()` / `Sphere.load()` / `Sphere.create()` — configures the main bundle's singleton
-- **Data flow:** on `configure()` → `performInitialLoad()`: try cache first (if fresh) → fall back to remote fetch (if `autoRefresh` is true) → start periodic auto-refresh
-- **Readiness:** `TokenRegistry.waitForReady(timeoutMs?)` — returns a promise that resolves when initial data is loaded (cache or remote). `PaymentsModule.load()` awaits this before parsing tokens to ensure metadata is available.
-- **Graceful degradation:** if no cache and no network, lookup methods return fallbacks (truncated coinId for symbol, 0 for decimals)
-- Remote URL per network: `constants.ts` → `NETWORKS[network].tokenRegistryUrl`
-- Cache keys: `STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE` (JSON) and `TOKEN_REGISTRY_CACHE_TS` (timestamp)
-- Race-safe: cache load skipped if remote data is already newer (`lastRefreshAt > cacheTs`)
-- Concurrent `refreshFromRemote()` calls are deduplicated (only one fetch at a time)
-- `TokenRegistry.destroy()` stops auto-refresh and resets singleton
+- `TokenRegistry` singleton provides token metadata (symbol, name, decimals,
+  icons) by coin ID. No bundled data — remote URL per network
+  (`NETWORKS[network].tokenRegistryUrl`; testnet/testnet2 use
+  `unicity-ids.testnet2.json`) + persistent cache.
+- `TokenRegistry.waitForReady()` gates token parsing in `PaymentsModule.load()`.
+- Configured both by provider factories and by `Sphere` itself (tsup bundles
+  duplicate the singleton per entry point — both bundle contexts need `configure()`).
 
-**tsup bundle duplication note:** tsup compiles multiple entry points (`index.ts`, `impl/browser/index.ts`, etc.) into separate bundles, each inlining its own copy of `TokenRegistry`. The static singleton in `dist/impl/browser/index.js` is a different instance from the one in `dist/index.js`. This is why `Sphere` must call `TokenRegistry.configure()` in its own bundle context, not rely on the factory functions alone.
-
-### Price Provider (CoinGecko)
-- `CoinGeckoPriceProvider` fetches token prices from CoinGecko API with multi-layer caching
-- **In-memory cache:** prices cached with configurable TTL (`cacheTtlMs`, default 60s)
-- **Persistent cache:** when `StorageProvider` is passed, prices are persisted to survive page reloads
-  - Cache keys: `STORAGE_KEYS_GLOBAL.PRICE_CACHE` (JSON) and `PRICE_CACHE_TS` (timestamp)
-  - On first `getPrices()` call: loads from storage if within TTL, populates in-memory cache
-  - After each successful API fetch: saves all cached prices to storage (fire-and-forget)
-  - Factory functions (`createBrowserProviders`, `createNodeProviders`) pass storage automatically
-- **Unlisted tokens:** tokens not found on CoinGecko (e.g., UCT, USDU) are cached with zero-price `TokenPrice` entries (`priceUsd: 0`), persisted to storage, and not re-requested until TTL expires
-- **Request deduplication:** concurrent `getPrices()` calls share an in-flight fetch promise if all requested tokens are covered by the current request
-- **Rate-limit backoff:** on 429 response, extends stale cache entries by 60s to prevent retry hammering
-- **Error resilience:** on fetch failure, returns stale cached data if available; corrupted storage data is silently ignored
-
-### Event Timestamp Persistence
-- Transport persists last processed wallet event timestamp via `TransportStorageAdapter`
-- Storage key: `last_wallet_event_ts_{pubkey_prefix}` (per-wallet, in `STORAGE_KEYS_GLOBAL`)
-- On reconnect: `since = stored timestamp` (existing wallet) or `since = now` (fresh wallet)
-- Only wallet events update the timestamp (TOKEN_TRANSFER, PAYMENT_REQUEST, PAYMENT_REQUEST_RESPONSE, DIRECT_MESSAGE)
-- Chat events (GIFT_WRAP/NIP-17) have no `since` filter — always real-time
-- Factory functions (`createBrowserProviders`, `createNodeProviders`) pass storage to transport automatically
+### Network-Scoped Storage
+- Token/payment operational state (pending transfers, outbox, history,
+  invoice/swap ledgers, …) is **per-address AND per-network**
+  (`isNetworkScopedAddressKey` in constants.ts) — a testnet2 auto-return ledger
+  can never fire a send on another network. Chat/identity keys stay
+  network-agnostic. Storage providers take a `network` parameter.
+- `PENDING_V2_DELIVERIES` (per-address, network-scoped) journals
+  finished-but-undelivered transfer blobs (see Send Pipeline).
 
 ### IndexedDB Databases (Browser)
-The SDK manages multiple IndexedDB databases:
 
 | Database | Provider | Purpose |
 |----------|----------|---------|
-| `sphere-storage` | `IndexedDBStorageProvider` | Wallet keys, per-address data (messages, etc.) |
-| `sphere-token-storage-{addressId}` | `IndexedDBTokenStorageProvider` | Token data per address (TXF format) |
+| `sphere-storage` | `IndexedDBStorageProvider` | Wallet keys, per-address data |
+| `sphere-token-storage-*` | `IndexedDBTokenStorageProvider` | Token data per address |
 | `SphereVestingCacheV5` | `VestingClassifier` | L1 UTXO→coinbase tracing cache |
 
-`Sphere.clear()` deletes all three via:
-1. `vestingClassifier.destroy()` → deletes `SphereVestingCacheV5`
-2. Bulk `indexedDB.databases()` → deletes all `sphere*` databases
-3. `tokenStorage.clear()` → deletes per-address token databases
-4. `storage.clear()` → deletes `sphere-storage`
-
-### Token Storage (TXF Format)
-```typescript
-TxfStorageDataBase {
-  _meta: TxfMeta           // Metadata (version, address, timestamp)
-  _tombstones?: []         // Deleted token markers
-  _outbox?: []             // Pending outgoing transfers
-  _sent?: []               // Completed transfers
-  [tokenId]: TxfToken      // Token data
-}
-```
-
-### Accounting / Invoicing
-
-`AccountingModule` (`sphere.accounting`) manages the full invoice lifecycle.
-
-**Invoice IS a token.** Minted as an L3 token with `tokenType = INVOICE_TOKEN_TYPE_HEX`. Terms serialized into `genesis.data.tokenData`.
-
-**State machine:** `OPEN -> PARTIAL -> COVERED -> CLOSED` (or `CANCELLED`, `EXPIRED`). Terminal states freeze balances.
-
-**Privacy: hashed invoice IDs.** On-chain memos embed `SHA-256(invoiceId)` instead of the raw ID. Third parties cannot correlate tokens to invoices. Recipients verify by re-hashing their known ID. Backward-compatible with legacy raw-ID memos via `resolveInvoiceRef()`.
-
-**Auto-return.** When enabled, automatically refunds payments to closed/cancelled invoices with dedup ledger to prevent double-refunds.
-
-### Token Swaps
-
-`SwapModule` (`sphere.swap`) orchestrates P2P token swaps via an escrow service.
-
-**Protocol v2:** Proposals include signed manifests with nametag binding proofs. All messages use NIP-17 encrypted DMs. Escrow holds deposits and executes payouts.
-
-**State machine:** `proposed -> accepted -> announced -> depositing -> concluding -> completed` (or `cancelled`, `failed` at any point).
-
-**Deposit via invoice.** Each party deposits by paying an escrow-created invoice. Payout is verified locally via `verifyPayout()`.
+`Sphere.clear({ storage, tokenStorage })` deletes all of them.
 
 ## Testing
 
 **Framework:** Vitest
-**Total tests:** 2539 (124 test files)
+**Test files:** 170 (`tests/unit/`, `tests/integration/`, `tests/e2e/`, `tests/relay/`)
+**Run:** `npm run test:run` (unit/integration), `npm run test:e2e` (live testnet2, needs `.env`), `npm run test:relay`
 
-Key test files:
-- `tests/unit/core/Sphere.nametag-sync.test.ts` - Nametag sync/recovery
-- `tests/unit/core/Sphere.clear.test.ts` - Wallet data cleanup (storage + tokenStorage + vesting)
-- `tests/unit/transport/NostrTransportProvider.test.ts` - Transport layer, event timestamp persistence
-- `tests/unit/modules/PaymentsModule.test.ts` - Payment operations
-- `tests/unit/modules/NametagMinter.test.ts` - Nametag minting
-- `tests/unit/modules/CommunicationsModule.storage.test.ts` - DM per-address storage, migration, pagination
-- `tests/unit/modules/CommunicationsModule.resolve.test.ts` - Peer nametag resolution via transport fallback
-- `tests/unit/modules/AccountingModule.*.test.ts` - Invoice lifecycle, status, auto-return, receipts, etc.
-- `tests/unit/modules/SwapModule.*.test.ts` - Swap lifecycle, deposits, payouts, cancellation
-- `tests/unit/registry/TokenRegistry.test.ts` - Token registry: remote fetch, caching, auto-refresh, waitForReady
-- `tests/unit/price/CoinGeckoPriceProvider.test.ts` - Price provider: caching, deduplication, rate-limit backoff, persistent storage, unlisted tokens
-- `tests/unit/l1/*.test.ts` - L1 blockchain utilities (incl. vesting Node.js fallback)
-- `tests/unit/l1/L1PaymentsHistory.test.ts` - L1 transaction history direction/amounts
-- `tests/unit/impl/browser/IndexedDBStorageProvider.test.ts` - IndexedDB kv storage, per-address scoping
-- `tests/integration/tracked-addresses.test.ts` - Tracked addresses registry
-- `tests/relay/groupchat-relay.test.ts` - GroupChat NIP-29 relay integration (Docker + remote)
-
-### Relay Integration Tests
-
-```bash
-# Run with Docker (testcontainers)
-npm run test:relay
-
-# Run against deployed relay
-RELAY_URL=wss://sphere-relay.unicity.network npm run test:relay
-```
+Key test areas:
+- `tests/unit/token-engine/` — engine contract, factory, FakeTokenEngine,
+  identity golden test (`identity.test.ts` locks the DIRECT:// derivation),
+  `wallet-address-invariant.test.ts`, `unicity-id-mint.test.ts`, token-blob codec
+- `tests/unit/modules/PaymentsModule*.test.ts` — send/receive/mint/validate,
+  V2_TRANSFER wire format, delivery journal, spend queue
+- `tests/unit/modules/AccountingModule.*.test.ts` — invoice lifecycle, status, auto-return, receipts
+- `tests/unit/modules/SwapModule.*.test.ts` — swap lifecycle, deposits, payouts, cancellation
+- `tests/unit/core/` — Sphere lifecycle, nametag sync/recovery, clear
+- `tests/e2e/token-engine.testnet2.e2e.test.ts`, `payments-v2.testnet2.e2e.test.ts`
+  — live testnet2 (skipped unless `TESTNET2_API_KEY` is set)
+- `tests/relay/groupchat-relay.test.ts` — NIP-29 relay integration (Docker + remote)
 
 ## Dependencies
 
-**Core:**
-- `@unicitylabs/state-transition-sdk` - L3 token/state operations
-- `@unicitylabs/nostr-js-sdk` - Nostr protocol
-- `@noble/hashes`, `@noble/curves` - Cryptography
-- `bip39` - Mnemonic generation
-- `elliptic` - secp256k1 operations
+**Core (from package.json):**
+- `@unicitylabs/state-transition-sdk` — **pinned `2.0.0-rc.6027e82`** (v2 engine; imported only via `token-engine/sdk.ts`)
+- `@unicitylabs/nostr-js-sdk` `^0.5.0` — Nostr protocol
+- `@noble/hashes` `^2`, `@noble/curves` `^2` — cryptography
+- `bip39`, `elliptic`, `crypto-js`, `canonicalize`, `buffer`
 
-**IPFS (built-in):**
-- `@libp2p/crypto` - Ed25519 key generation for IPNS
-- `@libp2p/peer-id` - PeerId derivation for IPNS names
-- `ipns` - IPNS record creation and marshalling
+**Optional/peer (IPFS + Node WebSocket):**
+- `@libp2p/crypto`, `@libp2p/peer-id`, `ipns`, `multiformats` — IPNS support
+- `ws` — Node.js WebSocket (peer, optional)
 
 ## File Size Reference
 
 Largest files (for context):
-- `modules/payments/PaymentsModule.ts` - ~200KB (main payment logic)
-- `core/Sphere.ts` - ~160KB (wallet lifecycle)
-- `modules/swap/SwapModule.ts` - ~150KB (swap lifecycle)
-- `modules/accounting/AccountingModule.ts` - ~130KB (invoice lifecycle)
+- `modules/accounting/AccountingModule.ts` — ~268KB (invoice lifecycle)
+- `modules/swap/SwapModule.ts` — ~169KB (swap lifecycle)
+- `core/Sphere.ts` — ~165KB (wallet lifecycle)
+- `modules/payments/PaymentsModule.ts` — ~139KB (payment logic)
 
 ## Code Style
 
 - TypeScript strict mode
-- ESLint with TypeScript rules
+- ESLint with TypeScript rules (+ the token-engine SDK import boundary)
 - ESM modules (with CJS build output)
 - Prefer `interface` over `type` for objects
 - Use `readonly` for immutable properties

--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ A modular TypeScript SDK for Unicity wallet operations supporting both Layer 1 (
 
 - **Wallet Management** - BIP39/BIP32 key derivation, AES-256 encryption
 - **L1 Payments** - ALPHA blockchain transactions via Fulcrum WebSocket
-- **L3 Payments** - Token transfers with state transition proofs, concurrent-send safety (SpendQueue)
-- **Invoicing / Accounting** - On-chain invoice lifecycle with payment attribution, auto-return, privacy-preserving hashed invoice IDs
+- **L3 Payments** - Token transfers via the v2 state-transition token engine, concurrent-send safety (SpendQueue)
+- **Invoicing / Accounting** - On-chain invoice lifecycle with payment attribution, auto-return, privacy-preserving hashed invoice IDs; invoices travel as v2 data-token blobs (hex strings) — `createInvoice()` returns the blob, `importInvoice()` accepts it
 - **Token Swaps** - P2P atomic swaps via escrow with DM-based negotiation protocol
 - **Payment Requests** - Request payments with async response tracking
+- **Market (Intents)** - Signed intent bulletin board with semantic search and live feed — see [docs/MARKET.md](docs/MARKET.md)
 - **Group Chat** - NIP-29 relay-based group messaging with moderation
 - **Nostr Transport** - Resilient P2P messaging with verified publish, health checks, NIP-17 gift-wrap
 - **IPFS Storage** - Decentralized token backup via HTTP API (browser + Node.js)
 - **Multi-Address** - HD address derivation (BIP32/BIP44)
-- **Token Validation** - Aggregator-based token verification
+- **Token Validation** - Engine-based token verification (trust base + spent check via the v2 gateway)
 - **Connect Protocol** - dApp ↔ wallet communication via `ConnectClient` / `ConnectHost` (browser extension + popup)
 - **CLI** - Comprehensive command-line interface with shell auto-completion
 
@@ -52,11 +53,13 @@ See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md) for the full command refere
 import { Sphere } from '@unicitylabs/sphere-sdk';
 import { createBrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
 
-// Create providers (browser) - defaults to mainnet
-const providers = createBrowserProviders();
-
-// Or use testnet for development
-const testnetProviders = createBrowserProviders({ network: 'testnet' });
+// Create providers (browser) — `network` is required (no default).
+// 'testnet' is the v2 testnet2 gateway; pass the gateway API key for
+// send/mint/invoice operations (see "API Key" below).
+const providers = createBrowserProviders({
+  network: 'testnet',
+  oracle: { apiKey: 'sk_...' },  // testnet2 key is not a secret — see .env.example
+});
 
 // Initialize (auto-creates wallet if needed)
 const { sphere, created, generatedMnemonic } = await Sphere.init({
@@ -76,10 +79,11 @@ const assets = await sphere.payments.getAssets();
 console.log('Assets:', assets);
 
 // Get total portfolio value in USD (requires PriceProvider)
-const balance = await sphere.payments.getBalance();
-console.log('Total USD:', balance); // number | null
+const totalUsd = await sphere.payments.getFiatBalance();
+console.log('Total USD:', totalUsd); // number | null
 
-// Send tokens
+// Send tokens — the recipient must have a published identity (chain pubkey),
+// e.g. a registered Unicity ID; otherwise send fails with INVALID_RECIPIENT
 const result = await sphere.payments.send({
   recipient: '@alice',
   amount: '1000000',
@@ -93,13 +97,16 @@ console.log('Address 1:', addr1.address);
 
 ## Network Configuration
 
-The SDK supports three network presets that configure all services automatically:
+The SDK ships network presets that configure all services automatically. `network` is **required** — there is no default:
 
-| Network | Aggregator | Nostr Relay | Electrum (L1) |
-|---------|------------|-------------|---------------|
-| `mainnet` | aggregator.unicity.network | relay.unicity.network | fulcrum.alpha.unicity.network |
-| `testnet` | goggregator-test.unicity.network | nostr-relay.testnet.unicity.network | fulcrum.alpha.testnet.unicity.network |
-| `dev` | dev-aggregator.dyndns.org | nostr-relay.testnet.unicity.network | fulcrum.alpha.testnet.unicity.network |
+| Network | Aggregator (gateway) | Nostr Relay | Electrum (L1) |
+|---------|----------------------|-------------|---------------|
+| `testnet` | gateway.testnet2.unicity.network (v2) | nostr-relay.testnet.unicity.network | fulcrum.unicity.network |
+| `testnet2` | alias of `testnet` (same configuration) | nostr-relay.testnet.unicity.network | fulcrum.unicity.network |
+| `mainnet` | aggregator.unicity.network (v1-era) | relay.unicity.network (+ public relays) | fulcrum.unicity.network |
+| `dev` | dev-aggregator.dyndns.org (v1-era) | nostr-relay.testnet.unicity.network | fulcrum.unicity.network |
+
+> **v1 → v2 cutover:** `testnet` now points at **testnet2**, the v2 state-transition gateway network (network id 4, taken from the trust base; own testnet2 token registry). The old `goggregator-test` testnet spoke the removed v1 protocol and is gone. `mainnet` and `dev` still point at v1-era aggregators — wallet operations that move money (`send`, `mintFungibleToken`, invoices) **fail loudly** (`AGGREGATOR_ERROR`) on those networks until their gateways are cut over to the v2 protocol. The only supported transfer wire payload is the finished v2 token blob — incoming v1-era payloads are dropped with an explicit error log, so peers must run a >= 0.8 wallet to send to this wallet.
 
 ```typescript
 // Use testnet for all services
@@ -108,15 +115,28 @@ const providers = createBrowserProviders({ network: 'testnet' });
 // Override specific services while using network preset
 const providers = createBrowserProviders({
   network: 'testnet',
-  oracle: { url: 'https://custom-aggregator.example.com' }, // custom oracle
+  oracle: { url: 'https://custom-gateway.example.com' }, // custom v2 gateway
 });
 
 // L1 is enabled by default — customize if needed
 const providers = createBrowserProviders({
   network: 'testnet',
-  l1: { enableVesting: true },  // uses testnet electrum URL automatically
+  l1: { enableVesting: true },  // uses network electrum URL automatically
 });
 ```
+
+### API Key
+
+The SDK bundles **no default API key**. Pass the gateway key via `oracle: { apiKey }` — without it, gateway requests are unauthenticated and money movement on testnet2 fails.
+
+```typescript
+const providers = createBrowserProviders({
+  network: 'testnet',
+  oracle: { apiKey: 'sk_...' },
+});
+```
+
+The **testnet2 key is not a secret** — it is published in [.env.example](.env.example) and safe to keep in docs and client code. A **mainnet** key, by contrast, IS a secret: keep it in your deploy environment only.
 
 ## Price Provider (Optional)
 
@@ -138,7 +158,7 @@ const providers = createBrowserProviders({
 const { sphere } = await Sphere.init({ ...providers, autoGenerate: true });
 
 // Total portfolio value in USD
-const totalUsd = await sphere.payments.getBalance();
+const totalUsd = await sphere.payments.getFiatBalance();
 // 1523.45
 
 // Assets with price data
@@ -146,7 +166,7 @@ const assets = await sphere.payments.getAssets();
 // [{ coinId, symbol, totalAmount, priceUsd: 97500, fiatValueUsd: 975.00, change24h: 2.3, ... }]
 ```
 
-Without `price` config, `getBalance()` returns `null` and price fields in `getAssets()` are `null`. All other functionality works normally.
+Without `price` config, `getFiatBalance()` returns `null` and price fields in `getAssets()` are `null`. All other functionality works normally. (`getBalance()` is the synchronous per-coin balance accessor — it returns `Asset[]` without price data.)
 
 You can also set the price provider after initialization:
 
@@ -159,27 +179,25 @@ sphere.setPriceProvider(createPriceProvider({
 }));
 ```
 
-## Testnet Faucet
+## Test Tokens on Testnet (Self-Mint)
 
-To get test tokens on testnet, you **must first register a nametag**:
+There is no faucet. On testnet you top up your wallet by **self-minting** fungible tokens via the v2 token engine — `mintFungibleToken(coinIdHex, amount)` mints a finished token directly to this wallet:
 
 ```typescript
-// 1. Create wallet and register nametag
-const { sphere } = await Sphere.init({
-  ...createBrowserProviders({ network: 'testnet' }),
-  autoGenerate: true,
-  nametag: 'myname',  // Register @myname
-});
+import { getCoinIdBySymbol } from '@unicitylabs/sphere-sdk';
 
-// 2. Request tokens from faucet using nametag
-const response = await fetch('https://faucet.unicity.network/api/v1/faucet/request', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ unicityId: 'myname', coin: 'unicity', amount: 100 }),
-});
+// Resolve the coin's hex id from the token registry (or pass a hex coinId directly)
+const coinId = getCoinIdBySymbol('UCT');
+
+const result = await sphere.payments.mintFungibleToken(coinId!, 1000n);
+if (result.success) {
+  console.log('Minted token:', result.tokenId);
+} else {
+  console.error('Mint failed:', result.error);
+}
 ```
 
-> **Note:** The faucet requires a registered nametag. Requests without a valid nametag will fail.
+> **Note:** Minting requires a working v2 oracle config (trust base + gateway URL + API key) — it fails with an error result otherwise. See [API Key](#api-key) above.
 
 ## Multi-Address Support
 
@@ -516,7 +534,7 @@ const { sphere } = await Sphere.init({
   ...providers,
   autoGenerate: true,
   // L1 config is optional — defaults are applied automatically:
-  // electrumUrl: network-specific (mainnet: fulcrum.alpha.unicity.network)
+  // electrumUrl: network-specific (default: wss://fulcrum.unicity.network:50004)
   // defaultFeeRate: 10 sat/byte
   // enableVesting: true
 });
@@ -563,8 +581,18 @@ import {
 } from '@unicitylabs/sphere-sdk/impl/browser';
 
 const storage = createLocalStorageProvider();
-const transport = createNostrTransportProvider();
-const oracle = createUnicityAggregatorProvider({ url: '/rpc' });
+// Without config the transport defaults to mainnet relays — pass the
+// testnet relay explicitly when pairing with the testnet2 gateway below.
+const transport = createNostrTransportProvider({
+  relays: ['wss://nostr-relay.testnet.unicity.network'],
+});
+// `network` (or `trustBaseUrl`) is required — it selects the trust base the
+// v2 token engine is built from. The apiKey authenticates gateway requests.
+const oracle = createUnicityAggregatorProvider({
+  url: 'https://gateway.testnet2.unicity.network',
+  apiKey: 'sk_...',
+  network: 'testnet',
+});
 
 // Check if wallet exists
 if (await Sphere.exists(storage)) {
@@ -718,7 +746,7 @@ import {
 
 ## TXF Serialization
 
-Token eXchange Format for storage and transfer:
+Token eXchange Format for storage. **Note:** TXF is the legacy v1 token format — post v2-cutover, stored v1 TXF tokens remain visible in the wallet (display only) but are unspendable; v2 tokens travel and persist as CBOR blob hex strings. These helpers remain for storage-data handling and legacy display:
 
 ```typescript
 import {
@@ -744,26 +772,14 @@ const storageData = await buildTxfStorageData(tokens, {
 
 ## Token Validation
 
-Validate tokens against the aggregator:
+Post v2-cutover, token verification goes through the token engine (structural validity via `engine.verify`, spent status via `engine.isSpent`). For applications, the supported entry point is the wallet itself:
 
 ```typescript
-import { createTokenValidator } from '@unicitylabs/sphere-sdk';
-
-const validator = createTokenValidator({
-  aggregatorClient: oracleProvider,
-  trustBase: trustBaseData,
-  skipVerification: false,
-});
-
-// Validate all tokens
-const { validTokens, issues } = await validator.validateAllTokens(tokens);
-
-// Check if token state is spent
-const isSpent = await validator.isTokenStateSpent(tokenId, stateHash, publicKey);
-
-// Check spent tokens in batch
-const { spentTokens, errors } = await validator.checkSpentTokens(tokens, publicKey);
+// Validate all wallet tokens against the network
+const { valid, invalid } = await sphere.payments.validate();
 ```
+
+A standalone `TokenValidator` also exists (`createTokenValidator(engine)`, exported from the SDK root) for advanced use. It operates on engine-level `SphereToken` objects and requires an `ITokenEngine` instance — the engine the wallet builds internally from the oracle's trust base + gateway config; there is currently no public factory entry point to construct one yourself.
 
 ## Architecture
 
@@ -784,7 +800,7 @@ mnemonic → master key → BIP32 derivation → identity
               ↓                  ↓                  ↓                  ↓
          L1 (ALPHA)        L3 (Unicity)        Group Chat           Nostr
      sphere.payments.l1  sphere.payments    sphere.groupChat  sphere.communications
-      UTXOs, blockchain  Tokens, aggregator  NIP-29 messaging    P2P messaging
+      UTXOs, blockchain  Tokens, v2 engine   NIP-29 messaging    P2P messaging
 ```
 
 ```
@@ -792,13 +808,25 @@ Sphere (main entry point)
 ├── identity       - Wallet identity (address, publicKey, nametag)
 ├── payments       - L3 token operations
 │   └── l1         - L1 ALPHA transactions (via sphere.payments.l1)
+├── accounting     - Invoice lifecycle (via sphere.accounting)
+├── swap           - P2P token swaps (via sphere.swap)
+├── market         - Intent bulletin board (via sphere.market)
 ├── groupChat      - NIP-29 group messaging (via sphere.groupChat)
 └── communications - Direct messages & broadcasts
+
+Token Engine (token-engine/)
+└── The wallet's boundary to the v2 state-transition SDK: all mint /
+    transfer / split / verify / spent-check operations go through the
+    ITokenEngine port. Sphere builds the engine from the oracle's config
+    (trust base JSON + gateway URL + API key); no state-transition SDK
+    objects cross this boundary.
 
 Providers (injectable dependencies)
 ├── StorageProvider      - Key-value persistence
 ├── TransportProvider    - P2P messaging (Nostr)
-├── OracleProvider       - State validation (Aggregator)
+├── OracleProvider       - Network config for the token engine (trust base
+│                          JSON + gateway URL + API key) + legacy v1 RPC
+│                          validateToken (display-only)
 └── TokenStorageProvider - Token backup (IPFS)
 
 Implementation (platform-specific)
@@ -887,7 +915,7 @@ The SDK includes browser-ready provider implementations:
 |----------|-------------|
 | `LocalStorageProvider` | Browser localStorage with SSR fallback |
 | `NostrTransportProvider` | Nostr relay messaging with NIP-04 |
-| `UnicityAggregatorProvider` | Unicity aggregator for state proofs |
+| `UnicityAggregatorProvider` | Network config for the v2 token engine (trust base + gateway URL + API key); also exposes a legacy `validateToken` RPC for v1-era tokens |
 | `IpfsStorageProvider` | HTTP-based IPFS/IPNS storage (cross-platform) |
 
 ## Node.js Providers
@@ -1265,13 +1293,13 @@ function getRelayStatuses() {
 }
 ```
 
-## Nametags
+## Nametags (Unicity IDs)
 
 Nametags provide human-readable addresses (e.g., `@alice`) for receiving payments. Valid formats: lowercase alphanumeric with `_` or `-` (3–20 chars), or E.164 phone numbers (e.g., `+14155552671`). Input is normalized to lowercase automatically.
 
-> **Important:** Nametags are required to use the testnet faucet. Register a nametag before requesting test tokens.
+**How registration works:** registering a nametag publishes a **Nostr identity binding** (name ↔ chain pubkey). Uniqueness is first-seen-wins — a name is available iff no binding already resolves for it (`sphere.isNametagAvailable(name)`). Runtime name resolution is binding-only; payments always go to the recipient's key-based `DIRECT://` address (there are no PROXY addresses).
 
-> **Note:** Nametag minting requires an aggregator API key for proof verification. Configure it via the `oracle.apiKey` option when creating providers. Contact Unicity to obtain an API key.
+In addition, a self-issued v2 `UnicityIdToken` (the on-chain claim) is minted and stored **best-effort** at registration — a gateway outage or missing v2 oracle config never fails registration; the mint is retried on the next load, and the token is not consumed anywhere at runtime yet.
 
 ### Registering a Nametag
 
@@ -1286,22 +1314,18 @@ const { sphere } = await Sphere.init({
 // Or after creation
 await sphere.registerNametag('alice');
 
-// Mint on-chain nametag token (required for receiving via PROXY addresses)
-const result = await sphere.mintNametag('alice');
-if (result.success) {
-  console.log('Nametag minted:', result.nametagData?.name);
-}
+// Check availability first
+const free = await sphere.isNametagAvailable('alice');
 ```
 
 ### Common Pitfall: Nametag Already Taken
 
 If you see this error:
 ```
-Failed to register nametag. It may already be taken.
-[NostrTransportProvider] Nametag already taken: myname - owner: f124f93ae6946ffd...
+Failed to register Unicity ID. It may already be taken.
 ```
 
-This means the nametag is registered to a **different public key**. Common causes:
+This means the nametag is registered (bound on Nostr) to a **different public key**. Common causes:
 
 1. **Storage cleared or not persisting**:
    - `Sphere.exists()` returns `false` because storage is empty/inaccessible

--- a/docs/ACCOUNTING-ARCHITECTURE.md
+++ b/docs/ACCOUNTING-ARCHITECTURE.md
@@ -1,4 +1,5 @@
 # Accounting Module Architecture
+> **Note: written against the v1 engine; invoices now mint via the v2 token engine (engine.mintDataToken) — see CHANGELOG.md and AccountingModule.ts.**
 
 > **Status:** Implemented
 > **Module path:** `modules/accounting/AccountingModule.ts`

--- a/docs/ACCOUNTING-SPEC.md
+++ b/docs/ACCOUNTING-SPEC.md
@@ -1,4 +1,5 @@
 # Accounting Module Specification
+> **Note: written against the v1 engine; invoices now mint via the v2 token engine (engine.mintDataToken) — see CHANGELOG.md and AccountingModule.ts.**
 
 > **Status:** Draft specification — no code yet
 > **Companion:** [ACCOUNTING-ARCHITECTURE.md](./ACCOUNTING-ARCHITECTURE.md)

--- a/docs/ACCOUNTING-TEST-SPEC.md
+++ b/docs/ACCOUNTING-TEST-SPEC.md
@@ -1,4 +1,5 @@
 # AccountingModule Test Suite Specification
+> **Note: written against the v1 engine; invoices now mint via the v2 token engine (engine.mintDataToken) — see CHANGELOG.md and AccountingModule.ts.**
 
 > **Status:** Specification document (no code) for comprehensive test coverage of AccountingModule
 > **Framework:** Vitest

--- a/docs/API.md
+++ b/docs/API.md
@@ -66,7 +66,7 @@ await Sphere.clear(storage);
 |----------|------|-------------|
 | `identity` | `FullIdentity \| null` | Current wallet identity (after init/load) |
 | `payments` | `PaymentsModule` | L3 token operations + L1 via `.l1` |
-| `payments.l1` | `L1PaymentsModule` | L1 ALPHA operations |
+| `payments.l1` | `L1PaymentsModule \| null` | L1 ALPHA operations (`null` when disabled via `l1: null`) |
 | `communications` | `CommunicationsModule` | Messaging operations |
 | `accounting` | `AccountingModule \| null` | Invoice lifecycle and payment attribution |
 | `swap` | `SwapModule \| null` | P2P token swap orchestration |
@@ -211,7 +211,6 @@ interface PeerInfo {
   chainPubkey: string;     // 33-byte compressed secp256k1
   l1Address: string;       // alpha1... L1 address
   directAddress: string;   // DIRECT://... L3 address
-  proxyAddress?: string;   // PROXY://... (only if nametag registered)
   timestamp: number;       // Binding event timestamp
 }
 ```
@@ -222,31 +221,26 @@ interface PeerInfo {
 
 Access via `sphere.payments`.
 
-Handles all L3 (Unicity state transition network) token operations including transfers, balance queries, token lifecycle management, nametag minting, and multi-provider sync.
+Handles all L3 (Unicity state transition network) token operations including transfers, balance queries, token lifecycle management, self-mint, and multi-provider sync.
 
-### Transfer Modes
+### How Transfers Work (v2, sender-driven)
 
-`send()` automatically selects the optimal transfer path:
+`send()` runs the entire transfer through the v2 token engine on the **sender** side:
 
 ```
-Path 1 — Whole-Token NOSTR-FIRST (no split needed):
-  ┌─────────┐    commitment + token    ┌───────────┐
-  │  Sender  │ ────── Nostr ──────────>│ Recipient  │
-  └────┬─────┘                         └─────┬──────┘
-       │  submit commitment (background)      │  submit commitment (idempotent)
-       └──────> Aggregator <──────────────────┘  poll for proof → finalize
-
-Path 2 — Instant Split V5 (~2.3s sender latency):
-  ┌─────────┐  burn  ┌────────────┐  bundle via Nostr  ┌───────────┐
-  │  Sender  │──────> │ Aggregator │                    │ Recipient  │
-  └────┬─────┘ proof  └────────────┘                    └─────┬──────┘
-       │ create mints + transfer commitment                   │
-       │ ──────────── Nostr ─────────────────────────────────>│
-       │  background: submit mints, save change               │ submit mint
-       │                                                      │ wait for proof
-       │                                                      │ submit transfer
-       │                                                      │ finalize
+  ┌─────────┐  engine.transfer / engine.split   ┌──────────┐
+  │  Sender  │ ─────────────────────────────────>│ Gateway   │  certify on-chain,
+  └────┬─────┘     (source state is spent)       └──────────┘  wait inclusion proof
+       │
+       │  V2_TRANSFER payload (finished token blob) via Nostr
+       └──────────────────────────────────────────> Recipient
+                                  verifies (engine.verify + ownership) → stores 'confirmed'
 ```
+
+- The recipient receives a **finished** token — there is no commitment submission, proof polling, or finalization phase on the receiving side.
+- Whole-token transfers use `engine.transfer`; partial amounts use `engine.split` (recipient output + change output certified in one on-chain operation — the change token is real and immediately spendable, no placeholder).
+- Finished-but-undelivered blobs are journaled under the `PENDING_V2_DELIVERIES` storage key **before** the transport send and replayed by `load()` — a transport failure or crash never loses the recipient's token.
+- Requirements: the token engine must be available (the oracle supplies a v2 trust base + gateway URL; otherwise `AGGREGATOR_ERROR`), and the recipient must have a published chain pubkey (otherwise `INVALID_RECIPIENT`).
 
 ### Methods: Balance & Assets
 
@@ -262,7 +256,7 @@ const totalUsd = await sphere.payments.getFiatBalance();
 
 #### `getBalance(coinId?: string): Asset[]`
 
-Returns aggregated assets (tokens grouped by coinId) with confirmed/unconfirmed breakdown. Synchronous.
+Returns aggregated assets (tokens grouped by coinId) with confirmed/unconfirmed breakdown. Synchronous — price fields are always `null` here; use `getAssets()` for fiat values.
 
 ```typescript
 const balances = sphere.payments.getBalance();
@@ -272,9 +266,6 @@ for (const bal of balances) {
   console.log(`  Confirmed:   ${bal.confirmedAmount} (${bal.confirmedTokenCount} tokens)`);
   console.log(`  Unconfirmed: ${bal.unconfirmedAmount} (${bal.unconfirmedTokenCount} tokens)`);
   console.log(`  Total:       ${bal.totalAmount}`);
-  if (bal.fiatValueUsd !== null) {
-    console.log(`  USD Value:   $${bal.fiatValueUsd.toFixed(2)}`);
-  }
 }
 
 // Filter to a single coin
@@ -298,6 +289,7 @@ interface Asset {
   readonly unconfirmedAmount: string;   // Unconfirmed token amounts
   readonly confirmedTokenCount: number; // Number of confirmed tokens
   readonly unconfirmedTokenCount: number; // Number of unconfirmed tokens
+  readonly transferringTokenCount: number; // Number of tokens currently being sent
   readonly priceUsd: number | null;     // Price per unit in USD
   readonly priceEur: number | null;     // Price per unit in EUR
   readonly change24h: number | null;    // 24h price change %
@@ -345,19 +337,21 @@ Get a single token by ID.
 
 #### `send(request: TransferRequest): Promise<TransferResult>`
 
-Send tokens to a recipient. Automatically splits tokens when the exact amount is not available as a single token.
+Send tokens to a recipient via the v2 token engine (the only send path). Automatically splits a token when the exact amount is not available as a single token.
 
 ```typescript
 interface TransferRequest {
   readonly coinId: string;       // Coin type (hex string)
   readonly amount: string;       // Amount in smallest units
-  readonly recipient: string;    // @nametag, hex pubkey, DIRECT://, PROXY://, or alpha1... address
-  readonly memo?: string;        // Optional message
-  readonly addressMode?: AddressMode;  // 'auto' | 'direct' | 'proxy'
-  readonly transferMode?: TransferMode;  // 'instant' | 'conservative'
+  readonly recipient: string;    // @nametag, hex chain pubkey, DIRECT://, or alpha1... address
+  readonly memo?: string;        // Optional message (transport-only; invoice refs also go on-chain)
+  readonly addressMode?: AddressMode;    // 'auto' | 'direct' — both resolve to the recipient's key-based DIRECT address
+  readonly transferMode?: TransferMode;  // Deprecated: accepted but IGNORED (single engine path)
+  readonly invoiceRefundAddress?: string; // Invoice refund address (DIRECT://) — embedded in the on-chain message
+  readonly invoiceContact?: { address: string; url?: string }; // Invoice contact — embedded in the on-chain message
 }
 
-type AddressMode = 'auto' | 'direct' | 'proxy';
+type AddressMode = 'auto' | 'direct';
 type TransferMode = 'instant' | 'conservative';
 
 interface TransferResult {
@@ -371,9 +365,6 @@ interface TransferResult {
 interface TokenTransferDetail {
   readonly sourceTokenId: string;   // Source token ID consumed
   readonly method: 'direct' | 'split';  // Transfer method
-  readonly requestIdHex?: string;   // Aggregator commitment request ID (direct)
-  readonly splitGroupId?: string;   // Split group ID (split)
-  readonly nostrEventId?: string;   // Nostr event ID (split)
 }
 
 type TransferStatus = 'pending' | 'submitted' | 'confirmed' | 'delivered' | 'completed' | 'failed';
@@ -386,25 +377,16 @@ const result = await sphere.payments.send({
   recipient: '@alice',
   amount: '1000000',
   coinId: 'UCT',
-  addressMode: 'auto',
 });
 console.log(result.status); // 'completed'
 ```
 
-**Transfer Modes:**
+**Semantics (v2):**
 
-- **`'instant'`** (default) — Sends tokens via Nostr immediately with commitment data. The receiver resolves aggregator proofs in the background. Fastest sender experience (~2-3s for splits).
-- **`'conservative'`** — Collects all aggregator proofs at the sender side before delivering fully finalized tokens (with `{ sourceToken, transferTx }`) via Nostr. Slower for the sender but the receiver gets immediately usable tokens with no background proof resolution needed.
-
-```typescript
-// Conservative transfer — receiver gets fully finalized tokens
-const result = await sphere.payments.send({
-  recipient: '@alice',
-  amount: '1000000',
-  coinId: 'UCT',
-  transferMode: 'conservative',
-});
-```
+- The wire payload is always `V2_TRANSFER` — a finished v2 token blob. The recipient verifies it (`engine.verify` + ownership check) and stores it as `'confirmed'`; no receiver-side proof resolution exists.
+- The token engine and the recipient's published chain pubkey are **mandatory**: `send()` throws `AGGREGATOR_ERROR` when the engine is unavailable (no v2 oracle config) and `INVALID_RECIPIENT` when the recipient has no published identity.
+- Every finished output blob is journaled under the `PENDING_V2_DELIVERIES` storage key **before** transport delivery and removed after success; `load()` replays undelivered blobs from a previous session.
+- **Failure handling:** source tokens whose spend was certified on-chain during a failed send become terminal `'spent'` — never restored to `'confirmed'` (the finished output blob stays journaled for delivery replay); genuinely untouched tokens are restored to `'confirmed'`.
 
 #### `receive(options?, callback?): Promise<ReceiveResult>`
 
@@ -414,106 +396,66 @@ Unlike the persistent subscription that delivers events asynchronously, `receive
 queries the Nostr relay and resolves after all stored events are processed. Useful for
 batch/CLI applications.
 
-- **options** (`ReceiveOptions`, optional): Finalization control and progress reporting.
+v2 transfers arrive as **finished** tokens — there is no finalization phase. Incoming tokens are
+verified (`engine.verify` + ownership check against this wallet's chain pubkey) and stored as
+`'confirmed'` before the call resolves.
+
+- **options** (`ReceiveOptions`, optional): **Deprecated.** The former finalization options
+  (`finalize`, `timeout`, `pollInterval`) are accepted for backwards compatibility and ignored.
 - **callback** (`(transfer: IncomingTransfer) => void`, optional): Invoked for each newly received transfer.
-
-**ReceiveOptions:**
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `finalize` | `boolean` | `false` | Wait for all tokens to be finalized |
-| `timeout` | `number` | `60000` | Finalization timeout in ms |
-| `pollInterval` | `number` | `2000` | Poll interval between finalization attempts |
-| `onProgress` | `function` | — | Progress callback during finalization |
 
 **ReceiveResult:**
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `transfers` | `IncomingTransfer[]` | Newly received transfers |
-| `finalization` | `UnconfirmedResolutionResult` | Result from resolveUnconfirmed() |
-| `timedOut` | `boolean` | Whether finalization timed out |
-| `finalizationDurationMs` | `number` | Duration of finalization in ms |
 
 ```typescript
-// Simple usage — fetch and submit commitments once
+// Fetch and process pending transfers once
 const { transfers } = await sphere.payments.receive();
 
-// With callback only
+// With per-transfer callback
 await sphere.payments.receive(undefined, (transfer) => {
-  console.log(`Received ${transfer.tokens.length} tokens`);
-});
-
-// Wait for finalization
-const result = await sphere.payments.receive({
-  finalize: true,
-  timeout: 30000,
-  onProgress: (res) => console.log(`${res.stillPending} pending`),
-});
-
-// Both options and callback
-const result = await sphere.payments.receive({ finalize: true }, (transfer) => {
   console.log(`Received ${transfer.tokens.length} tokens`);
 });
 ```
 
 ---
 
-### Methods: Unconfirmed Token Resolution
+### Methods: Self-Mint
 
-#### `resolveUnconfirmed(): Promise<UnconfirmedResolutionResult>`
+#### `mintFungibleToken(coinIdHex: string, amount: bigint): Promise<{ success: true; token: Token; tokenId: string } | { success: false; error: string }>`
 
-Attempt to resolve unconfirmed (`status: 'submitted'`) tokens by acquiring missing aggregator proofs.
+Self-mint fungible tokens to this wallet via the v2 token engine (`engine.mint` — a finished
+token, no commitment round-trip). There is no faucet in v2; this is the way to top up a fresh
+wallet on networks where standalone mint is allowed (e.g. testnet2).
 
-V5 tokens progress through stages:
-
-```
-RECEIVED → MINT_SUBMITTED → MINT_PROVEN → TRANSFER_SUBMITTED → FINALIZED
-```
-
-- Uses 500ms quick-timeouts per proof check (non-blocking).
-- Tokens exceeding 50 failed attempts are marked `'invalid'`.
-- Automatically called (fire-and-forget) by `getBalance()` and `load()`.
+- `coinIdHex` must be even-length lowercase hex; `amount` must be `> 0n`.
+- Requires the token engine (v2 oracle config with trust base + gateway); otherwise returns
+  `{ success: false, error }` — this method returns an error result instead of throwing.
+- On success the minted token is stored as a `'confirmed'` wallet token; `tokenId` is the
+  genesis-stable 64-char hex id.
 
 ```typescript
-interface UnconfirmedResolutionResult {
-  resolved: number;       // Tokens fully confirmed
-  stillPending: number;   // Tokens still waiting for proofs
-  failed: number;         // Tokens that exceeded retry limit
-  details: Array<{
-    tokenId: string;
-    stage: string;        // Current V5FinalizationStage
-    status: 'resolved' | 'pending' | 'failed';
-  }>;
+const result = await sphere.payments.mintFungibleToken(coinIdHex, 1_000_000n);
+if (result.success) {
+  console.log('Minted token:', result.tokenId, result.token.amount);
+} else {
+  console.error('Mint failed:', result.error);
 }
-
-type V5FinalizationStage = 'RECEIVED' | 'MINT_SUBMITTED' | 'MINT_PROVEN' | 'TRANSFER_SUBMITTED' | 'FINALIZED';
 ```
 
 ---
 
 ### Methods: Balance & Token Queries
 
-#### `getBalance(coinId?: string): TokenBalance[]`
+#### `getBalance(coinId?: string): Asset[]`
 
-Get token balances grouped by coin type. **Synchronous** (no await needed).
+Get token balances grouped by coin type. **Synchronous** (no await needed) — returns the same
+`Asset` shape as `getAssets()` but with all price fields `null` (use `getAssets()` for prices).
 
-Skips tokens with status `'spent'`, `'invalid'`, or `'transferring'`. Fires a non-blocking `resolveUnconfirmed()` call as a side effect.
-
-```typescript
-interface TokenBalance {
-  readonly coinId: string;
-  readonly symbol: string;
-  readonly name: string;
-  readonly totalAmount: string;          // confirmedAmount + unconfirmedAmount
-  readonly confirmedAmount: string;      // Tokens with inclusion proofs
-  readonly unconfirmedAmount: string;    // Tokens pending proof (status: 'submitted')
-  readonly tokenCount: number;           // Total token count
-  readonly confirmedTokenCount: number;
-  readonly unconfirmedTokenCount: number;
-  readonly decimals: number;
-}
-```
+Skips tokens with status `'spent'` or `'invalid'`. Tokens with status `'transferring'` remain
+visible (counted in `unconfirmedAmount` and `transferringTokenCount`).
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -565,7 +507,7 @@ Get all in-progress (pending) outgoing transfers.
 
 ### Methods: Token CRUD
 
-#### `addToken(token: Token, skipHistory?: boolean): Promise<boolean>`
+#### `addToken(token: Token): Promise<boolean>`
 
 Add a token to the wallet.
 
@@ -573,26 +515,20 @@ Add a token to the wallet.
 - **Duplicate check**: Rejected if same composite key already exists.
 - **State replacement**: If same `tokenId` with different `stateHash`, archives old state and adds new.
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `token` | `Token` | — | Token to add |
-| `skipHistory` | `boolean` | `false` | Skip creating a RECEIVED history entry |
-
 Returns `true` if added, `false` if rejected.
 
 #### `updateToken(token: Token): Promise<void>`
 
 Update an existing token. Matches by genesis tokenId or `token.id`. Falls back to `addToken()` if not found.
 
-#### `removeToken(tokenId: string, recipientNametag?: string, skipHistory?: boolean): Promise<void>`
+#### `removeToken(tokenId: string, excludeReservationId?: string): Promise<void>`
 
-Remove a token. Archives it first, creates a tombstone `(tokenId, stateHash)`, and optionally adds a SENT history entry.
+Remove a token. Archives it first and creates a tombstone `(tokenId, stateHash)`.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `tokenId` | `string` | — | Local UUID of the token |
-| `recipientNametag` | `string?` | — | Recipient nametag for history |
-| `skipHistory` | `boolean` | `false` | Skip creating a SENT history entry |
+| `excludeReservationId` | `string?` | — | Reservation to exclude when notifying the spend queue (internal send-path use) |
 
 ---
 
@@ -674,68 +610,57 @@ Keep at most `maxCount` forked tokens (default: 50).
 
 #### `getHistory(): TransactionHistoryEntry[]`
 
-Get transaction history sorted newest-first.
+Get transaction history sorted newest-first. `TransactionHistoryEntry` is an alias of the
+shared `HistoryRecord` storage type:
 
 ```typescript
 interface TransactionHistoryEntry {
-  id: string;
+  dedupKey: string;               // Composite dedup key (primary key)
+  id: string;                     // UUID for public API consumption
   type: 'SENT' | 'RECEIVED' | 'SPLIT' | 'MINT';
   amount: string;
   coinId: string;
   symbol: string;
   timestamp: number;
-  recipientNametag?: string;
-  senderPubkey?: string;
   transferId?: string;            // Links to TransferResult.id (for SENT entries)
+  tokenId?: string;               // Genesis tokenId this entry relates to
+  // Sender info (for RECEIVED)
+  senderPubkey?: string;
+  senderAddress?: string;
+  senderNametag?: string;
+  // Recipient info (for SENT)
+  recipientPubkey?: string;
+  recipientAddress?: string;
+  recipientNametag?: string;
+  memo?: string;                  // Optional memo attached to the transfer
+  tokenIds?: Array<{ id: string; amount: string; source: 'split' | 'direct' }>;
 }
 ```
 
-#### `addToHistory(entry: Omit<TransactionHistoryEntry, 'id'>): Promise<void>`
+#### `addToHistory(entry: Omit<TransactionHistoryEntry, 'id' | 'dedupKey'>): Promise<void>`
 
-Append a history entry (UUID auto-generated). Persisted immediately.
+Append a history entry (UUID and dedup key auto-generated). Persisted immediately.
 
 ---
 
-### Methods: Nametag Management
+### Methods: Nametag Data (Unicity ID)
 
-#### `mintNametag(nametag: string): Promise<MintNametagResult>`
-
-Mint a nametag token on-chain. Required for receiving tokens via PROXY addresses.
-
-```typescript
-interface MintNametagResult {
-  success: boolean;
-  token?: Token;
-  nametagData?: NametagData;
-  readonly id: string;                       // Local transfer UUID
-  status: TransferStatus;                    // Current status
-  readonly tokens: Token[];                  // Tokens involved
-  readonly tokenTransfers: TokenTransferDetail[];  // Per-token transfer details
-  error?: string;                            // Error message if failed
-}
-
-interface TokenTransferDetail {
-  readonly sourceTokenId: string;   // Source token ID consumed
-  readonly method: 'direct' | 'split';  // Transfer method
-  readonly requestIdHex?: string;   // Aggregator commitment request ID (direct)
-  readonly splitGroupId?: string;   // Split group ID (split)
-  readonly nostrEventId?: string;   // Nostr event ID (split)
-}
-
-type TransferStatus = 'pending' | 'submitted' | 'confirmed' | 'delivered' | 'completed' | 'failed';
-```
-
-#### `isNametagAvailable(nametag: string): Promise<boolean>`
-
-Check if a nametag is available for minting.
+Nametag **registration** lives on the `Sphere` instance (`sphere.registerNametag()`,
+`sphere.isNametagAvailable()`) — see the [Unicity ID (Nametag) Registration](#unicity-id-nametag-registration)
+section. `PaymentsModule` only stores/loads the per-address `NametagData` records (including the
+self-issued v2 UnicityIdToken claim):
 
 #### `setNametag(nametag: NametagData): Promise<void>`
 
-Set nametag data (persists to storage and file).
+Set nametag data (persists to storage and token storage).
 
 #### `getNametag(): NametagData | null`
 
-Get current nametag data.
+Get the current (first) nametag data record.
+
+#### `getNametags(): NametagData[]`
+
+Get all nametag data records for the active address.
 
 #### `hasNametag(): boolean`
 
@@ -760,7 +685,10 @@ console.log(`Sync: +${result.added} -${result.removed}`);
 
 #### `validate(): Promise<{ valid: Token[]; invalid: Token[] }>`
 
-Validate tokens against the aggregator (checks state proofs).
+Validate all tokens. v2 blob tokens are verified via the token engine (`engine.verify` +
+on-chain `engine.isSpent`); legacy v1 TXF tokens fall back to the oracle's best-effort
+`validateToken` RPC. Tokens that fail are marked `'invalid'`; transient engine/network failures
+skip the token instead of invalidating funds.
 
 ```typescript
 const { valid, invalid } = await sphere.payments.validate();
@@ -776,7 +704,11 @@ Get transfers that are still in progress.
 
 #### `load(): Promise<void>`
 
-Load all token data from storage providers. Restores pending V5 tokens and triggers `resolveUnconfirmed()`.
+Load all token data from storage providers. Also performs v2 recovery work:
+
+- terminalizes orphaned pending-V5 tokens (from the removed v1 instant-split receiver) to `'invalid'` (data kept for audit);
+- reconciles tokens stuck in `'transferring'` after a crash against the network (`spent` on-chain → terminal `'spent'`, unspent → back to `'confirmed'`);
+- replays finished-but-undelivered transfer blobs from the `PENDING_V2_DELIVERIES` journal (fire-and-forget; failures stay journaled for the next load).
 
 #### `destroy(): void`
 
@@ -1304,18 +1236,26 @@ type SphereEventType =
   | 'payment_request:paid'
   | 'payment_request:response'
   | 'message:dm'
+  | 'message:read'
+  | 'message:typing'
+  | 'composing:started'
   | 'message:broadcast'
   | 'sync:started'
   | 'sync:completed'
   | 'sync:provider'
   | 'sync:error'
+  | 'sync:remote-update'
   | 'connection:changed'
   | 'nametag:registered'
   | 'nametag:recovered'
   | 'identity:changed'
   | 'address:activated'
   | 'address:hidden'
-  | 'address:unhidden';
+  | 'address:unhidden'
+  | 'communications:ready'
+  | 'history:updated';
+  // ...plus group chat ('groupchat:*'), invoice ('invoice:*'), and swap ('swap:*')
+  // events — see the GroupChatModule, AccountingModule, and SwapModule sections.
 ```
 
 ### SphereEventMap
@@ -1331,12 +1271,15 @@ interface SphereEventMap {
   'payment_request:paid': IncomingPaymentRequest;
   'payment_request:response': PaymentRequestResponse;
   'message:dm': DirectMessage;
+  'message:read': { messageIds: string[]; peerPubkey: string };
+  'message:typing': { senderPubkey: string; senderNametag?: string; timestamp: number };
   'message:broadcast': BroadcastMessage;
   'sync:started': { source: string };
   'sync:completed': { source: string; count: number };
   'sync:provider': { providerId: string; success: boolean; added?: number; removed?: number; error?: string };
   'sync:error': { source: string; error: string };
-  'connection:changed': { provider: string; connected: boolean };
+  'sync:remote-update': { providerId: string; name: string; sequence: number; cid: string; added: number; removed: number };
+  'connection:changed': { provider: string; connected: boolean; status?: ProviderStatus; enabled?: boolean; error?: string };
   'nametag:registered': { nametag: string; addressIndex: number };
   'nametag:recovered': { nametag: string };
   'identity:changed': {
@@ -1349,50 +1292,28 @@ interface SphereEventMap {
   'address:activated': { address: TrackedAddress };
   'address:hidden': { index: number; addressId: string };
   'address:unhidden': { index: number; addressId: string };
+  'communications:ready': { conversationCount: number };
+  'history:updated': TransactionHistoryEntry;
+  // ... plus 'groupchat:*', 'invoice:*', and 'swap:*' payloads (see module sections)
 }
 ```
 
-### InstantSplitBundleV5
+### V2_TRANSFER Wire Payload
 
-The production bundle format for instant split transfers (~2.3s sender latency).
+The only supported token-transfer payload post v1-cutover — a **finished** v2 token blob:
 
 ```typescript
-interface InstantSplitBundleV5 {
-  version: '5.0';
-  type: 'INSTANT_SPLIT';
-  burnTransaction: string;         // Proven burn transaction JSON
-  recipientMintData: string;       // MintTransactionData JSON
-  transferCommitment: string;      // Pre-created TransferCommitment JSON
-  amount: string;                  // Payment amount
-  coinId: string;                  // Coin ID hex
-  tokenTypeHex: string;
-  splitGroupId: string;            // Recovery correlation ID
-  senderPubkey: string;
-  recipientSaltHex: string;
-  transferSaltHex: string;
-  mintedTokenStateJson: string;    // Intermediate minted token state
-  finalRecipientStateJson: string; // Final recipient state after transfer
-  recipientAddressJson: string;    // PROXY or DIRECT address
-  nametagTokenJson?: string;       // Nametag token for PROXY transfers
+{
+  type: 'V2_TRANSFER';
+  version: '2.0';
+  tokenBlob: string;   // hex of CBOR(TokenBlob) — the finished recipient token
+  memo?: string;       // optional transport-level memo
 }
 ```
 
-### PendingV5Finalization
-
-Metadata stored in unconfirmed token's `sdkData` to track finalization progress.
-
-```typescript
-interface PendingV5Finalization {
-  type: 'v5_bundle';
-  stage: V5FinalizationStage;
-  bundleJson: string;
-  senderPubkey: string;
-  savedAt: number;
-  lastAttemptAt?: number;
-  attemptCount: number;
-  mintProofJson?: string;
-}
-```
+Incoming v1-era payloads (V5/V6 instant-split bundles, NOSTR-FIRST, `{sourceToken, transferTx}`,
+plain token JSON) are dropped with an explicit error log — peers must run a >=0.8 wallet to send
+to this wallet.
 
 ### PaymentsModuleDependencies
 
@@ -1400,144 +1321,118 @@ interface PendingV5Finalization {
 interface PaymentsModuleDependencies {
   identity: FullIdentity;
   storage: StorageProvider;
+  /** @deprecated Use tokenStorageProviders instead */
+  tokenStorage?: TokenStorageProvider;
+  /** Multiple token storage providers (e.g., IPFS, MongoDB, file) */
   tokenStorageProviders?: Map<string, TokenStorageProvider>;
   transport: TransportProvider;
   oracle: OracleProvider;
-  emitEvent: (type: SphereEventType, data: SphereEventMap[type]) => void;
+  /** v2 token engine — required for send/mint/validate of v2 tokens (wired by Sphere) */
+  tokenEngine?: ITokenEngine;
+  emitEvent: <T extends SphereEventType>(type: T, data: SphereEventMap[T]) => void;
+  /** Chain code for BIP32 HD derivation (for L1 multi-address support) */
   chainCode?: string;
+  /** Additional L1 addresses to watch */
   l1Addresses?: string[];
+  /** Price provider (optional — enables fiat value display) */
+  price?: PriceProvider;
+  /** Set of disabled provider IDs — skipped during sync/save */
+  disabledProviderIds?: ReadonlySet<string>;
 }
 ```
 
 ---
 
-## Nametag Minting
+## Unicity ID (Nametag) Registration
 
-Mint nametag tokens on-chain for PROXY address support (required for receiving tokens via @nametag).
+Nametags (Unicity IDs, `@alice`) are **Nostr identity bindings** (name ↔ chainPubkey) — there is
+no PROXY address scheme and receive is always locked to the recipient's chain pubkey
+(`SignaturePredicate`). Registration publishes the binding; global uniqueness is first-seen-wins
+on the binding.
 
 ### Sphere Methods
 
 ```typescript
-// Mint nametag token on-chain
-const result = await sphere.mintNametag('alice');
+// Register the nametag for the current active address.
+// Publishes the Nostr identity binding; throws SphereError('VALIDATION_ERROR')
+// when the name is invalid or already taken.
+await sphere.registerNametag('alice');
 
-if (result.success) {
-  console.log('Token minted:', result.nametagData?.name);
-} else {
-  console.error('Failed:', result.error);
-}
-
-// Check if nametag is available
+// Check if a nametag is available (no binding resolves for it)
 const available = await sphere.isNametagAvailable('alice');
 ```
 
-### MintNametagResult
+### On-chain Claim (best-effort)
+
+In addition to the Nostr binding, `registerNametag()` mints + stores a **self-issued v2
+`UnicityIdToken`** as an on-chain claim:
+
+- Stored via `payments.setNametag()` as `NametagData { format: 'v2-cbor', token: <hex CBOR> }`.
+- **Best-effort and idempotent** — a gateway outage or missing v2 oracle config never fails
+  registration; the mint is deterministic per (name, wallet key), so a later load re-mints the
+  identical token (lost-storage recovery). On networks without a v2 oracle config a warning is
+  logged on each load.
+- **Unused at runtime** — name resolution stays Nostr-binding-only; the token is kept for a
+  future issuer/verification model.
+
+The claim is also (re-)minted on wallet init/load and on address switch when a nametag exists
+but the v2 token is missing.
+
+### NametagData
 
 ```typescript
-interface MintNametagResult {
-  success: boolean;
-  token?: Token;           // The minted nametag token
-  nametagData?: NametagData;  // Nametag metadata
-  error?: string;          // Error message if failed
-}
-
 interface NametagData {
   name: string;            // Nametag without @ prefix
-  token: object;           // Token JSON (genesis + state)
+  token: object | string;  // 'v2-cbor': hex-encoded UnicityIdToken CBOR (string)
+                           // legacy 'txf': v1 nametag token JSON (object, inert)
   timestamp: number;       // Mint timestamp
-  format?: string;         // 'txf'
-  version?: string;        // '2.0'
+  format: string;          // 'v2-cbor' (current) | 'txf' (legacy)
+  version: string;         // '2.0'
 }
 ```
 
-### NametagMinter Class
+### Standalone Minter (token-engine)
 
-For advanced usage, create a NametagMinter directly:
+For advanced usage, mint the self-issued UnicityIdToken directly. `createUnicityIdMinter`,
+`IUnicityIdMinter`, and `UnicityIdMintResult` are exported from the SDK's `token-engine` module
+(`token-engine/index.ts`; not currently re-exported from the package root):
 
 ```typescript
-import { NametagMinter, createNametagMinter } from '@unicitylabs/sphere-sdk';
+import { createUnicityIdMinter } from './token-engine';          // sphere-sdk token-engine module
+import type { IUnicityIdMinter, UnicityIdMintResult } from './token-engine';
 
-const minter = createNametagMinter({
-  stateTransitionClient: client,
-  trustBase: trustBase,
-  signingService: signingService,
-  debug: false,
-  skipVerification: false,
+// Built from the same config shape the token engine uses (EngineConfig)
+const minter: IUnicityIdMinter = createUnicityIdMinter({
+  aggregatorUrl: 'https://gateway.testnet2.unicity.network',
+  apiKey: 'sk_...',                  // optional gateway API key
+  privateKey: privateKeyBytes,       // Uint8Array (32-byte secp256k1 scalar)
+  trustBaseJson,                     // required — throws INVALID_CONFIG when missing
 });
 
-// Mint nametag
-const result = await minter.mintNametag('alice', ownerAddress);
-
-// Check availability
-const available = await minter.isNametagAvailable('alice');
+const result: UnicityIdMintResult = await minter.mintUnicityIdToken('alice');
+console.log(result.tokenCborHex);  // UnicityIdToken CBOR, hex-encoded (storable form)
+console.log(result.tokenId);       // 64-char hex token id, stable across re-mints
 ```
 
-### NametagMinterConfig
-
 ```typescript
-interface NametagMinterConfig {
-  stateTransitionClient: StateTransitionClient;  // Required
-  trustBase: TrustBase;                          // Required
-  signingService: SigningService;                // Required
-  debug?: boolean;                               // Default: false
-  skipVerification?: boolean;                    // Default: false
+// Real signatures (token-engine/unicity-id.ts)
+interface UnicityIdMintResult {
+  readonly tokenCborHex: string;  // UnicityIdToken CBOR, hex — UnicityIdToken.fromCBOR round-trips it
+  readonly tokenId: string;       // 64-char hex, derived from the name (stable across re-mints)
 }
-```
 
-### Auto-mint on Registration
-
-The SDK automatically mints the nametag token on-chain whenever `registerNametag()` is called:
-
-```typescript
-// Option 1: During init (new wallet)
-const { sphere } = await Sphere.init({
-  ...providers,
-  mnemonic: 'your words...',
-  nametag: 'alice',  // Registers on Nostr AND mints token on-chain
-});
-
-// Option 2: Manual registration (e.g., for new derived address)
-await sphere.switchToAddress(1);
-await sphere.registerNametag('bob');  // Also mints token automatically
-
-// Option 3: On wallet load (auto-mint if token missing)
-const { sphere } = await Sphere.init({ ...providers });
-// If nametag exists but token is missing, it will be minted automatically
-```
-
-**When minting happens:**
-- `Sphere.create()` with nametag → mints via `registerNametag()`
-- `Sphere.load()` → mints if nametag exists but token is missing
-- `Sphere.import()` with nametag → mints via `registerNametag()`
-- `registerNametag()` → always mints if token not present
-
-Nametag token is required for receiving tokens via PROXY addresses (`finalizeTransaction` requires nametag token for PROXY scheme).
-
----
-
-## Token Split Calculator
-
-Utility for calculating optimal token splits for partial transfers.
-
-```typescript
-import { createTokenSplitCalculator } from '@unicitylabs/sphere-sdk';
-
-const calculator = createTokenSplitCalculator();
-
-const plan = await calculator.calculateOptimalSplit(
-  availableTokens,  // Token[]
-  targetAmount,     // bigint
-  coinIdHex         // string
-);
-
-if (plan) {
-  console.log('Requires split:', plan.requiresSplit);
-  console.log('Tokens to transfer:', plan.tokensToTransferDirectly);
-  console.log('Token to split:', plan.tokenToSplit);
-  console.log('Split amount:', plan.splitAmount);
-  console.log('Change amount:', plan.changeAmount);
+interface IUnicityIdMinter {
+  mintUnicityIdToken(name: string, options?: EngineOpOptions): Promise<UnicityIdMintResult>;
 }
+
+function createUnicityIdMinter(config: EngineConfig): IUnicityIdMinter;
 ```
+
+Trust model: **self-issued** — the wallet's own key is the issuer lock script, the recipient,
+and the target predicate. `tokenId = SHA256(CBOR["NAMETAG_", null, name])` with a pinned token
+type, so a re-mint re-certifies the same state and yields the identical token. On-chain
+uniqueness is per-issuer only; global name uniqueness remains the Nostr binding's job. Mint
+failures throw `SphereError('AGGREGATOR_ERROR')`.
 
 ---
 
@@ -1553,24 +1448,80 @@ createNodeIpfsStorageProvider(config?: IpfsStorageConfig, storage?: StorageProvi
 createNostrTransportProvider(config?: NostrTransportProviderConfig): NostrTransportProvider
 // NostrTransportProviderConfig accepts optional `storage` for event timestamp persistence
 
-// Oracle
-createUnicityAggregatorProvider(config?: UnicityAggregatorProviderConfig): UnicityAggregatorProvider
+// Oracle (network-config provider for the v2 token engine; see below)
+createUnicityAggregatorProvider(config: UnicityAggregatorProviderConfig): UnicityAggregatorProvider
 
 // Payments
 createPaymentsModule(config?: PaymentsModuleConfig): PaymentsModule
-// PaymentsModuleConfig includes optional l1?: L1PaymentsModuleConfig
+// PaymentsModuleConfig includes optional l1?: L1PaymentsModuleConfig | null
 createL1PaymentsModule(config?: L1PaymentsModuleConfig): L1PaymentsModule
 
 // Communications
 createCommunicationsModule(config?: CommunicationsModuleConfig): CommunicationsModule
 
-// Token Split
-createTokenSplitCalculator(): TokenSplitCalculator
-createTokenSplitExecutor(client, trustBase): TokenSplitExecutor
-
-// Validation
-createTokenValidator(options?: TokenValidatorOptions): TokenValidator
+// Validation (engine-based)
+createTokenValidator(engine: ITokenEngine): TokenValidator
 ```
+
+---
+
+## OracleProvider (Network-Config Provider)
+
+Post v1-cutover the oracle is a **thin network-config provider** for the v2 token engine: it
+loads the root trust base (JSON) and exposes the gateway URL + API key. The engine
+(`token-engine/`) builds its own SDK clients from these — no state-transition SDK objects cross
+this boundary. The v1 client surface (`submitCommitment`, `getProof`, `waitForProof`, `isSpent`,
+`getTokenState`, `getCurrentRound`, `mint`, `getStateTransitionClient`, `getAggregatorClient`,
+`waitForProofSdk`, …) is gone.
+
+```typescript
+interface OracleProvider extends BaseProvider {
+  /**
+   * Initialize the provider. Loads the trust base JSON via the configured
+   * platform loader when none is passed explicitly.
+   */
+  initialize(trustBaseJson?: unknown): Promise<void>;
+
+  /**
+   * Validate a LEGACY v1 TXF token against the aggregator (best-effort JSON-RPC,
+   * display path only). v2 blob tokens never reach this — they are verified via
+   * the token engine.
+   */
+  validateToken(tokenData: unknown): Promise<ValidationResult>;
+
+  // ── v2 token-engine config surface (REQUIRED — custom implementations must provide them) ──
+  /** Raw trust-base JSON (the engine parses it; the networkId comes from it). */
+  getTrustBaseJson(): unknown | null;
+  /** Gateway (aggregator) base URL. */
+  getAggregatorUrl(): string;
+  /** Gateway API key, when the gateway requires one (e.g. testnet2). */
+  getApiKey(): string | undefined;
+}
+
+interface ValidationResult {
+  valid: boolean;
+  spent: boolean;
+  error?: string;
+  stateHash?: string;
+}
+```
+
+### UnicityAggregatorProviderConfig
+
+```typescript
+interface UnicityAggregatorProviderConfig {
+  url: string;                       // Aggregator (gateway) URL — required
+  apiKey?: string;                   // API key for gateway authentication
+  timeout?: number;                  // Request timeout (ms)
+  skipVerification?: boolean;        // Skip trust base loading (dev only)
+  debug?: boolean;                   // Enable debug logging
+  trustBaseLoader?: TrustBaseLoader; // Platform-specific trust base loader
+}
+```
+
+The browser factory (`impl/browser`) additionally accepts `trustBaseUrl` / `network` and wires a
+fetch-based trust base loader; the Node.js factory uses a file-based loader (`trustBasePath`) —
+both fall back to the embedded per-network trust base.
 
 ---
 
@@ -1779,44 +1730,48 @@ countCommittedTransactions(token: Token): number
 
 ### TokenValidator
 
+Engine-based (v2): a thin, platform-independent wrapper over `ITokenEngine` — structural
+validity via `engine.verify`, spent-status via `engine.isSpent` (with a per-state TTL cache).
+Operates on `SphereToken` (the engine's token type); the v1 TXF / aggregator-client path is
+gone. This is a standalone public utility and is NOT on the live wallet path (payments validate
+via the engine/oracle internally).
+
 ```typescript
-const validator = createTokenValidator(options?: {
-  aggregatorClient?: AggregatorClient;
-  trustBase?: unknown;
-  skipVerification?: boolean;
-});
+import { createTokenValidator } from '@unicitylabs/sphere-sdk';
+
+const validator = createTokenValidator(engine);  // engine: ITokenEngine
 ```
 
 ### Methods
 
 ```typescript
-// Validate all tokens
+// Validate all tokens (parallel, with a batch limit)
 validateAllTokens(
-  tokens: Token[],
+  tokens: SphereToken[],
   options?: { batchSize?: number; onProgress?: (completed: number, total: number) => void }
 ): Promise<ValidationResult>
 
 interface ValidationResult {
-  validTokens: Token[];
+  validTokens: SphereToken[];
   issues: ValidationIssue[];
 }
 
-// Validate single token
-validateToken(token: Token): Promise<TokenValidationResult>
+// Validate a single token's structural integrity against the trust base
+validateToken(token: SphereToken): Promise<TokenValidationResult>
 
 interface TokenValidationResult {
   isValid: boolean;
   reason?: string;
-  action?: 'ACCEPT' | 'RETRY_LATER' | 'DISCARD_FORK';
+  action?: 'ACCEPT' | 'RETRY_LATER' | 'DISCARD_FORK';  // declared on the type; not set by the engine-based validator
 }
 
-// Check if token state is spent
-isTokenStateSpent(tokenId: string, stateHash: string, publicKey: string): Promise<boolean>
+// Whether the token's current state has been spent on the network
+// (cached: SPENT permanently, UNSPENT for 5 minutes; engine errors → treated as unspent)
+isSpent(token: SphereToken): Promise<boolean>
 
-// Check spent tokens in batch
+// Check which tokens are spent, returning them by per-state id
 checkSpentTokens(
-  tokens: Token[],
-  publicKey: string,
+  tokens: SphereToken[],
   options?: { batchSize?: number; onProgress?: (completed: number, total: number) => void }
 ): Promise<SpentTokenResult>
 
@@ -1826,36 +1781,11 @@ interface SpentTokenResult {
 }
 
 interface SpentTokenInfo {
-  tokenId: string;
-  localId: string;
-  stateHash: string;
+  stateId: string;  // SHA-256 of the token's CBOR — unique per state
 }
-
-// Set/update dependencies
-setAggregatorClient(client: AggregatorClient): void
-setTrustBase(trustBase: unknown): void
 
 // Cache management
 clearSpentStateCache(): void
-```
-
-### AggregatorClient Interface
-
-```typescript
-interface AggregatorClient {
-  getInclusionProof(requestId: unknown): Promise<{
-    inclusionProof?: {
-      authenticator: unknown | null;
-      merkleTreePath: {
-        verify(key: bigint): Promise<{
-          isPathValid: boolean;
-          isPathIncluded: boolean;
-        }>;
-      };
-    };
-  }>;
-  isTokenStateSpent?(trustBase: unknown, token: unknown, pubKey: Buffer): Promise<boolean>;
-}
 ```
 
 ---
@@ -2322,9 +2252,9 @@ const accounting = new AccountingModule({ debug: false });
 accounting.initialize({
   payments,        // PaymentsModule
   tokenStorage,    // TokenStorageProvider
-  oracle,          // OracleProvider
-  trustBase,       // aggregator trust base (from oracle config)
+  oracle,          // OracleProvider (network/trust-base config source)
   identity,        // FullIdentity
+  tokenEngine,     // ITokenEngine (v2) — required for createInvoice/importInvoice
   getActiveAddresses: () => sphere.getActiveAddresses(),
   emitEvent: (type, data) => sphere.emit(type, data),
   on: (type, handler) => sphere.on(type, handler),
@@ -2356,13 +2286,13 @@ const { invoiceId, token, terms } = await accounting.createInvoice({
   dueDate: Date.now() + 7 * 24 * 60 * 60 * 1000,  // 7 days
 });
 
-// Export the raw TXF token to share with the buyer
-const txfToken = await sphere.payments.getTokens().find(t => t.id === invoiceId);
+// `token` is the transmittable v2 invoice blob (hex string) — share it with
+// the buyer over any channel (DM, QR, file).
 
 // --- Payer (buyer) ---
 
-// Import the invoice token received out-of-band
-const terms = await accounting.importInvoice(txfToken);
+// Import the invoice blob received out-of-band
+const terms = await accounting.importInvoice(token);
 
 // Pay the first target's first asset
 const result = await accounting.payInvoice(invoiceId!, {
@@ -2413,7 +2343,9 @@ Unsubscribe from all events, drain in-flight operations, and mark the module as 
 
 #### `createInvoice(request: CreateInvoiceRequest): Promise<CreateInvoiceResult>`
 
-Mint a new invoice token on-chain via the Aggregator. The token IS the invoice: its genesis `tokenData` field contains the serialized `InvoiceTerms`.
+Mint a new invoice token on-chain as a v2 **data token** (`engine.mintDataToken`). The token IS
+the invoice: its genesis token data contains the serialized `InvoiceTerms`. The v2 token engine
+is **mandatory** — without it (no v2 oracle config) the call throws `INVOICE_ORACLE_REQUIRED`.
 
 ```typescript
 interface CreateInvoiceRequest {
@@ -2452,13 +2384,15 @@ interface InvoiceRequestedAsset {
 interface CreateInvoiceResult {
   readonly success: boolean;
   readonly invoiceId?: string;     // Invoice token ID (64-char hex)
-  readonly token?: TxfToken;       // Raw TXF token
+  readonly token?: string;         // Transmittable v2 invoice blob, hex-encoded —
+                                   // pass it to importInvoice on the receiving side
   readonly terms?: InvoiceTerms;   // Parsed invoice terms
   readonly error?: string;
 }
 ```
 
 **Throws:**
+- `INVOICE_ORACLE_REQUIRED` — no token engine (v2 oracle config with trust base + gateway missing).
 - `INVOICE_NO_TARGETS` — targets array is empty.
 - `INVOICE_TOO_MANY_TARGETS` — more than 100 targets.
 - `INVOICE_INVALID_ADDRESS` — a target address is not a valid `DIRECT://` address.
@@ -2476,15 +2410,18 @@ interface CreateInvoiceResult {
 - `INVOICE_MINT_FAILED` — aggregator submission failed after retries.
 - `NOT_INITIALIZED` / `MODULE_DESTROYED`
 
-#### `importInvoice(token: TxfToken): Promise<InvoiceTerms>`
+#### `importInvoice(token: string): Promise<InvoiceTerms>`
 
-Import an invoice token received out-of-band (e.g., shared by a creator via IPFS, DM, or QR code). Validates token type and parses `InvoiceTerms`. Persists the token in `TokenStorage` and adds it to the in-memory cache. Idempotent for the same token but fails if already exists with a different state.
+Import an invoice token received out-of-band (e.g., shared by a creator via IPFS, DM, or QR code). `token` is the **v2 invoice blob as a hex string** (the `CreateInvoiceResult.token` value). The token is verified via the engine, its `InvoiceTerms` parsed, persisted in `TokenStorage`, and added to the in-memory cache.
+
+Legacy v1 TXF invoice tokens (objects / TXF JSON) are **rejected** with `INVOICE_INVALID_DATA` — their proof verification required the removed v1 engine.
 
 **Returns:** Parsed `InvoiceTerms`.
 
 **Throws:**
-- `INVOICE_WRONG_TOKEN_TYPE` — token's `tokenType` is not the invoice type constant.
-- `INVOICE_INVALID_DATA` — `tokenData` field is missing or cannot be parsed as `InvoiceTerms`.
+- `INVOICE_ORACLE_REQUIRED` — no token engine (v2 oracle config missing).
+- `INVOICE_INVALID_PROOF` — inclusion proof is invalid.
+- `INVOICE_INVALID_DATA` — token data cannot be parsed as `InvoiceTerms`, or a legacy v1 TXF token was supplied.
 - `INVOICE_ALREADY_EXISTS` — an invoice with this token ID is already stored locally.
 - `NOT_INITIALIZED` / `MODULE_DESTROYED`
 
@@ -2864,8 +2801,8 @@ All invoice events are emitted via `sphere.on(eventType, handler)`.
 | `INVOICE_INVALID_CONTACT` | contact.address or contact.url is malformed |
 | `INVOICE_MINT_FAILED` | Aggregator token mint failed after retries |
 | `INVOICE_INVALID_PROOF` | Aggregator inclusion proof is invalid |
-| `INVOICE_WRONG_TOKEN_TYPE` | Token type does not match the invoice type constant |
-| `INVOICE_INVALID_DATA` | `tokenData` is missing, not JSON, or not a valid `InvoiceTerms` object |
+| `INVOICE_WRONG_TOKEN_TYPE` | Token type does not match the invoice type constant (declared but no longer thrown post v1-cutover) |
+| `INVOICE_INVALID_DATA` | Token data is missing / not a valid `InvoiceTerms` object, or a legacy v1 TXF token was supplied to `importInvoice` |
 | `INVOICE_ALREADY_EXISTS` | Invoice with this token ID already exists locally |
 | `INVOICE_NOT_FOUND` | Invoice token not found in local cache |
 | `INVOICE_NOT_TARGET` | Calling wallet is not a target of this invoice |
@@ -2874,7 +2811,7 @@ All invoice events are emitted via `sphere.on(eventType, handler)`.
 | `INVOICE_TERMINATED` | Invoice is in a terminal state (CLOSED or CANCELLED) |
 | `INVOICE_NOT_TERMINATED` | Invoice is not yet in a terminal state |
 | `INVOICE_NOT_CANCELLED` | Invoice is not in CANCELLED state (sendCancellationNotices only) |
-| `INVOICE_ORACLE_REQUIRED` | Oracle provider is required but not configured |
+| `INVOICE_ORACLE_REQUIRED` | Token engine unavailable — invoices require the v2 oracle config (trust base + gateway URL) |
 | `INVOICE_INVALID_TARGET` | `targetIndex` is out of range |
 | `INVOICE_INVALID_ASSET_INDEX` | `assetIndex` is out of range |
 | `INVOICE_RETURN_EXCEEDS_BALANCE` | Return amount exceeds the payer's net balance |
@@ -3169,6 +3106,17 @@ try {
 | `TIMEOUT` | Operation timed out |
 | `DECRYPTION_ERROR` | Wallet decryption failed |
 | `MODULE_NOT_AVAILABLE` | Requested module not registered |
+| `SIGNING_ERROR` | Message signing/verification failed |
+| `SEND_QUEUE_TIMEOUT` | Queued send timed out waiting for change tokens |
+| `SEND_INSUFFICIENT_BALANCE` | Not enough spendable tokens for the requested send |
+| `SEND_RESERVATION_CANCELLED` | Token reservation was cancelled while queued |
+| `SEND_QUEUE_FULL` | Send queue capacity exceeded |
+| `MODULE_DESTROYED` | Module was destroyed — no further calls accepted |
+| `REENTRANT_GATE` | Re-entrant call into a serialized (gated) operation |
+| `RATE_LIMITED` | Operation called within its cooldown window |
+| `COMMUNICATIONS_UNAVAILABLE` | CommunicationsModule not provided (receipt/notice DMs) |
+
+Invoice (`INVOICE_*`) and swap (`SWAP_*`) codes are listed in their module sections.
 
 ### Logger
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -33,7 +33,7 @@ The easiest way to set up providers is using the factory functions:
 // Browser (requires CORS proxy for free CoinGecko API — see "CORS Proxy" section below)
 import { createBrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
 const providers = createBrowserProviders({
-  network: 'testnet',
+  network: 'testnet',  // = testnet2: the v2 gateway network (gateway.testnet2.unicity.network)
   price: {
     platform: 'coingecko',
     baseUrl: '/api/coingecko',  // CORS proxy path (see below)
@@ -43,12 +43,17 @@ const providers = createBrowserProviders({
 // Node.js (no proxy needed)
 import { createNodeProviders } from '@unicitylabs/sphere-sdk/impl/nodejs';
 const providers = createNodeProviders({
-  network: 'testnet',
+  network: 'testnet',  // = testnet2 (alias 'testnet2' also accepted)
   dataDir: './wallet',
   tokensDir: './tokens',
   price: { platform: 'coingecko', apiKey: 'CG-xxx' },  // Optional
 });
 ```
+
+> **Networks (post v1-cutover):** `testnet` now points at **testnet2** — the v2 state-transition
+> gateway network (`testnet2` remains as an alias of the same configuration). `mainnet` and `dev`
+> still point at v1-era aggregators; the v2 token engine cannot operate against them, so wallet
+> operations there fail loudly (`AGGREGATOR_ERROR`) until those gateways are cut over.
 
 ### Aggregator API key
 
@@ -61,7 +66,9 @@ createBrowserProviders({
   oracle: {
     url: 'https://gateway.testnet2.unicity.network',
     apiKey: import.meta.env.VITE_AGGREGATOR_API_KEY, // browser: build-time env
-    // trustBaseUrl: '<testnet2 trustbase url>',
+    // trustBaseUrl: '<trust base JSON url>',  // browser-only override; Node.js uses
+    //                                          // trustBasePath. Both fall back to the
+    //                                          // embedded per-network trust base.
   },
 });
 ```
@@ -236,7 +243,9 @@ sphere.on('address:hidden', ({ index, addressId }) => {
 
 ## L3 Payments
 
-L3 is the primary payment layer. Tokens are transferred peer-to-peer via Nostr with state proofs committed to the Unicity aggregator.
+L3 is the primary payment layer. Transfers are **sender-driven** (v2): the sender's token engine
+certifies the transfer on-chain via the gateway and delivers a **finished** token to the
+recipient over Nostr — the recipient verifies it and stores it as `'confirmed'` immediately.
 
 ### Typical Wallet Flow
 
@@ -352,7 +361,7 @@ const result = await sphere.payments.send({
 
 // Check result
 console.log('Transfer ID:', result.id);
-console.log('Status:', result.status);  // 'pending' | 'submitted' | 'delivered' | 'completed' | 'failed'
+console.log('Status:', result.status);  // 'pending' | 'submitted' | 'confirmed' | 'delivered' | 'completed' | 'failed'
 if (result.error) {
   console.error('Error:', result.error);
 }
@@ -366,6 +375,10 @@ if (result.error) {
 | `amount` | Yes | Amount in smallest unit (string) |
 | `coinId` | Yes | Token coin ID (e.g., `'UCT'`) |
 | `memo` | No | Optional message to recipient |
+
+The recipient must have a **published chain pubkey** (Nostr identity binding) — otherwise
+`send()` throws `INVALID_RECIPIENT`. The v2 token engine must be available (oracle with a v2
+trust base + gateway URL) — otherwise `AGGREGATOR_ERROR`.
 
 ### Receive Tokens
 
@@ -388,7 +401,7 @@ sphere.on('transfer:incoming', (transfer) => {
 const syncResult = await sphere.payments.sync();
 console.log(`Sync: +${syncResult.added} -${syncResult.removed}`);
 
-// Validate tokens against the aggregator
+// Validate tokens (v2 blobs via the engine; legacy v1 TXF via the oracle RPC)
 const { valid, invalid } = await sphere.payments.validate();
 console.log(`Valid: ${valid.length}, Invalid: ${invalid.length}`);
 ```
@@ -515,31 +528,17 @@ const unconfirmed = sphere.payments.getTokens({ status: 'submitted' });
 
 ### Send Tokens
 
-`send()` auto-selects the optimal transfer path (whole-token NOSTR-FIRST or instant split V5).
+`send()` transfers whole tokens directly and splits a token automatically when the exact amount
+is not available (`engine.split` — the recipient output and your change token are certified in
+one on-chain operation).
 
 ```typescript
-// Send to nametag (auto address mode, instant transfer — default)
+// Send to nametag
 const result = await sphere.payments.send({
   recipient: '@alice',
   amount: '1000000',
   coinId: 'UCT',
   memo: 'Payment for coffee',
-});
-
-// Send with conservative mode (collect all proofs first, then deliver)
-const result2 = await sphere.payments.send({
-  recipient: '@bob',
-  amount: '500000',
-  coinId: 'UCT',
-  transferMode: 'conservative',  // 'instant' (default) | 'conservative'
-});
-
-// Send with explicit address mode
-const result3 = await sphere.payments.send({
-  recipient: '@bob',
-  amount: '500000',
-  coinId: 'UCT',
-  addressMode: 'direct',  // 'auto' | 'direct' | 'proxy'
 });
 
 // Check result
@@ -550,12 +549,10 @@ if (result.status === 'completed') {
 }
 ```
 
-**Transfer Modes:**
-
-| Mode | Description |
-|------|-------------|
-| `'instant'` (default) | Sends tokens via Nostr immediately. Receiver resolves proofs in background. Fastest sender experience (~2-3s for splits). |
-| `'conservative'` | Collects all aggregator proofs first, then sends fully finalized tokens. Slower but receiver gets immediately usable tokens. |
+> The legacy `transferMode` field (`'instant' | 'conservative'`) is still accepted for
+> backwards compatibility but **ignored** — there is a single engine path, and the receiver
+> always gets a finished token. `addressMode` accepts `'auto' | 'direct'` (both resolve to the
+> recipient's key-based DIRECT address; the PROXY scheme is gone).
 
 ### Receive Tokens
 
@@ -593,75 +590,22 @@ await sphere.payments.load();
 
 ---
 
-## Instant Transfers & Token Resolution
+## How Transfers Work (v2, Sender-Driven)
 
-### How Transfers Work Internally
+When you call `send()`, the entire transfer is executed by the v2 token engine on the **sender**
+side: the engine spends the source token (or splits it when the exact amount is unavailable),
+submits the certification to the gateway, waits for the inclusion proof, and produces a
+**finished** token addressed to the recipient's chain pubkey. That finished token blob is then
+delivered over Nostr as a `V2_TRANSFER` payload. The recipient verifies it (`engine.verify` +
+ownership check) and stores it as `'confirmed'` — there is no receiver-side commitment
+submission, proof polling, or finalization phase.
 
-When you call `send()`, the SDK automatically selects the optimal path:
-
-1. **Whole-token transfers** (no split needed): Sends the commitment and source token via Nostr immediately, then submits the commitment to the aggregator in the background. The recipient polls for the inclusion proof and finalizes.
-
-2. **Split transfers** (exact amount unavailable): Uses the Instant Split V5 flow — burns the source token, creates mint commitments for the payment and change amounts, and sends the bundle via Nostr. The recipient saves the token as unconfirmed and resolves proofs lazily.
-
-### Receiving Unconfirmed Tokens
-
-V5 split tokens arrive as unconfirmed (status: `'submitted'`). They are immediately usable for balance display but require proof resolution before they can be spent.
-
-```typescript
-sphere.on('transfer:incoming', (transfer) => {
-  for (const token of transfer.tokens) {
-    if (token.status === 'submitted') {
-      console.log('Unconfirmed token received — will resolve automatically');
-    } else if (token.status === 'confirmed') {
-      console.log('Fully confirmed token received');
-    }
-  }
-});
-```
-
-### Checking Confirmed vs Unconfirmed Balance
-
-```typescript
-const balances = sphere.payments.getBalance();
-for (const bal of balances) {
-  if (BigInt(bal.unconfirmedAmount) > 0n) {
-    console.log(`${bal.symbol}: ${bal.unconfirmedAmount} awaiting confirmation`);
-  }
-}
-```
-
-### Resolving Unconfirmed Tokens
-
-`resolveUnconfirmed()` is called automatically by `load()`, but you can call it explicitly:
-
-```typescript
-const result = await sphere.payments.resolveUnconfirmed();
-console.log(`Resolved: ${result.resolved}, Still pending: ${result.stillPending}, Failed: ${result.failed}`);
-
-for (const detail of result.details) {
-  console.log(`  Token ${detail.tokenId}: stage=${detail.stage}, status=${detail.status}`);
-}
-```
-
-### Waiting for Full Confirmation
-
-To wait until all tokens are confirmed, poll `resolveUnconfirmed()`:
-
-```typescript
-async function waitForAllConfirmed(maxWaitMs = 60000) {
-  const start = Date.now();
-  while (Date.now() - start < maxWaitMs) {
-    const result = await sphere.payments.resolveUnconfirmed();
-    if (result.stillPending === 0) {
-      console.log(`All tokens confirmed (${result.resolved} resolved)`);
-      return;
-    }
-    console.log(`Still pending: ${result.stillPending}`);
-    await new Promise(r => setTimeout(r, 3000));
-  }
-  console.log('Timeout waiting for confirmation');
-}
-```
+Money safety: every finished output blob is journaled (`PENDING_V2_DELIVERIES`) **before** the
+transport delivery and replayed by `load()` after a crash or transport failure, so the
+recipient's token is never lost. Source tokens whose spend was certified on-chain during a
+failed send become terminal `'spent'` — they are never restored to the spendable pool. For
+splits, your change token is minted by the same on-chain operation and is immediately spendable
+(no placeholder, no background proof step).
 
 ---
 
@@ -891,7 +835,10 @@ await sphere.communications.broadcast('Hello world!', ['general']);
 
 ## Invoicing / Accounting
 
-The `AccountingModule` manages the full lifecycle of on-chain invoices: creation, sharing, payment attribution, status tracking, returns, and receipts. An invoice is a special token minted on the Unicity aggregator. Its terms (payment targets, amounts, due date, memo) are embedded in the token's genesis data, making them tamper-evident and independently verifiable by any party who holds the token.
+The `AccountingModule` manages the full lifecycle of on-chain invoices: creation, sharing, payment attribution, status tracking, returns, and receipts. An invoice is a v2 **data token** minted via the token engine on the Unicity gateway. Its terms (payment targets, amounts, due date, memo) are embedded in the token's genesis data, making them tamper-evident and independently verifiable by any party who holds the token.
+
+> Invoice creation and import **require the v2 token engine** (oracle with a v2 trust base +
+> gateway URL) — otherwise `createInvoice()` / `importInvoice()` throw `INVOICE_ORACLE_REQUIRED`.
 
 ### Enable the Accounting Module
 
@@ -953,7 +900,7 @@ if (!result.success) {
 } else {
   console.log('Invoice ID:', result.invoiceId);      // 64-char hex token ID
   console.log('Terms:', result.terms);               // Parsed InvoiceTerms
-  console.log('Token (TXF):', result.token);         // Raw TxfToken for sharing
+  console.log('Token (hex blob):', result.token);    // Transmittable v2 invoice blob (string)
 }
 ```
 
@@ -961,32 +908,25 @@ Multi-target invoices — where separate parties each receive a different asset 
 
 ### Share an Invoice
 
-The `result.token` is a plain `TxfToken` object (JSON-serializable). Share it with payers over any channel — DM, email, QR code, file, etc.:
+The `result.token` is the v2 invoice blob — a plain **hex string**. Share it with payers over any channel — DM, email, QR code, file, etc.:
 
 ```typescript
-// Serialize for transmission
-const invoiceJson = JSON.stringify(result.token);
-
 // Send over DM (example — use your preferred transport)
-await sphere.communications.sendDM('@bob', invoiceJson);
+await sphere.communications.sendDM('@bob', result.token);
 ```
 
 ### Import an Invoice (Payer Side)
 
-The payer imports the token to start tracking the invoice locally:
+The payer imports the blob to start tracking the invoice locally:
 
 ```typescript
-import type { TxfToken } from '@unicitylabs/sphere-sdk';
-
-const token: TxfToken = JSON.parse(receivedJson);
-
-const terms = await accounting.importInvoice(token);
+const terms = await accounting.importInvoice(receivedHexBlob);
 console.log('Invoice creator:', terms.creator);     // Chain pubkey of issuer
 console.log('Due date:', terms.dueDate ? new Date(terms.dueDate) : 'none');
 console.log('Targets:', terms.targets.length);
 ```
 
-`importInvoice()` validates the inclusion proof embedded in the token and rejects tokens with an invalid or tampered proof chain.
+`importInvoice()` verifies the token via the engine and rejects tokens with an invalid or tampered proof chain. Legacy v1 TXF invoice tokens (objects / TXF JSON) are rejected with `INVOICE_INVALID_DATA` — v1 support was removed.
 
 ### Pay an Invoice
 
@@ -1263,8 +1203,8 @@ const { invoiceId, token } = await payeeAccounting.createInvoice({
   dueDate: Date.now() + 3 * 24 * 60 * 60 * 1000,
 });
 
-// 2. Share with payer (here via DM)
-await payee.communications.sendDM('@customer', JSON.stringify(token));
+// 2. Share with payer (here via DM — invoiceId + the hex blob)
+await payee.communications.sendDM('@customer', JSON.stringify({ invoiceId, token }));
 
 // 3. Listen for payments
 payee.on('invoice:covered', async ({ invoiceId: id }) => {
@@ -1282,18 +1222,18 @@ const { sphere: payer } = await Sphere.init({
 });
 const payerAccounting = payer.accounting!;
 
-// 4. Receive the invoice token via DM
+// 4. Receive the invoice via DM
 payer.communications.onDirectMessage(async (msg) => {
-  let token;
-  try { token = JSON.parse(msg.content); } catch { return; }
+  let invoiceId, token;
+  try { ({ invoiceId, token } = JSON.parse(msg.content)); } catch { return; }
 
-  // 5. Import and pay
+  // 5. Import (hex blob string) and pay
   await payerAccounting.importInvoice(token);
 
-  const status = await payerAccounting.getInvoiceStatus(token.id);
+  const status = await payerAccounting.getInvoiceStatus(invoiceId);
   console.log('Invoice state before payment:', status.state);  // 'OPEN'
 
-  await payerAccounting.payInvoice(token.id, { targetIndex: 0 });
+  await payerAccounting.payInvoice(invoiceId, { targetIndex: 0 });
 });
 
 // 6. Payer receives a receipt DM once payee confirms
@@ -1386,11 +1326,10 @@ try {
 | `INVOICE_NO_ASSETS` | `createInvoice` | A target has no assets |
 | `INVOICE_INVALID_AMOUNT` | `createInvoice`, `payInvoice` | Asset amount is not a positive integer, or zero-amount send |
 | `INVOICE_INVALID_ADDRESS` | `createInvoice` | A target address is not a valid `DIRECT://` address |
-| `INVOICE_ORACLE_REQUIRED` | `createInvoice` | Oracle provider is not available (required for minting) |
-| `INVOICE_MINT_FAILED` | `createInvoice` | Aggregator submission failed after retries |
+| `INVOICE_ORACLE_REQUIRED` | `createInvoice`, `importInvoice` | Token engine unavailable (v2 oracle config with trust base + gateway required) |
+| `INVOICE_MINT_FAILED` | `createInvoice` | Gateway submission failed |
 | `INVOICE_INVALID_PROOF` | `importInvoice` | Inclusion proof is invalid or tampered |
-| `INVOICE_WRONG_TOKEN_TYPE` | `importInvoice` | Token is not an invoice token |
-| `INVOICE_INVALID_DATA` | `importInvoice` | `tokenData` cannot be parsed as `InvoiceTerms` |
+| `INVOICE_INVALID_DATA` | `importInvoice` | Token data cannot be parsed as `InvoiceTerms`, or a legacy v1 TXF token was supplied |
 | `INVOICE_ALREADY_EXISTS` | `importInvoice` | Invoice token already held locally |
 | `INVOICE_NOT_FOUND` | Most methods | Invoice is not known locally |
 | `INVOICE_NOT_TARGET` | `closeInvoice`, `cancelInvoice`, `returnInvoicePayment`, `sendInvoiceReceipts`, `sendCancellationNotices` | Wallet is not one of the invoice targets |
@@ -1462,15 +1401,27 @@ interface TransportProvider {
 
 ### Oracle Provider Interface
 
+Post v1-cutover the oracle is a thin **network-config provider** for the v2 token engine: it
+loads the root trust base (JSON) and exposes the gateway URL + API key. The engine builds its
+own clients from these — custom implementations MUST provide the three config accessors.
+
 ```typescript
 interface OracleProvider {
   connect(): Promise<void>;
   disconnect(): Promise<void>;
+  isConnected(): boolean;
+  getStatus(): ProviderStatus;
 
-  submitCommitment(commitment: TransferCommitment): Promise<SubmitResult>;
-  getInclusionProof(requestId: string): Promise<InclusionProof | null>;
+  /** Loads the trust base JSON (via the platform loader when not passed explicitly). */
+  initialize(trustBaseJson?: unknown): Promise<void>;
+
+  /** Best-effort JSON-RPC check for LEGACY v1 TXF tokens (display path only). */
   validateToken(tokenData: unknown): Promise<ValidationResult>;
-  getCurrentRound(): Promise<bigint>;
+
+  // v2 token-engine config surface (REQUIRED)
+  getTrustBaseJson(): unknown | null;   // raw trust-base JSON (networkId comes from it)
+  getAggregatorUrl(): string;           // gateway (aggregator) base URL
+  getApiKey(): string | undefined;      // gateway API key, when required (e.g. testnet2)
 }
 ```
 
@@ -1481,14 +1432,8 @@ interface OracleProvider {
 ### Available Events
 
 ```typescript
-// Wallet events
-sphere.on('wallet:created', () => { });
-sphere.on('wallet:loaded', () => { });
-sphere.on('wallet:cleared', () => { });
-
 // Transfer events
 sphere.on('transfer:incoming', (transfer) => { });
-sphere.on('transfer:outgoing', (transfer) => { });
 sphere.on('transfer:confirmed', (transfer) => { });
 sphere.on('transfer:failed', (transfer) => { });
 
@@ -1506,7 +1451,9 @@ sphere.on('message:broadcast', (broadcast) => { });
 // Sync events
 sphere.on('sync:started', ({ source }) => { });
 sphere.on('sync:completed', ({ source, count }) => { });
+sphere.on('sync:provider', ({ providerId, success, added, removed, error }) => { });
 sphere.on('sync:error', ({ source, error }) => { });
+sphere.on('sync:remote-update', ({ providerId, name, sequence, cid, added, removed }) => { });
 
 // Connection events
 sphere.on('connection:changed', ({ provider, connected }) => { });
@@ -1533,9 +1480,11 @@ unsubscribe();
 
 ---
 
-## Nametags
+## Nametags (Unicity IDs)
 
-Nametags provide human-readable addresses (e.g., `@alice`) for receiving tokens.
+Nametags provide human-readable addresses (e.g., `@alice`) for receiving tokens. A nametag is a
+**Nostr identity binding** (name ↔ chainPubkey) — receive is always locked to your chain pubkey;
+there is no PROXY address scheme.
 
 ### Registration Flow
 
@@ -1550,9 +1499,14 @@ const { sphere } = await Sphere.init({
 // Or register after wallet is created
 await sphere.registerNametag('alice');
 
-// Mint nametag token on-chain (required for PROXY address transfers)
-const result = await sphere.mintNametag('alice');
+// Check availability first (no binding resolves for the name)
+const available = await sphere.isNametagAvailable('alice');
 ```
+
+Registration also mints + stores a self-issued v2 **UnicityIdToken** as an on-chain claim
+(best-effort and idempotent — a gateway outage never fails registration; the claim is re-minted
+on a later load if missing). The claim is not used at runtime — name resolution stays
+Nostr-binding-only.
 
 ### Multi-Address Nametags
 
@@ -1685,7 +1639,7 @@ if (result.status === 'failed') {
 ### Token Validation
 
 ```typescript
-// Validate all tokens against the aggregator
+// Validate all tokens (v2 blobs via the engine: verify + spent check)
 const { valid, invalid } = await sphere.payments.validate();
 
 if (invalid.length > 0) {
@@ -1837,42 +1791,29 @@ npm run test:run
 # Run specific test file
 npx vitest run tests/unit/core/crypto.test.ts
 
+# E2E tests against live testnet2 (requires .env — see .env.example)
+npm run test:e2e
+
 # Run with coverage
 npm test -- --coverage
 ```
 
 ### Test Coverage
 
-| Module | Tests | Description |
-|--------|-------|-------------|
-| `core/crypto` | 43 | BIP39, BIP32, hashing, address generation |
-| `core/bech32` | 30 | Bech32 encoding/decoding |
-| `core/currency` | 37 | Amount conversion and formatting |
-| `core/encryption` | 39 | AES-256-CBC encryption |
-| `core/utils` | 40 | Base58, validation, utilities |
-| `core/Sphere.clear` | 11 | Wallet data cleanup (storage + tokenStorage) |
-| `l1/address` | 18 | HD key derivation |
-| `l1/addressToScriptHash` | 7 | Electrum scripthash |
-| `l1/tx` | 23 | SegWit transactions, UTXO selection |
-| `l1/crypto` | 22 | Wallet encryption, WIF conversion |
-| `l1/addressHelpers` | 36 | Address management utilities |
-| `l1/vesting` | 20 | Vesting classification, Node.js memory-only fallback |
-| `l1/L1PaymentsHistory` | 12 | L1 transaction history direction/amounts |
-| `serialization/txf` | 44 | TXF token format |
-| `serialization/wallet-text` | 32 | Text wallet backup format |
-| `serialization/wallet-dat` | 18 | SQLite wallet.dat parsing |
-| `modules/TokenSplitCalculator` | 23 | Token split optimization |
-| `modules/TokenSplitExecutor` | 16 | Token split execution |
-| `modules/PaymentsModule` | 36 | Payments, nametag, PROXY |
-| `modules/NametagMinter` | 22 | On-chain nametag minting |
-| `modules/CommunicationsModule.storage` | 16 | DM per-address storage, migration, pagination |
-| `price/CoinGeckoPriceProvider` | 29 | Price provider, cache, negative cache |
-| `transport/NostrTransportProvider` | 43 | Nostr P2P messaging, event timestamp persistence |
-| `impl/browser/IndexedDBStorageProvider` | 17 | IndexedDB kv storage, per-address key scoping |
-| `integration/wallet-import-export` | 20 | Wallet import/export |
-| `integration/nametag-roundtrip` | 9 | Nametag serialization |
-| `impl/shared/resolvers` | 41 | Config resolution utilities |
-| **Total** | **1613** | All passing (63 test files) |
+The suite spans ~170 test files. Major areas:
+
+| Area | Description |
+|------|-------------|
+| `tests/unit/core` | Crypto (BIP39/BIP32), bech32, currency, encryption, Sphere lifecycle |
+| `tests/unit/token-engine` | v2 engine adapter: mint, transfer, split, verify, Unicity ID mint |
+| `tests/unit/modules` | PaymentsModule (v2 send/receive/mint/validate, spend queue, history), AccountingModule (full invoice lifecycle), Communications, GroupChat, Market |
+| `tests/unit/l1` | L1 addresses, transactions, vesting, history |
+| `tests/unit/serialization` | TXF format, wallet text/dat backups |
+| `tests/unit/transport` | Nostr P2P messaging, event timestamp persistence |
+| `tests/unit/validation` | Engine-based TokenValidator |
+| `tests/unit/impl` | Storage providers (IndexedDB, file), config resolvers, IPFS |
+| `tests/integration` | Wallet import/export, nametag round-trips |
+| `tests/e2e` | Live testnet2 flows (gated behind `.env` keys; skipped otherwise) |
 
 ### Writing Tests
 
@@ -1881,47 +1822,20 @@ Tests follow the structure:
 ```
 tests/
 ├── unit/
-│   ├── core/
-│   │   ├── crypto.test.ts
-│   │   ├── bech32.test.ts
-│   │   ├── currency.test.ts
-│   │   ├── encryption.test.ts
-│   │   ├── utils.test.ts
-│   │   ├── Sphere.providers.test.ts
-│   │   ├── Sphere.nametag-sync.test.ts
-│   │   └── Sphere.clear.test.ts
+│   ├── core/            # crypto, bech32, currency, encryption, Sphere.*
+│   ├── token-engine/    # v2 engine adapter + Unicity ID minter
+│   ├── modules/         # PaymentsModule.*, AccountingModule.*, Communications*, ...
 │   ├── l1/
-│   │   ├── address.test.ts
-│   │   ├── addressHelpers.test.ts
-│   │   ├── addressToScriptHash.test.ts
-│   │   ├── crypto.test.ts
-│   │   ├── L1PaymentsHistory.test.ts
-│   │   ├── tx.test.ts
-│   │   └── vesting.test.ts
-│   ├── modules/
-│   │   ├── TokenSplitCalculator.test.ts
-│   │   ├── TokenSplitExecutor.test.ts
-│   │   ├── PaymentsModule.test.ts
-│   │   ├── NametagMinter.test.ts
-│   │   └── CommunicationsModule.storage.test.ts
 │   ├── price/
-│   │   └── CoinGeckoPriceProvider.test.ts
 │   ├── transport/
-│   │   └── NostrTransportProvider.test.ts
 │   ├── serialization/
-│   │   ├── txf-serializer.test.ts
-│   │   ├── wallet-text.test.ts
-│   │   └── wallet-dat.test.ts
-│   └── impl/
-│       ├── browser/
-│       │   └── IndexedDBStorageProvider.test.ts
-│       └── shared/
-│           └── resolvers.test.ts
+│   ├── validation/
+│   ├── connect/
+│   └── impl/            # browser / nodejs / shared providers
 ├── integration/
-│   ├── wallet-import-export.test.ts
-│   └── nametag-roundtrip.test.ts
+├── e2e/                 # live-network tests (vitest.e2e.config.ts)
+├── relay/
 └── fixtures/
-    └── test-vectors.ts
 ```
 
 Example test:

--- a/docs/NAMETAG-BINDINGS.md
+++ b/docs/NAMETAG-BINDINGS.md
@@ -22,18 +22,20 @@ Sphere.init()
        ├─ initializeProviders()
        ├─ initializeModules()
        └─ registerNametag('alice')
-            ├─ 1. mintNametag('alice')         ← on-chain first
-            │    └─ submits to Aggregator, waits for proof
-            ├─ 2. publishIdentityBinding(...)  ← Nostr second
+            ├─ 1. publishIdentityBinding(...)  ← the sole registration act
             │    └─ nostrClient.publishNametagBinding('alice', pubkey, identity)
             │         ├─ queryPubkeyByNametag('alice')  ← conflict check
             │         └─ publishEvent(bindingEvent)      ← kind 30078
-            └─ 3. update local state
+            ├─ 2. update local state
+            └─ 3. ensureUnicityIdTokenStored()  ← best-effort, fire-and-forget
+                 └─ mints a self-issued v2 UnicityIdToken via the v2 gateway
+                    and stores it (format: 'v2-cbor'); never blocks/fails
+                    registration
 ```
 
 **Events published: 1** — a nametag binding event with full identity fields.
 
-Mint-before-publish ordering ensures no unbacked nametag claims exist on the relay. If minting fails, nothing is published.
+Since the v1→v2 cutover there is **no on-chain nametag mint as part of registration**: publishing the Nostr binding is the registration act, and its first-seen-wins failure path is the uniqueness guard. A self-issued v2 **UnicityIdToken** is *additionally* minted and stored (format `'v2-cbor'`) **best-effort** after the binding is published — a gateway outage or missing v2 oracle config never fails registration, and the mint is retried on a later wallet load (it is deterministic per name + address key). The token is not consumed anywhere yet; **runtime name resolution stays Nostr-binding-only**.
 
 ### Path B: Without nametag (`Sphere.init({ autoGenerate: true })`)
 
@@ -91,8 +93,7 @@ Published by `registerNametag()` via nostr-js-sdk's `publishNametagBinding()`.
     ["pubkey", "<chainPubkey>"],
     ["t", "<SHA256('unicity:address:' + l1Address)>"],
     ["l1", "<l1Address>"],
-    ["t", "<SHA256('unicity:address:' + directAddress)>"],
-    ["t", "<SHA256('unicity:address:' + proxyAddress)>"]
+    ["t", "<SHA256('unicity:address:' + directAddress)>"]
   ],
   "content": {
     "nametag_hash": "<SHA256('unicity:nametag:alice')>",
@@ -102,11 +103,12 @@ Published by `registerNametag()` via nostr-js-sdk's `publishNametagBinding()`.
     "encrypted_nametag": "<AES-GCM encrypted>",
     "public_key": "02abc...",
     "l1_address": "alpha1...",
-    "direct_address": "DIRECT://...",
-    "proxy_address": "PROXY://..."
+    "direct_address": "DIRECT://..."
   }
 }
 ```
+
+> The wire format (nostr-js-sdk) still allows an optional `proxy_address` field and tag, but the SDK no longer emits them — PROXY addressing was removed in the v1→v2 cutover. Events published by older wallets may still contain them.
 
 ### Base Identity Binding Event (without nametag)
 
@@ -148,7 +150,7 @@ These are different d-tags, so they create **separate** replaceable events. A wa
 
 `publishNametagBinding()` queries the relay before publishing. If the nametag is already claimed by a different pubkey, it throws `"already claimed"`. Same pubkey re-publishing (update) is allowed.
 
-**TOCTOU caveat:** There is a race window between the conflict check and the publish. Another user can claim the same nametag in between. This is inherent to Nostr's eventually-consistent relay model — there is no atomic check-and-publish. The mint-before-publish ordering (see below) provides the real enforcement via on-chain state.
+**TOCTOU caveat:** There is a race window between the conflict check and the publish. Another user can claim the same nametag in between. This is inherent to Nostr's eventually-consistent relay model — there is no atomic check-and-publish. The first-seen-wins resolution strategy (below) is what settles such races at query time: the earliest `created_at` claim wins.
 
 ### Resolution Strategy (query-time)
 
@@ -162,12 +164,14 @@ All query methods (`queryPubkeyByNametag`, `queryBindingByNametag`, `queryBindin
 
 This is critical for Path C (register nametag after creation). Address-based lookups find both the old bare binding and the newer nametag binding. Without latest-wins-for-same-author, the stale bare binding (without nametag) would be returned.
 
-### Mint-Before-Publish
+### Self-Issued Unicity ID Token (v2)
 
-`registerNametag()` mints the nametag token on-chain **before** publishing to Nostr. This ensures:
-- If minting fails → nothing published (no unbacked claims)
-- If minting succeeds but publishing fails → error is surfaced to the user
-- No relay-only nametag claims without blockchain backing
+Since the v1→v2 cutover, the Nostr binding alone IS the registration — there is no on-chain mint gating it. After the binding is published, `registerNametag()` (and wallet create/import/load paths) call `ensureUnicityIdTokenStored()`, which **best-effort** mints a self-issued v2 `UnicityIdToken` via the v2 gateway (`createUnicityIdMinter().mintUnicityIdToken(name)`) and stores it in the wallet's nametag list with `format: 'v2-cbor'`:
+
+- Fire-and-forget: a gateway outage or missing v2 oracle config never fails registration
+- Idempotent: skipped if a `'v2-cbor'` token for the name is already stored
+- Deterministic per (name, address key): a later load re-mints the identical token (lost-storage recovery)
+- Not consumed anywhere yet — **runtime name resolution stays Nostr-binding-only**
 
 ## Privacy
 
@@ -182,7 +186,8 @@ This is critical for Path C (register nametag after creation). Address-based loo
 ### Publishing
 
 ```typescript
-// Register nametag (mints on-chain first, then publishes)
+// Register nametag (publishes the Nostr binding; afterwards a self-issued
+// v2 UnicityIdToken is minted + stored best-effort)
 await sphere.registerNametag('alice');
 
 // Low-level: publish identity binding directly
@@ -194,7 +199,7 @@ await transport.publishIdentityBinding(chainPubkey, l1Address, directAddress, 'a
 ```typescript
 // Unified resolution (accepts @nametag, address, pubkey)
 const peer = await sphere.resolve('@alice');
-// { nametag, transportPubkey, chainPubkey, l1Address, directAddress, proxyAddress, timestamp }
+// { nametag, transportPubkey, chainPubkey, l1Address, directAddress, timestamp }
 
 // Low-level nostr-js-sdk methods
 const pubkey = await nostrClient.queryPubkeyByNametag('alice');

--- a/docs/QUICKSTART-BROWSER.md
+++ b/docs/QUICKSTART-BROWSER.md
@@ -14,7 +14,9 @@ npm install @unicitylabs/sphere-sdk
 
 **That's it!** No additional dependencies for basic usage. Browser uses native WebSocket. IPFS sync is built-in — no extra packages needed.
 
-> **Note:** API key for aggregator is included by default. For custom deployments, configure via `oracle: { apiKey: 'your-key' }`.
+> **Note:** No API key is bundled with the SDK. The `testnet` gateway (testnet2, see below) requires one — inject it via `oracle: { apiKey: '...' }`. The testnet2 key is **not a secret** (see `.env.example`): `sk_ddc3cfcc001e4a28ac3fad7407f99590`. A mainnet key, by contrast, IS a secret — keep it in your deploy environment only.
+>
+> **Networks:** since the v1→v2 cutover, `network: 'testnet'` points at the **testnet2 v2 gateway** (`https://gateway.testnet2.unicity.network`; the network id comes from the trust base). `'testnet2'` is an alias of the same configuration. `mainnet`/`dev` still point at v1-era aggregators and cannot serve the v2 engine yet — wallet operations there fail with `AGGREGATOR_ERROR`.
 
 ## Framework Setup
 
@@ -25,10 +27,14 @@ import { Sphere } from '@unicitylabs/sphere-sdk';
 import { createBrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
 
 async function initWallet() {
-  const providers = createBrowserProviders({ network: 'testnet' });
+  const providers = createBrowserProviders({
+    network: 'testnet',
+    oracle: { apiKey: 'sk_ddc3cfcc001e4a28ac3fad7407f99590' }, // public testnet2 key
+  });
 
   const { sphere, created, generatedMnemonic } = await Sphere.init({
     ...providers,
+    network: 'testnet', // required — Sphere.init throws without it
     autoGenerate: true,
   });
 
@@ -59,6 +65,7 @@ function useWallet() {
 
       const { sphere, created, generatedMnemonic } = await Sphere.init({
         ...providers,
+        network: 'testnet',
         autoGenerate: true,
       });
 
@@ -123,6 +130,7 @@ onMounted(async () => {
 
   const result = await Sphere.init({
     ...providers,
+    network: 'testnet',
     autoGenerate: true,
   });
 
@@ -169,6 +177,7 @@ async function initWallet() {
 
   return Sphere.init({
     ...providers,
+    network: 'testnet',
     autoGenerate: true,
   });
 }
@@ -202,7 +211,9 @@ Browser SDK uses two storage mechanisms automatically:
 
 ```typescript
 const providers = createBrowserProviders({
-  // Network: 'mainnet' | 'testnet' | 'dev'
+  // Network: 'mainnet' | 'testnet' | 'testnet2' | 'dev'
+  // ('testnet' IS testnet2 — the v2 gateway; mainnet/dev are still v1-era and
+  //  cannot serve the v2 engine yet)
   network: 'testnet',
 
   // Transport options
@@ -214,12 +225,14 @@ const providers = createBrowserProviders({
     debug: false,
   },
 
-  // Oracle options
+  // Oracle (v2 gateway) options
   oracle: {
-    aggregatorUrl: 'https://custom-aggregator.com/rpc',
-    trustBaseUrl: '/trustbase.json',  // Fetch from your server
-    apiKey: 'your-api-key',
+    url: 'https://gateway.testnet2.unicity.network',   // Replace default gateway URL
+    apiKey: 'sk_ddc3cfcc001e4a28ac3fad7407f99590',     // Gateway API key (public testnet2 key)
   },
+  // For a custom trust base URL, build the oracle directly with
+  // createUnicityAggregatorProvider({ url, apiKey, trustBaseUrl, network })
+  // from '@unicitylabs/sphere-sdk/impl/browser'.
 
   // L1 blockchain options
   l1: {
@@ -269,13 +282,33 @@ for (const asset of assets) {
   }
 }
 
+// Per-coin balances (synchronous, no price data)
+const balances = sphere.payments.getBalance();
+
 // Total portfolio value in USD (null if PriceProvider not configured)
-const totalUsd = await sphere.payments.getBalance();
+const totalUsd = await sphere.payments.getFiatBalance();
 document.getElementById('balance').textContent =
   totalUsd != null ? `$${totalUsd.toFixed(2)}` : 'N/A';
 
-// L1 (ALPHA) balance
-const l1Balance = await sphere.payments.l1.getBalance();
+// L1 (ALPHA) balance (payments.l1 is null when L1 is disabled via l1: null)
+const l1Balance = await sphere.payments.l1?.getBalance();
+```
+
+### Top Up (Testnet Self-Mint)
+
+There is no faucet — on testnet you top up by **self-minting** tokens via the v2 token engine:
+
+```typescript
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+
+// mintFungibleToken takes the hex coin id, not the symbol
+const coinId = TokenRegistry.getInstance().getCoinIdBySymbol('UCT');
+const res = await sphere.payments.mintFungibleToken(coinId!, 100_000_000n);
+if (res.success) {
+  console.log('Minted token:', res.tokenId);
+} else {
+  console.error('Mint failed:', res.error);
+}
 ```
 
 ### Look Up Asset Metadata
@@ -339,41 +372,45 @@ const { transfers } = await sphere.payments.receive();
 console.log(`Received ${transfers.length} new transfers`);
 ```
 
+> The legacy `ReceiveOptions` (`finalize`, `timeout`, `pollInterval`) are deprecated **no-ops**: v2 transfers arrive as finished tokens and are stored confirmed immediately — there is no finalization phase.
+
 ### Register Nametag
 
-> **Note:** `registerNametag()` mints a token on-chain. This uses the Oracle (Aggregator) provider which is included by default with `createBrowserProviders()`.
+> **Note:** `registerNametag()` registers the name by publishing a Nostr identity binding (name ↔ chain pubkey, first-seen-wins). A self-issued v2 Unicity ID token is additionally minted and stored **best-effort** — registration never fails because of it. Runtime name resolution uses only the Nostr binding.
 
 ```typescript
 async function registerNametag(username: string) {
-  // This registers on Nostr AND mints token on-chain
+  // Publishes the Nostr binding; throws if the name is already taken
   await sphere.registerNametag(username);
   console.log('Registered:', sphere.identity?.nametag);
 }
 
-// Alternative: register during init (also mints token)
+// Alternative: register during init
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   autoGenerate: true,
-  nametag: 'alice',  // Mints token on-chain!
+  nametag: 'alice',
 });
 ```
 
 ### Listen for Events
 
 ```typescript
-// Incoming transfers
-sphere.on('transfer:incoming', (event) => {
-  showNotification(`Received ${event.data.amount} from ${event.data.sender}`);
+// Incoming transfers — handlers receive the event payload directly
+sphere.on('transfer:incoming', (transfer) => {
+  const from = transfer.senderNametag ?? transfer.senderPubkey;
+  showNotification(`Received ${transfer.tokens.length} token(s) from ${from}`);
 });
 
 // Direct messages
 sphere.communications.onDirectMessage((msg) => {
-  showNotification(`Message from ${msg.sender}: ${msg.content}`);
+  showNotification(`Message from ${msg.senderNametag ?? msg.senderPubkey}: ${msg.content}`);
 });
 
 // Connection status
-sphere.on('connection:changed', (event) => {
-  updateConnectionStatus(event.data.connected);
+sphere.on('connection:changed', (status) => {
+  updateConnectionStatus(status.connected);
 });
 ```
 
@@ -390,12 +427,13 @@ Enable the accounting module when initializing the wallet:
 ```typescript
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   autoGenerate: true,
   accounting: true,  // Enable with defaults
 });
 ```
 
-**Create an invoice** (mints a token on-chain via the aggregator):
+**Create an invoice** (mints an invoice data token via the v2 token engine):
 
 ```typescript
 const result = await sphere.accounting!.createInvoice({
@@ -449,16 +487,16 @@ for (const ref of invoices) {
 **Listen for invoice events:**
 
 ```typescript
-sphere.on('invoice:payment', (event) => {
-  console.log(`Payment received for invoice ${event.data.invoiceId}`);
+sphere.on('invoice:payment', (data) => {
+  console.log(`Payment received for invoice ${data.invoiceId}`);
 });
 
-sphere.on('invoice:covered', (event) => {
-  console.log(`Invoice ${event.data.invoiceId} fully covered!`);
+sphere.on('invoice:covered', (data) => {
+  console.log(`Invoice ${data.invoiceId} fully covered!`);
 });
 ```
 
-> **Note:** `createInvoice()` requires the Oracle (Aggregator) provider, which is included automatically by `createBrowserProviders()`.
+> **Note:** `createInvoice()` requires the Oracle provider (v2 gateway config), which is included automatically by `createBrowserProviders()`.
 
 ### Token Swaps
 
@@ -467,6 +505,7 @@ The swap module enables trustless two-party token exchanges via an escrow servic
 ```typescript
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   autoGenerate: true,
   accounting: true,  // Required (swap uses invoices internally)
   swap: true,        // Enable swap module
@@ -547,12 +586,14 @@ console.log('Progress:', status.progress, 'Escrow state:', status.escrowState);
 // From mnemonic (recovery, plaintext storage — default)
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   mnemonic: 'word1 word2 word3 ... word12',
 });
 
 // From mnemonic with password encryption
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   mnemonic: 'word1 word2 word3 ... word12',
   password: 'my-secret-password',
 });
@@ -560,12 +601,13 @@ const { sphere } = await Sphere.init({
 // Load existing wallet with password
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   password: 'my-secret-password',
 });
 
 // Nametag will be auto-recovered from Nostr if it was registered
-sphere.on('nametag:recovered', (event) => {
-  console.log('Recovered nametag:', event.data.nametag);
+sphere.on('nametag:recovered', (data) => {
+  console.log('Recovered nametag:', data.nametag);
 });
 ```
 
@@ -589,6 +631,7 @@ function WalletApp() {
       const providers = createBrowserProviders({ network: 'testnet' });
       const { sphere, created, generatedMnemonic } = await Sphere.init({
         ...providers,
+        network: 'testnet',
         autoGenerate: true,
       });
 
@@ -601,12 +644,12 @@ function WalletApp() {
       setStatus('Connected');
 
       // Load balance (total USD value, null if no PriceProvider)
-      const bal = await sphere.payments.getBalance();
+      const bal = await sphere.payments.getFiatBalance();
       setBalance(bal != null ? `$${bal.toFixed(2)}` : 'N/A');
 
       // Listen for incoming
       sphere.on('transfer:incoming', async () => {
-        const newBal = await sphere.payments.getBalance();
+        const newBal = await sphere.payments.getFiatBalance();
         setBalance(newBal != null ? `$${newBal.toFixed(2)}` : 'N/A');
       });
     };
@@ -632,7 +675,7 @@ function WalletApp() {
       setAmount('');
 
       // Refresh balance
-      const bal = await sphere.payments.getBalance();
+      const bal = await sphere.payments.getFiatBalance();
       setBalance(bal != null ? `$${bal.toFixed(2)}` : 'N/A');
     } catch (err: any) {
       setStatus('Error: ' + err.message);
@@ -651,7 +694,7 @@ function WalletApp() {
             <br />
             <strong>Nametag:</strong> {sphere.identity?.nametag || 'Not registered'}
             <br />
-            <strong>Balance:</strong> {balance} UCT
+            <strong>Balance:</strong> {balance}
           </div>
 
           <div>
@@ -753,9 +796,11 @@ if (created && generatedMnemonic) {
 // When user logs out
 await sphere.destroy();
 
-// Optionally clear storage
-localStorage.clear();
-indexedDB.deleteDatabase('sphere-tokens');
+// Optionally clear all SDK-owned wallet data (keys + tokens)
+await Sphere.clear({
+  storage: providers.storage,
+  tokenStorage: providers.tokenStorage,
+});
 ```
 
 ### Use HTTPS

--- a/docs/QUICKSTART-CLI.md
+++ b/docs/QUICKSTART-CLI.md
@@ -10,7 +10,7 @@ The Sphere CLI covers wallet management, payments, messaging, and invoicing — 
 
 ```bash
 # Full help
-npm run cli -- --help
+sphere --help
 ```
 
 > **Asset amount convention:** All CLI commands that reference assets use the format `<amount> <symbol>`.
@@ -28,29 +28,28 @@ npm run cli -- --help
 
 ## Shell Auto-Completion (Optional)
 
-Enable tab-completion for all sphere-cli commands and flags.
+Enable tab-completion for all CLI commands and flags.
 
 ### Step 1: Install the CLI globally
 
 ```bash
-cd /path/to/sphere-sdk
-npm link
+npm install -g @unicity-sphere/cli
 ```
 
-This makes `sphere-cli` available as a global command (instead of `npm run cli --`).
+This makes `sphere` available as a global command.
 
 ### Step 2: Generate and install completions
 
 **Bash:**
 ```bash
-sphere-cli completions bash >> ~/.bashrc
+sphere completions bash >> ~/.bashrc
 source ~/.bashrc
 ```
 
 **Zsh:**
 ```bash
 mkdir -p ~/.zsh/completions
-sphere-cli completions zsh > ~/.zsh/completions/_sphere-cli
+sphere completions zsh > ~/.zsh/completions/_sphere
 # Add to ~/.zshrc if not already there:
 # fpath=(~/.zsh/completions $fpath)
 # autoload -Uz compinit && compinit
@@ -59,26 +58,18 @@ source ~/.zshrc
 
 **Fish:**
 ```bash
-sphere-cli completions fish > ~/.config/fish/completions/sphere-cli.fish
-```
-
-### Without `npm link` (using `npm run cli`)
-
-```bash
-eval "$(npm run --silent cli -- completions bash)"  # bash
-eval "$(npm run --silent cli -- completions zsh)"   # zsh
-npm run --silent cli -- completions fish > ~/.config/fish/completions/sphere-cli.fish  # fish
+sphere completions fish > ~/.config/fish/completions/sphere.fish
 ```
 
 ### What it provides
 
 After setup, press Tab to auto-complete:
 ```
-sphere-cli <TAB>                    # all commands
-sphere-cli swap-<TAB>               # swap-propose swap-list swap-accept ...
-sphere-cli swap-propose --<TAB>     # --to --offer --want --escrow --timeout --message
-sphere-cli invoice-<TAB>            # invoice-create invoice-list ...
-sphere-cli wallet <TAB>             # list create use current delete
+sphere <TAB>                    # all commands
+sphere swap-<TAB>               # swap-propose swap-list swap-accept ...
+sphere swap-propose --<TAB>     # --to --offer --want --escrow --timeout --message
+sphere invoice-<TAB>            # invoice-create invoice-list ...
+sphere wallet <TAB>             # list create use current delete
 ```
 
 ---
@@ -106,7 +97,7 @@ sphere-cli wallet <TAB>             # list create use current delete
 | `receive` | Check for incoming transfers |
 | `history [limit]` | Transaction history |
 | `l1-balance` | L1 (ALPHA) balance |
-| `topup [<amount> <symbol>]` | Request test tokens from faucet |
+| `topup [<amount> <symbol>]` | Top up by self-minting test tokens (v2 engine — no faucet) |
 | `addresses` | List tracked addresses |
 | `switch <index>` | Switch to HD address |
 | `hide <index>` | Hide address |
@@ -178,12 +169,10 @@ sphere-cli wallet <TAB>             # list create use current delete
 ### Prerequisites
 
 - Node.js 18.0.0 or higher
-- Clone or install the SDK:
+- Install the CLI globally:
 
 ```bash
-git clone <repo>
-cd sphere-sdk
-npm install
+npm install -g @unicity-sphere/cli
 ```
 
 ### First-Time Wallet Initialization
@@ -192,31 +181,33 @@ The `init` command creates a new wallet or imports an existing one. It is the si
 
 ```bash
 # Create a new wallet on testnet (default)
-npm run cli -- init
+sphere init
 
-# Specify network: mainnet | testnet | dev
-npm run cli -- init --network testnet
+# Specify network: mainnet | testnet | testnet2 | dev
+# ('testnet' IS testnet2 — the v2 gateway; mainnet/dev are still v1-era
+#  aggregators and cannot serve the v2 engine yet)
+sphere init --network testnet
 
 # Create wallet and immediately register a nametag
-# NOTE: --nametag mints a token on-chain using the Aggregator
-npm run cli -- init --network testnet --nametag alice
+# NOTE: --nametag publishes a Nostr identity binding (first-seen-wins)
+sphere init --network testnet --nametag alice
 
 # Import an existing wallet from a 12 or 24-word mnemonic
-npm run cli -- init --mnemonic "word1 word2 word3 ... word24"
+sphere init --mnemonic "word1 word2 word3 ... word24"
 
 # Interactive mnemonic import (more secure — mnemonic never in process args)
-npm run cli -- init --mnemonic
+sphere init --mnemonic
 # Prompts: "Enter mnemonic phrase: "
 
 # Import with a nametag registration in one step
-npm run cli -- init --mnemonic "word1 ..." --nametag alice
+sphere init --mnemonic "word1 ..." --nametag alice
 ```
 
 > **Security:** Using `--mnemonic` without a value prompts interactively, keeping the mnemonic out of shell history and `/proc/<pid>/cmdline`. Prefer this mode for production wallets.
 
 > **Important:** When a new wallet is created without `--mnemonic`, a 24-word mnemonic is generated and printed once to the terminal. Save it immediately — it cannot be recovered.
 
-> **Important:** `--nametag` and the standalone `nametag` command both mint a token on-chain. This requires the Aggregator (Oracle) provider, which is included by default on `testnet` and `mainnet`.
+> **Important:** `--nametag` and the standalone `nametag` command register the name by publishing a Nostr identity binding (name ↔ chain pubkey, first-seen-wins). A self-issued v2 Unicity ID token is additionally minted and stored best-effort; runtime name resolution uses only the Nostr binding.
 
 On first run, `init` prints the full wallet identity:
 
@@ -260,7 +251,7 @@ All CLI data is stored in the current working directory under `.sphere-cli/`:
 ### Show Wallet Status
 
 ```bash
-npm run cli -- status
+sphere status
 ```
 
 ```
@@ -279,16 +270,16 @@ Nametag:       alice
 
 ```bash
 # Show current configuration
-npm run cli -- config
+sphere config
 
 # Change the network
-npm run cli -- config set network mainnet
+sphere config set network mainnet
 
 # Change data directory
-npm run cli -- config set dataDir ./my-wallet
+sphere config set dataDir ./my-wallet
 
 # Change token storage directory
-npm run cli -- config set tokensDir ./my-tokens
+sphere config set tokensDir ./my-tokens
 ```
 
 ---
@@ -299,25 +290,25 @@ Wallet profiles let you manage multiple independent wallets (e.g., for testing w
 
 ```bash
 # Create a new profile (creates .sphere-cli-alice/ and switches to it)
-npm run cli -- wallet create alice
+sphere wallet create alice
 
 # Create on a specific network
-npm run cli -- wallet create bob --network mainnet
+sphere wallet create bob --network mainnet
 
 # Initialize the wallet inside the active profile
-npm run cli -- init --nametag alice
+sphere init --nametag alice
 
 # List all profiles (→ marks the active profile)
-npm run cli -- wallet list
+sphere wallet list
 
 # Switch to a different profile
-npm run cli -- wallet use bob
+sphere wallet use bob
 
 # Show the currently active profile
-npm run cli -- wallet current
+sphere wallet current
 
 # Delete a profile (data directory is NOT deleted automatically)
-npm run cli -- wallet delete bob
+sphere wallet delete bob
 ```
 
 > **Note:** Deleting a profile removes the registry entry only. The data directory (e.g., `.sphere-cli-bob/`) is left on disk and must be removed manually if no longer needed.
@@ -326,23 +317,23 @@ npm run cli -- wallet delete bob
 
 ```bash
 # Create alice wallet
-npm run cli -- wallet create alice
-npm run cli -- init --nametag alice
+sphere wallet create alice
+sphere init --nametag alice
 
 # Create bob wallet
-npm run cli -- wallet create bob
-npm run cli -- init --nametag bob
+sphere wallet create bob
+sphere init --nametag bob
 
-# Get test tokens for alice
-npm run cli -- wallet use alice
-npm run cli -- topup
+# Top up alice with test tokens (self-mint)
+sphere wallet use alice
+sphere topup 100 UCT
 
 # Send from alice to bob
-npm run cli -- send @bob 100 UCT
+sphere send @bob 100 UCT
 
 # Check bob's balance
-npm run cli -- wallet use bob
-npm run cli -- balance --finalize
+sphere wallet use bob
+sphere balance
 ```
 
 ---
@@ -353,14 +344,13 @@ npm run cli -- balance --finalize
 
 ```bash
 # Show L3 token balance (fetches pending transfers first)
-npm run cli -- balance
-
-# Also finalize unconfirmed tokens (waits for aggregator proofs)
-npm run cli -- balance --finalize
+sphere balance
 
 # Skip IPFS sync before showing balance
-npm run cli -- balance --no-sync
+sphere balance --no-sync
 ```
+
+> v2 transfers arrive as finished tokens — there is no receiver-side finalization step. The old `--finalize` flag is obsolete.
 
 Example output:
 
@@ -383,10 +373,10 @@ UCT: 50.00000000 (+ 50.00000000 unconfirmed) [2+1 tokens]
 
 ```bash
 # List all tokens with details
-npm run cli -- tokens
+sphere tokens
 
 # Skip IPFS sync
-npm run cli -- tokens --no-sync
+sphere tokens --no-sync
 ```
 
 Example output:
@@ -412,16 +402,16 @@ Browse the token registry to see all known coins and NFTs on the network.
 
 ```bash
 # List all registered assets
-npm run cli -- assets
+sphere assets
 
 # Filter by type
-npm run cli -- assets --type fungible
-npm run cli -- assets --type nft
+sphere assets --type fungible
+sphere assets --type nft
 
 # Get detailed info for a specific asset (by symbol, name, or coin ID)
-npm run cli -- asset-info UCT
-npm run cli -- asset-info bitcoin
-npm run cli -- asset-info 0a1b2c3d4e5f...
+sphere asset-info UCT
+sphere asset-info bitcoin
+sphere asset-info 0a1b2c3d4e5f...
 ```
 
 ### Verify Tokens Against Aggregator
@@ -430,14 +420,14 @@ Detects tokens that have already been spent (transferred out) but are still in l
 
 ```bash
 # Check for spent tokens without removing them
-npm run cli -- verify-balance
+sphere verify-balance
 
 # Also remove any spent tokens from storage (moves to archive + creates tombstone)
-npm run cli -- verify-balance --remove
+sphere verify-balance --remove
 
 # Show all tokens, not just spent ones
-npm run cli -- verify-balance --verbose
-npm run cli -- verify-balance -v
+sphere verify-balance --verbose
+sphere verify-balance -v
 ```
 
 Example output:
@@ -453,13 +443,13 @@ Summary:
   Valid tokens: 2
   Spent tokens: 1
 
-To move spent tokens to Sent folder, run: npm run cli -- verify-balance --remove
+To move spent tokens to Sent folder, run: sphere verify-balance --remove
 ```
 
 ### Sync with IPFS
 
 ```bash
-npm run cli -- sync
+sphere sync
 ```
 
 Merges local tokens with tokens stored on IPFS/IPNS. Useful for recovering tokens after local data loss (re-initialize with the same mnemonic, then sync).
@@ -468,10 +458,10 @@ Merges local tokens with tokens stored on IPFS/IPNS. Useful for recovering token
 
 ```bash
 # Show last 10 transactions
-npm run cli -- history
+sphere history
 
 # Show last N transactions
-npm run cli -- history 25
+sphere history 25
 ```
 
 Example output:
@@ -491,7 +481,7 @@ Transaction History (last 10):
 
 ```bash
 # Delete all wallet data for the active profile (keys + tokens)
-npm run cli -- clear
+sphere clear
 ```
 
 > **Warning:** This permanently deletes the wallet keys and all tokens from local storage. Only tokens synced to IPFS can be recovered afterward.
@@ -500,24 +490,23 @@ npm run cli -- clear
 
 ## 4. Nametags
 
-Nametags (e.g., `@alice`) are human-readable aliases for wallet addresses. They are registered on Nostr and also minted as tokens on-chain.
+Nametags (e.g., `@alice`) are human-readable aliases for wallet addresses. Registration publishes a Nostr identity binding (name ↔ chain pubkey, first-seen-wins); a self-issued v2 Unicity ID token is additionally minted and stored best-effort. Runtime name resolution uses only the Nostr binding.
 
 ```bash
 # Register a nametag for the current address
-# NOTE: mints a token on-chain
-npm run cli -- nametag alice
-npm run cli -- nametag @alice   # @ prefix is stripped automatically
+sphere nametag alice
+sphere nametag @alice   # @ prefix is stripped automatically
 
 # Show your current nametag
-npm run cli -- my-nametag
+sphere my-nametag
 
 # Look up another user's nametag
-npm run cli -- nametag-info alice
-npm run cli -- nametag-info @alice
+sphere nametag-info alice
+sphere nametag-info @alice
 
 # Re-publish nametag with chainPubkey (fixes legacy nametags registered
 # before the direct-address binding was introduced)
-npm run cli -- nametag-sync
+sphere nametag-sync
 ```
 
 > **Note:** Each derived HD address can have its own nametag. Use `switch` to move to a different address before registering a new nametag.
@@ -531,7 +520,7 @@ The wallet uses BIP-32 HD derivation. You can generate and track multiple indepe
 ```bash
 # List all tracked addresses
 # → marks the currently active address
-npm run cli -- addresses
+sphere addresses
 ```
 
 Example output:
@@ -550,13 +539,13 @@ Tracked Addresses:
 
 ```bash
 # Switch to a different HD address index
-npm run cli -- switch 1
+sphere switch 1
 
 # Hide an address from the active list (does not delete data)
-npm run cli -- hide 2
+sphere hide 2
 
 # Unhide an address
-npm run cli -- unhide 2
+sphere unhide 2
 ```
 
 ---
@@ -567,50 +556,29 @@ npm run cli -- unhide 2
 
 ```bash
 # Basic send to a nametag
-npm run cli -- send @bob 100 UCT
+sphere send @bob 100 UCT
 
 # Send to a DIRECT:// address
-npm run cli -- send DIRECT://0000be36... 50 UCT
+sphere send DIRECT://0000be36... 50 UCT
 
 # Send to an L1 address (alpha1...)
-npm run cli -- send alpha1qxy... 0.001 BTC
+sphere send alpha1qxy... 0.001 BTC
 
 # Send to a raw chain pubkey (02... or 03...)
-npm run cli -- send 02abc123def456... 1000000 UCT
+sphere send 02abc123def456... 1000000 UCT
 ```
 
 **Available coin symbols:** UCT, BTC, ETH, SOL, USDT, USDC, USDU, EURU, ALPHT
 
 **Amounts** are specified as human-readable decimals (e.g., `0.5`, `100`, `1000000`). The CLI converts to the smallest unit automatically.
 
-#### Transfer Modes
+#### Transfer Flow
 
-| Mode | Flag | Behavior |
-|------|------|----------|
-| Instant (default) | `--instant` | Sends tokens via Nostr immediately. Receiver finishes proof collection in the background. Fastest for sender (~2-3s). |
-| Conservative | `--conservative` | Collects all aggregator proofs first, then delivers. Slower but receiver gets immediately confirmed tokens. |
+v2 transfers are **sender-driven**: the sender certifies the transfer on-chain (collects the inclusion proof) and delivers a finished token via Nostr; the receiver stores it as confirmed immediately. The old `--instant`/`--conservative` transfer modes and the `--proxy` address mode (PROXY:// addressing) no longer exist — all transfers go to the recipient's key-based DIRECT address resolved from their published identity binding.
 
 ```bash
-# Instant mode (explicit — same as default)
-npm run cli -- send @bob 100 UCT --instant
-
-# Conservative mode
-npm run cli -- send @bob 100 UCT --conservative
-```
-
-#### Address Mode Flags
-
-By default, the CLI resolves the recipient's address automatically. You can force a specific mode:
-
-```bash
-# Force DirectAddress transfer
-npm run cli -- send @bob 100 UCT --direct
-
-# Force PROXY address transfer (compatible with all nametags)
-npm run cli -- send @bob 100 UCT --proxy
-
 # Skip IPFS sync after sending
-npm run cli -- send @bob 100 UCT --no-sync
+sphere send @bob 100 UCT --no-sync
 ```
 
 ### Receive Tokens
@@ -619,14 +587,13 @@ The `receive` command shows your receive addresses and fetches any pending incom
 
 ```bash
 # Show addresses and fetch pending transfers
-npm run cli -- receive
-
-# Also finalize unconfirmed tokens (waits for aggregator proofs)
-npm run cli -- receive --finalize
+sphere receive
 
 # Skip IPFS sync after receiving
-npm run cli -- receive --no-sync
+sphere receive --no-sync
 ```
+
+> v2 transfers arrive as finished tokens and are stored confirmed — there is no `--finalize` step.
 
 Example output:
 
@@ -642,27 +609,21 @@ Checking for incoming transfers...
 
 Received 2 new transfer(s):
   100.00000000 UCT
-  0.04200000 ETH [unconfirmed]
+  0.04200000 ETH
 ```
 
-### Request Test Tokens (Testnet Faucet)
+### Top Up With Test Tokens (Testnet Self-Mint)
+
+There is no faucet — `topup` **self-mints** tokens to your own wallet via the v2 token engine (`payments.mintFungibleToken`):
 
 ```bash
-# Request all supported test coins (requires a registered nametag)
-npm run cli -- topup
-
-# Request a specific amount and coin
-npm run cli -- topup 10 UCT
-npm run cli -- topup 13 ETH
-npm run cli -- topup 200 BTC
-
-# Aliases: top-up, faucet
-npm run cli -- faucet
+# Mint a specific amount and coin
+sphere topup 10 UCT
+sphere topup 13 ETH
+sphere topup 200 BTC
 ```
 
-Supported faucet coins: `unicity`, `bitcoin`, `ethereum`, `solana`, `tether`, `usd-coin`, `unicity-usd`
-
-> **Note:** The faucet is only available on testnet. You must have a registered nametag before requesting tokens.
+> **Note:** Self-mint is intended for test networks (testnet/testnet2).
 
 ---
 
@@ -672,7 +633,7 @@ L1 operations use the ALPHA blockchain (UTXO-based, RandomX PoW). The Fulcrum We
 
 ```bash
 # Check L1 balance
-npm run cli -- l1-balance
+sphere l1-balance
 ```
 
 ```
@@ -695,15 +656,15 @@ DMs are end-to-end encrypted via NIP-17 (gift-wrapped messages) over the Nostr r
 
 ```bash
 # Send a direct message to a nametag
-npm run cli -- dm @alice "Hello, how are you?"
+sphere dm @alice "Hello, how are you?"
 
 # Send to a raw chain pubkey
-npm run cli -- dm 02abc123def456... "Hello!"
+sphere dm 02abc123def456... "Hello!"
 ```
 
 ```
 # List all conversations and unread counts
-npm run cli -- dm-inbox
+sphere dm-inbox
 ```
 
 Example output:
@@ -723,11 +684,11 @@ Inbox (2 conversations, 3 unread):
 
 ```bash
 # Show conversation history with a peer
-npm run cli -- dm-history @alice
+sphere dm-history @alice
 
 # Limit to last N messages (default: 50)
-npm run cli -- dm-history @alice --limit 20
-npm run cli -- dm-history 02abc123def456... --limit 5
+sphere dm-history @alice --limit 20
+sphere dm-history 02abc123def456... --limit 5
 ```
 
 ### Group Chat (NIP-29)
@@ -736,13 +697,13 @@ Group chat uses the NIP-29 relay protocol for managed groups with roles (ADMIN, 
 
 ```bash
 # Create a new public group
-npm run cli -- group-create "Trading Chat"
+sphere group-create "Trading Chat"
 
 # Create with description
-npm run cli -- group-create "Trading Chat" --description "Discuss token trades"
+sphere group-create "Trading Chat" --description "Discuss token trades"
 
 # Create a private group (invite-only)
-npm run cli -- group-create "Private Team" --private
+sphere group-create "Private Team" --private
 ```
 
 ```
@@ -754,35 +715,35 @@ npm run cli -- group-create "Private Team" --private
 
 ```bash
 # List all groups available on the relay
-npm run cli -- group-list
+sphere group-list
 
 # List groups you have joined
-npm run cli -- group-my
+sphere group-my
 
 # Join a group
-npm run cli -- group-join trading-chat-abc123
+sphere group-join trading-chat-abc123
 
 # Join a private group with invite code
-npm run cli -- group-join private-group-id --invite code123
+sphere group-join private-group-id --invite code123
 
 # Send a message to a group
-npm run cli -- group-send trading-chat-abc123 "Hello everyone!"
+sphere group-send trading-chat-abc123 "Hello everyone!"
 
 # Reply to a specific message (by event ID)
-npm run cli -- group-send trading-chat-abc123 "Agreed!" --reply <eventId>
+sphere group-send trading-chat-abc123 "Agreed!" --reply <eventId>
 
 # Read group messages (fetches from relay and marks as read)
-npm run cli -- group-messages trading-chat-abc123
-npm run cli -- group-messages trading-chat-abc123 --limit 20
+sphere group-messages trading-chat-abc123
+sphere group-messages trading-chat-abc123 --limit 20
 
 # List group members (with roles)
-npm run cli -- group-members trading-chat-abc123
+sphere group-members trading-chat-abc123
 
 # Show group details
-npm run cli -- group-info trading-chat-abc123
+sphere group-info trading-chat-abc123
 
 # Leave a group
-npm run cli -- group-leave trading-chat-abc123
+sphere group-leave trading-chat-abc123
 ```
 
 ---
@@ -795,19 +756,19 @@ The market module lets you post buy/sell/service intents and search for matching
 
 ```bash
 # Post a buy intent
-npm run cli -- market-post "Buying 100 UCT tokens" --type buy
+sphere market-post "Buying 100 UCT tokens" --type buy
 
 # Post a sell intent with price
-npm run cli -- market-post "Selling ETH" --type sell --price 2500 --currency USD
+sphere market-post "Selling ETH" --type sell --price 2500 --currency USD
 
 # Post a service offer
-npm run cli -- market-post "Web development services" --type service
+sphere market-post "Web development services" --type service
 
 # Post an announcement
-npm run cli -- market-post "New feature released" --type announcement
+sphere market-post "New feature released" --type announcement
 
 # Full options
-npm run cli -- market-post "Buying UCT" \
+sphere market-post "Buying UCT" \
   --type buy \
   --category tokens \
   --price 100 \
@@ -825,42 +786,42 @@ npm run cli -- market-post "Buying UCT" \
 
 ```bash
 # Semantic search
-npm run cli -- market-search "UCT tokens"
+sphere market-search "UCT tokens"
 
 # Filter by type
-npm run cli -- market-search "tokens" --type sell
+sphere market-search "tokens" --type sell
 
 # Filter by price range
-npm run cli -- market-search "ETH" --min-price 2000 --max-price 3000
+sphere market-search "ETH" --min-price 2000 --max-price 3000
 
 # Set minimum similarity score (0.0 to 1.0)
-npm run cli -- market-search "tokens" --min-score 0.7
+sphere market-search "tokens" --min-score 0.7
 
 # Filter by location and category
-npm run cli -- market-search "services" --category dev --location Berlin
+sphere market-search "services" --category dev --location Berlin
 
 # Limit results (default: 10)
-npm run cli -- market-search "tokens" --limit 5
+sphere market-search "tokens" --limit 5
 ```
 
 ### Managing Your Intents
 
 ```bash
 # List your posted intents
-npm run cli -- market-my
+sphere market-my
 
 # Close (delete) an intent by ID
-npm run cli -- market-close <intentId>
+sphere market-close <intentId>
 ```
 
 ### Live Market Feed
 
 ```bash
 # Watch the live listing feed via WebSocket (Ctrl+C to stop)
-npm run cli -- market-feed
+sphere market-feed
 
 # Use REST fallback to fetch recent listings once (no persistent connection)
-npm run cli -- market-feed --rest
+sphere market-feed --rest
 ```
 
 ---
@@ -877,23 +838,23 @@ Invoices are on-chain tokens that encode payment terms: target address, coin, am
 
 ```bash
 # Create invoice requesting 1 UCT (amount in smallest units)
-npm run cli -- invoice-create --target @alice --asset "1000000 UCT"
+sphere invoice-create --target @alice --asset "1000000 UCT"
 
 # Create targeting a DIRECT address
-npm run cli -- invoice-create --target DIRECT://0000be36... --asset "1000000 UCT"
+sphere invoice-create --target DIRECT://0000be36... --asset "1000000 UCT"
 
 # With optional metadata
-npm run cli -- invoice-create \
+sphere invoice-create \
   --target @alice \
   --asset "1000000 UCT" \
   --due 2026-12-31 \
   --memo "Order #1234"
 
 # Request an NFT token
-npm run cli -- invoice-create --target @alice --nft <tokenId>
+sphere invoice-create --target @alice --nft <tokenId>
 
 # Load full invoice terms from a JSON file
-npm run cli -- invoice-create --terms invoice-terms.json
+sphere invoice-create --terms invoice-terms.json
 ```
 
 The `--asset` flag takes a quoted `"<amount> <symbol>"` string. The amount must be a positive integer in the smallest unit (no decimals, no leading zeros). For UCT with 8 decimals: `1000000` = 0.01 UCT.
@@ -914,28 +875,28 @@ Example output:
 
 ```bash
 # Import an invoice from a token JSON file (shared by the issuer)
-npm run cli -- invoice-import invoice-a1b2c3d4.json
+sphere invoice-import invoice-a1b2c3d4.json
 ```
 
 ### List Invoices
 
 ```bash
 # List all invoices
-npm run cli -- invoice-list
+sphere invoice-list
 
 # Filter by state (comma-separated)
-npm run cli -- invoice-list --state OPEN
-npm run cli -- invoice-list --state OPEN,PARTIAL
+sphere invoice-list --state OPEN
+sphere invoice-list --state OPEN,PARTIAL
 
 # Filter by role
-npm run cli -- invoice-list --role creator    # Invoices you created
-npm run cli -- invoice-list --role payer      # Invoices targeting you
+sphere invoice-list --role creator    # Invoices you created
+sphere invoice-list --role payer      # Invoices targeting you
 
 # Limit results
-npm run cli -- invoice-list --limit 10
+sphere invoice-list --limit 10
 
 # Output as JSON array
-npm run cli -- invoice-list --json
+sphere invoice-list --json
 ```
 
 **Valid states:** `OPEN`, `PARTIAL`, `COVERED`, `CLOSED`, `CANCELLED`, `EXPIRED`
@@ -944,10 +905,10 @@ npm run cli -- invoice-list --json
 
 ```bash
 # Full ID or a unique prefix (as few characters as needed to be unambiguous)
-npm run cli -- invoice-status a1b2c3d4
+sphere invoice-status a1b2c3d4
 
 # Output as JSON
-npm run cli -- invoice-status a1b2c3d4 --json
+sphere invoice-status a1b2c3d4 --json
 ```
 
 Example output:
@@ -976,37 +937,37 @@ Example output:
 
 ```bash
 # Pay the full remaining amount on the first target
-npm run cli -- invoice-pay a1b2c3d4
+sphere invoice-pay a1b2c3d4
 
 # Pay a specific amount (in smallest units)
-npm run cli -- invoice-pay a1b2c3d4 --amount 500000
+sphere invoice-pay a1b2c3d4 --amount 500000
 
 # Pay a specific target in a multi-target invoice (0-indexed)
-npm run cli -- invoice-pay a1b2c3d4 --target-index 1
+sphere invoice-pay a1b2c3d4 --target-index 1
 ```
 
 ### Close an Invoice
 
 ```bash
 # Close the invoice (no further payments accepted after this)
-npm run cli -- invoice-close a1b2c3d4
+sphere invoice-close a1b2c3d4
 
 # Close and trigger auto-return for any overpayments
-npm run cli -- invoice-close a1b2c3d4 --auto-return
+sphere invoice-close a1b2c3d4 --auto-return
 ```
 
 ### Cancel an Invoice
 
 ```bash
 # Cancel an invoice as the target (payer-side cancellation)
-npm run cli -- invoice-cancel a1b2c3d4
+sphere invoice-cancel a1b2c3d4
 ```
 
 ### Return a Payment
 
 ```bash
 # Return a specific amount to the original sender
-npm run cli -- invoice-return a1b2c3d4 \
+sphere invoice-return a1b2c3d4 \
   --recipient @bob \
   --asset "500000 UCT"
 ```
@@ -1017,10 +978,10 @@ Both `--recipient` and `--asset` flags are required.
 
 ```bash
 # Send payment receipts for a terminated invoice (CLOSED or COVERED)
-npm run cli -- invoice-receipts a1b2c3d4
+sphere invoice-receipts a1b2c3d4
 
 # Send cancellation notices to all parties
-npm run cli -- invoice-notices a1b2c3d4
+sphere invoice-notices a1b2c3d4
 ```
 
 ### Auto-Return Settings
@@ -1029,36 +990,36 @@ Auto-return automatically returns overpayments when an invoice is closed.
 
 ```bash
 # Show current auto-return settings
-npm run cli -- invoice-auto-return
+sphere invoice-auto-return
 
 # Enable globally (applies to all future close operations)
-npm run cli -- invoice-auto-return --enable
+sphere invoice-auto-return --enable
 
 # Disable globally
-npm run cli -- invoice-auto-return --disable
+sphere invoice-auto-return --disable
 
 # Enable for a specific invoice
-npm run cli -- invoice-auto-return --enable --invoice a1b2c3d4
+sphere invoice-auto-return --enable --invoice a1b2c3d4
 
 # Disable for a specific invoice
-npm run cli -- invoice-auto-return --disable --invoice a1b2c3d4
+sphere invoice-auto-return --disable --invoice a1b2c3d4
 ```
 
 ### List Related Transfers
 
 ```bash
 # List all transfers related to an invoice in chronological order
-npm run cli -- invoice-transfers a1b2c3d4
+sphere invoice-transfers a1b2c3d4
 
 # Output as JSON array
-npm run cli -- invoice-transfers a1b2c3d4 --json
+sphere invoice-transfers a1b2c3d4 --json
 ```
 
 ### Export an Invoice
 
 ```bash
 # Export invoice data to a JSON file (e.g., invoice-a1b2c3d4.json)
-npm run cli -- invoice-export a1b2c3d4
+sphere invoice-export a1b2c3d4
 ```
 
 ### Parse an Invoice Memo
@@ -1066,7 +1027,7 @@ npm run cli -- invoice-export a1b2c3d4
 Invoice memos embed a compact reference string that can be decoded back to the invoice ID and state.
 
 ```bash
-npm run cli -- invoice-parse-memo "INV:a1b2c3d4...:F"
+sphere invoice-parse-memo "INV:a1b2c3d4...:F"
 ```
 
 ---
@@ -1091,11 +1052,11 @@ This example shows Alice proposing a swap and Bob accepting it, using two termin
 
 ```bash
 # 1. Check Alice's balance
-npm run cli -- balance
+sphere balance
 # Output: UCT: 10,000,000 (10 UCT)
 
 # 2. Propose a swap: Alice offers 1,000,000 UCT for 500,000 USDU
-npm run cli -- swap-propose \
+sphere swap-propose \
   --to @bob \
   --offer "1000000 UCT" \
   --want "500000 USDU" \
@@ -1116,23 +1077,23 @@ npm run cli -- swap-propose \
 # }
 
 # 3. Check swap list
-npm run cli -- swap-list
+sphere swap-list
 # SWAP ID   ROLE        PROGRESS            OFFER             WANT              COUNTERPARTY    CREATED
 # a1b2c3d4  proposer    proposed            1000000 UCT       500000 USDU       @bob            just now
 
 # 4. Wait for Bob to accept...
-npm run cli -- swap-status a1b2c3d4e5f6...full64hex...
+sphere swap-status a1b2c3d4e5f6...full64hex...
 ```
 
 **Terminal 2: Bob (@bob) -- the acceptor**
 
 ```bash
 # 1. Check Bob's balance
-npm run cli -- balance
+sphere balance
 # Output: USDU: 5,000,000 (5 USDU)
 
 # 2. Check incoming swap proposals
-npm run cli -- swap-list
+sphere swap-list
 # SWAP ID   ROLE        PROGRESS            OFFER             WANT              COUNTERPARTY    CREATED
 # a1b2c3d4  acceptor    proposed            500000 USDU       1000000 UCT       @alice          30 sec ago
 #
@@ -1140,7 +1101,7 @@ npm run cli -- swap-list
 # and "WANT" is what he receives (UCT).
 
 # 3. Accept the swap AND deposit in one command
-npm run cli -- swap-accept a1b2c3d4e5f6...full64hex... --deposit
+sphere swap-accept a1b2c3d4e5f6...full64hex... --deposit
 # Output:
 # Swap accepted. Announced to escrow. Waiting for deposit invoice...
 # Deposit sent: transfer_xyz789
@@ -1152,12 +1113,12 @@ npm run cli -- swap-accept a1b2c3d4e5f6...full64hex... --deposit
 
 ```bash
 # 5. Alice sees the swap is now 'announced' (escrow ready)
-npm run cli -- swap-list
+sphere swap-list
 # SWAP ID   ROLE        PROGRESS            OFFER             WANT              COUNTERPARTY    CREATED
 # a1b2c3d4  proposer    announced           1000000 UCT       500000 USDU       @bob            2 min ago
 
 # 6. Alice deposits her side
-npm run cli -- swap-deposit a1b2c3d4e5f6...full64hex...
+sphere swap-deposit a1b2c3d4e5f6...full64hex...
 # Output:
 # Deposit result:
 # {
@@ -1166,7 +1127,7 @@ npm run cli -- swap-deposit a1b2c3d4e5f6...full64hex...
 # }
 
 # 7. Check progress -- both deposits made
-npm run cli -- swap-status a1b2c3d4e5f6...full64hex...
+sphere swap-status a1b2c3d4e5f6...full64hex...
 # progress: "concluding"
 # escrowState: "CONCLUDING"
 ```
@@ -1177,18 +1138,18 @@ After the escrow processes payouts, both parties receive their tokens.
 
 ```bash
 # Alice checks:
-npm run cli -- swap-list --all
+sphere swap-list --all
 # a1b2c3d4  proposer    completed           1000000 UCT       500000 USDU       @bob            5 min ago
 
-npm run cli -- balance
+sphere balance
 # UCT: 9,000,000 (was 10M, sent 1M)
 # USDU: 500,000 (received from swap!)
 
 # Bob checks:
-npm run cli -- swap-list --all
+sphere swap-list --all
 # a1b2c3d4  acceptor    completed           500000 USDU       1000000 UCT       @alice          5 min ago
 
-npm run cli -- balance
+sphere balance
 # USDU: 4,500,000 (was 5M, sent 0.5M)
 # UCT: 1,000,000 (received from swap!)
 ```
@@ -1197,18 +1158,18 @@ npm run cli -- balance
 
 ```bash
 # Detailed status with escrow query (asks the escrow for its view)
-npm run cli -- swap-status a1b2c3d4...full64hex... --query-escrow
+sphere swap-status a1b2c3d4...full64hex... --query-escrow
 
 # Filter swaps by progress state
-npm run cli -- swap-list --progress depositing
-npm run cli -- swap-list --progress announced
+sphere swap-list --progress depositing
+sphere swap-list --progress announced
 
 # Filter by role
-npm run cli -- swap-list --role proposer
-npm run cli -- swap-list --role acceptor
+sphere swap-list --role proposer
+sphere swap-list --role acceptor
 
 # Show all swaps including completed/cancelled/failed (default hides terminal)
-npm run cli -- swap-list --all
+sphere swap-list --all
 ```
 
 ### Cancellation and Timeouts
@@ -1217,13 +1178,13 @@ Swaps that are not fully deposited within the timeout period are automatically c
 
 ```bash
 # If you proposed a swap and want to check if it timed out:
-npm run cli -- swap-status a1b2c3d4...full64hex...
+sphere swap-status a1b2c3d4...full64hex...
 # progress: "cancelled"
 # escrowState: "CANCELLED"
 
 # Deposits are returned automatically by the escrow.
 # Check your balance to confirm tokens were returned:
-npm run cli -- balance
+sphere balance
 ```
 
 You can also explicitly reject or cancel swaps:
@@ -1287,22 +1248,22 @@ The daemon runs in the background and reacts to wallet events — incoming trans
 
 ```bash
 # Listen for incoming transfers and auto-receive them
-npm run cli -- daemon start --event transfer:incoming --action auto-receive
+sphere daemon start --event transfer:incoming --action auto-receive
 
 # Start in background (detaches, writes PID and log files)
-npm run cli -- daemon start --event transfer:incoming --action auto-receive --detach
+sphere daemon start --event transfer:incoming --action auto-receive --detach
 
 # Check if daemon is running
-npm run cli -- daemon status
+sphere daemon status
 
 # Stop daemon
-npm run cli -- daemon stop
+sphere daemon stop
 ```
 
 ### Start Options
 
 ```bash
-npm run cli -- daemon start [options]
+sphere daemon start [options]
 
   --config <path>      Config file path (default: .sphere-cli/daemon.json)
   --detach             Fork to background; redirect output to log file
@@ -1325,25 +1286,25 @@ npm run cli -- daemon start [options]
 
 ```bash
 # Auto-receive all incoming transfers
-npm run cli -- daemon start --event transfer:incoming --action auto-receive
+sphere daemon start --event transfer:incoming --action auto-receive
 
 # Webhook: POST to URL on any transfer event
-npm run cli -- daemon start \
+sphere daemon start \
   --event "transfer:*" \
   --action "webhook:https://example.com/hook" \
   --detach
 
 # Log all events to a file
-npm run cli -- daemon start --event "*" --action "log:./events.jsonl" --verbose
+sphere daemon start --event "*" --action "log:./events.jsonl" --verbose
 
 # Bash: run a shell command on DM receipt
 # Environment variables: SPHERE_SENDER, SPHERE_EVENT, SPHERE_DATA, etc.
-npm run cli -- daemon start \
+sphere daemon start \
   --event message:dm \
   --action "bash:echo DM from \$SPHERE_SENDER"
 
 # Multiple events and actions via config file
-npm run cli -- daemon start --config ./my-daemon.json --detach
+sphere daemon start --config ./my-daemon.json --detach
 ```
 
 ### Config File Format
@@ -1361,7 +1322,7 @@ For complex setups, write a JSON config file at `.sphere-cli/daemon.json`:
       "name": "auto-receive on transfer",
       "events": ["transfer:incoming"],
       "actions": [
-        { "type": "builtin", "action": "auto-receive", "finalize": true }
+        { "type": "builtin", "action": "auto-receive" }
       ]
     },
     {
@@ -1394,26 +1355,26 @@ For complex setups, write a JSON config file at `.sphere-cli/daemon.json`:
 
 ```bash
 # Encrypt a string with a password (AES-256-GCM output as JSON)
-npm run cli -- encrypt "my secret data" mypassword
+sphere encrypt "my secret data" mypassword
 
 # Decrypt encrypted JSON
-npm run cli -- decrypt '{"ciphertext":"...","iv":"...","tag":"..."}' mypassword
+sphere decrypt '{"ciphertext":"...","iv":"...","tag":"..."}' mypassword
 ```
 
 ### Wallet File Parsing
 
 ```bash
 # Parse a wallet backup file (.txt, .dat, .json)
-npm run cli -- parse-wallet wallet.txt
-npm run cli -- parse-wallet wallet.dat
-npm run cli -- parse-wallet wallet.json
+sphere parse-wallet wallet.txt
+sphere parse-wallet wallet.dat
+sphere parse-wallet wallet.json
 
 # Parse encrypted wallet (provide password)
-npm run cli -- parse-wallet wallet.txt mypassword
+sphere parse-wallet wallet.txt mypassword
 
 # Show metadata only (format, encrypted?, SQLite?)
-npm run cli -- wallet-info wallet.txt
-npm run cli -- wallet-info wallet.dat
+sphere wallet-info wallet.txt
+sphere wallet-info wallet.dat
 ```
 
 ### Key Operations
@@ -1422,40 +1383,40 @@ These commands work without a wallet and are useful for low-level key management
 
 ```bash
 # Generate a fresh secp256k1 key pair (private key hidden by default)
-npm run cli -- generate-key
+sphere generate-key
 # Output: Public Key: 02abc... / Address: alpha1...
 
 # Show private key and WIF (use with caution — never in scripts/CI)
-npm run cli -- generate-key --unsafe-print
+sphere generate-key --unsafe-print
 # Output: { privateKey, publicKey, wif, address }
 
 # Validate a private key
-npm run cli -- validate-key 64-char-hex-string
+sphere validate-key 64-char-hex-string
 
 # Convert private key hex to WIF format
-npm run cli -- hex-to-wif 64-char-hex-string
+sphere hex-to-wif 64-char-hex-string
 
 # Derive the compressed public key from a private key
-npm run cli -- derive-pubkey 64-char-hex-string
+sphere derive-pubkey 64-char-hex-string
 
 # Derive the L1 address at a given HD index (default: 0)
-npm run cli -- derive-address 64-char-hex-string
-npm run cli -- derive-address 64-char-hex-string 3
+sphere derive-address 64-char-hex-string
+sphere derive-address 64-char-hex-string 3
 ```
 
 ### Currency Conversion
 
 ```bash
 # Convert human-readable amount to smallest unit (default: 8 decimals)
-npm run cli -- to-smallest 1.5
+sphere to-smallest 1.5
 # Output: 150000000
 
 # Convert smallest unit to human-readable
-npm run cli -- to-human 150000000
+sphere to-human 150000000
 # Output: 1.5
 
 # Format with explicit decimal places
-npm run cli -- format 150000000 8
+sphere format 150000000 8
 # Output: 1.50000000
 ```
 
@@ -1463,10 +1424,10 @@ npm run cli -- format 150000000 8
 
 ```bash
 # Encode a hex string to base58
-npm run cli -- base58-encode deadbeef01234567
+sphere base58-encode deadbeef01234567
 
 # Decode a base58 string back to hex
-npm run cli -- base58-decode Xm4A9...
+sphere base58-decode Xm4A9...
 ```
 
 ---
@@ -1480,8 +1441,8 @@ These flags are accepted by all commands:
 | `--no-nostr` | Disable Nostr transport (uses a no-op stub). Useful for testing IPFS-only recovery. |
 
 ```bash
-npm run cli -- balance --no-nostr
-npm run cli -- init --network testnet --no-nostr
+sphere balance --no-nostr
+sphere init --network testnet --no-nostr
 ```
 
 ---
@@ -1492,127 +1453,128 @@ npm run cli -- init --network testnet --no-nostr
 
 ```bash
 # 1. Initialize wallet with nametag on testnet
-npm run cli -- init --network testnet --nametag alice
+sphere init --network testnet --nametag alice
 
-# 2. Get test tokens from the faucet
-npm run cli -- topup
+# 2. Top up with test tokens (self-mint via the v2 engine)
+sphere topup 10 UCT
 
 # 3. Check your balance
-npm run cli -- balance --finalize
+sphere balance
 
 # 4. Send 50 UCT to bob
-npm run cli -- send @bob 50 UCT
+sphere send @bob 50 UCT
 
 # 5. Confirm the transfer is reflected in history
-npm run cli -- history 5
+sphere history 5
 ```
 
 ### Import Wallet from Mnemonic
 
 ```bash
 # Import and optionally register a nametag in one step
-npm run cli -- init \
+sphere init \
   --mnemonic "abandon ability able about above absent absorb abstract absurd abuse access accident" \
   --nametag alice \
   --network testnet
 
 # Sync with IPFS to restore any previously stored tokens
-npm run cli -- sync
-npm run cli -- balance --finalize
+sphere sync
+sphere balance
 ```
 
 ### Create Invoice, Share, Pay, Close
 
 ```bash
 # Alice creates an invoice requesting 1 UCT from Bob
-npm run cli -- wallet use alice
-npm run cli -- invoice-create --target @alice --asset "100000000 UCT" --memo "Order #1234"
+sphere wallet use alice
+sphere invoice-create --target @alice --asset "100000000 UCT" --memo "Order #1234"
 # Note the invoice ID prefix, e.g., a1b2c3d4
 
 # Alice exports the invoice token to share with Bob
-npm run cli -- invoice-export a1b2c3d4
+sphere invoice-export a1b2c3d4
 # Creates: invoice-a1b2c3d4.json
 
 # Bob imports the invoice
-npm run cli -- wallet use bob
-npm run cli -- invoice-import invoice-a1b2c3d4.json
+sphere wallet use bob
+sphere invoice-import invoice-a1b2c3d4.json
 
 # Bob pays it
-npm run cli -- invoice-pay a1b2c3d4
+sphere invoice-pay a1b2c3d4
 
 # Alice checks status
-npm run cli -- wallet use alice
-npm run cli -- invoice-status a1b2c3d4
+sphere wallet use alice
+sphere invoice-status a1b2c3d4
 
 # Alice closes the invoice and sends receipts
-npm run cli -- invoice-close a1b2c3d4
-npm run cli -- invoice-receipts a1b2c3d4
+sphere invoice-close a1b2c3d4
+sphere invoice-receipts a1b2c3d4
 ```
 
 ### Set Up Daemon for Automated Receiving
 
 ```bash
-# Start daemon that auto-receives incoming tokens and finalizes them
-npm run cli -- daemon start \
+# Start daemon that auto-receives incoming tokens
+sphere daemon start \
   --event transfer:incoming \
   --action auto-receive \
   --detach
 
 # Verify it is running
-npm run cli -- daemon status
+sphere daemon status
 
 # Stop when no longer needed
-npm run cli -- daemon stop
+sphere daemon stop
 ```
 
 ---
 
 ## Troubleshooting
 
-### "No wallet found. Run: npm run cli -- init"
+### "No wallet found. Run: sphere init"
 
 The active profile directory contains no wallet data. Either:
-- Run `npm run cli -- init` to create a new wallet, or
-- Run `npm run cli -- wallet use <name>` to switch to a profile that has one.
+- Run `sphere init` to create a new wallet, or
+- Run `sphere wallet use <name>` to switch to a profile that has one.
 
-### Unconfirmed tokens not resolving
+### Incoming transfer not showing up
+
+v2 transfers arrive as finished tokens (no finalization phase). If a transfer is missing, fetch pending Nostr events explicitly:
 
 ```bash
-# Force finalization (waits for aggregator proof collection)
-npm run cli -- balance --finalize
-npm run cli -- receive --finalize
+sphere receive
+sphere balance
 ```
 
 ### Balance shows old tokens that have already been sent
 
 ```bash
 # Detect and remove spent tokens
-npm run cli -- verify-balance --remove
+sphere verify-balance --remove
 ```
 
 ### Nametag not found after registration
 
 ```bash
 # Re-publish the nametag binding with chainPubkey
-npm run cli -- nametag-sync
+sphere nametag-sync
 ```
 
 ### Recovering tokens after data loss
 
 ```bash
 # Re-import from mnemonic, then sync with IPFS
-npm run cli -- init --mnemonic "your mnemonic here ..."
-npm run cli -- sync
-npm run cli -- balance --finalize
+sphere init --mnemonic "your mnemonic here ..."
+sphere sync
+sphere balance
 ```
 
 ### Daemon does not start
 
 Check for an existing PID file:
 ```bash
-npm run cli -- daemon status
+sphere daemon status
 # If stale: rm .sphere-cli/daemon.pid
-npm run cli -- daemon start --event transfer:incoming --action auto-receive
+sphere daemon start --event transfer:incoming --action auto-receive
 ```
 
 ---

--- a/docs/QUICKSTART-NODEJS.md
+++ b/docs/QUICKSTART-NODEJS.md
@@ -15,7 +15,9 @@ npm install @unicitylabs/sphere-sdk ws
 
 **Node.js version:** 18.0.0 or higher
 
-> **Note:** API key for aggregator is included by default. For custom deployments, configure via `oracle: { apiKey: 'your-key' }`.
+> **Note:** No API key is bundled with the SDK. The `testnet` gateway (testnet2, see below) requires one — inject it via `oracle: { apiKey: '...' }`. The testnet2 key is **not a secret** (see `.env.example`): `sk_ddc3cfcc001e4a28ac3fad7407f99590`. A mainnet key, by contrast, IS a secret — keep it in your deploy environment only.
+>
+> **Networks:** since the v1→v2 cutover, `network: 'testnet'` points at the **testnet2 v2 gateway** (`https://gateway.testnet2.unicity.network`; the network id comes from the trust base). `'testnet2'` is an alias of the same configuration. `mainnet`/`dev` still point at v1-era aggregators and cannot serve the v2 engine yet — wallet operations there fail with `AGGREGATOR_ERROR`.
 
 ## CLI (Quick Testing)
 
@@ -29,99 +31,91 @@ sphere --help
 The examples below use `sphere <command>` — replace any old `npm run cli -- <command>` references accordingly.
 
 ```bash
-# Initialize wallet (no token minted)
-npm run cli -- init --network testnet
+# Initialize wallet
+sphere init --network testnet
 
-# Initialize wallet WITH nametag (mints token on-chain!)
-npm run cli -- init --network testnet --nametag alice
+# Initialize wallet WITH nametag (publishes a Nostr identity binding)
+sphere init --network testnet --nametag alice
 
 # Check status
-npm run cli -- status
+sphere status
 
-# Check balance
-npm run cli -- balance
+# Check balance (fetches pending transfers first)
+sphere balance
 
-# Fetch pending transfers and finalize unconfirmed tokens
-npm run cli -- balance --finalize
-
-# Send tokens (instant mode — default, ~2-3s sender latency)
-npm run cli -- send @alice 1 UCT --instant
-
-# Send tokens (conservative mode — collect all proofs first)
-npm run cli -- send @alice 1 UCT --conservative
+# Send tokens (the sender certifies the transfer on-chain, then delivers
+# the finished token via Nostr)
+sphere send @alice 1 UCT
 
 # Show receive address
-npm run cli -- receive
+sphere receive
 
-# Request test tokens from faucet
-npm run cli -- topup
+# Top up with test tokens (self-mint via the v2 token engine — no faucet)
+sphere topup 10 UCT
 
-# Register nametag (mints token on-chain!)
-npm run cli -- nametag myname
+# Register nametag (publishes a Nostr identity binding)
+sphere nametag myname
 
-# Verify tokens against aggregator (detect spent tokens)
-npm run cli -- verify-balance
+# Verify tokens against the gateway (detect spent tokens)
+sphere verify-balance
 
 # Full help
-npm run cli -- --help
+sphere --help
 ```
 
-> **Important:** Commands with `--nametag` or `nametag` mint a token on-chain. This uses the Oracle (Aggregator) provider which is included by default with `createNodeProviders()`.
+> **Note:** Nametag registration publishes a Nostr identity binding (name ↔ chain pubkey, first-seen-wins). A self-issued v2 Unicity ID token is additionally minted and stored best-effort; runtime name resolution uses only the Nostr binding.
 
-### Transfer Modes
+### Transfer Mode
 
-| Mode | Flag | Description |
-|------|------|-------------|
-| **Instant** (default) | `--instant` | Sends tokens via Nostr immediately. Receiver resolves proofs in background. Fastest sender experience (~2-3s). |
-| **Conservative** | `--conservative` | Collects all aggregator proofs first, then sends fully finalized tokens. Slower but receiver gets immediately usable tokens. |
+v2 transfers are **sender-driven**: the sender certifies the transfer on-chain (collects the inclusion proof) and delivers a finished token via Nostr — the receiver stores it as confirmed with no finalization phase. The old `instant`/`conservative` transfer modes from the v1 engine no longer exist; the `transferMode` field on `TransferRequest` is still accepted for backwards compatibility but ignored.
 
 ### Address Management
 
 ```bash
-npm run cli -- addresses                        # List all tracked addresses
-npm run cli -- switch 1                         # Switch to address at HD index 1
-npm run cli -- hide 2                           # Hide address from active list
-npm run cli -- unhide 2                         # Unhide address
+sphere addresses                        # List all tracked addresses
+sphere switch 1                         # Switch to address at HD index 1
+sphere hide 2                           # Hide address from active list
+sphere unhide 2                         # Unhide address
 ```
 
 ### Direct Messages
 
 ```bash
-npm run cli -- dm @alice "Hello, how are you?"  # Send a DM
-npm run cli -- dm-inbox                         # List conversations + unread counts
-npm run cli -- dm-history @alice                 # Show conversation history
-npm run cli -- dm-history @alice --limit 20      # Limit messages shown
+sphere dm @alice "Hello, how are you?"  # Send a DM
+sphere dm-inbox                         # List conversations + unread counts
+sphere dm-history @alice                 # Show conversation history
+sphere dm-history @alice --limit 20      # Limit messages shown
 ```
 
 ### Group Chat (NIP-29)
 
 ```bash
-npm run cli -- group-list                                        # List available groups
-npm run cli -- group-create "Trading Chat" --description "Discuss trades"  # Create group
-npm run cli -- group-create "Private" --private                  # Create private group
-npm run cli -- group-join <groupId>                              # Join a group
-npm run cli -- group-join <groupId> --invite <code>              # Join with invite code
-npm run cli -- group-send <groupId> "Hello everyone!"            # Send message
-npm run cli -- group-send <groupId> "Reply" --reply <eventId>    # Reply to message
-npm run cli -- group-messages <groupId> --limit 20               # Show messages
-npm run cli -- group-members <groupId>                           # List members
-npm run cli -- group-info <groupId>                              # Show group details
-npm run cli -- group-leave <groupId>                             # Leave group
-npm run cli -- group-my                                          # List your groups
+sphere group-list                                        # List available groups
+sphere group-create "Trading Chat" --description "Discuss trades"  # Create group
+sphere group-create "Private" --private                  # Create private group
+sphere group-join <groupId>                              # Join a group
+sphere group-join <groupId> --invite <code>              # Join with invite code
+sphere group-send <groupId> "Hello everyone!"            # Send message
+sphere group-send <groupId> "Reply" --reply <eventId>    # Reply to message
+sphere group-messages <groupId> --limit 20               # Show messages
+sphere group-members <groupId>                           # List members
+sphere group-info <groupId>                              # Show group details
+sphere group-leave <groupId>                             # Leave group
+sphere group-my                                          # List your groups
 ```
 
 ### Market (Intent Bulletin Board)
 
 ```bash
-npm run cli -- market-post "Buying 100 UCT" --type buy                    # Post buy intent
-npm run cli -- market-post "Selling ETH" --type sell --price 50 --currency USD  # Post sell intent
-npm run cli -- market-post "Web dev services" --type service              # Post service intent
-npm run cli -- market-search "UCT tokens" --type sell --limit 5           # Search intents
-npm run cli -- market-search "tokens" --min-score 0.7                     # Search with score threshold
-npm run cli -- market-my                                                  # List own intents
-npm run cli -- market-close <id>                                          # Close an intent
-npm run cli -- market-feed                                                # Watch live feed (WebSocket)
-npm run cli -- market-feed --rest                                         # Fetch recent (REST fallback)
+sphere market-post "Buying 100 UCT" --type buy                    # Post buy intent
+sphere market-post "Selling ETH" --type sell --price 50 --currency USD  # Post sell intent
+sphere market-post "Web dev services" --type service              # Post service intent
+sphere market-search "UCT tokens" --type sell --limit 5           # Search intents
+sphere market-search "tokens" --min-score 0.7                     # Search with score threshold
+sphere market-my                                                  # List own intents
+sphere market-close <id>                                          # Close an intent
+sphere market-feed                                                # Watch live feed (WebSocket)
+sphere market-feed --rest                                         # Fetch recent (REST fallback)
 ```
 
 ### Wallet Profiles
@@ -129,15 +123,15 @@ npm run cli -- market-feed --rest                                         # Fetc
 Manage multiple wallets for testing:
 
 ```bash
-npm run cli -- wallet create alice              # Create profile "alice"
-npm run cli -- init --nametag alice             # Initialize wallet in profile
-npm run cli -- wallet create bob                # Create another profile
-npm run cli -- init --nametag bob               # Initialize second wallet
-npm run cli -- wallet list                      # List all profiles
-npm run cli -- wallet use alice                 # Switch to alice
-npm run cli -- send @bob 0.1 BTC                 # Send from alice to bob
-npm run cli -- wallet use bob                   # Switch to bob
-npm run cli -- balance --finalize               # Check bob's balance (fetch + finalize)
+sphere wallet create alice              # Create profile "alice"
+sphere init --nametag alice             # Initialize wallet in profile
+sphere wallet create bob                # Create another profile
+sphere init --nametag bob               # Initialize second wallet
+sphere wallet list                      # List all profiles
+sphere wallet use alice                 # Switch to alice
+sphere send @bob 0.1 BTC                 # Send from alice to bob
+sphere wallet use bob                   # Switch to bob
+sphere balance                          # Check bob's balance
 ```
 
 CLI stores data in `./.sphere-cli/` directory.
@@ -170,6 +164,7 @@ async function main() {
   // 2. Initialize wallet (auto-creates if doesn't exist)
   const { sphere, created, generatedMnemonic } = await Sphere.init({
     ...providers,
+    network: 'testnet', // required — Sphere.init throws without it
     autoGenerate: true,
   });
 
@@ -204,7 +199,9 @@ main().catch(console.error);
 
 ```typescript
 const providers = createNodeProviders({
-  // Network: 'mainnet' | 'testnet' | 'dev'
+  // Network: 'mainnet' | 'testnet' | 'testnet2' | 'dev'
+  // ('testnet' IS testnet2 — the v2 gateway; mainnet/dev are still v1-era and
+  //  cannot serve the v2 engine yet)
   network: 'testnet',
 
   // Storage directories (required)
@@ -224,11 +221,11 @@ const providers = createNodeProviders({
     debug: false,
   },
 
-  // Oracle options
+  // Oracle (v2 gateway) options
   oracle: {
-    aggregatorUrl: 'https://custom-aggregator.com/rpc',
-    trustBasePath: './trustbase.json',  // Local trustbase file
-    apiKey: 'your-api-key',             // If required
+    url: 'https://gateway.testnet2.unicity.network',  // Replace default gateway URL
+    trustBasePath: './trustbase.json',                // Local trust base file (optional)
+    apiKey: 'sk_ddc3cfcc001e4a28ac3fad7407f99590',    // Gateway API key (public testnet2 key)
   },
 
   // L1 blockchain options
@@ -260,7 +257,7 @@ const providers = createNodeProviders({
   },
 });
 
-const { sphere } = await Sphere.init({ ...providers, autoGenerate: true });
+const { sphere } = await Sphere.init({ ...providers, network: 'testnet', autoGenerate: true });
 
 // Sync tokens with IPFS (merges local and remote data)
 const result = await sphere.payments.sync();
@@ -285,13 +282,33 @@ for (const asset of assets) {
   }
 }
 
+// Per-coin balances (synchronous, no price data)
+const balances = sphere.payments.getBalance(); // Asset[]
+
 // Total portfolio value in USD (null if PriceProvider not configured)
-const totalUsd = await sphere.payments.getBalance();
+const totalUsd = await sphere.payments.getFiatBalance();
 console.log('Total USD:', totalUsd); // number | null
 
-// L1 (ALPHA) balance
-const l1Balance = await sphere.payments.l1.getBalance();
+// L1 (ALPHA) balance (payments.l1 is null when L1 is disabled via l1: null)
+const l1Balance = await sphere.payments.l1?.getBalance();
 console.log('L1 Balance:', l1Balance);
+```
+
+### Top Up (Testnet Self-Mint)
+
+There is no faucet — on testnet you top up by **self-minting** tokens via the v2 token engine:
+
+```typescript
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+
+// mintFungibleToken takes the hex coin id, not the symbol
+const coinId = TokenRegistry.getInstance().getCoinIdBySymbol('UCT');
+const res = await sphere.payments.mintFungibleToken(coinId!, 100_000_000n);
+if (res.success) {
+  console.log('Minted token:', res.tokenId);
+} else {
+  console.error('Mint failed:', res.error);
+}
 ```
 
 ### Look Up Asset Metadata
@@ -321,28 +338,23 @@ const coinId = registry.getCoinIdBySymbol('UCT');
 ### Send Tokens
 
 ```typescript
-// Send to nametag (instant mode — default)
+// Send to nametag — the sender certifies the transfer on-chain (collects the
+// inclusion proof) and delivers a finished token via Nostr
 const result = await sphere.payments.send({
   recipient: '@alice',
   amount: '1000000',  // In base units
-  coinId: 'UCT',
-});
-
-// Send with conservative mode (collect proofs first, then deliver)
-const result = await sphere.payments.send({
-  recipient: '@alice',
-  amount: '1000000',
-  coinId: 'UCT',
-  transferMode: 'conservative',
+  coinId: 'UCT',      // Short symbols are resolved via the TokenRegistry
 });
 
 // Send to direct address
-const result = await sphere.payments.send({
+const result2 = await sphere.payments.send({
   recipient: 'DIRECT://0000be36...',
   amount: '500000',
   coinId: 'UCT',
 });
 ```
+
+> The legacy `transferMode` field (`'instant' | 'conservative'`) is still accepted on `TransferRequest` for backwards compatibility but **ignored** — v2 has a single sender-driven transfer flow.
 
 ### Fetch Pending Transfers (Explicit Receive)
 
@@ -359,12 +371,14 @@ await sphere.payments.receive(undefined, (transfer) => {
 });
 ```
 
+> The legacy `ReceiveOptions` (`finalize`, `timeout`, `pollInterval`) are deprecated **no-ops**: v2 transfers arrive as finished tokens and are stored confirmed immediately — there is no finalization phase.
+
 ### Register Nametag
 
-> **Note:** `registerNametag()` mints a token on-chain. This uses the Oracle (Aggregator) provider which is included by default with `createNodeProviders()`.
+> **Note:** `registerNametag()` registers the name by publishing a Nostr identity binding (name ↔ chain pubkey, first-seen-wins). A self-issued v2 Unicity ID token is additionally minted and stored **best-effort** — registration never fails because of it. Runtime name resolution uses only the Nostr binding.
 
 ```typescript
-// This registers on Nostr AND mints token on-chain
+// Publishes the Nostr binding; throws if the name is already taken
 await sphere.registerNametag('myusername');
 console.log('Registered:', sphere.identity?.nametag);
 ```
@@ -372,9 +386,12 @@ console.log('Registered:', sphere.identity?.nametag);
 ### Listen for Incoming Transfers
 
 ```typescript
-sphere.on('transfer:incoming', (event) => {
-  console.log('Received:', event.data.amount, event.data.coinId);
-  console.log('From:', event.data.sender);
+// Handlers receive the event payload directly (IncomingTransfer)
+sphere.on('transfer:incoming', (transfer) => {
+  for (const token of transfer.tokens) {
+    console.log('Received:', token.amount, token.symbol);
+  }
+  console.log('From:', transfer.senderNametag ?? transfer.senderPubkey);
 });
 ```
 
@@ -384,7 +401,7 @@ sphere.on('transfer:incoming', (event) => {
 await sphere.communications.sendDM('@alice', 'Hello!');
 
 sphere.communications.onDirectMessage((msg) => {
-  console.log('Message from', msg.sender, ':', msg.content);
+  console.log('Message from', msg.senderNametag ?? msg.senderPubkey, ':', msg.content);
 });
 ```
 
@@ -394,12 +411,14 @@ sphere.communications.onDirectMessage((msg) => {
 // From mnemonic (plaintext storage — default)
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   mnemonic: 'your twelve word mnemonic phrase here ...',
 });
 
 // From mnemonic with password encryption
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   mnemonic: 'your twelve word mnemonic phrase here ...',
   password: 'my-secret-password',
 });
@@ -410,6 +429,7 @@ const sphere = await Sphere.import({
   chainCode: '64-char-hex-chain-code',
   basePath: "m/84'/1'/0'",
   derivationMode: 'bip32',
+  network: 'testnet',
   ...providers,
 });
 ```
@@ -422,6 +442,7 @@ By default, the mnemonic is stored as **plaintext** in `wallet.json`. You can op
 // Create wallet with password encryption
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   autoGenerate: true,
   password: 'my-secret-password',
 });
@@ -429,11 +450,12 @@ const { sphere } = await Sphere.init({
 // Load wallet with password
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   password: 'my-secret-password',
 });
 
 // Load wallet without password (plaintext mnemonic — default)
-const { sphere } = await Sphere.init({ ...providers });
+const { sphere } = await Sphere.init({ ...providers, network: 'testnet' });
 ```
 
 **Backwards compatibility:** Wallets created with older SDK versions (encrypted with the internal default key) will load correctly without a password.
@@ -476,6 +498,7 @@ const { sphere } = await Sphere.init({
   tokenStorage: providers.tokenStorage,
   transport: providers.transport,
   oracle: providers.oracle,
+  network: 'testnet',
 });
 ```
 
@@ -500,10 +523,10 @@ console.log(addr.address, addr.publicKey);
 ## Event Handling
 
 ```typescript
-// All available events
+// Commonly used events (see SphereEventMap in types/index.ts for the full list)
 sphere.on('transfer:incoming', handler);
-sphere.on('transfer:sent', handler);
-sphere.on('transfer:pending', handler);
+sphere.on('transfer:confirmed', handler);
+sphere.on('transfer:failed', handler);
 sphere.on('payment_request:incoming', handler);
 sphere.on('payment_request:paid', handler);
 sphere.on('message:dm', handler);
@@ -525,11 +548,12 @@ unsubscribe(); // Stop listening
 
 The `AccountingModule` handles the full invoice lifecycle — creation, status queries, payment, and closing. Enable it by passing `accounting: true` to `Sphere.init()`.
 
-> **Note:** The accounting module requires the Oracle (Aggregator) provider, which is included by default with `createNodeProviders()`.
+> **Note:** The accounting module requires the Oracle provider (v2 gateway config), which is included by default with `createNodeProviders()`. Invoices are minted as data tokens via the v2 token engine.
 
 ```typescript
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   autoGenerate: true,
   accounting: true,   // Enable with defaults
 });
@@ -639,6 +663,7 @@ The swap module enables trustless two-party token exchanges via an escrow servic
 ```typescript
 const { sphere } = await Sphere.init({
   ...providers,
+  network: 'testnet',
   autoGenerate: true,
   accounting: true,  // Required (swap uses invoices internally)
   swap: true,        // Enable swap module
@@ -717,7 +742,7 @@ try {
     amount: '1000000',
     recipient: '@alice',
   });
-  console.log('Sent:', result.txId);
+  console.log('Sent:', result.id, result.status);
 } catch (error) {
   if (isSphereError(error)) {
     switch (error.code) {
@@ -773,6 +798,7 @@ async function main() {
 
   const { sphere, created, generatedMnemonic } = await Sphere.init({
     ...providers,
+    network: 'testnet',
     autoGenerate: true,
   });
 
@@ -786,11 +812,13 @@ async function main() {
   console.log('Direct Address:', sphere.identity?.directAddress);
   console.log('Nametag:', sphere.identity?.nametag || '(not registered)');
 
-  // Listen for incoming transfers
-  sphere.on('transfer:incoming', (event) => {
+  // Listen for incoming transfers (handler receives the IncomingTransfer payload)
+  sphere.on('transfer:incoming', (transfer) => {
     console.log('\nIncoming transfer!');
-    console.log('Amount:', event.data.amount);
-    console.log('From:', event.data.sender);
+    for (const token of transfer.tokens) {
+      console.log('Amount:', token.amount, token.symbol);
+    }
+    console.log('From:', transfer.senderNametag ?? transfer.senderPubkey);
   });
 
   // Keep running

--- a/docs/SPEC-TOKEN-SPEND-QUEUE.md
+++ b/docs/SPEC-TOKEN-SPEND-QUEUE.md
@@ -1,4 +1,5 @@
 # Token Spend Queue — Feature Specification
+> **Note: written against the v1 engine — the `instant`/`conservative` transfer modes no longer exist after the v1→v2 cutover (2026-06-10); the reservation/queue design now applies to the single sender-driven `send()` path. See CHANGELOG.md.**
 
 **Document status:** Draft v1.0
 **Scope:** `sphere-sdk` — `modules/payments/`

--- a/docs/SPHERE-CLI-EXTRACTION-PLAN.md
+++ b/docs/SPHERE-CLI-EXTRACTION-PLAN.md
@@ -1,4 +1,5 @@
 # Sphere CLI Extraction & DM-Transport Migration Plan
+> **Status: HISTORICAL — the extraction shipped; the CLI now lives in `@unicity-sphere/cli` (github.com/unicity-sphere/sphere-cli) and `sphere-sdk/cli/` was removed. Faucet/topup references below predate the v1→v2 cutover — top-up is now a v2 self-mint (payments.mintFungibleToken).**
 
 **Status:** Phase 0 complete (2026-04-21). Phase 1 in progress.
 **Target repo:** `github.com/unicity-sphere/sphere-cli` (created 2026-04-21)

--- a/docs/STATE-TRANSITION-V2-MIGRATION-DETAILED.md
+++ b/docs/STATE-TRANSITION-V2-MIGRATION-DETAILED.md
@@ -1,4 +1,5 @@
 # State Transition v2 Migration — Detailed Specifications (companion)
+> **Status: HISTORICAL — the v1→v2 cutover completed 2026-06-10 (PRs #479/#480/#481). v1 is removed; see CHANGELOG.md.**
 
 > Companion to **STATE-TRANSITION-V2-MIGRATION.md** (read that first for goals, decisions, identity, the 2-owner split, phasing, risks). This doc is the deep, code-grounded reference: full engine contract, v2 flow sequences, per-file caller migration, serialization/storage, and the test plan.
 >

--- a/docs/STATE-TRANSITION-V2-MIGRATION.md
+++ b/docs/STATE-TRANSITION-V2-MIGRATION.md
@@ -1,4 +1,5 @@
 # Migration Plan — State Transition SDK v1.6.1 → v2
+> **Status: HISTORICAL — the v1→v2 cutover completed 2026-06-10 (PRs #479/#480/#481). v1 is removed; see CHANGELOG.md.**
 
 **Repository:** `sphere-sdk` · **Branch:** `feat/migrate-state-transition-sdk` (cut from `v0.7.2`)
 **Target dependency:** `@unicitylabs/state-transition-sdk@2.0.0-rc.6027e82` (replaces `1.6.1-rc.f37cb85`) — latest RC; the v2 API has been **stable across the recent RCs** (they differ only by packaging/CI), so pinning a newer RC is safe. **Requires Node ≥ 22** (the SDK now declares `engines >=22`, CI on Node 24) — sphere-sdk dev/CI must move to Node 22+ (ideally 24).

--- a/docs/TOKEN-SPEND-QUEUE.md
+++ b/docs/TOKEN-SPEND-QUEUE.md
@@ -1,4 +1,5 @@
 # Token Spend Queue Architecture
+> **Note: written against the v1 engine — `sendInstant()` no longer exists after the v1→v2 cutover (2026-06-10); the reservation/queue design now applies to the single `send()` path. See CHANGELOG.md.**
 
 **Status:** Proposal — v1.0
 **Date:** 2026-03-12

--- a/docs/TRACK-A-STATUS.md
+++ b/docs/TRACK-A-STATUS.md
@@ -1,4 +1,5 @@
 # Track A — Status (for Track B)
+> **Status: HISTORICAL — the v1→v2 cutover completed 2026-06-10 (PRs #479/#480/#481). v1 is removed; see CHANGELOG.md.**
 
 **The v2 token engine is ready to consume.** The full sender-driven engine over
 state-transition v2 is implemented, twice adversarially reviewed, and proven to

--- a/docs/TRACK-B-KICKOFF.md
+++ b/docs/TRACK-B-KICKOFF.md
@@ -1,4 +1,5 @@
 # Track B — Kickoff (state-transition v2 migration)
+> **Status: HISTORICAL — the v1→v2 cutover completed 2026-06-10 (PRs #479/#480/#481). v1 is removed; see CHANGELOG.md.**
 
 You own **Track B: callers, identity wiring & tests** (Person 2). Phase 0 is merged: the
 `ITokenEngine` contract is **frozen** and `FakeTokenEngine` exists, so you can start now —

--- a/docs/TRACK-B-PREP.md
+++ b/docs/TRACK-B-PREP.md
@@ -1,4 +1,5 @@
 # Track B — Prep (state-transition v2 migration)
+> **Status: HISTORICAL — the v1→v2 cutover completed 2026-06-10 (PRs #479/#480/#481). v1 is removed; see CHANGELOG.md.**
 
 > **Status: PREP ONLY. No implementation written yet.** Produced while Phase 0's
 > hard-stop is interpreted conservatively (no code changes). Track A has already

--- a/docs/TRACK-B-STATUS.md
+++ b/docs/TRACK-B-STATUS.md
@@ -1,4 +1,5 @@
 # Track B — Status
+> **Status: HISTORICAL — the v1→v2 cutover completed 2026-06-10 (PRs #479/#480/#481). v1 is removed; see CHANGELOG.md.**
 
 > Caller / identity / test side of the `@unicitylabs/state-transition-sdk` **v1 → v2** migration.
 > Companion to [`TRACK-B-KICKOFF.md`](TRACK-B-KICKOFF.md) (scope, locked decisions) and


### PR DESCRIPTION
Documentation was frozen pre-0.7.2 (CLAUDE.md at 0.6.14). This brings every doc in line with the post-cutover code; four parallel reviewers verified each claim against the source before writing (no invented APIs).

- **CLAUDE.md** — full rewrite: compiling v0.8 quick start, token-engine architecture, NETWORKS table (testnet = testnet2 alias), real Connect surface (18/15/16), directory tree, Windows DTS-trap note.
- **README.md** — network table from constants.ts, API-key policy (no bundled default), self-mint instead of faucet, engine boundary, nametag = Nostr binding + best-effort v2 UnicityIdToken.
- **docs/API.md** — v1 sections (NametagMinter, instant-split, resolveUnconfirmed, v1 oracle) deleted; v2 transfer model, slim OracleProvider contract, accounting blob-string contracts, real error-code table.
- **docs/INTEGRATION.md** — sender-driven v2 flow, oracle interface, invoice workflow on blob strings.
- **QUICKSTART-BROWSER/NODEJS/CLI** — every example now runs against the real API (the old ones would throw INVALID_CONFIG without `network`, used a non-existent bundled API key, `getBalance()` for USD, faucet commands, `--finalize/--conservative` flags).
- **NAMETAG-BINDINGS.md** — binding-only registration + self-issued v2 claim.
- Historical/spec docs (MIGRATION/TRACK-*, ACCOUNTING-SPEC family, TOKEN-SPEND-QUEUE) — status banners instead of rewrites.

Notable honest call-outs now in the docs: `createSphereTokenEngine`/`createUnicityIdMinter` are exported from `token-engine/index.ts` but NOT from the package root or an exports-map subpath (internal-only today); `TransferRequest.transferMode` still exists as an accepted-but-ignored field.