### PR TITLE
fix(wallet-api): recipient-ECDH payment-request memo carries requester nametag + message (#553)

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -48,6 +48,11 @@ import type {
 import type { DeliveryProvider, IncomingDelivery } from '../../transport/delivery-provider';
 import { TransportDeliveryAdapter } from './TransportDeliveryAdapter';
 import { deriveFieldEncryptionKey, encryptField, decryptField } from '../../core/field-encryption';
+import {
+  deriveDeliveryEncryptionKey,
+  encryptDeliveryBundle,
+  decryptDeliveryBundle,
+} from '../../core/delivery-envelope';
 import type { OracleProvider } from '../../oracle';
 import type { PriceProvider } from '../../price';
 import type {
@@ -2182,13 +2187,24 @@ export class PaymentsModule {
         };
       }
 
+      // S6: the requester's nametag + message ride ONE recipient-addressed
+      // envelope keyed off ECDH(requesterPriv, PAYER chain pubkey) — symmetric,
+      // so the payer re-derives it from its own key + this request's fromPubkey
+      // (the PR twin of #546/#547). The self-scoped field key was wrong here:
+      // a memo encrypted with the requester's key could never be opened by the
+      // payer. Same `enc1.` XChaCha20-Poly1305 wire (operator-blind, backend-
+      // valid — no wire/backend change); attached whenever there is a nametag
+      // OR a message, so the payer renders "@requester" even with no message.
+      const memoEnvelope = encryptDeliveryBundle(
+        deriveDeliveryEncryptionKey(this.deps!.identity.privateKey, toPubkey),
+        { senderNametag: this.getNametag()?.name, memo: request.message }
+      );
+
       const wire = await api.createPaymentRequest({
         toPubkey,
         // Amounts are decimal strings end-to-end (§11) — BigInt round-trips them exactly.
         assets: [{ coinId: request.coinId, amount: BigInt(request.amount) }],
-        ...(request.message !== undefined
-          ? { memo: encryptField(this.getFieldEncryptionKey(), request.message) }
-          : {}),
+        ...(memoEnvelope !== undefined ? { memo: memoEnvelope } : {}),
         ...(request.expiresAt !== undefined ? { expiresAt: request.expiresAt } : {}),
       });
 
@@ -4699,6 +4715,28 @@ export class PaymentsModule {
   }
 
   /**
+   * Decrypt a payment-request's recipient-addressed memo envelope into
+   * `{ memo, senderNametag }` (the requester's message + nametag). The key is
+   * the ECDH shared secret between THIS wallet (the payer) and the requester's
+   * chain pubkey (`wire.fromPubkey`) — symmetric with the requester's
+   * create-time derivation. Returns an empty bundle (and logs at debug) on any
+   * absence/failure so the incoming view never wedges on an unreadable memo
+   * (PR twin of #546/#547).
+   */
+  private decryptPaymentRequestMemo(
+    wire: WalletApiPaymentRequest
+  ): { memo?: string; senderNametag?: string } {
+    if (wire.memo === undefined) return {};
+    try {
+      const key = deriveDeliveryEncryptionKey(this.deps!.identity.privateKey, wire.fromPubkey);
+      return decryptDeliveryBundle(key, wire.memo);
+    } catch {
+      logger.debug('Payments', `Payment request ${wire.id.slice(0, 12)}… memo not addressed here / not decryptable`);
+      return {};
+    }
+  }
+
+  /**
    * Map a §16 wire request onto the public {@link IncomingPaymentRequest}
    * surface and notify (event + handlers). Only `open` requests are
    * actionable; the in-memory id-dedup doubles as the replay guard for
@@ -4713,21 +4751,19 @@ export class PaymentsModule {
     const coinId = wire.assets[0]?.coinId ?? '';
     const coinDef = TokenRegistry.getInstance().getDefinition(coinId);
 
-    // S6: the memo decrypts only under the REQUESTER's wallet key (field keys
-    // are wallet-scoped) — for the payer it is opaque ciphertext, surfaced as
-    // absent rather than garbage (same rule as mailbox memos).
-    let message: string | undefined;
-    if (wire.memo !== undefined) {
-      try {
-        message = decryptField(this.getFieldEncryptionKey(), wire.memo);
-      } catch {
-        logger.debug('Payments', `Payment request ${wire.id.slice(0, 12)}… memo not decryptable with this wallet's key`);
-      }
-    }
+    // S6: the memo is a recipient-addressed envelope keyed off
+    // ECDH(payerPriv, requester chain pubkey = wire.fromPubkey) — symmetric
+    // with the requester's create-time derivation (the PR twin of #546/#547).
+    // It carries the requester's nametag AND message, so the payer renders
+    // "@requester" + the message instead of a raw pubkey. An envelope not
+    // addressed here, or any tamper, fails authentication and surfaces as
+    // absent — never garbage, and never thrown into the view path.
+    const { memo: message, senderNametag } = this.decryptPaymentRequestMemo(wire);
 
     const request: IncomingPaymentRequest = {
       id: wire.id,
       senderPubkey: wire.fromPubkey,
+      ...(senderNametag !== undefined ? { senderNametag } : {}),
       amount: (wire.assets[0]?.amount ?? 0n).toString(),
       coinId,
       symbol: coinDef?.symbol || coinId.slice(0, 8),

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -29,6 +29,7 @@ import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../.
 import { encodeTokenBlob } from '../../../token-engine/token-blob';
 import { hexToBytes } from '../../../core/crypto';
 import { FIELD_ENVELOPE_PREFIX } from '../../../core/field-encryption';
+import { deriveDeliveryEncryptionKey, decryptDeliveryBundle } from '../../../core/delivery-envelope';
 
 const UCT = '11'.repeat(32);
 const REQUESTER = testIdentity(21);
@@ -192,6 +193,13 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     expect(requester.transport.onPaymentRequest).not.toHaveBeenCalled();
     expect(requester.transport.onPaymentRequestResponse).not.toHaveBeenCalled();
 
+    // The requester has a nametag — it must reach the PAYER as the surfaced
+    // request's counterparty identity (the PR twin of #546/#547's "Someone"
+    // fix). Set after load so it survives to send time.
+    await requester.module.setNametag({
+      name: 'api-1', token: {}, timestamp: Date.now(), format: 'txf', version: '2.0',
+    });
+
     const result = await requester.module.sendPaymentRequest('@bob', {
       amount: '25',
       coinId: UCT,
@@ -201,7 +209,8 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     expect(result.requestId).toBeDefined();
     expect(requester.transport.sendPaymentRequest).not.toHaveBeenCalled();
 
-    // Server-side: open, addressed payer, memo S6-ENCRYPTED — never plaintext (§8.3).
+    // Server-side: open, addressed payer, memo is a recipient-addressed `enc1.`
+    // envelope (S6) — never plaintext, neither the message nor the nametag.
     const row = fake.getPaymentRequest(result.requestId!);
     expect(row).toMatchObject({
       status: 'open',
@@ -211,6 +220,26 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     });
     expect(row!.memo!.startsWith(FIELD_ENVELOPE_PREFIX)).toBe(true);
     expect(row!.memo).not.toContain('lunch');
+    expect(row!.memo).not.toContain('api-1');
+
+    // S6 (the fix): the memo is addressed to the PAYER via ECDH — only the
+    // payer's own key opens it; a THIRD wallet cannot. Asserted at the crypto
+    // boundary against the verbatim wire bytes.
+    const stranger = testIdentity(99);
+    expect(() =>
+      decryptDeliveryBundle(
+        deriveDeliveryEncryptionKey(stranger.privateKey, REQUESTER.chainPubkey),
+        row!.memo!
+      )
+    ).toThrow();
+    // …and the requester re-derives the SAME shared secret (ECDH symmetry), so
+    // it can still read its own sent message + nametag from the wire.
+    expect(
+      decryptDeliveryBundle(
+        deriveDeliveryEncryptionKey(REQUESTER.privateKey, PAYER.chainPubkey),
+        row!.memo!
+      )
+    ).toEqual({ senderNametag: 'api-1', memo: 'lunch?' });
 
     // Notify: the payer's polled ?since= stream surfaces it (handler + event).
     const surfaced: IncomingPaymentRequest[] = [];
@@ -226,8 +255,11 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
       coinId: UCT,
       status: 'pending',
     });
-    // S6: the requester-encrypted memo is opaque to the payer — absent, not garbage.
-    expect(surfaced[0].message).toBeUndefined();
+    // S6 (the fix): the payer DECRYPTS the requester-addressed envelope — both
+    // the message AND the requester's nametag surface (was undefined / raw
+    // pubkey before #553).
+    expect(surfaced[0].message).toBe('lunch?');
+    expect(surfaced[0].senderNametag).toBe('api-1');
     expect(payer.emitEvent.mock.calls.some((c) => c[0] === 'payment_request:incoming')).toBe(true);
     expect(payer.module.getPendingPaymentRequestsCount()).toBe(1);
 
@@ -250,7 +282,11 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     const response: PaymentRequestResponse = await wait;
     expect(response.responseType).toBe('rejected');
     expect(response.requestId).toBe(result.requestId);
-    expect(requester.module.getOutgoingPaymentRequests()[0].status).toBe('rejected');
+    const outgoing = requester.module.getOutgoingPaymentRequests()[0];
+    expect(outgoing.status).toBe('rejected');
+    // The requester's outgoing view still reads its OWN message (held in-memory
+    // at create time; the ECDH key change never breaks the requester's read).
+    expect(outgoing.message).toBe('lunch?');
     expect(requester.emitEvent.mock.calls.some((c) => c[0] === 'payment_request:response')).toBe(true);
 
     // Respond is open-only server-side: a second decline propagates the 409.


### PR DESCRIPTION
Fixes #553 (manual close at merge — this PR targets `feat/wallet-api-integration`, not the default branch).

## The bug (the PR twin of #546/#547)
On the wallet-api **payment-request** path, the requester's MESSAGE and NAMETAG were encrypted **self-scoped to the requester** (the S6 wallet-scoped field key), so the **PAYER could never decrypt them** — the payer's incoming view showed a raw sender pubkey and no message. Identical to the transfer-memo BUG-A (sender rendered as a raw pubkey / "Someone") and BUG-B (memo dropped) that #547 fixed for the delivery (mailbox) path; the PR path was never given the same treatment. Surfaced by the #356 Playwright run, confirmed pre-existing.

## The fix — reuse the #547 mechanism (`core/delivery-envelope.ts`), wire shape unchanged
The three touch points:

1. **Create** (`sendWalletApiPaymentRequest`): encrypt `{ n: requesterNametag, t: message }` with `deriveDeliveryEncryptionKey(requesterPriv, PAYER chain pubkey = toPubkey)` instead of the self-scoped field key. The requester's own nametag is `this.getNametag()?.name` (the same source #547 used). Attached whenever there is a nametag OR a message (so the payer renders "@requester" even with no message). Same `enc1.` XChaCha20-Poly1305 envelope.
2. **Payer incoming view** (`surfaceIncomingPaymentRequest`): new `decryptPaymentRequestMemo` decrypts with `ECDH(payerPriv, wire.fromPubkey)` (symmetric) and populates **both** the `message` AND the requester's nametag (`senderNametag`) on the surfaced `IncomingPaymentRequest`. Decrypt/parse failure drops gracefully (memo + nametag absent), never thrown into the view path.
3. **Requester outgoing view**: unchanged — it reads its own plaintext `message` held in-memory at create time; the same shared secret re-derives it (`ECDH(requesterPriv, wire.toPubkey)`), so the read stays consistent (test asserts it).

**No duplicated crypto** — reuses `deriveDeliveryEncryptionKey`/`encryptDeliveryBundle`/`decryptDeliveryBundle` from #547's `core/delivery-envelope.ts` verbatim.

## Invariants held
- The wire stays a single `enc1.` `memo` field — backend `assertFieldEnvelopeShape` + size cap unchanged, operator stays blind. **No backend change.**
- Self-scoped S6 field key is unchanged for genuine self-data (history at rest, intent payloads).

## Tests
The S4 payment-request test rewritten to the corrected behavior: the requester sets a nametag; the server row `memo` is an `enc1.` envelope carrying neither plaintext (no `lunch`, no `api-1`); a **THIRD wallet cannot decrypt** it; the requester re-derives the **same shared secret**; the **payer's surfaced view decrypts BOTH** message + nametag; the requester's **outgoing view still reads its own message**. Local: `typecheck` clean, `eslint` 0 new errors (2 pre-existing unrelated warnings), the targeted test file + the `delivery-envelope` unit pass. CI verifies the full suites.

## Spec follow-up (owner to apply)
`sdk-changes.md` S6 note: the **payment-request memo is now recipient-ECDH too** (same envelope as the delivery memo), alongside the delivery-memo note from #547.