### PR TITLE
Wire burnStateMask + bump base SDK to 2.0.0-rc.68bc1e5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,8 @@ This repo is part of the wallet-api program (process: `../wallet-api/development
   (wallet-api backend, sphere frontend) pin exact dev versions. The backend consumes ONLY the
   `./token-engine` subpath (must stay browser/IPFS/Nostr-free — there's an import-closure check in
   its CI eventually; keep `token-engine/` clean).
-- Pinned base SDK: `@unicitylabs/state-transition-sdk@2.0.0-rc.6027e82` (bump only via PR when the
-  #125 rc lands; then re-validate the wallet-api spike's vendored mock).
+- Pinned base SDK: `@unicitylabs/state-transition-sdk@2.0.0-rc.68bc1e5` (the #125 rc: burnStateMask
+  + tolerant status parsing; bump only via PR).
 
 ## Quick Start (Using SDK as Dependency)
 
@@ -384,7 +384,7 @@ sphere-sdk/
 ### Token Engine (v2) — the only L3 money path
 
 The legacy v1 `@unicitylabs/state-transition-sdk@1.6.1-rc` engine is **removed**.
-The canonical package name resolves to the **v2 SDK, pinned `2.0.0-rc.6027e82`**.
+The canonical package name resolves to the **v2 SDK, pinned `2.0.0-rc.68bc1e5`**.
 
 - The SDK is imported in exactly ONE file: `token-engine/sdk.ts`. An ESLint
   `no-restricted-imports` rule blocks any other import of
@@ -684,7 +684,7 @@ Key test areas:
 ## Dependencies
 
 **Core (from package.json):**
-- `@unicitylabs/state-transition-sdk` — **pinned `2.0.0-rc.6027e82`** (v2 engine; imported only via `token-engine/sdk.ts`)
+- `@unicitylabs/state-transition-sdk` — **pinned `2.0.0-rc.68bc1e5`** (v2 engine; imported only via `token-engine/sdk.ts`)
 - `@unicitylabs/nostr-js-sdk` `^0.5.0` — Nostr protocol
 - `@noble/hashes` `^2`, `@noble/curves` `^2` — cryptography
 - `bip39`, `elliptic`, `crypto-js`, `canonicalize`, `buffer`

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@unicitylabs/nostr-js-sdk": "^0.5.0",
-        "@unicitylabs/state-transition-sdk": "2.0.0-rc.6027e82",
+        "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
         "canonicalize": "^3.0.0",
@@ -2029,9 +2029,9 @@
       }
     },
     "node_modules/@unicitylabs/state-transition-sdk": {
-      "version": "2.0.0-rc.6027e82",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.6027e82.tgz",
-      "integrity": "sha512-PV6lHwJOCjpICG0Vd7Ty+5mZa7migGtopa1QVBjp9xRRtfNXDAvf8YPzXE6PQOtKCVP5ymmKuWKRKkNoNOw2zA==",
+      "version": "2.0.0-rc.68bc1e5",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.68bc1e5.tgz",
+      "integrity": "sha512-JJ1jQFTexMBRwpn3pmhm4s2FulBcOBGyNZmQ4qd5ZheenbVLUkY5KSJ++J3Gnh/Vmhd6WVuCBw+FCyqXN39aHQ==",
       "license": "ISC",
       "dependencies": {
         "@noble/curves": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@unicitylabs/nostr-js-sdk": "^0.5.0",
-    "@unicitylabs/state-transition-sdk": "2.0.0-rc.6027e82",
+    "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
     "bip39": "^3.1.0",
     "buffer": "^6.0.3",
     "canonicalize": "^3.0.0",

--- a/tests/unit/token-engine/recoverable-engine.test.ts
+++ b/tests/unit/token-engine/recoverable-engine.test.ts
@@ -182,6 +182,18 @@ describe('recoverable engine (Part E) — real adapter over in-memory aggregator
     expect(HexConverter.encode(runA.outputs[0].sdkToken.genesis.salt.toBytes())).not.toBe(
       HexConverter.encode(runA.outputs[1].sdkToken.genesis.salt.toBytes()),
     );
+
+    // AC-E1/AC-E2 split legs (complete since the burnStateMask rc): a full
+    // re-run against the SAME aggregator recovers BYTE-IDENTICAL finished
+    // outputs. This is also the burn-determinism proof: a random burn mask
+    // would rebuild a DIFFERENT burn transaction, the duplicate submit would
+    // be first-write-wins, and E.2's match-verify would throw
+    // TransferConflictError instead of completing. (Finished tokens are never
+    // byte-comparable across DIFFERENT aggregators — inclusion proofs embed
+    // aggregator state; AC-E1's cross-run byte-identity is about the rebuilt
+    // transactions, which the salt/tokenId assertions above pin cross-engine.)
+    const rerun = await engineA.split({ token: srcA, outputs }, { transferId });
+    expect(rerun.outputs.map((o) => engineA.encodeToken(o))).toEqual(runA.outputs.map((o) => engineA.encodeToken(o)));
   }, 40000);
 
   // E.2 status-agnostic submit: a submit that THROWS (response-parse failure)

--- a/tests/unit/token-engine/support/TestAggregatorClient.ts
+++ b/tests/unit/token-engine/support/TestAggregatorClient.ts
@@ -38,6 +38,8 @@ export class TestAggregatorClient implements IAggregatorClient {
   public readonly rootTrustBase: RootTrustBase;
   private readonly predicateVerifier: PredicateVerifierService;
   private readonly requests: Map<bigint, CertificationData> = new Map();
+  /** Inclusion proofs anchored at submission time (round-stable, like the real aggregator). */
+  private readonly proofs: Map<bigint, InclusionProofResponse> = new Map();
 
   private constructor(
     private readonly smt: SparseMerkleTree,
@@ -60,30 +62,27 @@ export class TestAggregatorClient implements IAggregatorClient {
 
   /**
    * @inheritDoc
+   *
+   * Fidelity note (deliberate divergence from the upstream copy): the real
+   * aggregator anchors an inclusion proof at the round the leaf was included —
+   * refetching it later returns the SAME proof, regardless of later
+   * submissions. The upstream test client recomputes from the current tree,
+   * which silently breaks crash-resume tests (a refetched proof would differ
+   * once unrelated leaves land). We snapshot the proof at submission time.
    */
   public async getInclusionProof(stateId: StateId): Promise<InclusionProofResponse> {
     const path = BitString.fromBytesReversedLSB(stateId.data).toBigInt();
-    const root = await this.smt.calculateRoot();
 
-    if (!this.requests.has(path)) {
-      return Promise.resolve(
-        new InclusionProofResponse(
-          1n,
-          new InclusionProof(null, null, await createUnicityCertificate(root.hash, this.signingService)),
-        ),
-      );
+    const snapshot = this.proofs.get(path);
+    if (snapshot !== undefined) {
+      return Promise.resolve(snapshot);
     }
 
-    const certificationData = this.requests.get(path);
-
+    const root = await this.smt.calculateRoot();
     return Promise.resolve(
       new InclusionProofResponse(
         1n,
-        new InclusionProof(
-          certificationData ?? null,
-          InclusionCertificate.create(root, stateId.data),
-          await createUnicityCertificate(root.hash, this.signingService),
-        ),
+        new InclusionProof(null, null, await createUnicityCertificate(root.hash, this.signingService)),
       ),
     );
   }
@@ -110,6 +109,19 @@ export class TestAggregatorClient implements IAggregatorClient {
       const leafValue = certificationData.transactionHash;
       await this.smt.addLeaf(stateId.data, leafValue.data);
       this.requests.set(path, certificationData);
+      // Anchor the proof at inclusion time (see getInclusionProof fidelity note).
+      const root = await this.smt.calculateRoot();
+      this.proofs.set(
+        path,
+        new InclusionProofResponse(
+          1n,
+          new InclusionProof(
+            certificationData,
+            InclusionCertificate.create(root, stateId.data),
+            await createUnicityCertificate(root.hash, this.signingService),
+          ),
+        ),
+      );
     }
 
     return CertificationResponse.create(CertificationStatus.SUCCESS);

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -245,11 +245,14 @@ export class SphereTokenEngine implements ITokenEngine {
     );
 
     // Value conservation is enforced inside the SDK split (root.value === source value).
-    // The burn transaction's state mask is still random INSIDE TokenSplit.split —
-    // the pinned base SDK has no burnStateMask parameter yet (it arrives via
-    // state-transition-sdk-js#125; wiring tracked in #492) — so the burn leg is
-    // not yet rebuildable and a split resume stops at the burn.
-    const split = await TokenSplit.split(params.token.sdkToken, decodeSpherePaymentData, requests);
+    // E.1: the burn state mask is HKDF-derived, so the whole split — burn leg
+    // included — is rebuildable from the wallet key + transferId (crash resume).
+    const split = await TokenSplit.split(
+      params.token.sdkToken,
+      decodeSpherePaymentData,
+      requests,
+      deriveRealization(this.privateKeyHex, transferId, 0, 'burn'),
+    );
 
     // 1. Burn the source: certify the burn transfer and append it -> burntToken.
     const burnUnlock = await SignaturePredicateUnlockScript.create(split.burn.transaction, this.deps.signingService);


### PR DESCRIPTION
Closes #492

The #125 rc landed (thanks for the fast review+publish). This completes Part E:
- deterministic burn mask wired → **AC-E1/AC-E2 split legs done** (full split re-run recovers byte-identical outputs; that assertion is simultaneously the burn-determinism proof — a random mask would throw `TransferConflictError`)
- **mock fidelity fix**: the vendored `TestAggregatorClient` now anchors inclusion proofs at submission time like the real aggregator (the upstream copy recomputes from the current tree — that instability surfaced as a false `TRANSACTION_HASH_MISMATCH` in the new resume test; filing upstream)
- token-engine: 97/97; full suite: 2884/2888 with the 4 known #487 pre-existing failures (CI authoritative)