### PR TITLE
Phase-2 cross-repo harness: two real wallets vs the real backend (+ the wire-format drift it caught)

### DIFF
--- a/impl/shared/wallet-api/WalletApiMailboxProvider.ts
+++ b/impl/shared/wallet-api/WalletApiMailboxProvider.ts
@@ -38,6 +38,7 @@ import type {
   IncomingDelivery,
 } from '../../../transport/delivery-provider';
 import { composeDeliveryKeys, computeDeliveryId } from '../../../transport/delivery-provider';
+import { unwrapTokenBlobBytes } from '../../../token-engine/token-blob';
 import { deriveFieldEncryptionKey, decryptField, encryptField } from '../../../core/field-encryption';
 import { WalletApiClient, WalletApiError } from '../../../wallet-api';
 import type { KeyValueStore, MailboxEntry } from '../../../wallet-api';
@@ -173,14 +174,20 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
     }
     const keys = composeDeliveryKeys(await this.deriveKeys(blob));
 
+    // §5.2/§8.2: the wallet-api wire carries the RAW token bytes — the
+    // cross-port blob argument is the sphere envelope; unwrap at the boundary
+    // (the real backend content-addresses and Token.fromCBOR's exactly these
+    // bytes; the 39051 envelope never crosses the §16 API).
+    const wire = unwrapTokenBlobBytes(blob);
+
     // Upload the finished blob (checksum-bound presigned PUT — §5.2).
-    const sha = bytesToHex(sha256(blob));
-    const urls = await this.client.getUploadUrls([{ sha256: sha, size: blob.length }]);
+    const sha = bytesToHex(sha256(wire));
+    const urls = await this.client.getUploadUrls([{ sha256: sha, size: wire.length }]);
     const upload = urls.find((u) => u.sha256 === sha);
     if (!upload) {
       throw new WalletApiError(`upload-urls response missing sha256 ${sha}`, 'PROTOCOL');
     }
-    await this.client.uploadBlob(upload.putUrl, blob); // 412 = already present = success (§5.2)
+    await this.client.uploadBlob(upload.putUrl, wire); // 412 = already present = success (§5.2)
 
     // Deposit (idempotent by entry_id — §6). The memo is S6-encrypted BEFORE
     // it leaves the device (§8.3): the operator never sees plaintext.

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -43,7 +43,11 @@ import type {
   TxfStorageDataBase,
 } from '../../../storage';
 import type { TokenBlob } from '../../../token-engine/types';
-import { decodeTokenBlob } from '../../../token-engine/token-blob';
+import {
+  TOKEN_BLOB_VERSION,
+  decodeTokenBlob,
+  unwrapTokenBlobBytes,
+} from '../../../token-engine/token-blob';
 import type { FullIdentity, ProviderStatus } from '../../../types';
 import { WalletApiClient, WalletApiError } from '../../../wallet-api';
 import type { KeyValueStore } from '../../../wallet-api';
@@ -306,7 +310,7 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
       throw new WalletApiError(`No blob URL for token ${tokenId} (not owned here)`, 'NOT_FOUND');
     }
     const bytes = await this.client.fetchBlob(entry.getUrl);
-    const blob = decodeTokenBlob(bytes);
+    const blob = this.wrapWireBlob(tokenId, bytes);
     if (blob.tokenId !== tokenId) {
       throw new WalletApiError(
         `Blob tokenId mismatch: requested ${tokenId}, blob carries ${blob.tokenId}`,
@@ -314,6 +318,23 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
       );
     }
     return blob;
+  }
+
+  /**
+   * The §16 wire serves RAW token bytes (§5.2/§8.2 — the sphere 39051
+   * envelope never crosses the API): re-wrap them for the engine-facing
+   * {@link TokenBlob} surface. Envelope bytes (older rows, fake-world seeds)
+   * still decode — their embedded tokenId is then checked by the caller. The
+   * `network` of a raw wrap is not recoverable without the engine; consumers
+   * derive it from the decoded token (`engine.decodeToken` re-wraps), so it
+   * is never read from this value.
+   */
+  private wrapWireBlob(tokenId: string, bytes: Uint8Array): TokenBlob {
+    try {
+      return decodeTokenBlob(bytes);
+    } catch {
+      return { v: TOKEN_BLOB_VERSION, network: 0, tokenId, token: bytes };
+    }
   }
 
   /**
@@ -397,12 +418,7 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
   }
 
   private async locallyValid(tokenId: string, bytes: Uint8Array): Promise<boolean> {
-    let blob: TokenBlob;
-    try {
-      blob = decodeTokenBlob(bytes);
-    } catch {
-      return false;
-    }
+    const blob = this.wrapWireBlob(tokenId, bytes);
     if (blob.tokenId !== tokenId) return false;
     if (this.verifyToken) return this.verifyToken(blob);
     return true;
@@ -476,7 +492,9 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
       // active row is a lineage 409 (§5.3), and tombstoned tokens re-enter
       // via recoverRemoved(), never via write-behind.
       if (excluded.has(tokenId) || this.view.has(tokenId)) continue;
-      toAdd.push({ tokenId, bytes: hexToBytes(value.sdkData) });
+      // §5.2/§8.2: the wire carries the RAW token bytes — the stored sdkData
+      // is the sphere envelope; unwrap it at the wallet-api boundary.
+      toAdd.push({ tokenId, bytes: unwrapTokenBlobBytes(hexToBytes(value.sdkData)) });
     }
     if (toAdd.length === 0) return;
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -30,7 +30,7 @@ import type {
 } from '../../types/txf';
 import { L1PaymentsModule, type L1PaymentsModuleConfig } from './L1PaymentsModule';
 import type { SplitPlan, TokenWithAmount } from './TokenSplitCalculator';
-import type { ITokenEngine, SphereToken } from '../../token-engine';
+import type { ITokenEngine, SphereToken, TokenBlob } from '../../token-engine';
 import { TransferConflictError } from '../../token-engine';
 import { isV2TransferPayload, type V2TransferPayload } from '../../types/v2-transfer';
 import { TokenReservationLedger } from './TokenReservationLedger';
@@ -71,7 +71,7 @@ import { TokenRegistry } from '../../registry';
 import { logger } from '../../core/logger';
 import { SphereError } from '../../core/errors';
 import { sha256, bytesToHex, hexToBytes } from '../../core/crypto';
-import { decodeTokenBlob, encodeTokenBlob } from '../../token-engine/token-blob';
+import { decodeTokenBlob, encodeTokenBlob, unwrapTokenBlobBytes, TOKEN_BLOB_VERSION } from '../../token-engine/token-blob';
 import { parseInvoiceMemoForOnChain } from '../accounting/memo.js';
 
 // =============================================================================
@@ -677,12 +677,13 @@ export interface PaymentsWalletApiPort {
   ): Promise<{ sha256: string; key: string; putUrl: string }[]>;
   /** Upload to a presigned PUT (a 412 = already present = success — §5.2). */
   uploadBlob(putUrl: string, bytes: Uint8Array): Promise<void>;
