### PR TITLE
S5 — live e2e on testnet2: two-wallet split flow + fresh-device crash resume (AC-E5); deliver() absorbs the §6 proof-variant conflict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,10 @@ This repo is part of the wallet-api program (process: `../wallet-api/development
   in the same PR, before code.
 - **Resume is status-agnostic** (sdk-changes E.2): never key engine resume off a submit status —
   submit, always `getInclusionProof`, match-verify (`OK` = mine, `TRANSACTION_HASH_MISMATCH` =
-  `TransferConflictError`). `STATE_ID_EXISTS` is transitional aggregator lag; tolerant parsing comes
-  via state-transition-sdk-js#125.
+  `TransferConflictError`). The `STATE_ID_EXISTS` aggregator lag is OVER (M7 live e2e observed
+  2026-06-12: the gateway answers `SUCCESS` for duplicate AND conflicting submits — the status
+  carries no conflict signal; see the dated OBSERVED note in `../wallet-api/sdk-changes.md` E.2);
+  tolerant parsing shipped via state-transition-sdk-js#125 and stays.
 - **Ports rule (S7 / covenant):** storage (`TokenStorageProvider`) and delivery (`DeliveryProvider`)
   are independent, swappable, contract-test-enforced ports; the Sphere frontend is a **view** — no
   provider-specific logic outside implementations; custody (`intoInventory`) is a composition-time

--- a/impl/shared/wallet-api/WalletApiMailboxProvider.ts
+++ b/impl/shared/wallet-api/WalletApiMailboxProvider.ts
@@ -191,14 +191,34 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
 
     // Deposit (idempotent by entry_id — §6). The memo is S6-encrypted BEFORE
     // it leaves the device (§8.3): the operator never sees plaintext.
-    const entryId = await this.client.depositMailbox({
-      recipientPubkey,
-      key: upload.key,
-      transferId: options.transferId,
-      stateHash: keys.stateHash,
-      tokenId: keys.tokenId,
-      ...(options.memo !== undefined ? { memo: encryptField(this.fieldKey, options.memo) } : {}),
-    });
+    let entryId: string;
+    try {
+      entryId = await this.client.depositMailbox({
+        recipientPubkey,
+        key: upload.key,
+        transferId: options.transferId,
+        stateHash: keys.stateHash,
+        tokenId: keys.tokenId,
+        ...(options.memo !== undefined ? { memo: encryptField(this.fieldKey, options.memo) } : {}),
+      });
+    } catch (err) {
+      // §6 CONFLICT = the backend already holds a record of EXACTLY this
+      // (tokenId, stateHash) with different bytes. Reachable honestly in one
+      // way: a resume re-derives the byte-identical TRANSACTION (E.1), but
+      // the aggregator RECOMPUTES inclusion proofs per request (st-sdk#126),
+      // so once the tree has advanced the rebuilt token blob's proof bytes —
+      // and its content-addressed key — differ from the originally-deposited
+      // blob's. The state itself is identical and bound to this recipient by
+      // its own predicate (§8.2), so the existing entry IS this delivery:
+      // succeed idempotently with the content-derived id (the port contract —
+      // deliver is idempotent per (token, state), S7). A foreign-spend
+      // conflict can never reach here: the engine's E.2 match-verify raises
+      // TransferConflictError before anything is delivered.
+      if (err instanceof WalletApiError && err.status === 409) {
+        return { deliveryId: keys.deliveryId };
+      }
+      throw err;
+    }
 
     // covenant §3.1-4: the id is CONTENT-DERIVED — computed client-side; a
     // backend returning anything else (e.g. a row id) is a protocol violation.

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:relay": "vitest run --config vitest.relay.config.ts",
     "test:harness": "vitest run --config vitest.harness.config.ts",
+    "test:e2e:live": "vitest run --config vitest.live.config.ts",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
     "cli": "echo 'The CLI has moved to @unicity-sphere/cli — install it with: npm install -g @unicity-sphere/cli' && exit 1"

--- a/tests/contract/wallet-api-mailbox-provider.contract.test.ts
+++ b/tests/contract/wallet-api-mailbox-provider.contract.test.ts
@@ -142,6 +142,30 @@ describe('WalletApiMailboxProvider — provider-specific semantics', () => {
       expect(replayed.find((d) => d.deliveryId === deliveryId)).toBeUndefined();
     });
 
+    it('deliver() absorbs a §6 key-variant CONFLICT as idempotent success (proof-bytes drift on resume)', async () => {
+      // The real aggregator RECOMPUTES inclusion proofs per request
+      // (st-sdk#126), so a resume's rebuilt blob for the SAME (tokenId,
+      // stateHash) can carry different proof bytes — a different
+      // content-addressed key — than the originally-deposited blob. The
+      // backend then answers 409 CONFLICT ("entry exists with a different
+      // key"), which the S7 deliver contract (idempotent per (token, state))
+      // absorbs as success: the existing entry IS this delivery. Found by the
+      // S5 live e2e crash drill (2026-06-12); the live-equivalent
+      // reproduction is the harness drill's tree-advance.
+      const blob = h.makeBlob();
+      const first = await h.sender.deliver(h.recipientPubkey, blob.bytes, { transferId: 'tf-h1b' });
+      // Simulate the stored entry having been deposited with byte-variant
+      // bytes: same entry_id, different content key.
+      h.fake.tamperMailboxEntryKey(h.recipientPubkey, first.deliveryId);
+
+      const again = await h.sender.deliver(h.recipientPubkey, blob.bytes, { transferId: 'tf-h1b' });
+      expect(again.deliveryId).toBe(first.deliveryId);
+
+      // No duplicate was created and the recipient still claims exactly once.
+      const incoming = await drain(h.recipientProvider);
+      expect(incoming.filter((d) => d.deliveryId === first.deliveryId)).toHaveLength(1);
+    });
+
     it('claims record intoInventory:false server-side (the §6 delivery-only disposition)', async () => {
       const blob = h.makeBlob();
       const { deliveryId } = await h.sender.deliver(h.recipientPubkey, blob.bytes, { transferId: 'tf-h2' });

--- a/tests/harness/crash-resume.test.ts
+++ b/tests/harness/crash-resume.test.ts
@@ -84,6 +84,26 @@ describe('SIGKILL mid-send → fresh-process resume (AC-E5)', () => {
 
     await sender.kill(); // SIGKILL — the apply/complete tail never happens
 
+    // ADVANCE THE AGGREGATOR TREE between kill and resume (live reality: other
+    // users' certifications always land in between). The aggregator recomputes
+    // inclusion proofs per request (st-sdk#126), so the resume's re-fetched
+    // proof — and the rebuilt token blob's content-addressed key — differ from
+    // the originally-deposited blob's. The re-deposit then 409s under §6, and
+    // the S7 deliver contract must absorb it as idempotent success (found by
+    // the S5 live e2e, 2026-06-12; without the absorption this drill fails
+    // exactly like the live one did).
+    const treeAdvancer = await createHarnessWallet({
+      stack,
+      identity: randomIdentity(),
+      deviceId: 'crash-tree-advance',
+      custody: 'inventory',
+    });
+    wallets.push(treeAdvancer);
+    await treeAdvancer.module.load();
+    expect((await treeAdvancer.module.mintFungibleToken(HARNESS_COIN, 1n)).success).toBe(true);
+    treeAdvancer.destroy();
+    wallets.pop();
+
     // Phase 2: a FRESH process from the same seed resumes open intents.
     const resumer = spawnRunner('resume', runnerEnv);
     const resultLine = await resumer.waitForLine(RESUME_RESULT_MARKER);

--- a/tests/harness/live/global-setup.ts
+++ b/tests/harness/live/global-setup.ts
@@ -1,0 +1,85 @@
+/**
+ * tests/harness/live/global-setup.ts — boots the wallet-api compose stack with
+ * the REAL testnet2 validation roots (docker-compose.dev.yml +
+ * docker-compose.live.yml override) once for the live S5 run, and probes the
+ * REAL gateway before any test spends the key.
+ *
+ * §18 triage rule (ARCHITECTURE): an unreachable testnet/gateway is an INFRA
+ * blocker — this setup fails loudly with a BLOCKER message; it never licenses
+ * code changes or test weakening. `HARNESS_REUSE_STACK=1` reuses a running
+ * stack (the fast inner loop); `WALLET_API_DIR` overrides the sibling path.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+
+import { walletApiDir } from '../support/stack';
+import { liveStackFromEnv } from './support/live-stack';
+
+const PROJECT = 'wallet-api-live';
+const FILES = ['-f', 'docker-compose.dev.yml', '-f', 'docker-compose.live.yml'];
+
+function compose(dir: string, args: string[]): void {
+  execFileSync('docker', ['compose', '-p', PROJECT, ...FILES, ...args], {
+    cwd: dir,
+    stdio: 'inherit',
+    timeout: 15 * 60 * 1000,
+  });
+}
+
+async function assertBackendAnswers(baseUrl: string): Promise<void> {
+  const url = `${baseUrl}/v1/health`;
+  const res = await fetch(url).catch((err: unknown) => {
+    throw new Error(`live stack not reachable at ${url}: ${String(err)}`);
+  });
+  if (!res.ok) throw new Error(`live stack unhealthy at ${url}: HTTP ${res.status}`);
+}
+
+/**
+ * Gateway reachability probe: an unauthenticated `get_inclusion_proof.v2` for
+ * a random (never-certified) stateId — answers 200 with a non-inclusion proof
+ * when the gateway is up. Spends nothing and needs no key.
+ */
+async function assertGatewayAnswers(aggregatorUrl: string): Promise<void> {
+  const body = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'get_inclusion_proof.v2',
+    params: { stateId: randomBytes(32).toString('hex') },
+  };
+  const res = await fetch(aggregatorUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }).catch((err: unknown) => {
+    throw new Error(
+      `§18 BLOCKER (infra): testnet2 gateway not reachable at ${aggregatorUrl}: ${String(err)} — ` +
+        'retry later; do NOT change code or weaken tests for this.'
+    );
+  });
+  if (!res.ok) {
+    throw new Error(
+      `§18 BLOCKER (infra): testnet2 gateway unhealthy at ${aggregatorUrl}: HTTP ${res.status} — ` +
+        'retry later; do NOT change code or weaken tests for this.'
+    );
+  }
+}
+
+export default async function setup(): Promise<() => Promise<void>> {
+  // Validates the key EXISTS (names only, never values) before a 2-minute
+  // compose build can waste the failure.
+  const stack = liveStackFromEnv();
+  await assertGatewayAnswers(stack.aggregatorUrl);
+
+  if (process.env.HARNESS_REUSE_STACK === '1') {
+    await assertBackendAnswers(stack.baseUrl);
+    return async () => {};
+  }
+  const dir = walletApiDir();
+  compose(dir, ['down', '-v', '--remove-orphans']); // self-heal a leaked stack
+  compose(dir, ['up', '--build', '--wait']); // returns when healthchecks pass (incl. real-roots pin fetch)
+  await assertBackendAnswers(stack.baseUrl);
+  return async () => {
+    compose(dir, ['down', '-v']);
+  };
+}

--- a/tests/harness/live/live-crash-resume.test.ts
+++ b/tests/harness/live/live-crash-resume.test.ts
@@ -1,0 +1,126 @@
+/**
+ * S5 live e2e — the SIGKILL crash drill on the REAL testnet2 aggregator
+ * (AC-E5: fresh-DEVICE resume; sdk-changes E.2/E.3 over the real gateway).
+ *
+ * Same deterministic drill as the phase-2 harness (tests/harness/
+ * crash-resume.test.ts), with every aggregator interaction REAL: the child
+ * wallet runner is SIGKILLed at the first `POST /v1/inventory/apply` — by the
+ * §7/E.3 pipeline ordering that is provably AFTER the intent was
+ * server-persisted, AFTER the transfer CERTIFIED on the real testnet2 chain,
+ * and AFTER the mailbox deposit was acked, but BEFORE the apply/complete tail.
+ * A fresh process from the SAME seed on a DIFFERENT deviceId (new device,
+ * empty local state — the AC-E5 posture) resumes via `resumeOpenIntents`:
+ * deterministic realization rebuilds the byte-identical transaction, the
+ * duplicate submit hits the real gateway (observed 2026-06-12, recorded in
+ * wallet-api sdk-changes E.2: first-write-wins `SUCCESS` — no
+ * STATE_ID_EXISTS), the proof is re-fetched, MATCH-VERIFIED and applied —
+ * no funds lost, delivered exactly once.
+ *
+ * Deliberately a WHOLE-TOKEN send: split full-rerun-after-certified-mints
+ * remains the #501 known gap (burn-certified resume only) — this drill does
+ * not touch that path and must not be extended to until #501 is decided.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { createHarnessWallet, createRawClient, type HarnessWallet } from '../support/harness-wallet';
+import { HARNESS_COIN, randomIdentity } from '../support/stack';
+import { KILL_POINT_MARKER, RESUME_RESULT_MARKER } from '../support/runner-protocol';
+import { spawnRunner } from '../support/spawn-runner';
+import { liveStackFromEnv } from './support/live-stack';
+import type { CoinBalance } from '../../../wallet-api';
+
+const stack = liveStackFromEnv();
+
+const wallets: HarnessWallet[] = [];
+afterEach(() => {
+  while (wallets.length) wallets.pop()?.destroy();
+});
+
+function totalOf(balances: CoinBalance[]): bigint {
+  return balances.find((b) => b.coinId === HARNESS_COIN)?.total ?? 0n;
+}
+
+describe('S5/AC-E5 — SIGKILL after REAL certification → fresh-device resume', () => {
+  it('recovers the certified transfer on a new device, delivers exactly once, loses nothing', async () => {
+    const aId = randomIdentity();
+    const bId = randomIdentity();
+
+    // Fund wallet A with a REAL testnet2 mint (full preset → server inventory).
+    const a = await createHarnessWallet({ stack, identity: aId, deviceId: 'live-crash-a-parent', custody: 'inventory' });
+    wallets.push(a);
+    await a.module.load();
+    expect((await a.module.mintFungibleToken(HARNESS_COIN, 1000n)).success).toBe(true);
+    expect(totalOf(await a.client.getBalances())).toBe(1000n);
+    a.destroy(); // no background pumps may touch A while the drill runs
+    wallets.pop();
+
+    // Pump-less raw clients for every wire assertion (deterministic reads).
+    const aClient = createRawClient(stack, aId, 'live-crash-a-raw');
+    const bClient = createRawClient(stack, bId, 'live-crash-b-raw');
+
+    const runnerEnv = {
+      HARNESS_PRIVKEY: aId.privateKey,
+      HARNESS_PUBKEY: aId.chainPubkey,
+      HARNESS_RECIPIENT: bId.chainPubkey,
+      HARNESS_AMOUNT: '1000', // whole token — the split-rerun path stays out (#501)
+    };
+
+    // Phase 1: the child certifies the transfer ON THE REAL CHAIN and reaches
+    // the deterministic kill point (the first inventory apply).
+    const sender = spawnRunner('send', runnerEnv);
+    await sender.waitForLine(KILL_POINT_MARKER, 240_000); // real certification budget
+    // Mid-send server facts, observed BEFORE the kill: open intent persisted
+    // (E.3), deposit landed (unclaimed), source still active (no apply ran).
+    const openIntents = await aClient.listIntents('open');
+    expect(openIntents).toHaveLength(1);
+    const transferId = openIntents[0].transferId;
+    const before = (await bClient.listMailbox()).entries.filter((e) => e.transferId === transferId);
+    expect(before).toHaveLength(1);
+    expect(before[0].status).toBe('unclaimed');
+    expect(totalOf(await aClient.getBalances())).toBe(1000n);
+
+    await sender.kill(); // SIGKILL — the apply/complete tail never happens
+
+    // Phase 2: a FRESH process, SAME seed, DIFFERENT deviceId (AC-E5's
+    // fresh-device posture) resumes open intents through the REAL gateway:
+    // byte-identical rebuild → duplicate submit (SUCCESS, first-write-wins) →
+    // proof re-fetch → match-verify OK → apply.
+    const resumer = spawnRunner('resume', runnerEnv);
+    const resultLine = await resumer.waitForLine(RESUME_RESULT_MARKER, 240_000);
+    await resumer.waitForExit();
+    const outcome = JSON.parse(resultLine.slice(RESUME_RESULT_MARKER.length + 1)) as {
+      resumed: string[];
+      conflicted: string[];
+      failed: string[];
+    };
+    expect(outcome).toEqual({ resumed: [transferId], conflicted: [], failed: [] });
+
+    // The intent closed; no duplicate delivery (the idempotent re-deposit
+    // landed on the same content-derived entry — §6).
+    expect(await aClient.listIntents('open')).toHaveLength(0);
+    const afterResume = (await bClient.listMailbox()).entries.filter((e) => e.transferId === transferId);
+    expect(afterResume).toHaveLength(1);
+    expect(afterResume[0].status).toBe('unclaimed');
+
+    // B claims exactly one delivery; its wallet verifies the REAL proof chain.
+    const b = await createHarnessWallet({ stack, identity: bId, deviceId: 'live-crash-b', custody: 'inventory' });
+    wallets.push(b);
+    await b.module.load();
+    const { transfers } = await b.module.receive();
+    expect(transfers).toHaveLength(1);
+    expect(transfers[0].tokens[0]).toMatchObject({ amount: '1000', status: 'confirmed' });
+
+    // No funds lost; both sides converge through the real backend.
+    expect(totalOf(await aClient.getBalances())).toBe(0n);
+    expect(totalOf(await bClient.getBalances())).toBe(1000n);
+
+    // Exactly ONE dedupKey'd SENT row under the original transferId (§10).
+    const history = await aClient.listHistory();
+    expect(history.records.filter((r) => r.dedupKey === `SENT_transfer_${transferId}`)).toHaveLength(1);
+
+    // Re-discovery is a no-op: the entry is resolved and seen.
+    const again = await b.module.receive();
+    expect(again.transfers).toHaveLength(0);
+  });
+});

--- a/tests/harness/live/live-flow.test.ts
+++ b/tests/harness/live/live-flow.test.ts
@@ -1,0 +1,105 @@
+/**
+ * S5 live e2e (sdk-changes S5) — two REAL SDK wallets send/receive **including
+ * a split** via wallet-api on testnet2: the phase-2 harness composition with
+ * the REAL aggregator gateway (API key from the wallet-api `.env`, never
+ * logged) and the backend booted with the REAL pinned testnet2 roots
+ * (docker-compose.live.yml). Every certification and inclusion proof in this
+ * file is real; every §8.2 validation runs under the real committee.
+ *
+ * LOCAL-ONLY (`npm run test:e2e:live`): needs Docker, the sibling wallet-api
+ * checkout and network egress; excluded from CI globs. §18 triage rule: infra
+ * failures block/retry — they never license code changes or test weakening.
+ *
+ * Determinism note (same as the mock harness): the live backend pushes §9
+ * wakes over WS, so a wallet composed BEFORE a deposit may claim it in the
+ * background. Recipients are created AFTER the send where receive() must BE
+ * the discovery; pre-existing wallets fence on CONVERGED state only.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { createHarnessWallet, type HarnessWallet } from '../support/harness-wallet';
+import { HARNESS_COIN, randomIdentity } from '../support/stack';
+import { liveStackFromEnv } from './support/live-stack';
+import type { CoinBalance } from '../../../wallet-api';
+
+const stack = liveStackFromEnv();
+
+const wallets: HarnessWallet[] = [];
+afterEach(() => {
+  while (wallets.length) wallets.pop()?.destroy();
+});
+
+async function newWallet(deviceId: string, identity = randomIdentity()): Promise<HarnessWallet> {
+  const wallet = await createHarnessWallet({ stack, identity, deviceId, custody: 'inventory' });
+  wallets.push(wallet);
+  await wallet.module.load();
+  return wallet;
+}
+
+function totalOf(balances: CoinBalance[], coinId = HARNESS_COIN): bigint {
+  return balances.find((b) => b.coinId === coinId)?.total ?? 0n;
+}
+
+describe('S5 — two wallets send/receive (incl. a split) over the REAL testnet2 aggregator', () => {
+  it('real mint → SPLIT send → claim → whole-token send back: both directions converge, value conserved', async () => {
+    const a = await newWallet('live-flow-a');
+    const bIdentity = randomIdentity();
+
+    // REAL open mint on testnet2 (small amount — testnet posture): the full
+    // preset pushes it into A's SERVER inventory (§5.2 upload + §5.3 apply,
+    // backend-validated under the REAL trustbase).
+    const mint = await a.module.mintFungibleToken(HARNESS_COIN, 1000n);
+    expect(mint.success).toBe(true);
+    expect(totalOf(await a.client.getBalances())).toBe(1000n);
+
+    // SPLIT send through the real gateway: burn + split-mints certified with
+    // real inclusion proofs; 300 to B, 700 change back to A (E.1 deterministic
+    // realization; intent persisted server-side per E.3 before the engine ran).
+    const sent = await a.module.send({
+      recipient: bIdentity.chainPubkey,
+      amount: '300',
+      coinId: HARNESS_COIN,
+      memo: 'live s5 split',
+    });
+    expect(sent.status).toBe('completed');
+
+    // Server truth: A keeps exactly the 700 change as ONE active row; the
+    // backend accepted the split-mint change blob under the real committee.
+    expect(await a.client.getBalances()).toEqual([{ coinId: HARNESS_COIN, total: 700n, tokenCount: 1 }]);
+    const change = a.module.getTokens().find((t) => t.amount === '700');
+    expect(change?.status).toBe('confirmed');
+
+    // B comes online AFTER the deposit (this poll IS the discovery), verifies
+    // the real proof chain locally (engine.verify under the real trustbase)
+    // and claims into inventory (§6 handoff).
+    const b = await newWallet('live-flow-b', bIdentity);
+    const { transfers } = await b.module.receive();
+    expect(transfers).toHaveLength(1);
+    expect(transfers[0].tokens[0]).toMatchObject({ amount: '300', coinId: HARNESS_COIN, status: 'confirmed' });
+    expect(totalOf(await b.client.getBalances())).toBe(300n);
+
+    // Reverse direction: B sends the 300 back WHOLE-TOKEN (no split). A
+    // existed before the deposit, so fence on CONVERGED state after receive().
+    const back = await b.module.send({ recipient: a.identity.chainPubkey, amount: '300', coinId: HARNESS_COIN });
+    expect(back.status).toBe('completed');
+    await a.module.receive();
+    expect(totalOf(await a.client.getBalances())).toBe(1000n);
+    expect(totalOf(await b.client.getBalances())).toBe(0n);
+
+    // Value conserved across the whole system after two real sends.
+    expect(totalOf(await a.client.getBalances()) + totalOf(await b.client.getBalances())).toBe(1000n);
+
+    // §10 history rows landed server-side for both directions, dedupKey'd.
+    const aHistory = await a.client.listHistory();
+    expect(aHistory.records.filter((r) => r.dedupKey === `SENT_transfer_${sent.id}`)).toHaveLength(1);
+    expect(aHistory.records.some((r) => r.dedupKey.startsWith('RECEIVED_'))).toBe(true);
+    const bHistory = await b.client.listHistory();
+    expect(bHistory.records.filter((r) => r.dedupKey === `SENT_transfer_${back.id}`)).toHaveLength(1);
+    expect(bHistory.records.some((r) => r.dedupKey.startsWith('RECEIVED_'))).toBe(true);
+
+    // Both sends closed their intents (E.3 uniform close) — nothing re-resumes.
+    expect(await a.client.listIntents('open')).toHaveLength(0);
+    expect(await b.client.listIntents('open')).toHaveLength(0);
+  });
+});

--- a/tests/harness/live/support/live-stack.ts
+++ b/tests/harness/live/support/live-stack.ts
@@ -1,0 +1,57 @@
+/**
+ * tests/harness/live/support/live-stack.ts — the S5 LIVE stack contract.
+ *
+ * Same backend surface as the phase-2 harness (the wallet-api compose stack on
+ * loopback), but the aggregator is the REAL testnet2 gateway and the trustbase
+ * is the REAL pinned testnet2 root (the backend boots with the same pins via
+ * wallet-api's docker-compose.live.yml override — see that repo's
+ * development-workflow.md).
+ *
+ * The gateway API key lives in the wallet-api checkout's gitignored `.env`
+ * (`AGGREGATOR_KEY`). It is read here at runtime, handed to engines/child
+ * runners via process env, and NEVER logged, committed, or echoed — error
+ * messages name missing KEYS only, never values.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseEnv } from 'node:util';
+
+import { stackFromEnv, walletApiDir, type HarnessStack } from '../../support/stack';
+
+const DEFAULT_AGGREGATOR_URL = 'https://gateway.testnet2.unicity.network';
+const DEFAULT_TRUSTBASE_URL =
+  'https://raw.githubusercontent.com/unicitynetwork/unicity-ids/refs/heads/main/bft-trustbase.testnet2.json';
+
+/** Node's own dotenv parser (handles inline comments/quoting exactly like --env-file). */
+function parseEnvFile(path: string): Record<string, string> {
+  return parseEnv(readFileSync(path, 'utf8')) as Record<string, string>;
+}
+
+/**
+ * Resolve the live stack, exporting HARNESS_LIVE_* into this process's env so
+ * spawned child runners (the crash drill) rebuild the same stack through the
+ * standard `stackFromEnv()`. Idempotent — safe to call from every suite file
+ * and from the global setup.
+ */
+export function liveStackFromEnv(): HarnessStack {
+  if (!process.env.HARNESS_LIVE_AGGREGATOR_URL) {
+    const envPath = resolve(walletApiDir(), '.env');
+    let vars: Record<string, string>;
+    try {
+      vars = parseEnvFile(envPath);
+    } catch {
+      throw new Error(
+        `live e2e needs the wallet-api .env at ${envPath} (it carries AGGREGATOR_KEY — ` +
+          'see wallet-api/development-workflow.md). This suite is LOCAL-ONLY.'
+      );
+    }
+    if (!vars.AGGREGATOR_KEY) {
+      throw new Error(`live e2e: AGGREGATOR_KEY is missing from ${envPath} — populate it (value never logged).`);
+    }
+    process.env.HARNESS_LIVE_AGGREGATOR_URL = vars.AGGREGATOR_URL || DEFAULT_AGGREGATOR_URL;
+    process.env.HARNESS_LIVE_TRUSTBASE_URL = vars.TRUSTBASE_URL || DEFAULT_TRUSTBASE_URL;
+    process.env.HARNESS_LIVE_AGGREGATOR_KEY = vars.AGGREGATOR_KEY;
+  }
+  return stackFromEnv();
+}

--- a/tests/harness/support/harness-wallet.ts
+++ b/tests/harness/support/harness-wallet.ts
@@ -213,13 +213,15 @@ export interface HarnessWallet {
 
 export async function createHarnessWallet(opts: HarnessWalletOptions): Promise<HarnessWallet> {
   const identity = fullIdentity(opts.identity);
-  const trustBaseJson = await fetchTrustbaseJson(opts.stack.aggregatorUrl);
+  const trustBaseJson = await fetchTrustbaseJson(opts.stack);
   // The REAL engine over the stack's aggregator via the SDK's real wire client;
-  // networkId comes from the trustbase (LOCAL = 3).
+  // networkId comes from the trustbase (LOCAL = 3; live testnet2 = 4). In live
+  // mode the gateway API key rides along (held by the engine, never logged).
   const engine = await createSphereTokenEngine({
     aggregatorUrl: opts.stack.aggregatorUrl,
     trustBaseJson,
     privateKey: hexToBytes(opts.identity.privateKey),
+    ...(opts.stack.aggregatorApiKey ? { apiKey: opts.stack.aggregatorApiKey } : {}),
   });
 
   const storage = memoryStorage();

--- a/tests/harness/support/stack.ts
+++ b/tests/harness/support/stack.ts
@@ -22,20 +22,46 @@ import { getPublicKey } from '../../../core/crypto';
 export interface HarnessStack {
   /** wallet-api base URL (loopback http — allowed by the §4 client rule). */
   readonly baseUrl: string;
-  /** Mock-aggregator JSON-RPC base URL (also serves /trustbase.json). */
+  /** Aggregator JSON-RPC base URL (the stack's mock, or the REAL gateway in live mode). */
   readonly aggregatorUrl: string;
   /** Must match the backend's NETWORK env (auth challenges embed it — §4). */
   readonly network: string;
+  /** Gateway API key (live mode only — testnet2 requires it for submits). NEVER logged. */
+  readonly aggregatorApiKey?: string;
+  /**
+   * Where the trustbase JSON lives. The mock aggregator serves its own at
+   * /trustbase.json; the live suite points at the REAL pinned testnet2 root
+   * (the same URL the backend's §8.2 boot pin uses).
+   */
+  readonly trustbaseUrl?: string;
 }
 
+/**
+ * Live-mode handoff to child processes: the crash-drill runner is a separate
+ * OS process that rebuilds its stack via `stackFromEnv()`, so the live suite
+ * exports its configuration through HARNESS_LIVE_* env vars (set by
+ * tests/harness/live/support/live-stack.ts; inherited via spawn env).
+ */
 export function stackFromEnv(): HarnessStack {
   const apiPort = process.env.WALLET_API_PORT ?? '3000';
   const aggPort = process.env.AGGREGATOR_PORT ?? '3001';
-  return {
+  const base = {
     baseUrl: `http://127.0.0.1:${apiPort}`,
-    aggregatorUrl: `http://127.0.0.1:${aggPort}`,
     network: 'testnet2', // docker-compose.dev.yml NETWORK; fixture tokens stay on NetworkId.LOCAL
   };
+  const liveAggregatorUrl = process.env.HARNESS_LIVE_AGGREGATOR_URL;
+  const liveTrustbaseUrl = process.env.HARNESS_LIVE_TRUSTBASE_URL;
+  if (liveAggregatorUrl && liveTrustbaseUrl) {
+    return {
+      ...base,
+      aggregatorUrl: liveAggregatorUrl,
+      trustbaseUrl: liveTrustbaseUrl,
+      ...(process.env.HARNESS_LIVE_AGGREGATOR_KEY
+        ? { aggregatorApiKey: process.env.HARNESS_LIVE_AGGREGATOR_KEY }
+        : {}),
+    };
+  }
+  return { ...base, aggregatorUrl: `http://127.0.0.1:${aggPort}` };
 }
 
 /** The wallet-api checkout that carries docker-compose.dev.yml. */
