### PR TITLE
fix(soak): trader-roundtrip default rate band must fit bob's hardcoded deposit

### DIFF
--- a/manual-test-trader-roundtrip.sh
+++ b/manual-test-trader-roundtrip.sh
@@ -14,16 +14,18 @@
 #            negotiates terms via NP-0 over NIP-17 DMs, and executes
 #            the matched deal through SwapModule.proposeSwap against
 #            the escrow ($ESCROW, default @escrow-test-02).
-#   COMPLETE alice's trader ends up with ~+5 ETH (and -50 UCT)
-#            bob's   trader ends up with ~+50 UCT (and -~5 ETH)
+#   COMPLETE alice's trader ends up with ~+4.25 ETH (and -50 UCT)
+#            bob's   trader ends up with ~+50 UCT (and -~4.25 ETH)
 #
 # Net (tenant view):
-#     alice-trader  -50 UCT  +~5 ETH
-#     bob-trader    +50 UCT  -~5 ETH
+#     alice-trader  -50 UCT  +~4.25 ETH
+#     bob-trader    +50 UCT  -~4.25 ETH
 #   Exact split is determined by the agreed rate, which the matching
 #   code computes as floor((overlap_min + overlap_max) / 2) over the
 #   intersection of both rate bands — see §5.2 of
-#   /home/vrogojin/trader-service/docs/protocol-spec.md.
+#   /home/vrogojin/trader-service/docs/protocol-spec.md. With the default
+#   [0.08, 0.09] band on both sides the midpoint is 0.085, so bob owes
+#   0.085 × 50 = 4.25 ETH — within his 4.5 ETH deposit.
 #
 # This soak is the TRADER analog of:
 #   - manual-test-swap-roundtrip.sh       (swap roundtrip)
@@ -72,7 +74,17 @@
 #   TRADER_RATE_MIN_ETH_PER_UCT  Lower edge of the rate band, as a
 #                                **human-friendly float**. Default 0.08
 #                                (= 0.08 ETH per 1 UCT).
-#   TRADER_RATE_MAX_ETH_PER_UCT  Upper edge of the rate band. Default 0.12.
+#   TRADER_RATE_MAX_ETH_PER_UCT  Upper edge of the rate band. Default 0.09.
+#                                Defaults must satisfy
+#                                  rate_max × volume_max ≤ bob's deposit
+#                                so the negotiation cannot land on a rate
+#                                bob cannot fund. Today's hardcoded bob
+#                                deposit is 4.5 ETH and volume is 50 UCT,
+#                                hence rate_max = 4.5 ÷ 50 = 0.09. Raising
+#                                the band requires raising bob's §5
+#                                deposit by the same factor — see
+#                                trader-service#29 for the upstream pre-
+#                                flight check that would catch this for us.
 #   TRADER_VOLUME_UCT            Volume to trade in **whole UCT**. Default 50.
 #   TRADER_CLI_FLOAT_NATIVE      0 = skip the float attempt and go straight
 #                                to the bigint shim. Default 1.
@@ -185,7 +197,13 @@ ESCROW="${ESCROW:-@escrow-test-02}"
 # to smallest-units (post-fix UX). The shim mode below converts inline
 # when the CLI still demands bigints.
 TRADER_RATE_MIN_ETH_PER_UCT="${TRADER_RATE_MIN_ETH_PER_UCT:-0.08}"
-TRADER_RATE_MAX_ETH_PER_UCT="${TRADER_RATE_MAX_ETH_PER_UCT:-0.12}"
+# rate_max × volume_max must stay ≤ bob's hardcoded deposit (4.5 ETH at
+# §5 below). 0.09 × 50 = 4.5 ETH — bob can fund any rate the negotiation
+# midpoint picks within [0.08, 0.09]. Raising rate_max without raising
+# bob's deposit by the matching factor reproduces sphere-sdk#536's soak
+# halt (deal fails with VOLUME_RESERVATION_FAILED at §8). Upstream
+# defensive check tracked in trader-service#29.
+TRADER_RATE_MAX_ETH_PER_UCT="${TRADER_RATE_MAX_ETH_PER_UCT:-0.09}"
 TRADER_VOLUME_UCT="${TRADER_VOLUME_UCT:-50}"
 TRADER_CLI_FLOAT_NATIVE="${TRADER_CLI_FLOAT_NATIVE:-1}"
 


