### PR TITLE
fix(vault): verifyVaultAuth never-throws guard on non-string challenge

### DIFF
--- a/tests/unit/vault/vault-auth-verify.test.ts
+++ b/tests/unit/vault/vault-auth-verify.test.ts
@@ -78,6 +78,15 @@ describe('verifyVaultAuth — server-side verifier', () => {
     ).toBeNull();
   });
 
+  it('returns null (never throws) on a non-string challenge', () => {
+    const signature = signMessage(PRIV, build());
+    for (const bad of [undefined, null, 42, {}]) {
+      expect(
+        verifyVaultAuth({ challenge: bad as unknown as string, signature, expectedPubkey: PUB, expectedNetwork: NETWORK, now: NOW }),
+      ).toBeNull();
+    }
+  });
+
   it('returns null when the embedded pubkey is not the expected one', () => {
     const challenge = build();
     const signature = signMessage(PRIV, challenge);

--- a/vault/auth.ts
+++ b/vault/auth.ts
@@ -97,6 +97,9 @@ export function verifyVaultAuth(params: VerifyVaultAuthParams): string | null {
 
 /** Assert the prefix and parse the JSON body; `null` on either failure. */
 function parseChallenge(challenge: string): ParsedAuthBody | null {
+  // Defense-in-depth: a non-string input must yield null, never a TypeError —
+  // the server adopts this as its auth gate and a throw here would 500 not 401.
+  if (typeof challenge !== 'string') return null;
   if (!challenge.startsWith(VAULT_AUTH_PREFIX)) return null;
   try {
     return JSON.parse(challenge.slice(VAULT_AUTH_PREFIX.length)) as ParsedAuthBody;


### PR DESCRIPTION
PR-1 review LOW follow-up (the guard missed the #530 squash because of a malformed commit heredoc). parseChallenge ran challenge.startsWith outside its try/catch, so a non-string input threw TypeError instead of returning null - contradicting the never-throws guarantee the server adopts as its auth gate (throw -> 500 not 401). Adds a typeof guard + a test (undefined/null/number/object -> null). 10/10 auth-verify tests, tsc clean.