@@ -51,10 +77,11 @@ export function walletApiDir(): string {
   return dir;
 }
 
-/** The shared LOCAL trustbase, fetched from the stack's mock aggregator. */
-export async function fetchTrustbaseJson(aggregatorUrl: string): Promise<unknown> {
-  const res = await fetch(`${aggregatorUrl}/trustbase.json`);
-  if (!res.ok) throw new Error(`trustbase fetch failed: HTTP ${res.status}`);
+/** The stack's trustbase: the mock's own LOCAL root, or the REAL pinned one in live mode. */
+export async function fetchTrustbaseJson(stack: HarnessStack): Promise<unknown> {
+  const url = stack.trustbaseUrl ?? `${stack.aggregatorUrl}/trustbase.json`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`trustbase fetch failed: HTTP ${res.status} (${url})`);
   return res.json();
 }
 

--- a/tests/support/fake-wallet-api.ts
+++ b/tests/support/fake-wallet-api.ts
@@ -456,6 +456,20 @@ export class FakeWalletApi {
     }
   }
 
+  /**
+   * Test hook for the §6 dedup-mismatch path: rewrite a stored entry's s3 key,
+   * simulating an original deposit whose BYTES differed from what a later
+   * re-deliver of the same (tokenId, stateHash) carries. The real-world cause
+   * is proof-bytes instability across fetches (st-sdk#126: the aggregator
+   * recomputes inclusion proofs, so a resume's rebuilt blob keys differently)
+   * — the server then answers 409 CONFLICT, which the S7 deliver contract
+   * absorbs as idempotent success (found by the S5 live e2e, 2026-06-12).
+   */
+  tamperMailboxEntryKey(recipientPubkey: string, entryId: string): void {
+    const entry = this.owner(recipientPubkey).mailbox.get(entryId);
+    if (entry) entry.s3Key = `${entry.s3Key}-proof-variant`;
+  }
+
   /** Server-side history inspection for tests (§10). */
   getHistoryRecords(pubkey: string): Record<string, unknown>[] {
     return [...this.owner(pubkey).history.values()];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,8 @@
     "token-engine/**/*.ts",
     "wallet-api/**/*.ts",
     "tests/harness/**/*.ts",
-    "vitest.harness.config.ts"
+    "vitest.harness.config.ts",
+    "vitest.live.config.ts"
   ],
   "exclude": [
     "node_modules",

--- a/vitest.harness.config.ts
+++ b/vitest.harness.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/harness/**/*.test.ts'],
+    // tests/harness/live/** is the S5 LIVE suite (real testnet2 gateway +
+    // AGGREGATOR_KEY) — own config: vitest.live.config.ts (`test:e2e:live`).
+    exclude: ['tests/harness/live/**'],
     globalSetup: ['tests/harness/global-setup.ts'],
     fileParallelism: false,
     testTimeout: 180_000,

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * S5 live e2e (tests/harness/live/ — sdk-changes S5): the phase-2 harness
+ * wallets against the REAL testnet2 aggregator gateway, with the wallet-api
+ * stack booted under the REAL pinned testnet2 roots (docker-compose.live.yml).
+ *
+ * LOCAL-ONLY by design (needs Docker, the sibling wallet-api checkout — whose
+ * gitignored `.env` carries AGGREGATOR_KEY — and network egress): excluded
+ * from `test:run` AND from `test:harness`; run via `npm run test:e2e:live`.
+ * ARCHITECTURE §18 triage rule applies: infra failures block/retry, never
+ * license code changes or test weakening.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/harness/live/**/*.test.ts'],
+    globalSetup: ['tests/harness/live/global-setup.ts'],
+    fileParallelism: false,
+    testTimeout: 300_000, // real certifications (~5 s/proof) + §18 headroom
+    hookTimeout: 600_000, // compose build + real-roots boot
+  },
+});


