### PR TITLE
Fix #549: hydrate history from the server on reload + read-back sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — history disappears on reload (#549)
+
+- **History reload (#549, the HISTORY twin of #521):** in the wallet-api
+  composition `PaymentsModule.loadHistory()` read from the local token storage
+  provider's `getHistoryEntries()`, but the thin `WalletApiTokenStorageProvider`
+  keeps no history — so a reloaded instance (tab refresh) fell into an empty KV
+  fallback and rendered an empty transaction history, even though every send /
+  receive POSTs the record to the server's §10 log. `loadHistory()` now rebuilds
+  `_historyCache` from `walletApi.listHistory()` (newest-first keyset pages until
+  `more:false`, deduped by `dedupKey`) whenever the `walletApi` client is
+  present; the S6 `memo` / `counterpartyNametag` envelopes are decrypted with the
+  owner's own field key on read-back (§8.3). Compositions without `walletApi`
+  keep the legacy local path. The `PaymentsWalletApiPort` gains a `listHistory`
+  member (the READ side of the §10 client-written log). Regression: send→reload
+  (SENT record, memo decrypted) and receive→reload (RECEIVED record, sender
+  nametag + memo decrypted) against the fake backend, asserting the in-session
+  and post-reload sets match (no loss, no dupes).
+
 ### Fixed — reload renders an empty wallet (#521)
 
 - **Thin-provider reload (#521):** `WalletApiTokenStorageProvider` persisted

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -100,6 +100,14 @@ function computeHistoryDedupKey(type: string, tokenId?: string, transferId?: str
 const MAX_SYNCED_HISTORY_ENTRIES = 5000;
 
 /**
+ * Cap on the number of newest-first keyset pages pulled when rebuilding history
+ * from the server on reload (the wallet-api composition). At the §16 page limit
+ * this bounds a single hydration well past any realistic wallet's recent
+ * history while staying finite if the server ever mis-reports `more`.
+ */
+const MAX_HISTORY_HYDRATION_PAGES = 100;
+
+/**
  * Overall timeout for a single engine transfer/split during send(). Overrides
  * the SDK's 10s default inclusion-proof abort — a slow aggregator must get a
  * fair window, because once the certification is submitted the source state is
@@ -653,6 +661,24 @@ export type WalletApiPaymentRequestsPage =
     };
 
 /**
+ * One §16 history wire record (§10 — the server never writes history rows).
+ * `memo` / `counterpartyNametag` are S6 `enc1.` envelopes, verbatim (§8.3) —
+ * encrypted on POST, returned encrypted on GET, decrypted by the owner only.
+ */
+export interface WalletApiHistoryRecord {
+  dedupKey: string;
+  id: string;
+  type: string;
+  ts: string;
+  assets: { coinId: string; amount: string }[];
+  transferId?: string;
+  tokenId?: string;
+  counterpartyPubkey?: string;
+  memo?: string;
+  counterpartyNametag?: string;
+}
+
+/**
  * The narrow, STRUCTURAL slice of the wallet-api client this module needs:
  * the E.3 intent lifecycle, blob uploads for spend outputs, and the §10
  * client-written history log. `WalletApiClient` satisfies it as-is; the
@@ -678,20 +704,21 @@ export interface PaymentsWalletApiPort {
   /** Upload to a presigned PUT (a 412 = already present = success — §5.2). */
   uploadBlob(putUrl: string, bytes: Uint8Array): Promise<void>;
   /** §10: client-asserted history records (§16 wire shape), deduped by dedupKey server-side. */
-  postHistoryRecords(
-    records: {
-      dedupKey: string;
-      id: string;
-      type: string;
-      ts: string;
-      assets: { coinId: string; amount: string }[];
-      transferId?: string;
-      tokenId?: string;
-      counterpartyPubkey?: string;
-      memo?: string;
-      counterpartyNametag?: string;
-    }[]
-  ): Promise<void>;
+  postHistoryRecords(records: WalletApiHistoryRecord[]): Promise<void>;
+  /**
+   * §10/§16: read the client-written history log back — newest-first keyset
+   * pages (`{records, more, cursor, syncEpoch}`). The READ side of the §10 log:
+   * a reloaded thin wallet rebuilds its history from here (the in-memory cache
+   * is process-lifetime; the durable log lives on the server). `memo` /
+   * `counterpartyNametag` come back as the verbatim S6 `enc1.` envelopes — the
+   * owner decrypts them with its own field key on display (§8.3).
+   */
+  listHistory(options?: { before?: string; limit?: number }): Promise<{
+    records: WalletApiHistoryRecord[];
+    more: boolean;
+    cursor: string | null;
+    syncEpoch: bigint;
+  }>;
 
   // ── payment requests (sdk-changes S4 — §10/§16) — OPTIONAL capability ───────
   // When the composed port carries all three endpoints (the S4 wallet-api
@@ -3522,10 +3549,20 @@ export class PaymentsModule {
   }
 
   /**
-   * Load history from the local token storage provider into the in-memory cache.
-   * Also performs one-time migration from legacy KV storage.
+   * Load history into the in-memory cache.
+   *
+   * In the wallet-api composition (the `walletApi` client is present) the
+   * durable §10 history log lives on the SERVER — the thin storage provider
+   * keeps none — so the cache is rebuilt from `walletApi.listHistory()`. The
+   * twin of the #521 inventory reload bug: `_historyCache` is process-lifetime,
+   * so a reload (tab refresh) must re-pull it or render an empty history.
+   * Compositions WITHOUT `walletApi` keep the legacy local path below.
    */
   async loadHistory(): Promise<void> {
+    if (this.deps!.walletApi?.listHistory) {
+      await this.hydrateHistoryFromServer(this.deps!.walletApi);
+      return;
+    }
     const provider = this.getLocalTokenStorageProvider();
     if (provider?.getHistoryEntries) {
       this._historyCache = await provider.getHistoryEntries();
@@ -3561,6 +3598,86 @@ export class PaymentsModule {
           this._historyCache = [];
         }
       }
+    }
+  }
+
+  /**
+   * Rebuild `_historyCache` from the server's §10 history log (the wallet-api
+   * composition). Pages newest-first via the keyset cursor until `more:false`
+   * or the page cap; dedups by `dedupKey` (a hydrate-then-receive in the same
+   * session must not double-list). The S6 `memo` / `counterpartyNametag`
+   * envelopes are decrypted with the owner's own field key on the way in.
+   *
+   * Best-effort, like the §10 history POST: history is untrusted DISPLAY data,
+   * so a backend outage during hydration must NEVER fail `load()` (the money
+   * path) — the in-session cache is left intact and the pull retries next load.
+   */
+  private async hydrateHistoryFromServer(api: PaymentsWalletApiPort): Promise<void> {
+    const byDedupKey = new Map<string, TransactionHistoryEntry>();
+    try {
+      let before: string | undefined;
+      for (let page = 0; page < MAX_HISTORY_HYDRATION_PAGES; page++) {
+        const result = await api.listHistory(before !== undefined ? { before } : {});
+        for (const wire of result.records) {
+          if (!byDedupKey.has(wire.dedupKey)) {
+            byDedupKey.set(wire.dedupKey, this.historyEntryFromWire(wire));
+          }
+        }
+        if (!result.more || result.cursor === null) break;
+        before = result.cursor;
+      }
+    } catch (err) {
+      logger.warn('Payments', 'history hydration from server failed (kept in-memory; retries next load):', err);
+      return;
+    }
+    this._historyCache = [...byDedupKey.values()];
+  }
+
+  /**
+   * Map one §16 history wire record onto the display
+   * {@link TransactionHistoryEntry}. `counterpartyNametag` lands on the role-
+   * appropriate field (sender for RECEIVED, recipient otherwise); the S6 memo +
+   * nametag envelopes decrypt under THIS wallet's field key (self-scoped at
+   * rest — §8.3), surfaced as absent if they don't decrypt rather than as
+   * ciphertext (same rule as mailbox/payment-request memos).
+   */
+  private historyEntryFromWire(wire: WalletApiHistoryRecord): TransactionHistoryEntry {
+    const asset = wire.assets[0];
+    const coinId = asset?.coinId ?? '';
+    const received = wire.type === 'RECEIVED';
+    const memo = this.tryDecryptField(wire.memo);
+    const nametag = this.tryDecryptField(wire.counterpartyNametag);
+    return {
+      id: wire.id,
+      dedupKey: wire.dedupKey,
+      type: wire.type as TransactionHistoryEntry['type'],
+      amount: asset?.amount ?? '0',
+      coinId,
+      symbol: this.getCoinSymbol(coinId),
+      timestamp: Date.parse(wire.ts),
+      ...(wire.transferId !== undefined ? { transferId: wire.transferId } : {}),
+      ...(wire.tokenId !== undefined ? { tokenId: wire.tokenId } : {}),
+      ...(wire.counterpartyPubkey !== undefined
+        ? received
+          ? { senderPubkey: wire.counterpartyPubkey }
+          : { recipientPubkey: wire.counterpartyPubkey }
+        : {}),
+      ...(nametag !== undefined
+        ? received
+          ? { senderNametag: nametag }
+          : { recipientNametag: nametag }
+        : {}),
+      ...(memo !== undefined ? { memo } : {}),
+    };
+  }
+
+  /** S6 field decrypt that surfaces an undecryptable envelope as absent (§8.3). */
+  private tryDecryptField(envelope?: string): string | undefined {
+    if (envelope === undefined) return undefined;
+    try {
+      return decryptField(this.getFieldEncryptionKey(), envelope);
+    } catch {
+      return undefined;
     }
   }
 

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -604,3 +604,90 @@ describe('reload (tab refresh) — durable cursor, rebuilt view (#521)', () => {
     expect(fake.inventoryGetLog).toEqual([null, cursor, cursor]);
   });
 });
