### PR TITLE
fix(core): address-switch inventory bleed — re-bind shared wallet-api identity on re-visit switch (#580)

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -2335,6 +2335,14 @@ export class Sphere {
       throw new SphereError('Invalid Unicity ID format. Use lowercase alphanumeric, underscore, or hyphen (3-20 chars), or a valid phone number.', 'VALIDATION_ERROR');
     }
 
+    // No-op switch: already active on this index with no nametag change. Skip the
+    // logout / re-bind / re-sign-in / re-sync cycle — it would otherwise reset the
+    // wallet-api JWT, clear caches, and cause needless network traffic + inventory
+    // flicker for a call that changes nothing (Copilot review on #581).
+    if (index === this._currentAddressIndex && newNametag === undefined) {
+      return;
+    }
+
     // S4 auth lifecycle: the wallet-api session is per identity — log out
     // before switching; the new address's module init signs back in.
     if (this._walletApi && index !== this._currentAddressIndex) {

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -2440,6 +2440,14 @@ export class Sphere {
           walletApi: this._walletApi ?? undefined,
           getCurrentNametag: () => this.getNametagForAddress(),
         });
+      } else {
+        // No nametag change → the module is NOT re-initialized, so nothing has
+        // re-bound the SHARED wallet-api/delivery client to this address. That
+        // client holds one identity+JWT; without this rebind it keeps the
+        // previously-active address's owner and inventory loads return the WRONG
+        // address's tokens (the #580 cross-address bleed). Re-establish identity
+        // + auth on the re-visit path before the pointer swap serves inventory.
+        await this.rebindWalletApiIdentity(newIdentity, moduleSet);
       }
     }
 