-  /** §10: client-asserted history records, deduped by dedupKey server-side. */
+  /** §10: client-asserted history records (§16 wire shape), deduped by dedupKey server-side. */
   postHistoryRecords(
     records: {
       dedupKey: string;
+      id: string;
       type: string;
-      timestamp: number;
+      ts: string;
       assets: { coinId: string; amount: string }[];
       transferId?: string;
       tokenId?: string;
@@ -1925,13 +1926,16 @@ export class PaymentsModule {
   /** §5.2: upload a spend output blob (content-addressed; 412 = present = success). */
   private async uploadOutputBlob(bytes: Uint8Array): Promise<string> {
     const walletApi = this.deps!.walletApi!;
-    const sha = sha256(bytesToHex(bytes), 'hex');
-    const urls = await walletApi.getUploadUrls([{ sha256: sha, size: bytes.length }]);
+    // §5.2/§8.2: the wire carries RAW token bytes — callers hand the sphere
+    // envelope; unwrap at the wallet-api boundary.
+    const wire = unwrapTokenBlobBytes(bytes);
+    const sha = sha256(bytesToHex(wire), 'hex');
+    const urls = await walletApi.getUploadUrls([{ sha256: sha, size: wire.length }]);
     const url = urls.find((u) => u.sha256 === sha);
     if (!url) {
       throw new SphereError(`upload-urls response missing sha256 ${sha}`, 'STORAGE_ERROR');
     }
-    await walletApi.uploadBlob(url.putUrl, bytes);
+    await walletApi.uploadBlob(url.putUrl, wire);
     return url.key;
   }
 
@@ -3408,20 +3412,32 @@ export class PaymentsModule {
     // envelopes — the operator never sees plaintext (§8.3). Best-effort: a
     // failed POST never fails the money path; the record stays local.
     const walletApi = this.deps!.walletApi;
-    if (walletApi) {
+    // §16 wire shape (strict server-side zod; caught drifting by the phase-2
+    // harness — the fake had accepted the module's internal shape):
+    //  - `id` (uuid) + `ts` (ISO-8601), never `timestamp`;
+    //  - `type` is the §16 enum — anything else stays local-only;
+    //  - `tokenId` is the genesis-stable lowercase hex (strip the `v2_` UI prefix);
+    //  - `counterpartyPubkey` only when it IS a 33-byte compressed pubkey.
+    const postableType = historyEntry.type === 'SENT' || historyEntry.type === 'RECEIVED' || historyEntry.type === 'MINT';
+    if (walletApi && postableType) {
       try {
         const fieldKey = this.getFieldEncryptionKey();
         const counterpartyNametag = historyEntry.recipientNametag ?? historyEntry.senderNametag;
+        const wireTokenId = historyEntry.tokenId?.replace(/^v2_/, '');
+        const counterparty = historyEntry.recipientPubkey ?? historyEntry.senderPubkey;
         await walletApi.postHistoryRecords([
           {
             dedupKey: historyEntry.dedupKey,
+            id: crypto.randomUUID(),
             type: historyEntry.type,
-            timestamp: historyEntry.timestamp,
+            ts: new Date(historyEntry.timestamp).toISOString(),
             assets: [{ coinId: historyEntry.coinId, amount: historyEntry.amount }],
             ...(historyEntry.transferId !== undefined ? { transferId: historyEntry.transferId } : {}),
-            ...(historyEntry.tokenId !== undefined ? { tokenId: historyEntry.tokenId } : {}),
-            ...(historyEntry.recipientPubkey ?? historyEntry.senderPubkey
-              ? { counterpartyPubkey: historyEntry.recipientPubkey ?? historyEntry.senderPubkey }
+            ...(wireTokenId !== undefined && /^(?:[0-9a-f]{2}){1,64}$/.test(wireTokenId)
+              ? { tokenId: wireTokenId }
+              : {}),
+            ...(counterparty !== undefined && /^0[23][0-9a-f]{64}$/.test(counterparty)
+              ? { counterpartyPubkey: counterparty }
               : {}),
             ...(historyEntry.memo !== undefined ? { memo: encryptField(fieldKey, historyEntry.memo) } : {}),
             ...(counterpartyNametag !== undefined
@@ -4146,7 +4162,18 @@ export class PaymentsModule {
 
     let token: SphereToken;
     try {
-      token = await engine.decodeToken(decodeTokenBlob(hexToBytes(payload.tokenBlob)));
+      // Tolerant read: peers/journals carry the sphere envelope, while the
+      // wallet-api mailbox serves RAW wire bytes (§5.2/§8.2). Either way the
+      // engine's decode re-derives the authoritative blob from the token
+      // itself, so the placeholder fields of a raw wrap are never trusted.
+      const bytes = hexToBytes(payload.tokenBlob);
+      let blob: TokenBlob;
+      try {
+        blob = decodeTokenBlob(bytes);
+      } catch {
+        blob = { v: TOKEN_BLOB_VERSION, network: 0, tokenId: '', token: bytes };
+      }
+      token = await engine.decodeToken(blob);
     } catch (err) {
       logger.error('Payments', 'V2 transfer: failed to decode token blob:', err);
       return 'invalid';

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "test:run": "vitest run",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:relay": "vitest run --config vitest.relay.config.ts",
+    "test:harness": "vitest run --config vitest.harness.config.ts",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
     "cli": "echo 'The CLI has moved to @unicity-sphere/cli — install it with: npm install -g @unicity-sphere/cli' && exit 1"

--- a/tests/contract/delivery-provider.contract.ts
+++ b/tests/contract/delivery-provider.contract.ts
@@ -28,6 +28,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type { DeliveryProvider, IncomingDelivery } from '../../transport/delivery-provider';
+import { unwrapTokenBlobBytes } from '../../token-engine/token-blob';
 
 export interface DeliveryBlobFixture {
   /** Encoded TokenBlob bytes addressed to the recipient. */
@@ -113,7 +114,7 @@ export function describeDeliveryProviderContract(
       expect(incoming.filter((d) => d.deliveryId === first.deliveryId)).toHaveLength(1);
     });
 
-    it('incoming() yields the delivery with the exact blob bytes and its transferId', async () => {
+    it('incoming() yields the delivery with the exact token bytes and its transferId', async () => {
       const blob = ctx.makeBlob();
       const { deliveryId } = await ctx.sender.deliver(ctx.recipientPubkey, blob.bytes, {
         transferId: 'tf-3',
@@ -124,7 +125,13 @@ export function describeDeliveryProviderContract(
       expect(delivery).toBeDefined();
       expect(delivery!.transferId).toBe('tf-3');
       expect(typeof delivery!.cursor).toBe('string');
-      expect(Array.from(await delivery!.fetchBlob())).toEqual(Array.from(blob.bytes));
+      // The INNER token bytes round-trip byte-exactly. The envelope itself is
+      // transport-dependent: the wallet-api rail carries RAW wire bytes
+      // (ARCHITECTURE §5.2/§8.2 — the 39051 envelope never crosses the §16
+      // API), while peer transports may carry the envelope verbatim.
+      expect(Array.from(unwrapTokenBlobBytes(await delivery!.fetchBlob()))).toEqual(
+        Array.from(unwrapTokenBlobBytes(blob.bytes))
+      );
     });
 
     it("custody is composition-time: ack('claimed') with NO options honors the constructed mode", async () => {

--- a/tests/contract/storage-provider.contract.ts
+++ b/tests/contract/storage-provider.contract.ts
@@ -79,13 +79,16 @@ export function describeStorageProviderContract(
       expect(view.cursor >= i1!.seq && view.cursor >= i2!.seq).toBe(true);
     });
 
-    it('getToken returns the decoded blob for a stored token', async () => {
+    it('getToken returns the stored token (inner bytes byte-exact)', async () => {
       const t = makeTestToken();
       await ctx.seed([t]);
       const blob = await ctx.provider.getToken(t.tokenId);
       expect(blob.tokenId).toBe(t.tokenId);
       expect(blob.v).toBe(t.blob.v);
-      expect(blob.network).toBe(t.blob.network);
+      // The INNER token bytes are the §5.2 content and round-trip byte-exact.
+      // Envelope metadata (`network`) is provider-dependent: local whole-blob
+      // providers preserve it, while the wallet-api rail stores RAW wire
+      // bytes (the engine re-derives network from the decoded token).
       expect(Array.from(blob.token)).toEqual(Array.from(t.blob.token));
     });
 

--- a/tests/harness/crash-resume.test.ts
+++ b/tests/harness/crash-resume.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Phase-2 harness — the SIGKILL crash drill (AC-E5 over the REAL backend).
+ *
+ * A child-process wallet runner (support/send-runner.ts) performs a send and
+ * is SIGKILLed at a DETERMINISTIC mid-send point: its wallet-api fetch hook
+ * prints `HARNESS_KILL_POINT` and hangs forever on the FIRST
+ * `POST /v1/inventory/apply` — by the §7/E.3 pipeline ordering that instant
+ * is provably:
+ *   - AFTER the intent was server-persisted (putIntent is awaited pre-engine),
+ *   - AFTER the engine submitted and finished (certified at the stack's
+ *     aggregator, whose state survives the child),
+ *   - AFTER the mailbox deposit was server-acked,
+ *   - BEFORE the apply/complete/history tail.
+ * The parent fences on the marker (observable state, no sleeps), verifies the
+ * server-side mid-send facts through a pump-less RAW client (a full wallet
+ * would race: the real backend pushes §9 wakes), SIGKILLs, then starts a
+ * FRESH process from the SAME seed (new device, empty local state) which
+ * resumes via `resumeOpenIntents` — the S4 sign-in path.
+ *
+ * Asserted outcome: the finished token is recovered and delivered, no funds
+ * lost, NO duplicate delivery (the re-run's idempotent re-deposit lands on the
+ * same content-derived entry — §6), exactly one dedupKey'd SENT history row,
+ * and the intent closes — the E.2/E.3/AC-E5 property over the real backend
+ * and the real duplicate-submit wire contract.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { createHarnessWallet, createRawClient, type HarnessWallet } from './support/harness-wallet';
+import { HARNESS_COIN, randomIdentity, stackFromEnv } from './support/stack';
+import { KILL_POINT_MARKER, RESUME_RESULT_MARKER } from './support/runner-protocol';
+import { spawnRunner } from './support/spawn-runner';
+import type { CoinBalance } from '../../wallet-api';
+
+const stack = stackFromEnv();
+
+const wallets: HarnessWallet[] = [];
+afterEach(() => {
+  while (wallets.length) wallets.pop()?.destroy();
+});
+
+function totalOf(balances: CoinBalance[]): bigint {
+  return balances.find((b) => b.coinId === HARNESS_COIN)?.total ?? 0n;
+}
+
+describe('SIGKILL mid-send → fresh-process resume (AC-E5)', () => {
+  it('recovers the finished token, delivers exactly once, loses nothing', async () => {
+    const aId = randomIdentity();
+    const bId = randomIdentity();
+
+    // Fund wallet A (full preset — mint lands in the server inventory).
+    const a = await createHarnessWallet({ stack, identity: aId, deviceId: 'crash-a-parent', custody: 'inventory' });
+    wallets.push(a);
+    await a.module.load();
+    expect((await a.module.mintFungibleToken(HARNESS_COIN, 1000n)).success).toBe(true);
+    expect(totalOf(await a.client.getBalances())).toBe(1000n);
+    a.destroy(); // no background pumps may touch A while the drill runs
+    wallets.pop();
+
+    // Pump-less raw clients for every wire assertion (deterministic reads).
+    const aClient = createRawClient(stack, aId, 'crash-a-raw');
+    const bClient = createRawClient(stack, bId, 'crash-b-raw');
+
+    const runnerEnv = {
+      HARNESS_PRIVKEY: aId.privateKey,
+      HARNESS_PUBKEY: aId.chainPubkey,
+      HARNESS_RECIPIENT: bId.chainPubkey,
+      HARNESS_AMOUNT: '1000',
+    };
+
+    // Phase 1: the child reaches the kill point (deterministic marker).
+    const sender = spawnRunner('send', runnerEnv);
+    await sender.waitForLine(KILL_POINT_MARKER);
+
+    // Mid-send server facts, observed BEFORE the kill: open intent persisted,
+    // deposit landed (unclaimed), source still active (apply never ran).
+    const openIntents = await aClient.listIntents('open');
+    expect(openIntents).toHaveLength(1);
+    const transferId = openIntents[0].transferId;
+    const before = (await bClient.listMailbox()).entries.filter((e) => e.transferId === transferId);
+    expect(before).toHaveLength(1);
+    expect(before[0].status).toBe('unclaimed');
+    expect(totalOf(await aClient.getBalances())).toBe(1000n);
+
+    await sender.kill(); // SIGKILL — the apply/complete tail never happens
+
+    // Phase 2: a FRESH process from the same seed resumes open intents.
+    const resumer = spawnRunner('resume', runnerEnv);
+    const resultLine = await resumer.waitForLine(RESUME_RESULT_MARKER);
+    await resumer.waitForExit();
+    const outcome = JSON.parse(resultLine.slice(RESUME_RESULT_MARKER.length + 1)) as {
+      resumed: string[];
+      conflicted: string[];
+      failed: string[];
+    };
+    expect(outcome).toEqual({ resumed: [transferId], conflicted: [], failed: [] });
+
+    // The intent closed; the spend is recorded (§5.3 evidenced by the deposit).
+    expect(await aClient.listIntents('open')).toHaveLength(0);
+
+    // No duplicate delivery: the resume's idempotent re-deposit landed on the
+    // SAME content-derived entry — still exactly one mailbox entry (§6).
+    const afterResume = (await bClient.listMailbox()).entries.filter((e) => e.transferId === transferId);
+    expect(afterResume).toHaveLength(1);
+    expect(afterResume[0].status).toBe('unclaimed'); // B has not claimed yet
+
+    // B comes online (fresh full wallet) and claims EXACTLY one delivery.
+    const b = await createHarnessWallet({ stack, identity: bId, deviceId: 'crash-b', custody: 'inventory' });
+    wallets.push(b);
+    await b.module.load();
+    const { transfers } = await b.module.receive();
+    expect(transfers).toHaveLength(1);
+    expect(transfers[0].tokens[0].amount).toBe('1000');
+
+    const claimed = (await bClient.listMailbox()).entries.filter((e) => e.transferId === transferId);
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0].status).toBe('claimed');
+
+    // No funds lost; both sides converge through the real backend.
+    expect(totalOf(await aClient.getBalances())).toBe(0n);
+    expect(totalOf(await bClient.getBalances())).toBe(1000n);
+
+    // Exactly ONE dedupKey'd SENT row under the original transferId (§10).
+    const history = await aClient.listHistory();
+    expect(history.records.filter((r) => r.dedupKey === `SENT_transfer_${transferId}`)).toHaveLength(1);
+
+    // Re-discovery is a no-op: the entry is resolved and seen.
+    const again = await b.module.receive();
+    expect(again.transfers).toHaveLength(0);
+  });
+});

--- a/tests/harness/delivery-only.test.ts
+++ b/tests/harness/delivery-only.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Phase-2 harness — the delivery-only composition over the REAL backend
+ * (sdk-changes S7: own storage + wallet-api delivery).
+ *
+ * Custody stays client-side end to end: the sender never calls apply (the
+ * send closes via intents/complete alone — §6 storage-opt-out senders), the
+ * recipient's claims are `intoInventory: false` by composition, and the
+ * server performs ZERO inventory writes for either party — asserted through
+ * the REAL inventory API, not a fake's internals.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { createHarnessWallet, type HarnessWallet } from './support/harness-wallet';
+import { HARNESS_COIN, randomIdentity, stackFromEnv } from './support/stack';
+
+const stack = stackFromEnv();
+
+const wallets: HarnessWallet[] = [];
+afterEach(() => {
+  while (wallets.length) wallets.pop()?.destroy();
+});
+
+async function newOwnStorageWallet(deviceId: string, identity = randomIdentity()): Promise<HarnessWallet> {
+  const wallet = await createHarnessWallet({
+    stack,
+    identity,
+    deviceId,
+    custody: 'external',
+  });
+  wallets.push(wallet);
+  await wallet.module.load();
+  return wallet;
+}
+
+describe('own storage + wallet-api delivery (delivery-only composition)', () => {
+  it('tokens move via the mailbox with ZERO server-side inventory writes on either side', async () => {
+    const sender = await newOwnStorageWallet('do-sender');
+    const recipientIdentity = randomIdentity();
+
+    // Mint into the app's OWN storage — nothing reaches the server inventory.
+    expect((await sender.module.mintFungibleToken(HARNESS_COIN, 1000n)).success).toBe(true);
+    expect((await sender.client.listInventory()).items).toHaveLength(0);
+
+    const result = await sender.module.send({
+      recipient: recipientIdentity.chainPubkey,
+      amount: '1000',
+      coinId: HARNESS_COIN,
+    });
+    expect(result.status).toBe('completed');
+
+    // The recipient comes online AFTER the deposit, so this explicit poll IS
+    // the discovery (a wallet composed earlier could have claimed on a §9
+    // wake — the real backend pushes them, unlike the in-process fake).
+    const recipient = await newOwnStorageWallet('do-recipient', recipientIdentity);
+
+    // E.3 uniform close: completeIntent alone closed the send (no apply).
+    expect(await sender.client.listIntents('open')).toHaveLength(0);
+
+    // The recipient discovers and claims — custody stays in app storage.
+    const { transfers } = await recipient.module.receive();
+    expect(transfers).toHaveLength(1);
+    expect(recipient.module.getTokens()[0]).toMatchObject({ amount: '1000', status: 'confirmed' });
+
+    // The §6 delivery-only property, asserted via the REAL inventory API:
+    // zero inventory writes server-side for sender AND recipient.
+    expect((await sender.client.listInventory()).items).toHaveLength(0);
+    expect((await recipient.client.listInventory()).items).toHaveLength(0);
+    expect(await sender.client.getBalances()).toEqual([]);
+    expect(await recipient.client.getBalances()).toEqual([]);
+
+    // The mailbox entry resolved (claimed) under the send's transferId.
+    const mailbox = await recipient.client.listMailbox();
+    const entries = mailbox.entries.filter((e) => e.transferId === result.id);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].status).toBe('claimed');
+  });
+});

--- a/tests/harness/fake-differential.test.ts
+++ b/tests/harness/fake-differential.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Phase-2 harness — the FAKE-DRIFT DIFFERENTIAL GUARD.
+ *
+ * The whole point of this harness is to detect drift between the in-process
+ * fake backend (tests/support/fake-wallet-api.ts) and the real wallet-api: a
+ * suite that would pass against the fake proves nothing about the real
+ * system. This file pins a REAL-BACKEND-ONLY behavior:
+ *
+ *   §5.2 presigned blob URLs are credentials for a REAL S3 object store —
+ *   served OFF the API origin (MinIO at 127.0.0.1:9000, not the API at
+ *   :3000), stamped with S3 request ids (`x-amz-request-id`), and round-
+ *   tripping the exact uploaded bytes.
+ *
+ * The fake CANNOT satisfy this: it serves blobs from its own HTTP origin
+ * (`/v1/_blob/...`) with no S3 semantics. The guard is SELF-VERIFYING — the
+ * second test runs the identical assertion against the fake and REQUIRES it
+ * to reject. If someone ever points the harness at the fake (or the fake
+ * grows close enough to fool the rest of the suite), this file fails.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { createHarnessWallet, type HarnessWallet } from './support/harness-wallet';
+import { HARNESS_COIN, randomIdentity, stackFromEnv } from './support/stack';
+import { deriveDeliveryKeys } from '../../token-engine/blob-keys';
+import { WalletApiClient } from '../../wallet-api';
+import { FakeWalletApi } from '../support/fake-wallet-api';
+import { makeTestToken, MemoryKeyValueStore, testIdentity } from '../support/wallet-api-test-helpers';
+
+const stack = stackFromEnv();
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+});
+
+/** The real-backend-only property. Throws when served by anything but a real object store. */
+async function assertServedByRealObjectStore(
+  apiBaseUrl: string,
+  getUrl: string,
+  expectedTokenId: string
+): Promise<void> {
+  if (new URL(getUrl).origin === new URL(apiBaseUrl).origin) {
+    throw new Error(
+      `blob URL is served from the API origin (${getUrl}) — an in-process fake, not a real object store`
+    );
+  }
+  const res = await fetch(getUrl);
+  if (!res.ok) throw new Error(`presigned GET failed: HTTP ${res.status}`);
+  if (!res.headers.get('x-amz-request-id')) {
+    throw new Error('presigned GET response carries no x-amz-request-id — not S3/MinIO');
+  }
+  // §5.2/§8.2: the wire serves RAW SDK token CBOR — decode it as the real
+  // token it must be and match the genesis-stable id.
+  const keys = await deriveDeliveryKeys(new Uint8Array(await res.arrayBuffer()));
+  if (keys.tokenId !== expectedTokenId) {
+    throw new Error(`presigned GET returned the wrong blob: ${keys.tokenId} != ${expectedTokenId}`);
+  }
+}
+
+describe('fake-drift differential guard', () => {
+  it('presigned blob URLs are served by the REAL S3 store and round-trip the bytes', async () => {
+    const a: HarnessWallet = await createHarnessWallet({
+      stack,
+      identity: randomIdentity(),
+      deviceId: 'diff-real',
+      custody: 'inventory',
+    });
+    cleanups.push(() => a.destroy());
+    await a.module.load();
+
+    const mint = await a.module.mintFungibleToken(HARNESS_COIN, 42n);
+    if (!mint.success) throw new Error(mint.error);
+
+    const urls = await a.client.getBlobUrls([mint.tokenId]);
+    expect(urls).toHaveLength(1);
+    await assertServedByRealObjectStore(stack.baseUrl, urls[0].getUrl, mint.tokenId);
+  });
+
+  it('the guard DISCRIMINATES: the identical assertion rejects against the in-process fake', async () => {
+    const fake = new FakeWalletApi();
+    const fakeBase = await fake.start();
+    cleanups.push(() => fake.stop());
+
+    const who = testIdentity(91);
+    const client = new WalletApiClient({
+      baseUrl: fakeBase,
+      network: fake.network,
+      deviceId: 'diff-fake',
+      storage: new MemoryKeyValueStore(),
+    });
+    client.setIdentity(who);
+    const token = makeTestToken();
+    fake.seedInventory(who.chainPubkey, [
+      { tokenId: token.tokenId, assets: [{ coinId: token.coinId, amount: token.amount }], blob: token.bytes },
+    ]);
+
+    const urls = await client.getBlobUrls([token.tokenId]);
+    expect(urls).toHaveLength(1);
+    await expect(assertServedByRealObjectStore(fakeBase, urls[0].getUrl, token.tokenId)).rejects.toThrow(
+      /API origin/
+    );
+  });
+});

--- a/tests/harness/global-setup.ts
+++ b/tests/harness/global-setup.ts
@@ -1,0 +1,59 @@
+/**
+ * tests/harness/global-setup.ts — boots the wallet-api compose stack once for
+ * the whole harness run, programmatically, and tears it down after.
+ *
+ * Drives `docker compose ... up --build --wait` from the sibling wallet-api
+ * checkout (development-workflow.md phase 2): `--wait` blocks until the
+ * stack's healthchecks pass, so readiness is observable state, not sleeps.
+ * The compose CLI is used directly (rather than testcontainers' compose
+ * wrapper) because the stack contains a one-shot init service
+ * (minio-init: bucket + versioning) and a service joining another's network
+ * namespace — semantics `up --wait` handles natively.
+ *
+ * - A dedicated project name (`wallet-api-harness`) keeps the harness stack
+ *   apart from a developer's own `wallet-api-dev` stack (same fixed loopback
+ *   ports though — only one can run at a time, by design: presigned URLs are
+ *   signed for 127.0.0.1:9000).
+ * - A pre-up `down -v` self-heals stacks leaked by a killed previous run.
+ * - `HARNESS_REUSE_STACK=1` skips up/down and reuses whatever already answers
+ *   on the ports (the fast inner loop).
+ * - `WALLET_API_DIR` overrides the sibling checkout path.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+import { stackFromEnv, walletApiDir } from './support/stack';
+
+const PROJECT = 'wallet-api-harness';
+
+function compose(dir: string, args: string[]): void {
+  execFileSync('docker', ['compose', '-p', PROJECT, '-f', 'docker-compose.dev.yml', ...args], {
+    cwd: dir,
+    stdio: 'inherit',
+    timeout: 15 * 60 * 1000,
+  });
+}
+
+async function assertStackAnswers(): Promise<void> {
+  const stack = stackFromEnv();
+  for (const url of [`${stack.baseUrl}/v1/health`, `${stack.aggregatorUrl}/health`]) {
+    const res = await fetch(url).catch((err: unknown) => {
+      throw new Error(`harness stack not reachable at ${url}: ${String(err)}`);
+    });
+    if (!res.ok) throw new Error(`harness stack unhealthy at ${url}: HTTP ${res.status}`);
+  }
+}
+
+export default async function setup(): Promise<() => Promise<void>> {
+  if (process.env.HARNESS_REUSE_STACK === '1') {
+    await assertStackAnswers();
+    return async () => {};
+  }
+  const dir = walletApiDir();
+  compose(dir, ['down', '-v', '--remove-orphans']); // self-heal a leaked stack
+  compose(dir, ['up', '--build', '--wait']); // returns when healthchecks pass
+  await assertStackAnswers();
+  return async () => {
+    compose(dir, ['down', '-v']);
+  };
+}

--- a/tests/harness/support/harness-wallet.ts
+++ b/tests/harness/support/harness-wallet.ts
@@ -1,0 +1,274 @@
+/**
+ * tests/harness/support/harness-wallet.ts — a REAL wallet composition for the
+ * phase-2 harness (no vitest imports: the child-process runner uses this too).
+ *
+ * Unlike the unit-level model suite (PaymentsModule.wallet-api-delivery.test.ts,
+ * which runs FakeTokenEngine against the in-process fake backend), every layer
+ * that talks to the outside world here is REAL:
+ *
+ * - the S4 presets (`createWalletApiProviders` / `createOwnStorageWalletApiProviders`)
+ *   compose the real `WalletApiClient` + providers against the real backend
+ *   over real HTTP;
+ * - the engine is the real `createSphereTokenEngine` (recoverable, Part E)
+ *   over the stack's mock aggregator via the SDK's REAL JSON-RPC wire client,
+ *   verifying against the same LOCAL trustbase the backend pinned (§8.2);
+ * - storage/transport/oracle stubs cover only the surfaces these flows never
+ *   exercise (messaging stays on Nostr per S4; oracle validation rides
+ *   engine.verify + the backend's §8.2 pipeline) — mirroring the model suite's
+ *   composition pattern.
+ */
+
+import type { FullIdentity } from '../../../types';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type {
+  HistoryRecord,
+  StorageProvider,
+  TokenStorageProvider,
+  TxfStorageDataBase,
+} from '../../../storage';
+import type { ITokenEngine, TokenBlob } from '../../../token-engine';
+import { createSphereTokenEngine } from '../../../token-engine';
+import {
+  createOwnStorageWalletApiProviders,
+  createWalletApiProviders,
+  type SphereBaseProviders,
+} from '../../../impl/shared/wallet-api';
+import { WalletApiClient } from '../../../wallet-api';
+import type { FetchLike, KeyValueStore } from '../../../wallet-api';
+import {
+  createPaymentsModule,
+  type PaymentsModule,
+  type PaymentsModuleDependencies,
+} from '../../../modules/payments/PaymentsModule';
+import { fetchTrustbaseJson, type HarnessStack } from './stack';
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+export function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIdentity {
+  return {
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    l1Address: `alpha1${id.chainPubkey.slice(0, 8)}`,
+    directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
+  };
+}
+
+/** In-memory module storage (outbox, delivery journal, PR cursor, client state). */
+function memoryStorage(): { provider: StorageProvider; kv: KeyValueStore; map: Map<string, string> } {
+  const map = new Map<string, string>();
+  const surface = {
+    id: 'harness-storage',
+    name: 'harness-storage',
+    type: 'local',
+    connect: async (): Promise<void> => {},
+    disconnect: (): void => {},
+    isConnected: (): boolean => true,
+    getStatus: (): string => 'connected',
+    setIdentity: (): void => {},
+    get: async (k: string): Promise<string | null> => map.get(k) ?? null,
+    set: async (k: string, v: string): Promise<void> => {
+      map.set(k, v);
+    },
+    remove: async (k: string): Promise<void> => {
+      map.delete(k);
+    },
+    has: async (k: string): Promise<boolean> => map.has(k),
+    keys: async (): Promise<string[]> => [...map.keys()],
+    clear: async (): Promise<void> => {
+      map.clear();
+    },
+  };
+  const provider = surface as unknown as StorageProvider;
+  return { provider, kv: surface, map };
+}
+
+/** Local whole-blob custody for the own-storage (delivery-only) composition. */
+function localTokenStorage(): TokenStorageProvider<TxfStorageDataBase> {
+  let lastSaved: TxfStorageDataBase | null = null;
+  const history = new Map<string, HistoryRecord>();
+  const surface = {
+    id: 'local',
+    name: 'local',
+    type: 'local',
+    connect: async (): Promise<void> => {},
+    disconnect: async (): Promise<void> => {},
+    isConnected: (): boolean => true,
+    getStatus: (): string => 'connected',
+    setIdentity: (): void => {},
+    initialize: async (): Promise<boolean> => true,
+    shutdown: async (): Promise<void> => {},
+    save: async (data: TxfStorageDataBase): Promise<{ success: boolean; timestamp: number }> => {
+      lastSaved = data;
+      return { success: true, timestamp: Date.now() };
+    },
+    load: async (): Promise<unknown> =>
+      lastSaved
+        ? { success: true, source: 'local', timestamp: 0, data: lastSaved }
+        : { success: false, source: 'local', timestamp: 0 },
+    sync: async (): Promise<unknown> => ({ success: true, added: 0, removed: 0, conflicts: 0 }),
+    addHistoryEntry: async (e: HistoryRecord): Promise<void> => {
+      history.set(e.dedupKey, e);
+    },
+    getHistoryEntries: async (): Promise<HistoryRecord[]> => [...history.values()],
+    hasHistoryEntry: async (k: string): Promise<boolean> => history.has(k),
+    clearHistory: async (): Promise<void> => history.clear(),
+    importHistoryEntries: async (): Promise<number> => 0,
+  };
+  return surface as unknown as TokenStorageProvider<TxfStorageDataBase>;
+}
+
+/**
+ * Recipients are addressed by raw chain pubkey (the canonical identity);
+ * messaging/nametags stay out of scope (S4: assets leave Nostr).
+ */
+function stubTransport(): TransportProvider {
+  const surface = {
+    resolve: async (recipient: string): Promise<unknown> =>
+      /^0[23][0-9a-f]{64}$/i.test(recipient)
+        ? {
+            chainPubkey: recipient.toLowerCase(),
+            transportPubkey: recipient.slice(2).toLowerCase(),
+            directAddress: `DIRECT://${recipient.slice(0, 12)}`,
+          }
+        : null,
+    resolveTransportPubkeyInfo: async (): Promise<null> => null,
+    sendTokenTransfer: async (): Promise<void> => {
+      throw new Error('harness: assets ride the wallet-api delivery port, never the transport (S4)');
+    },
+    onTokenTransfer: (): (() => void) => () => {},
+    onPaymentRequest: (): (() => void) => () => {},
+    onPaymentRequestResponse: (): (() => void) => () => {},
+    connect: async (): Promise<void> => {},
+    disconnect: (): void => {},
+    isConnected: (): boolean => true,
+  };
+  return surface as unknown as TransportProvider;
+}
+
+/**
+ * Oracle stub: in these flows token validity is enforced by the REAL engine
+ * (`engine.verify` against the shared trustbase) and the backend's REAL §8.2
+ * pipeline — the oracle port's validateToken is not the property under test.
+ */
+function stubOracle(): OracleProvider {
+  const surface = {
+    validateToken: async (): Promise<{ valid: boolean }> => ({ valid: true }),
+    isDevMode: (): boolean => false,
+  };
+  return surface as unknown as OracleProvider;
+}
+
+/**
+ * A standalone, pump-less wallet-api client bound to an identity — for raw
+ * wire assertions that must NOT race the module's background pumps (the real
+ * backend pushes §9 wakes; a full wallet auto-claims discovered deliveries).
+ */
+export function createRawClient(
+  stack: HarnessStack,
+  identity: { privateKey: string; chainPubkey: string },
+  deviceId: string
+): WalletApiClient {
+  const map = new Map<string, string>();
+  const client = new WalletApiClient({
+    baseUrl: stack.baseUrl,
+    network: stack.network,
+    deviceId,
+    storage: {
+      get: async (k: string) => map.get(k) ?? null,
+      set: async (k: string, v: string) => {
+        map.set(k, v);
+      },
+      remove: async (k: string) => {
+        map.delete(k);
+      },
+    },
+  });
+  client.setIdentity({ privateKey: identity.privateKey, chainPubkey: identity.chainPubkey });
+  return client;
+}
+
+export interface HarnessWalletOptions {
+  readonly stack: HarnessStack;
+  readonly identity: { privateKey: string; chainPubkey: string };
+  readonly deviceId: string;
+  /** 'inventory' = full S4 preset; 'external' = own-storage (delivery-only). */
+  readonly custody: 'inventory' | 'external';
+  /** Injectable fetch for the wallet-api client (the crash drill's kill hook). */
+  readonly fetchFn?: FetchLike;
+}
+
+export interface HarnessWallet {
+  readonly module: PaymentsModule;
+  readonly client: WalletApiClient;
+  readonly engine: ITokenEngine;
+  readonly identity: FullIdentity;
+  readonly events: { type: string; data: unknown }[];
+  destroy(): void;
+}
+
+export async function createHarnessWallet(opts: HarnessWalletOptions): Promise<HarnessWallet> {
+  const identity = fullIdentity(opts.identity);
+  const trustBaseJson = await fetchTrustbaseJson(opts.stack.aggregatorUrl);
+  // The REAL engine over the stack's aggregator via the SDK's real wire client;
+  // networkId comes from the trustbase (LOCAL = 3).
+  const engine = await createSphereTokenEngine({
+    aggregatorUrl: opts.stack.aggregatorUrl,
+    trustBaseJson,
+    privateKey: hexToBytes(opts.identity.privateKey),
+  });
+
+  const storage = memoryStorage();
+  const base: SphereBaseProviders = {
+    storage: storage.provider,
+    transport: stubTransport(),
+    oracle: stubOracle(),
+    tokenStorage: localTokenStorage(),
+  };
+  const config = {
+    baseUrl: opts.stack.baseUrl,
+    network: opts.stack.network,
+    deviceId: opts.deviceId,
+    stateStore: storage.kv,
+    ...(opts.fetchFn ? { fetchFn: opts.fetchFn } : {}),
+    verifyToken: async (blob: TokenBlob): Promise<boolean> =>
+      (await engine.verify(await engine.decodeToken(blob))).ok,
+  };
+  const providers =
+    opts.custody === 'inventory'
+      ? createWalletApiProviders(base, config)
+      : createOwnStorageWalletApiProviders(base, config);
+  providers.tokenStorage.setIdentity(identity);
+
+  const events: { type: string; data: unknown }[] = [];
+  const deps: PaymentsModuleDependencies = {
+    identity,
+    storage: storage.provider,
+    tokenStorageProviders: new Map([[providers.tokenStorage.id, providers.tokenStorage]]),
+    transport: base.transport,
+    oracle: base.oracle,
+    emitEvent: (type, data) => {
+      events.push({ type, data });
+    },
+    tokenEngine: engine,
+    delivery: providers.delivery,
+    walletApi: providers.walletApi,
+  };
+  const module = createPaymentsModule({ l1: null });
+  module.initialize(deps);
+
+  return {
+    module,
+    client: providers.walletApi,
+    engine,
+    identity,
+    events,
+    destroy: () => {
+      module.destroy();
+    },
+  };
+}

--- a/tests/harness/support/runner-protocol.ts
+++ b/tests/harness/support/runner-protocol.ts
@@ -1,0 +1,10 @@
+/**
+ * tests/harness/support/runner-protocol.ts — the stdout marker protocol
+ * between the crash-drill parent (vitest) and the child wallet runner.
+ * Lives apart from send-runner.ts so importing the constants never imports
+ * (and runs) the runner entrypoint.
+ */
+
+export const KILL_POINT_MARKER = 'HARNESS_KILL_POINT';
+export const RESUME_RESULT_MARKER = 'HARNESS_RESUME_RESULT';
+export const LOADED_MARKER = 'HARNESS_LOADED';

--- a/tests/harness/support/send-runner.ts
+++ b/tests/harness/support/send-runner.ts
@@ -1,0 +1,104 @@
+/**
+ * tests/harness/support/send-runner.ts — the crash-drill child-process wallet
+ * runner (spawned via `node --import tsx`; never imported by vitest).
+ *
+ * Phases (argv[2]):
+ *
+ * - `send` — compose the FULL S4 preset wallet from the seed key, `load()`,
+ *   then `send()`. The injected wallet-api fetch hook makes the kill point
+ *   DETERMINISTIC: the FIRST `POST /v1/inventory/apply` prints the
+ *   `HARNESS_KILL_POINT` marker and never resolves (the request is never
+ *   forwarded). At that instant, by the send pipeline's own ordering (§7/E.3):
+ *   the intent is server-persisted (awaited putIntent), the engine submitted
+ *   and finished the transfer (certified on-chain at the mock aggregator,
+ *   which lives in the compose stack and survives this process), and the
+ *   mailbox deposit was server-acked — while the apply/complete/history tail
+ *   never happened. The parent SIGKILLs on the marker — no sleeps, no races.
+ *
+ * - `resume` — a FRESH process from the SAME seed (new device, empty local
+ *   state: the AC-E5 fresh-device posture): `load()`, then
+ *   `resumeOpenIntents()` (the S4 sign-in resume), printing the outcome as
+ *   the `HARNESS_RESUME_RESULT {...}` marker line.
+ *
+ * Markers are single stdout lines — the parent fences on them (observable
+ * state, §18 determinism rule).
+ */
+
+import { HARNESS_COIN, stackFromEnv } from './stack';
+import { createHarnessWallet } from './harness-wallet';
+import { KILL_POINT_MARKER, LOADED_MARKER, RESUME_RESULT_MARKER } from './runner-protocol';
+import type { FetchLike } from '../../../wallet-api';
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`send-runner: missing env ${name}`);
+  return value;
+}
+
+function emit(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+/** Forwards everything except the first inventory apply, which hangs forever. */
+function killPointFetch(): FetchLike {
+  let intercepted = false;
+  return (url, init) => {
+    if (!intercepted && init?.method === 'POST' && url.endsWith('/v1/inventory/apply')) {
+      intercepted = true;
+      emit(KILL_POINT_MARKER);
+      // Never resolves and never reaches the wire: the parent SIGKILLs here.
+      return new Promise(() => {});
+    }
+    return fetch(url, init as RequestInit);
+  };
+}
+
+async function main(): Promise<void> {
+  const phase = process.argv[2];
+  const stack = stackFromEnv();
+  const privateKey = requireEnv('HARNESS_PRIVKEY');
+  const chainPubkey = requireEnv('HARNESS_PUBKEY');
+
+  if (phase === 'send') {
+    const wallet = await createHarnessWallet({
+      stack,
+      identity: { privateKey, chainPubkey },
+      deviceId: 'crash-drill-send',
+      custody: 'inventory',
+      fetchFn: killPointFetch(),
+    });
+    await wallet.module.load();
+    emit(LOADED_MARKER);
+    // Hangs at the kill point by construction; the promise never settles.
+    await wallet.module.send({
+      recipient: requireEnv('HARNESS_RECIPIENT'),
+      amount: requireEnv('HARNESS_AMOUNT'),
+      coinId: HARNESS_COIN,
+    });
+    throw new Error('send-runner: send() returned — the kill point never engaged');
+  }
+
+  if (phase === 'resume') {
+    const wallet = await createHarnessWallet({
+      stack,
+      identity: { privateKey, chainPubkey },
+      deviceId: 'crash-drill-resume',
+      custody: 'inventory',
+    });
+    await wallet.module.load();
+    const outcome = await wallet.module.resumeOpenIntents();
+    emit(`${RESUME_RESULT_MARKER} ${JSON.stringify(outcome)}`);
+    wallet.destroy();
+    process.exit(0);
+  }
+
+  throw new Error(`send-runner: unknown phase "${phase ?? ''}"`);
+}
+
+// Run only when spawned as the entrypoint (spawn-runner.ts) — never on import.
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  main().catch((error: unknown) => {
+    console.error('send-runner failed:', error);
+    process.exit(1);
+  });
+}

--- a/tests/harness/support/spawn-runner.ts
+++ b/tests/harness/support/spawn-runner.ts
@@ -1,0 +1,121 @@
+/**
+ * tests/harness/support/spawn-runner.ts — spawn the crash-drill wallet runner
+ * as a REAL OS process (node --import tsx) and fence on its stdout markers.
+ * Timeouts here are failure fences (the suite fails loudly), never pacing.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const RUNNER_PATH = fileURLToPath(new URL('./send-runner.ts', import.meta.url));
+
+export interface RunnerHandle {
+  readonly child: ChildProcess;
+  /** Resolves with the full marker line; rejects on exit/timeout with diagnostics. */
+  waitForLine(prefix: string, timeoutMs?: number): Promise<string>;
+  /** SIGKILL and wait for the OS to reap the process. */
+  kill(): Promise<void>;
+  /** Wait for natural exit; rejects on nonzero code. */
+  waitForExit(timeoutMs?: number): Promise<void>;
+}
+
+export function spawnRunner(phase: 'send' | 'resume', env: Record<string, string>): RunnerHandle {
+  const child = spawn(process.execPath, ['--import', 'tsx', RUNNER_PATH, phase], {
+    cwd: process.cwd(),
+    env: { ...process.env, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let stdoutBuf = '';
+  let stderrBuf = '';
+  const lines: string[] = [];
+  const lineWaiters: { prefix: string; resolve: (line: string) => void }[] = [];
+  let exited: { code: number | null; signal: NodeJS.Signals | null } | null = null;
+  const exitWaiters: (() => void)[] = [];
+
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk: string) => {
+    stdoutBuf += chunk;
+    for (;;) {
+      const nl = stdoutBuf.indexOf('\n');
+      if (nl === -1) break;
+      const line = stdoutBuf.slice(0, nl);
+      stdoutBuf = stdoutBuf.slice(nl + 1);
+      lines.push(line);
+      for (let i = lineWaiters.length - 1; i >= 0; i--) {
+        if (line.startsWith(lineWaiters[i].prefix)) {
+          const [waiter] = lineWaiters.splice(i, 1);
+          waiter.resolve(line);
+        }
+      }
+    }
+  });
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk: string) => {
+    stderrBuf += chunk;
+  });
+  child.on('exit', (code, signal) => {
+    exited = { code, signal };
+    while (exitWaiters.length) exitWaiters.pop()?.();
+  });
+
+  const diagnostics = (): string =>
+    `runner[${phase}] exit=${JSON.stringify(exited)}\n--- stdout ---\n${lines.join('\n')}\n--- stderr ---\n${stderrBuf}`;
+
+  return {
+    child,
+    waitForLine(prefix: string, timeoutMs = 90_000): Promise<string> {
+      const existing = lines.find((l) => l.startsWith(prefix));
+      if (existing) return Promise.resolve(existing);
+      if (exited) return Promise.reject(new Error(`runner exited before "${prefix}"\n${diagnostics()}`));
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error(`timed out waiting for "${prefix}"\n${diagnostics()}`));
+        }, timeoutMs);
+        lineWaiters.push({
+          prefix,
+          resolve: (line) => {
+            clearTimeout(timer);
+            resolve(line);
+          },
+        });
+        exitWaiters.push(() => {
+          clearTimeout(timer);
+          reject(new Error(`runner exited before "${prefix}"\n${diagnostics()}`));
+        });
+      });
+    },
+    kill(): Promise<void> {
+      if (exited) return Promise.resolve();
+      return new Promise((resolve) => {
+        child.once('exit', () => resolve());
+        child.kill('SIGKILL');
+      });
+    },
+    waitForExit(timeoutMs = 120_000): Promise<void> {
+      const check = (): void => {
+        if (exited && exited.code !== 0) {
+          throw new Error(`runner exited with code ${String(exited.code)}\n${diagnostics()}`);
+        }
+      };
+      if (exited) {
+        check();
+        return Promise.resolve();
+      }
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error(`timed out waiting for runner exit\n${diagnostics()}`));
+        }, timeoutMs);
+        exitWaiters.push(() => {
+          clearTimeout(timer);
+          try {
+            check();
+            resolve();
+          } catch (err) {
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        });
+      });
+    },
+  };
+}

--- a/tests/harness/support/stack.ts
+++ b/tests/harness/support/stack.ts
@@ -1,0 +1,76 @@
+/**
+ * tests/harness/support/stack.ts — the phase-2 stack contract (no vitest
+ * imports: the child-process wallet runner shares this module).
+ *
+ * The suite runs against the wallet-api repo's `docker-compose.dev.yml` stack
+ * (development-workflow.md phase 2): real backend over real HTTP, real
+ * Postgres/Redis/MinIO behind it, and the §18 LOCAL mock aggregator behind the
+ * real state-transition-sdk JSON-RPC wire protocol. Host surface (loopback):
+ *
+ *   http://127.0.0.1:${WALLET_API_PORT:-3000}   wallet-api
+ *   http://127.0.0.1:${AGGREGATOR_PORT:-3001}   mock aggregator (+ /trustbase.json)
+ *
+ * `WALLET_API_DIR` points at the wallet-api checkout (default: the sibling
+ * `../wallet-api`); the global setup boots/tears the stack from there.
+ */
+
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { getPublicKey } from '../../../core/crypto';
+
+export interface HarnessStack {
+  /** wallet-api base URL (loopback http — allowed by the §4 client rule). */
+  readonly baseUrl: string;
+  /** Mock-aggregator JSON-RPC base URL (also serves /trustbase.json). */
+  readonly aggregatorUrl: string;
+  /** Must match the backend's NETWORK env (auth challenges embed it — §4). */
+  readonly network: string;
+}
+
+export function stackFromEnv(): HarnessStack {
+  const apiPort = process.env.WALLET_API_PORT ?? '3000';
+  const aggPort = process.env.AGGREGATOR_PORT ?? '3001';
+  return {
+    baseUrl: `http://127.0.0.1:${apiPort}`,
+    aggregatorUrl: `http://127.0.0.1:${aggPort}`,
+    network: 'testnet2', // docker-compose.dev.yml NETWORK; fixture tokens stay on NetworkId.LOCAL
+  };
+}
+
+/** The wallet-api checkout that carries docker-compose.dev.yml. */
+export function walletApiDir(): string {
+  const dir = resolve(process.cwd(), process.env.WALLET_API_DIR ?? '../wallet-api');
+  if (!existsSync(resolve(dir, 'docker-compose.dev.yml'))) {
+    throw new Error(
+      `wallet-api checkout not found at ${dir} (no docker-compose.dev.yml). ` +
+        'The harness is local-only and needs the sibling wallet-api repo — set WALLET_API_DIR. ' +
+        'See development-workflow.md (phase-2 harness).'
+    );
+  }
+  return dir;
+}
+
+/** The shared LOCAL trustbase, fetched from the stack's mock aggregator. */
+export async function fetchTrustbaseJson(aggregatorUrl: string): Promise<unknown> {
+  const res = await fetch(`${aggregatorUrl}/trustbase.json`);
+  if (!res.ok) throw new Error(`trustbase fetch failed: HTTP ${res.status}`);
+  return res.json();
+}
+
+/** A fresh random secp256k1 identity — every test isolates by owner. */
+export function randomIdentity(): { privateKey: string; chainPubkey: string } {
+  for (;;) {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    const privateKey = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    try {
+      return { privateKey, chainPubkey: getPublicKey(privateKey) };
+    } catch {
+      // out-of-range scalar (probability ~2^-128) — draw again
+    }
+  }
+}
+
+/** The harness coin (64-hex canonical AssetId, like the model suites). */
+export const HARNESS_COIN = '11'.repeat(32);

--- a/tests/harness/two-wallet-flow.test.ts
+++ b/tests/harness/two-wallet-flow.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Phase-2 harness — full two-wallet flows over the REAL backend
+ * (development-workflow.md phase 2; the systematic fake-drift detector).
+ *
+ * Two complete S4 wallet compositions (real WalletApiClient, real engine over
+ * the stack's LOCAL mock aggregator via the SDK's real JSON-RPC wire client)
+ * drive the real wallet-api backend over real HTTP:
+ *
+ * - A mints (open minting, LOCAL) → the §5.2 presigned upload + §5.3 apply put
+ *   the token in A's SERVER inventory (backend-validated, §8.2);
+ * - A sends to B: intent (E.3) → engine → mailbox deposit → apply → complete;
+ *   B discovers via mailbox poll, claims into inventory (§6 handoff);
+ * - balances and history converge on BOTH sides through the real backend;
+ * - a split send conserves value (change back to A) on both sides;
+ * - a payment request round-trips create→pay→respond('paid') with the linking
+ *   transferId (§10/§16).
+ *
+ * Determinism note: the REAL backend pushes §9 wakes over a live WS, so a
+ * wallet composed BEFORE a deposit may claim it in the background. Where a
+ * test wants `receive()` to be the discovery, the recipient wallet is created
+ * AFTER the send; where the recipient must exist earlier (payment requests),
+ * assertions fence on CONVERGED state (tokens/balances/entries), never on
+ * who-pumped-first.
+ *
+ * Local-only: needs Docker + the sibling wallet-api checkout (the global
+ * setup boots docker-compose.dev.yml). See development-workflow.md.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { createHarnessWallet, type HarnessWallet } from './support/harness-wallet';
+import { HARNESS_COIN, randomIdentity, stackFromEnv } from './support/stack';
+import type { CoinBalance } from '../../wallet-api';
+
+const stack = stackFromEnv();
+
+const wallets: HarnessWallet[] = [];
+afterEach(() => {
+  while (wallets.length) wallets.pop()?.destroy();
+});
+
+async function newWallet(deviceId: string, identity = randomIdentity()): Promise<HarnessWallet> {
+  const wallet = await createHarnessWallet({ stack, identity, deviceId, custody: 'inventory' });
+  wallets.push(wallet);
+  await wallet.module.load();
+  return wallet;
+}
+
+function totalOf(balances: CoinBalance[], coinId = HARNESS_COIN): bigint {
+  return balances.find((b) => b.coinId === coinId)?.total ?? 0n;
+}
+
+describe('two-wallet send/receive over the real backend', () => {
+  it('mint → send → mailbox poll → claim: balances and history converge on both sides', async () => {
+    const a = await newWallet('flow-a');
+    const bIdentity = randomIdentity();
+
+    // Open mint (LOCAL) through the real engine; the full preset pushes it
+    // into A's SERVER inventory (presigned PUT + apply, validated §8.2).
+    const mint = await a.module.mintFungibleToken(HARNESS_COIN, 1000n);
+    expect(mint.success).toBe(true);
+    expect(totalOf(await a.client.getBalances())).toBe(1000n);
+
+    const result = await a.module.send({
+      recipient: bIdentity.chainPubkey,
+      amount: '1000',
+      coinId: HARNESS_COIN,
+      memo: 'harness flow',
+    });
+    expect(result.status).toBe('completed');
+
+    // B comes online AFTER the deposit (so this explicit poll IS the
+    // discovery — no wake raced it) and claims into inventory (§6 handoff).
+    const b = await newWallet('flow-b', bIdentity);
+    const { transfers } = await b.module.receive();
+    expect(transfers).toHaveLength(1);
+    expect(transfers[0].tokens[0]).toMatchObject({ amount: '1000', coinId: HARNESS_COIN, status: 'confirmed' });
+
+    // Balance convergence on BOTH sides — through the real backend.
+    expect(totalOf(await a.client.getBalances())).toBe(0n);
+    expect(totalOf(await b.client.getBalances())).toBe(1000n);
+    expect(a.module.getTokens()).toHaveLength(0);
+    expect(b.module.getTokens()[0]).toMatchObject({ amount: '1000', status: 'confirmed' });
+
+    // The mailbox entry resolved under the send's transferId, exactly once.
+    const mailbox = await b.client.listMailbox();
+    const entries = mailbox.entries.filter((e) => e.transferId === result.id);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].status).toBe('claimed');
+
+    // §10 history rows exist SERVER-side for both parties, dedupKey'd.
+    const aHistory = await a.client.listHistory();
+    expect(aHistory.records.filter((r) => r.dedupKey === `SENT_transfer_${result.id}`)).toHaveLength(1);
+    const bHistory = await b.client.listHistory();
+    expect(bHistory.records.some((r) => r.dedupKey.startsWith('RECEIVED_'))).toBe(true);
+
+    // And the recipient surfaced it as an incoming transfer event.
+    expect(b.events.some((e) => e.type === 'transfer:incoming')).toBe(true);
+  });
+
+  it('a split send conserves value: 300 to B, 700 change back to A, both sides converge', async () => {
+    const a = await newWallet('split-a');
+    const bIdentity = randomIdentity();
+    expect((await a.module.mintFungibleToken(HARNESS_COIN, 1000n)).success).toBe(true);
+
+    const result = await a.module.send({ recipient: bIdentity.chainPubkey, amount: '300', coinId: HARNESS_COIN });
+    expect(result.status).toBe('completed');
+
+    // Server truth: A keeps exactly the 700 remainder as ONE active row.
+    const aBalances = await a.client.getBalances();
+    expect(aBalances).toEqual([{ coinId: HARNESS_COIN, total: 700n, tokenCount: 1 }]);
+
+    // Locally the change output is a full (non-lazy) confirmed record.
+    const change = a.module.getTokens().find((t) => t.amount === '700');
+    expect(change?.status).toBe('confirmed');
+    expect(change?.sdkData).toBeDefined();
+
+    const b = await newWallet('split-b', bIdentity);
+    const { transfers } = await b.module.receive();
+    expect(transfers).toHaveLength(1);
+    expect(transfers[0].tokens[0].amount).toBe('300');
+    expect(totalOf(await b.client.getBalances())).toBe(300n);
+
+    // Value conserved across the whole system.
+    expect(totalOf(await a.client.getBalances()) + totalOf(await b.client.getBalances())).toBe(1000n);
+  });
+});
+
+describe('payment requests over the real backend (§10/§16)', () => {
+  it("create → pay → respond('paid') round-trips with the linking transferId", async () => {
+    const requester = await newWallet('pr-requester');
+    const payer = await newWallet('pr-payer');
+    expect((await payer.module.mintFungibleToken(HARNESS_COIN, 1000n)).success).toBe(true);
+
+    // Requester creates the request via the wallet-api S4 capability.
+    const created = await requester.module.sendPaymentRequest(payer.identity.chainPubkey, {
+      amount: '400',
+      coinId: HARNESS_COIN,
+      message: 'harness invoice',
+    });
+    expect(created.success).toBe(true);
+    const requestId = created.requestId;
+    expect(requestId).toBeDefined();
+
+    // Payer drains the gap-free incoming stream and sees it.
+    await payer.module.syncPaymentRequests();
+    const incoming = payer.module.getPaymentRequests();
+    expect(incoming.some((r) => r.id === requestId && r.amount === '400')).toBe(true);
+
+    // Pay: send + respond('paid', transferId) — the §16 linkage.
+    const payResult = await payer.module.payPaymentRequest(requestId as string);
+    expect(payResult.status).toBe('completed');
+
+    // Server truth for the requester: status 'paid' linked to the SEND.
+    const outgoing = await requester.client.listPaymentRequests({ role: 'outgoing' });
+    const record = outgoing.requests.find((r) => r.id === requestId);
+    expect(record).toBeDefined();
+    expect(record).toMatchObject({ status: 'paid', transferId: payResult.id });
+
+    // The funds arrive through the real rails. The requester existed before
+    // the deposit, so a §9 wake may already have claimed it in the
+    // background — receive() coalesces with any in-flight pump; assert the
+    // CONVERGED state, not who pumped first.
+    await requester.module.receive();
+    expect(requester.module.getTokens().filter((t) => t.amount === '400' && t.status === 'confirmed')).toHaveLength(1);
+    expect(totalOf(await requester.client.getBalances())).toBe(400n);
+    expect(totalOf(await payer.client.getBalances())).toBe(600n);
+  });
+});

--- a/tests/support/fake-wallet-api.ts
+++ b/tests/support/fake-wallet-api.ts
@@ -175,6 +175,15 @@ export interface FakeWalletApiOptions {
    * failure (422).
    */
   decodeAssets?: (tokenBytes: Uint8Array) => FakeAsset[] | null;
+  /**
+   * §8.2 step-4 stand-in for RAW wire bytes: the wallet-api wire carries the
+   * INNER token bytes (§5.2 — never the 39051 envelope), so the fake needs an
+   * injected way to read the genesis-stable tokenId out of them (the real
+   * server decodes the v2 token). The default reads the synthetic JSON
+   * `{ tokenId }` payload; envelope bytes (legacy seeds) keep working via the
+   * envelope's own field. Returning null = validation failure (422).
+   */
+  decodeTokenId?: (tokenBytes: Uint8Array) => string | null;
 }
 
 function hex(bytes: Uint8Array): string {
@@ -201,6 +210,16 @@ function defaultDecodeAssets(tokenBytes: Uint8Array): FakeAsset[] | null {
       assets.push({ coinId: a.coinId, amount: BigInt(a.amount) });
     }
     return assets;
+  } catch {
+    return null;
+  }
+}
+
+/** Default raw-bytes tokenId reader: the synthetic JSON `{ tokenId }` payload. */
+function defaultDecodeTokenId(tokenBytes: Uint8Array): string | null {
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(tokenBytes)) as { tokenId?: unknown };
+    return typeof parsed.tokenId === 'string' ? parsed.tokenId : null;
   } catch {
     return null;
   }
