### PR TITLE
feat(vault): e2e in CI [HIGH] + courier backoff/journal-first + anti-rollback baseline + courier-key doc

### DIFF
--- a/.github/workflows/vault-e2e.yml
+++ b/.github/workflows/vault-e2e.yml
@@ -1,0 +1,98 @@
+# ============================================================================
+# Vault cross-repo e2e (vault-e2e-not-in-ci).
+# ============================================================================
+# The unit/integration CI (ci.yml) runs the vault suite against an in-process
+# FAKE courier/vault server. This workflow runs the REAL cross-repo e2e
+# (tests/e2e/vault.e2e.test.ts), which boots the REAL token-api in-process over
+# `mongodb-memory-server` and drives the FULL SDK path (auth + vault CAS +
+# courier) through the real fetch HTTP clients — no fakes.
+#
+# INTERIM cross-repo setup (mirror of token-api/.github/workflows/ci.yml):
+#   token-api depends on the SDK via `file:../sphere-sdk` — a LOCAL v2 build —
+#   and the e2e imports token-api's COMPILED `dist/` (loadConfig/buildDeps/
+#   buildApp). There is NO co-published stable v2 SDK + token-api on npm yet, so
+#   this job checks out BOTH repos under the workspace, builds the SDK from
+#   source, then builds token-api against that local SDK, then runs the e2e.
+#
+#   ONCE a stable v2 @unicitylabs/sphere-sdk + a published token-api exist and
+#   are CO-PUBLISHED: drop the sibling token-api checkout + its build steps,
+#   drop the SDK token, and resolve token-api from its published artifact
+#   instead (the e2e would import the installed token-api package). Until then
+#   this cross-repo checkout is the only way to run the e2e against the real
+#   server.
+#
+# Layout (so token-api's `file:../sphere-sdk` link resolves and the e2e's
+# `../token-api` boot path resolves):
+#   $GITHUB_WORKSPACE/sphere-sdk   <- this repo (the e2e runs here)
+#   $GITHUB_WORKSPACE/token-api    <- the sibling backend @ main
+#
+# Linux runner: tsup's DTS emit works here (no Windows DTS segfault), and
+# mongodb-memory-server downloads + starts a real mongod, so the e2e runs green.
+
+name: Vault e2e (cross-repo)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: vault-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vault-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sphere-sdk
+        uses: actions/checkout@v4
+        with:
+          path: sphere-sdk
+
+      # INTERIM: check out + build the sibling token-api (no co-published
+      # artifact yet). Drop this checkout + the two build steps below once a
+      # stable token-api is published and the e2e imports it from the package.
+      - name: Checkout token-api (main)
+        uses: actions/checkout@v4
+        with:
+          repository: unicity-sphere/token-api
+          ref: main
+          path: token-api
+          # A token with read access to the sibling private repo. The default
+          # GITHUB_TOKEN is scoped to THIS repo only and cannot read the sibling.
+          token: ${{ secrets.TOKEN_API_REPO_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            sphere-sdk/package-lock.json
+            token-api/package-lock.json
+
+      # Build the SDK to dist/ so token-api's `file:../sphere-sdk` link resolves
+      # to a built package. Linux runner => tsup DTS emit works.
+      - name: Build sphere-sdk
+        working-directory: sphere-sdk
+        run: |
+          npm ci
+          npm run build
+
+      # token-api's `npm ci` resolves `file:../sphere-sdk` to the freshly built
+      # SDK above; `npm run build` then emits token-api's `dist/` — the e2e
+      # imports its compiled loadConfig/buildDeps/buildApp.
+      - name: Build token-api
+        working-directory: token-api
+        run: |
+          npm ci
+          npm run build
+
+      # The e2e boots token-api in-process over mongodb-memory-server (it carries
+      # its own mongod download + replica-set helper) and drives the real fetch
+      # HTTP clients. The dedicated vitest config scopes the run to tests/e2e/**.
+      - name: Run vault e2e
+        working-directory: sphere-sdk
+        run: npx vitest run --config vitest.e2e.config.ts tests/e2e/vault.e2e.test.ts

--- a/storage/remote/load-delta.ts
+++ b/storage/remote/load-delta.ts
@@ -208,6 +208,16 @@ export class LoadDeltaTracker {
   /**
    * Persist a fresh signed baseline after a clean load. `known` is the provider's
    * authoritative post-load state; the root binds `(network, ownerId, cursor)`.
+   *
+   * FIRST-LOAD RESIDUAL (finding remote-anti-rollback-no-baseline-on-fresh-load):
+   * the root gate is a no-op on a load with NO prior signed baseline (first load,
+   * post-reset, wiped local KV) — you cannot detect a truncated/withheld first load
+   * without a prior reference, so a genuinely fresh device trusts its first sync
+   * like any first sync. This is unavoidable. What IS guaranteed: this commit runs
+   * on EVERY clean load, including the first, so a durable signed baseline always
+   * exists afterward and ALL subsequent loads re-fold against it and are gated. A
+   * from-scratch reload that finds a durable baseline runs the full root gate
+   * (`beginLoad` rebuilds the accumulator from `known` and re-folds each delta).
    */
   async commitBaseline(cursor: number, epoch: number, _epochSig: string): Promise<void> {
     if (this.config.baseline && this.walletPriv) {

--- a/tests/integration/vault/anti-rollback.test.ts
+++ b/tests/integration/vault/anti-rollback.test.ts
@@ -115,3 +115,62 @@ describe('anti-rollback root comparison', () => {
     expect(events.some((e) => e.type === 'storage:error')).toBe(false);
   });
 });
+
+/**
+ * First-load baseline persistence (finding remote-anti-rollback-no-baseline-on-fresh-load).
+ *
+ * RESIDUAL (fundamental): the root gate cannot detect a TRUNCATED/withheld first
+ * load — there is no prior signed reference to fold against, so a genuinely fresh
+ * device trusts its first sync exactly like any first sync of an untrusted server.
+ * That part is unavoidable.
+ *
+ * What IS guaranteed and asserted here: the FIRST successful load PERSISTS a signed
+ * baseline (no sync needed), so EVERY subsequent load is gated against it. A fresh
+ * provider with no prior local baseline that loads then sees a server-injected
+ * delta on its NEXT load is alarmed.
+ */
+describe('anti-rollback first-load baseline', () => {
+  const baselineKey = `vault_baseline:${NETWORK}:${PUB}`;
+
+  it('the FIRST successful load persists a signed baseline even with no sync', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const store = memStore();
+    const provider = makeProvider(server, store);
+
+    // No baseline before the first load (genuinely fresh / wiped-KV device).
+    expect(await store.get(baselineKey)).toBeNull();
+
+    // initialize() runs the provider's own FIRST load. The gate is a no-op on this
+    // load (no prior baseline — the unavoidable residual), but it MUST persist one.
+    const ok = await provider.initialize();
+    expect(ok).toBe(true);
+    expect(await store.get(baselineKey)).not.toBeNull(); // baseline now durable
+  });
+
+  it('the SECOND load IS gated: a server-injected delta after the first load alarms', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const store = memStore();
+    const provider = makeProvider(server, store);
+
+    // First load on a fresh provider, with ONE real flushed entry so there is a
+    // concrete row the hostile server can mutate at the next cursor.
+    await provider.initialize();
+    await provider.sync(txf({ a: { n: 1 } }));
+    const first = await provider.load();
+    expect(first.success).toBe(true);
+    expect(await store.get(baselineKey)).not.toBeNull();
+
+    // Hostile server mutates the entry at the next monotonic cursor, no epoch bump.
+    const wkA = wireKey(PRIV, NETWORK, 'a');
+    server.mutateEntry(PUB, wkA, seal('a', 99, { n: 'tampered' }));
+
+    const events: StorageEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+    const res = await provider.load(); // the SECOND load is gated against the baseline
+
+    expect(res.success).toBe(false);
+    const err = events.find((e) => e.type === 'storage:error');
+    expect(err).toBeDefined();
+    expect((err!.data as { reason: string }).reason).toBe('rollback');
+  });
+});

--- a/tests/integration/vault/courier.deposit.test.ts
+++ b/tests/integration/vault/courier.deposit.test.ts
@@ -120,3 +120,95 @@ describe('courier deposit', () => {
     expect(server.deliveryCount).toBe(1);
   });
 });
