### PR TITLE
fix(payments): rebuild full incoming payment-request view on reload (#556)

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -113,6 +113,16 @@ const MAX_SYNCED_HISTORY_ENTRIES = 5000;
 const MAX_HISTORY_HYDRATION_PAGES = 100;
 
 /**
+ * Cap on the number of gap-free `?since=` pages pulled when rebuilding the
+ * incoming payment-request view from the server on reload (the wallet-api
+ * composition — the #556 reload fix). At the §16 page limit this bounds a
+ * single hydration past any realistic payer's request history while staying
+ * finite if the server ever mis-reports `more`. Mirrors
+ * {@link MAX_HISTORY_HYDRATION_PAGES}.
+ */
+const MAX_PR_HYDRATION_PAGES = 100;
+
+/**
  * Overall timeout for a single engine transfer/split during send(). Overrides
  * the SDK's 10s default inclusion-proof abort — a slow aggregator must get a
  * fair window, because once the certification is submitted the source state is
@@ -937,10 +947,13 @@ export class PaymentsModule {
   /** Coalesces concurrent payment-request pump runs. */
   private prPumpInFlight: Promise<void> | null = null;
   /**
-   * Set after the once-per-session `status=open` bootstrap scan: the surfaced
-   * incoming list is in-memory only, so still-open requests BELOW the
-   * persisted cursor must be recovered at session start (bounded by the §5.5
-   * per-payer open cap).
+   * Set after the once-per-session full incoming hydration (#556): the surfaced
+   * incoming list is in-memory only, so on a fresh engine the CURRENT state of
+   * ALL incoming requests — open AND resolved (paid/declined/expired) — must be
+   * rebuilt from a `role=incoming&since=0` pull, not just the still-open ones.
+   * A status-filtered bootstrap (the pre-#556 `status=open` scan) dropped
+   * requests resolved in a PRIOR session, so the payer reopened and the
+   * 'Paid Successfully' request was gone (twin of #521/#549).
    */
   private prBootstrapped = false;
 
@@ -4678,27 +4691,33 @@ export class PaymentsModule {
    * mailbox-cursor pattern: the persisted `{cursor, syncEpoch}` is the resume
    * point; a `syncEpoch` change (server restore — §5.4) voids cursor
    * continuity, so the tail re-pulls from 0 and the id-dedup in
-   * {@link surfaceIncomingPaymentRequest} absorbs the replays. Because the
-   * surfaced list is in-memory only, each session ALSO starts with one
-   * `status=open` bootstrap scan from 0 — still-open requests below the
-   * cursor (bounded by the §5.5 per-payer open cap) are recovered; resolved
-   * ones are not re-surfaced.
+   * {@link surfaceIncomingPaymentRequest} absorbs the replays.
+   *
+   * Because the surfaced list is in-memory only, each session FIRST runs one
+   * full incoming hydration from `since=0` with NO status filter (#556 —
+   * mirrors {@link hydrateHistoryFromServer}): a fresh engine rebuilds the
+   * CURRENT state of ALL incoming requests — open AND resolved — so a request
+   * paid/declined/expired in a PRIOR session is still present (with its
+   * resolved status) instead of vanishing once the cursor advanced past it.
+   * Hydration NEVER fires the new-incoming handlers/events for resolved
+   * requests — only `open` ones notify (the status-aware
+   * {@link surfaceIncomingPaymentRequest}) — so reopening can't spam stale
+   * 'new request' notifications. After hydration the `since`-cursor delta poll
+   * picks up live updates from the resume point.
    */
   private async pumpIncomingPaymentRequests(api: PaymentRequestsApi): Promise<void> {
     const persisted = await this.readPrCursorState();
 
     if (!this.prBootstrapped) {
-      if (persisted !== null && persisted.cursor > 0n) {
-        let scan = await api.listPaymentRequests({ role: 'incoming', status: 'open', since: 0n });
-        for (;;) {
-          for (const wire of scan.requests) this.surfaceIncomingPaymentRequest(wire);
-          if (!scan.more) break;
-          scan = await api.listPaymentRequests({ role: 'incoming', status: 'open', since: scan.cursor });
-        }
+      let scan = await api.listPaymentRequests({ role: 'incoming', since: 0n });
+      for (let pageCount = 0; pageCount < MAX_PR_HYDRATION_PAGES; pageCount++) {
+        for (const wire of scan.requests) this.surfaceIncomingPaymentRequest(wire);
+        if (!scan.more) break;
+        scan = await api.listPaymentRequests({ role: 'incoming', since: scan.cursor });
       }
-      // Marked only after the scan SUCCEEDS — a transient failure here must
+      // Marked only after the hydration SUCCEEDS — a transient failure here must
       // not skip recovery for the rest of the session (the next poll retries;
-      // the id-dedup makes a re-scan safe).
+      // the id-dedup makes a re-hydration safe).
       this.prBootstrapped = true;
     }
 
@@ -4736,18 +4755,28 @@ export class PaymentsModule {
     }
   }
 
+  /** §16 wire status → the public {@link PaymentRequestStatus} display status. */
+  private static readonly PR_WIRE_STATUS: Record<
+    WalletApiPaymentRequest['status'],
+    PaymentRequestStatus
+  > = { open: 'pending', paid: 'paid', declined: 'rejected', expired: 'expired' };
+
   /**
    * Map a §16 wire request onto the public {@link IncomingPaymentRequest}
-   * surface and notify (event + handlers). Only `open` requests are
-   * actionable; the in-memory id-dedup doubles as the replay guard for
-   * cursor resets. Multi-asset requests surface their first asset (the
-   * module's request surface is single-asset; module-created requests
-   * always are).
+   * surface, deduped by id (the in-memory id-dedup doubles as the replay guard
+   * for cursor resets). Requests of EVERY status are surfaced so a reloaded
+   * thin wallet rebuilds the CURRENT state of its incoming view (#556) — open
+   * ones land as actionable `pending`, resolved ones carry their paid/declined
+   * (→ `rejected`)/expired status. Only `open` requests fire the new-incoming
+   * event + handlers; resolved requests are folded into the list silently, so a
+   * reload (or a `syncEpoch` re-pull) never re-notifies for already-resolved
+   * requests. Multi-asset requests surface their first asset (the module's
+   * request surface is single-asset; module-created requests always are).
    */
   private surfaceIncomingPaymentRequest(wire: WalletApiPaymentRequest): void {
-    if (wire.status !== 'open') return;
     if (this.paymentRequests.some((r) => r.id === wire.id)) return;
 
+    const status = PaymentsModule.PR_WIRE_STATUS[wire.status];
     const coinId = wire.assets[0]?.coinId ?? '';
     const coinDef = TokenRegistry.getInstance().getDefinition(coinId);
 
@@ -4757,7 +4786,9 @@ export class PaymentsModule {
     // It carries the requester's nametag AND message, so the payer renders
     // "@requester" + the message instead of a raw pubkey. An envelope not
     // addressed here, or any tamper, fails authentication and surfaces as
-    // absent — never garbage, and never thrown into the view path.
+    // absent — never garbage, and never thrown into the view path. Decrypted
+    // for resolved requests too (#554/dev.12), so a reloaded view renders the
+    // memo/nametag of a paid/declined request, not a raw pubkey.
     const { memo: message, senderNametag } = this.decryptPaymentRequestMemo(wire);
 
     const request: IncomingPaymentRequest = {
@@ -4770,21 +4801,27 @@ export class PaymentsModule {
       ...(message !== undefined ? { message } : {}),
       requestId: wire.id,
       timestamp: wire.createdAt,
-      status: 'pending',
+      status,
     };
 
     // Add to list (newest first)
     this.paymentRequests.unshift(request);
-    this.deps?.emitEvent('payment_request:incoming', request);
-    for (const handler of this.paymentRequestHandlers) {
-      try {
-        handler(request);
-      } catch (error) {
-        logger.debug('Payments', 'Payment request handler error:', error);
+
+    // Notify ONLY for actionable (open) requests — a reload-hydrated resolved
+    // request must not re-fire 'new incoming request' (#556). Open requests
+    // surfaced during hydration DO notify, exactly as the prior bootstrap did.
+    if (status === 'pending') {
+      this.deps?.emitEvent('payment_request:incoming', request);
+      for (const handler of this.paymentRequestHandlers) {
+        try {
+          handler(request);
+        } catch (error) {
+          logger.debug('Payments', 'Payment request handler error:', error);
+        }
       }
     }
 
-    logger.debug('Payments', `Incoming payment request: ${request.id} for ${request.amount} ${request.symbol}`);
+    logger.debug('Payments', `Incoming payment request: ${request.id} (${status}) for ${request.amount} ${request.symbol}`);
   }
 
   /**

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -9,8 +9,11 @@
  *   respond(action:'paid'); declining maps to action:'declined' (server-
  *   confirmed BEFORE the local flip — a 409 propagates);
  * - the incoming cursor is persisted per network+identity (mirroring the
- *   mailbox cursor) and a restarted module recovers still-open requests via
- *   the status=open bootstrap without re-surfacing resolved ones;
+ *   mailbox cursor) and a restarted module rebuilds the CURRENT state of ALL
+ *   incoming requests — open AND resolved — via a full `since=0` hydration
+ *   (#556, the SDK-level J12: a request resolved in a prior session is still
+ *   present with its resolved status on reopen; resolved ones never re-fire
+ *   the new-incoming handlers/events);
  * - compositions WITHOUT wallet-api keep the Nostr transport path untouched
  *   (port selection, covenant §3.1-6).
  */
@@ -342,41 +345,66 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     });
   });
 
-  it('a restarted module bootstraps still-open requests below the persisted cursor; resolved ones stay resolved', async () => {
+  it('#556 (SDK-level J12): a restarted module rebuilds ALL incoming requests — resolved ones present with status, opens still actionable, no re-notify', async () => {
     const { fake, baseUrl } = await startFake();
     const requester = makeWalletApiWallet(baseUrl, fake.network, REQUESTER, 'pr-5');
     const payer = makeWalletApiWallet(baseUrl, fake.network, PAYER, 'pr-6');
+    await seedServerToken(fake, payer, PAYER, 1000n);
 
-    const first = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '1', coinId: UCT });
-    const second = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '2', coinId: UCT });
+    const paidReq = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '1', coinId: UCT, message: 'invoice 1' });
+    const declinedReq = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '2', coinId: UCT });
+    const openReq = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '3', coinId: UCT });
 