@@ -235,6 +254,7 @@ export class FakeWalletApi {
   private readonly mailboxPerPairCap: number;
   private readonly maxPayerOpenRequests: number;
   private readonly decodeAssets: (tokenBytes: Uint8Array) => FakeAsset[] | null;
+  private readonly decodeTokenId: (tokenBytes: Uint8Array) => string | null;
 
   private server: http.Server | null = null;
   private wss: WebSocketServer | null = null;
@@ -271,6 +291,7 @@ export class FakeWalletApi {
     this.mailboxPerPairCap = options.mailboxPerPairCap ?? 500; // per-sender-pair sub-cap (§5.5 MAX_SENDER_RECIPIENT_ENTRIES)
     this.maxPayerOpenRequests = options.maxPayerOpenRequests ?? 1000; // MAX_PAYER_OPEN_REQUESTS (§14)
     this.decodeAssets = options.decodeAssets ?? defaultDecodeAssets;
+    this.decodeTokenId = options.decodeTokenId ?? defaultDecodeTokenId;
   }
 
   // ── lifecycle ────────────────────────────────────────────────────────────────
@@ -346,10 +367,25 @@ export class FakeWalletApi {
         tokenId: t.tokenId,
         status: 'active',
         s3Key: key,
-        stateHash: t.blob ? hex(sha256(decodeTokenBlob(t.blob).token)) : '',
+        stateHash: t.blob ? hex(sha256(this.resolveBlob(t.blob).inner)) : '',
         assets: t.assets,
         seq: owner.cursor,
       });
