### PR TITLE
fix(wallet-api): self-healing wake socket — reconnect supervisor + liveness watchdog + catch-up resync

### DIFF
--- a/impl/shared/wallet-api/WalletApiMailboxProvider.ts
+++ b/impl/shared/wallet-api/WalletApiMailboxProvider.ts
@@ -37,6 +37,7 @@ import type {
   DeliveryReceipt,
   IncomingDelivery,
   WakeStream,
+  WakeChannelStatus,
 } from '../../../transport/delivery-provider';
 import { composeDeliveryKeys, computeDeliveryId } from '../../../transport/delivery-provider';
 import { unwrapTokenBlobBytes } from '../../../token-engine/token-blob';
@@ -400,25 +401,29 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
   // payment_requests to their respective pulls. (Previously only `mailbox`
   // was surfaced — inventory and payment-request nudges were dropped, leaving
   // a second session with no realtime path for those streams.)
-  onWake(callback: (stream: WakeStream) => void): () => void {
-    let closed = false;
-    let close: (() => void) | null = null;
-    void this.client
-      .connectWakeSocket((wake) => {
-        callback(wake.stream);
-      })
-      .then((handle) => {
-        if (closed) handle.close();
-        else close = () => handle.close();
-      })
-      .catch((err) => {
-        // Wakes are best-effort; polling remains the correctness path (§9).
-        logger.debug(TAG, 'wake socket unavailable (polling continues):', err);
-      });
-    return () => {
-      closed = true;
-      close?.();
-    };
+  //
+  // The socket SELF-HEALS via the client's supervisor (§9): it reconnects with
+  // backoff on any drop and a liveness watchdog catches a half-open socket.
+  // Because wakes missed while the socket was dead are NOT replayed, every
+  // (re)connect runs a full catch-up pull of ALL THREE streams — done by firing
+  // `callback` once per stream, which the consumer already routes to each
+  // stream's pull. This is what converges a window whose socket went dark.
+  onWake(
+    callback: (stream: WakeStream) => void,
+    onStatus?: (status: WakeChannelStatus) => void
+  ): () => void {
+    const handle = this.client.superviseWakeSocket({
+      onWake: (wake) => callback(wake.stream),
+      onReconnect: () => this.catchUpAllStreams(callback),
+      onStatus,
+    });
+    return () => handle.close();
+  }
+
+  /** §9: replay one synthetic nudge per stream so the consumer full-resyncs after a (re)connect. */
+  private catchUpAllStreams(callback: (stream: WakeStream) => void): void {
+    const streams: WakeStream[] = ['inventory', 'mailbox', 'payment_requests'];
+    for (const stream of streams) callback(stream);
   }
 }
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1152,7 +1152,13 @@ export class PaymentsModule {
       // every stream below also has a poll backstop that is the correctness
       // path. (Before this, only `mailbox` was consumed, so a second session
       // saw no realtime inventory/payment-request convergence.)
-      this.deliveryWakeUnsub = this.injectedDelivery.onWake?.((stream) => this.handleWake(stream)) ?? null;
+      this.deliveryWakeUnsub =
+        this.injectedDelivery.onWake?.(
+          (stream) => this.handleWake(stream),
+          // §9: surface TRUE wake-socket liveness, decoupled from sign-in state,
+          // so the frontend can show a "live/reconnecting" indicator.
+          (status) => this.deps?.emitEvent('realtime:status', { status })
+        ) ?? null;
       // Poll is the correctness path; the wake is just a nudge (§9).
       this.deliveryPollTimer = setInterval(() => {
         void this.pumpIncomingDeliveries().catch((err) =>

--- a/tests/support/fake-wallet-api.ts
+++ b/tests/support/fake-wallet-api.ts
@@ -405,6 +405,38 @@ export class FakeWalletApi {
     return this.socketsByOwner.get(pubkey)?.size ?? 0;
   }
 
+  /**
+   * §9 reconnect-supervisor test seam: forcibly drop ALL of an owner's wake
+   * sockets server-side — the abrupt drop the supervisor must self-heal from
+   * (a proxy/idle kill, a missed-heartbeat `terminate()`, etc.). `terminate`
+   * (default) is an unclean drop with no close frame; pass `{ code }` for a
+   * clean close with a specific code (e.g. 4401 logout-close) instead. Returns
+   * the number of sockets dropped.
+   */
+  dropSockets(pubkey: string, opts: { code?: number; reason?: string } = {}): number {
+    const sockets = this.socketsByOwner.get(pubkey);
+    if (!sockets) return 0;
+    const victims = [...sockets];
+    for (const ws of victims) {
+      if (opts.code !== undefined) ws.close(opts.code, opts.reason);
+      else ws.terminate();
+    }
+    return victims.length;
+  }
+
+  /**
+   * §9 watchdog test seam: send a protocol-level ping to every one of an
+   * owner's sockets (the heartbeat the real gateway emits). Withholding these
+   * while the socket stays open server-side simulates a half-open socket — the
+   * client liveness watchdog must then force a reconnect. Returns the count.
+   */
+  pingOwner(pubkey: string): number {
+    const sockets = this.socketsByOwner.get(pubkey);
+    if (!sockets) return 0;
+    for (const ws of sockets) ws.ping();
+    return sockets.size;
+  }
+
   getIntent(pubkey: string, transferId: string): { payload: string; status: string } | null {
     const intent = this.owner(pubkey).intents.get(transferId);
     return intent ? { payload: intent.payload, status: intent.status } : null;

--- a/tests/support/wallet-api-test-helpers.ts
+++ b/tests/support/wallet-api-test-helpers.ts
@@ -10,12 +10,13 @@
  * without an aggregator.
  */
 
+import WebSocket from 'ws';
 import { getPublicKey } from '../../core/crypto';
 import { decodeTokenBlob, encodeTokenBlob } from '../../token-engine/token-blob';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type { TokenBlob } from '../../token-engine/types';
 import type { TxfStorageDataBase } from '../../storage';
-import type { KeyValueStore } from '../../wallet-api';
+import type { KeyValueStore, WebSocketLike } from '../../wallet-api';
 
 let tokenCounter = 0;
 
@@ -93,6 +94,34 @@ export class MemoryKeyValueStore implements KeyValueStore {
   async remove(key: string): Promise<void> {
     this.map.delete(key);
   }
+}
+
+/**
+ * Adapt the `ws` package to {@link WebSocketLike} INCLUDING the protocol
+ * `onPing`/`onPong` liveness hooks (the bare W3C `ws` surface exposes
+ * `onopen/onmessage/onerror/onclose` only — not ping/pong). The §9 wake
+ * supervisor's liveness watchdog observes these, so tests that exercise the
+ * watchdog inject sockets through this. `onclose` is forwarded WITH the close
+ * code so a 4401/auth-gone close is distinguishable from a plain drop.
+ */
+export function wsLikeWithPing(url: string): WebSocketLike {
+  const raw = new WebSocket(url);
+  const like: WebSocketLike = {
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    onclose: null,
+    onPing: null,
+    onPong: null,
+    close: (code, reason) => raw.close(code, reason),
+  };
+  raw.on('open', () => like.onopen?.());
+  raw.on('message', (data) => like.onmessage?.({ data: data.toString() }));
+  raw.on('error', (err) => like.onerror?.(err));
+  raw.on('close', (code, reason) => like.onclose?.({ code, reason: reason.toString() }));
+  raw.on('ping', () => like.onPing?.());
+  raw.on('pong', () => like.onPong?.());
+  return like;
 }
 
 /** Deterministic test identity n (secp256k1). */

--- a/tests/unit/modules/PaymentsModule.wake-reconnect.test.ts
+++ b/tests/unit/modules/PaymentsModule.wake-reconnect.test.ts
@@ -1,0 +1,207 @@
+/**
+ * PaymentsModule × the §9 wake-socket RECONNECT SUPERVISOR, end-to-end against
+ * the in-process fake backend — the heart of the cross-session-sync fix.
+ *
+ * The wake socket self-heals: when window B's socket drops, the supervisor
+ * reconnects (backoff) AND runs a full catch-up pull of all three streams,
+ * because wakes that fired while B was dark are NOT replayed by the server
+ * (best-effort pub/sub). The KEY guarantee: a state change window A made while
+ * B's socket was dead converges in B on RECONNECT — without waiting for the
+ * 30 s poll backstop.
+ *
+ * Node < 22 has no global WebSocket — sockets are injected via the `ws` package
+ * (this exact omission already broke a CI node-20 leg).
+ */
+import WebSocket from 'ws';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createPaymentsModule, type PaymentsModule, type PaymentsModuleDependencies } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity, IncomingPaymentRequest } from '../../../types';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type { StorageProvider } from '../../../storage';
+import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
+import { FakeWalletApi } from '../../support/fake-wallet-api';
+import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
+import { WalletApiClient, type WebSocketLike } from '../../../wallet-api';
+import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../../impl/shared/wallet-api';
+import { encodeTokenBlob } from '../../../token-engine/token-blob';
+import { hexToBytes } from '../../../core/crypto';
+
+const UCT = '11'.repeat(32);
+const OWNER = testIdentity(81);
+const REQUESTER = testIdentity(82);
+
+function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIdentity {
+  return {
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    l1Address: `alpha1${id.chainPubkey.slice(0, 8)}`,
+    directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
+    transportPubkey: id.chainPubkey.slice(2),
+  };
+}
+
+function mockStorage(): { provider: StorageProvider } {
+  const s = new Map<string, string>();
+  const provider = {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+  return { provider };
+}
+
+function mockTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('nostr-event'),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('nostr-event'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn(async (recipient: string) =>
+      /^0[23][0-9a-f]{64}$/i.test(recipient)
+        ? { chainPubkey: recipient.toLowerCase(), transportPubkey: recipient.slice(2), directAddress: `DIRECT://${recipient.slice(0, 12)}` }
+        : null
+    ),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return { validateToken: vi.fn().mockResolvedValue({ valid: true }), isDevMode: () => false } as unknown as OracleProvider;
+}
+
+interface Wallet {
+  module: PaymentsModule;
+  engine: FakeTokenEngine;
+  client: WalletApiClient;
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!();
+});
+
+async function startFake(): Promise<{ fake: FakeWalletApi; baseUrl: string }> {
+  const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
+  const baseUrl = await fake.start();
+  cleanups.push(() => fake.stop());
+  return { fake, baseUrl };
+}
+
+function makeWallet(baseUrl: string, network: string, who: { privateKey: string; chainPubkey: string }, deviceId: string): Wallet {
+  const identity = fullIdentity(who);
+  const kv = new MemoryKeyValueStore();
+  const client = new WalletApiClient({
+    baseUrl,
+    network,
+    deviceId,
+    storage: kv,
+    webSocketFactory: (url) => new WebSocket(url) as unknown as WebSocketLike,
+  });
+  const tokenStorage = new WalletApiTokenStorageProvider({ client, stateStore: kv });
+  tokenStorage.setIdentity(identity);
+  const delivery = new WalletApiMailboxProvider({ client, custody: 'inventory', stateStore: kv });
+  const engine = new FakeTokenEngine({ chainPubkey: hexToBytes(who.chainPubkey) });
+  const deps: PaymentsModuleDependencies = {
+    identity,
+    storage: mockStorage().provider,
+    tokenStorageProviders: new Map([[tokenStorage.id, tokenStorage]]),
+    transport: mockTransport(),
+    oracle: mockOracle(),
+    emitEvent: vi.fn(),
+    tokenEngine: engine,
+    delivery,
+    walletApi: client,
+  };
+  const module = createPaymentsModule({ l1: null });
+  module.initialize(deps);
+  cleanups.push(() => module.destroy());
+  return { module, engine, client };
+}
+
+async function seedServerToken(fake: FakeWalletApi, wallet: Wallet, who: { chainPubkey: string }, amount: bigint): Promise<void> {
+  const minted = await wallet.engine.mint({ recipientPubkey: wallet.engine.getIdentity().chainPubkey, value: { assets: [{ coinId: UCT, amount }] } });
+  const bytes = encodeTokenBlob(wallet.engine.encodeToken(minted));
+  fake.seedInventory(who.chainPubkey, [{ tokenId: wallet.engine.tokenId(minted), assets: [{ coinId: UCT, amount }], blob: bytes }]);
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 4000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error('waitFor: predicate never became true');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe('wallet-api wake reconnect converges a window whose socket went dark (§9)', () => {
+  it('B reconnects after a drop AND catches up an inventory top-up made while it was dark — no 30 s poll', async () => {
+    const { fake, baseUrl } = await startFake();
+    const windowB = makeWallet(baseUrl, fake.network, OWNER, 'win-b');
+    await windowB.module.load();
+    expect(windowB.module.getTokens()).toHaveLength(0);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1);
+
+    // B's wake socket dies (proxy/idle/network kill) — unobserved by the bare handle.
+    expect(fake.dropSockets(OWNER.chainPubkey)).toBe(1);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0);
+
+    // While B is DARK, window A tops up the shared inventory (+ the wake that
+    // fires now reaches nobody — B has no socket; the server does not replay it).
+    await seedServerToken(fake, windowB, OWNER, 1000n);
+    fake.wakeOwner(OWNER.chainPubkey, 'inventory'); // lands on zero sockets
+
+    // The supervisor reconnects and its catch-up pump full-resyncs every stream:
+    // B converges on the top-up it NEVER got a live wake for.
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1);
+    await waitFor(() => windowB.module.getTokens().length === 1);
+    expect(windowB.module.getTokens()[0]).toMatchObject({ amount: '1000', coinId: UCT, status: 'confirmed' });
+  });
+
+  it('B reconnects and catches up a payment-request created while it was dark', async () => {
+    const { fake, baseUrl } = await startFake();
+    const payer = makeWallet(baseUrl, fake.network, OWNER, 'pay-b');
+    const requester = makeWallet(baseUrl, fake.network, REQUESTER, 'req-a');
+    await payer.module.load();
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1);
+
+    const surfaced: IncomingPaymentRequest[] = [];
+    payer.module.onPaymentRequest((r) => surfaced.push(r));
+
+    // The payer's socket dies.
+    fake.dropSockets(OWNER.chainPubkey);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0);
+
+    // The requester creates a PR while the payer is dark — its `payment_requests`
+    // wake reaches no socket.
+    const created = await requester.module.sendPaymentRequest(OWNER.chainPubkey, { amount: '25', coinId: UCT });
+    expect(created.success).toBe(true);
+
+    // On reconnect the catch-up PR pump surfaces the request the payer never got
+    // a live wake for — convergence from the reconnect alone, not the poll.
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1);
+    await waitFor(() => surfaced.length === 1);
+    expect(surfaced[0]).toMatchObject({ id: created.requestId, amount: '25', coinId: UCT, status: 'pending' });
+  });
+
+  it('destroy() tears the wake socket down and it does not reconnect', async () => {
+    const { fake, baseUrl } = await startFake();
+    const windowB = makeWallet(baseUrl, fake.network, OWNER, 'win-destroy');
+    await windowB.module.load();
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1);
+
+    windowB.module.destroy();
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0);
+
+    // A torn-down module must never re-establish the socket.
+    await new Promise((r) => setTimeout(r, 150));
+    expect(fake.socketCount(OWNER.chainPubkey)).toBe(0);
+  });
+});

