### PR TITLE
fix(vault): multi-device sync correctness + multi-device-aware anti-rollback

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -900,33 +900,76 @@ export class PaymentsModule {
       // Precompute this wallet's acceptable `_meta.address` set once (the chainPubkey
       // the vault stamps is included) so a vault restore is not rejected.
       const ownAddresses = await this.ownMetaAddresses();
-      for (const [id, provider] of providers) {
-        try {
-          const result = await provider.load();
-          if (result.success && result.data) {
-            // Address guard: reject data from a DIFFERENT address. The stored
-            // `_meta.address` may be the L1 address (local TXF stores), the chain
-            // pubkey (the vault stamps THIS — v2 identity), or the runtime DIRECT://
-            // predicate address (local IndexedDB/file stores) — accept any of OUR own.
-            const loadedMeta = (result.data as TxfStorageDataBase)?._meta;
-            if (!this.isOwnAddress(loadedMeta?.address, ownAddresses)) {
-              logger.warn('Payments', `Load: rejecting data from provider ${id} — address mismatch (got=${loadedMeta!.address.slice(0, 20)}... expected one of this wallet's addresses)`);
-              continue;
-            }
 
-            this.loadFromStorageData(result.data);
-            // Rebuild parsedTokenCache for spend queue (loadFromStorageData bypasses addToken)
-            await this.rebuildParsedTokenCache();
-            // Import history from IPFS TXF data into local store
-            const txfData = result.data as TxfStorageDataBase;
-            if (txfData._history && txfData._history.length > 0) {
-              await this.importRemoteHistoryEntries(txfData._history as HistoryRecord[]);
-            }
-            logger.debug('Payments', `Loaded metadata from provider ${id}`);
-            break; // Use first successful provider
-          }
-        } catch (err) {
+      // Restore by MERGING every OWN provider — NOT "first successful then break".
+      // A fresh device's LOCAL store loads successfully but EMPTY, and breaking there
+      // SHADOWED the cloud VAULT, so a reinstall / logout-relogin restored ZERO tokens
+      // even though the vault held them (finding: vault-restore-shadowed-by-empty-local).
+      // Union token/archived/forked entries (first provider wins on a key collision —
+      // local is loaded first and is the freshest for THIS device) plus union
+      // tombstones + history. loadFromStorageData applies tombstones FIRST, so a token
+      // spent in one store is filtered out even if another store still lists it live.
+      let mergedData: TxfStorageDataBase | null = null;
+      const mergedHistory: HistoryRecord[] = [];
+      const tombKeys = new Set<string>();
+      for (const [id, provider] of providers) {
+        const result = await provider.load().catch((err) => {
           logger.error('Payments', `Failed to load from provider ${id}:`, err);
+          return null;
+        });
+        if (!result || !result.success || !result.data) continue;
+        const data = result.data as TxfStorageDataBase;
+        // Address guard: reject data from a DIFFERENT address. The stored
+        // `_meta.address` may be the L1 address (local TXF stores), the chain pubkey
+        // (the vault stamps THIS — v2 identity), or the runtime DIRECT:// predicate
+        // address (local IndexedDB/file stores) — accept any of OUR own.
+        if (!this.isOwnAddress(data?._meta?.address, ownAddresses)) {
+          logger.warn('Payments', `Load: rejecting data from provider ${id} — address mismatch (got=${data._meta?.address?.slice(0, 20)}... expected one of this wallet's addresses)`);
+          continue;
+        }
+        if (!mergedData) mergedData = { _meta: data._meta };
+        // Union every non-meta/history/tombstone slot; first provider wins on collision.
+        for (const [k, v] of Object.entries(data)) {
+          if (k === '_meta' || k === '_history' || k === '_tombstones') continue;
+          if (!(k in mergedData)) mergedData[k as `_${string}`] = v;
+        }
+        // Union tombstones across providers (dedup by tokenId:stateHash).
+        for (const t of data._tombstones ?? []) {
+          const tk = `${t.tokenId}:${t.stateHash}`;
+          if (tombKeys.has(tk)) continue;
+          tombKeys.add(tk);
+          (mergedData._tombstones ??= []).push(t);
+        }
+        if (data._history?.length) mergedHistory.push(...(data._history as HistoryRecord[]));
+        logger.debug('Payments', `Merged token data from provider ${id}`);
+      }
+
+      if (mergedData) {
+        // Honor cross-device spends: DROP any token the VAULT marks DELETED (spent on
+        // another device). Without this, a device that still holds the token locally
+        // would (a) INFLATE the balance by unioning it with the vault, and (b) RESURRECT
+        // it via the delete-resurrect sync path — the two devices then fight
+        // (delete ↔ resurrect) and the spent token never dies
+        // (finding: vault-cross-device-resurrect).
+        const deletionCheckers = [...providers.values()].filter(
+          (p): p is typeof p & { isPlainKeyDeleted(k: string): boolean } =>
+            typeof (p as { isPlainKeyDeleted?: unknown }).isPlainKeyDeleted === 'function',
+        );
+        if (deletionCheckers.length > 0) {
+          for (const k of Object.keys(mergedData)) {
+            if (!/^_[0-9a-f]{64}$/i.test(k)) continue; // only v2 genesis token entries
+            const plainKey = k.slice(1);
+            if (deletionCheckers.some((p) => p.isPlainKeyDeleted(plainKey))) {
+              delete mergedData[k as `_${string}`];
+              logger.debug('Payments', `load(): dropping ${plainKey.slice(0, 12)}… — vault marks it spent (cross-device)`);
+            }
+          }
+        }
+        this.loadFromStorageData(mergedData);
+        // Rebuild parsedTokenCache for spend queue (loadFromStorageData bypasses addToken)
+        await this.rebuildParsedTokenCache();
+        if (mergedHistory.length > 0) {
+          await this.importRemoteHistoryEntries(mergedHistory);
         }
       }
 
@@ -3282,11 +3325,34 @@ export class PaymentsModule {
 
     this.syncDebounceTimer = setTimeout(() => {
       this.syncDebounceTimer = null;
+      // GUARD: a realtime vault wake can fire while the wallet's local storage is
+      // mid-(re)connect or already torn down (e.g. during a reinitialize, or a stale
+      // wake from a provider whose Sphere instance was replaced). Running receive()/
+      // sync() then throws "IndexedDBStorageProvider not connected" / "db not
+      // initialized" and floods the console. Skip the wake-driven sync entirely unless
+      // the wallet storage is actually connected — a real change re-fires on the next
+      // wake / load anyway.
+      const storage = this.deps?.storage as { isConnected?: () => boolean } | undefined;
+      if (storage?.isConnected && !storage.isConnected()) {
+        logger.debug('Payments', 'Remote-update wake ignored — wallet storage not connected');
+        return;
+      }
       void (async () => {
         try {
           await this.receive();
         } catch (err) {
           logger.debug('Payments', 'Auto-receive from remote update failed:', err);
+        }
+        // Pull + reconcile the FULL vault state so a peer device's SPEND (a deletion)
+        // propagates WITHOUT a page reload. receive() only surfaces ARRIVING tokens; it
+        // cannot remove a token spent on another device. load() re-pulls every provider,
+        // merges them, and honors vault deletions (drops tokens the vault marks spent) —
+        // the same reconcile a reload does, so it can never inflate or resurrect a
+        // balance (finding: vault-cross-device-spend-not-live).
+        try {
+          await this.load();
+        } catch (err) {
+          logger.debug('Payments', 'Auto-load (reconcile) from remote update failed:', err);
         }
         try {
           const result = await this.sync();

--- a/storage/remote/RemoteTokenStorageProvider.ts
+++ b/storage/remote/RemoteTokenStorageProvider.ts
@@ -346,7 +346,13 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     this.wakeClient = new VaultWakeClient({
       vaultUrl: this.config.vaultUrl,
       auth: this.auth,
-      onWake: () => this.emit('storage:remote-updated', { source: 'vault-wake' }),
+      // Only wake when this provider is actually connected. A stale wake (e.g. fired
+      // after shutdown/identity-switch, before stop() lands) must NOT drive a receive/
+      // sync against torn-down wallet storage ("IndexedDBStorageProvider not connected").
+      onWake: () => {
+        if (this.status !== 'connected') return;
+        this.emit('storage:remote-updated', { source: 'vault-wake' });
+      },
     });
     this.wakeClient.start();
   }
@@ -461,11 +467,18 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
 
   /** Diff the TXF snapshot vs internal last-known state into a list of CAS ops. */
   private planFlush(localData: TData): PlannedOp[] {
+    // Deletes are driven by EXPLICIT spend tombstones, NEVER by absence from the
+    // snapshot (vault-orphan-sweep-data-loss): an empty/partial local view — the
+    // load pull not yet run, a failed decrypt, a fresh device — must not wipe the
+    // vault. A live token is keyed by its genesis-stable tokenId, so a tombstone's
+    // tokenId maps straight to the wireKey to delete.
+    const tombstones = (localData as unknown as TxfStorageDataBase)._tombstones ?? [];
     return planOps({
       tokens: extractTokens(localData),
       known: this.known,
       wireKeyOf: (plainKey) => this.wireKeyFor(plainKey),
       changed: (wk, value) => this.hasChanged(wk, value),
+      tombstonedTokenIds: tombstones.map((t) => t.tokenId),
     });
   }
 
@@ -937,6 +950,17 @@ export class RemoteTokenStorageProvider<TData extends TxfStorageDataBase = TxfSt
     let n = 0;
     for (const e of this.known.values()) if (!e.deleted) n += 1;
     return n;
+  }
+
+  /**
+   * True if the vault's last-known view has this token's wireKey TOMBSTONED — i.e.
+   * another device SPENT it. PaymentsModule.load uses this to DROP a stale local
+   * token the vault marked spent, so the `delete-resurrect` sync path can't
+   * re-create it and inflate the balance (finding: vault-cross-device-resurrect).
+   * `plainKey` is the genesis tokenId (v2TokenId === engine.tokenId === keyFromTokenId base).
+   */
+  isPlainKeyDeleted(plainKey: string): boolean {
+    return this.known.get(this.wireKeyFor(plainKey))?.deleted === true;
   }
 
   /** Snapshot the internal last-known state as a merkle `EntryState` map. */

--- a/storage/remote/diff.ts
+++ b/storage/remote/diff.ts
@@ -73,6 +73,15 @@ export interface PlanOpsParams {
    * token entries — never swept as orphan deletes even though they live in `known`.
    */
   reserved?: ReadonlySet<string>;
+  /**
+   * Plaintext token ids the wallet has POSITIVELY spent (from `_tombstones`).
+   * ONLY these are deleted from the server. An entry merely ABSENT from `tokens`
+   * is NEVER deleted: absence ≠ spend — the local snapshot can be incomplete
+   * (the load pull hasn't run, a decrypt failed, a fresh device), and deleting on
+   * absence wiped the whole vault when local was empty
+   * (finding: vault-orphan-sweep-data-loss).
+   */
+  tombstonedTokenIds?: Iterable<string>;
 }
 
 /**
@@ -82,8 +91,9 @@ export interface PlanOpsParams {
  *    AGAINST the deleted row (delete-resurrect, #16 — NOT rebased to its version);
  *  - a token whose wireKey is a known LIVE row → update at the known version, but
  *    only when the value changed;
- *  - a known LIVE wireKey with no matching local token → delete (except reserved
- *    provider-managed slots, which are never orphan-swept).
+ *  - a token POSITIVELY spent (its id in `tombstonedTokenIds`) whose wireKey is a
+ *    known LIVE row → delete. An entry merely ABSENT from `tokens` is NEVER
+ *    deleted (absence ≠ spend); reserved provider-managed slots are never touched.
  */
 export function planOps(params: PlanOpsParams): PlannedOp[] {
   const { tokens, known, wireKeyOf, changed, reserved } = params;
@@ -106,9 +116,21 @@ export function planOps(params: PlanOpsParams): PlannedOp[] {
       ops.push({ plainKey, wireKey: wk, baseVersion: cur.version, sealVersion: cur.version + 1, isDelete: false, value });
     }
   }
-  for (const [wk, cur] of known) {
-    if (!cur.deleted && !liveWire.has(wk) && !reserved?.has(wk)) {
-      ops.push({ plainKey: '', wireKey: wk, baseVersion: cur.version, sealVersion: cur.version + 1, isDelete: true });
+  // DELETE only POSITIVELY-spent tokens (explicit tombstones) — NEVER an entry that
+  // is merely absent from `tokens`. Absence is not proof of a spend: the local
+  // snapshot can be empty/partial (the load pull hasn't run, a decrypt failed, a
+  // fresh device), and deleting on absence wiped the whole vault when local was
+  // empty (vault-orphan-sweep-data-loss). A live token is keyed by its
+  // genesis-stable tokenId, so a tombstone's tokenId maps straight to its wireKey.
+  const sweptWire = new Set<string>();
+  for (const tokenId of params.tombstonedTokenIds ?? []) {
+    const wk = wireKeyOf(tokenId);
+    if (sweptWire.has(wk)) continue;
+    sweptWire.add(wk);
+    const cur = known.get(wk);
+    // Never delete a token we still hold locally (liveWire) or a reserved slot.
+    if (cur && !cur.deleted && !liveWire.has(wk) && !reserved?.has(wk)) {
+      ops.push({ plainKey: tokenId, wireKey: wk, baseVersion: cur.version, sealVersion: cur.version + 1, isDelete: true });
     }
   }
   return ops;

--- a/storage/remote/load-delta.ts
+++ b/storage/remote/load-delta.ts
@@ -40,6 +40,15 @@ interface SignedBaseline {
   root: string;
   sig: string;
   epoch: number;
+  /**
+   * The wallet's committed last-known server entry set (`root` = computeRoot of this).
+   * Stored so the gate detects a TRUE regression (a known entry removed or its version
+   * lowered) instead of false-alarming on a peer device's forward write
+   * (finding: vault-anti-rollback-single-writer). Optional for back-compat: a legacy
+   * root-only baseline recomputes a mismatching root → treated as a fresh load, then
+   * re-persisted WITH entries on the next clean commit.
+   */
+  entries?: Array<[string, EntryState]>;
 }
 
 export interface LoadDeltaConfig {
@@ -114,11 +123,20 @@ export class LoadDeltaTracker {
    */
   async beginLoad(known: Map<string, EntryState>): Promise<void> {
     this.baseline = await this.loadBaseline();
-    this.accState = new Map(known);
-    if (this.baseline && !verifyRoot(this.bindingFor(this.baseline.cursor, this.baseline.root), this.baseline.sig, this.ownerPubForVerify())) {
-      // A corrupt/forged local baseline is treated as no baseline (a fresh load).
-      this.baseline = null;
+    if (this.baseline) {
+      const entries = new Map(this.baseline.entries ?? []);
+      const sigOk = verifyRoot(this.bindingFor(this.baseline.cursor, this.baseline.root), this.baseline.sig, this.ownerPubForVerify());
+      // The committed entry set must hash to the SIGNED root — otherwise it was
+      // locally tampered, or it is a legacy root-only baseline. Either way, treat as
+      // no baseline (a fresh load), which re-persists a full entry set on commit.
+      const entriesOk = (this.baseline.entries?.length ?? 0) > 0 && computeRoot(entries) === this.baseline.root;
+      if (!sigOk || !entriesOk) this.baseline = null;
     }
+    // Seed the accumulator from the baseline's committed set (the authoritative
+    // last-known server state) so a DELTA or a full load both reconstruct the CURRENT
+    // server state — the regression check then has the full picture even on a cold
+    // provider instance. With no baseline (first load) seed from `known`.
+    this.accState = this.baseline ? new Map(this.baseline.entries ?? []) : new Map(known);
   }
 
   /**
@@ -152,7 +170,7 @@ export class LoadDeltaTracker {
     if (!mono.ok) return mono;
     this.fold(page.entries);
     if (this.baseline) {
-      const verdict = this.checkRoot();
+      const verdict = this.checkRegression();
       if (!verdict.ok) return verdict;
     }
     return { ok: true, reset: false };
@@ -193,14 +211,22 @@ export class LoadDeltaTracker {
   }
 
   /**
-   * The folded root must equal the signed baseline root: the wallet is the only
-   * writer, so a delta it did not author (no intervening flush advanced the
-   * baseline) means the server injected state — a rollback.
+   * Multi-device anti-rollback (finding: vault-anti-rollback-single-writer). Alarm
+   * ONLY on a REGRESSION of a committed entry — a baseline key now MISSING from, or
+   * at a LOWER version than, the folded server state. New keys and higher versions
+   * are legitimate FORWARD progress (this OR another device wrote them), never a
+   * rollback. Vault versions are strictly monotonic per key (create→update→delete→
+   * resurrect all increment), so a version going backwards (or a known entry
+   * vanishing) is the rollback signature, independent of which device authored the
+   * forward writes. (The old root-EQUALITY check assumed a SINGLE writer and so
+   * false-alarmed on every peer-device write — which broke multi-device sync.)
    */
-  private checkRoot(): { ok: true } | { ok: false; reason: string } {
-    const folded = computeRoot(this.accState!);
-    if (folded !== this.baseline!.root) {
-      return { ok: false, reason: 'rollback' };
+  private checkRegression(): { ok: true } | { ok: false; reason: string } {
+    for (const [key, base] of this.baseline!.entries ?? []) {
+      const cur = this.accState!.get(key);
+      if (!cur || cur.version < base.version) {
+        return { ok: false, reason: 'rollback' };
+      }
     }
     return { ok: true };
   }
@@ -221,9 +247,10 @@ export class LoadDeltaTracker {
    */
   async commitBaseline(cursor: number, epoch: number, _epochSig: string): Promise<void> {
     if (this.config.baseline && this.walletPriv) {
-      const root = computeRoot(this.accState ?? new Map());
+      const acc = this.accState ?? new Map<string, EntryState>();
+      const root = computeRoot(acc);
       const sig = signRoot(this.walletPriv, this.bindingFor(cursor, root));
-      const baseline: SignedBaseline = { cursor, root, sig, epoch };
+      const baseline: SignedBaseline = { cursor, root, sig, epoch, entries: [...acc] };
       await this.config.baseline.set(this.baselineKey(), JSON.stringify(baseline));
     }
     this.accState = null; // close the pass regardless of whether a baseline was persisted
@@ -241,7 +268,7 @@ export class LoadDeltaTracker {
     const root = computeRoot(known);
     const epoch = this.baseline?.epoch ?? 0;
     const sig = signRoot(this.walletPriv, this.bindingFor(cursor, root));
-    const baseline: SignedBaseline = { cursor, root, sig, epoch };
+    const baseline: SignedBaseline = { cursor, root, sig, epoch, entries: [...known] };
     this.baseline = baseline;
     await this.config.baseline.set(this.baselineKey(), JSON.stringify(baseline));
   }

--- a/tests/helpers/fake-vault-server.ts
+++ b/tests/helpers/fake-vault-server.ts
@@ -534,6 +534,22 @@ export class FakeVaultServer {
     row.seq = this.nextSeq(ownerId);
   }
 
+  /**
+   * HOSTILE-REGRESSION injector: REPLAY a previously-valid entry at a LOWER version
+   * (the server kept an old, validly-sealed ciphertext and re-presents it at a fresh
+   * seq). No wallet key is needed. Because the replayed payload is genuinely sealed at
+   * `toVersion`, the AEAD open SUCCEEDS — so only the anti-rollback GATE (version
+   * monotonicity vs the signed baseline) can catch it. Tests that the gate still
+   * alarms on a true rollback after the multi-device forward-tolerance change.
+   */
+  regressEntry(ownerId: string, key: string, toVersion: number, payload: VaultEntryPayload): void {
+    const row = this.entries.find((e) => e.ownerId === ownerId && e.key === key);
+    if (!row) throw new Error(`regressEntry: no entry ${key}`);
+    row.payload = payload;
+    row.version = toVersion; // SET (may be lower) — replays an older version
+    row.seq = this.nextSeq(ownerId); // fresh seq so it surfaces in the next /state delta
+  }
+
   /** A session id for an owner (logout tests). */
   sessionIdFor(ownerId: string): string | undefined {
     return this.sessions.find((s) => s.ownerId === ownerId && !s.revoked)?.sessionId;

--- a/tests/integration/vault/anti-rollback.test.ts
+++ b/tests/integration/vault/anti-rollback.test.ts
@@ -94,9 +94,42 @@ describe('anti-rollback root comparison', () => {
     const err = events.find((e) => e.type === 'storage:error');
     expect(err).toBeDefined();
     expect(err!.type).toBe('storage:error'); // the FROZEN union member, exactly
-    expect((err!.data as { reason: string }).reason).toBe('rollback');
+    // mutateEntry bumps the version FORWARD + swaps the ciphertext, so the multi-device
+    // gate lets it pass and the AEAD open rejects the mismatched ciphertext ('load'); a
+    // true version REGRESSION trips the gate ('rollback'). EITHER way the hostile state
+    // is REJECTED (success:false) — the security property under test.
+    expect(['rollback', 'load']).toContain((err!.data as { reason: string }).reason);
     // NEVER a 'storage:rollback' member.
     expect(events.some((e) => (e.type as string) === 'storage:rollback')).toBe(false);
+  });
+
+  it('the gate ALARMS on a true version REGRESSION (a replayed old version), even with a valid seal', async () => {
+    const server = new FakeVaultServer(NETWORK);
+    const store = memStore();
+    const provider = makeProvider(server, store);
+    await provider.initialize();
+
+    // Bump 'a' to v2 so there is an older, validly-sealed version to replay.
+    await provider.sync(txf({ a: { n: 1 } })); // a -> v1
+    await provider.sync(txf({ a: { n: 2 } })); // a -> v2
+    const first = await provider.load(); // signed baseline: a@v2
+    expect(first.success).toBe(true);
+
+    // Hostile server REPLAYS the wallet's own old v1 entry (validly sealed at v1) at a
+    // fresh seq. AEAD OPENS it (real seal), so ONLY the gate can catch the rollback:
+    // baseline a@v2, replayed a@v1 → version regresses → 'rollback' (gate fires before
+    // materialize, so the valid seal is never the deciding factor — multi-device safe).
+    const wkA = wireKey(PRIV, NETWORK, 'a');
+    server.regressEntry(PUB, wkA, 1, seal('a', 1, { n: 1 }));
+
+    const events: StorageEvent[] = [];
+    provider.onEvent((e) => events.push(e));
+    const res = await provider.load();
+
+    expect(res.success).toBe(false);
+    const err = events.find((e) => e.type === 'storage:error');
+    expect(err).toBeDefined();
+    expect((err!.data as { reason: string }).reason).toBe('rollback'); // the GATE caught it
   });
 
   it('a clean re-load (empty delta) does NOT alarm — the gate only fires on injected state', async () => {
@@ -171,6 +204,7 @@ describe('anti-rollback first-load baseline', () => {
     expect(res.success).toBe(false);
     const err = events.find((e) => e.type === 'storage:error');
     expect(err).toBeDefined();
-    expect((err!.data as { reason: string }).reason).toBe('rollback');
+    // Rejected either by the gate ('rollback') or by AEAD on the swapped ciphertext ('load').
+    expect(['rollback', 'load']).toContain((err!.data as { reason: string }).reason);
   });
 });

--- a/tests/integration/vault/vault-rehydrate.test.ts
+++ b/tests/integration/vault/vault-rehydrate.test.ts
@@ -42,11 +42,16 @@ function makeProvider(server: FakeVaultServer): RemoteTokenStorageProvider {
   return p;
 }
 
-function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+function txf(tokens: Record<string, unknown>, tombstonedIds: string[] = []): TxfStorageDataBase {
   const data: TxfStorageDataBase = {
     _meta: { version: 1, address: 'DIRECT://x', formatVersion: '2.0', updatedAt: Date.now() },
   };
   for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  // Deletes are driven by EXPLICIT spend tombstones (vault-orphan-sweep-data-loss),
+  // NOT by mere absence of the key from the snapshot.
+  if (tombstonedIds.length > 0) {
+    data._tombstones = tombstonedIds.map((tokenId) => ({ tokenId, stateHash: 'sh', timestamp: 1 }));
+  }
   return data;
 }
 
@@ -95,8 +100,8 @@ describe('load() rehydrates token entries (Phase 7.2)', () => {
     const writer = makeProvider(server);
     await writer.initialize();
     await writer.sync(txf({ ddd: { id: 'ddd', sdkData: 'aa' }, eee: { id: 'eee', sdkData: 'bb' } }));
-    // Drop 'ddd' → orphan delete (tombstone on the server).
-    await writer.sync(txf({ eee: { id: 'eee', sdkData: 'bb' } }));
+    // Spend 'ddd' → an EXPLICIT tombstone drives the server delete (absence alone never deletes).
+    await writer.sync(txf({ eee: { id: 'eee', sdkData: 'bb' } }, ['ddd']));
 
     const reader = makeProvider(server);
     const res = await reader.load();
@@ -137,8 +142,8 @@ describe('load() rehydrates token entries (Phase 7.2)', () => {
     const first = await reader.load();
     expect((first.data as TxfStorageDataBase)['_hhh' as `_${string}`]).toEqual({ id: 'hhh', sdkData: 'aa' });
 
-    // Tombstone hhh via the writer, then reader picks up the delete-only delta.
-    await writer.sync(txf({}));
+    // Tombstone hhh via the writer (explicit spend), then reader picks up the delete-only delta.
+    await writer.sync(txf({}, ['hhh']));
     const afterDelete = await reader.load();
     expect((afterDelete.data as TxfStorageDataBase)['_hhh' as `_${string}`]).toBeUndefined();
   });

--- a/tests/integration/vault/vault-resurrect-aead-version.test.ts
+++ b/tests/integration/vault/vault-resurrect-aead-version.test.ts
@@ -49,11 +49,16 @@ function makeProvider(server: FakeVaultServer): RemoteTokenStorageProvider {
   return p;
 }
 
-function txf(tokens: Record<string, unknown>): TxfStorageDataBase {
+function txf(tokens: Record<string, unknown>, tombstonedIds: string[] = []): TxfStorageDataBase {
   const data: TxfStorageDataBase = {
     _meta: { version: 1, address: 'DIRECT://x', formatVersion: '2.0', updatedAt: Date.now() },
   };
   for (const [id, val] of Object.entries(tokens)) data[`_${id}` as `_${string}`] = val;
+  // Deletes are driven by EXPLICIT spend tombstones (vault-orphan-sweep-data-loss),
+  // NOT by mere absence of the key from the snapshot.
+  if (tombstonedIds.length > 0) {
+    data._tombstones = tombstonedIds.map((tokenId) => ({ tokenId, stateHash: 'sh', timestamp: 1 }));
+  }
   return data;
 }
 
@@ -89,8 +94,8 @@ describe('resurrect AEAD version binding', () => {
     await provider.sync(txf({ k: { amt: '1' } }));
     expect(server.getEntry(PUB, wk)?.version).toBe(1);
 
-    // delete -> server tombstones at v2
-    await provider.sync(txf({})); // 'k' absent → orphan delete
+    // delete -> server tombstones at v2 (driven by an EXPLICIT spend tombstone)
+    await provider.sync(txf({}, ['k']));
     expect(server.getEntry(PUB, wk)?.deleted).toBe(true);
     expect(server.getEntry(PUB, wk)?.version).toBe(2);
 

--- a/tests/integration/vault/vault-testnet-reset.test.ts
+++ b/tests/integration/vault/vault-testnet-reset.test.ts
@@ -146,7 +146,10 @@ describe('epoch-gated testnet reset', () => {
     const err = events.find((e) => e.type === 'storage:error');
     expect(err).toBeDefined();
     expect(err!.type).toBe('storage:error'); // FROZEN union member, exactly
-    expect((err!.data as { reason: string }).reason).toBe('rollback');
+    // The forged epoch sig is INVALID, so it is NOT a sanctioned reset → the mutated
+    // entry is rejected: by the gate ('rollback') or, since mutateEntry swaps in an
+    // unsealed ciphertext, by AEAD ('load'). Either way the bad state never lands.
+    expect(['rollback', 'load']).toContain((err!.data as { reason: string }).reason);
     expect(events.some((e) => (e.type as string) === 'storage:rollback')).toBe(false);
   });
 
@@ -184,7 +187,9 @@ describe('epoch-gated testnet reset', () => {
     expect(res.success).toBe(false);
     const err = events.find((e) => e.type === 'storage:error');
     expect(err).toBeDefined();
-    expect((err!.data as { reason: string }).reason).toBe('rollback');
+    // No epoch bump → not a sanctioned reset → rejected by the gate ('rollback') or by
+    // AEAD on the swapped ciphertext ('load').
+    expect(['rollback', 'load']).toContain((err!.data as { reason: string }).reason);
     expect(events.some((e) => (e.type as string) === 'storage:rollback')).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

The cloud vault is meant to back up tokens and sync them across a user's devices,
but in multi-device use it lost or inflated balances and constantly raised a
"Vault sync failed" alarm. Root cause: several paths assumed the wallet is the
**only writer** of the vault, which is false the moment a second device (or the
same wallet after a reinstall/relogin) is involved.

## Fixes

1. **Deletes are tombstone-driven, never absence-driven**
   (`diff.ts` / `RemoteTokenStorageProvider.planFlush`). A token is removed from
   the vault only when it carries an explicit spend tombstone — never because it
   is missing from the local snapshot. An empty/partial local view (the load pull
   hasn't run, a decrypt failed, a fresh device) no longer wipes the vault.

2. **`load()` merges all token providers** (`PaymentsModule.load`) instead of
   "first successful then break". A fresh device's empty local store no longer
   shadows the cloud vault, so a reinstall / logout-relogin actually restores.

3. **Cross-device spends are honored on load**
   (`PaymentsModule.load` + `RemoteTokenStorageProvider.isPlainKeyDeleted`). A
   token the vault marks DELETED (spent on another device) is dropped locally
   instead of being resurrected — which previously inflated the balance and made
   two devices fight delete <-> resurrect.

4. **Realtime wake reconciles** (`PaymentsModule.debouncedSyncFromRemoteUpdate`).
   A vault change-stream wake now also runs `load()`, so a peer device's spend or
   mint propagates live without a page reload (`receive()` alone only surfaces
   arriving tokens, never removals).

5. **Multi-device-aware anti-rollback** (`load-delta.ts`). The signed baseline now
   stores the committed entry set and the gate alarms only on a true REGRESSION (a
   known entry removed or its version lowered), not on a peer device's forward
   write. The previous root-EQUALITY check assumed a single writer and so
   false-alarmed on every cross-device write. The on-chain aggregator remains the
   ultimate double-spend guard; a content tamper is still rejected by the AEAD open.

## Tests

- vault rehydrate/resurrect moved to tombstone-driven deletes.
- anti-rollback + testnet-reset moved to the realistic (keyless-server) threat
  model; added an explicit version-regression gate test; `fake-vault-server`
  gains `regressEntry`.
- Verified end-to-end against a live token-api: fresh-device restore and realtime
  two-device sync both pass (a peer mint reflects on the other device with no
  reload). Full suite green (1931), lint 0 errors.
