### PR TITLE
Part E — Recoverable engine: deterministic realization + status-agnostic idempotent submit with conflict detection

### DIFF
--- a/core/errors.ts
+++ b/core/errors.ts
@@ -32,6 +32,9 @@ export type SphereErrorCode =
   | 'INSUFFICIENT_BALANCE'
   | 'INVALID_RECIPIENT'
   | 'TRANSFER_FAILED'
+  // The source state was consumed by a DIFFERENT transaction (lost race, not a
+  // resume) — raised as TransferConflictError (token-engine/errors.ts, Part E.2).
+  | 'TRANSFER_CONFLICT'
   | 'STORAGE_ERROR'
   | 'TRANSPORT_ERROR'
   | 'AGGREGATOR_ERROR'

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -31,6 +31,7 @@ import type {
 import { L1PaymentsModule, type L1PaymentsModuleConfig } from './L1PaymentsModule';
 import type { SplitPlan, TokenWithAmount } from './TokenSplitCalculator';
 import type { ITokenEngine, SphereToken } from '../../token-engine';
+import { TransferConflictError } from '../../token-engine';
 import { isV2TransferPayload, type V2TransferPayload } from '../../types/v2-transfer';
 import { TokenReservationLedger } from './TokenReservationLedger';
 import { SpendPlanner, SpendQueue, type ParsedTokenEntry, type ParsedTokenPool } from './SpendQueue';
@@ -1212,7 +1213,10 @@ export class PaymentsModule {
           } as unknown as import('../../transport').TokenTransferPayload);
         };
 
-        // Whole-token direct transfers.
+        // Whole-token direct transfers. Each engine op gets its own UUIDv4
+        // realization seed (Part E): the transaction is deterministic in
+        // (key, transferId, inputs), so a certified-but-uncaptured op stays
+        // rebuildable. Server-side intent persistence + resume are Part S.
         for (const tw of splitPlan.tokensToTransferDirectly) {
           const finished = await engine.transfer(
             {
@@ -1220,7 +1224,7 @@ export class PaymentsModule {
               recipientPubkey: recipientChainPubkey,
               data: memoData,
             },
-            { signal: AbortSignal.timeout(SEND_ENGINE_OP_TIMEOUT_MS) },
+            { signal: AbortSignal.timeout(SEND_ENGINE_OP_TIMEOUT_MS), transferId: crypto.randomUUID() },
           );
           // The source state is spent on-chain from here on.
           committedOnChainTokenIds.add(tw.uiToken.id);
@@ -1253,7 +1257,8 @@ export class PaymentsModule {
                 { recipientPubkey: selfChainPubkey, coinId: request.coinId, amount: splitPlan.remainderAmount! },
               ],
             },
-            { signal: AbortSignal.timeout(SEND_ENGINE_OP_TIMEOUT_MS) },
+            // Per-op realization seed (Part E) — see the direct-transfer loop above.
+            { signal: AbortSignal.timeout(SEND_ENGINE_OP_TIMEOUT_MS), transferId: crypto.randomUUID() },
           );
           // The split source is burnt on-chain from here on. Persist BOTH outputs
           // (journal the recipient's blob, store our change token) BEFORE the
@@ -1323,7 +1328,14 @@ export class PaymentsModule {
       this.reservationLedger.cancel(result.id);
 
       result.status = 'failed';
-      result.error = error instanceof Error ? error.message : String(error);
+      // A TransferConflictError is a LOST RACE (Part E.2): another transaction —
+      // typically this owner's other device — already consumed a source token.
+      // Fail this send cleanly with a distinct message; the restore loop below
+      // marks the conflicted source 'spent' via the on-chain isSpent check.
+      // (Re-planning the uncovered remainder automatically is Part S.)
+      result.error = error instanceof TransferConflictError
+        ? `Send conflicted: a source token was already spent by a concurrent transfer — re-plan and retry (${error.message})`
+        : error instanceof Error ? error.message : String(error);
 
       // Restore tokens. Three classes (W23-R2/R3, v2 edition):
       //  - already removeToken()'d during a partially-successful loop → skip

--- a/tests/unit/token-engine/realization.test.ts
+++ b/tests/unit/token-engine/realization.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveRealization,
+  REALIZATION_HKDF_INFO_PREFIX,
+  type RealizationField,
+} from '../../../token-engine/realization';
+import { HexConverter } from '../../../token-engine/sdk';
+
+const PRIV_KEY_HEX = '01'.repeat(32);
+const TRANSFER_ID = '123e4567-e89b-42d3-a456-426614174000';
+
+// Independently computed with Node's built-in crypto:
+//   crypto.hkdfSync('sha256', Buffer.from('01'.repeat(32), 'hex'), Buffer.alloc(0),
+//     Buffer.from(`sphere-realization-v1:123e4567-e89b-42d3-a456-426614174000:${field}:${index}`), 32)
+// (empty HKDF salt ≡ HashLen zero bytes per RFC 5869 — the same "no salt" form
+// @noble/hashes uses, mirroring ipns-key-derivation.ts). Pins both the formula
+// and the info-string layout `sphere-realization-v1:<transferId>:<field>:<index>`.
+const VECTORS: ReadonlyArray<{ field: RealizationField; index: number; hex: string }> = [
+  { field: 'stateMask', index: 0, hex: '0745faebed15108b55d8e6ef0d7aad11f6c11218c2b09544d073884d03c1dd46' },
+  { field: 'salt', index: 0, hex: '53613bb1d688648ca08ebd4d3b686983391115f895e3d97f905efd2a932ca369' },
+  { field: 'salt', index: 1, hex: 'fa0927805faf413df18aabfc6b0fd9190160487b04f5c3d4d8ac339d078cd20d' },
+  { field: 'burn', index: 0, hex: '002f07f2ab9369791b91cc65ef907371e345251466d28afb56ea6cfb7c2fdd52' },
+  { field: 'tokenType', index: 0, hex: 'fdfef585980fd90aa1eae39ce2063b88b47eedcd3f50279e7cf4e1cb88f2f503' },
+];
+
+describe('deriveRealization (Part E.1)', () => {
+  it('is versioned with the spec prefix', () => {
+    expect(REALIZATION_HKDF_INFO_PREFIX).toBe('sphere-realization-v1');
+  });
+
+  it('returns 32 bytes', () => {
+    const out = deriveRealization(PRIV_KEY_HEX, TRANSFER_ID, 0, 'stateMask');
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(out.length).toBe(32);
+  });
+
+  it('is deterministic for the same (key, transferId, index, field)', () => {
+    const a = deriveRealization(PRIV_KEY_HEX, TRANSFER_ID, 3, 'salt');
+    const b = deriveRealization(PRIV_KEY_HEX, TRANSFER_ID, 3, 'salt');
+    expect(HexConverter.encode(a)).toBe(HexConverter.encode(b));
+  });
+
+  it('matches the hand-computed HKDF-SHA256 vectors', () => {
+    for (const v of VECTORS) {
+      expect(HexConverter.encode(deriveRealization(PRIV_KEY_HEX, TRANSFER_ID, v.index, v.field))).toBe(v.hex);
+    }
+  });
+
+  it('is distinct across transferId, field, index and key', () => {
+    const base = HexConverter.encode(deriveRealization(PRIV_KEY_HEX, TRANSFER_ID, 0, 'salt'));
+    const otherTransfer = HexConverter.encode(
+      deriveRealization(PRIV_KEY_HEX, '00000000-0000-4000-8000-000000000000', 0, 'salt'),
+    );
+    const otherField = HexConverter.encode(deriveRealization(PRIV_KEY_HEX, TRANSFER_ID, 0, 'stateMask'));
+    const otherIndex = HexConverter.encode(deriveRealization(PRIV_KEY_HEX, TRANSFER_ID, 1, 'salt'));
+    const otherKey = HexConverter.encode(deriveRealization('02'.repeat(32), TRANSFER_ID, 0, 'salt'));
+    const all = [base, otherTransfer, otherField, otherIndex, otherKey];
+    expect(new Set(all).size).toBe(all.length);
+  });
+});

