### PR TITLE
feat(courier): Phase 5 — CourierDeliveryProvider (blind delivery, signed ack, sender gate)

### DIFF
--- a/tests/helpers/fake-courier-server.ts
+++ b/tests/helpers/fake-courier-server.ts
@@ -22,6 +22,7 @@
  */
 
 import { verifySignedMessage } from '../../core/crypto';
+import { courierAckTemplate } from '../../transport/courier/ack-template';
 import type {
   CourierAckNonceResponse,
   CourierAckRequest,
@@ -159,7 +160,7 @@ export class FakeCourierServer {
     const nonce = this.ackNonces.get(req.entryId);
     if (!nonce) return { result: 'failed' };
     this.ackNonces.delete(req.entryId); // single-use
-    const tmpl = `unicity:courier:ack:v1\n${this.network}\n${d.senderId}\n${req.entryId}\n${nonce}`;
+    const tmpl = courierAckTemplate(this.network, d.senderId, req.entryId, nonce);
     if (!verifySignedMessage(tmpl, req.ackSig, recipientId)) return { result: 'failed' };
     d.status = 'claimed';
     d.ackSig = req.ackSig;

--- a/tests/helpers/fake-courier-server.ts
+++ b/tests/helpers/fake-courier-server.ts
@@ -1,0 +1,224 @@
+/**
+ * fake-courier-server — an in-memory, faithful re-implementation of the
+ * token-api courier wire endpoints (DESIGN §6), for the Phase 5 integration
+ * tests. The REAL token-api is only exercised in Phase 8.3; this fake lets the
+ * provider's logic run identically against a swappable in-process server.
+ *
+ * Faithful to Part A's wire contract:
+ *  - deposit: idempotent on `(recipientId, entryId)`; allocates gap-free
+ *    per-recipient `seq` and per-sender `sentSeq`; `{ entryId, seq, sentSeq, status }`.
+ *  - inbox?since=: rows with `seq > since`, sorted; carries `ciphertext` /
+ *    `senderPubkey` / `ackSig`.
+ *  - ack-nonce?entryId=: single-use server nonce.
+ *  - ack {entryId, ackSig}: addressee-only; nonce consumed AFTER the addressee
+ *    check; verifies `ackSig` over the bound template via `verifySignedMessage`;
+ *    flips unclaimed→claimed; returns the single frozen `{ result }`.
+ *  - sent?since=: rows with `sentSeq > since`; carries `ackSig`.
+ *
+ * Swap seam: the provider talks to a {@link CourierHttpClient}. `clientFor(ownerId)`
+ * returns one scoped to a caller (the authenticated `chainPubkey`). Phase 8.3
+ * swaps in a real HTTP client (fetch + JWT against `vaultUrl`) implementing the
+ * same interface — no provider changes.
+ */
+
+import { verifySignedMessage } from '../../core/crypto';
+import type {
+  CourierAckNonceResponse,
+  CourierAckRequest,
+  CourierAckResponse,
+  CourierDeliveryStatus,
+  CourierDepositRequest,
+  CourierDepositResponse,
+  CourierHttpClient,
+  CourierInboxResponse,
+  CourierSentResponse,
+} from '../../transport/courier/types';
+
+interface DeliveryRow {
+  recipientId: string;
+  senderId: string;
+  entryId: string;
+  transferId: string;
+  ciphertext: string;
+  hint: string | null;
+  status: CourierDeliveryStatus;
+  seq: number;
+  sentSeq: number;
+  ackSig: string | null;
+}
+
+let randomCounter = 0;
+const nextNonce = (): string => `nonce-${++randomCounter}-${Math.random().toString(36).slice(2)}`;
+
+/**
+ * The in-memory courier server. Hold ONE instance per test; obtain a
+ * caller-scoped {@link CourierHttpClient} via {@link FakeCourierServer.clientFor}.
+ */
+export class FakeCourierServer {
+  /** Canonical network literal baked into the ack template (DESIGN §6.4). */
+  readonly network: string;
+
+  private readonly deliveries: DeliveryRow[] = [];
+  private readonly recipientSeq = new Map<string, number>();
+  private readonly senderSeq = new Map<string, number>();
+  private readonly readPointers = new Map<string, number>();
+  /** Live ack-nonces by entryId (single-use). */
+  private readonly ackNonces = new Map<string, string>();
+  private syncEpoch = 1;
+
+  /** Per-endpoint call log — tests assert request bodies and call counts. */
+  readonly calls: {
+    deposit: CourierDepositRequest[];
+    ack: CourierAckRequest[];
+    ackNonce: string[];
+    inbox: number[];
+    sent: number[];
+  } = { deposit: [], ack: [], ackNonce: [], inbox: [], sent: [] };
+
+  constructor(network = 'testnet2') {
+    this.network = network;
+  }
+
+  /** A {@link CourierHttpClient} bound to a caller (the authenticated chainPubkey). */
+  clientFor(ownerId: string): CourierHttpClient {
+    return {
+      deposit: (req) => this.deposit(ownerId, req),
+      inbox: (since) => this.inbox(ownerId, since),
+      ackNonce: (entryId) => this.ackNonce(entryId),
+      ack: (req) => this.ack(ownerId, req),
+      sent: (since) => this.sent(ownerId, since),
+    };
+  }
+
+  // --- endpoints ------------------------------------------------------------
+
+  private deposit(senderId: string, req: CourierDepositRequest): CourierDepositResponse {
+    this.calls.deposit.push(req);
+    const recipientId = req.recipientPubkey;
+    // Idempotent on (recipientId, entryId) — the ciphertext bytes never affect dedup.
+    const existing = this.deliveries.find(
+      (d) => d.recipientId === recipientId && d.entryId === req.entryId,
+    );
+    if (existing) {
+      return { entryId: existing.entryId, seq: existing.seq, sentSeq: existing.sentSeq, status: existing.status };
+    }
+    const seq = this.alloc(this.recipientSeq, recipientId);
+    const sentSeq = this.alloc(this.senderSeq, senderId);
+    this.deliveries.push({
+      recipientId,
+      senderId,
+      entryId: req.entryId,
+      transferId: req.transferId,
+      ciphertext: req.ciphertext,
+      hint: req.hint ?? null,
+      status: 'unclaimed',
+      seq,
+      sentSeq,
+      ackSig: null,
+    });
+    return { entryId: req.entryId, seq, sentSeq, status: 'unclaimed' };
+  }
+
+  private inbox(recipientId: string, since: number): CourierInboxResponse {
+    this.calls.inbox.push(since);
+    const items = this.deliveries
+      .filter((d) => d.recipientId === recipientId && d.seq > since)
+      .sort((a, b) => a.seq - b.seq)
+      .map((d) => ({
+        entryId: d.entryId,
+        seq: d.seq,
+        status: d.status,
+        senderPubkey: d.senderId,
+        ciphertext: d.ciphertext,
+        transferId: d.transferId,
+        hint: d.hint,
+        ackSig: d.ackSig,
+      }));
+    return {
+      readPointer: this.readPointers.get(recipientId) ?? 0,
+      syncEpoch: this.syncEpoch,
+      more: false,
+      items,
+    };
+  }
+
+  private ackNonce(entryId: string): CourierAckNonceResponse {
+    this.calls.ackNonce.push(entryId);
+    const serverNonce = nextNonce();
+    this.ackNonces.set(entryId, serverNonce);
+    return { serverNonce };
+  }
+
+  private ack(recipientId: string, req: CourierAckRequest): CourierAckResponse {
+    this.calls.ack.push(req);
+    const d = this.deliveries.find((x) => x.entryId === req.entryId);
+    // Addressee-only: a non-addressee (or unknown entry) fails BEFORE the nonce
+    // is consumed (so a non-addressee can't burn it).
+    if (!d || d.recipientId !== recipientId) return { result: 'failed' };
+    if (d.status === 'claimed') return { result: 'alreadyClaimed' };
+    const nonce = this.ackNonces.get(req.entryId);
+    if (!nonce) return { result: 'failed' };
+    this.ackNonces.delete(req.entryId); // single-use
+    const tmpl = `unicity:courier:ack:v1\n${this.network}\n${d.senderId}\n${req.entryId}\n${nonce}`;
+    if (!verifySignedMessage(tmpl, req.ackSig, recipientId)) return { result: 'failed' };
+    d.status = 'claimed';
+    d.ackSig = req.ackSig;
+    this.advanceReadPointer(recipientId);
+    return { result: 'claimed' };
+  }
+
+  private sent(senderId: string, since: number): CourierSentResponse {
+    this.calls.sent.push(since);
+    const items = this.deliveries
+      .filter((d) => d.senderId === senderId && d.sentSeq > since)
+      .sort((a, b) => a.sentSeq - b.sentSeq)
+      .map((d) => ({
+        entryId: d.entryId,
+        recipientPubkey: d.recipientId,
+        status: d.status,
+        ackSig: d.ackSig,
+      }));
+    return { more: false, items };
+  }
+
+  // --- test affordances -----------------------------------------------------
+
+  /**
+   * Inject a FORGED `ackSig` onto a sent row WITHOUT the addressee check — a
+   * hostile/broken server that flips the flag without a valid signature. Used to
+   * prove the sender's verify-gate keeps redelivering (§6.5 negative path).
+   */
+  forgeSentAckSig(entryId: string, ackSig: string): void {
+    const d = this.deliveries.find((x) => x.entryId === entryId);
+    if (d) {
+      d.ackSig = ackSig;
+      d.status = 'claimed';
+    }
+  }
+
+  /** Number of stored deliveries (for assertions). */
+  get deliveryCount(): number {
+    return this.deliveries.length;
+  }
+
+  // --- internals ------------------------------------------------------------
+
+  private alloc(counter: Map<string, number>, id: string): number {
+    const next = (counter.get(id) ?? 0) + 1;
+    counter.set(id, next);
+    return next;
+  }
+
+  /** Read pointer = highest contiguous claimed/rejected seq (DESIGN §6.5). */
+  private advanceReadPointer(recipientId: string): void {
+    const rows = this.deliveries
+      .filter((d) => d.recipientId === recipientId)
+      .sort((a, b) => a.seq - b.seq);
+    let rp = 0;
+    for (const d of rows) {
+      if (d.status !== 'claimed' && d.status !== 'rejected') break;
+      rp = d.seq;
+    }
+    this.readPointers.set(recipientId, rp);
+  }
+}

--- a/tests/helpers/fake-courier-server.ts
+++ b/tests/helpers/fake-courier-server.ts
@@ -46,6 +46,8 @@ interface DeliveryRow {
   seq: number;
   sentSeq: number;
   ackSig: string | null;
+  /** The server nonce the claim consumed (surfaced to the sender via /sent). */
+  ackNonce: string | null;
 }
 
 let randomCounter = 0;
@@ -116,6 +118,7 @@ export class FakeCourierServer {
       seq,
       sentSeq,
       ackSig: null,
+      ackNonce: null,
     });
     return { entryId: req.entryId, seq, sentSeq, status: 'unclaimed' };
   }
