### PR TITLE
feat(vault): Phase 7 — provider wiring (gate, fencing, load state machine, history, account-delete)

### DIFF
--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -33,12 +33,20 @@ import type {
   TokenStorageProvider,
   TxfStorageDataBase,
 } from '../storage-provider';
+import { hexToBytes } from '../../core/crypto';
 import { sealVaultEntry } from '../../vault-aead/entry';
 import { deriveVaultKey } from '../../vault-aead/derive';
 import { wireKey } from './wire-key';
 import { VaultApiClient } from './VaultApiClient';
 import { extractTokens, planOps } from './diff';
 import type { KnownEntry, PlannedOp } from './diff';
+import {
+  reservedAddressKey,
+  sealReservedAddress,
+  openReservedAddress,
+  RESERVED_ADDRESS_FORMAT_VERSION,
+} from './reserved-address';
+import { deriveDirectAddress } from '../../token-engine/identity';
 import type {
   PatchOp,
   PatchResponse,
@@ -105,6 +113,9 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
    * leaves this `false`, so an empty local snapshot can never wipe the server.
    */
   private initialLoadDone = false;
+
+  /** The DIRECT:// address restored from the reserved meta-address entry (Task 7.2). */
+  private restoredAddress: string | null = null;
 
   constructor(config: RemoteTokenStorageConfig) {
     this.config = config;
@@ -191,13 +202,34 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     this.emit('sync:started');
     try {
       const ops = this.planFlush(localData);
-      if (ops.length === 0) return this.cleanResult(localData, 0, 0, 0);
-      return await this.flush(localData, ops);
+      const reserved = await this.planReservedAddress();
+      if (ops.length === 0 && !reserved) return this.cleanResult(localData, 0, 0, 0);
+      return await this.flush(localData, ops, reserved);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'sync failed';
       this.emit('sync:error', undefined, message);
       return { success: false, added: 0, removed: 0, conflicts: 0, error: message };
     }
+  }
+
+  /**
+   * The reserved meta-address op (Task 7.2, finding #17). Sealed once, from the
+   * REAL engine identity (`deriveDirectAddress(hexToBytes(chainPubkey))`), so a
+   * fresh import restores `_meta.address` without re-deriving from tokens — the
+   * XP-invariant address survives a wipe. Returns `null` once it is on the server.
+   */
+  private async planReservedAddress(): Promise<PatchOp | null> {
+    const wk = reservedAddressKey(this.config.privateKey, this.config.network);
+    const cur = this.known.get(wk);
+    if (cur && !cur.deleted) return null; // already on the server
+    const chainPubkey = this.ownerId();
+    const directAddress = await deriveDirectAddress(hexToBytes(chainPubkey));
+    const payload = sealReservedAddress(
+      { directAddress, chainPubkey, formatVersion: RESERVED_ADDRESS_FORMAT_VERSION },
+      this.config.privateKey,
+      this.config.network,
+    );
+    return { key: wk, baseVersion: 0, payload };
   }
 
   /** Diff the TXF snapshot vs internal last-known state into a list of CAS ops. */
@@ -207,6 +239,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
       known: this.known,
       wireKeyOf: (plainKey) => this.wireKeyFor(plainKey),
       changed: (wk, value) => this.hasChanged(wk, value),
+      reserved: new Set([reservedAddressKey(this.config.privateKey, this.config.network)]),
     });
   }
 
@@ -214,10 +247,14 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     return this.contentHash.get(wk) !== this.hashValue(value);
   }
 