+    // Session 1: surface all three, then RESOLVE two (pay one, decline one).
     await payer.module.load();
     await payer.module.syncPaymentRequests();
-    expect(payer.module.getPaymentRequests()).toHaveLength(2);
-    await payer.module.rejectPaymentRequest(first.requestId!);
+    expect(payer.module.getPaymentRequests()).toHaveLength(3);
+    await payer.module.payPaymentRequest(paidReq.requestId!);
+    await payer.module.rejectPaymentRequest(declinedReq.requestId!);
+    expect(fake.getPaymentRequest(paidReq.requestId!)).toMatchObject({ status: 'paid' });
+    expect(fake.getPaymentRequest(declinedReq.requestId!)).toMatchObject({ status: 'declined' });
 
-    // "Restart": a fresh module over the SAME storage/providers. The cursor
-    // (now past both seqs) is persisted, but the surfaced list is in-memory —
-    // the status=open bootstrap recovers exactly the still-open request.
-    const restarted = createPaymentsModule({ l1: null });
-    restarted.initialize({ ...payer.deps });
-    cleanups.push(() => restarted.destroy());
-    await restarted.load();
-    await restarted.syncPaymentRequests();
+    // Reopen: a fresh module over the SAME persisted stateStore/providers. The
+    // cursor (now past all seqs) is persisted, but the surfaced list is
+    // in-memory — pre-#556 only the still-open `openReq` survived, and the
+    // resolved paid/declined requests VANISHED. The #556 full `since=0`
+    // hydration must rebuild the CURRENT state of ALL incoming requests.
+    const reopened = createPaymentsModule({ l1: null });
+    reopened.initialize({ ...payer.deps });
+    cleanups.push(() => reopened.destroy());
+    const reNotified: IncomingPaymentRequest[] = [];
+    reopened.onPaymentRequest((r) => reNotified.push(r));
+    await reopened.load();
+    await reopened.syncPaymentRequests();
 
