### PR TITLE
fix(oracle,soak): payments.validate() always reported invalid; stale swap-soak escrow

### DIFF
--- a/manual-test-swap-roundtrip.sh
+++ b/manual-test-swap-roundtrip.sh
@@ -43,22 +43,20 @@
 #
 # Required env:
 #   ESCROW          — escrow @nametag or DIRECT:// address
-#                     (default: @escrow-testnet)
+#                     (default: @escrow-test-02 — the canonical
+#                      DEFAULT_ESCROW_ADDRESS exported by sphere-sdk
+#                      since PR #468 / sphere-sdk#456)
 #
 # Requires `sphere` on PATH, outbound HTTPS+WSS to testnet, and a
 # reachable escrow service.
 #
-# Escrow nametag resolution fallback (sphere-sdk#456):
-#   If the @escrow-testnet nametag does not resolve on the testnet
-#   relay (the §2.5 `sphere swap ping` pre-flight will fail with
+# Escrow nametag resolution fallback:
+#   If the default nametag does not resolve on the testnet relay
+#   (the §2.5 `sphere swap ping` pre-flight will fail with
 #   `Could not resolve recipient`), re-run with the escrow's raw
-#   DIRECT address. The production testnet escrow currently lives at:
-#
-#     ESCROW="DIRECT://00007968fa28648e4670438bf1f3c936296e84ff46dd5ebb2e34e20092e780b652da2d3d695b" \
-#       bash manual-test-swap-roundtrip.sh
-#
-#   The nametag remains the canonical reference — switch back once
-#   the operator republishes the binding event.
+#   DIRECT address — discover it via
+#       sphere resolve @escrow-test-02
+#   on a working wallet and pass it through ESCROW=DIRECT://...
 
 set -euo pipefail
 
@@ -77,7 +75,7 @@ PEER_ALICE="$ROOT/alice-peer"
 PEER_BOB="$ROOT/bob-peer"
 mkdir -p "$PEER_ALICE" "$PEER_BOB"
 
-ESCROW="${ESCROW:-@escrow-testnet}"
+ESCROW="${ESCROW:-@escrow-test-02}"
 echo "ESCROW=$ESCROW"
 
 SCENARIO="${SCENARIO:-AB}"
@@ -228,12 +226,9 @@ sphere wallet use alice
 if ! sphere swap ping "$ESCROW" 2>&1 | tee "$SNAP/alice-escrow-ping.log"; then
   echo "ASSERT FAIL (escrow-unreachable): $ESCROW did not respond to swap ping" >&2
   echo "Hint: set ESCROW=<addr> to point at a different escrow service." >&2
-  if [[ "$ESCROW" == "@escrow-testnet" ]]; then
-    echo "Hint (sphere-sdk#456): the @escrow-testnet nametag binding may be" >&2
-    echo "  missing on the testnet relay. Re-run with the DIRECT-address fallback:" >&2
-    echo "  ESCROW=\"DIRECT://00007968fa28648e4670438bf1f3c936296e84ff46dd5ebb2e34e20092e780b652da2d3d695b\" \\" >&2
-    echo "    bash manual-test-swap-roundtrip.sh" >&2
-  fi
+  echo "  The canonical DEFAULT_ESCROW_ADDRESS is @escrow-test-02 (sphere-sdk constants.ts);" >&2
+  echo "  if its nametag binding is missing on the relay, resolve a working wallet's" >&2
+  echo "  view with 'sphere resolve @escrow-test-02' and pass the DIRECT://... directly." >&2
   exit 1
 fi
 echo "ASSERT OK (escrow-reachable): $ESCROW responded"