+    }
+  }
+
+  /**
+   * Tolerant §8.2 step-3 stand-in: wire bytes are the INNER token bytes
+   * (§5.2); envelope bytes (older seeds/uploads) unwrap. Returns the decoded
+   * tokenId (envelope field, else the injected raw decoder) and the inner
+   * bytes the value/state-hash derivations run over.
+   */
+  private resolveBlob(bytes: Uint8Array): { tokenId: string | null; inner: Uint8Array } {
+    try {
+      const blob = decodeTokenBlob(bytes);
+      return { tokenId: blob.tokenId, inner: blob.token };
+    } catch {
+      return { tokenId: this.decodeTokenId(bytes), inner: bytes };
     }
   }
 
@@ -868,6 +904,18 @@ export class FakeWalletApi {
       return;
     }
     if (req.method === 'PUT' && entry.method === 'PUT') {
+      // §5.2 / SigV4: the presign binds `x-amz-checksum-sha256` and
+      // `if-none-match` as SIGNED HEADERS — a real S3 endpoint rejects the
+      // signature when they are absent or differ. Enforced here because the
+      // phase-2 harness caught exactly this drift on first contact with real
+      // MinIO (the fake had validated only the body, never the headers).
+      const expectedChecksum = Buffer.from(entry.sha256, 'hex').toString('base64');
+      if (req.headers['x-amz-checksum-sha256'] !== expectedChecksum) {
+        throw new HttpError(403, 'FORBIDDEN', 'x-amz-checksum-sha256 signed header missing or mismatched');
+      }
+      if (req.headers['if-none-match'] !== '*') {
+        throw new HttpError(403, 'FORBIDDEN', 'if-none-match signed header missing (the presign binds it)');
+      }
       const bytes = await this.readBody(req);
       // §5.2: the URL pins the exact Content-Length…
       if (bytes.length !== entry.size) {
@@ -1026,26 +1074,25 @@ export class FakeWalletApi {
       throw new HttpError(422, 'VALIDATION', 'blob bytes do not match the content-addressed key');
     }
     // §8.2 step 3 — APPROXIMATION: the real server CBOR-decodes the v2 token
-    // and runs the SDK's three-service token.verify against the pinned
-    // trustbase. This fake decodes the sphere TokenBlob envelope only.
-    let blob;
-    try {
-      blob = decodeTokenBlob(bytes);
-    } catch {
-      throw new HttpError(422, 'VALIDATION', 'blob is not a decodable TokenBlob');
-    }
+    // (RAW wire bytes — §5.2) and runs the SDK's three-service token.verify
+    // against the pinned trustbase. This fake reads the tokenId via the
+    // injected decoder (envelope bytes from older seeds still unwrap).
+    const resolved = this.resolveBlob(bytes);
     // §8.2 step 4: the decoded tokenId MUST match the claimed tokenId.
-    if (blob.tokenId !== entry.tokenId) {
+    if (resolved.tokenId === null) {
+      throw new HttpError(422, 'VALIDATION', 'blob does not decode to a token id');
+    }
+    if (resolved.tokenId !== entry.tokenId) {
       throw new HttpError(422, 'VALIDATION', 'decoded tokenId does not match the claimed tokenId');
     }
     // §8.2 step 5 (ownership = self) is NOT modeled — the fake has no
     // predicate decoding. APPROXIMATION, noted.
     // §8.2 step 6: decode the value to populate the index (injected decoder
     // standing in for SpherePaymentData — see FakeWalletApiOptions).
-    const assets = this.decodeAssets(blob.token);
+    const assets = this.decodeAssets(resolved.inner);
     if (assets === null) throw new HttpError(422, 'VALIDATION', 'token value does not decode');
     // The per-state hash convention: hex(SHA-256(inner token bytes)).
-    return { tokenId: entry.tokenId, key: entry.key, stateHash: hex(sha256(blob.token)), assets };
+    return { tokenId: entry.tokenId, key: entry.key, stateHash: hex(sha256(resolved.inner)), assets };
   }
 
   /**
@@ -1202,27 +1249,26 @@ export class FakeWalletApi {
       throw new HttpError(422, 'VALIDATION', 'blob bytes do not match the content-addressed key');
     }
     // step 3 — APPROXIMATION: the real server runs the SDK's three-service
-    // token.verify against the pinned trustbase; this fake decodes the sphere
-    // TokenBlob envelope only.
-    let blob;
-    try {
-      blob = decodeTokenBlob(bytes);
-    } catch {
-      throw new HttpError(422, 'VALIDATION', 'blob is not a decodable TokenBlob');
-    }
+    // token.verify against the pinned trustbase over the RAW wire bytes
+    // (§5.2); this fake reads the tokenId via the injected decoder (envelope
+    // bytes from older seeds still unwrap).
+    const resolved = this.resolveBlob(bytes);
     // step 4 — decoded tokenId MUST match the claim, and (deposits claim one)
     // the decoded final state_hash MUST match the claimed stateHash.
-    if (blob.tokenId !== tokenId) {
+    if (resolved.tokenId === null) {
+      throw new HttpError(422, 'VALIDATION', 'blob does not decode to a token id');
+    }
+    if (resolved.tokenId !== tokenId) {
       throw new HttpError(422, 'VALIDATION', 'decoded tokenId does not match the claimed tokenId');
     }
-    if (hex(sha256(blob.token)) !== stateHash) {
+    if (hex(sha256(resolved.inner)) !== stateHash) {
       throw new HttpError(422, 'VALIDATION', 'decoded state hash does not match the claimed stateHash');
     }
     // step 5 — APPROXIMATION: recipient-ownership (predicate decode) is not
     // modeled; the fake cannot read predicates. The REAL backend rejects a
     // deposit whose current owner is not the addressed recipient.
     // step 6 — decode the value to populate the entry (injected decoder).
-    const assets = this.decodeAssets(blob.token);
+    const assets = this.decodeAssets(resolved.inner);
     if (assets === null) throw new HttpError(422, 'VALIDATION', 'token value does not decode');
     // step 7 (lineage) applies to inventory writes; the mailbox append itself
     // is replay-guarded by the content-derived entry_id above.
@@ -1484,8 +1530,29 @@ export class FakeWalletApi {
       if (typeof rec.dedupKey !== 'string' || rec.dedupKey === '') {
         throw new HttpError(422, 'VALIDATION', 'record.dedupKey is required');
       }
-      if (typeof rec.type !== 'string' || typeof rec.timestamp !== 'number') {
-        throw new HttpError(422, 'VALIDATION', 'record.type and record.timestamp are required');
+      // §16 strict record shape (mirrors the REAL backend's zod schema —
+      // caught drifting by the phase-2 harness): id uuid + ts ISO datetime,
+      // never `timestamp`; type is the §16 enum; hex-shaped tokenId/pubkey.
+      if (typeof rec.id !== 'string' || !UUID_RE.test(rec.id)) {
+        throw new HttpError(422, 'VALIDATION', 'record.id must be a uuid');
+      }
+      if (typeof rec.type !== 'string' || !['SENT', 'RECEIVED', 'MINT'].includes(rec.type)) {
+        throw new HttpError(422, 'VALIDATION', "record.type must be 'SENT' | 'RECEIVED' | 'MINT'");
+      }
+      if (typeof rec.ts !== 'string' || Number.isNaN(Date.parse(rec.ts))) {
+        throw new HttpError(422, 'VALIDATION', 'record.ts must be an ISO-8601 datetime');
+      }
+      if ('timestamp' in rec) {
+        throw new HttpError(422, 'VALIDATION', "Unrecognized key(s) in object: 'timestamp'");
+      }
+      if (rec.tokenId !== undefined && (typeof rec.tokenId !== 'string' || !/^(?:[0-9a-f]{2}){1,64}$/.test(rec.tokenId))) {
+        throw new HttpError(422, 'VALIDATION', 'record.tokenId must be a lowercase-hex token id');
+      }
+      if (
+        rec.counterpartyPubkey !== undefined &&
+        (typeof rec.counterpartyPubkey !== 'string' || !/^0[23][0-9a-f]{64}$/.test(rec.counterpartyPubkey))
+      ) {
+        throw new HttpError(422, 'VALIDATION', 'record.counterpartyPubkey must be a 33-byte compressed pubkey');
       }
       if (!Array.isArray(rec.assets)) throw new HttpError(422, 'VALIDATION', 'record.assets must be an array');
       for (const a of rec.assets as { coinId?: unknown; amount?: unknown }[]) {
@@ -1513,7 +1580,7 @@ export class FakeWalletApi {
     this.json(res, 200, {});
   }
 
-  /** §10/§16: newest-first, opaque keyset cursor over (timestamp, dedupKey). */
+  /** §10/§16: newest-first, opaque keyset cursor over (ts, dedupKey); the §16 page shape. */
   private handleHistoryGet(req: http.IncomingMessage, res: http.ServerResponse, url: URL): void {
     const session = this.authenticate(req);
     const owner = this.owner(session.pubkey);
@@ -1521,15 +1588,19 @@ export class FakeWalletApi {
     const limitRaw = url.searchParams.get('limit');
     const limit = limitRaw !== null ? Math.max(1, Math.min(Number(limitRaw), this.pageLimit)) : this.pageLimit;
 
-    const keyOf = (rec: Record<string, unknown>): string =>
-      `${String(rec.timestamp).padStart(16, '0')}:${rec.dedupKey as string}`;
+    const keyOf = (rec: Record<string, unknown>): string => `${rec.ts as string}:${rec.dedupKey as string}`;
     const sorted = [...owner.history.values()].sort((a, b) => (keyOf(a) < keyOf(b) ? 1 : -1));
     const filtered = before !== null ? sorted.filter((rec) => keyOf(rec) < before) : sorted;
     const page = filtered.slice(0, limit);
     const hasMore = filtered.length > page.length;
+    // §16 page shape (mirrors the real backend): records + more + cursor
+    // (string | null) + syncEpoch — `nextBefore` never existed on the wire
+    // (caught by the phase-2 harness).
     this.json(res, 200, {
       records: page,
-      ...(hasMore && page.length > 0 ? { nextBefore: keyOf(page[page.length - 1]) } : {}),
+      more: hasMore,
+      cursor: hasMore && page.length > 0 ? keyOf(page[page.length - 1]) : null,
+      syncEpoch: this.syncEpoch.toString(),
     });
   }
 

--- a/tests/support/wallet-api-test-helpers.ts
+++ b/tests/support/wallet-api-test-helpers.ts
@@ -40,8 +40,12 @@ export function makeTestToken(opts: { tokenId?: string; coinId?: string; amount?
     opts.tokenId ?? `${tokenCounter.toString(16).padStart(8, '0')}${'ab'.repeat(28)}`;
   const coinId = opts.coinId ?? 'c0'.repeat(32);
   const amount = opts.amount ?? 1000n;
+  // Self-describing inner bytes (tokenId included): the wallet-api WIRE
+  // carries the INNER bytes (§5.2/§8.2 — never the 39051 envelope), so the
+  // fake world's raw-bytes derivations need the id in-band, like the real
+  // SDK token carries its own id.
   const inner = new TextEncoder().encode(
-    JSON.stringify({ assets: [{ coinId, amount: amount.toString() }], salt: tokenCounter })
+    JSON.stringify({ tokenId, assets: [{ coinId, amount: amount.toString() }], salt: tokenCounter })
   );
   const blob: TokenBlob = { v: 1, network: 3, tokenId, token: inner };
   const bytes = encodeTokenBlob(blob);
@@ -103,7 +107,17 @@ export function testIdentity(n: number): { privateKey: string; chainPubkey: stri
  * the REAL SDK derivation is pinned by delivery-keys.test.ts + the harness.
  */
 export function fakeDeliveryKeys(blobBytes: Uint8Array): Promise<{ tokenId: string; stateHash: string }> {
-  const blob = decodeTokenBlob(blobBytes);
-  const hex = Array.from(sha256(blob.token), (b) => b.toString(16).padStart(2, '0')).join('');
-  return Promise.resolve({ tokenId: blob.tokenId, stateHash: hex });
+  // Tolerant like the real derivation (token-engine/blob-keys.ts): envelope
+  // bytes (the cross-port blob form) or raw wire bytes (§5.2/§8.2 — what the
+  // wallet-api serves) derive the identical pair for the same token.
+  try {
+    const blob = decodeTokenBlob(blobBytes);
+    const hex = Array.from(sha256(blob.token), (b) => b.toString(16).padStart(2, '0')).join('');
+    return Promise.resolve({ tokenId: blob.tokenId, stateHash: hex });
+  } catch {
+    const parsed = JSON.parse(new TextDecoder().decode(blobBytes)) as { tokenId?: unknown };
+    if (typeof parsed.tokenId !== 'string') throw new Error('fakeDeliveryKeys: bytes carry no tokenId');
+    const hex = Array.from(sha256(blobBytes), (b) => b.toString(16).padStart(2, '0')).join('');
+    return Promise.resolve({ tokenId: parsed.tokenId, stateHash: hex });
+  }
 }

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -21,7 +21,7 @@ import type { FullIdentity, IncomingPaymentRequest, PaymentRequestResponse } fro
 import type { TransportProvider } from '../../../transport';
 import type { OracleProvider } from '../../../oracle';
 import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../../storage';
-import { FakeTokenEngine, decodeFakeTokenAssets } from '../token-engine/FakeTokenEngine';
+import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
 import { WalletApiClient } from '../../../wallet-api';
@@ -131,7 +131,7 @@ afterEach(async () => {
 });
 
 async function startFake(): Promise<{ fake: FakeWalletApi; baseUrl: string }> {
-  const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets });
+  const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
   const baseUrl = await fake.start();
   cleanups.push(() => fake.stop());
   return { fake, baseUrl };
@@ -369,7 +369,7 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
   });
 
   it('the §5.5 per-payer cap surfaces as a failed result, never a throw (cap → 429 QUOTA_EXCEEDED)', async () => {
-    const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, maxPayerOpenRequests: 1 });
+    const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId, maxPayerOpenRequests: 1 });
     const baseUrl = await fake.start();
     cleanups.push(() => fake.stop());
     const requester = makeWalletApiWallet(baseUrl, fake.network, REQUESTER, 'pr-7');

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -23,7 +23,7 @@ import type { FullIdentity } from '../../../types';
 import type { TransportProvider } from '../../../transport';
 import type { OracleProvider } from '../../../oracle';
 import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../../storage';
-import { FakeTokenEngine, decodeFakeTokenAssets } from '../token-engine/FakeTokenEngine';
+import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
 import { WalletApiClient } from '../../../wallet-api';
@@ -130,7 +130,7 @@ afterEach(async () => {
 });
 
 async function startFake(): Promise<{ fake: FakeWalletApi; baseUrl: string }> {
-  const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets });
+  const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
   const baseUrl = await fake.start();
   cleanups.push(() => fake.stop());
   return { fake, baseUrl };