-    const recovered = restarted.getPaymentRequests();
-    expect(recovered.map((r) => r.id)).toEqual([second.requestId]);
-    expect(recovered[0].status).toBe('pending');
+    // J12: the resolved requests are PRESENT with their resolved status…
+    const byId = new Map(reopened.getPaymentRequests().map((r) => [r.id, r]));
+    expect(byId.size).toBe(3);
+    expect(byId.get(paidReq.requestId!)?.status).toBe('paid');
+    expect(byId.get(declinedReq.requestId!)?.status).toBe('rejected');
+    // …and the still-open one re-hydrates as actionable (pending).
+    expect(byId.get(openReq.requestId!)?.status).toBe('pending');
+    // The resolved request's decrypted memo survives the reload (#554/dev.12).
+    expect(byId.get(paidReq.requestId!)?.message).toBe('invoice 1');
 
-    // The tail still works from the persisted cursor: a NEW request arrives.
-    const third = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '3', coinId: UCT });
-    await restarted.syncPaymentRequests();
-    expect(restarted.getPaymentRequests().map((r) => r.id).sort()).toEqual(
-      [second.requestId, third.requestId].sort()
+    // Re-notification guard: the reopened module's new-incoming handler fires
+    // ONLY for the still-open request — never for the paid/declined ones (the
+    // hydration folds resolved requests into the list silently, #556). The
+    // handler is registered on the reopened module alone, so it observes only
+    // this session's notifications.
+    expect(reNotified.map((r) => r.id)).toEqual([openReq.requestId]);
+
+    // The tail still works from the persisted cursor: a NEW request arrives,
+    // notifies, and does not disturb the hydrated resolved rows.
+    const fresh = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '4', coinId: UCT });
+    await reopened.syncPaymentRequests();
+    expect(reopened.getPaymentRequests().map((r) => r.id).sort()).toEqual(
+      [paidReq.requestId, declinedReq.requestId, openReq.requestId, fresh.requestId].sort()
     );
