### PR TITLE
refactor(vault): single-source contract module + v2 wallet-auth (challenge/verifyVaultAuth)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -554,6 +554,30 @@ export type {
 
 export { normalizeVaultNetwork } from './storage/remote/normalize-network';
 
+// Single-source contract + wallet→backend auth (the token-api server imports these
+// so both sides share ONE definition of every signing template / domain separator /
+// wire-reason label, and ONE auth recipe — the `verifySphereAuth` v2 successor).
+export {
+  EPOCH_CANON_PREFIX,
+  vaultEpochCanon,
+  ACCOUNT_DELETE_CANON_PREFIX,
+  vaultAccountDeleteCanon,
+  DELETE_CANON_PREFIX,
+  vaultDeleteCanon,
+  COURIER_ACK_PREFIX,
+  courierAckTemplate,
+  WIREKEY_DOMAIN,
+  ENTRYID_DOMAIN,
+  LEAF_DOMAIN,
+  VAULT_AEAD_DOMAIN,
+  COURIER_AEAD_DOMAIN,
+  VAULT_REASON,
+  VAULT_AUTH_PREFIX,
+  vaultAuthChallenge,
+  verifyVaultAuth,
+} from './vault/index';
+export type { VaultReason, VaultAuthChallengeBody, VerifyVaultAuthParams } from './vault/index';
+
 // Real fetch HTTP clients (Task 8.3): the swap-in for the in-memory fakes — the
 // raw auth client, the authenticated vault data client, the courier client, and a
 // convenience factory that builds the two authenticated clients over one shared

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -48,6 +48,7 @@ import {
 } from './reserved-address';
 import { sealHistoryRecord, openHistoryRecord } from './history-codec';
 import { deleteCanon } from '../../vault-aead/canon';
+import { VAULT_REASON } from '../../vault/contracts';
 import { signMessage } from '../../core/crypto';
 import { SphereError } from '../../core/errors';
 import { deriveDirectAddress } from '../../token-engine/identity';
@@ -273,14 +274,14 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
       await this.requireAuth().authenticate();
     } catch (error) {
       this.status = 'error';
-      this.emit('storage:error', { reason: 'auth' }, this.errMsg(error, 'vault auth failed'));
+      this.emit('storage:error', { reason: VAULT_REASON.AUTH }, this.errMsg(error, 'vault auth failed'));
       return false; // degrade — do NOT brick the wallet
     }
     this.status = 'connected';
     const first = await this.load(); // load() never throws (it try/catches internally)
     if (!first.success) {
       this.status = 'error';
-      this.emit('storage:error', { reason: 'initial-load' }, first.error);
+      this.emit('storage:error', { reason: VAULT_REASON.INITIAL_LOAD }, first.error);
       return false; // first load failed → gate stays SHUT, wallet still loads locally
     }
     return true;
@@ -340,7 +341,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
    * flush (gate OPEN, nothing to push), which stays success:true.
    */
   private degraded(localData: TData): SyncResult<TData> {
-    const reason = 'awaiting-initial-load';
+    const reason = VAULT_REASON.AWAITING_INITIAL_LOAD;
     this.emit('sync:error', { reason }, 'vault backup inactive: awaiting a successful initial load');
     return { success: false, merged: localData, added: 0, removed: 0, conflicts: 0, error: reason };
   }
@@ -666,7 +667,7 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   }
 
   private rollback(reason: string): LoadResult<TData> {
-    this.emit('storage:error', { reason: 'rollback', detail: reason });
+    this.emit('storage:error', { reason: VAULT_REASON.ROLLBACK, detail: reason });
     return { success: false, error: `vault rollback: ${reason}`, source: 'remote', timestamp: Date.now() };
   }
 

--- a/storage/remote/VaultApiClient.ts
+++ b/storage/remote/VaultApiClient.ts
@@ -15,10 +15,8 @@
  */
 
 import { signMessage } from '../../core/crypto';
+import { VAULT_AUTH_PREFIX } from '../../vault/auth';
 import type { AuthTokens, ChallengeResponse, VaultAuthHttpClient } from './types';
-
-/** Auth prefix the server stamps on every challenge (`services/auth.service.ts`). */
-const AUTH_PREFIX = 'unicity:vault:auth:v1\n';
 
 /** Reject challenges whose lifetime is implausibly long (a clamp on a hostile TTL). */
 const MAX_CHALLENGE_TTL_MS = 60 * 60_000; // 1 hour — the real server uses 5 min
