### PR TITLE
Part B Phase 0+1: vault-aead crypto module + NetworkConfig

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -3,6 +3,8 @@
  * Default configuration values and storage keys
  */
 
+import { getPublicKey } from './core/crypto';
+
 // =============================================================================
 // Storage Keys
 // =============================================================================
@@ -398,7 +400,24 @@ export interface NetworkConfig {
   readonly electrumUrl: string;
   readonly groupRelays: readonly string[];
   readonly tokenRegistryUrl: string;
+  /** Base URL of the Token-Vault v2 deployment for this network. */
+  readonly vaultUrl: string;
+  /**
+   * Compressed secp256k1 pubkey (66-hex) of the vault deployment's signing key
+   * (`SERVER_SIGN_PRIV`). The SDK verifies the server's signed epoch (§5.4/§8.2)
+   * against this key. Must equal the public key the deployment publishes.
+   */
+  readonly vaultServerKey: string;
 }
+
+/**
+ * testnet2 vault server signing key — the compressed pubkey of the shared
+ * deployment fixture `SERVER_SIGN_PRIV = 'a'.repeat(64)`. Part A pins the SAME
+ * private key (its `auth-signing` test signs epochs with it), so the SDK can
+ * verify the server's `epochSig` byte-for-byte. Computed (not hand-written) so
+ * it can never drift from the fixture.
+ */
+const TESTNET2_VAULT_SERVER_KEY = getPublicKey('a'.repeat(64), true);
 
 /** Network configurations */
 export const NETWORKS = {
@@ -410,6 +429,10 @@ export const NETWORKS = {
     electrumUrl: DEFAULT_ELECTRUM_URL,
     groupRelays: DEFAULT_GROUP_RELAYS,
     tokenRegistryUrl: TOKEN_REGISTRY_URL,
+    vaultUrl: 'https://vault.unicity.network',
+    // Placeholder server key until the mainnet vault deployment is provisioned
+    // (compressed pubkey of priv 0x01..01); replace with the real published key.
+    vaultServerKey: '031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f',
   },
   // v1 cutover: 'testnet' now POINTS AT TESTNET2 (the v2 gateway network). The
   // old goggregator testnet spoke the removed v1 protocol — a v2 engine cannot
@@ -424,6 +447,9 @@ export const NETWORKS = {
     groupRelays: DEFAULT_GROUP_RELAYS,
     tokenRegistryUrl:
       'https://raw.githubusercontent.com/unicitynetwork/unicity-ids/refs/heads/main/unicity-ids.testnet2.json',
+    // 'testnet' is an alias of testnet2 — share the same vault deployment + key.
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    vaultServerKey: TESTNET2_VAULT_SERVER_KEY,
   },
   testnet2: {
     name: 'Testnet2',
@@ -435,6 +461,8 @@ export const NETWORKS = {
     groupRelays: DEFAULT_GROUP_RELAYS,
     tokenRegistryUrl:
       'https://raw.githubusercontent.com/unicitynetwork/unicity-ids/refs/heads/main/unicity-ids.testnet2.json',
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    vaultServerKey: TESTNET2_VAULT_SERVER_KEY,
   },
   // NOTE: mainnet/dev still point at v1-era aggregators. The v2 engine cannot
   // operate against them until their gateways are cut over to the v2 protocol —
@@ -447,6 +475,9 @@ export const NETWORKS = {
     electrumUrl: TEST_ELECTRUM_URL,
     groupRelays: DEFAULT_GROUP_RELAYS,
     tokenRegistryUrl: TOKEN_REGISTRY_URL,
+    vaultUrl: 'http://localhost:3000',
+    // Placeholder server key for local dev (compressed pubkey of priv 0x02..02).
+    vaultServerKey: '024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766',
   },
 } as const satisfies Record<string, NetworkConfig>;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9.0-dev.0",
       "license": "MIT",
       "dependencies": {
+        "@noble/ciphers": "2.2.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@unicitylabs/nostr-js-sdk": "^0.5.0",
@@ -1132,10 +1133,12 @@
       }
     },
     "node_modules/@noble/ciphers": {
-      "version": "1.3.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
       "license": "MIT",
       "engines": {
-        "node": "^14.21.3 || >=16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2001,6 +2004,18 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "url": "https://github.com/unicity-sphere/sphere-sdk.git"
   },
   "dependencies": {
+    "@noble/ciphers": "2.2.0",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@unicitylabs/nostr-js-sdk": "^0.5.0",

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -1,0 +1,109 @@
+/**
+ * RemoteTokenStorageProvider — the Token-Vault v2 remote box.
+ *
+ * Implements the FROZEN `TokenStorageProvider` contract verbatim. All CAS /
+ * cursor / signed-root / rejected state is internal (finding #29). The real
+ * bodies land in Phases 6–7; this is the typed skeleton from Task 0.1.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import type { FullIdentity } from '../../types';
+import type {
+  HistoryRecord,
+  LoadResult,
+  SaveResult,
+  StorageEventCallback,
+  SyncResult,
+  TokenStorageProvider,
+  TxfStorageDataBase,
+} from '../storage-provider';
+
+export interface RemoteTokenStorageConfig {
+  /** Vault base URL — `NETWORKS[network].vaultUrl`. */
+  vaultUrl: string;
+  /** Canonical network name (storage scope). */
+  network: string;
+}
+
+export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfStorageDataBase>
+  implements TokenStorageProvider<TData>
+{
+  readonly id = 'remote-token-storage';
+  readonly name = 'Remote Token Storage (Vault v2)';
+  readonly type = 'cloud' as const;
+
+  constructor(_config: RemoteTokenStorageConfig) {
+    // Phase 6
+  }
+
+  // --- BaseProvider ---
+
+  connect(_config?: unknown): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  disconnect(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  isConnected(): boolean {
+    throw new Error('not implemented');
+  }
+
+  getStatus(): 'disconnected' | 'connecting' | 'connected' | 'error' {
+    throw new Error('not implemented');
+  }
+
+  // --- TokenStorageProvider ---
+
+  setIdentity(_identity: FullIdentity): void {
+    throw new Error('not implemented');
+  }
+
+  initialize(): Promise<boolean> {
+    throw new Error('not implemented');
+  }
+
+  shutdown(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  save(_data: TData): Promise<SaveResult> {
+    throw new Error('not implemented');
+  }
+
+  load(_identifier?: string): Promise<LoadResult<TData>> {
+    throw new Error('not implemented');
+  }
+
+  sync(_localData: TData): Promise<SyncResult<TData>> {
+    throw new Error('not implemented');
+  }
+
+  onEvent(_callback: StorageEventCallback): () => void {
+    throw new Error('not implemented');
+  }
+
+  // --- History ops ---
+
+  addHistoryEntry(_entry: HistoryRecord): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  getHistoryEntries(): Promise<HistoryRecord[]> {
+    throw new Error('not implemented');
+  }
+
+  hasHistoryEntry(_dedupKey: string): Promise<boolean> {
+    throw new Error('not implemented');
+  }
+
+  clearHistory(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  importHistoryEntries(_entries: HistoryRecord[]): Promise<number> {
+    throw new Error('not implemented');
+  }
+}

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -6,8 +6,6 @@
  * bodies land in Phases 6–7; this is the typed skeleton from Task 0.1.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import type { FullIdentity } from '../../types';
 import type {
   HistoryRecord,

--- a/tests/unit/vault/network-config.test.ts
+++ b/tests/unit/vault/network-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+
+import { NETWORKS } from '../../../constants';
+import { getPublicKey } from '../../../core/crypto';
+
+describe('NetworkConfig vaultUrl + vaultServerKey', () => {
+  it('pins the production vault URLs', () => {
+    expect(NETWORKS.testnet2.vaultUrl).toBe('https://vault.testnet.unicity.network');
+    expect(NETWORKS.mainnet.vaultUrl).toBe('https://vault.unicity.network');
+  });
+
+  it('every network has a vaultUrl', () => {
+    for (const net of Object.values(NETWORKS)) {
+      expect(typeof net.vaultUrl).toBe('string');
+      expect(net.vaultUrl.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('vaultServerKey is a 66-hex compressed pubkey on every network', () => {
+    for (const net of Object.values(NETWORKS)) {
+      expect(net.vaultServerKey).toMatch(/^0[23][0-9a-f]{64}$/);
+    }
+  });
+
+  it('testnet2.vaultServerKey is the compressed pubkey of SERVER_SIGN_PRIV=`a`.repeat(64)', () => {
+    // Part A pins the same fixture (SERVER_SIGN_PRIV = 'a'.repeat(64)); the SDK
+    // must be able to verify the server's epochSig against this key.
+    expect(NETWORKS.testnet2.vaultServerKey).toBe(getPublicKey('a'.repeat(64), true));
+  });
+});

--- a/tests/unit/vault/noble-ciphers-dep.test.ts
+++ b/tests/unit/vault/noble-ciphers-dep.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+
+import { xchacha20poly1305 } from '@noble/ciphers/chacha.js';
+import pkg from '../../../package.json' with { type: 'json' };
+
+describe('@noble/ciphers phantom-dep guard', () => {
+  it('declares @noble/ciphers ^2 as a direct dependency', () => {
+    const dep = (pkg as { dependencies: Record<string, string> }).dependencies[
+      '@noble/ciphers'
+    ];
+    expect(dep).toBeDefined();
+    expect(dep).toMatch(/^\^?2/);
+  });
+
+  it('xchacha20poly1305 resolves from the declared dep', () => {
+    expect(typeof xchacha20poly1305).toBe('function');
+  });
+});

--- a/tests/unit/vault/scaffold.test.ts
+++ b/tests/unit/vault/scaffold.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+
+import * as vaultAead from '../../../vault-aead/index';
+import { CourierDeliveryProvider } from '../../../transport/courier/CourierDeliveryProvider';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+
+describe('vault module skeleton', () => {
+  it('vault-aead/index re-exports the module surface', () => {
+    expect(typeof vaultAead.seal).toBe('function');
+    expect(typeof vaultAead.open).toBe('function');
+    expect(typeof vaultAead.deriveVaultKey).toBe('function');
+    expect(typeof vaultAead.deriveCourierKey).toBe('function');
+    expect(typeof vaultAead.lengthDelim).toBe('function');
+    expect(typeof vaultAead.u64be).toBe('function');
+    expect(typeof vaultAead.assertOnCurve).toBe('function');
+    expect(typeof vaultAead.ecdhX).toBe('function');
+    expect(typeof vaultAead.sealVaultEntry).toBe('function');
+    expect(typeof vaultAead.openVaultEntry).toBe('function');
+    expect(typeof vaultAead.sealCourierEnvelope).toBe('function');
+    expect(typeof vaultAead.openCourierEnvelope).toBe('function');
+    expect(typeof vaultAead.packCourier).toBe('function');
+    expect(typeof vaultAead.unpackCourier).toBe('function');
+  });
+
+  it('CourierDeliveryProvider is a constructable class', () => {
+    expect(typeof CourierDeliveryProvider).toBe('function');
+  });
+
+  it('RemoteTokenStorageProvider is a constructable class', () => {
+    expect(typeof RemoteTokenStorageProvider).toBe('function');
+  });
+});

--- a/tests/unit/vault/vault-aead.aad-binding.test.ts
+++ b/tests/unit/vault/vault-aead.aad-binding.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+
+import { sealVaultEntry, openVaultEntry } from '../../../vault-aead/entry';
+import { deriveVaultKey } from '../../../vault-aead/derive';
+
+const NETWORK = 'testnet2';
+const OWNER_A = '02' + 'aa'.repeat(32);
+const OWNER_B = '02' + 'bb'.repeat(32);
+const KEY_X = 'token:keyX';
+const KEY_Y = 'token:keyY';
+const KEY32 = deriveVaultKey('44'.repeat(32), NETWORK);
+const PT = new TextEncoder().encode('{"sdkData":"deadbeef"}');
+
+function sealAt(ownerId: string, key: string, version: number) {
+  return sealVaultEntry({ network: NETWORK, ownerId, key, version, plaintext: PT, key32: KEY32 });
+}
+
+describe('vault-aead entry: AAD-binding tamper matrix', () => {
+  it('returns a {nonce, ct} base64 payload', () => {
+    const p = sealAt(OWNER_A, KEY_X, 3);
+    expect(typeof p.nonce).toBe('string');
+    expect(typeof p.ct).toBe('string');
+    // base64 round-trips back to 24-byte nonce
+    expect(Buffer.from(p.nonce, 'base64').length).toBe(24);
+  });
+
+  it('open succeeds for the exact (network, ownerA, keyX, v3)', () => {
+    const payload = sealAt(OWNER_A, KEY_X, 3);
+    const pt = openVaultEntry({
+      network: NETWORK,
+      ownerId: OWNER_A,
+      key: KEY_X,
+      version: 3,
+      payload,
+      key32: KEY32,
+    });
+    expect(Buffer.from(pt).equals(Buffer.from(PT))).toBe(true);
+  });
+
+  it('throws on owner mutation (ownerB instead of ownerA)', () => {
+    const payload = sealAt(OWNER_A, KEY_X, 3);
+    expect(() =>
+      openVaultEntry({ network: NETWORK, ownerId: OWNER_B, key: KEY_X, version: 3, payload, key32: KEY32 }),
+    ).toThrow();
+  });
+
+  it('throws on key mutation (keyY instead of keyX)', () => {
+    const payload = sealAt(OWNER_A, KEY_X, 3);
+    expect(() =>
+      openVaultEntry({ network: NETWORK, ownerId: OWNER_A, key: KEY_Y, version: 3, payload, key32: KEY32 }),
+    ).toThrow();
+  });
+
+  it('throws on version mutation (v4 instead of v3)', () => {
+    const payload = sealAt(OWNER_A, KEY_X, 3);
+    expect(() =>
+      openVaultEntry({ network: NETWORK, ownerId: OWNER_A, key: KEY_X, version: 4, payload, key32: KEY32 }),
+    ).toThrow();
+  });
+
+  it('throws on network mutation', () => {
+    const payload = sealAt(OWNER_A, KEY_X, 3);
+    expect(() =>
+      openVaultEntry({ network: 'mainnet', ownerId: OWNER_A, key: KEY_X, version: 3, payload, key32: KEY32 }),
+    ).toThrow();
+  });
+});

--- a/tests/unit/vault/vault-aead.courier.test.ts
+++ b/tests/unit/vault/vault-aead.courier.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import {
+  sealCourierEnvelope,
+  openCourierEnvelope,
+  packCourier,
+  unpackCourier,
+} from '../../../vault-aead/courier';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+
+const NETWORK = 'testnet2';
+const SENDER_PRIV = '55'.repeat(32);
+const RECIPIENT_PRIV = '66'.repeat(32);
+const SENDER_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(SENDER_PRIV), true));
+const RECIPIENT_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIPIENT_PRIV), true));
+const ENTRY_ID = 'ab'.repeat(32); // 64-hex
+const PT = new TextEncoder().encode('{"token":"v2blob","memo":"hi"}');
+const FIXED_NONCE = new Uint8Array(24).map((_, i) => 0x10 + i);
+
+function sealParams(extra?: Partial<Record<string, string>>) {
+  return {
+    network: NETWORK,
+    senderPriv: SENDER_PRIV,
+    senderPubkey: SENDER_PUB,
+    recipientPubkey: RECIPIENT_PUB,
+    entryId: ENTRY_ID,
+    plaintext: PT,
+    ...extra,
+  };
+}
+
+function openParams(ciphertext: string, extra?: Partial<Record<string, string>>) {
+  return {
+    network: NETWORK,
+    recipientPriv: RECIPIENT_PRIV,
+    senderPubkey: SENDER_PUB,
+    recipientPubkey: RECIPIENT_PUB,
+    entryId: ENTRY_ID,
+    ciphertext,
+    ...extra,
+  };
+}
+
+describe('vault-aead courier: envelope + base64(nonce‖ct) framing', () => {
+  it('packCourier/unpackCourier are inverse; first 24 bytes are the nonce', () => {
+    const nonce = new Uint8Array(24).map((_, i) => i);
+    const ct = new Uint8Array([1, 2, 3, 4, 5]);
+    const packed = packCourier(nonce, ct);
+    const { nonce: n2, ct: c2 } = unpackCourier(packed);
+    expect(bytesToHex(n2)).toBe(bytesToHex(nonce));
+    expect(bytesToHex(c2)).toBe(bytesToHex(ct));
+  });
+
+  it('round-trips via the two ECDH endpoints', () => {
+    const ciphertext = sealCourierEnvelope(sealParams());
+    const pt = openCourierEnvelope(openParams(ciphertext));
+    expect(Buffer.from(pt).equals(Buffer.from(PT))).toBe(true);
+  });
+
+  it('deposit round-trip vector (fixed nonce -> fixed packed base64)', () => {
+    const ciphertext = sealCourierEnvelope(sealParams(), FIXED_NONCE);
+    // KAT — generated once from the real seal with the fixed nonce.
+    expect(ciphertext).toBe(
+      'EBESExQVFhcYGRobHB0eHyAhIiMkJSYnKgg7ixHAGvoM+Cu8a3VdkGKNbXDiVRO+eWAIaAg02ItCOTT5lW0n3WTkpdwcFg==',
+    );
+    // and it still opens back to plaintext
+    const pt = openCourierEnvelope(openParams(ciphertext));
+    expect(Buffer.from(pt).equals(Buffer.from(PT))).toBe(true);
+  });
+
+  it('1-byte tamper of entryId (AAD) -> open throws', () => {
+    const ciphertext = sealCourierEnvelope(sealParams());
+    const badEntryId = 'ac' + ENTRY_ID.slice(2); // flip first byte
+    expect(() => openCourierEnvelope(openParams(ciphertext, { entryId: badEntryId }))).toThrow();
+  });
+
+  it('1-byte tamper of the packed ciphertext -> open throws', () => {
+    const ciphertext = sealCourierEnvelope(sealParams());
+    const bytes = new Uint8Array(Buffer.from(ciphertext, 'base64'));
+    bytes[bytes.length - 1] ^= 0x01; // flip a ct byte (not nonce)
+    const tampered = Buffer.from(bytes).toString('base64');
+    expect(() => openCourierEnvelope(openParams(tampered))).toThrow();
+  });
+});

--- a/tests/unit/vault/vault-aead.derive.test.ts
+++ b/tests/unit/vault/vault-aead.derive.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  lengthDelim,
+  u32be,
+  u64be,
+  deriveVaultKey,
+  deriveCourierKey,
+} from '../../../vault-aead/derive';
+import { bytesToHex } from '../../../core/crypto';
+
+const WALLET_PRIV = '11'.repeat(32);
+
+describe('vault-aead derive: lengthDelim / u64be / HKDF', () => {
+  it('lengthDelim is unambiguous (length-prefix prevents concatenation collision)', () => {
+    const a = lengthDelim(['a', 'bc']);
+    const b = lengthDelim(['ab', 'c']);
+    expect(bytesToHex(a)).not.toBe(bytesToHex(b));
+  });
+
+  it('lengthDelim frames each part as u32be(len)‖bytes', () => {
+    const out = lengthDelim(['a']); // 00 00 00 01 61
+    expect(bytesToHex(out)).toBe('0000000161');
+  });
+
+  it('u32be encodes 4-byte big-endian', () => {
+    expect(bytesToHex(u32be(1))).toBe('00000001');
+    expect(bytesToHex(u32be(0x01020304))).toBe('01020304');
+  });
+
+  it('u64be encodes 8-byte big-endian (pinned for v=3)', () => {
+    expect(bytesToHex(u64be(3))).toBe('0000000000000003');
+    expect(bytesToHex(u64be(0))).toBe('0000000000000000');
+    // accepts bigint too
+    expect(bytesToHex(u64be(0xdeadbeefn))).toBe('00000000deadbeef');
+  });
+
+  it('deriveVaultKey: pinned KAT', () => {
+    const k = deriveVaultKey(WALLET_PRIV, 'testnet2');
+    expect(k.length).toBe(32);
+    // KAT — generated once from the real HKDF-SHA256 implementation.
+    expect(bytesToHex(k)).toBe(
+      'a7015dbb1eeb9cf7abb42450697e4d3b78d6cb85b49c72bcc2b5aeeb9d4e5780',
+    );
+  });
+
+  it('deriveVaultKey is per-network (different network -> different key)', () => {
+    const a = deriveVaultKey(WALLET_PRIV, 'testnet2');
+    const b = deriveVaultKey(WALLET_PRIV, 'mainnet');
+    expect(bytesToHex(a)).not.toBe(bytesToHex(b));
+  });
+
+  it('deriveCourierKey: pinned KAT', () => {
+    const ecdh = new Uint8Array(32).map((_, i) => i + 1);
+    const k = deriveCourierKey(ecdh, 'unicity-courier-entryid-v1');
+    expect(k.length).toBe(32);
+    // KAT — generated once from the real HKDF-SHA256 implementation.
+    expect(bytesToHex(k)).toBe(
+      '7d2ab774e1d350d734f590e65b3aa4720b6d49083a251b89d52748e7027f0984',
+    );
+  });
+});

--- a/tests/unit/vault/vault-aead.ecdh.test.ts
+++ b/tests/unit/vault/vault-aead.ecdh.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { assertOnCurve, ecdhX } from '../../../vault-aead/ecdh';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+
+const SENDER_PRIV = '22'.repeat(32);
+const RECIPIENT_PRIV = '33'.repeat(32);
+const SENDER_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(SENDER_PRIV), true));
+const RECIPIENT_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIPIENT_PRIV), true));
+
+describe('vault-aead ecdh: on-curve guard + ECDH-x', () => {
+  it('assertOnCurve passes for a real derived compressed pubkey', () => {
+    expect(() => assertOnCurve(RECIPIENT_PUB)).not.toThrow();
+  });
+
+  it('assertOnCurve throws on a fabricated bad point (x not on curve)', () => {
+    // '02' + an x-coord that is not a valid field element / not on the curve.
+    expect(() => assertOnCurve('02' + 'ff'.repeat(32))).toThrow();
+  });
+
+  it('ecdhX returns 32 bytes and is symmetric across the two endpoints', () => {
+    const a = ecdhX(SENDER_PRIV, RECIPIENT_PUB);
+    const b = ecdhX(RECIPIENT_PRIV, SENDER_PUB);
+    expect(a.length).toBe(32);
+    expect(b.length).toBe(32);
+    expect(bytesToHex(a)).toBe(bytesToHex(b));
+  });
+
+  it('ecdhX pins the x-coordinate (slice [1,33), NOT [0,32))', () => {
+    // KAT — generated once. A wrong slice round-trips but yields a wrong KAT.
+    const x = ecdhX(SENDER_PRIV, RECIPIENT_PUB);
+    expect(bytesToHex(x)).toBe(
+      '9110f8760a37d96052e3dcaf14862a147654f49f722cf213568ccef1eca2ec71',
+    );
+  });
+
+  it('@noble v2 getSharedSecret rejects a hex string (must pass Uint8Array)', () => {
+    // Documents the gotcha: ecdhX hexToBytes-es internally; calling the raw
+    // primitive with a hex string throws.
+    expect(() => secp256k1.getSharedSecret(SENDER_PRIV as never, hexToBytes(RECIPIENT_PUB))).toThrow();
+  });
+});