+    expect(reNotified.map((r) => r.id).sort()).toEqual([openReq.requestId, fresh.requestId].sort());
   });
 
-  it('a failed bootstrap scan is retried on the next pump (the flag is burned only on success)', async () => {
+  it('a failed hydration is retried on the next pump (the flag is burned only on success)', async () => {
     const { fake, baseUrl } = await startFake();
     const requester = makeWalletApiWallet(baseUrl, fake.network, REQUESTER, 'pr-8');
     const payer = makeWalletApiWallet(baseUrl, fake.network, PAYER, 'pr-9');
@@ -387,8 +415,8 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     await payer.module.syncPaymentRequests();
     expect(payer.module.getPaymentRequests()).toHaveLength(1);
 
-    // Restarted session: the bootstrap scan (the FIRST list call, since the
-    // persisted cursor > 0) hits a transient outage.
+    // Restarted session: the #556 full `since=0` hydration (the FIRST list
+    // call of the session) hits a transient outage.
     vi.spyOn(payer.client, 'listPaymentRequests').mockImplementationOnce(() =>
       Promise.reject(new Error('simulated outage'))
     );


### PR DESCRIPTION
## What

Third instance of the reload-class bug (after inventory #521 and history #549/#550), this time on the incoming payment-request view — caught by sphere#356's J12 Playwright assertion.

On a fresh engine (page reopen) in the wallet-api composition, the incoming payment-request reload only re-fetched `role=incoming&status=open` and advanced its `since` cursor past resolved rows, so a request that was paid/declined/expired in a PRIOR session was never replayed into the incoming view — the payer reopened and the resolved request was gone. The data is durable on the server (`role=incoming&since=0` returns it); the client just never issued that query on a fresh engine.

## Fix (mirrors `hydrateHistoryFromServer`, #549)

- `pumpIncomingPaymentRequests` now runs a once-per-session **full hydration** from `role=incoming&since=0` (no status filter), paginated to `MAX_PR_HYDRATION_PAGES`, deduped by id — so a fresh engine rebuilds the CURRENT state of ALL incoming requests, open AND resolved.
- `surfaceIncomingPaymentRequest` surfaces every status (wire→display: `open→pending`, `paid→paid`, `declined→rejected`, `expired→expired`) and decrypts the recipient-ECDH memo/nametag (#554/dev.12) for resolved requests too. It fires the new-incoming event + handlers **only for open requests**, so reopening never re-notifies for already-resolved ones.
- The in-session `since`-cursor delta poll is unchanged and still runs after hydration; the id-dedup absorbs the overlap.
- Best-effort: `prBootstrapped` is set only on success, so a transient outage retries on the next pump (never fails `load()`).

### Exact change
- `modules/payments/PaymentsModule.ts`: `pumpIncomingPaymentRequests` bootstrap now `listPaymentRequests({ role: 'incoming', since: 0n })` paginated (was `status: 'open'`); `surfaceIncomingPaymentRequest` drops the `if (wire.status !== 'open') return;` early-out, maps via the new `PR_WIRE_STATUS` table, and gates the event/handler notify on `status === 'pending'`. New `MAX_PR_HYDRATION_PAGES = 100` cap.

### Re-notification guard
Resolved requests are folded into the list **silently** — only `open` (→ `pending`) requests reach the `payment_request:incoming` event + handler loop. So the VIEW reflects current state of all incoming requests, but the "new incoming request" surface never re-fires for already-resolved ones on reload or a `syncEpoch` re-pull.

## Tests
- Adds the **SDK-level J12 reload regression** (`PaymentsModule.payment-requests.test.ts`): create three incoming requests, pay one + decline one, reopen a SECOND module over the SAME persisted stateStore, and assert (a) both resolved requests are present with `paid`/`rejected` status, (b) the open one re-hydrates as actionable `pending`, (c) the resolved request's decrypted memo survives the reload, and (d) the reopened module's new-incoming handler fired ONLY for the open request (no re-notification of resolved ones). The in-session tail still picks up a new request.
- Updated the prior bootstrap/retry tests to the new full-hydration semantics.

## No fake/backend change
The fake's `GET /v1/payment-requests?role=incoming` already returns resolved rows at `since=0` (no status filter) — confirmed; no extension needed.

## Verification
`tsc --noEmit` clean; `eslint` clean (only two pre-existing unused-import warnings, untouched lines); the targeted unit file passes 6/6. Heavy suites + Playwright left to CI.

Refs #556 (manual close at merge per process).