### PR DESCRIPTION
## Summary

- Narrow the trader-roundtrip soak's default `TRADER_RATE_MAX_ETH_PER_UCT` from `0.12` to `0.09` so the upper-bound exposure (`rate_max × volume_max = 0.09 × 50 = 4.5 ETH`) exactly matches bob's hardcoded 4.5 ETH deposit at §5.
- Document the invariant in the env-contract docstring and inline next to the default so future operators don't reproduce the trap.
- Update the predicted end-state in the script header (bob `-~5 ETH` → `-~4.25 ETH`) to match the new midpoint (`0.085 × 50 = 4.25`).

## Why

Surfaced while running the soak to validate sphere-sdk#535 (PR #536). With the prior defaults, bob's `[0.08, 0.12]` band promised to honor up to `0.12 × 50 = 6 ETH`, but bob only had 4.5 ETH deposited. Trader-service's NP-0 matcher (`trader-main.ts:355-364`) picks the midpoint of the overlap, which for two identical `[0.08, 0.12]` bands is `0.10` → 5 ETH owed. Reservation correctly refused (`4.5 < 5`), and the deal went terminal with `VOLUME_RESERVATION_FAILED`. Settlement never started — `verifyPayout` (the code PR #536 changed) was never even reached.

Unit handling along the way is **correct**, per the project convention:

> Intents work in human-readable decimal strings; actual swaps work in exact bigint smallest-units.

`trader-main.ts:489-493` does `Number(volume) × Number(rate)` (decimal strings → JS number for the ratio) → `toSmallestUnitsBigInt` at the wallet-reservation boundary. The unit-conversion seam is in the right place.

The bug was purely that **the soak made bob post an intent he couldn't honor at his own declared upper bound**. This PR fixes that by trimming the band; defense-in-depth (the trader engine refusing to create the intent in the first place) is tracked separately as vrogojin/trader-service#29.

## Test plan

- [x] `npx tsc --noEmit` — no code changes to TS, soak is a bash script
- [x] **Empirical**: rebuilt the trader image against this branch's sphere-sdk and re-ran the soak. With `rate_max=0.09`, alice's trader proposals fire at rate `0.08499999999999999` (vs the prior `0.10`), so bob's required reservation is `0.085 × 50 = 4.25 ETH ≤ 4.5 ETH deposited` — no `VOLUME_RESERVATION_FAILED`. Trace:
  ```
  alice-trader: np_deal_proposed { rate: "0.08499999999999999", volume: "50" }
  ```
  (Prior run on the same branch with `rate_max=0.12`: `rate: "0.1"`, reservation aborts.)
- [ ] End-to-end soak completion was blocked on the re-run by orphan BUY intents from the prior failed attempt still sitting on the market feed (`expiry_ms` ~40 min out). Alice's matcher locked onto a stale acceptor pubkey whose container was already gone, and her proposals timed out instead of being responded to. This is an unrelated market-feed isolation issue, not regressed by this PR.

## Related

- vrogojin/trader-service#29 — upstream pre-flight check (refuse to create an intent the trader can't fund at `rate_max`). Once landed, the soak's old defaults would have failed at intent-create time instead of deal-time. This PR unblocks the soak now without waiting on that fix.
- PR #536 / issue #535 — the original reason this soak was being run. The swap-CLI soak already validated PR #536 end-to-end (see #536 PR body). This soak fix unblocks the trader-CLI path too, once the orphan market intents from prior runs expire.