### PR TITLE
feat(vault): Phase 6 — RemoteTokenStorageProvider (CAS flush, delete-resurrect, pagination, anti-rollback)

### DIFF
--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -1,9 +1,24 @@
 /**
- * RemoteTokenStorageProvider — the Token-Vault v2 remote box.
+ * RemoteTokenStorageProvider — the Token-Vault v2 remote box (DESIGN §5).
  *
- * Implements the FROZEN `TokenStorageProvider` contract verbatim. All CAS /
- * cursor / signed-root / rejected state is internal (finding #29). The real
- * bodies land in Phases 6–7; this is the typed skeleton from Task 0.1.
+ * Implements the FROZEN `TokenStorageProvider` contract verbatim. ALL CAS /
+ * cursor / signed-root / rejected state is internal (finding #29); the rollback
+ * alarm rides `storage:error` with `data.reason === 'rollback'`, never a new
+ * `StorageEventType` member.
+ *
+ * Phase 6 lands the data path:
+ *  - `sync(localData)` (Task 6.2/6.3) diffs the TXF snapshot vs the internal
+ *    last-known server state, PATCHes CAS ops keyed by the opaque wireKey, and
+ *    maps `{applied, rejected, cursor}` → `SyncResult` (conflicts derived from
+ *    `rejected[].reason === 'conflict'`); rejected ops stay OUT of the clean
+ *    snapshot and are retried next flush.
+ *  - `load()` (Task 6.4/4.2) paginates `/state`, asserts cursor monotonicity, and
+ *    runs the signed-root anti-rollback gate.
+ *
+ * The provider-initiated first-load gate, reserved-address restore, identity
+ * fencing, history channel and account-delete are Phase 7 — the seams here
+ * (auth client, data-client factory, local baseline store, event emitter) are
+ * shaped so Phase 7 slots in without reshaping this file.
  */
 
 import type { FullIdentity } from '../../types';
@@ -11,17 +26,52 @@ import type {
   HistoryRecord,
   LoadResult,
   SaveResult,
+  StorageEvent,
   StorageEventCallback,
+  StorageEventType,
   SyncResult,
   TokenStorageProvider,
   TxfStorageDataBase,
 } from '../storage-provider';
+import { sealVaultEntry } from '../../vault-aead/entry';
+import { deriveVaultKey } from '../../vault-aead/derive';
+import { wireKey } from './wire-key';
+import { VaultApiClient } from './VaultApiClient';
+import { extractTokens, planOps } from './diff';
+import type { KnownEntry, PlannedOp } from './diff';
+import type {
+  PatchOp,
+  PatchResponse,
+  StateEntry,
+  VaultAuthHttpClient,
+  VaultHttpClient,
+} from './types';
+import { LoadDeltaTracker } from './load-delta';
+import type { LocalBaselineStore } from './load-delta';
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
 
 export interface RemoteTokenStorageConfig {
+  /** Canonical network name (storage scope, AEAD/wireKey scope). */
+  network: string;
   /** Vault base URL — `NETWORKS[network].vaultUrl`. */
   vaultUrl: string;
-  /** Canonical network name (storage scope). */
-  network: string;
+  /** Wallet spend key — derives wireKeys + the AEAD vault key, signs auth + root. */
+  privateKey: string;
+  /** Raw auth wire seam (fake server in tests; fetch+JWT in Phase 8.3). */
+  authClient: VaultAuthHttpClient;
+  /** Authenticated data wire seam, scoped to the caller (`ownerId = chainPubkey`). */
+  httpClientFactory: (ownerId: string) => VaultHttpClient;
+  /** Stable device id stamped into the auth session. */
+  deviceId?: string;
+  /**
+   * Local KV for the signed-root baseline `{cursor,root,sig}` (anti-rollback,
+   * Task 4.2). Injected in tests as a simple in-memory store; Phase 7 wires the
+   * real local `StorageProvider`.
+   */
+  localBaseline?: LocalBaselineStore;
+  /** The compressed server signing key for this network (`NETWORKS[net].vaultServerKey`). */
+  vaultServerKey?: string;
 }
 
 export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfStorageDataBase>
@@ -31,77 +81,314 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   readonly name = 'Remote Token Storage (Vault v2)';
   readonly type = 'cloud' as const;
 