@@ -164,6 +167,7 @@ export class FakeCourierServer {
     if (!verifySignedMessage(tmpl, req.ackSig, recipientId)) return { result: 'failed' };
     d.status = 'claimed';
     d.ackSig = req.ackSig;
+    d.ackNonce = nonce;
     this.advanceReadPointer(recipientId);
     return { result: 'claimed' };
   }
@@ -178,6 +182,7 @@ export class FakeCourierServer {
         recipientPubkey: d.recipientId,
         status: d.status,
         ackSig: d.ackSig,
+        ackNonce: d.ackNonce,
       }));
     return { more: false, items };
   }
@@ -189,10 +194,11 @@ export class FakeCourierServer {
    * hostile/broken server that flips the flag without a valid signature. Used to
    * prove the sender's verify-gate keeps redelivering (§6.5 negative path).
    */
-  forgeSentAckSig(entryId: string, ackSig: string): void {
+  forgeSentAckSig(entryId: string, ackSig: string, ackNonce = 'forged-nonce'): void {
     const d = this.deliveries.find((x) => x.entryId === entryId);
     if (d) {
       d.ackSig = ackSig;
+      d.ackNonce = ackNonce;
       d.status = 'claimed';
     }
   }

--- a/tests/integration/vault/courier.ack.test.ts
+++ b/tests/integration/vault/courier.ack.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Courier ack — signed durable-copy claim (Task 5.3, §6.4/§8.2).
+ *
+ *  - ackSig = signMessage(recipientPriv, ackTemplate(network, sender, entryId, serverNonce));
+ *    the fake server verifies it via verifySignedMessage and flips to `claimed`.
+ *  - ORDERING: `courier_ack_pending[entryId]` is journaled AFTER the custody
+ *    commit and BEFORE the ack POST (custody-commit ≺ ack-journal ≺ ack-POST). A
+ *    simulated crash between the journal and the POST re-fires on the next load.
+ *  - WIRE: `POST /v1/courier/ack` body is EXACTLY `{entryId, ackSig}` — never the
+ *    retired batch `{claimed[]}` shape. `serverNonce` is fetched via GET ack-nonce.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import { CourierDeliveryProvider } from '../../../transport/courier/CourierDeliveryProvider';
+import { FakeCourierServer } from '../../helpers/fake-courier-server';
+import type { FullIdentity } from '../../../types';
+import type {
+  CourierHttpClient,
+  CourierJournalStore,
+  V2TransferSink,
+} from '../../../transport/courier/CourierDeliveryProvider';
+import type { V2TransferPayload } from '../../../types/v2-transfer';
+
+const NETWORK = 'testnet2';
+const SENDER_PRIV = '55'.repeat(32);
+const RECIPIENT_PRIV = '66'.repeat(32);
+const SENDER_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(SENDER_PRIV), true));
+const RECIPIENT_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIPIENT_PRIV), true));
+
+const TOKEN_ID = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const TOKEN_BYTES = new Uint8Array(40).map((_, i) => (i * 7 + 3) & 0xff);
+const BLOB_HEX = bytesToHex(encodeTokenBlob({ v: 1, network: 0, tokenId: TOKEN_ID, token: TOKEN_BYTES }));
+
+const sender: FullIdentity = { chainPubkey: SENDER_PUB, l1Address: 'alpha1s', privateKey: SENDER_PRIV };
+const recipient: FullIdentity = { chainPubkey: RECIPIENT_PUB, l1Address: 'alpha1r', privateKey: RECIPIENT_PRIV };
+
+const noopSink: V2TransferSink = async (_p: V2TransferPayload, _s: string) => {};
+
+function memJournal(): CourierJournalStore & { events: string[]; map: Map<string, string> } {
+  const map = new Map<string, string>();
+  const events: string[] = [];
+  return {
+    map,
+    events,
+    get: async (k) => map.get(k) ?? null,
+    set: async (k, v) => {
+      events.push(`set:${k.split(':')[0]}`);
+      map.set(k, v);
+    },
+  };
+}
+
+function provider(
+  id: FullIdentity,
+  client: CourierHttpClient,
+  journal: CourierJournalStore,
+  sink: V2TransferSink = noopSink,
+): CourierDeliveryProvider {
+  const p = new CourierDeliveryProvider({
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    network: NETWORK,
+    httpClientFactory: () => client,
+    journal,
+    onV2Transfer: sink,
+  });
+  p.setIdentity(id);
+  return p;
+}
+
+async function deposit(server: FakeCourierServer): Promise<void> {
+  const sp = provider(sender, server.clientFor(SENDER_PUB), memJournal());
+  await sp.deposit({
+    recipientChainPubkey: RECIPIENT_PUB,
+    senderChainPubkey: SENDER_PUB,
+    transferId: 'tx-1',
+    tokenBlobHex: BLOB_HEX,
+  });
+}
+
+describe('courier ack', () => {
+  it('ack body is EXACTLY {entryId, ackSig} and flips the entry to claimed', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    await deposit(server);
+
+    const rp = provider(recipient, server.clientFor(RECIPIENT_PUB), memJournal());
+    await rp.receive();
+
+    expect(server.calls.ackNonce).toHaveLength(1);
+    expect(server.calls.ack).toHaveLength(1);
+    expect(Object.keys(server.calls.ack[0]).sort()).toEqual(['ackSig', 'entryId']);
+    // claimed: the sender's /sent now carries the ackSig.
+    const sent = await server.clientFor(SENDER_PUB).sent(0);
+    expect(sent.items[0].status).toBe('claimed');
+    expect(sent.items[0].ackSig).toBe(server.calls.ack[0].ackSig);
+  });
+
+  it('journals ACK-PENDING AFTER custody commit and BEFORE the ack POST', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    await deposit(server);
+
+    const order: string[] = [];
+    const realClient = server.clientFor(RECIPIENT_PUB);
+    const client: CourierHttpClient = {
+      ...realClient,
+      ack: vi.fn(async (req) => {
+        order.push('ack-post');
+        return realClient.ack(req);
+      }),
+    };
+    const journal = memJournal();
+    const sink: V2TransferSink = async () => void order.push('custody-commit');
+    // Record the ack-pending journal write.
+    const origSet = journal.set;
+    journal.set = async (k, v) => {
+      if (k.startsWith('courier_ack_pending')) order.push('ack-journal');
+      return origSet(k, v);
+    };
+
+    const rp = provider(recipient, client, journal, sink);
+    await rp.receive();
+
+    // The invariant is the PREFIX ordering custody-commit ≺ ack-journal ≺ ack-POST.
+    // (A trailing ack-journal write is the post-claim journal cleanup — irrelevant.)
+    expect(order.slice(0, 3)).toEqual(['custody-commit', 'ack-journal', 'ack-post']);
+    expect(order.indexOf('ack-journal')).toBeLessThan(order.indexOf('ack-post'));
+  });
+
+  it('crash between journal and POST -> re-fired on next load (replayAckPending)', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    await deposit(server);
+
+    // First client: the ack POST throws (crash after the journal write).
+    const realClient = server.clientFor(RECIPIENT_PUB);
+    let crash = true;
+    const client: CourierHttpClient = {
+      ...realClient,
+      ack: async (req) => {
+        if (crash) throw new Error('network down after journal write');
+        return realClient.ack(req);
+      },
+    };
+    const journal = memJournal();
+    const rp = provider(recipient, client, journal);
+
+    // receive() journals ACK-PENDING, then the ack POST crashes.
+    await expect(rp.receive()).rejects.toThrow();
+    expect(journal.map.has(`courier_ack_pending:${NETWORK}:${RECIPIENT_PUB}`)).toBe(true);
+    // The server still shows the entry unclaimed.
+    let sent = await server.clientFor(SENDER_PUB).sent(0);
+    expect(sent.items[0].status).toBe('unclaimed');
+
+    // Recover: a fresh load re-fires the journaled ack, now the POST succeeds.
+    crash = false;
+    await rp.replayAckPending();
+    sent = await server.clientFor(SENDER_PUB).sent(0);
+    expect(sent.items[0].status).toBe('claimed');
+    // The journal row is cleared after a successful claim.
+    const pending = JSON.parse(journal.map.get(`courier_ack_pending:${NETWORK}:${RECIPIENT_PUB}`)!);
+    expect(Object.keys(pending)).toHaveLength(0);
+  });
+});

