### PR TITLE
fix(swap)(sphere-sdk#535): use state-transition-sdk primitives for verifyPayout

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -4012,7 +4012,12 @@ export class Sphere {
             getTokenIdsForInvoice: (id: string) => acctForSwap.getTokenIdsForInvoice(id),
             on: onForSwap,
           },
-          payments: { validate: () => payments.validate() },
+          payments: { getToken: (id: string) => payments.getToken(id) },
+          oracle: {
+            isSpent: (pk: string, sh: string) => this._oracle.isSpent(pk, sh),
+            getRootTrustBase: () =>
+              (this._oracle as { getRootTrustBase?: () => unknown | null }).getRootTrustBase?.() ?? null,
+          },
           communications: {
             sendDM: async (recipientPubkey: string, content: string) => {
               const msg = await communications.sendDM(recipientPubkey, content);
@@ -7423,7 +7428,12 @@ export class Sphere {
             getTokenIdsForInvoice: (id: string) => acctForSwap.getTokenIdsForInvoice(id),
             on: onForSwap,
           },
-          payments: { validate: () => paymentsForSwap.validate() },
+          payments: { getToken: (id: string) => paymentsForSwap.getToken(id) },
+          oracle: {
+            isSpent: (pk: string, sh: string) => this._oracle.isSpent(pk, sh),
+            getRootTrustBase: () =>
+              (this._oracle as { getRootTrustBase?: () => unknown | null }).getRootTrustBase?.() ?? null,
+          },
           communications: {
             sendDM: async (recipientPubkey: string, content: string) => {
               const msg = await commsForSwap.sendDM(recipientPubkey, content);

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -283,6 +283,7 @@ import {
 
 // SDK imports for token parsing and transfers
 import { PredicateEngineService } from '@unicitylabs/state-transition-sdk/lib/predicate/PredicateEngineService';
+import { extractCurrentStatePublicKeyHexFromSdkData } from './extract-state-publickey';
 import { Token as SdkToken } from '@unicitylabs/state-transition-sdk/lib/token/Token';
 import { CoinId } from '@unicitylabs/state-transition-sdk/lib/token/fungible/CoinId';
 import { TransferCommitment } from '@unicitylabs/state-transition-sdk/lib/transaction/TransferCommitment';
@@ -774,67 +775,10 @@ function extractStateHashFromSdkData(sdkData: string | undefined): string {
   return parseSdkDataCached(sdkData).stateHash;
 }
 
-/**
- * Issue #245 #1 — extract the hex-encoded publicKey of the CURRENT
- * state's predicate from a token's TXF sdkData.
- *
- * Why: the canonical aggregator indexes commitments by
- * `requestId = SHA256(publicKey || stateHash)` where publicKey is
- * the OWNER of the source state being consumed. Callers that probe
- * `oracle.isSpent(publicKey, stateHash)` MUST pass the predicate's
- * actual publicKey — not the wallet's `chainPubkey` — otherwise the
- * derived requestId misses for tokens whose state.predicate was
- * constructed under a foreign or non-current key (sync race,
- * migration data, multi-address wallets where the worker runs
- * against address A while the token's predicate was constructed
- * under address B).
- *
- * Returns the hex-encoded publicKey, or `null` if the predicate
- * cannot be parsed. Callers SHOULD fall back to `chainPubkey` on
- * `null` so the probe still happens (preserves legacy behaviour for
- * wallet-owned tokens with non-parseable predicates).
- *
- * Best-effort and async — does one SDK Token parse + one
- * PredicateEngineService.createPredicate. Safe to call on the hot
- * path: each parse is bounded by a small cache (the SDK's internal
- * fromJSON caching) and the wrapper falls back to `chainPubkey` on
- * any throw.
- */
-async function extractCurrentStatePublicKeyHexFromSdkData(
-  sdkData: string | undefined,
-): Promise<string | null> {
-  if (!sdkData) return null;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(sdkData);
-  } catch {
-    return null;
-  }
-  let sdkTokenInstance;
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sdkTokenInstance = await SdkToken.fromJSON(parsed as any);
-  } catch {
-    return null;
-  }
-  if (!sdkTokenInstance?.state?.predicate) return null;
-  let predicate;
-  try {
-    predicate = await PredicateEngineService.createPredicate(
-      sdkTokenInstance.state.predicate,
-    );
-  } catch {
-    return null;
-  }
-  // DefaultPredicate / MaskedPredicate / UnmaskedPredicate all expose
-  // `publicKey: Uint8Array`. The IPredicate interface doesn't declare
-  // it, so narrow via runtime check + cast (matches the recipe at
-  // `recoverStrandedReceivedTokens`, line ~8979).
-  const pubkey = (predicate as unknown as { publicKey?: Uint8Array })
-    .publicKey;
-  if (!(pubkey instanceof Uint8Array) || pubkey.length === 0) return null;
-  return bytesToHex(pubkey);
-}
+// Issue #245 #1 — `extractCurrentStatePublicKeyHexFromSdkData` was extracted
+// to `./extract-state-publickey.ts` (issue #535) so SwapModule.verifyPayout
+// can reuse the same logic without re-implementing predicate parsing.
+// Rationale + fall-back guidance: see that file's docstring.
 
 /**
  * Create composite key from tokenId and stateHash

--- a/modules/payments/extract-state-publickey.ts
+++ b/modules/payments/extract-state-publickey.ts
@@ -1,0 +1,59 @@
+/**
+ * Extract the current-state predicate publicKey (hex) from a token's
+ * serialized SDK data (the JSON string persisted in TXF storage as
+ * `Token.sdkData`).
+ *
+ * Used by:
+ *   - PaymentsModule's spent-state rescan worker (chooses the predicate
+ *     pubkey instead of falling back to `chainPubkey` for tokens whose
+ *     state is locked to a non-self predicate).
+ *   - SwapModule.verifyPayout (issue #535) — derives the predicate
+ *     pubkey for the per-payout-token `oracle.isSpent` probe.
+ *
+ * Returns null when:
+ *   - `sdkData` is undefined / empty.
+ *   - JSON parse fails.
+ *   - `SdkToken.fromJSON` rejects the shape.
+ *   - PredicateEngineService cannot build a predicate (unknown engine).
+ *   - The built predicate does not carry a `publicKey` field.
+ *
+ * Callers SHOULD fall back to `chainPubkey` (or another sensible default)
+ * on null so the probe still happens — never fail-open on the spent
+ * check itself.
+ */
+
+import { Token as SdkToken } from '@unicitylabs/state-transition-sdk/lib/token/Token';
+import { PredicateEngineService } from '@unicitylabs/state-transition-sdk/lib/predicate/PredicateEngineService';
+import { bytesToHex } from '../../core/hex';
+
+export async function extractCurrentStatePublicKeyHexFromSdkData(
+  sdkData: string | undefined,
+): Promise<string | null> {
+  if (!sdkData) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(sdkData);
+  } catch {
+    return null;
+  }
+  let sdkTokenInstance;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sdkTokenInstance = await SdkToken.fromJSON(parsed as any);
+  } catch {
+    return null;
+  }
+  if (!sdkTokenInstance?.state?.predicate) return null;
+  let predicate;
+  try {
+    predicate = await PredicateEngineService.createPredicate(
+      sdkTokenInstance.state.predicate,
+    );
+  } catch {
+    return null;
+  }
+  const pubkey = (predicate as unknown as { publicKey?: Uint8Array })
+    .publicKey;
+  if (!(pubkey instanceof Uint8Array) || pubkey.length === 0) return null;
+  return bytesToHex(pubkey);
+}

--- a/modules/swap/SwapModule.ts
+++ b/modules/swap/SwapModule.ts
@@ -50,6 +50,7 @@ import {
   sendRequestInvoice,
   withRetry,
 } from './escrow-client.js';
+import { verifyPayoutTokens } from './payout-verifier.js';
 import type { TransferResult } from '../../types/index.js';
 import { TokenRegistry } from '../../registry/index.js';
 import type {
@@ -2238,56 +2239,34 @@ export class SwapModule {
       }
     }
 
-    // Validate L3 inclusion proofs — but ONLY for tokens that cover this
-    // specific payout invoice. validate() checks the full wallet; any
-    // unrelated invalid token (e.g. a now-spent original UCT consumed by
-    // a split for some other operation, or an unrelated incoming transfer
-    // that hasn't finalized yet) would otherwise pin verifyPayout to false
-    // forever even when the payout itself is fully covered and valid.
-    //
-    // Multiple wallet tokens can share the same coinId (e.g. the original
-    // funded balance + the incoming payout); coinId-only filtering is too
-    // loose. Use accounting.getTokenIdsForInvoice() to get the exact set of
-    // tokens linked to THIS invoice and filter the invalid set to that.
-    const validationResult = await deps.payments.validate();
-    if (validationResult.invalid.length > 0) {
-      const payoutTokenIds = deps.accounting.getTokenIdsForInvoice(swap.payoutInvoiceId);
-
-      // SECURITY: fail-CLOSED when payoutTokenIds is empty AND there are
-      // invalid tokens we can't classify. An empty set means the reverse
-      // index (tokenInvoiceMap) hasn't been rebuilt yet OR the orphan-buffer
-      // hasn't been replayed for this invoice. We cannot determine relevance,
-      // so we cannot safely fall through to "verified". The next retry tick
-      // will pick up after the rebuild/replay completes.
-      if (payoutTokenIds.size === 0) {
-        logger.warn(
-          LOG_TAG,
-          `verifyPayout for ${swapId.slice(0, 12)}: ${validationResult.invalid.length} invalid token(s) but tokenInvoiceMap is empty for this payout invoice — failing closed until reverse index rebuilds`,
-        );
-        return returnFalse();
-      }
-
-      // Filter the validate-invalid set to tokens that are linked to THIS
-      // payout invoice via tokenInvoiceMap (populated by both
-      // _processTokenTransactions's on-chain path AND the synthetic /
-      // orphan-buffer paths after the round-1/2/3 fixes). Unrelated
-      // invalids — typically the now-spent original UCT consumed by an
-      // earlier deposit split, or unrelated incoming transfers in flight —
-      // must not block this swap's verification.
-      const relevantInvalid = validationResult.invalid.filter((t) =>
-        payoutTokenIds.has(t.id),
-      );
-      if (relevantInvalid.length > 0) {
-        logger.warn(
-          LOG_TAG,
-          `verifyPayout for ${swapId.slice(0, 12)}: L3 validation found ${relevantInvalid.length} invalid token(s) covering this payout invoice — retry after wallet sync`,
-        );
-        return returnFalse();
-      }
-      logger.debug(
+    // Issue #535 — verify the payout tokens directly using state-transition-sdk
+    // primitives (finalization → SdkToken.verify(trustBase) → oracle.isSpent),
+    // scoped to the tokens that actually back THIS payout invoice. Replaces
+    // the wallet-wide `payments.validate()` sweep that produced opaque retry
+    // hangs and could not distinguish "not finalized yet" from
+    // "cryptographically invalid" from "already spent". See
+    // `modules/swap/payout-verifier.ts` for the full rationale.
+    const payoutTokenIds = deps.accounting.getTokenIdsForInvoice(swap.payoutInvoiceId);
+    const verifyResult = await verifyPayoutTokens({
+      payoutTokenIds,
+      getToken: (id: string) => deps.payments.getToken(id),
+      trustBase: deps.oracle.getRootTrustBase(),
+      isSpent: (pk: string, sh: string) => deps.oracle.isSpent(pk, sh),
+      // Payouts are minted to OUR predicate, so the wallet's chainPubkey is
+      // the correct spent-probe target when extraction can't recover the
+      // predicate bytes from sdkData. Matches the wallet-owned fallback
+      // pattern in PaymentsModule's spent-state rescan worker.
+      fallbackPublicKey: deps.identity.chainPubkey,
+    });
+    if (verifyResult.kind === 'transient') {
+      logger.warn(
         LOG_TAG,
-        `verifyPayout for ${swapId.slice(0, 12)}: ${validationResult.invalid.length} unrelated invalid token(s) ignored (not linked to this payout invoice)`,
+        `verifyPayout for ${swapId.slice(0, 12)}: transient (${verifyResult.reason}) — will retry`,
       );
+      return returnFalse();
+    }
+    if (verifyResult.kind === 'terminal') {
+      return failPayout(verifyResult.reason);
     }
 
     // All checks passed — mark payout as verified.

--- a/modules/swap/payout-verifier.ts
+++ b/modules/swap/payout-verifier.ts
@@ -1,0 +1,189 @@
+/**
+ * Per-payout-token verification used by `SwapModule.verifyPayout` (issue #535).
+ *
+ * Background
+ * ----------
+ * Until issue #535, `SwapModule.verifyPayout` called the wallet-wide
+ * `payments.validate()` and then filtered its `invalid` set down to tokens
+ * linked to the payout invoice. That had three problems:
+ *
+ *   1. **Wrong primitive.** `payments.validate()` is conceptually the
+ *      user-facing "audit my whole wallet" diagnostic. Once an inclusion
+ *      proof is cryptographically valid against the trustBase, the
+ *      aggregator can never revoke it (the SMT is append-only; the BFT
+ *      certificate is signed by an immutable validator set for that
+ *      epoch). Re-running it across every wallet token is wasted work.
+ *   2. **No targeted failure modes.** "not finalized yet" (transient),
+ *      "cryptographically invalid" (terminal fraud), and "already spent
+ *      out from under us" (terminal fraud, the actual reason this gate
+ *      exists) were lumped into one opaque retry loop.
+ *   3. **Pre-fix, `validate()` always reported invalid** (PR #534). That
+ *      defect masked the design issue for months — the retry loop
+ *      naturally hung instead of completing.
+ *
+ * This module replaces the `validate()`-driven block with three checks
+ * scoped to the specific payout tokens:
+ *
+ *   (a) Finalization — last `transactions[]` entry (or `genesis` for an
+ *       unmoved mint) MUST carry an `inclusionProof`. A null proof means
+ *       the aggregator hasn't anchored this transition yet → transient.
+ *   (b) Cryptographic verify — `SdkToken.verify(trustBase)` runs the full
+ *       genesis-→-current chain check locally against the bundled
+ *       RootTrustBase. Failure means the escrow signed an invalid mint
+ *       (or the token was tampered with) → terminal fraud.
+ *   (c) Spent check — `oracle.isSpent(predicatePublicKey, stateHash)`
+ *       asks the aggregator whether the predicate guarding the current
+ *       state has already produced a transition (i.e. someone spent the
+ *       payout out from under us between mint and delivery). True →
+ *       terminal fraud.
+ *
+ * Result discrimination
+ * --------------------
+ * The function returns a tagged union so the caller can distinguish:
+ *
+ *   - `{ kind: 'ok' }` — all tokens passed all three checks.
+ *   - `{ kind: 'transient', reason }` — caller should `returnFalse()` and
+ *     retry on the next verify tick.
+ *   - `{ kind: 'terminal', reason }` — caller should `failPayout(reason)`
+ *     and transition the swap to `failed`.
+ *
+ * Throws
+ * ------
+ * `oracle.isSpent` MUST NOT fail-open per its interface contract. An RPC
+ * failure throws — and that throw propagates out of this function to the
+ * caller's outer auto-verify catch (which logs and retries). This matches
+ * the existing pattern: transient infrastructure problems are retried;
+ * cryptographically-verified bad state terminally fails the swap.
+ */
+
+import { Token as SdkToken } from '@unicitylabs/state-transition-sdk/lib/token/Token';
+import { extractCurrentStatePublicKeyHexFromSdkData } from '../payments/extract-state-publickey';
+import type { Token } from '../../types';
+
+export type PayoutVerificationResult =
+  | { readonly kind: 'ok' }
+  | { readonly kind: 'transient'; readonly reason: string }
+  | { readonly kind: 'terminal'; readonly reason: string };
+
+export interface VerifyPayoutTokensInput {
+  /** Token IDs linked to the payout invoice via accounting.getTokenIdsForInvoice. */
+  readonly payoutTokenIds: ReadonlySet<string>;
+  /** PaymentsModule's getToken — returns the wallet's local Token or undefined. */
+  readonly getToken: (id: string) => Token | undefined;
+  /** Bundled RootTrustBase from the oracle. SDK-shaped (typed as unknown to keep
+   *  this module free of a hard SDK import beyond Token itself). */
+  readonly trustBase: unknown | null;
+  /** OracleProvider.isSpent — throws on RPC failure (intentional, see file docstring). */
+  readonly isSpent: (publicKey: string, stateHash: string) => Promise<boolean>;
+  /** Fallback predicate publicKey when extraction from sdkData fails. Typically
+   *  the wallet's own chainPubkey — payouts are minted to our predicate so this
+   *  is the correct spent-probe target when extraction can't recover the bytes. */
+  readonly fallbackPublicKey: string;
+}
+
+export async function verifyPayoutTokens(
+  input: VerifyPayoutTokensInput,
+): Promise<PayoutVerificationResult> {
+  const { payoutTokenIds, getToken, trustBase, isSpent, fallbackPublicKey } = input;
+
+  // SECURITY: fail-closed when the reverse index for this invoice is empty.
+  // An empty set means accounting's `tokenInvoiceMap` hasn't been rebuilt
+  // yet for this invoice (snapshot/restart race) — we cannot determine
+  // which tokens to check, so we cannot safely fall through to verified.
+  // Transient: the next verify tick picks up after the rebuild completes.
+  if (payoutTokenIds.size === 0) {
+    return { kind: 'transient', reason: 'payout-reverse-index-empty' };
+  }
+
+  if (!trustBase) {
+    return { kind: 'transient', reason: 'trustbase-not-loaded' };
+  }
+
+  for (const tokenId of payoutTokenIds) {
+    const tok = getToken(tokenId);
+    if (!tok) {
+      return { kind: 'transient', reason: `token-not-in-wallet:${tokenId}` };
+    }
+    if (!tok.sdkData) {
+      return { kind: 'transient', reason: `token-missing-sdkdata:${tokenId}` };
+    }
+
+    // (a) Finalization — last transaction (or genesis for an unmoved
+    //     mint) must carry an inclusion proof. Parse defensively: a
+    //     storage-corrupted sdkData throws here and routes to terminal
+    //     (we'd never be able to verify this token, no point retrying).
+    let parsedSdkData: unknown;
+    try {
+      parsedSdkData = JSON.parse(tok.sdkData);
+    } catch (err) {
+      return {
+        kind: 'terminal',
+        reason: `PAYOUT_TOKEN_SDKDATA_UNPARSEABLE: ${tokenId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      };
+    }
+    const sdkDataShape = parsedSdkData as {
+      transactions?: ReadonlyArray<{ inclusionProof?: unknown }>;
+      genesis?: { inclusionProof?: unknown };
+    };
+    const txs = sdkDataShape.transactions ?? [];
+    const lastTx = txs.length > 0 ? txs[txs.length - 1] : sdkDataShape.genesis;
+    if (!lastTx || lastTx.inclusionProof == null) {
+      return { kind: 'transient', reason: `payout-token-not-finalized:${tokenId}` };
+    }
+
+    // (b) Cryptographic verify — SdkToken.fromJSON + verify(trustBase).
+    //     A fromJSON throw on well-formed-but-out-of-spec input is
+    //     terminal (we can never accept this shape); a verify failure
+    //     is also terminal (escrow attested an invalid mint).
+    let sdkToken;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sdkToken = await SdkToken.fromJSON(parsedSdkData as any);
+    } catch (err) {
+      return {
+        kind: 'terminal',
+        reason: `PAYOUT_TOKEN_PARSE_FAILED: ${tokenId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      };
+    }
+
+    let verifyResult: { isSuccessful: boolean };
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      verifyResult = await sdkToken.verify(trustBase as any);
+    } catch (err) {
+      return {
+        kind: 'terminal',
+        reason: `PAYOUT_TOKEN_VERIFY_THREW: ${tokenId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      };
+    }
+    if (!verifyResult.isSuccessful) {
+      return {
+        kind: 'terminal',
+        reason: `PAYOUT_TOKEN_VERIFY_FAILED: ${tokenId}`,
+      };
+    }
+
+    // (c) Spent check — derive the predicate publicKey, compute the
+    //     state hash, ask the aggregator. RPC errors propagate (per
+    //     OracleProvider contract — never fail-open).
+    const publicKeyHex =
+      (await extractCurrentStatePublicKeyHexFromSdkData(tok.sdkData)) ??
+      fallbackPublicKey;
+    const stateHashHex = (await sdkToken.state.calculateHash()).toJSON();
+    const spent = await isSpent(publicKeyHex, stateHashHex);
+    if (spent) {
+      return {
+        kind: 'terminal',
+        reason: `PAYOUT_STATE_ALREADY_SPENT: ${tokenId}`,
+      };
+    }
+  }
+
+  return { kind: 'ok' };
+}

--- a/modules/swap/types.ts
+++ b/modules/swap/types.ts
@@ -792,11 +792,27 @@ export interface SwapModuleDependencies {
     on<T extends SphereEventType>(type: T, handler: (data: SphereEventMap[T]) => void): () => void;
   };
   /**
-   * PaymentsModule subset -- L3 token validation during payout verification.
+   * PaymentsModule subset — per-payout-token lookup for payout verification.
+   *
+   * Issue #535: dropped the `validate()` wallet-wide sweep in favour of
+   * a per-token `getToken(id)` + state-transition-sdk primitives. See
+   * `modules/swap/payout-verifier.ts` for the verification flow.
    */
   readonly payments: {
-    /** Validate all tokens against the aggregator */
-    validate(): Promise<{ valid: Token[]; invalid: Token[] }>;
+    /** Fetch a specific local Token (with `sdkData`) by ID. */
+    getToken(id: string): Token | undefined;
+  };
+  /**
+   * OracleProvider subset — used by `verifyPayout` to (a) probe the
+   * aggregator for already-spent payout-state (defense vs malicious
+   * escrow) and (b) fetch the bundled RootTrustBase for local
+   * cryptographic verification.
+   */
+  readonly oracle: {
+    /** Throws on RPC failure (never fail-open). */
+    isSpent(publicKey: string, stateHash: string): Promise<boolean>;
+    /** May return null when the oracle is configured with skipVerification. */
+    getRootTrustBase(): unknown | null;
   };
   /**
    * CommunicationsModule subset -- DM send/receive for peer and escrow messaging.

--- a/tests/integration/swap-lifecycle.test.ts
+++ b/tests/integration/swap-lifecycle.test.ts
@@ -26,10 +26,13 @@ import {
   createMockAccountingModule,
   createMockStorageProvider,
   createMockPaymentsModule,
+  createMockOracleProvider,
   type MockAccountingModule,
   type MockStorageProvider,
   type MockPaymentsModule,
+  type MockOracleProvider,
 } from '../unit/modules/swap-test-helpers.js';
+import { Token as SdkToken } from '@unicitylabs/state-transition-sdk/lib/token/Token';
 
 // =============================================================================
 // Constants
@@ -361,6 +364,7 @@ interface IntegrationParty {
   accounting: MockAccountingModule;
   storage: MockStorageProvider;
   payments: MockPaymentsModule;
+  oracle: MockOracleProvider;
   events: Array<[string, unknown]>;
 }
 
@@ -422,6 +426,7 @@ function createParty(
   const accounting = createMockAccountingModule();
   const storage = createMockStorageProvider();
   const payments = createMockPaymentsModule();
+  const oracle = createMockOracleProvider();
   const events: Array<[string, unknown]> = [];
 
   const emitEvent = vi.fn().mockImplementation((type: string, data: unknown) => {
@@ -479,6 +484,7 @@ function createParty(
   const deps: SwapModuleDependencies = {
     accounting,
     payments,
+    oracle,
     communications,
     storage,
     identity,
@@ -489,7 +495,7 @@ function createParty(
 
   module.initialize(deps);
 
-  return { module, identity, accounting, storage, payments, events };
+  return { module, identity, accounting, storage, payments, oracle, events };
 }
 
 function createSwapTestPair(): SwapTestContext {
@@ -604,6 +610,34 @@ function configureAccountingForDeposit(
   });
 }
 
+/**
+ * Stub SdkToken.fromJSON to return a verify-success token so the new
+ * issue-#535 per-payout-token verification path (added in PR #536) reaches
+ * the `ok` branch in these mock-driven integration tests. Tracks whether
+ * the spy has been installed for this test run so calling
+ * `configureAccountingForPayout` multiple times in the same `it` (e.g.
+ * once for party A, once for party B) doesn't re-stub redundantly.
+ *
+ * Real SDK crypto verification is exercised by tests that wire
+ * @unicitylabs/state-transition-sdk against real tokens — out of scope
+ * for these state-machine + DM integration tests.
+ */
+let __sdkTokenStubInstalled = false;
+function installSdkTokenStub(): void {
+  if (__sdkTokenStubInstalled) return;
+  __sdkTokenStubInstalled = true;
+  vi.spyOn(SdkToken, 'fromJSON').mockImplementation(async (_input: unknown) => {
+    return {
+      verify: async () => ({ isSuccessful: true }),
+      state: {
+        calculateHash: async () => ({ toJSON: () => 'stub-state-hash' }),
+        predicate: null,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  });
+}
+
 function configureAccountingForPayout(
   party: IntegrationParty,
   _swapId: string,
@@ -612,6 +646,52 @@ function configureAccountingForPayout(
   currency: string,
   amount: string,
 ): void {
+  // Wire the new issue-#535 deps (PR #536) so verifyPayout's per-token
+  // checks reach the `ok` branch in mock-driven integration tests:
+  //
+  //   - accounting.getTokenIdsForInvoice — non-empty Set keyed by this invoice
+  //   - payments.getToken                 — returns a Token with stub sdkData
+  //                                         (finalized: genesis carries an
+  //                                         inclusionProof; verify is stubbed
+  //                                         to succeed via SdkToken.fromJSON
+  //                                         spy installed lazily)
+  //   - oracle.isSpent                    — false (not spent)
+  //   - oracle.getRootTrustBase           — non-null sentinel
+  //
+  // The defaults from `createMock{Oracle,Payments,Accounting}Provider`
+  // already return non-null trustBase and isSpent=false; we only need
+  // to override the per-invoice mappings here.
+  const stubPayoutTokenId = `stub-payout-token-${payoutInvoiceId}`;
+  const stubSdkData = JSON.stringify({
+    state: { predicate: 'stub-predicate' },
+    genesis: { inclusionProof: { __mock_proof: 1 } },
+    transactions: [],
+    nametags: [],
+  });
+  const stubToken: Token = {
+    id: stubPayoutTokenId,
+    coinId: currency,
+    symbol: currency,
+    name: currency,
+    decimals: 6,
+    amount,
+    status: 'confirmed',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    sdkData: stubSdkData,
+  };
+  const prevGetTokenIds = party.accounting.getTokenIdsForInvoice.getMockImplementation();
+  party.accounting.getTokenIdsForInvoice.mockImplementation((invoiceId: string): Set<string> => {
+    if (invoiceId === payoutInvoiceId) return new Set([stubPayoutTokenId]);
+    return prevGetTokenIds ? prevGetTokenIds(invoiceId) : new Set();
+  });
+  const prevGetToken = party.payments.getToken.getMockImplementation();
+  party.payments.getToken.mockImplementation((id: string): Token | undefined => {
+    if (id === stubPayoutTokenId) return stubToken;
+    return prevGetToken ? prevGetToken(id) : undefined;
+  });
+  installSdkTokenStub();
+
   // Store payout invoice lookup as a separate function so the deposit mock
   // can delegate to it without circular chaining issues.
   const payoutInvoices: Map<string, unknown> = (party.accounting as any)._payoutInvoices ?? new Map();
@@ -686,6 +766,12 @@ describe('Swap Lifecycle Integration Tests', () => {
   afterEach(async () => {
     await ctx.partyA.module.destroy();
     await ctx.partyB.module.destroy();
+    // Tear down the SdkToken.fromJSON spy installed by
+    // `configureAccountingForPayout` so each test gets a fresh stub
+    // (and tests that never call configureAccountingForPayout see the
+    // real SdkToken implementation).
+    vi.restoreAllMocks();
+    __sdkTokenStubInstalled = false;
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/modules/SwapModule.verify.test.ts
+++ b/tests/unit/modules/SwapModule.verify.test.ts
@@ -5,7 +5,8 @@
  * Tests for verifyPayout() method.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Token as SdkToken } from '@unicitylabs/state-transition-sdk/lib/token/Token';
 import {
   createTestSwapModule,
   createTestSwapRef,
@@ -19,6 +20,7 @@ import {
   type TestSwapModuleMocks,
 } from './swap-test-helpers.js';
 import type { SwapModule } from '../../../modules/swap/index.js';
+import type { Token } from '../../../types/index.js';
 
 /**
  * Helper: create a concluding SwapRef with payoutInvoiceId and configure
@@ -104,6 +106,66 @@ function setupVerifiableSwap(
   return ref;
 }
 
+/**
+ * Configure the new issue-#535 payout-verification path with a single
+ * valid payout token so verifyPayout reaches the success branch.
+ *
+ * Required for happy-path tests because the per-token check fail-closes
+ * when:
+ *   - `getTokenIdsForInvoice` returns an empty Set (reverse-index empty)
+ *   - `payments.getToken` returns undefined
+ *   - the token's last transaction has no inclusion proof
+ *   - `SdkToken.verify` returns isSuccessful=false
+ *   - `oracle.isSpent` returns true
+ *
+ * We mock `SdkToken.fromJSON` to bypass the real SDK crypto path —
+ * tests asserting cryptographic correctness live in
+ * `tests/unit/modules/swap/payout-verifier.test.ts`.
+ */
+function setupValidPayoutToken(
+  mocks: TestSwapModuleMocks,
+  payoutInvoiceId: string,
+  tokenId: string = 'payout-token-001',
+): void {
+  mocks.accounting.getTokenIdsForInvoice.mockImplementation((id: string): Set<string> => {
+    return id === payoutInvoiceId ? new Set([tokenId]) : new Set();
+  });
+  const stubSdkData = JSON.stringify({
+    state: {},
+    genesis: { inclusionProof: { __mock: true } },
+    transactions: [],
+    nametags: [],
+  });
+  const stubToken: Token = {
+    id: tokenId,
+    coinId: 'USDU',
+    symbol: 'USDU',
+    name: 'USDU',
+    decimals: 6,
+    amount: '500000',
+    status: 'confirmed',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    sdkData: stubSdkData,
+  };
+  mocks.payments.getToken.mockImplementation((id: string): Token | undefined => {
+    return id === tokenId ? stubToken : undefined;
+  });
+  // SdkToken.fromJSON returns a minimal stub with verify()=success and a
+  // state hash that does not collide with anything (the spent-probe is
+  // already mocked to return false).
+  vi.spyOn(SdkToken, 'fromJSON').mockImplementation(async (_input: unknown) => {
+    return {
+      verify: async () => ({ isSuccessful: true }),
+      state: {
+        calculateHash: async () => ({ toJSON: () => 'stub-payout-state-hash' }),
+        predicate: null,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  });
+}
+
 describe('SwapModule — verifyPayout', () => {
   let module: SwapModule;
   let mocks: TestSwapModuleMocks;
@@ -115,11 +177,16 @@ describe('SwapModule — verifyPayout', () => {
     await module.load();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   // --------------------------------------------------------------------------
   // UT-SWAP-VERIFY-001: verifyPayout checks coverage
   // --------------------------------------------------------------------------
   it('UT-SWAP-VERIFY-001: verifyPayout checks invoice status isCovered', async () => {
     const ref = setupVerifiableSwap(module, mocks);
+    setupValidPayoutToken(mocks, ref.payoutInvoiceId!);
 
     const result = await module.verifyPayout(ref.swapId);
 
@@ -163,6 +230,7 @@ describe('SwapModule — verifyPayout', () => {
   // --------------------------------------------------------------------------
   it('UT-SWAP-VERIFY-004: verifyPayout transitions to completed on success', async () => {
     const ref = setupVerifiableSwap(module, mocks);
+    setupValidPayoutToken(mocks, ref.payoutInvoiceId!);
 
     await module.verifyPayout(ref.swapId);
 
@@ -176,6 +244,7 @@ describe('SwapModule — verifyPayout', () => {
   // --------------------------------------------------------------------------
   it('UT-SWAP-VERIFY-005: verifyPayout emits swap:completed event', async () => {
     const ref = setupVerifiableSwap(module, mocks);
+    setupValidPayoutToken(mocks, ref.payoutInvoiceId!);
 
     await module.verifyPayout(ref.swapId);
 

--- a/tests/unit/modules/swap-test-helpers.ts
+++ b/tests/unit/modules/swap-test-helpers.ts
@@ -83,6 +83,7 @@ export interface MockAccountingModule {
   getInvoice: ReturnType<typeof vi.fn>;
   getInvoiceStatus: ReturnType<typeof vi.fn>;
   payInvoice: ReturnType<typeof vi.fn>;
+  getTokenIdsForInvoice: ReturnType<typeof vi.fn>;
   closeInvoice: ReturnType<typeof vi.fn>;
   cancelInvoice: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
@@ -144,6 +145,12 @@ export function createMockAccountingModule(): MockAccountingModule {
     return Promise.resolve(mock._payResult);
   });
 
+  // Default: return empty Set. Tests that exercise verifyPayout's per-token
+  // checks override this to return Set<string> with the payout token IDs.
+  const getTokenIdsForInvoice = vi.fn().mockImplementation((_invoiceId: string): Set<string> => {
+    return new Set<string>();
+  });
+
   const closeInvoice = vi.fn().mockResolvedValue(undefined);
   const cancelInvoice = vi.fn().mockResolvedValue(undefined);
 
@@ -173,6 +180,7 @@ export function createMockAccountingModule(): MockAccountingModule {
     getInvoice,
     getInvoiceStatus,
     payInvoice,
+    getTokenIdsForInvoice,
     closeInvoice,
     cancelInvoice,
     on,
@@ -249,12 +257,35 @@ export function createMockCommunicationsModule(): MockCommunicationsModule {
 // =============================================================================
 
 export interface MockPaymentsModule {
-  validate: ReturnType<typeof vi.fn>;
+  getToken: ReturnType<typeof vi.fn>;
 }
 
 export function createMockPaymentsModule(): MockPaymentsModule {
   return {
-    validate: vi.fn().mockResolvedValue({ valid: [], invalid: [] }),
+    // Default: no token in wallet. Tests exercising verifyPayout's
+    // per-token checks override this to return a stub Token.
+    getToken: vi.fn().mockImplementation((_id: string): Token | undefined => undefined),
+  };
+}
+
+// =============================================================================
+// Mock: OracleProvider subset
+// =============================================================================
+
+export interface MockOracleProvider {
+  isSpent: ReturnType<typeof vi.fn>;
+  getRootTrustBase: ReturnType<typeof vi.fn>;
+}
+
+export function createMockOracleProvider(): MockOracleProvider {
+  return {
+    // Default: not spent. Tests exercising the spent-detection terminal
+    // branch override to return true.
+    isSpent: vi.fn().mockResolvedValue(false),
+    // Default: provide a non-null sentinel object so verifyPayoutTokens
+    // does not abort at the trustBase-not-loaded transient gate. The
+    // sentinel never reaches SdkToken.verify because tests stub that out.
+    getRootTrustBase: vi.fn().mockImplementation((): unknown => ({ __mock_trust_base: true })),
   };
 }
 
@@ -414,6 +445,7 @@ export function createMockEmitEvent(): MockEmitEvent {
 export interface TestSwapModuleMocks {
   accounting: MockAccountingModule;
   payments: MockPaymentsModule;
+  oracle: MockOracleProvider;
   communications: MockCommunicationsModule;
   storage: MockStorageProvider;
   emitEvent: MockEmitEvent;
@@ -436,6 +468,7 @@ export function createTestSwapModule(configOverrides?: Partial<SwapModuleConfig>
 } {
   const accounting = createMockAccountingModule();
   const payments = createMockPaymentsModule();
+  const oracle = createMockOracleProvider();
   const communications = createMockCommunicationsModule();
   const storage = createMockStorageProvider();
   const emitEvent = createMockEmitEvent();
@@ -465,6 +498,7 @@ export function createTestSwapModule(configOverrides?: Partial<SwapModuleConfig>
   const deps: SwapModuleDependencies = {
     accounting,
     payments,
+    oracle,
     communications,
     storage,
     identity,
@@ -478,6 +512,7 @@ export function createTestSwapModule(configOverrides?: Partial<SwapModuleConfig>
   const mocks: TestSwapModuleMocks = {
     accounting,
     payments,
+    oracle,
     communications,
     storage,
     emitEvent,

--- a/tests/unit/modules/swap/payout-verifier.test.ts
+++ b/tests/unit/modules/swap/payout-verifier.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Unit tests for `verifyPayoutTokens` (issue #535).
+ *
+ * The function replaces `SwapModule.verifyPayout`'s prior wallet-wide
+ * `payments.validate()` sweep with three checks scoped to the specific
+ * payout tokens: finalization → SdkToken.verify(trustBase) →
+ * oracle.isSpent. See `modules/swap/payout-verifier.ts` for the full
+ * design rationale.
+ *
+ * Result discrimination under test
+ * --------------------------------
+ *   - `ok`        — happy path: all tokens pass all three checks.
+ *   - `transient` — caller retries on next verify tick. Reasons covered:
+ *                   reverse-index empty, trustBase missing, token absent,
+ *                   sdkData missing, not finalized.
+ *   - `terminal`  — caller fails the swap. Reasons covered: sdkData
+ *                   unparseable, fromJSON throw, verify throw,
+ *                   isSuccessful=false, already-spent.
+ *
+ * SDK isolation
+ * -------------
+ * `SdkToken.fromJSON` is spied per-test so we never touch real crypto.
+ * The state-transition-sdk is exercised end-to-end in integration tests.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Token as SdkToken } from '@unicitylabs/state-transition-sdk/lib/token/Token';
+import { verifyPayoutTokens } from '../../../../modules/swap/payout-verifier';
+import type { Token } from '../../../../types';
+
+const STATE_HASH_HEX = 'stub-state-hash';
+const FALLBACK_PUBKEY = '02' + 'f'.repeat(64);
+
+const TRUST_BASE = { __mock: 'trust-base' };
+
+function makeFinalizedSdkData(): string {
+  // Minimal shape that satisfies the finalization check (last tx — or
+  // genesis when transactions is empty — must have inclusionProof != null).
+  return JSON.stringify({
+    state: { predicate: 'stub-predicate' },
+    genesis: { inclusionProof: { __mock_proof: 1 } },
+    transactions: [],
+    nametags: [],
+  });
+}
+
+function makeUnfinalizedSdkData(): string {
+  return JSON.stringify({
+    state: { predicate: 'stub-predicate' },
+    genesis: { inclusionProof: null },
+    transactions: [],
+    nametags: [],
+  });
+}
+
+function makeStubToken(id: string, sdkData: string | undefined = makeFinalizedSdkData()): Token {
+  return {
+    id,
+    coinId: 'USDU',
+    symbol: 'USDU',
+    name: 'USDU',
+    decimals: 6,
+    amount: '500000',
+    status: 'confirmed',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    sdkData,
+  };
+}
+
+function stubSdkVerifySuccess(): void {
+  vi.spyOn(SdkToken, 'fromJSON').mockImplementation(async (_input: unknown) => {
+    return {
+      verify: async () => ({ isSuccessful: true }),
+      state: {
+        calculateHash: async () => ({ toJSON: () => STATE_HASH_HEX }),
+        predicate: null,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  });
+}
+
+function stubSdkVerifyFailed(): void {
+  vi.spyOn(SdkToken, 'fromJSON').mockImplementation(async (_input: unknown) => {
+    return {
+      verify: async () => ({ isSuccessful: false }),
+      state: {
+        calculateHash: async () => ({ toJSON: () => STATE_HASH_HEX }),
+        predicate: null,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  });
+}
+
+function stubSdkFromJsonThrows(): void {
+  vi.spyOn(SdkToken, 'fromJSON').mockImplementation(async (_input: unknown) => {
+    throw new Error('mock fromJSON failure');
+  });
+}
+
+function stubSdkVerifyThrows(): void {
+  vi.spyOn(SdkToken, 'fromJSON').mockImplementation(async (_input: unknown) => {
+    return {
+      verify: async () => {
+        throw new Error('mock verify failure');
+      },
+      state: {
+        calculateHash: async () => ({ toJSON: () => STATE_HASH_HEX }),
+        predicate: null,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  });
+}
+
+describe('verifyPayoutTokens', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // ok / happy path
+  // -------------------------------------------------------------------------
+
+  describe('ok', () => {
+    it('returns ok when a single token passes all three checks', async () => {
+      stubSdkVerifySuccess();
+      const tok = makeStubToken('tok-1');
+      const isSpent = vi.fn().mockResolvedValue(false);
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['tok-1']),
+        getToken: (id) => (id === 'tok-1' ? tok : undefined),
+        trustBase: TRUST_BASE,
+        isSpent,
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('ok');
+      // isSpent must be called once per token with the predicate pubkey
+      // (or fallback when extraction fails on a stub-predicate shape).
+      expect(isSpent).toHaveBeenCalledTimes(1);
+      const [pk, sh] = isSpent.mock.calls[0]!;
+      expect(typeof pk).toBe('string');
+      expect(pk.length).toBeGreaterThan(0);
+      expect(sh).toBe(STATE_HASH_HEX);
+    });
+
+    it('returns ok when every token in a multi-token set passes', async () => {
+      stubSdkVerifySuccess();
+      const tok1 = makeStubToken('tok-1');
+      const tok2 = makeStubToken('tok-2');
+      const isSpent = vi.fn().mockResolvedValue(false);
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['tok-1', 'tok-2']),
+        getToken: (id) => ({ 'tok-1': tok1, 'tok-2': tok2 }[id]),
+        trustBase: TRUST_BASE,
+        isSpent,
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('ok');
+      expect(isSpent).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // transient — caller should returnFalse and retry
+  // -------------------------------------------------------------------------
+
+  describe('transient', () => {
+    it('returns transient when payoutTokenIds is empty (reverse-index not rebuilt)', async () => {
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(),
+        getToken: () => undefined,
+        trustBase: TRUST_BASE,
+        isSpent: vi.fn(),
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('transient');
+      expect((result as { reason: string }).reason).toContain('reverse-index-empty');
+    });
+
+    it('returns transient when trustBase is null (oracle not initialized)', async () => {
+      const tok = makeStubToken('tok-1');
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['tok-1']),
+        getToken: () => tok,
+        trustBase: null,
+        isSpent: vi.fn(),
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('transient');
+      expect((result as { reason: string }).reason).toContain('trustbase-not-loaded');
+    });
+
+    it('returns transient when getToken returns undefined for a token in the set', async () => {
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['missing-token']),
+        getToken: () => undefined,
+        trustBase: TRUST_BASE,
+        isSpent: vi.fn(),
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('transient');
+      expect((result as { reason: string }).reason).toContain('token-not-in-wallet');
+    });
+
+    it('returns transient when token sdkData is missing', async () => {
+      // Construct the Token literal directly — `makeStubToken('tok-1', undefined)`
+      // would substitute the default param value, not propagate undefined.
+      const tok: Token = {
+        id: 'tok-1',
+        coinId: 'USDU',
+        symbol: 'USDU',
+        name: 'USDU',
+        decimals: 6,
+        amount: '500000',
+        status: 'confirmed',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        // sdkData intentionally omitted (undefined).
+      };
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['tok-1']),
+        getToken: () => tok,
+        trustBase: TRUST_BASE,
+        isSpent: vi.fn(),
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('transient');
+      expect((result as { reason: string }).reason).toContain('missing-sdkdata');
+    });
+
+    it('returns transient when the last transaction has no inclusion proof (not finalized)', async () => {
+      const tok = makeStubToken('tok-1', makeUnfinalizedSdkData());
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['tok-1']),
+        getToken: () => tok,
+        trustBase: TRUST_BASE,
+        isSpent: vi.fn(),
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('transient');
+      expect((result as { reason: string }).reason).toContain('not-finalized');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // terminal — caller should failPayout
+  // -------------------------------------------------------------------------
+
+  describe('terminal', () => {
+    it('returns terminal when sdkData is unparseable JSON', async () => {
+      const tok = makeStubToken('tok-1', 'not-valid-json{{{');
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['tok-1']),
+        getToken: () => tok,
+        trustBase: TRUST_BASE,
+        isSpent: vi.fn(),
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('terminal');
+      expect((result as { reason: string }).reason).toContain('SDKDATA_UNPARSEABLE');
+    });
+
+    it('returns terminal when SdkToken.fromJSON throws', async () => {
+      stubSdkFromJsonThrows();
+      const tok = makeStubToken('tok-1');
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['tok-1']),
+        getToken: () => tok,
+        trustBase: TRUST_BASE,
+        isSpent: vi.fn(),
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('terminal');
+      expect((result as { reason: string }).reason).toContain('PARSE_FAILED');
+    });
+
+    it('returns terminal when verify() throws', async () => {
+      stubSdkVerifyThrows();
+      const tok = makeStubToken('tok-1');
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['tok-1']),
+        getToken: () => tok,
+        trustBase: TRUST_BASE,
+        isSpent: vi.fn(),
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('terminal');
+      expect((result as { reason: string }).reason).toContain('VERIFY_THREW');
+    });
+
+    it('returns terminal when verify().isSuccessful is false', async () => {
+      stubSdkVerifyFailed();
+      const tok = makeStubToken('tok-1');
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['tok-1']),
+        getToken: () => tok,
+        trustBase: TRUST_BASE,
+        isSpent: vi.fn(),
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('terminal');
+      expect((result as { reason: string }).reason).toContain('VERIFY_FAILED');
+    });
+
+    it('returns terminal when oracle.isSpent returns true', async () => {
+      stubSdkVerifySuccess();
+      const tok = makeStubToken('tok-1');
+      const isSpent = vi.fn().mockResolvedValue(true);
+      const result = await verifyPayoutTokens({
+        payoutTokenIds: new Set(['tok-1']),
+        getToken: () => tok,
+        trustBase: TRUST_BASE,
+        isSpent,
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('terminal');
+      expect((result as { reason: string }).reason).toContain('ALREADY_SPENT');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Spent-check propagation — OracleProvider.isSpent contract says
+  // "MUST NOT fail-open"; RPC failure throws out of the verifier, which
+  // the SwapModule caller's auto-verify catch logs and retries.
+  // -------------------------------------------------------------------------
+
+  describe('isSpent RPC failure', () => {
+    it('propagates oracle.isSpent throw (does NOT silently route to terminal/transient)', async () => {
+      stubSdkVerifySuccess();
+      const tok = makeStubToken('tok-1');
+      const rpcError = new Error('AGGREGATOR_ERROR: timeout');
+      await expect(
+        verifyPayoutTokens({
+          payoutTokenIds: new Set(['tok-1']),
+          getToken: () => tok,
+          trustBase: TRUST_BASE,
+          isSpent: vi.fn().mockRejectedValue(rpcError),
+          fallbackPublicKey: FALLBACK_PUBKEY,
+        }),
+      ).rejects.toThrow('AGGREGATOR_ERROR: timeout');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Short-circuit: terminal-on-first-token must not check subsequent tokens.
+  // -------------------------------------------------------------------------
+
+  describe('short-circuit', () => {
+    it('stops checking once a terminal failure is found', async () => {
+      stubSdkVerifyFailed();
+      const tok1 = makeStubToken('tok-1');
+      const getToken = vi.fn().mockImplementation((id: string): Token | undefined => {
+        if (id === 'tok-1') return tok1;
+        // tok-2 would also be defined in a real wallet — but we should never
+        // be asked because tok-1's verify fails terminally first.
+        return undefined;
+      });
+      const result = await verifyPayoutTokens({
+        // Map iteration order is insertion order — tok-1 first.
+        payoutTokenIds: new Set(['tok-1', 'tok-2']),
+        getToken,
+        trustBase: TRUST_BASE,
+        isSpent: vi.fn().mockResolvedValue(false),
+        fallbackPublicKey: FALLBACK_PUBKEY,
+      });
+      expect(result.kind).toBe('terminal');
+      // Only one getToken call — tok-2 was not reached.
+      expect(getToken).toHaveBeenCalledTimes(1);
+      expect(getToken).toHaveBeenCalledWith('tok-1');
+    });
+  });
+});
+


### PR DESCRIPTION
Closes #535.

## Summary

- Replace `SwapModule.verifyPayout`'s wallet-wide `payments.validate()` sweep with three checks scoped to the specific payout tokens: finalization → `SdkToken.verify(trustBase)` → `oracle.isSpent(predicatePublicKey, stateHash)`.
- Distinguishes transient (not finalized / reverse-index empty / trustBase loading / token absent) from terminal (verify-fail / already-spent / unparseable sdkData) failures. Returns a tagged union the caller routes to `returnFalse()` (retry) or `failPayout(reason)` (terminal).
- Extracted the predicate-publicKey derivation helper from PaymentsModule into `modules/payments/extract-state-publickey.ts` so SwapModule reuses identical logic.

## Why

A Unicity inclusion proof, once cryptographically verified against the trustBase, stays valid forever — the SMT is append-only and the BFT certificate is signed by an immutable validator set for that epoch. The only legitimate aggregator round-trip for a payout token is the spent check. The pre-existing code:

1. Used the wrong primitive (`payments.validate()` is the user-facing "audit my whole wallet" diagnostic).
2. Operated on every wallet token regardless of relevance to the payout invoice.
3. Lumped "not finalized yet", "cryptographically invalid", and "already spent" into one opaque retry loop.
4. Hit a no-op RPC fallback (the aggregator has no `validateToken` method — see #534) that made the loop always report invalid.

PR #534 fixed (4) so the loop at least terminates. This PR replaces the loop entirely with the right primitive set.

## Files

- **`modules/swap/payout-verifier.ts`** (new) — pure function `verifyPayoutTokens` with injectable deps for testability.
- **`modules/payments/extract-state-publickey.ts`** (new) — extracted shared helper.
- **`modules/swap/types.ts`** — `SwapModuleDependencies`: replaced `payments.validate()` with `payments.getToken(id)`; added `oracle: { isSpent, getRootTrustBase }`.
- **`core/Sphere.ts`** — both SwapModule init sites updated.
- **`modules/swap/SwapModule.ts`** — replaced the 50-line `validate()`-based block with a `verifyPayoutTokens` call + tagged-union routing.

## Test plan

- [x] `npx vitest run tests/unit/modules/swap/payout-verifier.test.ts` — 14 tests covering ok/transient/terminal matrix, isSpent RPC propagation, short-circuit on first terminal.
- [x] `npx vitest run tests/unit/modules/SwapModule.verify.test.ts` — 9 tests (3 happy-path tests updated to set up stub payout tokens).
- [x] `npx vitest run tests/unit/modules/SwapModule` — full 276-test suite green (no regressions).
- [x] `npx vitest run tests/unit/modules/PaymentsModule tests/unit/oracle` — 512 tests green (extraction-induced regression check + oracle dependency surface).
- [x] `npx tsc --noEmit` — clean.
- [ ] Trader-roundtrip soak (`manual-test-trader-roundtrip.sh`) — `payoutVerified` should flip to `true` within one verify tick after escrow's `payInvoice` completes, no 40 × 30s hang.

## Out of scope

- The user-facing `sphere payments validate` CLI keeps `PaymentsModule.validate()` intact — only the SwapModule deps contract was tightened.
- Cleanup of `oracle.validateToken`'s dead RPC fallback (the aggregator has no `validateToken` method) — separate refactor after this lands.

## Related

- Issue #535 — design rationale + proposed code shape this PR implements.
- PR #534 — fixed `oracle.validateToken` so `payments.validate()` no longer reports every token invalid (prerequisite — without it, this gate would still wait for the broken sweep).