### PR TITLE
feat(vault): Phase 8.3 — real fetch HTTP clients + in-process token-api e2e

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -554,6 +554,28 @@ export type {
 
 export { normalizeVaultNetwork } from './storage/remote/normalize-network';
 
+// Real fetch HTTP clients (Task 8.3): the swap-in for the in-memory fakes — the
+// raw auth client, the authenticated vault data client, the courier client, and a
+// convenience factory that builds the two authenticated clients over one shared
+// JWT/refresh session (a `VaultApiClient`, or a provider's `authTokenSource()`).
+export {
+  HttpVaultAuthClient,
+  HttpVaultClient,
+  HttpCourierClient,
+  VaultHttpError,
+  createVaultHttpClients,
+  createVaultAuthClient,
+} from './storage/remote/http/index';
+export type {
+  HttpVaultAuthClientConfig,
+  HttpVaultClientConfig,
+  HttpCourierClientConfig,
+  VaultHttpClientsConfig,
+  VaultHttpClients,
+  VaultTokenSource,
+  FetchLike,
+} from './storage/remote/http/index';
+
 // vault-aead public crypto API (seal/open, key derivation, on-curve guard,
 // AAD-bound vault entries, courier envelope framing).
 export {

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -727,6 +727,17 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     return this.auth;
   }
 
+  /**
+   * The provider's live JWT source (Task 8.3 wiring). The REAL `HttpVaultClient`
+   * reads the Bearer JWT + drives the serialized refresh through this same
+   * `VaultApiClient`, so the data client and the provider share ONE auth session.
+   * `setIdentity()` must have run first. Resolved lazily by the http-client factory
+   * (the factory closure is supplied at construction, before `setIdentity`).
+   */
+  authTokenSource(): VaultApiClient {
+    return this.requireAuth();
+  }
+
   private ownerId(): string {
     return this.requireIdentity().chainPubkey;
   }

--- a/storage/remote/http/HttpVaultAuthClient.ts
+++ b/storage/remote/http/HttpVaultAuthClient.ts
@@ -1,0 +1,80 @@
+/**
+ * HttpVaultAuthClient (Task 8.3, DESIGN §4) — the REAL fetch implementation of the
+ * raw auth seam {@link VaultAuthHttpClient}, against `POST {vaultUrl}/v1/auth/*`.
+ *
+ * It is the swap-in for the fake server's `authClient()`: `VaultApiClient` wraps it
+ * with challenge-template verification + serialized refresh, so this layer carries
+ * ONLY the wire mapping:
+ *  - challenge → `{nonce,challenge,expiresAt}` (200).
+ *  - verify / refresh → `{jwt,refreshToken}` (200) or **`null` on a 401** (bad
+ *    signature / stale-or-reused token) — the 401 is modelled as `null`, never an
+ *    error, exactly as the interface promises.
+ *  - logout → 204 (Bearer); any 2xx is accepted.
+ */
+
+import type {
+  AuthTokens,
+  ChallengeResponse,
+  VaultAuthHttpClient,
+  VerifyRequest,
+} from '../types';
+import { joinUrl, postJson, VaultHttpError } from './http-core';
+import type { FetchLike } from './http-core';
+
+export interface HttpVaultAuthClientConfig {
+  /** Vault base URL — `NETWORKS[network].vaultUrl`. */
+  vaultUrl: string;
+  /** Defaults to the global `fetch`; injectable for tests / custom agents. */
+  fetchImpl?: FetchLike;
+}
+
+export class HttpVaultAuthClient implements VaultAuthHttpClient {
+  private readonly base: string;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(config: HttpVaultAuthClientConfig) {
+    this.base = config.vaultUrl;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  /** `POST /v1/auth/challenge {pubkey}` → the literal challenge to sign. */
+  challenge(pubkey: string): Promise<ChallengeResponse> {
+    return postJson<ChallengeResponse>(this.fetchImpl, this.base, '/v1/auth/challenge', { pubkey });
+  }
+
+  /** `POST /v1/auth/verify` — `null` on a 401 (the server rejected the signature). */
+  verify(req: VerifyRequest): Promise<AuthTokens | null> {
+    return this.tokensOrNull('/v1/auth/verify', req);
+  }
+
+  /** `POST /v1/auth/refresh {refreshToken}` — `null` on a 401 (stale / reused). */
+  refresh(refreshToken: string): Promise<AuthTokens | null> {
+    return this.tokensOrNull('/v1/auth/refresh', { refreshToken });
+  }
+
+  /** `POST /v1/auth/logout {sessionId}` — best-effort; any 2xx (incl. 204) is fine. */
+  async logout(sessionId: string): Promise<void> {
+    const res = await this.fetchImpl(joinUrl(this.base, '/v1/auth/logout'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId }),
+    });
+    if (!res.ok) throw new VaultHttpError(res.status, '/v1/auth/logout', await res.text());
+  }
+
+  /**
+   * POST a JSON body to a token endpoint, returning the token pair on 200 and
+   * `null` on a 401 (the interface's model of a rejected signature / stale token).
+   * Any other non-2xx is a real failure → throw.
+   */
+  private async tokensOrNull(path: string, body: unknown): Promise<AuthTokens | null> {
+    const res = await this.fetchImpl(joinUrl(this.base, path), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (res.status === 401) return null;
+    if (!res.ok) throw new VaultHttpError(res.status, path, await res.text());
+    return (await res.json()) as AuthTokens;
+  }
+}

--- a/storage/remote/http/HttpVaultClient.ts
+++ b/storage/remote/http/HttpVaultClient.ts
@@ -1,0 +1,131 @@
+/**
+ * HttpVaultClient (Task 8.3, DESIGN §5.4/§5.6/§7.4) — the REAL fetch implementation
+ * of the authenticated data seam {@link VaultHttpClient}, against the Bearer-gated
+ * `{vaultUrl}/v1/*` endpoints. The swap-in for the fake server's `clientFor(ownerId)`.
+ *
+ * The owner (`ownerId = chainPubkey`) is NOT a body field — it is carried by the
+ * JWT minted by {@link VaultApiClient}. This client reads that JWT (and drives one
+ * serialized refresh on a 401) through the injected {@link VaultTokenSource}.
+ *
+ * Two wire quirks it honours exactly:
+ *  - **507 is NOT an error.** A storage-watermark 507 on `PATCH /v1/entries` carries
+ *    a full {@link PatchResponse} body (the route does `reply.code(status).send(body)`),
+ *    so the client PARSES and RETURNS it (`okStatuses: [507]`). The provider then
+ *    folds `rejected[].reason === 'insufficient_storage'`. Other non-2xx throw.
+ *  - **401 → ONE refresh + retry** (DESIGN §4.3), serialized in `VaultApiClient`.
+ */
+
+import type {
+  AccountDeleteResponse,
+  DeleteNonceResponse,
+  HistoryAppendRecord,
+  HistoryAppendResponse,
+  HistorySinceResponse,
+  PatchOp,
+  PatchResponse,
+  StateResponse,
+  VaultHttpClient,
+} from '../types';
+import { authedJson } from './http-core';
+import type { FetchLike, VaultTokenSource } from './http-core';
+
+/** A 507 body is still a valid PatchResponse — never thrown (DESIGN §5.4). */
+const PATCH_OK_STATUSES = [507];
+
+export interface HttpVaultClientConfig {
+  /** Vault base URL — `NETWORKS[network].vaultUrl`. */
+  vaultUrl: string;
+  /** The JWT + serialized-refresh seam (a `VaultApiClient` satisfies it). */
+  auth: VaultTokenSource;
+  /** Defaults to the global `fetch`; injectable for tests. */
+  fetchImpl?: FetchLike;
+}
+
+export class HttpVaultClient implements VaultHttpClient {
+  private readonly base: string;
+  private readonly auth: VaultTokenSource;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(config: HttpVaultClientConfig) {
+    this.base = config.vaultUrl;
+    this.auth = config.auth;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  /** `PATCH /v1/entries {ops}` — 200 OR 507 both return a `PatchResponse` body. */
+  patchEntries(ops: PatchOp[]): Promise<PatchResponse> {
+    return this.call<PatchResponse>({
+      method: 'PATCH',
+      path: '/v1/entries',
+      body: { ops },
+      okStatuses: PATCH_OK_STATUSES,
+    });
+  }
+
+  /** `GET /v1/state?since=<cursor>`. */
+  getState(since: number): Promise<StateResponse> {
+    return this.call<StateResponse>({ method: 'GET', path: `/v1/state?since=${since}` });
+  }
+
+  /** `POST /v1/history {records}` — idempotent append; `{accepted, rejected}`. */
+  appendHistory(records: HistoryAppendRecord[]): Promise<HistoryAppendResponse> {
+    return this.call<HistoryAppendResponse>({
+      method: 'POST',
+      path: '/v1/history',
+      body: { records },
+    });
+  }
+
+  /** `GET /v1/history?since=<seq>`. */
+  historySince(since: number): Promise<HistorySinceResponse> {
+    return this.call<HistorySinceResponse>({ method: 'GET', path: `/v1/history?since=${since}` });
+  }
+
+  /** `POST /v1/account/delete-nonce` — a fresh single-use delete nonce. */
+  deleteNonce(): Promise<DeleteNonceResponse> {
+    return this.call<DeleteNonceResponse>({
+      method: 'POST',
+      path: '/v1/account/delete-nonce',
+      body: {},
+    });
+  }
+
+  /** `DELETE /v1/account {nonce, signature}` — fresh-sig gated; `{ok:false}` on a 401. */
+  async deleteAccount(nonce: string, signature: string): Promise<AccountDeleteResponse> {
+    // A bad/stale signature is a 401 here; the route models it as `{ok:false}` and
+    // the provider returns the boolean. We surface `{ok:false}` rather than throwing.
+    try {
+      return await this.call<AccountDeleteResponse>({
+        method: 'DELETE',
+        path: '/v1/account',
+        body: { nonce, signature },
+      });
+    } catch (err) {
+      if (isAccountUnauthorized(err)) return { ok: false };
+      throw err;
+    }
+  }
+
+  /** One authenticated round trip (Bearer + 401-refresh-retry) to a JSON endpoint. */
+  private call<T>(req: {
+    method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+    path: string;
+    body?: unknown;
+    okStatuses?: number[];
+  }): Promise<T> {
+    return authedJson<T>(this.fetchImpl, this.base, this.auth, req);
+  }
+}
+
+/**
+ * A 401 that survived the single refresh+retry on `DELETE /v1/account` means the
+ * delete signature itself was rejected (fresh-sig gate) — the server's `{ok:false}`,
+ * not a transport failure. Mapped to `{ok:false}` so the caller returns `false`.
+ */
+function isAccountUnauthorized(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    err.name === 'VaultHttpError' &&
+    (err as { status?: number }).status === 401
+  );
+}

--- a/storage/remote/http/http-core.ts
+++ b/storage/remote/http/http-core.ts
@@ -1,0 +1,139 @@
+/**
+ * Shared fetch core for the REAL token-api HTTP clients (Task 8.3, DESIGN §4/§5/§6).
+ *
+ * Three concerns live here so the per-endpoint clients stay tiny:
+ *  - {@link VaultHttpError} — the typed non-2xx error the data/courier clients throw
+ *    for anything that is NOT a sanctioned status (so callers never see a raw
+ *    `Response`). 401 and 507 are NOT errors at this layer (see below).
+ *  - {@link VaultTokenSource} — the seam onto {@link VaultApiClient}: the Bearer JWT
+ *    plus the serialized refresh. The real clients attach the CURRENT token per
+ *    request and, on a 401, drive exactly ONE refresh and retry (DESIGN §4.3).
+ *  - {@link postJson} / {@link getJson} / {@link authedJson} — the fetch wrappers.
+ *    `authedJson` runs the attach → 401? → refresh → retry-once cycle; a treat-as-ok
+ *    predicate lets the PATCH path accept 507 as a valid {@link PatchResponse} body.
+ */
+
+/** A non-2xx (non-sanctioned) response from the vault — carries the status + body text. */
+export class VaultHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly path: string,
+    readonly bodyText: string,
+  ) {
+    super(`vault http ${status} on ${path}: ${bodyText.slice(0, 200)}`);
+    this.name = 'VaultHttpError';
+  }
+}
+
+/**
+ * The auth seam the authenticated clients read: the live JWT plus the serialized
+ * refresh. {@link VaultApiClient} satisfies this structurally (its `token` getter
+ * and `refresh()`), so the real client never re-implements refresh bookkeeping.
+ */
+export interface VaultTokenSource {
+  /** The current JWT, or `null` until `authenticate()` has run. */
+  readonly token: string | null;
+  /** Rotate the JWT (serialized; concurrent callers share one in-flight promise). */
+  refresh(): Promise<string>;
+}
+
+/** The `fetch` implementation — injectable so tests can pass a custom one if needed. */
+export type FetchLike = typeof fetch;
+
+/** Build `{vaultUrl}{path}` with the base's trailing slash collapsed. */
+export function joinUrl(base: string, path: string): string {
+  return `${base.replace(/\/+$/, '')}${path}`;
+}
+
+/** Bearer header for a token (empty when unauthenticated — the server then 401s). */
+function bearer(token: string | null): Record<string, string> {
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+/** Parse a JSON body, throwing a typed error if it is not valid JSON. */
+async function parseJson<T>(res: Response, path: string): Promise<T> {
+  const text = await res.text();
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new VaultHttpError(res.status, path, `non-JSON body: ${text.slice(0, 120)}`);
+  }
+}
+
+/** UNAUTHENTICATED `POST {base}{path}` with a JSON body; 2xx → parsed JSON. */
+export async function postJson<T>(
+  fetchImpl: FetchLike,
+  base: string,
+  path: string,
+  body: unknown,
+): Promise<T> {
+  const res = await fetchImpl(joinUrl(base, path), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new VaultHttpError(res.status, path, await res.text());
+  return parseJson<T>(res, path);
+}
+
+/** Options for one authenticated request (after the Bearer + refresh cycle). */
+export interface AuthedRequest {
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  path: string;
+  /** JSON body for write methods; omitted for GET. */
+  body?: unknown;
+  /**
+   * Status codes whose BODY is still a valid response to parse (never thrown). The
+   * PATCH path passes `[507]` so a storage-watermark 507 returns its PatchResponse.
+   */
+  okStatuses?: number[];
+}
+
+/** True when a status is 2xx or in the caller's treat-as-ok set (e.g. 507 for PATCH). */
+function isOk(status: number, okStatuses?: number[]): boolean {
+  return (status >= 200 && status < 300) || (okStatuses?.includes(status) ?? false);
+}
+
+/**
+ * One authenticated round trip with the 401→refresh→retry-once cycle (DESIGN §4.3).
+ * Attaches the current Bearer JWT; on a 401 it drives ONE serialized refresh and
+ * retries; any other non-ok status throws {@link VaultHttpError}. A status in
+ * `okStatuses` (e.g. 507) is parsed as a normal body, never thrown.
+ */
+export async function authedJson<T>(
+  fetchImpl: FetchLike,
+  base: string,
+  auth: VaultTokenSource,
+  req: AuthedRequest,
+): Promise<T> {
+  const first = await sendAuthed(fetchImpl, base, auth.token, req);
+  if (first.status !== 401) return finishAuthed<T>(first, req);
+  // 401 → rotate the JWT exactly once and retry with the fresh token.
+  await auth.refresh();
+  const retry = await sendAuthed(fetchImpl, base, auth.token, req);
+  return finishAuthed<T>(retry, req);
+}
+
+/** Issue one authenticated fetch with the given token attached. */
+function sendAuthed(
+  fetchImpl: FetchLike,
+  base: string,
+  token: string | null,
+  req: AuthedRequest,
+): Promise<Response> {
+  const headers: Record<string, string> = { ...bearer(token) };
+  if (req.body !== undefined) headers['content-type'] = 'application/json';
+  return fetchImpl(joinUrl(base, req.path), {
+    method: req.method,
+    headers,
+    body: req.body !== undefined ? JSON.stringify(req.body) : undefined,
+  });
+}
+
+/** Map a settled response to parsed JSON, throwing on a non-ok (non-sanctioned) status. */
+async function finishAuthed<T>(res: Response, req: AuthedRequest): Promise<T> {
+  if (!isOk(res.status, req.okStatuses)) {
+    throw new VaultHttpError(res.status, req.path, await res.text());
+  }
+  return parseJson<T>(res, req.path);
+}

--- a/storage/remote/http/index.ts
+++ b/storage/remote/http/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Real fetch HTTP clients for the Token-Vault v2 (Task 8.3) — the public barrel.
+ *
+ * Phase 6/7 ran the providers against in-memory fakes; this is the REAL layer over
+ * `fetch` against `NETWORKS[net].vaultUrl`:
+ *  - {@link HttpVaultAuthClient} — raw `/v1/auth/*` (challenge / verify / refresh / logout).
+ *  - {@link HttpVaultClient} — authenticated `/v1/entries` · `/state` · `/history` ·
+ *    `/account/*` (Bearer JWT + 401-refresh-retry; a 507 PATCH body is a valid response).
+ *  - {@link HttpCourierClient} — authenticated `/v1/courier/*`.
+ *
+ * {@link createVaultHttpClients} is the convenience factory: given a base URL + a
+ * {@link VaultTokenSource} (a `VaultApiClient`, or `RemoteTokenStorageProvider`'s
+ * `authTokenSource()`), it builds the two authenticated clients sharing that one
+ * auth session.
+ */
+
+import { HttpVaultAuthClient } from './HttpVaultAuthClient';
+import { HttpVaultClient } from './HttpVaultClient';
+import { HttpCourierClient } from '../../../transport/courier/http/HttpCourierClient';
+import type { FetchLike, VaultTokenSource } from './http-core';
+
+export { HttpVaultAuthClient } from './HttpVaultAuthClient';
+export type { HttpVaultAuthClientConfig } from './HttpVaultAuthClient';
+export { HttpVaultClient } from './HttpVaultClient';
+export type { HttpVaultClientConfig } from './HttpVaultClient';
+export { HttpCourierClient } from '../../../transport/courier/http/HttpCourierClient';
+export type { HttpCourierClientConfig } from '../../../transport/courier/http/HttpCourierClient';
+export { VaultHttpError } from './http-core';
+export type { VaultTokenSource, FetchLike } from './http-core';
+
+/** Config for the {@link createVaultHttpClients} convenience factory. */
+export interface VaultHttpClientsConfig {
+  /** Vault base URL — `NETWORKS[network].vaultUrl`. */
+  vaultUrl: string;
+  /** The JWT + serialized-refresh seam shared by the data + courier clients. */
+  auth: VaultTokenSource;
+  /** Defaults to the global `fetch`; injectable for tests / custom agents. */
+  fetchImpl?: FetchLike;
+}
+
+/** The real authenticated clients, built over one shared auth session. */
+export interface VaultHttpClients {
+  vault: HttpVaultClient;
+  courier: HttpCourierClient;
+}
+
+/**
+ * Build the authenticated vault + courier clients over ONE shared {@link
+ * VaultTokenSource}. The raw {@link HttpVaultAuthClient} (which `VaultApiClient`
+ * wraps) is built separately — pass it as the provider's `authClient`.
+ */
+export function createVaultHttpClients(config: VaultHttpClientsConfig): VaultHttpClients {
+  const { vaultUrl, auth, fetchImpl } = config;
+  return {
+    vault: new HttpVaultClient({ vaultUrl, auth, fetchImpl }),
+    courier: new HttpCourierClient({ vaultUrl, auth, fetchImpl }),
+  };
+}
+
+/** Build the raw auth client (the provider's `authClient`) over `fetch`. */
+export function createVaultAuthClient(vaultUrl: string, fetchImpl?: FetchLike): HttpVaultAuthClient {
+  return new HttpVaultAuthClient({ vaultUrl, fetchImpl });
+}

--- a/tests/e2e/support/token-api-boot.ts
+++ b/tests/e2e/support/token-api-boot.ts
@@ -1,0 +1,103 @@
+/**
+ * In-process token-api boot for the cross-repo vault e2e (Task 8.3, finding #13).
+ *
+ * token-api is a SIBLING repo (`../token-api`, `@unicity-sphere/token-api`, ESM, no
+ * package `exports`). It is already compiled to `dist/` and carries its own
+ * `mongodb-memory-server` + `mongoose` + `fastify`. We boot the REAL server in the
+ * SAME test process by:
+ *  1. starting a `mongodb-memory-server` REPLICA SET (transactions need a replset),
+ *     resolved through token-api's own module tree via `createRequire`;
+ *  2. importing token-api's compiled `loadConfig` / `buildDeps` / `buildApp`
+ *     (relative `dist/src/*.js` paths — Node resolves token-api's deps from its own
+ *     `node_modules` because the imported files live under token-api/);
+ *  3. `buildApp(deps)` + `app.listen({ port: 0 })`, returning the base URL.
+ *
+ * `SERVER_SIGN_PRIV = 'a'*64`, whose pubkey == `NETWORKS.testnet2.vaultServerKey`,
+ * so the SDK-under-test verifies the server's signed epoch byte-for-byte.
+ *
+ * If `TOKEN_API_URL` is set, NO local server is booted — the e2e runs against that
+ * remote deploy instead (the boot here is a no-op shell returning the override URL).
+ *
+ * The cross-repo import is dynamic + loosely typed on purpose (the sibling has no
+ * published types we can import); the wire contract is asserted by the test itself.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- dynamic sibling-repo import */
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+/** Server signing key whose pubkey == `NETWORKS.testnet2.vaultServerKey`. */
+export const TEST_SERVER_PRIV = 'a'.repeat(64);
+
+/** Absolute path to the sibling token-api repo root. */
+const TOKEN_API_ROOT = resolve(process.cwd(), '..', 'token-api');
+
+/** A booted (or remote-override) token-api the e2e drives over HTTP. */
+export interface BootedTokenApi {
+  /** Base URL the SDK HTTP clients point at. */
+  baseUrl: string;
+  /** Network the server stamps (`testnet2`). */
+  network: string;
+  /** Tear down the app + mongod (no-op for a remote override). */
+  stop(): Promise<void>;
+}
+
+/** Import a compiled token-api module by its `dist/src/*` path. */
+async function importDist(rel: string): Promise<any> {
+  const url = pathToFileURL(resolve(TOKEN_API_ROOT, 'dist', 'src', rel)).href;
+  return import(url);
+}
+
+/** Resolve + import `mongodb-memory-server` from token-api's own module tree. */
+async function importMms(): Promise<any> {
+  const require = createRequire(pathToFileURL(resolve(TOKEN_API_ROOT, 'package.json')).href);
+  const entry = require.resolve('mongodb-memory-server');
+  return import(pathToFileURL(entry).href);
+}
+
+/**
+ * Boot the REAL token-api in-process against a fresh mongodb-memory-server replica
+ * set — UNLESS `TOKEN_API_URL` overrides it with a remote deploy. Returns the base
+ * URL + a teardown.
+ */
+export async function bootTokenApi(network = 'testnet2'): Promise<BootedTokenApi> {
+  const override = process.env.TOKEN_API_URL;
+  if (override) {
+    return { baseUrl: override.replace(/\/+$/, ''), network, stop: () => Promise.resolve() };
+  }
+  return bootInProcess(network);
+}
+
+/** Start mongod + buildApp + listen; returns the base URL and a full teardown. */
+async function bootInProcess(network: string): Promise<BootedTokenApi> {
+  const mms = await importMms();
+  const { loadConfig } = await importDist('config.js');
+  const { buildDeps } = await importDist('deps.js');
+  const { buildApp } = await importDist('app.js');
+
+  const replset = await mms.MongoMemoryReplSet.create({ replSet: { count: 1 } });
+  await replset.waitUntilRunning();
+  try {
+    const config = loadConfig({
+      NETWORK: network,
+      MONGODB_URI: replset.getUri(),
+      JWT_SECRET: 's'.repeat(32),
+      SERVER_SIGN_PRIV: TEST_SERVER_PRIV,
+    });
+    const deps = await buildDeps(config);
+    const app = await buildApp(deps);
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const { port } = app.server.address() as { port: number };
+    const stop = async (): Promise<void> => {
+      await app.close();
+      await deps.dispose();
+      await replset.stop();
+    };
+    return { baseUrl: `http://127.0.0.1:${port}`, network, stop };
+  } catch (err) {
+    await replset.stop();
+    throw err;
+  }
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/tests/e2e/vault.e2e.test.ts
+++ b/tests/e2e/vault.e2e.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Cross-repo vault e2e (Task 8.3, Deliverable 2 / finding #13).
+ *
+ * Boots the REAL token-api in-process (sibling repo, compiled `dist/`, over a
+ * mongodb-memory-server replica set) and drives the FULL SDK path through the REAL
+ * fetch HTTP clients — no fakes:
+ *  1. AUTH — `VaultApiClient` + `HttpVaultAuthClient`: challenge → verify → JWT.
+ *  2. VAULT CAS — `RemoteTokenStorageProvider` over `HttpVaultClient`: flush a
+ *     couple of token entries + the reserved meta-address, then RELOAD from a fresh
+ *     provider and assert the CAS round-trip + the restored `_meta.address` (#17).
+ *  3. COURIER — `CourierDeliveryProvider` over `HttpCourierClient`: deposit a sealed
+ *     envelope to a second identity, `receive()` + ack it, and confirm the SENDER
+ *     sees the valid ack on `/sent`.
+ *
+ * `TOKEN_API_URL` (optional) points the whole suite at a remote deploy instead of
+ * the in-process app. Defaults to the in-process boot.
+ *
+ * HONESTY: this needs a real mongod (mongodb-memory-server). If the binary cannot
+ * start in CI it will error here — the suite is gated to the e2e config so it never
+ * blocks the unit run, and runs green wherever a mongod is available.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../core/crypto';
+import { deriveDirectAddress } from '../../token-engine/identity';
+import { VaultApiClient } from '../../storage/remote/VaultApiClient';
+import { RemoteTokenStorageProvider } from '../../storage/remote/RemoteTokenStorageProvider';
+import { CourierDeliveryProvider } from '../../transport/courier/CourierDeliveryProvider';
+import { HttpVaultAuthClient } from '../../storage/remote/http/HttpVaultAuthClient';
+import { HttpVaultClient } from '../../storage/remote/http/HttpVaultClient';
+import { HttpCourierClient } from '../../transport/courier/http/HttpCourierClient';
+import { encodeTokenBlob } from '../../token-engine/token-blob';
+import { bootTokenApi, type BootedTokenApi } from './support/token-api-boot';
+import type { FullIdentity } from '../../types';
+import type { TxfStorageDataBase } from '../../storage';
+import type { V2TransferPayload } from '../../types/v2-transfer';
+import type { CourierJournalStore } from '../../transport/courier/CourierDeliveryProvider';
+import type { LocalBaselineStore } from '../../storage/remote/load-delta';
+
+const NETWORK = 'testnet2';
+
+/** A VALID CBOR(TokenBlob) — `courierEntryId`/`courierStateHash` decode it. */
+const TOKEN_ID = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const TOKEN_BYTES = new Uint8Array(40).map((_, i) => (i * 7 + 3) & 0xff);
+const BLOB_HEX = bytesToHex(encodeTokenBlob({ v: 1, network: 0, tokenId: TOKEN_ID, token: TOKEN_BYTES }));
+
+/** Build a deterministic engine-shaped identity from a private key. */
+async function makeIdentity(priv: string): Promise<FullIdentity> {
+  const chainPubkey = bytesToHex(secp256k1.getPublicKey(hexToBytes(priv), true));
+  const directAddress = await deriveDirectAddress(hexToBytes(chainPubkey));
+  return { chainPubkey, privateKey: priv, l1Address: `alpha-${chainPubkey.slice(0, 8)}`, directAddress };
+}
+
+/** A trivial in-memory KV (satisfies both the baseline store and the courier journal). */
+function memKv(): LocalBaselineStore & CourierJournalStore {
+  const m = new Map<string, string>();
+  return {
+    get: (k) => Promise.resolve(m.get(k) ?? null),
+    set: (k, v) => {
+      m.set(k, v);
+      return Promise.resolve();
+    },
+  };
+}
+
+/**
+ * Authenticate a standalone `VaultApiClient` over the real fetch auth client. The
+ * `deviceId` is parameterised because the REAL server enforces a UNIQUE
+ * `(ownerId, deviceId)` session — two providers for the same owner need distinct
+ * device ids (the fake server does not enforce this).
+ */
+async function authedApi(baseUrl: string, id: FullIdentity, deviceId = 'e2e-device'): Promise<VaultApiClient> {
+  const api = new VaultApiClient({
+    network: NETWORK,
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    deviceId,
+    authClient: new HttpVaultAuthClient({ vaultUrl: baseUrl }),
+  });
+  await api.authenticate();
+  return api;
+}
+
+/**
+ * Build a vault storage provider whose data client shares the provider's own auth
+ * session. The factory closure resolves the provider's `authTokenSource()` LAZILY
+ * (via a one-field holder), because the `httpClientFactory` must be supplied at
+ * construction — before the provider instance exists.
+ */
+function makeVaultProvider(baseUrl: string, priv: string, deviceId: string): RemoteTokenStorageProvider {
+  const holder: { provider?: RemoteTokenStorageProvider } = {};
+  holder.provider = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: baseUrl,
+    privateKey: priv,
+    deviceId,
+    authClient: new HttpVaultAuthClient({ vaultUrl: baseUrl }),
+    httpClientFactory: () =>
+      new HttpVaultClient({ vaultUrl: baseUrl, auth: holder.provider!.authTokenSource() }),
+    localBaseline: memKv(),
+  });
+  return holder.provider;
+}
+
+let server: BootedTokenApi;
+
+beforeAll(async () => {
+  server = await bootTokenApi(NETWORK);
+}, 120_000);
+
+afterAll(async () => {
+  await server?.stop();
+});
+
+describe('vault e2e — in-process token-api', () => {
+  it('auth: challenge → verify → JWT against the real server', async () => {
+    const id = await makeIdentity('11'.repeat(32));
+    const api = await authedApi(server.baseUrl, id);
+    const first = api.token;
+    expect(typeof first).toBe('string');
+    expect(first!.length).toBeGreaterThan(0);
+    // A refresh rotates the JWT (proves the real rotating-refresh wire).
+    const rotated = await api.refresh();
+    expect(rotated).not.toBe(first);
+  });
+
+  it('vault CAS round-trip: flush → reload restores entries + reserved address', async () => {
+    const priv = '22'.repeat(32);
+    const id = await makeIdentity(priv);
+    const writer = makeVaultProvider(server.baseUrl, priv, 'writer-device');
+    writer.setIdentity(id);
+    await writer.initialize(); // authenticates + opens the flush gate via first load
+
+    const snapshot: TxfStorageDataBase & Record<string, unknown> = {
+      _meta: { version: 1, address: id.directAddress!, formatVersion: '2.0', updatedAt: Date.now() },
+      _tokenA: { id: 'tokenA', amount: '100' },
+      _tokenB: { id: 'tokenB', amount: '250' },
+    };
+    const synced = await writer.sync(snapshot);
+    expect(synced.success).toBe(true);
+    expect(writer.knownCount()).toBeGreaterThanOrEqual(2); // 2 tokens (+ reserved address)
+
+    // A FRESH provider (cold local state) reloads purely from the server. It must
+    // authenticate first (load() does not — only initialize() does); we drive the
+    // provider's own auth session so its data client carries a live JWT.
+    const reader = makeVaultProvider(server.baseUrl, priv, 'reader-device');
+    reader.setIdentity(id);
+    await reader.authTokenSource().authenticate();
+    const loaded = await reader.load();
+    expect(loaded.success).toBe(true);
+    const data = loaded.data as TxfStorageDataBase;
+    // The reserved meta-address entry was restored (#17 — XP-invariant address).
+    expect(data._meta.address).toBe(id.directAddress);
+    // The two token entries are back as known server rows (2 tokens + reserved slot).
+    expect(reader.knownCount()).toBeGreaterThanOrEqual(3);
+  });
+
+  it('courier: deposit → receive → ack → sender sees the ack on /sent', async () => {
+    const senderId = await makeIdentity('33'.repeat(32));
+    const recipId = await makeIdentity('44'.repeat(32));
+    const senderApi = await authedApi(server.baseUrl, senderId);
+    const recipApi = await authedApi(server.baseUrl, recipId);
+
+    const received: Array<{ payload: V2TransferPayload; sender: string }> = [];
+    const sender = new CourierDeliveryProvider({
+      vaultUrl: server.baseUrl,
+      network: NETWORK,
+      httpClientFactory: () => new HttpCourierClient({ vaultUrl: server.baseUrl, auth: senderApi }),
+      journal: memKv(),
+      onV2Transfer: () => Promise.resolve(),
+    });
+    const recipient = new CourierDeliveryProvider({
+      vaultUrl: server.baseUrl,
+      network: NETWORK,
+      httpClientFactory: () => new HttpCourierClient({ vaultUrl: server.baseUrl, auth: recipApi }),
+      journal: memKv(),
+      onV2Transfer: (payload, s) => {
+        received.push({ payload, sender: s });
+        return Promise.resolve();
+      },
+    });
+    sender.setIdentity(senderId);
+    recipient.setIdentity(recipId);
+
+    // Deposit a sealed envelope (a finished v2 token blob) to the recipient.
+    const handle = await sender.deposit({
+      recipientChainPubkey: recipId.chainPubkey,
+      senderChainPubkey: senderId.chainPubkey,
+      transferId: 'transfer-1',
+      tokenBlobHex: BLOB_HEX,
+      memo: 'gm',
+    });
+    expect(handle.recipientChainPubkey).toBe(recipId.chainPubkey);
+
+    // Recipient pulls, decrypts, feeds handleV2Transfer, then acks.
+    await recipient.receive();
+    expect(received).toHaveLength(1);
+    expect(received[0].payload.type).toBe('V2_TRANSFER');
+    expect(received[0].sender).toBe(senderId.chainPubkey);
+
+    // The SENDER's delivery gate verifies the recipient ackSig on /sent. This
+    // requires the real `/sent` row to carry `ackNonce` (the consumed serverNonce)
+    // so the sender can rebuild + verify the bound ack template (Part A WIRE-2).
+    await sender.pollSent();
+    const receipt = await sender.confirmReceipt(handle);
+    expect(receipt).not.toBeNull();
+    expect(receipt!.recipientChainPubkey).toBe(recipId.chainPubkey);
+    expect(receipt!.entryId).toBe(handle.entryId);
+  });
+});

--- a/tests/helpers/real-vault-socket.ts
+++ b/tests/helpers/real-vault-socket.ts
@@ -1,0 +1,262 @@
+/**
+ * real-vault-socket — wraps the in-memory {@link FakeVaultServer} +
+ * {@link FakeCourierServer} behind a REAL `node:http` listening socket, so the
+ * Phase-8.3 fetch clients are exercised over an actual TCP round trip (real fetch,
+ * real JWT header, real status codes) WITHOUT needing mongo.
+ *
+ * It faithfully reproduces the token-api WIRE that the SDK clients depend on:
+ *  - the Bearer-JWT → ownerId binding (the fake binds via `clientFor(ownerId)`; here
+ *    the JWT the fake mints carries the ownerId, and the socket recovers it to scope
+ *    the data/courier seam);
+ *  - the **507** status on a whole-batch storage block, with the PatchResponse STILL
+ *    in the body (`reply.code(507).send(body)` — DESIGN §5.4);
+ *  - **401** for a missing/expired Bearer on an authenticated endpoint (drives the
+ *    client's refresh+retry), and **401 → null** on `/auth/verify` · `/auth/refresh`.
+ *
+ * The fake mints a JWT shaped `jwt.<ownerId>.<deviceId>.<uniq>` — we split out the
+ * ownerId from the Bearer to pick `clientFor(ownerId)`. A token issued before a
+ * `forceExpire()` flips to expired so the next authed call 401s exactly once.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { FakeVaultServer } from './fake-vault-server';
+import { FakeCourierServer } from './fake-courier-server';
+import type { VaultHttpClient } from '../../storage/remote/types';
+import type { CourierHttpClient } from '../../transport/courier/types';
+
+/** A listening real-socket vault server wrapping the in-memory fakes. */
+export interface RealVaultSocket {
+  baseUrl: string;
+  vault: FakeVaultServer;
+  courier: FakeCourierServer;
+  /** Force the NEXT authed request to 401 once (expired JWT), then accept the retry. */
+  expireNextToken(): void;
+  close(): Promise<void>;
+}
+
+const enc = new TextEncoder();
+
+/** Split the ownerId out of the fake's `jwt.<ownerId>.<deviceId>.<uniq>` token. */
+function ownerOfJwt(jwt: string): string | null {
+  const parts = jwt.split('.');
+  return parts.length >= 2 && parts[0] === 'jwt' ? parts[1] : null;
+}
+
+/** Read the whole request body as text (JSON or empty). */
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const c of req) chunks.push(c as Buffer);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/** Send a JSON response with a status code (or 204 with no body). */
+function sendJson(res: ServerResponse, status: number, body?: unknown): void {
+  if (status === 204 || body === undefined) {
+    res.writeHead(status);
+    res.end();
+    return;
+  }
+  const text = JSON.stringify(body);
+  res.writeHead(status, { 'content-type': 'application/json', 'content-length': enc.encode(text).length });
+  res.end(text);
+}
+
+/** Mutable one-shot flag: when armed, the next authed request 401s, then disarms. */
+class ExpiryGate {
+  private armed = false;
+  arm(): void {
+    this.armed = true;
+  }
+  /** Returns true (and disarms) if this request should be forced to 401. */
+  consume(): boolean {
+    if (!this.armed) return false;
+    this.armed = false;
+    return true;
+  }
+}
+
+/** Boot a real `node:http` server fronting fresh fake vault + courier instances. */
+export async function startRealVaultSocket(network = 'testnet2'): Promise<RealVaultSocket> {
+  const vault = new FakeVaultServer(network);
+  const courier = new FakeCourierServer(network);
+  const expiry = new ExpiryGate();
+  const router = new Router(vault, courier, expiry);
+  const server = createServer((req, res) => {
+    void router.handle(req, res);
+  });
+  await listen(server);
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    vault,
+    courier,
+    expireNextToken: () => expiry.arm(),
+    close: () => closeServer(server),
+  };
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+}
+
+/** Routes one HTTP request onto the matching fake-server seam method. */
+class Router {
+  constructor(
+    private readonly vault: FakeVaultServer,
+    private readonly courier: FakeCourierServer,
+    private readonly expiry: ExpiryGate,
+  ) {}
+
+  async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      const body = await readBody(req);
+      const json = body ? (JSON.parse(body) as Record<string, unknown>) : {};
+      if (await this.route(req, url, json, res)) return;
+      sendJson(res, 404, { error: 'not_found' });
+    } catch (err) {
+      sendJson(res, 500, { error: err instanceof Error ? err.message : 'server_error' });
+    }
+  }
+
+  /** Dispatch; returns true once handled. */
+  private async route(
+    req: IncomingMessage,
+    url: URL,
+    json: Record<string, unknown>,
+    res: ServerResponse,
+  ): Promise<boolean> {
+    if (url.pathname.startsWith('/v1/auth/')) return this.auth(url.pathname, json, req, res);
+    if (url.pathname.startsWith('/v1/courier/')) return this.courierRoute(url, json, req, res);
+    return this.vaultRoute(req.method ?? 'GET', url, json, req, res);
+  }
+
+  // --- auth (no Bearer except logout) --------------------------------------
+
+  private async auth(
+    path: string,
+    json: Record<string, unknown>,
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<boolean> {
+    const a = this.vault.authClient();
+    if (path === '/v1/auth/challenge') return ok(res, await a.challenge(json.pubkey as string));
+    if (path === '/v1/auth/verify') return orNull(res, await a.verify(json as never));
+    if (path === '/v1/auth/refresh') return orNull(res, await a.refresh(json.refreshToken as string));
+    if (path === '/v1/auth/logout') return logout(res, this.vault, req);
+    return false;
+  }
+
+  // --- vault data (Bearer) -------------------------------------------------
+
+  private async vaultRoute(
+    method: string,
+    url: URL,
+    json: Record<string, unknown>,
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<boolean> {
+    const client = this.authed(req, res, (id) => this.vault.clientFor(id));
+    if (!client) return true; // 401 already sent
+    const p = url.pathname;
+    if (method === 'PATCH' && p === '/v1/entries') return patch(res, client, json);
+    if (method === 'GET' && p === '/v1/state') return ok(res, await client.getState(sinceOf(url)));
+    if (method === 'POST' && p === '/v1/history') return ok(res, await client.appendHistory(json.records as never));
+    if (method === 'GET' && p === '/v1/history') return ok(res, await client.historySince(sinceOf(url)));
+    if (method === 'POST' && p === '/v1/account/delete-nonce') return ok(res, await client.deleteNonce());
+    if (method === 'DELETE' && p === '/v1/account') return accountDelete(res, client, json);
+    return false;
+  }
+
+  // --- courier (Bearer) ----------------------------------------------------
+
+  private async courierRoute(
+    url: URL,
+    json: Record<string, unknown>,
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<boolean> {
+    const client = this.authed(req, res, (id) => this.courier.clientFor(id));
+    if (!client) return true;
+    const p = url.pathname;
+    if (p === '/v1/courier/deposit') return ok(res, await client.deposit(json as never));
+    if (p === '/v1/courier/inbox') return ok(res, await client.inbox(sinceOf(url)));
+    if (p === '/v1/courier/ack-nonce') return ok(res, await client.ackNonce(url.searchParams.get('entryId') ?? ''));
+    if (p === '/v1/courier/ack') return ok(res, await client.ack(json as never));
+    if (p === '/v1/courier/sent') return ok(res, await client.sent(sinceOf(url)));
+    return false;
+  }
+
+  /** Resolve the Bearer → ownerId; 401 (and the one-shot expiry gate) on failure. */
+  private authed<T>(req: IncomingMessage, res: ServerResponse, make: (ownerId: string) => T): T | null {
+    if (this.expiry.consume()) {
+      sendJson(res, 401, { error: 'unauthorized' });
+      return null;
+    }
+    const owner = ownerOfJwt(bearerOf(req) ?? '');
+    if (!owner) {
+      sendJson(res, 401, { error: 'unauthorized' });
+      return null;
+    }
+    return make(owner);
+  }
+}
+
+/** Extract the Bearer token from the Authorization header. */
+function bearerOf(req: IncomingMessage): string | null {
+  const h = req.headers.authorization;
+  return h?.startsWith('Bearer ') ? h.slice(7) : null;
+}
+
+function sinceOf(url: URL): number {
+  return Number(url.searchParams.get('since') ?? 0);
+}
+
+/** Plain 200 JSON helper that satisfies the `route` boolean contract. */
+function ok(res: ServerResponse, body: unknown): true {
+  sendJson(res, 200, body);
+  return true;
+}
+
+/** 200 with the token pair, or 401 when the fake returned `null`. */
+function orNull(res: ServerResponse, tokens: unknown): true {
+  if (tokens === null) sendJson(res, 401, { error: 'unauthorized' });
+  else sendJson(res, 200, tokens);
+  return true;
+}
+
+async function logout(res: ServerResponse, vault: FakeVaultServer, req: IncomingMessage): Promise<true> {
+  const body = await readBody(req).catch(() => '');
+  void body;
+  await vault.authClient().logout(''); // sessionId is opaque to the fake here
+  sendJson(res, 204);
+  return true;
+}
+
+/** PATCH /v1/entries — 507 status when the whole batch was storage-blocked, body intact. */
+async function patch(res: ServerResponse, client: VaultHttpClient, json: Record<string, unknown>): Promise<true> {
+  const body = await client.patchEntries((json.ops as never) ?? []);
+  const blocked = body.applied.length === 0 && body.rejected.some((r) => r.reason === 'insufficient_storage');
+  sendJson(res, blocked ? 507 : 200, body);
+  return true;
+}
+
+/** DELETE /v1/account — 401 (never `{ok:false}`) when the delete signature is rejected. */
+async function accountDelete(
+  res: ServerResponse,
+  client: VaultHttpClient,
+  json: Record<string, unknown>,
+): Promise<true> {
+  const r = await client.deleteAccount(json.nonce as string, json.signature as string);
+  if (r.ok) sendJson(res, 200, { ok: true });
+  else sendJson(res, 401, { error: 'unauthorized' });
+  return true;
+}
+
+// Keep the courier client type referenced for the seam (compile-time aid).
+export type { CourierHttpClient };

--- a/tests/integration/vault/http-clients.test.ts
+++ b/tests/integration/vault/http-clients.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Real fetch HTTP clients (Task 8.3, Deliverable 1) over a REAL `node:http` socket.
+ *
+ * Proves the fetch/JWT/error-mapping layer WITHOUT mongo: each client runs against
+ * an actual listening socket fronting the in-memory fakes (`real-vault-socket`), so
+ * real fetch, real Bearer headers and real status codes are exercised. The hard
+ * cases the Phase-6 review flagged are covered explicitly:
+ *  - **507 → body** on `PATCH /v1/entries` is PARSED and returned (never thrown).
+ *  - **401 → ONE refresh + retry** drives `VaultApiClient.refresh()` exactly once.
+ *  - JSON round-trips through challenge → verify → JWT → authed data + courier.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes, signMessage } from '../../../core/crypto';
+import { VaultApiClient } from '../../../storage/remote/VaultApiClient';
+import { HttpVaultAuthClient } from '../../../storage/remote/http/HttpVaultAuthClient';
+import { HttpVaultClient } from '../../../storage/remote/http/HttpVaultClient';
+import { HttpCourierClient } from '../../../transport/courier/http/HttpCourierClient';
+import { VaultHttpError, createVaultHttpClients } from '../../../storage/remote/http/index';
+import { courierAckTemplate } from '../../../transport/courier/ack-template';
+import { startRealVaultSocket, type RealVaultSocket } from '../../helpers/real-vault-socket';
+import type { VaultEntryPayload } from '../../../vault-aead/entry';
+
+const NETWORK = 'testnet2';
+const PRIV = '7c'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+
+const RECIP_PRIV = '5a'.repeat(32);
+const RECIP_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIP_PRIV), true));
+
+const payload = (ct: string): VaultEntryPayload => ({ nonce: 'bg==', ct });
+
+let socket: RealVaultSocket;
+
+beforeEach(async () => {
+  socket = await startRealVaultSocket(NETWORK);
+});
+afterEach(async () => {
+  await socket.close();
+});
+
+/** Build + authenticate a `VaultApiClient` over the REAL fetch auth client. */
+async function authedApi(priv = PRIV, pub = PUB): Promise<VaultApiClient> {
+  const authClient = new HttpVaultAuthClient({ vaultUrl: socket.baseUrl });
+  const api = new VaultApiClient({
+    network: NETWORK,
+    chainPubkey: pub,
+    privateKey: priv,
+    deviceId: 'device-1',
+    authClient,
+  });
+  await api.authenticate();
+  return api;
+}
+
+describe('HttpVaultAuthClient — real socket', () => {
+  it('challenge → verify → JWT round-trips over real fetch', async () => {
+    const api = await authedApi();
+    expect(typeof api.token).toBe('string');
+    expect(api.token!.length).toBeGreaterThan(0);
+    expect(socket.vault.calls.verify).toHaveLength(1);
+    expect(socket.vault.calls.verify[0].deviceId).toBe('device-1');
+  });
+
+  it('a refresh rotates the JWT (200 → new token)', async () => {
+    const api = await authedApi();
+    const before = api.token;
+    const after = await api.refresh();
+    expect(after).not.toBe(before);
+    expect(socket.vault.calls.refresh).toHaveLength(1);
+  });
+
+  it('verify returns null on a 401 (bad signature)', async () => {
+    const authClient = new HttpVaultAuthClient({ vaultUrl: socket.baseUrl });
+    const ch = await authClient.challenge(PUB);
+    const badSig = signMessage(RECIP_PRIV, ch.challenge); // wrong key → recovers to RECIP
+    const tokens = await authClient.verify({ nonce: ch.nonce, signature: badSig, deviceId: 'd' });
+    expect(tokens).toBeNull();
+  });
+});
+
+describe('HttpVaultClient — real socket', () => {
+  it('patchEntries + getState JSON round-trip (CAS create → readback)', async () => {
+    const api = await authedApi();
+    const vault = new HttpVaultClient({ vaultUrl: socket.baseUrl, auth: api });
+    const res = await vault.patchEntries([{ key: 'k1', baseVersion: 0, payload: payload('YQ==') }]);
+    expect(res.applied).toEqual(['k1']);
+    expect(res.conflicts).toEqual([]);
+    const state = await vault.getState(0);
+    expect(state.entries.map((e) => e.key)).toContain('k1');
+    expect(state.formatVersion).toBe('entries-v1');
+    expect(state.epochSig.length).toBeGreaterThan(0);
+  });
+
+  it('507 → PatchResponse BODY is parsed and returned, NOT thrown', async () => {
+    const api = await authedApi();
+    const vault = new HttpVaultClient({ vaultUrl: socket.baseUrl, auth: api });
+    socket.vault.setStorageFull(true); // whole batch blocked → 507 with a body
+    const res = await vault.patchEntries([{ key: 'big', baseVersion: 0, payload: payload('YQ==') }]);
+    expect(res.applied).toEqual([]);
+    expect(res.rejected).toEqual([{ key: 'big', reason: 'insufficient_storage' }]);
+    expect(res.conflicts).toEqual([]);
+  });
+
+  it('401 → ONE refresh + retry succeeds (drives VaultApiClient.refresh once)', async () => {
+    const api = await authedApi();
+    const vault = new HttpVaultClient({ vaultUrl: socket.baseUrl, auth: api });
+    socket.expireNextToken(); // the next authed request 401s exactly once
+    const res = await vault.patchEntries([{ key: 'k2', baseVersion: 0, payload: payload('YQ==') }]);
+    expect(res.applied).toEqual(['k2']); // retried with a fresh JWT after the refresh
+    expect(socket.vault.calls.refresh).toHaveLength(1); // exactly one rotation
+  });
+
+  it('a non-2xx (non-507) throws a typed VaultHttpError', async () => {
+    const api = await authedApi();
+    // Point at a path the socket does not serve so it 404s through authedJson.
+    const vault = new HttpVaultClient({ vaultUrl: `${socket.baseUrl}/nope`, auth: api });
+    await expect(vault.getState(0)).rejects.toBeInstanceOf(VaultHttpError);
+  });
+
+  it('history append + historySince round-trip', async () => {
+    const api = await authedApi();
+    const vault = new HttpVaultClient({ vaultUrl: socket.baseUrl, auth: api });
+    const r = await vault.appendHistory([{ dedupKey: 'd1', payload: payload('aA==') }]);
+    expect(r.accepted).toBe(1);
+    const page = await vault.historySince(0);
+    expect(page.records.map((x) => x.dedupKey)).toEqual(['d1']);
+  });
+});
+
+describe('HttpCourierClient — real socket', () => {
+  it('deposit → inbox → ack-nonce → ack → sent over real fetch', async () => {
+    const senderApi = await authedApi();
+    const recipApi = await authedApi(RECIP_PRIV, RECIP_PUB);
+    const senderCourier = new HttpCourierClient({ vaultUrl: socket.baseUrl, auth: senderApi });
+    const recipCourier = new HttpCourierClient({ vaultUrl: socket.baseUrl, auth: recipApi });
+
+    const dep = await senderCourier.deposit({
+      recipientPubkey: RECIP_PUB,
+      entryId: 'e1',
+      transferId: 't1',
+      ciphertext: 'ZW52',
+    });
+    expect(dep.status).toBe('unclaimed');
+
+    const inbox = await recipCourier.inbox(0);
+    expect(inbox.items.map((i) => i.entryId)).toEqual(['e1']);
+
+    const { serverNonce } = await recipCourier.ackNonce('e1');
+    const tmpl = courierAckTemplate(NETWORK, PUB, 'e1', serverNonce);
+    const ackSig = signMessage(RECIP_PRIV, tmpl);
+    const ack = await recipCourier.ack({ entryId: 'e1', ackSig });
+    expect(ack.result).toBe('claimed');
+
+    // The sender sees the ack (with the consumed ackNonce) on /sent.
+    const sent = await senderCourier.sent(0);
+    const row = sent.items.find((i) => i.entryId === 'e1');
+    expect(row?.status).toBe('claimed');
+    expect(row?.ackSig).toBe(ackSig);
+    expect(row?.ackNonce).toBe(serverNonce);
+  });
+});
+
+describe('createVaultHttpClients — convenience factory', () => {
+  it('builds vault + courier sharing one auth session', async () => {
+    const api = await authedApi();
+    const { vault, courier } = createVaultHttpClients({ vaultUrl: socket.baseUrl, auth: api });
+    expect(vault).toBeInstanceOf(HttpVaultClient);
+    expect(courier).toBeInstanceOf(HttpCourierClient);
+    const res = await vault.patchEntries([{ key: 'kf', baseVersion: 0, payload: payload('YQ==') }]);
+    expect(res.applied).toEqual(['kf']);
+  });
+});