--- a/tests/integration/vault/courier.deposit.test.ts
+++ b/tests/integration/vault/courier.deposit.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Courier deposit (Task 5.1, §6.2/§6.3) against the in-process fake server.
+ *
+ * Asserts the provider seals + packs `ciphertext = base64(nonce24‖ct)`, POSTs the
+ * exact deposit body `{recipientPubkey, entryId, transferId, ciphertext}` (entryId
+ * = the ECDH `courierEntryId`; NO `{nonce,ct}` hint object), and that the recipient
+ * can open the deposited envelope back to the original V2_TRANSFER payload.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import { CourierDeliveryProvider } from '../../../transport/courier/CourierDeliveryProvider';
+import { courierEntryId } from '../../../transport/courier/entryId';
+import { openCourierEnvelope, unpackCourier } from '../../../vault-aead/courier';
+import { FakeCourierServer } from '../../helpers/fake-courier-server';
+import type { FullIdentity } from '../../../types';
+import type { CourierJournalStore, V2TransferSink } from '../../../transport/courier/CourierDeliveryProvider';
+
+const NETWORK = 'testnet2';
+const SENDER_PRIV = '55'.repeat(32);
+const RECIPIENT_PRIV = '66'.repeat(32);
+const SENDER_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(SENDER_PRIV), true));
+const RECIPIENT_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIPIENT_PRIV), true));
+
+const TOKEN_ID = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const TOKEN_BYTES = new Uint8Array(40).map((_, i) => (i * 7 + 3) & 0xff);
+const BLOB_HEX = bytesToHex(encodeTokenBlob({ v: 1, network: 0, tokenId: TOKEN_ID, token: TOKEN_BYTES }));
+
+function memJournal(): CourierJournalStore {
+  const m = new Map<string, string>();
+  return { get: async (k) => m.get(k) ?? null, set: async (k, v) => void m.set(k, v) };
+}
+
+const senderId: FullIdentity = {
+  chainPubkey: SENDER_PUB,
+  l1Address: 'alpha1sender',
+  privateKey: SENDER_PRIV,
+};
+
+function makeProvider(server: FakeCourierServer, sink: V2TransferSink): CourierDeliveryProvider {
+  const p = new CourierDeliveryProvider({
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    network: NETWORK,
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+    journal: memJournal(),
+    onV2Transfer: sink,
+  });
+  p.setIdentity(senderId);
+  return p;
+}
+
+describe('courier deposit', () => {
+  it('POSTs exactly {recipientPubkey, entryId, transferId, ciphertext} (no hint object)', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    const provider = makeProvider(server, async () => {});
+
+    const handle = await provider.deposit({
+      recipientChainPubkey: RECIPIENT_PUB,
+      senderChainPubkey: SENDER_PUB,
+      transferId: 'tx-1',
+      tokenBlobHex: BLOB_HEX,
+    });
+
+    expect(server.calls.deposit).toHaveLength(1);
+    const body = server.calls.deposit[0];
+    expect(Object.keys(body).sort()).toEqual(['ciphertext', 'entryId', 'recipientPubkey', 'transferId']);
+    expect(body.recipientPubkey).toBe(RECIPIENT_PUB);
+    expect(body.transferId).toBe('tx-1');
+    expect(body.entryId).toBe(courierEntryId(SENDER_PRIV, RECIPIENT_PUB, BLOB_HEX));
+    expect(handle.entryId).toBe(body.entryId);
+    // ciphertext is a single packed base64 string (NOT a {nonce,ct} object).
+    expect(typeof body.ciphertext).toBe('string');
+    expect((body as Record<string, unknown>).hint).toBeUndefined();
+  });
+
+  it('ciphertext is base64(nonce24‖ct) — first 24 bytes are the nonce, opens to the payload', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    const provider = makeProvider(server, async () => {});
+
+    await provider.deposit({
+      recipientChainPubkey: RECIPIENT_PUB,
+      senderChainPubkey: SENDER_PUB,
+      transferId: 'tx-1',
+      tokenBlobHex: BLOB_HEX,
+      memo: 'hello',
+    });
+
+    const { ciphertext, entryId } = server.calls.deposit[0];
+    const { nonce } = unpackCourier(ciphertext);
+    expect(nonce).toHaveLength(24);
+
+    const pt = openCourierEnvelope({
+      network: NETWORK,
+      recipientPriv: RECIPIENT_PRIV,
+      senderPubkey: SENDER_PUB,
+      recipientPubkey: RECIPIENT_PUB,
+      entryId,
+      ciphertext,
+    });
+    const decoded = JSON.parse(new TextDecoder().decode(pt));
+    expect(decoded.type).toBe('V2_TRANSFER');
+    expect(decoded.tokenBlob).toBe(BLOB_HEX);
+    expect(decoded.memo).toBe('hello');
+  });
+
+  it('deposit is idempotent (same entryId -> single stored row)', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    const provider = makeProvider(server, async () => {});
+    const env = {
+      recipientChainPubkey: RECIPIENT_PUB,
+      senderChainPubkey: SENDER_PUB,
+      transferId: 'tx-1',
+      tokenBlobHex: BLOB_HEX,
+    };
+    await provider.deposit(env);
+    await provider.deposit(env);
+    expect(server.deliveryCount).toBe(1);
+  });
+});

--- a/tests/integration/vault/courier.receive.test.ts
+++ b/tests/integration/vault/courier.receive.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Courier receive (Task 5.2, §3/§6.4) against the in-process fake server.
+ *
+ * A deposited envelope, on `receive()`, is unpacked (first 24 bytes = nonce),
+ * opened with `openCourierEnvelope`, decoded to a V2_TRANSFER payload, and fed to
+ * the EXISTING `handleV2Transfer` path UNCHANGED. The test wires the provider's
+ * `onV2Transfer` sink to a faithful mini-host that mirrors handleV2Transfer
+ * (engine.verify → isOwnedBy → dedup `v2_<tokenId>` → store → RECEIVED history)
+ * and asserts each step runs and the RECEIVED entry records the sender chainPubkey
+ * with the nametag omitted (Nostr no-op over the courier).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { encodeTokenBlob, decodeTokenBlob } from '../../../token-engine/token-blob';
+import { CourierDeliveryProvider } from '../../../transport/courier/CourierDeliveryProvider';
+import { FakeCourierServer } from '../../helpers/fake-courier-server';
+import type { FullIdentity } from '../../../types';
+import type { V2TransferPayload } from '../../../types/v2-transfer';
+import type { CourierJournalStore } from '../../../transport/courier/CourierDeliveryProvider';
+
+const NETWORK = 'testnet2';
+const SENDER_PRIV = '55'.repeat(32);
+const RECIPIENT_PRIV = '66'.repeat(32);
+const SENDER_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(SENDER_PRIV), true));
+const RECIPIENT_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIPIENT_PRIV), true));
+
+const TOKEN_ID = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const TOKEN_BYTES = new Uint8Array(40).map((_, i) => (i * 7 + 3) & 0xff);
+const BLOB_HEX = bytesToHex(encodeTokenBlob({ v: 1, network: 0, tokenId: TOKEN_ID, token: TOKEN_BYTES }));
+
+function memJournal(): CourierJournalStore {
+  const m = new Map<string, string>();
+  return { get: async (k) => m.get(k) ?? null, set: async (k, v) => void m.set(k, v) };
+}
+
+const sender: FullIdentity = { chainPubkey: SENDER_PUB, l1Address: 'alpha1s', privateKey: SENDER_PRIV };
+const recipient: FullIdentity = { chainPubkey: RECIPIENT_PUB, l1Address: 'alpha1r', privateKey: RECIPIENT_PRIV };
+
+/**
+ * A faithful mini-host mirroring PaymentsModule.handleV2Transfer. It is what the
+ * provider's `onV2Transfer` sink feeds — the receive path is unchanged.
+ */
+function makeHandleV2Host() {
+  const stored = new Set<string>(); // dedup by v2_<tokenId>
+  const history: Array<Record<string, unknown>> = [];
+  const engine = {
+    verify: vi.fn(async () => ({ ok: true })),
+    isOwnedBy: vi.fn(() => true),
+    tokenId: vi.fn(() => TOKEN_ID),
+  };
+  const sink = async (payload: V2TransferPayload, senderPubkey: string): Promise<void> => {
+    const blob = decodeTokenBlob(hexToBytes(payload.tokenBlob)); // decode like handleV2Transfer
+    const verdict = await engine.verify(blob);
+    if (!verdict.ok) return;
+    if (!engine.isOwnedBy(blob, RECIPIENT_PUB)) return;
+    const id = `v2_${engine.tokenId(blob)}`;
+    if (stored.has(id)) return; // dedup
+    stored.add(id);
+    history.push({ type: 'RECEIVED', senderPubkey, tokenId: id }); // nametag omitted
+  };
+  return { sink, engine, stored, history };
+}
+
+function provider(id: FullIdentity, server: FakeCourierServer, sink: ReturnType<typeof makeHandleV2Host>['sink']) {
+  const p = new CourierDeliveryProvider({
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    network: NETWORK,
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+    journal: memJournal(),
+    onV2Transfer: sink,
+  });
+  p.setIdentity(id);
+  return p;
+}
+
+async function deposit(server: FakeCourierServer): Promise<void> {
+  const sp = provider(sender, server, async () => {});
+  await sp.deposit({
+    recipientChainPubkey: RECIPIENT_PUB,
+    senderChainPubkey: SENDER_PUB,
+    transferId: 'tx-1',
+    tokenBlobHex: BLOB_HEX,
+    memo: 'hi',
+  });
+}
+
+describe('courier receive', () => {
+  it('opens the envelope and feeds handleV2Transfer (verify/isOwnedBy/dedup run)', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    await deposit(server);
+
+    const host = makeHandleV2Host();
+    const rp = provider(recipient, server, host.sink);
+    await rp.receive();
+
+    expect(host.engine.verify).toHaveBeenCalledTimes(1);
+    expect(host.engine.isOwnedBy).toHaveBeenCalledTimes(1);
+    expect(host.engine.tokenId).toHaveBeenCalled();
+    expect(host.stored.has(`v2_${TOKEN_ID}`)).toBe(true);
+  });
+
+  it('RECEIVED history records the sender chainPubkey, nametag omitted', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    await deposit(server);
+
+    const host = makeHandleV2Host();
+    const rp = provider(recipient, server, host.sink);
+    await rp.receive();
+
+    expect(host.history).toHaveLength(1);
+    expect(host.history[0].type).toBe('RECEIVED');
+    expect(host.history[0].senderPubkey).toBe(SENDER_PUB);
+    expect(host.history[0].senderNametag).toBeUndefined();
+  });
+
+  it('re-receiving a still-unclaimed item is harmless (dedup by v2_<tokenId>)', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    await deposit(server);
+
+    const host = makeHandleV2Host();
+    const rp = provider(recipient, server, host.sink);
+    await rp.receive();
+    await rp.receive();
+
+    // The sink ran twice but stored once (dedup) — exactly-once stored.
+    expect(host.stored.size).toBe(1);
+    expect(host.history).toHaveLength(1);
+  });
+});

