### PR TITLE
diag(transport)(sphere-sdk#559): instrument Mux dedup hydration + hit path

### DIFF
--- a/manual-test-559-soak-collector.sh
+++ b/manual-test-559-soak-collector.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# manual-test-559-soak-collector.sh — F1 soak runbook for sphere-sdk#559.
+#
+# Drives ONE round of the trader-roundtrip soak with the
+# `diag/issue-559-mux-dedup-instrumentation` branch's `[#559-diag]` log
+# pair surfaced at INFO level, and prints a compact verdict table from
+# the captured logs.
+#
+# What it does:
+#   1. Verifies the local sphere-sdk checkout is on
+#      `diag/issue-559-mux-dedup-instrumentation` (PR #582) OR a branch
+#      that contains the F1 commit.
+#   2. Verifies sphere-cli is using `file:` link to the local sphere-sdk
+#      (so the F1 instrumentation is picked up live, no vendor-bump
+#      needed).
+#   3. Runs `manual-test-trader-roundtrip.sh` with SPHERE_DEBUG=Mux=info
+#      and the trader-soak workspace preserved (KEEP=1).
+#   4. Greps `[#559-diag]` + `[acp-m9]` lines from the captured §3
+#      snapshots and prints a three-row verdict table.
+#
+# The verdict logic mirrors the table in PR #582's description.
+#
+# Run:
+#   bash manual-test-559-soak-collector.sh
+#
+# Env contract:
+#   SPHERE_SDK_DIR     Local sphere-sdk checkout. Default $PWD.
+#   SPHERE_CLI_DIR     Local sphere-cli checkout. Default
+#                      ~/sphere-cli-work/sphere-cli (matches @vrogojin's
+#                      workspace).
+#   TRADER_TEST_DIR    Forwarded to manual-test-trader-roundtrip.sh.
+#                      Default /tmp/trader-559-collector-$$.
+
+set -euo pipefail
+
+SPHERE_SDK_DIR="${SPHERE_SDK_DIR:-$PWD}"
+SPHERE_CLI_DIR="${SPHERE_CLI_DIR:-$HOME/sphere-cli-work/sphere-cli}"
+TRADER_TEST_DIR="${TRADER_TEST_DIR:-/tmp/trader-559-collector-$$}"
+
+banner() {
+  echo
+  echo "================================================================"
+  echo "$@"
+  echo "================================================================"
+}
+
+banner "Step 1: verify SDK branch"
+cd "$SPHERE_SDK_DIR"
+
+# F1 commit (51598330) introduced the `[#559-diag]` log pair. Accept any
+# branch that contains it.
+if ! git log HEAD --oneline | grep -q '51598330\|#559-diag'; then
+  echo "ERROR: $SPHERE_SDK_DIR doesn't contain the F1 commit (51598330)."
+  echo "Check out the F1 branch first:"
+  echo "  git fetch origin diag/issue-559-mux-dedup-instrumentation"
+  echo "  git checkout diag/issue-559-mux-dedup-instrumentation"
+  exit 1
+fi
+echo "OK: F1 instrumentation present in $SPHERE_SDK_DIR ($(git rev-parse --short HEAD))"
+
+banner "Step 2: verify sphere-cli SDK pin"
+if [[ ! -d "$SPHERE_CLI_DIR" ]]; then
+  echo "ERROR: SPHERE_CLI_DIR=$SPHERE_CLI_DIR not found."
+  exit 1
+fi
+sdk_pin=$(grep '"@unicitylabs/sphere-sdk"' "$SPHERE_CLI_DIR/package.json" || true)
+if [[ "$sdk_pin" != *"file:"* ]]; then
+  echo "ERROR: sphere-cli SDK pin is not a file: link — F1 won't be picked up live."
+  echo "Current pin: $sdk_pin"
+  exit 1
+fi
+echo "OK: $sdk_pin"
+
+banner "Step 3: rebuild SDK + run trader-soak with F1 instrumentation"
+cd "$SPHERE_SDK_DIR"
+npx tsup 2>&1 | tail -10 | grep -E 'ESM Build|CJS Build|build succeeded' || {
+  echo "ERROR: SDK build failed."
+  exit 1
+}
+
+mkdir -p "$TRADER_TEST_DIR"
+LOG_FILE="$TRADER_TEST_DIR/559-soak.log"
+
+# Run the soak with SPHERE_DEBUG=Mux=info so the [#559-diag] lines surface.
+# KEEP=1 preserves the workspace for post-mortem grep.
+SPHERE_DEBUG='Mux=info' \
+KEEP=1 \
+TRADER_TEST_DIR="$TRADER_TEST_DIR" \
+bash "$SPHERE_SDK_DIR/manual-test-trader-roundtrip.sh" 2>&1 | tee "$LOG_FILE" || {
+  echo "WARN: soak exited non-zero — collector still ran the verdict."
+}
+
+banner "Step 4: verdict"
+
+# Count diag-log occurrences in the full log AND the §3 snapshots.
+hydrated_lines=$(grep -h '\[#559-diag\] hydrated' "$LOG_FILE" 2>/dev/null || true)
+dedup_hit_lines=$(grep -h '\[#559-diag\] dedup hit' "$LOG_FILE" 2>/dev/null || true)
+acp_m9_lines=$(grep -h '\[acp-m9\] resolvedPubkey set' "$LOG_FILE" 2>/dev/null || true)
+
+echo "----------------------------------------"
+echo "  Hydrated samples (first 5):"
+echo "$hydrated_lines" | head -5
+echo "----------------------------------------"
+echo "  Dedup-hit count: $(echo "$dedup_hit_lines" | grep -c '.' || echo 0)"
+echo "  Sample dedup hits (first 3):"
+echo "$dedup_hit_lines" | head -3
+echo "----------------------------------------"
+echo "  ACP M9 resolve samples (first 5):"
+echo "$acp_m9_lines" | head -5
+echo "----------------------------------------"
+
+# Auto-conclude based on §3 first SET_STRATEGY pattern.
+first_hydrated=$(echo "$hydrated_lines" | sed -n '1p')
+if [[ -z "$first_hydrated" ]]; then
+  echo "VERDICT: No [#559-diag] hydrated lines found. Either SPHERE_DEBUG didn't"
+  echo "         propagate or the SDK build wasn't picked up by sphere-cli."
+  echo "         Check: $LOG_FILE"
+  exit 2
+fi
+
+# Read N from the first hydrate line: "hydrated: N event IDs"
+n_hydrated=$(echo "$first_hydrated" | grep -oE 'hydrated: [0-9]+' | head -1 | grep -oE '[0-9]+' || echo "?")
+
+if [[ "$n_hydrated" == "0" ]]; then
+  echo "VERDICT: hydrated=0 in the first process. If you re-used a workspace,"
+  echo "         this is CAUSE (1) — persistent dedup not surviving cross-process."
+  echo "         File the OrbitDB Profile flush issue (F2)."
+else
+  echo "VERDICT: hydrated=$n_hydrated in the first sampled process."
+  if [[ -n "$dedup_hit_lines" ]]; then
+    echo "         Dedup is firing. CASE (3) self-wrap-race is the live"
+    echo "         suspect: lift PR #558's hold and wire selfWrap: false"
+    echo "         in sphere-cli's HMCP send sites (F3)."
+  else
+    echo "         Dedup loaded but never fires — buffered events are NEW IDs."
+    echo "         Confirms CASE (3): the prior process never received what it"
+    echo "         published. Lift #558 hold and wire selfWrap: false (F3)."
+  fi
+fi
+
+echo
+echo "Full log preserved at: $LOG_FILE"
+echo "Workspace preserved at: $TRADER_TEST_DIR (set KEEP=0 to clean)"

--- a/transport/MultiAddressTransportMux.ts
+++ b/transport/MultiAddressTransportMux.ts
@@ -1872,10 +1872,12 @@ export class MultiAddressTransportMux {
       'Mux',
       `[#275] Mux dedup hydrated: ${this.processedEventIds.size} event IDs`,
     );
-    // [#559-diag] Promote post-hydration size to INFO so it appears in
-    // production CLI logs without DEBUG_LOG=1. Discriminator for #559:
-    //   hydrated=0 in §3 SET_STRATEGY → cross-process flush is failing
-    //     (OrbitDB Profile durability — see #234/#239/#266/#268 family)
+    // [#559-diag] Post-hydration size at INFO so it appears with
+    // SPHERE_DEBUG=Mux=info (default min-level is warn — quiet otherwise).
+    // Discriminator semantics for #559:
+    //   hydrated=0 across processes → cross-process persistence is failing
+    //     (OrbitDB Profile durability — see #234/#239/#266/#268 family).
+    //     Empirically ruled out for Node.js FileStorage in #559's verdict.
     //   hydrated=N>0 + no dedup-hit log → events arrive via a path that
     //     bypasses the Mux handleEvent gate (look at outer
     //     NostrTransportProvider.processedEventIds and fetchPendingEvents).

--- a/transport/MultiAddressTransportMux.ts
+++ b/transport/MultiAddressTransportMux.ts
@@ -1103,6 +1103,17 @@ export class MultiAddressTransportMux {
     }
     if (event.id) {
       this.processedEventIds.add(event.id);
+      // [#559-diag] new event arrived — never seen before this process.
+      // Combined with the dedup-hit log + final set-size, this tells us
+      // exactly how many "fresh" events leaked past dedup → reached
+      // CommunicationsModule → AcpDmTransport.handleIncoming. That's the
+      // number that the M9 `buffered=K` would have measured.
+      logger.info(
+        'Mux',
+        `[#559-diag] new event ${event.id.slice(0, 12)}... ` +
+        `(kind=${event.kind}, sender=${(event.pubkey ?? '').slice(0, 12)}..., ` +
+        `total dedup set size=${this.processedEventIds.size})`,
+      );
       // FIFO half-flush — preserves the legacy "evict half on overflow"
       // behavior to avoid thrashing at the cap boundary under bursts.
       if (this.processedEventIds.size > MultiAddressTransportMux.MAX_PROCESSED_IDS) {

--- a/transport/MultiAddressTransportMux.ts
+++ b/transport/MultiAddressTransportMux.ts
@@ -1089,7 +1089,18 @@ export class MultiAddressTransportMux {
   private async handleEvent(event: NostrEvent): Promise<void> {
     // Dedup — bounded set with FIFO eviction. Issue #275 persists this
     // set so cross-process CLI invocations short-circuit at this gate.
-    if (event.id && this.processedEventIds.has(event.id)) return;
+    if (event.id && this.processedEventIds.has(event.id)) {
+      // [#559-diag] cross-process dedup hit — the prior CLI process's
+      // persisted MUX_PROCESSED_EVENT_IDS caught this replay. If this fires
+      // in §3 of trader-soak, the OrbitDB Profile flush survived
+      // process exit and (A.2) requires a different fix surface.
+      logger.info(
+        'Mux',
+        `[#559-diag] dedup hit on event ${event.id.slice(0, 12)}... ` +
+        `(kind=${event.kind}, total dedup set size=${this.processedEventIds.size})`,
+      );
+      return;
+    }
     if (event.id) {
       this.processedEventIds.add(event.id);
       // FIFO half-flush — preserves the legacy "evict half on overflow"
@@ -1840,6 +1851,18 @@ export class MultiAddressTransportMux {
     logger.debug(
       'Mux',
       `[#275] Mux dedup hydrated: ${this.processedEventIds.size} event IDs`,
+    );
+    // [#559-diag] Promote post-hydration size to INFO so it appears in
+    // production CLI logs without DEBUG_LOG=1. Discriminator for #559:
+    //   hydrated=0 in §3 SET_STRATEGY → cross-process flush is failing
+    //     (OrbitDB Profile durability — see #234/#239/#266/#268 family)
+    //   hydrated=N>0 + no dedup-hit log → events arrive via a path that
+    //     bypasses the Mux handleEvent gate (look at outer
+    //     NostrTransportProvider.processedEventIds and fetchPendingEvents).
+    logger.info(
+      'Mux',
+      `[#559-diag] hydrated: ${this.processedEventIds.size} event IDs ` +
+      `(storage=${this.storage ? 'present' : 'absent'})`,
     );
   }
 


### PR DESCRIPTION
## Summary

F1 from the [#559 refined analysis](https://github.com/unicity-sphere/sphere-sdk/issues/559#issuecomment-4715746951). Adds two `[#559-diag]` log lines at INFO level so they appear in production CLI logs without `DEBUG_LOG=1`:

1. `MultiAddressTransportMux.hydrateProcessedDedup` (post-hydration): prints `processedEventIds.size` immediately after the storage load. The pre-existing #275 `logger.debug` line at the same site stays for debug-stream consumers.
2. `MultiAddressTransportMux.handleEvent` dedup-hit branch: prints the event id prefix + kind + total set size whenever a cross-process replay is caught.

No behavior change. Removable in one revert once the diag run confirms the cause.

## Discriminator semantics

After PR #560 ruled out (A.1) (relay `#p`-filter looseness — 0/0/0 events across 3 testnet runs), the leading hypothesis for #559's fresh-wallet backlog is (A.2): something publishes to the controller pubkey before the controller's first `sendDM` resolves, and the SDK's persistent cross-process dedup (#275) is not catching it.

But §3 SET_STRATEGY's `buffered=4` (alice) / `buffered=3` (bob) on every fresh CLI process suggests dedup is silently failing. Two candidate causes from the comment thread:

- **(1)** OrbitDB Profile flush doesn't survive `process.exit()` — entangled with the #234/#239/#266/#268 family.
- **(2)** Events reach the buffer via a path that bypasses `Mux.handleEvent`.

A single trader-soak run with this branch picked up will print, on §3's first SET_STRATEGY:

| Log pattern | Conclusion |
| --- | --- |
| `[#559-diag] hydrated: 0 event IDs ...` | **cause (1)** — persistent dedup not surviving cross-process. File the OrbitDB Profile flush issue. |
| `[#559-diag] hydrated: 3 event IDs ...` + **no dedup-hit log** | **cause (2)** — events arrive via a path that bypasses Mux.handleEvent. Re-examine `NostrTransportProvider.processedEventIds` + `fetchPendingEvents`. |
| `[#559-diag] hydrated: 3 event IDs ...` + dedup-hit logs | Dedup is working; the soak's `[acp-m9] buffered=K` count must measure something other than post-decrypt arrivals. Re-read the §3 diag patch. |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/unit/transport/MultiAddressTransportMux` — 39 / 39 pass
- [ ] One trader-soak round on a fresh wallet with this branch checked out; capture the `[#559-diag]` lines from the first §3 SET_STRATEGY process
- [ ] Update #559 with the verdict; either land F2 (file the persistent-dedup-cross-process issue) or pivot to the bypass-path investigation

## Related

- #555 — original investigation
- #559 — fresh-wallet backlog anomaly + open hypothesis list
- #275 — persistent cross-process Mux dedup (the mechanism under test)
- PR #560 — diagnostic script (ruled out A.1)
- PR #558 — M8 self-wrap opt-out (held; orthogonal)
- #234 / #239 / #266 / #268 — OrbitDB Profile durability family (candidate cause (1) home)

Draft until the soak run produces a verdict.