--- a/tests/unit/token-engine/recoverable-engine.test.ts
+++ b/tests/unit/token-engine/recoverable-engine.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Part E — recoverable engine (sdk-changes E.1/E.2/E.3, ARCHITECTURE §8.1).
+ *
+ * Runs the REAL SphereTokenEngine over the vendored in-memory
+ * TestAggregatorClient, whose first-write-wins duplicate submit + proof
+ * re-fetch is the target aggregator contract for E.2.
+ *
+ * Split legs note: per-output salts/tokenType are deterministic here, but the
+ * burn mask is still random inside the pinned base SDK's TokenSplit.split
+ * (state-transition-sdk-js#125; wiring tracked in #492) — so split tests
+ * assert salt/tokenId determinism, not burn-leg resume.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { TransferConflictError } from '../../../token-engine/errors';
+import { deriveRealization } from '../../../token-engine/realization';
+import {
+  type CertificationData,
+  type CertificationResponse,
+  HexConverter,
+  type IAggregatorClient,
+  InclusionProofVerificationStatus,
+  type InclusionProofResponse,
+  PredicateVerifierService,
+  SignaturePredicate,
+  SigningService,
+  type StateId,
+  StateTransitionClient,
+  TransferTransaction,
+  waitInclusionProof,
+} from '../../../token-engine/sdk';
+import { TestAggregatorClient } from './support/TestAggregatorClient';
+import { createTestEngine, freshPubkey } from './test-engine';
+
+const COIN = 'a'.repeat(64);
+
+/** Forwards the submit, then throws — the "response-parse failure" shape of E.2
+ * (e.g. the live gateway's transitional STATE_ID_EXISTS, which this SDK's
+ * CertificationResponse.fromJSON cannot parse). The certification EXISTS. */
+class SubmitForwardsThenThrowsClient implements IAggregatorClient {
+  public constructor(private readonly inner: TestAggregatorClient) {}
+
+  public getInclusionProof(stateId: StateId): Promise<InclusionProofResponse> {
+    return this.inner.getInclusionProof(stateId);
+  }
+
+  public async submitCertificationRequest(certificationData: CertificationData): Promise<CertificationResponse> {
+    await this.inner.submitCertificationRequest(certificationData);
+    throw new Error('CertificationResponse.fromJSON: unknown certification status STATE_ID_EXISTS');
+  }
+}
+
+/** Submit never reaches the aggregator — a genuine submit failure (no proof will exist). */
+class SubmitUnreachableClient implements IAggregatorClient {
+  public constructor(private readonly inner: TestAggregatorClient) {}
+
+  public getInclusionProof(stateId: StateId): Promise<InclusionProofResponse> {
+    return this.inner.getInclusionProof(stateId);
+  }
+
+  public submitCertificationRequest(): Promise<CertificationResponse> {
+    return Promise.reject(new Error('aggregator unreachable (simulated)'));
+  }
+}
+
+describe('recoverable engine (Part E) — real adapter over in-memory aggregator', () => {
+  // AC-E1 (transfer leg) + the AC-E2 mock-resume shape: the duplicate submit is
+  // absorbed first-write-wins, the existing proof match-verifies, and the
+  // re-run returns the byte-identical finished token — no funds lost.
+  it('AC-E1/AC-E2: re-running a transfer with the same transferId returns byte-identical results', async () => {
+    const e = createTestEngine();
+    const src = await e.mint({
+      recipientPubkey: e.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 100n }] },
+    });
+    const recipientPubkey = freshPubkey();
+    const transferId = crypto.randomUUID();
+
+    const first = await e.transfer({ token: src, recipientPubkey }, { transferId });
+    // Same transferId + same inputs, against the same aggregator: this is the
+    // resume path (an interrupted attempt whose certification already landed).
+    const second = await e.transfer({ token: src, recipientPubkey }, { transferId });
+
+    expect(second.blob.tokenId).toBe(first.blob.tokenId);
+    expect(HexConverter.encode(second.blob.token)).toBe(HexConverter.encode(first.blob.token));
+    expect((await e.verify(second)).ok).toBe(true);
+  }, 20000);
+
+  // AC-E4: the same source consumed under DIFFERENT transferIds is a lost race,
+  // not a resume — the proof kept by the aggregator (first leaf wins) does not
+  // match the second rebuilt transaction.
+  it('AC-E4: a second transfer of the same source under a different transferId throws TransferConflictError', async () => {
+    const e = createTestEngine();
+    const src = await e.mint({
+      recipientPubkey: e.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 100n }] },
+    });
+    await e.transfer({ token: src, recipientPubkey: freshPubkey() }, { transferId: crypto.randomUUID() });
+
+    const err = await e
+      .transfer({ token: src, recipientPubkey: freshPubkey() }, { transferId: crypto.randomUUID() })
+      .then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+    expect(err).toBeInstanceOf(TransferConflictError);
+    expect((err as TransferConflictError).code).toBe('TRANSFER_CONFLICT');
+
+    // The race is lost for that source only: a re-plan under a new transferId
+    // succeeds for the remaining sources.
+    const other = await e.mint({
+      recipientPubkey: e.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 5n }] },
+    });
+    const replanned = await e.transfer({ token: other, recipientPubkey: freshPubkey() }, { transferId: crypto.randomUUID() });
+    expect((await e.verify(replanned)).ok).toBe(true);
+  }, 25000);
+
+  // AC-E3: deterministic realization is invisible downstream — the transferred
+  // token and every split output still fully verify.
+  it('AC-E3: deterministically-realized transfer and split outputs pass engine.verify', async () => {
+    const e = createTestEngine();
+    const self = e.getIdentity().chainPubkey;
+    const transferId = crypto.randomUUID();
+
+    const srcA = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 10n }] } });
+    const transferred = await e.transfer({ token: srcA, recipientPubkey: freshPubkey() }, { transferId });
+    expect((await e.verify(transferred)).ok).toBe(true);
+
+    const srcB = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+    const { outputs } = await e.split(
+      {
+        token: srcB,
+        outputs: [
+          { recipientPubkey: freshPubkey(), coinId: COIN, amount: 60n },
+          { recipientPubkey: self, coinId: COIN, amount: 40n },
+        ],
+      },
+      { transferId: crypto.randomUUID() },
+    );
+    expect(outputs).toHaveLength(2);
+    for (const o of outputs) {
+      expect((await e.verify(o)).ok).toBe(true);
+    }
+  }, 30000);
+
+  // Split determinism (burn excluded — #492): the same wallet key + transferId
+  // reproduce the same per-output salts and (salt-derived) tokenIds on a second
+  // device/chain. Two aggregators sharing one trust-base key stand in for
+  // "another device rebuilding the same split".
+  it('split: same transferId reproduces identical per-output salts and tokenIds', async () => {
+    const aggregatorKey = SigningService.generatePrivateKey();
+    const walletKey = SigningService.generatePrivateKey();
+    const engineA = createTestEngine({ aggregator: TestAggregatorClient.create(aggregatorKey), privateKey: walletKey });
+    const engineB = createTestEngine({ aggregator: TestAggregatorClient.create(aggregatorKey), privateKey: walletKey });
+
+    const self = engineA.getIdentity().chainPubkey;
+    const payee = freshPubkey();
+    const srcA = await engineA.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+    const srcB = await engineB.decodeToken(engineA.encodeToken(srcA));
+
+    const transferId = crypto.randomUUID();
+    const outputs = [
+      { recipientPubkey: payee, coinId: COIN, amount: 70n },
+      { recipientPubkey: self, coinId: COIN, amount: 30n },
+    ];
+    const runA = await engineA.split({ token: srcA, outputs }, { transferId });
+    const runB = await engineB.split({ token: srcB, outputs }, { transferId });
+
+    expect(runA.outputs.map((o) => engineA.tokenId(o))).toEqual(runB.outputs.map((o) => engineB.tokenId(o)));
+    for (let i = 0; i < runA.outputs.length; i++) {
+      const saltA = runA.outputs[i].sdkToken.genesis.salt.toBytes();
+      const saltB = runB.outputs[i].sdkToken.genesis.salt.toBytes();
+      // Identical across runs AND equal to the spec derivation for index i.
+      expect(HexConverter.encode(saltA)).toBe(HexConverter.encode(saltB));
+      expect(HexConverter.encode(saltA)).toBe(
+        HexConverter.encode(deriveRealization(HexConverter.encode(walletKey), transferId, i, 'salt')),
+      );
+    }
+    // Distinct outputs of one split must not share a salt (index domain separation).
+    expect(HexConverter.encode(runA.outputs[0].sdkToken.genesis.salt.toBytes())).not.toBe(
+      HexConverter.encode(runA.outputs[1].sdkToken.genesis.salt.toBytes()),
+    );
+  }, 40000);
+
+  // E.2 status-agnostic submit: a submit that THROWS (response-parse failure)
+  // after the certification landed is absorbed — the proof is fetched,
+  // match-verified and applied. Resume never keys off a submit status.
+  it('E.2: a throwing submit whose certification exists still completes via proof fetch + match-verify', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const walletKey = SigningService.generatePrivateKey();
+    const plain = createTestEngine({ aggregator, privateKey: walletKey });
+    const flaky = createTestEngine({
+      aggregator,
+      privateKey: walletKey,
+      wireClient: new SubmitForwardsThenThrowsClient(aggregator),
+    });
+
+    const src = await plain.mint({
+      recipientPubkey: plain.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 42n }] },
+    });
+    const finished = await flaky.transfer(
+      { token: src, recipientPubkey: freshPubkey() },
+      { transferId: crypto.randomUUID() },
+    );
+    expect(plain.balanceOf(finished, COIN)).toBe(42n);
+    expect((await plain.verify(finished)).ok).toBe(true);
+  }, 20000);
+
+  // E.2 third arm: no certification ever landed AND the submit failed — the
+  // ORIGINAL submit error surfaces (a genuine failure, not a resume case).
+  it('E.2: a failed submit with no existing proof rethrows the original submit error', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const walletKey = SigningService.generatePrivateKey();
+    const plain = createTestEngine({ aggregator, privateKey: walletKey });
+    const dead = createTestEngine({
+      aggregator,
+      privateKey: walletKey,
+      wireClient: new SubmitUnreachableClient(aggregator),
+    });
+
+    const src = await plain.mint({
+      recipientPubkey: plain.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 1n }] },
+    });
+    await expect(
+      dead.transfer(
+        { token: src, recipientPubkey: freshPubkey() },
+        // Short proof-poll budget: with no certification the probe can only time out.
+        { transferId: crypto.randomUUID(), signal: AbortSignal.timeout(500) },
+      ),
+    ).rejects.toThrow('aggregator unreachable (simulated)');
+  }, 20000);
+
+  // Pins the EXACT SDK error surface the engine maps to TransferConflictError:
+  // waitInclusionProof rejects a mismatching proof with a generic Error whose
+  // message embeds the verification status. If upstream changes this string,
+  // this test fails loudly — update the mapping in SphereTokenEngine alongside.
+  it('pins the SDK conflict surface: waitInclusionProof throws the TRANSACTION_HASH_MISMATCH message', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const engine = createTestEngine({ aggregator });
+    const src = await engine.mint({
+      recipientPubkey: engine.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 9n }] },
+    });
+    await engine.transfer({ token: src, recipientPubkey: freshPubkey() }, { transferId: crypto.randomUUID() });
+
+    // A DIFFERENT transaction for the already-consumed source state.
+    const foreignTx = await TransferTransaction.create(
+      src.sdkToken,
+      SignaturePredicate.create(freshPubkey()),
+      new Uint8Array(32).fill(7),
+      null,
+    );
+    const err = await waitInclusionProof(
+      new StateTransitionClient(aggregator),
+      aggregator.rootTrustBase,
+      PredicateVerifierService.create(),
+      foreignTx,
+      AbortSignal.timeout(2000),
+    ).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe(
+      `Invalid inclusion proof status: ${InclusionProofVerificationStatus.TRANSACTION_HASH_MISMATCH}`,
+    );
+  }, 20000);
+
+  it('rejects a non-canonical transferId before any network work', async () => {
+    const e = createTestEngine();
+    const src = await e.mint({
+      recipientPubkey: e.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 1n }] },
+    });
+    for (const bad of ['not-a-uuid', '123E4567-E89B-42D3-A456-426614174000', 'a:b:c']) {
+      await expect(e.transfer({ token: src, recipientPubkey: freshPubkey() }, { transferId: bad })).rejects.toThrow(
+        /canonical lowercase UUID/,
+      );
+    }
+  }, 15000);
+});