+
+describe('courier deposit — journal-first ordering (courier-deposit-journal-ordering-vs-design)', () => {
+  const env = {
+    recipientChainPubkey: RECIPIENT_PUB,
+    senderChainPubkey: SENDER_PUB,
+    transferId: 'tx-1',
+    tokenBlobHex: BLOB_HEX,
+  };
+
+  /** The provider's sent-pending journal key for the sender on this network. */
+  const sentPendingKey = `courier_sent_pending:${NETWORK}:${SENDER_PUB}`;
+
+  function providerWith(
+    journal: CourierJournalStore,
+    depositImpl: (req: { entryId: string }) => Promise<{ entryId: string; seq: number; sentSeq: number; status: 'unclaimed' }>,
+  ): CourierDeliveryProvider {
+    const p = new CourierDeliveryProvider({
+      vaultUrl: 'https://vault.testnet.unicity.network',
+      network: NETWORK,
+      httpClientFactory: () => ({
+        deposit: (req) => depositImpl(req),
+        inbox: async () => ({ readPointer: 0, syncEpoch: 1, more: false, items: [] }),
+        ackNonce: async () => ({ serverNonce: 'n' }),
+        ack: async () => ({ result: 'failed' as const }),
+        sent: async () => ({ more: false, items: [] }),
+      }),
+      journal,
+      onV2Transfer: async () => {},
+    });
+    p.setIdentity(senderId);
+    return p;
+  }
+
+  it('journals the sender-side pending tracking BEFORE the deposit POST (journal ≺ POST)', async () => {
+    const journal = memJournal();
+    // A crash simulated AT the POST: the journal entry must already exist, so the
+    // delivery is tracked + reconcilable even though the POST never returned.
+    let journalAtPostTime: string | null = null;
+    const provider = providerWith(journal, async () => {
+      journalAtPostTime = await journal.get(sentPendingKey); // snapshot at POST time
+      throw new Error('network down at POST');
+    });
+
+    await expect(provider.deposit(env)).rejects.toThrow('network down at POST');
+
+    // The pending tracking was journaled BEFORE the POST was attempted.
+    expect(journalAtPostTime).not.toBeNull();
+    const atPost = JSON.parse(journalAtPostTime!) as Record<string, { recipientPubkey: string; state: string }>;
+    const entries = Object.values(atPost);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].recipientPubkey).toBe(RECIPIENT_PUB);
+    expect(entries[0].state).toBe('pending');
+  });
+
+  it('records the server sentSeq onto the journaled entry after a successful POST', async () => {
+    const journal = memJournal();
+    const provider = providerWith(journal, async (req) => ({
+      entryId: req.entryId,
+      seq: 1,
+      sentSeq: 42,
+      status: 'unclaimed' as const,
+    }));
+
+    const handle = await provider.deposit(env);
+    expect(handle.sentSeq).toBe(42);
+
+    const stored = JSON.parse((await journal.get(sentPendingKey))!) as Record<string, { sentSeq?: number }>;
+    expect(Object.values(stored)[0].sentSeq).toBe(42);
+  });
+
+  it('a re-POST of an already-journaled deposit is harmless (server dedups on entryId)', async () => {
+    // After a crash AFTER the POST, a reload re-deposits. The server dedups on
+    // (recipientPubkey, entryId) so the row count stays 1 — idempotent.
+    const server = new FakeCourierServer(NETWORK);
+    const journal = memJournal();
+    const p = new CourierDeliveryProvider({
+      vaultUrl: 'https://vault.testnet.unicity.network',
+      network: NETWORK,
+      httpClientFactory: (ownerId) => server.clientFor(ownerId),
+      journal,
+      onV2Transfer: async () => {},
+    });
+    p.setIdentity(senderId);
+
+    await p.deposit(env);
+    await p.deposit(env); // re-POST after a simulated crash
+    expect(server.deliveryCount).toBe(1);
+    // A single journal entry survives the re-deposit (no duplicate tracking).
+    const stored = JSON.parse((await journal.get(sentPendingKey))!) as Record<string, unknown>;
+    expect(Object.keys(stored)).toHaveLength(1);
+  });
+});