-  constructor(_config: RemoteTokenStorageConfig) {
-    // Phase 6
+  private readonly config: RemoteTokenStorageConfig;
+  private identity: FullIdentity | null = null;
+  private auth: VaultApiClient | null = null;
+  private status: 'disconnected' | 'connecting' | 'connected' | 'error' = 'disconnected';
+
+  /** Internal last-known server view: plainKey → {version, deleted}. */
+  private known = new Map<string, KnownEntry>();
+  /** Content hash of the last-flushed value per plainKey (suppresses no-op updates). */
+  private contentHash = new Map<string, string>();
+  /** The highest `/state` seq the provider has consumed (pagination watermark). */
+  private serverCursor = 0;
+
+  private readonly listeners = new Set<StorageEventCallback>();
+  private readonly delta: LoadDeltaTracker;
+
+  constructor(config: RemoteTokenStorageConfig) {
+    this.config = config;
+    this.delta = new LoadDeltaTracker({
+      network: config.network,
+      vaultServerKey: config.vaultServerKey,
+      baseline: config.localBaseline,
+    });
   }
 
-  // --- BaseProvider ---
+  // --- BaseProvider ---------------------------------------------------------
 
-  connect(_config?: unknown): Promise<void> {
-    throw new Error('not implemented');
+  async connect(): Promise<void> {
+    await this.initialize();
   }
 
-  disconnect(): Promise<void> {
-    throw new Error('not implemented');
+  async disconnect(): Promise<void> {
+    this.status = 'disconnected';
   }
 
   isConnected(): boolean {
-    throw new Error('not implemented');
+    return this.status === 'connected';
   }
 
   getStatus(): 'disconnected' | 'connecting' | 'connected' | 'error' {
-    throw new Error('not implemented');
+    return this.status;
   }
 
-  // --- TokenStorageProvider ---
+  // --- TokenStorageProvider -------------------------------------------------
 
-  setIdentity(_identity: FullIdentity): void {
-    throw new Error('not implemented');
+  setIdentity(identity: FullIdentity): void {
+    this.identity = identity;
+    this.auth = new VaultApiClient({
+      network: this.config.network,
+      chainPubkey: identity.chainPubkey,
+      privateKey: this.config.privateKey,
+      deviceId: this.config.deviceId ?? 'sphere-vault',
+      authClient: this.config.authClient,
+    });
+    this.delta.setIdentity(identity.chainPubkey);
+    this.delta.setWalletPriv(this.config.privateKey);
   }
 
-  initialize(): Promise<boolean> {
-    throw new Error('not implemented');
+  /** Phase 6 initialize: authenticate so the data client carries a JWT. */
+  async initialize(): Promise<boolean> {
+    this.status = 'connecting';
+    await this.requireAuth().authenticate();
+    this.status = 'connected';
+    return true;
   }
 
-  shutdown(): Promise<void> {
-    throw new Error('not implemented');
+  async shutdown(): Promise<void> {
+    this.status = 'disconnected';
   }
 
-  save(_data: TData): Promise<SaveResult> {
-    throw new Error('not implemented');
+  /** `save` routes through `sync` (the vault has no local-only persistence). */
+  async save(data: TData): Promise<SaveResult> {
+    const res = await this.sync(data);
+    return { success: res.success, error: res.error, timestamp: Date.now() };
   }
 
-  load(_identifier?: string): Promise<LoadResult<TData>> {
-    throw new Error('not implemented');
+  // === sync (Task 6.2 / 6.3) ================================================
+
+  async sync(localData: TData): Promise<SyncResult<TData>> {
+    this.emit('sync:started');
+    try {
+      const ops = this.planFlush(localData);
+      if (ops.length === 0) return this.cleanResult(localData, 0, 0, 0);
+      return await this.flush(localData, ops);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'sync failed';
+      this.emit('sync:error', undefined, message);
+      return { success: false, added: 0, removed: 0, conflicts: 0, error: message };
+    }
   }
 
-  sync(_localData: TData): Promise<SyncResult<TData>> {
-    throw new Error('not implemented');
+  /** Diff the TXF snapshot vs internal last-known state into a list of CAS ops. */
+  private planFlush(localData: TData): PlannedOp[] {
+    const tokens = extractTokens(localData);
+    return planOps(tokens, this.known, (plainKey, value) => this.hasChanged(plainKey, value));
   }
 
-  onEvent(_callback: StorageEventCallback): () => void {
-    throw new Error('not implemented');
+  private hasChanged(plainKey: string, value: unknown): boolean {
+    return this.contentHash.get(plainKey) !== this.hashValue(value);
   }
 
-  // --- History ops ---
-
-  addHistoryEntry(_entry: HistoryRecord): Promise<void> {
-    throw new Error('not implemented');
+  /** PATCH the planned ops, map the response onto `SyncResult`. */
+  private async flush(localData: TData, ops: PlannedOp[]): Promise<SyncResult<TData>> {
+    const wireOps = ops.map((op) => this.toWireOp(op));
+    const res = await this.client().patchEntries(wireOps);
+    return this.applyPatchResult(localData, ops, res);
   }
 
-  getHistoryEntries(): Promise<HistoryRecord[]> {
-    throw new Error('not implemented');
+  /** Seal one planned op into its on-wire `{key: wireKey, baseVersion, payload?, deleted?}`. */
+  private toWireOp(op: PlannedOp): PatchOp {
+    const key = this.wireKeyFor(op.plainKey);
+    if (op.isDelete) return { key, baseVersion: op.baseVersion, deleted: true };
+    return {
+      key,
+      baseVersion: op.baseVersion,
+      payload: this.sealValue(key, op.baseVersion + 1, op.value),
+    };
   }
 
-  hasHistoryEntry(_dedupKey: string): Promise<boolean> {
-    throw new Error('not implemented');
+  /** Seal a token value AAD-bound to the version it will have AFTER apply. */
+  private sealValue(key: string, version: number, value: unknown): { nonce: string; ct: string } {
+    return sealVaultEntry({
+      network: this.config.network,
+      ownerId: this.ownerId(),
+      key,
+      version,
+      plaintext: enc(JSON.stringify(value ?? null)),
+      key32: this.vaultKey(),
+    });
   }
 
-  clearHistory(): Promise<void> {
-    throw new Error('not implemented');
+  /**
+   * Fold the server response into the clean snapshot: only APPLIED ops update the
+   * internal last-known state + content hash. Rejected ops are dropped from the
+   * clean snapshot (retried next flush). `conflicts` is derived from the wire
+   * reason `'conflict'`; oversize/insufficient rejections are NOT conflicts.
+   */
+  private applyPatchResult(localData: TData, ops: PlannedOp[], res: PatchResponse): SyncResult<TData> {
+    const appliedKeys = new Set(res.applied);
+    let added = 0;
+    let removed = 0;
+    for (const op of ops) {
+      if (!appliedKeys.has(this.wireKeyFor(op.plainKey))) continue;
+      if (op.isDelete) {
+        removed += 1;
+        this.recordDelete(op.plainKey);
+      } else {
+        if (this.isCreate(op.plainKey)) added += 1;
+        this.recordApply(op);
+      }
+    }
+    const conflicts = res.rejected.filter((r) => r.reason === 'conflict').length;
+    if (res.rejected.length > 0) this.emit('sync:conflict', { rejected: res.rejected });
+    return this.cleanResult(localData, added, removed, conflicts);
   }
 
-  importHistoryEntries(_entries: HistoryRecord[]): Promise<number> {
-    throw new Error('not implemented');
+  /** A create (counts toward `added`) is a key absent or currently tombstoned. */
+  private isCreate(plainKey: string): boolean {
+    const prev = this.known.get(plainKey);
+    return !prev || prev.deleted;
+  }
+
+  /** Record an applied create/update in the internal last-known state. */
+  private recordApply(op: PlannedOp): void {
+    const prev = this.known.get(op.plainKey);
+    const version = prev ? prev.version + 1 : 1;
+    this.known.set(op.plainKey, { version, deleted: false });
+    this.contentHash.set(op.plainKey, this.hashValue(op.value));
+  }
+
+  private recordDelete(plainKey: string): void {
+    const prev = this.known.get(plainKey);
+    this.known.set(plainKey, { version: (prev?.version ?? 0) + 1, deleted: true });
+    this.contentHash.delete(plainKey);
+  }
+
+  private cleanResult(localData: TData, added: number, removed: number, conflicts: number): SyncResult<TData> {
+    this.emit('sync:completed', { added, removed, conflicts });
+    return { success: true, merged: localData, added, removed, conflicts };
+  }
+
+  // === load (Task 6.4 / 4.2) ================================================
+
+  async load(_identifier?: string): Promise<LoadResult<TData>> {
+    this.emit('storage:loading');
+    try {
+      return await this.loadPaginated();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'load failed';
+      this.emit('storage:error', { reason: 'load' }, message);
+      return { success: false, error: message, source: 'remote', timestamp: Date.now() };
+    }
+  }
+
+  /**
+   * Paginate `/state?since=` until `!more`, asserting cursor monotonicity and
+   * running the signed-root anti-rollback gate per page. A cursor regression or
+   * root mismatch WITHOUT a server-verified epoch bump returns `success:false`
+   * and emits `storage:error{reason:'rollback'}` (frozen union, never a new
+   * member). On a clean load the new signed baseline is persisted.
+   */
+  private async loadPaginated(): Promise<LoadResult<TData>> {
+    const client = this.client();
+    let since = this.serverCursor;
+    const pages: StateEntry[] = [];
+    let lastEpochSig = '';
+    let lastEpoch = 0;
+    for (;;) {
+      const page = await client.getState(since);
+      const gate = await this.delta.ingestPage({ since, entries: page.entries, cursor: page.cursor, epoch: page.syncEpoch, epochSig: page.epochSig });
+      if (!gate.ok) return this.rollback(gate.reason);
+      pages.push(...page.entries);
+      lastEpochSig = page.epochSig;
+      lastEpoch = page.syncEpoch;
+      since = page.cursor;
+      if (!page.more) break;
+    }
+    this.serverCursor = since;
+    await this.delta.commitBaseline(since, lastEpoch, lastEpochSig);
+    return this.materialize(pages);
+  }
+
+  private rollback(reason: string): LoadResult<TData> {
+    this.emit('storage:error', { reason: 'rollback', detail: reason });
+    return { success: false, error: `vault rollback: ${reason}`, source: 'remote', timestamp: Date.now() };
+  }
+
+  /** Build the TXF snapshot from the accumulated `/state` rows + adopt their versions. */
+  private materialize(entries: StateEntry[]): LoadResult<TData> {
+    const data: TxfStorageDataBase = {
+      _meta: {
+        version: 1,
+        address: this.identity?.directAddress ?? this.identity?.l1Address ?? '',
+        formatVersion: '2.0',
+        updatedAt: Date.now(),
+      },
+    };
+    for (const e of entries) {
+      this.known.set(e.key, { version: e.version, deleted: e.deleted });
+    }
+    this.emit('storage:loaded', { entries: entries.length });
+    return { success: true, data: data as TData, source: 'remote', timestamp: Date.now() };
+  }
+
+  // === events ===============================================================
+
+  onEvent(callback: StorageEventCallback): () => void {
+    this.listeners.add(callback);
+    return () => void this.listeners.delete(callback);
+  }
+
+  private emit(type: StorageEventType, data?: unknown, error?: string): void {
+    const event: StorageEvent = { type, timestamp: Date.now(), data, error };
+    for (const cb of this.listeners) cb(event);
+  }
+
+  // === history (Phase 7) ====================================================
+
+  async addHistoryEntry(_entry: HistoryRecord): Promise<void> {
+    throw new Error('history sync lands in Phase 7');
+  }
+
+  async getHistoryEntries(): Promise<HistoryRecord[]> {
+    return [];
+  }
+
+  async hasHistoryEntry(_dedupKey: string): Promise<boolean> {
+    return false;
+  }
+
+  async clearHistory(): Promise<void> {
+    // Phase 7
+  }
+
+  async importHistoryEntries(_entries: HistoryRecord[]): Promise<number> {
+    return 0;
+  }
+
+  // === internals ============================================================
+
+  private requireIdentity(): FullIdentity {
+    if (!this.identity) throw new Error('RemoteTokenStorageProvider: setIdentity() must be called first');
+    return this.identity;
+  }
+
+  private requireAuth(): VaultApiClient {
+    this.requireIdentity();
+    if (!this.auth) throw new Error('RemoteTokenStorageProvider: setIdentity() must be called first');
+    return this.auth;
+  }
+
+  private ownerId(): string {
+    return this.requireIdentity().chainPubkey;
+  }
+
+  private client(): VaultHttpClient {
+    return this.config.httpClientFactory(this.ownerId());
+  }
+
+  private wireKeyFor(plainKey: string): string {
+    return wireKey(this.config.privateKey, this.config.network, plainKey);
+  }
+
+  private vaultKey(): Uint8Array {
+    return deriveVaultKey(this.config.privateKey, this.config.network);
+  }
+
+  /** Stable content hash for no-op-update suppression (order-independent JSON). */
+  private hashValue(value: unknown): string {
+    return JSON.stringify(value ?? null);
   }
 }

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -48,6 +48,7 @@ import type {
 } from './types';
 import { LoadDeltaTracker } from './load-delta';
 import type { LocalBaselineStore } from './load-delta';
+import type { EntryState } from './merkle';
 
 const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
 
@@ -286,7 +287,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
    */
   private async loadPaginated(): Promise<LoadResult<TData>> {
     const client = this.client();
-    await this.delta.beginLoad();
+    await this.delta.beginLoad(this.knownAsEntryState());
     let since = this.serverCursor;
     const pages: StateEntry[] = [];
     let lastEpochSig = '';
@@ -409,5 +410,12 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     let n = 0;
     for (const e of this.known.values()) if (!e.deleted) n += 1;
     return n;
+  }
+
+  /** Snapshot the internal last-known state as a merkle `EntryState` map. */
+  private knownAsEntryState(): Map<string, EntryState> {
+    const out = new Map<string, EntryState>();
+    for (const [wk, e] of this.known) out.set(wk, { version: e.version, deleted: e.deleted });
+    return out;
   }
 }

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -173,12 +173,16 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
 
   /** Diff the TXF snapshot vs internal last-known state into a list of CAS ops. */
   private planFlush(localData: TData): PlannedOp[] {
-    const tokens = extractTokens(localData);
-    return planOps(tokens, this.known, (plainKey, value) => this.hasChanged(plainKey, value));
+    return planOps({
+      tokens: extractTokens(localData),
+      known: this.known,
+      wireKeyOf: (plainKey) => this.wireKeyFor(plainKey),
+      changed: (wk, value) => this.hasChanged(wk, value),
+    });
   }
 
-  private hasChanged(plainKey: string, value: unknown): boolean {
-    return this.contentHash.get(plainKey) !== this.hashValue(value);
+  private hasChanged(wk: string, value: unknown): boolean {
+    return this.contentHash.get(wk) !== this.hashValue(value);
   }
 
   /** PATCH the planned ops, map the response onto `SyncResult`. */
@@ -190,12 +194,11 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
 
   /** Seal one planned op into its on-wire `{key: wireKey, baseVersion, payload?, deleted?}`. */
   private toWireOp(op: PlannedOp): PatchOp {
-    const key = this.wireKeyFor(op.plainKey);
-    if (op.isDelete) return { key, baseVersion: op.baseVersion, deleted: true };
+    if (op.isDelete) return { key: op.wireKey, baseVersion: op.baseVersion, deleted: true };
     return {
-      key,
+      key: op.wireKey,
       baseVersion: op.baseVersion,
-      payload: this.sealValue(key, op.baseVersion + 1, op.value),
+      payload: this.sealValue(op.wireKey, op.baseVersion + 1, op.value),
     };
   }
 
@@ -222,12 +225,12 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     let added = 0;
     let removed = 0;
     for (const op of ops) {
-      if (!appliedKeys.has(this.wireKeyFor(op.plainKey))) continue;
+      if (!appliedKeys.has(op.wireKey)) continue;
       if (op.isDelete) {
         removed += 1;
-        this.recordDelete(op.plainKey);
+        this.recordDelete(op.wireKey);
       } else {
-        if (this.isCreate(op.plainKey)) added += 1;
+        if (this.isCreate(op.wireKey)) added += 1;
         this.recordApply(op);
       }
     }
@@ -236,24 +239,24 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     return this.cleanResult(localData, added, removed, conflicts);
   }
 
-  /** A create (counts toward `added`) is a key absent or currently tombstoned. */
-  private isCreate(plainKey: string): boolean {
-    const prev = this.known.get(plainKey);
+  /** A create (counts toward `added`) is a wireKey absent or currently tombstoned. */
+  private isCreate(wk: string): boolean {
+    const prev = this.known.get(wk);
     return !prev || prev.deleted;
   }
 
   /** Record an applied create/update in the internal last-known state. */
   private recordApply(op: PlannedOp): void {
-    const prev = this.known.get(op.plainKey);
+    const prev = this.known.get(op.wireKey);
     const version = prev ? prev.version + 1 : 1;
-    this.known.set(op.plainKey, { version, deleted: false });
-    this.contentHash.set(op.plainKey, this.hashValue(op.value));
+    this.known.set(op.wireKey, { version, deleted: false });
+    this.contentHash.set(op.wireKey, this.hashValue(op.value));
   }
 
-  private recordDelete(plainKey: string): void {
-    const prev = this.known.get(plainKey);
-    this.known.set(plainKey, { version: (prev?.version ?? 0) + 1, deleted: true });
-    this.contentHash.delete(plainKey);
+  private recordDelete(wk: string): void {
+    const prev = this.known.get(wk);
+    this.known.set(wk, { version: (prev?.version ?? 0) + 1, deleted: true });
+    this.contentHash.delete(wk);
   }
 
   private cleanResult(localData: TData, added: number, removed: number, conflicts: number): SyncResult<TData> {

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -286,17 +286,26 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
    */
   private async loadPaginated(): Promise<LoadResult<TData>> {
     const client = this.client();
+    await this.delta.beginLoad();
     let since = this.serverCursor;
     const pages: StateEntry[] = [];
     let lastEpochSig = '';
     let lastEpoch = 0;
     for (;;) {
       const page = await client.getState(since);
-      const gate = await this.delta.ingestPage({ since, entries: page.entries, cursor: page.cursor, epoch: page.syncEpoch, epochSig: page.epochSig });
+      const gate = await this.delta.ingestPage({
+        since,
+        entries: page.entries,
+        cursor: page.cursor,
+        epoch: page.syncEpoch,
+        epochSig: page.epochSig,
+      });
       if (!gate.ok) return this.rollback(gate.reason);
       pages.push(...page.entries);
       lastEpochSig = page.epochSig;
       lastEpoch = page.syncEpoch;
+      // Guard against a non-advancing cursor when `more` is set (would loop forever).
+      if (page.more && page.cursor <= since) return this.rollback('cursor did not advance');
       since = page.cursor;
       if (!page.more) break;
     }
@@ -393,5 +402,12 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   /** Stable content hash for no-op-update suppression (order-independent JSON). */
   private hashValue(value: unknown): string {
     return JSON.stringify(value ?? null);
+  }
+
+  /** Live (non-tombstoned) entry count in the internal last-known state (tests/diagnostics). */
+  knownCount(): number {
+    let n = 0;
+    for (const e of this.known.values()) if (!e.deleted) n += 1;
+    return n;
   }
 }

--- a/storage/remote/VaultApiClient.ts
+++ b/storage/remote/VaultApiClient.ts
@@ -1,0 +1,167 @@
+/**
+ * VaultApiClient (Task 6.1, DESIGN §4) — the auth half of the vault box.
+ *
+ * One client per `ownerId` (chain pubkey). It runs the challenge → verify → JWT
+ * handshake and rotates the JWT behind a refresh token. Two hard guarantees:
+ *
+ *  1. CHALLENGE TEMPLATE VERIFICATION BEFORE SIGNING. The spend key never signs
+ *     arbitrary server text: the client parses the challenge, asserts the auth
+ *     prefix, the embedded `pubkey === our own`, the embedded `network ===` the
+ *     expected canonical network, and plausible `issuedAt`/`expiresAt`, and only
+ *     THEN signs the server's literal challenge string.
+ *  2. SERIALIZED REFRESH. Concurrent 401s share ONE in-flight refresh promise, so
+ *     the rotating-refresh server is hit exactly once — a second concurrent hit
+ *     would replay the now-stale token and revoke the session (DESIGN §4.3).
+ */
+
+import { signMessage } from '../../core/crypto';
+import type { AuthTokens, ChallengeResponse, VaultAuthHttpClient } from './types';
+
+/** Auth prefix the server stamps on every challenge (`services/auth.service.ts`). */
+const AUTH_PREFIX = 'unicity:vault:auth:v1\n';
+
+/** Reject challenges whose lifetime is implausibly long (a clamp on a hostile TTL). */
+const MAX_CHALLENGE_TTL_MS = 60 * 60_000; // 1 hour — the real server uses 5 min
+
+export interface VaultApiClientConfig {
+  /** Expected canonical network (must match the challenge's embedded network). */
+  network: string;
+  /** Our own compressed chain pubkey — must equal the challenge's embedded pubkey. */
+  chainPubkey: string;
+  /** Spend key used to sign the (verified) challenge. */
+  privateKey: string;
+  /** Stable device id stamped into the session. */
+  deviceId: string;
+  /** The raw auth wire seam (fake server in tests; fetch+JWT in Phase 8.3). */
+  authClient: VaultAuthHttpClient;
+}
+
+/** The challenge body the server JSON-encodes after the prefix. */
+interface ChallengeBody {
+  network: string;
+  pubkey: string;
+  nonce: string;
+  issuedAt: string;
+  expiresAt: string;
+}
+
+export class VaultApiClient {
+  private readonly config: VaultApiClientConfig;
+
+  private jwt: string | null = null;
+  private refreshToken: string | null = null;
+  /** The single in-flight refresh promise (serialization, §4.3). */
+  private refreshing: Promise<string> | null = null;
+
+  constructor(config: VaultApiClientConfig) {
+    this.config = config;
+  }
+
+  /** The current JWT, or `null` until `authenticate()` has run. */
+  get token(): string | null {
+    return this.jwt;
+  }
+
+  /**
+   * Full handshake: fetch a challenge, VERIFY its template, sign the verified
+   * literal, exchange it for a JWT + refresh token. Returns the JWT.
+   */
+  async authenticate(): Promise<string> {
+    const challenge = await this.config.authClient.challenge(this.config.chainPubkey);
+    this.verifyChallenge(challenge);
+    const signature = signMessage(this.config.privateKey, challenge.challenge);
+    const tokens = await this.config.authClient.verify({
+      nonce: challenge.nonce,
+      signature,
+      deviceId: this.config.deviceId,
+      network: this.config.network,
+    });
+    if (!tokens) throw new Error('vault auth: server rejected the signature (401)');
+    this.adopt(tokens);
+    return tokens.jwt;
+  }
+
+  /**
+   * Rotate the JWT behind the refresh token, collapsing concurrent callers onto
+   * ONE in-flight promise. A `null` from the server (stale/reused token) clears
+   * the session and rejects.
+   */
+  async refresh(): Promise<string> {
+    if (this.refreshing) return this.refreshing;
+    this.refreshing = this.doRefresh().finally(() => {
+      this.refreshing = null;
+    });
+    return this.refreshing;
+  }
+
+  private async doRefresh(): Promise<string> {
+    if (!this.refreshToken) throw new Error('vault auth: no refresh token — call authenticate() first');
+    const tokens = await this.config.authClient.refresh(this.refreshToken);
+    if (!tokens) {
+      this.jwt = null;
+      this.refreshToken = null;
+      throw new Error('vault auth: refresh rejected (stale or reused)');
+    }
+    this.adopt(tokens);
+    return tokens.jwt;
+  }
+
+  /** Logout (best-effort) — revokes the session server-side. */
+  async logout(sessionId: string): Promise<void> {
+    await this.config.authClient.logout(sessionId);
+    this.jwt = null;
+    this.refreshToken = null;
+  }
+
+  private adopt(tokens: AuthTokens): void {
+    this.jwt = tokens.jwt;
+    this.refreshToken = tokens.refreshToken;
+  }
+
+  /**
+   * Verify the challenge template BEFORE signing. Throws (so the spend key never
+   * signs) if the prefix is wrong, the embedded pubkey/network mismatch, or the
+   * timestamps are implausible.
+   */
+  private verifyChallenge(c: ChallengeResponse): void {
+    if (!c.challenge.startsWith(AUTH_PREFIX)) {
+      throw new Error('vault auth: challenge missing the expected prefix — refusing to sign');
+    }
+    const body = this.parseBody(c.challenge);
+    if (body.pubkey !== this.config.chainPubkey) {
+      throw new Error('vault auth: challenge pubkey is not our own — refusing to sign');
+    }
+    if (body.network !== this.config.network) {
+      throw new Error(
+        `vault auth: challenge network "${body.network}" != expected "${this.config.network}" — refusing to sign`,
+      );
+    }
+    this.verifyTimestamps(body);
+  }
+
+  private parseBody(challenge: string): ChallengeBody {
+    let body: ChallengeBody;
+    try {
+      body = JSON.parse(challenge.slice(AUTH_PREFIX.length)) as ChallengeBody;
+    } catch {
+      throw new Error('vault auth: challenge body is not valid JSON — refusing to sign');
+    }
+    return body;
+  }
+
+  /** Plausible window: not already expired, and not an implausibly long TTL. */
+  private verifyTimestamps(body: ChallengeBody): void {
+    const issued = Date.parse(body.issuedAt);
+    const expires = Date.parse(body.expiresAt);
+    if (Number.isNaN(issued) || Number.isNaN(expires)) {
+      throw new Error('vault auth: challenge has unparseable timestamps — refusing to sign');
+    }
+    const now = Date.now();
+    if (expires <= now) {
+      throw new Error('vault auth: challenge already expired — refusing to sign');
+    }
+    if (expires - issued > MAX_CHALLENGE_TTL_MS) {
+      throw new Error('vault auth: challenge TTL implausibly long — refusing to sign');
+    }
+  }
+}

--- a/storage/remote/diff.ts
+++ b/storage/remote/diff.ts
@@ -1,0 +1,83 @@
+/**
+ * TXF ↔ vault-entry diff (DESIGN §5.4) — the pure core of `sync()`.
+ *
+ * Maps a {@link TxfStorageDataBase} snapshot to the set of plaintext token keys
+ * it carries (the dynamic `_<tokenId>` entries, excluding the reserved meta
+ * slots), and computes the CAS ops needed to converge the server toward it given
+ * the provider's INTERNAL last-known server state. All version/CAS bookkeeping is
+ * internal (finding #29); the caller seals each op's payload separately.
+ */
+
+import type { TxfStorageDataBase } from '../storage-provider';
+
+/** Reserved TXF keys that are NOT token entries (never flushed as CAS rows here). */
+const RESERVED_KEYS = new Set(['_meta', '_tombstones', '_outbox', '_sent', '_invalid', '_history']);
+
+/** The provider's last-known view of one server entry. */
+export interface KnownEntry {
+  /** The server version this key was last observed/applied at. */
+  version: number;
+  deleted: boolean;
+}
+
+/** A pending CAS op the provider must seal + PATCH. `plainKey` is pre-wire. */
+export interface PlannedOp {
+  plainKey: string;
+  baseVersion: number;
+  /** false → create/update (carries a payload); true → delete (tombstone). */
+  isDelete: boolean;
+  /** The raw token value to seal (omitted on a delete). */
+  value?: unknown;
+}
+
+/**
+ * Extract the `{tokenId → value}` map from a TXF snapshot: every `_<id>` key that
+ * is not a reserved meta slot, with the leading underscore stripped.
+ */
+export function extractTokens(data: TxfStorageDataBase): Map<string, unknown> {
+  const out = new Map<string, unknown>();
+  for (const [key, value] of Object.entries(data)) {
+    if (!key.startsWith('_') || RESERVED_KEYS.has(key)) continue;
+    out.set(key.slice(1), value);
+  }
+  return out;
+}
+
+/**
+ * Plan the CAS ops to converge the server from `known` toward `tokens`:
+ *  - a token absent from `known` → create (`baseVersion 0`);
+ *  - a token present in `known` (even as a tombstone) → re-create/update at
+ *    `baseVersion 0` if the known row is deleted (delete-resurrect), else update
+ *    at the known version. (We only emit an update when the value changed —
+ *    callers pass already-changed values; here we re-flush every present token
+ *    that is missing from the clean known map, which the provider suppresses via
+ *    its content hash before calling this.)
+ *  - a token in `known` (live) but absent from `tokens` → delete.
+ *
+ * `changed(plainKey, value)` lets the caller suppress no-op updates by comparing
+ * against a content hash it persisted (returns false ⇒ skip the update op).
+ */
+export function planOps(
+  tokens: Map<string, unknown>,
+  known: Map<string, KnownEntry>,
+  changed: (plainKey: string, value: unknown) => boolean,
+): PlannedOp[] {
+  const ops: PlannedOp[] = [];
+  for (const [plainKey, value] of tokens) {
+    const cur = known.get(plainKey);
+    if (!cur) {
+      ops.push({ plainKey, baseVersion: 0, isDelete: false, value });
+    } else if (cur.deleted) {
+      // Delete-resurrect: create AGAINST the deleted row at baseVersion 0 (#16).
+      ops.push({ plainKey, baseVersion: 0, isDelete: false, value });
+    } else if (changed(plainKey, value)) {
+      ops.push({ plainKey, baseVersion: cur.version, isDelete: false, value });
+    }
+  }
+  for (const [plainKey, cur] of known) {
+    if (!cur.deleted && !tokens.has(plainKey)) {
+      ops.push({ plainKey, baseVersion: cur.version, isDelete: true });
+    }
+  }
+  return ops;
+}

--- a/storage/remote/diff.ts
+++ b/storage/remote/diff.ts
@@ -4,8 +4,13 @@
  * Maps a {@link TxfStorageDataBase} snapshot to the set of plaintext token keys
  * it carries (the dynamic `_<tokenId>` entries, excluding the reserved meta
  * slots), and computes the CAS ops needed to converge the server toward it given
- * the provider's INTERNAL last-known server state. All version/CAS bookkeeping is
- * internal (finding #29); the caller seals each op's payload separately.
+ * the provider's INTERNAL last-known server state.
+ *
+ * The last-known state is keyed by the OPAQUE wireKey — that is what `/state`
+ * reports (the server is operator-blind and never sees plaintext token ids). The
+ * diff computes `wireKey(plainKey)` for each local token to look it up, so a
+ * deleted server row (known only by its wireKey) is matched and resurrected.
+ * All version/CAS bookkeeping is internal (finding #29).
  */
 
 import type { TxfStorageDataBase } from '../storage-provider';
@@ -13,16 +18,19 @@ import type { TxfStorageDataBase } from '../storage-provider';
 /** Reserved TXF keys that are NOT token entries (never flushed as CAS rows here). */
 const RESERVED_KEYS = new Set(['_meta', '_tombstones', '_outbox', '_sent', '_invalid', '_history']);
 
-/** The provider's last-known view of one server entry. */
+/** The provider's last-known view of one server entry, keyed by wireKey. */
 export interface KnownEntry {
   /** The server version this key was last observed/applied at. */
   version: number;
   deleted: boolean;
 }
 
-/** A pending CAS op the provider must seal + PATCH. `plainKey` is pre-wire. */
+/** A pending CAS op the provider must seal + PATCH. Carries the OPAQUE wireKey. */
 export interface PlannedOp {
+  /** The plaintext token id (for content-hash bookkeeping). */
   plainKey: string;
+  /** The opaque wireKey the op targets on the wire. */
+  wireKey: string;
   baseVersion: number;
   /** false → create/update (carries a payload); true → delete (tombstone). */
   isDelete: boolean;
@@ -43,40 +51,42 @@ export function extractTokens(data: TxfStorageDataBase): Map<string, unknown> {
   return out;
 }
 
+export interface PlanOpsParams {
+  tokens: Map<string, unknown>;
+  /** Last-known server state, keyed by wireKey. */
+  known: Map<string, KnownEntry>;
+  /** Map a plaintext token id to its opaque wireKey. */
+  wireKeyOf: (plainKey: string) => string;
+  /** True when the value differs from the last-flushed content hash (skip no-op updates). */
+  changed: (wireKey: string, value: unknown) => boolean;
+}
+
 /**
  * Plan the CAS ops to converge the server from `known` toward `tokens`:
- *  - a token absent from `known` → create (`baseVersion 0`);
- *  - a token present in `known` (even as a tombstone) → re-create/update at
- *    `baseVersion 0` if the known row is deleted (delete-resurrect), else update
- *    at the known version. (We only emit an update when the value changed —
- *    callers pass already-changed values; here we re-flush every present token
- *    that is missing from the clean known map, which the provider suppresses via
- *    its content hash before calling this.)
- *  - a token in `known` (live) but absent from `tokens` → delete.
- *
- * `changed(plainKey, value)` lets the caller suppress no-op updates by comparing
- * against a content hash it persisted (returns false ⇒ skip the update op).
+ *  - a token whose wireKey is absent from `known` → create (`baseVersion 0`);
+ *  - a token whose wireKey is a known TOMBSTONE → re-create at `baseVersion 0`
+ *    AGAINST the deleted row (delete-resurrect, #16 — NOT rebased to its version);
+ *  - a token whose wireKey is a known LIVE row → update at the known version, but
+ *    only when the value changed;
+ *  - a known LIVE wireKey with no matching local token → delete.
  */
-export function planOps(
-  tokens: Map<string, unknown>,
-  known: Map<string, KnownEntry>,
-  changed: (plainKey: string, value: unknown) => boolean,
-): PlannedOp[] {
+export function planOps(params: PlanOpsParams): PlannedOp[] {
+  const { tokens, known, wireKeyOf, changed } = params;
   const ops: PlannedOp[] = [];
+  const liveWire = new Set<string>();
   for (const [plainKey, value] of tokens) {
-    const cur = known.get(plainKey);
-    if (!cur) {
-      ops.push({ plainKey, baseVersion: 0, isDelete: false, value });
-    } else if (cur.deleted) {
-      // Delete-resurrect: create AGAINST the deleted row at baseVersion 0 (#16).
-      ops.push({ plainKey, baseVersion: 0, isDelete: false, value });
-    } else if (changed(plainKey, value)) {
-      ops.push({ plainKey, baseVersion: cur.version, isDelete: false, value });
+    const wk = wireKeyOf(plainKey);
+    liveWire.add(wk);
+    const cur = known.get(wk);
+    if (!cur || cur.deleted) {
+      ops.push({ plainKey, wireKey: wk, baseVersion: 0, isDelete: false, value });
+    } else if (changed(wk, value)) {
+      ops.push({ plainKey, wireKey: wk, baseVersion: cur.version, isDelete: false, value });
     }
   }
-  for (const [plainKey, cur] of known) {
-    if (!cur.deleted && !tokens.has(plainKey)) {
-      ops.push({ plainKey, baseVersion: cur.version, isDelete: true });
+  for (const [wk, cur] of known) {
+    if (!cur.deleted && !liveWire.has(wk)) {
+      ops.push({ plainKey: '', wireKey: wk, baseVersion: cur.version, isDelete: true });
     }
   }
   return ops;

--- a/storage/remote/load-delta.ts
+++ b/storage/remote/load-delta.ts
@@ -70,8 +70,6 @@ export class LoadDeltaTracker {
   private accState: Map<string, EntryState> | null = null;
   /** The signed baseline loaded at the start of this pass (null = first ever load). */
   private baseline: SignedBaseline | null = null;
-  /** Whether this pass observed a server-verified epoch bump (sanctioned reset). */
-  private sanctionedEpoch = false;
 
   constructor(config: LoadDeltaConfig) {
     this.config = config;
@@ -88,12 +86,18 @@ export class LoadDeltaTracker {
 
   /**
    * Begin a load pass: load + verify the persisted signed baseline and seed the
-   * accumulator from it. MUST be called once before the pagination loop.
+   * accumulator from the provider's authoritative `known` state (what it believes
+   * the server holds). MUST be called once before the pagination loop.
+   *
+   * Seeding from `known` is what makes the root gate precise: the wallet is the
+   * ONLY writer, so a clean re-load returns an EMPTY delta and the accumulator
+   * (= known) recomputes to the signed baseline root. A NON-empty delta the
+   * wallet did not author (mutation / injection) shifts the root away from the
+   * signed baseline → rollback.
    */
-  async beginLoad(): Promise<void> {
-    this.sanctionedEpoch = false;
+  async beginLoad(known: Map<string, EntryState>): Promise<void> {
     this.baseline = await this.loadBaseline();
-    this.accState = new Map();
+    this.accState = new Map(known);
     if (this.baseline && !verifyRoot(this.bindingFor(this.baseline.cursor, this.baseline.root), this.baseline.sig, this.ownerPubForVerify())) {
       // A corrupt/forged local baseline is treated as no baseline (a fresh load).
       this.baseline = null;
@@ -102,7 +106,7 @@ export class LoadDeltaTracker {
 
   /** Ingest one `/state` page: monotonicity + root gate. */
   async ingestPage(page: LoadPage): Promise<GateResult> {
-    if (this.accState === null) await this.beginLoad();
+    if (this.accState === null) await this.beginLoad(new Map());
     const epochOk = this.recogniseEpoch(page);
     const mono = this.checkMonotonic(page);
     if (!mono.ok && !epochOk) return mono;
@@ -120,9 +124,7 @@ export class LoadDeltaTracker {
     const baseEpoch = this.baseline?.epoch ?? 0;
     if (page.epoch <= baseEpoch) return false;
     const canon = epochCanon(this.config.network, page.epoch);
-    const verified = verifySignedMessage(canon, page.epochSig, this.config.vaultServerKey);
-    if (verified) this.sanctionedEpoch = true;
-    return verified;
+    return verifySignedMessage(canon, page.epochSig, this.config.vaultServerKey);
   }
 
   /** Cursor must be non-decreasing relative to the `since` it answered. */
@@ -167,18 +169,6 @@ export class LoadDeltaTracker {
     this.accState = null; // close the pass regardless of whether a baseline was persisted
   }
 
-  /**
-   * Persist a signed baseline for an EXPLICIT `known` state (used after a flush so
-   * a subsequent `load()` has a baseline to compare the delta against).
-   */
-  async baselineFromState(cursor: number, epoch: number, known: Map<string, EntryState>): Promise<void> {
-    if (!this.config.baseline || !this.walletPriv) return;
-    const root = computeRoot(known);
-    const sig = signRoot(this.walletPriv, this.bindingFor(cursor, root));
-    const baseline: SignedBaseline = { cursor, root, sig, epoch };
-    await this.config.baseline.set(this.baselineKey(), JSON.stringify(baseline));
-  }
-
   private async loadBaseline(): Promise<SignedBaseline | null> {
     if (!this.config.baseline) return null;
     const raw = await this.config.baseline.get(this.baselineKey());
@@ -196,10 +186,5 @@ export class LoadDeltaTracker {
 
   private baselineKey(): string {
     return `vault_baseline:${this.config.network}:${this.ownerId}`;
-  }
-
-  /** Whether the last pass saw a sanctioned (server-verified) epoch bump. */
-  get lastPassSanctioned(): boolean {
-    return this.sanctionedEpoch;
   }
 }

--- a/storage/remote/load-delta.ts
+++ b/storage/remote/load-delta.ts
@@ -87,11 +87,22 @@ export class LoadDeltaTracker {
   }
 
   /**
-   * Ingest one `/state` page: monotonicity + root gate. On the first page of a
-   * pass it lazily loads + verifies the persisted signed baseline.
+   * Begin a load pass: load + verify the persisted signed baseline and seed the
+   * accumulator from it. MUST be called once before the pagination loop.
    */
+  async beginLoad(): Promise<void> {
+    this.sanctionedEpoch = false;
+    this.baseline = await this.loadBaseline();
+    this.accState = new Map();
+    if (this.baseline && !verifyRoot(this.bindingFor(this.baseline.cursor, this.baseline.root), this.baseline.sig, this.ownerPubForVerify())) {
+      // A corrupt/forged local baseline is treated as no baseline (a fresh load).
+      this.baseline = null;
+    }
+  }
+
+  /** Ingest one `/state` page: monotonicity + root gate. */
   async ingestPage(page: LoadPage): Promise<GateResult> {
-    if (this.accState === null) await this.beginPass();
+    if (this.accState === null) await this.beginLoad();
     const epochOk = this.recogniseEpoch(page);
     const mono = this.checkMonotonic(page);
     if (!mono.ok && !epochOk) return mono;
@@ -101,17 +112,6 @@ export class LoadDeltaTracker {
       if (!verdict.ok) return verdict;
     }
     return { ok: true };
-  }
-
-  /** Load + verify the persisted signed baseline; seed the accumulator from it. */
-  private async beginPass(): Promise<void> {
-    this.sanctionedEpoch = false;
-    this.baseline = await this.loadBaseline();
-    this.accState = new Map();
-    if (this.baseline && !verifyRoot(this.bindingFor(this.baseline.cursor, this.baseline.root), this.baseline.sig, this.ownerPubForVerify())) {
-      // A corrupt/forged local baseline is treated as no baseline (a fresh load).
-      this.baseline = null;
-    }
   }
 
   /** Recognise a server-verified epoch bump (sanctioned reset — 8.2 seam). */
@@ -158,12 +158,13 @@ export class LoadDeltaTracker {
    * authoritative post-load state; the root binds `(network, ownerId, cursor)`.
    */
   async commitBaseline(cursor: number, epoch: number, _epochSig: string): Promise<void> {
-    if (!this.config.baseline || !this.walletPriv) return;
-    const root = computeRoot(this.accState ?? new Map());
-    const sig = signRoot(this.walletPriv, this.bindingFor(cursor, root));
-    const baseline: SignedBaseline = { cursor, root, sig, epoch };
-    await this.config.baseline.set(this.baselineKey(), JSON.stringify(baseline));
-    this.accState = null; // close the pass
+    if (this.config.baseline && this.walletPriv) {
+      const root = computeRoot(this.accState ?? new Map());
+      const sig = signRoot(this.walletPriv, this.bindingFor(cursor, root));
+      const baseline: SignedBaseline = { cursor, root, sig, epoch };
+      await this.config.baseline.set(this.baselineKey(), JSON.stringify(baseline));
+    }
+    this.accState = null; // close the pass regardless of whether a baseline was persisted
   }
 
   /**

--- a/storage/remote/load-delta.ts
+++ b/storage/remote/load-delta.ts
@@ -1,0 +1,204 @@
+/**
+ * LoadDeltaTracker (Tasks 6.4 + 4.2, DESIGN §5.4) — the anti-rollback gate.
+ *
+ * The provider's `load()` paginates `/state?since=` and feeds each page here. The
+ * tracker:
+ *  1. CURSOR MONOTONICITY (6.4): the reported `cursor` must never regress below
+ *     the `since` it answered — a regression with no sanctioned epoch is a
+ *     rollback.
+ *  2. SIGNED-ROOT COMPARISON (4.2): the wallet persists a signed baseline
+ *     `{cursor, root, sig}` after each clean flush/load. On the next load the
+ *     tracker folds the `/state` delta into the baseline accumulator and recomputes
+ *     the root. Because the wallet is the ONLY writer, any non-empty delta it did
+ *     NOT itself author (no intervening flush advanced the baseline) yields a root
+ *     that diverges from the signed baseline root → rollback. The mismatch surfaces
+ *     as `storage:error{reason:'rollback'}` in the provider (the FROZEN union is
+ *     untouched — there is no `storage:rollback` member).
+ *  3. EPOCH SHORT-CIRCUIT SEAM (Task 8.2): a `/state` `epochSig` that verifies under
+ *     `NETWORKS[net].vaultServerKey` AND advances the epoch is a SANCTIONED reset —
+ *     it re-baselines instead of alarming. Here we only RECOGNISE a verified bump
+ *     so the gate does not false-alarm on a real reset; the full drop+re-baseline
+ *     behaviour is completed in 8.2. With no verified bump, any regression / root
+ *     divergence alarms.
+ */
+
+import { computeRoot, foldDelta, signRoot, verifyRoot } from './merkle';
+import type { EntryState } from './merkle';
+import { epochCanon } from '../../vault-aead/canon';
+import { verifySignedMessage } from '../../core/crypto';
+import type { StateEntry } from './types';
+
+/** Minimal local KV the signed baseline persists into (injected in tests). */
+export interface LocalBaselineStore {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+}
+
+/** The wallet-signed baseline `{cursor, root, sig, epoch}` for one owner. */
+interface SignedBaseline {
+  cursor: number;
+  root: string;
+  sig: string;
+  epoch: number;
+}
+
+export interface LoadDeltaConfig {
+  network: string;
+  /** Compressed server signing key (`NETWORKS[net].vaultServerKey`) for epoch verify. */
+  vaultServerKey?: string;
+  baseline?: LocalBaselineStore;
+}
+
+/** One `/state` page handed to the tracker. */
+export interface LoadPage {
+  since: number;
+  entries: StateEntry[];
+  cursor: number;
+  epoch: number;
+  epochSig: string;
+}
+
+/** Gate verdict for one page. */
+export type GateResult = { ok: true } | { ok: false; reason: string };
+
+export class LoadDeltaTracker {
+  private readonly config: LoadDeltaConfig;
+  private ownerId = '';
+  private walletPriv = '';
+
+  /** The accumulator state for THIS load pass (rebuilt from the signed baseline). */
+  private accState: Map<string, EntryState> | null = null;
+  /** The signed baseline loaded at the start of this pass (null = first ever load). */
+  private baseline: SignedBaseline | null = null;
+  /** Whether this pass observed a server-verified epoch bump (sanctioned reset). */
+  private sanctionedEpoch = false;
+
+  constructor(config: LoadDeltaConfig) {
+    this.config = config;
+  }
+
+  setIdentity(ownerId: string): void {
+    this.ownerId = ownerId;
+  }
+
+  /** The wallet private key, needed to (re)sign the baseline root. */
+  setWalletPriv(priv: string): void {
+    this.walletPriv = priv;
+  }
+
+  /**
+   * Ingest one `/state` page: monotonicity + root gate. On the first page of a
+   * pass it lazily loads + verifies the persisted signed baseline.
+   */
+  async ingestPage(page: LoadPage): Promise<GateResult> {
+    if (this.accState === null) await this.beginPass();
+    const epochOk = this.recogniseEpoch(page);
+    const mono = this.checkMonotonic(page);
+    if (!mono.ok && !epochOk) return mono;
+    this.fold(page.entries);
+    if (this.baseline && !epochOk) {
+      const verdict = this.checkRoot();
+      if (!verdict.ok) return verdict;
+    }
+    return { ok: true };
+  }
+
+  /** Load + verify the persisted signed baseline; seed the accumulator from it. */
+  private async beginPass(): Promise<void> {
+    this.sanctionedEpoch = false;
+    this.baseline = await this.loadBaseline();
+    this.accState = new Map();
+    if (this.baseline && !verifyRoot(this.bindingFor(this.baseline.cursor, this.baseline.root), this.baseline.sig, this.ownerPubForVerify())) {
+      // A corrupt/forged local baseline is treated as no baseline (a fresh load).
+      this.baseline = null;
+    }
+  }
+
+  /** Recognise a server-verified epoch bump (sanctioned reset — 8.2 seam). */
+  private recogniseEpoch(page: LoadPage): boolean {
+    if (!this.config.vaultServerKey) return false;
+    const baseEpoch = this.baseline?.epoch ?? 0;
+    if (page.epoch <= baseEpoch) return false;
+    const canon = epochCanon(this.config.network, page.epoch);
+    const verified = verifySignedMessage(canon, page.epochSig, this.config.vaultServerKey);
+    if (verified) this.sanctionedEpoch = true;
+    return verified;
+  }
+
+  /** Cursor must be non-decreasing relative to the `since` it answered. */
+  private checkMonotonic(page: LoadPage): GateResult {
+    if (page.cursor < page.since) {
+      return { ok: false, reason: `cursor regressed: ${page.cursor} < since ${page.since}` };
+    }
+    return { ok: true };
+  }
+
+  private fold(entries: StateEntry[]): void {
+    const delta = new Map<string, EntryState>();
+    for (const e of entries) delta.set(e.key, { version: e.version, deleted: e.deleted });
+    const { state } = foldDelta(this.accState!, delta);
+    this.accState = state;
+  }
+
+  /**
+   * The folded root must equal the signed baseline root: the wallet is the only
+   * writer, so a delta it did not author (no intervening flush advanced the
+   * baseline) means the server injected state — a rollback.
+   */
+  private checkRoot(): GateResult {
+    const folded = computeRoot(this.accState!);
+    if (folded !== this.baseline!.root) {
+      return { ok: false, reason: 'rollback' };
+    }
+    return { ok: true };
+  }
+
+  /**
+   * Persist a fresh signed baseline after a clean load. `known` is the provider's
+   * authoritative post-load state; the root binds `(network, ownerId, cursor)`.
+   */
+  async commitBaseline(cursor: number, epoch: number, _epochSig: string): Promise<void> {
+    if (!this.config.baseline || !this.walletPriv) return;
+    const root = computeRoot(this.accState ?? new Map());
+    const sig = signRoot(this.walletPriv, this.bindingFor(cursor, root));
+    const baseline: SignedBaseline = { cursor, root, sig, epoch };
+    await this.config.baseline.set(this.baselineKey(), JSON.stringify(baseline));
+    this.accState = null; // close the pass
+  }
+
+  /**
+   * Persist a signed baseline for an EXPLICIT `known` state (used after a flush so
+   * a subsequent `load()` has a baseline to compare the delta against).
+   */
+  async baselineFromState(cursor: number, epoch: number, known: Map<string, EntryState>): Promise<void> {
+    if (!this.config.baseline || !this.walletPriv) return;
+    const root = computeRoot(known);
+    const sig = signRoot(this.walletPriv, this.bindingFor(cursor, root));
+    const baseline: SignedBaseline = { cursor, root, sig, epoch };
+    await this.config.baseline.set(this.baselineKey(), JSON.stringify(baseline));
+  }
+
+  private async loadBaseline(): Promise<SignedBaseline | null> {
+    if (!this.config.baseline) return null;
+    const raw = await this.config.baseline.get(this.baselineKey());
+    return raw ? (JSON.parse(raw) as SignedBaseline) : null;
+  }
+
+  private bindingFor(cursor: number, root: string): { network: string; ownerId: string; cursor: number; root: string } {
+    return { network: this.config.network, ownerId: this.ownerId, cursor, root };
+  }
+
+  /** The signed root is verified against the wallet's OWN pubkey (it self-signs). */
+  private ownerPubForVerify(): string {
+    return this.ownerId;
+  }
+
+  private baselineKey(): string {
+    return `vault_baseline:${this.config.network}:${this.ownerId}`;
+  }
+
+  /** Whether the last pass saw a sanctioned (server-verified) epoch bump. */
+  get lastPassSanctioned(): boolean {
+    return this.sanctionedEpoch;
+  }
+}

--- a/storage/remote/types.ts
+++ b/storage/remote/types.ts
@@ -1,0 +1,128 @@
+/**
+ * Vault wire seam (mirrors token-api `/v1/auth/*` + `/v1/entries` + `/v1/state`
+ * — DESIGN §4, §5.4). The provider talks to the vault through these typed
+ * interfaces, never raw `fetch`.
+ *
+ * Two seams, mirroring the courier's {@link CourierHttpClient} pattern:
+ *  - {@link VaultAuthHttpClient} — the raw auth endpoints (challenge / verify /
+ *    refresh / logout). {@link VaultApiClient} wraps it with template
+ *    verification + serialized refresh. The fake server and the real fetch+JWT
+ *    client both implement it.
+ *  - {@link VaultHttpClient} — the AUTHENTICATED data endpoints (PATCH /entries,
+ *    GET /state). The caller (`ownerId = chainPubkey`) is implied: the fake
+ *    server binds it via `clientFor(ownerId)`; the real client supplies it via
+ *    the JWT minted by {@link VaultApiClient}.
+ *
+ * Phase 8.3 swaps the fake for a real token-api HTTP client implementing these
+ * same interfaces — the provider logic is unchanged.
+ */
+
+import type { VaultEntryPayload } from '../../vault-aead/entry';
+
+// =============================================================================
+// Auth wire (DESIGN §4) — raw endpoints
+// =============================================================================
+
+/** `POST /v1/auth/challenge` response. `challenge` is the literal string to sign. */
+export interface ChallengeResponse {
+  nonce: string;
+  challenge: string;
+  /** ISO-8601 (the server sends a serialized Date). */
+  expiresAt: string;
+}
+
+/** `POST /v1/auth/verify` / `POST /v1/auth/refresh` response — the token pair. */
+export interface AuthTokens {
+  jwt: string;
+  refreshToken: string;
+}
+
+/** `POST /v1/auth/verify` request body. */
+export interface VerifyRequest {
+  nonce: string;
+  signature: string;
+  deviceId: string;
+  /** Accepted but IGNORED by the server (it stamps `config.NETWORK`). */
+  network?: string;
+}
+
+/**
+ * The raw auth endpoints. A `null` return models the server's 401 (bad
+ * signature / stale-or-reused refresh) — the client maps it to an auth failure
+ * without leaking the HTTP layer.
+ */
+export interface VaultAuthHttpClient {
+  /** `POST /v1/auth/challenge {pubkey}`. */
+  challenge(pubkey: string): Promise<ChallengeResponse>;
+  /** `POST /v1/auth/verify` — `null` on a 401 (bad signature). */
+  verify(req: VerifyRequest): Promise<AuthTokens | null>;
+  /** `POST /v1/auth/refresh {refreshToken}` — `null` on a 401 (stale / reused). */
+  refresh(refreshToken: string): Promise<AuthTokens | null>;
+  /** `POST /v1/auth/logout {sessionId}` (Bearer) — 204. */
+  logout(sessionId: string): Promise<void>;
+}
+
+// =============================================================================
+// Vault data wire (DESIGN §5.4) — authenticated endpoints
+// =============================================================================
+
+/** Reason a single op was rejected. Lowercase — exactly the server's wire labels. */
+export type RejectionReason = 'conflict' | 'entry_too_large' | 'insufficient_storage';
+
+/** One CAS op in a `PATCH /v1/entries` batch. `key` is the OPAQUE wireKey. */
+export interface PatchOp {
+  key: string;
+  baseVersion: number;
+  /** Omitted on a delete op (the server retains the last ciphertext). */
+  payload?: VaultEntryPayload;
+  /** true → tombstone the entry. */
+  deleted?: boolean;
+}
+
+/** A single rejected op surfaced in the PATCH response. */
+export interface PatchRejection {
+  key: string;
+  reason: RejectionReason;
+}
+
+/**
+ * `PATCH /v1/entries` response. `conflicts` is ALWAYS an empty array on the wire
+ * (the SDK derives its own conflict COUNT from `rejected[].reason === 'conflict'`).
+ */
+export interface PatchResponse {
+  cursor: number;
+  applied: string[];
+  rejected: PatchRejection[];
+  conflicts: never[];
+}
+
+/** One `{key,version,payload,deleted,seq}` row in a `/state` page. */
+export interface StateEntry {
+  key: string;
+  version: number;
+  payload: VaultEntryPayload;
+  deleted: boolean;
+  seq: number;
+}
+
+/** `GET /v1/state?since=` response page. */
+export interface StateResponse {
+  cursor: number;
+  syncEpoch: number;
+  /** Server signature over `epochCanon(network, syncEpoch)`. */
+  epochSig: string;
+  formatVersion: string;
+  more: boolean;
+  entries: StateEntry[];
+}
+
+/**
+ * The authenticated vault data seam. The caller (`ownerId = chainPubkey`) is
+ * implied by how the client was obtained. Each method is one `/v1/*` endpoint.
+ */
+export interface VaultHttpClient {
+  /** `PATCH /v1/entries {ops}`. */
+  patchEntries(ops: PatchOp[]): Promise<PatchResponse>;
+  /** `GET /v1/state?since=<cursor>`. */
+  getState(since: number): Promise<StateResponse>;
+}

--- a/tests/helpers/fake-vault-server.ts
+++ b/tests/helpers/fake-vault-server.ts
@@ -1,0 +1,385 @@
+/**
+ * fake-vault-server — an in-memory, faithful re-implementation of the token-api
+ * AUTH + VAULT + EPOCH wire (Part A: `routes/auth.ts`, `routes/vault.ts`,
+ * `services/auth.service.ts`, `services/vault.service.ts`, `services/epoch.service.ts`,
+ * `storage/mongo/repos/vault-tokens.repo.ts`). The REAL token-api is only
+ * exercised in Phase 8.3; this fake lets the provider's logic run identically
+ * against a swappable in-process server (mirrors `fake-courier-server.ts`).
+ *
+ * Faithful to Part A:
+ *  - AUTH: single-use challenge whose literal is
+ *    `'unicity:vault:auth:v1\n' + JSON.stringify({network,pubkey,nonce,issuedAt,expiresAt})`
+ *    (Dates serialize to ISO strings); `/verify` recovers the signer from the
+ *    challenge and checks it equals `pubkey`; rotating refresh where reusing a
+ *    now-stale token REVOKES the session (`refreshToken = '<ownerId>.<hex>'`).
+ *  - VAULT CAS: per-`(ownerId,key)` CAS — `baseVersion 0` creates (v1) or
+ *    resurrects a deleted row (v+1); `baseVersion N>0` requires the live version
+ *    to equal N AND not be deleted. Rejections land in `rejected[]` with the
+ *    lowercase wire reason; 507 ONLY when the whole batch was blocked by a
+ *    storage watermark. `conflicts` is ALWAYS `[]`; the internal `status` is
+ *    stripped from the body. PATCH `cursor` = per-owner commit counter.
+ *  - STATE: `/state?since=` returns rows with `seq > since`, page-limited, with
+ *    `more`; `cursor` = the last entry's `seq` on the page (or `since` if empty).
+ *    `epochSig` = the server signature over `epochCanon(net, syncEpoch)`,
+ *    verifiable under `NETWORKS[net].vaultServerKey`.
+ *
+ * Swap seam: the provider talks to {@link VaultAuthHttpClient} (raw auth) and
+ * {@link VaultHttpClient} (authenticated data). `authClient()` returns the auth
+ * seam; `clientFor(ownerId)` returns a data seam scoped to a caller. Phase 8.3
+ * swaps in a real HTTP client (fetch + JWT) implementing the same interfaces —
+ * no provider changes.
+ */
+
+import { recoverPubkeyFromSignature, verifySignedMessage, signMessage } from '../../core/crypto';
+import { epochCanon } from '../../vault-aead/canon';
+import type { VaultEntryPayload } from '../../vault-aead/entry';
+import type {
+  AuthTokens,
+  ChallengeResponse,
+  PatchOp,
+  PatchRejection,
+  PatchResponse,
+  RejectionReason,
+  StateEntry,
+  StateResponse,
+  VaultAuthHttpClient,
+  VaultHttpClient,
+  VerifyRequest,
+} from '../../storage/remote/types';
+
+/** Shared deployment-fixture server signing key — its pubkey = `NETWORKS.testnet2.vaultServerKey`. */
+export const SERVER_SIGN_PRIV = 'a'.repeat(64);
+
+const AUTH_PREFIX = 'unicity:vault:auth:v1\n';
+const CHALLENGE_TTL_MS = 5 * 60_000;
+const DEFAULT_PAGE_LIMIT = 1000;
+
+let counter = 0;
+const uniq = (p: string): string => `${p}-${++counter}-${Math.random().toString(36).slice(2)}`;
+
+interface NonceRow {
+  pubkey: string;
+  challenge: string;
+  expiresAt: number;
+}
+
+interface SessionRow {
+  sessionId: string;
+  ownerId: string;
+  deviceId: string;
+  /** Current live refresh token. */
+  refreshToken: string;
+  /** The immediately-prior refresh token (reuse-detection). */
+  priorToken: string | null;
+  revoked: boolean;
+}
+
+/** Live vault entry (mirrors `VaultTokenDoc`). */
+interface EntryRow {
+  ownerId: string;
+  key: string;
+  version: number;
+  payload: VaultEntryPayload;
+  deleted: boolean;
+  seq: number;
+}
+
+export interface FakeVaultServerOptions {
+  network?: string;
+  pageLimit?: number;
+}
+
+/**
+ * The in-memory vault server. Hold ONE instance per test; obtain the auth seam
+ * via {@link FakeVaultServer.authClient} and a caller-scoped data seam via
+ * {@link FakeVaultServer.clientFor}.
+ */
+export class FakeVaultServer {
+  readonly network: string;
+  private readonly pageLimit: number;
+
+  private readonly nonces = new Map<string, NonceRow>();
+  private readonly sessions: SessionRow[] = [];
+  private readonly entries: EntryRow[] = [];
+  /** Per-owner monotonic seq allocator (the `/state` pagination watermark). */
+  private readonly seqCounter = new Map<string, number>();
+  /** Per-owner commit counter (the PATCH-response `cursor`). */
+  private readonly cursorCounter = new Map<string, number>();
+
+  /** Current signed storage epoch (DESIGN §5.4) — injectable bump for 8.2/4.2. */
+  private epoch = 1;
+  /** When true, `insufficient_storage` blocks ALL ops (whole-batch 507 path). */
+  private storageFull = false;
+  /** Per-key byte cap for the `entry_too_large` path; undefined = unbounded. */
+  private maxEntryBytes: number | undefined;
+
+  /** Per-endpoint call log — tests assert request bodies and call counts. */
+  readonly calls: {
+    challenge: string[];
+    verify: VerifyRequest[];
+    refresh: string[];
+    logout: string[];
+    patch: PatchOp[][];
+    state: number[];
+  } = { challenge: [], verify: [], refresh: [], logout: [], patch: [], state: [] };
+
+  constructor(opts: FakeVaultServerOptions | string = {}) {
+    const o = typeof opts === 'string' ? { network: opts } : opts;
+    this.network = o.network ?? 'testnet2';
+    this.pageLimit = o.pageLimit ?? DEFAULT_PAGE_LIMIT;
+  }
+
+  /** The raw auth seam (challenge / verify / refresh / logout). */
+  authClient(): VaultAuthHttpClient {
+    return {
+      challenge: (pubkey) => Promise.resolve(this.challenge(pubkey)),
+      verify: (req) => Promise.resolve(this.verify(req)),
+      refresh: (token) => Promise.resolve(this.refresh(token)),
+      logout: (sessionId) => Promise.resolve(this.logout(sessionId)),
+    };
+  }
+
+  /** A {@link VaultHttpClient} bound to the authenticated caller (`ownerId`). */
+  clientFor(ownerId: string): VaultHttpClient {
+    return {
+      patchEntries: (ops) => Promise.resolve(this.patchEntries(ownerId, ops)),
+      getState: (since) => Promise.resolve(this.getState(ownerId, since)),
+    };
+  }
+
+  // === AUTH ==================================================================
+
+  private challenge(pubkey: string): ChallengeResponse {
+    this.calls.challenge.push(pubkey);
+    const nonce = uniq('nonce');
+    const issuedAt = new Date();
+    const expiresAt = new Date(issuedAt.getTime() + CHALLENGE_TTL_MS);
+    // EXACT server template: JSON.stringify serializes Dates to ISO strings.
+    const challenge = AUTH_PREFIX + JSON.stringify({ network: this.network, pubkey, nonce, issuedAt, expiresAt });
+    this.nonces.set(nonce, { pubkey, challenge, expiresAt: expiresAt.getTime() });
+    return { nonce, challenge, expiresAt: expiresAt.toISOString() };
+  }
+
+  private verify(req: VerifyRequest): AuthTokens | null {
+    this.calls.verify.push(req);
+    const row = this.nonces.get(req.nonce);
+    if (!row) return null; // single-use / unknown nonce
+    this.nonces.delete(req.nonce); // consume once
+    if (Date.now() > row.expiresAt) return null;
+    let owner: string;
+    try {
+      owner = recoverPubkeyFromSignature(row.challenge, req.signature);
+    } catch {
+      return null;
+    }
+    if (owner !== row.pubkey) return null;
+    if (!verifySignedMessage(row.challenge, req.signature, owner)) return null;
+    return this.openSession(owner, req.deviceId);
+  }
+
+  private openSession(ownerId: string, deviceId: string): AuthTokens {
+    const refreshToken = `${ownerId}.${uniq('r')}`;
+    this.sessions.push({ sessionId: uniq('sess'), ownerId, deviceId, refreshToken, priorToken: null, revoked: false });
+    return { jwt: this.mintJwt(ownerId, deviceId), refreshToken };
+  }
+
+  private refresh(token: string): AuthTokens | null {
+    this.calls.refresh.push(token);
+    const live = this.sessions.find((s) => !s.revoked && s.refreshToken === token);
+    if (live) return this.rotate(live);
+    // Reusing a now-stale (prior) token REVOKES the session (DESIGN §4.3).
+    const stale = this.sessions.find((s) => s.priorToken === token);
+    if (stale) stale.revoked = true;
+    return null;
+  }
+
+  private rotate(s: SessionRow): AuthTokens {
+    s.priorToken = s.refreshToken;
+    s.refreshToken = `${s.ownerId}.${uniq('r')}`;
+    return { jwt: this.mintJwt(s.ownerId, s.deviceId), refreshToken: s.refreshToken };
+  }
+
+  private logout(sessionId: string): void {
+    this.calls.logout.push(sessionId);
+    const s = this.sessions.find((x) => x.sessionId === sessionId);
+    if (s) s.revoked = true;
+  }
+
+  /** A faux JWT — the fake never parses it; the data seam is bound by `clientFor`. */
+  private mintJwt(sub: string, deviceId: string): string {
+    return `jwt.${sub}.${deviceId}.${uniq('j')}`;
+  }
+
+  // === VAULT (PATCH /v1/entries) ============================================
+
+  private patchEntries(ownerId: string, ops: PatchOp[]): PatchResponse {
+    this.calls.patch.push(ops);
+    const applied: string[] = [];
+    const rejected: PatchRejection[] = [];
+    for (const op of ops) {
+      this.applyOne(ownerId, op, applied, rejected);
+    }
+    const cursor = this.bumpCursor(ownerId);
+    // The route strips `status`; we replicate only the body the SDK observes.
+    // (`status === 507` ⟺ whole batch blocked — the provider tolerates either.)
+    return { cursor, applied, rejected, conflicts: [] };
+  }
+
+  private applyOne(ownerId: string, op: PatchOp, applied: string[], rejected: PatchRejection[]): void {
+    const reason = this.checkEntry(op);
+    if (reason) {
+      rejected.push({ key: op.key, reason });
+      return;
+    }
+    if (!this.upsertCas(ownerId, op)) {
+      rejected.push({ key: op.key, reason: 'conflict' });
+      return;
+    }
+    applied.push(op.key);
+  }
+
+  /** Quota gate: oversize → `entry_too_large`; storage watermark → `insufficient_storage`. */
+  private checkEntry(op: PatchOp): RejectionReason | null {
+    if (this.maxEntryBytes !== undefined && this.payloadBytes(op.payload) > this.maxEntryBytes) {
+      return 'entry_too_large';
+    }
+    if (this.storageFull) return 'insufficient_storage';
+    return null;
+  }
+
+  private payloadBytes(payload?: VaultEntryPayload): number {
+    if (!payload) return 0;
+    return payload.nonce.length + payload.ct.length;
+  }
+
+  /**
+   * CAS, mirroring `vault-tokens.repo.ts::applyCas`:
+   *  - baseVersion 0 → create when absent (v1) OR resurrect a deleted row (v+1);
+   *    a live non-deleted row → conflict.
+   *  - baseVersion N>0 → require the live version to equal N AND not be deleted.
+   */
+  private upsertCas(ownerId: string, op: PatchOp): boolean {
+    const cur = this.entries.find((e) => e.ownerId === ownerId && e.key === op.key);
+    if (op.baseVersion === 0) return this.createOrResurrect(ownerId, op, cur);
+    if (!cur || cur.deleted || cur.version !== op.baseVersion) return false;
+    this.writeNext(cur, op);
+    return true;
+  }
+
+  private createOrResurrect(ownerId: string, op: PatchOp, cur: EntryRow | undefined): boolean {
+    if (!cur) {
+      this.entries.push({
+        ownerId,
+        key: op.key,
+        version: 1,
+        payload: op.payload!,
+        deleted: op.deleted ?? false,
+        seq: this.nextSeq(ownerId),
+      });
+      return true;
+    }
+    if (!cur.deleted) return false; // a live row cannot be re-created at baseVersion 0
+    this.writeNext(cur, op);
+    return true;
+  }
+
+  /** Apply the next version to a row; a delete op RETAINS the last ciphertext. */
+  private writeNext(row: EntryRow, op: PatchOp): void {
+    row.version += 1;
+    row.deleted = op.deleted ?? false;
+    if (op.payload) row.payload = op.payload;
+    row.seq = this.nextSeq(row.ownerId);
+  }
+
+  // === STATE (GET /v1/state) ================================================
+
+  private getState(ownerId: string, since: number): StateResponse {
+    this.calls.state.push(since);
+    const rows = this.entries
+      .filter((e) => e.ownerId === ownerId && e.seq > since)
+      .sort((a, b) => a.seq - b.seq);
+    const more = rows.length > this.pageLimit;
+    const page = more ? rows.slice(0, this.pageLimit) : rows;
+    return {
+      cursor: page.length ? page[page.length - 1].seq : since,
+      syncEpoch: this.epoch,
+      epochSig: this.signEpoch(this.epoch),
+      formatVersion: 'entries-v1',
+      more,
+      entries: page.map(toStateEntry),
+    };
+  }
+
+  private signEpoch(epoch: number): string {
+    return signMessage(SERVER_SIGN_PRIV, epochCanon(this.network, epoch));
+  }
+
+  // === seq / cursor allocators ==============================================
+
+  private nextSeq(ownerId: string): number {
+    const next = (this.seqCounter.get(ownerId) ?? 0) + 1;
+    this.seqCounter.set(ownerId, next);
+    return next;
+  }
+
+  private bumpCursor(ownerId: string): number {
+    const next = (this.cursorCounter.get(ownerId) ?? 0) + 1;
+    this.cursorCounter.set(ownerId, next);
+    return next;
+  }
+
+  // === test affordances =====================================================
+
+  /** Bump the signed storage epoch (sanctioned reset — DESIGN §8.2). */
+  bumpEpoch(): number {
+    this.epoch += 1;
+    return this.epoch;
+  }
+
+  /** Force the whole-batch storage watermark (507 path). */
+  setStorageFull(full: boolean): void {
+    this.storageFull = full;
+  }
+
+  /** Set the per-entry byte cap (oversize → `entry_too_large`). */
+  setMaxEntryBytes(max: number | undefined): void {
+    this.maxEntryBytes = max;
+  }
+
+  /** Number of live entries for an owner (assertions). */
+  entryCount(ownerId: string): number {
+    return this.entries.filter((e) => e.ownerId === ownerId).length;
+  }
+
+  /** Read a stored entry row (assertions). */
+  getEntry(ownerId: string, key: string): EntryRow | undefined {
+    return this.entries.find((e) => e.ownerId === ownerId && e.key === key);
+  }
+
+  /**
+   * HOSTILE-ROLLBACK injector (Task 4.2): mutate a stored entry's ciphertext at a
+   * FRESH monotonic seq WITHOUT bumping the signed epoch. This surfaces a `/state`
+   * delta whose recomputed root diverges from the signed baseline — a rollback the
+   * client must catch (no sanctioned epoch ⇒ alarm).
+   */
+  mutateEntry(ownerId: string, key: string, payload: VaultEntryPayload): void {
+    const row = this.entries.find((e) => e.ownerId === ownerId && e.key === key);
+    if (!row) throw new Error(`mutateEntry: no entry ${key}`);
+    row.payload = payload;
+    row.version += 1;
+    row.seq = this.nextSeq(ownerId);
+  }
+
+  /** A session id for an owner (logout tests). */
+  sessionIdFor(ownerId: string): string | undefined {
+    return this.sessions.find((s) => s.ownerId === ownerId && !s.revoked)?.sessionId;
+  }
+}
+
+const toStateEntry = (e: EntryRow): StateEntry => ({
+  key: e.key,
+  version: e.version,
+  payload: e.payload,
+  deleted: e.deleted,
+  seq: e.seq,
+});

--- a/tests/integration/vault/anti-rollback.test.ts
+++ b/tests/integration/vault/anti-rollback.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Anti-rollback root comparison + rollback event (Task 4.2, finding #11) against
+ * the in-process fake server.
+ *
+ * Baseline: flush N entries, then load() — which persists a wallet-SIGNED baseline
+ * `{cursor, root, sig}` under a reserved LOCAL key (an injected in-memory store).
+ * The server then surfaces, at the NEXT monotonic cursor, a `?since=` delta with a
+ * MUTATED entry whose recomputed root ≠ the signed baseline's expected fold.
+ * `load()` must return `LoadResult.success === false` AND emit
+ * `storage:error{reason:'rollback'}` — the event member is EXACTLY 'storage:error'
+ * (the FROZEN union), with `data.reason === 'rollback'`, NEVER a 'storage:rollback'
+ * member. With no server-signed epoch bump, a cursor regression / root mismatch
+ * always alarms (the epoch short-circuit re-baseline is Task 8.2).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { wireKey } from '../../../storage/remote/wire-key';
+import { sealVaultEntry } from '../../../vault-aead/entry';
+import { deriveVaultKey } from '../../../vault-aead/derive';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import type { LocalBaselineStore } from '../../../storage/remote/load-delta';
+import type { StorageEvent, TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+
+const NETWORK = 'testnet2';
+const PRIV = '3c'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+function memStore(): LocalBaselineStore {
+  const m = new Map<string, string>();
+  return { get: async (k) => m.get(k) ?? null, set: async (k, v) => void m.set(k, v) };
+}
+
+function makeProvider(server: FakeVaultServer, baseline: LocalBaselineStore): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    privateKey: PRIV,
+    authClient: server.authClient(),
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+    localBaseline: baseline,
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: 'DIRECT://x', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+function seal(plainKey: string, version: number, value: unknown): { nonce: string; ct: string } {
+  return sealVaultEntry({
+    network: NETWORK,
+    ownerId: PUB,
+    key: wireKey(PRIV, NETWORK, plainKey),
+    version,
+    plaintext: new TextEncoder().encode(JSON.stringify(value)),
+    key32: deriveVaultKey(PRIV, NETWORK),
+  });
+}
+
+describe('anti-rollback root comparison', () => {
+  it('a mutated /state delta with no epoch bump fails load() and emits storage:error{reason:rollback}', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const store = memStore();
+    const provider = makeProvider(server, store);
+    await provider.initialize();
+
+    // Baseline: flush 3 entries, then load() to persist the signed {cursor,root,sig}.
+    await provider.sync(txf({ a: { n: 1 }, b: { n: 2 }, c: { n: 3 } }));
+    const first = await provider.load();
+    expect(first.success).toBe(true);
+    const baselineKey = `vault_baseline:${NETWORK}:${PUB}`;
+    expect(await store.get(baselineKey)).not.toBeNull(); // the signed baseline persisted
+
+    // Hostile server: mutate entry 'a' at the NEXT monotonic cursor, NO epoch bump.
+    const wkA = wireKey(PRIV, NETWORK, 'a');
+    server.mutateEntry(PUB, wkA, seal('a', 99, { n: 'tampered' }));
+
+    const events: StorageEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+    const res = await provider.load();
+
+    expect(res.success).toBe(false);
+    const err = events.find((e) => e.type === 'storage:error');
+    expect(err).toBeDefined();
+    expect(err!.type).toBe('storage:error'); // the FROZEN union member, exactly
+    expect((err!.data as { reason: string }).reason).toBe('rollback');
+    // NEVER a 'storage:rollback' member.
+    expect(events.some((e) => (e.type as string) === 'storage:rollback')).toBe(false);
+  });
+
+  it('a clean re-load (empty delta) does NOT alarm — the gate only fires on injected state', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const store = memStore();
+    const provider = makeProvider(server, store);
+    await provider.initialize();
+    await provider.sync(txf({ a: { n: 1 }, b: { n: 2 } }));
+    await provider.load(); // establishes baseline
+
+    const events: StorageEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+    const res = await provider.load(); // empty delta — nothing changed
+
+    expect(res.success).toBe(true);
+    expect(events.some((e) => e.type === 'storage:error')).toBe(false);
+  });
+});

--- a/tests/integration/vault/vault-auth.test.ts
+++ b/tests/integration/vault/vault-auth.test.ts
@@ -1,0 +1,137 @@
+/**
+ * VaultApiClient auth (Task 6.1, DESIGN §4) against the in-process fake server.
+ *
+ * Asserts the client VERIFIES the challenge template BEFORE signing it (the spend
+ * key never signs arbitrary server text), that `authenticate()` yields a usable
+ * JWT, and that concurrent 401s collapse to ONE in-flight refresh promise (no
+ * double-rotate → no spurious reuse-revoke).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { VaultApiClient } from '../../../storage/remote/VaultApiClient';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import type {
+  AuthTokens,
+  ChallengeResponse,
+  VaultAuthHttpClient,
+  VerifyRequest,
+} from '../../../storage/remote/types';
+
+const NETWORK = 'testnet2';
+const PRIV = '7c'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+
+function makeClient(auth: VaultAuthHttpClient, network = NETWORK): VaultApiClient {
+  return new VaultApiClient({
+    network,
+    chainPubkey: PUB,
+    privateKey: PRIV,
+    deviceId: 'device-1',
+    authClient: auth,
+  });
+}
+
+describe('VaultApiClient — challenge template verification', () => {
+  it('authenticates and yields a JWT over a faithful challenge', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const client = makeClient(server.authClient());
+    const jwt = await client.authenticate();
+    expect(typeof jwt).toBe('string');
+    expect(jwt.length).toBeGreaterThan(0);
+    // The server only issues a JWT if the signature recovered to PUB over the
+    // exact challenge — proving the client signed the server's literal.
+    expect(server.calls.verify).toHaveLength(1);
+    expect(server.calls.verify[0].deviceId).toBe('device-1');
+  });
+
+  it('REJECTS a challenge missing the auth prefix (never signs arbitrary text)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const auth = tamperedAuth(server.authClient(), (c) => ({ ...c, challenge: c.challenge.slice(20) }));
+    const client = makeClient(auth);
+    await expect(client.authenticate()).rejects.toThrow(/challenge/i);
+    expect(auth.verifyCalls).toHaveLength(0); // never reached verify → never signed
+  });
+
+  it('REJECTS a challenge whose embedded pubkey is not our own', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const auth = tamperedAuth(server.authClient(), (c) => ({
+      ...c,
+      challenge: c.challenge.replace(PUB, 'ff'.repeat(33)),
+    }));
+    const client = makeClient(auth);
+    await expect(client.authenticate()).rejects.toThrow(/pubkey/i);
+    expect(auth.verifyCalls).toHaveLength(0);
+  });
+
+  it('REJECTS a challenge whose embedded network is not the expected canonical one', async () => {
+    const server = new FakeVaultServer('mainnet'); // server stamps a different net
+    const auth = tamperedAuth(server.authClient(), (c) => c);
+    const client = makeClient(auth, NETWORK); // client expects testnet2
+    await expect(client.authenticate()).rejects.toThrow(/network/i);
+    expect(auth.verifyCalls).toHaveLength(0);
+  });
+
+  it('REJECTS a challenge with an implausible expiry (already expired)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const auth = tamperedAuth(server.authClient(), (c) => mutateExpiry(c, -10 * 60_000));
+    const client = makeClient(auth);
+    await expect(client.authenticate()).rejects.toThrow(/expir|timestamp/i);
+    expect(auth.verifyCalls).toHaveLength(0);
+  });
+});
+
+describe('VaultApiClient — serialized refresh', () => {
+  it('collapses concurrent 401s to ONE in-flight refresh (no double-rotate)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const client = makeClient(server.authClient());
+    await client.authenticate();
+
+    // Fire three concurrent refreshes; they must share ONE in-flight promise so
+    // the rotating-refresh server is hit exactly ONCE (a second hit would reuse
+    // the now-stale token and revoke the session).
+    const [a, b, c] = await Promise.all([client.refresh(), client.refresh(), client.refresh()]);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(server.calls.refresh).toHaveLength(1);
+  });
+
+  it('a fresh refresh after the in-flight one resolves rotates again (one hit each)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const client = makeClient(server.authClient());
+    await client.authenticate();
+    const j1 = await client.refresh();
+    const j2 = await client.refresh();
+    expect(j1).not.toBe(j2);
+    expect(server.calls.refresh).toHaveLength(2);
+  });
+});
+
+// --- helpers ----------------------------------------------------------------
+
+/** Wrap an auth client, tampering the challenge and counting `verify` calls. */
+function tamperedAuth(
+  inner: VaultAuthHttpClient,
+  mutate: (c: ChallengeResponse) => ChallengeResponse,
+): VaultAuthHttpClient & { verifyCalls: VerifyRequest[] } {
+  const verifyCalls: VerifyRequest[] = [];
+  return {
+    verifyCalls,
+    challenge: async (pubkey) => mutate(await inner.challenge(pubkey)),
+    verify: async (req: VerifyRequest): Promise<AuthTokens | null> => {
+      verifyCalls.push(req);
+      return inner.verify(req);
+    },
+    refresh: (token) => inner.refresh(token),
+    logout: (sessionId) => inner.logout(sessionId),
+  };
+}
+
+/** Shift the challenge's embedded `expiresAt` by `deltaMs` (keeps it parseable). */
+function mutateExpiry(c: ChallengeResponse, deltaMs: number): ChallengeResponse {
+  const body = JSON.parse(c.challenge.slice('unicity:vault:auth:v1\n'.length));
+  body.expiresAt = new Date(new Date(body.expiresAt).getTime() + deltaMs).toISOString();
+  return { ...c, challenge: 'unicity:vault:auth:v1\n' + JSON.stringify(body) };
+}

--- a/tests/integration/vault/vault-cas.test.ts
+++ b/tests/integration/vault/vault-cas.test.ts
@@ -1,0 +1,133 @@
+/**
+ * CAS flush → SyncResult mapping (Task 6.2, DESIGN §5.4, finding #29) against the
+ * in-process fake server.
+ *
+ * Asserts the provider diffs TxfStorageData vs its INTERNAL last-known server
+ * state, PATCHes CAS ops keyed by the opaque wireKey, and maps the server
+ * `{applied, rejected, cursor}` onto `SyncResult` — `conflicts` derived from
+ * `rejected[].reason === 'conflict'`. A partial-batch rejection emits
+ * `sync:conflict` and keeps the rejected op OUT of the clean snapshot (retried
+ * next flush); a per-op oversize op is rejected ALONE while the rest apply.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { wireKey } from '../../../storage/remote/wire-key';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import type { StorageEvent } from '../../../storage/storage-provider';
+import type { TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+
+const NETWORK = 'testnet2';
+const PRIV = '4d'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+function makeProvider(server: FakeVaultServer): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    privateKey: PRIV,
+    authClient: server.authClient(),
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: 'DIRECT://x', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) {
+    data[`_${id}` as `_${string}`] = val;
+  }
+  return data;
+}
+
+describe('CAS flush → SyncResult', () => {
+  it('flushes new token entries as CAS creates keyed by wireKey', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    await provider.initialize();
+
+    const res = await provider.sync(txf({ aaa: { amt: '1' }, bbb: { amt: '2' } }));
+    expect(res.success).toBe(true);
+    expect(res.added).toBe(2);
+    expect(res.conflicts).toBe(0);
+
+    // Keyed by the opaque wireKey, NEVER the plaintext token id.
+    const wkA = wireKey(PRIV, NETWORK, 'aaa');
+    expect(server.getEntry(PUB, wkA)?.version).toBe(1);
+    expect(server.getEntry(PUB, 'aaa')).toBeUndefined();
+
+    // A create op carries baseVersion 0.
+    expect(server.calls.patch).toHaveLength(1);
+    expect(server.calls.patch[0].every((op) => op.baseVersion === 0)).toBe(true);
+  });
+
+  it('partial-batch rejection → conflicts>0, sync:conflict event, rejected kept out of the clean snapshot', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    await provider.initialize();
+
+    // Seed 'aaa' at v1 via a foreign writer so the provider's next create against
+    // it (baseVersion 0) collides with a LIVE non-deleted row → 'conflict'.
+    const wkA = wireKey(PRIV, NETWORK, 'aaa');
+    await server.clientFor(PUB).patchEntries([
+      { key: wkA, baseVersion: 0, payload: { nonce: 'bm9uY2U=', ct: 'Y3Q=' } },
+    ]);
+
+    const events: StorageEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+
+    const res = await provider.sync(txf({ aaa: { amt: '1' }, bbb: { amt: '2' } }));
+    expect(res.success).toBe(true);
+    expect(res.added).toBe(1); // only 'bbb' applied
+    expect(res.conflicts).toBe(1); // 'aaa' rejected as conflict
+    expect(events.some((e) => e.type === 'sync:conflict')).toBe(true);
+    const conflictEvent = events.find((e) => e.type === 'sync:conflict')!;
+    expect((conflictEvent.data as { rejected: unknown[] }).rejected).toHaveLength(1);
+
+    // The rejected key is NOT in the clean snapshot — a re-flush retries it.
+    server.clientFor(PUB); // no-op, readability
+    const res2 = await provider.sync(txf({ aaa: { amt: '1' }, bbb: { amt: '2' } }));
+    // 'bbb' already applied last flush → no-op; 'aaa' retried → still conflict.
+    expect(res2.conflicts).toBe(1);
+    expect(res2.added).toBe(0);
+  });
+
+  it('per-op oversize op is rejected ALONE; the rest apply', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    server.setMaxEntryBytes(200); // small cap: a 500-char blob exceeds it, a tiny token does not
+    const provider = makeProvider(server);
+    await provider.initialize();
+
+    // 'big' seals to a payload over the cap; 'small' stays under it.
+    const big = { blob: 'x'.repeat(500) };
+    const res = await provider.sync(txf({ big, small: { amt: '1' } }));
+    expect(res.added).toBe(1); // only 'small'
+    expect(res.conflicts).toBe(0); // oversize is NOT a conflict
+    const wkSmall = wireKey(PRIV, NETWORK, 'small');
+    expect(server.getEntry(PUB, wkSmall)?.version).toBe(1);
+    const wkBig = wireKey(PRIV, NETWORK, 'big');
+    expect(server.getEntry(PUB, wkBig)).toBeUndefined();
+  });
+
+  it('an unchanged second flush is a no-op (last-known state suppresses re-writes)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    await provider.initialize();
+    const data = txf({ aaa: { amt: '1' } });
+    await provider.sync(data);
+    const res2 = await provider.sync(data);
+    expect(res2.added).toBe(0);
+    expect(res2.removed).toBe(0);
+    // No second PATCH when there is nothing to flush.
+    expect(server.calls.patch).toHaveLength(1);
+  });
+});

--- a/tests/integration/vault/vault-pagination.test.ts
+++ b/tests/integration/vault/vault-pagination.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Paginated state load + cursor monotonicity (Task 6.4, DESIGN §5.4) against the
+ * in-process fake server.
+ *
+ * `load()` loops `GET /state?since=` on `more` until `!more`, accumulating every
+ * page; the server `cursor` is asserted non-decreasing across pages. A page whose
+ * cursor REGRESSES (with no sanctioned epoch bump) trips the rollback gate
+ * (links to Task 4.2) — `success:false` + `storage:error{reason:'rollback'}`.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import type { StorageEvent, TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+import type { StateResponse, VaultHttpClient } from '../../../storage/remote/types';
+
+const NETWORK = 'testnet2';
+const PRIV = '6a'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+interface ProviderOpts {
+  httpClientFactory?: (ownerId: string) => VaultHttpClient;
+}
+
+function makeProvider(server: FakeVaultServer, opts: ProviderOpts = {}): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    privateKey: PRIV,
+    authClient: server.authClient(),
+    httpClientFactory: opts.httpClientFactory ?? ((ownerId) => server.clientFor(ownerId)),
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: 'DIRECT://x', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+describe('paginated state load', () => {
+  it('loops GET /state?since= on `more`, accumulating every page; cursor is monotonic', async () => {
+    const server = new FakeVaultServer({ network: NETWORK, pageLimit: 2 });
+    const seed = makeProvider(server);
+    await seed.initialize();
+    await seed.sync(txf({ a: { n: 1 }, b: { n: 2 }, c: { n: 3 }, d: { n: 4 }, e: { n: 5 } }));
+
+    // A fresh provider loads from scratch (serverCursor 0) and must paginate.
+    const reader = makeProvider(server);
+    await reader.initialize();
+    server.calls.state.length = 0; // count only the reader's pages
+    const res = await reader.load();
+
+    expect(res.success).toBe(true);
+    // 5 entries / pageLimit 2 → since 0,2,4 → 3 pages.
+    expect(server.calls.state).toEqual([0, 2, 4]);
+    // The reader adopted all 5 entries into its known state.
+    expect(reader.knownCount()).toBe(5);
+  });
+
+  it('a regressing page cursor (no sanctioned epoch) trips the rollback gate', async () => {
+    const server = new FakeVaultServer({ network: NETWORK, pageLimit: 2 });
+    const seed = makeProvider(server);
+    await seed.initialize();
+    await seed.sync(txf({ a: { n: 1 }, b: { n: 2 }, c: { n: 3 } }));
+
+    // Wrap the data client so the SECOND /state page reports a cursor BELOW its
+    // `since` — a hostile regression with no server-signed epoch.
+    const wrap = (ownerId: string): VaultHttpClient => {
+      const inner = server.clientFor(ownerId);
+      let calls = 0;
+      return {
+        patchEntries: (ops) => inner.patchEntries(ops),
+        getState: async (since): Promise<StateResponse> => {
+          const page = await inner.getState(since);
+          calls += 1;
+          return calls === 2 ? { ...page, cursor: since - 1, more: false } : page;
+        },
+      };
+    };
+
+    const reader = makeProvider(server, { httpClientFactory: wrap });
+    await reader.initialize();
+    const events: StorageEvent[] = [];
+    reader.onEvent((e) => events.push(e));
+    const res = await reader.load();
+
+    expect(res.success).toBe(false);
+    const err = events.find((e) => e.type === 'storage:error');
+    expect(err).toBeDefined();
+    expect((err!.data as { reason: string }).reason).toBe('rollback');
+    // The FROZEN union has no 'storage:rollback' member.
+    expect(events.some((e) => (e.type as string) === 'storage:rollback')).toBe(false);
+  });
+});

--- a/tests/integration/vault/vault-resurrect.test.ts
+++ b/tests/integration/vault/vault-resurrect.test.ts
@@ -1,0 +1,95 @@
+/**
+ * CAS delete-resurrect (Task 6.3, finding #16) against the in-process fake server.
+ *
+ * A server `deleted` row for key 'k' must be RESURRECTED by a create op at
+ * `baseVersion:0` (NOT rebased to the deleted row's version). `patchEntries` is
+ * called EXACTLY ONCE and resolves `{applied:['k'], rejected:[], cursor:N}`;
+ * `op.baseVersion === 0`, `conflicts === 0`, and 'k' is live in the clean
+ * snapshot afterward. (The server, mirroring vault-tokens.repo.ts::createOrResurrect,
+ * converges baseVersion 0 against a deleted row → version+1, deleted:false.)
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { wireKey } from '../../../storage/remote/wire-key';
+import { sealVaultEntry } from '../../../vault-aead/entry';
+import { deriveVaultKey } from '../../../vault-aead/derive';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import type { TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+
+const NETWORK = 'testnet2';
+const PRIV = '5e'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+function makeProvider(server: FakeVaultServer): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    privateKey: PRIV,
+    authClient: server.authClient(),
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: 'DIRECT://x', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+/** Seal a payload for key 'k' at a given version (server-side seeding helper). */
+function seal(plainKey: string, version: number, value: unknown): { nonce: string; ct: string } {
+  return sealVaultEntry({
+    network: NETWORK,
+    ownerId: PUB,
+    key: wireKey(PRIV, NETWORK, plainKey),
+    version,
+    plaintext: new TextEncoder().encode(JSON.stringify(value)),
+    key32: deriveVaultKey(PRIV, NETWORK),
+  });
+}
+
+describe('CAS delete-resurrect', () => {
+  it('resurrects a deleted server row via baseVersion:0 in a single patch call', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const wkK = wireKey(PRIV, NETWORK, 'k');
+
+    // Seed a server row for 'k' (create v1), then tombstone it (v2, deleted).
+    const direct = server.clientFor(PUB);
+    await direct.patchEntries([{ key: wkK, baseVersion: 0, payload: seal('k', 1, { amt: '1' }) }]);
+    await direct.patchEntries([{ key: wkK, baseVersion: 1, deleted: true }]);
+    expect(server.getEntry(PUB, wkK)?.deleted).toBe(true);
+
+    const provider = makeProvider(server);
+    await provider.initialize();
+    // load() teaches the provider that 'k' is currently a deleted row.
+    await provider.load();
+
+    const patchesBefore = server.calls.patch.length;
+    // Local data carries 'k' again → resurrect.
+    const res = await provider.sync(txf({ k: { amt: '2' } }));
+
+    // EXACTLY ONE patch call for the resurrect.
+    expect(server.calls.patch.length).toBe(patchesBefore + 1);
+    const ops = server.calls.patch[server.calls.patch.length - 1];
+    expect(ops).toHaveLength(1);
+    expect(ops[0].key).toBe(wkK);
+    expect(ops[0].baseVersion).toBe(0); // NOT rebased to the deleted row's version
+
+    // Server converged: applied, not rejected; the row is live again at v3.
+    expect(res.added).toBe(1);
+    expect(res.conflicts).toBe(0);
+    const row = server.getEntry(PUB, wkK);
+    expect(row?.deleted).toBe(false);
+    expect(row?.version).toBe(3); // v1 create -> v2 delete -> v3 resurrect
+  });
+});


### PR DESCRIPTION
Part B Phase 6 — `RemoteTokenStorageProvider` (the operator-blind vault box) + the deferred Task 4.2 anti-rollback. Implements the FROZEN `TokenStorageProvider` contract; all CAS/version/root state stays internal and maps onto `SyncResult.conflicts` + `onEvent`.

## Tasks (strict TDD, one commit each)
- **6.1** `feat(vault): VaultApiClient auth + serialized refresh` — challenge→verify→JWT; the client verifies the challenge template BEFORE signing (prefix / own-pubkey / network / timestamp), so the spend key never signs arbitrary server text; concurrent 401s share ONE in-flight refresh promise (no double-rotate → no self-revoke).
- **6.2** `feat(vault): CAS flush → SyncResult mapping` — diff TxfStorageData → `PATCH /v1/entries` CAS ops `{wireKey, baseVersion, payload?}`; `SyncResult.conflicts` = count of `rejected[].reason==='conflict'` (the wire `conflicts` is always `[]`); rejected ops kept OUT of the clean snapshot (retry next flush); oversize rejected alone; `sync:conflict` emitted.
- **6.3** `feat(vault): delete-resurrect CAS convergence` — a create against a server `deleted` row uses `baseVersion:0` (not rebased); `patchEntries` called exactly once; `conflicts===0`.
- **6.4** `feat(vault): paginated state load + cursor monotonicity` — `GET /v1/state?since=` loops on `more`; `serverCursor` non-decreasing; a regress without a sanctioned epoch trips the rollback gate.
- **4.2** `feat(vault): anti-rollback root comparison + rollback event` — signed monotonic Merkle root re-verified on load; a mutated delta at the next cursor → `LoadResult.success===false` + `onEvent('storage:error',{reason:'rollback'})` (FROZEN union, never a new member).

## Tests
89 vault tests green (`vitest run tests/unit/vault/ tests/integration/vault/`), `tsc --noEmit` clean, eslint clean. Tested against a faithful in-memory `FakeVaultServer` mirroring Part A `auth/vault/epoch`; the `VaultAuthHttpClient`/`VaultHttpClient` seam lets Phase 8.3 swap in the real token-api with zero provider changes. FROZEN `StorageEventType` union unchanged (empty diff).

## Reviewed (adversarial)
PASS. Anti-rollback sound (no fund-loss false-negative at this layer, no false-positive on legit forward deltas); CAS/conflict mapping correct; auth challenge-before-sign verified; fake↔real fidelity audited against the real Part A wire.

## Phase 8.3 follow-up (recorded, not a Phase-6 change)
The real `VaultHttpClient` must map HTTP **507** (whole-batch storage-watermark block) to a body-bearing `PatchResponse` (NOT throw) so the provider's rejection-folding handles it — the fake returns body-only and can't reveal a throw-vs-body divergence.

## Phase-7 scope
`load()` returns only `_meta` so far; payload decode + `_<tokenId>` reconstruction + reserved-address restore + EMPTY/POPULATED/LOAD_FAILED state machine + flush gate + identity fencing + history + account-delete are Phase 7. Seams are shaped for it. Not yet safe to wire into `PaymentsModule.load()` until 7.2.