### PR TITLE
test+fix(vault): HTTP-client network-failure coverage + request timeout + confirmReceipt pagination

### DIFF
--- a/storage/remote/http/HttpVaultAuthClient.ts
+++ b/storage/remote/http/HttpVaultAuthClient.ts
@@ -18,7 +18,7 @@ import type {
   VaultAuthHttpClient,
   VerifyRequest,
 } from '../types';
-import { joinUrl, postJson, VaultHttpError } from './http-core';
+import { joinUrl, postJson, VaultHttpError, withTimeout } from './http-core';
 import type { FetchLike } from './http-core';
 
 export interface HttpVaultAuthClientConfig {
@@ -26,6 +26,8 @@ export interface HttpVaultAuthClientConfig {
   vaultUrl: string;
   /** Defaults to the global `fetch`; injectable for tests / custom agents. */
   fetchImpl?: FetchLike;
+  /** Per-request deadline (ms); defaults to `DEFAULT_REQUEST_TIMEOUT_MS`. `0` disables. */
+  timeoutMs?: number;
 }
 
 export class HttpVaultAuthClient implements VaultAuthHttpClient {
@@ -34,7 +36,7 @@ export class HttpVaultAuthClient implements VaultAuthHttpClient {
 
   constructor(config: HttpVaultAuthClientConfig) {
     this.base = config.vaultUrl;
-    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.fetchImpl = withTimeout(config.fetchImpl ?? fetch, config.timeoutMs);
   }
 
   /** `POST /v1/auth/challenge {pubkey}` → the literal challenge to sign. */

--- a/storage/remote/http/HttpVaultClient.ts
+++ b/storage/remote/http/HttpVaultClient.ts
@@ -26,7 +26,7 @@ import type {
   StateResponse,
   VaultHttpClient,
 } from '../types';
-import { authedJson } from './http-core';
+import { authedJson, withTimeout } from './http-core';
 import type { FetchLike, VaultTokenSource } from './http-core';
 
 /** A 507 body is still a valid PatchResponse — never thrown (DESIGN §5.4). */
@@ -39,6 +39,8 @@ export interface HttpVaultClientConfig {
   auth: VaultTokenSource;
   /** Defaults to the global `fetch`; injectable for tests. */
   fetchImpl?: FetchLike;
+  /** Per-request deadline (ms); defaults to `DEFAULT_REQUEST_TIMEOUT_MS`. `0` disables. */
+  timeoutMs?: number;
 }
 
 export class HttpVaultClient implements VaultHttpClient {
@@ -49,7 +51,7 @@ export class HttpVaultClient implements VaultHttpClient {
   constructor(config: HttpVaultClientConfig) {
     this.base = config.vaultUrl;
     this.auth = config.auth;
-    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.fetchImpl = withTimeout(config.fetchImpl ?? fetch, config.timeoutMs);
   }
 
   /** `PATCH /v1/entries {ops}` — 200 OR 507 both return a `PatchResponse` body. */

--- a/storage/remote/http/http-core.ts
+++ b/storage/remote/http/http-core.ts
@@ -40,6 +40,45 @@ export interface VaultTokenSource {
 /** The `fetch` implementation — injectable so tests can pass a custom one if needed. */
 export type FetchLike = typeof fetch;
 
+/**
+ * Default per-request deadline (ms). Without a client-side timeout a stalled or
+ * half-open server (accepts the socket, never writes a response) would hang the
+ * wallet's flush/auth forever; this bounds every vault/courier round trip.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Synthetic status for an error that never reached an HTTP response (timeout/refused). */
+const TRANSPORT_ERROR_STATUS = 0;
+
+/**
+ * Wrap a `fetch` so every request is bounded by `timeoutMs` (an `AbortController`
+ * deadline) AND any transport failure is surfaced as a typed {@link VaultHttpError}
+ * — so a stalled server, a connection-refused, or a DNS/socket error REJECTS with a
+ * catchable error (status `0`) instead of hanging or leaking a raw `TypeError`.
+ * `0`/negative `timeoutMs` disables the deadline (no AbortController).
+ */
+export function withTimeout(fetchImpl: FetchLike, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS): FetchLike {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const controller = timeoutMs > 0 ? new AbortController() : null;
+    const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+    try {
+      return await fetchImpl(input, controller ? { ...init, signal: controller.signal } : init);
+    } catch (err) {
+      throw transportError(input, err, controller?.signal.aborted ?? false, timeoutMs);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
+}
+
+/** Map an aborted/refused/socket fetch rejection to a typed VaultHttpError. */
+function transportError(input: RequestInfo | URL, err: unknown, aborted: boolean, timeoutMs: number): VaultHttpError {
+  const path = String(input);
+  if (aborted) return new VaultHttpError(TRANSPORT_ERROR_STATUS, path, `request timed out after ${timeoutMs}ms`);
+  const reason = err instanceof Error ? err.message : String(err);
+  return new VaultHttpError(TRANSPORT_ERROR_STATUS, path, `transport error: ${reason}`);
+}
+
 /** Build `{vaultUrl}{path}` with the base's trailing slash collapsed. */
 export function joinUrl(base: string, path: string): string {
   return `${base.replace(/\/+$/, '')}${path}`;

--- a/storage/remote/http/index.ts
+++ b/storage/remote/http/index.ts
@@ -25,7 +25,7 @@ export { HttpVaultClient } from './HttpVaultClient';
 export type { HttpVaultClientConfig } from './HttpVaultClient';
 export { HttpCourierClient } from '../../../transport/courier/http/HttpCourierClient';
 export type { HttpCourierClientConfig } from '../../../transport/courier/http/HttpCourierClient';
-export { VaultHttpError } from './http-core';
+export { VaultHttpError, withTimeout, DEFAULT_REQUEST_TIMEOUT_MS } from './http-core';
 export type { VaultTokenSource, FetchLike } from './http-core';
 
 /** Config for the {@link createVaultHttpClients} convenience factory. */
@@ -36,6 +36,8 @@ export interface VaultHttpClientsConfig {
   auth: VaultTokenSource;
   /** Defaults to the global `fetch`; injectable for tests / custom agents. */
   fetchImpl?: FetchLike;
+  /** Per-request deadline (ms); defaults to `DEFAULT_REQUEST_TIMEOUT_MS`. `0` disables. */
+  timeoutMs?: number;
 }
 
 /** The real authenticated clients, built over one shared auth session. */
@@ -50,10 +52,10 @@ export interface VaultHttpClients {
  * wraps) is built separately — pass it as the provider's `authClient`.
  */
 export function createVaultHttpClients(config: VaultHttpClientsConfig): VaultHttpClients {
-  const { vaultUrl, auth, fetchImpl } = config;
+  const { vaultUrl, auth, fetchImpl, timeoutMs } = config;
   return {
-    vault: new HttpVaultClient({ vaultUrl, auth, fetchImpl }),
-    courier: new HttpCourierClient({ vaultUrl, auth, fetchImpl }),
+    vault: new HttpVaultClient({ vaultUrl, auth, fetchImpl, timeoutMs }),
+    courier: new HttpCourierClient({ vaultUrl, auth, fetchImpl, timeoutMs }),
   };
 }
 

--- a/tests/integration/vault/courier.confirm-receipt.test.ts
+++ b/tests/integration/vault/courier.confirm-receipt.test.ts
@@ -1,0 +1,124 @@
+/**
+ * confirmReceipt pagination (finding confirmReceipt-non-paginated-sent(0)).
+ *
+ * Before the fix `confirmReceipt(handle)` did `client.sent(0)` + `.find()` — a
+ * SINGLE, non-paginated page. So a handle whose `/sent` row is on page 2+ (its
+ * `sentSeq` past the first page) returned a false `null`: the delivery looked
+ * unconfirmed even though the recipient had validly claimed it.
+ *
+ * The fix anchors the query on the handle's OWN `sentSeq` (`since = sentSeq - 1`),
+ * so the target row is the FIRST row of the response regardless of how many other
+ * deliveries precede it — cheaper than looping every `/sent` page.
+ *
+ * This suite forces a small page size (pageLimit:1) and deposits SEVERAL entries so
+ * the entry under test lands beyond page 1, then asserts `confirmReceipt` still
+ * finds its valid ack. The single-page happy path is kept green by the existing
+ * `courier.sent.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import { CourierDeliveryProvider } from '../../../transport/courier/CourierDeliveryProvider';
+import { FakeCourierServer } from '../../helpers/fake-courier-server';
+import type { FullIdentity } from '../../../types';
+import type {
+  CourierJournalStore,
+  V2TransferSink,
+} from '../../../transport/courier/CourierDeliveryProvider';
+import type { DeliveryHandle } from '../../../transport/courier/types';
+import type { V2TransferPayload } from '../../../types/v2-transfer';
+
+const NETWORK = 'testnet2';
+const SENDER_PRIV = '55'.repeat(32);
+const RECIPIENT_PRIV = '66'.repeat(32);
+const SENDER_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(SENDER_PRIV), true));
+const RECIPIENT_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIPIENT_PRIV), true));
+
+/** A one-row /sent + /inbox page, so any entry past the first lands on page 2+. */
+const PAGE_LIMIT = 1;
+/** Deposit this many entries; the LAST one's /sent row is on page N (well past 1). */
+const ENTRY_COUNT = 4;
+
+const sender: FullIdentity = { chainPubkey: SENDER_PUB, l1Address: 'alpha1s', privateKey: SENDER_PRIV };
+const recipient: FullIdentity = { chainPubkey: RECIPIENT_PUB, l1Address: 'alpha1r', privateKey: RECIPIENT_PRIV };
+const noopSink: V2TransferSink = async (_p: V2TransferPayload, _s: string) => {};
+
+/** A distinct token blob per index so each deposit is a distinct entryId + tokenId. */
+function blobFor(i: number): string {
+  const tokenId = i.toString(16).padStart(64, '0');
+  const token = new Uint8Array(16).map((_, j) => (i * 13 + j) & 0xff);
+  return bytesToHex(encodeTokenBlob({ v: 1, network: 0, tokenId, token }));
+}
+
+function memJournal(): CourierJournalStore {
+  const m = new Map<string, string>();
+  return { get: async (k) => m.get(k) ?? null, set: async (k, v) => void m.set(k, v) };
+}
+
+function makeProvider(id: FullIdentity, server: FakeCourierServer): CourierDeliveryProvider {
+  const p = new CourierDeliveryProvider({
+    vaultUrl: 'https://vault.testnet.unicity.network',
+    network: NETWORK,
+    httpClientFactory: (ownerId) => server.clientFor(ownerId),
+    journal: memJournal(),
+    onV2Transfer: noopSink,
+  });
+  p.setIdentity(id);
+  return p;
+}
+
+describe('courier confirmReceipt pagination', () => {
+  it('finds a VALID ack whose /sent row is BEYOND page 1', async () => {
+    const server = new FakeCourierServer({ network: NETWORK, pageLimit: PAGE_LIMIT });
+    const sp = makeProvider(sender, server);
+
+    // Deposit several entries; the last one's /sent row (sentSeq=ENTRY_COUNT) sits
+    // on page ENTRY_COUNT — never page 1 with a one-row page size.
+    const handles: DeliveryHandle[] = [];
+    for (let i = 1; i <= ENTRY_COUNT; i++) {
+      handles.push(
+        await sp.deposit({
+          recipientChainPubkey: RECIPIENT_PUB,
+          senderChainPubkey: SENDER_PUB,
+          transferId: `tx-${i}`,
+          tokenBlobHex: blobFor(i),
+        }),
+      );
+    }
+    const last = handles[ENTRY_COUNT - 1];
+    expect(last.sentSeq).toBe(ENTRY_COUNT); // sanity: this row is well past page 1
+
+    // The recipient validly claims EVERY entry (across all inbox pages).
+    await makeProvider(recipient, server).receive();
+
+    // The bug: sent(0) returns only page 1 (sentSeq 1), so the last handle's ack is
+    // never seen → false null. The fix anchors on the handle's own sentSeq.
+    const receipt = await sp.confirmReceipt(last);
+    expect(receipt).not.toBeNull();
+    expect(receipt?.entryId).toBe(last.entryId);
+    expect(receipt?.recipientChainPubkey).toBe(RECIPIENT_PUB);
+    expect(receipt?.ackSig).toBeTruthy();
+  });
+
+  it('still returns null for an unclaimed handle on page 2+', async () => {
+    const server = new FakeCourierServer({ network: NETWORK, pageLimit: PAGE_LIMIT });
+    const sp = makeProvider(sender, server);
+
+    const handles: DeliveryHandle[] = [];
+    for (let i = 1; i <= ENTRY_COUNT; i++) {
+      handles.push(
+        await sp.deposit({
+          recipientChainPubkey: RECIPIENT_PUB,
+          senderChainPubkey: SENDER_PUB,
+          transferId: `tx-${i}`,
+          tokenBlobHex: blobFor(i),
+        }),
+      );
+    }
+    // Nobody claims anything — the page-2 handle is genuinely unconfirmed.
+    expect(await sp.confirmReceipt(handles[ENTRY_COUNT - 1])).toBeNull();
+  });
+});

--- a/tests/integration/vault/http-network-failures.test.ts
+++ b/tests/integration/vault/http-network-failures.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Real network-failure behaviour for the vault + courier HTTP clients
+ * (finding sdk-no-real-network-failures).
+ *
+ * The clients were only proven against 401/404/507. This drives the remaining
+ * transport failures over a REAL `node:http` socket (scripted responses) and a
+ * CLOSED port, and asserts each one surfaces a CATCHABLE typed error (never a hang,
+ * an unhandled rejection, or an opaque JSON-parse crash), AND that the client stays
+ * usable for a subsequent successful call:
+ *
+ *  - server down / connection refused → REJECTS with a typed VaultHttpError.
+ *  - 5xx (500 / 502)                  → throws a typed VaultHttpError carrying status.
+ *  - non-JSON body where JSON expected → typed VaultHttpError (no opaque parse crash).
+ *  - persistent 401 after refresh      → ONE refresh + retry, then throw (no infinite
+ *                                        loop); refresh is driven EXACTLY once.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
+import { HttpVaultAuthClient } from '../../../storage/remote/http/HttpVaultAuthClient';
+import { HttpVaultClient } from '../../../storage/remote/http/HttpVaultClient';
+import { HttpCourierClient } from '../../../transport/courier/http/HttpCourierClient';
+import { VaultHttpError } from '../../../storage/remote/http/http-core';
+import type { VaultTokenSource } from '../../../storage/remote/http/http-core';
+import { VaultApiClient } from '../../../storage/remote/VaultApiClient';
+import { VAULT_AUTH_PREFIX } from '../../../vault/auth';
+
+/** A scripted response: status + body (string body lets us serve non-JSON). */
+interface ScriptedResponse {
+  status: number;
+  /** A raw body string (e.g. HTML/empty) OR an object that is JSON-stringified. */
+  body: string | object;
+  /** When true, send `body` verbatim with NO content-type (mimics a non-JSON 502). */
+  raw?: boolean;
+}
+
+/** A `node:http` server that replays a FIFO queue of scripted responses. */
+class ScriptedServer {
+  private readonly queue: ScriptedResponse[] = [];
+  private server!: Server;
+  private readonly sockets = new Set<Socket>();
+  baseUrl = '';
+  /** Every request path the server saw, in order (for call-count assertions). */
+  readonly seen: string[] = [];
+
+  enqueue(...responses: ScriptedResponse[]): this {
+    this.queue.push(...responses);
+    return this;
+  }
+
+  async start(): Promise<void> {
+    this.server = createServer((req, res) => this.handle(req, res));
+    this.server.on('connection', (s) => {
+      this.sockets.add(s);
+      s.on('close', () => this.sockets.delete(s));
+    });
+    await new Promise<void>((resolve) => this.server.listen(0, '127.0.0.1', resolve));
+    this.baseUrl = `http://127.0.0.1:${(this.server.address() as AddressInfo).port}`;
+  }
+
+  /** Resolve the bound port, then close so a client points at a refused port. */
+  async startThenClose(): Promise<void> {
+    await this.start();
+    await this.stop();
+  }
+
+  async stop(): Promise<void> {
+    for (const s of this.sockets) s.destroy();
+    this.sockets.clear();
+    if (this.server?.listening) await new Promise<void>((resolve) => this.server.close(() => resolve()));
+  }
+
+  private handle(req: IncomingMessage, res: ServerResponse): void {
+    this.seen.push(req.url ?? '/');
+    // Drain the body so the socket is free, then reply with the next script entry.
+    req.on('data', () => {});
+    req.on('end', () => this.reply(res));
+  }
+
+  private reply(res: ServerResponse): void {
+    const next = this.queue.shift() ?? { status: 500, body: { error: 'no_script' } };
+    if (next.raw) {
+      res.writeHead(next.status);
+      res.end(typeof next.body === 'string' ? next.body : JSON.stringify(next.body));
+      return;
+    }
+    const text = typeof next.body === 'string' ? next.body : JSON.stringify(next.body);
+    res.writeHead(next.status, { 'content-type': 'application/json' });
+    res.end(text);
+  }
+}
+
+const TOKENS = { jwt: 'jwt.owner.dev.fresh', refreshToken: 'refresh-1' };
+
+/** A spy token source: counts refresh() calls and hands back a fixed token. */
+function spyAuth(): VaultTokenSource & { refreshCount: number } {
+  return {
+    refreshCount: 0,
+    token: 'jwt.owner.dev.x',
+    refresh() {
+      this.refreshCount += 1;
+      return Promise.resolve('jwt.owner.dev.rotated');
+    },
+  };
+}
+
+let srv: ScriptedServer;
+afterEach(async () => {
+  await srv?.stop();
+});
+
+describe('vault HTTP clients — connection refused', () => {
+  it('an unauthenticated call to a CLOSED port rejects with a typed VaultHttpError', async () => {
+    srv = new ScriptedServer();
+    await srv.startThenClose(); // bind a port then free it → ECONNREFUSED
+    const auth = new HttpVaultAuthClient({ vaultUrl: srv.baseUrl, timeoutMs: 2_000 });
+    await expect(auth.challenge('pubkey')).rejects.toBeInstanceOf(VaultHttpError);
+  });
+
+  it('an authed call to a CLOSED port rejects with a typed VaultHttpError', async () => {
+    srv = new ScriptedServer();
+    await srv.startThenClose();
+    const vault = new HttpVaultClient({ vaultUrl: srv.baseUrl, auth: spyAuth(), timeoutMs: 2_000 });
+    await expect(vault.getState(0)).rejects.toBeInstanceOf(VaultHttpError);
+  });
+});
+
+describe('vault HTTP clients — 5xx', () => {
+  it('a 500 on an authed GET throws a typed VaultHttpError carrying the status', async () => {
+    srv = new ScriptedServer().enqueue({ status: 500, body: { error: 'boom' } });
+    await srv.start();
+    const vault = new HttpVaultClient({ vaultUrl: srv.baseUrl, auth: spyAuth() });
+    const err = await vault.getState(0).catch((e) => e);
+    expect(err).toBeInstanceOf(VaultHttpError);
+    expect((err as VaultHttpError).status).toBe(500);
+  });
+
+  it('a 502 on the courier is NOT swallowed (typed error with status 502)', async () => {
+    srv = new ScriptedServer().enqueue({ status: 502, body: { error: 'bad_gateway' } });
+    await srv.start();
+    const courier = new HttpCourierClient({ vaultUrl: srv.baseUrl, auth: spyAuth() });
+    const err = await courier.inbox(0).catch((e) => e);
+    expect(err).toBeInstanceOf(VaultHttpError);
+    expect((err as VaultHttpError).status).toBe(502);
+  });
+
+  it('the client stays usable: a success after a 500 round-trips normally', async () => {
+    srv = new ScriptedServer().enqueue(
+      { status: 500, body: { error: 'boom' } },
+      { status: 200, body: { records: [{ dedupKey: 'd1', payload: { nonce: 'bg==', ct: 'aA==' } }] } },
+    );
+    await srv.start();
+    const vault = new HttpVaultClient({ vaultUrl: srv.baseUrl, auth: spyAuth() });
+    await expect(vault.historySince(0)).rejects.toBeInstanceOf(VaultHttpError);
+    const page = await vault.historySince(0); // same client, fresh request — works
+    expect(page.records.map((r) => r.dedupKey)).toEqual(['d1']);
+  });
+});
+
+describe('vault HTTP clients — non-JSON body where JSON expected', () => {
+  it('a 200 with an HTML body surfaces a typed VaultHttpError, not an opaque parse crash', async () => {
+    srv = new ScriptedServer().enqueue({ status: 200, body: '<html>502 Bad Gateway</html>', raw: true });
+    await srv.start();
+    const vault = new HttpVaultClient({ vaultUrl: srv.baseUrl, auth: spyAuth() });
+    const err = await vault.getState(0).catch((e) => e);
+    expect(err).toBeInstanceOf(VaultHttpError);
+    expect((err as VaultHttpError).message).toContain('non-JSON');
+  });
+
+  it('an EMPTY 200 body surfaces a typed VaultHttpError', async () => {
+    srv = new ScriptedServer().enqueue({ status: 200, body: '', raw: true });
+    await srv.start();
+    const courier = new HttpCourierClient({ vaultUrl: srv.baseUrl, auth: spyAuth() });
+    await expect(courier.sent(0)).rejects.toBeInstanceOf(VaultHttpError);
+  });
+});
+
+describe('vault HTTP clients — persistent 401 after refresh', () => {
+  it('does ONE refresh + retry then throws (no infinite loop); refresh called exactly once', async () => {
+    // Both authed attempts 401 (the first, and the retry after the refresh).
+    srv = new ScriptedServer().enqueue(
+      { status: 401, body: { error: 'unauthorized' } },
+      { status: 401, body: { error: 'unauthorized' } },
+    );
+    await srv.start();
+    const auth = spyAuth();
+    const vault = new HttpVaultClient({ vaultUrl: srv.baseUrl, auth });
+
+    const err = await vault.getState(0).catch((e) => e);
+    expect(err).toBeInstanceOf(VaultHttpError);
+    expect((err as VaultHttpError).status).toBe(401);
+    // Exactly one refresh, exactly two authed round trips (initial + single retry).
+    expect(auth.refreshCount).toBe(1);
+    expect(srv.seen.filter((p) => p.startsWith('/v1/state'))).toHaveLength(2);
+  });
+
+  it('full stack: a verify→ok then data-401 with the refresh ALSO 401 throws without looping', async () => {
+    // challenge(200) → verify(200) → state(401) → refresh(401: null → throws).
+    const challenge = {
+      nonce: 'n1',
+      challenge: challengeFor('owner-pub'),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    srv = new ScriptedServer().enqueue(
+      { status: 200, body: challenge },
+      { status: 200, body: TOKENS },
+      { status: 401, body: { error: 'unauthorized' } },
+      { status: 401, body: { error: 'unauthorized' } },
+    );
+    await srv.start();
+
+    const api = new VaultApiClient({
+      network: 'testnet2',
+      chainPubkey: 'owner-pub',
+      privateKey: '7c'.repeat(32),
+      deviceId: 'd1',
+      authClient: new HttpVaultAuthClient({ vaultUrl: srv.baseUrl }),
+    });
+    await api.authenticate();
+    const vault = new HttpVaultClient({ vaultUrl: srv.baseUrl, auth: api });
+
+    // state 401 → ONE refresh, which itself 401s → VaultApiClient.refresh() throws
+    // and that propagates: the call terminates (no infinite retry loop).
+    await expect(vault.getState(0)).rejects.toBeInstanceOf(Error);
+    // Exactly one /v1/auth/refresh attempt (no loop hammering the refresh endpoint).
+    expect(srv.seen.filter((p) => p === '/v1/auth/refresh')).toHaveLength(1);
+  });
+});
+
+/** Build a vault-auth challenge string the VaultApiClient template-check accepts. */
+function challengeFor(pubkey: string): string {
+  const body = {
+    network: 'testnet2',
+    pubkey,
+    nonce: 'n1',
+    issuedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  };
+  return VAULT_AUTH_PREFIX + JSON.stringify(body);
+}

--- a/tests/integration/vault/http-timeout.test.ts
+++ b/tests/integration/vault/http-timeout.test.ts
@@ -1,0 +1,92 @@
+/**
+ * HTTP request timeout for the vault/courier fetch core
+ * (finding sdk-no-client-side-timeout = hang on a stalled server).
+ *
+ * Before this, the shared fetch core (`http-core.ts`) issued `fetch` with NO
+ * `signal`/deadline, so a stalled or half-open server (accepts the socket, never
+ * writes a response) hung the wallet's flush/auth FOREVER. `withTimeout` now wraps
+ * the client `fetch` with a configurable `AbortController` deadline (named-const
+ * default `DEFAULT_REQUEST_TIMEOUT_MS`) AND maps the abort to a typed
+ * {@link VaultHttpError}; a stalled request REJECTS within the deadline instead of
+ * hanging. The clients read `timeoutMs` from their config and wrap `fetch` in the
+ * constructor, so the bound applies to EVERY round trip.
+ *
+ * Harness: a raw `node:http` server that ACCEPTS the request but never responds, so
+ * only the client-side timeout can unblock the call. Open sockets are tracked and
+ * destroyed on close so the server shuts down despite the never-finished request.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
+import { HttpVaultAuthClient } from '../../../storage/remote/http/HttpVaultAuthClient';
+import { HttpVaultClient } from '../../../storage/remote/http/HttpVaultClient';
+import {
+  VaultHttpError,
+  withTimeout,
+  DEFAULT_REQUEST_TIMEOUT_MS,
+} from '../../../storage/remote/http/http-core';
+import type { VaultTokenSource } from '../../../storage/remote/http/http-core';
+
+const SHORT_TIMEOUT_MS = 150;
+
+let server: Server;
+let baseUrl: string;
+const sockets = new Set<Socket>();
+
+/** Boot a server that accepts every request but NEVER writes a response. */
+async function startStalledServer(): Promise<void> {
+  server = createServer(() => {
+    // Intentionally never call res.end() — the connection stays open forever.
+  });
+  server.on('connection', (s) => {
+    sockets.add(s);
+    s.on('close', () => sockets.delete(s));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+}
+
+afterEach(async () => {
+  for (const s of sockets) s.destroy();
+  sockets.clear();
+  if (!server?.listening) return; // a synchronous test never booted the server
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+/** A token source whose refresh must NEVER run (timeout fires before any 401). */
+const noRefreshAuth: VaultTokenSource = {
+  token: 'jwt.owner.dev.x',
+  refresh: () => Promise.reject(new Error('refresh should not be called on a timeout')),
+};
+
+describe('vault http-core request timeout', () => {
+  it('exposes a sane named-const default timeout', () => {
+    expect(DEFAULT_REQUEST_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(DEFAULT_REQUEST_TIMEOUT_MS).toBeLessThanOrEqual(60_000);
+  });
+
+  it('withTimeout rejects a stalled fetch with a typed error, not a hang', async () => {
+    await startStalledServer();
+    const timed = withTimeout(fetch, SHORT_TIMEOUT_MS);
+    const started = Date.now();
+    await expect(timed(`${baseUrl}/v1/state`)).rejects.toBeInstanceOf(VaultHttpError);
+    expect(Date.now() - started).toBeLessThan(SHORT_TIMEOUT_MS + 2_000);
+  });
+
+  it('an unauthenticated client call REJECTS on a stalled server within the timeout', async () => {
+    await startStalledServer();
+    const auth = new HttpVaultAuthClient({ vaultUrl: baseUrl, timeoutMs: SHORT_TIMEOUT_MS });
+    const started = Date.now();
+    await expect(auth.challenge('pubkey')).rejects.toBeInstanceOf(VaultHttpError);
+    // Resolved fast — the client-side deadline fired, not a hung socket.
+    expect(Date.now() - started).toBeLessThan(SHORT_TIMEOUT_MS + 2_000);
+  });
+
+  it('an authed client call REJECTS on a stalled server WITHOUT driving a refresh', async () => {
+    await startStalledServer();
+    const vault = new HttpVaultClient({ vaultUrl: baseUrl, auth: noRefreshAuth, timeoutMs: SHORT_TIMEOUT_MS });
+    await expect(vault.getState(0)).rejects.toBeInstanceOf(VaultHttpError);
+  });
+});

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -504,11 +504,19 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
   /**
    * Verify a delivery handle's signed receipt (DESIGN §3 port method). Returns the
    * {@link SignedReceipt} only when the recipient's ackSig validly claims it.
+   *
+   * PAGINATION (finding confirmReceipt-non-paginated-sent(0)): a `/sent` page is
+   * bounded, so a plain `sent(0).find()` returns a false `null` for any handle whose
+   * row sits on page 2+. We ANCHOR the query on the handle's own `sentSeq` — the row
+   * is the FIRST one of `sent(sentSeq - 1)` (rows with `sentSeq > since`) regardless
+   * of how many other deliveries precede it, so a single cheap page always contains
+   * it. Handles minted by an older build (no `sentSeq`) fall back to `sent(0)`.
    */
   async confirmReceipt(handle: DeliveryHandle): Promise<SignedReceipt | null> {
     const me = this.requireIdentity();
     const client = this.config.httpClientFactory(me.chainPubkey);
-    const res = await client.sent(0);
+    const since = handle.sentSeq !== undefined ? handle.sentSeq - 1 : 0;
+    const res = await client.sent(since);
     const row = res.items.find((i) => i.entryId === handle.entryId);
     if (!row || !this.isValidReceipt(me, row)) return null;
     return { entryId: row.entryId, ackSig: row.ackSig!, recipientChainPubkey: row.recipientPubkey };

--- a/transport/courier/http/HttpCourierClient.ts
+++ b/transport/courier/http/HttpCourierClient.ts
@@ -27,7 +27,7 @@ import type {
   CourierInboxResponse,
   CourierSentResponse,
 } from '../types';
-import { authedJson } from '../../../storage/remote/http/http-core';
+import { authedJson, withTimeout } from '../../../storage/remote/http/http-core';
 import type { FetchLike, VaultTokenSource } from '../../../storage/remote/http/http-core';
 
 export interface HttpCourierClientConfig {
@@ -37,6 +37,8 @@ export interface HttpCourierClientConfig {
   auth: VaultTokenSource;
   /** Defaults to the global `fetch`; injectable for tests. */
   fetchImpl?: FetchLike;
+  /** Per-request deadline (ms); defaults to `DEFAULT_REQUEST_TIMEOUT_MS`. `0` disables. */
+  timeoutMs?: number;
 }
 
 export class HttpCourierClient implements CourierHttpClient {
@@ -47,7 +49,7 @@ export class HttpCourierClient implements CourierHttpClient {
   constructor(config: HttpCourierClientConfig) {
     this.base = config.vaultUrl;
     this.auth = config.auth;
-    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.fetchImpl = withTimeout(config.fetchImpl ?? fetch, config.timeoutMs);
   }
 
   /** `POST /v1/courier/deposit` — the caller is the sender (a 413/429 quota → throw). */


### PR DESCRIPTION
MED robustness on the wallet HTTP path. (1) 9 real-socket network-failure tests: connection-refused/5xx/non-JSON/persistent-401 (exactly one refresh+retry, no infinite loop; client stays usable after a 500). (2) ADDED a client-side request timeout (AbortController, DEFAULT_REQUEST_TIMEOUT_MS=30s; 0 disables) - the clients had NONE, so a stalled server hung flush/auth forever; transport errors now map to a typed VaultHttpError(status 0), never a false 401/refresh-loop. (3) confirmReceipt sentSeq-anchored query (sent(handle.sentSeq-1)) so a page-2+ ack is found (was a false null); ackSig sender-gate unchanged. 166/166, tsc+eslint clean. Reviewed PASS (timeout fresh-per-request, no leaked timers, refresh/retry intact; confirmReceipt still gates ackSig).