### PR TITLE
feat(transport)(sphere-sdk#555): NIP-17 self-wrap opt-out (M8 mitigation)

### DIFF
--- a/modules/communications/CommunicationsModule.ts
+++ b/modules/communications/CommunicationsModule.ts
@@ -16,7 +16,12 @@ import type {
   SphereEventMap,
 } from '../../types';
 import type { StorageProvider } from '../../storage';
-import type { TransportProvider, IncomingMessage, IncomingBroadcast } from '../../transport';
+import type {
+  TransportProvider,
+  IncomingMessage,
+  IncomingBroadcast,
+  SendMessageOptions,
+} from '../../transport';
 import { STORAGE_KEYS_ADDRESS } from '../../constants';
 
 // =============================================================================
@@ -334,15 +339,26 @@ export class CommunicationsModule {
 
   /**
    * Send direct message
+   *
+   * @param recipient - @nametag, DIRECT://, PROXY://, L1 address, or chain/transport pubkey
+   * @param content   - Message body
+   * @param options   - Optional per-call transport behaviors. The most common
+   *                    use is `{ selfWrap: false }` for short-lived senders
+   *                    (CLI RPC) that exit before they could ever read their
+   *                    own self-wrap — see sphere-sdk#555.
    */
-  async sendDM(recipient: string, content: string): Promise<DirectMessage> {
+  async sendDM(
+    recipient: string,
+    content: string,
+    options?: SendMessageOptions,
+  ): Promise<DirectMessage> {
     this.ensureInitialized();
 
     // Resolve recipient
     const resolved = await this.resolveRecipient(recipient);
 
     // Send via transport
-    const eventId = await this.deps!.transport.sendMessage(resolved.pubkey, content);
+    const eventId = await this.deps!.transport.sendMessage(resolved.pubkey, content, options);
 
     // Create message record
     // isRead=false for sent messages means "not yet read by recipient".

--- a/tests/unit/modules/CommunicationsModule.cache.test.ts
+++ b/tests/unit/modules/CommunicationsModule.cache.test.ts
@@ -166,7 +166,9 @@ describe('CommunicationsModule cacheMessages option', () => {
 
       // Transport receives x-only key (02 prefix stripped by resolver)
       const xOnlyPeer = 'b'.repeat(64);
-      expect(deps.transport.sendMessage).toHaveBeenCalledWith(xOnlyPeer, 'hi');
+      // `options` arg added per sphere-sdk#555 (selfWrap opt-out); undefined
+      // when caller omits it (default behavior unchanged).
+      expect(deps.transport.sendMessage).toHaveBeenCalledWith(xOnlyPeer, 'hi', undefined);
       expect(message).toMatchObject({ content: 'hi' });
       expect(mod.getConversation(PEER_PUBKEY)).toEqual([]);
       expect(deps.storage.set).not.toHaveBeenCalled();

--- a/tests/unit/transport/MultiAddressTransportMux.selfWrapOptOut.test.ts
+++ b/tests/unit/transport/MultiAddressTransportMux.selfWrapOptOut.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the NIP-17 self-wrap opt-out path on MultiAddressTransportMux.
+ *
+ * Issue sphere-sdk#555 — every NIP-17 sendDM publishes TWO events: the
+ * gift-wrap addressed to the recipient AND a self-wrap copy addressed to
+ * the sender's own pubkey (so the sender can recover outbound history on
+ * reconnect). For short-lived senders (one-shot CLI RPC like
+ * `sphere trader portfolio`) the process exits before it could ever read
+ * its own self-wrap, making the second publish pure relay-index
+ * pollution — directly contributing to the M5 amplification described
+ * in #555.
+ *
+ * The fix: `SendMessageOptions.selfWrap = false` skips the second publish.
+ * Default behavior (`selfWrap` unset OR `selfWrap: true`) is unchanged.
+ *
+ * These tests confirm the contract by counting `publishEvent` calls on a
+ * mocked NostrClient — no real socket traffic.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Buffer } from 'buffer';
+
+const mockSubscribe = vi.fn().mockReturnValue('mock-sub-id');
+const mockUnsubscribe = vi.fn();
+const mockConnect = vi.fn().mockResolvedValue(undefined);
+const mockDisconnect = vi.fn();
+const mockIsConnected = vi.fn().mockReturnValue(true);
+const mockGetConnectedRelays = vi.fn().mockReturnValue(new Set(['wss://relay1.test']));
+const mockAddConnectionListener = vi.fn();
+const mockRemoveConnectionListener = vi.fn();
+const mockPublishEvent = vi.fn().mockResolvedValue('mock-event-id');
+
+const NostrClientCtor = vi.fn().mockImplementation(() => ({
+  connect: mockConnect,
+  disconnect: mockDisconnect,
+  isConnected: mockIsConnected,
+  getConnectedRelays: mockGetConnectedRelays,
+  subscribe: mockSubscribe,
+  unsubscribe: mockUnsubscribe,
+  publishEvent: mockPublishEvent,
+  addConnectionListener: mockAddConnectionListener,
+  removeConnectionListener: mockRemoveConnectionListener,
+}));
+
+vi.mock('@unicitylabs/nostr-js-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/nostr-js-sdk')>();
+  return {
+    ...actual,
+    NostrClient: NostrClientCtor,
+  };
+});
+
+const { MultiAddressTransportMux } = await import('../../../transport/MultiAddressTransportMux');
+const { NostrKeyManager } = await import('@unicitylabs/nostr-js-sdk');
+
+// Real key material — the Mux runs NIP-17 gift-wrap construction inline,
+// which performs ECDH against the recipient pubkey, so stub byte-fills
+// like 'cc'.repeat(32) would fail (point-not-on-curve). Derive two real
+// keypairs from fixed seeds for determinism.
+const SENDER_SK_HEX = '11'.repeat(32);
+const RECIPIENT_SK_HEX = '22'.repeat(32);
+const senderKm = NostrKeyManager.fromPrivateKey(
+  Uint8Array.from(Buffer.from(SENDER_SK_HEX, 'hex')),
+);
+const recipientKm = NostrKeyManager.fromPrivateKey(
+  Uint8Array.from(Buffer.from(RECIPIENT_SK_HEX, 'hex')),
+);
+const RECIPIENT_X_PUBKEY = recipientKm.getPublicKeyHex(); // 64 hex (x-only)
+// Compressed (33-byte) form derived from the same x-only pubkey — exercises
+// the prefix-strip branch inside sendGiftWrap.
+const RECIPIENT_COMPRESSED_PUBKEY = '02' + RECIPIENT_X_PUBKEY;
+
+const SENDER_IDENTITY = {
+  chainPubkey: '02' + senderKm.getPublicKeyHex(),
+  l1Address: 'alpha1sender',
+  directAddress: 'DIRECT://sender',
+  transportPubkey: senderKm.getPublicKeyHex(),
+  privateKey: SENDER_SK_HEX,
+};
+
+function buildMux() {
+  return new MultiAddressTransportMux({
+    relays: ['wss://relay1.test'],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    createWebSocket: (() => {}) as any,
+    timeout: 100,
+    autoReconnect: false,
+  });
+}
+
+describe('Mux NIP-17 self-wrap opt-out (sphere-sdk#555)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+    mockGetConnectedRelays.mockReturnValue(new Set(['wss://relay1.test']));
+    mockSubscribe.mockReturnValue('mock-sub-id');
+    mockPublishEvent.mockResolvedValue('mock-event-id');
+  });
+
+  it('publishes gift-wrap + self-wrap by default (2 publishes)', async () => {
+    const mux = buildMux();
+    await mux.addAddress(0, SENDER_IDENTITY);
+    await mux.connect();
+    mockPublishEvent.mockClear();
+
+    await mux.sendGiftWrap(0, RECIPIENT_X_PUBKEY, 'hello');
+
+    // Wait one microtask tick so the fire-and-forget self-wrap publish lands.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockPublishEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('publishes only the gift-wrap when selfWrap is explicitly false', async () => {
+    const mux = buildMux();
+    await mux.addAddress(0, SENDER_IDENTITY);
+    await mux.connect();
+    mockPublishEvent.mockClear();
+
+    await mux.sendGiftWrap(0, RECIPIENT_X_PUBKEY, 'hello', { selfWrap: false });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockPublishEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours selfWrap: true the same as default (2 publishes)', async () => {
+    const mux = buildMux();
+    await mux.addAddress(0, SENDER_IDENTITY);
+    await mux.connect();
+    mockPublishEvent.mockClear();
+
+    await mux.sendGiftWrap(0, RECIPIENT_X_PUBKEY, 'hello', { selfWrap: true });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockPublishEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('strips the 02/03 prefix from the recipient pubkey on both branches', async () => {
+    // Each option-shape must produce a publish even when given a 33-byte
+    // compressed pubkey — confirms the new branch did not break the
+    // prefix-stripping path.
+    const mux = buildMux();
+    await mux.addAddress(0, SENDER_IDENTITY);
+    await mux.connect();
+    mockPublishEvent.mockClear();
+
+    await mux.sendGiftWrap(0, RECIPIENT_COMPRESSED_PUBKEY, 'hello', { selfWrap: false });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockPublishEvent).toHaveBeenCalledTimes(1);
+
+    mockPublishEvent.mockClear();
+    await mux.sendGiftWrap(0, RECIPIENT_COMPRESSED_PUBKEY, 'hello');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockPublishEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('AddressTransportAdapter.sendMessage threads selfWrap through to the Mux', async () => {
+    const mux = buildMux();
+    const adapter = await mux.addAddress(0, SENDER_IDENTITY);
+    await mux.connect();
+    mockPublishEvent.mockClear();
+
+    await adapter.sendMessage(RECIPIENT_X_PUBKEY, 'hello', { selfWrap: false });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockPublishEvent).toHaveBeenCalledTimes(1);
+
+    mockPublishEvent.mockClear();
+    await adapter.sendMessage(RECIPIENT_X_PUBKEY, 'hello');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockPublishEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/transport/MultiAddressTransportMux.ts
+++ b/transport/MultiAddressTransportMux.ts
@@ -33,6 +33,7 @@ import type { ProviderStatus, FullIdentity } from '../types';
 import type {
   TransportProvider,
   MessageHandler,
+  SendMessageOptions,
   ComposingHandler,
   TokenTransferHandler,
   BroadcastHandler,
@@ -1567,11 +1568,17 @@ export class MultiAddressTransportMux {
 
   /**
    * Create and publish a NIP-17 gift wrap message for a specific address.
+   *
+   * When `options.selfWrap === false`, the self-wrap copy that normally goes
+   * to the sender's own pubkey is skipped. Used by short-lived senders (CLI
+   * RPC, sphere-sdk#555) that exit before they could ever read their own
+   * self-wrap.
    */
   async sendGiftWrap(
     addressIndex: number,
     recipientPubkey: string,
-    content: string
+    content: string,
+    options?: SendMessageOptions,
   ): Promise<string> {
     const entry = this.addresses.get(addressIndex);
     if (!entry) throw new SphereError('Address not registered in mux', 'NOT_INITIALIZED');
@@ -1587,21 +1594,23 @@ export class MultiAddressTransportMux {
     const giftWrapEvent = NostrEventClass.fromJSON(giftWrap);
     await this.nostrClient.publishEvent(giftWrapEvent);
 
-    // Self-wrap for relay replay
-    const selfPubkey = entry.keyManager.getPublicKeyHex();
-    const senderNametag = entry.identity.nametag;
-    const selfWrapContent = JSON.stringify({
-      selfWrap: true,
-      originalId: giftWrap.id,
-      recipientPubkey,
-      senderNametag,
-      text: content,
-    });
-    const selfGiftWrap = NIP17.createGiftWrap(entry.keyManager, selfPubkey, selfWrapContent);
-    const selfGiftWrapEvent = NostrEventClass.fromJSON(selfGiftWrap);
-    this.nostrClient.publishEvent(selfGiftWrapEvent).catch((err: unknown) => {
-      logger.debug('Mux', 'Self-wrap publish failed:', err);
-    });
+    // Self-wrap for relay replay (skipped when opted out — see sphere-sdk#555)
+    if (options?.selfWrap !== false) {
+      const selfPubkey = entry.keyManager.getPublicKeyHex();
+      const senderNametag = entry.identity.nametag;
+      const selfWrapContent = JSON.stringify({
+        selfWrap: true,
+        originalId: giftWrap.id,
+        recipientPubkey,
+        senderNametag,
+        text: content,
+      });
+      const selfGiftWrap = NIP17.createGiftWrap(entry.keyManager, selfPubkey, selfWrapContent);
+      const selfGiftWrapEvent = NostrEventClass.fromJSON(selfGiftWrap);
+      this.nostrClient.publishEvent(selfGiftWrapEvent).catch((err: unknown) => {
+        logger.debug('Mux', 'Self-wrap publish failed:', err);
+      });
+    }
 
     return giftWrap.id;
   }
@@ -2012,13 +2021,17 @@ export class AddressTransportAdapter implements TransportProvider {
   // Sending — delegates to mux with this address's keyManager
   // ===========================================================================
 
-  async sendMessage(recipientPubkey: string, content: string): Promise<string> {
+  async sendMessage(
+    recipientPubkey: string,
+    content: string,
+    options?: SendMessageOptions,
+  ): Promise<string> {
     const senderNametag = this.identity.nametag;
     const wrappedContent = senderNametag
       ? JSON.stringify({ senderNametag, text: content })
       : content;
 
-    return this.mux.sendGiftWrap(this.addressIndex, recipientPubkey, wrappedContent);
+    return this.mux.sendGiftWrap(this.addressIndex, recipientPubkey, wrappedContent, options);
   }
 
   async sendTokenTransfer(recipientPubkey: string, payload: TokenTransferPayload): Promise<string> {

--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -39,6 +39,7 @@ import { SphereError } from '../core/errors';
 import type {
   TransportProvider,
   MessageHandler,
+  SendMessageOptions,
   ComposingHandler,
   TokenTransferHandler,
   BroadcastHandler,
@@ -786,7 +787,11 @@ export class NostrTransportProvider implements TransportProvider {
     return this.keyManager.getPublicKeyHex();
   }
 
-  async sendMessage(recipientPubkey: string, content: string): Promise<string> {
+  async sendMessage(
+    recipientPubkey: string,
+    content: string,
+    options?: SendMessageOptions,
+  ): Promise<string> {
     this.ensureReady();
 
     // NIP-17 requires 32-byte x-only pubkey; strip 02/03 prefix if present
@@ -807,18 +812,24 @@ export class NostrTransportProvider implements TransportProvider {
 
     // NIP-17 self-wrap: send a copy to ourselves so relay can replay sent messages.
     // Content includes recipientPubkey and originalId for dedup against the live-sent record.
-    const selfWrapContent = JSON.stringify({
-      selfWrap: true,
-      originalId: giftWrap.id,
-      recipientPubkey,
-      senderNametag,
-      text: content,
-    });
-    const selfPubkey = this.keyManager!.getPublicKeyHex();
-    const selfGiftWrap = NIP17.createGiftWrap(this.keyManager!, selfPubkey, selfWrapContent);
-    this.publishEvent(selfGiftWrap).catch(err => {
-      logger.debug('Nostr', 'Self-wrap publish failed:', err);
-    });
+    //
+    // Skipped when `options.selfWrap === false` — short-lived senders (CLI RPC,
+    // sphere-sdk#555) exit before they could ever read their own self-wrap, so
+    // the publish is pure relay-index pollution for them.
+    if (options?.selfWrap !== false) {
+      const selfWrapContent = JSON.stringify({
+        selfWrap: true,
+        originalId: giftWrap.id,
+        recipientPubkey,
+        senderNametag,
+        text: content,
+      });
+      const selfPubkey = this.keyManager!.getPublicKeyHex();
+      const selfGiftWrap = NIP17.createGiftWrap(this.keyManager!, selfPubkey, selfWrapContent);
+      this.publishEvent(selfGiftWrap).catch(err => {
+        logger.debug('Nostr', 'Self-wrap publish failed:', err);
+      });
+    }
 
     this.emitEvent({
       type: 'message:sent',

--- a/transport/transport-provider.ts
+++ b/transport/transport-provider.ts
@@ -23,9 +23,14 @@ export interface TransportProvider extends BaseProvider {
   /**
    * Send encrypted direct message
    * @param recipientTransportPubkey - Transport-specific pubkey for messaging
-   * @returns Event ID
+   * @param options - Optional behaviors (see {@link SendMessageOptions})
+   * @returns Event ID of the gift-wrap to the recipient (NOT the self-wrap)
    */
-  sendMessage(recipientTransportPubkey: string, content: string): Promise<string>;
+  sendMessage(
+    recipientTransportPubkey: string,
+    content: string,
+    options?: SendMessageOptions,
+  ): Promise<string>;
 
   /**
    * Subscribe to incoming direct messages
@@ -401,6 +406,26 @@ export interface IncomingMessage {
 }
 
 export type MessageHandler = (message: IncomingMessage) => void;
+
+/**
+ * Per-call options for {@link TransportProvider.sendMessage}.
+ *
+ * Default behavior — when `options` is omitted or `selfWrap` is unset — is
+ * unchanged from before these options existed (gift-wrap + self-wrap both
+ * publish).
+ */
+export interface SendMessageOptions {
+  /**
+   * When `true` (default), publish a second NIP-17 gift-wrap addressed to the
+   * sender's own pubkey so a returning client can replay outbound history on
+   * reconnect.
+   *
+   * When `false`, skip the self-wrap publish. Use for short-lived senders
+   * (e.g. one-shot CLI RPC like `sphere trader portfolio`) that exit before
+   * they could ever read their own self-wrap — see sphere-sdk#555.
+   */
+  selfWrap?: boolean;
+}
 
 // =============================================================================
 // Token Transfer Types


### PR DESCRIPTION
## Summary

- Adds `SendMessageOptions.selfWrap` to the `TransportProvider.sendMessage` interface and threads it through `NostrTransportProvider`, `MultiAddressTransportMux.sendGiftWrap`, `AddressTransportAdapter.sendMessage`, and `CommunicationsModule.sendDM`.
- When `{ selfWrap: false }` is passed, the second NIP-17 publish (the gift-wrap addressed to the sender's own pubkey) is skipped.
- Default behavior is unchanged — callers that don't pass options, or pass `{ selfWrap: true }`, still get both publishes.

This is the **M8 mitigation** for sphere-sdk#555. See [this investigation comment](https://github.com/unicity-sphere/sphere-sdk/issues/555#issuecomment-4709144920) for the full rationale and the discriminator-ordering before this PR's contribution is enabled in practice.

## Why this matters

Every `NostrTransportProvider.sendMessage` / `Mux.sendGiftWrap` has always published TWO kind-1059 events: the recipient gift-wrap and a self-wrap copy. The self-wrap exists so a returning client can recover outbound history on reconnect.

For short-lived senders — one-shot CLI RPC like `sphere trader portfolio` — the process exits ~3 s after sending, well before it could ever read its self-wrap. The publish is pure relay-index pollution targeting the controller's own `#p` filter, which the next retry then re-subscribes to. Per the trader-soak `wait_for_tenant_running` §4 phase (~72 retries × 2 tenants), this doubling alone is **~144 extra NIP-17 events on the testnet relay per §4** — half the total publish volume.

`#555`'s monotonic across-runs degradation could not be fully explained by per-pubkey index growth alone (each soak run uses fresh wallets, so the per-`#p` slice resets), but global kind-1059 accumulation IS plausible — and halving the per-call publish rate cuts that growth in half regardless of relay implementation.

## What this PR does NOT do

- Does NOT change the default. Existing callers see no behavior change.
- Does NOT yet wire the opt-out into the sphere-cli ACP transport. That belongs in [sphere-cli#TBD](https://github.com/unicity-sphere/sphere-cli) — the ACP transport calls `comms.sendDM(tenantAddress, payload, { selfWrap: false })` and the SDK contract is now ready for it.
- Does NOT fix M5 (per-IP rate-limit) or M9 (`EARLY_MESSAGE_CAP=32` silent drop). Those need separate work — see the issue comment.

## Verification ordering

Per the investigation comment, the recommended order is:
1. Run the **M10b discriminator** first (run trader soak's §4 from a different IP after a slow day on the dev box) — if §4 latency resets, the per-IP rate-limit is the dominant cause and this M8 PR is a partial mitigation, not the full fix.
2. If M10b doesn't reset it, this M8 PR + its sphere-cli counterpart should measurably reduce §4 latency growth across consecutive runs. Discriminator: 8 consecutive soak runs with vs without `selfWrap: false` in the CLI ACP transport, compare run-8/run-1 latency ratio.

## Tests

- `tests/unit/transport/MultiAddressTransportMux.selfWrapOptOut.test.ts` — 5 new tests:
  - default behavior → 2 publishes (gift-wrap + self-wrap)
  - explicit `selfWrap: true` → 2 publishes
  - `selfWrap: false` → 1 publish
  - both branches handle the 02/03 prefix-stripped 33-byte recipient pubkey form
  - `AddressTransportAdapter.sendMessage` threads the option through to the Mux
- `tests/unit/modules/CommunicationsModule.cache.test.ts:169` — adjusted to expect the new trailing `options` arg position (still `undefined` for unchanged callers)
- All 8491 unit tests pass; typecheck clean; no new lint warnings on touched files

## Test plan

- [x] New self-wrap opt-out tests pass (5/5)
- [x] Full unit suite passes (8491/8496, 5 pre-existing skips)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all touched files (3 pre-existing warnings unchanged)
- [ ] sphere-cli's `acp-transport.ts` opts in (`comms.sendDM(addr, payload, { selfWrap: false })`) — separate PR
- [ ] Soak verification: 8 consecutive trader soaks before/after the sphere-cli opt-in, comparing §4 latency ratio