--- a/tests/unit/wallet-api/client.wake-supervisor.test.ts
+++ b/tests/unit/wallet-api/client.wake-supervisor.test.ts
@@ -1,0 +1,186 @@
+/**
+ * S1 realtime — the wake-socket reconnect SUPERVISOR (§9). The bare
+ * `connectWakeSocket` nulled `onclose`/`onerror` after open, so ANY post-open
+ * drop (server `terminate()` on a missed heartbeat, a 4401 token-expiry close,
+ * a proxy/idle/network drop) went unobserved: the handle looked open but was
+ * dead until a reload. `superviseWakeSocket` makes it self-heal — these tests
+ * prove the real behaviour against the in-process fake:
+ *
+ *  - a forcibly dropped socket RECONNECTS (a fresh socket appears for the owner);
+ *  - the liveness watchdog force-reconnects a HALF-OPEN socket (pongs/pings stop
+ *    while the server socket stays open);
+ *  - an intentional `close()` spawns NO reconnect loop and leaks no timers;
+ *  - `onReconnect` (the catch-up pump) runs on every (re)connect;
+ *  - a 4401 logout-close is distinguished from a drop (drops the JWT for a
+ *    re-auth, and an intentional close after it does not loop);
+ *  - `onStatus` surfaces true liveness (connected → reconnecting → connected →
+ *    closed).
+ *
+ * Node < 22 has no global WebSocket — sockets are injected via the `ws` package
+ * (this exact omission already broke a CI node-20 leg). `wsLikeWithPing` also
+ * bridges the protocol ping/pong events the watchdog observes.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { WalletApiClient, type WakeSocketStatus } from '../../../wallet-api';
+import { FakeWalletApi } from '../../support/fake-wallet-api';
+import { MemoryKeyValueStore, testIdentity, wsLikeWithPing } from '../../support/wallet-api-test-helpers';
+
+const identity = testIdentity(70);
+
+// Tiny backoff/heartbeat so the suite runs well under the 10 s test timeout.
+const FAST_TIMING = { backoffBaseMs: 5, backoffCapMs: 20, heartbeatMs: 25 };
+
+async function waitFor(predicate: () => boolean, timeoutMs = 4000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error('waitFor: predicate never became true');
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe('WalletApiClient — wake-socket reconnect supervisor (§9)', () => {
+  let fake: FakeWalletApi;
+  let baseUrl: string;
+  let client: WalletApiClient;
+
+  beforeEach(async () => {
+    fake = new FakeWalletApi();
+    baseUrl = await fake.start();
+    client = new WalletApiClient({
+      baseUrl,
+      network: fake.network,
+      deviceId: 'dev-sup',
+      storage: new MemoryKeyValueStore(),
+      webSocketFactory: wsLikeWithPing,
+    });
+    client.setIdentity(identity);
+  });
+
+  afterEach(async () => {
+    await fake.stop();
+  });
+
+  it('reconnects after a forced drop — a fresh socket appears for the owner', async () => {
+    const statuses: WakeSocketStatus[] = [];
+    const handle = client.superviseWakeSocket(
+      { onWake: () => undefined, onStatus: (s) => statuses.push(s) },
+      FAST_TIMING
+    );
+    try {
+      await waitFor(() => fake.socketCount(identity.chainPubkey) === 1);
+      await waitFor(() => handle.status === 'connected');
+
+      // The exact defect: a post-open drop the bare handle never noticed.
+      expect(fake.dropSockets(identity.chainPubkey)).toBe(1);
+      await waitFor(() => fake.socketCount(identity.chainPubkey) === 0);
+
+      // The supervisor heals it — a NEW socket is established (backoff applied).
+      await waitFor(() => fake.socketCount(identity.chainPubkey) === 1);
+      await waitFor(() => handle.status === 'connected');
+      // It went through the reconnecting state, not straight back to connected.
+      expect(statuses).toContain('reconnecting');
+      expect(statuses[statuses.length - 1]).toBe('connected');
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('survives REPEATED drops — heals each time (bounded backoff never gives up)', async () => {
+    const handle = client.superviseWakeSocket({ onWake: () => undefined }, FAST_TIMING);
+    try {
+      for (let i = 0; i < 3; i += 1) {
+        await waitFor(() => fake.socketCount(identity.chainPubkey) === 1);
+        fake.dropSockets(identity.chainPubkey);
+        await waitFor(() => fake.socketCount(identity.chainPubkey) === 0);
+      }
+      // After three drops it is still self-healing.
+      await waitFor(() => fake.socketCount(identity.chainPubkey) === 1);
+      await waitFor(() => handle.status === 'connected');
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('liveness watchdog force-reconnects a HALF-OPEN socket (pings stop)', async () => {
+    const ownerSockets = (): Set<unknown> =>
+      (fake as unknown as { socketsByOwner: Map<string, Set<unknown>> }).socketsByOwner.get(identity.chainPubkey) ?? new Set();
+
+    // Keep the socket alive with periodic protocol pings — the watchdog (2× the
+    // 25 ms heartbeat) stays armed while they flow.
+    const ping = setInterval(() => fake.pingOwner(identity.chainPubkey), 10);
+    const handle = client.superviseWakeSocket({ onWake: () => undefined }, FAST_TIMING);
+    try {
+      await waitFor(() => fake.socketCount(identity.chainPubkey) === 1);
+      const firstSocket = [...ownerSockets()][0];
+
+      // Half-open: stop the heartbeat but DON'T close the server socket. The
+      // client sees only silence — the bare handle would stay "open" forever.
+      clearInterval(ping);
+
+      // The watchdog fires (~50 ms) and forces a reconnect: a DIFFERENT socket
+      // instance ends up subscribed (the dead one was force-closed by the client).
+      await waitFor(() => {
+        const set = ownerSockets();
+        return set.size === 1 && [...set][0] !== firstSocket;
+      });
+      await waitFor(() => handle.status === 'connected');
+    } finally {
+      clearInterval(ping);
+      handle.close();
+    }
+  });
+
+  it('an intentional close() spawns NO reconnect (no loop, no leaked socket)', async () => {
+    const statuses: WakeSocketStatus[] = [];
+    const handle = client.superviseWakeSocket(
+      { onWake: () => undefined, onStatus: (s) => statuses.push(s) },
+      FAST_TIMING
+    );
+    await waitFor(() => fake.socketCount(identity.chainPubkey) === 1);
+
+    handle.close();
+    await waitFor(() => fake.socketCount(identity.chainPubkey) === 0);
+    expect(handle.status).toBe('closed');
+    expect(statuses[statuses.length - 1]).toBe('closed');
+
+    // Stays at zero — a closed supervisor must never reconnect. Wait several
+    // backoff windows to be sure no socket reappears.
+    await new Promise((r) => setTimeout(r, 120));
+    expect(fake.socketCount(identity.chainPubkey)).toBe(0);
+  });
+
+  it('runs the catch-up pump (onReconnect) on EVERY (re)connect', async () => {
+    let catchUps = 0;
+    const handle = client.superviseWakeSocket(
+      { onWake: () => undefined, onReconnect: () => { catchUps += 1; } },
+      FAST_TIMING
+    );
+    try {
+      // First connect.
+      await waitFor(() => catchUps === 1);
+      // A drop → reconnect runs the catch-up again (missed wakes aren't replayed).
+      fake.dropSockets(identity.chainPubkey);
+      await waitFor(() => catchUps === 2);
+    } finally {
+      handle.close();
+    }
+  });
+
+  it('a 4401 logout-close drops the JWT (re-auth) and does not loop after close()', async () => {
+    const handle = client.superviseWakeSocket({ onWake: () => undefined }, FAST_TIMING);
+    await waitFor(() => fake.socketCount(identity.chainPubkey) === 1);
+
+    // A clean 4401 close (auth gone) — the supervisor reconnects with a fresh
+    // ticket (and a refreshed token), so a new socket appears.
+    fake.dropSockets(identity.chainPubkey, { code: 4401, reason: 'access token expired' });
+    await waitFor(() => fake.socketCount(identity.chainPubkey) === 0);
+    await waitFor(() => fake.socketCount(identity.chainPubkey) === 1);
+    await waitFor(() => handle.status === 'connected');
+
+    // A deliberate close after the 4401 must NOT spin up an infinite reconnect.
+    handle.close();
+    await waitFor(() => fake.socketCount(identity.chainPubkey) === 0);
+    await new Promise((r) => setTimeout(r, 120));
+    expect(fake.socketCount(identity.chainPubkey)).toBe(0);
+  });
+});

--- a/transport/delivery-provider.ts
+++ b/transport/delivery-provider.ts
@@ -100,6 +100,16 @@ export type DeliveryDisposition = 'claimed' | 'rejected';
 export type WakeStream = 'inventory' | 'mailbox' | 'payment_requests';
 
 /**
+ * True liveness of the realtime wake channel (§9), decoupled from sign-in
+ * session state: `connecting`/`connected` — a socket is (being) established;
+ * `reconnecting` — it dropped and is backing off to re-establish (the poll
+ * backstop carries correctness meanwhile); `closed` — torn down intentionally.
+ * The wake is a nudge, so this is informational for the frontend (a "live"
+ * indicator) — never a correctness gate.
+ */
+export type WakeChannelStatus = 'connecting' | 'connected' | 'reconnecting' | 'closed';
+
+/**
  * Custody mode (composition-time): `'inventory'` — acknowledged deliveries
  * enter the wallet-api inventory (the full wallet-api preset); `'external'` —
  * the app's own storage keeps custody and acks perform ZERO inventory writes
@@ -157,9 +167,19 @@ export interface DeliveryProvider {
    * correctness dependency, ARCHITECTURE §9). The wallet-api wake socket
    * multiplexes all three owner streams (`mailbox` | `inventory` |
    * `payment_requests`); the consumer routes each to that stream's pull.
-   * Returns an unsubscribe function.
+   *
+   * The underlying socket SELF-HEALS (§9): it reconnects with backoff on any
+   * drop and a liveness watchdog force-reconnects a half-open socket. On every
+   * (re)connect the consumer MUST run a full catch-up pull of every stream —
+   * wakes missed while the socket was dead are not replayed — so `callback`
+   * fires once for EACH stream on (re)connect (a synthetic catch-up nudge).
+   * `onStatus` (optional) surfaces true socket liveness for the frontend,
+   * decoupled from sign-in state. Returns an unsubscribe function.
    */
