### PR TITLE
Prove PR senderNametag survives cross-session resolution — data issue, not a regression (Closes #574)

### DIFF
--- a/tests/harness/multi-session-sync.test.ts
+++ b/tests/harness/multi-session-sync.test.ts
@@ -133,6 +133,16 @@ describe('two sessions of the same owner converge over the real wake socket (#52
     const a = await newSession('owner-pr-a', owner);
     const b = await newSession('owner-pr-b', owner);
 
+    // The requester publishes a nametag — it rides INSIDE the S6 memo envelope
+    // (ECDH-addressed to the payer), so the payer renders "@requester" in the
+    // request's "From" field instead of a raw pubkey. This MUST survive the
+    // cross-session resolution upsert — the exact staging report ("From" field
+    // regressed to the raw pubkey once the request flipped to paid in both
+    // windows). Set AFTER load so it is live at send time.
+    await requester.module.setNametag({
+      name: 'requester-tag', token: {}, timestamp: Date.now(), format: 'txf', version: '2.0',
+    });
+
     // Fund session A so it can actually pay (mint converges on B too, but the
     // PR is the property under test here).
     expect((await a.module.mintFungibleToken(HARNESS_COIN, 1000n)).success).toBe(true);
@@ -147,9 +157,13 @@ describe('two sessions of the same owner converge over the real wake socket (#52
     const requestId = created.requestId as string;
     expect(requestId).toBeDefined();
 
-    // BOTH sessions surface it as actionable `pending` from the wake alone.
-    await waitFor(() => a.module.getPaymentRequests().find((r) => r.id === requestId && r.status === 'pending'));
-    await waitFor(() => b.module.getPaymentRequests().find((r) => r.id === requestId && r.status === 'pending'));
+    // BOTH sessions surface it as actionable `pending` from the wake alone, AND
+    // decrypt the requester's nametag from the memo envelope (the "From" field).
+    const pendingOnA = await waitFor(() => a.module.getPaymentRequests().find((r) => r.id === requestId && r.status === 'pending'));
+    const pendingOnB = await waitFor(() => b.module.getPaymentRequests().find((r) => r.id === requestId && r.status === 'pending'));
+    expect(pendingOnA.senderNametag).toBe('requester-tag');
+    expect(pendingOnB.senderNametag).toBe('requester-tag');
+    expect(pendingOnB.message).toBe('multi-session invoice');
 
     // Session A pays it (send + respond('paid', transferId) — the §16 linkage).
     const payResult = await a.module.payPaymentRequest(requestId);
@@ -162,6 +176,10 @@ describe('two sessions of the same owner converge over the real wake socket (#52
       b.module.getPaymentRequests().find((r) => r.id === requestId && r.status === 'paid')
     );
     expect(resolved?.status).toBe('paid');
+    // The resolved row STILL carries the requester's nametag — the upsert mutated
+    // status in place without dropping the counterparty identity. This is the
+    // real-backend proof for the staging "From shows pubkey on resolve" report.
+    expect(resolved?.senderNametag).toBe('requester-tag');
     expect(b.module.getPaymentRequests({ status: 'pending' }).some((r) => r.id === requestId)).toBe(false);
 
     // Session B fired the resolution event so the UI can drop the action card.

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -410,7 +410,16 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     const windowA = makeWalletApiWallet(baseUrl, fake.network, PAYER, 'pr-xa');
     const windowB = makeWalletApiWallet(baseUrl, fake.network, PAYER, 'pr-xb'); // SAME wallet, 2nd window
 
-    const created = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '5', coinId: UCT });
+    // The requester has a nametag — it rides INSIDE the S6 memo envelope, so the
+    // payer renders "@requester" in the request's "From" field rather than a raw
+    // pubkey. It must SURVIVE the cross-session upsert (the staging report: the
+    // request flipped to paid in both windows but the "From" field regressed to
+    // the raw pubkey on the resolved row).
+    await requester.module.setNametag({
+      name: 'api-1', token: {}, timestamp: Date.now(), format: 'txf', version: '2.0',
+    });
+
+    const created = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '5', coinId: UCT, message: 'cross-session' });
     expect(created.success).toBe(true);
 
     // Both windows surface it as actionable (pending), each from its own since=0 bootstrap.
@@ -420,6 +429,9 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     await windowB.module.syncPaymentRequests();
     expect(windowA.module.getPaymentRequests({ status: 'pending' })).toHaveLength(1);
     expect(windowB.module.getPaymentRequests({ status: 'pending' })).toHaveLength(1);
+    // Both windows decrypt the requester's nametag from the memo envelope while pending.
+    expect(windowA.module.getPaymentRequests({ status: 'pending' })[0].senderNametag).toBe('api-1');
+    expect(windowB.module.getPaymentRequests({ status: 'pending' })[0].senderNametag).toBe('api-1');
 
     // Window A declines it — the server respond re-stamps the payer's seq (PR-A).
     await windowA.module.rejectPaymentRequest(created.requestId!);
@@ -434,11 +446,57 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     const onB = windowB.module.getPaymentRequests();
     expect(onB).toHaveLength(1);
     expect(onB[0].status).toBe('rejected'); // upserted, not frozen at first-seen 'pending'