--- a/tests/integration/vault/courier.sent.test.ts
+++ b/tests/integration/vault/courier.sent.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Sender-gated delivery confirmation (Task 5.4, §6.5).
+ *
+ *  - `GET /v1/courier/sent?since=` rows carry `ackSig`.
+ *  - The SENDER — not the server — gates "delivered" + GC: ONLY a valid
+ *    `verifySignedMessage(ackSig, recipientChainPubkey)` over the bound template
+ *    licenses `onDelivered` (which removes PENDING_V2_DELIVERIES). A FORGED flag
+ *    without a valid sig is rejected → the entry keeps redelivering and, past the
+ *    attempt cap, surfaces `delivery_unconfirmed`. Backoff bound asserted.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes, signMessage } from '../../../core/crypto';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import { CourierDeliveryProvider } from '../../../transport/courier/CourierDeliveryProvider';
+import { FakeCourierServer } from '../../helpers/fake-courier-server';
+import type { FullIdentity } from '../../../types';
+import type {
+  CourierDeliveryConfig,
+  CourierJournalStore,
+  V2TransferSink,
+} from '../../../transport/courier/CourierDeliveryProvider';
+import type { V2TransferPayload } from '../../../types/v2-transfer';
+
+const NETWORK = 'testnet2';
+const SENDER_PRIV = '55'.repeat(32);
+const RECIPIENT_PRIV = '66'.repeat(32);
+const ATTACKER_PRIV = '99'.repeat(32);
+const SENDER_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(SENDER_PRIV), true));
+const RECIPIENT_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIPIENT_PRIV), true));
+
+const TOKEN_ID = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const TOKEN_BYTES = new Uint8Array(40).map((_, i) => (i * 7 + 3) & 0xff);
+const BLOB_HEX = bytesToHex(encodeTokenBlob({ v: 1, network: 0, tokenId: TOKEN_ID, token: TOKEN_BYTES }));
+
+const sender: FullIdentity = { chainPubkey: SENDER_PUB, l1Address: 'alpha1s', privateKey: SENDER_PRIV };
+const recipient: FullIdentity = { chainPubkey: RECIPIENT_PUB, l1Address: 'alpha1r', privateKey: RECIPIENT_PRIV };
+const noopSink: V2TransferSink = async (_p: V2TransferPayload, _s: string) => {};
+
+function memJournal(): CourierJournalStore {
+  const m = new Map<string, string>();
+  return { get: async (k) => m.get(k) ?? null, set: async (k, v) => void m.set(k, v) };
+}
+
+function makeSender(server: FakeCourierServer, overrides: Partial<CourierDeliveryConfig> = {}, journal = memJournal()) {
+  const p = new CourierDeliveryProvider({
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    network: NETWORK,
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+    journal,
+    onV2Transfer: noopSink,
+    ...overrides,
+  });
+  p.setIdentity(sender);
+  return p;
+}
+
+function makeRecipient(server: FakeCourierServer, sink: V2TransferSink = noopSink) {
+  const p = new CourierDeliveryProvider({
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    network: NETWORK,
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+    journal: memJournal(),
+    onV2Transfer: sink,
+  });
+  p.setIdentity(recipient);
+  return p;
+}
+
+const env = {
+  recipientChainPubkey: RECIPIENT_PUB,
+  senderChainPubkey: SENDER_PUB,
+  transferId: 'tx-1',
+  tokenBlobHex: BLOB_HEX,
+};
+
+describe('courier sender-gated delivery confirmation', () => {
+  it('a VALID recipient ackSig licenses onDelivered (removes PENDING_V2_DELIVERIES)', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    const delivered: string[] = [];
+    const sp = makeSender(server, { onDelivered: async (id) => void delivered.push(id) });
+    const handle = await sp.deposit(env);
+
+    // Recipient claims it for real (valid signed ack).
+    await makeRecipient(server).receive();
+
+    // /sent row carries the ackSig.
+    const sent = await server.clientFor(SENDER_PUB).sent(0);
+    expect(sent.items[0].ackSig).toBeTruthy();
+
+    await sp.pollSent();
+    expect(delivered).toEqual([handle.entryId]);
+    expect(await sp.sentState(handle.entryId)).toBe('delivered');
+  });
+
+  it('a FORGED ackSig (no valid recipient sig) does NOT license delivery — keeps redelivering', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    const delivered: string[] = [];
+    const sp = makeSender(server, { onDelivered: async (id) => void delivered.push(id) });
+    const handle = await sp.deposit(env);
+
+    // The server forges a `claimed` flag with an ackSig NOT signed by the recipient
+    // (signed by an attacker key over a bogus nonce) — a hostile/broken operator.
+    const forged = signMessage(ATTACKER_PRIV, 'unicity:courier:ack:v1\n' + NETWORK + '\nx\n' + handle.entryId + '\nz');
+    server.forgeSentAckSig(handle.entryId, forged);
+
+    await sp.pollSent();
+    // Not delivered: the forged sig fails verifySignedMessage against the recipient pubkey.
+    expect(delivered).toEqual([]);
+    expect(await sp.sentState(handle.entryId)).toBe('pending');
+  });
+
+  it('past the attempt cap a still-unconfirmed entry surfaces delivery_unconfirmed', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    const sp = makeSender(server, { maxRedeliveryAttempts: 3 });
+    const handle = await sp.deposit(env);
+    // Recipient never claims; each pollSent finds it unclaimed -> bumps attempts.
+    await sp.pollSent();
+    await sp.pollSent();
+    expect(await sp.sentState(handle.entryId)).toBe('pending');
+    await sp.pollSent(); // attempts hits 3 == cap
+    expect(await sp.sentState(handle.entryId)).toBe('delivery_unconfirmed');
+  });
+
+  it('backoff is exponential and capped', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    const sp = makeSender(server, { backoffBaseMs: 1000, backoffMaxMs: 8000 });
+    expect(sp.backoffMs(0)).toBe(1000);
+    expect(sp.backoffMs(1)).toBe(2000);
+    expect(sp.backoffMs(2)).toBe(4000);
+    expect(sp.backoffMs(3)).toBe(8000);
+    expect(sp.backoffMs(10)).toBe(8000); // capped
+  });
+
+  it('confirmReceipt returns the signed receipt only for a validly-claimed handle', async () => {
+    const server = new FakeCourierServer(NETWORK);
+    const sp = makeSender(server);
+    const handle = await sp.deposit(env);
+
+    expect(await sp.confirmReceipt(handle)).toBeNull(); // not yet claimed
+    await makeRecipient(server).receive();
+    const receipt = await sp.confirmReceipt(handle);
+    expect(receipt?.entryId).toBe(handle.entryId);
+    expect(receipt?.recipientChainPubkey).toBe(RECIPIENT_PUB);
+    expect(receipt?.ackSig).toBeTruthy();
+  });
+});

--- a/tests/unit/vault/courier.entryid.test.ts
+++ b/tests/unit/vault/courier.entryid.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Courier entryId (§6.2) — HMAC over the ECDH shared secret (finding #12).
+ *
+ *   entryId = HMAC-SHA256(
+ *     HKDF-SHA256(ecdhX(senderPriv, recipientPub), 'unicity-courier-entryid-v1'),
+ *     tokenId ‖ stateHash
+ *   )                                                              -> 64-hex
+ *
+ * The entryId binds to the EXACT `stateHash` that `PaymentsModule.tryParseBlobKeys`
+ * derives (`sha256(bytesToHex(blob.token), 'hex')`) — pinned here against a fixture
+ * blob so a divergence on either side is caught. The sender holds the ECDH secret
+ * and the journaled blob, so it recomputes the identical entryId for replay-dedup.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { sha256 } from '../../../core/crypto';
+import { encodeTokenBlob, decodeTokenBlob } from '../../../token-engine/token-blob';
+import { hexToBytes, bytesToHex } from '../../../core/crypto';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { courierEntryId, courierStateHash } from '../../../transport/courier/entryId';
+
+const SENDER_PRIV = '55'.repeat(32);
+const RECIPIENT_PRIV = '66'.repeat(32);
+const SENDER_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(SENDER_PRIV), true));
+const RECIPIENT_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIPIENT_PRIV), true));
+
+// A fixed v2 token blob: { v:1, network:0, tokenId, token } (token = the CBOR bytes).
+const TOKEN_ID = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const TOKEN_BYTES = new Uint8Array(40).map((_, i) => (i * 7 + 3) & 0xff);
+const BLOB = encodeTokenBlob({ v: 1, network: 0, tokenId: TOKEN_ID, token: TOKEN_BYTES });
+const BLOB_HEX = bytesToHex(BLOB);
+
+describe('courier entryId', () => {
+  it('stateHash equals tryParseBlobKeys (sha256(bytesToHex(blob.token)))', () => {
+    // The exact computation tryParseBlobKeys performs.
+    const blob = decodeTokenBlob(hexToBytes(BLOB_HEX));
+    const expected = sha256(bytesToHex(blob.token), 'hex');
+    expect(courierStateHash(BLOB_HEX)).toBe(expected);
+  });
+
+  it('pinned KAT', () => {
+    const id = courierEntryId(SENDER_PRIV, RECIPIENT_PUB, BLOB_HEX);
+    expect(id).toHaveLength(64);
+    expect(id).toBe('6947a85f3d95dc27728b2f05e1c4480b7be86b3877262100277de2ede57cbfab');
+  });
+
+  it('sender recompute is identical (replay-dedup holds)', () => {
+    const a = courierEntryId(SENDER_PRIV, RECIPIENT_PUB, BLOB_HEX);
+    const b = courierEntryId(SENDER_PRIV, RECIPIENT_PUB, BLOB_HEX);
+    expect(a).toBe(b);
+  });
+
+  it('different recipient -> different entryId', () => {
+    const other = bytesToHex(secp256k1.getPublicKey(hexToBytes('77'.repeat(32)), true));
+    expect(courierEntryId(SENDER_PRIV, RECIPIENT_PUB, BLOB_HEX)).not.toBe(
+      courierEntryId(SENDER_PRIV, other, BLOB_HEX),
+    );
+  });
+});

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -1,76 +1,142 @@
 /**
- * CourierDeliveryProvider — the reference token-delivery transport over the
- * Token-Vault v2 courier endpoints (§3, §6).
+ * CourierDeliveryProvider — the reference {@link TokenDeliveryTransport} over the
+ * Token-Vault v2 courier endpoints (DESIGN §3, §6).
  *
- * Seals each transfer into a courier envelope (ECDH-derived key, AAD-bound
- * entryId) and exchanges it via deposit / receive / ack / sent. The real
- * bodies land in Phase 5; this is the typed skeleton from Task 0.1.
+ * It seals each transfer into a courier envelope (ECDH-derived key, AAD-bound
+ * entryId) and exchanges it via deposit / receive / ack / sent. Resolution
+ * (nametag→pubkey via Nostr) is a SEPARATE concern handled before delivery — the
+ * courier addresses purely by `recipientChainPubkey`.
+ *
+ * The provider talks to the courier through an injected {@link CourierHttpClient}
+ * (the swap seam): the Phase 5 tests inject the in-process fake server; Phase 8.3
+ * injects a real fetch+JWT client against `vaultUrl`. The incoming path feeds the
+ * EXISTING `handleV2Transfer` (verify + isOwnedBy + dedup) unchanged via an
+ * injected {@link V2TransferSink}.
  */
 
 import type { FullIdentity } from '../../types';
