### PR TITLE
fix(vault): stabilize multi-device sync + realtime receive

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -3266,8 +3266,14 @@ export class PaymentsModule {
   }
 
   /**
-   * Debounced sync triggered by a storage:remote-updated event.
-   * Waits 500ms to batch rapid updates, then performs sync.
+   * Debounced reaction to a storage:remote-updated event (e.g. the vault's realtime
+   * wake on an inbound courier delivery / a peer vault write). Waits 500ms to batch
+   * rapid wakes, then:
+   *   1. receive() — pull incoming courier + Nostr transfers. This is what surfaces an
+   *      ARRIVING token WITHOUT a page reload; it is additive + dedup'd (the SAME path
+   *      as a reload), so it can never inflate or resurrect a balance.
+   *   2. sync()   — push the vault / merge IPFS (unchanged provider sync).
+   * Sequential so the two never race on the token map; each degrades on failure.
    */
   private debouncedSyncFromRemoteUpdate(providerId: string, eventData: unknown): void {
     if (this.syncDebounceTimer) {
@@ -3276,8 +3282,14 @@ export class PaymentsModule {
 
     this.syncDebounceTimer = setTimeout(() => {
       this.syncDebounceTimer = null;
-      this.sync()
-        .then((result) => {
+      void (async () => {
+        try {
+          await this.receive();
+        } catch (err) {
+          logger.debug('Payments', 'Auto-receive from remote update failed:', err);
+        }
+        try {
+          const result = await this.sync();
           const data = eventData as { name?: string; sequence?: number; cid?: string } | undefined;
           this.deps?.emitEvent('sync:remote-update', {
             providerId,
@@ -3287,10 +3299,10 @@ export class PaymentsModule {
             added: result.added,
             removed: result.removed,
           });
-        })
-        .catch((err) => {
+        } catch (err) {
           logger.debug('Payments', 'Auto-sync from remote update failed:', err);
-        });
+        }
+      })();
     }, PaymentsModule.SYNC_DEBOUNCE_MS);
   }
 

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -42,7 +42,8 @@ import { getPublicKey } from '../../core/crypto';
 import { sealVaultEntry, openVaultEntry } from '../../vault-aead/entry';
 import { deriveVaultKey } from '../../vault-aead/derive';
 import { wireKey } from './wire-key';
-import { VaultApiClient } from './VaultApiClient';
+import { VaultApiClient, type VaultSessionStore } from './VaultApiClient';
+import { VaultWakeClient } from './http/VaultWakeClient';
 import { extractTokens, planOps } from './diff';
 import type { KnownEntry, PlannedOp } from './diff';
 import { sealHistoryRecord, openHistoryRecord } from './history-codec';
@@ -116,6 +117,9 @@ export interface RemoteTokenStorageConfig {
   localBaseline?: LocalBaselineStore;
   /** The compressed server signing key for this network (`NETWORKS[net].vaultServerKey`). */
   vaultServerKey?: string;
+  /** Durable auth-session store — persists the JWT/refresh so a reload reuses the
+   *  session instead of re-authenticating (kills the reload→Unauthorized churn). */
+  sessionStore?: VaultSessionStore;
 }
 
 export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfStorageDataBase>
@@ -137,6 +141,10 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   private readonly vaultNetwork: string;
   private identity: FullIdentity | null = null;
   private auth: VaultApiClient | null = null;
+  /** Realtime wake channel (token-api change-stream). On wake the provider emits
+   *  `storage:remote-updated`; PaymentsModule responds with receive() (pull incoming
+   *  — additive, the same path as a reload). NEVER drives the sync snapshot. */
+  private wakeClient: VaultWakeClient | null = null;
   private status: 'disconnected' | 'connecting' | 'connected' | 'error' = 'disconnected';
 
   /** Internal last-known server view: plainKey → {version, deleted}. */
@@ -248,12 +256,16 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     this.pushedHistory.clear();
     this.localHistory.clear();
     this.historyCursor = 0;
+    // Drop the wake channel bound to the OLD auth session — initialize() re-opens it.
+    this.wakeClient?.stop();
+    this.wakeClient = null;
     this.auth = new VaultApiClient({
       network: this.vaultNetwork,
       chainPubkey: identity.chainPubkey,
       privateKey: this.config.privateKey,
       deviceId: this.config.deviceId ?? 'sphere-vault',
       authClient: this.config.authClient,
+      sessionStore: this.config.sessionStore,
     });
     this.delta.setIdentity(identity.chainPubkey);
     this.delta.setWalletPriv(this.config.privateKey);
@@ -302,7 +314,9 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   async initialize(): Promise<boolean> {
     this.status = 'connecting';
     try {
-      await this.requireAuth().authenticate();
+      // Reuse a persisted session if one survived the reload (sphere-api pattern),
+      // re-authenticating only when there is none — no challenge→verify per reload.
+      await this.requireAuth().ensureAuthenticated();
     } catch (error) {
       this.status = 'error';
       this.emit('storage:error', { reason: VAULT_REASON.AUTH }, this.errMsg(error, 'vault auth failed'));
@@ -315,7 +329,26 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
       this.emit('storage:error', { reason: VAULT_REASON.INITIAL_LOAD }, first.error);
       return false; // first load failed → gate stays SHUT, wallet still loads locally
     }
+    this.startWakeChannel(); // realtime: a server wake → PaymentsModule.receive() (no reload)
     return true;
+  }
+
+  /**
+   * Open the realtime wake channel (token-api change-stream). On a server wake the
+   * provider emits `storage:remote-updated`; PaymentsModule pulls incoming transfers
+   * via receive() (additive — the SAME path as a page reload), so an arriving token
+   * shows WITHOUT a reload. NARROW BY DESIGN: the wake never drives the sync snapshot
+   * (that path caused the balance-resurrection bug). Best-effort — a failure degrades
+   * to load()-time polling + the client's own 4–6 min backstop; never breaks init.
+   */
+  private startWakeChannel(): void {
+    if (this.wakeClient || !this.auth) return;
+    this.wakeClient = new VaultWakeClient({
+      vaultUrl: this.config.vaultUrl,
+      auth: this.auth,
+      onWake: () => this.emit('storage:remote-updated', { source: 'vault-wake' }),
+    });
+    this.wakeClient.start();
   }
 
   /** Extract a human message from an unknown thrown value (degraded-path logging). */
@@ -329,6 +362,8 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
   }
 
   async shutdown(): Promise<void> {
+    this.wakeClient?.stop();
+    this.wakeClient = null;
     // Route through the queue so an in-flight flush drains first (Task 7.3).
     await this.queue.enqueue(() => {
       this.status = 'disconnected';
@@ -383,6 +418,13 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
       this.assertEpoch(epoch);
       const ops = this.planFlush(localData);
       await this.pushHistory(localData, epoch); // single-channel history (Task 7.4)
+      // PUSH-ONLY (fund safety): merged = localData, never a rehydrated snapshot.
+      // Returning the rehydration map here resurrected just-spent tokens — after a
+      // send, `rehydrated` is STALE (still holds the spent input, lacks the change)
+      // until the next load() re-materializes, so PaymentsModule's merge re-added the
+      // spent token AND the change → balance inflation. Multi-device PULL belongs to
+      // load() (a FRESH /state that reflects the spend) + the wake→receive() path,
+      // NOT to sync.
       if (ops.length === 0) return this.cleanResult(localData, 0, 0, 0);
       return await this.flush(localData, ops, epoch);
     } catch (error) {
@@ -707,22 +749,39 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
       this.rehydrated.set(e.key, { plainKey: k, value: v });
     }
     // Build the FULL TXF snapshot from the accumulated rehydration map every load,
-    // so a delta-only `load()` still returns the complete token set. v2 identity is
-    // the chainPubkey, so `_meta.address` is restored to OUR chainPubkey (locally
-    // known from the key — no server entry needed); the address guard accepts it.
-    const data: TxfStorageDataBase & { isEmpty?: boolean } = {
+    // so a delta-only `load()` still returns the complete token set.
+    const data = this.buildSnapshot(history) as TxfStorageDataBase & { isEmpty?: boolean };
+    const isEmpty = this.knownCount() === 0 && history.length === 0;
+    if (isEmpty) data.isEmpty = true;
+    this.initialLoadDone = true; // the flush gate opens on a successful load (Task 7.1)
+    this.emit('storage:loaded', { entries: entries.length, tokens: this.rehydrated.size, history: history.length });
+    return { success: true, data: data as TData, source: 'remote', timestamp: Date.now() };
+  }
+
+  /**
+   * Build the FULL TXF snapshot from the persistent rehydration map — NO side
+   * effects. Used ONLY by load()'s materialize(), so a delta-only `load()` still
+   * returns the complete token set.
+   *
+   * NOT used by sync(): sync is PUSH-ONLY (`merged = localData`, see cleanResult).
+   * Returning this rehydrated snapshot as sync's `merged` resurrected just-spent
+   * tokens — between loads the map is STALE (still holds a spent input, lacks the
+   * change) → PaymentsModule re-added them → balance inflation. Multi-device PULL is
+   * owned by load() (a FRESH /state that reflects the spend) + the wake→receive()
+   * path, never sync. v2 identity is the chainPubkey, so `_meta.address` is OUR
+   * chainPubkey (locally known from the key — no server entry needed); the address
+   * guard accepts it.
+   */
+  private buildSnapshot(history: HistoryRecord[] = []): TxfStorageDataBase {
+    const data: TxfStorageDataBase = {
       _meta: { version: 1, address: this.ownerId(), formatVersion: '2.0', updatedAt: Date.now() },
     };
     for (const { plainKey, value } of this.rehydrated.values()) {
       data[`${TXF_TOKEN_KEY_PREFIX}${plainKey}` as `_${string}`] = value;
     }
-    const isEmpty = this.knownCount() === 0 && history.length === 0;
     // Attach recovered history for the existing import hook (importHistoryEntries).
     if (history.length > 0) data._history = history;
-    if (isEmpty) data.isEmpty = true;
-    this.initialLoadDone = true; // the flush gate opens on a successful load (Task 7.1)
-    this.emit('storage:loaded', { entries: entries.length, tokens: this.rehydrated.size, history: history.length });
-    return { success: true, data: data as TData, source: 'remote', timestamp: Date.now() };
+    return data;
   }
 
   /**

--- a/storage/remote/VaultApiClient.ts
+++ b/storage/remote/VaultApiClient.ts
@@ -21,6 +21,19 @@ import type { AuthTokens, ChallengeResponse, VaultAuthHttpClient } from './types
 /** Reject challenges whose lifetime is implausibly long (a clamp on a hostile TTL). */
 const MAX_CHALLENGE_TTL_MS = 60 * 60_000; // 1 hour — the real server uses 5 min
 
+/**
+ * Durable session store — persists `{jwt, refreshToken}` so a PAGE RELOAD reuses
+ * the existing session instead of re-running challenge→verify (which is what made
+ * every reload flash `Unauthorized` and churn the rotating session). Mirrors the
+ * sphere-api `userApi.ts` pattern (it keeps its JWT in localStorage). Backed by the
+ * wallet's own StorageProvider (IndexedDB in browser), so it is cross-env.
+ */
+export interface VaultSessionStore {
+  load(): Promise<{ jwt: string; refreshToken: string } | null>;
+  save(tokens: { jwt: string; refreshToken: string }): Promise<void>;
+  clear(): Promise<void>;
+}
+
 export interface VaultApiClientConfig {
   /** Expected canonical network (must match the challenge's embedded network). */
   network: string;
@@ -32,6 +45,8 @@ export interface VaultApiClientConfig {
   deviceId: string;
   /** The raw auth wire seam (fake server in tests; fetch+JWT in Phase 8.3). */
   authClient: VaultAuthHttpClient;
+  /** Optional durable session store (persists across reloads — see VaultSessionStore). */
+  sessionStore?: VaultSessionStore;
 }
 
 /** The challenge body the server JSON-encodes after the prefix. */
@@ -50,6 +65,10 @@ export class VaultApiClient {
   private refreshToken: string | null = null;
   /** The single in-flight refresh promise (serialization, §4.3). */
   private refreshing: Promise<string> | null = null;
+  /** The single in-flight handshake promise (serialization — see authenticate()). */
+  private authenticating: Promise<string> | null = null;
+  /** The single in-flight ensure (reuse-persisted-or-auth) promise. */
+  private ensuring: Promise<string> | null = null;
 
   constructor(config: VaultApiClientConfig) {
     this.config = config;
@@ -61,10 +80,24 @@ export class VaultApiClient {
   }
 
   /**
-   * Full handshake: fetch a challenge, VERIFY its template, sign the verified
-   * literal, exchange it for a JWT + refresh token. Returns the JWT.
+   * Full handshake (SERIALIZED): fetch a challenge, VERIFY its template, sign the
+   * verified literal, exchange it for a JWT + refresh token. Returns the JWT.
+   *
+   * Concurrent callers collapse onto ONE in-flight handshake — the vault data
+   * client and the courier SHARE this instance, so a boot where both the vault's
+   * initialize() and a courier 401-self-heal authenticate at once must NOT run two
+   * handshakes (each `verify` opens a session on the unique (ownerId, deviceId) row,
+   * so the second would rotate the first off and 401 it).
    */
   async authenticate(): Promise<string> {
+    if (this.authenticating) return this.authenticating;
+    this.authenticating = this.doAuthenticate().finally(() => {
+      this.authenticating = null;
+    });
+    return this.authenticating;
+  }
+
+  private async doAuthenticate(): Promise<string> {
     const challenge = await this.config.authClient.challenge(this.config.chainPubkey);
     this.verifyChallenge(challenge);
     const signature = signMessage(this.config.privateKey, challenge.challenge);
@@ -77,6 +110,51 @@ export class VaultApiClient {
     if (!tokens) throw new Error('vault auth: server rejected the signature (401)');
     this.adopt(tokens);
     return tokens.jwt;
+  }
+
+  /**
+   * Return a usable JWT, REUSING a persisted session across reloads (the sphere-api
+   * pattern) instead of re-running challenge→verify every time — this is why a plain
+   * page reload no longer flashes `Unauthorized`. Serialized so the vault data client
+   * and the shared courier collapse onto ONE in-flight ensure. Order: in-memory valid
+   * JWT → persisted session (rotate if its JWT expired) → full authenticate().
+   */
+  async ensureAuthenticated(): Promise<string> {
+    if (this.jwt && !this.isExpired(this.jwt)) return this.jwt;
+    if (this.ensuring) return this.ensuring;
+    this.ensuring = this.doEnsure().finally(() => {
+      this.ensuring = null;
+    });
+    return this.ensuring;
+  }
+
+  private async doEnsure(): Promise<string> {
+    if (this.jwt && !this.isExpired(this.jwt)) return this.jwt;
+    // Load the persisted session (survives reload) when we have neither an
+    // in-memory JWT nor a refresh token yet.
+    if (!this.jwt && !this.refreshToken) {
+      const stored = await this.config.sessionStore?.load();
+      if (stored) {
+        this.jwt = stored.jwt;
+        this.refreshToken = stored.refreshToken;
+      }
+    }
+    if (this.jwt && !this.isExpired(this.jwt)) return this.jwt;
+    // A loaded-but-expired JWT: rotate quietly via the long-lived refresh token;
+    // refresh() self-heals to a full authenticate() if the refresh is also dead.
+    if (this.refreshToken) return this.refresh();
+    return this.authenticate();
+  }
+
+  /** True if the JWT `exp` is past (30s skew). Unparseable → treat as valid (a 401 catches it). */
+  private isExpired(jwt: string): boolean {
+    try {
+      const part = jwt.split('.')[1] ?? '';
+      const exp = (JSON.parse(atob(part.replace(/-/g, '+').replace(/_/g, '/'))) as { exp?: number }).exp;
+      return typeof exp === 'number' ? exp * 1000 <= Date.now() + 30_000 : false;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -93,27 +171,37 @@ export class VaultApiClient {
   }
 
   private async doRefresh(): Promise<string> {
-    if (!this.refreshToken) throw new Error('vault auth: no refresh token — call authenticate() first');
+    // SELF-HEAL (was: throw). A 401 must RE-ESTABLISH the session, not dead-end the
+    // whole vault+courier. Two cases both fall back to a full authenticate():
+    //  - no refresh token: a fresh page load where a request (e.g. courier inbox)
+    //    fired before initialize()'s authenticate() completed.
+    //  - server rejected the refresh: the token was stale/reused, or the session was
+    //    rotated/expired (e.g. a deviceId change orphaned the old session).
+    // authenticate() is serialized, so concurrent 401s share ONE handshake.
+    if (!this.refreshToken) return this.authenticate();
     const tokens = await this.config.authClient.refresh(this.refreshToken);
     if (!tokens) {
       this.jwt = null;
       this.refreshToken = null;
-      throw new Error('vault auth: refresh rejected (stale or reused)');
+      return this.authenticate();
     }
     this.adopt(tokens);
     return tokens.jwt;
   }
 
-  /** Logout (best-effort) — revokes the session server-side. */
+  /** Logout (best-effort) — revokes the session server-side + drops the persisted one. */
   async logout(sessionId: string): Promise<void> {
     await this.config.authClient.logout(sessionId);
     this.jwt = null;
     this.refreshToken = null;
+    void this.config.sessionStore?.clear();
   }
 
   private adopt(tokens: AuthTokens): void {
     this.jwt = tokens.jwt;
     this.refreshToken = tokens.refreshToken;
+    // Persist so a page reload reuses this session instead of re-authenticating.
+    void this.config.sessionStore?.save({ jwt: tokens.jwt, refreshToken: tokens.refreshToken });
   }
 
   /**

--- a/storage/remote/factory.ts
+++ b/storage/remote/factory.ts
@@ -24,6 +24,43 @@ import { RemoteTokenStorageProvider } from './RemoteTokenStorageProvider';
 import { StorageBaselineStore } from './local-baseline-store';
 import { createVaultAuthClient, createVaultHttpClients } from './http/index';
 import type { FetchLike } from './http/index';
+import type { VaultSessionStore } from './VaultApiClient';
+
+/** Storage key prefix for the persisted vault auth session (per network + owner). */
+const SESSION_KEY_PREFIX = 'sphere_vault_session';
+
+/**
+ * A durable {@link VaultSessionStore} over the wallet's KV storage so the JWT +
+ * refresh token survive a page reload (the sphere-api pattern) — without it every
+ * reload re-authenticates and flashes `Unauthorized`. Scoped by network + owner so
+ * two wallets/networks never share a session row. A corrupt/blank value reads as
+ * `null` (→ a clean re-authenticate), so a bad token never wedges the client.
+ */
+function createSessionStore(
+  storage: Pick<StorageProvider, 'get' | 'set'>,
+  network: string,
+  chainPubkey: string,
+): VaultSessionStore {
+  const key = `${SESSION_KEY_PREFIX}:${network}:${chainPubkey}`;
+  return {
+    async load() {
+      const raw = await storage.get(key);
+      if (!raw) return null;
+      try {
+        const p = JSON.parse(raw) as { jwt?: string; refreshToken?: string };
+        return p.jwt && p.refreshToken ? { jwt: p.jwt, refreshToken: p.refreshToken } : null;
+      } catch {
+        return null;
+      }
+    },
+    async save(tokens) {
+      await storage.set(key, JSON.stringify(tokens));
+    },
+    async clear() {
+      await storage.set(key, '');
+    },
+  };
+}
 
 /** Inputs for {@link createVaultTokenStorage} — only the identity carries the key. */
 export interface CreateVaultTokenStorageConfig {
@@ -55,6 +92,7 @@ export function createVaultTokenStorage(
 
   const authClient = createVaultAuthClient(vaultUrl, fetchImpl);
   const localBaseline = new StorageBaselineStore(storage, network, identity.chainPubkey);
+  const sessionStore = createSessionStore(storage, network, identity.chainPubkey);
 
   // The data client must share the provider's OWN auth session (`authTokenSource()`),
   // but the provider does not exist yet — capture a mutable ref and resolve it LAZILY
@@ -76,6 +114,7 @@ export function createVaultTokenStorage(
     vaultServerKey,
     deviceId,
     localBaseline,
+    sessionStore,
   });
   ref.provider = provider;
   return provider;

--- a/storage/remote/http/VaultWakeClient.ts
+++ b/storage/remote/http/VaultWakeClient.ts
@@ -1,0 +1,135 @@
+/**
+ * VaultWakeClient — the REALTIME wake channel against the token-api change-stream
+ * (server side: DESIGN §5.1 ws-ticket + §6.7 fan-out). Without it, incoming courier
+ * deliveries + a peer device's vault writes are only seen on the next `load()`
+ * (i.e. a page reload); with it the wallet re-pulls the moment the server wakes it.
+ *
+ * Protocol (server `routes/ws.ts` + `change-stream.plugin.ts`):
+ *  1. `POST /v1/ws/ticket` (Bearer JWT, via the shared {@link VaultTokenSource}) →
+ *     `{ ticket }` — single-use, 30s, bound to ownerId.
+ *  2. `GET  /v1/ws?ticket=…` (WS upgrade) → the socket is registered; the server
+ *     fans a PAYLOAD-FREE `{ type:'wake', epoch }` frame to it on any insert/update
+ *     of `deliveries` (recipientId) or `vault_tokens` (ownerId).
+ *  3. Every frame → `onWake()` (the wallet re-pulls; the frame carries no data, so a
+ *     spurious wake is just a harmless re-pull).
+ *
+ * Resilience: capped exponential reconnect on close/error; a jittered 4–6 min
+ * backstop poll fires `onWake()` even with no frames, covering a missed wake when the
+ * server's change-stream resume point fell out of the oplog (DESIGN §6.7).
+ */
+
+import { authedJson } from './http-core';
+import type { FetchLike, VaultTokenSource } from './http-core';
+
+/** Minimal structural WebSocket surface this client uses (browser + Node 22 global). */
+interface WsLike {
+  onopen: (() => void) | null;
+  onmessage: ((ev: unknown) => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+  close(): void;
+}
+type WsCtor = new (url: string) => WsLike;
+
+export interface VaultWakeClientConfig {
+  /** Vault/courier base URL — `NETWORKS[network].vaultUrl`. */
+  vaultUrl: string;
+  /** Shared JWT source (the vault's VaultApiClient) — used to mint the ws-ticket. */
+  auth: VaultTokenSource;
+  /** Called on every wake frame AND on each backstop tick. */
+  onWake: () => void;
+  /** Injectable fetch (defaults to global). */
+  fetchImpl?: FetchLike;
+  /** Injectable WebSocket ctor (defaults to `globalThis.WebSocket`; tests pass a fake). */
+  webSocketImpl?: WsCtor;
+}
+
+const BACKSTOP_MIN_MS = 4 * 60_000;
+const BACKSTOP_MAX_MS = 6 * 60_000;
+const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+
+export class VaultWakeClient {
+  private socket: WsLike | null = null;
+  private stopped = false;
+  private reconnectMs = RECONNECT_BASE_MS;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private backstopTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly ws: WsCtor | undefined;
+
+  constructor(private readonly config: VaultWakeClientConfig) {
+    this.ws = config.webSocketImpl ?? (globalThis as { WebSocket?: WsCtor }).WebSocket;
+  }
+
+  /** Begin the wake channel: arm the backstop poll, then connect. Idempotent-safe. */
+  start(): void {
+    if (this.stopped || !this.ws) return;
+    this.armBackstop();
+    void this.connect();
+  }
+
+  /** Tear down: stop reconnecting, clear timers, close the socket. */
+  stop(): void {
+    this.stopped = true;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    if (this.backstopTimer) clearTimeout(this.backstopTimer);
+    this.reconnectTimer = null;
+    this.backstopTimer = null;
+    try { this.socket?.close(); } catch { /* ignore */ }
+    this.socket = null;
+  }
+
+  /** `http(s)://host` → `ws(s)://host/v1/ws?ticket=…`. */
+  private wsUrl(ticket: string): string {
+    const base = this.config.vaultUrl.replace(/^http/, 'ws').replace(/\/+$/, '');
+    return `${base}/v1/ws?ticket=${encodeURIComponent(ticket)}`;
+  }
+
+  private async connect(): Promise<void> {
+    if (this.stopped || !this.ws) return;
+    let ticket: string;
+    try {
+      const res = await authedJson<{ ticket: string }>(
+        this.config.fetchImpl ?? fetch,
+        this.config.vaultUrl,
+        this.config.auth,
+        { method: 'POST', path: '/v1/ws/ticket' },
+      );
+      ticket = res.ticket;
+    } catch {
+      this.scheduleReconnect(); // auth/network down — retry with backoff
+      return;
+    }
+    try {
+      const socket = new this.ws(this.wsUrl(ticket));
+      this.socket = socket;
+      socket.onopen = () => { this.reconnectMs = RECONNECT_BASE_MS; };
+      socket.onmessage = () => { this.config.onWake(); };
+      socket.onclose = () => { this.socket = null; this.scheduleReconnect(); };
+      socket.onerror = () => { try { socket.close(); } catch { /* ignore */ } };
+    } catch {
+      this.scheduleReconnect();
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer) return;
+    const delay = this.reconnectMs;
+    this.reconnectMs = Math.min(this.reconnectMs * 2, RECONNECT_MAX_MS);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connect();
+    }, delay);
+  }
+
+  private armBackstop(): void {
+    if (this.stopped) return;
+    const jitter = BACKSTOP_MIN_MS + Math.floor(Math.random() * (BACKSTOP_MAX_MS - BACKSTOP_MIN_MS));
+    this.backstopTimer = setTimeout(() => {
+      this.backstopTimer = null;
+      if (this.stopped) return;
+      this.config.onWake(); // periodic re-pull covers a missed wake (oplog gap)
+      this.armBackstop();
+    }, jitter);
+  }
+}


### PR DESCRIPTION
## What
Stabilizes the wallet <-> token-api vault integration (multi-device sync + realtime receive) — root-causes the churn found in two-browser testing.

## Changes
- **VaultApiClient**: persisted session (`VaultSessionStore`) so a reload reuses the JWT/refresh instead of re-running challenge->verify; self-healing `doRefresh` re-authenticates instead of throwing when the refresh is missing/rejected; `authenticate()` / `ensureAuthenticated()` serialized so the shared vault+courier client never runs two concurrent handshakes (which rotated each other off).
- **factory**: `createSessionStore` over the wallet KV, scoped by network+owner.
- **RemoteTokenStorageProvider**: realtime `VaultWakeClient` (token-api change-stream WS) -> emits `storage:remote-updated`; torn down on identity switch/shutdown. `sync()` stays **push-only** (`merged = localData`) — returning the rehydrated snapshot resurrected just-spent tokens -> balance inflation; multi-device PULL is owned by `load()` + the wake->receive() path. `buildSnapshot` extracted for `load()` only.
- **PaymentsModule**: a remote-update wake now `receive()`s (pull incoming — additive + dedup, the same path as a reload) then `sync()`s -> an arriving token shows without a page reload.

## Tests
Local: lint 0 errors, typecheck clean, 253 vault+payments tests green. Verified end-to-end on a fresh wallet (realtime receive, vault green, no churn, no inflation).