@@ -124,7 +122,7 @@ export class VaultApiClient {
    * timestamps are implausible.
    */
   private verifyChallenge(c: ChallengeResponse): void {
-    if (!c.challenge.startsWith(AUTH_PREFIX)) {
+    if (!c.challenge.startsWith(VAULT_AUTH_PREFIX)) {
       throw new Error('vault auth: challenge missing the expected prefix — refusing to sign');
     }
     const body = this.parseBody(c.challenge);
@@ -142,7 +140,7 @@ export class VaultApiClient {
   private parseBody(challenge: string): ChallengeBody {
     let body: ChallengeBody;
     try {
-      body = JSON.parse(challenge.slice(AUTH_PREFIX.length)) as ChallengeBody;
+      body = JSON.parse(challenge.slice(VAULT_AUTH_PREFIX.length)) as ChallengeBody;
     } catch {
       throw new Error('vault auth: challenge body is not valid JSON — refusing to sign');
     }

--- a/storage/remote/merkle.ts
+++ b/storage/remote/merkle.ts
@@ -15,9 +15,7 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, signMessage, verifySignedMessage } from '../../core/crypto';
 import { lengthDelim, u64be } from '../../vault-aead/derive';
-
-/** Domain-separation prefix for a vault leaf. */
-const LEAF_PREFIX = 'vault-leaf-v1';
+import { LEAF_DOMAIN } from '../../vault/contracts';
 
 /** High bit of the u64 version field — set for a tombstone (deleted) leaf. */
 const TOMBSTONE_BIT = 1n << 63n;
@@ -47,7 +45,7 @@ function concatBytes(parts: Uint8Array[]): Uint8Array {
  */
 export function leaf(key: string, version: number | bigint, deleted = false): Uint8Array {
   const v = deleted ? BigInt(version) | TOMBSTONE_BIT : BigInt(version);
-  return sha256(concatBytes([utf8(LEAF_PREFIX), utf8(key), u64be(v)]));
+  return sha256(concatBytes([utf8(LEAF_DOMAIN), utf8(key), u64be(v)]));
 }
 
 /**

--- a/storage/remote/wire-key.ts
+++ b/storage/remote/wire-key.ts
@@ -18,11 +18,9 @@ import { hmac } from '@noble/hashes/hmac.js';
 import { hkdf } from '@noble/hashes/hkdf.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { hexToBytes, bytesToHex } from '../../core/crypto';
+import { WIREKEY_DOMAIN } from '../../vault/contracts';
 
 const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
-
-/** HKDF info prefix for the per-network wire-key derivation. */
-const WIRE_KEY_INFO_PREFIX = 'unicity-vault-wirekey-v1:';
 
 /**
  * Derive the opaque wire key for a plaintext vault key.
@@ -33,7 +31,7 @@ export function wireKey(walletPriv: string, network: string, plainKey: string): 
     sha256,
     hexToBytes(walletPriv),
     undefined,
-    utf8(WIRE_KEY_INFO_PREFIX + network),
+    utf8(WIREKEY_DOMAIN + network),
     32,
   );
   return bytesToHex(hmac(sha256, prk, utf8(plainKey)));

--- a/tests/helpers/fake-vault-server.ts
+++ b/tests/helpers/fake-vault-server.ts
@@ -32,7 +32,8 @@
 
 import { randomUUID } from 'node:crypto';
 import { recoverPubkeyFromSignature, verifySignedMessage, signMessage } from '../../core/crypto';
-import { epochCanon } from '../../vault-aead/canon';
+import { epochCanon, deleteCanon } from '../../vault-aead/canon';
+import { vaultAuthChallenge } from '../../vault/auth';
 import type { VaultEntryPayload } from '../../vault-aead/entry';
 import type {
   AccountDeleteResponse,
@@ -58,14 +59,9 @@ import type {
 /** Shared deployment-fixture server signing key — its pubkey = `NETWORKS.testnet2.vaultServerKey`. */
 export const SERVER_SIGN_PRIV = 'a'.repeat(64);
 
-const AUTH_PREFIX = 'unicity:vault:auth:v1\n';
 const CHALLENGE_TTL_MS = 5 * 60_000;
 const DEFAULT_PAGE_LIMIT = 1000;
 const DELETE_NONCE_TTL_MS = 5 * 60_000;
-
-/** REAL `deleteCanon` (account.service.ts:11) — `delete:v1`, NOT `account-delete:v1`. */
-const deleteCanon = (net: string, ownerId: string, nonce: string): string =>
-  `unicity:vault:delete:v1\n${net}\n${ownerId}\n${nonce}`;
 
 let counter = 0;
 const uniq = (p: string): string => `${p}-${++counter}-${Math.random().toString(36).slice(2)}`;
@@ -202,8 +198,8 @@ export class FakeVaultServer {
     const nonce = uniq('nonce');
     const issuedAt = new Date();
     const expiresAt = new Date(issuedAt.getTime() + CHALLENGE_TTL_MS);
-    // EXACT server template: JSON.stringify serializes Dates to ISO strings.
-    const challenge = AUTH_PREFIX + JSON.stringify({ network: this.network, pubkey, nonce, issuedAt, expiresAt });
+    // EXACT server template — built via the single-source contract (vault/auth.ts).
+    const challenge = vaultAuthChallenge({ network: this.network, pubkey, nonce, issuedAt, expiresAt });
     this.nonces.set(nonce, { pubkey, challenge, expiresAt: expiresAt.getTime() });
     return { nonce, challenge, expiresAt: expiresAt.toISOString() };
   }

--- a/tests/unit/vault/vault-auth-verify.test.ts
+++ b/tests/unit/vault/vault-auth-verify.test.ts
@@ -1,0 +1,121 @@
+/**
+ * vault/auth.ts — the wallet→backend auth contract (Part 2, the `verifySphereAuth`
+ * v2 successor).
+ *
+ * Pins the challenge builder's EXACT byte-string (key order network,pubkey,nonce,
+ * issuedAt,expiresAt; Dates→ISO via JSON.stringify) and proves the SERVER-side
+ * `verifyVaultAuth` returns the verified ownerId on a faithful bundle and `null`
+ * (never throws) on every tamper: wrong prefix, wrong pubkey, wrong network,
+ * expired, bad signature.
+ *
+ * The golden challenge is derived from the SHARED fixture keypair, so the same
+ * 130-hex `signMessage` scheme the cross-plan golden vector pins is exercised here.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { signMessage } from '../../../core/crypto';
+import { vaultAuthChallenge, verifyVaultAuth, VAULT_AUTH_PREFIX } from '../../../vault/auth';
+import vectors from '../../fixtures/vault-signing-vectors.json';
+
+const { sig } = vectors;
+const NETWORK = 'testnet2';
+const PUB = sig.pubkey;
+const PRIV = sig.priv;
+const NONCE = 'NONCE123';
+const ISSUED = '2026-06-13T00:00:00.000Z';
+const EXPIRES = '2026-06-13T00:05:00.000Z';
+
+/** The golden challenge — a fixed, human-auditable byte-string. */
+const GOLDEN_CHALLENGE =
+  VAULT_AUTH_PREFIX +
+  JSON.stringify({ network: NETWORK, pubkey: PUB, nonce: NONCE, issuedAt: ISSUED, expiresAt: EXPIRES });
+
+/** A clock comfortably inside the [issued, expires] window. */
+const NOW = Date.parse('2026-06-13T00:02:00.000Z');
+
+function build(over: Partial<{ network: string; pubkey: string; nonce: string; issuedAt: string; expiresAt: string }> = {}): string {
+  return vaultAuthChallenge({
+    network: over.network ?? NETWORK,
+    pubkey: over.pubkey ?? PUB,
+    nonce: over.nonce ?? NONCE,
+    issuedAt: over.issuedAt ?? ISSUED,
+    expiresAt: over.expiresAt ?? EXPIRES,
+  });
+}
+
+describe('vaultAuthChallenge — single-source builder', () => {
+  it('emits the EXACT prefixed, fixed-key-order JSON challenge', () => {
+    expect(build()).toBe(GOLDEN_CHALLENGE);
+  });
+
+  it('serializes Date issuedAt/expiresAt to ISO via JSON.stringify (byte-identical to strings)', () => {
+    const fromDates = vaultAuthChallenge({
+      network: NETWORK,
+      pubkey: PUB,
+      nonce: NONCE,
+      issuedAt: new Date(ISSUED),
+      expiresAt: new Date(EXPIRES),
+    });
+    expect(fromDates).toBe(GOLDEN_CHALLENGE);
+  });
+});
+
+describe('verifyVaultAuth — server-side verifier', () => {
+  it('returns the ownerId for a faithful challenge + signature', () => {
+    const challenge = build();
+    const signature = signMessage(PRIV, challenge);
+    expect(
+      verifyVaultAuth({ challenge, signature, expectedPubkey: PUB, expectedNetwork: NETWORK, now: NOW }),
+    ).toBe(PUB);
+  });
+
+  it('returns null (never throws) on a wrong prefix', () => {
+    const challenge = build();
+    const signature = signMessage(PRIV, challenge);
+    expect(
+      verifyVaultAuth({ challenge: challenge.slice(5), signature, expectedPubkey: PUB, expectedNetwork: NETWORK, now: NOW }),
+    ).toBeNull();
+  });
+
+  it('returns null when the embedded pubkey is not the expected one', () => {
+    const challenge = build();
+    const signature = signMessage(PRIV, challenge);
+    expect(
+      verifyVaultAuth({ challenge, signature, expectedPubkey: 'ff'.repeat(33), expectedNetwork: NETWORK, now: NOW }),
+    ).toBeNull();
+  });
+
+  it('returns null when the embedded network is not the expected one', () => {
+    const challenge = build();
+    const signature = signMessage(PRIV, challenge);
+    expect(
+      verifyVaultAuth({ challenge, signature, expectedPubkey: PUB, expectedNetwork: 'mainnet', now: NOW }),
+    ).toBeNull();
+  });
+
+  it('returns null when the challenge is already expired', () => {
+    const challenge = build();
+    const signature = signMessage(PRIV, challenge);
+    const afterExpiry = Date.parse(EXPIRES) + 1;
+    expect(
+      verifyVaultAuth({ challenge, signature, expectedPubkey: PUB, expectedNetwork: NETWORK, now: afterExpiry }),
+    ).toBeNull();
+  });
+
+  it('returns null on a bad signature (a bad sig is a 401, not a 500)', () => {
+    const challenge = build();
+    // A signature over a DIFFERENT challenge — recovers to a different/None pubkey.
+    const wrongSig = signMessage(PRIV, build({ nonce: 'OTHER' }));
+    expect(
+      verifyVaultAuth({ challenge, signature: wrongSig, expectedPubkey: PUB, expectedNetwork: NETWORK, now: NOW }),
+    ).toBeNull();
+  });
+
+  it('returns null on a malformed (wrong-length) signature without throwing', () => {
+    const challenge = build();
+    expect(
+      verifyVaultAuth({ challenge, signature: 'deadbeef', expectedPubkey: PUB, expectedNetwork: NETWORK, now: NOW }),
+    ).toBeNull();
+  });
+});

--- a/transport/courier/ack-template.ts
+++ b/transport/courier/ack-template.ts
@@ -7,18 +7,10 @@
  * The signature is the fund-critical attestation: bound to `(network, sender,
  * entryId, serverNonce)` so it is NOT replayable across senders, deposits, or
  * deployments. Both the SDK (signs) and token-api (verifies) build this EXACT
- * literal — pinned by the integration tests so a divergence is caught.
+ * literal.
+ *
+ * The literal is now DEFINED ONCE in `vault/contracts.ts`; this file re-exports it
+ * so existing call sites keep their import path.
  */
 
-/** Canonical prefix for the courier ack attestation. */
-export const COURIER_ACK_PREFIX = 'unicity:courier:ack:v1';
-
-/** Build the exact ack message bound to `(network, senderPubkey, entryId, serverNonce)`. */
-export function courierAckTemplate(
-  network: string,
-  senderPubkey: string,
-  entryId: string,
-  serverNonce: string,
-): string {
-  return `${COURIER_ACK_PREFIX}\n${network}\n${senderPubkey}\n${entryId}\n${serverNonce}`;
-}
+export { COURIER_ACK_PREFIX, courierAckTemplate } from '../../vault/contracts';

--- a/transport/courier/entryId.ts
+++ b/transport/courier/entryId.ts
@@ -19,11 +19,9 @@ import { sha256 as nobleSha256 } from '@noble/hashes/sha2.js';
 import { sha256, bytesToHex, hexToBytes } from '../../core/crypto';
 import { decodeTokenBlob } from '../../token-engine/token-blob';
 import { ecdhX } from '../../vault-aead/ecdh';
+import { ENTRYID_DOMAIN } from '../../vault/contracts';
 
 const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
-
-/** HKDF info for the courier entryId key. */
-const ENTRYID_INFO = 'unicity-courier-entryid-v1';
 
 /**
  * The per-state hash bound into the entryId — IDENTICAL to the value
@@ -47,7 +45,7 @@ export function courierStateHash(tokenBlobHex: string): string {
 export function courierEntryId(senderPriv: string, recipientPub: string, tokenBlobHex: string): string {
   const blob = decodeTokenBlob(hexToBytes(tokenBlobHex));
   const stateHash = sha256(bytesToHex(blob.token), 'hex');
-  const kEntry = hkdf(nobleSha256, ecdhX(senderPriv, recipientPub), undefined, utf8(ENTRYID_INFO), 32);
+  const kEntry = hkdf(nobleSha256, ecdhX(senderPriv, recipientPub), undefined, utf8(ENTRYID_DOMAIN), 32);
   // tokenId ‖ stateHash, both as their utf8 hex-string bytes (the values the
   // sender and recipient both hold as strings — see tryParseBlobKeys).
   const msg = utf8(blob.tokenId + stateHash);

--- a/vault-aead/canon.ts
+++ b/vault-aead/canon.ts
@@ -1,55 +1,25 @@
 /**
  * Canonical signing literals shared with the token-api server (§8.1).
  *
- * These templates are the EXACT byte-strings both plans sign/verify. They are
- * pinned by the shared golden vectors (`tests/fixtures/vault-signing-vectors.json`)
- * so a divergence on either side is caught by a failing test.
+ * These templates are now DEFINED ONCE in `vault/contracts.ts` (the single-source
+ * contract module). This file is a thin compatibility shim: it re-exports them
+ * under the historical `epochCanon` / `deleteCanon` / `accountDeleteCanon` names so
+ * existing call sites keep working. No literal lives here — see `vault/contracts.ts`.
  *
  * `epochCanon` is the message the vault server signs to attest a monotonic
  * storage-epoch (§5.4/§8.2). The SDK verifies the server's `epochSig` against
  * `NETWORKS[net].vaultServerKey` — a server-signed epoch bump is the only thing
  * that distinguishes a sanctioned testnet reset from a hostile rollback.
- */
-
-/** HKDF/canon prefix for the server epoch attestation. */
-export const EPOCH_CANON_PREFIX = 'unicity:vault:epoch:v1';
-
-/**
- * Canonical epoch message: `'unicity:vault:epoch:v1\n' + network + '\n' + epoch`.
- * The epoch is concatenated as its decimal string.
- */
-export function epochCanon(network: string, epoch: number | bigint): string {
-  return `${EPOCH_CANON_PREFIX}\n${network}\n${epoch}`;
-}
-
-/**
- * Account-delete canonical template (scheme fixture — §8.1).
  *
- * NOTE: this `account-delete:v1` literal exists only as a golden scheme vector
- * (Task 2.2). The ACTUAL runtime account-delete template used by the provider
- * (Phase 7, matching Part A's delete route) is `unicity:vault:delete:v1` — do
- * NOT swap the runtime path onto this literal.
+ * The `account-delete:v1` literal exists ONLY as a golden scheme vector; the REAL
+ * runtime account-delete template is `delete:v1` (see `vault/contracts.ts`).
  */
-export const ACCOUNT_DELETE_CANON_PREFIX = 'unicity:vault:account-delete:v1';
 
-/**
- * Canonical account-delete message:
- * `'unicity:vault:account-delete:v1\n' + network + '\n' + chainPubkey + '\n' + nonce`.
- */
-export function accountDeleteCanon(network: string, chainPubkey: string, nonce: string): string {
-  return `${ACCOUNT_DELETE_CANON_PREFIX}\n${network}\n${chainPubkey}\n${nonce}`;
-}
-
-/** Runtime account-delete prefix — the REAL Part A literal (`account.service.ts:11`). */
-export const DELETE_CANON_PREFIX = 'unicity:vault:delete:v1';
-
-/**
- * The REAL runtime account-delete message the wallet signs (Task 7.5, §7.4):
- * `'unicity:vault:delete:v1\n' + network + '\n' + ownerId + '\n' + nonce`.
- *
- * This is the `delete:v1` template Part A's `deleteCanon` verifies — NOT the
- * `account-delete:v1` scheme fixture above.
- */
-export function deleteCanon(network: string, ownerId: string, nonce: string): string {
-  return `${DELETE_CANON_PREFIX}\n${network}\n${ownerId}\n${nonce}`;
-}
+export {
+  EPOCH_CANON_PREFIX,
+  vaultEpochCanon as epochCanon,
+  ACCOUNT_DELETE_CANON_PREFIX,
+  vaultAccountDeleteCanon as accountDeleteCanon,
+  DELETE_CANON_PREFIX,
+  vaultDeleteCanon as deleteCanon,
+} from '../vault/contracts';

--- a/vault-aead/courier.ts
+++ b/vault-aead/courier.ts
@@ -14,9 +14,7 @@ import { randomBytes } from '@noble/hashes/utils.js';
 import { seal, open } from './aead';
 import { deriveCourierKey, lengthDelim } from './derive';
 import { ecdhX } from './ecdh';
-
-/** HKDF info for the courier AEAD key. */
-const COURIER_KEY_INFO = 'unicity-courier-aead-v1';
+import { COURIER_AEAD_DOMAIN } from '../vault/contracts';
 
 export interface SealCourierParams {
   network: string;
@@ -66,7 +64,7 @@ function courierAad(p: { network: string; senderPubkey: string; recipientPubkey:
  * production callers omit it so a fresh random nonce is drawn.
  */
 export function sealCourierEnvelope(params: SealCourierParams, nonce?: Uint8Array): string {
-  const key = deriveCourierKey(ecdhX(params.senderPriv, params.recipientPubkey), COURIER_KEY_INFO);
+  const key = deriveCourierKey(ecdhX(params.senderPriv, params.recipientPubkey), COURIER_AEAD_DOMAIN);
   const n = nonce ?? randomBytes(24);
   const aad = courierAad(params);
   const ct = seal(key, n, params.plaintext, aad);
@@ -75,7 +73,7 @@ export function sealCourierEnvelope(params: SealCourierParams, nonce?: Uint8Arra
 
 /** Open a packed courier envelope; returns the plaintext. Throws on any tamper. */
 export function openCourierEnvelope(params: OpenCourierParams): Uint8Array {
-  const key = deriveCourierKey(ecdhX(params.recipientPriv, params.senderPubkey), COURIER_KEY_INFO);
+  const key = deriveCourierKey(ecdhX(params.recipientPriv, params.senderPubkey), COURIER_AEAD_DOMAIN);
   const { nonce, ct } = unpackCourier(params.ciphertext);
   const aad = courierAad(params);
   return open(key, nonce, ct, aad);

--- a/vault-aead/derive.ts
+++ b/vault-aead/derive.ts
@@ -10,11 +10,9 @@
 import { hkdf } from '@noble/hashes/hkdf.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { hexToBytes } from '../core/crypto';
+import { VAULT_AEAD_DOMAIN } from '../vault/contracts';
 
 const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
-
-/** HKDF info prefix for the per-network vault AEAD key. */
-const VAULT_KEY_INFO_PREFIX = 'unicity-vault-aead-v1:';
 
 /** 4-byte big-endian encoding of an unsigned 32-bit integer. */
 export function u32be(n: number): Uint8Array {
@@ -59,7 +57,7 @@ export function deriveVaultKey(walletPriv: string, network: string): Uint8Array 
     sha256,
     hexToBytes(walletPriv),
     undefined,
-    utf8(VAULT_KEY_INFO_PREFIX + network),
+    utf8(VAULT_AEAD_DOMAIN + network),
     32,
   );
 }

--- a/vault/auth.ts
+++ b/vault/auth.ts
@@ -1,0 +1,128 @@
+/**
+ * vault/auth.ts — the v2 wallet→backend AUTH contract (successor to the removed
+ * `verifySphereAuth`).
+ *
+ * The challenge is the single byte-string both sides agree on:
+ *
+ *   challenge = 'unicity:vault:auth:v1\n'
+ *             + JSON.stringify({ network, pubkey, nonce, issuedAt, expiresAt })
+ *
+ * KEY ORDER is exactly `network, pubkey, nonce, issuedAt, expiresAt`; `Date`s are
+ * serialized to ISO-8601 by `JSON.stringify`. {@link vaultAuthChallenge} builds it;
+ * the wallet (client) verifies the template before signing, and the SERVER verifies
+ * the returned signature with {@link verifyVaultAuth} — the misuse-resistant,
+ * domain-separated recipe that wallet-api's review found MISSING in the v2 SDK.
+ *
+ * `verifyVaultAuth` is SELF-CONTAINED (only `core/crypto` primitives) so the
+ * token-api server can import it without pulling in any provider/storage code, and
+ * it NEVER throws on a bad signature — a bad sig is a 401, not a 500.
+ */
+
+import { recoverPubkeyFromSignature, verifySignedMessage } from '../core/crypto';
+
+/** The auth-challenge prefix the server stamps on every challenge. */
+export const VAULT_AUTH_PREFIX = 'unicity:vault:auth:v1\n';
+
+/** The challenge body the server JSON-encodes after the prefix (key order is load-bearing). */
+export interface VaultAuthChallengeBody {
+  network: string;
+  pubkey: string;
+  nonce: string;
+  /** `Date` (serialized to ISO by JSON.stringify) or a pre-formatted ISO string. */
+  issuedAt: string | Date;
+  /** `Date` (serialized to ISO by JSON.stringify) or a pre-formatted ISO string. */
+  expiresAt: string | Date;
+}
+
+/**
+ * Build the EXACT auth challenge string the server issues. The body key order is
+ * fixed at `network, pubkey, nonce, issuedAt, expiresAt`; `Date` values serialize
+ * to ISO-8601 strings via `JSON.stringify` (matching token-api `auth.service.ts`
+ * byte-for-byte — pinned by the golden auth vector + the e2e).
+ */
+export function vaultAuthChallenge(body: VaultAuthChallengeBody): string {
+  return (
+    VAULT_AUTH_PREFIX +
+    JSON.stringify({
+      network: body.network,
+      pubkey: body.pubkey,
+      nonce: body.nonce,
+      issuedAt: body.issuedAt,
+      expiresAt: body.expiresAt,
+    })
+  );
+}
+
+/** Parsed challenge body (timestamps land as ISO strings off the wire). */
+interface ParsedAuthBody {
+  network: string;
+  pubkey: string;
+  nonce: string;
+  issuedAt: string;
+  expiresAt: string;
+}
+
+export interface VerifyVaultAuthParams {
+  /** The literal challenge string the wallet signed. */
+  challenge: string;
+  /** The wallet's 130-hex signature over `challenge`. */
+  signature: string;
+  /** The pubkey the challenge claims (must equal the embedded + recovered signer). */
+  expectedPubkey: string;
+  /** The canonical network the server expects (must equal the embedded network). */
+  expectedNetwork: string;
+  /** Clock for the expiry check; defaults to `Date.now()`. */
+  now?: number;
+}
+
+/**
+ * SERVER-side verifier (the `verifySphereAuth` v2 successor). Asserts the auth
+ * prefix, parses the body, checks the embedded `pubkey`/`network` against the
+ * expected values and a non-expired `expiresAt`, then recovers the signer and
+ * verifies the signature under the SDK scheme.
+ *
+ * @returns the verified ownerId (the chain pubkey / signer) on success, or `null`
+ * on ANY failure (wrong prefix, bad body, pubkey/network mismatch, expired, bad
+ * sig). NEVER throws — a bad signature is a 401, not a 500 (mirrors token-api
+ * `auth.service.ts recoverOwner`'s swallow-throws behavior).
+ */
+export function verifyVaultAuth(params: VerifyVaultAuthParams): string | null {
+  const body = parseChallenge(params.challenge);
+  if (!body) return null;
+  if (body.pubkey !== params.expectedPubkey) return null;
+  if (body.network !== params.expectedNetwork) return null;
+  if (!isUnexpired(body, params.now ?? Date.now())) return null;
+  return recoverAndVerify(params.challenge, params.signature, body.pubkey);
+}
+
+/** Assert the prefix and parse the JSON body; `null` on either failure. */
+function parseChallenge(challenge: string): ParsedAuthBody | null {
+  if (!challenge.startsWith(VAULT_AUTH_PREFIX)) return null;
+  try {
+    return JSON.parse(challenge.slice(VAULT_AUTH_PREFIX.length)) as ParsedAuthBody;
+  } catch {
+    return null;
+  }
+}
+
+/** Plausible window: parseable timestamps and not already expired. */
+function isUnexpired(body: ParsedAuthBody, now: number): boolean {
+  const expires = Date.parse(body.expiresAt);
+  if (Number.isNaN(expires)) return false;
+  return expires > now;
+}
+
+/**
+ * Recover the signer and verify the SDK-scheme signature; the recovered signer
+ * MUST equal the (already validated) embedded pubkey. Swallows all throws → null.
+ */
+function recoverAndVerify(challenge: string, signature: string, pubkey: string): string | null {
+  try {
+    const signer = recoverPubkeyFromSignature(challenge, signature);
+    if (signer !== pubkey) return null;
+    if (!verifySignedMessage(challenge, signature, signer)) return null;
+    return signer;
+  } catch {
+    return null;
+  }
+}

--- a/vault/contracts.ts
+++ b/vault/contracts.ts
@@ -1,0 +1,132 @@
+/**
+ * vault/contracts.ts — the SINGLE SOURCE for every Token-Vault v2 contract string.
+ *
+ * Each signing template, domain separator and wire-reason label that the SDK and
+ * the token-api server must agree on byte-for-byte is defined HERE, exactly once.
+ * Every other module (and the token-api server) imports from this file rather than
+ * re-typing the literal. For a financial system a typo'd duplicate would silently
+ * break signature verification → funds inaccessible, so the constants live in one
+ * place and are pinned by the shared golden vectors + KAT tests.
+ *
+ * Three groups:
+ *  1. Signing templates / canons — the EXACT byte-strings both plans sign/verify
+ *     (epoch attestation, account-delete, courier ack, auth challenge → see auth.ts).
+ *  2. AAD / domain separators — the HKDF-info / HMAC / leaf domain prefixes.
+ *  3. Wire-reason labels — the `data.reason` strings carried on the FROZEN
+ *     `storage:error` / `sync:error` events (NOT new `StorageEventType` members).
+ *
+ * NONE of these VALUES may change: they are a wire contract proven byte-identical
+ * by `tests/fixtures/vault-signing-vectors.json` and the wirekey/entryId/leaf KATs.
+ */
+
+// =============================================================================
+// 1. Signing templates / canons
+// =============================================================================
+
+/** HKDF/canon prefix for the server epoch attestation (`unicity:vault:epoch:v1`). */
+export const EPOCH_CANON_PREFIX = 'unicity:vault:epoch:v1';
+
+/**
+ * Canonical epoch message: `'unicity:vault:epoch:v1\n' + network + '\n' + epoch`.
+ *
+ * The vault server signs this to attest a monotonic storage-epoch (§5.4/§8.2); the
+ * SDK verifies the server's `epochSig` against `NETWORKS[net].vaultServerKey`. The
+ * epoch is concatenated as its decimal string.
+ */
+export function vaultEpochCanon(network: string, epoch: number | bigint): string {
+  return `${EPOCH_CANON_PREFIX}\n${network}\n${epoch}`;
+}
+
+/**
+ * Account-delete SCHEME prefix (`unicity:vault:account-delete:v1`).
+ *
+ * NOTE: this literal exists ONLY as a golden scheme vector (§8.1, Task 2.2). The
+ * ACTUAL runtime account-delete template the provider signs is `delete:v1`
+ * ({@link vaultDeleteCanon}) — do NOT swap the runtime path onto this literal.
+ */
+export const ACCOUNT_DELETE_CANON_PREFIX = 'unicity:vault:account-delete:v1';
+
+/**
+ * Canonical account-delete SCHEME message (golden fixture only):
+ * `'unicity:vault:account-delete:v1\n' + network + '\n' + chainPubkey + '\n' + nonce`.
+ */
+export function vaultAccountDeleteCanon(network: string, chainPubkey: string, nonce: string): string {
+  return `${ACCOUNT_DELETE_CANON_PREFIX}\n${network}\n${chainPubkey}\n${nonce}`;
+}
+
+/** Runtime account-delete prefix — the REAL Part A literal (`account.service.ts:11`). */
+export const DELETE_CANON_PREFIX = 'unicity:vault:delete:v1';
+
+/**
+ * The REAL runtime account-delete message the wallet signs (Task 7.5, §7.4):
+ * `'unicity:vault:delete:v1\n' + network + '\n' + ownerId + '\n' + nonce`.
+ *
+ * This is the `delete:v1` template Part A's `deleteCanon` verifies — NOT the
+ * `account-delete:v1` scheme fixture above.
+ */
+export function vaultDeleteCanon(network: string, ownerId: string, nonce: string): string {
+  return `${DELETE_CANON_PREFIX}\n${network}\n${ownerId}\n${nonce}`;
+}
+
+/** Canonical prefix for the courier ack attestation (`unicity:courier:ack:v1`). */
+export const COURIER_ACK_PREFIX = 'unicity:courier:ack:v1';
+
+/**
+ * Build the exact courier-ack message bound to `(network, senderPubkey, entryId,
+ * serverNonce)`: `'unicity:courier:ack:v1\n' + network + '\n' + senderPubkey +
+ * '\n' + entryId + '\n' + serverNonce`.
+ *
+ * The signature is the fund-critical attestation: bound to the tuple so it is NOT
+ * replayable across senders, deposits, or deployments. Both the SDK (signs) and
+ * token-api (verifies) build this EXACT literal.
+ */
+export function courierAckTemplate(
+  network: string,
+  senderPubkey: string,
+  entryId: string,
+  serverNonce: string,
+): string {
+  return `${COURIER_ACK_PREFIX}\n${network}\n${senderPubkey}\n${entryId}\n${serverNonce}`;
+}
+
+// =============================================================================
+// 2. AAD / domain separators
+// =============================================================================
+
+/** HKDF info prefix for the per-network wire-key derivation (`wire-key.ts`). */
+export const WIREKEY_DOMAIN = 'unicity-vault-wirekey-v1:';
+
+/** HKDF info for the courier entryId key (`transport/courier/entryId.ts`). */
+export const ENTRYID_DOMAIN = 'unicity-courier-entryid-v1';
+
+/** Domain-separation prefix for a vault Merkle leaf (`storage/remote/merkle.ts`). */
+export const LEAF_DOMAIN = 'vault-leaf-v1';
+
+/** HKDF info prefix for the per-network vault AEAD key (`vault-aead/derive.ts`). */
+export const VAULT_AEAD_DOMAIN = 'unicity-vault-aead-v1:';
+
+/** HKDF info for the courier AEAD key (`vault-aead/courier.ts`). */
+export const COURIER_AEAD_DOMAIN = 'unicity-courier-aead-v1';
+
+// =============================================================================
+// 3. Wire-reason labels (frozen-event `data.reason`)
+// =============================================================================
+
+/**
+ * The `data.reason` labels carried on the FROZEN `storage:error` / `sync:error`
+ * events. These are NOT new `StorageEventType` members — they ride the existing
+ * frozen event union as a data field, so the union is untouched.
+ */
+export const VAULT_REASON = {
+  /** Signed-root anti-rollback gate tripped (`storage:error`). */
+  ROLLBACK: 'rollback',
+  /** Flush attempted before a successful initial load (`sync:error`). */
+  AWAITING_INITIAL_LOAD: 'awaiting-initial-load',
+  /** Auth handshake failed during initialize (`storage:error`). */
+  AUTH: 'auth',
+  /** First load failed after a successful auth (`storage:error`). */
+  INITIAL_LOAD: 'initial-load',
+} as const;
+
+/** A wire-reason label value (`'rollback' | 'awaiting-initial-load' | ...`). */
+export type VaultReason = (typeof VAULT_REASON)[keyof typeof VAULT_REASON];

--- a/vault/index.ts
+++ b/vault/index.ts
@@ -1,0 +1,32 @@
+/**
+ * vault — single-source contract + auth surface for Token-Vault v2.
+ *
+ * Re-exports the contract module (every signing template, domain separator and
+ * wire-reason label, defined ONCE in `contracts.ts`) and the wallet→backend auth
+ * recipe (`vault/auth.ts`). The token-api server imports the auth verifier + the
+ * canons/domains from here so both sides share one definition.
+ */
+
+export {
+  // signing templates / canons
+  EPOCH_CANON_PREFIX,
+  vaultEpochCanon,
+  ACCOUNT_DELETE_CANON_PREFIX,
+  vaultAccountDeleteCanon,
+  DELETE_CANON_PREFIX,
+  vaultDeleteCanon,
+  COURIER_ACK_PREFIX,
+  courierAckTemplate,
+  // AAD / domain separators
+  WIREKEY_DOMAIN,
+  ENTRYID_DOMAIN,
+  LEAF_DOMAIN,
+  VAULT_AEAD_DOMAIN,
+  COURIER_AEAD_DOMAIN,
+  // wire-reason labels
+  VAULT_REASON,
+} from './contracts';
+export type { VaultReason } from './contracts';
+
+export { VAULT_AUTH_PREFIX, vaultAuthChallenge, verifyVaultAuth } from './auth';
+export type { VaultAuthChallengeBody, VerifyVaultAuthParams } from './auth';


### PR DESCRIPTION
Every contract string now has ONE definition in vault/contracts.ts + vault/auth.ts (templates: epoch/delete/ack/auth; domains: wirekey/entryId/leaf/vault-aead/courier-aead; VAULT_REASON wire-reasons). New v2 wallet->backend auth module (successor to the removed verifySphereAuth): vaultAuthChallenge builder + verifyVaultAuth server-side verifier (binds to expectedPubkey, never throws -> null on any failure), exported publicly so token-api imports it (PR-2). PURE refactor: golden/KAT fixture SHA256 UNCHANGED, every literal byte-identical, 150/150 vault tests with original expected values. FROZEN StorageEventType union + token-engine boundary untouched. Reviewed PASS (byte-identical verified; verifyVaultAuth binds-to-expected + never-throws confirmed; non-string guard added).