### PR TITLE
fix(vault): courier read-pointer/watermark persistence + pagination; AEAD resurrect version

### DIFF
--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -455,7 +455,11 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     return {
       key: op.wireKey,
       baseVersion: op.baseVersion,
-      payload: this.sealValue(op.wireKey, op.baseVersion + 1, op.value),
+      // AAD seal version = the version the SERVER will store (op.sealVersion), NOT
+      // `baseVersion + 1`: a delete-resurrect sends baseVersion:0 but the server
+      // converges to deletedRow.version + 1, so sealing at baseVersion+1 (=1) would
+      // make the resurrected entry undecryptable on load (resurrect-version-mismatch).
+      payload: this.sealValue(op.wireKey, op.sealVersion, op.value),
     };
   }
 

--- a/storage/remote/diff.ts
+++ b/storage/remote/diff.ts
@@ -32,6 +32,15 @@ export interface PlannedOp {
   /** The opaque wireKey the op targets on the wire. */
   wireKey: string;
   baseVersion: number;
+  /**
+   * The version the SERVER will assign to this entry once applied — the AAD seal
+   * version (finding vault-aead-resurrect-version-mismatch). For a fresh create it
+   * is 1 and for an update it is `baseVersion + 1`, BUT for a delete-RESURRECT
+   * (CAS `baseVersion:0` against a known tombstone) the server converges the row
+   * monotonically to `deletedRow.version + 1` — NOT 1 — so the payload AAD MUST be
+   * sealed at that version or a fresh load() cannot decrypt the resurrected entry.
+   */
+  sealVersion: number;
   /** false → create/update (carries a payload); true → delete (tombstone). */
   isDelete: boolean;
   /** The raw token value to seal (omitted on a delete). */
@@ -84,15 +93,22 @@ export function planOps(params: PlanOpsParams): PlannedOp[] {
     const wk = wireKeyOf(plainKey);
     liveWire.add(wk);
     const cur = known.get(wk);
-    if (!cur || cur.deleted) {
-      ops.push({ plainKey, wireKey: wk, baseVersion: 0, isDelete: false, value });
+    if (!cur) {
+      // Fresh create: server assigns v1; seal the AAD at v1.
+      ops.push({ plainKey, wireKey: wk, baseVersion: 0, sealVersion: 1, isDelete: false, value });
+    } else if (cur.deleted) {
+      // Delete-resurrect (#16): CAS baseVersion 0 against the tombstone, but the
+      // server converges to `deletedRow.version + 1` (monotonic) — seal at THAT
+      // version so a fresh load() can decrypt it (vault-aead-resurrect-version-mismatch).
+      ops.push({ plainKey, wireKey: wk, baseVersion: 0, sealVersion: cur.version + 1, isDelete: false, value });
     } else if (changed(wk, value)) {
-      ops.push({ plainKey, wireKey: wk, baseVersion: cur.version, isDelete: false, value });
+      // Update: CAS at the known version; server assigns `version + 1`.
+      ops.push({ plainKey, wireKey: wk, baseVersion: cur.version, sealVersion: cur.version + 1, isDelete: false, value });
     }
   }
   for (const [wk, cur] of known) {
     if (!cur.deleted && !liveWire.has(wk) && !reserved?.has(wk)) {
-      ops.push({ plainKey: '', wireKey: wk, baseVersion: cur.version, isDelete: true });
+      ops.push({ plainKey: '', wireKey: wk, baseVersion: cur.version, sealVersion: cur.version + 1, isDelete: true });
     }
   }
   return ops;

--- a/tests/helpers/fake-courier-server.ts
+++ b/tests/helpers/fake-courier-server.ts
@@ -53,6 +53,12 @@ interface DeliveryRow {
 let randomCounter = 0;
 const nextNonce = (): string => `nonce-${++randomCounter}-${Math.random().toString(36).slice(2)}`;
 
+export interface FakeCourierServerOptions {
+  network?: string;
+  /** Max rows returned per `/inbox` or `/sent` page; the rest set `more:true`. */
+  pageLimit?: number;
+}
+
 /**
  * The in-memory courier server. Hold ONE instance per test; obtain a
  * caller-scoped {@link CourierHttpClient} via {@link FakeCourierServer.clientFor}.
@@ -60,6 +66,8 @@ const nextNonce = (): string => `nonce-${++randomCounter}-${Math.random().toStri
 export class FakeCourierServer {
   /** Canonical network literal baked into the ack template (DESIGN §6.4). */
   readonly network: string;
+  /** Page size for `/inbox` + `/sent` (mirrors token-api `config.PAGE_LIMIT`). */
+  private readonly pageLimit: number;
 
   private readonly deliveries: DeliveryRow[] = [];
   private readonly recipientSeq = new Map<string, number>();
@@ -78,8 +86,10 @@ export class FakeCourierServer {
     sent: number[];
   } = { deposit: [], ack: [], ackNonce: [], inbox: [], sent: [] };
 
-  constructor(network = 'testnet2') {
-    this.network = network;
+  constructor(opts: FakeCourierServerOptions | string = {}) {
+    const o = typeof opts === 'string' ? { network: opts } : opts;
+    this.network = o.network ?? 'testnet2';
+    this.pageLimit = o.pageLimit ?? 1000;
   }
 
   /** A {@link CourierHttpClient} bound to a caller (the authenticated chainPubkey). */
@@ -125,23 +135,26 @@ export class FakeCourierServer {
 
   private inbox(recipientId: string, since: number): CourierInboxResponse {
     this.calls.inbox.push(since);
-    const items = this.deliveries
+    const rows = this.deliveries
       .filter((d) => d.recipientId === recipientId && d.seq > since)
-      .sort((a, b) => a.seq - b.seq)
-      .map((d) => ({
-        entryId: d.entryId,
-        seq: d.seq,
-        status: d.status,
-        senderPubkey: d.senderId,
-        ciphertext: d.ciphertext,
-        transferId: d.transferId,
-        hint: d.hint,
-        ackSig: d.ackSig,
-      }));
+      .sort((a, b) => a.seq - b.seq);
+    // Page-limited (mirrors token-api: fetch limit+1, `more` when overshot).
+    const more = rows.length > this.pageLimit;
+    const page = more ? rows.slice(0, this.pageLimit) : rows;
+    const items = page.map((d) => ({
+      entryId: d.entryId,
+      seq: d.seq,
+      status: d.status,
+      senderPubkey: d.senderId,
+      ciphertext: d.ciphertext,
+      transferId: d.transferId,
+      hint: d.hint,
+      ackSig: d.ackSig,
+    }));
     return {
       readPointer: this.readPointers.get(recipientId) ?? 0,
       syncEpoch: this.syncEpoch,
-      more: false,
+      more,
       items,
     };
   }
@@ -174,17 +187,20 @@ export class FakeCourierServer {
 
   private sent(senderId: string, since: number): CourierSentResponse {
     this.calls.sent.push(since);
-    const items = this.deliveries
+    const rows = this.deliveries
       .filter((d) => d.senderId === senderId && d.sentSeq > since)
-      .sort((a, b) => a.sentSeq - b.sentSeq)
-      .map((d) => ({
-        entryId: d.entryId,
-        recipientPubkey: d.recipientId,
-        status: d.status,
-        ackSig: d.ackSig,
-        ackNonce: d.ackNonce,
-      }));
-    return { more: false, items };
+      .sort((a, b) => a.sentSeq - b.sentSeq);
+    const more = rows.length > this.pageLimit;
+    const page = more ? rows.slice(0, this.pageLimit) : rows;
+    const items = page.map((d) => ({
+      entryId: d.entryId,
+      recipientPubkey: d.recipientId,
+      status: d.status,
+      sentSeq: d.sentSeq,
+      ackSig: d.ackSig,
+      ackNonce: d.ackNonce,
+    }));
+    return { more, items };
   }
 
   // --- test affordances -----------------------------------------------------

--- a/tests/integration/vault/courier.pagination.test.ts
+++ b/tests/integration/vault/courier.pagination.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Courier inbox/sent pagination + watermark persistence
+ * (finding courier-readpointer-and-watermark-never-persisted).
+ *
+ * Before the fix the provider READ a since/watermark but NEVER wrote it back and
+ * IGNORED the `more` flag, so:
+ *  - `receive()` only processed the FIRST page and always re-queried `since=0` —
+ *    a delivery on page 2 was a LOST TRANSFER (never received/acked).
+ *  - `pollSent()` likewise dropped page-2 confirmations and re-polled from 0.
+ *
+ * This suite drives MORE than one page (pageLimit:2) and asserts:
+ *  - every inbox entry across ALL pages is received (page-2 delivery is NOT lost);
+ *  - a SECOND `receive()` resumes from the persisted read pointer (not `since=0`);
+ *  - `pollSent()` confirms a page-2 delivery and persists the sent watermark so the
+ *    next poll resumes past the already-delivered prefix.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import { CourierDeliveryProvider } from '../../../transport/courier/CourierDeliveryProvider';
+import { FakeCourierServer } from '../../helpers/fake-courier-server';
+import type { FullIdentity } from '../../../types';
+import type { V2TransferPayload } from '../../../types/v2-transfer';
+import type {
+  CourierDeliveryConfig,
+  CourierJournalStore,
+  V2TransferSink,
+} from '../../../transport/courier/CourierDeliveryProvider';
+
+const NETWORK = 'testnet2';
+const SENDER_PRIV = '55'.repeat(32);
+const RECIPIENT_PRIV = '66'.repeat(32);
+const SENDER_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(SENDER_PRIV), true));
+const RECIPIENT_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIPIENT_PRIV), true));
+
+const sender: FullIdentity = { chainPubkey: SENDER_PUB, l1Address: 'alpha1s', privateKey: SENDER_PRIV };
+const recipient: FullIdentity = { chainPubkey: RECIPIENT_PUB, l1Address: 'alpha1r', privateKey: RECIPIENT_PRIV };
+const noopSink: V2TransferSink = async (_p: V2TransferPayload, _s: string) => {};
+
+/** A distinct token blob per index so each deposit is a distinct entryId + tokenId. */
+function blobFor(i: number): string {
+  const tokenId = i.toString(16).padStart(64, '0');
+  const token = new Uint8Array(16).map((_, j) => (i * 13 + j) & 0xff);
+  return bytesToHex(encodeTokenBlob({ v: 1, network: 0, tokenId, token }));
+}
+
+function memJournal(): CourierJournalStore & { map: Map<string, string> } {
+  const map = new Map<string, string>();
+  return { map, get: async (k) => map.get(k) ?? null, set: async (k, v) => void map.set(k, v) };
+}
+
+function makeProvider(
+  id: FullIdentity,
+  server: FakeCourierServer,
+  journal: CourierJournalStore,
+  overrides: Partial<CourierDeliveryConfig> = {},
+): CourierDeliveryProvider {
+  const p = new CourierDeliveryProvider({
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    network: NETWORK,
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+    journal,
+    onV2Transfer: noopSink,
+    ...overrides,
+  });
+  p.setIdentity(id);
+  return p;
+}
+
+/** Deposit `count` distinct envelopes from the sender to the recipient. */
+async function depositMany(server: FakeCourierServer, count: number): Promise<void> {
+  const sp = makeProvider(sender, server, memJournal());
+  for (let i = 1; i <= count; i++) {
+    await sp.deposit({
+      recipientChainPubkey: RECIPIENT_PUB,
+      senderChainPubkey: SENDER_PUB,
+      transferId: `tx-${i}`,
+      tokenBlobHex: blobFor(i),
+    });
+  }
+}
+
+describe('courier inbox pagination + read-pointer persistence', () => {
+  it('receive() pulls ALL entries across pages (a page-2 delivery is NOT lost)', async () => {
+    const server = new FakeCourierServer({ network: NETWORK, pageLimit: 2 });
+    await depositMany(server, 5); // 5 entries / pageLimit 2 → 3 pages
+
+    const received: string[] = [];
+    const sink: V2TransferSink = async (p) => void received.push(p.tokenBlob);
+    const rp = makeProvider(recipient, server, memJournal(), { onV2Transfer: sink });
+    await rp.receive();
+
+    // All 5 envelopes (including those on pages 2 and 3) were opened + handled.
+    expect(received).toHaveLength(5);
+    const expected = [1, 2, 3, 4, 5].map(blobFor).sort();
+    expect([...received].sort()).toEqual(expected);
+  });
+
+  it('a SECOND receive() resumes from the persisted read pointer, not since=0', async () => {
+    const server = new FakeCourierServer({ network: NETWORK, pageLimit: 2 });
+    await depositMany(server, 5);
+
+    const journal = memJournal();
+    const rp = makeProvider(recipient, server, journal, { onV2Transfer: noopSink });
+    await rp.receive();
+
+    // The persisted read pointer advanced to the highest processed seq (5).
+    const ptr = journal.map.get(`courier_read_pointer:${NETWORK}:${RECIPIENT_PUB}`);
+    expect(ptr).toBe('5');
+
+    // A second receive() must NOT re-query from 0 — it resumes from the watermark.
+    server.calls.inbox.length = 0;
+    await rp.receive();
+    expect(server.calls.inbox[0]).toBe(5);
+    // No re-query from 0 at all on the second pass.
+    expect(server.calls.inbox).not.toContain(0);
+  });
+});
+
+describe('courier /sent pagination + watermark persistence', () => {
+  it('pollSent confirms a page-2 delivery and persists the sent watermark', async () => {
+    const server = new FakeCourierServer({ network: NETWORK, pageLimit: 2 });
+    const delivered: string[] = [];
+    const journal = memJournal();
+    const sp = makeProvider(sender, server, journal, { onDelivered: async (id) => void delivered.push(id) });
+
+    const handles: string[] = [];
+    for (let i = 1; i <= 5; i++) {
+      const h = await sp.deposit({
+        recipientChainPubkey: RECIPIENT_PUB,
+        senderChainPubkey: SENDER_PUB,
+        transferId: `tx-${i}`,
+        tokenBlobHex: blobFor(i),
+      });
+      handles.push(h.entryId);
+    }
+
+    // The recipient claims EVERY entry (across all inbox pages) for real.
+    const rp = makeProvider(recipient, server, memJournal());
+    await rp.receive();
+
+    await sp.pollSent();
+
+    // Every deposited entry — including those whose /sent row is on page 2/3 — is
+    // confirmed delivered (the page-2 confirmation is NOT dropped).
+    expect([...delivered].sort()).toEqual([...handles].sort());
+    // The sent watermark advanced to the highest contiguously-delivered sentSeq (5).
+    expect(journal.map.get(`courier_sent_watermark:${NETWORK}:${SENDER_PUB}`)).toBe('5');
+
+    // A subsequent poll resumes past the delivered prefix, not from 0.
+    server.calls.sent.length = 0;
+    await sp.pollSent();
+    expect(server.calls.sent[0]).toBe(5);
+    expect(server.calls.sent).not.toContain(0);
+  });
+
+  it('the sent watermark does NOT advance past a still-pending entry', async () => {
+    const server = new FakeCourierServer({ network: NETWORK, pageLimit: 2 });
+    const journal = memJournal();
+    const sp = makeProvider(sender, server, journal);
+
+    for (let i = 1; i <= 3; i++) {
+      await sp.deposit({
+        recipientChainPubkey: RECIPIENT_PUB,
+        senderChainPubkey: SENDER_PUB,
+        transferId: `tx-${i}`,
+        tokenBlobHex: blobFor(i),
+      });
+    }
+    // Nobody claims anything → no entry is delivered.
+    await sp.pollSent();
+
+    // The watermark must stay at 0: advancing past unconfirmed entries would drop
+    // their future delivery confirmation (a lost transfer).
+    expect(journal.map.get(`courier_sent_watermark:${NETWORK}:${SENDER_PUB}`) ?? '0').toBe('0');
+  });
+});

--- a/tests/integration/vault/vault-resurrect-aead-version.test.ts
+++ b/tests/integration/vault/vault-resurrect-aead-version.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Resurrect AEAD version binding (finding vault-aead-resurrect-version-mismatch).
+ *
+ * The vault entry AAD binds `(network, ownerId, key, version)`. In the
+ * delete-resurrect path a locally-recreated token is sent with CAS `baseVersion:0`
+ * against a server `deleted` row, but the SERVER converges the row to
+ * `deletedRow.version + 1` (monotonic), NOT to version 1. Before the fix the
+ * client sealed the payload AAD at version `baseVersion + 1 = 1`, so the AAD
+ * version (1) disagreed with the server-stored version (deletedRow.version + 1) —
+ * a fresh `load()` would then rebuild the AAD at the server version and decryption
+ * would FAIL, making the resurrected token permanently unreadable.
+ *
+ * Fix: a resurrect seals the AAD at `known[wireKey].version + 1` (the version the
+ * server will assign), while still sending CAS `baseVersion:0`.
+ *
+ * This test exercises the full provider lifecycle (create v1 → delete v2 →
+ * resurrect v3) against the in-process fake server, then reads back the server's
+ * STORED ciphertext and opens it at the SERVER-REPORTED version. The open must
+ * succeed and round-trip to the resurrected plaintext (it threw before the fix),
+ * and the AAD version sealed must equal the version the server stored.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { RemoteTokenStorageProvider } from '../../../storage/remote/RemoteTokenStorageProvider';
+import { wireKey } from '../../../storage/remote/wire-key';
+import { openVaultEntry } from '../../../vault-aead/entry';
+import { deriveVaultKey } from '../../../vault-aead/derive';
+import { FakeVaultServer } from '../../helpers/fake-vault-server';
+import type { TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+
+const NETWORK = 'testnet2';
+const PRIV = '7c'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1me', privateKey: PRIV };
+
+function makeProvider(server: FakeVaultServer): RemoteTokenStorageProvider {
+  const p = new RemoteTokenStorageProvider({
+    network: NETWORK,
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    privateKey: PRIV,
+    authClient: server.authClient(),
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+  });
+  p.setIdentity(identity);
+  return p;
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: 'DIRECT://x', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+/** Decrypt a stored entry's ciphertext at the SERVER-reported version (the load-time AAD). */
+function openStored(server: FakeVaultServer, plainKey: string): unknown {
+  const wk = wireKey(PRIV, NETWORK, plainKey);
+  const row = server.getEntry(PUB, wk)!;
+  const pt = openVaultEntry({
+    network: NETWORK,
+    ownerId: PUB,
+    key: wk,
+    version: row.version, // the AAD version a fresh load() would rebuild from /state
+    payload: row.payload,
+    key32: deriveVaultKey(PRIV, NETWORK),
+  });
+  return JSON.parse(new TextDecoder().decode(pt));
+}
+
+describe('resurrect AEAD version binding', () => {
+  it('the resurrected entry decrypts at the server-stored version and round-trips', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const wk = wireKey(PRIV, NETWORK, 'k');
+    const provider = makeProvider(server);
+    await provider.initialize();
+
+    // create v1
+    await provider.sync(txf({ k: { amt: '1' } }));
+    expect(server.getEntry(PUB, wk)?.version).toBe(1);
+
+    // delete -> server tombstones at v2
+    await provider.sync(txf({})); // 'k' absent → orphan delete
+    expect(server.getEntry(PUB, wk)?.deleted).toBe(true);
+    expect(server.getEntry(PUB, wk)?.version).toBe(2);
+
+    // recreate the same token locally → resurrect; server stores at v3 (baseVersion:0)
+    const resurrected = { amt: '2' };
+    await provider.sync(txf({ k: resurrected }));
+    const row = server.getEntry(PUB, wk)!;
+    expect(row.deleted).toBe(false);
+    expect(row.version).toBe(3); // v1 create -> v2 delete -> v3 resurrect
+
+    // PROOF: the ciphertext stored at v3 must DECRYPT when the AAD is rebuilt at the
+    // server version (3) — exactly what a fresh load() does. Before the fix the AAD
+    // was sealed at version 1, so this threw (a permanently-unreadable token).
+    const decoded = openStored(server, 'k');
+    expect(decoded).toEqual(resurrected);
+
+    // A fresh provider loads the resurrected row and round-trips the plaintext too.
+    const reader = makeProvider(server);
+    await reader.initialize();
+    expect(openStored(server, 'k')).toEqual(resurrected);
+  });
+
+  it('a normal create/update still seals the AAD at the server-stored version', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const provider = makeProvider(server);
+    await provider.initialize();
+
+    // create v1 then update v2 (no delete in between)
+    await provider.sync(txf({ k: { n: 1 } }));
+    await provider.sync(txf({ k: { n: 2 } }));
+    const row = server.getEntry(PUB, wireKey(PRIV, NETWORK, 'k'))!;
+    expect(row.version).toBe(2);
+    // The update ciphertext decrypts at v2 (regression guard for the non-resurrect path).
+    expect(openStored(server, 'k')).toEqual({ n: 2 });
+  });
+});

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -24,12 +24,27 @@ import { courierEntryId } from './entryId';
 import { courierAckTemplate } from './ack-template';
 import type {
   CourierHttpClient,
+  CourierInboxItem,
   DeliveryHandle,
   SignedReceipt,
   TokenDeliveryCapabilities,
   TokenDeliveryTransport,
   TokenEnvelope,
 } from './types';
+
+/** The highest `seq` across a page of rows, falling back to `fallback` when empty. */
+function highestSeq(items: ReadonlyArray<{ seq: number }>, fallback: number): number {
+  let max = fallback;
+  for (const item of items) if (item.seq > max) max = item.seq;
+  return max;
+}
+
+/** The highest `sentSeq` across a /sent page, falling back to `fallback` when empty. */
+function highestSentSeq(items: ReadonlyArray<{ sentSeq: number }>, fallback: number): number {
+  let max = fallback;
+  for (const item of items) if (item.sentSeq > max) max = item.sentSeq;
+  return max;
+}
 
 /**
  * Sink for a decoded incoming transfer — bound by PaymentsModule to its existing
@@ -49,6 +64,13 @@ interface SentPendingEntry {
   recipientPubkey: string;
   attempts: number;
   state: SenderDeliveryState;
+  /**
+   * The server-assigned per-sender watermark for this entry (from the deposit
+   * response). Lets `pollSent()` advance the persisted sent watermark by sentSeq —
+   * present on entries deposited after the watermark fix; absent (undefined) on
+   * rows journaled by an older build (watermark still advances via the /sent row).
+   */
+  sentSeq?: number;
 }
 
 /** Minimal persistent KV the journal needs (matches PaymentsModule storage). */
