### PR TITLE
fix(payments): outgoing memos read the canonical Sphere nametag, not the empty minted-token store (6bd3058 regression)

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -2438,6 +2438,7 @@ export class Sphere {
           tokenEngine: moduleSet.tokenEngine,
           delivery: this._delivery ?? undefined,
           walletApi: this._walletApi ?? undefined,
+          getCurrentNametag: () => this.getNametagForAddress(),
         });
       }
     }
@@ -2580,6 +2581,7 @@ export class Sphere {
       tokenEngine,
       delivery: this._delivery ?? undefined,
       walletApi: this._walletApi ?? undefined,
+      getCurrentNametag: () => this.getNametagForAddress(),
     });
 
     communications.initialize({
@@ -4461,6 +4463,7 @@ export class Sphere {
       tokenEngine,
       delivery: this._delivery ?? undefined,
       walletApi: this._walletApi ?? undefined,
+      getCurrentNametag: () => this.getNametagForAddress(),
     });
 
     this._communications.initialize({

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1640,13 +1640,14 @@ export class PaymentsModule {
         // the port replaced the direct relay leg; recipients are addressed by
         // CHAIN pubkey — the canonical identity).
         const deliverBlob = async (tokenBlob: string): Promise<void> => {
+          // Carry the sender's own CANONICAL nametag so the recipient renders
+          // "@name" instead of "Someone" — bundled with the memo in ONE
+          // recipient-addressed envelope (S6).
+          const nm = this.currentNametagName();
           await delivery.deliver(recipientChainPubkeyHex, hexToBytes(tokenBlob), {
             transferId: result.id,
             memo: request.memo,
-            // Carry the sender's own nametag so the recipient renders "@name"
-            // instead of "Someone" — bundled with the memo in ONE
-            // recipient-addressed envelope (S6).
-            ...(this.getNametag()?.name !== undefined ? { senderNametag: this.getNametag()!.name } : {}),
+            ...(nm !== undefined ? { senderNametag: nm } : {}),
           });
         };
 
@@ -2231,7 +2232,7 @@ export class PaymentsModule {
       // OR a message, so the payer renders "@requester" even with no message.
       const memoEnvelope = encryptDeliveryBundle(
         deriveDeliveryEncryptionKey(this.deps!.identity.privateKey, toPubkey),
-        { senderNametag: this.getNametag()?.name, memo: request.message }
+        { senderNametag: this.currentNametagName(), memo: request.message }
       );
 
       const wire = await api.createPaymentRequest({
@@ -3812,6 +3813,23 @@ export class PaymentsModule {
   }
 
   /**
+   * The requester's CURRENT display nametag for outgoing memos: the canonical
+   * Sphere-level (Nostr-backed) store first, then the local minted-token store.
+   *
+   * The minted-token `nametags[]` is populated only by the best-effort,
+   * oracle-gated mint path, so in the real app it is empty at send time even
+   * when the user has a nametag — reading it dropped the nametag from the
+   * payment-request/delivery memo and the payer rendered a raw pubkey. The
+   * canonical store (injected via `getCurrentNametag`) is the one the UI shows
+   * and is reliably loaded on every startup. (#576, 6bd3058 regression)
+   *
+   * @returns The bare nametag name (no leading '@'), or `undefined`.
+   */
+  private currentNametagName(): string | undefined {
+    return this.deps?.getCurrentNametag?.() ?? this.nametags[0]?.name;
+  }
+
+  /**
    * Get all nametag data entries.
    *
    * @returns A copy of the nametags array.
@@ -5086,10 +5104,11 @@ export class PaymentsModule {
         memo: payload.memo,
         createdAt: Date.now(),
       });
+      const nm = this.currentNametagName();
       await delivery.deliver(payload.recipient, hexToBytes(tokenBlobHex), {
         transferId,
         memo: payload.memo,
-        ...(this.getNametag()?.name !== undefined ? { senderNametag: this.getNametag()!.name } : {}),
+        ...(nm !== undefined ? { senderNametag: nm } : {}),
       });
       await this.removePendingV2Delivery(tokenBlobHex);
     };
@@ -5314,10 +5333,11 @@ export class PaymentsModule {
     logger.warn('Payments', `${entries.length} undelivered v2 transfer(s) journaled from a previous session — replaying`);
     for (const e of entries) {
       try {
+        const nm = this.currentNametagName();
         await this.delivery!.deliver(e.recipientPubkey, hexToBytes(e.tokenBlob), {
           transferId: e.transferId,
           memo: e.memo,
-          ...(this.getNametag()?.name !== undefined ? { senderNametag: this.getNametag()!.name } : {}),
+          ...(nm !== undefined ? { senderNametag: nm } : {}),
         });
         await this.removePendingV2Delivery(e.tokenBlob);
         logger.debug('Payments', `Replayed undelivered v2 transfer ${e.transferId.slice(0, 8)}...`);

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -833,6 +833,8 @@ export interface PaymentsModuleDependencies {
    * ones.
    */
   walletApi?: PaymentsWalletApiPort;
+  /** Current address's canonical display nametag (bare, no '@'), from the Sphere-level Nostr-backed store. Preferred over the local minted-token nametags[] for outgoing memos. */
+  getCurrentNametag?: () => string | undefined;
 }
 
 /** The provider {@link PaymentsModule.getActiveTokenStorageProvider} will pick:

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -141,12 +141,19 @@ async function startFake(): Promise<{ fake: FakeWalletApi; baseUrl: string }> {
   return { fake, baseUrl };
 }
 
-/** A wallet over the FULL wallet-api preset (the S4 composition). */
+/** A wallet over the FULL wallet-api preset (the S4 composition).
+ *
+ * `getCurrentNametag` mirrors the Sphere wiring of the canonical (Nostr-backed)
+ * display nametag store — the one the real app reliably loads on every startup.
+ * When supplied, outgoing memos read it WITHOUT the local minted-token
+ * `setNametag()` path ever being populated (the real-app state the #553 fix
+ * regressed on). */
 function makeWalletApiWallet(
   baseUrl: string,
   network: string,
   who: { privateKey: string; chainPubkey: string },
-  deviceId: string
+  deviceId: string,
+  getCurrentNametag?: () => string | undefined
 ): Wallet {
   const identity = fullIdentity(who);
   const kv = new MemoryKeyValueStore();
@@ -168,6 +175,7 @@ function makeWalletApiWallet(
     tokenEngine: engine,
     delivery,
     walletApi: client,
+    ...(getCurrentNametag !== undefined ? { getCurrentNametag } : {}),
   };
   const module = createPaymentsModule({ l1: null });
   module.initialize(deps);
@@ -297,6 +305,53 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
       code: 'CONFLICT',
       status: 409,
     });
+  });
+
+  it('real-app scenario: the requester nametag rides the memo from the CANONICAL store even when the minted-token nametags[] is empty (6bd3058 regression)', async () => {
+    // The #553 fix read the requester nametag from `this.nametags` — populated
+    // ONLY by the best-effort, oracle-gated minted-token path. In the real app
+    // that array is EMPTY at send time; the nametag the UI shows lives in the
+    // Sphere-level Nostr-backed store (getNametagForAddress). So the memo
+    // dropped the nametag and the payer rendered the raw pubkey. Here the
+    // requester has the canonical nametag (`getCurrentNametag`) but NEVER calls
+    // setNametag() — exactly that real-app state. Cross-check: the existing
+    // setNametag('api-1') test above still passes via the nametags[] fallback.
+    const { fake, baseUrl } = await startFake();
+    const requester = makeWalletApiWallet(baseUrl, fake.network, REQUESTER, 'pr-canon-1', () => 'api-1');
+    const payer = makeWalletApiWallet(baseUrl, fake.network, PAYER, 'pr-canon-2');
+
+    // No setNametag() — the minted-token store stays empty (the regression's
+    // precondition). The memo must still carry the canonical nametag.
+    expect(requester.module.hasNametag()).toBe(false);
+
+    const result = await requester.module.sendPaymentRequest('@bob', {
+      amount: '25',
+      coinId: UCT,
+      message: 'hi',
+    });
+    expect(result.success).toBe(true);
+
+    // At the crypto boundary: the requester-addressed envelope carries BOTH the
+    // canonical nametag AND the message (pre-fix the plaintext was `{"t":"hi"}`
+    // — no `senderNametag` field at all).
+    const row = fake.getPaymentRequest(result.requestId!);
+    expect(
+      decryptDeliveryBundle(
+        deriveDeliveryEncryptionKey(REQUESTER.privateKey, PAYER.chainPubkey),
+        row!.memo!
+      )
+    ).toEqual({ senderNametag: 'api-1', memo: 'hi' });
+
+    // …and through the payer surface: the "From" field renders "@api-1", not the
+    // raw pubkey.
+    const surfaced: IncomingPaymentRequest[] = [];
+    payer.module.onPaymentRequest((request) => surfaced.push(request));
+    await payer.module.load();
+    await payer.module.syncPaymentRequests();
+
+    expect(surfaced).toHaveLength(1);
+    expect(surfaced[0].senderNametag).toBe('api-1');
+    expect(surfaced[0].message).toBe('hi');
   });
 
   it("paying a request links the fulfilling send's transferId via respond(action:'paid')", async () => {


### PR DESCRIPTION
Refs #576. **Base is the non-default `feat/wallet-api-integration`** — squash-merge to a non-default base does NOT auto-close the issue, so #576 must be closed manually after merge.

## Root cause
6bd3058 made the payment-request and delivery memos embed the requester's nametag by reading `getNametag()?.name` = `this.nametags[0]` — a token-store array populated ONLY by the best-effort, oracle-gated minted-token path (`ensureUnicityIdTokenStored` → `payments.setNametag`). In the real app that array is empty at send time, so the memo omitted `senderNametag` and the payer rendered the requester's raw pubkey instead of "@name". The nametag the UI actually shows lives in the Sphere-level Nostr-backed store (`getNametagForAddress`), reliably loaded on every startup. Confirmed empirically: a real on-wire memo decrypted to just `{"t":"<msg>"}` — no `n` (nametag) field.

## Fix
Inject the canonical store into `PaymentsModule` via the optional `getCurrentNametag` dep and route the four memo-building sites through a new `currentNametagName()` helper — canonical store first, minted-token `nametags[]` fallback for backward-compat.

### The four call sites (modules/payments/PaymentsModule.ts)
1. delivery bundle `senderNametag` (send path, ~L1646)
2. payment-request memo envelope (`{ senderNametag, memo }`, ~L2235)
3. v2 delivery `senderNametag` (~L5107)
4. v2 delivery replay `senderNametag` (~L5336)

Wired in all three Sphere deps-assembly sites (core/Sphere.ts) to `() => this.getNametagForAddress()` (current address, bare name). The minted-token accessors (`getNametag`/`getNametags`/`setNametag`) are unchanged.

## Failing-first test (commit 1)
`tests/unit/modules/PaymentsModule.payment-requests.test.ts` — reproduces the real-app state: the requester has the canonical nametag (`getCurrentNametag: () => 'api-1'`) but NEVER calls `setNametag()`, so `this.nametags` stays empty. Asserts both the decrypted memo envelope AND the payer-surfaced request carry `senderNametag: 'api-1'`.

Failing-first output (test committed before the fix):
```
AssertionError: expected { memo: 'hi' } to deeply equal { senderNametag: 'api-1', memo: 'hi' }
- Expected
+ Received
  Object {
    "memo": "hi",
-   "senderNametag": "api-1",
  }
```
After the fix (commit 2): all 9 tests in the file pass, including the pre-existing `setNametag('api-1')` tests (green via the `nametags[]` fallback).

## Verification
Full unit suite (`npm ci && npm run build && npm run test:run`; the default vitest config already excludes e2e/relay/harness — no AGGREGATOR_KEY/network needed), in-container:
- **node 22**: 183 files / 3060 tests passed
- **node 20**: 183 files / 3060 tests passed
- typecheck clean; eslint 0 errors (2 pre-existing unused-var warnings, untouched)

No version bump, no release script (owner handles release + downstream bump).