--- a/oracle/UnicityAggregatorProvider.ts
+++ b/oracle/UnicityAggregatorProvider.ts
@@ -543,17 +543,27 @@ export class UnicityAggregatorProvider implements OracleProvider {
     // publicKey for the spent-cache key. Aligning the cache key with
     // `isSpent`'s `${publicKey}:${stateHash}` format lets a
     // validateToken-driven spent decision short-circuit a subsequent
-    // `isSpent(pubkey, sameHash)` call (and vice versa). Pre-parsing
-    // is cheap relative to the RPC fallback and is best-effort —
-    // failure here only prevents the spent-cache key from including
-    // the publicKey (cached under bare stateHash as legacy fallback).
+    // `isSpent(pubkey, sameHash)` call (and vice versa).
+    //
+    // Normalize input shape: callers pass either the parsed token object
+    // (UXF receive / transfer-in paths build it from `.toJSON()`) OR a
+    // JSON string (PaymentsModule.validate() pulls `token.sdkData` straight
+    // from storage). state-transition-sdk's `Token.fromJSON` checks
+    // `'transactions' in input` and throws InvalidJsonStructureError for
+    // string input — silently dropping us to the RPC fallback. The
+    // aggregator does not expose a `validateToken` JSON-RPC method (see
+    // rpcCall site below), so that fallback always returns invalid. The
+    // net effect was that `payments.validate()` reported every token
+    // invalid, which permanently broke `SwapModule.verifyPayout`'s retry
+    // loop. Parse once here so the SDK path runs with pure local crypto.
+    const parsedTokenData =
+      typeof tokenData === 'string' ? JSON.parse(tokenData) : tokenData;
     let sdkToken: Awaited<ReturnType<typeof SdkToken.fromJSON>> | null = null;
     try {
-      sdkToken = await SdkToken.fromJSON(tokenData);
+      sdkToken = await SdkToken.fromJSON(parsedTokenData);
     } catch {
-      // Pre-parse failed; SDK path will detect the same failure and
-      // fall through to RPC. Cache key falls back to legacy bare-
-      // stateHash form below.
+      // Pre-parse still failed (malformed token JSON) — SDK path will
+      // skip via the `sdkToken !== null` guard and fall through to RPC.
     }
 
     try {
@@ -586,7 +596,7 @@ export class UnicityAggregatorProvider implements OracleProvider {
       }
 
       // Fallback to RPC validation
-      const response = await this.rpcCall<RpcValidateResponse>('validateToken', { token: tokenData });
+      const response = await this.rpcCall<RpcValidateResponse>('validateToken', { token: parsedTokenData });
 
       const valid = response.valid ?? false;
       const spent = response.spent ?? false;

--- a/tests/unit/oracle/UnicityAggregatorProvider.validateToken.test.ts
+++ b/tests/unit/oracle/UnicityAggregatorProvider.validateToken.test.ts
@@ -1,0 +1,174 @@
+/**
+ * `UnicityAggregatorProvider.validateToken` — accept both JSON string
+ * and parsed object as token input.
+ *
+ * Bug history (pre-fix):
+ *   - `PaymentsModule.validate()` (line ~12636) calls
+ *     `oracle.validateToken(token.sdkData)` where `sdkData` is a
+ *     JSON string persisted in TXF storage.
+ *   - All other oracle.validateToken call sites (UXF receive,
+ *     legacy receive) pass a parsed object built from `.toJSON()`.
+ *   - state-transition-sdk's `Token.fromJSON` checks
+ *     `'transactions' in input && 'nametags' in input` and throws
+ *     `InvalidJsonStructureError` for string input — there is no
+ *     `JSON.parse` fallback inside `fromJSON`.
+ *   - The historical `_validateTokenImpl` pre-parsed via
+ *     `SdkToken.fromJSON(tokenData)` with no normalization, so the
+ *     string-input branch silently produced `sdkToken=null`, which
+ *     skipped the local-crypto SDK path via the `sdkToken !== null`
+ *     guard and fell through to the RPC fallback.
+ *   - The aggregator does not implement a `validateToken` JSON-RPC
+ *     method (it exposes only `submit_commitment`,
+ *     `get_inclusion_proof`, etc.), so the RPC always returned
+ *     HTTP 400, and `validateToken` returned `{valid:false}`.
+ *   - Net effect: `payments.validate()` reported every wallet token
+ *     invalid even though local crypto verification succeeded,
+ *     permanently blocking `SwapModule.verifyPayout`'s retry loop.
+ *
+ * Fix contract:
+ *   - Both `validateToken(jsonString)` and `validateToken(object)`
+ *     must route into the SDK-path local verifier when trustBase is
+ *     loaded — without an aggregator round-trip.
+ *   - The string-input path must NOT silently fall through to the
+ *     dead RPC fallback.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { UnicityAggregatorProvider } from '../../../oracle/UnicityAggregatorProvider';
+import { RootTrustBase } from '@unicitylabs/state-transition-sdk/lib/bft/RootTrustBase';
+import { Token as SdkToken } from '@unicitylabs/state-transition-sdk/lib/token/Token';
+
+// Minimal trustBase shape — single-node quorum, version 1, network 3.
+// The SDK `verify` path consults trustBase metadata but the actual
+// proof verification uses the embedded UnicityCertificate's BFT
+// signatures, which the spy below stubs out.
+const TRUST_BASE_JSON = {
+  version: 1,
+  networkId: 3,
+  epoch: 1,
+  epochStartRound: 1,
+  rootNodes: [
+    {
+      nodeId: '16Uiu2HAkyQRiA7pMgzgLj9GgaBJEJa8zmx9dzqUDa6WxQPJ82ghU',
+      sigKey: '0x' + '0'.repeat(66),
+      stake: 1,
+    },
+  ],
+  quorumThreshold: 1,
+  stateHash: '',
+  changeRecordHash: '',
+  previousEntryHash: '',
+  signatures: {},
+};
+
+// Minimal valid Token JSON shape — has the keys `Token.isJSON` checks
+// (`state`, `genesis`, `transactions`, `nametags`). We do NOT exercise
+// the full crypto path here; we mock `SdkToken.fromJSON` so the test
+// stays scoped to oracle wiring (string-normalization + path routing).
+const TOKEN_OBJ = Object.freeze({
+  state: {},
+  genesis: {},
+  transactions: [],
+  nametags: [],
+});
+const TOKEN_STR = JSON.stringify(TOKEN_OBJ);
+
+function makeProvider(opts?: {
+  trustBase?: unknown;
+}): UnicityAggregatorProvider {
+  const provider = new UnicityAggregatorProvider({
+    url: 'https://test.example/',
+    timeout: 1000,
+    skipVerification: false,
+  });
+  (provider as unknown as { status: string }).status = 'connected';
+  if (opts?.trustBase !== undefined) {
+    (provider as unknown as { trustBase: unknown }).trustBase = opts.trustBase;
+  }
+  return provider;
+}
+
+// Stub a parsed SdkToken so `verify` returns isSuccessful=true. Calling
+// the real verify on a hand-crafted minimal token would fail crypto
+// checks; the routing assertions here only need to observe that the
+// SDK path was entered.
+function mockSdkTokenFromJSON(verifyResult: { isSuccessful: boolean }): void {
+  vi.spyOn(SdkToken, 'fromJSON').mockImplementation(async (input: unknown) => {
+    // Reproduce real fromJSON's `Token.isJSON` invariant — reject
+    // anything that isn't a parsed object. This is what's broken
+    // pre-fix when the validateToken caller passes a JSON string;
+    // the fix should normalize before reaching this mock.
+    if (
+      !input ||
+      typeof input !== 'object' ||
+      !('transactions' in input) ||
+      !('nametags' in input)
+    ) {
+      throw new Error('Invalid JSON structure.');
+    }
+    return {
+      verify: async () => verifyResult,
+      state: { calculateHash: async () => ({ toJSON: () => 'stub-state-hash' }) },
+    } as unknown as Awaited<ReturnType<typeof SdkToken.fromJSON>>;
+  });
+}
+
+describe('UnicityAggregatorProvider.validateToken — string-or-object input normalization', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('routes JSON-string input into the SDK local-verify path (no RPC round-trip)', async () => {
+    // If the fix is in place, the pre-parse normalizes the string
+    // to an object before SdkToken.fromJSON, sdkToken is non-null,
+    // the SDK gate at `sdkToken !== null` passes, and `verify()`
+    // is invoked locally. `fetch` MUST NOT be called.
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('fetch should not be called when SDK path runs');
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+    mockSdkTokenFromJSON({ isSuccessful: true });
+
+    const provider = makeProvider({ trustBase: RootTrustBase.fromJSON(TRUST_BASE_JSON) });
+
+    const result = await provider.validateToken(TOKEN_STR);
+
+    expect(result.valid).toBe(true);
+    expect(result.spent).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('routes parsed-object input into the same SDK local-verify path', async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('fetch should not be called when SDK path runs');
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+    mockSdkTokenFromJSON({ isSuccessful: true });
+
+    const provider = makeProvider({ trustBase: RootTrustBase.fromJSON(TRUST_BASE_JSON) });
+
+    const result = await provider.validateToken(TOKEN_OBJ);
+
+    expect(result.valid).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports invalid (NOT throws) when SDK verify returns isSuccessful=false', async () => {
+    mockSdkTokenFromJSON({ isSuccessful: false });
+
+    const provider = makeProvider({ trustBase: RootTrustBase.fromJSON(TRUST_BASE_JSON) });
+
+    const result = await provider.validateToken(TOKEN_STR);
+
+    expect(result.valid).toBe(false);
+    expect(result.spent).toBe(false);
+    expect(result.error).toBe('SDK verification failed');
+  });
+});


### PR DESCRIPTION
## Summary

Two unrelated-but-co-discovered bugs surfaced while debugging the trader-roundtrip soak (`manual-test-trader-roundtrip.sh`) hanging at `SwapModule.verifyPayout`.

### Bug 1 — `oracle.validateToken` silently routes string inputs to a dead RPC fallback

`PaymentsModule.validate()` (line ~12636) calls `oracle.validateToken(token.sdkData)` where `sdkData` is the JSON **string** persisted in TXF storage. All other call sites (UXF receive, legacy receive paths at lines ~3024 / ~16713) build `tokenData` from `.toJSON()` and pass a parsed **object**.

state-transition-sdk's `Token.fromJSON(input)` checks `'transactions' in input && 'nametags' in input` and throws `InvalidJsonStructureError` for string input — no `JSON.parse` fallback inside `fromJSON`.

The historical `_validateTokenImpl` pre-parsed `SdkToken.fromJSON(tokenData)` outside the SDK-path try-block with no normalization. The string branch silently produced `sdkToken=null`, which then skipped the local-crypto SDK path via `if (... && sdkToken !== null)` at line ~561 and fell through to the RPC fallback.

The aggregator does **not** implement a `validateToken` JSON-RPC method (it exposes only `submit_commitment`, `get_inclusion_proof`, `get_no_deletion_proof`, `get_block_height`). The RPC returned HTTP 400, `rpcCall` threw `SphereError`, the outer catch returned `{valid:false}`.

**Net effect:** `payments.validate()` reported every wallet token invalid — including tokens the wallet just minted itself — even when local crypto verification succeeded.

Reproduced empirically against a captured trader tenant wallet on HEAD: 2 confirmed-status tokens, both pass `tok.verify(trustBase).isSuccessful === true` standalone, but `sphere.payments.validate()` returns `{valid:0, invalid:2}`.

**Why nobody noticed for so long:** the only hot-path caller is `SwapModule.verifyPayout` (line 2252), and swap completion does NOT gate on `payoutVerified` (completed-with-payoutVerified=false is an explicitly allowed terminal state per lines 1976-1979). So swaps work end-to-end, but trader-service's verifyPayout retry loop hangs for the full 40 × 30s budget because it actually awaits `payoutVerified` flipping.

**Fix:** normalize `tokenData` once — accept string or object — before the shared pre-parse. SDK path now runs with pure local crypto for both shapes. Bonus: pass the normalized shape to the RPC fallback too for wire consistency.

**Empirical verification:** reran `payments.validate()` against the captured tenant wallet with the fix applied — both tokens now report valid.

New unit test (`tests/unit/oracle/UnicityAggregatorProvider.validateToken.test.ts`) covers:
- string input → SDK path entered, `fetch` NOT called
- object input → SDK path entered, `fetch` NOT called
- SDK `verify` `isSuccessful=false` → invalid+error (no throw)

### Bug 2 — `manual-test-swap-roundtrip.sh` default escrow is stale

The script's `ESCROW="${ESCROW:-@escrow-testnet}"` predates PR #468 which hardcoded and exported `DEFAULT_ESCROW_ADDRESS = '@escrow-test-02'` in `constants.ts`. The legacy `@escrow-testnet` nametag binding is no longer published on the testnet relay, so the soak's §2.5 pre-flight fails immediately with "Could not resolve recipient".

**Fix:** default to `@escrow-test-02`. Drop the stale `DIRECT://00007968...` fallback hint (that escrow is gone too); replace with generic guidance to run `sphere resolve @escrow-test-02` from a working wallet if the nametag binding ever goes missing again.

## Test plan

- [x] `npx vitest run tests/unit/oracle/` — all 33 oracle tests pass (including 3 new)
- [x] `npx tsc --noEmit` — clean
- [x] Empirical: reran `sphere.payments.validate()` against the captured trader tenant wallet with the fix → both tokens now `valid`
- [ ] Rebuild trader-service image with this SDK and rerun trader-roundtrip soak — expect `verifyPayout` to succeed and §8 to complete
- [ ] Rerun `manual-test-swap-roundtrip.sh` with the updated default escrow

## Related

- Surfaced by trader-roundtrip soak (sphere-sdk#474)
- Pre-existing regression — `SdkToken.fromJSON(tokenData)` has been called without normalization since the init commit `225eb593`. The earlier shape (pre-#245) had the same string-rejection behaviour but inside the SDK-path try-block, so it logged "SDK validation failed, falling back to RPC" on every call. PR #245 hoisted the pre-parse out, eliminating the log line and making the bug invisible.