-  onWake?(callback: (stream: WakeStream) => void): () => void;
+  onWake?(
+    callback: (stream: WakeStream) => void,
+    onStatus?: (status: WakeChannelStatus) => void
+  ): () => void;
 
   /**
    * Late-bind the backend-true (tokenId, stateHash) derivation —

--- a/types/index.ts
+++ b/types/index.ts
@@ -400,6 +400,7 @@ export type SphereEventType =
   | 'sync:error'
   | 'storage:degraded'
   | 'walletapi:session'
+  | 'realtime:status'
   | 'connection:changed'
   | 'nametag:registered'
   | 'nametag:recovered'
@@ -495,6 +496,16 @@ export interface SphereEventMap {
    * `sphere.walletApiSessionStatus`.
    */
   'walletapi:session': { status: 'online' | 'offline'; error?: string };
+  /**
+   * True liveness of the realtime wake socket (§9), DISTINCT from sign-in
+   * session state (`walletapi:session`) and from provider connectivity
+   * (`connection:changed`): `connected` — a wake socket is open; `reconnecting`
+   * — it dropped and the supervisor is backing off (the poll backstop carries
+   * correctness meanwhile); `closed` — torn down on logout/destroy. The wake is
+   * only a nudge, so this is a frontend "live" indicator, never a correctness
+   * gate.
+   */
+  'realtime:status': { status: 'connecting' | 'connected' | 'reconnecting' | 'closed' };
   'connection:changed': { provider: string; connected: boolean; status?: ProviderStatus; enabled?: boolean; error?: string };
   'nametag:registered': { nametag: string; addressIndex: number };
   'nametag:recovered': { nametag: string };

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -33,6 +33,11 @@ import { signMessage } from '../core/crypto';
 import { WalletApiError } from './errors';
 import { verifyChallengeTemplate } from './challenge';
 import {
+  WakeSocketSupervisor,
+  DEFAULT_WAKE_TIMING,
+  type WakeSupervisorTiming,
+} from './wake-supervisor';
+import {
   parseApplyResult,
   parseAuthChallenge,
   parseAuthTokens,
@@ -70,6 +75,8 @@ import type {
   PaymentRequestRecord,
   PaymentRequestsPage,
   RespondPaymentRequestInput,
+  SupervisedWakeSocketHandle,
+  SuperviseWakeOptions,
   UploadUrlEntry,
   UploadUrlRequest,
   WakeCallback,
@@ -77,6 +84,7 @@ import type {
   WalletApiClientConfig,
   WalletApiIdentity,
   WebSocketFactoryLike,
+  WebSocketLike,
 } from './types';
 
 interface LocalIntent {
@@ -702,16 +710,7 @@ export class WalletApiClient {
    * Wakes are nudges only; correctness comes from the `?since=` cursors.
    */
   async connectWakeSocket(onWake: WakeCallback): Promise<WakeSocketHandle> {
-    const ticket = parseWsTicket(await this.requestJson('POST', '/v1/ws-ticket'));
-    const wsBase = this.baseUrl.replace(/^http/, 'ws');
-    const ws = this.wsFactory(`${wsBase}/v1/ws?ticket=${encodeURIComponent(ticket)}`);
-
-    await new Promise<void>((resolve, reject) => {
-      ws.onopen = () => resolve();
-      ws.onerror = (err) => reject(new WalletApiError('wake socket failed to connect', 'NETWORK', undefined, err));
-      ws.onclose = () => reject(new WalletApiError('wake socket closed before connecting', 'NETWORK'));
-    });
-
+    const ws = await this.openWakeSocket();
     ws.onerror = null;
     ws.onclose = null;
     ws.onmessage = (ev) => {
@@ -720,7 +719,69 @@ export class WalletApiClient {
       void this.noteSyncEpoch(frame.syncEpoch);
       onWake(frame);
     };
-
     return { close: () => ws.close() };
+  }
+
+  /**
+   * Mint a single-use ticket (a 401 silently re-auths via {@link requestJson}),
+   * upgrade to a wake socket and resolve once it opens. ONE socket, no
+   * auto-reconnect — the building block reused by {@link connectWakeSocket} and
+   * the {@link superviseWakeSocket} supervisor.
+   */
+  private async openWakeSocket(): Promise<WebSocketLike> {
+    const ticket = parseWsTicket(await this.requestJson('POST', '/v1/ws-ticket'));
+    const wsBase = this.baseUrl.replace(/^http/, 'ws');
+    const ws = this.wsFactory(`${wsBase}/v1/ws?ticket=${encodeURIComponent(ticket)}`);
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve();
+      ws.onerror = (err) => reject(new WalletApiError('wake socket failed to connect', 'NETWORK', undefined, err));
+      ws.onclose = () => reject(new WalletApiError('wake socket closed before connecting', 'NETWORK'));
+    });
+    return ws;
+  }
+
+  /**
+   * Open a SELF-HEALING wake channel (§9): the supervisor keeps the socket
+   * alive across drops — bounded backoff + jitter reconnects (fresh ticket each
+   * attempt; a 4401/auth-gone close also refreshes the token), a client-side
+   * liveness watchdog that force-reconnects a half-open socket, and a full
+   * catch-up pull of every stream on each (re)connect (`onReconnect`) so a dead
+   * window converges WITHOUT waiting for the poll. `onStatus` surfaces true
+   * socket liveness, decoupled from sign-in state. `close()` tears it down with
+   * no further reconnects (a deliberate logout-close never loops).
+   */
+  superviseWakeSocket(
+    options: SuperviseWakeOptions,
+    timing: WakeSupervisorTiming = DEFAULT_WAKE_TIMING
+  ): SupervisedWakeSocketHandle {
+    const supervisor = new WakeSocketSupervisor(
+      {
+        onWake: (wake) => {
+          void this.noteSyncEpoch(wake.syncEpoch);
+          options.onWake(wake);
+        },
+        onReconnect: options.onReconnect,
+        onStatus: options.onStatus,
+      },
+      {
+        openSocket: () => this.openWakeSocket(),
+        // A 4401/expiry close means the bound token is gone — drop the cached
+        // JWT so the next ticket mint re-auths (refresh → challenge fallback).
+        onAuthGone: () => {
+          this.jwt = null;
+        },
+        setTimeout: (cb, ms) => setTimeout(cb, ms),
+        clearTimeout: (h) => clearTimeout(h),
+        random: () => Math.random(),
+      },
+      timing
+    );
+    supervisor.start();
+    return {
+      close: () => supervisor.close(),
+      get status() {
+        return supervisor.currentStatus;
+      },
+    };
   }
 }

--- a/wallet-api/index.ts
+++ b/wallet-api/index.ts
@@ -43,4 +43,7 @@ export type {
   WakeEvent,
   WakeCallback,
   WakeSocketHandle,
+  WakeSocketStatus,
+  SuperviseWakeOptions,
+  SupervisedWakeSocketHandle,
 } from './types';

--- a/wallet-api/types.ts
+++ b/wallet-api/types.ts
@@ -42,8 +42,17 @@ export interface WebSocketLike {
   onopen: ((ev?: unknown) => void) | null;
   onmessage: ((ev: { data: unknown }) => void) | null;
   onerror: ((ev?: unknown) => void) | null;
-  onclose: ((ev?: unknown) => void) | null;
-  close(): void;
+  onclose: ((ev?: { code?: number; reason?: string }) => void) | null;
+  /**
+   * Protocol-level ping/pong observers (the `ws` package fires `'ping'`/`'pong'`
+   * events; browsers auto-pong silently and surface neither). Optional — the
+   * liveness watchdog (§9) treats any of ping/pong/message as a sign of life and
+   * never depends on these being present. Assigned via the optional setters
+   * below so the minimal browser surface still satisfies the type.
+   */
+  onPing?: ((ev?: unknown) => void) | null;
+  onPong?: ((ev?: unknown) => void) | null;
+  close(code?: number, reason?: string): void;
 }
 
 export type WebSocketFactoryLike = (url: string) => WebSocketLike;
@@ -315,4 +324,45 @@ export type WakeCallback = (wake: WakeEvent) => void;
 /** Handle returned by the wake-socket connect. */
 export interface WakeSocketHandle {
   close(): void;
+}
+
+/**
+ * True liveness of the supervised wake socket (§9), decoupled from sign-in
+ * session state: `connected` — a socket is open and receiving; `reconnecting`
+ * — the socket dropped and the supervisor is backing off to re-establish it
+ * (the poll backstop carries correctness meanwhile); `closed` — torn down
+ * intentionally (`destroy`/logout), no further reconnects.
+ */
+export type WakeSocketStatus = 'connecting' | 'connected' | 'reconnecting' | 'closed';
+
+/**
+ * Options for {@link WalletApiClient.superviseWakeSocket} — the self-healing
+ * wake channel (§9). The socket re-mints a fresh ticket and reconnects with
+ * bounded backoff + jitter on every drop, and a client-side liveness watchdog
+ * forces a reconnect on a half-open socket (no pings/frames for 2× the server
+ * heartbeat). Wakes missed while the socket was dead are NOT replayed by the
+ * server (best-effort Redis pub/sub) — so `onReconnect` runs a full catch-up
+ * pull of every stream on each (re)connect: that pull is what guarantees
+ * convergence (correctness is the pull; the wake is only a nudge).
+ */
+export interface SuperviseWakeOptions {
+  /** A wake nudge arrived — pull that stream's cursor. */
+  onWake: WakeCallback;
+  /**
+   * Run once on every (re)connect: a full catch-up pull of ALL streams, since
+   * wakes missed during the dead window are gone. The supervisor awaits
+   * nothing — failures here are the caller's to log; the poll backstop covers
+   * a failed catch-up.
+   */
+  onReconnect?: () => void;
+  /** True socket liveness changed — surface it to the frontend (§9). */
+  onStatus?: (status: WakeSocketStatus) => void;
+}
+
+/** Handle returned by {@link WalletApiClient.superviseWakeSocket}. */
+export interface SupervisedWakeSocketHandle {
+  /** Tear down: stop the watchdog, cancel any pending reconnect, close the live socket. Idempotent. */
+  close(): void;
+  /** Current true liveness (§9). */
+  readonly status: WakeSocketStatus;
 }

--- a/wallet-api/wake-supervisor.ts
+++ b/wallet-api/wake-supervisor.ts
@@ -1,0 +1,239 @@
+/**
+ * Wake-socket reconnect supervisor (§9) — makes the single multiplexed wake
+ * socket self-heal.
+ *
+ * The wake socket is a best-effort NUDGE; correctness is the pull. But a
+ * SILENTLY dead socket starves every realtime consumer until a reload: the
+ * server `terminate()`s on a missed heartbeat, hard-closes at access-token
+ * expiry (code 4401), and proxies/idle/network/tab-suspend drop it — none of
+ * which the bare `connectWakeSocket` observed once it nulled `onclose`/`onerror`
+ * after open.
+ *
+ * This supervisor keeps `onclose`/`onerror` live and:
+ *  - reconnects on any drop with bounded exponential backoff + full jitter,
+ *    re-minting a fresh ticket each attempt (and refreshing the JWT on a 4401 /
+ *    auth-expiry close) — never giving up while the session is valid;
+ *  - runs a client-side liveness watchdog: any inbound signal (message, server
+ *    ping, or pong) is a sign of life; `2×` the server heartbeat of silence
+ *    means a half-open socket → force-close and reconnect;
+ *  - runs a full catch-up pull of ALL streams on every (re)connect (`onReconnect`)
+ *    — wakes missed during the dead window are gone (best-effort pub/sub), so
+ *    the client MUST full-resync to converge;
+ *  - distinguishes an intentional close (`destroy`/logout) from a drop so a
+ *    deliberate 4401 logout-close never spawns an infinite reconnect loop.
+ *
+ * Lives at the client layer because reconnecting re-mints a ws-ticket and may
+ * refresh the JWT — both client-private. The socket OWNER (the MailboxProvider)
+ * just supplies the catch-up/wake/status callbacks.
+ */
+import { WalletApiError } from './errors';
+import { parseWakeFrame } from './codec';
+import type {
+  SuperviseWakeOptions,
+  WakeSocketStatus,
+  WebSocketLike,
+} from './types';
+
+/** App-defined WS close code: authentication gone — reconnect needs a fresh ticket + token (server `CLOSE_AUTH_GONE`, §9). */
+export const CLOSE_AUTH_GONE = 4401;
+
+export interface WakeSupervisorTiming {
+  /** First reconnect delay; doubles each attempt up to {@link backoffCapMs}. */
+  readonly backoffBaseMs: number;
+  /** Backoff ceiling — the delay never exceeds this (before jitter). */
+  readonly backoffCapMs: number;
+  /**
+   * Server heartbeat interval (§9 — 30 s). The liveness watchdog fires after
+   * `2×` this of total silence (one whole missed ping/pong cycle + margin).
+   */
+  readonly heartbeatMs: number;
+}
+
+export const DEFAULT_WAKE_TIMING: WakeSupervisorTiming = {
+  backoffBaseMs: 500,
+  backoffCapMs: 30_000,
+  heartbeatMs: 30_000,
+};
+
+/** Injectable seams so tests drive time/randomness deterministically. */
+export interface WakeSupervisorEnv {
+  /** Re-mint a ticket and open ONE socket (no auto-reconnect). */
+  readonly openSocket: () => Promise<WebSocketLike>;
+  /** On a 4401/auth-gone close, drop the cached JWT so the next ticket mint re-auths. */
+  readonly onAuthGone: () => void;
+  readonly setTimeout: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimeout: (handle: ReturnType<typeof setTimeout>) => void;
+  /** [0,1) — defaults to Math.random; injected for deterministic jitter in tests. */
+  readonly random: () => number;
+}
+
+type Timer = ReturnType<typeof setTimeout>;
+
+/**
+ * Owns the lifecycle of ONE logical wake channel across reconnects. Construct,
+ * call {@link start}, and {@link close} to tear down (idempotent).
+ */
+export class WakeSocketSupervisor {
+  private status: WakeSocketStatus = 'connecting';
+  private socket: WebSocketLike | null = null;
+  private reconnectTimer: Timer | null = null;
+  private watchdogTimer: Timer | null = null;
+  private attempt = 0;
+  private stopped = false;
+  /** A reconnect cycle is already scheduled/in-flight — coalesce concurrent drop signals. */
+  private reconnecting = false;
+
+  constructor(
+    private readonly opts: SuperviseWakeOptions,
+    private readonly env: WakeSupervisorEnv,
+    private readonly timing: WakeSupervisorTiming = DEFAULT_WAKE_TIMING
+  ) {}
+
+  get currentStatus(): WakeSocketStatus {
+    return this.status;
+  }
+
+  /** Open the first socket; subsequent drops self-heal until {@link close}. */
+  start(): void {
+    void this.connect();
+  }
+
+  /** Idempotent teardown — no leaked timers or sockets, and no further reconnects. */
+  close(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.clearReconnect();
+    this.clearWatchdog();
+    this.detachAndClose(this.socket);
+    this.socket = null;
+    this.setStatus('closed');
+  }
+
+  // ── connect / drop ──────────────────────────────────────────────────────────
+
+  private async connect(): Promise<void> {
+    if (this.stopped) return;
+    this.clearReconnect();
+    try {
+      const ws = await this.env.openSocket();
+      if (this.stopped) {
+        this.detachAndClose(ws);
+        return;
+      }
+      this.adopt(ws);
+    } catch (err) {
+      if (this.stopped) return;
+      // A failed mint/open is just another drop — back off and retry. A 401 in
+      // the mint path already triggers the client's silent re-auth, so an
+      // auth-expired ticket heals here too.
+      this.onDrop(err instanceof WalletApiError && err.status === 401);
+    }
+  }
+
+  /** Wire a freshly opened socket: keep onclose/onerror LIVE, arm the watchdog, run catch-up. */
+  private adopt(ws: WebSocketLike): void {
+    this.socket = ws;
+    this.attempt = 0;
+    this.reconnecting = false;
+    ws.onmessage = (ev): void => this.onFrame(ev);
+    ws.onerror = (): void => this.onDrop(false);
+    ws.onclose = (ev): void => this.onClose(ev);
+    // Ping/pong (when the transport surfaces them) are pure liveness signals.
+    if ('onPing' in ws) ws.onPing = (): void => this.touch();
+    if ('onPong' in ws) ws.onPong = (): void => this.touch();
+    this.armWatchdog();
+    this.setStatus('connected');
+    // §9: wakes missed while dark are NOT replayed — full-resync every stream.
+    this.opts.onReconnect?.();
+  }
+
+  private onFrame(ev: { data: unknown }): void {
+    this.touch(); // any frame proves the socket is alive
+    const frame = parseWakeFrame(typeof ev.data === 'string' ? ev.data : String(ev.data));
+    if (frame) this.opts.onWake(frame);
+  }
+
+  private onClose(ev?: { code?: number }): void {
+    this.onDrop(ev?.code === CLOSE_AUTH_GONE);
+  }
+
+  /** A drop from any cause: schedule a backed-off reconnect (unless intentionally stopped). */
+  private onDrop(authGone: boolean): void {
+    if (this.stopped) return;
+    if (authGone) this.env.onAuthGone(); // force a token refresh on the next mint
+    if (this.reconnecting) return; // a reconnect is already queued — don't pile up
+    this.reconnecting = true;
+    this.clearWatchdog();
+    this.detachAndClose(this.socket);
+    this.socket = null;
+    this.setStatus('reconnecting');
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect(): void {
+    const delay = this.backoffDelay(this.attempt);
+    this.attempt += 1;
+    this.reconnectTimer = this.env.setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connect();
+    }, delay);
+  }
+
+  /** Exponential `base·2^n` capped at `cap`, then full jitter in `[0, capped]` (thundering-herd guard). */
+  private backoffDelay(attempt: number): number {
+    const capped = Math.min(this.timing.backoffCapMs, this.timing.backoffBaseMs * 2 ** attempt);
+    return Math.floor(this.env.random() * capped);
+  }
+
+  // ── liveness watchdog ────────────────────────────────────────────────────────
+
+  /** Mark the socket alive — re-arm the silence watchdog. */
+  private touch(): void {
+    if (this.stopped || !this.socket) return;
+    this.armWatchdog();
+  }
+
+  private armWatchdog(): void {
+    this.clearWatchdog();
+    this.watchdogTimer = this.env.setTimeout(() => {
+      this.watchdogTimer = null;
+      // Silence for a whole heartbeat cycle ⇒ half-open. Force a reconnect.
+      this.onDrop(false);
+    }, this.timing.heartbeatMs * 2);
+  }
+
+  private clearWatchdog(): void {
+    if (this.watchdogTimer !== null) {
+      this.env.clearTimeout(this.watchdogTimer);
+      this.watchdogTimer = null;
+    }
+  }
+
+  private clearReconnect(): void {
+    if (this.reconnectTimer !== null) {
+      this.env.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  /** Detach our handlers (so a late close from THIS socket can't re-trigger) then close it. */
+  private detachAndClose(ws: WebSocketLike | null): void {
+    if (!ws) return;
+    ws.onmessage = null;
+    ws.onerror = null;
+    ws.onclose = null;
+    if ('onPing' in ws) ws.onPing = null;
+    if ('onPong' in ws) ws.onPong = null;
+    try {
+      ws.close();
+    } catch {
+      // already closing/closed — nothing to do
+    }
+  }
+
+  private setStatus(status: WakeSocketStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    this.opts.onStatus?.(status);
+  }
+}


### PR DESCRIPTION
Closes #566. Step 5 of the cross-session-sync fix.

## The defect
The SDK opens ONE multiplexed wake WebSocket. `connectWakeSocket` nulled `onclose`/`onerror` immediately after open, leaving only `onmessage` — **no liveness check, no reconnect, no backoff, no re-subscribe**. So any post-open drop (server `terminate()` on a missed heartbeat, a `4401` token-expiry close, a proxy/idle/network/tab-suspend drop) went unobserved: the handle looked "open" but was dead until a page reload, starving all three realtime streams. The socket was established exactly once in `WalletApiMailboxProvider.onWake` and never re-armed.

## Design
**The supervisor lives at the client layer** (`wallet-api/wake-supervisor.ts`, driven by `WalletApiClient.superviseWakeSocket`). Justification: reconnecting must re-mint a ws-ticket and may refresh the JWT — both client-private (the client already does silent 401 re-auth in `requestJson`). The socket OWNER (the MailboxProvider) just supplies the wake/catch-up/status callbacks; the per-stream consumers (`handleWake` → inventory resync / delivery pump / PR pump) added in the prior step are reused unchanged.

- **Reconnect**: bounded exponential backoff `base·2^n` capped at `cap`, then **full jitter** in `[0, capped]` (thundering-herd guard). A fresh ticket is minted each attempt; a `4401`/auth-gone close drops the cached JWT so the next mint re-auths (refresh → challenge fallback). Never gives up while the session is valid.
- **Liveness watchdog**: any inbound signal — message frame, server protocol ping, or pong — re-arms the timer; `2×` the server heartbeat of total silence ⇒ half-open socket ⇒ force-close + reconnect. `WebSocketLike` gains optional `onPing`/`onPong` (the `ws` package fires these; browsers auto-pong silently — for them the wake/message traffic + the watchdog still cover liveness).
- **Catch-up pump** (§9 — the convergence guarantee): wakes missed while the socket was dead are NOT replayed (best-effort Redis pub/sub), so on every (re)connect the MailboxProvider replays one synthetic nudge per stream → a full resync of inventory + mailbox + payment-requests.
- **True liveness surfaced** via a new `realtime:status` event (`connecting`/`connected`/`reconnecting`/`closed`), distinct from `walletapi:session` (sign-in) and `connection:changed` (provider).
- **Clean teardown**: `close()` is idempotent — cancels the pending reconnect, clears the watchdog, detaches handlers, closes the live socket, and sets `closed`. An intentional close (incl. a deliberate logout `4401`) never spawns a reconnect loop. Wired through the existing `destroy()` → `teardownDeliveryPump()` → `deliveryWakeUnsub` path.

## Files
- `wallet-api/wake-supervisor.ts` (new) — the supervisor.
- `wallet-api/client.ts` — extract `openWakeSocket()`; add `superviseWakeSocket()`.
- `wallet-api/types.ts` / `index.ts` — `SuperviseWakeOptions`, `SupervisedWakeSocketHandle`, `WakeSocketStatus`; `WebSocketLike.onPing/onPong` + close code.
- `impl/shared/wallet-api/WalletApiMailboxProvider.ts` — `onWake` drives the supervisor + catch-up replay.
- `modules/payments/PaymentsModule.ts` / `types/index.ts` / `transport/delivery-provider.ts` — `realtime:status` event + `onStatus` plumbing.
- Tests + fake seams (`fake.dropSockets`, `fake.pingOwner`, `wsLikeWithPing`).

## Tests (meaningful, against the in-process fake; `ws` injected for Node < 22)
- a dropped socket **reconnects** (a fresh socket appears for the owner); survives **repeated** drops;
- the **liveness watchdog** force-reconnects a **half-open** socket when pings stop (a *different* socket instance ends up subscribed);
- **the key test**: a top-up / a PR made while a window is **DARK** converges on the **reconnect catch-up**, WITHOUT waiting for the 30 s poll;
- `destroy()` / intentional `close()` spawns **no reconnect loop** and leaks no timers; a `4401` logout-close re-auths but does not loop after close.

Tested locally: node20 + node22 full suite — typecheck + lint (0 errors) + **3057 tests pass (182 files)** on each.