### PR TITLE
fix(wallet-api): recipient-ECDH delivery envelope carries sender nametag + memo (#546)

### DIFF
--- a/core/delivery-envelope.ts
+++ b/core/delivery-envelope.ts
@@ -1,0 +1,113 @@
+/**
+ * core/delivery-envelope.ts — recipient-addressed delivery envelopes
+ * (sdk-changes S6; ARCHITECTURE §8.3).
+ *
+ * The mailbox `memo` is the one S6 field that is NOT self-scoped: it is written
+ * by the SENDER but must be readable by the RECIPIENT (a different wallet). The
+ * wallet-scoped field key ({@link deriveFieldEncryptionKey}) is wrong for it —
+ * a memo encrypted with the sender's key can never be opened by the recipient.
+ *
+ * So delivery envelopes key off an **ECDH-to-recipient** shared secret instead:
+ *
+ *   key = HKDF-SHA256(ikm = secp256k1.getSharedSecret(senderPriv, recipientPub),
+ *                     info = "sphere-deliveryenc-v1")          [0..32)
+ *
+ * ECDH is symmetric, so the recipient re-derives the identical key from
+ * `(recipientPriv, senderPub)` — `entry.senderPubkey` on the wire. A self-send
+ * (sender == recipient) is just `ECDH(priv, ownPub)` on both sides and still
+ * round-trips.
+ *
+ * Crucially, the **wire bytes stay the SAME `enc1.` envelope** the self-scoped
+ * field encryption uses (XChaCha20-Poly1305, random 24-byte nonce — reused
+ * verbatim from {@link encryptField}/{@link decryptField}). The backend cannot
+ * tell a delivery envelope from a self-scoped one and stores both opaquely:
+ * operator-blind, and NO backend change (the wire prefix and size cap are
+ * unchanged).
+ *
+ * The plaintext is a compact JSON bundle — `{ n?: senderNametag, t?: memo }`
+ * (absent fields omitted) — mirroring the Nostr `{ senderNametag, text }`
+ * structure so both rails carry the same two facts.
+ */
+
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { encryptField, decryptField } from './field-encryption';
+import { SphereError } from './errors';
+
+/** HKDF info label for the ECDH-derived delivery key — versioned, distinct from S6's. */
+export const DELIVERY_ENCRYPTION_HKDF_INFO = 'sphere-deliveryenc-v1';
+
+/** The decrypted delivery bundle (sender nametag + memo; either may be absent). */
+export interface DeliveryBundle {
+  /** The sender's own nametag (without a leading `@`). */
+  senderNametag?: string;
+  /** The human memo attached to the transfer. */
+  memo?: string;
+}
+
+function hexToBytesStrict(hex: string, what: string): Uint8Array {
+  if (hex.length === 0 || hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
+    throw new SphereError(`Invalid ${what} hex for delivery-envelope key derivation`, 'INVALID_CONFIG');
+  }
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+/**
+ * Derive the 32-byte symmetric key for a delivery envelope between `privKeyHex`
+ * and `peerPubkeyHex` (a 33-byte compressed secp256k1 pubkey, hex):
+ *
+ *   HKDF-SHA256(ikm = secp256k1.getSharedSecret(priv, peerPub), info = "sphere-deliveryenc-v1")
+ *
+ * Symmetric in (priv, peerPub) by ECDH, so sender and recipient derive the same
+ * key; reused for a self-send (peerPub == own pubkey).
+ */
+export function deriveDeliveryEncryptionKey(privKeyHex: string, peerPubkeyHex: string): Uint8Array {
+  const priv = hexToBytesStrict(privKeyHex, 'private key');
+  const peerPub = hexToBytesStrict(peerPubkeyHex, 'peer public key');
+  // getSharedSecret returns the 33-byte compressed shared point (incl. its
+  // 02/03 prefix). HKDF the whole thing — the prefix is deterministic for a
+  // fixed pair and folds into the derived key identically on both sides.
+  const shared = secp256k1.getSharedSecret(priv, peerPub);
+  const info = new TextEncoder().encode(DELIVERY_ENCRYPTION_HKDF_INFO);
+  return hkdf(sha256, shared, undefined, info, 32);
+}
+
+/**
+ * Encrypt a delivery bundle into the S6 `enc1.` wire envelope under the
+ * ECDH-derived key. Returns `undefined` when there is nothing to carry (no
+ * nametag and no memo) — callers then omit the field entirely.
+ */
+export function encryptDeliveryBundle(key: Uint8Array, bundle: DeliveryBundle): string | undefined {
+  const compact: { n?: string; t?: string } = {};
+  if (bundle.senderNametag !== undefined && bundle.senderNametag !== '') compact.n = bundle.senderNametag;
+  if (bundle.memo !== undefined && bundle.memo !== '') compact.t = bundle.memo;
+  if (compact.n === undefined && compact.t === undefined) return undefined;
+  return encryptField(key, JSON.stringify(compact));
+}
+
+/**
+ * Decrypt + parse a delivery envelope under the ECDH-derived key. Throws a
+ * `SphereError('DECRYPTION_ERROR')` on a wrong key, tamper, or non-JSON
+ * plaintext — the receive loop treats that as "not for me / unreadable" and
+ * drops it, never as a fatal error.
+ */
+export function decryptDeliveryBundle(key: Uint8Array, envelope: string): DeliveryBundle {
+  const plaintext = decryptField(key, envelope);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(plaintext);
+  } catch (err) {
+    throw new SphereError('Delivery envelope payload is not valid JSON', 'DECRYPTION_ERROR', err);
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new SphereError('Delivery envelope payload is not an object', 'DECRYPTION_ERROR');
+  }
+  const obj = parsed as { n?: unknown; t?: unknown };
+  const bundle: DeliveryBundle = {};
+  if (typeof obj.n === 'string') bundle.senderNametag = obj.n;
+  if (typeof obj.t === 'string') bundle.memo = obj.t;
+  return bundle;
+}

--- a/core/index.ts
+++ b/core/index.ts
@@ -4,6 +4,7 @@ export * from './discover';
 export * from './crypto';
 export * from './encryption';
 export * from './field-encryption';
+export * from './delivery-envelope';
 export * from './currency';
 export * from './bech32';
 export * from './utils';

--- a/impl/shared/wallet-api/WalletApiMailboxProvider.ts
+++ b/impl/shared/wallet-api/WalletApiMailboxProvider.ts
@@ -39,7 +39,11 @@ import type {
 } from '../../../transport/delivery-provider';
 import { composeDeliveryKeys, computeDeliveryId } from '../../../transport/delivery-provider';
 import { unwrapTokenBlobBytes } from '../../../token-engine/token-blob';
-import { deriveFieldEncryptionKey, decryptField, encryptField } from '../../../core/field-encryption';
+import {
+  deriveDeliveryEncryptionKey,
+  encryptDeliveryBundle,
+  decryptDeliveryBundle,
+} from '../../../core/delivery-envelope';
 import { WalletApiClient, WalletApiError } from '../../../wallet-api';
 import type { KeyValueStore, MailboxEntry } from '../../../wallet-api';
 import { logger } from '../../../core/logger';
@@ -78,8 +82,7 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
   private readonly stateStore: KeyValueStore;
   private deriveKeysFn: ((blobBytes: Uint8Array) => Promise<{ tokenId: string; stateHash: string }>) | null = null;
 
-  private identity: { privateKey: string; chainPubkey: string } | null = null;
-  private fieldKey: Uint8Array | null = null;
+  private identity: { privateKey: string; chainPubkey: string; nametag?: string } | null = null;
 
   constructor(config: WalletApiMailboxProviderConfig) {
     this.client = config.client;
@@ -103,11 +106,16 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
     return this.deriveKeysFn(blobBytes);
   }
 
-  /** Bind the wallet identity (derives the S6 field key; binds the client). */
-  setIdentity(identity: { privateKey: string; chainPubkey: string }): void {
+  /**
+   * Bind the wallet identity (binds the client). The optional `nametag` is the
+   * sender's own nametag — bundled into outgoing delivery envelopes so the
+   * recipient can render the human identity (it is the wallet's own public
+   * name, not a secret). Delivery memos are encrypted per-recipient (ECDH —
+   * see {@link deriveDeliveryEncryptionKey}), so no self-scoped key is held.
+   */
+  setIdentity(identity: { privateKey: string; chainPubkey: string; nametag?: string }): void {
     this.identity = identity;
-    this.fieldKey = deriveFieldEncryptionKey(identity.privateKey);
-    this.client.setIdentity(identity);
+    this.client.setIdentity({ privateKey: identity.privateKey, chainPubkey: identity.chainPubkey });
   }
 
   // ── persisted state (per network + identity) ────────────────────────────────
@@ -169,10 +177,26 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
    * (§6), which is what makes the sender's journal replay safe.
    */
   async deliver(recipientPubkey: string, blob: Uint8Array, options: DeliverOptions): Promise<DeliveryReceipt> {
-    if (!this.fieldKey) {
+    if (!this.identity) {
       throw new WalletApiError('No identity set — call setIdentity() first', 'CONFIG');
     }
     const keys = composeDeliveryKeys(await this.deriveKeys(blob));
+
+    // S6: bundle the sender's nametag + memo into ONE recipient-addressed
+    // envelope. The key is the ECDH shared secret between the sender's private
+    // key and the RECIPIENT's chain pubkey (symmetric — the recipient
+    // re-derives it from its own key + this entry's senderPubkey), HKDF'd into
+    // the SAME `enc1.` XChaCha20-Poly1305 envelope the self-scoped field
+    // encryption uses (operator-blind, backend-valid — §8.3; no wire change).
+    // Attached whenever there is a nametag OR a memo (so the nametag travels
+    // even on a memo-less transfer); `undefined` ⇒ no `memo` field is sent.
+    const deliveryKey = deriveDeliveryEncryptionKey(this.identity.privateKey, recipientPubkey);
+    const envelope = encryptDeliveryBundle(deliveryKey, {
+      // The per-call nametag (threaded by PaymentsModule) wins; setIdentity's
+      // nametag is the standalone fallback.
+      senderNametag: options.senderNametag ?? this.identity.nametag,
+      memo: options.memo,
+    });
 
     // §5.2/§8.2: the wallet-api wire carries the RAW token bytes — the
     // cross-port blob argument is the sphere envelope; unwrap at the boundary
@@ -189,8 +213,9 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
     }
     await this.client.uploadBlob(upload.putUrl, wire); // 412 = already present = success (§5.2)
 
-    // Deposit (idempotent by entry_id — §6). The memo is S6-encrypted BEFORE
-    // it leaves the device (§8.3): the operator never sees plaintext.
+    // Deposit (idempotent by entry_id — §6). The nametag+memo envelope is
+    // ECDH-encrypted to the recipient BEFORE it leaves the device (§8.3): the
+    // operator never sees plaintext.
     let entryId: string;
     try {
       entryId = await this.client.depositMailbox({
@@ -199,7 +224,7 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
         transferId: options.transferId,
         stateHash: keys.stateHash,
         tokenId: keys.tokenId,
-        ...(options.memo !== undefined ? { memo: encryptField(this.fieldKey, options.memo) } : {}),
+        ...(envelope !== undefined ? { memo: envelope } : {}),
       });
     } catch (err) {
       // §6 CONFLICT = the backend already holds a record of EXACTLY this
@@ -277,29 +302,43 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
     }
   }
 
+  /**
+   * Decrypt an entry's recipient-addressed envelope into `{ memo, senderNametag }`.
+   * Needs both the entry's `senderPubkey` (the ECDH peer) and an identity;
+   * returns an empty bundle (and logs at debug) on any absence/failure so the
+   * receive loop never wedges on an unreadable counterparty memo.
+   */
+  private decryptDeliveryEnvelope(entry: MailboxEntry): { memo?: string; senderNametag?: string } {
+    if (entry.memo === undefined || !this.identity || entry.senderPubkey === undefined) {
+      return {};
+    }
+    try {
+      const key = deriveDeliveryEncryptionKey(this.identity.privateKey, entry.senderPubkey);
+      return decryptDeliveryBundle(key, entry.memo);
+    } catch {
+      logger.debug(TAG, `delivery envelope for entry ${entry.entryId.slice(0, 12)}… not decryptable (not addressed here / tampered)`);
+      return {};
+    }
+  }
+
   private toIncomingDelivery(entry: MailboxEntry): IncomingDelivery {
     const client = this.client;
-    const fieldKey = this.fieldKey;
     const deriveKeys = (bytes: Uint8Array): Promise<{ tokenId: string; stateHash: string }> => this.deriveKeys(bytes);
 
-    // S6: decrypt the memo envelope. NOTE: the S6 key is wallet-scoped (HKDF
-    // from the wallet key), so only memos written by THIS wallet's key
-    // decrypt (self-sends / multi-device). A counterparty's memo fails
-    // authentication and is surfaced as absent rather than as ciphertext.
-    let memo: string | undefined;
-    if (entry.memo !== undefined && fieldKey) {
-      try {
-        memo = decryptField(fieldKey, entry.memo);
-      } catch {
-        logger.debug(TAG, `memo for entry ${entry.entryId.slice(0, 12)}… not decryptable with this wallet's key`);
-      }
-    }
+    // S6: decrypt the recipient-addressed envelope (nametag + memo). The key is
+    // the ECDH shared secret between THIS wallet's private key and the entry's
+    // senderPubkey (symmetric with the sender's derivation; self-sends use the
+    // own pubkey). An envelope addressed to a DIFFERENT recipient, or any
+    // tamper, fails authentication and is surfaced as absent — never as
+    // ciphertext, and never thrown into the receive loop.
+    const { memo, senderNametag } = this.decryptDeliveryEnvelope(entry);
 
     return {
       deliveryId: entry.entryId,
       transferId: entry.transferId,
       senderPubkey: entry.senderPubkey,
       ...(memo !== undefined ? { memo } : {}),
+      ...(senderNametag !== undefined ? { senderNametag } : {}),
       cursor: entry.seq.toString(),
       async fetchBlob(): Promise<Uint8Array> {
         if (entry.blobCollected || !entry.getUrl) {

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1577,6 +1577,10 @@ export class PaymentsModule {
           await delivery.deliver(recipientChainPubkeyHex, hexToBytes(tokenBlob), {
             transferId: result.id,
             memo: request.memo,
+            // Carry the sender's own nametag so the recipient renders "@name"
+            // instead of "Someone" — bundled with the memo in ONE
+            // recipient-addressed envelope (S6).
+            ...(this.getNametag()?.name !== undefined ? { senderNametag: this.getNametag()!.name } : {}),
           });
         };
 
@@ -4274,12 +4278,17 @@ export class PaymentsModule {
       logger.warn('Payments', `V2 transfer ${id.slice(0, 16)}... rejected by storage (tombstoned/duplicate) — no event emitted`);
       return 'storage-rejected';
     }
+    // The sender's nametag rides the recipient-addressed delivery envelope
+    // (S6) — the PRIMARY counterparty identity. resolveSenderInfo (a Nostr
+    // transport-pubkey lookup that does NOT understand chain pubkeys) is only a
+    // best-effort FALLBACK and never gates receive.
     const senderInfo = await this.resolveSenderInfo(senderPubkey);
+    const senderNametag = payload.senderNametag ?? senderInfo.senderNametag;
 
     this.deps!.emitEvent('transfer:incoming', {
       id,
       senderPubkey,
-      senderNametag: senderInfo.senderNametag,
+      senderNametag,
       tokens: [uiToken],
       memo: payload.memo,
       receivedAt: Date.now(),
@@ -4293,6 +4302,7 @@ export class PaymentsModule {
       timestamp: Date.now(),
       senderPubkey,
       ...senderInfo,
+      ...(senderNametag !== undefined ? { senderNametag } : {}),
       memo: payload.memo,
       tokenId: id,
     });
@@ -4409,7 +4419,11 @@ export class PaymentsModule {
       type: 'V2_TRANSFER',
       version: '2.0',
       tokenBlob: bytesToHex(bytes),
+      // memo + senderNametag both ride the recipient-addressed delivery
+      // envelope (S6) the provider already decrypted — the nametag is the
+      // PRIMARY counterparty identity (no Nostr lookup; fixes "Someone").
       memo: incoming.memo,
+      ...(incoming.senderNametag !== undefined ? { senderNametag: incoming.senderNametag } : {}),
     };
     const verdict = await this.handleV2Transfer(payload, incoming.senderPubkey ?? '');
     switch (verdict) {
@@ -4754,6 +4768,7 @@ export class PaymentsModule {
       await delivery.deliver(payload.recipient, hexToBytes(tokenBlobHex), {
         transferId,
         memo: payload.memo,
+        ...(this.getNametag()?.name !== undefined ? { senderNametag: this.getNametag()!.name } : {}),
       });
       await this.removePendingV2Delivery(tokenBlobHex);
     };
@@ -4981,6 +4996,7 @@ export class PaymentsModule {
         await this.delivery!.deliver(e.recipientPubkey, hexToBytes(e.tokenBlob), {
           transferId: e.transferId,
           memo: e.memo,
+          ...(this.getNametag()?.name !== undefined ? { senderNametag: this.getNametag()!.name } : {}),
         });
         await this.removePendingV2Delivery(e.tokenBlob);
         logger.debug('Payments', `Replayed undelivered v2 transfer ${e.transferId.slice(0, 8)}...`);

--- a/tests/contract/wallet-api-mailbox-provider.contract.test.ts
+++ b/tests/contract/wallet-api-mailbox-provider.contract.test.ts
@@ -18,6 +18,7 @@ import { WalletApiClient } from '../../wallet-api';
 import { WalletApiMailboxProvider } from '../../impl/shared/wallet-api';
 import type { DeliveryCustody, IncomingDelivery } from '../../transport/delivery-provider';
 import { FIELD_ENVELOPE_PREFIX } from '../../core/field-encryption';
+import { deriveDeliveryEncryptionKey, decryptDeliveryBundle } from '../../core/delivery-envelope';
 import {
   describeDeliveryProviderContract,
   type DeliveryProviderContractContext,
@@ -230,7 +231,11 @@ describe('WalletApiMailboxProvider — provider-specific semantics', () => {
       expect(h.fake.getRow(RECIPIENT.chainPubkey, blob.tokenId)).toMatchObject({ status: 'active' });
     });
 
-    it('S6: a memo travels as an enc1 envelope (never plaintext); a foreign wallet surfaces it as absent', async () => {
+    it('S6: a memo+nametag travel as ONE enc1 envelope (never plaintext); the RECIPIENT decrypts both', async () => {
+      // The sender's own nametag is bundled with the memo into one
+      // recipient-addressed (ECDH) envelope — fixes both the dropped memo and
+      // the missing sender identity ("Someone").
+      h.sender.setIdentity({ ...SENDER, nametag: 'api-1' });
       const blob = h.makeBlob();
       const { deliveryId } = await h.sender.deliver(h.recipientPubkey, blob.bytes, {
         transferId: 'tf-h4',
@@ -238,24 +243,68 @@ describe('WalletApiMailboxProvider — provider-specific semantics', () => {
       });
 
       // The wire/stored form is the S6 envelope — the operator never sees
-      // plaintext (ARCHITECTURE §8.3).
+      // plaintext (ARCHITECTURE §8.3); the wire prefix is unchanged (no backend
+      // change).
       const stored = h.fake.getMailboxEntry(h.recipientPubkey, deliveryId);
       expect(stored?.memo?.startsWith(FIELD_ENVELOPE_PREFIX)).toBe(true);
       expect(stored?.memo).not.toContain('coffee');
+      expect(stored?.memo).not.toContain('api-1');
 
-      // The S6 key is WALLET-scoped (HKDF from the wallet key): only the
-      // writing wallet's devices can decrypt. The recipient is a DIFFERENT
-      // wallet, so its provider surfaces the memo as absent — never as raw
-      // ciphertext.
+      // The envelope is ECDH-addressed to the RECIPIENT (symmetric in
+      // senderPriv+recipientPub / recipientPriv+senderPub), so the recipient
+      // — a DIFFERENT wallet — decrypts BOTH the memo and the sender nametag.
+      const incoming = await drain(h.recipientProvider);
+      const delivery = incoming.find((d) => d.deliveryId === deliveryId);
+      expect(delivery).toBeDefined();
+      expect(delivery!.memo).toBe('coffee money');
+      expect(delivery!.senderNametag).toBe('api-1');
+    });
+
+    it('S6: a memo-less transfer still delivers the sender nametag', async () => {
+      h.sender.setIdentity({ ...SENDER, nametag: 'api-1' });
+      const blob = h.makeBlob();
+      const { deliveryId } = await h.sender.deliver(h.recipientPubkey, blob.bytes, {
+        transferId: 'tf-h4-nomemo',
+      });
       const incoming = await drain(h.recipientProvider);
       const delivery = incoming.find((d) => d.deliveryId === deliveryId);
       expect(delivery).toBeDefined();
       expect(delivery!.memo).toBeUndefined();
+      expect(delivery!.senderNametag).toBe('api-1');
     });
 
-    it('S6: a SELF-send memo round-trips (the wallet-scoped key decrypts its own envelope)', async () => {
-      // Sender deposits to their own mailbox (multi-device / self-transfer).
-      const selfProvider = h.sender; // bound to SENDER's identity
+    it('S6: a THIRD wallet CANNOT decrypt the same entry (ECDH addressed to the recipient only)', async () => {
+      h.sender.setIdentity({ ...SENDER, nametag: 'api-1' });
+      const blob = h.makeBlob();
+      const { deliveryId } = await h.sender.deliver(h.recipientPubkey, blob.bytes, {
+        transferId: 'tf-h4c',
+        memo: 'coffee money',
+      });
+      const stored = h.fake.getMailboxEntry(h.recipientPubkey, deliveryId);
+      expect(stored?.memo).toBeDefined();
+
+      // The RECIPIENT opens it (sanity — it really is decryptable to the
+      // addressed party).
+      const recipientKey = deriveDeliveryEncryptionKey(RECIPIENT.privateKey, SENDER.chainPubkey);
+      expect(decryptDeliveryBundle(recipientKey, stored!.memo!)).toMatchObject({
+        memo: 'coffee money',
+        senderNametag: 'api-1',
+      });
+
+      // A third wallet (neither sender nor recipient) derives a DIFFERENT ECDH
+      // key over any (sender, *) pair — authentication fails, so it cannot open
+      // the envelope. The provider surfaces this as absent, never ciphertext
+      // and never a throw into the receive loop (covered by the unit suite).
+      const eavesdropper = testIdentity(99);
+      const intruderKey = deriveDeliveryEncryptionKey(eavesdropper.privateKey, SENDER.chainPubkey);
+      expect(() => decryptDeliveryBundle(intruderKey, stored!.memo!)).toThrow();
+    });
+
+    it('S6: a SELF-send memo+nametag round-trips (ECDH over own pubkey on both sides)', async () => {
+      // Sender deposits to their own mailbox (multi-device / self-transfer):
+      // ECDH(priv, ownPub) is identical on encrypt and decrypt.
+      const selfProvider = h.sender;
+      selfProvider.setIdentity({ ...SENDER, nametag: 'api-1' });
       const t = makeTestToken();
       const { deliveryId } = await selfProvider.deliver(SENDER.chainPubkey, t.bytes, {
         transferId: 'tf-h4b',
@@ -265,6 +314,7 @@ describe('WalletApiMailboxProvider — provider-specific semantics', () => {
       const delivery = incoming.find((d) => d.deliveryId === deliveryId);
       expect(delivery).toBeDefined();
       expect(delivery!.memo).toBe('note to self');
+      expect(delivery!.senderNametag).toBe('api-1');
     });
 
     it('blobCollected: an entry without a fetchable blob throws a typed error from fetchBlob', async () => {

--- a/tests/unit/core/delivery-envelope.test.ts
+++ b/tests/unit/core/delivery-envelope.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Recipient-addressed delivery envelopes (sdk-changes S6 / wallet-api delivery):
+ * an ECDH-to-recipient `{ n?: senderNametag, t?: memo }` bundle in the SAME
+ * `enc1.` XChaCha20-Poly1305 wire envelope the self-scoped field encryption
+ * uses — so the backend cannot tell the two apart and stores both opaquely.
+ *
+ * Pins the fixes for the two receiver-side bugs:
+ *   A) the sender nametag travels (so the recipient never renders "Someone");
+ *   B) the memo decrypts for the RECIPIENT (the self-scoped key never could).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveDeliveryEncryptionKey,
+  encryptDeliveryBundle,
+  decryptDeliveryBundle,
+  DELIVERY_ENCRYPTION_HKDF_INFO,
+} from '../../../core/delivery-envelope';
+import { FIELD_ENVELOPE_PREFIX, encryptField } from '../../../core/field-encryption';
+import { getPublicKey } from '../../../core/crypto';
+import { SphereError } from '../../../core/errors';
+
+// Three real secp256k1 identities (sender, recipient, eavesdropper).
+const SENDER_PRIV = '11'.repeat(32);
+const RECIPIENT_PRIV = '22'.repeat(32);
+const INTRUDER_PRIV = '33'.repeat(32);
+const SENDER_PUB = getPublicKey(SENDER_PRIV);
+const RECIPIENT_PUB = getPublicKey(RECIPIENT_PRIV);
+
+describe('delivery-envelope (ECDH-to-recipient S6)', () => {
+  it('the ECDH key is symmetric: senderPriv+recipientPub === recipientPriv+senderPub', () => {
+    const senderSide = deriveDeliveryEncryptionKey(SENDER_PRIV, RECIPIENT_PUB);
+    const recipientSide = deriveDeliveryEncryptionKey(RECIPIENT_PRIV, SENDER_PUB);
+    expect(Array.from(senderSide)).toEqual(Array.from(recipientSide));
+    expect(senderSide.length).toBe(32);
+  });
+
+  it('bundles nametag + memo into one enc1 envelope the RECIPIENT decrypts (bug A + B)', () => {
+    const senderKey = deriveDeliveryEncryptionKey(SENDER_PRIV, RECIPIENT_PUB);
+    const envelope = encryptDeliveryBundle(senderKey, { senderNametag: 'api-1', memo: 'hi' });
+    expect(envelope).toBeDefined();
+    expect(envelope!.startsWith(FIELD_ENVELOPE_PREFIX)).toBe(true); // wire shape unchanged
+    expect(envelope).not.toContain('api-1');
+    expect(envelope).not.toContain('hi');
+
+    const recipientKey = deriveDeliveryEncryptionKey(RECIPIENT_PRIV, SENDER_PUB);
+    expect(decryptDeliveryBundle(recipientKey, envelope!)).toEqual({ senderNametag: 'api-1', memo: 'hi' });
+  });
+
+  it('a self-send round-trips: ECDH(priv, ownPub) on both sides', () => {
+    const selfKey = deriveDeliveryEncryptionKey(SENDER_PRIV, SENDER_PUB);
+    const envelope = encryptDeliveryBundle(selfKey, { senderNametag: 'api-1', memo: 'note to self' });
+    expect(decryptDeliveryBundle(selfKey, envelope!)).toEqual({ senderNametag: 'api-1', memo: 'note to self' });
+  });
+
+  it('a THIRD wallet CANNOT decrypt (addressed to the recipient only) — throws, not silent garbage', () => {
+    const senderKey = deriveDeliveryEncryptionKey(SENDER_PRIV, RECIPIENT_PUB);
+    const envelope = encryptDeliveryBundle(senderKey, { senderNametag: 'api-1', memo: 'hi' });
+    const intruderKey = deriveDeliveryEncryptionKey(INTRUDER_PRIV, SENDER_PUB);
+    expect(() => decryptDeliveryBundle(intruderKey, envelope!)).toThrow(SphereError);
+  });
+
+  it('attaches the nametag even with no memo (memo-less transfer still fixes bug A)', () => {
+    const key = deriveDeliveryEncryptionKey(SENDER_PRIV, RECIPIENT_PUB);
+    const envelope = encryptDeliveryBundle(key, { senderNametag: 'api-1' });
+    expect(envelope).toBeDefined();
+    const recipientKey = deriveDeliveryEncryptionKey(RECIPIENT_PRIV, SENDER_PUB);
+    expect(decryptDeliveryBundle(recipientKey, envelope!)).toEqual({ senderNametag: 'api-1' });
+  });
+
+  it('carries a memo with no nametag', () => {
+    const key = deriveDeliveryEncryptionKey(SENDER_PRIV, RECIPIENT_PUB);
+    const envelope = encryptDeliveryBundle(key, { memo: 'just a memo' });
+    expect(envelope).toBeDefined();
+    expect(decryptDeliveryBundle(key, envelope!)).toEqual({ memo: 'just a memo' });
+  });
+
+  it('returns undefined when there is nothing to carry (no nametag, no memo, empty strings)', () => {
+    const key = deriveDeliveryEncryptionKey(SENDER_PRIV, RECIPIENT_PUB);
+    expect(encryptDeliveryBundle(key, {})).toBeUndefined();
+    expect(encryptDeliveryBundle(key, { senderNametag: '', memo: '' })).toBeUndefined();
+  });
+
+  it('uses a delivery-specific HKDF label distinct from self-scoped S6', () => {
+    expect(DELIVERY_ENCRYPTION_HKDF_INFO).toBe('sphere-deliveryenc-v1');
+  });
+
+  it('rejects a non-JSON plaintext as a decryption error (not a silent pass)', () => {
+    // Hand a valid enc1 envelope over the SAME key whose plaintext is not JSON:
+    // a tampered/legacy envelope must not crash the receive loop.
+    const key = deriveDeliveryEncryptionKey(SENDER_PRIV, RECIPIENT_PUB);
+    // encryptDeliveryBundle always emits JSON; go one level down to forge a
+    // valid enc1 envelope whose plaintext is NOT JSON.
+    const bad = encryptField(key, 'not json');
+    expect(() => decryptDeliveryBundle(key, bad)).toThrow(SphereError);
+  });
+});

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -30,7 +30,7 @@ import { WalletApiClient } from '../../../wallet-api';
 import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../../impl/shared/wallet-api';
 import { encodeTokenBlob } from '../../../token-engine/token-blob';
 import { bytesToHex, hexToBytes } from '../../../core/crypto';
-import { deriveFieldEncryptionKey, encryptField, FIELD_ENVELOPE_PREFIX } from '../../../core/field-encryption';
+import { deriveFieldEncryptionKey, decryptField, encryptField, FIELD_ENVELOPE_PREFIX } from '../../../core/field-encryption';
 
 const UCT = '11'.repeat(32);
 const SENDER = testIdentity(11);
@@ -302,12 +302,18 @@ describe('send — full wallet-api preset (S2 consumer + S3 + §7 pipeline)', ()
 });
 
 describe('incoming — mailbox pull feeds handleV2Transfer (S3)', () => {
-  it('receive(): fetch → local verify → store → ack claimed (handoff) → RECEIVED history POST', async () => {
+  it('receive(): fetch → local verify → store → ack claimed (handoff) → RECEIVED history POST carrying the sender nametag + memo', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-in-1');
     const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
     await sender.module.load();
-    const result = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT });
+    // The sender has a nametag — it must reach the recipient as the RECEIVED
+    // record's counterparty identity (fixes "Someone"); the memo must arrive
+    // decrypted (fixes the dropped memo). Set AFTER load so it survives to send.
+    await sender.module.setNametag({
+      name: 'api-1', token: {}, timestamp: Date.now(), format: 'txf', version: '2.0',
+    });
+    const result = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT, memo: 'hi' });
 
     const recipient = makeFullPresetWallet(baseUrl, fake.network, RECIPIENT, 'd-in-2');
     await recipient.module.load();
@@ -324,12 +330,24 @@ describe('incoming — mailbox pull feeds handleV2Transfer (S3)', () => {
     });
     expect(fake.getRow(RECIPIENT.chainPubkey, sourceTokenId)).toMatchObject({ status: 'active' });
 
-    // transfer:incoming fired; the claim's RECEIVED record was POSTed (§10).
-    expect(recipient.emitEvent.mock.calls.some((c) => c[0] === 'transfer:incoming')).toBe(true);
+    // transfer:incoming fired carrying the sender's nametag + memo (bug A + B).
+    const incomingEvent = recipient.emitEvent.mock.calls.find((c) => c[0] === 'transfer:incoming');
+    expect(incomingEvent).toBeDefined();
+    expect(incomingEvent![1]).toMatchObject({ senderNametag: 'api-1', memo: 'hi' });
+
+    // §10: the RECEIVED record was POSTed; its counterparty nametag + memo are
+    // S6 envelopes (operator-blind), decryptable by the recipient (self-scoped
+    // at rest). The nametag came from the delivery envelope, NOT the broken
+    // Nostr chain-pubkey lookup.
     const received = fake
       .getHistoryRecords(RECIPIENT.chainPubkey)
       .find((r) => (r.dedupKey as string).startsWith('RECEIVED_'));
     expect(received).toBeDefined();
+    expect((received!.counterpartyNametag as string).startsWith(FIELD_ENVELOPE_PREFIX)).toBe(true);
+    expect((received!.memo as string).startsWith(FIELD_ENVELOPE_PREFIX)).toBe(true);
+    const recipientFieldKey = deriveFieldEncryptionKey(RECIPIENT.privateKey);
+    expect(decryptField(recipientFieldKey, received!.counterpartyNametag as string)).toBe('api-1');
+    expect(decryptField(recipientFieldKey, received!.memo as string)).toBe('hi');
     expect(result.id).toBeDefined();
   });
 

--- a/transport/delivery-provider.ts
+++ b/transport/delivery-provider.ts
@@ -53,6 +53,14 @@ export interface DeliverOptions {
   transferId: string;
   /** Optional human memo. Implementations encrypt it client-side (S6). */
   memo?: string;
+  /**
+   * The SENDER's own nametag (without a leading `@`), so the recipient can
+   * render the human identity instead of a raw pubkey ("Someone"). Bundled
+   * with the memo into ONE recipient-addressed (ECDH) `enc1.` envelope (S6) —
+   * the operator never sees it. Attached whenever the sender has a nametag OR
+   * a memo (so the nametag travels even on a memo-less transfer).
+   */
+  senderNametag?: string;
 }
 
 /** One incoming delivery pulled from the feed. */
@@ -65,6 +73,14 @@ export interface IncomingDelivery {
   senderPubkey?: string;
   /** Decrypted memo (S6), when present and decryptable. */
   memo?: string;
+  /**
+   * The sender's nametag (without a leading `@`), decrypted from the same
+   * recipient-addressed delivery envelope as {@link memo} (S6). Lets the
+   * receiver render the human identity instead of a raw pubkey, with no
+   * Nostr/transport lookup. Absent when the envelope carried none or could
+   * not be decrypted.
+   */
+  senderNametag?: string;
   /** Fetch the finished token blob bytes (the encoded TokenBlob). */
   fetchBlob(): Promise<Uint8Array>;
   /** Transport-local resume cursor (opaque to callers). */

--- a/types/v2-transfer.ts
+++ b/types/v2-transfer.ts
@@ -15,6 +15,12 @@ export interface V2TransferPayload {
   readonly tokenBlob: string;
   /** Optional opaque memo. */
   readonly memo?: string;
+  /**
+   * The sender's nametag (without a leading `@`), decrypted from the delivery
+   * envelope by the transport (S6). The PRIMARY source for the RECEIVED
+   * record's counterparty identity — no Nostr/transport lookup needed.
+   */
+  readonly senderNametag?: string;
 }
 
 /** Narrow an unknown wire payload to a {@link V2TransferPayload}. */


### PR DESCRIPTION
Fixes two receiver-side defects in the wallet-api delivery path (see #546). Both share one root and one mechanism. **The frontend is not touched; NostrTransportProvider is not touched; no backend change.**

## The bugs
On a wallet-api transfer (sender → recipient, memo), the RECEIVER was wrong:
- **A — "Someone":** the delivery wire had no sender-nametag slot. `handleV2Transfer` → `resolveSenderInfo` fed the sender's **chain** pubkey to `resolveTransportPubkeyInfo` (a Nostr-transport-pubkey lookup) → null → no nametag.
- **B — dropped memo:** `WalletApiMailboxProvider.deliver` encrypted the memo with the **sender's** self-scoped S6 field key (`deriveFieldEncryptionKey(senderPriv)`); the recipient's decrypt with its **own** key failed → silently dropped.

## The fix — one recipient-addressed envelope, wire shape unchanged
- **`core/delivery-envelope.ts` (new):** ECDH(senderPriv, recipientPub) via `@noble/curves` `secp256k1.getSharedSecret` → HKDF-SHA256 (label `sphere-deliveryenc-v1`) → the **same** `enc1.` XChaCha20-Poly1305 envelope the self-scoped field encryption uses (reuses `encryptField`/`decryptField`). ECDH is symmetric, so the receiver re-derives from `(receiverPriv, entry.senderPubkey)`; self-send is `ECDH(priv, ownPub)` on both sides. Payload is compact JSON `{ n?: senderNametag, t?: memo }`.
- **`WalletApiMailboxProvider`:** `deliver` ECDH-encrypts the bundle (attached whenever there is a nametag **or** a memo, so the nametag travels on memo-less transfers); `incoming` ECDH-decrypts and exposes both `memo` and `senderNametag`; decrypt/parse failure drops gracefully (no throw into the receive loop). The self-scoped `fieldKey` member is gone.
- **`transport/delivery-provider.ts`:** `DeliverOptions.senderNametag`, `IncomingDelivery.senderNametag`.
- **`PaymentsModule`:** threads `this.getNametag()?.name` into every `deliver` call (send, resume, journal replay); receive populates the RECEIVED record's counterparty nametag from `incoming.senderNametag` (PRIMARY; `resolveSenderInfo` stays a best-effort fallback) and the memo from `incoming.memo`. `V2TransferPayload` gains `senderNametag?`.

## Invariants
- **enc1. wire shape unchanged → no backend change.** The backend still sees only an opaque `enc1.` envelope (operator-blind, §8.3); same prefix, same size cap.
- Self-scoped S6 field encryption is **unchanged** for genuine self-data (history-at-rest, intent payloads). Only the delivery memo moves to ECDH-to-recipient.

## Tests
- `delivery-envelope` unit: ECDH symmetry; recipient decrypts memo+nametag; **third wallet cannot decrypt** (throws, not silent); self-send round-trips; memo-less nametag delivery; non-JSON plaintext rejected.
- mailbox-provider contract S6 tests rewritten to the corrected behavior (recipient decrypts both; third wallet cannot; self-send + memo-less round-trip).
- PaymentsModule receive: a wallet-api delivery produces a RECEIVED record carrying the sender nametag + memo (both decrypt for the recipient) and fires `transfer:incoming` with both.

CI verifies the full suite. Local: `tsc --noEmit` clean, lint clean (0 new errors/warnings), and the directly-affected suites (delivery-envelope, mailbox contract ×2 custody modes, wallet-api-delivery, v2-receive) pass.

Manually close at merge (PR targets the integration branch).
