### PR TITLE
Export ./impl/shared/wallet-api subpath with dts (frontend gate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,16 @@
         "default": "./dist/impl/nodejs/index.cjs"
       }
     },
+    "./impl/shared/wallet-api": {
+      "import": {
+        "types": "./dist/impl/shared/wallet-api/index.d.ts",
+        "default": "./dist/impl/shared/wallet-api/index.js"
+      },
+      "require": {
+        "types": "./dist/impl/shared/wallet-api/index.d.cts",
+        "default": "./dist/impl/shared/wallet-api/index.cjs"
+      }
+    },
     "./core": {
       "import": {
         "types": "./dist/core/index.d.ts",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -119,6 +119,23 @@ export default defineConfig([
       /^@unicitylabs\//,
     ],
   },
+  // Shared wallet-api providers (S4 composition presets) — platform-neutral,
+  // consumed by the Sphere frontend; ships dts (unlike impl/browser, whose
+  // missing types forced a consumer-side shim — sphere-sdk#511).
+  {
+    entry: { 'impl/shared/wallet-api/index': 'impl/shared/wallet-api/index.ts' },
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: false,
+    splitting: false,
+    sourcemap: true,
+    platform: 'browser',
+    target: 'es2022',
+    noExternal: [/^@noble\//],
+    external: [
+      /^@unicitylabs\//,
+    ],
+  },
   // Browser IPFS implementation (requires helia)
   // Separate entry point so users can opt-in to IPFS functionality
   {


### PR DESCRIPTION
Closes #511

New tsup entry (`dts: true`, platform browser, same external/noExternal posture as `./impl/browser`) + exports-map entry mirroring `./impl/nodejs` (types for both import and require). `npm pack --dry-run` shows all six `dist/impl/shared/wallet-api/index.*` artifacts; the publish workflow's manifest gate will enforce them at release. Unblocks the Sphere frontend provider swap (phase 3) — it imports `createWalletApiProviders` from this subpath instead of carrying a d.ts shim.