### PR TITLE
fix(vault): provider fund-safety - no-brick init, honest durability signal, multi-address key guard

### DIFF
--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -284,13 +284,34 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   async sync(localData: TData): Promise<SyncResult<TData>> {
     // Flush gate (Task 7.1): no PATCH before a successful first load, so a
     // transient load failure can never wipe the server with empty local data.
+    //
+    // FUND-SAFETY (remote-provider-silent-backup-failure-reports-success): while
+    // the gate is shut the backup did NOT happen, so we must NOT report a silent
+    // success — that would tell the wallet its tokens are durably backed up when
+    // nothing was persisted. We SIGNAL the degraded state: return success:false
+    // with a reason AND emit a degraded `sync:error` event (frozen union, a
+    // data.reason — never a new union member). Empty-import protection is intact:
+    // we still perform NO PATCH before a successful first load.
     if (!this.initialLoadDone) {
-      return { success: true, merged: localData, added: 0, removed: 0, conflicts: 0 };
+      return this.degraded(localData);
     }
     // Capture the identity epoch BEFORE queueing; the flush aborts if it advances
     // across any await (Task 7.3). Serialized so flushes never interleave.
     const epoch = this.identityEpoch;
     return this.queue.enqueue(() => this.runSync(localData, epoch));
+  }
+
+  /**
+   * The gate-shut degraded result (finding
+   * remote-provider-silent-backup-failure-reports-success): emit a `sync:error`
+   * degraded signal with a `data.reason` and return success:false. NO PATCH is
+   * performed (empty-import protection). Distinct from a genuine successful no-op
+   * flush (gate OPEN, nothing to push), which stays success:true.
+   */
+  private degraded(localData: TData): SyncResult<TData> {
+    const reason = 'awaiting-initial-load';
+    this.emit('sync:error', { reason }, 'vault backup inactive: awaiting a successful initial load');
+    return { success: false, merged: localData, added: 0, removed: 0, conflicts: 0, error: reason };
   }
 
   private async runSync(localData: TData, epoch: number): Promise<SyncResult<TData>> {

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -717,7 +717,12 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
 
   private emit(type: StorageEventType, data?: unknown, error?: string): void {
     const event: StorageEvent = { type, timestamp: Date.now(), data, error };
-    for (const cb of this.listeners) cb(event);
+    // Isolate listeners: a throwing handler must NOT propagate out of emit() —
+    // otherwise it re-rejects initialize()/load() and re-bricks the wallet,
+    // defeating the no-throw guarantee. Matches IpfsStorageProvider.emitEvent.
+    for (const cb of this.listeners) {
+      try { cb(event); } catch { /* handler errors must not break the provider */ }
+    }
   }
 
   // === history (Task 7.4 — single channel) ==================================

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -225,18 +225,39 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   /**
    * Authenticate, then run the FIRST load ourselves so the flush gate opens even
    * when `PaymentsModule.load()` short-circuits before reaching this provider
-   * (Task 7.1). A transient first-load failure is swallowed (the gate stays SHUT,
-   * `sync()` no-ops) so an empty local import can never overwrite the server.
+   * (Task 7.1).
+   *
+   * FUND-SAFETY (remote-provider-init-auth-throw-bricks-wallet): this is a BACKUP
+   * provider and the wallet loads providers together — a throw here would reject
+   * the WHOLE wallet load and brick the wallet because the vault is unreachable.
+   * So `initialize()` NEVER throws on auth / network / first-load failure: it
+   * logs (via `storage:error`), leaves the flush gate SHUT (`initialLoadDone`
+   * stays false → `sync()` degrades, never wipes the server with empty local
+   * data) and RETURNS the contract's non-fatal `false` so the wallet still loads
+   * from local storage. A vault outage degrades to "remote backup inactive".
    */
   async initialize(): Promise<boolean> {
     this.status = 'connecting';
-    await this.requireAuth().authenticate();
+    try {
+      await this.requireAuth().authenticate();
+    } catch (error) {
+      this.status = 'error';
+      this.emit('storage:error', { reason: 'auth' }, this.errMsg(error, 'vault auth failed'));
+      return false; // degrade — do NOT brick the wallet
+    }
     this.status = 'connected';
-    const first = await this.load();
+    const first = await this.load(); // load() never throws (it try/catches internally)
     if (!first.success) {
+      this.status = 'error';
       this.emit('storage:error', { reason: 'initial-load' }, first.error);
+      return false; // first load failed → gate stays SHUT, wallet still loads locally
     }
     return true;
+  }
+
+  /** Extract a human message from an unknown thrown value (degraded-path logging). */
+  private errMsg(error: unknown, fallback: string): string {
+    return error instanceof Error ? error.message : fallback;
   }
 
   /** True once the first successful load opened the flush gate (Task 7.1). */

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -33,7 +33,7 @@ import type {
   TokenStorageProvider,
   TxfStorageDataBase,
 } from '../storage-provider';
-import { hexToBytes } from '../../core/crypto';
+import { getPublicKey, hexToBytes } from '../../core/crypto';
 import { sealVaultEntry } from '../../vault-aead/entry';
 import { deriveVaultKey } from '../../vault-aead/derive';
 import { wireKey } from './wire-key';
@@ -49,6 +49,7 @@ import {
 import { sealHistoryRecord, openHistoryRecord } from './history-codec';
 import { deleteCanon } from '../../vault-aead/canon';
 import { signMessage } from '../../core/crypto';
+import { SphereError } from '../../core/errors';
 import { deriveDirectAddress } from '../../token-engine/identity';
 import type {
   PatchOp,
@@ -192,6 +193,15 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   // --- TokenStorageProvider -------------------------------------------------
 
   setIdentity(identity: FullIdentity): void {
+    // FUND-SAFETY (remote-provider-multiaddress-key-desync): the AEAD vault key,
+    // wireKeys and the auth signature are all derived from the CONSTRUCTION-TIME
+    // `config.privateKey`, while `ownerId` comes from `identity`. If `identity`
+    // belongs to a DIFFERENT address (an HD address switch), the crypto would
+    // desync from the owner — blobs sealed under the wrong key, auth 401. Multi-
+    // address requires a per-address provider instance keyed to THAT address's
+    // private key (see `createForAddress()` in the contract). FAIL LOUD on a
+    // mismatch so a cross-identity write can NEVER reach the server.
+    this.assertIdentityMatchesKey(identity);
     // Bump the identity epoch FIRST so any in-flight flush awaiting an I/O round
     // trip aborts the moment it next re-checks (Task 7.3) — no cross-identity write.
     this.identityEpoch += 1;
@@ -215,6 +225,27 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     });
     this.delta.setIdentity(identity.chainPubkey);
     this.delta.setWalletPriv(this.config.privateKey);
+  }
+
+  /**
+   * Guard against a multi-address key desync (remote-provider-multiaddress-key-desync):
+   * `config.privateKey` is fixed at construction and drives ALL vault-boundary
+   * crypto (AEAD key, wireKey, auth signature), so the identity's pubkey MUST be
+   * the public key of THAT private key. A mismatch means a different HD address is
+   * being pointed at this provider — which would seal blobs under the wrong key
+   * and 401 the auth. Throw a clear error so the desync can never reach the wire;
+   * the caller must spawn a per-address provider keyed to that address instead.
+   */
+  private assertIdentityMatchesKey(identity: FullIdentity): void {
+    const expected = getPublicKey(this.config.privateKey);
+    if (identity.chainPubkey !== expected) {
+      throw new SphereError(
+        'RemoteTokenStorageProvider.setIdentity: identity pubkey does not match the ' +
+          "provider's configured private key — multi-address requires a per-address " +
+          'provider instance (createForAddress) keyed to that address.',
+        'INVALID_IDENTITY',
+      );
+    }
   }
 
   /** Abort the flush path if the identity epoch advanced (Task 7.3). */

--- a/tests/integration/vault/vault-degraded-signal.test.ts
+++ b/tests/integration/vault/vault-degraded-signal.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Fund-safety: a gate-shut flush must SIGNAL false durability, never report a
+ * silent success (remote-provider-silent-backup-failure-reports-success).
+ *
+ * When the flush gate is shut (first load failed / never succeeded), the wallet
+ * must NOT believe its tokens are durably backed up. So `sync()` / `save()` must
+ * return `success:false` with a reason AND emit a degraded event on the FROZEN
+ * `StorageEventType` union (`sync:error` with `data.reason`) — while STILL never
+ * PATCHing the server (empty-import protection). A genuine successful no-op
+ * flush (gate OPEN, nothing to push) stays `success:true` with no degraded event.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import type { TxfStorageDataBase, StorageEvent } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+import type { VaultAuthHttpClient, VaultHttpClient } from '../../../storage/remote/types';
+
+const NETWORK = 'testnet2';
+const PRIV = '71'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+interface ProviderOpts {
+  httpClientFactory?: (ownerId: string) => VaultHttpClient;
+  authClient?: VaultAuthHttpClient;
+}
+
+function makeProvider(server: FakeVaultServer, opts: ProviderOpts = {}): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    privateKey: PRIV,
+    authClient: opts.authClient ?? server.authClient(),
+    httpClientFactory: opts.httpClientFactory ?? ((ownerId) => server.clientFor(ownerId)),
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: 'DIRECT://x', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+/** An auth seam whose /challenge always throws (vault server is down → gate stays shut). */
+function downAuthClient(): VaultAuthHttpClient {
+  return {
+    challenge: () => Promise.reject(new Error('ECONNREFUSED: vault server down')),
+    verify: () => Promise.resolve(null),
+    refresh: () => Promise.resolve(null),
+    logout: () => Promise.resolve(),
+  };
+}
+
+describe('gate-shut flush signals degraded durability (not silent success)', () => {
+  it('sync() while gate shut returns success:false with a reason and emits a degraded sync:error event', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server, { authClient: downAuthClient() });
+    await provider.initialize(); // gate stays shut (auth down)
+    expect(provider.isInitialLoadDone()).toBe(false);
+
+    const events: StorageEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+
+    server.calls.patch.length = 0;
+    const res = await provider.sync(txf({ aaa: { amt: '1' } }));
+
+    expect(res.success).toBe(false);
+    expect(res.error).toBeTruthy();
+    expect(res.added).toBe(0);
+    // The degraded signal rides the FROZEN union (sync:error) with a data.reason.
+    const degraded = events.find((e) => e.type === 'sync:error');
+    expect(degraded).toBeDefined();
+    expect((degraded!.data as { reason?: string }).reason).toBeTruthy();
+    // Empty-import protection: NO PATCH reached the server.
+    expect(server.calls.patch).toHaveLength(0);
+  });
+
+  it('save() while gate shut returns success:false (degraded, not a silent backup success)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server, { authClient: downAuthClient() });
+    await provider.initialize();
+
+    server.calls.patch.length = 0;
+    const res = await provider.save(txf({ aaa: { amt: '1' } }));
+    expect(res.success).toBe(false);
+    expect(res.error).toBeTruthy();
+    expect(server.calls.patch).toHaveLength(0);
+  });
+
+  it('gate-OPEN empty flush is still a genuine success:true no-op (no false-degrade)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server); // healthy auth + first load opens the gate
+    await provider.initialize();
+    expect(provider.isInitialLoadDone()).toBe(true);
+
+    const events: StorageEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+    server.calls.patch.length = 0;
+
+    // Nothing changed since the (empty) load → a clean no-op flush.
+    const res = await provider.sync(txf({}));
+    expect(res.success).toBe(true);
+    expect(res.added).toBe(0);
+    expect(res.removed).toBe(0);
+    // A clean no-op flush must NOT emit a degraded signal.
+    expect(events.find((e) => e.type === 'sync:error')).toBeUndefined();
+    expect(events.find((e) => e.type === 'storage:error')).toBeUndefined();
+  });
+});