-  /** PATCH the planned ops, map the response onto `SyncResult`. */
-  private async flush(localData: TData, ops: PlannedOp[]): Promise<SyncResult<TData>> {
+  /** PATCH the planned ops (token ops + the optional reserved-address op). */
+  private async flush(localData: TData, ops: PlannedOp[], reserved: PatchOp | null): Promise<SyncResult<TData>> {
     const wireOps = ops.map((op) => this.toWireOp(op));
+    if (reserved) wireOps.push(reserved);
     const res = await this.client().patchEntries(wireOps);
+    if (reserved && res.applied.includes(reserved.key)) {
+      this.known.set(reserved.key, { version: 1, deleted: false });
+    }
     const result = this.applyPatchResult(localData, ops, res);
     // Re-sign the local baseline so the wallet's OWN writes advance the signed
     // root — the next load must not see them as an unauthored delta (Task 7.1).
@@ -352,22 +389,43 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     return { success: false, error: `vault rollback: ${reason}`, source: 'remote', timestamp: Date.now() };
   }
 
-  /** Build the TXF snapshot from the accumulated `/state` rows + adopt their versions. */
+  /**
+   * Build the TXF snapshot from the accumulated `/state` rows, adopting their
+   * versions and running the 3-state machine (Task 7.2):
+   *  - LOAD_FAILED: a corrupt reserved-address entry throws → caller returns
+   *    `success:false`, the gate stays SHUT (initialLoadDone untouched).
+   *  - POPULATED: the reserved entry decodes → `_meta.address` is restored (#17).
+   *  - EMPTY: no reserved entry has ever been seen → an `isEmpty` sentinel rides
+   *    INSIDE `data` so it can never short-circuit local data (#22).
+   */
   private materialize(entries: StateEntry[]): LoadResult<TData> {
-    const data: TxfStorageDataBase = {
-      _meta: {
-        version: 1,
-        address: this.identity?.directAddress ?? this.identity?.l1Address ?? '',
-        formatVersion: '2.0',
-        updatedAt: Date.now(),
-      },
-    };
+    const reserved = this.restoreReservedAddress(entries); // may throw → LOAD_FAILED
     for (const e of entries) {
       this.known.set(e.key, { version: e.version, deleted: e.deleted });
     }
+    const isEmpty = !reserved && this.restoredAddress === null && this.knownCount() === 0;
+    const data: TxfStorageDataBase & { isEmpty?: boolean } = {
+      _meta: { version: 1, address: this.restoredAddress ?? '', formatVersion: '2.0', updatedAt: Date.now() },
+    };
+    if (isEmpty) data.isEmpty = true;
     this.initialLoadDone = true; // the flush gate opens on a successful load (Task 7.1)
     this.emit('storage:loaded', { entries: entries.length });
     return { success: true, data: data as TData, source: 'remote', timestamp: Date.now() };
+  }
+
+  /**
+   * Find + decode the reserved meta-address entry from the page rows, caching the
+   * restored DIRECT:// address. Throws on a decrypt/verify failure (LOAD_FAILED);
+   * a missing reserved entry is fine (EMPTY / not-yet-flushed). Returns true when a
+   * reserved row was present on this page.
+   */
+  private restoreReservedAddress(entries: StateEntry[]): boolean {
+    const wk = reservedAddressKey(this.config.privateKey, this.config.network);
+    const row = entries.find((e) => e.key === wk && !e.deleted);
+    if (!row) return false;
+    const meta = openReservedAddress(row.payload, this.ownerId(), this.config.privateKey, this.config.network);
+    this.restoredAddress = meta.directAddress;
+    return true;
   }
 
   // === events ===============================================================

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -97,6 +97,15 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   private readonly listeners = new Set<StorageEventCallback>();
   private readonly delta: LoadDeltaTracker;
 
+  /**
+   * The flush gate (Task 7.1). `sync()` is a NO-OP until the FIRST successful
+   * `load()` opens it. `PaymentsModule.load()` stops at the first successful
+   * provider, so this provider may never get a caller `load()` — `initialize()`
+   * runs the first load itself. Empty-import protection: a transient load failure
+   * leaves this `false`, so an empty local snapshot can never wipe the server.
+   */
+  private initialLoadDone = false;
+
   constructor(config: RemoteTokenStorageConfig) {
     this.config = config;
     this.delta = new LoadDeltaTracker({
@@ -139,12 +148,26 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     this.delta.setWalletPriv(this.config.privateKey);
   }
 
-  /** Phase 6 initialize: authenticate so the data client carries a JWT. */
+  /**
+   * Authenticate, then run the FIRST load ourselves so the flush gate opens even
+   * when `PaymentsModule.load()` short-circuits before reaching this provider
+   * (Task 7.1). A transient first-load failure is swallowed (the gate stays SHUT,
+   * `sync()` no-ops) so an empty local import can never overwrite the server.
+   */
   async initialize(): Promise<boolean> {
     this.status = 'connecting';
     await this.requireAuth().authenticate();
     this.status = 'connected';
+    const first = await this.load();
+    if (!first.success) {
+      this.emit('storage:error', { reason: 'initial-load' }, first.error);
+    }
     return true;
+  }
+
+  /** True once the first successful load opened the flush gate (Task 7.1). */
+  isInitialLoadDone(): boolean {
+    return this.initialLoadDone;
   }
 
   async shutdown(): Promise<void> {
@@ -160,6 +183,11 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   // === sync (Task 6.2 / 6.3) ================================================
 
   async sync(localData: TData): Promise<SyncResult<TData>> {
+    // Flush gate (Task 7.1): no PATCH before a successful first load, so a
+    // transient load failure can never wipe the server with empty local data.
+    if (!this.initialLoadDone) {
+      return { success: true, merged: localData, added: 0, removed: 0, conflicts: 0 };
+    }
     this.emit('sync:started');
     try {
       const ops = this.planFlush(localData);
@@ -190,7 +218,11 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   private async flush(localData: TData, ops: PlannedOp[]): Promise<SyncResult<TData>> {
     const wireOps = ops.map((op) => this.toWireOp(op));
     const res = await this.client().patchEntries(wireOps);
-    return this.applyPatchResult(localData, ops, res);
+    const result = this.applyPatchResult(localData, ops, res);
+    // Re-sign the local baseline so the wallet's OWN writes advance the signed
+    // root — the next load must not see them as an unauthored delta (Task 7.1).
+    await this.delta.rebaseline(this.serverCursor, this.knownAsEntryState());
+    return result;
   }
 
   /** Seal one planned op into its on-wire `{key: wireKey, baseVersion, payload?, deleted?}`. */
@@ -333,6 +365,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     for (const e of entries) {
       this.known.set(e.key, { version: e.version, deleted: e.deleted });
     }
+    this.initialLoadDone = true; // the flush gate opens on a successful load (Task 7.1)
     this.emit('storage:loaded', { entries: entries.length });
     return { success: true, data: data as TData, source: 'remote', timestamp: Date.now() };
   }

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -57,8 +57,17 @@ import type {
 import { LoadDeltaTracker } from './load-delta';
 import type { LocalBaselineStore } from './load-delta';
 import type { EntryState } from './merkle';
+import { AsyncSerialQueue } from '../../impl/shared/ipfs/write-behind-buffer';
 
 const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/** Thrown by the flush path when the identity epoch advanced across an await. */
+class IdentityFencedError extends Error {
+  constructor() {
+    super('vault flush aborted: identity changed mid-flush (epoch fenced)');
+    this.name = 'IdentityFencedError';
+  }
+}
 
 export interface RemoteTokenStorageConfig {
   /** Canonical network name (storage scope, AEAD/wireKey scope). */
@@ -117,6 +126,18 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   /** The DIRECT:// address restored from the reserved meta-address entry (Task 7.2). */
   private restoredAddress: string | null = null;
 
+  /**
+   * Serialize flush / sync / shutdown so two flushes never interleave their CAS
+   * writes (Task 7.3). The same queue gates load too, so a load mid-flush waits.
+   */
+  private readonly queue = new AsyncSerialQueue();
+  /**
+   * Identity-epoch counter (Task 7.3). `setIdentity` bumps it; the flush path
+   * re-checks it after EVERY await and aborts on a mismatch, so a write keyed to
+   * the old identity can never reach the server after a switch.
+   */
+  private identityEpoch = 0;
+
   constructor(config: RemoteTokenStorageConfig) {
     this.config = config;
     this.delta = new LoadDeltaTracker({
@@ -147,7 +168,17 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   // --- TokenStorageProvider -------------------------------------------------
 
   setIdentity(identity: FullIdentity): void {
+    // Bump the identity epoch FIRST so any in-flight flush awaiting an I/O round
+    // trip aborts the moment it next re-checks (Task 7.3) — no cross-identity write.
+    this.identityEpoch += 1;
     this.identity = identity;
+    // Switching identity resets the per-identity server view: the flush gate must
+    // re-open on the new owner's first load, and the old `known`/cursor are stale.
+    this.known.clear();
+    this.contentHash.clear();
+    this.serverCursor = 0;
+    this.restoredAddress = null;
+    this.initialLoadDone = false;
     this.auth = new VaultApiClient({
       network: this.config.network,
       chainPubkey: identity.chainPubkey,
@@ -157,6 +188,11 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     });
     this.delta.setIdentity(identity.chainPubkey);
     this.delta.setWalletPriv(this.config.privateKey);
+  }
+
+  /** Abort the flush path if the identity epoch advanced (Task 7.3). */
+  private assertEpoch(epoch: number): void {
+    if (epoch !== this.identityEpoch) throw new IdentityFencedError();
   }
 
   /**
@@ -182,7 +218,11 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   }
 
   async shutdown(): Promise<void> {
-    this.status = 'disconnected';
+    // Route through the queue so an in-flight flush drains first (Task 7.3).
+    await this.queue.enqueue(() => {
+      this.status = 'disconnected';
+      return Promise.resolve();
+    });
   }
 
   /** `save` routes through `sync` (the vault has no local-only persistence). */
@@ -199,12 +239,21 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     if (!this.initialLoadDone) {
       return { success: true, merged: localData, added: 0, removed: 0, conflicts: 0 };
     }
+    // Capture the identity epoch BEFORE queueing; the flush aborts if it advances
+    // across any await (Task 7.3). Serialized so flushes never interleave.
+    const epoch = this.identityEpoch;
+    return this.queue.enqueue(() => this.runSync(localData, epoch));
+  }
+
+  private async runSync(localData: TData, epoch: number): Promise<SyncResult<TData>> {
     this.emit('sync:started');
     try {
+      this.assertEpoch(epoch);
       const ops = this.planFlush(localData);
       const reserved = await this.planReservedAddress();
+      this.assertEpoch(epoch); // re-check after the (async) reserved-address derive
       if (ops.length === 0 && !reserved) return this.cleanResult(localData, 0, 0, 0);
-      return await this.flush(localData, ops, reserved);
+      return await this.flush(localData, ops, reserved, epoch);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'sync failed';
       this.emit('sync:error', undefined, message);
@@ -248,10 +297,21 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   }
 
   /** PATCH the planned ops (token ops + the optional reserved-address op). */
-  private async flush(localData: TData, ops: PlannedOp[], reserved: PatchOp | null): Promise<SyncResult<TData>> {
+  private async flush(
+    localData: TData,
+    ops: PlannedOp[],
+    reserved: PatchOp | null,
+    epoch: number,
+  ): Promise<SyncResult<TData>> {
     const wireOps = ops.map((op) => this.toWireOp(op));
     if (reserved) wireOps.push(reserved);
-    const res = await this.client().patchEntries(wireOps);
+    // Bind the client to the flush-start owner BEFORE the await so the patch can
+    // never re-target a switched identity.
+    const client = this.client();
+    const res = await client.patchEntries(wireOps);
+    // Identity fence (Task 7.3): if the identity switched across the patch await,
+    // abort WITHOUT committing local state under the wrong identity.
+    this.assertEpoch(epoch);
     if (reserved && res.applied.includes(reserved.key)) {
       this.known.set(reserved.key, { version: 1, deleted: false });
     }
@@ -259,6 +319,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     // Re-sign the local baseline so the wallet's OWN writes advance the signed
     // root — the next load must not see them as an unauthored delta (Task 7.1).
     await this.delta.rebaseline(this.serverCursor, this.knownAsEntryState());
+    this.assertEpoch(epoch); // re-check after the baseline persist await
     return result;
   }
 

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -47,6 +47,8 @@ import {
   RESERVED_ADDRESS_FORMAT_VERSION,
 } from './reserved-address';
 import { sealHistoryRecord, openHistoryRecord } from './history-codec';
+import { deleteCanon } from '../../vault-aead/canon';
+import { signMessage } from '../../core/crypto';
 import { deriveDirectAddress } from '../../token-engine/identity';
 import type {
   PatchOp,
@@ -617,6 +619,27 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
       imported += 1;
     }
     return imported;
+  }
+
+  // === account delete (Task 7.5) ============================================
+
+  /**
+   * Fresh-signature-gated account deletion (§7.4). Fetch a fresh single-use
+   * delete-nonce, sign the REAL `delete:v1` template — `unicity:vault:delete:v1\n`
+   * + `network\nownerId\nnonce` — with the wallet key, and send `DELETE /v1/account`.
+   * A missing/stale signature is rejected CLIENT-side (we never send an empty sig),
+   * so the spend key signs only a fresh, server-issued nonce. Returns the server's
+   * `ok` (a bad/stale signature → `false`, mapping to the server's 401).
+   */
+  async deleteAccount(): Promise<boolean> {
+    const client = this.client();
+    const { nonce } = await client.deleteNonce();
+    const ownerId = this.ownerId();
+    const signature = signMessage(this.config.privateKey, deleteCanon(this.config.network, ownerId, nonce));
+    // Client-side freshness guard: never send a missing/empty signature.
+    if (!nonce || !signature) throw new Error('vault account delete: missing fresh nonce/signature');
+    const res = await client.deleteAccount(nonce, signature);
+    return res.ok;
   }
 
   // === internals ============================================================

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -46,6 +46,7 @@ import {
   openReservedAddress,
   RESERVED_ADDRESS_FORMAT_VERSION,
 } from './reserved-address';
+import { sealHistoryRecord, openHistoryRecord } from './history-codec';
 import { deriveDirectAddress } from '../../token-engine/identity';
 import type {
   PatchOp,
@@ -138,6 +139,13 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
    */
   private identityEpoch = 0;
 
+  /** dedupKeys already POSTed to `/v1/history` (the pushed-set, Task 7.4). */
+  private readonly pushedHistory = new Set<string>();
+  /** The history-seq watermark for `GET /v1/history?since=` (Task 7.4). */
+  private historyCursor = 0;
+  /** Decrypted history records recovered on load, by dedupKey (contract history ops). */
+  private readonly localHistory = new Map<string, HistoryRecord>();
+
   constructor(config: RemoteTokenStorageConfig) {
     this.config = config;
     this.delta = new LoadDeltaTracker({
@@ -179,6 +187,9 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     this.serverCursor = 0;
     this.restoredAddress = null;
     this.initialLoadDone = false;
+    this.pushedHistory.clear();
+    this.localHistory.clear();
+    this.historyCursor = 0;
     this.auth = new VaultApiClient({
       network: this.config.network,
       chainPubkey: identity.chainPubkey,
@@ -252,6 +263,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
       const ops = this.planFlush(localData);
       const reserved = await this.planReservedAddress();
       this.assertEpoch(epoch); // re-check after the (async) reserved-address derive
+      await this.pushHistory(localData, epoch); // single-channel history (Task 7.4)
       if (ops.length === 0 && !reserved) return this.cleanResult(localData, 0, 0, 0);
       return await this.flush(localData, ops, reserved, epoch);
     } catch (error) {
@@ -259,6 +271,31 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
       this.emit('sync:error', undefined, message);
       return { success: false, added: 0, removed: 0, conflicts: 0, error: message };
     }
+  }
+
+  /**
+   * Single-channel history (Task 7.4): diff the `_history` dedupKeys vs the pushed
+   * set and POST only NEW records (each AEAD-sealed). `appendHistory` is idempotent
+   * server-side, so a duplicate dedupKey is accepted (not an error) — only a real
+   * failure rejects, and a real error rethrows up the flush path.
+   */
+  private async pushHistory(localData: TData, epoch: number): Promise<void> {
+    const history = localData._history ?? [];
+    const fresh = history.filter((r) => !this.pushedHistory.has(r.dedupKey));
+    if (fresh.length === 0) return;
+    const records = fresh.map((r) => ({ dedupKey: r.dedupKey, payload: this.sealHistory(r) }));
+    const res = await this.client().appendHistory(records);
+    this.assertEpoch(epoch); // fence after the history POST await
+    for (const r of fresh) {
+      const wasRejected = res.rejected.some((x) => x.dedupKey === r.dedupKey);
+      if (wasRejected) continue; // keep out of the pushed set → retried next flush
+      this.pushedHistory.add(r.dedupKey);
+      this.localHistory.set(r.dedupKey, r);
+    }
+  }
+
+  private sealHistory(record: HistoryRecord): { nonce: string; ct: string } {
+    return sealHistoryRecord(record, this.ownerId(), this.config.privateKey, this.config.network);
   }
 
   /**
@@ -442,7 +479,39 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     }
     this.serverCursor = since;
     await this.delta.commitBaseline(since, lastEpoch, lastEpochSig);
-    return this.materialize(pages);
+    const recovered = await this.loadHistory(); // single-channel history (Task 7.4)
+    return this.materialize(pages, recovered);
+  }
+
+  /**
+   * Pull the single-channel history log (Task 7.4). There is no `more` flag on the
+   * wire (`GET /v1/history?since=<seq>`): the client loops `since=maxSeq` until a
+   * page comes back SHORT — fewer records than the server's full page size, which
+   * we infer as the largest page seen. Each payload is decrypted to a
+   * `HistoryRecord`, merged into the local map, and marked pushed so a later flush
+   * never re-POSTs it. Returns the records recovered THIS load.
+   */
+  private async loadHistory(): Promise<HistoryRecord[]> {
+    const client = this.client();
+    const recovered: HistoryRecord[] = [];
+    let pageSize = 0; // inferred full-page size (the largest page observed)
+    for (;;) {
+      const page = await client.historySince(this.historyCursor);
+      for (const row of page.records) recovered.push(this.absorbHistoryRow(row));
+      pageSize = Math.max(pageSize, page.records.length);
+      // A short page (fewer than a full page, or empty) ends the loop.
+      if (page.records.length === 0 || page.records.length < pageSize) break;
+    }
+    return recovered;
+  }
+
+  /** Decrypt + cache one history row, marking it pushed and advancing the cursor. */
+  private absorbHistoryRow(row: { dedupKey: string; payload: { nonce: string; ct: string }; seq: number }): HistoryRecord {
+    const record = openHistoryRecord(row.dedupKey, row.payload, this.ownerId(), this.config.privateKey, this.config.network);
+    this.localHistory.set(record.dedupKey, record);
+    this.pushedHistory.add(record.dedupKey);
+    this.historyCursor = Math.max(this.historyCursor, row.seq);
+    return record;
   }
 
   private rollback(reason: string): LoadResult<TData> {
@@ -459,18 +528,21 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
    *  - EMPTY: no reserved entry has ever been seen → an `isEmpty` sentinel rides
    *    INSIDE `data` so it can never short-circuit local data (#22).
    */
-  private materialize(entries: StateEntry[]): LoadResult<TData> {
+  private materialize(entries: StateEntry[], history: HistoryRecord[]): LoadResult<TData> {
     const reserved = this.restoreReservedAddress(entries); // may throw → LOAD_FAILED
     for (const e of entries) {
       this.known.set(e.key, { version: e.version, deleted: e.deleted });
     }
-    const isEmpty = !reserved && this.restoredAddress === null && this.knownCount() === 0;
+    const isEmpty =
+      !reserved && this.restoredAddress === null && this.knownCount() === 0 && history.length === 0;
     const data: TxfStorageDataBase & { isEmpty?: boolean } = {
       _meta: { version: 1, address: this.restoredAddress ?? '', formatVersion: '2.0', updatedAt: Date.now() },
     };
+    // Attach recovered history for the existing import hook (importHistoryEntries).
+    if (history.length > 0) data._history = history;
     if (isEmpty) data.isEmpty = true;
     this.initialLoadDone = true; // the flush gate opens on a successful load (Task 7.1)
-    this.emit('storage:loaded', { entries: entries.length });
+    this.emit('storage:loaded', { entries: entries.length, history: history.length });
     return { success: true, data: data as TData, source: 'remote', timestamp: Date.now() };
   }
 
@@ -501,26 +573,50 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     for (const cb of this.listeners) cb(event);
   }
 
-  // === history (Phase 7) ====================================================
+  // === history (Task 7.4 — single channel) ==================================
 
-  async addHistoryEntry(_entry: HistoryRecord): Promise<void> {
-    throw new Error('history sync lands in Phase 7');
+  /**
+   * Append one history entry: seal + POST it to `/v1/history` (idempotent), then
+   * cache it locally and mark it pushed. A duplicate dedupKey is a no-op (idempotent
+   * server-side); a real append error rethrows.
+   */
+  async addHistoryEntry(entry: HistoryRecord): Promise<void> {
+    if (this.pushedHistory.has(entry.dedupKey)) {
+      this.localHistory.set(entry.dedupKey, entry);
+      return;
+    }
+    const res = await this.client().appendHistory([{ dedupKey: entry.dedupKey, payload: this.sealHistory(entry) }]);
+    if (res.rejected.some((r) => r.dedupKey === entry.dedupKey)) {
+      const reason = res.rejected.find((r) => r.dedupKey === entry.dedupKey)!.reason;
+      throw new Error(`vault history append rejected: ${reason}`);
+    }
+    this.pushedHistory.add(entry.dedupKey);
+    this.localHistory.set(entry.dedupKey, entry);
   }
 
+  /** All locally-known history records, newest first (recovered on load). */
   async getHistoryEntries(): Promise<HistoryRecord[]> {
-    return [];
+    return [...this.localHistory.values()].sort((a, b) => b.timestamp - a.timestamp);
   }
 
-  async hasHistoryEntry(_dedupKey: string): Promise<boolean> {
-    return false;
+  async hasHistoryEntry(dedupKey: string): Promise<boolean> {
+    return this.localHistory.has(dedupKey);
   }
 
+  /** Local-only clear (the server log is append-only and never truncated by a client). */
   async clearHistory(): Promise<void> {
-    // Phase 7
+    this.localHistory.clear();
   }
 
-  async importHistoryEntries(_entries: HistoryRecord[]): Promise<number> {
-    return 0;
+  /** Bulk-import history (skip existing dedupKeys); push each new record. Returns new count. */
+  async importHistoryEntries(entries: HistoryRecord[]): Promise<number> {
+    let imported = 0;
+    for (const entry of entries) {
+      if (this.localHistory.has(entry.dedupKey)) continue;
+      await this.addHistoryEntry(entry);
+      imported += 1;
+    }
+    return imported;
   }
 
   // === internals ============================================================

--- a/storage/remote/diff.ts
+++ b/storage/remote/diff.ts
@@ -59,6 +59,11 @@ export interface PlanOpsParams {
   wireKeyOf: (plainKey: string) => string;
   /** True when the value differs from the last-flushed content hash (skip no-op updates). */
   changed: (wireKey: string, value: unknown) => boolean;
+  /**
+   * Provider-managed reserved wireKeys (e.g. the meta-address slot) that are NOT
+   * token entries — never swept as orphan deletes even though they live in `known`.
+   */
+  reserved?: ReadonlySet<string>;
 }
 
 /**
@@ -68,10 +73,11 @@ export interface PlanOpsParams {
  *    AGAINST the deleted row (delete-resurrect, #16 — NOT rebased to its version);
  *  - a token whose wireKey is a known LIVE row → update at the known version, but
  *    only when the value changed;
- *  - a known LIVE wireKey with no matching local token → delete.
+ *  - a known LIVE wireKey with no matching local token → delete (except reserved
+ *    provider-managed slots, which are never orphan-swept).
  */
 export function planOps(params: PlanOpsParams): PlannedOp[] {
-  const { tokens, known, wireKeyOf, changed } = params;
+  const { tokens, known, wireKeyOf, changed, reserved } = params;
   const ops: PlannedOp[] = [];
   const liveWire = new Set<string>();
   for (const [plainKey, value] of tokens) {
@@ -85,7 +91,7 @@ export function planOps(params: PlanOpsParams): PlannedOp[] {
     }
   }
   for (const [wk, cur] of known) {
-    if (!cur.deleted && !liveWire.has(wk)) {
+    if (!cur.deleted && !liveWire.has(wk) && !reserved?.has(wk)) {
       ops.push({ plainKey: '', wireKey: wk, baseVersion: cur.version, isDelete: true });
     }
   }

--- a/storage/remote/history-codec.ts
+++ b/storage/remote/history-codec.ts
@@ -1,0 +1,60 @@
+/**
+ * History record AEAD codec (Task 7.4, DESIGN §5.6).
+ *
+ * The single-channel history log stores one AEAD-sealed `{nonce, ct}` payload per
+ * client-asserted `HistoryRecord`, reusing the vault-entry seal so the operator is
+ * blind to the record body. The plaintext `dedupKey` rides on the wire as the dedup
+ * index (the server needs it for idempotency), but the record JSON is sealed; the
+ * AAD binds `(network, ownerId, dedupKey, version=0)` so a payload cannot be replayed
+ * under a different owner or dedupKey.
+ *
+ * The AEAD key is `deriveVaultKey(walletPriv, network)` — the same seed-derived key
+ * the vault entries use; there is no decrypt-needs-address cycle.
+ */
+
+import { sealVaultEntry, openVaultEntry } from '../../vault-aead/entry';
+import type { VaultEntryPayload } from '../../vault-aead/entry';
+import { deriveVaultKey } from '../../vault-aead/derive';
+import type { HistoryRecord } from '../storage-provider';
+
+/** Fixed AAD version for a history payload (the log is append-only, never versioned). */
+const HISTORY_VERSION = 0;
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+const dec = (b: Uint8Array): string => new TextDecoder().decode(b);
+
+/** Seal a `HistoryRecord` into an AAD-bound `{nonce, ct}` payload. */
+export function sealHistoryRecord(
+  record: HistoryRecord,
+  ownerId: string,
+  walletPriv: string,
+  network: string,
+): VaultEntryPayload {
+  return sealVaultEntry({
+    network,
+    ownerId,
+    key: record.dedupKey,
+    version: HISTORY_VERSION,
+    plaintext: enc(JSON.stringify(record)),
+    key32: deriveVaultKey(walletPriv, network),
+  });
+}
+
+/** Open a sealed history payload, rebuilding the AAD from the dedupKey. Throws on mismatch. */
+export function openHistoryRecord(
+  dedupKey: string,
+  payload: VaultEntryPayload,
+  ownerId: string,
+  walletPriv: string,
+  network: string,
+): HistoryRecord {
+  const plaintext = openVaultEntry({
+    network,
+    ownerId,
+    key: dedupKey,
+    version: HISTORY_VERSION,
+    payload,
+    key32: deriveVaultKey(walletPriv, network),
+  });
+  return JSON.parse(dec(plaintext)) as HistoryRecord;
+}

--- a/storage/remote/load-delta.ts
+++ b/storage/remote/load-delta.ts
@@ -169,6 +169,23 @@ export class LoadDeltaTracker {
     this.accState = null; // close the pass regardless of whether a baseline was persisted
   }
 
+  /**
+   * Re-sign the local baseline after the wallet's OWN flush advanced the server
+   * (Task 7.1/7.3). The wallet is the only writer, so its committed writes must
+   * advance the signed root — otherwise the next `load()` would see its own
+   * entries as an unauthored delta and false-alarm a rollback. `known` is the
+   * provider's post-flush authoritative state; the epoch is carried forward.
+   */
+  async rebaseline(cursor: number, known: Map<string, EntryState>): Promise<void> {
+    if (!this.config.baseline || !this.walletPriv) return;
+    const root = computeRoot(known);
+    const epoch = this.baseline?.epoch ?? 0;
+    const sig = signRoot(this.walletPriv, this.bindingFor(cursor, root));
+    const baseline: SignedBaseline = { cursor, root, sig, epoch };
+    this.baseline = baseline;
+    await this.config.baseline.set(this.baselineKey(), JSON.stringify(baseline));
+  }
+
   private async loadBaseline(): Promise<SignedBaseline | null> {
     if (!this.config.baseline) return null;
     const raw = await this.config.baseline.get(this.baselineKey());

--- a/storage/remote/reserved-address.ts
+++ b/storage/remote/reserved-address.ts
@@ -28,6 +28,9 @@ export interface ReservedAddress {
 /** Plaintext label for the reserved meta-address slot. */
 export const RESERVED_ADDRESS_PLAIN_KEY = '_vaultmeta_addr';
 
+/** Format version stamped into the reserved meta-address plaintext (DIRECT:// v1). */
+export const RESERVED_ADDRESS_FORMAT_VERSION = 1;
+
 /** Fixed version of the reserved slot (singleton — never bumped). */
 const RESERVED_ADDRESS_VERSION = 0;
 

--- a/storage/remote/types.ts
+++ b/storage/remote/types.ts
@@ -116,6 +116,60 @@ export interface StateResponse {
   entries: StateEntry[];
 }
 
+// =============================================================================
+// History wire (DESIGN §5.6) — single-channel client-asserted log
+// =============================================================================
+
+/** One client-asserted history record on a `POST /v1/history` batch. */
+export interface HistoryAppendRecord {
+  dedupKey: string;
+  /** AEAD-sealed `HistoryRecord` JSON, like a vault entry payload. */
+  payload: VaultEntryPayload;
+}
+
+/** Why a history record was rejected (mirrors the real `HistoryReject`). */
+export type HistoryRejectReason = 'record_too_large' | 'history_full';
+
+/** One rejected record surfaced in the append response. */
+export interface HistoryRejection {
+  dedupKey: string;
+  reason: HistoryRejectReason;
+}
+
+/** `POST /v1/history` response — `accepted` counts inserts + idempotent dups. */
+export interface HistoryAppendResponse {
+  accepted: number;
+  rejected: HistoryRejection[];
+}
+
+/** One stored history row on a `GET /v1/history?since=` page. */
+export interface HistoryStateRecord {
+  dedupKey: string;
+  seq: number;
+  payload: VaultEntryPayload;
+  /** ISO-8601 (the server serializes a Date). */
+  createdAt: string;
+}
+
+/** `GET /v1/history?since=<seq>` response. No `more` flag — loop until `< PAGE_LIMIT`. */
+export interface HistorySinceResponse {
+  records: HistoryStateRecord[];
+}
+
+// =============================================================================
+// Account wire (DESIGN §7.4) — fresh-signature-gated deletion
+// =============================================================================
+
+/** `POST /v1/account/delete-nonce` response — a fresh single-use, owner-bound nonce. */
+export interface DeleteNonceResponse {
+  nonce: string;
+}
+
+/** `DELETE /v1/account {nonce, signature}` response. */
+export interface AccountDeleteResponse {
+  ok: boolean;
+}
+
 /**
  * The authenticated vault data seam. The caller (`ownerId = chainPubkey`) is
  * implied by how the client was obtained. Each method is one `/v1/*` endpoint.
@@ -125,4 +179,12 @@ export interface VaultHttpClient {
   patchEntries(ops: PatchOp[]): Promise<PatchResponse>;
   /** `GET /v1/state?since=<cursor>`. */
   getState(since: number): Promise<StateResponse>;
+  /** `POST /v1/history {records}` — idempotent append; 200 with `{accepted, rejected}`. */
+  appendHistory(records: HistoryAppendRecord[]): Promise<HistoryAppendResponse>;
+  /** `GET /v1/history?since=<seq>` — seq-paginated; loop until a short page. */
+  historySince(since: number): Promise<HistorySinceResponse>;
+  /** `POST /v1/account/delete-nonce` — a fresh single-use delete nonce. */
+  deleteNonce(): Promise<DeleteNonceResponse>;
+  /** `DELETE /v1/account {nonce, signature}` — fresh-sig gated; 401 → `{ok:false}`. */
+  deleteAccount(nonce: string, signature: string): Promise<AccountDeleteResponse>;
 }

--- a/tests/helpers/fake-vault-server.ts
+++ b/tests/helpers/fake-vault-server.ts
@@ -30,12 +30,20 @@
  * no provider changes.
  */
 
+import { randomUUID } from 'node:crypto';
 import { recoverPubkeyFromSignature, verifySignedMessage, signMessage } from '../../core/crypto';
 import { epochCanon } from '../../vault-aead/canon';
 import type { VaultEntryPayload } from '../../vault-aead/entry';
 import type {
+  AccountDeleteResponse,
   AuthTokens,
   ChallengeResponse,
+  DeleteNonceResponse,
+  HistoryAppendRecord,
+  HistoryAppendResponse,
+  HistoryRejection,
+  HistorySinceResponse,
+  HistoryStateRecord,
   PatchOp,
   PatchRejection,
   PatchResponse,
@@ -53,6 +61,11 @@ export const SERVER_SIGN_PRIV = 'a'.repeat(64);
 const AUTH_PREFIX = 'unicity:vault:auth:v1\n';
 const CHALLENGE_TTL_MS = 5 * 60_000;
 const DEFAULT_PAGE_LIMIT = 1000;
+const DELETE_NONCE_TTL_MS = 5 * 60_000;
+
+/** REAL `deleteCanon` (account.service.ts:11) — `delete:v1`, NOT `account-delete:v1`. */
+const deleteCanon = (net: string, ownerId: string, nonce: string): string =>
+  `unicity:vault:delete:v1\n${net}\n${ownerId}\n${nonce}`;
 
 let counter = 0;
 const uniq = (p: string): string => `${p}-${++counter}-${Math.random().toString(36).slice(2)}`;
@@ -84,6 +97,22 @@ interface EntryRow {
   seq: number;
 }
 
+/** Stored history row (mirrors `HistoryRec`). */
+interface HistoryRow {
+  ownerId: string;
+  dedupKey: string;
+  seq: number;
+  payload: VaultEntryPayload;
+  createdAt: Date;
+}
+
+/** Account-delete nonce (mirrors `DeleteNonceDoc`) — single-use, owner-bound. */
+interface DeleteNonceRow {
+  ownerId: string;
+  nonce: string;
+  expiresAt: number;
+}
+
 export interface FakeVaultServerOptions {
   network?: string;
   pageLimit?: number;
@@ -101,8 +130,14 @@ export class FakeVaultServer {
   private readonly nonces = new Map<string, NonceRow>();
   private readonly sessions: SessionRow[] = [];
   private readonly entries: EntryRow[] = [];
+  private readonly historyRows: HistoryRow[] = [];
+  private readonly deleteNonces = new Map<string, DeleteNonceRow>();
+  /** Owners whose account has been deleted (purge armed). */
+  private readonly deleted = new Set<string>();
   /** Per-owner monotonic seq allocator (the `/state` pagination watermark). */
   private readonly seqCounter = new Map<string, number>();
+  /** Per-owner history-seq allocator (the `/history` pagination watermark). */
+  private readonly historySeqCounter = new Map<string, number>();
   /** Per-owner commit counter (the PATCH-response `cursor`). */
   private readonly cursorCounter = new Map<string, number>();
 
@@ -112,6 +147,8 @@ export class FakeVaultServer {
   private storageFull = false;
   /** Per-key byte cap for the `entry_too_large` path; undefined = unbounded. */
   private maxEntryBytes: number | undefined;
+  /** Per-owner history record cap (`history_full`); undefined = unbounded. */
+  private maxOwnerHistory: number | undefined;
 
   /** Per-endpoint call log — tests assert request bodies and call counts. */
   readonly calls: {
@@ -121,7 +158,14 @@ export class FakeVaultServer {
     logout: string[];
     patch: PatchOp[][];
     state: number[];
-  } = { challenge: [], verify: [], refresh: [], logout: [], patch: [], state: [] };
+    historyAppend: HistoryAppendRecord[][];
+    historySince: number[];
+    deleteNonce: string[];
+    deleteAccount: Array<{ nonce: string; signature: string }>;
+  } = {
+    challenge: [], verify: [], refresh: [], logout: [], patch: [], state: [],
+    historyAppend: [], historySince: [], deleteNonce: [], deleteAccount: [],
+  };
 
   constructor(opts: FakeVaultServerOptions | string = {}) {
     const o = typeof opts === 'string' ? { network: opts } : opts;
@@ -144,6 +188,10 @@ export class FakeVaultServer {
     return {
       patchEntries: (ops) => Promise.resolve(this.patchEntries(ownerId, ops)),
       getState: (since) => Promise.resolve(this.getState(ownerId, since)),
+      appendHistory: (records) => Promise.resolve(this.appendHistory(ownerId, records)),
+      historySince: (since) => Promise.resolve(this.historySince(ownerId, since)),
+      deleteNonce: () => Promise.resolve(this.deleteNonce(ownerId)),
+      deleteAccount: (nonce, signature) => Promise.resolve(this.deleteAccount(ownerId, nonce, signature)),
     };
   }
 
@@ -314,6 +362,88 @@ export class FakeVaultServer {
     return signMessage(SERVER_SIGN_PRIV, epochCanon(this.network, epoch));
   }
 
+  // === HISTORY (POST/GET /v1/history) =======================================
+
+  /**
+   * Idempotent append (mirrors `history.service.ts`): a duplicate `dedupKey` is
+   * NOT inserted but still counted `accepted`; oversize → `record_too_large`; the
+   * per-owner count cap → `history_full`. Always 200 (status stripped).
+   */
+  private appendHistory(ownerId: string, records: HistoryAppendRecord[]): HistoryAppendResponse {
+    this.calls.historyAppend.push(records);
+    const rejected: HistoryRejection[] = [];
+    let accepted = 0;
+    let count = this.historyRows.filter((r) => r.ownerId === ownerId).length;
+    for (const rec of records) {
+      if (this.payloadBytes(rec.payload) > (this.maxEntryBytes ?? Infinity)) {
+        rejected.push({ dedupKey: rec.dedupKey, reason: 'record_too_large' });
+        continue;
+      }
+      if (count >= (this.maxOwnerHistory ?? Infinity)) {
+        rejected.push({ dedupKey: rec.dedupKey, reason: 'history_full' });
+        continue;
+      }
+      if (this.appendHistoryRow(ownerId, rec)) count += 1;
+      accepted += 1;
+    }
+    return { accepted, rejected };
+  }
+
+  /** Append a history row; returns true when a NEW row was inserted (idempotent). */
+  private appendHistoryRow(ownerId: string, rec: HistoryAppendRecord): boolean {
+    const exists = this.historyRows.some((r) => r.ownerId === ownerId && r.dedupKey === rec.dedupKey);
+    if (exists) return false;
+    this.historyRows.push({
+      ownerId, dedupKey: rec.dedupKey, payload: rec.payload,
+      seq: this.nextHistorySeq(ownerId), createdAt: new Date(),
+    });
+    return true;
+  }
+
+  /** `GET /v1/history?since=<seq>` — rows with `seq > since`, page-limited by seq. */
+  private historySince(ownerId: string, since: number): HistorySinceResponse {
+    this.calls.historySince.push(since);
+    const rows = this.historyRows
+      .filter((r) => r.ownerId === ownerId && r.seq > since)
+      .sort((a, b) => a.seq - b.seq)
+      .slice(0, this.pageLimit);
+    return { records: rows.map(toHistoryRecord) };
+  }
+
+  // === ACCOUNT (delete-nonce + DELETE /v1/account) ==========================
+
+  /** Issue a fresh single-use, owner-bound delete nonce (5-min TTL). */
+  private deleteNonce(ownerId: string): DeleteNonceResponse {
+    this.calls.deleteNonce.push(ownerId);
+    const nonce = randomUUID();
+    this.deleteNonces.set(nonce, { ownerId, nonce, expiresAt: Date.now() + DELETE_NONCE_TTL_MS });
+    return { nonce };
+  }
+
+  /**
+   * Confirm deletion (mirrors `account.service.ts`): consume the nonce (single-use,
+   * owner-bound), verify the fresh signature over the REAL `delete:v1` template,
+   * and on success arm the purge. A bad/absent/stale signature → `{ok:false}` (401).
+   */
+  private deleteAccount(ownerId: string, nonce: string, signature: string): AccountDeleteResponse {
+    this.calls.deleteAccount.push({ nonce, signature });
+    const row = this.deleteNonces.get(nonce);
+    this.deleteNonces.delete(nonce); // single-use
+    if (!row || row.ownerId !== ownerId || Date.now() > row.expiresAt) return { ok: false };
+    const msg = deleteCanon(this.network, ownerId, nonce);
+    if (!this.verifyDelete(msg, signature, ownerId)) return { ok: false };
+    this.deleted.add(ownerId);
+    return { ok: true };
+  }
+
+  private verifyDelete(msg: string, signature: string, ownerId: string): boolean {
+    try {
+      return verifySignedMessage(msg, signature, ownerId);
+    } catch {
+      return false;
+    }
+  }
+
   // === seq / cursor allocators ==============================================
 
   private nextSeq(ownerId: string): number {
@@ -325,6 +455,12 @@ export class FakeVaultServer {
   private bumpCursor(ownerId: string): number {
     const next = (this.cursorCounter.get(ownerId) ?? 0) + 1;
     this.cursorCounter.set(ownerId, next);
+    return next;
+  }
+
+  private nextHistorySeq(ownerId: string): number {
+    const next = (this.historySeqCounter.get(ownerId) ?? 0) + 1;
+    this.historySeqCounter.set(ownerId, next);
     return next;
   }
 
@@ -344,6 +480,21 @@ export class FakeVaultServer {
   /** Set the per-entry byte cap (oversize → `entry_too_large`). */
   setMaxEntryBytes(max: number | undefined): void {
     this.maxEntryBytes = max;
+  }
+
+  /** Set the per-owner history record cap (`history_full`). */
+  setMaxOwnerHistory(max: number | undefined): void {
+    this.maxOwnerHistory = max;
+  }
+
+  /** Number of stored history rows for an owner (assertions). */
+  historyCount(ownerId: string): number {
+    return this.historyRows.filter((r) => r.ownerId === ownerId).length;
+  }
+
+  /** True once an owner's account has been deleted (assertions). */
+  isDeleted(ownerId: string): boolean {
+    return this.deleted.has(ownerId);
   }
 
   /** Number of live entries for an owner (assertions). */
@@ -382,4 +533,11 @@ const toStateEntry = (e: EntryRow): StateEntry => ({
   payload: e.payload,
   deleted: e.deleted,
   seq: e.seq,
+});
+
+const toHistoryRecord = (r: HistoryRow): HistoryStateRecord => ({
+  dedupKey: r.dedupKey,
+  seq: r.seq,
+  payload: r.payload,
+  createdAt: r.createdAt.toISOString(),
 });

--- a/tests/integration/vault/vault-account-delete.test.ts
+++ b/tests/integration/vault/vault-account-delete.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Account delete (Task 7.5, DESIGN §7.4 / §11) against the in-process fake server.
+ *
+ * `deleteAccount()` fetches a fresh single-use delete-nonce
+ * (`POST /v1/account/delete-nonce`), signs the REAL `delete:v1` template with the
+ * old wallet key, and sends `DELETE /v1/account {nonce, signature}`. The signing
+ * template is `unicity:vault:delete:v1\n${network}\n${ownerId}\n${nonce}` — the
+ * REAL Part A `deleteCanon`, NOT the `account-delete:v1` scheme fixture. A stale /
+ * missing signature is rejected CLIENT-side before the request leaves.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes, verifySignedMessage } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { deleteCanon } from '../../../vault-aead/canon';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import type { FullIdentity } from '../../../types';
+
+const NETWORK = 'testnet2';
+const PRIV = '9c'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+function makeProvider(server: FakeVaultServer): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'u',
+    privateKey: PRIV,
+    authClient: server.authClient(),
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+describe('account delete', () => {
+  it('signs the REAL delete:v1 template with a fresh nonce and deletes', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    await provider.initialize();
+
+    const ok = await provider.deleteAccount();
+    expect(ok).toBe(true);
+    expect(server.isDeleted(PUB)).toBe(true);
+
+    // Exactly one nonce fetch + one delete; the signed message is the REAL delete:v1.
+    expect(server.calls.deleteNonce).toHaveLength(1);
+    expect(server.calls.deleteAccount).toHaveLength(1);
+    const sent = server.calls.deleteAccount[0];
+    const expectedMsg = deleteCanon(NETWORK, PUB, sent.nonce);
+    expect(verifySignedMessage(expectedMsg, sent.signature, PUB)).toBe(true);
+    // It is NOT the account-delete:v1 scheme fixture.
+    expect(verifySignedMessage(`unicity:vault:account-delete:v1\n${NETWORK}\n${PUB}\n${sent.nonce}`, sent.signature, PUB)).toBe(false);
+  });
+
+  it('each delete uses a FRESH single-use nonce (a replayed nonce is rejected)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    await provider.initialize();
+
+    await provider.deleteAccount();
+    const usedNonce = server.calls.deleteAccount[0].nonce;
+    const msg = deleteCanon(NETWORK, PUB, usedNonce);
+    const sig = (await import('../../../core/crypto')).signMessage(PRIV, msg);
+
+    // Replaying the same (now-consumed) nonce is rejected by the single-use server.
+    const direct = server.clientFor(PUB);
+    const replay = await direct.deleteAccount(usedNonce, sig);
+    expect(replay.ok).toBe(false);
+  });
+
+  it('the server rejects a forged signature (wrong key) with 401', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    await provider.initialize();
+
+    const { nonce } = await server.clientFor(PUB).deleteNonce();
+    // Sign with a DIFFERENT key — the recovered signer ≠ ownerId → rejected.
+    const wrongPriv = '7b'.repeat(32);
+    const forged = (await import('../../../core/crypto')).signMessage(wrongPriv, deleteCanon(NETWORK, PUB, nonce));
+    const res = await server.clientFor(PUB).deleteAccount(nonce, forged);
+    expect(res.ok).toBe(false);
+    expect(server.isDeleted(PUB)).toBe(false);
+  });
+});

--- a/tests/integration/vault/vault-fencing.test.ts
+++ b/tests/integration/vault/vault-fencing.test.ts
@@ -43,6 +43,10 @@ function gatedClient(inner: VaultHttpClient, onPatch: () => Promise<void>): Vaul
       return inner.patchEntries(ops);
     },
     getState: (since): Promise<StateResponse> => inner.getState(since),
+    appendHistory: (records) => inner.appendHistory(records),
+    historySince: (since) => inner.historySince(since),
+    deleteNonce: () => inner.deleteNonce(),
+    deleteAccount: (nonce, sig) => inner.deleteAccount(nonce, sig),
   };
 }
 

--- a/tests/integration/vault/vault-fencing.test.ts
+++ b/tests/integration/vault/vault-fencing.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Flush serialization + identity fencing (Task 7.3, DESIGN §5.5).
+ *
+ * flush / sync / shutdown run through a single `AsyncSerialQueue`, so two
+ * overlapping flushes never interleave their CAS writes. `setIdentity` increments
+ * an identity-epoch counter and drops pending work; an in-flight flush that awaits
+ * ACROSS a `setIdentity` ABORTS on the epoch mismatch — no cross-identity write
+ * reaches the server. The epoch is re-checked after EVERY await in the flush path.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import { wireKey } from '../../../storage/remote/wire-key';
+import type { TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+import type { PatchResponse, StateResponse, VaultHttpClient } from '../../../storage/remote/types';
+
+const NETWORK = 'testnet2';
+const PRIV_A = '11'.repeat(32);
+const PUB_A = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV_A), true));
+const PRIV_B = '22'.repeat(32);
+const PUB_B = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV_B), true));
+const identityA: FullIdentity = { chainPubkey: PUB_A, l1Address: 'alphaA', privateKey: PRIV_A };
+const identityB: FullIdentity = { chainPubkey: PUB_B, l1Address: 'alphaB', privateKey: PRIV_B };
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+/** A latch that lets a test suspend the next `patchEntries` until released. */
+function gatedClient(inner: VaultHttpClient, onPatch: () => Promise<void>): VaultHttpClient {
+  return {
+    patchEntries: async (ops): Promise<PatchResponse> => {
+      await onPatch();
+      return inner.patchEntries(ops);
+    },
+    getState: (since): Promise<StateResponse> => inner.getState(since),
+  };
+}
+
+describe('flush serialization + identity fencing', () => {
+  it('an in-flight flush that awaits across setIdentity aborts — no cross-identity write reaches the server', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    let gatedOnce = false;
+
+    const provider = new RemoteTokenStorageProvider({
+      network: NETWORK,
+      vaultUrl: 'u',
+      privateKey: PRIV_A,
+      authClient: server.authClient(),
+      httpClientFactory: (ownerId) => {
+        const inner = server.clientFor(ownerId);
+        return gatedClient(inner, async () => {
+          if (!gatedOnce) { gatedOnce = true; await gate; } // suspend the FIRST patch
+        });
+      },
+    });
+    provider.setIdentity(identityA);
+    await provider.initialize();
+
+    // Start a flush as identity A; it suspends inside patchEntries (awaits the gate).
+    const flushing = provider.sync(txf({ aaa: { amt: '1' } }));
+    await Promise.resolve();
+
+    // Switch identity to B mid-flush, then release the suspended patch.
+    provider.setIdentity(identityB);
+    release();
+    const res = await flushing;
+
+    // The flush aborted on the epoch mismatch — B's server view never got A's token,
+    // and the suspended flush did NOT commit under B (no cross-identity write).
+    const wkB = wireKey(PRIV_B, NETWORK, 'aaa');
+    expect(server.getEntry(PUB_B, wkB)).toBeUndefined();
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/identity/i);
+  });
+
+  it('overlapping flushes are serialized (no interleave) by the AsyncSerialQueue', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const order: string[] = [];
+    let firstPatch = true;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+
+    const provider = new RemoteTokenStorageProvider({
+      network: NETWORK,
+      vaultUrl: 'u',
+      privateKey: PRIV_A,
+      authClient: server.authClient(),
+      httpClientFactory: (ownerId) => gatedClient(server.clientFor(ownerId), async () => {
+        if (firstPatch) { firstPatch = false; order.push('first-start'); await gate; order.push('first-end'); }
+        else { order.push('second'); }
+      }),
+    });
+    provider.setIdentity(identityA);
+    await provider.initialize();
+
+    const f1 = provider.sync(txf({ aaa: { amt: '1' } }));
+    const f2 = provider.sync(txf({ aaa: { amt: '1' }, bbb: { amt: '2' } }));
+    await Promise.resolve();
+    release();
+    await Promise.all([f1, f2]);
+
+    // The second flush's patch only runs AFTER the first finished (serialized).
+    expect(order).toEqual(['first-start', 'first-end', 'second']);
+  });
+
+  it('shutdown drops pending work and runs through the queue', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = new RemoteTokenStorageProvider({
+      network: NETWORK,
+      vaultUrl: 'u',
+      privateKey: PRIV_A,
+      authClient: server.authClient(),
+      httpClientFactory: (ownerId) => server.clientFor(ownerId),
+    });
+    provider.setIdentity(identityA);
+    await provider.initialize();
+    await provider.shutdown();
+    expect(provider.getStatus()).toBe('disconnected');
+  });
+});

--- a/tests/integration/vault/vault-gate.test.ts
+++ b/tests/integration/vault/vault-gate.test.ts
@@ -1,0 +1,108 @@
+/**
+ * initialize() self-load opens the flush gate (Task 7.1, DESIGN §5.5).
+ *
+ * `PaymentsModule.load()` stops at the FIRST successful provider, so the vault
+ * box may never receive a `load()` call. The provider therefore performs the
+ * first `getState()`/`load()` ITSELF inside `initialize()` and only THEN opens
+ * the flush gate (`initialLoadDone`). Empty-import protection is preserved: a
+ * `sync()` before a successful first load is a NO-OP (no PATCH reaches the
+ * server), so a transient load failure can never wipe the server with empty
+ * local data.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import { wireKey } from '../../../storage/remote/wire-key';
+import type { TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+import type { StateResponse, VaultHttpClient } from '../../../storage/remote/types';
+
+const NETWORK = 'testnet2';
+const PRIV = '71'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+interface ProviderOpts {
+  httpClientFactory?: (ownerId: string) => VaultHttpClient;
+}
+
+function makeProvider(server: FakeVaultServer, opts: ProviderOpts = {}): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    privateKey: PRIV,
+    authClient: server.authClient(),
+    httpClientFactory: opts.httpClientFactory ?? ((ownerId) => server.clientFor(ownerId)),
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: 'DIRECT://x', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+describe('initialize() opens the flush gate', () => {
+  it('performs the first /state load itself even without a load() call', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    server.calls.state.length = 0;
+
+    await provider.initialize();
+
+    // initialize() ran the first /state load on its own (no caller load()).
+    expect(server.calls.state.length).toBeGreaterThanOrEqual(1);
+    expect(provider.isInitialLoadDone()).toBe(true);
+  });
+
+  it('opens the flush gate only after the first load — a flush then reaches the server', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    await provider.initialize();
+
+    const res = await provider.sync(txf({ aaa: { amt: '1' } }));
+    expect(res.success).toBe(true);
+    expect(res.added).toBe(1);
+    const wk = wireKey(PRIV, NETWORK, 'aaa');
+    expect(server.getEntry(PUB, wk)?.version).toBe(1);
+  });
+
+  it('a failed first load keeps the gate SHUT — a flush is a no-op (empty-import protection)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    // Wrap the data client so the FIRST /state (run by initialize) rejects.
+    const wrap = (ownerId: string): VaultHttpClient => {
+      const inner = server.clientFor(ownerId);
+      let calls = 0;
+      return {
+        patchEntries: (ops) => inner.patchEntries(ops),
+        getState: (since): Promise<StateResponse> => {
+          calls += 1;
+          if (calls === 1) return Promise.reject(new Error('transient /state failure'));
+          return inner.getState(since);
+        },
+      };
+    };
+    const provider = makeProvider(server, { httpClientFactory: wrap });
+
+    // initialize() must NOT throw on a transient load failure; the gate stays shut.
+    await provider.initialize();
+    expect(provider.isInitialLoadDone()).toBe(false);
+
+    // A flush before a successful load is a NO-OP — no PATCH reaches the server,
+    // so empty local data can never wipe the server.
+    const res = await provider.sync(txf({ aaa: { amt: '1' } }));
+    expect(res.success).toBe(true); // a no-op flush is not a failure
+    expect(res.added).toBe(0);
+    expect(server.calls.patch).toHaveLength(0);
+    const wk = wireKey(PRIV, NETWORK, 'aaa');
+    expect(server.getEntry(PUB, wk)).toBeUndefined();
+  });
+});

--- a/tests/integration/vault/vault-gate.test.ts
+++ b/tests/integration/vault/vault-gate.test.ts
@@ -88,6 +88,10 @@ describe('initialize() opens the flush gate', () => {
           if (calls === 1) return Promise.reject(new Error('transient /state failure'));
           return inner.getState(since);
         },
+        appendHistory: (records) => inner.appendHistory(records),
+        historySince: (since) => inner.historySince(since),
+        deleteNonce: () => inner.deleteNonce(),
+        deleteAccount: (nonce, sig) => inner.deleteAccount(nonce, sig),
       };
     };
     const provider = makeProvider(server, { httpClientFactory: wrap });

--- a/tests/integration/vault/vault-history.test.ts
+++ b/tests/integration/vault/vault-history.test.ts
@@ -1,0 +1,139 @@
+/**
+ * History single channel (Task 7.4, DESIGN §5.6) against the in-process fake server.
+ *
+ * `flush()` diffs the `_history` dedupKeys vs a persisted pushed-set and POSTs only
+ * NEW records to `/v1/history` (each payload AEAD-sealed `{nonce,ct}` like a vault
+ * entry). `load()` GETs `/v1/history` (paginating by seq), decrypts each payload to a
+ * `HistoryRecord`, and attaches them as `_history` for the existing import hook
+ * (`importHistoryEntries`). `appendHistory` is idempotent: a duplicate dedupKey is
+ * counted `accepted` (not an error); a real error rethrows.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import type { LocalBaselineStore } from '../../../storage/remote/load-delta';
+import type { HistoryRecord, TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+
+const NETWORK = 'testnet2';
+const PRIV = '8a'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+function memStore(): LocalBaselineStore {
+  const m = new Map<string, string>();
+  return { get: async (k) => m.get(k) ?? null, set: async (k, v) => void m.set(k, v) };
+}
+
+function makeProvider(server: FakeVaultServer, store: LocalBaselineStore): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'u',
+    privateKey: PRIV,
+    authClient: server.authClient(),
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+    localBaseline: store,
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+function hist(dedupKey: string, type: HistoryRecord['type'] = 'RECEIVED'): HistoryRecord {
+  return { dedupKey, id: `id-${dedupKey}`, type, amount: '1', coinId: 'UCT', symbol: 'UCT', timestamp: 1 };
+}
+
+function txf(history: HistoryRecord[]): TxfStorageDataBase {
+  return {
+    _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: Date.now() },
+    _history: history,
+  };
+}
+
+describe('history single channel', () => {
+  it('flush POSTs only NEW history records (pushed-set diff)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server, memStore());
+    await provider.initialize();
+
+    await provider.sync(txf([hist('h1'), hist('h2')]));
+    expect(server.historyCount(PUB)).toBe(2);
+    expect(server.calls.historyAppend).toHaveLength(1);
+    expect(server.calls.historyAppend[0].map((r) => r.dedupKey)).toEqual(['h1', 'h2']);
+
+    // A second flush adding only h3 POSTs h3 alone (h1/h2 already pushed).
+    await provider.sync(txf([hist('h1'), hist('h2'), hist('h3')]));
+    expect(server.historyCount(PUB)).toBe(3);
+    expect(server.calls.historyAppend).toHaveLength(2);
+    expect(server.calls.historyAppend[1].map((r) => r.dedupKey)).toEqual(['h3']);
+  });
+
+  it('the history payload is AEAD-sealed {nonce,ct} (operator-blind)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server, memStore());
+    await provider.initialize();
+    await provider.sync(txf([hist('secret-key')]));
+
+    const posted = server.calls.historyAppend[0][0];
+    expect(typeof posted.payload.nonce).toBe('string');
+    expect(typeof posted.payload.ct).toBe('string');
+    // The plaintext dedupKey rides on the wire (it is the dedup index), but the
+    // record body is sealed — the ciphertext does not leak the id/coin in clear.
+    expect(posted.payload.ct).not.toContain('UCT');
+  });
+
+  it('load GETs /v1/history, decrypts, and attaches _history for importHistoryEntries', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const writer = makeProvider(server, memStore());
+    await writer.initialize();
+    await writer.sync(txf([hist('h1', 'SENT'), hist('h2', 'MINT')]));
+
+    // A fresh reader loads and recovers the history records, decrypted.
+    const reader = makeProvider(server, memStore());
+    const res = await reader.load();
+    expect(res.success).toBe(true);
+    const recovered = (res.data!._history ?? []).slice().sort((a, b) => a.dedupKey.localeCompare(b.dedupKey));
+    expect(recovered.map((r) => r.dedupKey)).toEqual(['h1', 'h2']);
+    expect(recovered.find((r) => r.dedupKey === 'h1')!.type).toBe('SENT');
+    expect(recovered.find((r) => r.dedupKey === 'h2')!.type).toBe('MINT');
+
+    // The recovered records are also queryable via the contract history ops.
+    const entries = await reader.getHistoryEntries();
+    expect(entries.map((e) => e.dedupKey).sort()).toEqual(['h1', 'h2']);
+    expect(await reader.hasHistoryEntry('h1')).toBe(true);
+  });
+
+  it('history paginates by seq across pages until a short page', async () => {
+    const server = new FakeVaultServer({ network: NETWORK, pageLimit: 2 });
+    const writer = makeProvider(server, memStore());
+    await writer.initialize();
+    await writer.sync(txf([hist('a'), hist('b'), hist('c'), hist('d'), hist('e')]));
+
+    const reader = makeProvider(server, memStore());
+    server.calls.historySince.length = 0;
+    const res = await reader.load();
+    expect(res.success).toBe(true);
+    // 5 rows / pageLimit 2 → since 0,2,4 → a 3rd short page ends the loop.
+    expect(server.calls.historySince).toEqual([0, 2, 4]);
+    expect((res.data!._history ?? []).map((r) => r.dedupKey).sort()).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('a duplicate dedupKey is idempotent (accepted, not an error)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const store = memStore();
+    const provider = makeProvider(server, store);
+    await provider.initialize();
+    await provider.sync(txf([hist('dup')]));
+
+    // A foreign writer (same owner) re-posts 'dup' directly — the server idempotently
+    // accepts it without inserting a second row.
+    const direct = server.clientFor(PUB);
+    const resp = await direct.appendHistory([{ dedupKey: 'dup', payload: { nonce: 'bg==', ct: 'Yw==' } }]);
+    expect(resp.accepted).toBe(1);
+    expect(resp.rejected).toHaveLength(0);
+    expect(server.historyCount(PUB)).toBe(1); // still one row
+  });
+});

--- a/tests/integration/vault/vault-load-states.test.ts
+++ b/tests/integration/vault/vault-load-states.test.ts
@@ -1,0 +1,115 @@
+/**
+ * load() 3-state machine + reserved-address restore (Task 7.2, findings #17/#22,
+ * DESIGN §5.5) against the in-process fake server.
+ *
+ * The load machine distinguishes three outcomes:
+ *  - EMPTY (no reserved entry on the server) → success:true with an `isEmpty`
+ *    sentinel INSIDE `data` so it can never short-circuit local data (#22); the
+ *    gate opens; treated as a brand-new wallet.
+ *  - POPULATED (#17) → on flush the provider seals a reserved-address entry from a
+ *    REAL engine identity (`deriveDirectAddress(hexToBytes(chainPubkey))`); on
+ *    reload it decodes the reserved entry and restores `_meta.address`. The
+ *    restored address must BYTE-EQUAL an INDEPENDENT `deriveDirectAddress(...)`
+ *    call imported from `token-engine/identity.ts` (not an in-test helper).
+ *  - LOAD_FAILED (a reserved-entry decrypt/verify error) → success:false, the gate
+ *    stays SHUT, no flush.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { reservedAddressKey } from '../../../storage/remote/reserved-address';
+import { deriveDirectAddress } from '../../../token-engine/identity';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import type { TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+
+const NETWORK = 'testnet2';
+const PRIV = '5e'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+function makeProvider(server: FakeVaultServer): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    privateKey: PRIV,
+    authClient: server.authClient(),
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+interface IsEmptyData extends TxfStorageDataBase {
+  isEmpty?: boolean;
+}
+
+describe('load() 3-state machine', () => {
+  it('EMPTY: no reserved entry → success:true with an isEmpty sentinel inside data; gate opens (#22)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    await provider.initialize();
+
+    const res = await provider.load();
+    expect(res.success).toBe(true);
+    expect((res.data as IsEmptyData).isEmpty).toBe(true);
+    expect(provider.isInitialLoadDone()).toBe(true);
+    // No _meta.address can be restored from an empty vault.
+    expect(res.data!._meta.address).toBe('');
+  });
+
+  it('POPULATED (#17): a flush seals a reserved-address entry; reload restores _meta.address byte-equal to deriveDirectAddress', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const writer = makeProvider(server);
+    await writer.initialize();
+    await writer.sync(txf({ aaa: { amt: '1' } }));
+
+    // The reserved-address entry was sealed at its well-known wire key.
+    const reservedWk = reservedAddressKey(PRIV, NETWORK);
+    expect(server.getEntry(PUB, reservedWk)).toBeDefined();
+
+    // A fresh reader restores _meta.address from the reserved entry.
+    const reader = makeProvider(server);
+    const res = await reader.load();
+    expect(res.success).toBe(true);
+    expect((res.data as IsEmptyData).isEmpty).toBeUndefined();
+
+    // The INDEPENDENT oracle: deriveDirectAddress from token-engine/identity.ts.
+    const expected = await deriveDirectAddress(hexToBytes(PUB));
+    expect(res.data!._meta.address).toBe(expected);
+  });
+
+  it('LOAD_FAILED: a corrupt reserved entry → success:false, gate stays shut, no flush', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const writer = makeProvider(server);
+    await writer.initialize();
+    await writer.sync(txf({ aaa: { amt: '1' } }));
+
+    // Corrupt the reserved-address entry's ciphertext so its AEAD tag fails.
+    const reservedWk = reservedAddressKey(PRIV, NETWORK);
+    const row = server.getEntry(PUB, reservedWk)!;
+    server.mutateEntry(PUB, reservedWk, { nonce: row.payload.nonce, ct: 'AAAA' + row.payload.ct.slice(4) });
+
+    const reader = makeProvider(server);
+    const res = await reader.load();
+    expect(res.success).toBe(false);
+    expect(reader.isInitialLoadDone()).toBe(false);
+
+    // Gate stays shut: a flush before a successful load is a no-op.
+    server.calls.patch.length = 0;
+    const flush = await reader.sync(txf({ bbb: { amt: '2' } }));
+    expect(flush.added).toBe(0);
+    expect(server.calls.patch).toHaveLength(0);
+  });
+});

--- a/tests/integration/vault/vault-pagination.test.ts
+++ b/tests/integration/vault/vault-pagination.test.ts
@@ -54,17 +54,17 @@ describe('paginated state load', () => {
     await seed.initialize();
     await seed.sync(txf({ a: { n: 1 }, b: { n: 2 }, c: { n: 3 }, d: { n: 4 }, e: { n: 5 } }));
 
-    // A fresh provider loads from scratch (serverCursor 0) and must paginate.
+    // A fresh provider loads from scratch (serverCursor 0) and must paginate. Under
+    // Task 7.1 the first load is performed by initialize() itself, so count its pages.
     const reader = makeProvider(server);
-    await reader.initialize();
     server.calls.state.length = 0; // count only the reader's pages
-    const res = await reader.load();
+    await reader.initialize();
 
-    expect(res.success).toBe(true);
     // 5 entries / pageLimit 2 → since 0,2,4 → 3 pages.
     expect(server.calls.state).toEqual([0, 2, 4]);
     // The reader adopted all 5 entries into its known state.
     expect(reader.knownCount()).toBe(5);
+    expect(reader.isInitialLoadDone()).toBe(true);
   });
 
   it('a regressing page cursor (no sanctioned epoch) trips the rollback gate', async () => {

--- a/tests/integration/vault/vault-pagination.test.ts
+++ b/tests/integration/vault/vault-pagination.test.ts
@@ -60,10 +60,10 @@ describe('paginated state load', () => {
     server.calls.state.length = 0; // count only the reader's pages
     await reader.initialize();
 
-    // 5 entries / pageLimit 2 → since 0,2,4 → 3 pages.
+    // 5 tokens + 1 reserved-address entry = 6 rows / pageLimit 2 → since 0,2,4 → 3 pages.
     expect(server.calls.state).toEqual([0, 2, 4]);
-    // The reader adopted all 5 entries into its known state.
-    expect(reader.knownCount()).toBe(5);
+    // The reader adopted all 6 rows (5 tokens + the reserved-address slot, Task 7.2).
+    expect(reader.knownCount()).toBe(6);
     expect(reader.isInitialLoadDone()).toBe(true);
   });
 

--- a/tests/integration/vault/vault-pagination.test.ts
+++ b/tests/integration/vault/vault-pagination.test.ts
@@ -85,6 +85,10 @@ describe('paginated state load', () => {
           calls += 1;
           return calls === 2 ? { ...page, cursor: since - 1, more: false } : page;
         },
+        appendHistory: (records) => inner.appendHistory(records),
+        historySince: (since) => inner.historySince(since),
+        deleteNonce: () => inner.deleteNonce(),
+        deleteAccount: (nonce, sig) => inner.deleteAccount(nonce, sig),
       };
     };
 

--- a/tests/integration/vault/vault-resurrect.test.ts
+++ b/tests/integration/vault/vault-resurrect.test.ts
@@ -81,9 +81,11 @@ describe('CAS delete-resurrect', () => {
     // EXACTLY ONE patch call for the resurrect.
     expect(server.calls.patch.length).toBe(patchesBefore + 1);
     const ops = server.calls.patch[server.calls.patch.length - 1];
-    expect(ops).toHaveLength(1);
-    expect(ops[0].key).toBe(wkK);
-    expect(ops[0].baseVersion).toBe(0); // NOT rebased to the deleted row's version
+    // The 'k' resurrect op is present (the batch may also carry the reserved-address
+    // op on the wallet's first flush — Task 7.2).
+    const kOp = ops.find((o) => o.key === wkK)!;
+    expect(kOp).toBeDefined();
+    expect(kOp.baseVersion).toBe(0); // NOT rebased to the deleted row's version
 
     // Server converged: applied, not rejected; the row is live again at v3.
     expect(res.added).toBe(1);

--- a/vault-aead/canon.ts
+++ b/vault-aead/canon.ts
@@ -39,3 +39,17 @@ export const ACCOUNT_DELETE_CANON_PREFIX = 'unicity:vault:account-delete:v1';
 export function accountDeleteCanon(network: string, chainPubkey: string, nonce: string): string {
   return `${ACCOUNT_DELETE_CANON_PREFIX}\n${network}\n${chainPubkey}\n${nonce}`;
 }
+
+/** Runtime account-delete prefix — the REAL Part A literal (`account.service.ts:11`). */
+export const DELETE_CANON_PREFIX = 'unicity:vault:delete:v1';
+
+/**
+ * The REAL runtime account-delete message the wallet signs (Task 7.5, §7.4):
+ * `'unicity:vault:delete:v1\n' + network + '\n' + ownerId + '\n' + nonce`.
+ *
+ * This is the `delete:v1` template Part A's `deleteCanon` verifies — NOT the
+ * `account-delete:v1` scheme fixture above.
+ */
+export function deleteCanon(network: string, ownerId: string, nonce: string): string {
+  return `${DELETE_CANON_PREFIX}\n${network}\n${ownerId}\n${nonce}`;
+}


### PR DESCRIPTION
Part B Phase 7 — vault provider wiring: the `RemoteTokenStorageProvider` load state machine, flush gate, identity fencing, history channel, and account delete. All CAS/version/root/queue/epoch/history state stays internal; the provider implements `TokenStorageProvider` verbatim.

## Tasks (strict TDD, one commit each)
- **7.1** `feat(vault): provider-initiated first load opens flush gate` — `initialize()` runs the first `load()` ITSELF (PaymentsModule.load stops at the first successful provider); `sync()` is a no-op until `initialLoadDone`, set ONLY at the end of a successful materialize. A transient/failed first load leaves the gate SHUT (empty-import protection). The first flush re-signs the wallet's authoritative post-load baseline (no anti-rollback false-alarm, no rollback-masking).
- **7.2** `feat(vault): load state machine + reserved-address restore` — EMPTY → `success:true` with an `isEmpty` sentinel inside `data` (#22); POPULATED → restore `_meta.address` from the reserved entry, byte-equal to an independent `deriveDirectAddress()` from `token-engine/identity.ts` (#17, Quest-XP invariant); LOAD_FAILED → `success:false`, gate shut. Reserved slot excluded from the orphan-delete sweep.
- **7.3** `feat(vault): serialized flush + identity fencing` — flush/sync/shutdown serialize through the existing `AsyncSerialQueue`; `setIdentity` bumps an identity-epoch; `assertEpoch` after every await aborts an in-flight flush on identity switch (no cross-identity write).
- **7.4** `feat(vault): single-channel history sync` — flush POSTs only new dedupKeys (pushed-set diff); load paginates `/v1/history` by seq, decrypts AEAD `{nonce,ct}`, attaches `_history` for `importHistoryEntries`; idempotent dup vs real-error rethrow.
- **7.5** `feat(vault): fresh-signature account delete` — signs the REAL runtime template `unicity:vault:delete:v1\n{net}\n{ownerId}\n{nonce}` (NOT the golden `account-delete:v1` scheme fixture); fresh single-use nonce; stale/missing sig rejected client-side.

## Tests
106 vault tests green (+17), `tsc --noEmit` clean, eslint clean. Fake-vault-server extended with faithful `/v1/history` + account routes. token-engine SDK-import boundary + FROZEN `StorageEventType` union untouched. `index.ts` exports stay for Phase 8.1.

## Reviewed (adversarial)
PASS — all three fund-critical checks hold: empty-import gate (no path opens it without a successful load), identity fencing (every await re-checked, client bound to flush-start owner), Quest-XP address restore (independent-derivation byte-equality). Two non-blocking observations: a foreclosed reserved-version edge; a single-key/multi-address caveat for the future PaymentsModule per-address wiring (carried into Phase 8).