### PR TITLE
feat(vault): wire RemoteTokenStorageProvider into Sphere as an opt-in backup/sync provider

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -58,6 +58,7 @@ import type {
 } from '../types';
 import { SphereError } from './errors';
 import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../storage';
+import { createVaultTokenStorage } from '../storage/remote/factory';
 import type { TransportProvider, PeerInfo } from '../transport';
 import { MultiAddressTransportMux, AddressTransportAdapter } from '../transport/MultiAddressTransportMux';
 import type { OracleProvider } from '../oracle';
@@ -131,6 +132,12 @@ import type {
   LegacyFileType,
   DecryptionProgressCallback,
 } from '../serialization/types';
+
+/**
+ * Provider id of the remote vault token-storage provider (must match
+ * `RemoteTokenStorageProvider.id`) — used to register/look it up additively.
+ */
+const VAULT_PROVIDER_ID = 'remote-token-storage';
 
 // =============================================================================
 // Progress Callback
@@ -209,6 +216,8 @@ export interface SphereCreateOptions {
    * - false/undefined: no auto-discovery (default)
    */
   discoverAddresses?: boolean | DiscoverAddressesOptions;
+  /** Remote Token-Vault v2 backup/sync (additive, default OFF). */
+  vault?: VaultInitConfig;
   /** Enable debug logging (default: false) */
   debug?: boolean;
   /** Optional callback to report initialization progress steps */
@@ -254,6 +263,8 @@ export interface SphereLoadOptions {
    * - false/undefined: no auto-discovery (default)
    */
   discoverAddresses?: boolean | DiscoverAddressesOptions;
+  /** Remote Token-Vault v2 backup/sync (additive, default OFF). */
+  vault?: VaultInitConfig;
   /** Enable debug logging (default: false) */
   debug?: boolean;
   /** Optional callback to report initialization progress steps */
@@ -311,6 +322,8 @@ export interface SphereImportOptions {
    * - false/undefined: no auto-discovery (default)
    */
   discoverAddresses?: boolean | DiscoverAddressesOptions;
+  /** Remote Token-Vault v2 backup/sync (additive, default OFF). */
+  vault?: VaultInitConfig;
   /** Enable debug logging (default: false) */
   debug?: boolean;
   /** Optional callback to report initialization progress steps */
@@ -325,6 +338,24 @@ export interface L1Config {
   defaultFeeRate?: number;
   /** Enable vesting classification (default: true) */
   enableVesting?: boolean;
+}
+
+/**
+ * Token-Vault v2 (remote backup/sync) configuration. The vault is an ADDITIVE,
+ * operator-blind backup/sync token-storage provider — it never replaces the primary
+ * local IndexedDB/file token store. Construction is SDK-internal (the provider needs
+ * the raw spend key, which the app never has), so the app only flips this flag.
+ *
+ * Default OFF: when this is omitted or `enabled` is false, no vault provider is
+ * registered and existing wallets are completely unaffected.
+ */
+export interface VaultInitConfig {
+  /** Enable the remote vault as a backup/sync provider. Default OFF. */
+  enabled: boolean;
+  /** Override the vault base URL (defaults to `NETWORKS[network].vaultUrl`). */
+  url?: string;
+  /** Stable device id stamped into the vault auth session. */
+  deviceId?: string;
 }
 
 /** Options for unified init (auto-create or load) */
@@ -386,6 +417,8 @@ export interface SphereInitOptions {
   dmSince?: number;
   /** Communications module configuration. */
   communications?: CommunicationsModuleConfig;
+  /** Remote Token-Vault v2 backup/sync (additive, default OFF). */
+  vault?: VaultInitConfig;
   /** Enable debug logging (default: false) */
   debug?: boolean;
   /** Optional callback to report initialization progress steps */
@@ -509,6 +542,10 @@ export class Sphere {
   private _groupChatConfig: GroupChatModuleConfig | undefined;
   private _marketConfig: MarketModuleConfig | undefined;
   private _communicationsConfig: CommunicationsModuleConfig | undefined;
+  /** Network this wallet runs on — drives the vault URL/server-key resolution. */
+  private _network: NetworkType | undefined;
+  /** Remote Token-Vault v2 backup/sync config (additive, default OFF). */
+  private _vaultConfig: VaultInitConfig | undefined;
 
   // Events
   private eventHandlers: Map<SphereEventType, Set<SphereEventHandler<SphereEventType>>> = new Map();
@@ -534,6 +571,8 @@ export class Sphere {
     accountingConfig?: AccountingModuleConfig,
     swapConfig?: SwapModuleConfig,
     communicationsConfig?: CommunicationsModuleConfig,
+    network?: NetworkType,
+    vaultConfig?: VaultInitConfig,
   ) {
     this._storage = storage;
     this._transport = transport;
@@ -550,6 +589,8 @@ export class Sphere {
     this._groupChatConfig = groupChatConfig;
     this._marketConfig = marketConfig;
     this._communicationsConfig = communicationsConfig;
+    this._network = network;
+    this._vaultConfig = vaultConfig;
 
     this._payments = createPaymentsModule({ l1: l1Config });
     this._communications = createCommunicationsModule(communicationsConfig);
@@ -654,6 +695,7 @@ export class Sphere {
         swap,
         password: options.password,
         discoverAddresses: options.discoverAddresses,
+        vault: options.vault,
         onProgress: options.onProgress,
       });
       // Store dmSince for forwarding to transport/mux when subscriptions are set up
@@ -697,6 +739,7 @@ export class Sphere {
       swap,
       password: options.password,
       discoverAddresses: options.discoverAddresses,
+      vault: options.vault,
       onProgress: options.onProgress,
     });
 
@@ -842,6 +885,8 @@ export class Sphere {
       accountingConfig,
       swapConfig,
       options.communications,
+      options.network,
+      options.vault,
     );
     sphere._password = options.password ?? null;
 
@@ -943,6 +988,8 @@ export class Sphere {
       accountingConfig,
       swapConfig,
       options.communications,
+      options.network,
+      options.vault,
     );
     sphere._password = options.password ?? null;
 
@@ -1047,6 +1094,8 @@ export class Sphere {
       accountingConfig,
       swapConfig,
       options.communications,
+      options.network,
+      options.vault,
     );
     sphere._password = options.password ?? null;
 
@@ -4162,9 +4211,41 @@ export class Sphere {
   // Private: Provider & Module Initialization
   // ===========================================================================
 
+  /**
+   * Build + register the remote vault token-storage provider when the init flag is
+   * on (default OFF — a no-op otherwise, so existing wallets are unaffected).
+   *
+   * The vault is ADDITIVE: it joins `_tokenStorageProviders` alongside the primary
+   * local store, never replacing it. Construction is SDK-internal via the factory
+   * because the provider needs the raw spend key (only `_identity` carries it). The
+   * provider is added to the map but NOT yet identity-set/initialized — the caller's
+   * existing setIdentity/initialize loop does that, so the vault takes the SAME path
+   * as every other provider. A duplicate (already-registered) id is skipped.
+   */
+  private maybeRegisterVaultProvider(): void {
+    if (!this._vaultConfig?.enabled) return;
+    if (this._tokenStorageProviders.has(VAULT_PROVIDER_ID)) return;
+    if (!this._identity || !this._network) return;
+    const provider = createVaultTokenStorage({
+      identity: this._identity,
+      network: this._network,
+      storage: this._storage,
+      vaultUrl: this._vaultConfig.url,
+      deviceId: this._vaultConfig.deviceId,
+    });
+    this._tokenStorageProviders.set(provider.id, provider);
+  }
+
   private async initializeProviders(): Promise<void> {
     // Set identity on providers
     this._storage.setIdentity(this._identity!);
+
+    // Register the remote vault as an ADDITIVE backup/sync provider when enabled.
+    // Built here (not in app code) because the provider needs the raw spend key,
+    // which only the in-scope FullIdentity carries. Added to the map BEFORE the
+    // setIdentity/initialize loop below so it flows through the SAME path as every
+    // other token storage provider (and is picked up by initializeModules).
+    this.maybeRegisterVaultProvider();
 
     // Provide fallback 'since' for existing wallets so Nostr subscriptions
     // pick up events sent while this address was inactive.

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -2259,6 +2259,48 @@ export class Sphere {
   }
 
   /**
+   * Build the per-address instance of a token storage provider for an HD address
+   * switch, then identity-set + initialize it.
+   *
+   * THREE cases:
+   *  1. The vault (FUND-SAFETY): its crypto key is bound at CONSTRUCTION to the
+   *     old address's privateKey, so the arg-less `createForAddress()` cannot clone
+   *     it for a new address — and reusing the shared instance would make
+   *     `setIdentity(newIdentity)` throw INVALID_IDENTITY (or seal under the wrong
+   *     key). Instead REBUILD it from scratch via the factory with the new identity's
+   *     privateKey in scope, so the new instance is keyed to the new address.
+   *  2. A `createForAddress`-capable provider clones itself (IPFS etc.).
+   *  3. Otherwise reuse the shared instance (legacy providers that are address-agnostic).
+   */
+  private async rebuildProviderForAddress(
+    providerId: string,
+    provider: TokenStorageProvider<TxfStorageDataBase>,
+    newIdentity: FullIdentity,
+  ): Promise<TokenStorageProvider<TxfStorageDataBase>> {
+    if (providerId === VAULT_PROVIDER_ID && this._network) {
+      const rebuilt = createVaultTokenStorage({
+        identity: newIdentity,
+        network: this._network,
+        storage: this._storage,
+        vaultUrl: this._vaultConfig?.url,
+        deviceId: this._vaultConfig?.deviceId,
+      });
+      rebuilt.setIdentity(newIdentity);
+      await rebuilt.initialize();
+      return rebuilt;
+    }
+    if (provider.createForAddress) {
+      const newProvider = provider.createForAddress();
+      newProvider.setIdentity(newIdentity);
+      await newProvider.initialize();
+      return newProvider;
+    }
+    // Legacy address-agnostic provider — reuse the shared instance.
+    logger.warn('Sphere', `Token storage provider ${providerId} does not support createForAddress, reusing shared instance`);
+    return provider;
+  }
+
+  /**
    * Switch to a different address by index
    * This changes the active identity to the derived address at the specified index.
    *
@@ -2352,17 +2394,8 @@ export class Sphere {
       // Create per-address token storage providers (each address needs its own instances)
       const addressTokenProviders = new Map<string, TokenStorageProvider<TxfStorageDataBase>>();
       for (const [providerId, provider] of this._tokenStorageProviders.entries()) {
-        if (provider.createForAddress) {
-          const newProvider = provider.createForAddress();
-          newProvider.setIdentity(newIdentity);
-          await newProvider.initialize();
-          addressTokenProviders.set(providerId, newProvider);
-        } else {
-          // Fallback: reuse existing provider (legacy behavior for providers
-          // that don't support createForAddress)
-          logger.warn('Sphere', `Token storage provider ${providerId} does not support createForAddress, reusing shared instance`);
-          addressTokenProviders.set(providerId, provider);
-        }
+        const rebuilt = await this.rebuildProviderForAddress(providerId, provider, newIdentity);
+        addressTokenProviders.set(providerId, rebuilt);
       }
 
       await this.initializeAddressModules(index, newIdentity, addressTokenProviders);

--- a/index.ts
+++ b/index.ts
@@ -56,6 +56,7 @@ export type {
   SphereInitOptions,
   SphereInitResult,
   SphereImportOptions,
+  VaultInitConfig,
   InitProgressStep,
   InitProgress,
   InitProgressCallback,

--- a/index.ts
+++ b/index.ts
@@ -538,6 +538,17 @@ export type { TxfToken } from './types/txf';
 export { RemoteTokenStorageProvider } from './storage/remote/RemoteTokenStorageProvider';
 export type { RemoteTokenStorageConfig } from './storage/remote/RemoteTokenStorageProvider';
 
+// SDK-internal vault factory + durable anti-rollback baseline store. The wallet
+// CANNOT construct the provider itself (it holds only the public identity, but the
+// provider needs the raw spend key at construction) — it flips a flag and the SDK
+// runs `createVaultTokenStorage` from a FullIdentity. `StorageBaselineStore` adapts
+// the wallet's StorageProvider into the durable LocalBaselineStore the anti-rollback
+// gate persists into.
+export { createVaultTokenStorage } from './storage/remote/factory';
+export type { CreateVaultTokenStorageConfig } from './storage/remote/factory';
+export { StorageBaselineStore, VAULT_BASELINE_KEY_PREFIX } from './storage/remote/local-baseline-store';
+export type { LocalBaselineStore } from './storage/remote/load-delta';
+
 export { CourierDeliveryProvider } from './transport/courier/CourierDeliveryProvider';
 export type {
   CourierDeliveryConfig,

--- a/storage/remote/factory.ts
+++ b/storage/remote/factory.ts
@@ -1,0 +1,82 @@
+/**
+ * createVaultTokenStorage — the SDK-internal factory that builds a wired
+ * {@link RemoteTokenStorageProvider} for the wallet (vault wallet wiring, concern 2).
+ *
+ * WHY A FACTORY (the key constraint): the provider needs the raw spend key at
+ * construction (`config.privateKey`; `setIdentity` asserts the identity pubkey ===
+ * `getPublicKey(privateKey)` and throws otherwise). But `Sphere.identity` exposes
+ * only the PUBLIC identity — never the privateKey. So construction MUST happen inside
+ * the SDK, where a `FullIdentity` (with `privateKey`) is in scope. The app flips a
+ * flag; the SDK runs this factory.
+ *
+ * It resolves the per-network vault URL + server signing key from `NETWORKS`, builds
+ * the real fetch auth client, wires a lazy data-client factory that shares the
+ * provider's OWN JWT/refresh session (`authTokenSource()`), and persists the
+ * anti-rollback baseline DURABLY via {@link StorageBaselineStore} (namespaced by
+ * network + owner) so the signed-root gate survives reloads.
+ */
+
+import { NETWORKS } from '../../constants';
+import type { NetworkType } from '../../constants';
+import type { FullIdentity } from '../../types';
+import type { StorageProvider } from '../storage-provider';
+import { RemoteTokenStorageProvider } from './RemoteTokenStorageProvider';
+import { StorageBaselineStore } from './local-baseline-store';
+import { createVaultAuthClient, createVaultHttpClients } from './http/index';
+import type { FetchLike } from './http/index';
+
+/** Inputs for {@link createVaultTokenStorage} — only the identity carries the key. */
+export interface CreateVaultTokenStorageConfig {
+  /** The full identity for THIS address — its `privateKey` is bound at construction. */
+  identity: FullIdentity;
+  /** Network whose `NETWORKS[network]` provides the vault URL + server signing key. */
+  network: NetworkType;
+  /** The wallet's key-value storage — backs the durable anti-rollback baseline. */
+  storage: Pick<StorageProvider, 'get' | 'set'>;
+  /** Override the vault base URL (defaults to `NETWORKS[network].vaultUrl`). */
+  vaultUrl?: string;
+  /** Stable device id stamped into the auth session. */
+  deviceId?: string;
+  /** Injectable `fetch` (tests/custom agents); defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+}
+
+/**
+ * Build a fully-wired {@link RemoteTokenStorageProvider} from a {@link FullIdentity}.
+ * The caller registers it via `Sphere.addTokenStorageProvider`, which runs the
+ * standard `setIdentity` + `initialize` + sync path.
+ */
+export function createVaultTokenStorage(
+  config: CreateVaultTokenStorageConfig,
+): RemoteTokenStorageProvider {
+  const { identity, network, storage, deviceId, fetchImpl } = config;
+  const vaultUrl = config.vaultUrl ?? NETWORKS[network].vaultUrl;
+  const vaultServerKey = NETWORKS[network].vaultServerKey;
+
+  const authClient = createVaultAuthClient(vaultUrl, fetchImpl);
+  const localBaseline = new StorageBaselineStore(storage, network, identity.chainPubkey);
+
+  // The data client must share the provider's OWN auth session (`authTokenSource()`),
+  // but the provider does not exist yet — capture a mutable ref and resolve it LAZILY
+  // at the first http call (which only happens during/after `initialize()`).
+  const ref: { provider: RemoteTokenStorageProvider | null } = { provider: null };
+  const httpClientFactory = (): ReturnType<typeof createVaultHttpClients>['vault'] =>
+    createVaultHttpClients({
+      vaultUrl,
+      auth: ref.provider!.authTokenSource(),
+      fetchImpl,
+    }).vault;
+
+  const provider = new RemoteTokenStorageProvider({
+    network,
+    vaultUrl,
+    privateKey: identity.privateKey,
+    authClient,
+    httpClientFactory,
+    vaultServerKey,
+    deviceId,
+    localBaseline,
+  });
+  ref.provider = provider;
+  return provider;
+}

--- a/storage/remote/local-baseline-store.ts
+++ b/storage/remote/local-baseline-store.ts
@@ -1,0 +1,54 @@
+/**
+ * StorageBaselineStore — a DURABLE {@link LocalBaselineStore} over the SDK's
+ * key-value {@link StorageProvider} (vault wallet wiring, concern 1).
+ *
+ * The anti-rollback gate (`load-delta.ts`) persists a wallet-signed baseline
+ * `{cursor,root,sig,epoch}` after every clean flush/load. Tests inject an in-memory
+ * store, but the WALLET needs a durable one: an in-memory baseline resets each page
+ * reload, which silently turns the root gate into a no-op (the first load after every
+ * reload trusts the server). This adapter persists the baseline into the same
+ * `StorageProvider` (IndexedDB in the browser, file on Node) the wallet already owns.
+ *
+ * NAMESPACING (fund-safety): the SDK `StorageProvider` only auto-scopes a fixed set
+ * of registered per-address keys; an arbitrary key like the baseline is stored
+ * GLOBALLY. So this adapter prefixes EVERY key with `network + chainPubkey` itself —
+ * otherwise two owners (HD address switch) or two networks would clobber a shared
+ * baseline row and a rollback could go undetected. The tracker also passes a
+ * pre-namespaced logical key (`vault_baseline:<net>:<owner>`); this adapter's own
+ * `network + chainPubkey` prefix is defense-in-depth so the storage row is bound to
+ * the owner regardless of what logical key the tracker hands us.
+ */
+
+import type { StorageProvider } from '../storage-provider';
+import type { LocalBaselineStore } from './load-delta';
+
+/** Stable prefix for every vault baseline row in the underlying StorageProvider. */
+export const VAULT_BASELINE_KEY_PREFIX = 'sphere_vault_baseline';
+
+/**
+ * Adapts a {@link StorageProvider} into a {@link LocalBaselineStore}, namespacing
+ * every key by `network + chainPubkey` so owners/networks never share a baseline.
+ */
+export class StorageBaselineStore implements LocalBaselineStore {
+  private readonly storage: Pick<StorageProvider, 'get' | 'set'>;
+  /** The `network:chainPubkey` segment prepended to every logical key. */
+  private readonly scope: string;
+
+  constructor(storage: Pick<StorageProvider, 'get' | 'set'>, network: string, chainPubkey: string) {
+    this.storage = storage;
+    this.scope = `${VAULT_BASELINE_KEY_PREFIX}:${network}:${chainPubkey}`;
+  }
+
+  get(key: string): Promise<string | null> {
+    return this.storage.get(this.scopedKey(key));
+  }
+
+  set(key: string, value: string): Promise<void> {
+    return this.storage.set(this.scopedKey(key), value);
+  }
+
+  /** Bind a logical key to this owner/network so storage rows can never collide. */
+  private scopedKey(key: string): string {
+    return `${this.scope}:${key}`;
+  }
+}

--- a/tests/integration/vault-switch-address.test.ts
+++ b/tests/integration/vault-switch-address.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Vault per-address rebuild on switchToAddress (vault wallet wiring, concern 4).
+ *
+ * FUND-SAFETY: RemoteTokenStorageProvider binds its AEAD/wireKey/auth crypto to the
+ * construction-time spend key. On an HD address switch the provider has no arg-less
+ * `createForAddress()` clone, so the old single-key instance could not be re-keyed —
+ * `setIdentity(newIdentity)` would throw INVALID_IDENTITY (or seal under the WRONG
+ * key). switchToAddress must therefore REBUILD the vault via the factory with the new
+ * address's private key in scope. This test drives a real address switch end-to-end
+ * against a real-socket fake vault and asserts:
+ *   - the switch does not throw (no INVALID_IDENTITY);
+ *   - a flush AFTER the switch lands under address-1's owner (its key), never address-0's.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Sphere } from '../../core/Sphere';
+import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
+import { FileTokenStorageProvider } from '../../impl/nodejs/storage/FileTokenStorageProvider';
+import { startRealVaultSocket, type RealVaultSocket } from '../helpers/real-vault-socket';
+import { wireKey } from '../../storage/remote/wire-key';
+import { normalizeVaultNetwork } from '../../storage/remote/normalize-network';
+import type { RemoteTokenStorageProvider } from '../../storage/remote/RemoteTokenStorageProvider';
+import type { TransportProvider, OracleProvider } from '../../index';
+import type { AddressModuleSet } from '../../core/Sphere';
+import type { ProviderStatus, FullIdentity } from '../../types';
+import type { TxfStorageDataBase } from '../../storage';
+import { TEST_NETWORK } from '../test-network';
+
+const TEST_DIR = path.join(__dirname, '.test-vault-switch-address');
+const DATA_DIR = path.join(TEST_DIR, 'data');
+const TOKENS_DIR = path.join(TEST_DIR, 'tokens');
+const VAULT_PROVIDER_ID = 'remote-token-storage';
+
+function createMockTransport(): TransportProvider {
+  return {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn().mockResolvedValue('transfer-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('request-id'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('response-id'),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    publishIdentityBinding: vi.fn().mockResolvedValue(true),
+    recoverNametag: vi.fn().mockResolvedValue(null),
+    resolveNametag: vi.fn().mockResolvedValue(null),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+  } as unknown as TransportProvider;
+}
+
+function createMockOracle(): OracleProvider {
+  return {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'aggregator' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    submitCommitment: vi.fn().mockResolvedValue({ requestId: 'test-id' }),
+    getProof: vi.fn().mockResolvedValue(null),
+    waitForProof: vi.fn().mockResolvedValue({ proof: 'mock' }),
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+  } as unknown as OracleProvider;
+}
+
+function cleanTestDir(): void {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true, force: true });
+}
+
+/** Reach into the per-address module set to read its registered vault provider. */
+function addressVault(sphere: Sphere, index: number): RemoteTokenStorageProvider {
+  const modules = (sphere as unknown as { _addressModules: Map<number, AddressModuleSet> })._addressModules;
+  const set = modules.get(index)!;
+  return set.tokenStorageProviders.get(VAULT_PROVIDER_ID) as unknown as RemoteTokenStorageProvider;
+}
+
+/** Read the FULL (private-key-bearing) active identity — the public getter strips it. */
+function fullIdentity(sphere: Sphere): FullIdentity {
+  return (sphere as unknown as { _identity: FullIdentity })._identity;
+}
+
+function txf(id: string): TxfStorageDataBase {
+  return {
+    _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: Date.now() },
+    [`_${id}`]: { amt: '1' },
+  } as TxfStorageDataBase;
+}
+
+let socket: RealVaultSocket;
+
+describe('vault per-address rebuild on switchToAddress', () => {
+  beforeEach(async () => {
+    cleanTestDir();
+    if (Sphere.getInstance()) (Sphere as unknown as { instance: null }).instance = null;
+    // The socket's epoch-signing key must match the network the wallet signs under.
+    socket = await startRealVaultSocket(normalizeVaultNetwork(TEST_NETWORK));
+  });
+
+  afterEach(async () => {
+    if (Sphere.getInstance()) {
+      try { await Sphere.getInstance()!.destroy(); } catch { /* ignore */ }
+    }
+    (Sphere as unknown as { instance: null }).instance = null;
+    await socket.close();
+    cleanTestDir();
+  });
+
+  it('rebuilds the vault keyed to the new address (no INVALID_IDENTITY) and flushes under its key', async () => {
+    const { sphere } = await Sphere.init({
+      storage: new FileStorageProvider({ dataDir: DATA_DIR }),
+      transport: createMockTransport(),
+      oracle: createMockOracle(),
+      tokenStorage: new FileTokenStorageProvider({ tokensDir: TOKENS_DIR }),
+      network: TEST_NETWORK,
+      autoGenerate: true,
+      vault: { enabled: true, url: socket.baseUrl },
+    });
+
+    const vault0 = addressVault(sphere, 0);
+    const id0 = fullIdentity(sphere).chainPubkey;
+
+    // Switch to address 1 — the buggy fallback (reuse the address-0-keyed vault)
+    // would throw INVALID_IDENTITY when PaymentsModule calls setIdentity here.
+    await expect(sphere.switchToAddress(1)).resolves.toBeUndefined();
+
+    const vault1 = addressVault(sphere, 1);
+    const id1 = fullIdentity(sphere).chainPubkey;
+
+    // The vault was REBUILT — a fresh instance, keyed to a different owner.
+    expect(vault1).not.toBe(vault0);
+    expect(id1).not.toBe(id0);
+
+    // A flush under address 1 lands on the server under address-1's owner + key.
+    const priv1 = fullIdentity(sphere).privateKey;
+    const res = await vault1.sync(txf('tok1'));
+    expect(res.success).toBe(true);
+    const wk1 = wireKey(priv1, normalizeVaultNetwork(TEST_NETWORK), 'tok1');
+    expect(socket.vault.getEntry(id1, wk1)).toBeDefined();
+    // Nothing was ever written under address-0's owner by the address-1 flush.
+    expect(socket.vault.getEntry(id0, wk1)).toBeUndefined();
+  });
+});

--- a/tests/integration/vault/vault-factory.test.ts
+++ b/tests/integration/vault/vault-factory.test.ts
@@ -1,0 +1,120 @@
+/**
+ * createVaultTokenStorage factory (vault wallet wiring, concern 2).
+ *
+ * The wallet cannot construct a RemoteTokenStorageProvider itself — it has only the
+ * PUBLIC identity, but the provider needs the raw spend key at construction. This
+ * factory is the SDK-internal seam that builds the provider from a FullIdentity (key
+ * in scope), resolving the vault URL + server key from NETWORKS, wiring the real http
+ * clients over ONE shared auth session, and persisting the anti-rollback baseline
+ * durably via StorageBaselineStore.
+ *
+ * Driven end-to-end over a REAL node:http socket fronting the in-memory fakes so the
+ * full handshake + data path runs through real fetch (no mongo).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { createVaultTokenStorage } from '../../../storage/remote/factory';
+import { VAULT_BASELINE_KEY_PREFIX } from '../../../storage/remote/local-baseline-store';
+import { startRealVaultSocket, type RealVaultSocket } from '../../helpers/real-vault-socket';
+import type { StorageProvider } from '../../../storage/storage-provider';
+import type { TxfStorageDataBase } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+
+const NETWORK = 'testnet2';
+const PRIV = '9d'.repeat(32);
+const PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(PRIV), true));
+const identity: FullIdentity = { chainPubkey: PUB, l1Address: 'alpha1factory', privateKey: PRIV };
+
+/** A minimal in-memory StorageProvider slice (the factory only needs get/set). */
+function memStorage(): Pick<StorageProvider, 'get' | 'set'> & { dump(): Map<string, string> } {
+  const m = new Map<string, string>();
+  return {
+    get: (k) => Promise.resolve(m.get(k) ?? null),
+    set: (k, v) => Promise.resolve(void m.set(k, v)),
+    dump: () => m,
+  };
+}
+
+function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+  const data: TxfStorageDataBase = {
+    _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: Date.now() },
+  };
+  for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  return data;
+}
+
+let socket: RealVaultSocket;
+beforeEach(async () => {
+  socket = await startRealVaultSocket(NETWORK);
+});
+afterEach(async () => {
+  await socket.close();
+});
+
+describe('createVaultTokenStorage', () => {
+  it('builds a provider that authenticates + flushes over real fetch (one shared session)', async () => {
+    const storage = memStorage();
+    const provider = createVaultTokenStorage({
+      identity,
+      network: NETWORK,
+      storage: storage as unknown as StorageProvider,
+      vaultUrl: socket.baseUrl, // override the NETWORKS url for the test socket
+    });
+
+    provider.setIdentity(identity);
+    expect(await provider.initialize()).toBe(true); // auth + first load via real http
+
+    const res = await provider.sync(txf({ aaa: { amt: '7' } }));
+    expect(res.success).toBe(true);
+    expect(res.added).toBe(1);
+    // The data client shared the provider's JWT session: the entry reached the server.
+    expect(socket.vault.entryCount(PUB)).toBeGreaterThanOrEqual(1);
+  });
+
+  it('persists the anti-rollback baseline durably into the injected StorageProvider', async () => {
+    const storage = memStorage();
+    const provider = createVaultTokenStorage({
+      identity,
+      network: NETWORK,
+      storage: storage as unknown as StorageProvider,
+      vaultUrl: socket.baseUrl,
+    });
+    provider.setIdentity(identity);
+    await provider.initialize();
+    await provider.sync(txf({ aaa: { amt: '7' } })); // a clean flush re-signs the baseline
+
+    const baselineRows = [...storage.dump().keys()].filter((k) => k.includes(VAULT_BASELINE_KEY_PREFIX));
+    expect(baselineRows.length).toBeGreaterThanOrEqual(1);
+    expect(baselineRows[0]).toContain(PUB); // namespaced by owner
+  });
+
+  it('resolves vaultUrl + vaultServerKey from NETWORKS when not overridden', () => {
+    const storage = memStorage();
+    // No vaultUrl override → the provider is built against NETWORKS[network].vaultUrl.
+    // It still accepts the matching identity (the construction-time key matches).
+    const provider = createVaultTokenStorage({
+      identity,
+      network: NETWORK,
+      storage: storage as unknown as StorageProvider,
+    });
+    expect(() => provider.setIdentity(identity)).not.toThrow();
+  });
+
+  it('builds a provider keyed to the identity it was given (mismatch fails loud)', () => {
+    const storage = memStorage();
+    const otherPriv = '4e'.repeat(32);
+    const otherPub = bytesToHex(secp256k1.getPublicKey(hexToBytes(otherPriv), true));
+    const provider = createVaultTokenStorage({
+      identity, // built for PRIV/PUB
+      network: NETWORK,
+      storage: storage as unknown as StorageProvider,
+      vaultUrl: socket.baseUrl,
+    });
+
+    // Pointing it at a DIFFERENT address must throw (the construction-time key is PRIV).
+    const mismatched: FullIdentity = { chainPubkey: otherPub, l1Address: 'x', privateKey: otherPriv };
+    expect(() => provider.setIdentity(mismatched)).toThrow(/identity|key|address/i);
+  });
+});

--- a/tests/unit/core/Sphere.vault-wiring.test.ts
+++ b/tests/unit/core/Sphere.vault-wiring.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Sphere vault wiring (vault wallet wiring, concern 3).
+ *
+ * The wallet enables the remote vault as a backup/sync token-storage provider with a
+ * single config flag: `Sphere.init({ vault: { enabled: true } })`. The SDK constructs
+ * the provider internally (the app never has the spend key) and registers it ADDITIVELY
+ * — the primary local token store is untouched. Everything is gated behind the flag and
+ * defaults OFF, so existing wallets are unaffected.
+ *
+ * These tests assert REGISTRATION + the flag gate, not vault liveness: the vault's
+ * `initialize()` is no-throw (a vault outage degrades), so registration must happen
+ * regardless of whether the (stubbed) vault endpoint answers.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TokenRegistry } from '../../../registry';
+import { Sphere } from '../../../core/Sphere';
+import { makeMockProviders } from './support/mock-providers';
+import { TEST_NETWORK } from '../../test-network';
+
+const VAULT_PROVIDER_ID = 'remote-token-storage';
+
+// Mock L1 network module so init() never reaches Fulcrum (mirrors other core tests).
+vi.mock('../../../l1/network', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  isWebSocketConnected: vi.fn().mockReturnValue(false),
+}));
+
+/** Stub fetch so the registry load + the vault's no-throw init resolve offline. */
+function stubFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      ({ ok: true, status: 200, statusText: 'OK', json: async () => [], text: async () => '[]' }) as unknown as Response,
+    ),
+  );
+}
+
+describe('Sphere vault wiring (init flag)', () => {
+  beforeEach(() => {
+    TokenRegistry.resetInstance();
+    if (Sphere.getInstance()) (Sphere as unknown as { instance: null }).instance = null;
+    stubFetch();
+  });
+
+  afterEach(async () => {
+    if (Sphere.getInstance()) {
+      try { await Sphere.getInstance()!.destroy(); } catch { /* ignore */ }
+    }
+    (Sphere as unknown as { instance: null }).instance = null;
+    TokenRegistry.destroy();
+    vi.unstubAllGlobals();
+  });
+
+  it('registers the vault provider when vault.enabled is true', async () => {
+    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: false });
+
+    const { sphere } = await Sphere.init({
+      storage,
+      transport,
+      oracle,
+      l1,
+      network: TEST_NETWORK,
+      autoGenerate: true,
+      vault: { enabled: true, url: 'http://localhost:1/unreachable' },
+    });
+
+    expect(sphere.hasTokenStorageProvider(VAULT_PROVIDER_ID)).toBe(true);
+  });
+
+  it('does NOT register the vault provider when vault is omitted (default OFF)', async () => {
+    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: false });
+
+    const { sphere } = await Sphere.init({
+      storage,
+      transport,
+      oracle,
+      l1,
+      network: TEST_NETWORK,
+      autoGenerate: true,
+    });
+
+    expect(sphere.hasTokenStorageProvider(VAULT_PROVIDER_ID)).toBe(false);
+  });
+
+  it('does NOT register the vault provider when vault.enabled is false', async () => {
+    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: false });
+
+    const { sphere } = await Sphere.init({
+      storage,
+      transport,
+      oracle,
+      l1,
+      network: TEST_NETWORK,
+      autoGenerate: true,
+      vault: { enabled: false },
+    });
+
+    expect(sphere.hasTokenStorageProvider(VAULT_PROVIDER_ID)).toBe(false);
+  });
+
+  it('registers the vault on the load path too (existing wallet)', async () => {
+    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: true });
+
+    const { sphere, created } = await Sphere.init({
+      storage,
+      transport,
+      oracle,
+      l1,
+      network: TEST_NETWORK,
+      vault: { enabled: true, url: 'http://localhost:1/unreachable' },
+    });
+
+    expect(created).toBe(false);
+    expect(sphere.hasTokenStorageProvider(VAULT_PROVIDER_ID)).toBe(true);
+  });
+
+  it('keeps the primary local token store registered alongside the vault (additive)', async () => {
+    const providers = makeMockProviders({ walletExists: false });
+
+    const { sphere } = await Sphere.init({
+      storage: providers.storage,
+      transport: providers.transport,
+      oracle: providers.oracle,
+      tokenStorage: providers.tokenStorage, // the primary local store
+      l1: providers.l1,
+      network: TEST_NETWORK,
+      autoGenerate: true,
+      vault: { enabled: true, url: 'http://localhost:1/unreachable' },
+    });
+
+    // The vault is ADDITIVE: the primary local store is still registered too.
+    expect(sphere.hasTokenStorageProvider(providers.tokenStorage.id)).toBe(true);
+    expect(sphere.hasTokenStorageProvider(VAULT_PROVIDER_ID)).toBe(true);
+  });
+});

