### PR TITLE
feat(vault): Phase 8.1+8.2 — normalizeVaultNetwork + exports + epoch-gated reset

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -526,5 +526,61 @@ export type {
 // TxfToken type for serialization workflows
 export type { TxfToken } from './types/txf';
 
+// =============================================================================
+// Token-Vault v2 (remote storage + courier delivery)
+// =============================================================================
+// The Token-Vault v2 client surface: the remote (operator-blind) token storage
+// provider, the reference courier delivery transport, the `vault-aead` crypto
+// module, and `normalizeVaultNetwork` (the canonical NETWORK literal at the vault
+// AEAD/wireKey/AAD boundary — `testnet → testnet2`; storage scoping elsewhere
+// still uses the literal network name).
+
+export { RemoteTokenStorageProvider } from './storage/remote/RemoteTokenStorageProvider';
+export type { RemoteTokenStorageConfig } from './storage/remote/RemoteTokenStorageProvider';
+
+export { CourierDeliveryProvider } from './transport/courier/CourierDeliveryProvider';
+export type {
+  CourierDeliveryConfig,
+  CourierJournalStore,
+  V2TransferSink,
+} from './transport/courier/CourierDeliveryProvider';
+export type {
+  TokenDeliveryTransport,
+  TokenDeliveryCapabilities,
+  TokenEnvelope,
+  DeliveryHandle,
+  SignedReceipt,
+} from './transport/courier/types';
+
+export { normalizeVaultNetwork } from './storage/remote/normalize-network';
+
+// vault-aead public crypto API (seal/open, key derivation, on-curve guard,
+// AAD-bound vault entries, courier envelope framing).
+export {
+  seal,
+  open,
+  lengthDelim,
+  u64be,
+  u32be,
+  deriveVaultKey,
+  deriveCourierKey,
+  assertOnCurve,
+  ecdhX,
+  sealVaultEntry,
+  openVaultEntry,
+  sealCourierEnvelope,
+  openCourierEnvelope,
+  packCourier,
+  unpackCourier,
+} from './vault-aead/index';
+export type {
+  VaultEntryPayload,
+  SealVaultEntryParams,
+  OpenVaultEntryParams,
+  SealCourierParams,
+  OpenCourierParams,
+  PackedCourier,
+} from './vault-aead/index';
+
 // Master-key provider status re-export (already re-exported via ./types barrel,
 // but keeping explicit here for consumers that want to import direct types).

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -485,6 +485,9 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
         epochSig: page.epochSig,
       });
       if (!gate.ok) return this.rollback(gate.reason);
+      // Task 8.2 / #14: a server-key-VERIFIED strict epoch bump is a SANCTIONED
+      // reset, not an alarm — drop local state and re-baseline at the new epoch.
+      if (gate.reset) return this.handleSanctionedReset();
       pages.push(...page.entries);
       lastEpochSig = page.epochSig;
       lastEpoch = page.syncEpoch;
@@ -497,6 +500,61 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     await this.delta.commitBaseline(since, lastEpoch, lastEpochSig);
     const recovered = await this.loadHistory(); // single-channel history (Task 7.4)
     return this.materialize(pages, recovered);
+  }
+
+  /**
+   * Sanctioned-reset path (Task 8.2 / finding #14). A server-key-verified strict
+   * epoch bump was recognised, so the operator legitimately reset the network (a
+   * testnet wipe). DROP all local vault state and re-paginate the fresh seq space
+   * from `since=0`, then re-baseline the signed root at the NEW epoch/cursor — NO
+   * rollback alarm. This is only ever reached AFTER `ingestPage` verified the bump
+   * against `NETWORKS[net].vaultServerKey`, so it cannot mask a hostile rollback.
+   */
+  private async handleSanctionedReset(): Promise<LoadResult<TData>> {
+    this.dropLocalVaultState();
+    this.delta.beginReset(); // empty accumulator, no stale-root gate for the re-pass
+    const { entries, cursor, epoch, epochSig } = await this.repaginateFromReset();
+    this.delta.foldReset(entries); // re-baseline root reflects the actual reset state
+    this.serverCursor = cursor;
+    await this.delta.commitBaseline(cursor, epoch, epochSig); // persist the NEW epoch
+    const recovered = await this.loadHistory();
+    return this.materialize(entries, recovered);
+  }
+
+  /** Re-pull the post-reset state from `since=0` UNGATED (the reset is sanctioned). */
+  private async repaginateFromReset(): Promise<{ entries: StateEntry[]; cursor: number; epoch: number; epochSig: string }> {
+    const client = this.client();
+    const entries: StateEntry[] = [];
+    let since = 0;
+    let cursor = 0;
+    let epoch = 0;
+    let epochSig = '';
+    for (;;) {
+      const page = await client.getState(since);
+      entries.push(...page.entries);
+      cursor = page.cursor;
+      epoch = page.syncEpoch;
+      epochSig = page.epochSig;
+      if (!page.more || page.cursor <= since) break;
+      since = page.cursor;
+    }
+    return { entries, cursor, epoch, epochSig };
+  }
+
+  /**
+   * Drop all per-owner local vault state for a sanctioned reset: the internal
+   * last-known server view, content hashes, the pagination watermark, the restored
+   * address and the history watermark. The signed baseline is re-persisted fresh by
+   * `commitBaseline`. Storage scope (the literal-network baseline KEY) is unchanged.
+   */
+  private dropLocalVaultState(): void {
+    this.known.clear();
+    this.contentHash.clear();
+    this.serverCursor = 0;
+    this.restoredAddress = null;
+    this.localHistory.clear();
+    this.pushedHistory.clear();
+    this.historyCursor = 0;
   }
 
   /**

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -60,6 +60,7 @@ import type {
 import { LoadDeltaTracker } from './load-delta';
 import type { LocalBaselineStore } from './load-delta';
 import type { EntryState } from './merkle';
+import { normalizeVaultNetwork } from './normalize-network';
 import { AsyncSerialQueue } from '../../impl/shared/ipfs/write-behind-buffer';
 
 const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
@@ -103,6 +104,15 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   readonly type = 'cloud' as const;
 
   private readonly config: RemoteTokenStorageConfig;
+  /**
+   * The CANONICAL vault network literal (`normalizeVaultNetwork(config.network)`).
+   * ALL vault-boundary derivations — AEAD vault key, wireKey, vault-entry AAD,
+   * history seal, the signed root + the server epoch canon — use THIS, so a
+   * wallet configured with the `'testnet'` alias and one configured with
+   * `'testnet2'` share vault keys (DESIGN §7.1). Storage SCOPING stays on the
+   * literal `config.network` (migration-v2 trap) — see the tracker's storageNetwork.
+   */
+  private readonly vaultNetwork: string;
   private identity: FullIdentity | null = null;
   private auth: VaultApiClient | null = null;
   private status: 'disconnected' | 'connecting' | 'connected' | 'error' = 'disconnected';