+import type { V2TransferPayload } from '../../types/v2-transfer';
+import { sealCourierEnvelope } from '../../vault-aead/courier';
+import { courierEntryId } from './entryId';
+import type {
+  CourierHttpClient,
+  DeliveryHandle,
+  TokenDeliveryCapabilities,
+  TokenDeliveryTransport,
+  TokenEnvelope,
+} from './types';
+
+/**
+ * Sink for a decoded incoming transfer — bound by PaymentsModule to its existing
+ * `handleV2Transfer(payload, senderPubkey)` so the receive path is unchanged.
+ */
+export type V2TransferSink = (payload: V2TransferPayload, senderPubkey: string) => Promise<void>;
+
+/** Minimal persistent KV the journal needs (matches PaymentsModule storage). */
+export interface CourierJournalStore {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+}
 
 export interface CourierDeliveryConfig {
   /** Vault/courier base URL — `NETWORKS[network].vaultUrl`. */
   vaultUrl: string;
-  /** Canonical network name. */
+  /** Canonical network name (DESIGN §7.1 — `testnet2` / `mainnet`). */
   network: string;
+  /** Swap seam: build a courier client scoped to the authenticated caller. */
+  httpClientFactory: (ownerId: string) => CourierHttpClient;
+  /** Durable journal (ACK-PENDING, read pointer, sent watermark). */
+  journal: CourierJournalStore;
+  /** Feeds decoded incoming transfers into the existing handleV2Transfer path. */
+  onV2Transfer: V2TransferSink;
+  /** Max envelope bytes the courier accepts (DESIGN §6.6 default 16 MiB). */
+  maxBytes?: number;
 }
 