+
+describe('history reload (tab refresh) — rebuilt from the server log (J4/J5, #549)', () => {
+  it('J4: send → reload → the SENT record is hydrated from the server with its memo decrypted (no loss, no dupes)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const kv = new MemoryKeyValueStore(); // the SHARED persisted stateStore — survives the "refresh"
+
+    // Session 1 — send; the SENT history record is POSTed to the server (§10),
+    // its memo an S6 envelope keyed by the SENDER's own field key (§8.3).
+    const tab1 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-h4', kv);
+    await seedServerToken(fake, tab1, SENDER, 1000n);
+    await tab1.module.load();
+    const sent = await tab1.module.send({ recipient: '@bob', amount: '1000', coinId: UCT, memo: 'lunch' });
+    expect(sent.status).toBe('completed');
+
+    const inSession = tab1.module.getHistory();
+    const sentDedup = `SENT_transfer_${sent.id}`;
+    expect(inSession.filter((e) => e.dedupKey === sentDedup)).toHaveLength(1);
+    expect(inSession.find((e) => e.dedupKey === sentDedup)).toMatchObject({
+      type: 'SENT', amount: '1000', coinId: UCT, transferId: sent.id, memo: 'lunch',
+    });
+
+    // Session 2 — a NEW module instance over the SAME persisted stateStore (the
+    // tab refresh). The thin provider keeps NO history, so before #549 this
+    // rendered an empty history; now it rehydrates from walletApi.listHistory().
+    const tab2 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-h4', kv);
+    await tab2.module.load();
+
+    const reloaded = tab2.module.getHistory();
+    const reloadedSent = reloaded.filter((e) => e.dedupKey === sentDedup);
+    expect(reloadedSent).toHaveLength(1); // present + de-duplicated
+    expect(reloadedSent[0]).toMatchObject({
+      id: expect.any(String),
+      type: 'SENT',
+      amount: '1000',
+      coinId: UCT,
+      transferId: sent.id,
+      memo: 'lunch', // S6 envelope decrypted with the owner's own field key
+    });
+    // The post-reload set matches the in-session set exactly (by dedupKey).
+    expect(new Set(reloaded.map((e) => e.dedupKey))).toEqual(new Set(inSession.map((e) => e.dedupKey)));
+  });
+
+  it('J5: receive → reload → the RECEIVED record is hydrated with the sender nametag + memo decrypted', async () => {
+    const { fake, baseUrl } = await startFake();
+    const recipientKv = new MemoryKeyValueStore(); // the recipient's persisted store — survives the refresh
+
+    // The sender (separate store) sends with a nametag + memo; both ride the
+    // recipient-addressed S6 delivery envelope (dev.10 recipient-ECDH).
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-h5-s');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+    await sender.module.setNametag({
+      name: 'api-1', token: {}, timestamp: Date.now(), format: 'txf', version: '2.0',
+    });
+    await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT, memo: 'hi' });
+
+    // Recipient receives in session 1 — the RECEIVED record is POSTed to the
+    // recipient's server history with nametag + memo encrypted under the
+    // RECIPIENT's own field key.
+    const rcpt1 = makeFullPresetWallet(baseUrl, fake.network, RECIPIENT, 'd-h5-r', recipientKv);
+    await rcpt1.module.load();
+    const { transfers } = await rcpt1.module.receive();
+    expect(transfers).toHaveLength(1);
+
+    const inSession = rcpt1.module.getHistory().filter((e) => e.type === 'RECEIVED');
+    expect(inSession).toHaveLength(1);
+    expect(inSession[0]).toMatchObject({ amount: '1000', coinId: UCT, senderNametag: 'api-1', memo: 'hi' });
+    const receivedDedup = inSession[0].dedupKey;
+
+    // Session 2 — a NEW recipient module instance over the SAME persisted store
+    // (reload). History rebuilds from the server; the RECEIVED record returns
+    // with its sender nametag + memo decrypted (self-scoped at rest, §8.3).
+    const rcpt2 = makeFullPresetWallet(baseUrl, fake.network, RECIPIENT, 'd-h5-r', recipientKv);
+    await rcpt2.module.load();
+
+    const reloaded = rcpt2.module.getHistory().filter((e) => e.type === 'RECEIVED');
+    expect(reloaded).toHaveLength(1); // present + de-duplicated
+    expect(reloaded[0]).toMatchObject({
+      type: 'RECEIVED',
+      amount: '1000',
+      coinId: UCT,
+      senderNametag: 'api-1', // decrypted counterparty identity
+      memo: 'hi', // decrypted memo
+    });
+    expect(reloaded[0].dedupKey).toBe(receivedDedup); // same record, no dupes
+  });
+});