--- a/tests/unit/token-engine/FakeTokenEngine.ts
+++ b/tests/unit/token-engine/FakeTokenEngine.ts
@@ -202,12 +202,28 @@ export class FakeTokenEngine implements ITokenEngine {
    * in delivery-keys.test.ts and, end-to-end, by the cross-repo harness.
    */
   public deliveryKeys(blobBytes: Uint8Array): Promise<{ tokenId: string; stateHash: string }> {
-    const blob = decodeTokenBlob(blobBytes);
-    return Promise.resolve({ tokenId: blob.tokenId, stateHash: bytesToHexLocal(sha256(blob.token)) });
+    // Tolerant like the real derivation (blob-keys.ts): the cross-port blob
+    // is the sphere envelope, the wallet-api WIRE carries raw inner bytes
+    // (§5.2/§8.2). Both forms of the same token derive the identical pair.
+    try {
+      const blob = decodeTokenBlob(blobBytes);
+      return Promise.resolve({ tokenId: blob.tokenId, stateHash: bytesToHexLocal(sha256(blob.token)) });
+    } catch {
+      const state = decodeFakeState(blobBytes);
+      return Promise.resolve({
+        tokenId: HexConverter.encode(state.tokenId),
+        stateHash: bytesToHexLocal(sha256(blobBytes)),
+      });
+    }
   }
 
   public decodeToken(blob: TokenBlob): Promise<SphereToken> {
-    return Promise.resolve({ sdkToken: handleFor(blob.token), blob, value: valueOf(decodeFakeState(blob.token)) });
+    // Normalize like the real engine's wrapToken: tokenId/network come from
+    // the decoded token, never from the (possibly placeholder) envelope
+    // fields of a raw wire wrap.
+    const state = decodeFakeState(blob.token);
+    const normalized: TokenBlob = { ...blob, network: this.network, tokenId: HexConverter.encode(state.tokenId) };
+    return Promise.resolve({ sdkToken: handleFor(blob.token), blob: normalized, value: valueOf(state) });
   }
 
   // ── internals ──────────────────────────────────────────────────────────────
@@ -261,6 +277,19 @@ export function decodeFakeTokenAssets(
     if (!state.genesisData || !isSpherePaymentData(state.genesisData)) return null;
     const value = SpherePaymentData.fromCBOR(state.genesisData).toValue();
     return value.assets.map((a) => ({ coinId: a.coinId, amount: a.amount }));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Genesis-stable token id of fake inner-token bytes — the injectable
+ * `decodeTokenId` port for FakeWalletApi's §8.2 step-4 stand-in over RAW wire
+ * bytes (the wallet-api wire carries inner bytes, never the envelope).
+ */
+export function decodeFakeTokenId(tokenBytes: Uint8Array): string | null {
+  try {
+    return HexConverter.encode(decodeFakeState(tokenBytes).tokenId);
   } catch {
     return null;
   }

--- a/token-engine/blob-keys.ts
+++ b/token-engine/blob-keys.ts
@@ -13,7 +13,7 @@
  * rule, see ./sdk.ts).
  */
 import { HexConverter, Token } from './sdk';
-import { decodeTokenBlob } from './token-blob';
+import { unwrapTokenBlobBytes } from './token-blob';
 
 export interface DeliveryKeys {
   /** Genesis-stable 64-hex token id (TokenBlob.tokenId). */
@@ -22,10 +22,15 @@ export interface DeliveryKeys {
   readonly stateHash: string;
 }
 
-/** Derive the backend-true (tokenId, stateHash) for a finished token blob. */
+/**
+ * Derive the backend-true (tokenId, stateHash) for a finished token blob.
+ * Accepts BOTH byte forms — the sphere envelope (the cross-port blob format)
+ * and raw wallet-api wire bytes (what the §16 API serves — §5.2/§8.2). Both
+ * keys come from the DECODED token (never trusted from an envelope field), so
+ * the pair is identical for either form of the same token.
+ */
 export async function deriveDeliveryKeys(blobBytes: Uint8Array): Promise<DeliveryKeys> {
-  const blob = decodeTokenBlob(blobBytes);
-  const token = await Token.fromCBOR(blob.token);
+  const token = await Token.fromCBOR(unwrapTokenBlobBytes(blobBytes));
   const stateHash = HexConverter.encode((await token.latestTransaction.calculateStateHash()).imprint);
-  return { tokenId: blob.tokenId, stateHash };
+  return { tokenId: HexConverter.encode(token.id.bytes), stateHash };
 }

--- a/token-engine/token-blob.ts
+++ b/token-engine/token-blob.ts
@@ -48,3 +48,21 @@ export function decodeTokenBlob(bytes: Uint8Array): TokenBlob {
     token: CborDeserializer.decodeByteString(fields[3]),
   };
 }
+
+/**
+ * The wallet-api WIRE bytes for a blob (ARCHITECTURE §5.2/§8.2): the backend
+ * stores, content-addresses and validates the INNER `token` bytes (the v2
+ * `Token.toCBOR()` form — `Token.fromCBOR` at §8.2 step 3). The sphere-private
+ * 39051 envelope never crosses the §16 API. Tolerant on input: envelope bytes
+ * unwrap to their inner `token` bytes; anything else is already wire format
+ * and passes through. (The phase-2 harness caught the envelope leaking onto
+ * the wire — the real backend 422s it at §8.2 step 3 with "Invalid CBOR tag
+ * for Token: 39051"; only the test fake's matching wrongness had masked it.)
+ */
+export function unwrapTokenBlobBytes(bytes: Uint8Array): Uint8Array {
+  try {
+    return decodeTokenBlob(bytes).token;
+  } catch {
+    return bytes;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,9 @@
     "l1/**/*.ts",
     "registry/**/*.ts",
     "token-engine/**/*.ts",
-    "wallet-api/**/*.ts"
+    "wallet-api/**/*.ts",
+    "tests/harness/**/*.ts",
+    "vitest.harness.config.ts"
   ],
   "exclude": [
     "node_modules",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
-    exclude: ['tests/e2e/**', 'tests/relay/**', 'tests/integration/daemon-cli.test.ts'],
+    // tests/harness/** is the local-only phase-2 cross-repo harness (needs
+    // Docker + the sibling wallet-api checkout) — own config: vitest.harness.config.ts.
+    exclude: ['tests/e2e/**', 'tests/relay/**', 'tests/harness/**', 'tests/integration/daemon-cli.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'json'],

--- a/vitest.harness.config.ts
+++ b/vitest.harness.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Phase-2 cross-repo harness (tests/harness/ — development-workflow.md):
+ * two real SDK wallets against the REAL wallet-api backend over real HTTP.
+ *
+ * Local-only by design (needs Docker + the sibling wallet-api checkout —
+ * the global setup boots that repo's docker-compose.dev.yml and tears it
+ * down): excluded from the default `test:run` glob, run via
+ * `npm run test:harness`. One stack, sequential files; tests isolate by
+ * fresh per-test owner identities.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/harness/**/*.test.ts'],
+    globalSetup: ['tests/harness/global-setup.ts'],
+    fileParallelism: false,
+    testTimeout: 180_000,
+    hookTimeout: 180_000,
+  },
+});

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -27,6 +27,8 @@
  * backstop.
  */
 
+import { sha256 } from '@noble/hashes/sha2.js';
+
 import { signMessage } from '../core/crypto';
 import { WalletApiError } from './errors';
 import { verifyChallengeTemplate } from './challenge';
@@ -108,6 +110,13 @@ function assertSecureBaseUrl(baseUrl: string): URL {
     );
   }
   return url;
+}
+
+/** Platform-neutral bytes→base64 (browser btoa + Node ≥16 global btoa). */
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
 }
 
 function defaultWebSocketFactory(url: string): import('./types').WebSocketLike {
@@ -376,13 +385,23 @@ export class WalletApiClient {
    * Upload blob bytes to a signed PUT URL. A `412 Precondition Failed` means
    * the identical blob already exists (content addressing, `If-None-Match: *`
    * — §5.2) and is treated as success.
+   *
+   * The §5.2 presign binds `x-amz-checksum-sha256` and `if-none-match` (plus
+   * `content-length`) as SIGNED HEADERS — a real S3 endpoint rejects the
+   * SigV4 signature unless the uploader sends them verbatim. (Caught by the
+   * phase-2 harness on first contact with real MinIO — the in-process fake
+   * had only validated the body, not the signed headers.)
    */
   async uploadBlob(putUrl: string, bytes: Uint8Array): Promise<void> {
     let res: FetchResponseLike;
     try {
       res = await this.fetchFn(putUrl, {
         method: 'PUT',
-        headers: { 'content-type': 'application/octet-stream' },
+        headers: {
+          'content-type': 'application/octet-stream',
+          'x-amz-checksum-sha256': bytesToBase64(sha256(bytes)),
+          'if-none-match': '*',
+        },
         body: bytes,
       });
     } catch (err) {

--- a/wallet-api/codec.ts
+++ b/wallet-api/codec.ts
@@ -313,14 +313,11 @@ export function parsePaymentRequestsPage(
 
 function parseHistoryRecord(raw: unknown, what: string): HistoryWireRecord {
   const rec = asRecord(raw, what);
-  const timestamp = rec.timestamp;
-  if (typeof timestamp !== 'number' || !Number.isSafeInteger(timestamp) || timestamp < 0) {
-    throw protocolError(`${what}.timestamp is not a non-negative integer`);
-  }
   return {
     dedupKey: asString(rec.dedupKey, `${what}.dedupKey`),
+    id: asString(rec.id, `${what}.id`),
     type: asString(rec.type, `${what}.type`),
-    timestamp,
+    ts: asString(rec.ts, `${what}.ts`),
     assets: asArray(rec.assets, `${what}.assets`).map((a, i) => {
       const asset = asRecord(a, `${what}.assets[${i}]`);
       // Amounts stay decimal strings on this surface — display data (§10).
@@ -341,11 +338,17 @@ function parseHistoryRecord(raw: unknown, what: string): HistoryWireRecord {
 /** `GET /v1/history` → {@link HistoryPage} (§16). */
 export function parseHistoryPage(body: unknown): HistoryPage {
   const rec = asRecord(body, 'history response');
+  if (typeof rec.more !== 'boolean') throw protocolError('history response .more is not a boolean');
+  if (rec.cursor !== null && typeof rec.cursor !== 'string') {
+    throw protocolError('history response .cursor is not a string or null');
+  }
   return {
     records: asArray(rec.records, 'history response .records').map((raw, i) =>
       parseHistoryRecord(raw, `records[${i}]`)
     ),
-    ...(typeof rec.nextBefore === 'string' ? { nextBefore: rec.nextBefore } : {}),
+    more: rec.more,
+    cursor: rec.cursor,
+    syncEpoch: parseCounter(rec.syncEpoch, 'history response .syncEpoch'),
   };
 }
 

--- a/wallet-api/types.ts
+++ b/wallet-api/types.ts
@@ -201,12 +201,18 @@ export interface MailboxClaimResult {
 export interface HistoryWireRecord {
   /** Client dedup key — POST is idempotent by it. */
   dedupKey: string;
+  /** Client-generated record id (UUID — §16). */
+  id: string;
+  /** §16 enum: 'SENT' | 'RECEIVED' | 'MINT'. */
   type: string;
-  timestamp: number;
+  /** ISO-8601 timestamp with offset (§16 `ts`). */
+  ts: string;
   /** Decimal-string amounts (§11). */
   assets: { coinId: string; amount: string }[];
   transferId?: string;
+  /** Genesis-stable token id, lowercase hex (§16 — never a `v2_…` UI id). */
   tokenId?: string;
+  /** 33-byte compressed secp256k1 pubkey, lowercase hex (§16). */
   counterpartyPubkey?: string;
   /** S6 envelope. */
   memo?: string;
@@ -217,8 +223,10 @@ export interface HistoryWireRecord {
 /** `GET /v1/history` page (§16): newest-first, opaque keyset cursor. */
 export interface HistoryPage {
   records: HistoryWireRecord[];
-  /** Pass as `before` to fetch the next (older) page; absent when drained. */
-  nextBefore?: string;
+  more: boolean;
+  /** Pass as `before` for the next (older) page; null on the last page (§16). */
+  cursor: string | null;
+  syncEpoch: bigint;
 }
 
 // ── payment requests (§10/§16) ────────────────────────────────────────────────


### PR DESCRIPTION
Closes #507

## What

The phase-2 **systematic fake-drift detector** (../wallet-api/development-workflow.md): a
`tests/harness/` suite where TWO full S4 wallet compositions (real `WalletApiClient`, real engine
via `createSphereTokenEngine` over the stack's LOCAL mock aggregator — through the SDK's REAL
JSON-RPC wire client) drive the REAL wallet-api backend over real HTTP, replacing the in-process
fake for the end-to-end properties.

```sh
npm run test:harness                                       # boots ../wallet-api's compose stack, runs, tears down
WALLET_API_DIR=/path/to/wallet-api npm run test:harness    # non-sibling checkout
HARNESS_REUSE_STACK=1 npm run test:harness                 # inner loop against a running stack
```

**Local-only by design** (Docker + the sibling wallet-api checkout on PR
unicity-sphere/wallet-api#36): own vitest config + `test:harness` script, excluded from the default
`test:run` glob, still typechecked (`tests/harness` added to tsconfig include) and linted. The
global setup drives `docker compose up --build --wait` programmatically (readiness = healthchecks,
never sleeps), self-heals leaked stacks, and tears down with `down -v`.

## The suite

- **two-wallet-flow** — mint (open minting, LOCAL) lands in the server inventory via real §5.2
  presigned PUT + §5.3 apply (backend-§8.2-validated); send via intent → engine → mailbox deposit
  → apply → complete; recipient discovers via mailbox poll and §6-claims; **balances AND §10
  history converge on both sides through the real backend**; a value-conserving split send;
  payment-request **create→pay→respond('paid')** with the linking `transferId` (§16).
- **delivery-only** — own storage + wallet-api delivery (S7): ZERO server-side inventory writes
  for either party, asserted via the real inventory API; the send closes via `intents/complete`
  alone.
- **crash-resume (AC-E5)** — a **child-process** wallet runner (`node --import tsx`) is
  **SIGKILLed at a deterministic mid-send point**: its injected fetch hook prints
  `HARNESS_KILL_POINT` and hangs forever on the FIRST `POST /v1/inventory/apply` — by pipeline
  ordering that is provably after the awaited intent PUT (E.3), after the engine submitted
  (certified at the stack aggregator, which survives the child) and after the server-acked
  deposit, before the apply/complete tail. A FRESH process from the same seed resumes via
  `resumeOpenIntents`: the finished token is recovered and delivered **exactly once** (idempotent
  re-deposit on the same content-derived entry — §6), the intent closes, exactly one dedupKey'd
  SENT row, no funds lost — and E.2's first-write-wins duplicate submit is exercised over the
  real wire. All fencing is on stdout markers + server-observable state; zero sleeps.
- **fake-differential** — the drift guard itself: presigned blob URLs must be served by a REAL S3
  object store **off the API origin** (`x-amz-request-id`, byte round-trip). **Self-verifying**:
  the identical assertion runs against the in-process `FakeWalletApi` and MUST reject — if the
  suite is ever pointed at the fake, this file fails.

## Drift caught on first contact with the real backend (the point of the exercise)

All three were masked by the fake's matching wrongness (cf. the S3 stateHash incident); spec'd
first in `../wallet-api/sdk-changes.md` S2 **“Wire formats”** (PR unicity-sphere/wallet-api#36):

1. **§5.2 presigned PUT signed headers** — the presign binds `x-amz-checksum-sha256` +
   `if-none-match` (+ `content-length`) as SIGNED headers; `uploadBlob` never sent them, so real
   S3 rejected every upload's SigV4 signature. Client fixed; fake now requires the headers.
2. **Raw token CBOR on the wire** — the backend stores/validates RAW v2 `Token.toCBOR()` bytes
   (§8.2 step 3 `Token.fromCBOR`; envelopes 422 with "Invalid CBOR tag for Token: 39051"). The
   sphere `TokenBlob` envelope is a CLIENT format and now never crosses the §16 API: providers +
   `uploadOutputBlob` unwrap at the wire boundary (`unwrapTokenBlobBytes`), `getToken`/incoming
   re-wrap for the engine surface, `deriveDeliveryKeys` derives from the decoded token for either
   byte form, `handleV2Transfer` reads both. Fake world aligned (FakeTokenEngine normalizes on
   decode + tolerant keys; FakeWalletApi resolves raw bytes via injected `decodeTokenId`); the
   shared contract suites now pin inner-bytes round-trips.
3. **§16 history wire shape** — `id` (uuid) + `ts` (ISO-8601), `type` enum, genesis-stable hex
   `tokenId` (no `v2_` prefix), pubkey-shaped `counterpartyPubkey`; page =
   `{records, more, cursor, syncEpoch}` (no `nextBefore`). Module mapping, client types/codec and
   the fake's validation/reply corrected.

Also pinned for determinism: the REAL backend pushes §9 wakes over a live WS, so a wallet composed
before a deposit may claim it in the background — tests fence on converged state (or compose the
recipient after the deposit); the crash drill reads the wire through a pump-less raw client.

## Verification

- `npm run test:harness` fully green against a from-scratch stack (compose boot → 7 tests →
  teardown) and with `HARNESS_REUSE_STACK=1`.
- `npm run typecheck`, `npm run lint` (0 errors), `npm run build` green.
- Full `npm run test:run`: 3009 passed; the only failures are the pre-existing #487
  `deriveIpnsName` Node-26-local flakes (untouched area; CI on Node 20/22 is authoritative).
- No `.skip`/`.only`/TODO/FIXME; the contract-suite assertion updates strengthen (inner-bytes
  byte-exactness + tighter fake validation), never weaken.

Companion PR: unicity-sphere/wallet-api#36 (the compose stack + spec-first wire-format notes).
The harness needs that branch checked out in the sibling wallet-api repo until it merges.