-/** A sealed transfer ready to hand to the courier `deposit` endpoint. */
-export interface CourierEnvelope {
-  recipientPubkey: string;
-  entryId: string;
-  transferId: string;
-  /** base64(nonce24‖ct) packed string. */
-  ciphertext: string;
-  /** Single base64 scalar hint string (NOT a {nonce,ct} object). */
-  hint?: string;
-}
-
-/** Result of a courier deposit. */
-export interface CourierDepositResult {
-  entryId: string;
-}
-
-/** A received courier delivery, pre-decrypt. */
-export interface CourierDelivery {
-  entryId: string;
-  senderPubkey: string;
-  transferId: string;
-  ciphertext: string;
-  hint?: string;
-}
-
-export class CourierDeliveryProvider {
+export class CourierDeliveryProvider implements TokenDeliveryTransport {
   readonly id = 'courier-delivery';
   readonly name = 'Courier Delivery (Vault v2)';
   readonly type = 'network' as const;
 
-  constructor(_config: CourierDeliveryConfig) {
-    // Phase 5
+  readonly capabilities: TokenDeliveryCapabilities;
+
+  private readonly config: CourierDeliveryConfig;
+  private identity: FullIdentity | null = null;
+
+  constructor(config: CourierDeliveryConfig) {
+    this.config = config;
+    this.capabilities = {
+      async: true,
+      ack: true,
+      addressing: 'pubkey',
+      maxBytes: config.maxBytes ?? 16 * 1024 * 1024,
+    };
   }
 
-  setIdentity(_identity: FullIdentity): void {
-    throw new Error('not implemented');
+  setIdentity(identity: FullIdentity): void {
+    this.identity = identity;
   }
 
-  /** Seal + POST a transfer to `/v1/courier/deposit`. */
-  deposit(_envelope: CourierEnvelope): Promise<CourierDepositResult> {
-    throw new Error('not implemented');
+  // ===========================================================================
+  // Deposit (Task 5.1)
+  // ===========================================================================
+
+  /**
+   * Seal the envelope to the recipient (ECDH key, AAD-bound entryId), pack the
+   * `base64(nonce24‖ct)` ciphertext, and POST `/v1/courier/deposit`. The caller
+   * (sender) is `this.identity.chainPubkey`; the server keys dedup on
+   * `(recipientPubkey, entryId)`.
+   */
+  async deposit(envelope: TokenEnvelope): Promise<DeliveryHandle> {
+    const me = this.requireIdentity();
+    const entryId = courierEntryId(me.privateKey, envelope.recipientChainPubkey, envelope.tokenBlobHex);
+    const ciphertext = this.sealEnvelope(me, envelope, entryId);
+    const client = this.config.httpClientFactory(me.chainPubkey);
+    const res = await client.deposit({
+      recipientPubkey: envelope.recipientChainPubkey,
+      entryId,
+      transferId: envelope.transferId,
+      ciphertext,
+      // hint stays undefined here — a single base64 SCALAR when present (never an object).
+    });
+    return {
+      entryId: res.entryId,
+      transferId: envelope.transferId,
+      recipientChainPubkey: envelope.recipientChainPubkey,
+      sentSeq: res.sentSeq,
+    };
   }
 
-  /** Pull-since read of pending deliveries; feeds `handleV2Transfer`. */
-  receive(): Promise<void> {
-    throw new Error('not implemented');
+  /**
+   * Seal the V2_TRANSFER payload as a courier envelope; returns the packed
+   * `base64(nonce24‖ct)` on-wire `ciphertext`.
+   */
+  private sealEnvelope(me: FullIdentity, envelope: TokenEnvelope, entryId: string): string {
+    const payload: V2TransferPayload = {
+      type: 'V2_TRANSFER',
+      version: '2.0',
+      tokenBlob: envelope.tokenBlobHex,
+      memo: envelope.memo,
+    };
+    const plaintext = new TextEncoder().encode(JSON.stringify(payload));
+    return sealCourierEnvelope({
+      network: this.config.network,
+      senderPriv: me.privateKey,
+      senderPubkey: me.chainPubkey,
+      recipientPubkey: envelope.recipientChainPubkey,
+      entryId,
+      plaintext,
+    });
   }
 
-  /** Signed durable-copy ack for a claimed entry. */
-  confirmReceipt(_entryId: string): Promise<void> {
-    throw new Error('not implemented');
-  }
+  // ===========================================================================
+  // Internals
+  // ===========================================================================
 
-  /** Sender-side poll of `/v1/courier/sent` to gate delivery confirmation. */
-  pollSent(): Promise<void> {
-    throw new Error('not implemented');
+  private requireIdentity(): FullIdentity {
+    if (!this.identity) {
+      throw new Error('CourierDeliveryProvider: setIdentity() must be called before use');
+    }
+    return this.identity;
   }
 }

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -16,7 +16,8 @@
 
 import type { FullIdentity } from '../../types';
 import type { V2TransferPayload } from '../../types/v2-transfer';
-import { sealCourierEnvelope } from '../../vault-aead/courier';
+import { isV2TransferPayload } from '../../types/v2-transfer';
+import { sealCourierEnvelope, openCourierEnvelope } from '../../vault-aead/courier';
 import { courierEntryId } from './entryId';
 import type {
   CourierHttpClient,
@@ -31,6 +32,11 @@ import type {
  * `handleV2Transfer(payload, senderPubkey)` so the receive path is unchanged.
  */
 export type V2TransferSink = (payload: V2TransferPayload, senderPubkey: string) => Promise<void>;
+
+/** One ACK-PENDING journal entry (re-fired until the server shows `claimed`). */
+interface AckPendingEntry {
+  senderPubkey: string;
+}
 
 /** Minimal persistent KV the journal needs (matches PaymentsModule storage). */
 export interface CourierJournalStore {
@@ -127,6 +133,109 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
       entryId,
       plaintext,
     });
+  }
+
+  // ===========================================================================
+  // Receive (Task 5.2)
+  // ===========================================================================
+
+  /**
+   * Pull the inbox since the server read pointer, open each envelope, decode it
+   * to a {@link TokenEnvelope}, map it to a {@link V2TransferPayload}, and feed
+   * the EXISTING `handleV2Transfer` path (via {@link V2TransferSink}) UNCHANGED.
+   *
+   * Re-pulling an already-processed-but-unclaimed item is harmless — the sink
+   * dedups by `v2_${tokenId}`. After a successful receive the entry is queued for
+   * the signed ack (Task 5.3).
+   */
+  async receive(): Promise<void> {
+    const me = this.requireIdentity();
+    const client = this.config.httpClientFactory(me.chainPubkey);
+    const since = await this.readPointer();
+    const res = await client.inbox(since);
+    for (const item of res.items) {
+      if (item.status === 'claimed') continue;
+      await this.receiveItem(me, item);
+    }
+  }
+
+  /** Open one inbox item and feed it to handleV2Transfer; then arm the ack. */
+  private async receiveItem(
+    me: FullIdentity,
+    item: { entryId: string; senderPubkey: string; ciphertext: string },
+  ): Promise<void> {
+    let payload: V2TransferPayload;
+    try {
+      payload = this.openItem(me, item);
+    } catch {
+      // A tampered / undecryptable envelope is dropped (the tag failure is the
+      // operator-blind integrity check); discovery is not wedged by one bad row.
+      return;
+    }
+    // Custody commit: hand the verified-by-engine payload to handleV2Transfer.
+    // The sender is addressed by chainPubkey; nametag enrichment no-ops over the
+    // courier (Nostr-keyed), so the RECEIVED history records the chainPubkey only.
+    await this.config.onV2Transfer(payload, item.senderPubkey);
+    // ACK-PENDING is journaled AFTER the custody commit (Task 5.3).
+    await this.journalAckPending(item.entryId, item.senderPubkey);
+  }
+
+  /**
+   * `unpackCourier` slices the first 24 bytes as the nonce; `openCourierEnvelope`
+   * rebuilds the AAD and verifies the tag, then we decode the JSON V2_TRANSFER.
+   */
+  private openItem(
+    me: FullIdentity,
+    item: { entryId: string; senderPubkey: string; ciphertext: string },
+  ): V2TransferPayload {
+    const pt = openCourierEnvelope({
+      network: this.config.network,
+      recipientPriv: me.privateKey,
+      senderPubkey: item.senderPubkey,
+      recipientPubkey: me.chainPubkey,
+      entryId: item.entryId,
+      ciphertext: item.ciphertext,
+    });
+    const decoded = JSON.parse(new TextDecoder().decode(pt)) as unknown;
+    if (!isV2TransferPayload(decoded)) {
+      throw new Error('courier: decoded envelope is not a V2_TRANSFER payload');
+    }
+    return decoded;
+  }
+
+  // ===========================================================================
+  // Journal (read pointer + ACK-PENDING)
+  // ===========================================================================
+
+  private readPointerKey(): string {
+    return `courier_read_pointer:${this.config.network}:${this.requireIdentity().chainPubkey}`;
+  }
+
+  private async readPointer(): Promise<number> {
+    const raw = await this.config.journal.get(this.readPointerKey());
+    return raw ? Number(raw) : 0;
+  }
+
+  private ackPendingKey(): string {
+    return `courier_ack_pending:${this.config.network}:${this.requireIdentity().chainPubkey}`;
+  }
+
+  private async loadAckPending(): Promise<Record<string, AckPendingEntry>> {
+    const raw = await this.config.journal.get(this.ackPendingKey());
+    return raw ? (JSON.parse(raw) as Record<string, AckPendingEntry>) : {};
+  }
+
+  /**
+   * Journal an ACK-PENDING entry keyed by entryId, written AFTER the custody
+   * commit and BEFORE the ack POST (invariant: custody-commit ≺ ack-journal ≺
+   * ack-POST). Re-fired from the journal until the server shows `claimed`.
+   */
+  private async journalAckPending(entryId: string, senderPubkey: string): Promise<void> {
+    const pending = await this.loadAckPending();
+    if (!pending[entryId]) {
+      pending[entryId] = { senderPubkey };
+      await this.config.journal.set(this.ackPendingKey(), JSON.stringify(pending));
+    }
   }
 
   // ===========================================================================

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -17,8 +17,10 @@
 import type { FullIdentity } from '../../types';
 import type { V2TransferPayload } from '../../types/v2-transfer';
 import { isV2TransferPayload } from '../../types/v2-transfer';
+import { signMessage } from '../../core/crypto';
 import { sealCourierEnvelope, openCourierEnvelope } from '../../vault-aead/courier';
 import { courierEntryId } from './entryId';
+import { courierAckTemplate } from './ack-template';
 import type {
   CourierHttpClient,
   DeliveryHandle,
@@ -176,8 +178,11 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
     // The sender is addressed by chainPubkey; nametag enrichment no-ops over the
     // courier (Nostr-keyed), so the RECEIVED history records the chainPubkey only.
     await this.config.onV2Transfer(payload, item.senderPubkey);
-    // ACK-PENDING is journaled AFTER the custody commit (Task 5.3).
+    // INVARIANT custody-commit ≺ ack-journal ≺ ack-POST: journal ACK-PENDING
+    // AFTER the custody commit, BEFORE the ack POST. A crash between the journal
+    // and the POST is recovered by replayAckPending() on the next load.
     await this.journalAckPending(item.entryId, item.senderPubkey);
+    await this.ackEntry(item.entryId, item.senderPubkey);
   }
 
   /**
@@ -235,6 +240,53 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
     if (!pending[entryId]) {
       pending[entryId] = { senderPubkey };
       await this.config.journal.set(this.ackPendingKey(), JSON.stringify(pending));
+    }
+  }
+
+  private async removeAckPending(entryId: string): Promise<void> {
+    const pending = await this.loadAckPending();
+    if (pending[entryId]) {
+      delete pending[entryId];
+      await this.config.journal.set(this.ackPendingKey(), JSON.stringify(pending));
+    }
+  }
+
+  // ===========================================================================
+  // Ack — signed durable-copy claim (Task 5.3)
+  // ===========================================================================
+
+  /**
+   * Send the signed ack for one entry: fetch a fresh server nonce, sign the bound
+   * template with the recipient spend key, and POST `{entryId, ackSig}`. On
+   * `claimed`/`alreadyClaimed` the ACK-PENDING journal row is cleared. Failure
+   * keeps the row so the next `replayAckPending()` re-fires it.
+   */
+  async ackEntry(entryId: string, senderPubkey: string): Promise<'claimed' | 'alreadyClaimed' | 'failed'> {
+    const me = this.requireIdentity();
+    const client = this.config.httpClientFactory(me.chainPubkey);
+    const { serverNonce } = await client.ackNonce(entryId);
+    const tmpl = courierAckTemplate(this.config.network, senderPubkey, entryId, serverNonce);
+    const ackSig = signMessage(me.privateKey, tmpl);
+    const { result } = await client.ack({ entryId, ackSig });
+    if (result === 'claimed' || result === 'alreadyClaimed') {
+      await this.removeAckPending(entryId);
+    }
+    return result;
+  }
+
+  /**
+   * Re-fire every journaled ACK-PENDING entry (called on `load()`). A crash
+   * between the ack-journal and the ack-POST is recovered here: the row survives,
+   * so the ack is retried until the server shows `claimed`/`alreadyClaimed`.
+   */
+  async replayAckPending(): Promise<void> {
+    const pending = await this.loadAckPending();
+    for (const [entryId, entry] of Object.entries(pending)) {
+      try {
+        await this.ackEntry(entryId, entry.senderPubkey);
+      } catch {
+        // Network failure — keep the row for the next load.
+      }
     }
   }
 

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -17,13 +17,14 @@
 import type { FullIdentity } from '../../types';
 import type { V2TransferPayload } from '../../types/v2-transfer';
 import { isV2TransferPayload } from '../../types/v2-transfer';
-import { signMessage } from '../../core/crypto';
+import { signMessage, verifySignedMessage } from '../../core/crypto';
 import { sealCourierEnvelope, openCourierEnvelope } from '../../vault-aead/courier';
 import { courierEntryId } from './entryId';
 import { courierAckTemplate } from './ack-template';
 import type {
   CourierHttpClient,
   DeliveryHandle,
+  SignedReceipt,
   TokenDeliveryCapabilities,
   TokenDeliveryTransport,
   TokenEnvelope,
@@ -38,6 +39,15 @@ export type V2TransferSink = (payload: V2TransferPayload, senderPubkey: string) 
 /** One ACK-PENDING journal entry (re-fired until the server shows `claimed`). */
 interface AckPendingEntry {
   senderPubkey: string;
+}
+
+/** Per-entry sender-side delivery state for the redelivery/backoff loop. */
+type SenderDeliveryState = 'pending' | 'delivered' | 'delivery_unconfirmed';
+
+interface SentPendingEntry {
+  recipientPubkey: string;
+  attempts: number;
+  state: SenderDeliveryState;
 }
 
 /** Minimal persistent KV the journal needs (matches PaymentsModule storage). */
@@ -57,8 +67,20 @@ export interface CourierDeliveryConfig {
   journal: CourierJournalStore;
   /** Feeds decoded incoming transfers into the existing handleV2Transfer path. */
   onV2Transfer: V2TransferSink;
+  /**
+   * Called when a delivery is CONFIRMED by a VALID recipient ackSig — the only
+   * thing that licenses removing `PENDING_V2_DELIVERIES` + GC (DESIGN §6.5).
+   * A forged/absent sig never triggers this (the sender keeps redelivering).
+   */
+  onDelivered?: (entryId: string) => Promise<void>;
   /** Max envelope bytes the courier accepts (DESIGN §6.6 default 16 MiB). */
   maxBytes?: number;
+  /** Max redelivery attempts before the entry is surfaced `delivery_unconfirmed`. */
+  maxRedeliveryAttempts?: number;
+  /** Base backoff (ms) for the redelivery loop; doubles per attempt up to a cap. */
+  backoffBaseMs?: number;
+  /** Backoff cap (ms). */
+  backoffMaxMs?: number;
 }
 
 export class CourierDeliveryProvider implements TokenDeliveryTransport {
@@ -107,6 +129,9 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
       ciphertext,
       // hint stays undefined here — a single base64 SCALAR when present (never an object).
     });
+    // Track the entry sender-side so pollSent() can gate "delivered" on a valid
+    // recipient ackSig before removing PENDING_V2_DELIVERIES (DESIGN §6.5).
+    await this.journalSentPending(entryId, envelope.recipientChainPubkey);
     return {
       entryId: res.entryId,
       transferId: envelope.transferId,
@@ -288,6 +313,119 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
         // Network failure — keep the row for the next load.
       }
     }
+  }
+
+  // ===========================================================================
+  // Sender-side delivery confirmation (Task 5.4)
+  // ===========================================================================
+
+  private sentWatermarkKey(): string {
+    return `courier_sent_watermark:${this.config.network}:${this.requireIdentity().chainPubkey}`;
+  }
+
+  private sentPendingKey(): string {
+    return `courier_sent_pending:${this.config.network}:${this.requireIdentity().chainPubkey}`;
+  }
+
+  private async loadSentPending(): Promise<Record<string, SentPendingEntry>> {
+    const raw = await this.config.journal.get(this.sentPendingKey());
+    return raw ? (JSON.parse(raw) as Record<string, SentPendingEntry>) : {};
+  }
+
+  private async saveSentPending(pending: Record<string, SentPendingEntry>): Promise<void> {
+    await this.config.journal.set(this.sentPendingKey(), JSON.stringify(pending));
+  }
+
+  private async journalSentPending(entryId: string, recipientPubkey: string): Promise<void> {
+    const pending = await this.loadSentPending();
+    if (!pending[entryId]) {
+      pending[entryId] = { recipientPubkey, attempts: 0, state: 'pending' };
+      await this.saveSentPending(pending);
+    }
+  }
+
+  /**
+   * The SENDER's delivery gate (DESIGN §6.5). Poll `/sent` since the per-sender
+   * watermark; for each row that the server marks `claimed`, the sender — NOT the
+   * server — verifies the recipient `ackSig` over the bound template. ONLY a valid
+   * signature licenses `onDelivered` (which removes `PENDING_V2_DELIVERIES` + GC).
+   * A forged flag without a valid sig is rejected → the entry stays pending and is
+   * redelivered (bounded by attempt count → `delivery_unconfirmed`).
+   */
+  async pollSent(): Promise<void> {
+    const me = this.requireIdentity();
+    const client = this.config.httpClientFactory(me.chainPubkey);
+    const since = await this.sentWatermark();
+    const res = await client.sent(since);
+    const pending = await this.loadSentPending();
+    for (const item of res.items) {
+      await this.reconcileSentItem(me, pending, item);
+    }
+    await this.saveSentPending(pending);
+  }
+
+  /** Verify one /sent row's ackSig and advance its sender-side state. */
+  private async reconcileSentItem(
+    me: FullIdentity,
+    pending: Record<string, SentPendingEntry>,
+    item: { entryId: string; recipientPubkey: string; ackSig: string | null; ackNonce: string | null },
+  ): Promise<void> {
+    const entry = pending[item.entryId];
+    if (!entry || entry.state === 'delivered') return;
+    if (this.isValidReceipt(me, item)) {
+      entry.state = 'delivered';
+      await this.config.onDelivered?.(item.entryId);
+      return;
+    }
+    // Not yet validly claimed (still unclaimed, or a FORGED ackSig that fails
+    // verification) — keep redelivering, bounded by the attempt cap.
+    entry.attempts += 1;
+    if (entry.attempts >= this.maxAttempts()) entry.state = 'delivery_unconfirmed';
+  }
+
+  /** True only for a recipient ackSig that verifies over the bound template. */
+  private isValidReceipt(
+    me: FullIdentity,
+    item: { entryId: string; recipientPubkey: string; ackSig: string | null; ackNonce: string | null },
+  ): boolean {
+    if (!item.ackSig || !item.ackNonce) return false;
+    const tmpl = courierAckTemplate(this.config.network, me.chainPubkey, item.entryId, item.ackNonce);
+    return verifySignedMessage(tmpl, item.ackSig, item.recipientPubkey);
+  }
+
+  /**
+   * Verify a delivery handle's signed receipt (DESIGN §3 port method). Returns the
+   * {@link SignedReceipt} only when the recipient's ackSig validly claims it.
+   */
+  async confirmReceipt(handle: DeliveryHandle): Promise<SignedReceipt | null> {
+    const me = this.requireIdentity();
+    const client = this.config.httpClientFactory(me.chainPubkey);
+    const res = await client.sent(0);
+    const row = res.items.find((i) => i.entryId === handle.entryId);
+    if (!row || !this.isValidReceipt(me, row)) return null;
+    return { entryId: row.entryId, ackSig: row.ackSig!, recipientChainPubkey: row.recipientPubkey };
+  }
+
+  private maxAttempts(): number {
+    return this.config.maxRedeliveryAttempts ?? 10;
+  }
+
+  /** Exponential backoff for the redelivery loop, capped (DESIGN §6.5). */
+  backoffMs(attempts: number): number {
+    const base = this.config.backoffBaseMs ?? 1000;
+    const cap = this.config.backoffMaxMs ?? 5 * 60_000;
+    return Math.min(cap, base * 2 ** attempts);
+  }
+
+  /** Current sender-side state for an entry (for the UI: pending/delivered/unconfirmed). */
+  async sentState(entryId: string): Promise<SenderDeliveryState | null> {
+    const pending = await this.loadSentPending();
+    return pending[entryId]?.state ?? null;
+  }
+
+  private async sentWatermark(): Promise<number> {
+    const raw = await this.config.journal.get(this.sentWatermarkKey());
+    return raw ? Number(raw) : 0;
   }
 
   // ===========================================================================

--- a/transport/courier/ack-template.ts
+++ b/transport/courier/ack-template.ts
@@ -1,0 +1,24 @@
+/**
+ * Courier ack canonical template (DESIGN §6.4 / §8.2).
+ *
+ *   ackSig = signMessage(recipientPriv,
+ *     'unicity:courier:ack:v1\n' + network + '\n' + senderPubkey + '\n' + entryId + '\n' + serverNonce)
+ *
+ * The signature is the fund-critical attestation: bound to `(network, sender,
+ * entryId, serverNonce)` so it is NOT replayable across senders, deposits, or
+ * deployments. Both the SDK (signs) and token-api (verifies) build this EXACT
+ * literal — pinned by the integration tests so a divergence is caught.
+ */
+
+/** Canonical prefix for the courier ack attestation. */
+export const COURIER_ACK_PREFIX = 'unicity:courier:ack:v1';
+
+/** Build the exact ack message bound to `(network, senderPubkey, entryId, serverNonce)`. */
+export function courierAckTemplate(
+  network: string,
+  senderPubkey: string,
+  entryId: string,
+  serverNonce: string,
+): string {
+  return `${COURIER_ACK_PREFIX}\n${network}\n${senderPubkey}\n${entryId}\n${serverNonce}`;
+}

--- a/transport/courier/entryId.ts
+++ b/transport/courier/entryId.ts
@@ -1,0 +1,55 @@
+/**
+ * Courier entryId derivation (§6.2) — HMAC over the ECDH shared secret.
+ *
+ *   K_entry = HKDF-SHA256(ecdhX(senderPriv, recipientPub), 'unicity-courier-entryid-v1')
+ *   entryId = HMAC-SHA256(K_entry, tokenId ‖ stateHash)                       -> 64-hex
+ *
+ * `stateHash` is derived EXACTLY as `PaymentsModule.tryParseBlobKeys` does
+ * (`sha256(bytesToHex(blob.token), 'hex')`) so the sender and recipient agree on
+ * the per-state binding without a new engine method. The operator lacks the ECDH
+ * secret → it cannot correlate an entryId with an on-chain token (privacy), and an
+ * attacker cannot pre-compute an entryId to squat the deposit slot.
+ *
+ * `.js` suffixes on `@noble/*` subpaths are mandatory for `@noble/hashes` ^2.
+ */
+
+import { hmac } from '@noble/hashes/hmac.js';
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 as nobleSha256 } from '@noble/hashes/sha2.js';
+import { sha256, bytesToHex, hexToBytes } from '../../core/crypto';
+import { decodeTokenBlob } from '../../token-engine/token-blob';
+import { ecdhX } from '../../vault-aead/ecdh';
+
+const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/** HKDF info for the courier entryId key. */
+const ENTRYID_INFO = 'unicity-courier-entryid-v1';
+
+/**
+ * The per-state hash bound into the entryId — IDENTICAL to the value
+ * `PaymentsModule.tryParseBlobKeys` computes: `sha256(bytesToHex(blob.token))`.
+ *
+ * @param tokenBlobHex - hex of CBOR(TokenBlob), the V2_TRANSFER payload blob.
+ */
+export function courierStateHash(tokenBlobHex: string): string {
+  const blob = decodeTokenBlob(hexToBytes(tokenBlobHex));
+  return sha256(bytesToHex(blob.token), 'hex');
+}
+
+/**
+ * Compute the courier entryId for a deposit.
+ *
+ * @param senderPriv    - sender spend private key (64-hex).
+ * @param recipientPub  - recipient compressed chain pubkey (66-hex).
+ * @param tokenBlobHex  - hex of CBOR(TokenBlob), the V2_TRANSFER payload blob.
+ * @returns 64-hex entryId.
+ */
+export function courierEntryId(senderPriv: string, recipientPub: string, tokenBlobHex: string): string {
+  const blob = decodeTokenBlob(hexToBytes(tokenBlobHex));
+  const stateHash = sha256(bytesToHex(blob.token), 'hex');
+  const kEntry = hkdf(nobleSha256, ecdhX(senderPriv, recipientPub), undefined, utf8(ENTRYID_INFO), 32);
+  // tokenId ‖ stateHash, both as their utf8 hex-string bytes (the values the
+  // sender and recipient both hold as strings — see tryParseBlobKeys).
+  const msg = utf8(blob.tokenId + stateHash);
+  return bytesToHex(hmac(nobleSha256, kEntry, msg));
+}

--- a/transport/courier/types.ts
+++ b/transport/courier/types.ts
@@ -1,0 +1,173 @@
+/**
+ * Universal delivery layer types (DESIGN §3) + the courier wire seam.
+ *
+ * `TokenEnvelope` is the universal unit — the finished v2 token blob (already
+ * locked to the recipient) plus its addressing metadata and the AEAD envelope.
+ * `TokenDeliveryTransport` is the narrow post-certification byte-push port: it
+ * carries `journal → deliver → unjournal` and NOTHING else (no resolution — that
+ * stays a separate Nostr step `send()` calls first).
+ *
+ * `CourierHttpClient` is the swap seam: the provider talks to the courier through
+ * this typed interface, never raw `fetch`. The in-process fake server (Phase 5
+ * tests) and the real token-api HTTP client (Phase 8.3) both implement it, so the
+ * provider's logic is exercised identically against the fake and the real server.
+ */
+
+// =============================================================================
+// Universal delivery unit (DESIGN §3)
+// =============================================================================
+
+/**
+ * The universal delivery unit: a finished v2 token blob (already locked to the
+ * recipient) + addressing metadata + the sealed AEAD envelope. "The file."
+ */
+export interface TokenEnvelope {
+  /** Recipient compressed chain pubkey (66-hex) — the courier address. */
+  recipientChainPubkey: string;
+  /** Sender compressed chain pubkey (66-hex). */
+  senderChainPubkey: string;
+  /** Transfer id grouping one (possibly multi-output) payment. */
+  transferId: string;
+  /** Hex of CBOR(TokenBlob) — the finished v2 token (the V2_TRANSFER payload). */
+  tokenBlobHex: string;
+  /** Optional opaque memo, sealed inside the envelope. */
+  memo?: string;
+}
+
+/** Transport-opaque handle returned by a deposit; identifies the delivery. */
+export interface DeliveryHandle {
+  entryId: string;
+  transferId: string;
+  recipientChainPubkey: string;
+  /** Server-assigned monotonic sender watermark, used to poll `/sent`. */
+  sentSeq?: number;
+}
+
+/** A verified signed receipt — the recipient's ack over the bound template. */
+export interface SignedReceipt {
+  entryId: string;
+  ackSig: string;
+  recipientChainPubkey: string;
+}
+
+/** Capabilities advertised by a {@link TokenDeliveryTransport}. */
+export interface TokenDeliveryCapabilities {
+  /** Delivery is async (store-and-forward), not a live handshake. */
+  async: boolean;
+  /** The channel returns a verifiable claim receipt. */
+  ack: boolean;
+  /** How the channel is addressed. */
+  addressing: 'pubkey' | 'outOfBand';
+  /** Max envelope bytes the channel accepts, if bounded. */
+  maxBytes?: number;
+}
+
+/**
+ * Narrow post-certification byte-push port (DESIGN §3). It addresses by
+ * `recipientChainPubkey`; it does NOT resolve nametags and is NOT the fat Nostr
+ * `TransportProvider`.
+ */
+export interface TokenDeliveryTransport {
+  readonly capabilities: TokenDeliveryCapabilities;
+  /** Seal + push an envelope; addresses by `recipientChainPubkey`. */
+  deposit(envelope: TokenEnvelope): Promise<DeliveryHandle>;
+  /** Pull pending envelopes (store-and-forward channels). */
+  receive?(): Promise<void>;
+  /** Verify + return the signed receipt for a delivery, if claimed. */
+  confirmReceipt?(handle: DeliveryHandle): Promise<SignedReceipt | null>;
+}
+
+// =============================================================================
+// Courier wire seam (mirrors token-api `/v1/courier/*` — DESIGN §6)
+// =============================================================================
+
+/** `POST /v1/courier/deposit` request body (DESIGN §6.3). `hint` is a base64 SCALAR. */
+export interface CourierDepositRequest {
+  recipientPubkey: string;
+  entryId: string;
+  transferId: string;
+  /** base64(nonce24‖ct) packed string. */
+  ciphertext: string;
+  /** Single base64 scalar hint string (NEVER a {nonce,ct} object). */
+  hint?: string;
+}
+
+/** `POST /v1/courier/deposit` response. */
+export interface CourierDepositResponse {
+  entryId: string;
+  seq: number;
+  sentSeq: number;
+  status: CourierDeliveryStatus;
+}
+
+export type CourierDeliveryStatus = 'unclaimed' | 'claimed' | 'rejected';
+
+/** One recipient-facing inbox row (DESIGN §6.5). */
+export interface CourierInboxItem {
+  entryId: string;
+  seq: number;
+  status: CourierDeliveryStatus;
+  senderPubkey: string;
+  ciphertext: string;
+  transferId: string;
+  hint: string | null;
+  ackSig: string | null;
+}
+
+/** `GET /v1/courier/inbox?since=` response. */
+export interface CourierInboxResponse {
+  readPointer: number;
+  syncEpoch: number;
+  more: boolean;
+  items: CourierInboxItem[];
+}
+
+/** One sender-facing `/sent` row — `ackSig` is null until the recipient claims. */
+export interface CourierSentItem {
+  entryId: string;
+  recipientPubkey: string;
+  status: CourierDeliveryStatus;
+  ackSig: string | null;
+}
+
+/** `GET /v1/courier/sent?since=` response. */
+export interface CourierSentResponse {
+  more: boolean;
+  items: CourierSentItem[];
+}
+
+/** `GET /v1/courier/ack-nonce?entryId=` response. */
+export interface CourierAckNonceResponse {
+  serverNonce: string;
+}
+
+/** `POST /v1/courier/ack` request — FROZEN single-entry shape (DESIGN §8.2). */
+export interface CourierAckRequest {
+  entryId: string;
+  ackSig: string;
+}
+
+/** `POST /v1/courier/ack` response — the single frozen outcome (never a batch). */
+export interface CourierAckResponse {
+  result: 'claimed' | 'alreadyClaimed' | 'failed';
+}
+
+/**
+ * The swap seam between the provider and the courier endpoints. The provider
+ * calls only these typed methods; the fake server and the real token-api HTTP
+ * client both implement it. Each method corresponds 1:1 to a `/v1/courier/*`
+ * endpoint and carries the AUTHENTICATED caller (`ownerId = chainPubkey`) — the
+ * fake server takes it as `senderId`; the real client supplies it via the JWT.
+ */
+export interface CourierHttpClient {
+  /** `POST /v1/courier/deposit` — the caller is the sender. */
+  deposit(req: CourierDepositRequest): Promise<CourierDepositResponse>;
+  /** `GET /v1/courier/inbox?since=` — the caller is the recipient. */
+  inbox(since: number): Promise<CourierInboxResponse>;
+  /** `GET /v1/courier/ack-nonce?entryId=` — the caller is the recipient. */
+  ackNonce(entryId: string): Promise<CourierAckNonceResponse>;
+  /** `POST /v1/courier/ack` — the caller is the recipient. */
+  ack(req: CourierAckRequest): Promise<CourierAckResponse>;
+  /** `GET /v1/courier/sent?since=` — the caller is the sender. */
+  sent(since: number): Promise<CourierSentResponse>;
+}

--- a/transport/courier/types.ts
+++ b/transport/courier/types.ts
@@ -128,6 +128,13 @@ export interface CourierSentItem {
   recipientPubkey: string;
   status: CourierDeliveryStatus;
   ackSig: string | null;
+  /**
+   * The server nonce the recipient's claim consumed — surfaced so the SENDER can
+   * rebuild the bound ack template and run `verifySignedMessage` itself. Null
+   * until claimed. (Part A coordination: the real `/sent` row must carry this so
+   * the sender's delivery gate can verify the recipient signature, §6.5.)
+   */
+  ackNonce: string | null;
 }
 
 /** `GET /v1/courier/sent?since=` response. */


### PR DESCRIPTION
Part B Phase 5 — `CourierDeliveryProvider`, the reference `TokenDeliveryTransport` (blind store-and-forward token delivery; replaces the Nostr asset path).

## Tasks (strict TDD, one commit each)
- **5.1** `feat(courier): ECDH entryId + deposit (base64 nonce-ct framing)` — `entryId = HMAC(HKDF(ecdhX(senderPriv,recipientPub),'unicity-courier-entryid-v1'), tokenId‖stateHash)`; `stateHash` byte-identical to `tryParseBlobKeys`. KAT pinned `6947a85f…cbfab`. Deposit packs `ciphertext = base64(nonce24‖ct)`; `hint` = single base64 scalar.
- **5.2** `feat(courier): receive unpack + handleV2Transfer reuse` — unpack (slice 24) → `openCourierEnvelope` → `V2TransferPayload` → injected sink bound to the EXISTING `handleV2Transfer` (no fork; engine.verify/isOwnedBy/dedup `v2_<tokenId>` run).
- **5.3** `feat(courier): signed single-entry ack + ACK-PENDING journal` — ack template `unicity:courier:ack:v1\n{net}\n{sender}\n{entryId}\n{serverNonce}` signed with recipient priv; body exactly `{entryId,ackSig}`; ordering custody-commit ≺ ack-journal ≺ ack-POST; crash between journal+POST re-fires on load.
- **5.4** `feat(courier): sender-gated delivery confirmation` — sender removes `PENDING_V2_DELIVERIES` ONLY on a valid `verifySignedMessage(ackSig, recipientChainPubkey)` over the bound template; forged flag → keeps redelivering; backoff + `delivery_unconfirmed`.

## Tests
73 vault tests green (`vitest run tests/unit/vault/ tests/integration/vault/`), `tsc --noEmit` clean, eslint clean. Provider tested against a faithful in-memory `FakeCourierServer` (mirrors Part A `courier.service.ts`/`deliveries.repo.ts`); the `CourierHttpClient` seam lets Phase 8.3 swap in the real token-api with zero provider changes.

## Cross-plan follow-ups (Part A wire fixes, tracked separately)
- **WIRE-2 (HIGH):** real `/sent` must surface `ackNonce` (consumed serverNonce) — the sender delivery-gate rebuilds the ack template from it. SDK already expects `ackNonce` on sent items.
- **WIRE-1 (MEDIUM):** real deposit response should include `sentSeq` (already computed, dropped in the route) to match the SDK `CourierDepositResponse` type.

Reviewed (spec + adversarial): both fund-critical gates verified genuine (not stubs); fake↔real fidelity audited against Part A.