--- a/transport/courier/http/HttpCourierClient.ts
+++ b/transport/courier/http/HttpCourierClient.ts
@@ -1,0 +1,87 @@
+/**
+ * HttpCourierClient (Task 8.3, DESIGN §6) — the REAL fetch implementation of the
+ * courier seam {@link CourierHttpClient}, against the Bearer-gated
+ * `{vaultUrl}/v1/courier/*` endpoints. The swap-in for the fake courier server's
+ * `clientFor(ownerId)`.
+ *
+ * The caller (`ownerId = chainPubkey`) is carried by the JWT, not the body. This
+ * client reads that JWT (and drives one serialized refresh on a 401) through the
+ * injected {@link VaultTokenSource}, reusing the vault's {@link authedJson} core so
+ * the Bearer + 401-refresh-retry semantics are identical to the vault data client.
+ *
+ * Wire notes honoured verbatim:
+ *  - deposit → `{entryId, seq, sentSeq, status}` (a 413/429 quota breach THROWS).
+ *  - ack ALWAYS returns HTTP 200 with `{result}` — a per-entry problem is `failed`,
+ *    never an HTTP error (DESIGN §8.2).
+ *  - `/sent` rows carry `ackNonce` (the consumed serverNonce) so the sender can
+ *    rebuild + verify the recipient ack template.
+ */
+
+import type {
+  CourierAckNonceResponse,
+  CourierAckRequest,
+  CourierAckResponse,
+  CourierDepositRequest,
+  CourierDepositResponse,
+  CourierHttpClient,
+  CourierInboxResponse,
+  CourierSentResponse,
+} from '../types';
+import { authedJson } from '../../../storage/remote/http/http-core';
+import type { FetchLike, VaultTokenSource } from '../../../storage/remote/http/http-core';
+
+export interface HttpCourierClientConfig {
+  /** Vault/courier base URL — `NETWORKS[network].vaultUrl`. */
+  vaultUrl: string;
+  /** The JWT + serialized-refresh seam (a `VaultApiClient` satisfies it). */
+  auth: VaultTokenSource;
+  /** Defaults to the global `fetch`; injectable for tests. */
+  fetchImpl?: FetchLike;
+}
+
+export class HttpCourierClient implements CourierHttpClient {
+  private readonly base: string;
+  private readonly auth: VaultTokenSource;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(config: HttpCourierClientConfig) {
+    this.base = config.vaultUrl;
+    this.auth = config.auth;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  /** `POST /v1/courier/deposit` — the caller is the sender (a 413/429 quota → throw). */
+  deposit(req: CourierDepositRequest): Promise<CourierDepositResponse> {
+    return this.call<CourierDepositResponse>({ method: 'POST', path: '/v1/courier/deposit', body: req });
+  }
+
+  /** `GET /v1/courier/inbox?since=` — the caller is the recipient. */
+  inbox(since: number): Promise<CourierInboxResponse> {
+    return this.call<CourierInboxResponse>({ method: 'GET', path: `/v1/courier/inbox?since=${since}` });
+  }
+
+  /** `GET /v1/courier/ack-nonce?entryId=` — single-use server nonce. */
+  ackNonce(entryId: string): Promise<CourierAckNonceResponse> {
+    const q = encodeURIComponent(entryId);
+    return this.call<CourierAckNonceResponse>({ method: 'GET', path: `/v1/courier/ack-nonce?entryId=${q}` });
+  }
+
+  /** `POST /v1/courier/ack` — frozen `{result}` at 200 (never an HTTP error). */
+  ack(req: CourierAckRequest): Promise<CourierAckResponse> {
+    return this.call<CourierAckResponse>({ method: 'POST', path: '/v1/courier/ack', body: req });
+  }
+
+  /** `GET /v1/courier/sent?since=` — rows carry `ackNonce` once claimed. */
+  sent(since: number): Promise<CourierSentResponse> {
+    return this.call<CourierSentResponse>({ method: 'GET', path: `/v1/courier/sent?since=${since}` });
+  }
+
+  /** One authenticated round trip (Bearer + 401-refresh-retry) to a courier endpoint. */
+  private call<T>(req: {
+    method: 'GET' | 'POST';
+    path: string;
+    body?: unknown;
+  }): Promise<T> {
+    return authedJson<T>(this.fetchImpl, this.base, this.auth, req);
+  }
+}


### PR DESCRIPTION
Part B Phase 8 Task 8.3 — the real fetch-based HTTP clients + the cross-repo e2e. This is the integration capstone: the full SDK↔server path validated against the REAL token-api.

## Deliverable 1 — real fetch HTTP clients (runtime code for the wallet integration)
- `storage/remote/http/HttpVaultAuthClient.ts` — `/v1/auth/challenge|verify|refresh|logout`.
- `storage/remote/http/HttpVaultClient.ts` — `/v1/entries` (PATCH, **507→body not throw**), `/v1/state`, `/v1/history`, `/v1/account/*`.
- `transport/courier/http/HttpCourierClient.ts` — `/v1/courier/deposit|inbox|ack-nonce|ack|sent|reject`.
- `storage/remote/http/http-core.ts` — shared fetch core: Bearer attach → 401 → ONE serialized refresh (shared in-flight promise, no storm / no double-rotate self-revoke) → retry-once; `okStatuses` lets PATCH treat 507 as a parseable body.
- `index.ts` exports the 3 clients + `createVaultHttpClients`/`createVaultAuthClient` + types.
- `tests/integration/vault/http-clients.test.ts` — 10 tests over a REAL `node:http` socket incl. the 507→body and 401→refresh→retry paths.
- One additive provider accessor `authTokenSource()` so the data client shares the provider's single JWT session (no contract break).

## Deliverable 2 — cross-repo e2e against in-process token-api (#13)
`tests/e2e/vault.e2e.test.ts` (+ `support/token-api-boot.ts`): boots the REAL token-api (`buildApp` + a real `mongodb-memory-server` REPLICA SET) on a real socket via token-api's compiled `dist`, then drives the full path through the REAL HTTP clients — auth challenge→verify→JWT (+refresh-rotate), vault flush → FRESH-provider reload (CAS rows + restored `_meta.address` Quest-XP invariant), courier deposit→receive→ack→sender-verifies-on-/sent. Separate vitest e2e include (excluded from the unit pass); `TOKEN_API_URL` is an optional remote override.

## Tests
**Ran GREEN locally:** unit+integration 125/125, e2e 3/3 against the real in-process token-api over real mongod (~2.7s). `tsc --noEmit` clean, eslint clean. No token-api SOURCE change (the merged ackNonce/epochSig fixes already cover the wire; only the gitignored `dist/` needed a rebuild). FROZEN `StorageEventType` union + token-engine import boundary untouched.

## Reviewed (adversarial, reviewer re-ran the e2e + suites)
PASS. 401-refresh serialized/retry-once/no-loop; 507→body scoped to patchEntries; wire fidelity confirmed against every Part A route; e2e substantive (real assertions, fresh-provider reload, Quest-XP invariant). Non-blocking notes: a wasted refresh on the rejected-delete path; the `/v1/courier/reject` seam intentionally omitted (provider uses a sender-side pending-gate, never server reject).