### PR DESCRIPTION
Refs #549 (manual close at merge — PR targets the integration branch).

The HISTORY twin of the already-fixed inventory reload bug #521: durable server state, process-lifetime in-memory view, reload renders empty. Frontend is correct; fixed in the SDK only.

## The bug

In the wallet-api composition, transaction history is **write-only** to the server and never read back on reload — history disappears after a page refresh.

- `PaymentsModule.loadHistory()` read from `getLocalTokenStorageProvider()?.getHistoryEntries()`, but the thin `WalletApiTokenStorageProvider` keeps **no** history — so `loadHistory()` fell into the empty KV fallback and rendered an empty history.
- Writes already work: `addToHistory()` POSTs each SENT/RECEIVED/MINT record to the server's §10 log (`postHistoryRecords`).
- The READ capability existed but was unwired: `WalletApiClient.listHistory({before?, limit?})` → `GET /v1/history` (keyset, newest-first `{records, more, cursor, syncEpoch}`).

## The fix (`loadHistory`)

When the `walletApi` client is present (the same detection the inventory/payment-request paths use), `loadHistory()` rebuilds `_historyCache` from `walletApi.listHistory()`:

- Paginate newest-first via the keyset cursor until `more === false`/`cursor === null`, bounded by `MAX_HISTORY_HYDRATION_PAGES = 100` (finite if the server ever mis-reports `more`).
- Dedup by `dedupKey` (`Map`) — a hydrate-then-receive in the same session never double-lists.
- Map each §16 wire record (`ts/id/type/assets/transferId/tokenId/counterpartyPubkey/counterpartyNametag/memo`) onto `TransactionHistoryEntry`; `counterpartyNametag`/`counterpartyPubkey` land on the role-appropriate field (sender for RECEIVED, recipient otherwise).
- **Decryption on read-back:** the S6 `memo` / `counterpartyNametag` come back as the verbatim `enc1.` envelopes (the codec passes them through). They are self-scoped at rest — encrypted under the OWNER's own field key — so `historyEntryFromWire` decrypts them with `getFieldEncryptionKey()` and surfaces an undecryptable envelope as **absent** rather than ciphertext (same rule as the mailbox/payment-request memos at `surfaceIncomingPaymentRequest`). This mirrors how the in-session SENT/RECEIVED records are already shown decrypted.