--- a/tests/integration/vault/vault-fencing.test.ts
+++ b/tests/integration/vault/vault-fencing.test.ts
@@ -14,7 +14,6 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '../../../core/crypto';
 import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
 import { FakeVaultServer } from '../../helpers/fake-vault-server';
-import { wireKey } from '../../../storage/remote/wire-key';
 import type { TxfStorageDataBase } from '../../../storage/storage-provider';
 import type { FullIdentity } from '../../../types';
 import type { PatchResponse, StateResponse, VaultHttpClient } from '../../../storage/remote/types';
@@ -22,10 +21,7 @@ import type { PatchResponse, StateResponse, VaultHttpClient } from '../../../sto
 const NETWORK = 'testnet2';
 const PRIV_A = '11'.repeat(32);
 const PUB_A = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV_A), true));
-const PRIV_B = '22'.repeat(32);
-const PUB_B = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV_B), true));
 const identityA: FullIdentity = { chainPubkey: PUB_A, l1Address: 'alphaA', privateKey: PRIV_A };
-const identityB: FullIdentity = { chainPubkey: PUB_B, l1Address: 'alphaB', privateKey: PRIV_B };
 
 function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
   const data: TxfStorageDataBase = {
@@ -51,7 +47,7 @@ function gatedClient(inner: VaultHttpClient, onPatch: () => Promise<void>): Vaul
 }
 
 describe('flush serialization + identity fencing', () => {
-  it('an in-flight flush that awaits across setIdentity aborts — no cross-identity write reaches the server', async () => {
+  it('an in-flight flush that awaits across setIdentity aborts on the epoch fence (no stale local commit)', async () => {
     const server = new FakeVaultServer(NETWORK);
     let release!: () => void;
     const gate = new Promise<void>((r) => { release = r; });
@@ -76,17 +72,22 @@ describe('flush serialization + identity fencing', () => {
     const flushing = provider.sync(txf({ aaa: { amt: '1' } }));
     await Promise.resolve();
 
-    // Switch identity to B mid-flush, then release the suspended patch.
-    provider.setIdentity(identityB);
+    // Bump the identity epoch mid-flush. The multi-address key guard
+    // (remote-provider-multiaddress-key-desync) forbids switching to a DIFFERENT
+    // key on the same instance, so the epoch bump uses a SAME-KEY identity variant
+    // (only l1Address differs) — exactly what exercises the epoch fence without a
+    // cross-key desync. Then release the suspended patch.
+    const identityASameKey: FullIdentity = { ...identityA, l1Address: 'alphaA-2' };
+    provider.setIdentity(identityASameKey);
     release();
     const res = await flushing;
 
-    // The flush aborted on the epoch mismatch — B's server view never got A's token,
-    // and the suspended flush did NOT commit under B (no cross-identity write).
-    const wkB = wireKey(PRIV_B, NETWORK, 'aaa');
-    expect(server.getEntry(PUB_B, wkB)).toBeUndefined();
+    // The flush aborted on the epoch mismatch: it threw the IdentityFencedError
+    // AFTER the patch await, so the local last-known state / signed baseline were
+    // NOT committed under the stale epoch and the result is a fenced failure.
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/identity/i);
+    expect(provider.knownCount()).toBe(0); // no stale local commit
   });
 
   it('overlapping flushes are serialized (no interleave) by the AsyncSerialQueue', async () => {

--- a/tests/integration/vault/vault-gate.test.ts
+++ b/tests/integration/vault/vault-gate.test.ts
@@ -75,7 +75,7 @@ describe('initialize() opens the flush gate', () => {
     expect(server.getEntry(PUB, wk)?.version).toBe(1);
   });
 
-  it('a failed first load keeps the gate SHUT — a flush is a no-op (empty-import protection)', async () => {
+  it('a failed first load keeps the gate SHUT — a flush performs NO PATCH but SIGNALS degraded (empty-import protection)', async () => {
     const server = new FakeVaultServer(NETWORK);
     // Wrap the data client so the FIRST /state (run by initialize) rejects.
     const wrap = (ownerId: string): VaultHttpClient => {
@@ -100,10 +100,12 @@ describe('initialize() opens the flush gate', () => {
     await provider.initialize();
     expect(provider.isInitialLoadDone()).toBe(false);
 
-    // A flush before a successful load is a NO-OP — no PATCH reaches the server,
-    // so empty local data can never wipe the server.
+    // A flush before a successful load performs NO PATCH (empty local data can
+    // never wipe the server) BUT it must SIGNAL the degraded state, not report a
+    // silent success (remote-provider-silent-backup-failure-reports-success).
     const res = await provider.sync(txf({ aaa: { amt: '1' } }));
-    expect(res.success).toBe(true); // a no-op flush is not a failure
+    expect(res.success).toBe(false); // degraded — the backup did NOT happen
+    expect(res.error).toBeTruthy();
     expect(res.added).toBe(0);
     expect(server.calls.patch).toHaveLength(0);
     const wk = wireKey(PRIV, NETWORK, 'aaa');

--- a/tests/integration/vault/vault-init-degrade.test.ts
+++ b/tests/integration/vault/vault-init-degrade.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Fund-safety: a vault outage must DEGRADE, never brick the wallet
+ * (remote-provider-init-auth-throw-bricks-wallet).
+ *
+ * Sphere loads token-storage providers together; one provider's throw rejects
+ * the whole wallet load. So `initialize()` must NEVER throw on auth / network /
+ * first-load failure: it logs, leaves the flush gate SHUT, and RESOLVES `false`
+ * (the contract's non-fatal value) so the wallet still loads from local storage.
+ * A vault outage degrades to "remote backup inactive", never blocks startup.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import { wireKey } from '../../../storage/remote/wire-key';
+import type { FullIdentity } from '../../../types';
+import type {
+  AuthTokens,
+  StateResponse,
+  VaultAuthHttpClient,
+  VaultHttpClient,
+  VerifyRequest,
+} from '../../../storage/remote/types';
+
+const NETWORK = 'testnet2';
+const PRIV = '71'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+interface ProviderOpts {
+  httpClientFactory?: (ownerId: string) => VaultHttpClient;
+  authClient?: VaultAuthHttpClient;
+}
+
+function makeProvider(server: FakeVaultServer, opts: ProviderOpts = {}): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    privateKey: PRIV,
+    authClient: opts.authClient ?? server.authClient(),
+    httpClientFactory: opts.httpClientFactory ?? ((ownerId) => server.clientFor(ownerId)),
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+/** An auth seam whose /verify always 401s (server rejects the signature). */
+function rejectingAuthClient(server: FakeVaultServer): VaultAuthHttpClient {
+  const inner = server.authClient();
+  return {
+    challenge: (pubkey) => inner.challenge(pubkey),
+    verify: (_req: VerifyRequest): Promise<AuthTokens | null> => Promise.resolve(null),
+    refresh: (token) => inner.refresh(token),
+    logout: (sessionId) => inner.logout(sessionId),
+  };
+}
+
+/** An auth seam whose /challenge always throws (vault server is down). */
+function downAuthClient(): VaultAuthHttpClient {
+  return {
+    challenge: () => Promise.reject(new Error('ECONNREFUSED: vault server down')),
+    verify: () => Promise.resolve(null),
+    refresh: () => Promise.resolve(null),
+    logout: () => Promise.resolve(),
+  };
+}
+
+describe('initialize() degrades, never bricks the wallet', () => {
+  it('auth 401 → initialize() resolves false (does NOT throw), gate stays shut', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server, { authClient: rejectingAuthClient(server) });
+
+    await expect(provider.initialize()).resolves.toBe(false);
+    expect(provider.isInitialLoadDone()).toBe(false);
+    expect(provider.getStatus()).toBe('error');
+  });
+
+  it('vault server down (auth throws) → initialize() resolves false, no throw, gate stays shut', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server, { authClient: downAuthClient() });
+
+    await expect(provider.initialize()).resolves.toBe(false);
+    expect(provider.isInitialLoadDone()).toBe(false);
+    expect(provider.getStatus()).toBe('error');
+  });
+
+  it('first /state load failure → initialize() resolves false (does NOT throw), gate stays shut', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const wrap = (ownerId: string): VaultHttpClient => {
+      const inner = server.clientFor(ownerId);
+      return {
+        patchEntries: (ops) => inner.patchEntries(ops),
+        getState: (_since): Promise<StateResponse> => Promise.reject(new Error('transient /state failure')),
+        appendHistory: (records) => inner.appendHistory(records),
+        historySince: (since) => inner.historySince(since),
+        deleteNonce: () => inner.deleteNonce(),
+        deleteAccount: (nonce, sig) => inner.deleteAccount(nonce, sig),
+      };
+    };
+    const provider = makeProvider(server, { httpClientFactory: wrap });
+
+    await expect(provider.initialize()).resolves.toBe(false);
+    expect(provider.isInitialLoadDone()).toBe(false);
+    // No flush ever happened during initialize (gate never opened, decrypt never ran).
+    expect(server.calls.patch).toHaveLength(0);
+    const wk = wireKey(PRIV, NETWORK, 'aaa');
+    expect(server.getEntry(PUB, wk)).toBeUndefined();
+  });
+
+  it('healthy auth + first load → initialize() resolves true and opens the gate (no regression)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    await expect(provider.initialize()).resolves.toBe(true);
+    expect(provider.isInitialLoadDone()).toBe(true);
+    expect(provider.getStatus()).toBe('connected');
+  });
+});

--- a/tests/integration/vault/vault-multiaddress-key.test.ts
+++ b/tests/integration/vault/vault-multiaddress-key.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Fund-safety: multi-address key desync (remote-provider-multiaddress-key-desync).
+ *
+ * The provider derives its AEAD vault key, wireKeys and the auth signature from a
+ * CONSTRUCTION-TIME `config.privateKey`, while `ownerId`/identity comes from
+ * `setIdentity()`. On an HD address switch the provider instance is reused (it has
+ * no `createForAddress`), so `setIdentity(identityB)` would leave the crypto keyed
+ * to address A — the new owner's blobs would be sealed under the WRONG key and the
+ * auth signature would 401. The provider must FAIL LOUD on that mismatch so a
+ * cross-identity write can never reach the server under the wrong key.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import { wireKey } from '../../../storage/remote/wire-key';
+import type { TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+
+const NETWORK = 'testnet2';
+const PRIV_A = '11'.repeat(32);
+const PUB_A = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV_A), true));
+const PRIV_B = '22'.repeat(32);
+const PUB_B = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV_B), true));
+const identityA: FullIdentity = { chainPubkey: PUB_A, l1Address: 'alphaA', privateKey: PRIV_A };
+const identityB: FullIdentity = { chainPubkey: PUB_B, l1Address: 'alphaB', privateKey: PRIV_B };
+
+function makeProvider(server: FakeVaultServer): RemoteTokenStorageProvider {
+  return new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'u',
+    privateKey: PRIV_A,
+    authClient: server.authClient(),
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+  });
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+describe('multi-address key desync guard', () => {
+  it('setIdentity with a pubkey != getPublicKey(config.privateKey) throws (no silent desync)', () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server); // config.privateKey = PRIV_A
+
+    expect(() => provider.setIdentity(identityB)).toThrowError(/identity|key|address|mismatch/i);
+  });
+
+  it('a cross-identity write can never reach the server under the wrong key', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+
+    provider.setIdentity(identityA); // matches config.privateKey → fine
+    await provider.initialize();
+
+    // Attempting to repoint at B must fail loud — the provider stays on A's key.
+    expect(() => provider.setIdentity(identityB)).toThrow();
+
+    // No B-keyed blob can ever have reached the server (the switch was rejected).
+    const wkB = wireKey(PRIV_B, NETWORK, 'aaa');
+    expect(server.getEntry(PUB_B, wkB)).toBeUndefined();
+  });
+
+  it('a matching identity works as before (no regression)', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+
+    provider.setIdentity(identityA); // PUB_A === getPublicKey(PRIV_A)
+    await provider.initialize();
+    const res = await provider.sync(txf({ aaa: { amt: '1' } }));
+    expect(res.success).toBe(true);
+    expect(res.added).toBe(1);
+    const wkA = wireKey(PRIV_A, NETWORK, 'aaa');
+    expect(server.getEntry(PUB_A, wkA)?.version).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes 3 HIGH fund-safety findings + 1 review MEDIUM in the vault RemoteTokenStorageProvider (135/135 tests, tsc+eslint clean; FROZEN StorageEventType union + token-engine boundary untouched). (1) initialize() catches auth/server-down/first-load failures -> gate stays shut, emits storage:error, returns false so a vault outage never bricks wallet startup. (2) gate-shut sync()/save() return success:false + emit sync:error (no silent false durability); genuine no-op flush still success:true; empty-import protection intact. (3) setIdentity() throws INVALID_IDENTITY when identity pubkey != getPublicKey(config.privateKey), preventing cross-identity writes under the wrong key. (4) emit() now isolates listeners so a throwing handler cannot re-reject initialize()/load(). Reviewed adversarially: PASS.