### PR DESCRIPTION
Closes #509

## What

The S5 integration target (sdk-changes S5): the phase-2 harness flows against the **REAL testnet2 aggregator gateway**, with the wallet-api backend booted under the **REAL pinned testnet2 roots** (`docker-compose.live.yml`, wallet-api PR unicity-sphere/wallet-api#38).

- `tests/harness/live/` + **`npm run test:e2e:live`** — LOCAL-ONLY (needs Docker, the sibling wallet-api checkout whose gitignored `.env` carries `AGGREGATOR_KEY`, and egress; excluded from `test:run` AND `test:harness` globs; typechecked/linted as usual). §18 triage encoded in the global setup: an unreachable gateway is a named BLOCKER, never a code change.
- **live-flow** — A real-mints 1000 → **SPLIT send** 300 to B (burn + split-mints certified with real inclusion proofs; 700 change conserved as one active row) → B claims (engine.verify under the real trustbase) → B sends 300 back whole-token → both directions converge: balances, §10 history (dedupKey'd both sides), intents all closed.
- **live-crash-resume** — the SIGKILL drill (AC-E5) with every aggregator interaction real: child killed AFTER the transfer **certified on the real chain** (and after intent-persist + deposit), fresh process from the same seed on a **different deviceId** resumes via `resumeOpenIntents` → byte-identical rebuild → duplicate submit (gateway answers `SUCCESS`, first-write-wins — recorded in wallet-api sdk-changes E.2) → proof re-fetch → match-verify → delivered exactly once, no funds lost.
- Harness plumbing: `HarnessStack` gains optional `aggregatorApiKey`/`trustbaseUrl`; `stackFromEnv()` honors `HARNESS_LIVE_*` (how the child-process runner inherits the live config); key parsing uses Node's own `util.parseEnv` and never logs values.

## The find: proof-bytes drift breaks naive re-delivery (fixed)

The live drill failed on first run — the first real hermetic-vs-live divergence of the program:

- the aggregator **recomputes inclusion proofs per request** (st-sdk#126; only `CertificationData` is stable). A resume re-derives the byte-identical *transaction* (E.1/AC-E1), but once the tree has advanced (live: other users' certifications always land in between) the rebuilt token **blob**'s proof bytes — and its content-addressed key — differ from the originally-deposited blob's;
- the §6 re-deposit then answers `409 CONFLICT` (same `entry_id`, different key). The **server is correct** (write-once per entry); the resume previously surfaced it as failure and the intent stayed open forever.

Fix (spec-first in wallet-api `sdk-changes.md` S7/E.3, same wallet-api PR): `deliver()` is *idempotent per (token, state)* **including byte variants** — `WalletApiMailboxProvider.deliver` absorbs the §6 key-variant CONFLICT as idempotent success (the entry id proves the backend holds exactly this state; the state's predicate binds it to the recipient; E.2 match-verify excludes foreign-spend conflicts upstream of delivery).

Reproduced hermetically, twice:
1. contract case (`tamperMailboxEntryKey` on the fake backend) — pins the provider behavior;
2. the mock-harness crash drill now **advances the aggregator tree between kill and resume** — verified to fail without the fix exactly like the live run did (the mock itself needed no change: it already recomputes proofs faithfully).

**#501 note:** split full-rerun-after-certified-mints remains the known gap — the crash drill is deliberately whole-token and does not touch that path (commented in the test).

## Runs (local, 2026-06-12)

| suite | result |
|---|---|
| `npm run test:e2e:live` (REAL gateway) | **2/2** — split flow 16.3 s, crash drill 9.4 s |
| `npm run test:harness` (mock stack, incl. the new tree-advance drill) | 7/7 |
| `npm run test:run` | 3010 passed; only the 3 known #487 ipns-network Node-26-local flakes fail (CI on 20/22 is authoritative) |
| typecheck / lint / build | clean (0 lint errors) |

First live run observations: zero infra retries; real certifications ~2–5 s/proof; duplicate submit `SUCCESS` (no `STATE_ID_EXISTS` — the removal landed; see the dated OBSERVED note in wallet-api sdk-changes E.2).

Note: the live suite ran against the wallet-api checkout on its `feat/m7-live-e2e` branch (PR #38), which carries `docker-compose.live.yml`.