--- a/tests/unit/token-engine/test-engine.ts
+++ b/tests/unit/token-engine/test-engine.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  type IAggregatorClient,
   MintJustificationVerifierService,
   NetworkId,
   PredicateVerifierService,
@@ -16,24 +17,41 @@ import { decodeSpherePaymentData } from '../../../token-engine/SpherePaymentData
 import { type EngineDeps, SphereTokenEngine } from '../../../token-engine/SphereTokenEngine';
 import { TestAggregatorClient } from './support/TestAggregatorClient';
 
-/**
- * Build a real engine backed by a fresh in-memory aggregator.
- * `networkId` can be overridden to exercise cross-network guards.
- */
-export function createTestEngine(opts: { networkId?: NetworkId } = {}): SphereTokenEngine {
-  const aggregator = TestAggregatorClient.create();
+export interface TestEngineOptions {
+  /** Override to exercise cross-network guards. */
+  networkId?: NetworkId;
+  /**
+   * Reuse a specific in-memory aggregator (trust base + SMT). Lets two engines
+   * share one chain (conflict tests) or two chains share one trust base
+   * (determinism-across-devices tests via TestAggregatorClient.create(sameKey)).
+   */
+  aggregator?: TestAggregatorClient;
+  /** Wallet private key (defaults to a fresh random key). */
+  privateKey?: Uint8Array;
+  /**
+   * Optional wire-client wrapper around the aggregator for fault injection
+   * (e.g. a submit that throws). Trust base still comes from `aggregator`.
+   */
+  wireClient?: IAggregatorClient;
+}
+
+/** Build a real engine backed by an in-memory aggregator (fresh by default). */
+export function createTestEngine(opts: TestEngineOptions = {}): SphereTokenEngine {
+  const aggregator = opts.aggregator ?? TestAggregatorClient.create();
   const trustBase = aggregator.rootTrustBase;
   const predicateVerifier = PredicateVerifierService.create();
   const mintJustificationVerifier = new MintJustificationVerifierService();
   mintJustificationVerifier.register(
     new SplitMintJustificationVerifier(trustBase, predicateVerifier, decodeSpherePaymentData),
   );
+  const privateKey = opts.privateKey ?? SigningService.generatePrivateKey();
   const deps: EngineDeps = {
-    client: new StateTransitionClient(aggregator),
+    client: new StateTransitionClient(opts.wireClient ?? aggregator),
     trustBase,
     predicateVerifier,
     mintJustificationVerifier,
-    signingService: new SigningService(SigningService.generatePrivateKey()),
+    signingService: new SigningService(privateKey),
+    privateKey,
     networkId: opts.networkId ?? NetworkId.LOCAL,
   };
   return new SphereTokenEngine(deps);

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -12,14 +12,19 @@
  * of how the aggregator/trust base are constructed.
  */
 
-import { SphereError } from '../core/errors';
-import { deriveDirectAddress } from './identity';
+import { SphereError, type SphereErrorCode } from '../core/errors';
+import { TransferConflictError } from './errors';
+import { deriveDirectAddress, UNICITY_TOKEN_TYPE_HEX } from './identity';
+import { deriveRealization } from './realization';
 import {
   CborDeserializer,
   CertificationData,
   CertificationStatus,
   EncodedPredicate,
   HexConverter,
+  type InclusionProof,
+  InclusionProofVerificationStatus,
+  type ITransaction,
   type MintJustificationVerifierService,
   MintTransaction,
   type NetworkId,
@@ -66,11 +71,24 @@ export interface EngineDeps {
   readonly mintJustificationVerifier: MintJustificationVerifierService;
   /** The wallet's signing key (its identity + the spender for transfers it owns). */
   readonly signingService: SigningService;
+  /**
+   * The same key as raw bytes — the HKDF ikm for deterministic realization
+   * (Part E.1; SigningService does not expose it back).
+   */
+  readonly privateKey: Uint8Array;
   readonly networkId: NetworkId;
 }
 
+/** Canonical lowercase UUID — the spec's `transferId` wire form (sdk-changes E.1). */
+const TRANSFER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
 export class SphereTokenEngine implements ITokenEngine {
-  public constructor(private readonly deps: EngineDeps) {}
+  /** Hex form of the wallet key — deriveRealization's ikm input (Part E.1). */
+  private readonly privateKeyHex: string;
+
+  public constructor(private readonly deps: EngineDeps) {
+    this.privateKeyHex = HexConverter.encode(deps.privateKey);
+  }
 
   // ── identity ────────────────────────────────────────────────────────────────
 
@@ -184,24 +202,22 @@ export class SphereTokenEngine implements ITokenEngine {
 
   public async transfer(params: TransferParams, options?: EngineOpOptions): Promise<SphereToken> {
     this.assertOwned(params.token);
+    const transferId = this.resolveTransferId(options);
     const recipient = SignaturePredicate.create(params.recipientPubkey);
-    const stateMask = crypto.getRandomValues(new Uint8Array(32));
+    // E.1 deterministic realization: same transferId + inputs ⇒ byte-identical
+    // transaction, so an interrupted transfer can be rebuilt and resumed (AC-E1/E2).
+    const stateMask = deriveRealization(this.privateKeyHex, transferId, 0, 'stateMask');
 
     const transferTx = await TransferTransaction.create(params.token.sdkToken, recipient, stateMask, params.data ?? null);
     const unlockScript = await SignaturePredicateUnlockScript.create(transferTx, this.deps.signingService);
     const certificationData = await CertificationData.fromTransaction(transferTx, unlockScript);
 
-    const response = await this.deps.client.submitCertificationRequest(certificationData);
-    if (response.status !== CertificationStatus.SUCCESS) {
-      throw new SphereError(`Transfer certification failed: ${response.status}`, 'TRANSFER_FAILED');
-    }
-
-    const proof = await waitInclusionProof(
-      this.deps.client,
-      this.deps.trustBase,
-      this.deps.predicateVerifier,
+    const proof = await this.submitAndAwaitProof(
+      certificationData,
       transferTx,
-      options?.signal,
+      'Transfer certification failed',
+      'TRANSFER_FAILED',
+      options,
     );
     const certified = await transferTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
     const transferred = await params.token.sdkToken.transfer(this.deps.trustBase, this.deps.predicateVerifier, certified);
@@ -213,30 +229,37 @@ export class SphereTokenEngine implements ITokenEngine {
     if (params.outputs.length === 0) {
       throw new SphereError('Split requires at least one output', 'VALIDATION_ERROR');
     }
+    const transferId = this.resolveTransferId(options);
 
-    const requests = params.outputs.map((o) =>
+    // E.1 deterministic realization: a fixed token type + per-output HKDF salts
+    // make every output's mint transaction (and its salt-derived tokenId)
+    // reproducible from the wallet key + transferId.
+    const tokenType = new TokenType(HexConverter.decode(UNICITY_TOKEN_TYPE_HEX));
+    const requests = params.outputs.map((o, i) =>
       SplitTokenRequest.create(
         SignaturePredicate.create(o.recipientPubkey),
         PaymentAssetCollection.create(sphereAssetToSdk(o.coinId, o.amount)),
+        tokenType,
+        TokenSalt.fromBytes(deriveRealization(this.privateKeyHex, transferId, i, 'salt')),
       ),
     );
 
     // Value conservation is enforced inside the SDK split (root.value === source value).
+    // The burn transaction's state mask is still random INSIDE TokenSplit.split —
+    // the pinned base SDK has no burnStateMask parameter yet (it arrives via
+    // state-transition-sdk-js#125; wiring tracked in #492) — so the burn leg is
+    // not yet rebuildable and a split resume stops at the burn.
     const split = await TokenSplit.split(params.token.sdkToken, decodeSpherePaymentData, requests);
 
     // 1. Burn the source: certify the burn transfer and append it -> burntToken.
     const burnUnlock = await SignaturePredicateUnlockScript.create(split.burn.transaction, this.deps.signingService);
     const burnCert = await CertificationData.fromTransaction(split.burn.transaction, burnUnlock);
-    const burnResponse = await this.deps.client.submitCertificationRequest(burnCert);
-    if (burnResponse.status !== CertificationStatus.SUCCESS) {
-      throw new SphereError(`Split burn failed: ${burnResponse.status}`, 'TRANSFER_FAILED');
-    }
-    const burnProof = await waitInclusionProof(
-      this.deps.client,
-      this.deps.trustBase,
-      this.deps.predicateVerifier,
+    const burnProof = await this.submitAndAwaitProof(
+      burnCert,
       split.burn.transaction,
-      options?.signal,
+      'Split burn failed',
+      'TRANSFER_FAILED',
+      options,
     );
     const burnCertified = await split.burn.transaction.toCertifiedTransaction(
       this.deps.trustBase,
@@ -265,17 +288,7 @@ export class SphereTokenEngine implements ITokenEngine {
         justification,
       );
       const certData = await CertificationData.fromMintTransaction(mintTx);
-      const response = await this.deps.client.submitCertificationRequest(certData);
-      if (response.status !== CertificationStatus.SUCCESS) {
-        throw new SphereError(`Split mint failed: ${response.status}`, 'AGGREGATOR_ERROR');
-      }
-      const proof = await waitInclusionProof(
-        this.deps.client,
-        this.deps.trustBase,
-        this.deps.predicateVerifier,
-        mintTx,
-        options?.signal,
-      );
+      const proof = await this.submitAndAwaitProof(certData, mintTx, 'Split mint failed', 'AGGREGATOR_ERROR', options);
       const certified = await mintTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
       const token = await Token.mint(
         this.deps.trustBase,
@@ -340,6 +353,89 @@ export class SphereTokenEngine implements ITokenEngine {
   }
 
   // ── internals ────────────────────────────────────────────────────────────────
+
+  /**
+   * The effective realization seed for one transfer/split (Part E). A caller
+   * that wants resumability supplies a pre-persisted UUIDv4 (sdk-changes E.3);
+   * otherwise one is generated here — same derivation path, just non-resumable.
+   * The canonical-lowercase-UUID check also keeps the HKDF info string
+   * unambiguous (no ':' injection, no case-variant double derivations).
+   */
+  private resolveTransferId(options?: EngineOpOptions): string {
+    const transferId = options?.transferId ?? crypto.randomUUID();
+    if (!TRANSFER_ID_RE.test(transferId)) {
+      throw new SphereError(
+        `transferId must be a canonical lowercase UUID string, got "${transferId}"`,
+        'VALIDATION_ERROR',
+      );
+    }
+    return transferId;
+  }
+
+  /**
+   * E.2 — status-agnostic idempotent submit with conflict detection
+   * (sdk-changes E.2, ARCHITECTURE §8.1).
+   *
+   * Submit the certification request and treat ANY outcome — success status,
+   * error status, or a response-parse throw (the live gateway may still emit
+   * statuses this SDK no longer parses, e.g. the transitional STATE_ID_EXISTS)
+   * — as "a certification for this state may already exist". Then ALWAYS fetch
+   * the inclusion proof and match-verify it against the rebuilt transaction
+   * (`waitInclusionProof` only returns an OK-verified proof):
+   *
+   * - match (OK)                    → proceed; this is how an interrupted
+   *                                   attempt with the same transferId resumes;
+   * - mismatch (hash ≠ rebuilt tx)  → `TransferConflictError`: the source was
+   *                                   consumed by a DIFFERENT transaction (lost
+   *                                   race) — never applied, never retried;
+   * - no proof & the submit failed  → the original submit error (a genuine
+   *                                   failure, not a resume case).
+   */
+  private async submitAndAwaitProof(
+    certificationData: CertificationData,
+    transaction: ITransaction,
+    failLabel: string,
+    failCode: SphereErrorCode,
+    options?: EngineOpOptions,
+  ): Promise<InclusionProof> {
+    let submitError: unknown = null;
+    try {
+      const response = await this.deps.client.submitCertificationRequest(certificationData);
+      if (response.status !== CertificationStatus.SUCCESS) {
+        submitError = new SphereError(`${failLabel}: ${response.status}`, failCode);
+      }
+    } catch (err) {
+      submitError = err ?? new SphereError(`${failLabel}: submit failed`, failCode);
+    }
+
+    try {
+      return await waitInclusionProof(
+        this.deps.client,
+        this.deps.trustBase,
+        this.deps.predicateVerifier,
+        transaction,
+        options?.signal,
+      );
+    } catch (err) {
+      // The SDK surfaces a match-verify mismatch as a generic Error whose
+      // message embeds the verification status. Mapping that fragile string is
+      // done HERE — in the anti-corruption layer — and nowhere else; a test
+      // pins the exact SDK message so an upstream change fails loudly.
+      if (
+        err instanceof Error &&
+        err.message === `Invalid inclusion proof status: ${InclusionProofVerificationStatus.TRANSACTION_HASH_MISMATCH}`
+      ) {
+        throw new TransferConflictError(
+          `${failLabel}: the source state was already consumed by a different transaction ` +
+            '(lost race — abort this intent and re-plan under a new transferId)',
+          err,
+        );
+      }
+      // No certification materialized and the submit itself had failed.
+      if (submitError !== null) throw submitError;
+      throw err;
+    }
+  }
 
   /** Fail fast if this engine's key does not own the token's current state. */
   private assertOwned(token: SphereToken): void {

--- a/token-engine/engine.ts
+++ b/token-engine/engine.ts
@@ -25,6 +25,19 @@ import type {
 export interface EngineOpOptions {
   /** Cancels the operation (including inclusion-proof polling). */
   readonly signal?: AbortSignal;
+  /**
+   * Realization seed for deterministic transfer/split (Part E, sdk-changes E.1/E.3):
+   * a client-generated UUIDv4 in canonical lowercase string form. Every value the
+   * transaction binds to (stateMask, per-output salts) is HKDF-derived from the
+   * wallet key + this id, so re-calling the op with the same `transferId` and
+   * inputs rebuilds the byte-identical transaction and resumes an interrupted
+   * attempt instead of losing funds. Persist it BEFORE calling the engine.
+   *
+   * If absent, the engine generates one internally (`crypto.randomUUID()`) — the
+   * derivation path is identical, but the call is NOT resumable (the seed is
+   * gone if the process dies mid-op).
+   */
+  readonly transferId?: string;
 }
 
 /**

--- a/token-engine/errors.ts
+++ b/token-engine/errors.ts
@@ -1,0 +1,23 @@
+/**
+ * token-engine/errors.ts — the engine's typed error surface (Part E.2).
+ */
+
+import { SphereError } from '../core/errors';
+
+/**
+ * The source state was already consumed by a *different* transaction — the
+ * fetched inclusion proof does not match the rebuilt transaction
+ * (`TRANSACTION_HASH_MISMATCH`). Typically the owner's other device raced the
+ * same source under a different `transferId` (ARCHITECTURE §7).
+ *
+ * This is a lost race, **not** an interrupted resume: the engine never applies
+ * the foreign proof and never retries. The caller's recovery is to abort the
+ * intent, drop the lost source from its plan, and re-plan the remainder under
+ * a NEW `transferId` (never reusing the old realization) — sdk-changes E.2.
+ */
+export class TransferConflictError extends SphereError {
+  constructor(message: string, cause?: unknown) {
+    super(message, 'TRANSFER_CONFLICT', cause);
+    this.name = 'TransferConflictError';
+  }
+}

--- a/token-engine/factory.ts
+++ b/token-engine/factory.ts
@@ -53,6 +53,9 @@ export async function createSphereTokenEngine(config: EngineConfig): Promise<ITo
     predicateVerifier,
     mintJustificationVerifier,
     signingService: new SigningService(config.privateKey),
+    // Also the HKDF ikm for deterministic realization (Part E.1) — the
+    // SigningService wraps the key but does not expose it back.
+    privateKey: config.privateKey,
     // The trust base is the single source of truth for the network id (it carries
     // NetworkId.fromId, so any id works — e.g. testnet2 = 4 — with no enum entry).
     networkId: trustBase.networkId,

--- a/token-engine/index.ts
+++ b/token-engine/index.ts
@@ -41,6 +41,11 @@ export { deriveDirectAddress } from './identity';
 // The concrete adapter factory (A4) — the public way to obtain an ITokenEngine.
 export { createSphereTokenEngine } from './factory';
 
+// Typed conflict surface of the recoverable engine (Part E.2): the source state
+// was consumed by a DIFFERENT transaction — a lost race, not a resume. Callers
+// abort the intent and re-plan under a new transferId.
+export { TransferConflictError } from './errors';
+
 // Self-issued Unicity ID (nametag) token mint — the v2 analog of the v1
 // nametag mint, stored at registration but unused at runtime (D5 + user
 // decision 2026-06-10; see unicity-id.ts header).

--- a/token-engine/realization.ts
+++ b/token-engine/realization.ts
@@ -1,0 +1,53 @@
+/**
+ * token-engine/realization.ts — deterministic realization values (Part E.1).
+ *
+ * Every "random" value a transfer/split binds to (stateMask, per-output salt,
+ * tokenType where not fixed, the split burn mask) is derived from the wallet
+ * key + a pre-persisted transferId instead of `crypto.getRandomValues`, so the
+ * exact transaction can be rebuilt later — on any device holding the seed.
+ * That is what makes an interrupted transfer resumable (sdk-changes Part E,
+ * ARCHITECTURE §8.1): re-running with the same transferId reproduces the
+ * byte-identical transaction, and the aggregator's existing proof applies.
+ *
+ * Derivation (mirrors impl/shared/ipfs/ipns-key-derivation.ts — same
+ * @noble/hashes HKDF, no salt):
+ *
+ *   HKDF-SHA256(ikm = privKey, info = "sphere-realization-v1:" + transferId
+ *               + ":" + field + ":" + index)[0..32)
+ *
+ * `field` is the domain separator between the values of one transfer;
+ * `index` separates per-output values (split salts). The output is
+ * per-transfer unique and unpredictable to outsiders (derived from the secret
+ * key — no privacy/unlinkability regression), yet reproducible by the owner.
+ */
+
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { HexConverter } from './sdk';
+
+/** HKDF info prefix — versioned; the same formula appears in ARCHITECTURE §8.1. */
+export const REALIZATION_HKDF_INFO_PREFIX = 'sphere-realization-v1';
+
+/** Domain separator between the realization values of one transfer. */
+export type RealizationField = 'stateMask' | 'salt' | 'tokenType' | 'burn';
+
+/**
+ * Derive one 32-byte realization value.
+ *
+ * @param privKeyHex - wallet secp256k1 private key, hex (the HKDF ikm is its raw bytes)
+ * @param transferId - client-generated UUIDv4 in canonical lowercase string form
+ *                     (validated by the engine before any derivation)
+ * @param index - per-output index within the transfer (0 for single-value fields)
+ * @param field - which value of the transfer is being derived
+ * @returns 32 deterministic bytes
+ */
+export function deriveRealization(
+  privKeyHex: string,
+  transferId: string,
+  index: number,
+  field: RealizationField,
+): Uint8Array {
+  const ikm = HexConverter.decode(privKeyHex);
+  const info = new TextEncoder().encode(`${REALIZATION_HKDF_INFO_PREFIX}:${transferId}:${field}:${index}`);
+  return hkdf(sha256, ikm, undefined, info, 32);
+}

--- a/token-engine/sdk.ts
+++ b/token-engine/sdk.ts
@@ -22,6 +22,7 @@ export { InclusionProof } from '@unicitylabs/state-transition-sdk/lib/api/Inclus
 export { InclusionProofResponse } from '@unicitylabs/state-transition-sdk/lib/api/InclusionProofResponse.js';
 export { RootTrustBase } from '@unicitylabs/state-transition-sdk/lib/api/bft/RootTrustBase.js';
 export { waitInclusionProof } from '@unicitylabs/state-transition-sdk/lib/util/InclusionProofUtils.js';
+export { InclusionProofVerificationStatus } from '@unicitylabs/state-transition-sdk/lib/transaction/verification/rule/InclusionProofVerificationRule.js';
 
 // ── token / transactions ────────────────────────────────────────────────────
 export { Token } from '@unicitylabs/state-transition-sdk/lib/transaction/Token.js';


### PR DESCRIPTION
Closes #491

Implements **Part E** of `wallet-api/sdk-changes.md` (normative; see also `wallet-api/ARCHITECTURE.md` §8.1) on the program integration branch.

## E.1 — Deterministic realization
- **`token-engine/realization.ts`** — `deriveRealization(privKeyHex, transferId, index, field)`: HKDF-SHA256 (`@noble/hashes`, no salt — mirrors `impl/shared/ipfs/ipns-key-derivation.ts`), ikm = raw key bytes, info = `sphere-realization-v1:${transferId}:${field}:${index}`, 32-byte output.
- **`EngineOpOptions.transferId?: string`** (UUIDv4, canonical lowercase — validated). Absent → the engine generates one via `crypto.randomUUID()`: single derivation code path, the call is simply non-resumable (JSDoc'd).
- **`transfer(...)`** — `stateMask` = `deriveRealization(key, transferId, 0, 'stateMask')` (replaces `crypto.getRandomValues`).
- **`split(...)`** — per-output `salt` = `deriveRealization(key, transferId, i, 'salt')` (`TokenSalt.fromBytes`), tokenType pinned to the fixed `UNICITY_TOKEN_TYPE_HEX` (deterministic; tokenIds are salt-derived). **Burn mask not wired**: the pinned base SDK (`2.0.0-rc.6027e82`) has no `burnStateMask` parameter on `TokenSplit.split` — follow-up **#492** wires it + bumps the pin when the state-transition-sdk-js#125 rc publishes (completes AC-E1/AC-E2 split legs).

## E.2 — Status-agnostic idempotent submit + conflict detection
New `submitAndAwaitProof` used by the transfer leg and both split legs (burn + per-output mints): submit; treat **any** outcome (success status, error status, response-parse throw) as "a certification may already exist"; **always** fetch + match-verify the inclusion proof against the rebuilt transaction.
- Match (`OK`) → proceed — this is resume.
- Mismatch → the SDK's `waitInclusionProof` surfaces it as a generic `Error` with message `Invalid inclusion proof status: TRANSACTION_HASH_MISMATCH`; mapped **inside the engine** (anti-corruption layer; the exact message is pinned by a test so an upstream change fails loudly) to the new typed **`TransferConflictError`** (`token-engine/errors.ts`, code `TRANSFER_CONFLICT`, exported from `token-engine/index.ts`). Foreign proofs are never applied, never retried.
- No proof + failed submit → the original submit error is rethrown.

## E.3 — engine-side slice
`PaymentsModule` passes a fresh UUIDv4 `transferId` per engine op (direct-transfer loop + split) and fails a conflicted send cleanly with a distinct error message. Server-side intent persistence, resume-at-sign-in and re-plan UX are Part S (out of scope here).

## Tests (real `SphereTokenEngine` over the vendored `TestAggregatorClient` — not FakeTokenEngine)
- `realization.test.ts` — 32-byte/deterministic/distinct + hand-computed vectors (independently produced with Node's `crypto.hkdfSync`; pins formula + info-string layout).
- `recoverable-engine.test.ts`:
  - **AC-E1/AC-E2** (transfer leg): re-running a transfer with the same `transferId`/inputs against the same aggregator absorbs the duplicate submit (first-write-wins) and returns the **byte-identical** finished token.
  - **AC-E4**: same source under a different `transferId` → `TransferConflictError`; a re-plan with a new source + new `transferId` then succeeds.
  - **AC-E3**: deterministically-realized transfer and split outputs pass `engine.verify`.
  - **Split determinism** (burn excluded — #492): same wallet key + `transferId` reproduce identical per-output salts/tokenIds on a second engine/chain (shared trust-base key), and the salts equal the spec derivation.
  - **E.2 arms**: a submit that throws after the certification landed still completes via proof fetch + match-verify; a failed submit with no proof rethrows the original error; the exact SDK mismatch message is pinned.
  - transferId canonical-form validation.

## Gates
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (170 pre-existing warnings, none in touched files)
- `npm run build` — success
- `npm run test:run` — **2884 passed / 4 failed (2888)**; the 4 failures are exactly the pre-existing #487 set: `ipns-network.test.ts` (3, Node-26-local-only — local is Node 26; CI on 20/22 is authoritative) and `AccountingModule.deliveryOrders.test.ts` (order-dependent flake; **passes in isolation**, verified). The two new Part E files: 13/13 passing.

Follow-up: #492 (wire `burnStateMask` + bump base-SDK pin when the #125 rc publishes).