@@ -2490,6 +2498,35 @@ export class Sphere {
     this.postSwitchSync(index, newNametag).catch(err => {
       logger.warn('Sphere', `Post-switch sync failed for address ${index}:`, err);
     });
+  }
+
+  /**
+   * Re-bind the SHARED wallet-api/delivery client to `identity` on a re-visit
+   * address switch that did NOT re-initialize the module (#580).
+   *
+   * The wallet-api preset composes ONE `WalletApiClient`, shared by the
+   * token-storage provider, the delivery provider and the `walletApi` session;
+   * it holds a single identity+JWT. `switchToAddress` logs out before switching
+   * and only re-authenticates inside `PaymentsModule.initialize` (via
+   * `delivery.setIdentity`) — which the no-nametag-change re-visit path skips.
+   * Without this rebind the shared client keeps the previous owner, so this
+   * address's inventory `load()` returns the WRONG address's tokens. Re-bind the
+   * delivery + wallet-api ports AND this address's wallet-api-backed token
+   * storage providers, then re-establish the session (sign-in is degradable:
+   * a failed sign-in is recorded, never thrown — boot/switch stays non-blocking).
+   */
+  private async rebindWalletApiIdentity(
+    identity: FullIdentity,
+    moduleSet: AddressModuleSet,
+  ): Promise<void> {
+    if (!this._walletApi && !this._delivery) return;
+    const idSlice = { privateKey: identity.privateKey, chainPubkey: identity.chainPubkey };
+    this._delivery?.setIdentity?.(idSlice);
+    this._walletApi?.setIdentity(idSlice);
+    for (const provider of moduleSet.tokenStorageProviders.values()) {
+      if (provider.requiresWalletApi) provider.setIdentity(identity);
+    }
+    if (this._walletApi) await this.startWalletApiSession(moduleSet.payments);
   }
 
   /**

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -2410,8 +2410,16 @@ export class Sphere {
           addressTokenProviders.set(providerId, newProvider);
         } else {
           // Fallback: reuse existing provider (legacy behavior for providers
-          // that don't support createForAddress)
+          // that don't support createForAddress). The reused SHARED provider
+          // is still bound to the PREVIOUS address — rebind it to this address
+          // before it serves inventory (#580 review). Its in-memory view AND
+          // its persisted cursor are per-identity (keyed by chainPubkey), so
+          // without this setIdentity a FIRST-VISIT switch loads the previous
+          // address's tokens / a wrong delta. Mirrors the createForAddress
+          // branch above; `payments.initialize` only rebinds delivery, never
+          // the token-storage providers, so nothing else covers this.
           logger.warn('Sphere', `Token storage provider ${providerId} does not support createForAddress, reusing shared instance`);
+          provider.setIdentity(newIdentity);
           addressTokenProviders.set(providerId, provider);
         }
       }

--- a/tests/integration/address-switch-inventory-bleed-first-visit.test.ts
+++ b/tests/integration/address-switch-inventory-bleed-first-visit.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Regression: address-switch inventory bleed on the FIRST-VISIT path
+ * (sphere-sdk#580 review follow-up).
+ *
+ * Companion to `address-switch-inventory-bleed.test.ts`, which covers the
+ * RE-VISIT path (switching back to an already-created address module). This
+ * file covers the OTHER half the #580 fix missed: the FIRST-EVER switch to an
+ * index, which CREATES that index's per-address module.
+ *
+ * In `Sphere.switchToAddress`, first-visit creates each per-address token-
+ * storage provider through a `createForAddress` loop. `WalletApiTokenStorage-
+ * Provider` has `requiresWalletApi = true` and does NOT implement
+ * `createForAddress`, so it hits the fallback that REUSES the single shared
+ * instance. That instance is still bound to the PREVIOUSLY-active address: its
+ * inventory VIEW (read via the shared `WalletApiClient`'s identity+JWT) and the
+ * `_meta.address` its `load()` stamps both belong to the previous address.
+ *
+ * Without re-binding it (`provider.setIdentity(newIdentity)` in the fallback),
+ * a first-time switch to a new index serves the previous address's owner:
+ * `PaymentsModule.load()`'s address guard sees `_meta.address != current` and
+ * REJECTS the whole provider, so the new address renders EMPTY even though it
+ * has its OWN assets — the inventory bleed, surfaced on first visit.
+ * `PaymentsModule.initialize` re-binds only the DELIVERY provider, never the
+ * token-storage providers, so nothing else covers this.
+ *
+ * A SEPARATE FILE on purpose: vitest's default `forks` pool runs each file in
+ * its own process, so the single Sphere here cannot contend with the re-visit
+ * file's Sphere (two wallet-api Spheres sharing one event loop race on
+ * background sign-in/wake activity — a harness artefact, not the product bug).
+ * One Sphere per process keeps the assertion deterministic.
+ *
+ * Real Sphere over the in-process fake wallet-api (real WalletApiClient -> real
+ * loopback HTTP -> fake backend keyed by pubkey + per-owner JWT) — the exact
+ * substrate the shared-client staleness leaks through. The lazy inventory VIEW
+ * renders balances with zero blob downloads, so the bleed shows without minting.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { Sphere } from '../../core/Sphere';
+import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
+import { createWalletApiProviders, type SphereBaseProviders } from '../../impl/shared/wallet-api';
+import { FakeWalletApi } from '../support/fake-wallet-api';
+import { makeTestToken } from '../support/wallet-api-test-helpers';
+import type { TransportProvider, OracleProvider } from '../../index';
+import type { ProviderStatus } from '../../types';
+import type { TokenStorageProvider, TxfStorageDataBase } from '../../storage';
+
+// A fixed 12-word mnemonic so address indices derive deterministically.
+const MNEMONIC = 'test test test test test test test test test test test junk';
+
+function createMockTransport(): TransportProvider {
+  return {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    description: 'Mock transport',
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn().mockResolvedValue('transfer-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('request-id'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('response-id'),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    subscribeToBroadcast: vi.fn().mockReturnValue(() => {}),
+    publishBroadcast: vi.fn().mockResolvedValue('broadcast-id'),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+    resolveNametag: vi.fn().mockResolvedValue(null),
+    publishIdentityBinding: vi.fn().mockResolvedValue(true),
+    recoverNametag: vi.fn().mockResolvedValue(null),
+  } as unknown as TransportProvider;
+}
+
+/** Mock oracle WITHOUT a trust base/url — Sphere falls back to the legacy
+ *  (no-engine) path; the lazy inventory view never needs the engine. */
+function createMockOracle(): OracleProvider {
+  return {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'aggregator' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+  } as unknown as OracleProvider;
+}
+
+interface Built {
+  sphere: Sphere;
+  fake: FakeWalletApi;
+  dataDir: string;
+}
+
+async function buildSphere(): Promise<Built> {
+  const fake = new FakeWalletApi();
+  const baseUrl = await fake.start();
+
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bleed-fv-test-'));
+  const storage = new FileStorageProvider({ dataDir });
+  const base: SphereBaseProviders = {
+    storage,
+    transport: createMockTransport(),
+    oracle: createMockOracle(),
+    // unused: the wallet-api preset overrides tokenStorage with its own.
+    tokenStorage: null as unknown as TokenStorageProvider<TxfStorageDataBase>,
+  };
+  const providers = createWalletApiProviders(base, {
+    baseUrl,
+    network: fake.network,
+    deviceId: 'bleed-fv-test-device',
+  });
+
+  const { sphere } = await Sphere.init({
+    storage,
+    transport: providers.transport,
+    oracle: providers.oracle,
+    tokenStorage: providers.tokenStorage,
+    delivery: providers.delivery,
+    walletApi: providers.walletApi,
+    network: 'testnet2',
+    mnemonic: MNEMONIC,
+  });
+
+  return { sphere, fake, dataDir };
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+  (Sphere as unknown as { instance: null }).instance = null;
+});
+
+/** The app's "refresh": converge the active address's inventory from the server. */
+async function refresh(sphere: Sphere): Promise<void> {
+  await sphere.payments.load();
+}
+
+function balanceTotal(sphere: Sphere, coinId: string): bigint {
+  return sphere.payments
+    .getTokens()
+    .filter((t) => t.coinId === coinId)
+    .reduce((sum, t) => sum + BigInt(t.amount), 0n);
+}
+
+/**
+ * Refresh until the active address's balance for `coinId` converges to
+ * `expected`, or fail after the budget. The wallet-api inventory is an
+ * EVENTUALLY-consistent server view (ARCHITECTURE §9: the poll is the
+ * correctness path), so the wallet's contract is convergence — not a single
+ * snapshot. The first `load()` right after a switch can race the still-settling
+ * sign-in; one or two more converge it. The bug is NOT a slow-converge: a
+ * mis-bound provider converges to the WRONG owner (the address guard rejects
+ * the stale data forever), so this poll never reaches `expected` and times out
+ * — exactly the failing-first signal. A correct rebind converges promptly.
+ */
+async function refreshUntilBalance(
+  sphere: Sphere,
+  coinId: string,
+  expected: bigint,
+): Promise<void> {
+  const deadline = Date.now() + 8_000;
+  let last = -1n;
+  for (;;) {
+    await refresh(sphere);
+    last = balanceTotal(sphere, coinId);
+    if (last === expected) return;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `balance for ${coinId.slice(0, 8)}… did not converge to ${expected} (last=${last})`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}
+
+describe('address-switch inventory bleed — first-visit path (#580)', () => {
+  // Real loopback HTTP + per-switch auth round-trips: headroom over the 10s
+  // default so heavy parallel suite load can't time it out.
+  it('a FIRST-VISIT switch to a new index renders ITS OWN inventory, not the previous address\'s', { timeout: 30_000 }, async () => {
+    const { sphere, fake, dataDir } = await buildSphere();
+    cleanups.push(() => fs.rmSync(dataDir, { recursive: true, force: true }));
+    cleanups.push(() => fake.stop());
+    cleanups.push(() => sphere.destroy());
+
+    // Index 5 is deliberately far from any index boot/this test has touched, so
+    // its switch is a genuine first-visit. Derive pubkeys WITHOUT visiting it
+    // (deriveAddress activates no module), keeping index 5 first-visited.
+    const FRESH = 5;
+    const pubkey0 = sphere.deriveAddress(0).publicKey;
+    const pubkeyFresh = sphere.deriveAddress(FRESH).publicKey;
+    expect(pubkey0).not.toBe(pubkeyFresh);
+
+    // Distinct coins per address so a bleed is unambiguous: index 0 holds COIN0
+    // (5000), the fresh index holds COINF (its own, smaller balance of 7).
+    const t0 = makeTestToken({ amount: 5000n, coinId: 'a0'.repeat(32) });
+    const tFresh = makeTestToken({ amount: 7n, coinId: 'b0'.repeat(32) });
+    expect(t0.coinId).not.toBe(tFresh.coinId);
+    fake.seedInventory(pubkey0, [
+      { tokenId: t0.tokenId, assets: [{ coinId: t0.coinId, amount: t0.amount }], blob: t0.bytes },
+    ]);
+    fake.seedInventory(pubkeyFresh, [
+      { tokenId: tFresh.tokenId, assets: [{ coinId: tFresh.coinId, amount: tFresh.amount }], blob: tFresh.bytes },
+    ]);
+
+    // Make index 0 the active address holding its assets — the owner the shared
+    // provider's view+identity are bound to right before the first-visit switch.
+    await sphere.switchToAddress(0);
+    await refreshUntilBalance(sphere, t0.coinId, 5000n);
+
+    // Precondition: the fresh index's per-address module must NOT exist yet, so
+    // its switch genuinely takes the first-visit `!_addressModules.has(index)`
+    // branch (the createForAddress fallback) — NOT the re-visit branch.
+    const addressModules = (sphere as unknown as { _addressModules: Map<number, unknown> })._addressModules;
+    expect(addressModules.has(FRESH)).toBe(false);
+
+    // FIRST-EVER switch to the fresh index -> the createForAddress fallback
+    // reuses the shared, still-index-0-bound provider.
+    await sphere.switchToAddress(FRESH);
+    expect(addressModules.has(FRESH)).toBe(true); // the switch did create the module
+
+    // It MUST render the fresh index's OWN balance (7). Without the fallback
+    // rebind the stale provider serves index 0, the address guard rejects it,
+    // and the fresh balance never converges off 0 — this call then times out
+    // (the failing-first signal). With the rebind it converges to 7.
+    await refreshUntilBalance(sphere, tFresh.coinId, 7n);
+
+    // And NONE of index 0's coin may bleed into the fresh address.
+    expect(balanceTotal(sphere, t0.coinId)).toBe(0n);
+  });
+});

--- a/tests/integration/address-switch-inventory-bleed.test.ts
+++ b/tests/integration/address-switch-inventory-bleed.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Regression: address-switch inventory bleed (sphere-sdk#580).
+ *
+ * One HD wallet, two addresses: index 0 HAS assets in its wallet-api inventory,
+ * index 1 is EMPTY. The owner reported (reproduced multiple times in the app):
+ *
+ *   1. select index 1 -> refresh -> EMPTY (correct)
+ *   2. switch to index 0 -> EMPTY (WRONG: it has assets)
+ *   3. switch back to index 1 -> shows index 0 ASSETS (WRONG: it is empty)
+ *
+ * The inventory view is "one address behind" — each address renders the
+ * PREVIOUSLY-selected address's inventory. Assets bleed across addresses
+ * (a balance/correctness hazard).
+ *
+ * Root cause: the wallet-api `WalletApiClient` is a SINGLE shared instance
+ * (composition.ts) wired into the token-storage provider, the delivery provider
+ * AND the `walletApi` session. It holds ONE mutable identity+jwt, so inventory
+ * reads return whatever owner it is currently authenticated as. On a re-visit
+ * `switchToAddress` whose nametag is unchanged (both addresses here have none),
+ * `Sphere` swaps the active module pointer WITHOUT re-running
+ * `PaymentsModule.initialize` — so `delivery.setIdentity()` (the only thing that
+ * calls `client.setIdentity()`) never fires, and the shared client keeps the
+ * last address's identity. `load()` then queries the wrong owner.
+ *
+ * This is a REAL Sphere driven against the in-process fake wallet-api over
+ * loopback HTTP (real WalletApiClient -> real HTTP -> fake backend keyed by
+ * pubkey + per-owner JWT) — the exact substrate the shared-client staleness
+ * leaks through. No aggregator/Docker: the lazy inventory VIEW renders balances
+ * with zero blob downloads, so the bleed shows up without minting.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { Sphere } from '../../core/Sphere';
+import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
+import { createWalletApiProviders, type SphereBaseProviders } from '../../impl/shared/wallet-api';
+import { FakeWalletApi } from '../support/fake-wallet-api';
+import { makeTestToken } from '../support/wallet-api-test-helpers';
+import type { TransportProvider, OracleProvider } from '../../index';
+import type { ProviderStatus } from '../../types';
+import type { TokenStorageProvider, TxfStorageDataBase } from '../../storage';
+
+// A fixed 12-word mnemonic so address indices 0/1 derive deterministically.
+const MNEMONIC = 'test test test test test test test test test test test junk';
+
+function createMockTransport(): TransportProvider {
+  return {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    description: 'Mock transport',
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn().mockResolvedValue('transfer-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('request-id'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('response-id'),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    subscribeToBroadcast: vi.fn().mockReturnValue(() => {}),
+    publishBroadcast: vi.fn().mockResolvedValue('broadcast-id'),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+    resolveNametag: vi.fn().mockResolvedValue(null),
+    publishIdentityBinding: vi.fn().mockResolvedValue(true),
+    recoverNametag: vi.fn().mockResolvedValue(null),
+  } as unknown as TransportProvider;
+}
+
+/** Mock oracle WITHOUT a trust base/url — Sphere falls back to the legacy
+ *  (no-engine) path; the lazy inventory view never needs the engine. */
+function createMockOracle(): OracleProvider {
+  return {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'aggregator' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+  } as unknown as OracleProvider;
+}
+
+interface Built {
+  sphere: Sphere;
+  fake: FakeWalletApi;
+  dataDir: string;
+}
+
+async function buildSphere(): Promise<Built> {
+  const fake = new FakeWalletApi();
+  const baseUrl = await fake.start();
+
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bleed-test-'));
+  const storage = new FileStorageProvider({ dataDir });
+  const base: SphereBaseProviders = {
+    storage,
+    transport: createMockTransport(),
+    oracle: createMockOracle(),
+    // unused: the wallet-api preset overrides tokenStorage with its own.
+    tokenStorage: null as unknown as TokenStorageProvider<TxfStorageDataBase>,
+  };
+  const providers = createWalletApiProviders(base, {
+    baseUrl,
+    network: fake.network,
+    deviceId: 'bleed-test-device',
+  });
+
+  const { sphere } = await Sphere.init({
+    storage,
+    transport: providers.transport,
+    oracle: providers.oracle,
+    tokenStorage: providers.tokenStorage,
+    delivery: providers.delivery,
+    walletApi: providers.walletApi,
+    network: 'testnet2',
+    mnemonic: MNEMONIC,
+  });
+
+  return { sphere, fake, dataDir };
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+  (Sphere as unknown as { instance: null }).instance = null;
+});
+
+/** The app's "refresh": converge the active address's inventory from the server. */
+async function refresh(sphere: Sphere): Promise<void> {
+  await sphere.payments.load();
+}
+
+function balanceTotal(sphere: Sphere, coinId: string): bigint {
+  return sphere.payments
+    .getTokens()
+    .filter((t) => t.coinId === coinId)
+    .reduce((sum, t) => sum + BigInt(t.amount), 0n);
+}
+
+describe('address-switch inventory bleed (#580)', () => {
+  // Real loopback HTTP + per-switch auth round-trips: give the whole sequence
+  // headroom over the 10s default so heavy parallel suite load can't time it out
+  // (it runs in ~5s alone; the budget is slack, not a hot path).
+  it('each address renders ITS OWN wallet-api inventory across re-visit switches', { timeout: 30_000 }, async () => {
+    const { sphere, fake, dataDir } = await buildSphere();
+    cleanups.push(() => fs.rmSync(dataDir, { recursive: true, force: true }));
+    cleanups.push(() => fake.stop());
+    cleanups.push(() => sphere.destroy());
+
+    // Capture the chain pubkeys of index 0 (has assets) and index 1 (empty).
+    await sphere.switchToAddress(0);
+    const pubkey0 = sphere.identity!.chainPubkey;
+    await sphere.switchToAddress(1);
+    const pubkey1 = sphere.identity!.chainPubkey;
+    expect(pubkey0).not.toBe(pubkey1);
+
+    // Seed index 0's server inventory with assets; index 1 stays empty.
+    const token = makeTestToken({ amount: 5000n });
+    fake.seedInventory(pubkey0, [
+      { tokenId: token.tokenId, assets: [{ coinId: token.coinId, amount: token.amount }], blob: token.bytes },
+    ]);
+    const COIN = token.coinId;
+
+    // The owner's exact sequence:
+    // 1. select index 1 -> refresh -> EMPTY (correct)
+    await sphere.switchToAddress(1);
+    await refresh(sphere);
+    expect(balanceTotal(sphere, COIN)).toBe(0n);
+
+    // 2. switch to index 0 -> refresh -> MUST show index 0's assets
+    await sphere.switchToAddress(0);
+    await refresh(sphere);
+    expect(balanceTotal(sphere, COIN)).toBe(5000n);
+
+    // 3. switch back to index 1 -> refresh -> MUST be empty (no bleed)
+    await sphere.switchToAddress(1);
+    await refresh(sphere);
+    expect(balanceTotal(sphere, COIN)).toBe(0n);
+  });
+});


### PR DESCRIPTION
Refs #580. Base is the NON-default integration branch `feat/wallet-api-integration` — the issue will be closed manually after merge.

## Root cause
The wallet-api preset (`impl/shared/wallet-api/composition.ts`) builds ONE `WalletApiClient` and shares it across the token-storage provider, the mailbox delivery provider AND the `walletApi` session. The client holds a SINGLE mutable `identity`+`jwt` (`wallet-api/client.ts:159-160`, `setIdentity` :184), so every inventory read serves whatever owner the client is currently authenticated as.

The shared client identity is (re)bound only as a side effect of `PaymentsModule.initialize()` calling `delivery.setIdentity()` (`modules/payments/PaymentsModule.ts:1132` -> `WalletApiMailboxProvider.setIdentity` -> `client.setIdentity`, `impl/shared/wallet-api/WalletApiMailboxProvider.ts:118-120`).

On `Sphere.switchToAddress`:
- FIRST visit: `initializeAddressModules` -> `payments.initialize` -> `delivery.setIdentity` -> `client.setIdentity(newOwner)`, then `startWalletApiSession` (sign-in). Correct.
- RE-VISIT to an already-created index: the else branch (`core/Sphere.ts:2420-2444`) re-initializes ONLY when the nametag changed (:2423). With an unchanged nametag (both addresses here have none) it just swaps the active pointer (`this._payments = activeModules.payments`, :2452) and NEVER re-binds / re-signs-in. `switchToAddress` also calls `_walletApi.logout()` on every switch (:2340-2346), so after a re-visit the client is left bound to the PREVIOUS owner with a cleared JWT.

Net: `payments.load()` -> `mergeLazyInventory` -> `provider.listInventory()` -> `client.listInventory()` queries the WRONG (previous) owner -> the re-visited address shows the previously-selected address inventory: the "one address behind" cross-address bleed (a balance/correctness hazard). `WalletApiTokenStorageProvider` also lacks `createForAddress`, so it is reused (shared) across addresses via the `else` fallback at `:2411-2416`, compounding it.

## Fix
On the re-visit (no-nametag-change) switch path, re-bind the shared delivery + wallet-api ports AND this address wallet-api-backed token-storage providers to the active identity, then re-establish the session — before inventory is served (`rebindWalletApiIdentity`). Mirrors the first-visit semantics (`startWalletApiSession`). Sign-in stays degradable (recorded, never thrown). Per-address-module design + DI invariants unchanged; no singletons. ESLint limits respected.

## Test (failing-first)
`tests/integration/address-switch-inventory-bleed.test.ts`: a REAL `Sphere` driven against the in-process fake wallet-api over loopback HTTP (real `WalletApiClient` -> real HTTP -> fake backend keyed by pubkey + per-owner JWT — the exact substrate the staleness leaks through). One HD wallet, index 0 funded / index 1 empty, runs the reported `select 1 / switch 0 / switch 1` sequence and asserts each address renders ITS OWN inventory.

Failing-first (fix reverted): step 2 fails `expected 0n to be 5000n` with `Load: rejecting data ... address mismatch` logs proving wrong-owner data — matches the owner symptom #2 exactly. With the fix: green.

## Verification
- node:20 — `npm ci && build && test:run`: 184 files / 3061 tests passed.
- node:22 — `npm ci && build && test:run`: 184 files / 3061 tests passed.
- `npm run build` clean; `npm run lint` 0 errors (pre-existing warnings only; changed files clean).

Do not merge yet — root-cause review requested first.