### PR TITLE
feat(delivery): fan-out — courier deposit + Nostr blast (recipient dedups)

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -3700,13 +3700,17 @@ export class PaymentsModule {
   /**
    * Deliver ONE finished v2 token blob, journal-first (DESIGN: never lose a token).
    *
-   * COEXIST POLICY (concern 4): when a `deliveryTransport` (courier) is configured it is
-   * PRIMARY — the blob is journaled tagged `'courier'` (with the courier entryId folded
-   * in) and deposited; the journal entry is then removed ONLY by a valid-ackSig
-   * `onDelivered` (NOT here). A courier `deposit()` FAILURE falls back to Nostr (no lost
-   * delivery), removing the journal entry after the send (today's behavior). With no
-   * courier, delivery is Nostr-only, byte-identical to today. Resolution stayed on Nostr;
-   * the courier only consumes the already-resolved `recipientChainPubkey`.
+   * FAN-OUT POLICY: when a `deliveryTransport` (courier) is configured the blob goes out
+   * on BOTH channels — it is journaled tagged `'courier'` (entryId folded in) and
+   * deposited (the durable, journaled guarantee; the journal entry is GC'd ONLY by a
+   * valid-ackSig `onDelivered`, NOT here), AND it is ALSO blasted over Nostr as the
+   * universal floor (realtime + redundancy). The Nostr blast is best-effort: the
+   * recipient dedups by the genesis-stable token id (handleV2Transfer) and the chain is
+   * the spend authority, so the same token arriving on both channels credits ONCE and a
+   * failed blast loses nothing. A courier `deposit()` FAILURE falls back to Nostr-only
+   * (journal 'nostr', send, GC — today's behavior). With no courier, delivery is
+   * Nostr-only, byte-identical to today. Resolution stayed on Nostr; the courier only
+   * consumes the already-resolved `recipientChainPubkey`.
    */
   private async deliverFinishedBlob(
     tokenBlob: string,
@@ -3716,7 +3720,10 @@ export class PaymentsModule {
     if (courier) {
       try {
         await this.depositToCourier(courier, tokenBlob, meta);
-        return; // journaled 'courier'; GC deferred to onDelivered (valid ackSig)
+        // FAN-OUT: courier is journaled (GC deferred to onDelivered); ALSO blast the SAME
+        // blob over Nostr (universal floor — realtime + redundancy; recipient dedups).
+        await this.blastOverNostr(meta.recipientPubkey, tokenBlob, meta.memo);
+        return;
       } catch (err) {
         logger.warn('Payments', 'Courier deposit failed — falling back to Nostr delivery:', err);
       }
@@ -3778,6 +3785,20 @@ export class PaymentsModule {
   }
 
   /**
+   * Best-effort fan-out blast over Nostr (the universal floor), used ALONGSIDE a
+   * journaled courier deposit. NEVER throws: the recipient dedups by the genesis-stable
+   * token id and the courier is the durable, journaled guarantee, so a failed blast
+   * (relay down) loses nothing — it only forfeits the realtime/redundancy bonus.
+   */
+  private async blastOverNostr(recipientPubkey: string, tokenBlob: string, memo?: string): Promise<void> {
+    try {
+      await this.sendBlobOverNostr(recipientPubkey, tokenBlob, memo);
+    } catch (err) {
+      logger.debug('Payments', 'Fan-out Nostr blast failed (courier is the journaled guarantee):', err);
+    }
+  }
+
+  /**
    * Replay journaled finished-but-undelivered v2 blobs (kicked fire-and-forget from
    * load()). ROUTING (concern 4): a `'courier'` entry is RE-DEPOSITED over the courier
    * (idempotent on entryId; GC stays deferred to onDelivered — NOT removed here), while
@@ -3811,6 +3832,8 @@ export class PaymentsModule {
         memo: e.memo,
       });
       await this.setPendingV2DeliveryEntryId(e.tokenBlob, handle.entryId);
+      // FAN-OUT: also re-blast over Nostr (best-effort; recipient dedups by token id).
+      await this.blastOverNostr(e.recipientPubkey, e.tokenBlob, e.memo);
       logger.debug('Payments', `Re-deposited undelivered courier transfer ${e.transferId.slice(0, 8)}...`);
       return;
     }

--- a/tests/unit/modules/PaymentsModule.courier-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.courier-delivery.test.ts
@@ -4,9 +4,11 @@
  * MONEY-PATH invariants asserted here (the courier is ADDITIVE, flag-gated, reversible):
  *  - DEFAULT OFF: with NO deliveryTransport, send/receive/load are byte-identical to
  *    today — delivery goes over Nostr `sendTokenTransfer`, the courier is never touched.
- *  - COEXIST (courier-primary): when a deliveryTransport is present, send DEPOSITS the
- *    envelope over the courier (recipientChainPubkey = the resolved peerInfo.chainPubkey),
- *    and does NOT also send over Nostr.
+ *  - FAN-OUT (courier + Nostr): when a deliveryTransport is present, send DEPOSITS the
+ *    envelope over the courier (recipientChainPubkey = the resolved peerInfo.chainPubkey)
+ *    AND ALSO blasts the same blob over Nostr (the universal floor) — the recipient dedups.
+ *  - BLAST IS BEST-EFFORT: a failed Nostr blast never breaks the send (courier is the
+ *    durable, journaled guarantee).
  *  - NOSTR FALLBACK: a courier `deposit()` FAILURE falls back to Nostr (no lost delivery).
  *  - JOURNAL-FIRST GC GATE: PENDING_V2_DELIVERIES is written BEFORE delivery and removed
  *    ONLY on a valid-ackSig `onDelivered(entryId)` for the courier path — NOT on bare
@@ -14,8 +16,8 @@
  *  - entryId↔blob mapping: the journal entry carries the courier entryId + transport tag
  *    so onDelivered(entryId) resolves the blob to GC (idempotent).
  *  - load() starts the courier receive/poll/replay loops alongside the Nostr replay.
- *  - REPLAY ROUTING: a courier-tagged journal entry replays over the COURIER (re-deposit),
- *    a Nostr-tagged / untagged entry replays over Nostr.
+ *  - REPLAY ROUTING: a courier-tagged journal entry replays over the COURIER (re-deposit)
+ *    AND re-blasts over Nostr; a Nostr-tagged / untagged entry replays over Nostr.
  *  - DEDUP: a token delivered over BOTH courier and Nostr is stored once (handleV2Transfer
  *    dedups by genesis id) — no double-spend.
  */
@@ -210,8 +212,8 @@ describe('send() delivery — default OFF (no deliveryTransport) is byte-identic
   });
 });
 
-describe('send() delivery — courier present (coexist, courier-primary)', () => {
-  it('deposits over the courier (recipientChainPubkey) and does NOT send over Nostr', async () => {
+describe('send() delivery — courier present (FAN-OUT: courier + Nostr)', () => {
+  it('deposits over the courier (recipientChainPubkey) AND blasts over Nostr', async () => {
     const delivery = new FakeDeliveryTransport();
     const { module, engine, transport, storage } = setup({ delivery });
     await deliver(module, await v2Payload(engine, 100n));
@@ -221,13 +223,29 @@ describe('send() delivery — courier present (coexist, courier-primary)', () =>
     expect(delivery.deposits).toHaveLength(1);
     expect(delivery.deposits[0].recipientChainPubkey).toBe(BOB_CHAIN_PUBKEY);
     expect(delivery.deposits[0].senderChainPubkey).toBe(FAKE_PUBKEY);
-    // Courier-primary: Nostr is NOT also used for the happy path.
-    expect(transport.sendTokenTransfer).not.toHaveBeenCalled();
-    // Journal carries the entryId + transport tag (entryId↔blob mapping for GC).
+    // FAN-OUT: ALSO blasted over Nostr (universal floor) to the TRANSPORT pubkey.
+    expect(transport.sendTokenTransfer).toHaveBeenCalledTimes(1);
+    expect((transport.sendTokenTransfer as any).mock.calls[0][0]).toBe(BOB_TRANSPORT_PUBKEY);
+    // Journal carries the entryId + transport tag (GC stays on the courier ack).
     const entries = journal(storage);
     expect(entries).toHaveLength(1);
     expect(entries[0].transport).toBe('courier');
     expect(entries[0].entryId).toBe('entry-1');
+  });
+
+  it('a FAILED Nostr blast never breaks the send (courier is the journaled guarantee)', async () => {
+    const delivery = new FakeDeliveryTransport();
+    const { module, engine, transport, storage } = setup({ delivery });
+    (transport.sendTokenTransfer as any).mockRejectedValue(new Error('relay down'));
+    await deliver(module, await v2Payload(engine, 100n));
+
+    const res = await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    expect(res.status).toBe('completed');           // send still completes
+    expect(delivery.deposits).toHaveLength(1);       // courier deposit succeeded
+    // Journal stays 'courier' (GC on ack) — the failed blast did not GC or corrupt it.
+    const entries = journal(storage);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].transport).toBe('courier');
   });
 
   it('does NOT GC PENDING_V2_DELIVERIES on bare deposit success — only on a valid-ackSig onDelivered', async () => {
@@ -290,20 +308,21 @@ describe('load() — starts the courier loops alongside the Nostr replay', () =>
   });
 });
 
-describe('replay routing — a courier-tagged entry replays over the courier', () => {
-  it('re-deposits a courier journal entry and does NOT push it over Nostr', async () => {
+describe('replay routing — a courier-tagged entry re-deposits over the courier (+ Nostr blast)', () => {
+  it('re-deposits a courier journal entry AND re-blasts over Nostr (recipient dedups)', async () => {
     const delivery = new FakeDeliveryTransport();
     const { module, engine, transport, storage } = setup({ delivery });
     await deliver(module, await v2Payload(engine, 100n));
     await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
-    expect(delivery.deposits).toHaveLength(1); // the original deposit
-    expect(journal(storage)).toHaveLength(1);  // not yet confirmed
+    expect(delivery.deposits).toHaveLength(1);                 // the original deposit
+    expect(transport.sendTokenTransfer).toHaveBeenCalledTimes(1); // original send already blasted once (fan-out)
+    expect(journal(storage)).toHaveLength(1);                  // not yet confirmed
 
     await (module as any).replayPendingV2Deliveries();
 
-    // Courier-tagged → re-deposited over the courier, never sent over Nostr.
+    // Courier-tagged → re-deposited over the courier AND re-blasted over Nostr.
     expect(delivery.deposits).toHaveLength(2);
-    expect(transport.sendTokenTransfer).not.toHaveBeenCalled();
+    expect(transport.sendTokenTransfer).toHaveBeenCalledTimes(2);
     // Still journaled (no onDelivered yet) — replay does not GC a courier entry.
     expect(journal(storage)).toHaveLength(1);
   });


### PR DESCRIPTION
## What
Item 1 (minimal, funds-safe scope). `deliverFinishedBlob` now does **fan-out** instead of courier-OR-Nostr: when a courier is configured the blob goes out on **both** channels.

## Why
The recipient already dedups by the genesis-stable token id (`handleV2Transfer`) and the chain is the spend authority, so the same token arriving on both channels credits **once** — redundant delivery is strictly safer (no single point of delivery failure) and gives realtime + durability together.

## Changes
- **deliverFinishedBlob**: courier-success path now also blasts the same blob over Nostr (universal floor). Courier stays the durable, journaled guarantee (GC deferred to a valid-ackSig `onDelivered`); the Nostr blast is best-effort.
- **blastOverNostr** (new): best-effort wrapper — never throws (a failed blast forfeits only the realtime/redundancy bonus; the courier is the guarantee).
- **replayPendingV2Deliveries**: a courier re-deposit also re-blasts over Nostr.
- No-courier delivery is **unchanged** (Nostr-only); courier-deposit failure still falls back to Nostr-only.

## Deferred (cleanup, not functional)
The full `NostrTokenDelivery`-behind-the-port + delivery-Map refactor is deferred — the minimal change achieves fan-out + crash-safety by reusing the existing journal, at far lower blast-radius on the money path.

## Tests
fan-out sends both; a failed Nostr blast does not break the send; replay re-blasts; same token on both channels credits once. **254 payments+vault tests green**, lint 0 errors, typecheck clean.