### PR TITLE
Fail closed on degraded wallet-api compositions; abort local intent on failed putIntent (#515, #516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — incident 2026-06-12 hardening (#515, #516)
+
+- **Fail-closed composition invariant (#515 F1):** wallet-api CUSTODY
+  artifacts (the thin `WalletApiTokenStorageProvider`, delivery custody
+  `'inventory'`) composed without the `walletApi` client now throw
+  `INVALID_CONFIG` at `PaymentsModule.initialize`/`Sphere.init` instead of
+  silently running local-custody semantics. `TokenStorageProvider` gains an
+  optional `requiresWalletApi` marker. `Sphere.init` now forwards the
+  `delivery`, `walletApi` and `communications` options to
+  `Sphere.create`/`Sphere.load` — previously they were silently dropped.
+- **Checked SaveResult (#515 F2):** `PaymentsModule` now checks
+  `SaveResult.success` of the ACTIVE custody provider. User-facing flows
+  (mint, the send pipeline's custody writes) fail loudly (`STORAGE_ERROR`);
+  background saves emit the new `storage:degraded` event.
+- **Surfaced wallet-api session state (#515 F3):** a failed sign-in is
+  recorded (readable via `sphere.walletApiSessionStatus`) and emitted as the
+  new `walletapi:session` event (`'offline'`/`'online'`); boot stays
+  non-blocking.
+- **Double-pay hazard (#516):** `WalletApiClient.abortIntent` flips the LOCAL
+  intent copy to `'aborted'` even when the server abort cannot land (dead
+  backend); the unlanded abort is replayed by `resyncOpenIntents`
+  (PUT + abort), so a send that failed at `putIntent` can never be re-executed
+  by `resumeOpenIntents` after reconnect.
+
 ### BREAKING — v1 state-transition-sdk removed (v2 engine cutover)
 
 The legacy `@unicitylabs/state-transition-sdk@1.6.1-rc` engine is gone. The

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -555,6 +555,8 @@ export class Sphere {
   private _delivery: DeliveryProvider | null = null;
   /** wallet-api session (S4) — null in fully-local compositions. */
   private _walletApi: SphereWalletApiSession | null = null;
+  /** S4 session state (#515 F3) — null until a wallet-api composition attempts sign-in. */
+  private _walletApiSessionStatus: 'online' | 'offline' | null = null;
   /** v2 token engine (built per active address from the oracle); injected into modules. */
   private _tokenEngine: ITokenEngine | undefined;
 
@@ -718,12 +720,17 @@ export class Sphere {
         transport: options.transport,
         oracle: options.oracle,
         tokenStorage: options.tokenStorage,
+        // S4/S7 ports (#515): dropping these silently degraded a wallet-api
+        // composition to the legacy local-custody one — forward them always.
+        delivery: options.delivery,
+        walletApi: options.walletApi,
         l1: options.l1,
         price: options.price,
         groupChat,
         market,
         accounting,
         swap,
+        communications: options.communications,
         password: options.password,
         discoverAddresses: options.discoverAddresses,
         onProgress: options.onProgress,
@@ -759,6 +766,10 @@ export class Sphere {
       transport: options.transport,
       oracle: options.oracle,
       tokenStorage: options.tokenStorage,
+      // S4/S7 ports (#515): dropping these silently degraded a wallet-api
+      // composition to the legacy local-custody one — forward them always.
+      delivery: options.delivery,
+      walletApi: options.walletApi,
       derivationPath: options.derivationPath,
       nametag: options.nametag,
       l1: options.l1,
@@ -767,6 +778,7 @@ export class Sphere {
       market,
       accounting,
       swap,
+      communications: options.communications,
       password: options.password,
       discoverAddresses: options.discoverAddresses,
       onProgress: options.onProgress,
@@ -4563,10 +4575,30 @@ export class Sphere {
   // ===========================================================================
 
   /**
+   * The wallet-api session state (#515 F3): `'offline'` means the last
+   * sign-in failed and the wallet runs degraded (boot stays non-blocking);
+   * `'online'` after a successful sign-in; `null` when no wallet-api session
+   * is composed (fully-local) or before the first attempt. Changes are
+   * surfaced as `walletapi:session` events.
+   */
+  get walletApiSessionStatus(): 'online' | 'offline' | null {
+    return this._walletApiSessionStatus;
+  }
+
+  /** Record + surface a wallet-api session state change (#515 F3). */
+  private noteWalletApiSession(status: 'online' | 'offline', error?: string): void {
+    if (this._walletApiSessionStatus === status) return;
+    this._walletApiSessionStatus = status;
+    this.emitEvent('walletapi:session', { status, ...(error !== undefined ? { error } : {}) });
+  }
+
+  /**
    * S4 auth lifecycle: establish the wallet-api session (sign-in on unlock —
    * silent: the wallet key is available) and resume open intents at sign-in
    * (E.3 — list + re-run via PaymentsModule, fire-and-forget). A failed
-   * sign-in degrades to offline operation; it never blocks the wallet.
+   * sign-in degrades to offline operation; it never blocks the wallet — but
+   * it is RECORDED and surfaced (`walletApiSessionStatus` + the
+   * `walletapi:session` event), never log-only (#515 F3).
    */
   private async startWalletApiSession(payments: PaymentsModule): Promise<void> {
     if (!this._walletApi) return;
@@ -4574,8 +4606,10 @@ export class Sphere {
       await this._walletApi.signIn();
     } catch (err) {
       logger.warn('Sphere', 'wallet-api sign-in failed — wallet continues offline:', err);
+      this.noteWalletApiSession('offline', err instanceof Error ? err.message : String(err));
       return;
     }
+    this.noteWalletApiSession('online');
     void payments
       .resumeOpenIntents()
       .then((outcome) => {

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -96,6 +96,9 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
   readonly id = 'wallet-api-token-storage';
   readonly name = 'Wallet API Token Storage';
   readonly type = 'cloud' as const;
+  /** Custody lives in the wallet-api backend — composing this provider without
+   * the wallet-api client is illegal (fail-closed, S7/#515). */
+  readonly requiresWalletApi = true;
 
   private readonly client: WalletApiClient;
   private readonly stateStore: KeyValueStore;

--- a/impl/shared/wallet-api/composition.ts
+++ b/impl/shared/wallet-api/composition.ts
@@ -107,7 +107,14 @@ export interface WalletApiCompositionConfig {
 /** What the wallet-api presets add to the base bundle. */
 export interface WalletApiProviderExtras {
   delivery: DeliveryProvider;
-  /** The S1 client — pass to `Sphere.init({ walletApi })` for the S4 auth lifecycle. */
+  /**
+   * The S1 client — pass to `Sphere.init({ walletApi })` for the S4 auth
+   * lifecycle. NOT optional in spirit (#515): wallet-api CUSTODY artifacts
+   * (the thin storage provider, delivery custody `'inventory'`) without this
+   * client are an illegal composition — `Sphere.init` /
+   * `PaymentsModule.initialize` throw `INVALID_CONFIG` (fail-closed) instead
+   * of silently degrading to local-custody semantics.
+   */
   walletApi: WalletApiClient;
 }
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -793,6 +793,58 @@ export interface PaymentsModuleDependencies {
   walletApi?: PaymentsWalletApiPort;
 }
 
+/** The provider {@link PaymentsModule.getActiveTokenStorageProvider} will pick:
+ * first non-disabled entry, mirroring getTokenStorageProviders' precedence. */
+function firstEnabledTokenStorage(
+  deps: PaymentsModuleDependencies
+): TokenStorageProvider<TxfStorageDataBase> | null {
+  const providers =
+    deps.tokenStorageProviders && deps.tokenStorageProviders.size > 0
+      ? [...deps.tokenStorageProviders.entries()]
+      : deps.tokenStorage
+        ? [[deps.tokenStorage.id, deps.tokenStorage] as const]
+        : [];
+  for (const [id, provider] of providers) {
+    if (!deps.disabledProviderIds?.has(id)) return provider;
+  }
+  return null;
+}
+
+/**
+ * Fail-closed composition invariant (#515 F1, sdk-changes S7): wallet-api
+ * CUSTODY artifacts — delivery custody `'inventory'` (acks write the server
+ * inventory) or an active token-storage provider that declares
+ * `requiresWalletApi` (the S2 thin provider) — are only legal WITH the
+ * wallet-api client. The E.3 intent barrier and §7 server apply are
+ * guard-by-presence on `deps.walletApi`, so an accidentally-degraded
+ * composition (e.g. a stale bundle dropping the client) would silently run
+ * local-custody semantics while the user believes wallet-api custody is
+ * active. Legal compositions (the composition.ts presets):
+ *  - fully local: no wallet-api artifacts, no client;
+ *  - FULL preset: thin storage + custody 'inventory' + client;
+ *  - OWN-STORAGE preset: own storage + custody 'external' + client.
+ * Own storage + custody 'external' WITHOUT a client stays legal (no custody
+ * artifact — delivery fails loudly at call time, nothing is silently lost).
+ */
+function assertLegalCustodyComposition(deps: PaymentsModuleDependencies): void {
+  if (deps.walletApi) return;
+  if (deps.delivery?.custody === 'inventory') {
+    throw new SphereError(
+      "Illegal composition (#515): delivery custody is 'inventory' (wallet-api server custody) but no `walletApi` client was provided — refusing to initialize. " +
+        "Pass the preset's `walletApi` to Sphere.init, or compose the own-storage preset (custody 'external').",
+      'INVALID_CONFIG'
+    );
+  }
+  const storage = firstEnabledTokenStorage(deps);
+  if (storage?.requiresWalletApi) {
+    throw new SphereError(
+      `Illegal composition (#515): the active token-storage provider '${storage.id}' keeps custody in the wallet-api backend but no \`walletApi\` client was provided — refusing to initialize. ` +
+        "Pass the preset's `walletApi` to Sphere.init, or compose a local storage provider.",
+      'INVALID_CONFIG'
+    );
+  }
+}
+
 // =============================================================================
 // Implementation
 // =============================================================================
@@ -960,6 +1012,9 @@ export class PaymentsModule {
    * Initialize module with dependencies
    */
   initialize(deps: PaymentsModuleDependencies): void {
+    // #515 F1: refuse illegal custody compositions BEFORE any state is touched.
+    assertLegalCustodyComposition(deps);
+
     // Clean up previous subscriptions before re-initializing
     this.unsubscribeTransfers?.();
     this.unsubscribeTransfers = null;
@@ -1450,13 +1505,15 @@ export class PaymentsModule {
       }
       result.tokens = tokensToSend;
 
-      // Mark as transferring and persist — UI shows "Pending" badge immediately
+      // Mark as transferring and persist — UI shows "Pending" badge immediately.
+      // critical (#515 F2): nothing is spent yet — an unwritable active custody
+      // provider must abort the send HERE, before the intent/engine run.
       for (const token of tokensToSend) {
         token.status = 'transferring';
         this.tokens.set(token.id, token);
         this.parsedTokenCache.delete(token.id);
       }
-      await this.save();
+      await this.save({ critical: true });
 
       // Save to outbox for recovery
       await this.saveToOutbox(result, recipientPubkey);
@@ -1608,7 +1665,10 @@ export class PaymentsModule {
             // recovery seed (a deterministic re-run rebuilds BOTH outputs), and
             // local storage follows the server apply below so the provider's
             // write-behind cannot race a second add of the same state.
-            await this.storeEngineToken(engine, changeOutput);
+            // critical (#515 F2): an unpersisted change token is value loss on
+            // reload — fail the send (the open intent resumes it) rather than
+            // report success.
+            await this.storeEngineToken(engine, changeOutput, { criticalSave: true });
           }
 
           await deliverBlob(recipientBlob);
@@ -2875,9 +2935,12 @@ export class PaymentsModule {
    *   the old state is archived and replaced with the incoming one.
    *
    * @param token - The token to add.
+   * @param opts - `criticalSave: true` on user-facing flows (mint/send): a
+   *   failed save of the ACTIVE custody provider then throws STORAGE_ERROR
+   *   (#515 F2) instead of emitting `storage:degraded`.
    * @returns `true` if the token was added, `false` if rejected as duplicate or tombstoned.
    */
-  async addToken(token: Token): Promise<boolean> {
+  async addToken(token: Token, opts: { criticalSave?: boolean } = {}): Promise<boolean> {
     this.ensureInitialized();
 
     logger.debug('Payments', `addToken called: id=${token.id.slice(0, 16)}... coinId=${token.coinId.slice(0, 16)}... status=${token.status}`);
@@ -2956,7 +3019,7 @@ export class PaymentsModule {
     // Archive the token (for recovery purposes)
     await this.archiveToken(token);
 
-    await this.save();
+    await this.save({ critical: opts.criticalSave });
     logger.debug('Payments', `addToken: saved id=${token.id.slice(0, 16)}...`);
 
     // Notify observers (e.g., AccountingModule) that a token was added
@@ -3662,6 +3725,7 @@ export class PaymentsModule {
   private async storeEngineToken(
     engine: ITokenEngine,
     token: SphereToken,
+    opts: { criticalSave?: boolean } = {},
   ): Promise<{ uiToken: Token; added: boolean }> {
     // Re-encode from the decoded blob; byte-identical to the wire blob (canonical CBOR).
     const sdkData = bytesToHex(encodeTokenBlob(engine.encodeToken(token)));
@@ -3679,7 +3743,7 @@ export class PaymentsModule {
       updatedAt: Date.now(),
       sdkData,
     };
-    const added = await this.addToken(uiToken);
+    const added = await this.addToken(uiToken, opts);
     return { uiToken, added };
   }
 
@@ -3726,7 +3790,10 @@ export class PaymentsModule {
         recipientPubkey: engine.getIdentity().chainPubkey,
         value: { assets: [{ coinId: coinIdHex, amount }] },
       });
-      const { uiToken } = await this.storeEngineToken(engine, minted);
+      // #515 F2: the mint is user-facing — a failed save of the ACTIVE custody
+      // provider must fail the mint (a RAM-only blob behind a success modal is
+      // permanent loss on reload), not report success.
+      const { uiToken } = await this.storeEngineToken(engine, minted, { criticalSave: true });
       return { success: true, token: uiToken, tokenId: engine.tokenId(minted) };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -4730,7 +4797,9 @@ export class PaymentsModule {
         { signal: AbortSignal.timeout(SEND_ENGINE_OP_TIMEOUT_MS), transferId, opIndex: payload.direct.length }
       );
       changeOutput = outputs[1];
-      if (!serverApply) await this.storeEngineToken(engine, changeOutput);
+      // critical (#515 F2): own-storage custody — persist-or-stay-open; a
+      // throw keeps the intent open and the next sign-in re-runs it.
+      if (!serverApply) await this.storeEngineToken(engine, changeOutput, { criticalSave: true });
       await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(outputs[0]))));
       spent.push(payload.split.tokenId);
     }
@@ -4803,7 +4872,21 @@ export class PaymentsModule {
   // Private: Storage
   // ===========================================================================
 
-  private async save(): Promise<void> {
+  /**
+   * Persist the token state to every (non-disabled) token storage provider.
+   *
+   * #515 D3b/F2: `SaveResult.success` is CHECKED for the ACTIVE custody
+   * provider (the thin wallet-api provider deliberately returns
+   * `{success:false}` on failure instead of throwing) — silent acceptance let
+   * a mint certify on-chain with the blob in RAM only. On an active-provider
+   * failure:
+   *  - `critical: true` (user-facing mint/send paths) → throws STORAGE_ERROR,
+   *    so the flow reports failure instead of success;
+   *  - otherwise (background writers) → emits `storage:degraded`.
+   * Non-active (secondary) provider failures keep the existing log-only
+   * behavior.
+   */
+  private async save(opts: { critical?: boolean } = {}): Promise<void> {
     // Save to TokenStorageProviders (IndexedDB/files)
     const providers = this.getTokenStorageProviders();
     // Debug: log token serialization status
@@ -4813,19 +4896,29 @@ export class PaymentsModule {
     });
     logger.debug('Payments', `save(): providers=${providers.size}, tokens=[${tokenStats.join(', ')}]`);
 
-    if (providers.size > 0) {
-      const data = await this.createStorageData();
-      const dataKeys = Object.keys(data).filter(k => k.startsWith('token-'));
-      logger.debug('Payments', `save(): TXF keys=${dataKeys.length} (${dataKeys.join(', ')})`);
-      for (const [id, provider] of providers) {
-        try {
-          await provider.save(data);
-        } catch (err) {
-          logger.error('Payments', `Failed to save to provider ${id}:`, err);
-        }
-      }
-    } else {
+    if (providers.size === 0) {
       logger.debug('Payments', 'save(): No token storage providers - TXF not persisted');
+      return;
+    }
+    const data = await this.createStorageData();
+    const dataKeys = Object.keys(data).filter(k => k.startsWith('token-'));
+    logger.debug('Payments', `save(): TXF keys=${dataKeys.length} (${dataKeys.join(', ')})`);
+    const activeId = providers.keys().next().value;
+    for (const [id, provider] of providers) {
+      let error: string | null = null;
+      try {
+        const result = await provider.save(data);
+        if (!result.success) error = result.error ?? 'save failed';
+      } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+      }
+      if (error === null) continue;
+      logger.error('Payments', `Failed to save to provider ${id}: ${error}`);
+      if (id !== activeId) continue;
+      if (opts.critical) {
+        throw new SphereError(`Token storage save failed (${id}): ${error}`, 'STORAGE_ERROR');
+      }
+      this.deps!.emitEvent('storage:degraded', { providerId: id, error });
     }
   }
 

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -199,6 +199,17 @@ export interface SyncResult<T = unknown> {
  */
 export interface TokenStorageProvider<TData = unknown> extends BaseProvider {
   /**
+   * Fail-closed composition invariant (sdk-changes S7, #515): set `true` on
+   * providers whose token custody lives behind the wallet-api backend (the S2
+   * thin provider). Composing such a provider as the ACTIVE token storage
+   * without the wallet-api client (`walletApi`) is an accidentally-degraded,
+   * ILLEGAL composition — `PaymentsModule.initialize` throws `INVALID_CONFIG`
+   * instead of silently running local-custody semantics. Local/whole-blob
+   * providers omit it.
+   */
+  readonly requiresWalletApi?: boolean;
+
+  /**
    * Set identity for storage scope
    */
   setIdentity(identity: FullIdentity): void;

--- a/tests/unit/core/Sphere.walletapi-session.test.ts
+++ b/tests/unit/core/Sphere.walletapi-session.test.ts
@@ -1,0 +1,210 @@
+/**
+ * #515 F3 — the wallet-api session state is RECORDED and SURFACED, never
+ * log-only: a failed sign-in keeps boot non-blocking but flips
+ * `walletApiSessionStatus` to 'offline' and emits `walletapi:session`;
+ * a later successful sign-in flips it back to 'online'.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type { ProviderStatus, SphereEventMap } from '../../../types';
+
+// Mock L1 network module before importing Sphere
+vi.mock('../../../l1/network', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  isWebSocketConnected: vi.fn().mockReturnValue(false),
+}));
+
+import { Sphere, type SphereWalletApiSession } from '../../../core/Sphere';
+import type { PaymentsModule } from '../../../modules/payments';
+import { TEST_NETWORK } from '../../test-network';
+
+function createMockStorage(): StorageProvider {
+  const data = new Map<string, string>();
+  return {
+    id: 'mock-storage', name: 'Mock Storage', type: 'local' as const,
+    setIdentity: vi.fn(),
+    get: vi.fn(async (key: string) => data.get(key) ?? null),
+    set: vi.fn(async (key: string, value: string) => { data.set(key, value); }),
+    remove: vi.fn(async (key: string) => { data.delete(key); }),
+    has: vi.fn(async (key: string) => data.has(key)),
+    keys: vi.fn(async () => Array.from(data.keys())),
+    clear: vi.fn(async () => { data.clear(); }),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+    isConnected: vi.fn(() => true),
+    getStatus: vi.fn((): ProviderStatus => 'connected'),
+    saveTrackedAddresses: vi.fn(async () => {}),
+    loadTrackedAddresses: vi.fn(async () => []),
+  };
+}
+
+function createMockTransport(): TransportProvider {
+  return {
+    id: 'mock-transport', name: 'Mock Transport', type: 'p2p' as const,
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn().mockResolvedValue('transfer-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('request-id'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('response-id'),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    publishIdentityBinding: vi.fn().mockResolvedValue(true),
+    recoverNametag: vi.fn().mockResolvedValue(null),
+    resolve: vi.fn().mockResolvedValue(null),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+  } as unknown as TransportProvider;
+}
+
+function createMockOracle(): OracleProvider {
+  return {
+    id: 'mock-oracle', name: 'Mock Oracle', type: 'network' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+  } as unknown as OracleProvider;
+}
+
+function createMockTokenStorage(): TokenStorageProvider<TxfStorageDataBase> {
+  return {
+    id: 'mock-tokens', name: 'Mock Tokens', type: 'local' as const,
+    setIdentity: vi.fn(),
+    initialize: vi.fn(async () => true),
+    shutdown: vi.fn(async () => {}),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+    isConnected: vi.fn(() => true),
+    getStatus: vi.fn((): ProviderStatus => 'connected'),
+    load: vi.fn(async () => ({
+      success: true,
+      data: { _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: Date.now() } },
+      source: 'local' as const,
+      timestamp: Date.now(),
+    })),
+    save: vi.fn(async () => ({ success: true, timestamp: Date.now() })),
+    sync: vi.fn(async (localData: TxfStorageDataBase) => ({
+      success: true, merged: localData, added: 0, removed: 0, conflicts: 0,
+    })),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+  };
+}
+
+/** Structural SphereWalletApiSession double whose signIn outcome is toggleable. */
+function createMockWalletApi(state: { fail: boolean }): SphereWalletApiSession {
+  return {
+    setIdentity: vi.fn(),
+    signIn: vi.fn(async () => {
+      if (state.fail) throw new Error('connect ECONNREFUSED 127.0.0.1:443');
+    }),
+    logout: vi.fn(async () => {}),
+    putIntent: vi.fn(async () => {}),
+    completeIntent: vi.fn(async () => {}),
+    abortIntent: vi.fn(async () => {}),
+    listIntents: vi.fn(async () => []),
+    getUploadUrls: vi.fn(async () => []),
+    uploadBlob: vi.fn(async () => {}),
+    postHistoryRecords: vi.fn(async () => {}),
+  } as unknown as SphereWalletApiSession;
+}
+
+/** Re-run the S4 session lifecycle (the same path init/address-switch uses). */
+async function rerunSession(sphere: Sphere): Promise<void> {
+  const internals = sphere as unknown as {
+    startWalletApiSession(payments: PaymentsModule): Promise<void>;
+    _payments: PaymentsModule;
+  };
+  await internals.startWalletApiSession(internals._payments);
+}
+
+describe('#515 F3 — surfaced wallet-api session state', () => {
+  beforeEach(() => {
+    (Sphere as unknown as { instance: null }).instance = null;
+  });
+
+  afterEach(async () => {
+    if (Sphere.getInstance()) {
+      try { await Sphere.getInstance()!.destroy(); } catch { /* ignore */ }
+    }
+    (Sphere as unknown as { instance: null }).instance = null;
+  });
+
+  async function initSphere(walletApi?: SphereWalletApiSession): Promise<Sphere> {
+    const { sphere } = await Sphere.init({
+      storage: createMockStorage(),
+      transport: createMockTransport(),
+      oracle: createMockOracle(),
+      tokenStorage: createMockTokenStorage(),
+      network: TEST_NETWORK,
+      autoGenerate: true,
+      ...(walletApi ? { walletApi } : {}),
+    } as Parameters<typeof Sphere.init>[0]);
+    return sphere;
+  }
+
+  it('is null when no wallet-api session is composed', async () => {
+    const sphere = await initSphere();
+    expect(sphere.walletApiSessionStatus).toBeNull();
+  });
+
+  it('a dead client at init records OFFLINE (boot stays non-blocking) and the state is readable', async () => {
+    const state = { fail: true };
+    const sphere = await initSphere(createMockWalletApi(state));
+    // Boot completed despite the failed sign-in — and the failure is STATE,
+    // not a log line (#515 D3a).
+    expect(sphere.walletApiSessionStatus).toBe('offline');
+  });
+
+  it('flips to ONLINE on a later successful sign-in, emitting walletapi:session', async () => {
+    const state = { fail: true };
+    const sphere = await initSphere(createMockWalletApi(state));
+    expect(sphere.walletApiSessionStatus).toBe('offline');
+
+    const events: SphereEventMap['walletapi:session'][] = [];
+    sphere.on('walletapi:session', (e) => events.push(e));
+
+    state.fail = false;
+    await rerunSession(sphere);
+    expect(sphere.walletApiSessionStatus).toBe('online');
+    expect(events).toEqual([{ status: 'online' }]);
+  });
+
+  it('a later failure flips back to OFFLINE with the error surfaced', async () => {
+    const state = { fail: false };
+    const sphere = await initSphere(createMockWalletApi(state));
+    expect(sphere.walletApiSessionStatus).toBe('online');
+
+    const events: SphereEventMap['walletapi:session'][] = [];
+    sphere.on('walletapi:session', (e) => events.push(e));
+
+    state.fail = true;
+    await rerunSession(sphere);
+    expect(sphere.walletApiSessionStatus).toBe('offline');
+    expect(events).toEqual([
+      { status: 'offline', error: expect.stringContaining('ECONNREFUSED') },
+    ]);
+  });
+
+  it('does not re-emit when the state is unchanged (offline stays offline)', async () => {
+    const state = { fail: true };
+    const sphere = await initSphere(createMockWalletApi(state));
+    const events: SphereEventMap['walletapi:session'][] = [];
+    sphere.on('walletapi:session', (e) => events.push(e));
+
+    await rerunSession(sphere); // fails again — same state
+    expect(sphere.walletApiSessionStatus).toBe('offline');
+    expect(events).toEqual([]);
+  });
+});

--- a/tests/unit/modules/PaymentsModule.fail-closed.test.ts
+++ b/tests/unit/modules/PaymentsModule.fail-closed.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Incident 2026-06-12 regression suite (#515 / #516):
+ *
+ * - #515 F1 — fail-closed composition invariant: wallet-api CUSTODY artifacts
+ *   (thin storage provider, delivery custody 'inventory') without the
+ *   wallet-api client refuse to initialize (INVALID_CONFIG) instead of
+ *   silently running local-custody semantics. Every composition.ts preset
+ *   still initializes.
+ * - #515 F2 — unchecked SaveResult: the ACTIVE custody provider returning
+ *   `{success:false}` fails user-facing flows (mint), and surfaces
+ *   `storage:degraded` on background writes — never a silent success.
+ * - #516 — double-pay hazard: a send whose `putIntent` dies on a dead backend
+ *   marks the LOCAL intent 'aborted'; after reconnect, `resumeOpenIntents`
+ *   executes NOTHING and the resync lands the intent as aborted (no-op
+ *   execution-wise).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createPaymentsModule, type PaymentsModuleDependencies } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity, Token } from '../../../types';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../../storage';
+import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
+import { FakeWalletApi } from '../../support/fake-wallet-api';
+import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
+import { WalletApiClient } from '../../../wallet-api';
+import type { FetchLike } from '../../../wallet-api';
+import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../../impl/shared/wallet-api';
+import { hexToBytes } from '../../../core/crypto';
+import { SphereError } from '../../../core/errors';
+
+const UCT = '11'.repeat(32);
+const SENDER = testIdentity(21);
+const RECIPIENT = testIdentity(22);
+
+// A dead, never-contacted backend (F1/F2 tests construct clients only).
+const DEAD_URL = 'http://127.0.0.1:9';
+const NETWORK = 'testnet2';
+
+function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIdentity {
+  return {
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    l1Address: `alpha1${id.chainPubkey.slice(0, 8)}`,
+    directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
+    transportPubkey: id.chainPubkey.slice(2),
+  };
+}
+
+function mockStorage(): StorageProvider {
+  const s = new Map<string, string>();
+  return {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+}
+
+function mockHistoryStore() {
+  const entries = new Map<string, HistoryRecord>();
+  return {
+    addHistoryEntry: vi.fn(async (e: HistoryRecord) => { entries.set(e.dedupKey, e); }),
+    getHistoryEntries: vi.fn(async () => [...entries.values()]),
+    hasHistoryEntry: vi.fn(async (k: string) => entries.has(k)),
+    clearHistory: vi.fn(async () => entries.clear()),
+    importHistoryEntries: vi.fn(async () => 0),
+  };
+}
+
+/** Local whole-blob provider mock (the own-storage / fully-local custody). */
+function mockLocalTokenStorage(): TokenStorageProvider<TxfStorageDataBase> {
+  let lastSaved: TxfStorageDataBase | null = null;
+  return {
+    id: 'local', name: 'local', type: 'local',
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(true), shutdown: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn(async (data: TxfStorageDataBase) => { lastSaved = data; return { success: true, timestamp: 0 }; }),
+    load: vi.fn(async () => (lastSaved
+      ? { success: true, source: 'local', timestamp: 0, data: lastSaved }
+      : { success: false, source: 'local', timestamp: 0 })),
+    sync: vi.fn().mockResolvedValue({ success: true, added: 0, removed: 0, conflicts: 0 }),
+    ...mockHistoryStore(),
+  } as unknown as TokenStorageProvider<TxfStorageDataBase>;
+}
+
+function mockTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue({
+      chainPubkey: RECIPIENT.chainPubkey,
+      transportPubkey: RECIPIENT.chainPubkey.slice(2),
+      directAddress: 'DIRECT://bob',
+      nametag: 'bob',
+    }),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    isDevMode: () => false,
+  } as unknown as OracleProvider;
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!();
+  vi.restoreAllMocks();
+});
+
+interface DepsParts {
+  client: WalletApiClient;
+  thinStorage: WalletApiTokenStorageProvider;
+  localStorage: TokenStorageProvider<TxfStorageDataBase>;
+  emitEvent: ReturnType<typeof vi.fn>;
+}
+
+/** Base deps + the wallet-api parts, composed per test into a legality case. */
+function makeParts(baseUrl = DEAD_URL): DepsParts {
+  const kv = new MemoryKeyValueStore();
+  const client = new WalletApiClient({ baseUrl, network: NETWORK, deviceId: 'd-fc', storage: kv });
+  const thinStorage = new WalletApiTokenStorageProvider({ client, stateStore: kv });
+  return { client, thinStorage, localStorage: mockLocalTokenStorage(), emitEvent: vi.fn() };
+}
+
+function makeDeps(
+  parts: DepsParts,
+  opts: {
+    storage: TokenStorageProvider<TxfStorageDataBase>;
+    custody?: 'inventory' | 'external';
+    walletApi?: boolean;
+  }
+): PaymentsModuleDependencies {
+  const kv = new MemoryKeyValueStore();
+  const delivery =
+    opts.custody !== undefined
+      ? new WalletApiMailboxProvider({ client: parts.client, custody: opts.custody, stateStore: kv })
+      : undefined;
+  return {
+    identity: fullIdentity(SENDER),
+    storage: mockStorage(),
+    tokenStorageProviders: new Map([[opts.storage.id, opts.storage]]),
+    transport: mockTransport(),
+    oracle: mockOracle(),
+    emitEvent: parts.emitEvent,
+    tokenEngine: new FakeTokenEngine({ chainPubkey: hexToBytes(SENDER.chainPubkey) }),
+    delivery,
+    walletApi: opts.walletApi ? parts.client : undefined,
+  };
+}
+
+function initModule(deps: PaymentsModuleDependencies) {
+  const module = createPaymentsModule({ l1: null });
+  module.initialize(deps);
+  cleanups.push(() => module.destroy());
+  return module;
+}
+
+describe('#515 F1 — fail-closed composition invariant (S7 legality matrix)', () => {
+  it('FULL preset (thin storage + custody inventory + walletApi) initializes', () => {
+    const parts = makeParts();
+    expect(() => initModule(makeDeps(parts, { storage: parts.thinStorage, custody: 'inventory', walletApi: true }))).not.toThrow();
+  });
+
+  it('OWN-STORAGE preset (local storage + custody external + walletApi) initializes', () => {
+    const parts = makeParts();
+    expect(() => initModule(makeDeps(parts, { storage: parts.localStorage, custody: 'external', walletApi: true }))).not.toThrow();
+  });
+
+  it('fully-local composition (no wallet-api artifacts, no client) initializes', () => {
+    const parts = makeParts();
+    expect(() => initModule(makeDeps(parts, { storage: parts.localStorage }))).not.toThrow();
+  });
+
+  it("own storage + custody 'external' WITHOUT walletApi stays legal (no custody artifact)", () => {
+    const parts = makeParts();
+    expect(() => initModule(makeDeps(parts, { storage: parts.localStorage, custody: 'external' }))).not.toThrow();
+  });
+
+  it("delivery custody 'inventory' without walletApi throws INVALID_CONFIG", () => {
+    const parts = makeParts();
+    const module = createPaymentsModule({ l1: null });
+    let thrown: unknown;
+    try {
+      module.initialize(makeDeps(parts, { storage: parts.localStorage, custody: 'inventory' }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(SphereError);
+    expect((thrown as SphereError).code).toBe('INVALID_CONFIG');
+    expect((thrown as SphereError).message).toMatch(/custody is 'inventory'.*walletApi/s);
+  });
+
+  it('an active thin storage provider without walletApi throws INVALID_CONFIG (any delivery)', () => {
+    const parts = makeParts();
+    const module = createPaymentsModule({ l1: null });
+    let thrown: unknown;
+    try {
+      module.initialize(makeDeps(parts, { storage: parts.thinStorage }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(SphereError);
+    expect((thrown as SphereError).code).toBe('INVALID_CONFIG');
+    expect((thrown as SphereError).message).toMatch(/wallet-api-token-storage.*walletApi/s);
+  });
+
+  it('the full degraded incident composition (thin storage + inventory delivery, no client) throws', () => {
+    const parts = makeParts();
+    const module = createPaymentsModule({ l1: null });
+    expect(() =>
+      module.initialize(makeDeps(parts, { storage: parts.thinStorage, custody: 'inventory' }))
+    ).toThrow(SphereError);
+  });
+});
+
+describe('#515 F2 — SaveResult.success is checked for the ACTIVE custody provider', () => {
+  function failingSaveWallet() {
+    const parts = makeParts();
+    const deps = makeDeps(parts, { storage: parts.thinStorage, custody: 'inventory', walletApi: true });
+    const module = initModule(deps);
+    // The thin provider deliberately reports failure via {success:false}
+    // (WalletApiTokenStorageProvider.save) instead of throwing.
+    vi.spyOn(parts.thinStorage, 'save').mockResolvedValue({
+      success: false,
+      error: 'wallet-api save failed: backend down',
+      timestamp: Date.now(),
+    });
+    return { parts, module };
+  }
+
+  it('mint reports FAILURE, not success, when the active provider cannot persist the blob', async () => {
+    const { parts, module } = failingSaveWallet();
+    const result = await module.mintFungibleToken(UCT, 100n);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('backend down');
+    // The user-facing path THROWS instead of degrading silently.
+    expect(parts.emitEvent).not.toHaveBeenCalledWith('storage:degraded', expect.anything());
+  });
+
+  it('a background save (public addToken) surfaces storage:degraded instead of silence', async () => {
+    const { parts, module } = failingSaveWallet();
+    const token: Token = {
+      id: 'tok-degraded-1', coinId: UCT, symbol: 'UCT', name: 'UCT', decimals: 0,
+      amount: '5', status: 'confirmed', createdAt: Date.now(), updatedAt: Date.now(),
+    };
+    const added = await module.addToken(token);
+    expect(added).toBe(true);
+    expect(parts.emitEvent).toHaveBeenCalledWith('storage:degraded', {
+      providerId: 'wallet-api-token-storage',
+      error: expect.stringContaining('backend down'),
+    });
+  });
+});
+
+describe('#516 — failed putIntent must NOT leave a re-executable open intent', () => {
+  it('dead backend at putIntent → send fails cleanly → resume executes NOTHING → resync lands aborted', async () => {
+    const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
+    const baseUrl = await fake.start();
+    cleanups.push(() => fake.stop());
+
+    // A client whose transport can be killed underneath it — putIntent writes
+    // the local backstop first, then the network PUT rejects (the incident
+    // shape: client.ts wrote local BEFORE the server PUT).
+    let dead = true;
+    const fetchFn: FetchLike = (url, init) =>
+      dead ? Promise.reject(new TypeError('fetch failed')) : (globalThis.fetch as unknown as FetchLike)(url, init);
+    const kv = new MemoryKeyValueStore();
+    const client = new WalletApiClient({ baseUrl, network: fake.network, deviceId: 'd-516', storage: kv, fetchFn });
+    const delivery = new WalletApiMailboxProvider({ client, custody: 'external', stateStore: kv });
+    const engine = new FakeTokenEngine({ chainPubkey: hexToBytes(SENDER.chainPubkey) });
+    const emitEvent = vi.fn();
+    const deps: PaymentsModuleDependencies = {
+      identity: fullIdentity(SENDER),
+      storage: mockStorage(),
+      tokenStorageProviders: new Map([['local', mockLocalTokenStorage()]]),
+      transport: mockTransport(),
+      oracle: mockOracle(),
+      emitEvent,
+      tokenEngine: engine,
+      delivery,
+      walletApi: client,
+    };
+    const module = createPaymentsModule({ l1: null });
+    module.initialize(deps);
+    cleanups.push(() => module.destroy());
+
+    await module.load();
+    const mint = await module.mintFungibleToken(UCT, 1000n);
+    expect(mint.success).toBe(true);
+
+    const transferSpy = vi.spyOn(engine, 'transfer');
+    const splitSpy = vi.spyOn(engine, 'split');
+    const putIntentSpy = vi.spyOn(client, 'putIntent');
+
+    // Phase 1 — dead backend: the PUT rejects, the send fails CLEANLY with
+    // nothing certified; the nothing-certified abort cannot land either.
+    await expect(module.send({ recipient: '@bob', amount: '1000', coinId: UCT })).rejects.toThrow();
+    expect(transferSpy).not.toHaveBeenCalled(); // E.3: engine never ran
+    expect(splitSpy).not.toHaveBeenCalled();
+    expect(putIntentSpy).toHaveBeenCalledTimes(1);
+    const transferId = putIntentSpy.mock.calls[0][0];
+    // The source is restored and spendable; nothing reached the mailbox.
+    expect(module.getTokens()[0].status).toBe('confirmed');
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);
+
+    // Phase 2 — reconnect (SAME storage, same client): resume must execute
+    // NOTHING — the local intent is 'aborted', the server never saw it.
+    dead = false;
+    const outcome = await module.resumeOpenIntents();
+    expect(outcome).toEqual({ resumed: [], conflicted: [], failed: [] });
+    expect(transferSpy).not.toHaveBeenCalled();
+    expect(splitSpy).not.toHaveBeenCalled();
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);
+
+    // The resync replays the unlanded abort: the intent lands ABORTED (a
+    // no-op execution-wise), never as an open intent resume would re-run.
+    await client.resyncOpenIntents();
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'aborted' });
+    expect(await client.listIntents('open')).toEqual([]);
+
+    // And a resume AFTER the resync still executes nothing.
+    const outcome2 = await module.resumeOpenIntents();
+    expect(outcome2).toEqual({ resumed: [], conflicted: [], failed: [] });
+    expect(transferSpy).not.toHaveBeenCalled();
+    expect(module.getTokens()[0].status).toBe('confirmed'); // no double-spend of the source
+  });
+});

--- a/tests/unit/wallet-api/client.inventory.test.ts
+++ b/tests/unit/wallet-api/client.inventory.test.ts
@@ -219,6 +219,37 @@ describe('WalletApiClient — intents (E.3, §16)', () => {
     await expect(client.putIntent(tid, envelope('different'))).rejects.toMatchObject({ code: 'CONFLICT' });
   });
 
+  it("#516: a failed server abort still flips the LOCAL copy to 'aborted'; resync replays the abort", async () => {
+    const payload = envelope('abort-backstop');
+    await client.putIntent(tid, payload); // server: open
+    fake.setIntentFailure(true);
+    await expect(client.abortIntent(tid)).rejects.toThrowError(WalletApiError);
+    // The local intent is no longer 'open' — resync/resume can never re-run it.
+    expect(await client.listLocalOpenIntents()).toEqual([]);
+
+    fake.setIntentFailure(false);
+    await client.resyncOpenIntents(); // replays the unlanded abort
+    expect(fake.getIntent(identity.chainPubkey, tid)).toMatchObject({ status: 'aborted' });
+    // Stable: a second resync is a no-op (the pending abort was cleared).
+    await client.resyncOpenIntents();
+    expect(fake.getIntent(identity.chainPubkey, tid)).toMatchObject({ status: 'aborted' });
+  });
+
+  it('#516: PUT and abort both dead → resync lands the intent as ABORTED, never re-opens it', async () => {
+    const payload = envelope('double-pay-guard');
+    fake.setIntentFailure(true);
+    await expect(client.putIntent(tid, payload)).rejects.toThrowError(WalletApiError);
+    await expect(client.abortIntent(tid)).rejects.toThrowError(WalletApiError);
+    expect(await client.listLocalOpenIntents()).toEqual([]);
+
+    fake.setIntentFailure(false);
+    await client.resyncOpenIntents();
+    // The seed row exists for audit/recovery but is aborted — `resumeOpenIntents`
+    // (which lists status=open) re-executes NOTHING.
+    expect(fake.getIntent(identity.chainPubkey, tid)).toMatchObject({ status: 'aborted' });
+    expect(await client.listIntents('open')).toEqual([]);
+  });
+
   it('completion wins and never reverts (§16)', async () => {
     await client.putIntent(tid, envelope('seed'));
     await client.completeIntent(tid);

--- a/types/index.ts
+++ b/types/index.ts
@@ -397,6 +397,8 @@ export type SphereEventType =
   | 'sync:completed'
   | 'sync:provider'
   | 'sync:error'
+  | 'storage:degraded'
+  | 'walletapi:session'
   | 'connection:changed'
   | 'nametag:registered'
   | 'nametag:recovered'
@@ -477,6 +479,20 @@ export interface SphereEventMap {
   'sync:completed': { source: string; count: number };
   'sync:provider': { providerId: string; success: boolean; added?: number; removed?: number; error?: string };
   'sync:error': { source: string; error: string };
+  /**
+   * The ACTIVE custody token-storage provider failed a background save
+   * (#515 D3b): the in-memory token state is NOT durably persisted until a
+   * later save succeeds. User-facing flows (mint/send) fail loudly instead of
+   * emitting this.
+   */
+  'storage:degraded': { providerId: string; error: string };
+  /**
+   * wallet-api session state change (#515 F3): 'offline' = sign-in failed and
+   * the wallet runs degraded (no intents barrier, no server custody writes);
+   * flips to 'online' when a later sign-in succeeds. Readable any time via
+   * `sphere.walletApiSessionStatus`.
+   */
+  'walletapi:session': { status: 'online' | 'offline'; error?: string };
   'connection:changed': { provider: string; connected: boolean; status?: ProviderStatus; enabled?: boolean; error?: string };
   'nametag:registered': { nametag: string; addressIndex: number };
   'nametag:recovered': { nametag: string };

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -83,6 +83,13 @@ interface LocalIntent {
   payload: string;
   status: 'open' | 'completed' | 'aborted';
   createdAt: number;
+  /**
+   * #516: set when the abort decision could NOT land on the server (dead
+   * backend at send-failure cleanup). {@link WalletApiClient.resyncOpenIntents}
+   * replays it (PUT + abort) so the server row converges to aborted instead of
+   * resume re-executing a send the user watched fail.
+   */
+  abortPending?: boolean;
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -569,12 +576,20 @@ export class WalletApiClient {
     await this.storage.set(this.intentsKey(), JSON.stringify(intents));
   }
 
-  private async setLocalIntentStatus(transferId: string, status: LocalIntent['status']): Promise<void> {
+  private async setLocalIntentStatus(
+    transferId: string,
+    status: LocalIntent['status'],
+    opts: { abortPending?: boolean } = {}
+  ): Promise<void> {
     const intents = await this.readLocalIntents();
     const intent = intents[transferId];
-    if (!intent || intent.status === status) return;
+    if (!intent) return;
     if (intent.status === 'completed') return; // completed never reverts (§16)
+    const abortPending = opts.abortPending === true;
+    if (intent.status === status && (intent.abortPending === true) === abortPending) return;
     intent.status = status;
+    if (abortPending) intent.abortPending = true;
+    else delete intent.abortPending;
     await this.writeLocalIntents(intents);
   }
 
@@ -599,9 +614,23 @@ export class WalletApiClient {
     return parseIntents(await this.requestJson('GET', `/v1/intents?status=${status}`));
   }
 
-  /** `POST /v1/intents/{id}/abort` — soft, recoverable (§16). */
+  /**
+   * `POST /v1/intents/{id}/abort` — soft, recoverable (§16).
+   *
+   * #516: the LOCAL copy flips to 'aborted' even when the server abort cannot
+   * land (dead backend) — leaving it 'open' would make {@link resyncOpenIntents}
+   * re-PUT it and the next sign-in's `resumeOpenIntents` RE-EXECUTE a send the
+   * user watched fail (and possibly retried manually): a double-pay hazard.
+   * An unlanded abort is marked pending and replayed by
+   * {@link resyncOpenIntents} (PUT + abort) so the server converges too.
+   */
   async abortIntent(transferId: string): Promise<void> {
-    await this.requestJson('POST', `/v1/intents/${transferId}/abort`);
+    try {
+      await this.requestJson('POST', `/v1/intents/${transferId}/abort`);
+    } catch (err) {
+      await this.setLocalIntentStatus(transferId, 'aborted', { abortPending: true });
+      throw err;
+    }
     await this.setLocalIntentStatus(transferId, 'aborted');
   }
 
@@ -624,10 +653,23 @@ export class WalletApiClient {
    * write-once while open/completed). Called after a `syncEpoch` change
    * (server restore — §5.4): intents are the one server table not
    * re-derivable from blobs.
+   *
+   * #516: also replays locally-aborted intents whose abort never landed on
+   * the server (`abortPending`) — PUT (no-op while open/completed; (re)creates
+   * the row after a restore or a failed original PUT) then abort, so the
+   * server row lands as 'aborted' instead of an 'open' intent that resume
+   * would re-execute. Completed-wins is preserved server-side (§16).
    */
   async resyncOpenIntents(): Promise<void> {
-    for (const intent of await this.listLocalOpenIntents()) {
-      await this.requestJson('PUT', `/v1/intents/${intent.transferId}`, { payload: intent.payload });
+    const intents = await this.readLocalIntents();
+    for (const [transferId, intent] of Object.entries(intents)) {
+      if (intent.status === 'open') {
+        await this.requestJson('PUT', `/v1/intents/${transferId}`, { payload: intent.payload });
+      } else if (intent.status === 'aborted' && intent.abortPending === true) {
+        await this.requestJson('PUT', `/v1/intents/${transferId}`, { payload: intent.payload });
+        await this.requestJson('POST', `/v1/intents/${transferId}/abort`);
+        await this.setLocalIntentStatus(transferId, 'aborted'); // clears abortPending
+      }
     }
   }
 


### PR DESCRIPTION
Fixes the two incident-derived defect clusters from the 2026-06-12 analysis. **Refs #515, #516** — close both manually at merge (non-default target branch).

## #515 — fail-closed composition + checked SaveResult + surfaced session state

**F1 — composition invariant (S7).** `PaymentsModule.initialize` (and therefore `Sphere.init`) now throws a typed `INVALID_CONFIG` `SphereError` when wallet-api **custody artifacts** are present without the wallet-api client. Legality matrix enforced:

| active token storage | delivery custody | `walletApi` | verdict |
|---|---|---|---|
| thin (`requiresWalletApi`) | `'inventory'` | present | OK (FULL preset) |
| own/local | `'external'` | present | OK (OWN-STORAGE preset) |
| own/local | none (transport adapter) | absent | OK (fully local) |
| own/local | `'external'` | absent | OK (no custody artifact; delivery fails loudly at call time) |
| any | `'inventory'` | **absent** | **throws INVALID_CONFIG** |
| thin (`requiresWalletApi`) | any | **absent** | **throws INVALID_CONFIG** |

The thin provider declares itself via a new optional `TokenStorageProvider.requiresWalletApi` port marker (no provider-specific logic in the module). While wiring the tests through the public entry point, `Sphere.init` turned out to **silently drop `delivery`/`walletApi` (and `communications`) when delegating to `Sphere.create`/`Sphere.load`** — exactly the accidental-degradation path F1 exists to catch; they are now forwarded.

**F2 — `SaveResult.success` checked.** `PaymentsModule.save()` validates the ACTIVE custody provider's result (the thin provider deliberately returns `{success:false}`). User-facing flows propagate (`STORAGE_ERROR`): mint, the pre-engine send save, and the own-custody change-token stores (send + intent resume). Background saves emit the new `storage:degraded` event. Post-apply mirror saves in the full preset stay non-fatal (server custody already updated; failing a completed transfer would misreport).

**F3 — surfaced session state.** A failed wallet-api sign-in is recorded (`sphere.walletApiSessionStatus`: `'online' | 'offline' | null`) and emitted as the new `walletapi:session` event; flips to `'online'` on a later successful sign-in. Boot stays non-blocking.

## #516 — double-pay: failed putIntent left the local intent 'open'

`WalletApiClient.abortIntent` now flips the LOCAL intent copy to `'aborted'` even when the server abort cannot land (dead backend), marking it `abortPending`; `resyncOpenIntents` replays the unlanded abort (PUT + abort, completed-wins preserved) so the server row converges to `aborted`. Deterministic regression test: dead transport at `putIntent` → send fails cleanly (engine never ran) → reconnect → `resumeOpenIntents` executes **nothing** (engine spies assert zero calls) → resync lands the intent as `aborted`, `status=open` list stays empty.

## API additions (non-breaking)

- `SphereEventMap`: `storage:degraded`, `walletapi:session`
- `Sphere.walletApiSessionStatus` getter
- `TokenStorageProvider.requiresWalletApi?` (optional)
- `PaymentsModule.addToken(token, opts?)` optional second param (`criticalSave`)

No preset signatures changed.

## Tests

- `tests/unit/modules/PaymentsModule.fail-closed.test.ts` — F1 matrix (all presets init; degraded combinations throw with clear messages), F2 (thin `{success:false}` → mint reports failure; background save → `storage:degraded`), #516 end-to-end module test.
- `tests/unit/wallet-api/client.inventory.test.ts` — #516 client-level: failed abort backstop + PUT-and-abort-both-dead → resync lands aborted, never re-opens.
- `tests/unit/core/Sphere.walletapi-session.test.ts` — F3 state/event lifecycle.

Gates: typecheck clean, lint clean, build clean, `test:run` green except the 3 sanctioned `ipns-network` Node-26-local flakes (#487).