+    // The status-only upsert must NOT clear the nametag/message the request was
+    // first surfaced with — the "From" field stays "@api-1" on the resolved row
+    // (the staging regression: "shows pubkey" == senderNametag lost on resolve).
+    expect(onB[0].senderNametag).toBe('api-1');
+    expect(onB[0].message).toBe('cross-session');
     expect(windowB.module.getPaymentRequests({ status: 'pending' })).toHaveLength(0);
     expect(windowB.module.getPendingPaymentRequestsCount()).toBe(0);
     expect(windowB.emitEvent.mock.calls.some((c) => c[0] === 'payment_request:rejected')).toBe(true);
     // …and it must NOT re-fire 'incoming' for an already-surfaced request.
     expect(windowB.emitEvent.mock.calls.some((c) => c[0] === 'payment_request:incoming')).toBe(false);
+
+    // The resolution event payload itself carries the nametag (the UI re-renders
+    // the action card from it), proving the upsert mutated status in place
+    // without dropping the counterparty identity.
+    const rejectedEvent = windowB.emitEvent.mock.calls.find((c) => c[0] === 'payment_request:rejected');
+    expect((rejectedEvent?.[1] as IncomingPaymentRequest | undefined)?.senderNametag).toBe('api-1');
+  });
+
+  it('a request first SEEN already-resolved (existing===undefined, status≠open) still decrypts the requester nametag/memo (#553 twin on the resolved path)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const requester = makeWalletApiWallet(baseUrl, fake.network, REQUESTER, 'pr-r1');
+    const payer = makeWalletApiWallet(baseUrl, fake.network, PAYER, 'pr-r2');
+    await requester.module.setNametag({
+      name: 'api-1', token: {}, timestamp: Date.now(), format: 'txf', version: '2.0',
+    });
+
+    // The request is created AND declined before this payer session ever surfaces
+    // it — so its FIRST sight of the row is already-resolved (the cross-session
+    // case where a window opens after the other already paid/declined). This
+    // takes the `existing===undefined` branch of surfaceIncomingPaymentRequest
+    // with a terminal status, which DOES decrypt the memo envelope.
+    const created = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '9', coinId: UCT, message: 'already done' });
+    expect(created.success).toBe(true);
+    await payer.module.load();
+    await payer.module.syncPaymentRequests();
+    await payer.module.rejectPaymentRequest(created.requestId!);
+    expect(fake.getPaymentRequest(created.requestId!)).toMatchObject({ status: 'declined' });
+
+    // A brand-new session of the SAME payer (a freshly-opened third window) sees
+    // the resolved row for the first time via its own since=0 bootstrap.
+    const fresh = makeWalletApiWallet(baseUrl, fake.network, PAYER, 'pr-r3');
+    await fresh.module.load();
+    await fresh.module.syncPaymentRequests();
+
+    const surfaced = fresh.module.getPaymentRequests();
+    expect(surfaced).toHaveLength(1);
+    expect(surfaced[0].status).toBe('rejected');
+    // The "From" field renders "@api-1" even though the row was first seen
+    // already-resolved — the memo envelope is decrypted on the resolved path too.
+    expect(surfaced[0].senderNametag).toBe('api-1');
+    expect(surfaced[0].message).toBe('already done');
   });
 
   it('a failed hydration is retried on the next pump (the flag is burned only on success)', async () => {


### PR DESCRIPTION
## Verdict: DATA issue, not a code regression

The staging report — the PR "From" field showing the requester's **raw pubkey instead of the nametag** once the request flips to *paid* in both windows — is **not** a regression introduced by the cross-session batch. The SDK preserves `senderNametag` through every resolution path. This PR adds the coverage that was missing to prove it; **no `src` change**.

### Why it's not a regression (evidence)

- The requester's nametag rides INSIDE the S6 recipient-ECDH memo envelope (#553). The payer decrypts it via `decryptPaymentRequestMemo(wire)` = `ECDH(payerPriv, wire.fromPubkey)`.
- The #562 cross-session upsert (`33de7b4`) added a **status-only** mutation branch to `surfaceIncomingPaymentRequest`: when a request is re-surfaced resolved, it mutates the EXISTING in-memory request's `status` in place — it never re-creates the object, so the `senderNametag` set at first-surface (OPEN) is preserved. The diff touched neither the nametag nor the decrypt path.
- The first-seen-already-resolved branch (`existing===undefined`, terminal status) DOES call `decryptPaymentRequestMemo` — it renders "@requester" on a row first seen resolved.
- Real backend: `respond()` re-stamps `seq`/`status`/`transfer_id` only — `memo` is untouched; `listIncoming`/`toWire` carry it for any status; the SDK codec (`parsePaymentRequestRecord`) carries `memo` through regardless of status.

"Shows pubkey" only happens when the **requester has no nametag set** — `encryptDeliveryBundle` omits the `n` field, so the payer surfaces `senderNametag` as absent (correct behavior).

### Coverage added

**Unit (in-process fake)** — `tests/unit/modules/PaymentsModule.payment-requests.test.ts`:
- the cross-session test now sets a requester nametag and asserts `senderNametag === 'api-1'` in BOTH windows while pending, that it SURVIVES window B's open→rejected upsert, and that the resolution event payload carries it;
- a NEW test for the first-seen-already-resolved branch: a fresh payer session surfaces a row that was created+declined before it ever saw it, and `senderNametag`/`message` still decrypt.

**Harness (real backend + real wake socket)** — `tests/harness/multi-session-sync.test.ts`:
- the two-session payment-request test sets a requester nametag and asserts the payer's surfaced request shows `senderNametag === 'requester-tag'` while pending AND on the resolved (paid) row after session A pays it cross-session — the real-backend proof.

### Local results

- node20: typecheck + lint clean, **3059/3059 unit** pass.
- node22: typecheck + lint clean, **3059/3059 unit** pass.
- Harness (real stack, docker-out-of-docker): `multi-session-sync.test.ts` **3/3 pass** including the new nametag assertions; full `test:harness` green.

Closes #574