### PR TITLE
Export SpherePaymentData codec via ./token-engine subpath; CI on integration-branch PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, feat/wallet-api-integration]
   pull_request:
-    branches: [main]
+    branches: [main, feat/wallet-api-integration]
 
 jobs:
   build:
@@ -27,6 +27,12 @@ jobs:
         run: |
           npm install --include=optional --ignore-scripts
           npm rebuild
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
 
       - name: Build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -45,6 +45,16 @@
         "default": "./dist/core/index.cjs"
       }
     },
+    "./token-engine": {
+      "import": {
+        "types": "./dist/token-engine/index.d.ts",
+        "default": "./dist/token-engine/index.js"
+      },
+      "require": {
+        "types": "./dist/token-engine/index.d.cts",
+        "default": "./dist/token-engine/index.cjs"
+      }
+    },
     "./l1": {
       "import": {
         "types": "./dist/l1/index.d.ts",
@@ -102,7 +112,7 @@
     "test:relay": "vitest run --config vitest.relay.config.ts",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
-    "cli": "echo 'The CLI has moved to @unicity-sphere/cli — install it with: npm install -g @unicity-sphere/cli' && exit 1"
+    "cli": "echo 'The CLI has moved to @unicity-sphere/cli \u2014 install it with: npm install -g @unicity-sphere/cli' && exit 1"
   },
   "keywords": [
     "unicity",

--- a/token-engine/index.ts
+++ b/token-engine/index.ts
@@ -46,3 +46,13 @@ export { createSphereTokenEngine } from './factory';
 // decision 2026-06-10; see unicity-id.ts header).
 export { createUnicityIdMinter } from './unicity-id';
 export type { IUnicityIdMinter, UnicityIdMintResult } from './unicity-id';
+
+// The SpherePaymentData codec (CBOR tag 39050) — the value envelope inside
+// Sphere tokens. Exported via the `./token-engine` subpath so server-side
+// consumers (wallet-api deposit validation) can decode token values without
+// pulling the browser/IPFS/Nostr dependency closure of the root entry.
+export {
+  SpherePaymentData,
+  decodeSpherePaymentData,
+  sphereAssetToSdk,
+} from './SpherePaymentData';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -45,6 +45,27 @@ export default defineConfig([
       'ws',
     ],
   },
+  // Token-engine (incl. the SpherePaymentData codec) — for server-side
+  // consumers (wallet-api validation) that must not pull browser/IPFS/Nostr
+  {
+    entry: { 'token-engine/index': 'token-engine/index.ts' },
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: false,
+    splitting: false,
+    sourcemap: true,
+    platform: 'node',
+    target: 'es2022',
+    noExternal: [/^@noble\//],
+    external: [
+      /^@unicitylabs\//,
+      'bip39',
+      'buffer',
+      'crypto-js',
+      'elliptic',
+      'ws',
+    ],
+  },
   // L1 module (for direct crypto operations)
   {
     entry: { 'l1/index': 'l1/index.ts' },


### PR DESCRIPTION
Closes #486

- `./token-engine` subpath: exports `SpherePaymentData`/`decodeSpherePaymentData`/`sphereAssetToSdk`, built to `dist/token-engine/*` (esm+cjs+dts). Smoke-tested: subpath import works, CBOR tag 39050, and the built artifact's import closure contains only `@unicitylabs/state-transition-sdk` deep paths — no nostr/helia/libp2p/ipfs (the ARCHITECTURE §8.2 requirement for wallet-api's server-side use).
- CI now runs on PRs targeting `feat/wallet-api-integration` and adds typecheck + lint steps (both clean today).
- Test suite: 2871/2875 pass; the 4 failures are pre-existing on the clean baseline (filed as #487).