@@ -150,8 +160,12 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
 
   constructor(config: RemoteTokenStorageConfig) {
     this.config = config;
+    this.vaultNetwork = normalizeVaultNetwork(config.network);
     this.delta = new LoadDeltaTracker({
-      network: config.network,
+      // Sign the root + verify the epoch under the CANONICAL vault literal …
+      network: this.vaultNetwork,
+      // … but scope the local baseline STORAGE key by the LITERAL network.
+      storageNetwork: config.network,
       vaultServerKey: config.vaultServerKey,
       baseline: config.localBaseline,
     });
@@ -193,7 +207,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     this.localHistory.clear();
     this.historyCursor = 0;
     this.auth = new VaultApiClient({
-      network: this.config.network,
+      network: this.vaultNetwork,
       chainPubkey: identity.chainPubkey,
       privateKey: this.config.privateKey,
       deviceId: this.config.deviceId ?? 'sphere-vault',
@@ -297,7 +311,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   }
 
   private sealHistory(record: HistoryRecord): { nonce: string; ct: string } {
-    return sealHistoryRecord(record, this.ownerId(), this.config.privateKey, this.config.network);
+    return sealHistoryRecord(record, this.ownerId(), this.config.privateKey, this.vaultNetwork);
   }
 
   /**
@@ -307,7 +321,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
    * XP-invariant address survives a wipe. Returns `null` once it is on the server.
    */
   private async planReservedAddress(): Promise<PatchOp | null> {
-    const wk = reservedAddressKey(this.config.privateKey, this.config.network);
+    const wk = reservedAddressKey(this.config.privateKey, this.vaultNetwork);
     const cur = this.known.get(wk);
     if (cur && !cur.deleted) return null; // already on the server
     const chainPubkey = this.ownerId();
@@ -315,7 +329,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     const payload = sealReservedAddress(
       { directAddress, chainPubkey, formatVersion: RESERVED_ADDRESS_FORMAT_VERSION },
       this.config.privateKey,
-      this.config.network,
+      this.vaultNetwork,
     );
     return { key: wk, baseVersion: 0, payload };
   }
@@ -327,7 +341,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
       known: this.known,
       wireKeyOf: (plainKey) => this.wireKeyFor(plainKey),
       changed: (wk, value) => this.hasChanged(wk, value),
-      reserved: new Set([reservedAddressKey(this.config.privateKey, this.config.network)]),
+      reserved: new Set([reservedAddressKey(this.config.privateKey, this.vaultNetwork)]),
     });
   }
 