--- a/tests/unit/vault/vault-aead.seal-open.test.ts
+++ b/tests/unit/vault/vault-aead.seal-open.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+
+import { seal, open } from '../../../vault-aead/aead';
+
+const KEY32 = new Uint8Array(32).map((_, i) => i + 1); // 01,02,...,20
+const NONCE24 = new Uint8Array(24).map((_, i) => 0xa0 + i); // a0,a1,...,b7
+const PT = new TextEncoder().encode('vault-aead plaintext payload');
+const AAD = new TextEncoder().encode('bound-aad');
+
+function b64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+describe('vault-aead seal/open (xchacha20poly1305, 24-byte nonce)', () => {
+  it('round-trips plaintext', () => {
+    const ct = seal(KEY32, NONCE24, PT, AAD);
+    const recovered = open(KEY32, NONCE24, ct, AAD);
+    expect(Buffer.from(recovered).equals(Buffer.from(PT))).toBe(true);
+  });
+
+  it('open with wrong AAD throws (tag failure)', () => {
+    const ct = seal(KEY32, NONCE24, PT, AAD);
+    const wrongAad = new TextEncoder().encode('other-aad');
+    expect(() => open(KEY32, NONCE24, ct, wrongAad)).toThrow();
+  });
+
+  it('seal with a 12-byte nonce throws (proves xchacha, not chacha)', () => {
+    const shortNonce = new Uint8Array(12).fill(0x05);
+    expect(() => seal(KEY32, shortNonce, PT, AAD)).toThrow();
+  });
+
+  it('pinned KAT: fixed (key,nonce,pt,aad) -> fixed base64 ct', () => {
+    const ct = seal(KEY32, NONCE24, PT, AAD);
+    // KAT — generated once from the real xchacha20poly1305 implementation.
+    expect(b64(ct)).toBe(
+      '8lPwc9ff5kTBaCuIQg7rWt9uEvcCS3i7zlinZUGcX1SAG4wh6GcGQvwTTFY=',
+    );
+  });
+});

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -7,8 +7,6 @@
  * bodies land in Phase 5; this is the typed skeleton from Task 0.1.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import type { FullIdentity } from '../../types';
 
 export interface CourierDeliveryConfig {

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -1,0 +1,78 @@
+/**
+ * CourierDeliveryProvider — the reference token-delivery transport over the
+ * Token-Vault v2 courier endpoints (§3, §6).
+ *
+ * Seals each transfer into a courier envelope (ECDH-derived key, AAD-bound
+ * entryId) and exchanges it via deposit / receive / ack / sent. The real
+ * bodies land in Phase 5; this is the typed skeleton from Task 0.1.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import type { FullIdentity } from '../../types';
+
+export interface CourierDeliveryConfig {
+  /** Vault/courier base URL — `NETWORKS[network].vaultUrl`. */
+  vaultUrl: string;
+  /** Canonical network name. */
+  network: string;
+}
+
+/** A sealed transfer ready to hand to the courier `deposit` endpoint. */
+export interface CourierEnvelope {
+  recipientPubkey: string;
+  entryId: string;
+  transferId: string;
+  /** base64(nonce24‖ct) packed string. */
+  ciphertext: string;
+  /** Single base64 scalar hint string (NOT a {nonce,ct} object). */
+  hint?: string;
+}
+
+/** Result of a courier deposit. */
+export interface CourierDepositResult {
+  entryId: string;
+}
+
+/** A received courier delivery, pre-decrypt. */
+export interface CourierDelivery {
+  entryId: string;
+  senderPubkey: string;
+  transferId: string;
+  ciphertext: string;
+  hint?: string;
+}
+
+export class CourierDeliveryProvider {
+  readonly id = 'courier-delivery';
+  readonly name = 'Courier Delivery (Vault v2)';
+  readonly type = 'network' as const;
+
+  constructor(_config: CourierDeliveryConfig) {
+    // Phase 5
+  }
+
+  setIdentity(_identity: FullIdentity): void {
+    throw new Error('not implemented');
+  }
+
+  /** Seal + POST a transfer to `/v1/courier/deposit`. */
+  deposit(_envelope: CourierEnvelope): Promise<CourierDepositResult> {
+    throw new Error('not implemented');
+  }
+
+  /** Pull-since read of pending deliveries; feeds `handleV2Transfer`. */
+  receive(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  /** Signed durable-copy ack for a claimed entry. */
+  confirmReceipt(_entryId: string): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  /** Sender-side poll of `/v1/courier/sent` to gate delivery confirmation. */
+  pollSent(): Promise<void> {
+    throw new Error('not implemented');
+  }
+}

--- a/vault-aead/aead.ts
+++ b/vault-aead/aead.ts
@@ -1,0 +1,24 @@
+/**
+ * AEAD seal/open over XChaCha20-Poly1305 (24-byte nonce, AAD).
+ * Filled in Task 1.1.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+export function seal(
+  _key: Uint8Array,
+  _nonce: Uint8Array,
+  _plaintext: Uint8Array,
+  _aad: Uint8Array,
+): Uint8Array {
+  throw new Error('not implemented');
+}
+
+export function open(
+  _key: Uint8Array,
+  _nonce: Uint8Array,
+  _ciphertext: Uint8Array,
+  _aad: Uint8Array,
+): Uint8Array {
+  throw new Error('not implemented');
+}

--- a/vault-aead/aead.ts
+++ b/vault-aead/aead.ts
@@ -1,24 +1,36 @@
 /**
  * AEAD seal/open over XChaCha20-Poly1305 (24-byte nonce, AAD).
- * Filled in Task 1.1.
+ *
+ * XChaCha (extended nonce) is used — NOT ChaCha20-Poly1305, which takes a
+ * 12-byte nonce. The 24-byte nonce lets us draw nonces at random without a
+ * birthday-bound concern. `seal` returns ciphertext‖tag; `open` verifies the
+ * Poly1305 tag and the AAD, throwing on any mismatch.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+import { xchacha20poly1305 } from '@noble/ciphers/chacha.js';
 
+/**
+ * Authenticated-encrypt `plaintext` under `key` (32 bytes) and `nonce`
+ * (24 bytes), binding `aad`. Returns `ciphertext‖tag`.
+ */
 export function seal(
-  _key: Uint8Array,
-  _nonce: Uint8Array,
-  _plaintext: Uint8Array,
-  _aad: Uint8Array,
+  key: Uint8Array,
+  nonce: Uint8Array,
+  plaintext: Uint8Array,
+  aad: Uint8Array,
 ): Uint8Array {
-  throw new Error('not implemented');
+  return xchacha20poly1305(key, nonce, aad).encrypt(plaintext);
 }
 
+/**
+ * Verify + decrypt `ciphertext` under `key`/`nonce`/`aad`. Throws if the tag or
+ * AAD does not match.
+ */
 export function open(
-  _key: Uint8Array,
-  _nonce: Uint8Array,
-  _ciphertext: Uint8Array,
-  _aad: Uint8Array,
+  key: Uint8Array,
+  nonce: Uint8Array,
+  ciphertext: Uint8Array,
+  aad: Uint8Array,
 ): Uint8Array {
-  throw new Error('not implemented');
+  return xchacha20poly1305(key, nonce, aad).decrypt(ciphertext);
 }

--- a/vault-aead/courier.ts
+++ b/vault-aead/courier.ts
@@ -1,0 +1,50 @@
+/**
+ * Courier-envelope seal/open + base64(nonce24‖ct) wire framing.
+ * The on-wire courier `ciphertext` is the single packed base64 string.
+ * Filled in Task 1.5.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+export interface SealCourierParams {
+  network: string;
+  senderPriv: string;
+  senderPubkey: string;
+  recipientPubkey: string;
+  entryId: string;
+  plaintext: Uint8Array;
+}
+
+export interface OpenCourierParams {
+  network: string;
+  recipientPriv: string;
+  senderPubkey: string;
+  recipientPubkey: string;
+  entryId: string;
+  ciphertext: string;
+}
+
+export interface PackedCourier {
+  nonce: Uint8Array;
+  ct: Uint8Array;
+}
+
+/** Pack a 24-byte nonce and ciphertext into a single base64 string. */
+export function packCourier(_nonce: Uint8Array, _ct: Uint8Array): string {
+  throw new Error('not implemented');
+}
+
+/** Slice the first 24 bytes back off as nonce, remainder as ct. */
+export function unpackCourier(_b64: string): PackedCourier {
+  throw new Error('not implemented');
+}
+
+/** Seal a courier envelope; returns the packed base64 ciphertext string. */
+export function sealCourierEnvelope(_params: SealCourierParams): string {
+  throw new Error('not implemented');
+}
+
+/** Open a packed courier envelope; returns the plaintext. */
+export function openCourierEnvelope(_params: OpenCourierParams): Uint8Array {
+  throw new Error('not implemented');
+}

--- a/vault-aead/courier.ts
+++ b/vault-aead/courier.ts
@@ -1,10 +1,22 @@
 /**
- * Courier-envelope seal/open + base64(nonce24‖ct) wire framing.
- * The on-wire courier `ciphertext` is the single packed base64 string.
- * Filled in Task 1.5.
+ * Courier-envelope seal/open + base64(nonce24‖ct) wire framing (findings #10, #12).
+ *
+ * The sender derives a courier key from its ECDH-x shared secret with the
+ * recipient, seals the transfer with AAD bound to
+ * `(network, senderPubkey, recipientPubkey, entryId)`, and frames it as a single
+ * `base64(nonce24‖ct)` string — the on-wire `ciphertext`. The recipient
+ * re-derives the identical key from its own ECDH side, slices the first 24 bytes
+ * back off as the nonce, and rebuilds the SAME AAD; any 1-byte tamper of the
+ * entryId (AAD) or of the packed ciphertext fails the Poly1305 tag.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+import { randomBytes } from '@noble/hashes/utils.js';
+import { seal, open } from './aead';
+import { deriveCourierKey, lengthDelim } from './derive';
+import { ecdhX } from './ecdh';
+
+/** HKDF info for the courier AEAD key. */
+const COURIER_KEY_INFO = 'unicity-courier-aead-v1';
 
 export interface SealCourierParams {
   network: string;
@@ -30,21 +42,41 @@ export interface PackedCourier {
 }
 
 /** Pack a 24-byte nonce and ciphertext into a single base64 string. */
-export function packCourier(_nonce: Uint8Array, _ct: Uint8Array): string {
-  throw new Error('not implemented');
+export function packCourier(nonce: Uint8Array, ct: Uint8Array): string {
+  const out = new Uint8Array(nonce.length + ct.length);
+  out.set(nonce, 0);
+  out.set(ct, nonce.length);
+  return Buffer.from(out).toString('base64');
 }
 
 /** Slice the first 24 bytes back off as nonce, remainder as ct. */
-export function unpackCourier(_b64: string): PackedCourier {
-  throw new Error('not implemented');
+export function unpackCourier(b64: string): PackedCourier {
+  const bytes = new Uint8Array(Buffer.from(b64, 'base64'));
+  return { nonce: bytes.slice(0, 24), ct: bytes.slice(24) };
 }
 
-/** Seal a courier envelope; returns the packed base64 ciphertext string. */
-export function sealCourierEnvelope(_params: SealCourierParams): string {
-  throw new Error('not implemented');
+/** Build the AAD that binds a courier envelope. */
+function courierAad(p: { network: string; senderPubkey: string; recipientPubkey: string; entryId: string }): Uint8Array {
+  return lengthDelim([p.network, p.senderPubkey, p.recipientPubkey, p.entryId]);
 }
 
-/** Open a packed courier envelope; returns the plaintext. */
-export function openCourierEnvelope(_params: OpenCourierParams): Uint8Array {
-  throw new Error('not implemented');
+/**
+ * Seal a courier envelope; returns the packed `base64(nonce24‖ct)` string.
+ * `nonce` is optional — supply a fixed one for deterministic test vectors;
+ * production callers omit it so a fresh random nonce is drawn.
+ */
+export function sealCourierEnvelope(params: SealCourierParams, nonce?: Uint8Array): string {
+  const key = deriveCourierKey(ecdhX(params.senderPriv, params.recipientPubkey), COURIER_KEY_INFO);
+  const n = nonce ?? randomBytes(24);
+  const aad = courierAad(params);
+  const ct = seal(key, n, params.plaintext, aad);
+  return packCourier(n, ct);
+}
+
+/** Open a packed courier envelope; returns the plaintext. Throws on any tamper. */
+export function openCourierEnvelope(params: OpenCourierParams): Uint8Array {
+  const key = deriveCourierKey(ecdhX(params.recipientPriv, params.senderPubkey), COURIER_KEY_INFO);
+  const { nonce, ct } = unpackCourier(params.ciphertext);
+  const aad = courierAad(params);
+  return open(key, nonce, ct, aad);
 }

--- a/vault-aead/derive.ts
+++ b/vault-aead/derive.ts
@@ -1,26 +1,73 @@
 /**
- * AAD framing (lengthDelim, u32be, u64be) + HKDF key derivations.
- * Filled in Task 1.2.
+ * AAD framing (lengthDelim, u32be, u64be) + HKDF key derivations for vault-aead.
+ *
+ * `lengthDelim` prefixes every part with its u32-be length so that distinct
+ * field tuples can never collide under concatenation (the AAD must bind each
+ * field unambiguously). HKDF-SHA256 matches the repo's existing IPNS pattern
+ * (`.js` suffixes, `sha2.js` subpath — mandatory for `@noble/hashes` ^2).
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { hexToBytes } from '../core/crypto';
 
-export function u32be(_n: number): Uint8Array {
-  throw new Error('not implemented');
+const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/** HKDF info prefix for the per-network vault AEAD key. */
+const VAULT_KEY_INFO_PREFIX = 'unicity-vault-aead-v1:';
+
+/** 4-byte big-endian encoding of an unsigned 32-bit integer. */
+export function u32be(n: number): Uint8Array {
+  const out = new Uint8Array(4);
+  new DataView(out.buffer).setUint32(0, n >>> 0, false);
+  return out;
 }
 
-export function u64be(_n: number | bigint): Uint8Array {
-  throw new Error('not implemented');
+/** 8-byte big-endian encoding of an unsigned 64-bit integer. */
+export function u64be(n: number | bigint): Uint8Array {
+  const out = new Uint8Array(8);
+  new DataView(out.buffer).setBigUint64(0, BigInt(n), false);
+  return out;
 }
 
-export function lengthDelim(_parts: (string | Uint8Array)[]): Uint8Array {
-  throw new Error('not implemented');
+/**
+ * Length-delimited concatenation: each part is encoded as `u32be(len)‖bytes`.
+ * The length prefix makes the framing injective — `['a','bc']` and `['ab','c']`
+ * yield different outputs, so an AAD built from a field tuple binds each field.
+ */
+export function lengthDelim(parts: (string | Uint8Array)[]): Uint8Array {
+  const encoded = parts.map((p) => (typeof p === 'string' ? utf8(p) : p));
+  const total = encoded.reduce((acc, b) => acc + 4 + b.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const b of encoded) {
+    out.set(u32be(b.length), offset);
+    offset += 4;
+    out.set(b, offset);
+    offset += b.length;
+  }
+  return out;
 }
 
-export function deriveVaultKey(_walletPriv: string, _network: string): Uint8Array {
-  throw new Error('not implemented');
+/**
+ * Derive the per-network vault AEAD key from the wallet private key:
+ * `HKDF-SHA256(walletPriv, info='unicity-vault-aead-v1:'+network, 32)`.
+ * Baking the network into the info isolates keys across networks.
+ */
+export function deriveVaultKey(walletPriv: string, network: string): Uint8Array {
+  return hkdf(
+    sha256,
+    hexToBytes(walletPriv),
+    undefined,
+    utf8(VAULT_KEY_INFO_PREFIX + network),
+    32,
+  );
 }
 
-export function deriveCourierKey(_ecdhX: Uint8Array, _info: string): Uint8Array {
-  throw new Error('not implemented');
+/**
+ * Derive a courier key from an ECDH shared-secret x-coordinate:
+ * `HKDF-SHA256(ecdhX, info, 32)`.
+ */
+export function deriveCourierKey(ecdhX: Uint8Array, info: string): Uint8Array {
+  return hkdf(sha256, ecdhX, undefined, utf8(info), 32);
 }

--- a/vault-aead/derive.ts
+++ b/vault-aead/derive.ts
@@ -1,0 +1,26 @@
+/**
+ * AAD framing (lengthDelim, u32be, u64be) + HKDF key derivations.
+ * Filled in Task 1.2.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+export function u32be(_n: number): Uint8Array {
+  throw new Error('not implemented');
+}
+
+export function u64be(_n: number | bigint): Uint8Array {
+  throw new Error('not implemented');
+}
+
+export function lengthDelim(_parts: (string | Uint8Array)[]): Uint8Array {
+  throw new Error('not implemented');
+}
+
+export function deriveVaultKey(_walletPriv: string, _network: string): Uint8Array {
+  throw new Error('not implemented');
+}
+
+export function deriveCourierKey(_ecdhX: Uint8Array, _info: string): Uint8Array {
+  throw new Error('not implemented');
+}

--- a/vault-aead/ecdh.ts
+++ b/vault-aead/ecdh.ts
@@ -1,0 +1,14 @@
+/**
+ * On-curve recipient-pubkey validation + ECDH-x shared secret.
+ * Filled in Task 1.3.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+export function assertOnCurve(_pubHex: string): void {
+  throw new Error('not implemented');
+}
+
+export function ecdhX(_privHex: string, _pubHex: string): Uint8Array {
+  throw new Error('not implemented');
+}

--- a/vault-aead/ecdh.ts
+++ b/vault-aead/ecdh.ts
@@ -1,14 +1,37 @@
 /**
- * On-curve recipient-pubkey validation + ECDH-x shared secret.
- * Filled in Task 1.3.
+ * On-curve recipient-pubkey validation + ECDH-x shared secret (finding #21).
+ *
+ * `assertOnCurve` rejects a recipient pubkey that is not a valid curve point
+ * (so we never derive a key against attacker-chosen garbage). `ecdhX` returns
+ * the 32-byte x-coordinate of the ECDH shared point.
+ *
+ * @noble/curves v2 gotcha: `getPublicKey`/`getSharedSecret` take Uint8Array,
+ * NOT hex strings (a hex string throws) — so we `hexToBytes` first.
+ * `getSharedSecret` returns a 33-byte COMPRESSED point (byte 0 = 0x02/0x03
+ * parity prefix); the x-coordinate is bytes `[1, 33)` — `.slice(0, 32)` is
+ * wrong (it keeps the prefix and drops the last x byte).
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { hexToBytes } from '../core/crypto';
 
-export function assertOnCurve(_pubHex: string): void {
-  throw new Error('not implemented');
+/**
+ * Throw if `pubHex` is not a valid secp256k1 point. Uses `Point.fromHex`, which
+ * rejects bad parity prefixes and off-curve x-coordinates.
+ */
+export function assertOnCurve(pubHex: string): void {
+  // Throws on a malformed / off-curve point.
+  secp256k1.Point.fromHex(pubHex);
 }
 
-export function ecdhX(_privHex: string, _pubHex: string): Uint8Array {
-  throw new Error('not implemented');
+/**
+ * ECDH x-coordinate: the 32-byte x of the shared point between `privHex` and
+ * `pubHex`. Validates `pubHex` is on-curve first.
+ */
+export function ecdhX(privHex: string, pubHex: string): Uint8Array {
+  assertOnCurve(pubHex);
+  const shared = secp256k1.getSharedSecret(hexToBytes(privHex), hexToBytes(pubHex));
+  // shared is a 33-byte compressed point: [parityPrefix, x0..x31]. Drop the
+  // prefix to get the 32-byte x-coordinate.
+  return shared.slice(1, 33);
 }

--- a/vault-aead/entry.ts
+++ b/vault-aead/entry.ts
@@ -1,9 +1,18 @@
 /**
- * AAD-bound vault-entry seal/open. The on-wire vault entry payload is a
- * `{nonce, ct}` object (both base64). Filled in Task 1.4.
+ * AAD-bound vault-entry seal/open (finding #10).
+ *
+ * Each entry's AEAD binds `(network, ownerId, key, version)` as AAD via
+ * `lengthDelim`, so a ciphertext sealed for one slot cannot be replayed into a
+ * different owner / key / version: `openVaultEntry` rebuilds the SAME AAD from
+ * the slot it is loading into, and the Poly1305 tag fails on any mismatch.
+ *
+ * The on-wire vault entry payload is a `{nonce, ct}` object (both base64) —
+ * PINNED. A fresh random 24-byte nonce is drawn per seal.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+import { randomBytes } from '@noble/hashes/utils.js';
+import { seal, open } from './aead';
+import { lengthDelim, u64be } from './derive';
 
 /** On-wire vault entry payload — both fields base64. */
 export interface VaultEntryPayload {
@@ -29,10 +38,26 @@ export interface OpenVaultEntryParams {
   key32: Uint8Array;
 }
 
-export function sealVaultEntry(_params: SealVaultEntryParams): VaultEntryPayload {
-  throw new Error('not implemented');
+const b64 = (b: Uint8Array): string => Buffer.from(b).toString('base64');
+const fromB64 = (s: string): Uint8Array => new Uint8Array(Buffer.from(s, 'base64'));
+
+/** Build the AAD that binds a vault slot: `lengthDelim([network, ownerId, key, u64be(version)])`. */
+function entryAad(network: string, ownerId: string, key: string, version: number | bigint): Uint8Array {
+  return lengthDelim([network, ownerId, key, u64be(version)]);
 }
 
-export function openVaultEntry(_params: OpenVaultEntryParams): Uint8Array {
-  throw new Error('not implemented');
+/** Seal a vault entry; returns the `{nonce, ct}` base64 payload. */
+export function sealVaultEntry(params: SealVaultEntryParams): VaultEntryPayload {
+  const { network, ownerId, key, version, plaintext, key32 } = params;
+  const nonce = randomBytes(24);
+  const aad = entryAad(network, ownerId, key, version);
+  const ct = seal(key32, nonce, plaintext, aad);
+  return { nonce: b64(nonce), ct: b64(ct) };
+}
+
+/** Open a vault entry, rebuilding the AAD from the target slot. Throws on mismatch. */
+export function openVaultEntry(params: OpenVaultEntryParams): Uint8Array {
+  const { network, ownerId, key, version, payload, key32 } = params;
+  const aad = entryAad(network, ownerId, key, version);
+  return open(key32, fromB64(payload.nonce), fromB64(payload.ct), aad);
 }

--- a/vault-aead/entry.ts
+++ b/vault-aead/entry.ts
@@ -1,0 +1,38 @@
+/**
+ * AAD-bound vault-entry seal/open. The on-wire vault entry payload is a
+ * `{nonce, ct}` object (both base64). Filled in Task 1.4.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/** On-wire vault entry payload — both fields base64. */
+export interface VaultEntryPayload {
+  nonce: string;
+  ct: string;
+}
+
+export interface SealVaultEntryParams {
+  network: string;
+  ownerId: string;
+  key: string;
+  version: number | bigint;
+  plaintext: Uint8Array;
+  key32: Uint8Array;
+}
+
+export interface OpenVaultEntryParams {
+  network: string;
+  ownerId: string;
+  key: string;
+  version: number | bigint;
+  payload: VaultEntryPayload;
+  key32: Uint8Array;
+}
+
+export function sealVaultEntry(_params: SealVaultEntryParams): VaultEntryPayload {
+  throw new Error('not implemented');
+}
+
+export function openVaultEntry(_params: OpenVaultEntryParams): Uint8Array {
+  throw new Error('not implemented');
+}

--- a/vault-aead/index.ts
+++ b/vault-aead/index.ts
@@ -1,0 +1,29 @@
+/**
+ * vault-aead — authenticated-encryption primitives for the Token-Vault v2 client.
+ *
+ * Public surface (filled across Phase 1):
+ *  - aead.ts    : seal / open over XChaCha20-Poly1305 (24-byte nonce, AAD)
+ *  - derive.ts  : lengthDelim AAD builder, u64be, HKDF key derivations
+ *  - ecdh.ts    : on-curve guard + ECDH-x shared secret
+ *  - entry.ts   : AAD-bound vault-entry seal/open ({nonce,ct} payload)
+ *  - courier.ts : courier envelope seal/open + base64(nonce‖ct) framing
+ *
+ * Re-exported here so consumers import the whole module from one path.
+ */
+
+export { seal, open } from './aead';
+export { lengthDelim, u64be, u32be, deriveVaultKey, deriveCourierKey } from './derive';
+export { assertOnCurve, ecdhX } from './ecdh';
+export { sealVaultEntry, openVaultEntry } from './entry';
+export type { VaultEntryPayload, SealVaultEntryParams, OpenVaultEntryParams } from './entry';
+export {
+  sealCourierEnvelope,
+  openCourierEnvelope,
+  packCourier,
+  unpackCourier,
+} from './courier';
+export type {
+  SealCourierParams,
+  OpenCourierParams,
+  PackedCourier,
+} from './courier';


### PR DESCRIPTION
Phase 0 skeletons + NetworkConfig.vaultUrl/vaultServerKey (testnet2 key matches Part A server, verified). Phase 1 vault-aead: xchacha20poly1305 seal/open, lengthDelim AAD + HKDF, on-curve guard + ecdhX slice(1,33), AAD-bound entries (tamper matrix), courier envelope framing. 36 tests, KATs frozen, tsc+lint clean. Review PASS.