### PR TITLE
Fix publish pack race (dts files missing from dev.2/dev.3 tarballs)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,10 @@ jobs:
           for f in dist/index.d.ts dist/core/index.d.ts dist/token-engine/index.d.ts dist/wallet-api/index.d.ts; do
             test -f "$f" || { echo "MISSING $f — refusing to publish a broken tarball (cf. 0.9.1-dev.2 dts regression)"; exit 1; }
           done
+          # prepublishOnly is verify-only: npm publish packs THIS dist (no rebuild;
+          # the dev.2/dev.3 tarballs lost dts files to a pack-vs-DTS-worker race)
+          npm pack --dry-run --json > /tmp/pack.json
+          node -e "const files=require('/tmp/pack.json')[0].files.map(f=>f.path);for(const f of ['dist/index.d.ts','dist/core/index.d.ts','dist/token-engine/index.d.ts','dist/wallet-api/index.d.ts']){if(!files.includes(f)){console.error('TARBALL MISSING '+f);process.exit(1)}}console.log('tarball manifest verified: '+files.length+' files')"
 
       - name: Determine npm dist-tag
         id: dist-tag

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "build": "tsup",
     "build:watch": "tsup --watch",
     "clean": "rm -rf dist",
-    "prepublishOnly": "npm run clean && npm run build",
+    "prepublishOnly": "node -e \"const fs=require('fs');const must=['dist/index.d.ts','dist/core/index.d.ts','dist/token-engine/index.d.ts','dist/wallet-api/index.d.ts','dist/token-engine/index.js','dist/wallet-api/index.js'];const missing=must.filter(f=>!fs.existsSync(f));if(missing.length){console.error('prepublishOnly: dist is stale or incomplete — run npm run build first. Missing: '+missing.join(', '));process.exit(1)}\"",
     "test": "vitest",
     "test:run": "vitest run",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",


### PR DESCRIPTION
Closes #498

Root cause + fix per the issue: prepublishOnly verify-only (no rebuild inside npm publish), plus a `npm pack --dry-run` manifest gate. Diagnosis evidence in the issue: the publish step's own log shows `DTS dist/token-engine/index.d.ts 22.71 KB` followed by a Tarball Contents listing without it.