### PR TITLE
Fix #521: full-pull on the first sync of each provider session (reload renders empty wallet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — reload renders an empty wallet (#521)
+
+- **Thin-provider reload (#521):** `WalletApiTokenStorageProvider` persisted
+  its inventory cursor durably while the item view lived only in process
+  memory, so a reloaded instance (tab refresh) delta-synced from the warm
+  cursor into an empty view and rendered an empty wallet. The first sync of
+  each instance/identity session is now always a full pull (both `load()`
+  entry paths and the lazy-view merge benefit); deltas resume within the
+  session.
+
 ### Fixed — incident 2026-06-12 hardening (#515, #516)
 
 - **Fail-closed composition invariant (#515 F1):** wallet-api CUSTODY

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -111,7 +111,10 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
   private readonly view = new Map<string, InventoryItem>();
   /**
    * Empty-import protection (§5.1): no removal is ever pushed before this
-   * flips on the first successful inventory load.
+   * flips on the first successful inventory load. Doubles as the per-session
+   * first-sync flag (#521): while false, `syncInventory` full-pulls even with
+   * a warm persisted cursor — the view Map is process-lifetime, so a reloaded
+   * instance (tab refresh) must rebuild it before deltas can resume.
    */
   private hadSuccessfulLoad = false;
 
@@ -258,7 +261,11 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
   /** Converge the local view with the server (delta when possible). */
   private async syncInventory(): Promise<void> {
     const cursor = await this.readCursor();
-    if (cursor === null) {
+    // #521: the cursor is durable but the view Map is not — a delta from a
+    // warm cursor into an empty view renders an empty wallet after a reload.
+    // The FIRST sync of each instance/identity session (the flag setIdentity
+    // resets) is therefore always a full pull; deltas resume afterwards.
+    if (cursor === null || !this.hadSuccessfulLoad) {
       await this.fullPull();
     } else if (await this.deltaLoop(cursor)) {
       await this.handleSyncEpochChange();

--- a/tests/support/fake-wallet-api.ts
+++ b/tests/support/fake-wallet-api.ts
@@ -275,6 +275,12 @@ export class FakeWalletApi {
   challengeRequests = 0;
   verifyRequests = 0;
   refreshRequests = 0;
+  /**
+   * Every `GET /v1/inventory` `since` param in arrival order (`null` = a
+   * since-less full-pull page). Lets tests pin the full-pull/delta sequence
+   * (#521: first sync of a session is a full pull, deltas resume after).
+   */
+  readonly inventoryGetLog: (string | null)[] = [];
   private tamperChallenge: ((challenge: string) => string) | null = null;
   private failInventory = false;
   private failIntents = false;
@@ -794,6 +800,7 @@ export class FakeWalletApi {
     if (this.failInventory) throw new HttpError(500, 'INTERNAL', 'simulated inventory outage');
     const owner = this.owner(session.pubkey);
     const sinceRaw = url.searchParams.get('since');
+    this.inventoryGetLog.push(sinceRaw);
     const since = sinceRaw !== null ? BigInt(sinceRaw) : null;
 
     // §5.1: a full pull (no since) returns ACTIVE rows only; a delta returns

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -136,15 +136,17 @@ async function startFake(): Promise<{ fake: FakeWalletApi; baseUrl: string }> {
   return { fake, baseUrl };
 }
 
-/** Build a wallet over the FULL wallet-api preset (storage + delivery, custody 'inventory'). */
+/** Build a wallet over the FULL wallet-api preset (storage + delivery, custody 'inventory').
+ * Pass `kv` to share the persisted client/provider state across instances — a
+ * reloaded tab keeps its localStorage (cursor, session), not its process state. */
 function makeFullPresetWallet(
   baseUrl: string,
   network: string,
   who: { privateKey: string; chainPubkey: string },
-  deviceId: string
+  deviceId: string,
+  kv: MemoryKeyValueStore = new MemoryKeyValueStore()
 ): Wallet {
   const identity = fullIdentity(who);
-  const kv = new MemoryKeyValueStore();
   const client = new WalletApiClient({ baseUrl, network, deviceId, storage: kv });
   const tokenStorage = new WalletApiTokenStorageProvider({ client, stateStore: kv });
   tokenStorage.setIdentity(identity);
@@ -530,5 +532,57 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
     const sent = fake.getHistoryRecords(SENDER.chainPubkey).find((r) => r.dedupKey === `SENT_transfer_${transferId}`);
     expect(sent).toBeDefined();
+  });
+});
+
+describe('reload (tab refresh) — durable cursor, rebuilt view (#521)', () => {
+  it('a reloaded provider+module instance full-pulls its FIRST sync and renders the full wallet; deltas resume within the session; a third reload is idempotent', async () => {
+    const { fake, baseUrl } = await startFake();
+    const kv = new MemoryKeyValueStore(); // the SHARED persisted stateStore — survives the "refresh"
+    const cursorKey = `wallet-api-storage:cursor:${fake.network}:${SENDER.chainPubkey}`;
+
+    // Session 1 — the full mint-and-send flow that warms the DURABLE cursor:
+    // mint 1000, send 300 → the server holds exactly the 700 change row.
+    const tab1 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-tab', kv);
+    await seedServerToken(fake, tab1, SENDER, 1000n);
+    await tab1.module.load();
+    const sent = await tab1.module.send({ recipient: '@bob', amount: '300', coinId: UCT });
+    expect(sent.status).toBe('completed');
+    expect(await tab1.client.getBalances()).toEqual([{ coinId: UCT, total: 700n, tokenCount: 1 }]);
+
+    // Session 2 — a NEW provider+module instance over the SAME persisted
+    // stateStore: the simulated tab refresh that used to delta-sync from the
+    // warm cursor into an empty process-lifetime view and render {items:[]}.
+    fake.inventoryGetLog.length = 0;
+    const tab2 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-tab', kv);
+    await tab2.module.load();
+
+    const tokens = tab2.module.getTokens();
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toMatchObject({ id: expect.stringMatching(/^v2_/), amount: '700', coinId: UCT, status: 'confirmed', lazy: true });
+
+    // The doubled load() GETs (provider.load() + mergeLazyInventory): the
+    // FIRST sync of the session is a FULL pull (since-less page + the §5.1
+    // closing delta from the warm cursor); the second sync rides the
+    // now-warm session as a plain delta — never a second full pull.
+    const cursor = await kv.get(cursorKey);
+    expect(cursor).toMatch(/^[0-9]+$/);
+    expect(fake.inventoryGetLog).toEqual([null, cursor, cursor]);
+
+    // WITHIN the session the delta path keeps operating: a further load()
+    // issues delta GETs only, and the view stays converged (no duplicates).
+    fake.inventoryGetLog.length = 0;
+    await tab2.module.load();
+    expect(fake.inventoryGetLog).toEqual([cursor, cursor]);
+    expect(tab2.module.getTokens()).toHaveLength(1);
+
+    // Session 3 — a THIRD instance over the same stateStore still renders
+    // everything (the first-sync full pull is idempotent across reloads).
+    fake.inventoryGetLog.length = 0;
+    const tab3 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-tab', kv);
+    await tab3.module.load();
+    expect(tab3.module.getTokens()).toHaveLength(1);
+    expect(tab3.module.getTokens()[0]).toMatchObject({ amount: '700', lazy: true });
+    expect(fake.inventoryGetLog).toEqual([null, cursor, cursor]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #521 (manual close at merge — this PR targets the integration branch, not the default branch).

Staging repro (twice-confirmed): `WalletApiTokenStorageProvider` keeps the item view in a process-lifetime `Map` while persisting the inventory cursor durably; `syncInventory` full-pulled only when `cursor === null`, so a reloaded instance (tab refresh) delta-synced from the warm cursor into an empty view → `{items:[]}` → empty wallet while the server held all active rows.

## Fix (minimal, as decided in #521)

`syncInventory` now full-pulls on the FIRST sync of each instance/identity session, reusing the existing session flag (`hadSuccessfulLoad`) that `setIdentity` already resets:

```ts
if (cursor === null || !this.hadSuccessfulLoad) {
  await this.fullPull();
} else if (await this.deltaLoop(cursor)) {
  await this.handleSyncEpochChange();
}
```

Both `load()` entry paths AND `mergeLazyInventory` go through `syncInventory`, so the doubled GET on refresh is now: full pull (since-less page + §5.1 closing delta) followed by a plain delta — never two deltas into an empty view.

## Regression test (defines the class)

`PaymentsModule.wallet-api-delivery.test.ts` — new describe `reload (tab refresh) — durable cursor, rebuilt view (#521)`:

- Session 1: full mint+send flow against the fake (mint 1000, send 300 → server holds the 700 change row; durable cursor warmed).
- Session 2: a SECOND provider+module instance over the SAME persisted `stateStore` (simulated tab refresh) — asserts the complete balance/token list renders (the pre-fix behavior rendered `[]`), and pins the `since=` sequence `[null, cursor, cursor]` (first sync = full pull + closing delta; merge = delta) via the fake's new `inventoryGetLog`.
- Within-session: a further `load()` issues `[cursor, cursor]` — pure deltas, no full-pull on every sync.
- Session 3: a THIRD instance renders too (idempotent), again `[null, cursor, cursor]`.

Verified red without the fix: the reload assertion fails with `expected [] to have a length of 1`.

## Also

- `FakeWalletApi.inventoryGetLog` test hook: records every `GET /v1/inventory` `since` param in arrival order.
- CHANGELOG entry under Unreleased.

Out of scope (tracked in #517, untouched): save-coalescing and partial-failure display.