--- a/tests/unit/vault/local-baseline-store.test.ts
+++ b/tests/unit/vault/local-baseline-store.test.ts
@@ -1,0 +1,80 @@
+/**
+ * LocalBaselineStore adapter (vault wallet wiring, concern 1).
+ *
+ * The wallet needs a DURABLE anti-rollback baseline `{cursor,root,sig,epoch}` so the
+ * signed-root gate survives a reload — an in-memory store resets every reload and
+ * silently disables the rollback gate. {@link StorageBaselineStore} adapts the SDK's
+ * key-value {@link StorageProvider} into the {@link LocalBaselineStore} the tracker
+ * expects, namespaced by `network + chainPubkey` so two owners (or two networks)
+ * never share a baseline row.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { StorageBaselineStore, VAULT_BASELINE_KEY_PREFIX } from '../../../storage/remote/local-baseline-store';
+import type { StorageProvider } from '../../../storage/storage-provider';
+
+const NETWORK = 'testnet2';
+const OWNER_A = '02' + 'aa'.repeat(32);
+const OWNER_B = '02' + 'bb'.repeat(32);
+
+/** Minimal in-memory KV satisfying the slice of StorageProvider the adapter reads. */
+function memStorage(): Pick<StorageProvider, 'get' | 'set'> & { dump(): Map<string, string> } {
+  const m = new Map<string, string>();
+  return {
+    get: (k) => Promise.resolve(m.get(k) ?? null),
+    set: (k, v) => Promise.resolve(void m.set(k, v)),
+    dump: () => m,
+  };
+}
+
+describe('StorageBaselineStore', () => {
+  it('round-trips a value through set → get', async () => {
+    const storage = memStorage();
+    const store = new StorageBaselineStore(storage as unknown as StorageProvider, NETWORK, OWNER_A);
+
+    expect(await store.get('vault_baseline:testnet2:' + OWNER_A)).toBeNull();
+    await store.set('vault_baseline:testnet2:' + OWNER_A, '{"cursor":5}');
+    expect(await store.get('vault_baseline:testnet2:' + OWNER_A)).toBe('{"cursor":5}');
+  });
+
+  it('namespaces the underlying storage key by network + chainPubkey', async () => {
+    const storage = memStorage();
+    const store = new StorageBaselineStore(storage as unknown as StorageProvider, NETWORK, OWNER_A);
+
+    await store.set('vault_baseline:testnet2:' + OWNER_A, 'v');
+
+    // The persisted key is the adapter's namespaced key, NOT the raw logical key.
+    const persistedKeys = [...storage.dump().keys()];
+    expect(persistedKeys).toHaveLength(1);
+    expect(persistedKeys[0]).toContain(VAULT_BASELINE_KEY_PREFIX);
+    expect(persistedKeys[0]).toContain(NETWORK);
+    expect(persistedKeys[0]).toContain(OWNER_A);
+  });
+
+  it('isolates owners: owner A and owner B never read each other’s baseline', async () => {
+    const storage = memStorage(); // one shared underlying storage, two owners
+    const storeA = new StorageBaselineStore(storage as unknown as StorageProvider, NETWORK, OWNER_A);
+    const storeB = new StorageBaselineStore(storage as unknown as StorageProvider, NETWORK, OWNER_B);
+
+    await storeA.set('k', 'A-baseline');
+    await storeB.set('k', 'B-baseline');
+
+    expect(await storeA.get('k')).toBe('A-baseline');
+    expect(await storeB.get('k')).toBe('B-baseline');
+    expect(storage.dump().size).toBe(2); // two distinct underlying rows
+  });
+
+  it('isolates networks: same owner on two networks never shares a baseline', async () => {
+    const storage = memStorage();
+    const mainnet = new StorageBaselineStore(storage as unknown as StorageProvider, 'mainnet', OWNER_A);
+    const testnet = new StorageBaselineStore(storage as unknown as StorageProvider, 'testnet2', OWNER_A);
+
+    await mainnet.set('k', 'mainnet-baseline');
+    await testnet.set('k', 'testnet-baseline');
+
+    expect(await mainnet.get('k')).toBe('mainnet-baseline');
+    expect(await testnet.get('k')).toBe('testnet-baseline');
+    expect(storage.dump().size).toBe(2);
+  });
+});


### PR DESCRIPTION
SDK-internal vault wiring so the wallet enables the vault with a flag (raw key stays in the SDK, never reaches app code). LocalBaselineStore over StorageProvider (namespaced by network+chainPubkey) for durable anti-rollback baseline; createVaultTokenStorage factory (shared VaultApiClient JWT session); Sphere.init vault:{enabled} flag (default OFF, additive - never replaces the local store); switchToAddress rebuilds the vault per-address from the new FullIdentity (fixes the single-key INVALID_IDENTITY on address switch). Money path untouched (only core/Sphere.ts + index.ts + 2 new files). 188 vault + 15 tracked-address tests green, tsc+eslint clean. Reviewed PASS (additive/OFF-by-default, no stale-key vault survives a switch, flush-gate/empty-import/FROZEN-union preserved).