--- a/tests/integration/vault/courier.sent.test.ts
+++ b/tests/integration/vault/courier.sent.test.ts
@@ -114,14 +114,70 @@ describe('courier sender-gated delivery confirmation', () => {
 
   it('past the attempt cap a still-unconfirmed entry surfaces delivery_unconfirmed', async () => {
     const server = new FakeCourierServer(NETWORK);
-    const sp = makeSender(server, { maxRedeliveryAttempts: 3 });
+    // A controllable clock — each poll only counts once the backoff window elapses.
+    let now = 0;
+    const sp = makeSender(server, {
+      maxRedeliveryAttempts: 3,
+      backoffBaseMs: 1000,
+      now: () => now,
+    });
     const handle = await sp.deposit(env);
-    // Recipient never claims; each pollSent finds it unclaimed -> bumps attempts.
-    await sp.pollSent();
-    await sp.pollSent();
+    // Recipient never claims; each pollSent past the backoff window bumps attempts.
+    await sp.pollSent(); // attempt 1 (first poll always counts)
+    now += sp.backoffMs(1); // wait the window for attempt 2
+    await sp.pollSent(); // attempt 2
     expect(await sp.sentState(handle.entryId)).toBe('pending');
+    now += sp.backoffMs(2); // wait the window for attempt 3
     await sp.pollSent(); // attempts hits 3 == cap
     expect(await sp.sentState(handle.entryId)).toBe('delivery_unconfirmed');
+  });
+
+  it('rapid polls inside the backoff window do NOT exhaust the attempt budget', async () => {
+    // Regression (courier-redelivery-backoff-not-enforced): a brief recipient-
+    // offline window used to flip the entry to delivery_unconfirmed because every
+    // raw poll bumped attempts. With the backoff enforced, a burst of polls inside
+    // the window counts as a SINGLE attempt — so the entry stays pending.
+    const server = new FakeCourierServer(NETWORK);
+    let now = 0;
+    const sp = makeSender(server, {
+      maxRedeliveryAttempts: 3,
+      backoffBaseMs: 1000,
+      now: () => now,
+    });
+    const handle = await sp.deposit(env);
+    // Hammer pollSent many times WITHOUT advancing the clock (recipient briefly
+    // offline). Only the first poll counts; the rest are inside the window.
+    for (let i = 0; i < 20; i++) await sp.pollSent();
+    expect(await sp.sentState(handle.entryId)).toBe('pending');
+
+    // Advance just under the window for attempt 2 — still no new attempt counted.
+    now += sp.backoffMs(1) - 1;
+    await sp.pollSent();
+    expect(await sp.sentState(handle.entryId)).toBe('pending');
+  });
+
+  it('once the recipient comes online inside the window, a valid ack still delivers', async () => {
+    // The backoff gate must not block a genuine delivery: even a poll INSIDE the
+    // window delivers when the /sent row now carries a valid recipient ackSig.
+    const server = new FakeCourierServer(NETWORK);
+    let now = 0;
+    const delivered: string[] = [];
+    const sp = makeSender(server, {
+      onDelivered: async (id) => void delivered.push(id),
+      backoffBaseMs: 1000,
+      now: () => now,
+    });
+    const handle = await sp.deposit(env);
+    await sp.pollSent(); // attempt 1, still unclaimed -> pending
+    expect(await sp.sentState(handle.entryId)).toBe('pending');
+
+    // Recipient claims (valid signed ack). A poll INSIDE the backoff window still
+    // delivers — the gate only throttles ATTEMPT counting, never confirmation.
+    await makeRecipient(server).receive();
+    now += 1; // far inside the backoff window
+    await sp.pollSent();
+    expect(delivered).toEqual([handle.entryId]);
+    expect(await sp.sentState(handle.entryId)).toBe('delivered');
   });
 
   it('backoff is exponential and capped', async () => {

--- a/tests/unit/vault/vault-aead.courier.test.ts
+++ b/tests/unit/vault/vault-aead.courier.test.ts
@@ -82,4 +82,17 @@ describe('vault-aead courier: envelope + base64(nonce‖ct) framing', () => {
     const tampered = Buffer.from(bytes).toString('base64');
     expect(() => openCourierEnvelope(openParams(tampered))).toThrow();
   });
+
+  it('cross-network isolation: opening with a different network throws (AAD binds network)', () => {
+    // Decision (courier-key-omits-network): the courier AEAD KEY deliberately omits
+    // `network` — cross-network isolation is provided by the AAD, which binds network
+    // as its first length-delimited field. A `testnet2`-sealed envelope cannot be
+    // opened under a `mainnet` AAD: the Poly1305 tag fails. This is the isolation
+    // guarantee that makes baking network into the key (wire-affecting KAT churn)
+    // unnecessary for single-network deployments.
+    const ciphertext = sealCourierEnvelope(sealParams()); // sealed on testnet2
+    expect(() => openCourierEnvelope(openParams(ciphertext, { network: 'mainnet' }))).toThrow();
+    // And it still opens on the matching network (sanity).
+    expect(() => openCourierEnvelope(openParams(ciphertext))).not.toThrow();
+  });
 });

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -168,11 +168,25 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
    * `base64(nonce24‖ct)` ciphertext, and POST `/v1/courier/deposit`. The caller
    * (sender) is `this.identity.chainPubkey`; the server keys dedup on
    * `(recipientPubkey, entryId)`.
+   *
+   * JOURNAL-FIRST (finding courier-deposit-journal-ordering-vs-design, DESIGN §6.3):
+   * the sender-side pending-delivery tracking is journaled BEFORE the POST. The
+   * entryId is derived purely locally (ECDH, no server round-trip), so it is known
+   * up front. A crash AFTER the POST therefore still has the tracking to reconcile
+   * on reload — the token was delivered AND the sender will track/GC it. The POST is
+   * idempotent (the server dedups on `(recipientPubkey, entryId)`), so a re-POST on
+   * reload is harmless. The server `sentSeq` is folded back onto the journaled entry
+   * AFTER the POST returns (it is only known then; its absence is reconciled later).
    */
   async deposit(envelope: TokenEnvelope): Promise<DeliveryHandle> {
     const me = this.requireIdentity();
     const entryId = courierEntryId(me.privateKey, envelope.recipientChainPubkey, envelope.tokenBlobHex);
     const ciphertext = this.sealEnvelope(me, envelope, entryId);
+    // Track the entry sender-side BEFORE the POST so pollSent() can gate "delivered"
+    // on a valid recipient ackSig before removing PENDING_V2_DELIVERIES (DESIGN §6.5)
+    // even if a crash interrupts the round trip. sentSeq is unknown until the POST
+    // returns — recorded below.
+    await this.journalSentPending(entryId, envelope.recipientChainPubkey);
     const client = this.config.httpClientFactory(me.chainPubkey);
     const res = await client.deposit({
       recipientPubkey: envelope.recipientChainPubkey,
@@ -181,10 +195,9 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
       ciphertext,
       // hint stays undefined here — a single base64 SCALAR when present (never an object).
     });
-    // Track the entry sender-side so pollSent() can gate "delivered" on a valid
-    // recipient ackSig before removing PENDING_V2_DELIVERIES (DESIGN §6.5). The
-    // sentSeq is captured so pollSent() can advance the persisted sent watermark.
-    await this.journalSentPending(entryId, envelope.recipientChainPubkey, res.sentSeq);
+    // Fold the server-assigned watermark onto the already-journaled entry so
+    // pollSent() can advance the persisted sent watermark by sentSeq.
+    await this.recordSentSeq(entryId, res.sentSeq);
     return {
       entryId: res.entryId,
       transferId: envelope.transferId,
@@ -428,10 +441,30 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
     await this.config.journal.set(this.sentPendingKey(), JSON.stringify(pending));
   }
 
-  private async journalSentPending(entryId: string, recipientPubkey: string, sentSeq?: number): Promise<void> {
+  /**
+   * Journal an entry's sender-side pending tracking. Written BEFORE the deposit
+   * POST (journal-first) so a crash during the round trip still leaves the entry
+   * tracked. The `sentSeq` is unknown at this point — folded in by
+   * {@link recordSentSeq} after the POST returns. Idempotent on entryId.
+   */
+  private async journalSentPending(entryId: string, recipientPubkey: string): Promise<void> {
     const pending = await this.loadSentPending();
     if (!pending[entryId]) {
-      pending[entryId] = { recipientPubkey, attempts: 0, state: 'pending', sentSeq };
+      pending[entryId] = { recipientPubkey, attempts: 0, state: 'pending' };
+      await this.saveSentPending(pending);
+    }
+  }
+
+  /**
+   * Fold the server-assigned `sentSeq` onto an already-journaled entry after the
+   * deposit POST returns (the watermark is only known then). No-op if the entry was
+   * already reconciled away. Leaves attempts/state untouched.
+   */
+  private async recordSentSeq(entryId: string, sentSeq: number): Promise<void> {
+    const pending = await this.loadSentPending();
+    const entry = pending[entryId];
+    if (entry && entry.sentSeq !== sentSeq) {
+      entry.sentSeq = sentSeq;
       await this.saveSentPending(pending);
     }
   }

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -32,6 +32,15 @@ import type {
   TokenEnvelope,
 } from './types';
 
+/** Default base backoff (ms) for the redelivery loop; doubles per attempt. */
+const DEFAULT_BACKOFF_BASE_MS = 1000;
+/** Default backoff cap (ms) — 5 minutes. */
+const DEFAULT_BACKOFF_MAX_MS = 5 * 60_000;
+/** Default max redelivery attempts before an entry surfaces `delivery_unconfirmed`. */
+const DEFAULT_MAX_REDELIVERY_ATTEMPTS = 10;
+/** Default max envelope bytes the courier accepts (DESIGN §6.6). */
+const DEFAULT_MAX_ENVELOPE_BYTES = 16 * 1024 * 1024;
+
 /** The highest `seq` across a page of rows, falling back to `fallback` when empty. */
 function highestSeq(items: ReadonlyArray<{ seq: number }>, fallback: number): number {
   let max = fallback;
@@ -71,6 +80,15 @@ interface SentPendingEntry {
    * rows journaled by an older build (watermark still advances via the /sent row).
    */
   sentSeq?: number;
+  /**
+   * Wall-clock ms of the LAST counted redelivery attempt (the backoff anchor,
+   * finding courier-redelivery-backoff-not-enforced). `reconcileSentItem` only
+   * counts a new attempt once `backoffMs(attempts)` has elapsed since this, so a
+   * burst of polls during a short recipient-offline window does not exhaust the
+   * attempt budget. Absent (undefined) until the first attempt is counted, and on
+   * rows journaled by an older build (treated as "window elapsed" → first poll counts).
+   */
+  lastAttemptAt?: number;
 }
 
 /** Minimal persistent KV the journal needs (matches PaymentsModule storage). */
@@ -104,6 +122,8 @@ export interface CourierDeliveryConfig {
   backoffBaseMs?: number;
   /** Backoff cap (ms). */
   backoffMaxMs?: number;
+  /** Wall-clock source (ms) for the redelivery backoff gate; injectable for tests. */
+  now?: () => number;
 }
 
 export class CourierDeliveryProvider implements TokenDeliveryTransport {
@@ -131,7 +151,7 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
       async: true,
       ack: true,
       addressing: 'pubkey',
-      maxBytes: config.maxBytes ?? 16 * 1024 * 1024,
+      maxBytes: config.maxBytes ?? DEFAULT_MAX_ENVELOPE_BYTES,
     };
   }
 
@@ -480,15 +500,39 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
   ): Promise<void> {
     const entry = pending[item.entryId];
     if (!entry || entry.state === 'delivered') return;
+    // A valid recipient ackSig ALWAYS delivers — confirmation is never throttled by
+    // the backoff gate (a poll inside the window still confirms a genuine delivery).
     if (this.isValidReceipt(me, item)) {
       entry.state = 'delivered';
       await this.config.onDelivered?.(item.entryId);
       return;
     }
     // Not yet validly claimed (still unclaimed, or a FORGED ackSig that fails
-    // verification) — keep redelivering, bounded by the attempt cap.
+    // verification). ENFORCE the backoff (finding courier-redelivery-backoff-not-
+    // enforced): only COUNT an attempt once `backoffMs(attempts)` has elapsed since
+    // the last counted one, so a burst of polls during a brief recipient-offline
+    // window does not prematurely exhaust the budget and flip to delivery_unconfirmed.
+    if (!this.backoffElapsed(entry)) return;
     entry.attempts += 1;
+    entry.lastAttemptAt = this.now();
     if (entry.attempts >= this.maxAttempts()) entry.state = 'delivery_unconfirmed';
+  }
+
+  /**
+   * True once the redelivery backoff window for `entry` has elapsed — i.e. the
+   * NEXT attempt may be counted. The window is `backoffMs(entry.attempts)` (the
+   * delay before the next attempt, scaled by attempts already made). The first
+   * attempt (no `lastAttemptAt`) always counts; older journal rows without a
+   * timestamp are treated as "window elapsed" so they are never wedged.
+   */
+  private backoffElapsed(entry: SentPendingEntry): boolean {
+    if (entry.lastAttemptAt === undefined) return true;
+    return this.now() - entry.lastAttemptAt >= this.backoffMs(entry.attempts);
+  }
+
+  /** Wall-clock source (ms) — injectable for the backoff gate's tests. */
+  private now(): number {
+    return (this.config.now ?? Date.now)();
   }
 
   /** True only for a recipient ackSig that verifies over the bound template. */
@@ -523,13 +567,13 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
   }
 
   private maxAttempts(): number {
-    return this.config.maxRedeliveryAttempts ?? 10;
+    return this.config.maxRedeliveryAttempts ?? DEFAULT_MAX_REDELIVERY_ATTEMPTS;
   }
 
   /** Exponential backoff for the redelivery loop, capped (DESIGN §6.5). */
   backoffMs(attempts: number): number {
-    const base = this.config.backoffBaseMs ?? 1000;
-    const cap = this.config.backoffMaxMs ?? 5 * 60_000;
+    const base = this.config.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS;
+    const cap = this.config.backoffMaxMs ?? DEFAULT_BACKOFF_MAX_MS;
     return Math.min(cap, base * 2 ** attempts);
   }
 

--- a/vault-aead/courier.ts
+++ b/vault-aead/courier.ts
@@ -53,7 +53,12 @@ export function unpackCourier(b64: string): PackedCourier {
   return { nonce: bytes.slice(0, 24), ct: bytes.slice(24) };
 }
 
-/** Build the AAD that binds a courier envelope. */
+/**
+ * Build the AAD that binds a courier envelope. `network` is the FIRST field, so it
+ * is what provides cross-network isolation: the courier AEAD KEY deliberately omits
+ * network (see `deriveCourierKey`), and the AAD binds it instead — a `testnet2`
+ * envelope cannot be opened under a `mainnet` AAD (finding courier-key-omits-network).
+ */
 function courierAad(p: { network: string; senderPubkey: string; recipientPubkey: string; entryId: string }): Uint8Array {
   return lengthDelim([p.network, p.senderPubkey, p.recipientPubkey, p.entryId]);
 }

--- a/vault-aead/derive.ts
+++ b/vault-aead/derive.ts
@@ -65,6 +65,16 @@ export function deriveVaultKey(walletPriv: string, network: string): Uint8Array 
 /**
  * Derive a courier key from an ECDH shared-secret x-coordinate:
  * `HKDF-SHA256(ecdhX, info, 32)`.
+ *
+ * DELIBERATELY omits `network` from the key derivation (finding
+ * courier-key-omits-network — decision: document, not change). Unlike
+ * {@link deriveVaultKey}, cross-network isolation for the courier rests on the
+ * AEAD AAD, which binds `network` as its first length-delimited field
+ * (`vault-aead/courier.ts#courierAad`): a `testnet2`-sealed envelope cannot be
+ * opened under a `mainnet` AAD (the Poly1305 tag fails — see the cross-network
+ * isolation test). Deployments are single-network, so adding `network` to the key
+ * would be pure defense-in-depth at the cost of a wire-affecting change to the
+ * KAT-pinned courier key/entryId/packed-base64 — not worth the churn.
  */
 export function deriveCourierKey(ecdhX: Uint8Array, info: string): Uint8Array {
   return hkdf(sha256, ecdhX, undefined, utf8(info), 32);


### PR DESCRIPTION
HIGH: vault e2e now in CI - new .github/workflows/vault-e2e.yml checks out the sibling token-api@main, builds both, runs the in-process real-server e2e (needs TOKEN_API_REPO_TOKEN secret, mirrors token-apis SDK_REPO_TOKEN). LOW: (1) redelivery backoff now ENFORCED (gate attempt-count on elapsed backoff so a rapid poll burst in a short offline window does not prematurely flip delivery_unconfirmed; valid ack still delivers immediately). (2) deposit journals sender-tracking BEFORE the POST (journal-first per DESIGN 6.3; entryId is locally derived; sentSeq folded after; re-POST idempotent). (3) anti-rollback: first load persists a signed baseline so subsequent loads are gated; fresh-device residual documented (fundamental, not falsely fixed) + second-load-gated test. (4) courier-key: documented that cross-network isolation is provided by the AAD (network bound there) rather than churning the KAT-pinned key. 174/174, e2e 3/3 local, tsc+eslint clean. Reviewed PASS.