### PR TITLE
fix(wallet-api): consume inventory + payment_requests wakes; add inventory poll backstop

### DIFF
--- a/impl/shared/wallet-api/WalletApiMailboxProvider.ts
+++ b/impl/shared/wallet-api/WalletApiMailboxProvider.ts
@@ -36,6 +36,7 @@ import type {
   DeliveryProvider,
   DeliveryReceipt,
   IncomingDelivery,
+  WakeStream,
 } from '../../../transport/delivery-provider';
 import { composeDeliveryKeys, computeDeliveryId } from '../../../transport/delivery-provider';
 import { unwrapTokenBlobBytes } from '../../../token-engine/token-blob';
@@ -394,12 +395,17 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
 
   // ── wake (optional hook — §9: a nudge, never a correctness dependency) ──────
 
-  onWake(callback: () => void): () => void {
+  // The wallet-api wake socket multiplexes all three owner streams; forward
+  // each so the consumer (PaymentsModule) can route mailbox/inventory/
+  // payment_requests to their respective pulls. (Previously only `mailbox`
+  // was surfaced — inventory and payment-request nudges were dropped, leaving
+  // a second session with no realtime path for those streams.)
+  onWake(callback: (stream: WakeStream) => void): () => void {
     let closed = false;
     let close: (() => void) | null = null;
     void this.client
       .connectWakeSocket((wake) => {
-        if (wake.stream === 'mailbox') callback();
+        callback(wake.stream);
       })
       .then((handle) => {
         if (closed) handle.close();

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -45,7 +45,7 @@ import type {
   IncomingPaymentRequest as TransportPaymentRequest,
   IncomingPaymentRequestResponse as TransportPaymentRequestResponse,
 } from '../../transport';
-import type { DeliveryProvider, IncomingDelivery } from '../../transport/delivery-provider';
+import type { DeliveryProvider, IncomingDelivery, WakeStream } from '../../transport/delivery-provider';
 import { TransportDeliveryAdapter } from './TransportDeliveryAdapter';
 import { deriveFieldEncryptionKey, encryptField, decryptField } from '../../core/field-encryption';
 import {
@@ -937,6 +937,12 @@ export class PaymentsModule {
   private injectedDelivery: DeliveryProvider | null = null;
   private deliveryWakeUnsub: (() => void) | null = null;
   private deliveryPollTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Low-frequency inventory poll (§9): the correctness backstop that converges
+   * the owned-token set even when an `inventory` wake is missed. Mirrors the
+   * delivery/PR pumps' interval; the wake is just a nudge that pulls sooner.
+   */
+  private inventoryPollTimer: ReturnType<typeof setInterval> | null = null;
   /** Coalesces concurrent incoming-pump runs. */
   private pumpInFlight: Promise<number> | null = null;
   /** S6 field-encryption key (intent payloads, history memos) — per identity. */
@@ -1141,16 +1147,23 @@ export class PaymentsModule {
     // token-transfer subscription is not installed. Without one, the relay
     // push subscription stays exactly as before.
     if (this.injectedDelivery) {
-      this.deliveryWakeUnsub =
-        this.injectedDelivery.onWake?.(() => {
-          void this.pumpIncomingDeliveries().catch((err) =>
-            logger.warn('Payments', 'Incoming delivery pump (wake) failed:', err)
-          );
-        }) ?? null;
+      // One wake socket multiplexes all three owner streams (§9): route each
+      // nudge to its own (debounced/coalesced) pull. The wake is best-effort —
+      // every stream below also has a poll backstop that is the correctness
+      // path. (Before this, only `mailbox` was consumed, so a second session
+      // saw no realtime inventory/payment-request convergence.)
+      this.deliveryWakeUnsub = this.injectedDelivery.onWake?.((stream) => this.handleWake(stream)) ?? null;
       // Poll is the correctness path; the wake is just a nudge (§9).
       this.deliveryPollTimer = setInterval(() => {
         void this.pumpIncomingDeliveries().catch((err) =>
           logger.warn('Payments', 'Incoming delivery pump (poll) failed:', err)
+        );
+      }, DELIVERY_POLL_INTERVAL_MS);
+      // Inventory poll backstop (§9): converges the owned-token set even if an
+      // `inventory` wake is missed, mirroring the delivery/PR pumps' interval.
+      this.inventoryPollTimer = setInterval(() => {
+        void this.resyncInventory().catch((err) =>
+          logger.warn('Payments', 'Inventory resync (poll) failed:', err)
         );
       }, DELIVERY_POLL_INTERVAL_MS);
     } else {
@@ -4508,6 +4521,78 @@ export class PaymentsModule {
       clearInterval(this.deliveryPollTimer);
       this.deliveryPollTimer = null;
     }
+    if (this.inventoryPollTimer !== null) {
+      clearInterval(this.inventoryPollTimer);
+      this.inventoryPollTimer = null;
+    }
+  }
+
+  /**
+   * Route a §9 wake nudge to the matching stream's pull. The wake is
+   * best-effort — each branch also runs on a poll backstop, so a dropped wake
+   * only delays convergence, never breaks it:
+   * - `mailbox` → drain incoming deliveries;
+   * - `inventory` → debounced inventory resync (the owned-token set changed —
+   *   e.g. a top-up or a claim on another device/session);
+   * - `payment_requests` → pump the payment-request streams.
+   */
+  private handleWake(stream: WakeStream): void {
+    switch (stream) {
+      case 'mailbox':
+        void this.pumpIncomingDeliveries().catch((err) =>
+          logger.warn('Payments', 'Incoming delivery pump (wake) failed:', err)
+        );
+        return;
+      case 'inventory':
+        this.debouncedInventorySyncFromWake();
+        return;
+      case 'payment_requests':
+        void this.pumpPaymentRequests().catch((err) =>
+          logger.warn('Payments', 'Payment-request pump (wake) failed:', err)
+        );
+        return;
+    }
+  }
+
+  /**
+   * Debounced inventory resync driven by an `inventory` wake — coalesces a
+   * burst of wakes into one pull. Runs the same {@link resyncInventory} as the
+   * poll backstop: a wake just makes it fire sooner.
+   */
+  private debouncedInventorySyncFromWake(): void {
+    if (this.syncDebounceTimer) {
+      clearTimeout(this.syncDebounceTimer);
+    }
+    this.syncDebounceTimer = setTimeout(() => {
+      this.syncDebounceTimer = null;
+      void this.resyncInventory().catch((err) =>
+        logger.debug('Payments', 'Inventory resync (wake) failed:', err)
+      );
+    }, PaymentsModule.SYNC_DEBOUNCE_MS);
+  }
+
+  /**
+   * Pull the wallet-api inventory delta and re-merge the lazy view (§5.1/§9):
+   * a fresh {@link load} re-pulls from the durable cursor and re-merges the
+   * owned-token set, then emits the existing `sync:remote-update` so the
+   * frontend's realtime view lights up (the same event the storage `onEvent`
+   * path emits — DEAD in custodial mode without this). The owned-token count
+   * delta stands in for the per-provider add/remove counts (the thin provider's
+   * `sync()` reports none). Used by BOTH the `inventory` wake and the poll
+   * backstop, so convergence never depends on a wake arriving.
+   */
+  private async resyncInventory(): Promise<void> {
+    const before = this.tokens.size;
+    await this.load();
+    const after = this.tokens.size;
+    this.deps?.emitEvent('sync:remote-update', {
+      providerId: 'wallet-api',
+      name: 'inventory',
+      sequence: 0,
+      cid: '',
+      added: Math.max(0, after - before),
+      removed: Math.max(0, before - after),
+    });
   }
 
   /**

--- a/tests/support/fake-wallet-api.ts
+++ b/tests/support/fake-wallet-api.ts
@@ -400,6 +400,11 @@ export class FakeWalletApi {
     return row ? { status: row.status, removal: row.removal } : null;
   }
 
+  /** Number of live wake sockets subscribed to this owner (§9 — test seam). */
+  socketCount(pubkey: string): number {
+    return this.socketsByOwner.get(pubkey)?.size ?? 0;
+  }
+
   getIntent(pubkey: string, transferId: string): { payload: string; status: string } | null {
     const intent = this.owner(pubkey).intents.get(transferId);
     return intent ? { payload: intent.payload, status: intent.status } : null;

--- a/tests/unit/modules/PaymentsModule.wake-consumers.test.ts
+++ b/tests/unit/modules/PaymentsModule.wake-consumers.test.ts
@@ -1,0 +1,233 @@
+/**
+ * PaymentsModule × wallet-api wake streams (§9), end-to-end against the
+ * in-process fake backend — the cross-session-sync fix:
+ *
+ * The wallet-api wake socket multiplexes THREE owner streams (`mailbox` |
+ * `inventory` | `payment_requests`) and the backend fans every owner-scoped
+ * change to ALL of that owner's sessions. Two sessions of the SAME custodial
+ * wallet model two browser windows. When window A mutates server state, window
+ * B's session must converge from the wake alone — WITHOUT waiting for the
+ * low-frequency poll backstop:
+ *
+ * - an `inventory` wake → a debounced inventory resync (a top-up / a claim on
+ *   another device shows up in window B);
+ * - a `payment_requests` wake → a PR pump (a request created elsewhere surfaces
+ *   in window B);
+ * - the `mailbox` wake still drives the incoming-delivery pump (unchanged).
+ *
+ * Before the fix only `mailbox` was consumed: inventory and payment-request
+ * wakes were parsed then dropped, and there was no inventory poll at all, so a
+ * second window had no realtime path for those streams.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createPaymentsModule, type PaymentsModule, type PaymentsModuleDependencies } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity, IncomingPaymentRequest } from '../../../types';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type { StorageProvider } from '../../../storage';
+import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
+import { FakeWalletApi } from '../../support/fake-wallet-api';
+import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
+import { WalletApiClient } from '../../../wallet-api';
+import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../../impl/shared/wallet-api';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import { hexToBytes } from '../../../core/crypto';
+
+const UCT = '11'.repeat(32);
+const OWNER = testIdentity(31);
+const REQUESTER = testIdentity(32);
+
+function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIdentity {
+  return {
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    l1Address: `alpha1${id.chainPubkey.slice(0, 8)}`,
+    directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
+    transportPubkey: id.chainPubkey.slice(2),
+  };
+}
+
+function mockStorage(): { provider: StorageProvider; map: Map<string, string> } {
+  const s = new Map<string, string>();
+  const provider = {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+  return { provider, map: s };
+}
+
+function mockTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('nostr-event'),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('nostr-event'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn(async (recipient: string) =>
+      /^0[23][0-9a-f]{64}$/i.test(recipient)
+        ? { chainPubkey: recipient.toLowerCase(), transportPubkey: recipient.slice(2), directAddress: `DIRECT://${recipient.slice(0, 12)}` }
+        : null
+    ),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    isDevMode: () => false,
+  } as unknown as OracleProvider;
+}
+
+interface Wallet {
+  module: PaymentsModule;
+  engine: FakeTokenEngine;
+  client: WalletApiClient;
+  emitEvent: ReturnType<typeof vi.fn>;
+  storage: { provider: StorageProvider; map: Map<string, string> };
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!();
+});
+
+async function startFake(): Promise<{ fake: FakeWalletApi; baseUrl: string }> {
+  const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
+  const baseUrl = await fake.start();
+  cleanups.push(() => fake.stop());
+  return { fake, baseUrl };
+}
+
+/** A wallet over the FULL wallet-api preset (storage + delivery + PRs). */
+function makeWallet(
+  baseUrl: string,
+  network: string,
+  who: { privateKey: string; chainPubkey: string },
+  deviceId: string
+): Wallet {
+  const identity = fullIdentity(who);
+  const kv = new MemoryKeyValueStore();
+  const client = new WalletApiClient({ baseUrl, network, deviceId, storage: kv });
+  const tokenStorage = new WalletApiTokenStorageProvider({ client, stateStore: kv });
+  tokenStorage.setIdentity(identity);
+  const delivery = new WalletApiMailboxProvider({ client, custody: 'inventory', stateStore: kv });
+  const engine = new FakeTokenEngine({ chainPubkey: hexToBytes(who.chainPubkey) });
+  const storage = mockStorage();
+  const emitEvent = vi.fn();
+  const deps: PaymentsModuleDependencies = {
+    identity,
+    storage: storage.provider,
+    tokenStorageProviders: new Map([[tokenStorage.id, tokenStorage]]),
+    transport: mockTransport(),
+    oracle: mockOracle(),
+    emitEvent,
+    tokenEngine: engine,
+    delivery,
+    walletApi: client,
+  };
+  const module = createPaymentsModule({ l1: null });
+  module.initialize(deps);
+  cleanups.push(() => module.destroy());
+  return { module, engine, client, emitEvent, storage };
+}
+
+/** Mint a token on the wallet's engine and seed it into the SERVER inventory. */
+async function seedServerToken(fake: FakeWalletApi, wallet: Wallet, who: { chainPubkey: string }, amount: bigint): Promise<string> {
+  const minted = await wallet.engine.mint({
+    recipientPubkey: wallet.engine.getIdentity().chainPubkey,
+    value: { assets: [{ coinId: UCT, amount }] },
+  });
+  const bytes = encodeTokenBlob(wallet.engine.encodeToken(minted));
+  const tokenId = wallet.engine.tokenId(minted);
+  fake.seedInventory(who.chainPubkey, [{ tokenId, assets: [{ coinId: UCT, amount }], blob: bytes }]);
+  return tokenId;
+}
+
+/** Poll a predicate up to `timeoutMs` (well under the 30s poll backstop). */
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error('waitFor: predicate never became true');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe('wallet-api wake streams converge a second session (§9 cross-session sync)', () => {
+  it('an `inventory` wake triggers a resync — window B sees a top-up WITHOUT the 30s poll', async () => {
+    const { fake, baseUrl } = await startFake();
+    // Two sessions of the SAME owner = two browser windows.
+    const windowB = makeWallet(baseUrl, fake.network, OWNER, 'win-b');
+    await windowB.module.load();
+    expect(windowB.module.getTokens()).toHaveLength(0);
+
+    // Window B's wake socket must be live before the backend can nudge it.
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) >= 1);
+
+    // Window A tops up: a new row lands in the OWNER's server inventory. The
+    // backend fans an `inventory` wake to every session of the owner.
+    await seedServerToken(fake, windowB, OWNER, 1000n);
+    fake.wakeOwner(OWNER.chainPubkey, 'inventory');
+
+    // Window B converges from the wake alone (debounced resync ≪ 30s poll).
+    await waitFor(() => windowB.module.getTokens().length === 1);
+    expect(windowB.module.getTokens()[0]).toMatchObject({ amount: '1000', coinId: UCT, status: 'confirmed' });
+
+    // The existing realtime event lights up for the frontend (`useSphereEvents`):
+    // the `sync:remote-update` path is DEAD in custodial mode without the wake.
+    await waitFor(() => windowB.emitEvent.mock.calls.some((c) => c[0] === 'sync:remote-update'));
+    const evt = windowB.emitEvent.mock.calls.find((c) => c[0] === 'sync:remote-update')![1];
+    expect(evt).toMatchObject({ providerId: 'wallet-api', name: 'inventory', added: 1 });
+
+    // Sanity: convergence was wake-driven, not a slow poll — no fake timers used.
+    expect(fake.socketCount(OWNER.chainPubkey)).toBeGreaterThanOrEqual(1);
+  });
+
+  it('a burst of `inventory` wakes coalesces into ONE resync (debounce)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const windowB = makeWallet(baseUrl, fake.network, OWNER, 'win-b2');
+    await windowB.module.load();
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) >= 1);
+
+    const loadSpy = vi.spyOn(windowB.module, 'load');
+    await seedServerToken(fake, windowB, OWNER, 500n);
+    // A rapid burst — they MUST collapse to a single trailing resync.
+    fake.wakeOwner(OWNER.chainPubkey, 'inventory');
+    fake.wakeOwner(OWNER.chainPubkey, 'inventory');
+    fake.wakeOwner(OWNER.chainPubkey, 'inventory');
+
+    await waitFor(() => windowB.module.getTokens().length === 1);
+    // One trailing debounced resync (a single burst → a single inventory pull).
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('a `payment_requests` wake triggers a PR pump — window B surfaces a request created elsewhere', async () => {
+    const { fake, baseUrl } = await startFake();
+    const payer = makeWallet(baseUrl, fake.network, OWNER, 'pay-b');
+    const requester = makeWallet(baseUrl, fake.network, REQUESTER, 'req-a');
+    await payer.module.load();
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) >= 1);
+
+    const surfaced: IncomingPaymentRequest[] = [];
+    payer.module.onPaymentRequest((r) => surfaced.push(r));
+
+    // The requester creates a request addressed to the payer (OWNER). The
+    // backend wakes the payer's sessions on the `payment_requests` stream.
+    const created = await requester.module.sendPaymentRequest(OWNER.chainPubkey, { amount: '25', coinId: UCT });
+    expect(created.success).toBe(true);
+
+    // The payer converges on the wake alone — no explicit syncPaymentRequests().
+    await waitFor(() => surfaced.length === 1);
+    expect(surfaced[0]).toMatchObject({ id: created.requestId, amount: '25', coinId: UCT, status: 'pending' });
+    expect(payer.module.getPendingPaymentRequestsCount()).toBe(1);
+  });
+});

--- a/tests/unit/modules/PaymentsModule.wake-consumers.test.ts
+++ b/tests/unit/modules/PaymentsModule.wake-consumers.test.ts
@@ -20,6 +20,7 @@
  * second window had no realtime path for those streams.
  */
 
+import WebSocket from 'ws';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createPaymentsModule, type PaymentsModule, type PaymentsModuleDependencies } from '../../../modules/payments/PaymentsModule';
 import type { FullIdentity, IncomingPaymentRequest } from '../../../types';
@@ -29,7 +30,7 @@ import type { StorageProvider } from '../../../storage';
 import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
-import { WalletApiClient } from '../../../wallet-api';
+import { WalletApiClient, type WebSocketLike } from '../../../wallet-api';
 import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../../impl/shared/wallet-api';
 import { encodeTokenBlob } from '../../../token-engine/token-blob';
 import { hexToBytes } from '../../../core/crypto';
@@ -117,7 +118,15 @@ function makeWallet(
 ): Wallet {
   const identity = fullIdentity(who);
   const kv = new MemoryKeyValueStore();
-  const client = new WalletApiClient({ baseUrl, network, deviceId, storage: kv });
+  // Node < 22 has no global WebSocket — inject `ws` so the wake socket connects on every
+  // CI node version (the wake path is the whole point of this suite). Mirrors client.ws.test.ts.
+  const client = new WalletApiClient({
+    baseUrl,
+    network,
+    deviceId,
+    storage: kv,
+    webSocketFactory: (url) => new WebSocket(url) as unknown as WebSocketLike,
+  });
   const tokenStorage = new WalletApiTokenStorageProvider({ client, stateStore: kv });
   tokenStorage.setIdentity(identity);
   const delivery = new WalletApiMailboxProvider({ client, custody: 'inventory', stateStore: kv });

--- a/transport/delivery-provider.ts
+++ b/transport/delivery-provider.ts
@@ -90,6 +90,16 @@ export interface IncomingDelivery {
 export type DeliveryDisposition = 'claimed' | 'rejected';
 
 /**
+ * The §9 wake streams a backend may nudge: `mailbox` (incoming deliveries),
+ * `inventory` (owned-token set changed — e.g. a top-up or a claim on another
+ * device), and `payment_requests` (a request created/answered). A wake on any
+ * of these is a NUDGE — the consumer pulls that stream's cursor; correctness
+ * never depends on the wake arriving (the poll backstop is the source of
+ * truth).
+ */
+export type WakeStream = 'inventory' | 'mailbox' | 'payment_requests';
+
+/**
  * Custody mode (composition-time): `'inventory'` — acknowledged deliveries
  * enter the wallet-api inventory (the full wallet-api preset); `'external'` —
  * the app's own storage keeps custody and acks perform ZERO inventory writes
@@ -142,11 +152,14 @@ export interface DeliveryProvider {
   ack(deliveryId: string, disposition: DeliveryDisposition): Promise<void>;
 
   /**
-   * Optional wake hook: `callback` fires when new deliveries may be available
-   * (e.g. a WS nudge — never a correctness dependency, ARCHITECTURE §9).
+   * Optional wake hook: `callback` fires with the {@link WakeStream} that was
+   * nudged when new data may be available on it (e.g. a WS nudge — never a
+   * correctness dependency, ARCHITECTURE §9). The wallet-api wake socket
+   * multiplexes all three owner streams (`mailbox` | `inventory` |
+   * `payment_requests`); the consumer routes each to that stream's pull.
    * Returns an unsubscribe function.
    */
-  onWake?(callback: () => void): () => void;
+  onWake?(callback: (stream: WakeStream) => void): () => void;
 
   /**
    * Late-bind the backend-true (tokenId, stateHash) derivation —


### PR DESCRIPTION
Closes #564

## Problem

Two browser windows, same custodial wallet. When window A tops up / receives tokens, window B's balance/inventory does not update even though its websocket is "connected".

The wallet-api wake socket multiplexes **three** owner streams (`mailbox` | `inventory` | `payment_requests`) and the backend fans every owner-scoped change to **all** of the owner's sessions — but the SDK only consumed `mailbox`. `inventory` and `payment_requests` wakes were parsed (`parseWakeFrame`) then **dropped**, and there was **no inventory poll** at all. So a second window had no realtime path for those streams and no inventory backstop either.

## Change

- **`transport/delivery-provider.ts`** — `onWake` callback now receives the `WakeStream` (new exported type) instead of taking no argument, so the consumer can route by stream. No third-party implementers exist (only the wallet-api mailbox provider).
- **`impl/shared/wallet-api/WalletApiMailboxProvider.ts`** — `onWake` forwards **all three** streams (`callback(wake.stream)`) instead of firing only on `mailbox`. (This is the single seam that owns the wake socket, so one socket serves all three streams — no second socket.)
- **`modules/payments/PaymentsModule.ts`** — a `handleWake(stream)` router:
  - `mailbox` → `pumpIncomingDeliveries()` (unchanged behaviour),
  - `inventory` → `debouncedInventorySyncFromWake()` → `resyncInventory()` (a debounced, coalesced inventory resync),
  - `payment_requests` → `pumpPaymentRequests()`.
  - Adds an **inventory poll timer** at `DELIVERY_POLL_INTERVAL_MS` (30s — the same constant the delivery/PR pumps use) calling `resyncInventory()` as the §9 correctness backstop. Torn down with the delivery pump.

### Inventory-wake routing choice (justified)

I route the `inventory` wake to PaymentsModule's existing inventory-refresh path (`resyncInventory()` → `load()` → `syncInventory()` §5.1 delta pull + `mergeLazyInventory()`), **not** through a new `onEvent`/`storage:remote-updated` emitter on the token storage provider. Reasons:

1. The mailbox provider already owns the only wake socket in custodial mode; adding a second socket consumer in the token storage provider would mean two ws-ticket/socket connections per session. Routing all three streams through the one existing seam keeps **one socket, one debounce owner**.
2. The thin wallet-api `TokenStorageProvider.sync()` is a write-behind no-op for reads (`merged: localData`) — it does **not** refresh the module's lazy inventory view. `load()`/`mergeLazyInventory()` is the proven path that re-pulls the §5.1 delta and re-merges the owned-token set (it is exactly what the existing reload/#521 test exercises).
3. `resyncInventory()` still emits the existing `sync:remote-update` event (owned-token-count delta → `added`/`removed`), so the frontend's `useSphereEvents` realtime path — **dead in custodial mode today** — lights up, with no new provider plumbing.

The wake is only a nudge; the poll backstop is the correctness path (§9). The wake-socket **reconnect** logic (`connectWakeSocket`) is deliberately untouched (separate step 5).

## Tests

New `tests/unit/modules/PaymentsModule.wake-consumers.test.ts` (in-process fake, real wake socket — no Testcontainers):

- an `inventory` wake → window B sees a server-side top-up converge **without** waiting for the 30s poll, and `sync:remote-update` fires with `added: 1`;
- a **burst** of `inventory` wakes coalesces into a **single** resync (debounce);
- a `payment_requests` wake → window B (the payer) surfaces a request created by another wallet, with no explicit `syncPaymentRequests()`.

Adds a `FakeWalletApi.socketCount(pubkey)` test seam to wait for the wake socket before driving wakes.

## Tested locally (containerized, node:22)

- `npm run typecheck`: clean.
- `eslint` on changed files: 0 errors (only pre-existing unrelated unused-var warnings).
- `vitest run` on the new test: **3/3 pass**.
- Regression check — `PaymentsModule.wallet-api-delivery` (13), `PaymentsModule.payment-requests`, `client.ws` (22 total), plus `PaymentsModule` + `PaymentsModule.concurrency` (91): **all green**.