Compositions WITHOUT `walletApi` keep the legacy local provider / KV path unchanged.

Spec/port: `PaymentsWalletApiPort` gains a `listHistory` member — the READ side of the §10 client-written log; the existing **S4 AC** already specifies "a send/claim produces its history record via `GET /v1/history`", so this implements an already-specified contract (no new API surface). A shared `WalletApiHistoryRecord` type now backs both `postHistoryRecords` and `listHistory`.

## Read-back sweep (S4 custody moved to the server)

Every `load*()`/`get*()` that reads persisted state for data that, in the wallet-api composition, lives on the server:

| Path | File:line | Status |
|---|---|---|
| inventory / tokens | `WalletApiTokenStorageProvider.syncInventory` | **FIXED** in #521 (first-sync full pull) |
| **history** | `PaymentsModule.loadHistory` (modules/payments/PaymentsModule.ts ~3547) | **FIXED here** |
| payment requests | `PaymentsModule.syncPaymentRequests` / `pumpPaymentRequests` (~4520) | **Already server-polled** — rebuilt each session from the §16 since/keyset streams + an open-bootstrap scan from 0; no local-storage reload dependency. Correct. |
| pending transfers (`PENDING_TRANSFERS`) | `PaymentsModule.load` (~1312) | **Reported, not changed.** Read at load but **never written** anywhere in the tree (only cleared on wallet-clear) — a vestigial legacy KV read. In v2 the send completes synchronously and crash-resume rides E.3 open intents (server) + the `PENDING_V2_DELIVERIES` journal. Not a server-custody read-back; out of scope for this fix. |
| outbox / pending-v2-deliveries | `loadOutbox` / `loadPendingV2Deliveries` (~4952/4961) | **Correct as-is** — local crash journals (finished-but-undelivered blobs / send replay), intentionally device-local, not server custody. |

## Regression tests (J4/J5 — pin the class)

Added to `tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts`, mirroring #521's pattern (a second module/provider instance over the **same** persisted `stateStore` + the fake-wallet-api as the server; the fake already stores POSTed history and serves `GET /v1/history` with real keyset pagination — no fake changes needed):

- **J4:** send → reload (new module instance) → the SENT record is hydrated from the server, **memo decrypted**; in-session and post-reload sets match by `dedupKey` (no loss, no dupes).
- **J5:** receive → reload → the RECEIVED record present with **sender nametag + memo decrypted** (dev.10 recipient-ECDH delivery); same `dedupKey`, no dupes.

Both tests **fail against the unfixed module** (`expected [] to have a length of 1` — empty reloaded history) and pass with the fix.

## Verification

`tsc --noEmit` clean; `eslint` clean on the changed files (the two pre-existing `ParsedTokenPool`/`fromHex` warnings are unrelated). The full `PaymentsModule.wallet-api-delivery.test.ts` file passes (13/13). No `.skip`/`.only`/`TODO`/`FIXME`. CI is authoritative for the heavy suites (known flakes per #487: the 3 ipns Node-26 + the wallet-password Node-22 message-skew — rerun, don't weaken).