@@ -375,7 +389,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   /** Seal a token value AAD-bound to the version it will have AFTER apply. */
   private sealValue(key: string, version: number, value: unknown): { nonce: string; ct: string } {
     return sealVaultEntry({
-      network: this.config.network,
+      network: this.vaultNetwork,
       ownerId: this.ownerId(),
       key,
       version,
@@ -509,7 +523,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
 
   /** Decrypt + cache one history row, marking it pushed and advancing the cursor. */
   private absorbHistoryRow(row: { dedupKey: string; payload: { nonce: string; ct: string }; seq: number }): HistoryRecord {
-    const record = openHistoryRecord(row.dedupKey, row.payload, this.ownerId(), this.config.privateKey, this.config.network);
+    const record = openHistoryRecord(row.dedupKey, row.payload, this.ownerId(), this.config.privateKey, this.vaultNetwork);
     this.localHistory.set(record.dedupKey, record);
     this.pushedHistory.add(record.dedupKey);
     this.historyCursor = Math.max(this.historyCursor, row.seq);
@@ -555,10 +569,10 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
    * reserved row was present on this page.
    */
   private restoreReservedAddress(entries: StateEntry[]): boolean {
-    const wk = reservedAddressKey(this.config.privateKey, this.config.network);
+    const wk = reservedAddressKey(this.config.privateKey, this.vaultNetwork);
     const row = entries.find((e) => e.key === wk && !e.deleted);
     if (!row) return false;
-    const meta = openReservedAddress(row.payload, this.ownerId(), this.config.privateKey, this.config.network);
+    const meta = openReservedAddress(row.payload, this.ownerId(), this.config.privateKey, this.vaultNetwork);
     this.restoredAddress = meta.directAddress;
     return true;
   }
@@ -635,7 +649,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     const client = this.client();
     const { nonce } = await client.deleteNonce();
     const ownerId = this.ownerId();
-    const signature = signMessage(this.config.privateKey, deleteCanon(this.config.network, ownerId, nonce));
+    const signature = signMessage(this.config.privateKey, deleteCanon(this.vaultNetwork, ownerId, nonce));
     // Client-side freshness guard: never send a missing/empty signature.
     if (!nonce || !signature) throw new Error('vault account delete: missing fresh nonce/signature');
     const res = await client.deleteAccount(nonce, signature);
@@ -664,11 +678,11 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   }
 
   private wireKeyFor(plainKey: string): string {
-    return wireKey(this.config.privateKey, this.config.network, plainKey);
+    return wireKey(this.config.privateKey, this.vaultNetwork, plainKey);
   }
 
   private vaultKey(): Uint8Array {
-    return deriveVaultKey(this.config.privateKey, this.config.network);
+    return deriveVaultKey(this.config.privateKey, this.vaultNetwork);
   }
 
   /** Stable content hash for no-op-update suppression (order-independent JSON). */

--- a/storage/remote/load-delta.ts
+++ b/storage/remote/load-delta.ts
@@ -43,7 +43,19 @@ interface SignedBaseline {
 }
 
 export interface LoadDeltaConfig {
+  /**
+   * The CANONICAL vault network literal (`normalizeVaultNetwork(...)`) — binds the
+   * signed-root message and the `epochCanon` the server epochSig is verified over,
+   * so a `testnet`-aliased and a `testnet2`-configured wallet share the same root /
+   * epoch signing domain.
+   */
   network: string;
+  /**
+   * The LITERAL network name for the local baseline STORAGE key. Storage scoping
+   * stays on the literal (migration-v2 trap), NOT the canonical literal — keep it
+   * distinct from {@link LoadDeltaConfig.network}. Defaults to `network` when omitted.
+   */
+  storageNetwork?: string;
   /** Compressed server signing key (`NETWORKS[net].vaultServerKey`) for epoch verify. */
   vaultServerKey?: string;
   baseline?: LocalBaselineStore;
@@ -202,6 +214,9 @@ export class LoadDeltaTracker {
   }
 
   private baselineKey(): string {
-    return `vault_baseline:${this.config.network}:${this.ownerId}`;
+    // Storage scope uses the LITERAL network (migration-v2 trap), NOT the
+    // canonical vault literal used for signing — see LoadDeltaConfig.
+    const scope = this.config.storageNetwork ?? this.config.network;
+    return `vault_baseline:${scope}:${this.ownerId}`;
   }
 }

--- a/storage/remote/load-delta.ts
+++ b/storage/remote/load-delta.ts
@@ -70,8 +70,13 @@ export interface LoadPage {
   epochSig: string;
 }
 
-/** Gate verdict for one page. */
-export type GateResult = { ok: true } | { ok: false; reason: string };
+/**
+ * Gate verdict for one page. `reset` is set on the `ok` branch when a SANCTIONED
+ * epoch reset was recognised (a server-key-verified strict epoch bump, Task 8.2):
+ * the provider DROPS local vault state + re-baselines at the new epoch instead of
+ * alarming. A normal clean page carries `reset:false`.
+ */
+export type GateResult = { ok: true; reset: boolean } | { ok: false; reason: string };
 
 export class LoadDeltaTracker {
   private readonly config: LoadDeltaConfig;
@@ -116,18 +121,41 @@ export class LoadDeltaTracker {
     }
   }
 
-  /** Ingest one `/state` page: monotonicity + root gate. */
+  /**
+   * Re-arm the tracker for a SANCTIONED-RESET re-pass (Task 8.2). After a verified
+   * strict epoch bump the provider drops local state and re-paginates the fresh
+   * (epoch-bumped) seq space from `since=0`. We seed an EMPTY accumulator and clear
+   * the in-memory baseline so the re-pass does NOT run the stale-root gate against
+   * the pre-reset root — `commitBaseline` then persists a fresh signed root at the
+   * new epoch/cursor. The bump is server-key-verified by `ingestPage` BEFORE this
+   * is ever called, so dropping the baseline here cannot mask a hostile rollback.
+   */
+  beginReset(): void {
+    this.accState = new Map();
+    this.baseline = null;
+  }
+
+  /**
+   * Ingest one `/state` page: monotonicity + root gate.
+   *
+   * A server-key-VERIFIED strict epoch bump is evaluated FIRST and short-circuits
+   * BOTH gates (it is a sanctioned reset, Task 8.2 / finding #14): the page is
+   * reported `ok` with `reset:true`, and the provider drops local state + has the
+   * tracker re-baseline at the new epoch. WITHOUT a verified strict bump, a cursor
+   * regression or a root divergence still alarms (Task 4.2 is NOT weakened).
+   */
   async ingestPage(page: LoadPage): Promise<GateResult> {
     if (this.accState === null) await this.beginLoad(new Map());
     const epochOk = this.recogniseEpoch(page);
+    if (epochOk) return { ok: true, reset: true }; // sanctioned reset — provider drops + re-baselines
     const mono = this.checkMonotonic(page);
-    if (!mono.ok && !epochOk) return mono;
+    if (!mono.ok) return mono;
     this.fold(page.entries);
-    if (this.baseline && !epochOk) {
+    if (this.baseline) {
       const verdict = this.checkRoot();
       if (!verdict.ok) return verdict;
     }
-    return { ok: true };
+    return { ok: true, reset: false };
   }
 
   /** Recognise a server-verified epoch bump (sanctioned reset — 8.2 seam). */
@@ -140,11 +168,21 @@ export class LoadDeltaTracker {
   }
 
   /** Cursor must be non-decreasing relative to the `since` it answered. */
-  private checkMonotonic(page: LoadPage): GateResult {
+  private checkMonotonic(page: LoadPage): { ok: true } | { ok: false; reason: string } {
     if (page.cursor < page.since) {
       return { ok: false, reason: `cursor regressed: ${page.cursor} < since ${page.since}` };
     }
     return { ok: true };
+  }
+
+  /**
+   * Fold the post-reset state into the accumulator (Task 8.2). The reset re-pass
+   * pulls the fresh seq space UNGATED (the bump is already verified), so the
+   * provider folds those entries here before `commitBaseline` signs the new root —
+   * keeping the re-baselined root correct even for a NON-empty reset.
+   */
+  foldReset(entries: StateEntry[]): void {
+    this.fold(entries);
   }
 
   private fold(entries: StateEntry[]): void {
@@ -159,7 +197,7 @@ export class LoadDeltaTracker {
    * writer, so a delta it did not author (no intervening flush advanced the
    * baseline) means the server injected state — a rollback.
    */
-  private checkRoot(): GateResult {
+  private checkRoot(): { ok: true } | { ok: false; reason: string } {
     const folded = computeRoot(this.accState!);
     if (folded !== this.baseline!.root) {
       return { ok: false, reason: 'rollback' };

--- a/storage/remote/normalize-network.ts
+++ b/storage/remote/normalize-network.ts
@@ -1,0 +1,40 @@
+/**
+ * normalizeVaultNetwork — the canonical NETWORK literal at the vault boundary
+ * (Task 8.1, finding #9, DESIGN §7.1).
+ *
+ * The wallet may be configured with the network alias `'testnet'`, which the v2
+ * cutover points at the SAME deployment as `'testnet2'` (same gateway, same trust
+ * base, same vault). Every value the vault derives from the network literal — the
+ * AEAD vault key (`deriveVaultKey`), the opaque wireKey (`wireKey`), and the
+ * vault-entry / courier-envelope AAD — MUST use ONE canonical literal, or a
+ * wallet that switches between the two aliases (or re-derives keys after a config
+ * change) would compute a different key and be unable to open its own blobs.
+ *
+ * `normalizeVaultNetwork` collapses the alias: `'testnet' → 'testnet2'`; every
+ * other network passes through unchanged. Call it at the vault boundary before
+ * deriving any AEAD/wire/AAD material.
+ *
+ * ⚠️ MIGRATION-V2 TRAP — do NOT generalize this into "storage is scoped by the
+ * canonical literal". It is NOT. The rest of the SDK still scopes STORAGE by the
+ * LITERAL network name (`isNetworkScopedAddressKey`, per-address/per-network
+ * operational state in `constants.ts`). This normalization applies ONLY at the
+ * vault AEAD / wireKey / AAD boundary so the two `testnet*` aliases share vault
+ * keys. Conflating the two would silently re-scope unrelated storage.
+ */
+
+/** The alias map: networks whose vault deployment is shared under one canonical name. */
+const VAULT_NETWORK_ALIASES: Readonly<Record<string, string>> = {
+  // v1→v2 cutover: 'testnet' points at the testnet2 deployment (shared vault).
+  testnet: 'testnet2',
+};
+
+/**
+ * Canonicalize a network literal for vault AEAD / wireKey / AAD derivation.
+ * Aliases `'testnet' → 'testnet2'`; all other networks pass through verbatim.
+ *
+ * NOTE: this is the vault-boundary canonical literal ONLY — storage scoping in
+ * the rest of the SDK still uses the literal network name (see the trap above).
+ */
+export function normalizeVaultNetwork(network: string): string {
+  return VAULT_NETWORK_ALIASES[network] ?? network;
+}

--- a/tests/helpers/fake-vault-server.ts
+++ b/tests/helpers/fake-vault-server.ts
@@ -472,6 +472,23 @@ export class FakeVaultServer {
     return this.epoch;
   }
 
+  /**
+   * SANCTIONED-RESET injector (Task 8.2): wipe an owner's vault entries, reset its
+   * seq + cursor allocators to 0, and BUMP the signed epoch (so `/state` now
+   * returns `{cursor:0, entries:[]}` with a strictly-increased, validly-signed
+   * `epochSig`). This is the only thing that distinguishes a real testnet reset
+   * from a hostile rollback — the client must DROP local state + re-baseline, NOT
+   * alarm. Returns the new epoch.
+   */
+  resetOwner(ownerId: string): number {
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      if (this.entries[i].ownerId === ownerId) this.entries.splice(i, 1);
+    }
+    this.seqCounter.set(ownerId, 0);
+    this.cursorCounter.set(ownerId, 0);
+    return this.bumpEpoch();
+  }
+
   /** Force the whole-batch storage watermark (507 path). */
   setStorageFull(full: boolean): void {
     this.storageFull = full;

--- a/tests/integration/vault/vault-testnet-reset.test.ts
+++ b/tests/integration/vault/vault-testnet-reset.test.ts
@@ -1,0 +1,201 @@
+/**
+ * testnet-reset vs hostile-rollback (Task 8.2, finding #14, DESIGN §8.2) against
+ * the in-process fake server.
+ *
+ * A reset is distinguishable from a hostile rollback by ONE thing only: a
+ * server-signed epoch bump (signed under the deployment key whose pubkey ==
+ * `NETWORKS[net].vaultServerKey`, over `epochCanon(net, bumpedEpoch)`).
+ *
+ *  - COMBINED RESET (positive): the server returns `getState{cursor:0, entries:[]}`
+ *    AND a bumped, validly-signed `epochSig`. `load()` SHORT-CIRCUITS the
+ *    cursor-regression / root gate: it DROPS local vault state, RE-BASELINES the
+ *    signed root at the new epoch/cursor, returns `success:true`, and does NOT emit
+ *    `storage:error{reason:'rollback'}`.
+ *  - NEGATIVE: the SAME `cursor:0` regression with an INVALID or ABSENT epoch sig
+ *    fires the rollback gate (Task 4.2): `success:false` + `storage:error{reason:'rollback'}`.
+ *
+ * The rollback event member is EXACTLY `'storage:error'` with `data.reason ===
+ * 'rollback'` — NEVER a `'storage:rollback'` member (the FROZEN union).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import { NETWORKS } from '../../../constants';
+import type { LocalBaselineStore } from '../../../storage/remote/load-delta';
+import type { StorageEvent, TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { StateResponse, VaultHttpClient } from '../../../storage/remote/types';
+import type { FullIdentity } from '../../../types';
+
+const NETWORK = 'testnet2';
+const PRIV = '4f'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+function memStore(): LocalBaselineStore {
+  const m = new Map<string, string>();
+  return { get: async (k) => m.get(k) ?? null, set: async (k, v) => void m.set(k, v) };
+}
+
+interface ProviderOpts {
+  baseline?: LocalBaselineStore;
+  httpClientFactory?: (ownerId: string) => VaultHttpClient;
+}
+
+function makeProvider(server: FakeVaultServer, opts: ProviderOpts = {}): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    privateKey: PRIV,
+    authClient: server.authClient(),
+    httpClientFactory: opts.httpClientFactory ?? ((ownerId) => server.clientFor(ownerId)),
+    localBaseline: opts.baseline,
+    vaultServerKey: NETWORKS[NETWORK].vaultServerKey, // enables the epoch gate
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: 'DIRECT://x', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+describe('epoch-gated testnet reset', () => {
+  it('combined reset (positive): a server-signed epoch bump drops local state, re-baselines, success:true, NO rollback', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const store = memStore();
+    const provider = makeProvider(server, { baseline: store });
+    await provider.initialize();
+
+    // Populate + load: establish a SIGNED baseline at epoch 1 with a non-empty root.
+    await provider.sync(txf({ a: { n: 1 }, b: { n: 2 }, c: { n: 3 } }));
+    const first = await provider.load();
+    expect(first.success).toBe(true);
+    expect(provider.knownCount()).toBeGreaterThan(0); // local vault state is populated
+    const baselineKey = `vault_baseline:${NETWORK}:${PUB}`;
+    const beforeRaw = await store.get(baselineKey);
+    expect(beforeRaw).not.toBeNull();
+    const beforeEpoch = (JSON.parse(beforeRaw!) as { epoch: number }).epoch;
+
+    // The server is RESET: entries wiped, seq reset, epoch bumped + freshly signed.
+    server.resetOwner(PUB);
+    expect(server.entryCount(PUB)).toBe(0);
+
+    const events: StorageEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+    const res = await provider.load();
+
+    // SANCTIONED reset, not an alarm.
+    expect(res.success).toBe(true);
+    expect(events.some((e) => e.type === 'storage:error')).toBe(false);
+    expect(events.some((e) => (e.type as string) === 'storage:rollback')).toBe(false);
+
+    // Local vault state was DROPPED (re-based on the empty reset state).
+    expect(provider.knownCount()).toBe(0);
+    // The signed root was RE-BASELINED at the NEW (strictly-increased) epoch.
+    const afterRaw = await store.get(baselineKey);
+    expect(afterRaw).not.toBeNull();
+    const after = JSON.parse(afterRaw!) as { epoch: number; cursor: number; root: string };
+    expect(after.epoch).toBeGreaterThan(beforeEpoch);
+    expect(after.cursor).toBe(0); // re-baselined at the reset cursor
+  });
+
+  it('negative: the same regression with an INVALID epoch sig fires the rollback gate (success:false + storage:error{rollback})', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const store = memStore();
+    const provider = makeProvider(server, { baseline: store });
+    await provider.initialize();
+    await provider.sync(txf({ a: { n: 1 }, b: { n: 2 }, c: { n: 3 } }));
+    await provider.load(); // baseline at epoch 1
+
+    // A hostile server: mutate an entry (root divergence) AND bump the epoch, but
+    // sign the epoch with a WRONG key — the bump does NOT verify under vaultServerKey.
+    const wrap = (ownerId: string): VaultHttpClient => {
+      const inner = server.clientFor(ownerId);
+      return {
+        patchEntries: (ops) => inner.patchEntries(ops),
+        getState: async (since): Promise<StateResponse> => {
+          const page = await inner.getState(since);
+          // Forge a bumped epoch with an INVALID signature (not the server key).
+          return { ...page, syncEpoch: page.syncEpoch + 5, epochSig: 'ff'.repeat(65) };
+        },
+        appendHistory: (records) => inner.appendHistory(records),
+        historySince: (since) => inner.historySince(since),
+        deleteNonce: () => inner.deleteNonce(),
+        deleteAccount: (nonce, sig) => inner.deleteAccount(nonce, sig),
+      };
+    };
+    const reader = makeProvider(server, { baseline: store, httpClientFactory: wrap });
+    // Mutate a stored entry's ciphertext at the next monotonic seq to force a root
+    // divergence — the wrap forges an INVALID epoch bump over it.
+    const someKey = firstEntryKey(server);
+    server.mutateEntry(PUB, someKey, { nonce: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', ct: 'BBBB' });
+
+    const events: StorageEvent[] = [];
+    reader.onEvent((e) => events.push(e));
+    const res = await reader.load();
+
+    expect(res.success).toBe(false);
+    const err = events.find((e) => e.type === 'storage:error');
+    expect(err).toBeDefined();
+    expect(err!.type).toBe('storage:error'); // FROZEN union member, exactly
+    expect((err!.data as { reason: string }).reason).toBe('rollback');
+    expect(events.some((e) => (e.type as string) === 'storage:rollback')).toBe(false);
+  });
+
+  it('negative: the same regression with an ABSENT epoch sig also fires the rollback gate', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const store = memStore();
+    const provider = makeProvider(server, { baseline: store });
+    await provider.initialize();
+    await provider.sync(txf({ a: { n: 1 }, b: { n: 2 } }));
+    await provider.load();
+
+    // Mutate an entry at the next monotonic seq, NO epoch bump at all (sig empty).
+    const someKey = firstEntryKey(server);
+    const wrap = (ownerId: string): VaultHttpClient => {
+      const inner = server.clientFor(ownerId);
+      return {
+        patchEntries: (ops) => inner.patchEntries(ops),
+        getState: async (since): Promise<StateResponse> => {
+          const page = await inner.getState(since);
+          return { ...page, epochSig: '' }; // absent epoch sig
+        },
+        appendHistory: (records) => inner.appendHistory(records),
+        historySince: (since) => inner.historySince(since),
+        deleteNonce: () => inner.deleteNonce(),
+        deleteAccount: (nonce, sig) => inner.deleteAccount(nonce, sig),
+      };
+    };
+    const reader = makeProvider(server, { baseline: store, httpClientFactory: wrap });
+    server.mutateEntry(PUB, someKey, { nonce: 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC', ct: 'DDDD' });
+
+    const events: StorageEvent[] = [];
+    reader.onEvent((e) => events.push(e));
+    const res = await reader.load();
+
+    expect(res.success).toBe(false);
+    const err = events.find((e) => e.type === 'storage:error');
+    expect(err).toBeDefined();
+    expect((err!.data as { reason: string }).reason).toBe('rollback');
+    expect(events.some((e) => (e.type as string) === 'storage:rollback')).toBe(false);
+  });
+});
+
+/** The first stored vault wire key for the owner (a non-reserved test entry). */
+function firstEntryKey(server: FakeVaultServer): string {
+  // The fake stores entries privately; read one via the public getEntry probe by
+  // scanning the keys we flushed. We flushed token keys + the reserved-address key;
+  // any present key forces a root divergence when mutated.
+  const rows = (server as unknown as { entries: { ownerId: string; key: string; deleted: boolean }[] }).entries;
+  const row = rows.find((e) => e.ownerId === PUB && !e.deleted);
+  if (!row) throw new Error('firstEntryKey: no entry to mutate');
+  return row.key;
+}

--- a/tests/unit/vault/normalize-network.test.ts
+++ b/tests/unit/vault/normalize-network.test.ts
@@ -1,0 +1,123 @@
+/**
+ * normalizeVaultNetwork + public exports (Task 8.1, finding #9, DESIGN §7.1).
+ *
+ * The vault NETWORK literal is canonicalized `testnet → testnet2` at the vault
+ * boundary so the AEAD vault key, the wireKey and the entry AAD all derive from
+ * ONE canonical literal. A wallet configured with the alias `'testnet'` and one
+ * configured with `'testnet2'` therefore share vault keys — an entry sealed under
+ * one opens under the other (the §7.1 network-switch re-derive).
+ *
+ * ⚠️ Migration-v2 trap (asserted in code comments, not weakened here): the literal
+ * is canonicalized ONLY at the vault boundary (AEAD / wireKey / AAD). STORAGE
+ * scoping elsewhere in the SDK is still keyed by the LITERAL network name — these
+ * two facts must not be conflated.
+ *
+ * The public-surface half asserts the main `index.ts` re-exports the vault
+ * providers, the `vault-aead` public API, `normalizeVaultNetwork`, and the
+ * relevant public types (compile-checked via the `tsc --noEmit` step + the
+ * runtime value checks below).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { normalizeVaultNetwork } from '../../../storage/remote/normalize-network';
+import { deriveVaultKey } from '../../../vault-aead/derive';
+import { wireKey } from '../../../storage/remote/wire-key';
+import { sealVaultEntry, openVaultEntry } from '../../../vault-aead/entry';
+
+import * as sdk from '../../../index';
+
+const PRIV = '7d'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+
+describe('normalizeVaultNetwork', () => {
+  it('aliases testnet → testnet2 and passes other networks through unchanged', () => {
+    expect(normalizeVaultNetwork('testnet')).toBe('testnet2');
+    expect(normalizeVaultNetwork('testnet2')).toBe('testnet2');
+    expect(normalizeVaultNetwork('mainnet')).toBe('mainnet');
+    expect(normalizeVaultNetwork('dev')).toBe('dev');
+  });
+
+  it('§7.1 round-trip: an entry sealed under the testnet alias opens after a testnet2 re-derive', () => {
+    // Seal configured with the alias 'testnet'; re-derive keys configured with
+    // 'testnet2'. Both go through normalizeVaultNetwork → identical canonical
+    // literal → identical AEAD vault key + wireKey → the blob survives the switch.
+    const sealNet = normalizeVaultNetwork('testnet');
+    const openNet = normalizeVaultNetwork('testnet2');
+    expect(sealNet).toBe(openNet);
+
+    const plainKey = 'token-abc';
+    const sealKey = deriveVaultKey(PRIV, sealNet);
+    const openKey = deriveVaultKey(PRIV, openNet);
+    expect(bytesToHex(sealKey)).toBe(bytesToHex(openKey)); // same canonical literal → same key
+
+    const wkSeal = wireKey(PRIV, sealNet, plainKey);
+    const wkOpen = wireKey(PRIV, openNet, plainKey);
+    expect(wkSeal).toBe(wkOpen); // wireKey survives the alias too
+
+    const plaintext = new TextEncoder().encode(JSON.stringify({ amount: '1000000' }));
+    const payload = sealVaultEntry({
+      network: sealNet,
+      ownerId: PUB,
+      key: wkSeal,
+      version: 1,
+      plaintext,
+      key32: sealKey,
+    });
+    // The re-derived (testnet2) side opens it: same network/owner/key/version AAD.
+    const opened = openVaultEntry({
+      network: openNet,
+      ownerId: PUB,
+      key: wkOpen,
+      version: 1,
+      payload,
+      key32: openKey,
+    });
+    expect(bytesToHex(opened)).toBe(bytesToHex(plaintext));
+  });
+
+  it('a NON-normalized testnet seal cannot be opened by a testnet2 re-derive (proves the alias is load-bearing)', () => {
+    // Sealed with the RAW alias literal (skipping normalize) → a different AAD
+    // network field → a testnet2 open throws. This is what normalizeVaultNetwork
+    // prevents.
+    const key = deriveVaultKey(PRIV, 'testnet2');
+    const wk = wireKey(PRIV, 'testnet2', 'k');
+    const pt = new TextEncoder().encode('x');
+    const payload = sealVaultEntry({ network: 'testnet', ownerId: PUB, key: wk, version: 1, plaintext: pt, key32: key });
+    expect(() =>
+      openVaultEntry({ network: 'testnet2', ownerId: PUB, key: wk, version: 1, payload, key32: key }),
+    ).toThrow();
+  });
+});
+
+describe('public vault exports (index.ts)', () => {
+  it('re-exports the vault providers as constructable classes', () => {
+    expect(typeof sdk.RemoteTokenStorageProvider).toBe('function');
+    expect(typeof sdk.CourierDeliveryProvider).toBe('function');
+  });
+
+  it('re-exports normalizeVaultNetwork', () => {
+    expect(typeof sdk.normalizeVaultNetwork).toBe('function');
+    expect(sdk.normalizeVaultNetwork('testnet')).toBe('testnet2');
+  });
+
+  it('re-exports the vault-aead public API', () => {
+    expect(typeof sdk.seal).toBe('function');
+    expect(typeof sdk.open).toBe('function');
+    expect(typeof sdk.deriveVaultKey).toBe('function');
+    expect(typeof sdk.deriveCourierKey).toBe('function');
+    expect(typeof sdk.lengthDelim).toBe('function');
+    expect(typeof sdk.u64be).toBe('function');
+    expect(typeof sdk.u32be).toBe('function');
+    expect(typeof sdk.assertOnCurve).toBe('function');
+    expect(typeof sdk.ecdhX).toBe('function');
+    expect(typeof sdk.sealVaultEntry).toBe('function');
+    expect(typeof sdk.openVaultEntry).toBe('function');
+    expect(typeof sdk.sealCourierEnvelope).toBe('function');
+    expect(typeof sdk.openCourierEnvelope).toBe('function');
+    expect(typeof sdk.packCourier).toBe('function');
+    expect(typeof sdk.unpackCourier).toBe('function');
+  });
+});

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -19,6 +19,7 @@ import type { V2TransferPayload } from '../../types/v2-transfer';
 import { isV2TransferPayload } from '../../types/v2-transfer';
 import { signMessage, verifySignedMessage } from '../../core/crypto';
 import { sealCourierEnvelope, openCourierEnvelope } from '../../vault-aead/courier';
+import { normalizeVaultNetwork } from '../../storage/remote/normalize-network';
 import { courierEntryId } from './entryId';
 import { courierAckTemplate } from './ack-template';
 import type {
@@ -91,10 +92,19 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
   readonly capabilities: TokenDeliveryCapabilities;
 
   private readonly config: CourierDeliveryConfig;
+  /**
+   * The CANONICAL vault network literal (`normalizeVaultNetwork(config.network)`).
+   * Used for the courier envelope AAD and the signed ack template, so a sender on
+   * the `'testnet'` alias and a recipient on `'testnet2'` derive the same envelope
+   * key/AAD and agree on the ack message. Storage SCOPING (read pointer, ack/sent
+   * journals) stays on the LITERAL `config.network` (migration-v2 trap).
+   */
+  private readonly vaultNetwork: string;
   private identity: FullIdentity | null = null;
 
   constructor(config: CourierDeliveryConfig) {
     this.config = config;
+    this.vaultNetwork = normalizeVaultNetwork(config.network);
     this.capabilities = {
       async: true,
       ack: true,
@@ -153,7 +163,7 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
     };
     const plaintext = new TextEncoder().encode(JSON.stringify(payload));
     return sealCourierEnvelope({
-      network: this.config.network,
+      network: this.vaultNetwork,
       senderPriv: me.privateKey,
       senderPubkey: me.chainPubkey,
       recipientPubkey: envelope.recipientChainPubkey,
@@ -219,7 +229,7 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
     item: { entryId: string; senderPubkey: string; ciphertext: string },
   ): V2TransferPayload {
     const pt = openCourierEnvelope({
-      network: this.config.network,
+      network: this.vaultNetwork,
       recipientPriv: me.privateKey,
       senderPubkey: item.senderPubkey,
       recipientPubkey: me.chainPubkey,
@@ -290,7 +300,7 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
     const me = this.requireIdentity();
     const client = this.config.httpClientFactory(me.chainPubkey);
     const { serverNonce } = await client.ackNonce(entryId);
-    const tmpl = courierAckTemplate(this.config.network, senderPubkey, entryId, serverNonce);
+    const tmpl = courierAckTemplate(this.vaultNetwork, senderPubkey, entryId, serverNonce);
     const ackSig = signMessage(me.privateKey, tmpl);
     const { result } = await client.ack({ entryId, ackSig });
     if (result === 'claimed' || result === 'alreadyClaimed') {
@@ -389,7 +399,7 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
     item: { entryId: string; recipientPubkey: string; ackSig: string | null; ackNonce: string | null },
   ): boolean {
     if (!item.ackSig || !item.ackNonce) return false;
-    const tmpl = courierAckTemplate(this.config.network, me.chainPubkey, item.entryId, item.ackNonce);
+    const tmpl = courierAckTemplate(this.vaultNetwork, me.chainPubkey, item.entryId, item.ackNonce);
     return verifySignedMessage(tmpl, item.ackSig, item.recipientPubkey);
   }
 


### PR DESCRIPTION
Part B Phase 8 Tasks 8.1 + 8.2 — the vault SDK public surface + the epoch-gated reset path.

## Tasks (strict TDD, one commit each)
- **8.1** `feat(vault): normalizeVaultNetwork + public exports` — `normalizeVaultNetwork('testnet')==='testnet2'` (alias at the vault boundary so a testnet- and a testnet2-config wallet share AEAD/wire keys); **storage scoping still uses the LITERAL network name** (migration-v2 trap — local baseline + courier journal keys stay literal). `index.ts` now re-exports `RemoteTokenStorageProvider`, `CourierDeliveryProvider`, the `vault-aead` API, `normalizeVaultNetwork`, and the public provider/transport types.
- **8.2** `feat(vault): epoch-gated testnet reset vs rollback` — `load()` verifies the `/state` `epochSig` against `NETWORKS[net].vaultServerKey` over `epochCanon(net, syncEpoch)` AND requires a STRICT epoch increase BEFORE the cursor-regression/root gate. A verified strict bump → drop local vault state, re-paginate from `since=0`, re-derive the signed root from the wallet's view, persist the NEW epoch, `success:true`, NO rollback event. An invalid/absent/non-increasing epoch with a regression → the existing rollback alarm fires. The only sanctioned root reset (DESIGN §5.4).

## Tests
115 vault tests green (+9), `tsc --noEmit` clean, eslint clean. Fake server gained `resetOwner()` (wipe + bump+sign epoch). 4.2 anti-rollback + 6.4 pagination unchanged and green (no weakening).

## Reviewed (adversarial)
PASS. Epoch gate airtight — reset short-circuit fires ONLY on {vaultServerKey present, sig verifies over exactly epochCanon(net, syncEpoch), strict epoch increase}; no bypass on absent/wrong-epoch/non-increasing/wrong-key. 4.2 strictly additive (unsigned rollback still alarms). Re-baseline re-derives root from the wallet view + persists the new epoch (replay-protected). FROZEN `StorageEventType` union + token-engine boundary untouched.

Remaining: Task 8.3 (real fetch-based HTTP clients + cross-repo e2e against in-process token-api) lands next.