### PR TITLE
feat(courier): wire CourierDeliveryProvider into PaymentsModule send/receive (flag-gated, Nostr default)

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -59,6 +59,9 @@ import type {
 import { SphereError } from './errors';
 import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../storage';
 import { createVaultTokenStorage } from '../storage/remote/factory';
+import { createCourierDeliveryTransport } from '../transport/courier/factory';
+import type { TokenDeliveryTransport } from '../transport/courier/types';
+import { RemoteTokenStorageProvider } from '../storage/remote/RemoteTokenStorageProvider';
 import type { TransportProvider, PeerInfo } from '../transport';
 import { MultiAddressTransportMux, AddressTransportAdapter } from '../transport/MultiAddressTransportMux';
 import type { OracleProvider } from '../oracle';
@@ -218,6 +221,8 @@ export interface SphereCreateOptions {
   discoverAddresses?: boolean | DiscoverAddressesOptions;
   /** Remote Token-Vault v2 backup/sync (additive, default OFF). */
   vault?: VaultInitConfig;
+  /** Token-Vault v2 courier delivery (additive, opt-in; Nostr stays default). */
+  courier?: CourierInitConfig;
   /** Enable debug logging (default: false) */
   debug?: boolean;
   /** Optional callback to report initialization progress steps */
@@ -265,6 +270,8 @@ export interface SphereLoadOptions {
   discoverAddresses?: boolean | DiscoverAddressesOptions;
   /** Remote Token-Vault v2 backup/sync (additive, default OFF). */
   vault?: VaultInitConfig;
+  /** Token-Vault v2 courier delivery (additive, opt-in; Nostr stays default). */
+  courier?: CourierInitConfig;
   /** Enable debug logging (default: false) */
   debug?: boolean;
   /** Optional callback to report initialization progress steps */
@@ -324,6 +331,8 @@ export interface SphereImportOptions {
   discoverAddresses?: boolean | DiscoverAddressesOptions;
   /** Remote Token-Vault v2 backup/sync (additive, default OFF). */
   vault?: VaultInitConfig;
+  /** Token-Vault v2 courier delivery (additive, opt-in; Nostr stays default). */
+  courier?: CourierInitConfig;
   /** Enable debug logging (default: false) */
   debug?: boolean;
   /** Optional callback to report initialization progress steps */
@@ -356,6 +365,24 @@ export interface VaultInitConfig {
   url?: string;
   /** Stable device id stamped into the vault auth session. */
   deviceId?: string;
+}
+
+/**
+ * Token-Vault v2 courier (token delivery) configuration. The courier is an ADDITIVE,
+ * opt-in delivery channel for finished v2 token blobs: when enabled, sends DEPOSIT
+ * over the courier (courier-primary) with a Nostr fallback, and receives pull the
+ * courier inbox in addition to Nostr. Construction is SDK-internal (the courier needs
+ * the raw spend key), so the app only flips this flag. Resolution stays on Nostr.
+ *
+ * Default OFF: when omitted or `enabled` is false, delivery is Nostr-only — existing
+ * wallets are completely unaffected. When the vault is ALSO enabled, the courier
+ * shares the vault's auth session (one JWT for vault + courier).
+ */
+export interface CourierInitConfig {
+  /** Enable the courier as an opt-in v2 token-delivery channel. Default OFF. */
+  enabled: boolean;
+  /** Override the courier base URL (defaults to `NETWORKS[network].vaultUrl`). */
+  url?: string;
 }
 
 /** Options for unified init (auto-create or load) */
@@ -419,6 +446,8 @@ export interface SphereInitOptions {
   communications?: CommunicationsModuleConfig;
   /** Remote Token-Vault v2 backup/sync (additive, default OFF). */
   vault?: VaultInitConfig;
+  /** Token-Vault v2 courier delivery (additive, opt-in; Nostr stays default). */
+  courier?: CourierInitConfig;
   /** Enable debug logging (default: false) */
   debug?: boolean;
   /** Optional callback to report initialization progress steps */
@@ -546,6 +575,8 @@ export class Sphere {
   private _network: NetworkType | undefined;
   /** Remote Token-Vault v2 backup/sync config (additive, default OFF). */
   private _vaultConfig: VaultInitConfig | undefined;
+  /** Token-Vault v2 courier delivery config (additive, opt-in; default OFF). */
+  private _courierConfig: CourierInitConfig | undefined;
 
   // Events
   private eventHandlers: Map<SphereEventType, Set<SphereEventHandler<SphereEventType>>> = new Map();
@@ -573,6 +604,7 @@ export class Sphere {
     communicationsConfig?: CommunicationsModuleConfig,
     network?: NetworkType,
     vaultConfig?: VaultInitConfig,
+    courierConfig?: CourierInitConfig,
   ) {
     this._storage = storage;
     this._transport = transport;
@@ -591,6 +623,7 @@ export class Sphere {
     this._communicationsConfig = communicationsConfig;
     this._network = network;
     this._vaultConfig = vaultConfig;
+    this._courierConfig = courierConfig;
 
     this._payments = createPaymentsModule({ l1: l1Config });
     this._communications = createCommunicationsModule(communicationsConfig);
@@ -696,6 +729,7 @@ export class Sphere {
         password: options.password,
         discoverAddresses: options.discoverAddresses,
         vault: options.vault,
+        courier: options.courier,
         onProgress: options.onProgress,
       });
       // Store dmSince for forwarding to transport/mux when subscriptions are set up
@@ -740,6 +774,7 @@ export class Sphere {
       password: options.password,
       discoverAddresses: options.discoverAddresses,
       vault: options.vault,
+      courier: options.courier,
       onProgress: options.onProgress,
     });
 
@@ -887,6 +922,7 @@ export class Sphere {
       options.communications,
       options.network,
       options.vault,
+      options.courier,
     );
     sphere._password = options.password ?? null;
 
@@ -990,6 +1026,7 @@ export class Sphere {
       options.communications,
       options.network,
       options.vault,
+      options.courier,
     );
     sphere._password = options.password ?? null;
 
@@ -1096,6 +1133,7 @@ export class Sphere {
       options.communications,
       options.network,
       options.vault,
+      options.courier,
     );
     sphere._password = options.password ?? null;
 
@@ -2413,6 +2451,7 @@ export class Sphere {
           storage: this._storage,
           tokenStorageProviders: moduleSet.tokenStorageProviders,
           transport: addressTransport,
+          deliveryTransport: this.buildCourierForIdentity(newIdentity, moduleSet.tokenStorageProviders),
           oracle: this._oracle,
           emitEvent: this.emitEvent.bind(this),
           chainCode: this._masterKey?.chainCode || undefined,
@@ -2553,6 +2592,7 @@ export class Sphere {
       storage: this._storage,
       tokenStorageProviders,
       transport: addressTransport,
+      deliveryTransport: this.buildCourierForIdentity(identity, tokenStorageProviders),
       oracle: this._oracle,
       emitEvent,
       chainCode: this._masterKey?.chainCode || undefined,
@@ -4269,6 +4309,34 @@ export class Sphere {
     this._tokenStorageProviders.set(provider.id, provider);
   }
 
+  /**
+   * Build the opt-in courier delivery transport for an address when `courier.enabled`
+   * (default OFF → returns undefined, so PaymentsModule stays Nostr-only and is
+   * byte-identical to today). Construction is SDK-internal — the courier needs the raw
+   * spend key, which only the in-scope FullIdentity carries. When the vault is ALSO
+   * enabled for this address, the courier SHARES the vault provider's auth session
+   * (`authTokenSource()`) so both use ONE JWT; otherwise the courier builds its own.
+   *
+   * The PaymentsModule binds the courier's sinks (`onV2Transfer` / `onDelivered`) in
+   * its `initialize()` once the deps are wired — here it is only constructed + keyed.
+   */
+  private buildCourierForIdentity(
+    identity: FullIdentity,
+    tokenStorageProviders: Map<string, TokenStorageProvider<TxfStorageDataBase>>,
+  ): TokenDeliveryTransport | undefined {
+    if (!this._courierConfig?.enabled || !this._network) return undefined;
+    const vaultProvider = tokenStorageProviders.get(VAULT_PROVIDER_ID);
+    const authTokenSource =
+      vaultProvider instanceof RemoteTokenStorageProvider ? vaultProvider.authTokenSource() : undefined;
+    return createCourierDeliveryTransport({
+      identity,
+      network: this._network,
+      storage: this._storage,
+      vaultUrl: this._courierConfig.url,
+      authTokenSource,
+    });
+  }
+
   private async initializeProviders(): Promise<void> {
     // Set identity on providers
     this._storage.setIdentity(this._identity!);
@@ -4458,6 +4526,7 @@ export class Sphere {
       storage: this._storage,
       tokenStorageProviders: this._tokenStorageProviders,
       transport: moduleTransport,
+      deliveryTransport: this.buildCourierForIdentity(this._identity!, this._tokenStorageProviders),
       oracle: this._oracle,
       emitEvent,
       // Pass chain code for L1 HD derivation

--- a/index.ts
+++ b/index.ts
@@ -560,6 +560,8 @@ export {
   StorageCourierJournalStore,
   COURIER_JOURNAL_KEY_PREFIX,
 } from './transport/courier/courier-journal-store';
+export { createCourierDeliveryTransport } from './transport/courier/factory';
+export type { CreateCourierDeliveryConfig } from './transport/courier/factory';
 export type {
   TokenDeliveryTransport,
   TokenDeliveryCapabilities,

--- a/index.ts
+++ b/index.ts
@@ -556,6 +556,10 @@ export type {
   CourierJournalStore,
   V2TransferSink,
 } from './transport/courier/CourierDeliveryProvider';
+export {
+  StorageCourierJournalStore,
+  COURIER_JOURNAL_KEY_PREFIX,
+} from './transport/courier/courier-journal-store';
 export type {
   TokenDeliveryTransport,
   TokenDeliveryCapabilities,

--- a/index.ts
+++ b/index.ts
@@ -57,6 +57,7 @@ export type {
   SphereInitResult,
   SphereImportOptions,
   VaultInitConfig,
+  CourierInitConfig,
   InitProgressStep,
   InitProgress,
   InitProgressCallback,

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1936,8 +1936,11 @@ export class PaymentsModule {
 
     // Also pull the courier inbox (store-and-forward) so an explicit receive() sees
     // courier-delivered transfers too. Awaited here (unlike load()'s fire-and-forget)
-    // so the reload below captures them; a no-op without a deliveryTransport.
-    await this.deps!.deliveryTransport?.receive?.();
+    // so the reload below captures them; a no-op without a deliveryTransport. A courier
+    // outage must DEGRADE, never throw out of the public receive() (the Nostr pull above
+    // already succeeded) — swallow + warn, the token stays in the inbox for next pull.
+    await this.deps!.deliveryTransport?.receive?.().catch((err: unknown) =>
+      logger.warn('Payments', 'Courier receive (receive) failed:', err));
 
     // Reload from storage to get a clean, consistent state.
     // Handlers save tokens during processing (with potentially different IDs for

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -44,6 +44,7 @@ import type {
   IncomingPaymentRequest as TransportPaymentRequest,
   IncomingPaymentRequestResponse as TransportPaymentRequestResponse,
 } from '../../transport';
+import type { TokenDeliveryTransport, TokenEnvelope } from '../../transport/courier/types';
 import type { OracleProvider } from '../../oracle';
 import type { PriceProvider } from '../../price';
 import type {
@@ -116,6 +117,20 @@ interface PendingV2Delivery {
   tokenBlob: string;
   memo?: string;
   createdAt: number;
+  /**
+   * The channel this blob was delivered over. `'courier'` entries are GC'd ONLY on a
+   * valid-ackSig `onDelivered(entryId)` and re-deposited (not Nostr-sent) on replay;
+   * `'nostr'` / undefined (legacy) entries are removed right after a successful send
+   * and replayed over Nostr — preserving today's behavior.
+   */
+  transport?: 'courier' | 'nostr';
+  /**
+   * The courier entryId for this delivery (present only on `transport: 'courier'`).
+   * `onDelivered(entryId)` resolves the blob to GC via this mapping.
+   */
+  entryId?: string;
+  /** Recipient compressed chain pubkey — the courier address (courier entries only). */
+  recipientChainPubkey?: string;
 }
 
 // =============================================================================
@@ -604,6 +619,15 @@ export interface PaymentsModuleDependencies {
   /** Multiple token storage providers (e.g., IPFS, MongoDB, file) */
   tokenStorageProviders?: Map<string, TokenStorageProvider<TxfStorageDataBase>>;
   transport: TransportProvider;
+  /**
+   * Optional v2 token-delivery transport (the courier). ADDITIVE + flag-gated: when
+   * present, finished v2 token blobs are DEPOSITED over this channel (courier-primary,
+   * with a Nostr fallback on deposit failure); when absent, delivery is Nostr-only —
+   * byte-identical to today. Resolution stays on Nostr (`transport.resolve`); the
+   * courier only consumes the already-resolved recipient chainPubkey. Its sinks
+   * (incoming feed + delivery-confirmed GC) are bound to this module in `initialize()`.
+   */
+  deliveryTransport?: TokenDeliveryTransport;
   oracle: OracleProvider;
   /**
    * Token engine (v2). Optional during migration (path B): when provided, value
@@ -826,6 +850,15 @@ export class PaymentsModule {
       this.handleIncomingTransfer(transfer)
     );
 
+    // Bind the courier (TokenDeliveryTransport) sinks to THIS module, so a
+    // courier-received transfer flows through the SAME handleV2Transfer path (dedup +
+    // verify + isOwnedBy) and a confirmed delivery GCs PENDING_V2_DELIVERIES. The
+    // courier is ADDITIVE — when absent, nothing here runs (Nostr-only, default OFF).
+    deps.deliveryTransport?.setSinks?.({
+      onV2Transfer: (payload, senderPubkey) => this.handleV2Transfer(payload, senderPubkey),
+      onDelivered: (entryId) => this.removePendingV2DeliveryByEntryId(entryId),
+    });
+
     // Subscribe to incoming payment requests (if supported)
     if (deps.transport.onPaymentRequest) {
       this.unsubscribePaymentRequests = deps.transport.onPaymentRequest((request) => {
@@ -1005,6 +1038,26 @@ export class PaymentsModule {
     // (fire-and-forget; failures are kept journaled for the next load).
     void this.replayPendingV2Deliveries().catch((err) =>
       logger.warn('Payments', 'Pending v2 delivery replay failed:', err));
+
+    // Drive the courier's store-and-forward loops once per load (additive; a no-op
+    // when no deliveryTransport is configured): pull the inbox, reconcile sender-side
+    // delivery confirmations, and re-fire any crash-interrupted acks.
+    this.runCourierLoops('load');
+  }
+
+  /**
+   * Kick the courier's receive / poll / ack-replay loops fire-and-forget. Each is
+   * optional on the {@link TokenDeliveryTransport}; a missing method (or a missing
+   * transport entirely) is simply skipped, so the Nostr-only path is unaffected.
+   */
+  private runCourierLoops(context: 'load' | 'receive'): void {
+    const courier = this.deps?.deliveryTransport;
+    if (!courier) return;
+    const warn = (op: string) => (err: unknown) =>
+      logger.warn('Payments', `Courier ${op} (${context}) failed:`, err);
+    void courier.receive?.().catch(warn('receive'));
+    void courier.pollSent?.().catch(warn('pollSent'));
+    void courier.replayAckPending?.().catch(warn('replayAckPending'));
   }
 
   /**
@@ -1202,16 +1255,6 @@ export class PaymentsModule {
         // parseInvoiceMemoForOnChain already produced the encoded bytes (or null).
         const memoData = onChainMessage ?? undefined;
 
-        // Deliver a journaled finished-token blob as a V2_TRANSFER payload.
-        const deliverBlob = async (tokenBlob: string): Promise<void> => {
-          await this.deps!.transport.sendTokenTransfer(recipientPubkey, {
-            type: 'V2_TRANSFER',
-            version: '2.0',
-            tokenBlob,
-            memo: request.memo,
-          } as unknown as import('../../transport').TokenTransferPayload);
-        };
-
         // Whole-token direct transfers.
         for (const tw of splitPlan.tokensToTransferDirectly) {
           const finished = await engine.transfer(
@@ -1224,18 +1267,15 @@ export class PaymentsModule {
           );
           // The source state is spent on-chain from here on.
           committedOnChainTokenIds.add(tw.uiToken.id);
-          // Journal the finished blob BEFORE delivery: a transport failure or a
-          // crash must not lose the recipient's token (replayed on next load()).
+          // Journal-first then deliver (courier-primary, Nostr fallback): a transport
+          // failure or crash must not lose the recipient's token (replayed on load()).
           const tokenBlob = bytesToHex(encodeTokenBlob(engine.encodeToken(finished)));
-          await this.savePendingV2Delivery({
+          await this.deliverFinishedBlob(tokenBlob, {
             transferId: result.id,
             recipientPubkey,
-            tokenBlob,
+            recipientChainPubkey: peerInfo.chainPubkey,
             memo: request.memo,
-            createdAt: Date.now(),
           });
-          await deliverBlob(tokenBlob);
-          await this.removePendingV2Delivery(tokenBlob);
           result.tokenTransfers.push({ sourceTokenId: tw.uiToken.id, method: 'direct' });
           await this.removeToken(tw.uiToken.id, result.id);
         }
@@ -1261,17 +1301,14 @@ export class PaymentsModule {
           // the transport succeeding.
           committedOnChainTokenIds.add(splitPlan.tokenToSplit.uiToken.id);
           const recipientBlob = bytesToHex(encodeTokenBlob(engine.encodeToken(outputs[0])));
-          await this.savePendingV2Delivery({
+          await this.storeEngineToken(engine, outputs[1]); // change token, confirmed (BEFORE delivery)
+
+          await this.deliverFinishedBlob(recipientBlob, {
             transferId: result.id,
             recipientPubkey,
-            tokenBlob: recipientBlob,
+            recipientChainPubkey: peerInfo.chainPubkey,
             memo: request.memo,
-            createdAt: Date.now(),
           });
-          await this.storeEngineToken(engine, outputs[1]); // change token, confirmed
-
-          await deliverBlob(recipientBlob);
-          await this.removePendingV2Delivery(recipientBlob);
 
           result.tokenTransfers.push({ sourceTokenId: splitPlan.tokenToSplit.uiToken.id, method: 'split' });
           await this.removeToken(splitPlan.tokenToSplit.uiToken.id, result.id);
@@ -1896,6 +1933,11 @@ export class PaymentsModule {
     // with await. Event dedup in the transport layer prevents double-processing
     // with the persistent subscription.
     await this.deps!.transport.fetchPendingEvents();
+
+    // Also pull the courier inbox (store-and-forward) so an explicit receive() sees
+    // courier-delivered transfers too. Awaited here (unlike load()'s fire-and-forget)
+    // so the reload below captures them; a no-op without a deliveryTransport.
+    await this.deps!.deliveryTransport?.receive?.();
 
     // Reload from storage to get a clean, consistent state.
     // Handlers save tokens during processing (with potentially different IDs for
@@ -3618,10 +3660,107 @@ export class PaymentsModule {
   }
 
   /**
-   * Replay journaled finished-but-undelivered v2 blobs (kicked fire-and-forget
-   * from load()). The recipient dedups re-deliveries by the genesis-stable
-   * token id, so replaying an already-delivered blob is harmless. Entries that
-   * still fail to send are kept for the next load.
+   * GC a courier delivery by its courier `entryId` (the entryId↔blob mapping, concern
+   * 5). Bound to the courier's `onDelivered` sink: it fires ONLY after the courier has
+   * verified a valid recipient ackSig, so this is the ONLY thing that removes a
+   * `transport: 'courier'` journal entry. Idempotent — an unknown / already-removed
+   * entryId is a no-op (a double-fired or stale onDelivered never corrupts the journal).
+   */
+  private async removePendingV2DeliveryByEntryId(entryId: string): Promise<void> {
+    const all = await this.loadPendingV2Deliveries();
+    const filtered = all.filter((e) => e.entryId !== entryId);
+    if (filtered.length !== all.length) {
+      await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(filtered));
+    }
+  }
+
+  /**
+   * Deliver ONE finished v2 token blob, journal-first (DESIGN: never lose a token).
+   *
+   * COEXIST POLICY (concern 4): when a `deliveryTransport` (courier) is configured it is
+   * PRIMARY — the blob is journaled tagged `'courier'` (with the courier entryId folded
+   * in) and deposited; the journal entry is then removed ONLY by a valid-ackSig
+   * `onDelivered` (NOT here). A courier `deposit()` FAILURE falls back to Nostr (no lost
+   * delivery), removing the journal entry after the send (today's behavior). With no
+   * courier, delivery is Nostr-only, byte-identical to today. Resolution stayed on Nostr;
+   * the courier only consumes the already-resolved `recipientChainPubkey`.
+   */
+  private async deliverFinishedBlob(
+    tokenBlob: string,
+    meta: { transferId: string; recipientPubkey: string; recipientChainPubkey: string; memo?: string },
+  ): Promise<void> {
+    const courier = this.deps!.deliveryTransport;
+    if (courier) {
+      try {
+        await this.depositToCourier(courier, tokenBlob, meta);
+        return; // journaled 'courier'; GC deferred to onDelivered (valid ackSig)
+      } catch (err) {
+        logger.warn('Payments', 'Courier deposit failed — falling back to Nostr delivery:', err);
+      }
+    }
+    // Nostr path (primary when no courier, or the courier-deposit fallback).
+    await this.savePendingV2Delivery({
+      transferId: meta.transferId, recipientPubkey: meta.recipientPubkey,
+      tokenBlob, memo: meta.memo, createdAt: Date.now(), transport: 'nostr',
+    });
+    await this.sendBlobOverNostr(meta.recipientPubkey, tokenBlob, meta.memo);
+    await this.removePendingV2Delivery(tokenBlob);
+  }
+
+  /**
+   * Journal the blob tagged `'courier'` THEN deposit it. Journal-first so a crash
+   * between the journal and the deposit still has the entry to replay; the courier
+   * deposit is idempotent (server dedups on entryId). The returned `entryId` is folded
+   * onto the journal entry so `onDelivered(entryId)` can later resolve the blob to GC.
+   */
+  private async depositToCourier(
+    courier: TokenDeliveryTransport,
+    tokenBlob: string,
+    meta: { transferId: string; recipientPubkey: string; recipientChainPubkey: string; memo?: string },
+  ): Promise<void> {
+    const envelope: TokenEnvelope = {
+      recipientChainPubkey: meta.recipientChainPubkey,
+      senderChainPubkey: this.deps!.identity.chainPubkey,
+      transferId: meta.transferId,
+      tokenBlobHex: tokenBlob,
+      memo: meta.memo,
+    };
+    await this.savePendingV2Delivery({
+      transferId: meta.transferId, recipientPubkey: meta.recipientPubkey,
+      recipientChainPubkey: meta.recipientChainPubkey,
+      tokenBlob, memo: meta.memo, createdAt: Date.now(), transport: 'courier',
+    });
+    const handle = await courier.deposit(envelope);
+    await this.setPendingV2DeliveryEntryId(tokenBlob, handle.entryId);
+  }
+
+  /** Fold the courier `entryId` onto an already-journaled `'courier'` entry. */
+  private async setPendingV2DeliveryEntryId(tokenBlob: string, entryId: string): Promise<void> {
+    const all = await this.loadPendingV2Deliveries();
+    const entry = all.find((e) => e.tokenBlob === tokenBlob);
+    if (entry && entry.entryId !== entryId) {
+      entry.entryId = entryId;
+      await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(all));
+    }
+  }
+
+  /** Send one finished blob as a V2_TRANSFER over the Nostr transport. */
+  private async sendBlobOverNostr(recipientPubkey: string, tokenBlob: string, memo?: string): Promise<void> {
+    await this.deps!.transport.sendTokenTransfer(recipientPubkey, {
+      type: 'V2_TRANSFER',
+      version: '2.0',
+      tokenBlob,
+      memo,
+    } as unknown as import('../../transport').TokenTransferPayload);
+  }
+
+  /**
+   * Replay journaled finished-but-undelivered v2 blobs (kicked fire-and-forget from
+   * load()). ROUTING (concern 4): a `'courier'` entry is RE-DEPOSITED over the courier
+   * (idempotent on entryId; GC stays deferred to onDelivered — NOT removed here), while
+   * a `'nostr'`/untagged (legacy) entry is re-sent over Nostr and removed on success.
+   * The recipient dedups re-deliveries by the genesis-stable token id, so replaying an
+   * already-delivered blob is harmless. Entries that still fail are kept for next load.
    */
   private async replayPendingV2Deliveries(): Promise<void> {
     const entries = await this.loadPendingV2Deliveries();
@@ -3629,18 +3768,33 @@ export class PaymentsModule {
     logger.warn('Payments', `${entries.length} undelivered v2 transfer(s) journaled from a previous session — replaying`);
     for (const e of entries) {
       try {
-        await this.deps!.transport.sendTokenTransfer(e.recipientPubkey, {
-          type: 'V2_TRANSFER',
-          version: '2.0',
-          tokenBlob: e.tokenBlob,
-          memo: e.memo,
-        } as unknown as import('../../transport').TokenTransferPayload);
-        await this.removePendingV2Delivery(e.tokenBlob);
-        logger.debug('Payments', `Replayed undelivered v2 transfer ${e.transferId.slice(0, 8)}...`);
+        await this.replayOneDelivery(e);
       } catch (err) {
         logger.warn('Payments', `Replay of undelivered v2 transfer ${e.transferId.slice(0, 8)}... failed (kept for next load):`, err);
       }
     }
+  }
+
+  /** Replay one journaled delivery over its tagged channel (courier re-deposit / Nostr). */
+  private async replayOneDelivery(e: PendingV2Delivery): Promise<void> {
+    const courier = this.deps!.deliveryTransport;
+    if (e.transport === 'courier' && courier && e.recipientChainPubkey) {
+      // Re-deposit; GC stays deferred to a valid-ackSig onDelivered (do NOT remove here).
+      const handle = await courier.deposit({
+        recipientChainPubkey: e.recipientChainPubkey,
+        senderChainPubkey: this.deps!.identity.chainPubkey,
+        transferId: e.transferId,
+        tokenBlobHex: e.tokenBlob,
+        memo: e.memo,
+      });
+      await this.setPendingV2DeliveryEntryId(e.tokenBlob, handle.entryId);
+      logger.debug('Payments', `Re-deposited undelivered courier transfer ${e.transferId.slice(0, 8)}...`);
+      return;
+    }
+    // Nostr / legacy entry: re-send and GC after success (today's behavior).
+    await this.sendBlobOverNostr(e.recipientPubkey, e.tokenBlob, e.memo);
+    await this.removePendingV2Delivery(e.tokenBlob);
+    logger.debug('Payments', `Replayed undelivered v2 transfer ${e.transferId.slice(0, 8)}...`);
   }
 
   private async createStorageData(): Promise<TxfStorageDataBase> {

--- a/tests/integration/vault/courier-factory.test.ts
+++ b/tests/integration/vault/courier-factory.test.ts
@@ -1,0 +1,156 @@
+/**
+ * createCourierDeliveryTransport factory (wallet-courier wiring, concern 2).
+ *
+ * The wallet cannot construct a CourierDeliveryProvider itself — it holds only the
+ * PUBLIC identity, but the provider reads the raw spend key (`me.privateKey`) on
+ * deposit/receive/ack. This factory is the SDK-internal seam that builds the provider
+ * from a FullIdentity (key in scope), resolving the vault URL from NETWORKS, wiring a
+ * real fetch+JWT courier client over an auth session, and a durable journal store.
+ *
+ * Two auth modes (both exercised here over a REAL node:http socket fronting the fake
+ * courier, so the full handshake + courier path runs through real fetch):
+ *  - SHARED: when the vault is enabled, the courier reuses the vault provider's
+ *    `authTokenSource()` — ONE JWT for vault + courier.
+ *  - OWN: when the vault is off, the courier builds its own VaultApiClient session.
+ *
+ * The PaymentsModule sinks (`onV2Transfer` / `onDelivered`) are bound AFTER
+ * construction via `setSinks`; the factory leaves them as no-ops.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '../../../core/crypto';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import { createCourierDeliveryTransport } from '../../../transport/courier/factory';
+import { createVaultTokenStorage } from '../../../storage/remote/factory';
+import { startRealVaultSocket, type RealVaultSocket } from '../../helpers/real-vault-socket';
+import type { StorageProvider } from '../../../storage/storage-provider';
+import type { FullIdentity } from '../../../types';
+import type { V2TransferPayload } from '../../../types/v2-transfer';
+
+const NETWORK = 'testnet2';
+const SENDER_PRIV = '9d'.repeat(32);
+const RECIP_PRIV = '7c'.repeat(32);
+const SENDER_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(SENDER_PRIV), true));
+const RECIP_PUB = bytesToHex(secp256k1.getPublicKey(hexToBytes(RECIP_PRIV), true));
+
+const senderId: FullIdentity = { chainPubkey: SENDER_PUB, l1Address: 'alpha1sender', privateKey: SENDER_PRIV };
+const recipId: FullIdentity = { chainPubkey: RECIP_PUB, l1Address: 'alpha1recip', privateKey: RECIP_PRIV };
+
+const TOKEN_ID = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const TOKEN_BYTES = new Uint8Array(40).map((_, i) => (i * 7 + 3) & 0xff);
+const BLOB_HEX = bytesToHex(encodeTokenBlob({ v: 1, network: 0, tokenId: TOKEN_ID, token: TOKEN_BYTES }));
+
+/** A minimal in-memory StorageProvider slice (the factory only needs get/set). */
+function memStorage(): Pick<StorageProvider, 'get' | 'set'> {
+  const m = new Map<string, string>();
+  return {
+    get: (k) => Promise.resolve(m.get(k) ?? null),
+    set: (k, v) => Promise.resolve(void m.set(k, v)),
+  };
+}
+
+let socket: RealVaultSocket;
+beforeEach(async () => {
+  socket = await startRealVaultSocket(NETWORK);
+});
+afterEach(async () => {
+  await socket.close();
+});
+
+describe('createCourierDeliveryTransport', () => {
+  it('builds a courier that deposits over real fetch on its OWN auth session (vault off)', async () => {
+    const courier = createCourierDeliveryTransport({
+      identity: senderId,
+      network: NETWORK,
+      storage: memStorage(),
+      vaultUrl: socket.baseUrl, // override NETWORKS url for the test socket
+    });
+
+    const handle = await courier.deposit({
+      recipientChainPubkey: RECIP_PUB,
+      senderChainPubkey: SENDER_PUB,
+      transferId: 'tx-own',
+      tokenBlobHex: BLOB_HEX,
+    });
+
+    expect(handle.transferId).toBe('tx-own');
+    // The deposit authenticated + reached the fake courier through real fetch + JWT.
+    expect(socket.courier.deliveryCount).toBe(1);
+  });
+
+  it('shares the vault provider auth session when authTokenSource is supplied (one JWT)', async () => {
+    // Build the vault provider; the courier reuses its authTokenSource() — one JWT.
+    const vault = createVaultTokenStorage({
+      identity: senderId,
+      network: NETWORK,
+      storage: memStorage() as unknown as StorageProvider,
+      vaultUrl: socket.baseUrl,
+    });
+    vault.setIdentity(senderId);
+    await vault.initialize(); // authenticates the shared session
+
+    const courier = createCourierDeliveryTransport({
+      identity: senderId,
+      network: NETWORK,
+      storage: memStorage(),
+      vaultUrl: socket.baseUrl,
+      authTokenSource: vault.authTokenSource(),
+    });
+
+    await courier.deposit({
+      recipientChainPubkey: RECIP_PUB,
+      senderChainPubkey: SENDER_PUB,
+      transferId: 'tx-shared',
+      tokenBlobHex: BLOB_HEX,
+    });
+    expect(socket.courier.deliveryCount).toBe(1);
+  });
+
+  it('round-trips a transfer end-to-end: sender deposits, recipient receives into the bound sink', async () => {
+    const sender = createCourierDeliveryTransport({
+      identity: senderId,
+      network: NETWORK,
+      storage: memStorage(),
+      vaultUrl: socket.baseUrl,
+    });
+    const recipient = createCourierDeliveryTransport({
+      identity: recipId,
+      network: NETWORK,
+      storage: memStorage(),
+      vaultUrl: socket.baseUrl,
+    });
+
+    const received: Array<{ payload: V2TransferPayload; sender: string }> = [];
+    recipient.setSinks({
+      onV2Transfer: async (payload, senderPubkey) => {
+        received.push({ payload, sender: senderPubkey });
+      },
+    });
+
+    await sender.deposit({
+      recipientChainPubkey: RECIP_PUB,
+      senderChainPubkey: SENDER_PUB,
+      transferId: 'tx-e2e',
+      tokenBlobHex: BLOB_HEX,
+      memo: 'gm',
+    });
+    await recipient.receive();
+
+    expect(received).toHaveLength(1);
+    expect(received[0].payload.type).toBe('V2_TRANSFER');
+    expect(received[0].payload.tokenBlob).toBe(BLOB_HEX);
+    expect(received[0].payload.memo).toBe('gm');
+    expect(received[0].sender).toBe(SENDER_PUB);
+  });
+
+  it('resolves vaultUrl from NETWORKS when not overridden (constructs without throwing)', () => {
+    expect(() =>
+      createCourierDeliveryTransport({
+        identity: senderId,
+        network: NETWORK,
+        storage: memStorage(),
+      }),
+    ).not.toThrow();
+  });
+});

--- a/tests/unit/core/Sphere.courier-wiring.test.ts
+++ b/tests/unit/core/Sphere.courier-wiring.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Sphere courier wiring (wallet-courier wiring — the Sphere.init flag).
+ *
+ * The wallet enables the opt-in courier delivery channel with a single config flag:
+ * `Sphere.init({ courier: { enabled: true } })`. The SDK constructs the courier
+ * internally (the app never has the spend key) and passes it to the PaymentsModule as
+ * `deliveryTransport`. Everything is gated behind the flag and defaults OFF, so
+ * existing wallets are Nostr-only and completely unaffected.
+ *
+ * These tests assert the FLAG GATE + that the constructed courier reaches the payments
+ * module init. The courier factory is mocked (this is wiring, not courier liveness).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TokenRegistry } from '../../../registry';
+import { Sphere } from '../../../core/Sphere';
+import { makeMockProviders } from './support/mock-providers';
+import { TEST_NETWORK } from '../../test-network';
+
+// Mock the courier factory so we observe construction + can pass a sentinel through
+// to the payments module without standing up a real courier.
+const courierSentinel = {
+  capabilities: { async: true, ack: true, addressing: 'pubkey' as const },
+  deposit: vi.fn(),
+  setSinks: vi.fn(),
+};
+const createCourierMock = vi.fn(() => courierSentinel);
+vi.mock('../../../transport/courier/factory', () => ({
+  createCourierDeliveryTransport: (...args: unknown[]) => createCourierMock(...args),
+}));
+
+// Mock L1 network module so init() never reaches Fulcrum (mirrors other core tests).
+vi.mock('../../../l1/network', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn(),
+  isWebSocketConnected: vi.fn().mockReturnValue(false),
+}));
+
+/** Stub fetch so the registry load resolves offline. */
+function stubFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      ({ ok: true, status: 200, statusText: 'OK', json: async () => [], text: async () => '[]' }) as unknown as Response,
+    ),
+  );
+}
+
+describe('Sphere courier wiring (init flag)', () => {
+  beforeEach(() => {
+    TokenRegistry.resetInstance();
+    if (Sphere.getInstance()) (Sphere as unknown as { instance: null }).instance = null;
+    createCourierMock.mockClear();
+    stubFetch();
+  });
+
+  afterEach(async () => {
+    if (Sphere.getInstance()) {
+      try { await Sphere.getInstance()!.destroy(); } catch { /* ignore */ }
+    }
+    (Sphere as unknown as { instance: null }).instance = null;
+    TokenRegistry.destroy();
+    vi.unstubAllGlobals();
+  });
+
+  it('constructs the courier and wires it as deliveryTransport when courier.enabled is true', async () => {
+    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: false });
+
+    const { sphere } = await Sphere.init({
+      storage, transport, oracle, l1,
+      network: TEST_NETWORK,
+      autoGenerate: true,
+      courier: { enabled: true, url: 'http://localhost:1/unreachable' },
+    });
+
+    expect(createCourierMock).toHaveBeenCalled();
+    // The first call's config carries the address identity + the configured url.
+    const cfg = createCourierMock.mock.calls[0][0] as { network: string; vaultUrl?: string; identity: { chainPubkey: string } };
+    expect(cfg.network).toBe(TEST_NETWORK);
+    expect(cfg.identity.chainPubkey).toBe(sphere.identity!.chainPubkey);
+  });
+
+  it('does NOT construct the courier when courier is omitted (default OFF)', async () => {
+    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: false });
+
+    await Sphere.init({
+      storage, transport, oracle, l1,
+      network: TEST_NETWORK,
+      autoGenerate: true,
+    });
+
+    expect(createCourierMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT construct the courier when courier.enabled is false', async () => {
+    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: false });
+
+    await Sphere.init({
+      storage, transport, oracle, l1,
+      network: TEST_NETWORK,
+      autoGenerate: true,
+      courier: { enabled: false },
+    });
+
+    expect(createCourierMock).not.toHaveBeenCalled();
+  });
+
+  it('constructs the courier on the load path too (existing wallet)', async () => {
+    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: true });
+
+    const { created } = await Sphere.init({
+      storage, transport, oracle, l1,
+      network: TEST_NETWORK,
+      courier: { enabled: true, url: 'http://localhost:1/unreachable' },
+    });
+
+    expect(created).toBe(false);
+    expect(createCourierMock).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/modules/PaymentsModule.courier-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.courier-delivery.test.ts
@@ -342,3 +342,15 @@ describe('dedup — a token delivered over BOTH courier and Nostr is stored once
     expect(emitEvent.mock.calls.find((c: any[]) => c[0] === 'transfer:incoming')).toBeUndefined();
   });
 });
+
+describe('receive() — a courier outage DEGRADES, never throws out of receive()', () => {
+  it('swallows a courier receive() rejection (the Nostr pull already succeeded)', async () => {
+    const delivery = new FakeDeliveryTransport();
+    delivery.receive = async () => { throw new Error('courier down'); };
+    const { module, transport } = setup({ delivery });
+    // receive() must resolve despite the courier outage — the token stays in the inbox
+    // for the next pull; a courier-down state cannot break the wallet's receive().
+    await expect(module.receive()).resolves.toBeDefined();
+    expect(transport.fetchPendingEvents).toHaveBeenCalled(); // Nostr pull still ran
+  });
+});

--- a/tests/unit/modules/PaymentsModule.courier-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.courier-delivery.test.ts
@@ -1,0 +1,344 @@
+/**
+ * PaymentsModule consumes a TokenDeliveryTransport (the courier seam) — concerns 3/4/5.
+ *
+ * MONEY-PATH invariants asserted here (the courier is ADDITIVE, flag-gated, reversible):
+ *  - DEFAULT OFF: with NO deliveryTransport, send/receive/load are byte-identical to
+ *    today — delivery goes over Nostr `sendTokenTransfer`, the courier is never touched.
+ *  - COEXIST (courier-primary): when a deliveryTransport is present, send DEPOSITS the
+ *    envelope over the courier (recipientChainPubkey = the resolved peerInfo.chainPubkey),
+ *    and does NOT also send over Nostr.
+ *  - NOSTR FALLBACK: a courier `deposit()` FAILURE falls back to Nostr (no lost delivery).
+ *  - JOURNAL-FIRST GC GATE: PENDING_V2_DELIVERIES is written BEFORE delivery and removed
+ *    ONLY on a valid-ackSig `onDelivered(entryId)` for the courier path — NOT on bare
+ *    deposit success. The Nostr-fallback path keeps the existing remove-after-send.
+ *  - entryId↔blob mapping: the journal entry carries the courier entryId + transport tag
+ *    so onDelivered(entryId) resolves the blob to GC (idempotent).
+ *  - load() starts the courier receive/poll/replay loops alongside the Nostr replay.
+ *  - REPLAY ROUTING: a courier-tagged journal entry replays over the COURIER (re-deposit),
+ *    a Nostr-tagged / untagged entry replays over Nostr.
+ *  - DEDUP: a token delivered over BOTH courier and Nostr is stored once (handleV2Transfer
+ *    dedups by genesis id) — no double-spend.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createPaymentsModule, type PaymentsModuleDependencies } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity } from '../../../types';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../../storage';
+import type {
+  TokenDeliveryTransport,
+  TokenEnvelope,
+  DeliveryHandle,
+} from '../../../transport/courier/types';
+import { STORAGE_KEYS_ADDRESS } from '../../../constants';
+import { FakeTokenEngine } from '../token-engine/FakeTokenEngine';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import { bytesToHex } from '../../../core/crypto';
+import type { V2TransferPayload } from '../../../types/v2-transfer';
+
+const FAKE_PRIVATE_KEY = 'a'.repeat(64);
+const FAKE_PUBKEY = '02' + 'b'.repeat(64);
+const SENDER_TRANSPORT_PUBKEY = 'cc'.repeat(32);
+const UCT = '11'.repeat(32);
+const BOB_CHAIN_PUBKEY = '02' + 'ee'.repeat(64);
+const BOB_TRANSPORT_PUBKEY = 'bob-transport-pubkey';
+
+function mockIdentity(): FullIdentity {
+  return {
+    chainPubkey: FAKE_PUBKEY, l1Address: 'alpha1x', directAddress: 'DIRECT://x',
+    privateKey: FAKE_PRIVATE_KEY, transportPubkey: 'dd'.repeat(32),
+  };
+}
+
+function mockStorage(): { provider: StorageProvider; map: Map<string, string> } {
+  const s = new Map<string, string>();
+  const provider = {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+  return { provider, map: s };
+}
+
+function mockHistoryStore() {
+  const entries = new Map<string, HistoryRecord>();
+  return {
+    addHistoryEntry: vi.fn(async (e: HistoryRecord) => { entries.set(e.dedupKey, e); }),
+    getHistoryEntries: vi.fn(async () => [...entries.values()]),
+    hasHistoryEntry: vi.fn(async (k: string) => entries.has(k)),
+    clearHistory: vi.fn(async () => entries.clear()),
+    importHistoryEntries: vi.fn(async () => 0),
+  };
+}
+
+function mockTokenStorage(): TokenStorageProvider<TxfStorageDataBase> {
+  let lastSaved: TxfStorageDataBase | null = null;
+  const provider = {
+    id: 'ts', name: 'ts', type: 'local',
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(true), shutdown: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn(async (data: TxfStorageDataBase) => { lastSaved = data; return { success: true, timestamp: 0 }; }),
+    load: vi.fn(async () => (lastSaved
+      ? { success: true, source: 'local', timestamp: 0, data: lastSaved }
+      : { success: false, source: 'local', timestamp: 0 })),
+    sync: vi.fn().mockResolvedValue({ success: true, added: 0, removed: 0, conflicts: 0 }),
+    ...mockHistoryStore(),
+  };
+  return provider as unknown as TokenStorageProvider<TxfStorageDataBase>;
+}
+
+function mockTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue({
+      chainPubkey: BOB_CHAIN_PUBKEY,
+      transportPubkey: BOB_TRANSPORT_PUBKEY,
+      directAddress: 'DIRECT://bob',
+      nametag: 'bob',
+    }),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    fetchPendingEvents: vi.fn().mockResolvedValue(undefined),
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return { validateToken: vi.fn().mockResolvedValue({ valid: true }), isDevMode: () => false } as unknown as OracleProvider;
+}
+
+/** A fake courier delivery transport that records deposits + exposes its bound sinks. */
+class FakeDeliveryTransport implements TokenDeliveryTransport {
+  readonly capabilities = { async: true, ack: true, addressing: 'pubkey' as const };
+  readonly deposits: TokenEnvelope[] = [];
+  receiveCalls = 0;
+  /** When set, deposit() rejects (drives the Nostr fallback). */
+  failDeposit = false;
+  private nextEntry = 1;
+  /** Captured from the module via setSinks — the GC sink keyed on the courier entryId. */
+  onDelivered?: (entryId: string) => Promise<void>;
+  /** Captured incoming-transfer sink (the module's handleV2Transfer). */
+  onV2Transfer?: (payload: V2TransferPayload, senderPubkey: string) => Promise<void>;
+
+  setSinks(sinks: {
+    onV2Transfer?: (payload: V2TransferPayload, senderPubkey: string) => Promise<void>;
+    onDelivered?: (entryId: string) => Promise<void>;
+  }): void {
+    if (sinks.onV2Transfer) this.onV2Transfer = sinks.onV2Transfer;
+    if (sinks.onDelivered) this.onDelivered = sinks.onDelivered;
+  }
+
+  async deposit(envelope: TokenEnvelope): Promise<DeliveryHandle> {
+    if (this.failDeposit) throw new Error('courier down');
+    this.deposits.push(envelope);
+    return {
+      entryId: `entry-${this.nextEntry++}`,
+      transferId: envelope.transferId,
+      recipientChainPubkey: envelope.recipientChainPubkey,
+      sentSeq: this.nextEntry,
+    };
+  }
+
+  async receive(): Promise<void> {
+    this.receiveCalls += 1;
+  }
+
+  /** Optional extra loop hooks the module calls when present (poll + ack replay). */
+  pollSent = vi.fn(async () => {});
+  replayAckPending = vi.fn(async () => {});
+}
+
+function setup(opts: { delivery?: TokenDeliveryTransport } = {}) {
+  const engine = new FakeTokenEngine();
+  const tsp = new Map<string, TokenStorageProvider<TxfStorageDataBase>>();
+  tsp.set('local', mockTokenStorage());
+  const emitEvent = vi.fn();
+  const transport = mockTransport();
+  const storage = mockStorage();
+  const deps: PaymentsModuleDependencies = {
+    identity: mockIdentity(), storage: storage.provider, tokenStorageProviders: tsp,
+    transport, oracle: mockOracle(), emitEvent, tokenEngine: engine,
+    deliveryTransport: opts.delivery,
+  };
+  const module = createPaymentsModule({ debug: false });
+  module.initialize(deps);
+  return { module, engine, emitEvent, transport, storage, deps };
+}
+
+async function v2Payload(engine: FakeTokenEngine, amount: bigint): Promise<V2TransferPayload> {
+  const st = await engine.mint({
+    recipientPubkey: engine.getIdentity().chainPubkey,
+    value: { assets: [{ coinId: UCT, amount }] },
+  });
+  return { type: 'V2_TRANSFER', version: '2.0', tokenBlob: bytesToHex(encodeTokenBlob(engine.encodeToken(st))) };
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function deliver(module: ReturnType<typeof setup>['module'], payload: V2TransferPayload, id = 't1') {
+  return (module as any).handleIncomingTransfer({
+    id, senderTransportPubkey: SENDER_TRANSPORT_PUBKEY, payload, timestamp: 0,
+  });
+}
+
+function journal(storage: { map: Map<string, string> }): Array<{
+  transferId: string; tokenBlob: string; recipientPubkey: string; entryId?: string; transport?: string;
+}> {
+  const raw = storage.map.get(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES);
+  return raw ? JSON.parse(raw) : [];
+}
+
+describe('send() delivery — default OFF (no deliveryTransport) is byte-identical to Nostr-only', () => {
+  it('delivers over Nostr and removes the journal entry; no courier involved', async () => {
+    const { module, engine, transport, storage } = setup();
+    await deliver(module, await v2Payload(engine, 100n));
+
+    const res = await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    expect(res.status).toBe('completed');
+
+    // Delivered over Nostr to the TRANSPORT pubkey (today's behavior), journal GC'd.
+    expect(transport.sendTokenTransfer).toHaveBeenCalledTimes(1);
+    expect((transport.sendTokenTransfer as any).mock.calls[0][0]).toBe(BOB_TRANSPORT_PUBKEY);
+    expect(journal(storage)).toHaveLength(0);
+  });
+});
+
+describe('send() delivery — courier present (coexist, courier-primary)', () => {
+  it('deposits over the courier (recipientChainPubkey) and does NOT send over Nostr', async () => {
+    const delivery = new FakeDeliveryTransport();
+    const { module, engine, transport, storage } = setup({ delivery });
+    await deliver(module, await v2Payload(engine, 100n));
+
+    await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+
+    expect(delivery.deposits).toHaveLength(1);
+    expect(delivery.deposits[0].recipientChainPubkey).toBe(BOB_CHAIN_PUBKEY);
+    expect(delivery.deposits[0].senderChainPubkey).toBe(FAKE_PUBKEY);
+    // Courier-primary: Nostr is NOT also used for the happy path.
+    expect(transport.sendTokenTransfer).not.toHaveBeenCalled();
+    // Journal carries the entryId + transport tag (entryId↔blob mapping for GC).
+    const entries = journal(storage);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].transport).toBe('courier');
+    expect(entries[0].entryId).toBe('entry-1');
+  });
+
+  it('does NOT GC PENDING_V2_DELIVERIES on bare deposit success — only on a valid-ackSig onDelivered', async () => {
+    const delivery = new FakeDeliveryTransport();
+    const { module, engine, storage } = setup({ delivery });
+    await deliver(module, await v2Payload(engine, 100n));
+
+    await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    // The token was deposited but not yet confirmed — the journal entry STAYS.
+    expect(journal(storage)).toHaveLength(1);
+    const entryId = journal(storage)[0].entryId!;
+
+    // The courier fires onDelivered after verifying the recipient ackSig → GC now.
+    await delivery.onDelivered!(entryId);
+    expect(journal(storage)).toHaveLength(0);
+  });
+
+  it('onDelivered for an unknown/already-GC’d entryId is idempotent (no throw, no corruption)', async () => {
+    const delivery = new FakeDeliveryTransport();
+    const { module, engine, storage } = setup({ delivery });
+    await deliver(module, await v2Payload(engine, 100n));
+    await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    const entryId = journal(storage)[0].entryId!;
+
+    await delivery.onDelivered!(entryId);
+    await delivery.onDelivered!(entryId);     // double-fire
+    await delivery.onDelivered!('never-seen'); // unknown
+    expect(journal(storage)).toHaveLength(0);
+  });
+});
+
+describe('send() delivery — courier outage falls back to Nostr (no lost delivery)', () => {
+  it('a courier deposit() failure delivers over Nostr and GCs the journal', async () => {
+    const delivery = new FakeDeliveryTransport();
+    delivery.failDeposit = true;
+    const { module, engine, transport, storage } = setup({ delivery });
+    await deliver(module, await v2Payload(engine, 100n));
+
+    const res = await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    expect(res.status).toBe('completed');
+
+    // Deposit was attempted (and failed) → Nostr fallback delivered it.
+    expect(transport.sendTokenTransfer).toHaveBeenCalledTimes(1);
+    expect((transport.sendTokenTransfer as any).mock.calls[0][0]).toBe(BOB_TRANSPORT_PUBKEY);
+    // The Nostr-fallback path removed the journal entry (today's behavior).
+    expect(journal(storage)).toHaveLength(0);
+  });
+});
+
+describe('load() — starts the courier loops alongside the Nostr replay', () => {
+  it('calls receive() / pollSent() / replayAckPending() on the courier when present', async () => {
+    const delivery = new FakeDeliveryTransport();
+    const { module } = setup({ delivery });
+    await module.load();
+    // Loops are kicked fire-and-forget; allow microtasks to flush.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(delivery.receiveCalls).toBeGreaterThanOrEqual(1);
+    expect(delivery.pollSent).toHaveBeenCalled();
+    expect(delivery.replayAckPending).toHaveBeenCalled();
+  });
+});
+
+describe('replay routing — a courier-tagged entry replays over the courier', () => {
+  it('re-deposits a courier journal entry and does NOT push it over Nostr', async () => {
+    const delivery = new FakeDeliveryTransport();
+    const { module, engine, transport, storage } = setup({ delivery });
+    await deliver(module, await v2Payload(engine, 100n));
+    await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    expect(delivery.deposits).toHaveLength(1); // the original deposit
+    expect(journal(storage)).toHaveLength(1);  // not yet confirmed
+
+    await (module as any).replayPendingV2Deliveries();
+
+    // Courier-tagged → re-deposited over the courier, never sent over Nostr.
+    expect(delivery.deposits).toHaveLength(2);
+    expect(transport.sendTokenTransfer).not.toHaveBeenCalled();
+    // Still journaled (no onDelivered yet) — replay does not GC a courier entry.
+    expect(journal(storage)).toHaveLength(1);
+  });
+
+  it('an untagged (legacy) journal entry replays over Nostr', async () => {
+    const delivery = new FakeDeliveryTransport();
+    const { module, transport, storage } = setup({ delivery });
+    // Seed a legacy entry with no transport tag (as an older build journaled it).
+    storage.map.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify([
+      { transferId: 'legacy', recipientPubkey: BOB_TRANSPORT_PUBKEY, tokenBlob: 'deadbeef', createdAt: 0 },
+    ]));
+
+    await (module as any).replayPendingV2Deliveries();
+
+    expect(transport.sendTokenTransfer).toHaveBeenCalledTimes(1);
+    expect(delivery.deposits).toHaveLength(0);
+    expect(journal(storage)).toHaveLength(0); // Nostr path GCs after send
+  });
+});
+
+describe('dedup — a token delivered over BOTH courier and Nostr is stored once', () => {
+  it('the second delivery (any channel) is deduped by genesis id — no double-spend', async () => {
+    const delivery = new FakeDeliveryTransport();
+    const { module, engine, emitEvent } = setup({ delivery });
+    const payload = await v2Payload(engine, 100n);
+    // The recipient's own engine owns the minted token, so handleV2Transfer accepts it.
+    // First delivery (e.g. courier path feeding the sink) stores it.
+    await deliver(module, payload, 'first');
+    const afterFirst = module.getTokens().length;
+    emitEvent.mockClear();
+
+    // Second delivery of the SAME token (e.g. the Nostr copy) — deduped.
+    await deliver(module, payload, 'second');
+
+    expect(module.getTokens()).toHaveLength(afterFirst); // stored once
+    expect(emitEvent.mock.calls.find((c: any[]) => c[0] === 'transfer:incoming')).toBeUndefined();
+  });
+});

--- a/tests/unit/vault/courier-journal-store.test.ts
+++ b/tests/unit/vault/courier-journal-store.test.ts
@@ -1,0 +1,87 @@
+/**
+ * CourierJournalStore adapter (wallet-courier wiring, concern 1).
+ *
+ * The {@link CourierDeliveryProvider} persists its read pointer, ACK-PENDING and
+ * sent-pending journals through a small {@link CourierJournalStore} (`get`/`set`).
+ * Tests inject an in-memory store, but the WALLET needs a durable one over the SDK's
+ * key-value {@link StorageProvider}. An in-memory journal resets every reload — the
+ * sender would forget which deliveries are still unconfirmed and a recipient would
+ * re-pull its whole inbox from `since=0`.
+ *
+ * {@link StorageCourierJournalStore} adapts the StorageProvider, namespacing every
+ * key by `network + chainPubkey` (mirroring {@link StorageBaselineStore}) so two
+ * owners (HD address switch) or two networks never share a courier journal row.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  StorageCourierJournalStore,
+  COURIER_JOURNAL_KEY_PREFIX,
+} from '../../../transport/courier/courier-journal-store';
+import type { StorageProvider } from '../../../storage/storage-provider';
+
+const NETWORK = 'testnet2';
+const OWNER_A = '02' + 'aa'.repeat(32);
+const OWNER_B = '02' + 'bb'.repeat(32);
+
+/** Minimal in-memory KV satisfying the slice of StorageProvider the adapter reads. */
+function memStorage(): Pick<StorageProvider, 'get' | 'set'> & { dump(): Map<string, string> } {
+  const m = new Map<string, string>();
+  return {
+    get: (k) => Promise.resolve(m.get(k) ?? null),
+    set: (k, v) => Promise.resolve(void m.set(k, v)),
+    dump: () => m,
+  };
+}
+
+describe('StorageCourierJournalStore', () => {
+  it('round-trips a value through set → get', async () => {
+    const storage = memStorage();
+    const store = new StorageCourierJournalStore(storage as unknown as StorageProvider, NETWORK, OWNER_A);
+
+    expect(await store.get('courier_read_pointer:testnet2:' + OWNER_A)).toBeNull();
+    await store.set('courier_read_pointer:testnet2:' + OWNER_A, '7');
+    expect(await store.get('courier_read_pointer:testnet2:' + OWNER_A)).toBe('7');
+  });
+
+  it('namespaces the underlying storage key by network + chainPubkey', async () => {
+    const storage = memStorage();
+    const store = new StorageCourierJournalStore(storage as unknown as StorageProvider, NETWORK, OWNER_A);
+
+    await store.set('courier_sent_pending:testnet2:' + OWNER_A, '{}');
+
+    // The persisted key is the adapter's namespaced key, NOT the raw logical key.
+    const persistedKeys = [...storage.dump().keys()];
+    expect(persistedKeys).toHaveLength(1);
+    expect(persistedKeys[0]).toContain(COURIER_JOURNAL_KEY_PREFIX);
+    expect(persistedKeys[0]).toContain(NETWORK);
+    expect(persistedKeys[0]).toContain(OWNER_A);
+  });
+
+  it('isolates owners: owner A and owner B never read each other’s journal', async () => {
+    const storage = memStorage(); // one shared underlying storage, two owners
+    const storeA = new StorageCourierJournalStore(storage as unknown as StorageProvider, NETWORK, OWNER_A);
+    const storeB = new StorageCourierJournalStore(storage as unknown as StorageProvider, NETWORK, OWNER_B);
+
+    await storeA.set('k', 'A-journal');
+    await storeB.set('k', 'B-journal');
+
+    expect(await storeA.get('k')).toBe('A-journal');
+    expect(await storeB.get('k')).toBe('B-journal');
+    expect(storage.dump().size).toBe(2); // two distinct underlying rows
+  });
+
+  it('isolates networks: same owner on two networks never shares a journal', async () => {
+    const storage = memStorage();
+    const mainnet = new StorageCourierJournalStore(storage as unknown as StorageProvider, 'mainnet', OWNER_A);
+    const testnet = new StorageCourierJournalStore(storage as unknown as StorageProvider, 'testnet2', OWNER_A);
+
+    await mainnet.set('k', 'mainnet-journal');
+    await testnet.set('k', 'testnet-journal');
+
+    expect(await mainnet.get('k')).toBe('mainnet-journal');
+    expect(await testnet.get('k')).toBe('testnet-journal');
+    expect(storage.dump().size).toBe(2);
+  });
+});

--- a/transport/courier/CourierDeliveryProvider.ts
+++ b/transport/courier/CourierDeliveryProvider.ts
@@ -143,10 +143,21 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
    */
   private readonly vaultNetwork: string;
   private identity: FullIdentity | null = null;
+  /**
+   * Live sinks. Default to the construction-time config, but may be REBOUND after
+   * construction via {@link setSinks} — the factory builds the provider with no-op
+   * placeholders and PaymentsModule binds its `handleV2Transfer` / GC methods once it
+   * initializes (the provider exists before the module deps are ready). Reading
+   * through these fields (not `config.*`) is what makes the late binding take effect.
+   */
+  private onV2TransferSink: V2TransferSink;
+  private onDeliveredSink?: (entryId: string) => Promise<void>;
 
   constructor(config: CourierDeliveryConfig) {
     this.config = config;
     this.vaultNetwork = normalizeVaultNetwork(config.network);
+    this.onV2TransferSink = config.onV2Transfer;
+    this.onDeliveredSink = config.onDelivered;
     this.capabilities = {
       async: true,
       ack: true,
@@ -157,6 +168,17 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
 
   setIdentity(identity: FullIdentity): void {
     this.identity = identity;
+  }
+
+  /**
+   * Rebind the PaymentsModule sinks AFTER construction (the factory leaves them as
+   * no-ops). `onV2Transfer` feeds the existing `handleV2Transfer` path; `onDelivered`
+   * licenses removing `PENDING_V2_DELIVERIES` on a valid recipient ackSig. Omitted
+   * fields keep their current binding.
+   */
+  setSinks(sinks: { onV2Transfer?: V2TransferSink; onDelivered?: (entryId: string) => Promise<void> }): void {
+    if (sinks.onV2Transfer) this.onV2TransferSink = sinks.onV2Transfer;
+    if (sinks.onDelivered) this.onDeliveredSink = sinks.onDelivered;
   }
 
   // ===========================================================================
@@ -307,7 +329,7 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
     // Custody commit: hand the verified-by-engine payload to handleV2Transfer.
     // The sender is addressed by chainPubkey; nametag enrichment no-ops over the
     // courier (Nostr-keyed), so the RECEIVED history records the chainPubkey only.
-    await this.config.onV2Transfer(payload, item.senderPubkey);
+    await this.onV2TransferSink(payload, item.senderPubkey);
     // INVARIANT custody-commit ≺ ack-journal ≺ ack-POST: journal ACK-PENDING
     // AFTER the custody commit, BEFORE the ack POST. A crash between the journal
     // and the POST is recovered by replayAckPending() on the next load.
@@ -537,7 +559,7 @@ export class CourierDeliveryProvider implements TokenDeliveryTransport {
     // the backoff gate (a poll inside the window still confirms a genuine delivery).
     if (this.isValidReceipt(me, item)) {
       entry.state = 'delivered';
-      await this.config.onDelivered?.(item.entryId);
+      await this.onDeliveredSink?.(item.entryId);
       return;
     }
     // Not yet validly claimed (still unclaimed, or a FORGED ackSig that fails

--- a/transport/courier/courier-journal-store.ts
+++ b/transport/courier/courier-journal-store.ts
@@ -1,0 +1,54 @@
+/**
+ * StorageCourierJournalStore — a DURABLE {@link CourierJournalStore} over the SDK's
+ * key-value {@link StorageProvider} (wallet-courier wiring, concern 1).
+ *
+ * The {@link CourierDeliveryProvider} persists three things through this small
+ * get/set seam: the recipient read pointer, the ACK-PENDING journal, and the
+ * sender-side sent-pending journal + watermark. Tests inject an in-memory store,
+ * but the WALLET needs a durable one — an in-memory journal resets every reload,
+ * which silently re-pulls the whole inbox from `since=0` and forgets which sends
+ * are still unconfirmed (so `PENDING_V2_DELIVERIES` could never be GC'd).
+ *
+ * NAMESPACING (fund-safety, mirrors {@link StorageBaselineStore}): the SDK
+ * `StorageProvider` only auto-scopes a fixed set of registered per-address keys; an
+ * arbitrary courier-journal key is stored GLOBALLY. So this adapter prefixes EVERY
+ * key with `network + chainPubkey` itself — otherwise two owners (HD address switch)
+ * or two networks would clobber a shared journal row and a delivery could be lost or
+ * a foreign inbox re-pulled. The provider also passes a pre-namespaced logical key
+ * (`courier_*:<net>:<owner>`); this adapter's own prefix is defense-in-depth so the
+ * storage row is bound to the owner regardless of the logical key handed in.
+ */
+
+import type { StorageProvider } from '../../storage/storage-provider';
+import type { CourierJournalStore } from './CourierDeliveryProvider';
+
+/** Stable prefix for every courier-journal row in the underlying StorageProvider. */
+export const COURIER_JOURNAL_KEY_PREFIX = 'sphere_courier_journal';
+
+/**
+ * Adapts a {@link StorageProvider} into a {@link CourierJournalStore}, namespacing
+ * every key by `network + chainPubkey` so owners/networks never share a journal.
+ */
+export class StorageCourierJournalStore implements CourierJournalStore {
+  private readonly storage: Pick<StorageProvider, 'get' | 'set'>;
+  /** The `network:chainPubkey` segment prepended to every logical key. */
+  private readonly scope: string;
+
+  constructor(storage: Pick<StorageProvider, 'get' | 'set'>, network: string, chainPubkey: string) {
+    this.storage = storage;
+    this.scope = `${COURIER_JOURNAL_KEY_PREFIX}:${network}:${chainPubkey}`;
+  }
+
+  get(key: string): Promise<string | null> {
+    return this.storage.get(this.scopedKey(key));
+  }
+
+  set(key: string, value: string): Promise<void> {
+    return this.storage.set(this.scopedKey(key), value);
+  }
+
+  /** Bind a logical key to this owner/network so storage rows can never collide. */
+  private scopedKey(key: string): string {
+    return `${this.scope}:${key}`;
+  }
+}

--- a/transport/courier/factory.ts
+++ b/transport/courier/factory.ts
@@ -1,0 +1,129 @@
+/**
+ * createCourierDeliveryTransport — the SDK-internal factory that builds a wired
+ * {@link CourierDeliveryProvider} for the wallet (wallet-courier wiring, concern 2).
+ *
+ * WHY A FACTORY (same constraint as the vault's `createVaultTokenStorage`): the
+ * provider reads the raw spend key (`me.privateKey`) on deposit/receive/ack, but
+ * `Sphere.identity` exposes only the PUBLIC identity. Construction MUST happen inside
+ * the SDK, where a `FullIdentity` (with `privateKey`) is in scope. The app flips a
+ * flag; the SDK runs this factory.
+ *
+ * AUTH session — TWO modes (DESIGN: one JWT for vault + courier when both are on):
+ *  - SHARED: when the vault is enabled, pass the vault provider's `authTokenSource()`
+ *    so the courier reuses the SAME `VaultApiClient` session (one challenge/verify,
+ *    one refresh chain). No second login.
+ *  - OWN: when the vault is off, build the courier's OWN `VaultApiClient` over
+ *    `createVaultAuthClient(vaultUrl)`, wrapped in a {@link LazyAuthTokenSource} that
+ *    runs the handshake on first use (the courier has no `initialize()` step).
+ *
+ * The PaymentsModule sinks (`onV2Transfer` / `onDelivered`) are bound AFTER
+ * construction via `provider.setSinks(...)` — the module exists only once its deps
+ * are ready, after this factory has run. Here they are no-op placeholders.
+ */
+
+import { NETWORKS } from '../../constants';
+import type { NetworkType } from '../../constants';
+import type { FullIdentity } from '../../types';
+import type { StorageProvider } from '../../storage/storage-provider';
+import { VaultApiClient } from '../../storage/remote/VaultApiClient';
+import { normalizeVaultNetwork } from '../../storage/remote/normalize-network';
+import { createVaultAuthClient, createVaultHttpClients } from '../../storage/remote/http/index';
+import type { FetchLike, VaultTokenSource } from '../../storage/remote/http/index';
+import { CourierDeliveryProvider } from './CourierDeliveryProvider';
+import { StorageCourierJournalStore } from './courier-journal-store';
+
+/** Device id stamped into the courier's OWN auth session (when the vault is off). */
+const COURIER_DEVICE_ID = 'sphere-courier';
+
+/** Inputs for {@link createCourierDeliveryTransport} — only the identity carries the key. */
+export interface CreateCourierDeliveryConfig {
+  /** The full identity for THIS address — its `privateKey` drives courier crypto. */
+  identity: FullIdentity;
+  /** Network whose `NETWORKS[network]` provides the vault/courier URL. */
+  network: NetworkType;
+  /** The wallet's key-value storage — backs the durable courier journal. */
+  storage: Pick<StorageProvider, 'get' | 'set'>;
+  /** Override the vault base URL (defaults to `NETWORKS[network].vaultUrl`). */
+  vaultUrl?: string;
+  /**
+   * Share an EXISTING auth session (the vault provider's `authTokenSource()`) so the
+   * courier and vault use ONE JWT. Omit to build the courier's own session.
+   */
+  authTokenSource?: VaultTokenSource;
+  /** Injectable `fetch` (tests/custom agents); defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+}
+
+/**
+ * A {@link VaultTokenSource} that lazily runs the challenge/verify handshake on first
+ * read. The courier has no `initialize()` hook (unlike the vault provider), so the
+ * own-auth path must authenticate on demand. `refresh()` delegates to the underlying
+ * client (which serializes concurrent refreshes itself).
+ */
+class LazyAuthTokenSource implements VaultTokenSource {
+  private authenticating: Promise<string> | null = null;
+
+  constructor(private readonly client: VaultApiClient) {}
+
+  get token(): string | null {
+    return this.client.token;
+  }
+
+  /**
+   * On the FIRST call (no JWT yet) run the full handshake once (collapsing concurrent
+   * callers onto one in-flight promise); afterwards delegate to the client's own
+   * serialized refresh.
+   */
+  refresh(): Promise<string> {
+    if (this.client.token !== null) return this.client.refresh();
+    if (!this.authenticating) {
+      this.authenticating = this.client.authenticate().finally(() => {
+        this.authenticating = null;
+      });
+    }
+    return this.authenticating;
+  }
+}
+
+/** Build the courier's OWN auth session (used when the vault is disabled). */
+function ownAuthSource(
+  identity: FullIdentity,
+  network: string,
+  vaultUrl: string,
+  fetchImpl?: FetchLike,
+): VaultTokenSource {
+  const client = new VaultApiClient({
+    network: normalizeVaultNetwork(network),
+    chainPubkey: identity.chainPubkey,
+    privateKey: identity.privateKey,
+    deviceId: COURIER_DEVICE_ID,
+    authClient: createVaultAuthClient(vaultUrl, fetchImpl),
+  });
+  return new LazyAuthTokenSource(client);
+}
+
+/**
+ * Build a fully-wired {@link CourierDeliveryProvider} from a {@link FullIdentity}.
+ * The caller binds the PaymentsModule sinks via `provider.setSinks(...)` once the
+ * module is initialized and passes the provider as `deliveryTransport`.
+ */
+export function createCourierDeliveryTransport(
+  config: CreateCourierDeliveryConfig,
+): CourierDeliveryProvider {
+  const { identity, network, storage, authTokenSource, fetchImpl } = config;
+  const vaultUrl = config.vaultUrl ?? NETWORKS[network].vaultUrl;
+  // Share the vault's session when given; otherwise build the courier's own.
+  const auth = authTokenSource ?? ownAuthSource(identity, network, vaultUrl, fetchImpl);
+  const journal = new StorageCourierJournalStore(storage, network, identity.chainPubkey);
+
+  const provider = new CourierDeliveryProvider({
+    vaultUrl,
+    network,
+    httpClientFactory: () => createVaultHttpClients({ vaultUrl, auth, fetchImpl }).courier,
+    journal,
+    // PaymentsModule binds the real sinks via setSinks() after it initializes.
+    onV2Transfer: async () => {},
+  });
+  provider.setIdentity(identity);
+  return provider;
+}

--- a/transport/courier/types.ts
+++ b/transport/courier/types.ts
@@ -75,6 +75,20 @@ export interface TokenDeliveryTransport {
   receive?(): Promise<void>;
   /** Verify + return the signed receipt for a delivery, if claimed. */
   confirmReceipt?(handle: DeliveryHandle): Promise<SignedReceipt | null>;
+  /**
+   * Bind the consumer's sinks AFTER construction (the SDK factory leaves them as
+   * no-ops). `onV2Transfer` feeds each decoded incoming transfer into the consumer's
+   * existing receive path; `onDelivered(entryId)` fires ONLY on a verified delivery
+   * receipt — it is what licenses the consumer to GC its pending-delivery journal.
+   */
+  setSinks?(sinks: {
+    onV2Transfer?: (payload: import('../../types/v2-transfer').V2TransferPayload, senderPubkey: string) => Promise<void>;
+    onDelivered?: (entryId: string) => Promise<void>;
+  }): void;
+  /** Poll for sender-side delivery confirmations (fires `onDelivered` on a valid ack). */
+  pollSent?(): Promise<void>;
+  /** Re-fire any journaled, unacked received deliveries (crash recovery). */
+  replayAckPending?(): Promise<void>;
 }
 
 // =============================================================================


### PR DESCRIPTION
Money-path courier integration, opt-in, reversible. CourierJournalStore over StorageProvider; createCourierDeliveryTransport factory (shares the vault VaultApiClient JWT when vault on, own session otherwise); PaymentsModuleDeps gains deliveryTransport?:TokenDeliveryTransport; send DEPOSITS to the courier (recipientChainPubkey from the Nostr-resolved peer) journal-first with Nostr fallback on deposit failure; receive/load drive courier receive/pollSent/replayAckPending; onV2Transfer feeds the UNFORKED handleV2Transfer (full verify/isOwnedBy/dedup); PENDING_V2_DELIVERIES GC ONLY on a valid-ackSig onDelivered (entryId<->blob mapping); replay routes by transport tag. Sphere.init courier:{enabled} flag (default OFF). Default-OFF is byte-identical to Nostr-only. Reviewed PASS (fund-critical: no lost delivery, no double-spend, reversible); MED receive-outage fix applied + test. tsc+eslint clean, payments+courier+core suites green.