@@ -140,8 +162,9 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
       // hint stays undefined here — a single base64 SCALAR when present (never an object).
     });
     // Track the entry sender-side so pollSent() can gate "delivered" on a valid
-    // recipient ackSig before removing PENDING_V2_DELIVERIES (DESIGN §6.5).
-    await this.journalSentPending(entryId, envelope.recipientChainPubkey);
+    // recipient ackSig before removing PENDING_V2_DELIVERIES (DESIGN §6.5). The
+    // sentSeq is captured so pollSent() can advance the persisted sent watermark.
+    await this.journalSentPending(entryId, envelope.recipientChainPubkey, res.sentSeq);
     return {
       entryId: res.entryId,
       transferId: envelope.transferId,
@@ -177,23 +200,62 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
   // ===========================================================================
 
   /**
-   * Pull the inbox since the server read pointer, open each envelope, decode it
+   * Pull the inbox since the persisted read pointer, open each envelope, decode it
    * to a {@link TokenEnvelope}, map it to a {@link V2TransferPayload}, and feed
    * the EXISTING `handleV2Transfer` path (via {@link V2TransferSink}) UNCHANGED.
    *
-   * Re-pulling an already-processed-but-unclaimed item is harmless — the sink
-   * dedups by `v2_${tokenId}`. After a successful receive the entry is queued for
-   * the signed ack (Task 5.3).
+   * PAGINATION (finding courier-readpointer-and-watermark-never-persisted): loop
+   * `/inbox?since=` while `more` so a delivery on page 2+ is NEVER dropped (a lost
+   * transfer). After processing, PERSIST the advanced read pointer — the highest
+   * CONTIGUOUSLY-processed seq — so the next `receive()` resumes from there and not
+   * from `since=0`. The fetch cursor advances by the highest seq seen per page even
+   * if an item failed mid-page (it is re-pulled next time from the persisted, lower
+   * pointer; re-receiving is harmless — the sink dedups by `v2_${tokenId}`).
    */
   async receive(): Promise<void> {
     const me = this.requireIdentity();
     const client = this.config.httpClientFactory(me.chainPubkey);
-    const since = await this.readPointer();
-    const res = await client.inbox(since);
-    for (const item of res.items) {
-      if (item.status === 'claimed') continue;
-      await this.receiveItem(me, item);
+    const start = await this.readPointer();
+    let watermark = start;
+    try {
+      let cursor = start;
+      for (;;) {
+        const res = await client.inbox(cursor);
+        watermark = await this.processInboxPage(me, res.items, watermark);
+        const next = highestSeq(res.items, cursor);
+        // No more pages, or `more` set but the page did not advance (defensive).
+        if (!res.more || next <= cursor) break;
+        cursor = next;
+      }
+    } finally {
+      // Persist whatever contiguous progress we made — even if a later item threw,
+      // the prefix we fully processed must not be re-pulled from since=0 next time.
+      if (watermark > start) {
+        await this.config.journal.set(this.readPointerKey(), String(watermark));
+      }
     }
+  }
+
+  /**
+   * Process one inbox page IN SEQ ORDER, advancing the contiguous read-pointer
+   * watermark. An item counts as processed when it is already `claimed` (skip) or
+   * `receiveItem` completes without throwing; the FIRST item that throws breaks
+   * contiguity AND propagates (the Phase-5 crash-recovery contract), so the
+   * watermark never advances past an item we did not fully process.
+   */
+  private async processInboxPage(
+    me: FullIdentity,
+    items: ReadonlyArray<CourierInboxItem>,
+    watermark: number,
+  ): Promise<number> {
+    let advanced = watermark;
+    for (const item of items) {
+      if (item.status !== 'claimed') {
+        await this.receiveItem(me, item); // throws → propagates, watermark frozen here
+      }
+      advanced = Math.max(advanced, item.seq);
+    }
+    return advanced;
   }
 
   /** Open one inbox item and feed it to handleV2Transfer; then arm the ack. */
@@ -346,10 +408,10 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
     await this.config.journal.set(this.sentPendingKey(), JSON.stringify(pending));
   }
 
-  private async journalSentPending(entryId: string, recipientPubkey: string): Promise<void> {
+  private async journalSentPending(entryId: string, recipientPubkey: string, sentSeq?: number): Promise<void> {
     const pending = await this.loadSentPending();
     if (!pending[entryId]) {
-      pending[entryId] = { recipientPubkey, attempts: 0, state: 'pending' };
+      pending[entryId] = { recipientPubkey, attempts: 0, state: 'pending', sentSeq };
       await this.saveSentPending(pending);
     }
   }
@@ -361,17 +423,53 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
    * signature licenses `onDelivered` (which removes `PENDING_V2_DELIVERIES` + GC).
    * A forged flag without a valid sig is rejected → the entry stays pending and is
    * redelivered (bounded by attempt count → `delivery_unconfirmed`).
+   *
+   * PAGINATION + WATERMARK (finding courier-readpointer-and-watermark-never-persisted):
+   * loop `/sent?since=` while `more` so a delivery confirmation on page 2+ is NEVER
+   * dropped, then PERSIST the advanced sent watermark — the highest CONTIGUOUSLY-
+   * delivered sentSeq — so the next poll resumes past the confirmed prefix and not
+   * from `since=0`. A still-pending entry holds the watermark back (it must keep
+   * being polled), so we never advance past an unconfirmed delivery.
    */
   async pollSent(): Promise<void> {
     const me = this.requireIdentity();
     const client = this.config.httpClientFactory(me.chainPubkey);
-    const since = await this.sentWatermark();
-    const res = await client.sent(since);
+    const start = await this.sentWatermark();
     const pending = await this.loadSentPending();
-    for (const item of res.items) {
-      await this.reconcileSentItem(me, pending, item);
+    let cursor = start;
+    for (;;) {
+      const res = await client.sent(cursor);
+      for (const item of res.items) {
+        await this.reconcileSentItem(me, pending, item);
+      }
+      const next = highestSentSeq(res.items, cursor);
+      if (!res.more || next <= cursor) break;
+      cursor = next;
     }
     await this.saveSentPending(pending);
+    await this.advanceSentWatermark(start, pending);
+  }
+
+  /**
+   * Persist the sent watermark to the highest CONTIGUOUSLY-delivered sentSeq.
+   * Entries are walked in sentSeq order; the first non-`delivered` entry (pending /
+   * delivery_unconfirmed) breaks contiguity so the watermark never advances past a
+   * delivery that still needs confirming. Entries without a known sentSeq (older
+   * journal rows) are conservatively treated as a contiguity break.
+   */
+  private async advanceSentWatermark(start: number, pending: Record<string, SentPendingEntry>): Promise<void> {
+    const rows = Object.values(pending)
+      .filter((e): e is SentPendingEntry & { sentSeq: number } => typeof e.sentSeq === 'number')
+      .sort((a, b) => a.sentSeq - b.sentSeq);
+    let watermark = start;
+    for (const row of rows) {
+      if (row.sentSeq <= start) continue; // already past the watermark
+      if (row.state !== 'delivered') break; // contiguity break — do not advance further
+      watermark = row.sentSeq;
+    }
+    if (watermark > start) {
+      await this.config.journal.set(this.sentWatermarkKey(), String(watermark));
+    }
   }
 
   /** Verify one /sent row's ackSig and advance its sender-side state. */

--- a/transport/courier/types.ts
+++ b/transport/courier/types.ts
@@ -127,6 +127,12 @@ export interface CourierSentItem {
   entryId: string;
   recipientPubkey: string;
   status: CourierDeliveryStatus;
+  /**
+   * The server-assigned per-sender monotonic watermark for this row (same space as
+   * the deposit `sentSeq`). Lets the sender persist a `/sent` watermark and paginate
+   * `?since=` across pages, so a delivery confirmation on page 2 is never dropped.
+   */
+  sentSeq: number;
   ackSig: string | null;
   /**
    * The server nonce the recipient's claim consumed — surfaced so the SENDER can


### PR DESCRIPTION
S2 [HIGH]: receive()/pollSent() persisted read-pointer + sent-watermark and loop on more (was always since=0, page-2 deliveries lost). S3 [MED]: resurrected vault entry now sealed at the server-assigned version (known.version+1) not 1 -> decrypts after fresh load (the mismatch reproduced as invalid-tag pre-fix). Added sentSeq to CourierSentItem wire type. 141/141 vault tests, tsc+eslint clean. FROZEN union + token-engine boundary intact.