### PR TITLE
fix(core): per-address wallet-api client isolation — disarm the address-switch bleed class (#583)

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -2653,12 +2653,12 @@ export class Sphere {
     const out = new Map<string, TokenStorageProvider<TxfStorageDataBase>>();
     for (const [providerId, provider] of this._tokenStorageProviders.entries()) {
       if (provider.createForAddress) {
-        // wallet-api providers accept the shared per-address client (structural
-        // arg, ignored by providers that don't take one).
-        const factory = provider.createForAddress as (c?: unknown) => TokenStorageProvider<TxfStorageDataBase>;
+        // `createForAddress(sharedClient?)` accepts an optional per-address
+        // context (the storage contract types it `unknown`): wallet-api
+        // providers reuse the address's already-built client; others ignore it.
         const newProvider = provider.requiresWalletApi && perAddressClient
-          ? factory.call(provider, perAddressClient)
-          : factory.call(provider);
+          ? provider.createForAddress(perAddressClient)
+          : provider.createForAddress();
         newProvider.setIdentity(identity);
         out.set(providerId, newProvider);
       } else {

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -516,6 +516,20 @@ export interface AddressModuleSet {
   tokenStorageProviders: Map<string, TokenStorageProvider<TxfStorageDataBase>>;
   /** v2 token engine for THIS address (bound to its signing key). */
   tokenEngine: ITokenEngine | undefined;
+  /**
+   * #583 per-address client isolation: this address's OWN delivery provider
+   * (cloned from the composition template, backed by its own identity-bound
+   * `WalletApiClient` + wake socket). Null in compositions without a delivery
+   * port, or when the composed provider can't isolate per address (no
+   * `createForAddress`) — then the shared template instance is reused.
+   */
+  delivery: DeliveryProvider | null;
+  /**
+   * #583: this address's OWN wallet-api session — the SAME client backing
+   * {@link delivery} (so the whole module set authenticates as one owner). Null
+   * in fully-local compositions or when isolation isn't available.
+   */
+  walletApi: SphereWalletApiSession | null;
   initialized: boolean;
 }
 
@@ -551,10 +565,28 @@ export class Sphere {
   private _transport: TransportProvider;
   private _oracle: OracleProvider;
   private _priceProvider: PriceProvider | null;
-  /** Delivery port (S7) — null = legacy transport adapter inside PaymentsModule. */
+  /**
+   * Delivery port (S7) for the ACTIVE address — null = legacy transport adapter
+   * inside PaymentsModule. #583: this now tracks the active address's OWN
+   * (per-address-isolated) instance, not a single shared one.
+   */
   private _delivery: DeliveryProvider | null = null;
-  /** wallet-api session (S4) — null in fully-local compositions. */
+  /**
+   * wallet-api session (S4) for the ACTIVE address — null in fully-local
+   * compositions. #583: reflects the active address's OWN client (so
+   * `walletApiSessionStatus` is the active owner's session state).
+   */
   private _walletApi: SphereWalletApiSession | null = null;
+  /**
+   * #583 per-address client isolation: the COMPOSITION-TIME delivery / wallet-api
+   * instances, retained as templates. Each HD address clones its OWN identity-
+   * bound delivery + session from these (via `createForAddress`) so an orphaned
+   * previous-address poll pump re-auths as ITS OWN owner — never driving a
+   * client re-bound to a different owner. Address 0 (the boot address) reuses
+   * the template instances directly; later addresses get clones.
+   */
+  private _deliveryTemplate: DeliveryProvider | null = null;
+  private _walletApiTemplate: SphereWalletApiSession | null = null;
   /** S4 session state (#515 F3) — null until a wallet-api composition attempts sign-in. */
   private _walletApiSessionStatus: 'online' | 'offline' | null = null;
   /** v2 token engine (built per active address from the oracle); injected into modules. */
@@ -611,8 +643,13 @@ export class Sphere {
     this._transport = transport;
     this._oracle = oracle;
     this._priceProvider = priceProvider ?? null;
+    // Active-address delivery/session start as the composition-time instances;
+    // they are retained as templates too (#583 — later addresses clone from
+    // them, address 0 / the boot address reuses them directly).
     this._delivery = delivery ?? null;
     this._walletApi = walletApi ?? null;
+    this._deliveryTemplate = delivery ?? null;
+    this._walletApiTemplate = walletApi ?? null;
 
     // Initialize token storage providers map
     if (tokenStorage) {
@@ -2343,15 +2380,14 @@ export class Sphere {
       return;
     }
 
-    // S4 auth lifecycle: the wallet-api session is per identity — log out
-    // before switching; the new address's module init signs back in.
-    if (this._walletApi && index !== this._currentAddressIndex) {
-      try {
-        await this._walletApi.logout();
-      } catch (err) {
-        logger.warn('Sphere', 'wallet-api logout on address switch failed (continuing):', err);
-      }
-    }
+    // #583: per-address client isolation — each HD address binds its OWN
+    // identity-bound wallet-api client (delivery + session + token storage). A
+    // switch does NOT log out the previous address's session: its modules keep
+    // running on their OWN client (the per-address architecture's "old address
+    // keeps running" contract), and the new address signs in on its own client
+    // at module init. The previous logout-before-switch existed only to stop
+    // the SINGLE shared client serving the wrong owner — now obsolete (and it
+    // would needlessly drop the previous address's still-live wake socket).
 
     // Derive the address at the given index
     const addressInfo = this.deriveAddress(index, false);
@@ -2399,7 +2435,9 @@ export class Sphere {
     // No destroy, no waitForPendingOperations — old address keeps running.
     // =========================================================================
 
-    if (!this._addressModules.has(index)) {
+    const firstVisit = !this._addressModules.has(index);
+
+    if (firstVisit) {
       // First time switching to this address — create independent modules
       logger.debug('Sphere', `switchToAddress(${index}): creating per-address modules (lazy init)`);
 
@@ -2408,31 +2446,24 @@ export class Sphere {
       // storage keys.  Without this, modules would load the previous address's data.
       this._storage.setIdentity(newIdentity);
 
-      // Create per-address token storage providers (each address needs its own instances)
-      const addressTokenProviders = new Map<string, TokenStorageProvider<TxfStorageDataBase>>();
-      for (const [providerId, provider] of this._tokenStorageProviders.entries()) {
-        if (provider.createForAddress) {
-          const newProvider = provider.createForAddress();
-          newProvider.setIdentity(newIdentity);
-          await newProvider.initialize();
-          addressTokenProviders.set(providerId, newProvider);
-        } else {
-          // Fallback: reuse existing provider (legacy behavior for providers
-          // that don't support createForAddress). The reused SHARED provider
-          // is still bound to the PREVIOUS address — rebind it to this address
-          // before it serves inventory (#580 review). Its in-memory view AND
-          // its persisted cursor are per-identity (keyed by chainPubkey), so
-          // without this setIdentity a FIRST-VISIT switch loads the previous
-          // address's tokens / a wrong delta. Mirrors the createForAddress
-          // branch above; `payments.initialize` only rebinds delivery, never
-          // the token-storage providers, so nothing else covers this.
-          logger.warn('Sphere', `Token storage provider ${providerId} does not support createForAddress, reusing shared instance`);
-          provider.setIdentity(newIdentity);
-          addressTokenProviders.set(providerId, provider);
-        }
+      // #583: build THIS address's OWN delivery + wallet-api session FIRST (one
+      // fresh identity-bound client), so the wallet-api token storage can share
+      // that SAME client — all of an address's wallet-api artifacts then run on
+      // ONE client + ONE refresh-token lineage (siblings sharing owner+deviceId
+      // would otherwise trip the server's rotation-reuse revocation).
+      const { delivery, walletApi } = this.buildAddressDelivery(newIdentity);
+      const addressTokenProviders = this.buildAddressTokenProviders(newIdentity, walletApi);
+      for (const provider of addressTokenProviders.values()) {
+        await provider.initialize();
       }
 
-      await this.initializeAddressModules(index, newIdentity, addressTokenProviders);
+      await this.initializeAddressModules({
+        index,
+        identity: newIdentity,
+        tokenStorageProviders: addressTokenProviders,
+        delivery,
+        walletApi,
+      });
     } else {
       // Modules already exist — update identity if nametag changed
       const moduleSet = this._addressModules.get(index)!;
@@ -2440,8 +2471,15 @@ export class Sphere {
         moduleSet.identity = newIdentity;
         // Use per-address transport if available
         const addressTransport: TransportProvider = moduleSet.transportAdapter ?? this._transport;
-        // Re-initialize with updated identity (nametag change). The signing key is
-        // unchanged (only the nametag label), so reuse this address's token engine.
+        // #583: re-init with THIS address's OWN (isolated) delivery + session —
+        // never the currently-active address's instances. The signing key is
+        // unchanged (only the nametag label), so reuse this address's token
+        // engine; rebind the per-address delivery's identity (nametag may ride
+        // outgoing envelopes) before payments.initialize re-wires it.
+        moduleSet.delivery?.setIdentity?.({
+          privateKey: newIdentity.privateKey,
+          chainPubkey: newIdentity.chainPubkey,
+        });
         moduleSet.payments.initialize({
           identity: newIdentity,
           storage: this._storage,
@@ -2452,19 +2490,16 @@ export class Sphere {
           chainCode: this._masterKey?.chainCode || undefined,
           price: this._priceProvider ?? undefined,
           tokenEngine: moduleSet.tokenEngine,
-          delivery: this._delivery ?? undefined,
-          walletApi: this._walletApi ?? undefined,
+          delivery: moduleSet.delivery ?? undefined,
+          walletApi: moduleSet.walletApi ?? undefined,
           getCurrentNametag: () => this.getNametagForAddress(),
         });
-      } else {
-        // No nametag change → the module is NOT re-initialized, so nothing has
-        // re-bound the SHARED wallet-api/delivery client to this address. That
-        // client holds one identity+JWT; without this rebind it keeps the
-        // previously-active address's owner and inventory loads return the WRONG
-        // address's tokens (the #580 cross-address bleed). Re-establish identity
-        // + auth on the re-visit path before the pointer swap serves inventory.
-        await this.rebindWalletApiIdentity(newIdentity, moduleSet);
       }
+      // No nametag change → no re-init needed. #583: this address already has
+      // its OWN identity-bound client (built at first visit); it never served
+      // another owner, so there is nothing to re-bind (the #580/#581 shared-
+      // client `rebindWalletApiIdentity` is retired). The pointer swap below
+      // just points the active references at this set's instances.
     }
 
     // Switch the active pointer — instant, no destroy
@@ -2477,6 +2512,25 @@ export class Sphere {
     this._communications = activeModules.communications;
     this._groupChat = activeModules.groupChat;
     this._market = activeModules.market;
+    // #583: point the active delivery/wallet-api references at THIS address's
+    // own instances so Sphere-level surfaces (walletApiSessionStatus, any
+    // delivery passthrough) reflect the ACTIVE owner — not whichever address
+    // was composed at boot. Previous addresses' instances keep running on their
+    // own clients in the background.
+    this._delivery = activeModules.delivery;
+    this._walletApi = activeModules.walletApi;
+
+    // #583: on a RE-VISIT (modules already existed, so initializeAddressModules
+    // did NOT run its sign-in), re-establish this address's session — re-sign-in
+    // (refresh-first, cheap + idempotent), refresh the Sphere-level
+    // walletApiSessionStatus to the ACTIVE owner's state (#515 F3), and re-run
+    // resumeOpenIntents (E.3) so an intent that failed to resume on an earlier
+    // visit retries. The retired rebindWalletApiIdentity used to cover this on
+    // the re-visit path; per-address isolation keeps the client itself bound,
+    // but these sign-in side effects still need re-running on each switch-back.
+    if (!firstVisit && activeModules.walletApi) {
+      await this.startWalletApiSession(activeModules.payments, activeModules.walletApi);
+    }
 
     // Persist current index
     await this._storage.set(STORAGE_KEYS_GLOBAL.CURRENT_ADDRESS_INDEX, index.toString());
@@ -2517,35 +2571,6 @@ export class Sphere {
   }
 
   /**
-   * Re-bind the SHARED wallet-api/delivery client to `identity` on a re-visit
-   * address switch that did NOT re-initialize the module (#580).
-   *
-   * The wallet-api preset composes ONE `WalletApiClient`, shared by the
-   * token-storage provider, the delivery provider and the `walletApi` session;
-   * it holds a single identity+JWT. `switchToAddress` logs out before switching
-   * and only re-authenticates inside `PaymentsModule.initialize` (via
-   * `delivery.setIdentity`) — which the no-nametag-change re-visit path skips.
-   * Without this rebind the shared client keeps the previous owner, so this
-   * address's inventory `load()` returns the WRONG address's tokens. Re-bind the
-   * delivery + wallet-api ports AND this address's wallet-api-backed token
-   * storage providers, then re-establish the session (sign-in is degradable:
-   * a failed sign-in is recorded, never thrown — boot/switch stays non-blocking).
-   */
-  private async rebindWalletApiIdentity(
-    identity: FullIdentity,
-    moduleSet: AddressModuleSet,
-  ): Promise<void> {
-    if (!this._walletApi && !this._delivery) return;
-    const idSlice = { privateKey: identity.privateKey, chainPubkey: identity.chainPubkey };
-    this._delivery?.setIdentity?.(idSlice);
-    this._walletApi?.setIdentity(idSlice);
-    for (const provider of moduleSet.tokenStorageProviders.values()) {
-      if (provider.requiresWalletApi) provider.setIdentity(identity);
-    }
-    if (this._walletApi) await this.startWalletApiSession(moduleSet.payments);
-  }
-
-  /**
    * Background transport sync and nametag operations after address switch.
    * Runs after switchToAddress returns so L1/L3 queries can start immediately.
    */
@@ -2573,6 +2598,81 @@ export class Sphere {
   }
 
   /**
+   * #583 per-address client isolation: build THIS address's OWN delivery
+   * provider + wallet-api session, both backed by ONE fresh identity-bound
+   * `WalletApiClient` cloned from the composition template. An orphaned
+   * previous-address poll pump then drives ITS OWN client (re-auths as its own
+   * owner — harmless) instead of a single shared client re-bound to the new
+   * owner, which is what stranded incoming tokens, leaked wake sockets onto the
+   * wrong owner, and bled payment-requests across addresses.
+   *
+   * Returns the composition templates unchanged when the delivery provider
+   * can't isolate per address (no `createForAddress` — e.g. a stateless legacy
+   * transport adapter); the no-op-switch guard + per-address token storage still
+   * apply. The new delivery's identity is bound here so its first pull
+   * authenticates as this address; `PaymentsModule.initialize` re-binds it (and
+   * the engine's deliveryKeys) idempotently.
+   */
+  private buildAddressDelivery(
+    identity: FullIdentity,
+  ): { delivery: DeliveryProvider | null; walletApi: SphereWalletApiSession | null } {
+    const template = this._deliveryTemplate;
+    if (!template?.createForAddress) {
+      // No isolation available — reuse the composition templates as-is.
+      return { delivery: this._deliveryTemplate, walletApi: this._walletApiTemplate };
+    }
+    const delivery = template.createForAddress();
+    delivery.setIdentity?.({ privateKey: identity.privateKey, chainPubkey: identity.chainPubkey });
+    // The wallet-api session for this address is the SAME client backing its
+    // delivery provider (so intents/history/PRs authenticate as one owner). It
+    // MUST come from the isolated clone's own `walletApiClient` — never the
+    // shared `_walletApiTemplate`: re-binding the boot address's still-active
+    // session to this address would reintroduce the very cross-owner bleed (#580)
+    // this isolation removes. A provider that isolates delivery but exposes no
+    // own client gets a null session (its delivery still works; intents/history
+    // ride the active address's session) rather than a poisoned shared one.
+    const walletApi =
+      (delivery as { walletApiClient?: SphereWalletApiSession }).walletApiClient ?? null;
+    walletApi?.setIdentity({ privateKey: identity.privateKey, chainPubkey: identity.chainPubkey });
+    return { delivery, walletApi };
+  }
+
+  /**
+   * #583: build THIS address's token storage providers. A wallet-api provider
+   * (the only kind needing per-owner auth) is cloned to share the address's
+   * `perAddressClient` — the SAME client backing its delivery + walletApi
+   * session — so all its wallet-api artifacts use ONE client + ONE refresh-token
+   * lineage. Other providers either isolate via the generic arg-less
+   * `createForAddress`, or (stateless/local) reuse the single shared instance,
+   * re-bound to this address. Returns the new (uninitialized) provider map.
+   */
+  private buildAddressTokenProviders(
+    identity: FullIdentity,
+    perAddressClient: unknown,
+  ): Map<string, TokenStorageProvider<TxfStorageDataBase>> {
+    const out = new Map<string, TokenStorageProvider<TxfStorageDataBase>>();
+    for (const [providerId, provider] of this._tokenStorageProviders.entries()) {
+      if (provider.createForAddress) {
+        // wallet-api providers accept the shared per-address client (structural
+        // arg, ignored by providers that don't take one).
+        const factory = provider.createForAddress as (c?: unknown) => TokenStorageProvider<TxfStorageDataBase>;
+        const newProvider = provider.requiresWalletApi && perAddressClient
+          ? factory.call(provider, perAddressClient)
+          : factory.call(provider);
+        newProvider.setIdentity(identity);
+        out.set(providerId, newProvider);
+      } else {
+        // Stateless/local provider: it keys all state by identity internally —
+        // re-bind it to this address and reuse the single instance.
+        logger.warn('Sphere', `Token storage provider ${providerId} does not support createForAddress, reusing shared instance`);
+        provider.setIdentity(identity);
+        out.set(providerId, provider);
+      }
+    }
+    return out;
+  }
+
+  /**
    * Create a new set of per-address modules for the given index.
    * Each address gets its own PaymentsModule, CommunicationsModule, etc.
    * Modules are fully independent — they have their own token storage,
@@ -2583,10 +2683,15 @@ export class Sphere {
    * @param tokenStorageProviders - Token storage providers for this address
    */
   private async initializeAddressModules(
-    index: number,
-    identity: FullIdentity,
-    tokenStorageProviders: Map<string, TokenStorageProvider<TxfStorageDataBase>>,
+    spec: {
+      index: number;
+      identity: FullIdentity;
+      tokenStorageProviders: Map<string, TokenStorageProvider<TxfStorageDataBase>>;
+      delivery: DeliveryProvider | null;
+      walletApi: SphereWalletApiSession | null;
+    },
   ): Promise<AddressModuleSet> {
+    const { index, identity, tokenStorageProviders, delivery, walletApi } = spec;
     // Destroy swap before accounting — swap depends on accounting.
     if (this._swap) {
       await this._swap.destroy();
@@ -2621,6 +2726,11 @@ export class Sphere {
     // v2 token engine for THIS address (bound to its signing key).
     const tokenEngine = await this.buildTokenEngine(identity);
 
+    // #583: `delivery` / `walletApi` are THIS address's OWN identity-bound
+    // instances (built by the caller via buildAddressDelivery, sharing one
+    // client with this address's token storage), so its pumps never share a
+    // client with another address.
+
     // Initialize with address-specific identity and per-address transport
     payments.initialize({
       identity,
@@ -2632,8 +2742,8 @@ export class Sphere {
       chainCode: this._masterKey?.chainCode || undefined,
       price: this._priceProvider ?? undefined,
       tokenEngine,
-      delivery: this._delivery ?? undefined,
-      walletApi: this._walletApi ?? undefined,
+      delivery: delivery ?? undefined,
+      walletApi: walletApi ?? undefined,
       getCurrentNametag: () => this.getNametagForAddress(),
     });
 
@@ -2712,8 +2822,9 @@ export class Sphere {
     await payments.load();
 
     // S4 auth lifecycle: sign in as this address's identity and resume its
-    // open intents (E.3) — sign-in on unlock / after an account switch.
-    await this.startWalletApiSession(payments);
+    // open intents (E.3) — sign-in on unlock / after an account switch. Drives
+    // THIS address's OWN session (#583), never a shared one.
+    await this.startWalletApiSession(payments, walletApi);
 
     // Non-critical modules load in parallel — failures are non-fatal
     const results = await Promise.allSettled([
@@ -2739,6 +2850,8 @@ export class Sphere {
       transportAdapter: adapter,
       tokenStorageProviders: new Map(tokenStorageProviders),
       tokenEngine,
+      delivery,
+      walletApi,
       initialized: true,
     };
 
@@ -4611,7 +4724,9 @@ export class Sphere {
     // S4 auth lifecycle: sign in on unlock and resume open intents (E.3).
     await this.startWalletApiSession(this._payments);
 
-    // Register in per-address module map
+    // Register in per-address module map. #583: the boot address reuses the
+    // composition-time delivery/session instances directly (they ARE this
+    // address's isolated client); later addresses clone their own.
     this._addressModules.set(this._currentAddressIndex, {
       index: this._currentAddressIndex,
       identity: this._identity!,
@@ -4622,6 +4737,8 @@ export class Sphere {
       transportAdapter: adapter,
       tokenStorageProviders: new Map(this._tokenStorageProviders),
       tokenEngine: this._tokenEngine,
+      delivery: this._delivery,
+      walletApi: this._walletApi,
       initialized: true,
     });
   }
@@ -4656,10 +4773,13 @@ export class Sphere {
    * it is RECORDED and surfaced (`walletApiSessionStatus` + the
    * `walletapi:session` event), never log-only (#515 F3).
    */
-  private async startWalletApiSession(payments: PaymentsModule): Promise<void> {
-    if (!this._walletApi) return;
+  private async startWalletApiSession(
+    payments: PaymentsModule,
+    session: SphereWalletApiSession | null = this._walletApi,
+  ): Promise<void> {
+    if (!session) return;
     try {
-      await this._walletApi.signIn();
+      await session.signIn();
     } catch (err) {
       logger.warn('Sphere', 'wallet-api sign-in failed — wallet continues offline:', err);
       this.noteWalletApiSession('offline', err instanceof Error ? err.message : String(err));

--- a/impl/shared/wallet-api/WalletApiMailboxProvider.ts
+++ b/impl/shared/wallet-api/WalletApiMailboxProvider.ts
@@ -93,6 +93,17 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
     this.deriveKeysFn = config.deliveryKeys ?? null;
   }
 
+  /**
+   * #583: the underlying authenticated client. Sphere's per-address wiring uses
+   * the SAME client for an address's delivery provider AND its `walletApi`
+   * session (intents/history/payment-requests), so one address holds ONE
+   * identity-bound client across its whole module set — not three siblings that
+   * would each sign in separately.
+   */
+  get walletApiClient(): WalletApiClient {
+    return this.client;
+  }
+
   /** @inheritDoc — wired by PaymentsModule at init (engine-owning seam). */
   bindDeliveryKeys(derive: (blobBytes: Uint8Array) => Promise<{ tokenId: string; stateHash: string }>): void {
     this.deriveKeysFn = derive;
@@ -118,6 +129,29 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
   setIdentity(identity: { privateKey: string; chainPubkey: string; nametag?: string }): void {
     this.identity = identity;
     this.client.setIdentity({ privateKey: identity.privateKey, chainPubkey: identity.chainPubkey });
+  }
+
+  /**
+   * #583 per-address client isolation: mint an INDEPENDENT delivery provider
+   * for a different HD address, backed by a FRESH {@link WalletApiClient} cloned
+   * from the same composition config (same composition-time `custody`). Each
+   * address's delivery provider then drives its OWN identity-bound client + wake
+   * socket — an orphaned previous-address delivery pump re-auths as ITS OWN
+   * owner (correct, harmless) instead of rejecting + marking-seen the NEW
+   * owner's mailbox entries through a re-bound shared client (the silent
+   * incoming-token loss / wrong-owner wake-routing class collapses). The cloned
+   * client starts identity-less; `Sphere.switchToAddress` / `PaymentsModule.
+   * initialize` bind identity + the engine's deliveryKeys before it pumps. The
+   * shared `stateStore` is fine — the seen-set / cursor keys are namespaced per
+   * (network, chainPubkey), so per-owner state stays separate.
+   */
+  createForAddress(): WalletApiMailboxProvider {
+    return new WalletApiMailboxProvider({
+      client: this.client.clone(),
+      custody: this.custody,
+      stateStore: this.stateStore,
+      ...(this.deriveKeysFn !== null ? { deliveryKeys: this.deriveKeysFn } : {}),
+    });
   }
 
   // ── persisted state (per network + identity) ────────────────────────────────

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -133,6 +133,32 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     this.hadSuccessfulLoad = false;
   }
 
+  /**
+   * #583 per-address client isolation: mint an INDEPENDENT provider for a
+   * different HD address. Each address's storage provider drives its OWN
+   * identity-bound client — an orphaned previous-address poll pump can never
+   * serve inventory from a client re-authed to a different owner (the
+   * address-switch bleed class collapses).
+   *
+   * `sharedClient` (Sphere threads it): the address's ALREADY-built client — the
+   * one backing its delivery provider + walletApi session. Reusing it makes ALL
+   * of an address's wallet-api artifacts share ONE client and ONE refresh-token
+   * rotation lineage. Two sibling clients of the SAME owner+deviceId over the
+   * shared stateStore would otherwise rotate the SAME refresh token and trip the
+   * server's rotation-reuse revocation (§4). A bare clone is the fallback when
+   * no shared client is threaded. The client starts identity-less here;
+   * `setIdentity` binds it before it serves inventory. The shared `stateStore`
+   * is fine — keys are namespaced per (network, chainPubkey), so per-owner
+   * cursors / known-spend sets stay separate.
+   */
+  createForAddress(sharedClient?: WalletApiClient): WalletApiTokenStorageProvider {
+    return new WalletApiTokenStorageProvider({
+      client: sharedClient ?? this.client.clone(),
+      stateStore: this.stateStore,
+      verifyToken: this.verifyToken,
+    });
+  }
+
   async initialize(): Promise<boolean> {
     this.status = 'connected';
     return true;

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -151,9 +151,12 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
    * is fine — keys are namespaced per (network, chainPubkey), so per-owner
    * cursors / known-spend sets stay separate.
    */
-  createForAddress(sharedClient?: WalletApiClient): WalletApiTokenStorageProvider {
+  createForAddress(sharedClient?: unknown): WalletApiTokenStorageProvider {
+    // The generic TokenStorageProvider contract types the context as `unknown`;
+    // for this provider it is the address's WalletApiClient (or absent → clone).
+    const client = sharedClient instanceof WalletApiClient ? sharedClient : this.client.clone();
     return new WalletApiTokenStorageProvider({
-      client: sharedClient ?? this.client.clone(),
+      client,
       stateStore: this.stateStore,
       verifyToken: this.verifyToken,
     });

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -3665,6 +3665,12 @@ export class PaymentsModule {
    * path) — the in-session cache is left intact and the pull retries next load.
    */
   private async hydrateHistoryFromServer(api: PaymentsWalletApiPort): Promise<void> {
+    // #583 defense-in-depth owner guard: capture the owner this hydration ran
+    // for and refuse to OVERWRITE `_historyCache` if the module's identity
+    // changed under us (a re-init mid-pull). Per-address isolation pins the
+    // client per owner so this can't normally happen; the guard ensures a stale
+    // pull never replaces the active owner's history with another owner's.
+    const owner = this.deps!.identity.chainPubkey;
     const byDedupKey = new Map<string, TransactionHistoryEntry>();
     try {
       let before: string | undefined;
@@ -3680,6 +3686,10 @@ export class PaymentsModule {
       }
     } catch (err) {
       logger.warn('Payments', 'history hydration from server failed (kept in-memory; retries next load):', err);
+      return;
+    }
+    if (this.deps!.identity.chainPubkey !== owner) {
+      logger.warn('Payments', 'history hydration owner changed mid-pull — discarding stale result (owner guard)');
       return;
     }
     this._historyCache = [...byDedupKey.values()];
@@ -4911,6 +4921,21 @@ export class PaymentsModule {
    * request surface is single-asset; module-created requests always are).
    */
   private surfaceIncomingPaymentRequest(wire: WalletApiPaymentRequest): void {
+    // #583 defense-in-depth owner guard: only surface requests actually
+    // addressed to THIS module's owner. Per-address client isolation means an
+    // orphaned previous-address PR pump runs against its OWN client (its own
+    // owner), so a wire for a different owner should never arrive here — but if
+    // any shared state ever slips through, this drops it (and keeps it out of
+    // the wrong owner's actionable view + cursor) rather than bleeding a foreign
+    // request across addresses. Mirrors the engine.isOwnedBy delivery guard.
+    if (wire.toPubkey !== this.deps!.identity.chainPubkey) {
+      logger.warn(
+        'Payments',
+        `Incoming payment request ${wire.id.slice(0, 12)}… addressed to a different owner — skipping (owner guard)`
+      );
+      return;
+    }
+
     const status = PaymentsModule.PR_WIRE_STATUS[wire.status];
 
     // §16 upsert: a request re-surfaces in the incoming ?since= delta at a higher seq when it is

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -304,7 +304,16 @@ export interface TokenStorageProvider<TData = unknown> extends BaseProvider {
    * Create a new independent instance of this provider for a different address.
    * Used by per-address module architecture — each address gets its own
    * TokenStorageProvider instance to avoid cross-address data contamination.
-   * If not implemented, the provider cannot be used in multi-address mode.
+   *
+   * Omitting `createForAddress` is safe ONLY for **stateless or identity-keyed**
+   * providers — ones that re-scope correctly when `Sphere.buildAddressTokenProviders`
+   * falls back to reusing the single instance and re-binding it via `setIdentity`
+   * (e.g. a local provider that namespaces every read/write by the active
+   * identity). A provider that holds **per-address mutable state** (cursors,
+   * caches, an embedded `WalletApiClient`, etc.) and does NOT implement
+   * `createForAddress` is UNSAFE in multi-address mode: the fallback hands every
+   * address the same instance and a stale-address poll/sync can bleed into the
+   * newly bound address. Such providers MUST implement `createForAddress`.
    *
    * `sharedClient` (#583): an optional, provider-specific per-address context —
    * for wallet-api-backed providers it is the address's already-built

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -305,8 +305,16 @@ export interface TokenStorageProvider<TData = unknown> extends BaseProvider {
    * Used by per-address module architecture — each address gets its own
    * TokenStorageProvider instance to avoid cross-address data contamination.
    * If not implemented, the provider cannot be used in multi-address mode.
+   *
+   * `sharedClient` (#583): an optional, provider-specific per-address context —
+   * for wallet-api-backed providers it is the address's already-built
+   * `WalletApiClient`, so all of an address's wallet-api artifacts share ONE
+   * client + one refresh-token lineage (separate sibling clients of the same
+   * owner+deviceId would trip the server's rotation-reuse revocation). Typed as
+   * `unknown` to keep this generic storage contract decoupled from the
+   * wallet-api layer; providers that don't need it ignore the argument.
    */
-  createForAddress?(): TokenStorageProvider<TData>;
+  createForAddress?(sharedClient?: unknown): TokenStorageProvider<TData>;
 
   /**
    * Subscribe to storage events

--- a/tests/integration/address-switch-incoming-token-loss.test.ts
+++ b/tests/integration/address-switch-incoming-token-loss.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Regression (#583, finding #1 — RUNTIME RE-CONFIRMATION OF #579): silent
+ * incoming-token LOSS on address switch.
+ *
+ * THIS TEST IS THE "re-confirm #579 at runtime" DELIVERABLE. #579 reported a
+ * 0.51 UCT delivery that was stranded — never claimed, never visible — after an
+ * address switch. The suspected root, confirmed here at runtime:
+ *
+ * The wallet-api preset composed ONE shared `WalletApiClient` + ONE delivery
+ * provider, reused across every per-address `PaymentsModule`. `switchToAddress`
+ * never quiesced the PREVIOUS address's module, so its 30s delivery poll pump
+ * kept running. After the shared client/provider was re-bound (re-authed +
+ * re-identified) to the NEW owner B, the PREVIOUS address A's still-live pump
+ * pulled B's mailbox through that shared provider, found B's legit entry NOT
+ * owned by A's engine, and `ack('rejected')` — which PERMANENTLY marks the entry
+ * SEEN in the provider's persistent (tokenId, stateHash) seen-set (keyed by the
+ * provider's CURRENT identity = B). B's own pump then skips the now-"seen" entry
+ * forever: the token is silently lost (exactly #579's stranded value).
+ *
+ * THE FIX (#583): each HD address binds its OWN identity-bound delivery provider
+ * (`createForAddress`). An orphaned previous-address pump runs against ITS OWN
+ * owner's mailbox (A's, empty) and re-auths as A — it can never reach B's
+ * mailbox, so it can never reject + mark-seen B's legit delivery. B claims and
+ * stores it.
+ *
+ * FAILING-FIRST mechanism: both A's and B's modules build their delivery via
+ * `template.createForAddress?.() ?? template`. On the PRE-FIX code
+ * `createForAddress` does not exist on `WalletApiMailboxProvider`, so BOTH fall
+ * back to the SHARED `template` — the orphaned A-pump poisons B's seen-set and
+ * B's `receive()` yields NOTHING (RED: the strand). With the per-address fix
+ * each gets its OWN isolated provider and B claims+stores the token (GREEN).
+ *
+ * Driven at the PaymentsModule + delivery-provider granularity with the
+ * deterministic `FakeTokenEngine` against the in-process fake wallet-api — the
+ * Sphere-level per-address modules build the REAL engine from the oracle trust
+ * base (needs an aggregator), so a CLAIM (which needs the engine to verify +
+ * derive delivery keys) is reproduced faithfully here instead of through
+ * `Sphere.init` with a mock (no-engine) oracle. The wiring exercised
+ * (`createForAddress`, the seen-set, reject-on-not-owned) is the exact product
+ * code Sphere's switch path now drives. ONE scenario per file for fork isolation.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  createPaymentsModule,
+  type PaymentsModule,
+  type PaymentsModuleDependencies,
+} from '../../modules/payments/PaymentsModule';
+import type { FullIdentity } from '../../types';
+import type { TransportProvider } from '../../transport';
+import type { OracleProvider } from '../../oracle';
+import type { StorageProvider } from '../../storage';
+import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../unit/token-engine/FakeTokenEngine';
+import { FakeWalletApi } from '../support/fake-wallet-api';
+import { MemoryKeyValueStore, testIdentity } from '../support/wallet-api-test-helpers';
+import { WalletApiClient } from '../../wallet-api';
+import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../impl/shared/wallet-api';
+import { encodeTokenBlob } from '../../token-engine/token-blob';
+import { hexToBytes } from '../../core/crypto';
+
+const UCT = '11'.repeat(32);
+const OWNER_A = testIdentity(21);
+const OWNER_B = testIdentity(22);
+const SENDER = testIdentity(23);
+
+function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIdentity {
+  return {
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    l1Address: `alpha1${id.chainPubkey.slice(0, 8)}`,
+    directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
+    transportPubkey: id.chainPubkey.slice(2),
+  };
+}
+
+function mockStorage(): StorageProvider {
+  const s = new Map<string, string>();
+  return {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+}
+
+function mockTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue(null),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return { validateToken: vi.fn().mockResolvedValue({ valid: true }), isDevMode: () => false } as unknown as OracleProvider;
+}
+
+interface Wallet {
+  module: PaymentsModule;
+  engine: FakeTokenEngine;
+  client: WalletApiClient;
+  delivery: WalletApiMailboxProvider;
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!();
+});
+
+/**
+ * Build a wallet whose DELIVERY provider models how `Sphere.switchToAddress`
+ * now isolates per address: from the composition `template`, take
+ * `createForAddress()` when available (the #583 fix) or fall back to the SHARED
+ * template instance (the pre-fix shared-client design). The fallback is what
+ * lets ONE test be RED pre-fix and GREEN post-fix.
+ */
+function makeWallet(
+  who: { privateKey: string; chainPubkey: string },
+  template: WalletApiMailboxProvider,
+  templateClient: WalletApiClient,
+  kv: MemoryKeyValueStore,
+): Wallet {
+  const identity = fullIdentity(who);
+  // Per-address isolation when supported (the #583 fix), else the SHARED
+  // template instance + its client (the pre-fix shared-client design). The
+  // fallback is what lets ONE test be RED pre-fix and GREEN post-fix WITHOUT
+  // crashing on the missing method/getter.
+  const isolated = template.createForAddress?.();
+  const delivery = isolated ?? template;
+  const client =
+    (isolated as unknown as { walletApiClient?: WalletApiClient } | undefined)?.walletApiClient ??
+    templateClient;
+  delivery.setIdentity(identity);
+  const engine = new FakeTokenEngine({ chainPubkey: hexToBytes(who.chainPubkey) });
+  // Each owner's token storage uses its OWN cloned client too (mirrors Sphere).
+  const tokenStorage = new WalletApiTokenStorageProvider({ client, stateStore: kv });
+  tokenStorage.setIdentity(identity);
+  const deps: PaymentsModuleDependencies = {
+    identity,
+    storage: mockStorage(),
+    tokenStorageProviders: new Map([[tokenStorage.id, tokenStorage]]),
+    transport: mockTransport(),
+    oracle: mockOracle(),
+    emitEvent: vi.fn(),
+    tokenEngine: engine,
+    delivery,
+    walletApi: client,
+  };
+  const module = createPaymentsModule({ l1: null });
+  module.initialize(deps);
+  cleanups.push(() => module.destroy());
+  return { module, engine, client, delivery };
+}
+
+function balanceOf(wallet: Wallet, coinId: string): bigint {
+  return wallet.module
+    .getTokens()
+    .filter((t) => t.coinId === coinId)
+    .reduce((sum, t) => sum + BigInt(t.amount), 0n);
+}
+
+describe('address-switch incoming-token loss — per-address client isolation (#583 finding #1 / #579 runtime re-confirmation)', () => {
+  it('B claims its valid delivery even after A\'s orphaned pump runs — the #579 strand does not happen', { timeout: 30_000 }, async () => {
+    const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
+    const baseUrl = await fake.start();
+    cleanups.push(() => fake.stop());
+
+    // ONE composition template + ONE shared persistence store — exactly the
+    // wallet-api preset's single-client composition that A and B are derived
+    // from (createForAddress clones the client; the shared kv is namespaced per
+    // owner so per-owner seen-sets/cursors stay separate).
+    const sharedKv = new MemoryKeyValueStore();
+    const templateClient = new WalletApiClient({ baseUrl, network: fake.network, deviceId: 'tmpl', storage: sharedKv });
+    const template = new WalletApiMailboxProvider({ client: templateClient, custody: 'inventory', stateStore: sharedKv });
+
+    // Two HD addresses A (index 0) and B (index 1) of the SAME wallet.
+    const a = makeWallet(OWNER_A, template, templateClient, sharedKv);
+    await a.module.load();
+    const b = makeWallet(OWNER_B, template, templateClient, sharedKv);
+    await b.module.load();
+
+    // A sender delivers a VALID token addressed to B (mint locked to B), 51 units
+    // — echoing #579's stranded 0.51 UCT.
+    const senderEngine = new FakeTokenEngine({ chainPubkey: hexToBytes(SENDER.chainPubkey) });
+    const senderKv = new MemoryKeyValueStore();
+    const senderClient = new WalletApiClient({ baseUrl, network: fake.network, deviceId: 'dev-s', storage: senderKv });
+    const senderDelivery = new WalletApiMailboxProvider({ client: senderClient, custody: 'inventory', stateStore: senderKv });
+    senderDelivery.setIdentity(fullIdentity(SENDER));
+    senderDelivery.bindDeliveryKeys((bytes) => senderEngine.deliveryKeys(bytes));
+    const forB = await senderEngine.mint({
+      recipientPubkey: hexToBytes(OWNER_B.chainPubkey),
+      value: { assets: [{ coinId: UCT, amount: 51n }] },
+    });
+    const bytesForB = encodeTokenBlob(senderEngine.encodeToken(forB));
+    const { deliveryId } = await senderDelivery.deliver(OWNER_B.chainPubkey, bytesForB, { transferId: 'tf-579' });
+    expect(fake.getMailboxEntry(OWNER_B.chainPubkey, deliveryId)).toMatchObject({ status: 'unclaimed' });
+
+    // The switch A→B happens. On the SHARED-client design this re-binds the one
+    // provider to B; A's still-running poll pump now points at B's mailbox.
+    // Simulate that orphaned A-pump firing (the 30s poll tick) — it must NOT
+    // strand B's delivery.
+    await a.module.pumpIncomingDeliveries();
+
+    // B receives: it MUST claim + store its 51-unit token. On the pre-fix shared
+    // design A's pump already rejected + marked-seen this entry under B's
+    // identity, so B's pull skips it and yields nothing — the #579 strand. With
+    // per-address isolation A never touched B's mailbox, and B claims it.
+    const { transfers } = await b.module.receive();
+    expect(transfers).toHaveLength(1);
+    expect(balanceOf(b, UCT)).toBe(51n);
+
+    // The entry was actually CLAIMED into B's inventory (the §6 handoff), not
+    // left rejected/stranded.
+    expect(fake.getMailboxEntry(OWNER_B.chainPubkey, deliveryId)).toMatchObject({
+      status: 'claimed',
+      intoInventory: true,
+    });
+
+    // And A — whose orphaned pump ran — holds NONE of B's value (no bleed).
+    expect(balanceOf(a, UCT)).toBe(0n);
+  });
+});

--- a/tests/integration/address-switch-payment-request-bleed.test.ts
+++ b/tests/integration/address-switch-payment-request-bleed.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Regression (#583, finding #3): payment-request BLEED on address switch.
+ *
+ * The wallet-api preset composed ONE shared `WalletApiClient` reused across
+ * every per-address `PaymentsModule`. `switchToAddress` never quiesced the
+ * previous address's module, so its payment-request poll pump kept running.
+ * After the shared client was re-bound (re-authed) to the NEW owner B, the
+ * PREVIOUS address A's still-live PR pump pulled B's incoming `?since=` stream
+ * through that shared client — surfacing the NEW owner's incoming payment
+ * requests into the OLD module's view (no `toPubkey` owner guard) AND advancing
+ * A's persisted PR cursor over B's entries (poisoning it).
+ *
+ * THE FIX (#583): each HD address binds its OWN identity-bound client; an
+ * orphaned previous-address PR pump runs against ITS OWN owner's stream (sees
+ * nothing of B's). A defense-in-depth `toPubkey !== owner` guard in
+ * `surfaceIncomingPaymentRequest` backstops any residual shared state.
+ *
+ * FAILING-FIRST: a requester creates a PR addressed to B. With the per-address
+ * fix it surfaces in B's module ONLY; on the pre-fix shared-client code the
+ * orphaned A-module's pump surfaces it too (A's `getPaymentRequests()` is
+ * non-empty — the bleed).
+ *
+ * Real Sphere over the in-process fake wallet-api. The PR pump is engine-free
+ * (it maps the §16 wire — no aggregator), so the bleed surfaces without minting.
+ * ONE Sphere per file for vitest fork isolation.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { Sphere } from '../../core/Sphere';
+import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
+import { createWalletApiProviders, type SphereBaseProviders } from '../../impl/shared/wallet-api';
+import { WalletApiClient } from '../../wallet-api';
+import { FakeWalletApi } from '../support/fake-wallet-api';
+import { MemoryKeyValueStore } from '../support/wallet-api-test-helpers';
+import { getPublicKey } from '../../core/crypto';
+import type { PaymentsModule } from '../../modules/payments/PaymentsModule';
+import type { TransportProvider, OracleProvider } from '../../index';
+import type { ProviderStatus } from '../../types';
+import type { TokenStorageProvider, TxfStorageDataBase } from '../../storage';
+
+const MNEMONIC = 'test test test test test test test test test test test junk';
+const UCT = 'c0'.repeat(32);
+
+function createMockTransport(): TransportProvider {
+  return {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    description: 'Mock transport',
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn().mockResolvedValue('transfer-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('request-id'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('response-id'),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    subscribeToBroadcast: vi.fn().mockReturnValue(() => {}),
+    publishBroadcast: vi.fn().mockResolvedValue('broadcast-id'),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+    resolveNametag: vi.fn().mockResolvedValue(null),
+    publishIdentityBinding: vi.fn().mockResolvedValue(true),
+    recoverNametag: vi.fn().mockResolvedValue(null),
+  } as unknown as TransportProvider;
+}
+
+function createMockOracle(): OracleProvider {
+  return {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'aggregator' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+  } as unknown as OracleProvider;
+}
+
+interface Built {
+  sphere: Sphere;
+  fake: FakeWalletApi;
+  baseUrl: string;
+  dataDir: string;
+}
+
+async function buildSphere(): Promise<Built> {
+  const fake = new FakeWalletApi();
+  const baseUrl = await fake.start();
+
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-bleed-test-'));
+  const storage = new FileStorageProvider({ dataDir });
+  const base: SphereBaseProviders = {
+    storage,
+    transport: createMockTransport(),
+    oracle: createMockOracle(),
+    tokenStorage: null as unknown as TokenStorageProvider<TxfStorageDataBase>,
+  };
+  const providers = createWalletApiProviders(base, {
+    baseUrl,
+    network: fake.network,
+    deviceId: 'pr-bleed-device',
+  });
+
+  const { sphere } = await Sphere.init({
+    storage,
+    transport: providers.transport,
+    oracle: providers.oracle,
+    tokenStorage: providers.tokenStorage,
+    delivery: providers.delivery,
+    walletApi: providers.walletApi,
+    network: 'testnet2',
+    mnemonic: MNEMONIC,
+  });
+
+  return { sphere, fake, baseUrl, dataDir };
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+  (Sphere as unknown as { instance: null }).instance = null;
+});
+
+/** A standalone "requester" wallet that creates a payment request addressed to a payer. */
+async function createPaymentRequestTo(
+  baseUrl: string,
+  network: string,
+  payerPubkey: string,
+): Promise<string> {
+  const requesterPriv = 'd1'.repeat(32);
+  const requesterPub = getPublicKey(requesterPriv);
+  const client = new WalletApiClient({
+    baseUrl,
+    network,
+    deviceId: 'requester-device',
+    storage: new MemoryKeyValueStore(),
+  });
+  client.setIdentity({ privateKey: requesterPriv, chainPubkey: requesterPub });
+  const record = await client.createPaymentRequest({
+    toPubkey: payerPubkey,
+    assets: [{ coinId: UCT, amount: 42n }],
+  });
+  return record.id;
+}
+
+describe('address-switch payment-request bleed — per-address client isolation (#583 finding #3)', () => {
+  it('a PR addressed to B surfaces in B only — A\'s orphaned module never bleeds it in', { timeout: 30_000 }, async () => {
+    const { sphere, fake, baseUrl, dataDir } = await buildSphere();
+    cleanups.push(() => fs.rmSync(dataDir, { recursive: true, force: true }));
+    cleanups.push(() => fake.stop());
+    cleanups.push(() => sphere.destroy());
+
+    // Activate A (index 0) and B (index 1).
+    await sphere.switchToAddress(0);
+    const pubkeyA = sphere.identity!.chainPubkey;
+    await sphere.switchToAddress(1);
+    const pubkeyB = sphere.identity!.chainPubkey;
+    expect(pubkeyA).not.toBe(pubkeyB);
+
+    // A requester creates a payment request addressed to B (the now-active owner).
+    const prId = await createPaymentRequestTo(baseUrl, fake.network, pubkeyB);
+
+    // The orphaned previous-address module (A) and the active module (B).
+    const modules = (sphere as unknown as {
+      _addressModules: Map<number, { payments: PaymentsModule }>;
+    })._addressModules;
+    const aPayments = modules.get(0)!.payments;
+    const bPayments = modules.get(1)!.payments;
+
+    // Force BOTH modules to pump their payment-request streams now (what the 30s
+    // poll / a wake nudge would otherwise do in the background). On the pre-fix
+    // shared client A's pump pulls B's incoming stream through the rebound
+    // client and surfaces the PR; with per-address isolation A pulls its OWN
+    // (empty) stream.
+    await bPayments.syncPaymentRequests();
+    await aPayments.syncPaymentRequests();
+
+    // B sees its incoming request…
+    const bRequests = bPayments.getPaymentRequests();
+    expect(bRequests.map((r) => r.id)).toContain(prId);
+
+    // …and A must NOT — no cross-owner bleed.
+    const aRequests = aPayments.getPaymentRequests();
+    expect(aRequests.map((r) => r.id)).not.toContain(prId);
+    expect(aRequests).toHaveLength(0);
+  });
+});

--- a/tests/integration/address-switch-session-isolation.test.ts
+++ b/tests/integration/address-switch-session-isolation.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Regression (#583, finding #4 + the structural root): cross-owner SPEND
+ * corruption via a shared wallet-api session on address switch.
+ *
+ * `startWalletApiSession` fires an un-awaited `resumeOpenIntents()` (E.3) at
+ * sign-in. On the shared-client design that resume ran on the ONE shared
+ * `walletApi` client. If an address switch re-bound that client to the NEW owner
+ * B while A's resume was still in flight, A's `applyDelta` (whose §16 body
+ * carries NO owner pubkey — it is authed purely by the bearer JWT) landed under
+ * B's JWT: A's spend written into B's inventory — silent cross-owner corruption.
+ *
+ * THE FIX (#583): each HD address binds its OWN identity-bound `walletApi`
+ * session (the SAME client backing its delivery provider). A's resume runs on
+ * A's client (A's JWT); it can NEVER write under B's JWT, because A's session is
+ * a DIFFERENT client object that authenticates as A. The whole race is removed
+ * structurally — there is no shared mutable session to re-bind mid-resume.
+ *
+ * This test asserts that structural property at the Sphere level (the exact
+ * mechanism that disarms finding #4, which cannot be deterministically RACED in
+ * the fake harness without a real engine to drive a spend through resume — the
+ * Sphere per-address modules build the real engine from the oracle trust base):
+ *
+ *  1. each per-address module set holds its OWN delivery + walletApi instances
+ *     (distinct objects across A and B) — pre-fix they were the ONE shared pair;
+ *  2. the Sphere-level active `_walletApi` reference tracks the ACTIVE address
+ *     (so `walletApiSessionStatus` is the active owner's session state);
+ *  3. each address's session is observably bound to its OWN owner — A's session
+ *     opens a wake socket under A and B's under B (the server witnesses the
+ *     authenticated pubkey of each client), so a resume on A's session acts as
+ *     A and never as B.
+ *
+ * Real Sphere over the in-process fake wallet-api. ONE Sphere per file (fork
+ * isolation). Owner-binding is engine-free (JWT-authed ws-ticket), so it
+ * surfaces without minting.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { Sphere } from '../../core/Sphere';
+import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
+import { createWalletApiProviders, type SphereBaseProviders } from '../../impl/shared/wallet-api';
+import { FakeWalletApi } from '../support/fake-wallet-api';
+import { wsLikeWithPing } from '../support/wallet-api-test-helpers';
+import type { TransportProvider, OracleProvider } from '../../index';
+import type { ProviderStatus } from '../../types';
+import type { TokenStorageProvider, TxfStorageDataBase } from '../../storage';
+
+const MNEMONIC = 'test test test test test test test test test test test junk';
+
+function createMockTransport(): TransportProvider {
+  return {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    description: 'Mock transport',
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn().mockResolvedValue('transfer-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('request-id'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('response-id'),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    subscribeToBroadcast: vi.fn().mockReturnValue(() => {}),
+    publishBroadcast: vi.fn().mockResolvedValue('broadcast-id'),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+    resolveNametag: vi.fn().mockResolvedValue(null),
+    publishIdentityBinding: vi.fn().mockResolvedValue(true),
+    recoverNametag: vi.fn().mockResolvedValue(null),
+  } as unknown as TransportProvider;
+}
+
+function createMockOracle(): OracleProvider {
+  return {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'aggregator' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+  } as unknown as OracleProvider;
+}
+
+interface Built {
+  sphere: Sphere;
+  fake: FakeWalletApi;
+  dataDir: string;
+}
+
+async function buildSphere(): Promise<Built> {
+  const fake = new FakeWalletApi();
+  const baseUrl = await fake.start();
+
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-iso-test-'));
+  const storage = new FileStorageProvider({ dataDir });
+  const base: SphereBaseProviders = {
+    storage,
+    transport: createMockTransport(),
+    oracle: createMockOracle(),
+    tokenStorage: null as unknown as TokenStorageProvider<TxfStorageDataBase>,
+  };
+  const providers = createWalletApiProviders(base, {
+    baseUrl,
+    network: fake.network,
+    deviceId: 'session-iso-device',
+    webSocketFactory: (url: string) => wsLikeWithPing(url),
+  });
+
+  const { sphere } = await Sphere.init({
+    storage,
+    transport: providers.transport,
+    oracle: providers.oracle,
+    tokenStorage: providers.tokenStorage,
+    delivery: providers.delivery,
+    walletApi: providers.walletApi,
+    network: 'testnet2',
+    mnemonic: MNEMONIC,
+  });
+
+  return { sphere, fake, dataDir };
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+  (Sphere as unknown as { instance: null }).instance = null;
+});
+
+async function waitUntil(pred: () => boolean, budgetMs = 8_000): Promise<boolean> {
+  const deadline = Date.now() + budgetMs;
+  for (;;) {
+    if (pred()) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+interface ModuleSet {
+  delivery: unknown;
+  walletApi: unknown;
+}
+
+describe('address-switch session isolation — per-address wallet-api client (#583 finding #4 + root)', () => {
+  it('each address has its OWN delivery + walletApi session, bound to its OWN owner; the active reference tracks the active address', { timeout: 30_000 }, async () => {
+    const { sphere, fake, dataDir } = await buildSphere();
+    cleanups.push(() => fs.rmSync(dataDir, { recursive: true, force: true }));
+    cleanups.push(() => fake.stop());
+    cleanups.push(() => sphere.destroy());
+
+    await sphere.switchToAddress(0);
+    const pubkeyA = sphere.identity!.chainPubkey;
+    await sphere.switchToAddress(1);
+    const pubkeyB = sphere.identity!.chainPubkey;
+    expect(pubkeyA).not.toBe(pubkeyB);
+
+    const modules = (sphere as unknown as { _addressModules: Map<number, ModuleSet> })._addressModules;
+    const setA = modules.get(0)!;
+    const setB = modules.get(1)!;
+
+    // (1) STRUCTURAL: A and B hold DISTINCT delivery + walletApi instances. On
+    // the pre-fix shared-client design both sets pointed at the ONE composed
+    // delivery/session pair (identical references) — the shared mutable session
+    // a mid-resume switch could re-bind under the wrong owner.
+    expect(setA.walletApi).toBeDefined();
+    expect(setB.walletApi).toBeDefined();
+    expect(setA.walletApi).not.toBe(setB.walletApi);
+    expect(setA.delivery).not.toBe(setB.delivery);
+    // Each address's session IS the client backing its OWN delivery provider
+    // (one identity-bound client per address — not three siblings).
+    expect((setA.delivery as { walletApiClient?: unknown }).walletApiClient).toBe(setA.walletApi);
+    expect((setB.delivery as { walletApiClient?: unknown }).walletApiClient).toBe(setB.walletApi);
+
+    // (2) The Sphere-level active reference tracks the ACTIVE address (B now).
+    const activeWalletApi = (sphere as unknown as { _walletApi: unknown })._walletApi;
+    expect(activeWalletApi).toBe(setB.walletApi);
+    expect(sphere.walletApiSessionStatus).not.toBeNull(); // a session was attempted for the active owner
+
+    // (3) BEHAVIORAL owner-binding: each session authenticates as its OWN owner.
+    // Both modules keep running (per-address architecture), each opening a wake
+    // socket through its own client — the server witnesses the authenticated
+    // pubkey of each. A resume on A's session therefore acts as A, never B.
+    expect(await waitUntil(() => fake.socketCount(pubkeyA) >= 1 && fake.socketCount(pubkeyB) >= 1)).toBe(true);
+    // Let any reconnect settle, then assert the exact owner→socket map: one
+    // each — A's session never authenticated as B (which #4's cross-owner write
+    // required).
+    await new Promise((r) => setTimeout(r, 1_000));
+    expect(fake.socketCount(pubkeyA)).toBe(1);
+    expect(fake.socketCount(pubkeyB)).toBe(1);
+  });
+});

--- a/tests/integration/address-switch-wake-routing.test.ts
+++ b/tests/integration/address-switch-wake-routing.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression (#583, finding #2): wrong-owner WAKE ROUTING on address switch.
+ *
+ * The wallet-api preset composed ONE shared `WalletApiClient` for the
+ * token-storage provider, the delivery provider AND the `walletApi` session,
+ * reused across every per-address `PaymentsModule`. `switchToAddress` never
+ * quiesced the previous address's module, so its delivery pump's self-healing
+ * WAKE SUPERVISOR kept running. After the shared client was re-bound (re-authed)
+ * to the NEW owner, the PREVIOUS address's still-live supervisor re-minted a
+ * ws-ticket through that shared client and opened a wake socket as the WRONG
+ * owner — B's wake stream driving A's module, one leaked socket per address.
+ *
+ * THE FIX (#583): each HD address binds its OWN identity-bound `WalletApiClient`
+ * (delivery + session + token storage) via `createForAddress`. An orphaned
+ * previous-address supervisor then re-auths as ITS OWN owner — its socket stays
+ * under A, never B. The owner→socket map is exact: one socket per owner.
+ *
+ * FAILING-FIRST: on the pre-fix shared-client code A's leaked supervisor lands a
+ * socket under B (so `socketCount(B) > 1`, or A holds none of its own); with the
+ * per-address fix `socketCount(A) === 1 && socketCount(B) === 1`.
+ *
+ * Real Sphere over the in-process fake wallet-api (real WalletApiClient → real
+ * loopback HTTP/WS → fake backend keyed by pubkey + per-owner JWT) — the exact
+ * substrate the shared-client staleness leaks through. The wake socket is
+ * engine-free (ws-ticket is JWT-authed; no aggregator needed), so the routing
+ * defect surfaces without minting. ONE Sphere per file for vitest fork
+ * isolation (two wallet-api Spheres in one event loop race on background
+ * sign-in/wake — a harness artefact, not the product bug).
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { Sphere } from '../../core/Sphere';
+import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
+import { createWalletApiProviders, type SphereBaseProviders } from '../../impl/shared/wallet-api';
+import { FakeWalletApi } from '../support/fake-wallet-api';
+import { wsLikeWithPing } from '../support/wallet-api-test-helpers';
+import type { TransportProvider, OracleProvider } from '../../index';
+import type { ProviderStatus } from '../../types';
+import type { TokenStorageProvider, TxfStorageDataBase } from '../../storage';
+
+const MNEMONIC = 'test test test test test test test test test test test junk';
+
+function createMockTransport(): TransportProvider {
+  return {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    description: 'Mock transport',
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    sendMessage: vi.fn().mockResolvedValue('event-id'),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn().mockResolvedValue('transfer-id'),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequest: vi.fn().mockResolvedValue('request-id'),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    sendPaymentRequestResponse: vi.fn().mockResolvedValue('response-id'),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    subscribeToBroadcast: vi.fn().mockReturnValue(() => {}),
+    publishBroadcast: vi.fn().mockResolvedValue('broadcast-id'),
+    onEvent: vi.fn().mockReturnValue(() => {}),
+    resolveNametag: vi.fn().mockResolvedValue(null),
+    publishIdentityBinding: vi.fn().mockResolvedValue(true),
+    recoverNametag: vi.fn().mockResolvedValue(null),
+  } as unknown as TransportProvider;
+}
+
+function createMockOracle(): OracleProvider {
+  return {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'aggregator' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+  } as unknown as OracleProvider;
+}
+
+interface Built {
+  sphere: Sphere;
+  fake: FakeWalletApi;
+  dataDir: string;
+}
+
+async function buildSphere(): Promise<Built> {
+  const fake = new FakeWalletApi();
+  const baseUrl = await fake.start();
+
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-route-test-'));
+  const storage = new FileStorageProvider({ dataDir });
+  const base: SphereBaseProviders = {
+    storage,
+    transport: createMockTransport(),
+    oracle: createMockOracle(),
+    tokenStorage: null as unknown as TokenStorageProvider<TxfStorageDataBase>,
+  };
+  const providers = createWalletApiProviders(base, {
+    baseUrl,
+    network: fake.network,
+    deviceId: 'wake-route-device',
+    // Inject a ws factory with ping/pong hooks so the §9 supervisor opens a
+    // real socket against the fake's upgrade handler (node global WebSocket
+    // lacks the protocol ping/pong seam the liveness watchdog observes).
+    webSocketFactory: (url: string) => wsLikeWithPing(url),
+  });
+
+  const { sphere } = await Sphere.init({
+    storage,
+    transport: providers.transport,
+    oracle: providers.oracle,
+    tokenStorage: providers.tokenStorage,
+    delivery: providers.delivery,
+    walletApi: providers.walletApi,
+    network: 'testnet2',
+    mnemonic: MNEMONIC,
+  });
+
+  return { sphere, fake, dataDir };
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+  (Sphere as unknown as { instance: null }).instance = null;
+});
+
+/** Poll until `pred()` holds or the budget elapses (§9 eventual consistency). */
+async function waitUntil(pred: () => boolean, budgetMs = 8_000): Promise<boolean> {
+  const deadline = Date.now() + budgetMs;
+  for (;;) {
+    if (pred()) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+describe('address-switch wake routing — per-address client isolation (#583 finding #2)', () => {
+  it('after A→B switch, each owner has exactly ONE wake socket — A never opens one as B', { timeout: 30_000 }, async () => {
+    const { sphere, fake, dataDir } = await buildSphere();
+    cleanups.push(() => fs.rmSync(dataDir, { recursive: true, force: true }));
+    cleanups.push(() => fake.stop());
+    cleanups.push(() => sphere.destroy());
+
+    // Address A (index 0) — its delivery pump's wake supervisor opens A's socket.
+    await sphere.switchToAddress(0);
+    const pubkeyA = sphere.identity!.chainPubkey;
+    expect(await waitUntil(() => fake.socketCount(pubkeyA) >= 1)).toBe(true);
+
+    // Switch to address B (index 1). A's module keeps running in the background
+    // (per-address architecture: no destroy). Its still-live wake supervisor
+    // must NOT re-route onto B's stream.
+    await sphere.switchToAddress(1);
+    const pubkeyB = sphere.identity!.chainPubkey;
+    expect(pubkeyA).not.toBe(pubkeyB);
+
+    // B opens its OWN socket.
+    expect(await waitUntil(() => fake.socketCount(pubkeyB) >= 1)).toBe(true);
+
+    // Give any orphaned supervisor ample time to (mis)reconnect; on the pre-fix
+    // shared client A's supervisor re-mints a ticket as B and lands a SECOND
+    // socket under B. With per-address isolation the owner→socket map stays
+    // exact: one each. (Allow a brief overlap window for a reconnect-in-flight,
+    // then assert the converged steady state.)
+    await new Promise((r) => setTimeout(r, 1_500));
+
+    expect(fake.socketCount(pubkeyB)).toBe(1); // B owns exactly its own socket — no leak from A
+    expect(fake.socketCount(pubkeyA)).toBe(1); // A keeps its OWN socket (authed as A), still live in background
+  });
+});

--- a/tests/unit/wallet-api/client.identity-switch.test.ts
+++ b/tests/unit/wallet-api/client.identity-switch.test.ts
@@ -1,5 +1,5 @@
 /**
- * #583 — auth-generation guard (Copilot review on PR #585).
+ * #583 (auth-generation guard) — landed in PR #585.
  *
  * `setIdentity()` (and `logout()`) bump a monotonic `authGeneration`. An
  * in-flight challenge→sign / refresh attempt captures the generation at its
@@ -71,9 +71,12 @@ function defer(): Deferred {
  */
 class ScriptedAuthFetch {
   readonly verifyGates: Deferred[] = [];
+  readonly refreshGates: Deferred[] = [];
   private readonly verifyTokens: Array<{ jwt: string; refreshToken: string }> = [];
   /** Bearer tokens seen on authenticated probe requests, in order. */
   readonly bearerSeen: string[] = [];
+  /** Pubkeys that reached `/v1/auth/challenge`, in order — proves a challenge cycle ran. */
+  readonly challengeSeen: string[] = [];
 
   queueVerifyTokens(jwt: string, refreshToken: string): void {
     this.verifyTokens.push({ jwt, refreshToken });
@@ -83,7 +86,16 @@ class ScriptedAuthFetch {
     const path = url.replace(BASE_URL.replace(/\/$/, ''), '');
     if (path === '/v1/auth/challenge') {
       const pubkey = JSON.parse(String(init?.body)).pubkey as string;
+      this.challengeSeen.push(pubkey);
       return Promise.resolve(jsonResponse(200, challengeBody(pubkey)));
+    }
+    if (path === '/v1/auth/refresh') {
+      // Gated like verify, so a refresh can be held in flight across a switch.
+      const gate = defer();
+      this.refreshGates.push(gate);
+      return gate.promise.then(() =>
+        jsonResponse(200, { jwt: 'JWT-REFRESHED', refreshToken: 'REFRESH-ROTATED' }),
+      );
     }
     if (path === '/v1/auth/verify') {
       const idx = this.verifyGates.length;
@@ -101,6 +113,10 @@ class ScriptedAuthFetch {
 
   releaseVerify(index: number): void {
     this.verifyGates[index].resolve();
+  }
+
+  releaseRefresh(index: number): void {
+    this.refreshGates[index].resolve();
   }
 }
 
@@ -157,6 +173,48 @@ describe('WalletApiClient — auth-generation guard on identity switch (#583)', 
     expect(script.bearerSeen).not.toContain('JWT-A');
     expect(storage.map.get(refreshKeyFor(ownerB.chainPubkey, 'dev-1'))).toBe('REFRESH-B');
     expect(storage.map.get(refreshKeyFor(ownerA.chainPubkey, 'dev-1'))).toBeUndefined();
+  });
+
+  it('a refresh that goes stale mid-flight bails WITHOUT starting a challenge cycle for the new owner', async () => {
+    const ownerA = testIdentity(73);
+    const ownerB = testIdentity(74);
+    const storage = new MemoryKeyValueStore();
+    const script = new ScriptedAuthFetch();
+    const client = new WalletApiClient({
+      baseUrl: BASE_URL,
+      network: NETWORK,
+      deviceId: 'dev-3',
+      storage,
+      fetchFn: script.fetchFn,
+    });
+
+    // Owner A has a stored refresh token, so signIn() takes the refresh path
+    // (which we hold in flight) rather than going straight to a challenge.
+    storage.map.set(refreshKeyFor(ownerA.chainPubkey, 'dev-3'), 'REFRESH-A');
+    client.setIdentity(ownerA);
+
+    const signInA = client.signIn();
+    await settleMicrotasks();
+    expect(script.refreshGates.length).toBe(1); // parked on /v1/auth/refresh
+    expect(script.challengeSeen).toEqual([]); // no challenge yet
+
+    // Identity switches to owner B while A's refresh is still in flight.
+    client.setIdentity(ownerB);
+
+    // Release the now-stale refresh. `tryRefresh` returns false (isStale); the
+    // fix makes `signInInner` bail. Without it, signInInner would fall through to
+    // `challengeSignIn(gen)` and run a full challenge→verify cycle for owner B.
+    script.releaseRefresh(0);
+    await settleMicrotasks();
+
+    // FAILING-FIRST DISCRIMINATOR: no challenge cycle was started for ANY owner.
+    expect(script.challengeSeen).toEqual([]);
+    // Nothing was persisted for the new owner, and A's pre-existing token is
+    // left intact (a stale refresh-false neither rotates nor removes it).
+    expect(storage.map.get(refreshKeyFor(ownerB.chainPubkey, 'dev-3'))).toBeUndefined();
+    expect(storage.map.get(refreshKeyFor(ownerA.chainPubkey, 'dev-3'))).toBe('REFRESH-A');
+
+    await signInA; // resolves cleanly under the fix
   });
 
   it('the happy path (no identity change) caches the jwt and persists the refresh token', async () => {

--- a/tests/unit/wallet-api/client.identity-switch.test.ts
+++ b/tests/unit/wallet-api/client.identity-switch.test.ts
@@ -1,0 +1,187 @@
+/**
+ * #583 — auth-generation guard (Copilot review on PR #585).
+ *
+ * `setIdentity()` (and `logout()`) bump a monotonic `authGeneration`. An
+ * in-flight challenge→sign / refresh attempt captures the generation at its
+ * START and bails — WITHOUT touching `this.jwt` or the refresh token — once the
+ * identity has moved on. This kills the cross-owner contamination class where a
+ * sign-in begun for owner A resolves AFTER a switch to owner B and (a) caches
+ * A's JWT for B's client and/or (b) writes/clears A's refresh token under B's
+ * storage key (`refreshTokenKey()` is derived from the CURRENT identity).
+ *
+ * The seam is the injected `fetchFn`: a controllable fake that lets a test hold
+ * `/v1/auth/verify` in flight, switch identity, then release the stale response
+ * and observe — purely through behaviour (the Bearer token on the next
+ * authenticated request, and the persisted refresh token) — that it was
+ * discarded.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WalletApiClient, AUTH_CHALLENGE_PREFIX } from '../../../wallet-api';
+import type { FetchLike, FetchResponseLike } from '../../../wallet-api';
+import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
+
+const NETWORK = 'testnet2';
+const BASE_URL = 'http://127.0.0.1:9/'; // loopback — never dialed (fetch is injected)
+
+function jsonResponse(status: number, body: unknown): FetchResponseLike {
+  const text = JSON.stringify(body);
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    text: () => Promise.resolve(text),
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+  };
+}
+
+function challengeBody(pubkey: string): { nonce: string; challenge: string } {
+  const nonce = 'nonce-' + pubkey.slice(0, 8);
+  const now = Date.now();
+  const challenge =
+    AUTH_CHALLENGE_PREFIX +
+    JSON.stringify({
+      network: NETWORK,
+      pubkey,
+      nonce,
+      issuedAt: new Date(now - 1000).toISOString(),
+      expiresAt: new Date(now + 60_000).toISOString(),
+    });
+  return { nonce, challenge };
+}
+
+/** A deferred-resolution gate for one fetch response. */
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+function defer(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * A scripted fetch over the §4 auth + a probe GET. `/v1/auth/challenge` answers
+ * immediately for the requested pubkey; `/v1/auth/verify` is GATED on a per-call
+ * deferred the test releases, so a sign-in can be held in-flight across a
+ * `setIdentity()`. `/v1/balances` records the Bearer token it was called with —
+ * the behavioural proof of which JWT the client believes is current.
+ */
+class ScriptedAuthFetch {
+  readonly verifyGates: Deferred[] = [];
+  private readonly verifyTokens: Array<{ jwt: string; refreshToken: string }> = [];
+  /** Bearer tokens seen on authenticated probe requests, in order. */
+  readonly bearerSeen: string[] = [];
+
+  queueVerifyTokens(jwt: string, refreshToken: string): void {
+    this.verifyTokens.push({ jwt, refreshToken });
+  }
+
+  readonly fetchFn: FetchLike = (url, init) => {
+    const path = url.replace(BASE_URL.replace(/\/$/, ''), '');
+    if (path === '/v1/auth/challenge') {
+      const pubkey = JSON.parse(String(init?.body)).pubkey as string;
+      return Promise.resolve(jsonResponse(200, challengeBody(pubkey)));
+    }
+    if (path === '/v1/auth/verify') {
+      const idx = this.verifyGates.length;
+      const gate = defer();
+      this.verifyGates.push(gate);
+      return gate.promise.then(() => jsonResponse(200, this.verifyTokens[idx]));
+    }
+    if (path === '/v1/balances') {
+      const auth = init?.headers?.['authorization'] ?? '';
+      this.bearerSeen.push(auth.replace(/^Bearer /, ''));
+      return Promise.resolve(jsonResponse(200, { balances: [] }));
+    }
+    throw new Error(`unexpected fetch to ${path}`);
+  };
+
+  releaseVerify(index: number): void {
+    this.verifyGates[index].resolve();
+  }
+}
+
+function refreshKeyFor(pubkey: string, deviceId: string): string {
+  return `wallet-api:refresh:${NETWORK}:${pubkey}:${deviceId}`;
+}
+
+/** Flush enough microtask turns for the parked challenge round-trip to settle. */
+async function settleMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe('WalletApiClient — auth-generation guard on identity switch (#583)', () => {
+  it('a sign-in for the previous owner does NOT cache its jwt or persist its refresh token after setIdentity()', async () => {
+    const ownerA = testIdentity(70);
+    const ownerB = testIdentity(71);
+    const storage = new MemoryKeyValueStore();
+    const script = new ScriptedAuthFetch();
+    const client = new WalletApiClient({
+      baseUrl: BASE_URL,
+      network: NETWORK,
+      deviceId: 'dev-1',
+      storage,
+      fetchFn: script.fetchFn,
+    });
+
+    // Owner A begins a sign-in; its verify is held in flight (gate 0).
+    client.setIdentity(ownerA);
+    script.queueVerifyTokens('JWT-A', 'REFRESH-A');
+    const signInA = client.signIn();
+    await settleMicrotasks();
+    expect(script.verifyGates.length).toBe(1);
+
+    // Identity switches to owner B mid-sign-in (the bug trigger).
+    client.setIdentity(ownerB);
+
+    // The held A sign-in now completes — it MUST discard its result.
+    script.releaseVerify(0);
+    await signInA;
+
+    // (b) A's refresh token landed under NEITHER owner's storage key.
+    expect(storage.map.get(refreshKeyFor(ownerB.chainPubkey, 'dev-1'))).toBeUndefined();
+    expect(storage.map.get(refreshKeyFor(ownerA.chainPubkey, 'dev-1'))).toBeUndefined();
+
+    // (a) An authenticated request as B re-signs-in fresh and uses B's JWT —
+    //     never the abandoned A JWT.
+    script.queueVerifyTokens('JWT-B', 'REFRESH-B');
+    const balances = client.getBalances();
+    await settleMicrotasks();
+    script.releaseVerify(1); // the fresh B sign-in's verify
+    await balances;
+
+    expect(script.bearerSeen).toEqual(['JWT-B']);
+    expect(script.bearerSeen).not.toContain('JWT-A');
+    expect(storage.map.get(refreshKeyFor(ownerB.chainPubkey, 'dev-1'))).toBe('REFRESH-B');
+    expect(storage.map.get(refreshKeyFor(ownerA.chainPubkey, 'dev-1'))).toBeUndefined();
+  });
+
+  it('the happy path (no identity change) caches the jwt and persists the refresh token', async () => {
+    const owner = testIdentity(72);
+    const storage = new MemoryKeyValueStore();
+    const script = new ScriptedAuthFetch();
+    const client = new WalletApiClient({
+      baseUrl: BASE_URL,
+      network: NETWORK,
+      deviceId: 'dev-2',
+      storage,
+      fetchFn: script.fetchFn,
+    });
+
+    client.setIdentity(owner);
+    script.queueVerifyTokens('JWT', 'REFRESH');
+    const signIn = client.signIn();
+    await settleMicrotasks();
+    script.releaseVerify(0);
+    await signIn;
+
+    expect(storage.map.get(refreshKeyFor(owner.chainPubkey, 'dev-2'))).toBe('REFRESH');
+
+    // The cached JWT is the one used by the next authenticated request.
+    await client.getBalances();
+    expect(script.bearerSeen).toEqual(['JWT']);
+  });
+});

--- a/transport/delivery-provider.ts
+++ b/transport/delivery-provider.ts
@@ -132,6 +132,19 @@ export interface DeliveryProvider {
   setIdentity?(identity: { privateKey: string; chainPubkey: string }): void;
 
   /**
+   * #583 per-address client isolation: mint an INDEPENDENT delivery provider for
+   * a different HD address, backed by its OWN authenticated client + wake socket
+   * (mirrors `TokenStorageProvider.createForAddress`). Implementations that hold
+   * a single mutable identity+session per instance (e.g. the wallet-api mailbox
+   * over one `WalletApiClient`) provide this so `Sphere.switchToAddress` can give
+   * each address its OWN delivery instance — an orphaned previous-address pump
+   * then re-auths as ITS OWN owner (harmless) instead of driving a client that
+   * was re-bound to the new owner. Stateless transports may omit it (the same
+   * instance serves every address).
+   */
+  createForAddress?(): DeliveryProvider;
+
+  /**
    * Hand a finished token blob to a recipient. `recipientPubkey` is the
    * recipient's CHAIN pubkey (33-byte compressed secp256k1, hex) — the
    * canonical Unicity identity (ARCHITECTURE §4); transports that address

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -161,6 +161,9 @@ export class WalletApiClient {
   /** Serializes concurrent re-auth attempts. */
   private authInFlight: Promise<void> | null = null;
 
+  /** The construction config, retained so {@link clone} can mint a sibling. */
+  private readonly config: WalletApiClientConfig;
+
   constructor(config: WalletApiClientConfig) {
     const url = assertSecureBaseUrl(config.baseUrl);
     this.baseUrl = url.toString().replace(/\/$/, '');
@@ -178,12 +181,36 @@ export class WalletApiClient {
       config.fetchFn ?? ((u, init) => (globalThis as unknown as { fetch: FetchLike }).fetch(u, init));
     this.wsFactory = config.webSocketFactory ?? defaultWebSocketFactory;
     this.now = config.now ?? (() => Date.now());
+    this.config = config;
+  }
+
+  /**
+   * #583: mint a FRESH, identity-less sibling client from the SAME construction
+   * config (baseUrl, network, deviceId, storage, fetch/ws factories, clock).
+   * Per-address client isolation builds one client per HD address from this, so
+   * each address's providers authenticate as their OWN owner with their OWN JWT
+   * — an orphaned previous-address poll pump can never drive a client that has
+   * been re-authed to a DIFFERENT owner. The shared `storage` is intentional:
+   * its keys are namespaced per (network, chainPubkey, deviceId), so per-owner
+   * refresh tokens / cursors stay separate (no cross-owner collision). The clone
+   * starts with no identity and no JWT — the caller binds it via setIdentity.
+   */
+  clone(): WalletApiClient {
+    return new WalletApiClient(this.config);
   }
 
   /** Bind the wallet identity this client authenticates as. Resets the session. */
   setIdentity(identity: WalletApiIdentity): void {
     this.identity = identity;
     this.jwt = null;
+    // #583: also abandon any in-flight sign-in. A pending challenge→sign cycle
+    // for the PREVIOUS identity could otherwise resolve here and cache a JWT
+    // for the wrong owner (`authInFlight` is keyed to the identity at the time
+    // the promise was created). Per-address client isolation makes a shared
+    // re-bind rare, but a defense-in-depth clear keeps `signIn()` re-minting
+    // for the new identity from a clean slate. The orphaned promise still runs
+    // to completion harmlessly (its `.finally` only nulls a field we've reset).
+    this.authInFlight = null;
   }
 
   // ── storage keys (scoped per network + pubkey + device) ────────────────────
@@ -210,10 +237,15 @@ export class WalletApiClient {
    */
   async signIn(): Promise<void> {
     if (this.authInFlight) return this.authInFlight;
-    this.authInFlight = this.signInInner().finally(() => {
-      this.authInFlight = null;
+    const inFlight = this.signInInner().finally(() => {
+      // #583: only clear the slot if it still holds THIS promise. setIdentity()
+      // may null `authInFlight` (abandoning a stale sign-in) and a fresh signIn()
+      // may have stored a NEW promise; an unconditional clear here would clobber
+      // that newer in-flight sign-in and break the de-dup guarantee.
+      if (this.authInFlight === inFlight) this.authInFlight = null;
     });
-    return this.authInFlight;
+    this.authInFlight = inFlight;
+    return inFlight;
   }
 
   private async signInInner(): Promise<void> {

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -276,6 +276,12 @@ export class WalletApiClient {
 
   private async signInInner(gen: number): Promise<void> {
     if (await this.tryRefresh(gen)) return;
+    // #583: `tryRefresh` returns false for TWO reasons — a genuine refresh miss
+    // (no/expired token) OR the identity moved on mid-refresh (`isStale`). In the
+    // stale case we must NOT fall through to a challenge→verify cycle: it would
+    // run under the NEW owner, hit the network, possibly throw, and be discarded
+    // by `challengeSignIn`'s own end-guard anyway. Bail cleanly instead.
+    if (this.isStale(gen)) return;
     await this.challengeSignIn(gen);
   }
 

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -160,6 +160,15 @@ export class WalletApiClient {
   private jwt: string | null = null;
   /** Serializes concurrent re-auth attempts. */
   private authInFlight: Promise<void> | null = null;
+  /**
+   * #583: monotonic auth-session counter. Bumped by every {@link setIdentity}
+   * and {@link logout}. A sign-in/refresh attempt captures it at its START and
+   * bails before any shared-state mutation (`this.jwt`, the refresh token) if it
+   * no longer matches — i.e. the identity moved on while the attempt was async,
+   * so its result is stale and would contaminate the new owner. See
+   * {@link isStale}.
+   */
+  private authGeneration = 0;
 
   /** The construction config, retained so {@link clone} can mint a sibling. */
   private readonly config: WalletApiClientConfig;
@@ -203,13 +212,16 @@ export class WalletApiClient {
   setIdentity(identity: WalletApiIdentity): void {
     this.identity = identity;
     this.jwt = null;
-    // #583: also abandon any in-flight sign-in. A pending challenge→sign cycle
-    // for the PREVIOUS identity could otherwise resolve here and cache a JWT
-    // for the wrong owner (`authInFlight` is keyed to the identity at the time
-    // the promise was created). Per-address client isolation makes a shared
-    // re-bind rare, but a defense-in-depth clear keeps `signIn()` re-minting
-    // for the new identity from a clean slate. The orphaned promise still runs
-    // to completion harmlessly (its `.finally` only nulls a field we've reset).
+    // #583: invalidate any in-flight sign-in for the PREVIOUS identity. Nulling
+    // `authInFlight` only drops our reference — the orphaned challenge→sign /
+    // refresh chain keeps running and could STILL resolve later, at which point
+    // it would (a) cache `this.jwt` for the wrong owner and (b) write/clear the
+    // refresh token under `refreshTokenKey()`, which is now derived from the NEW
+    // identity — cross-owner contamination. Bumping `authGeneration` makes those
+    // late mutations self-cancel: every attempt captured the generation at its
+    // start and `isStale()`-guards each shared-state write, so a stale chain
+    // discards its result instead of clobbering the new owner's session.
+    this.authGeneration += 1;
     this.authInFlight = null;
   }
 
@@ -229,6 +241,16 @@ export class WalletApiClient {
     return `${this.scopedKey('refresh')}:${this.deviceId}`;
   }
 
+  /**
+   * #583: true once the identity has moved on since `gen` was captured (a
+   * {@link setIdentity}/{@link logout} bumped {@link authGeneration}). A sign-in
+   * attempt checks this before every mutation of `this.jwt` or the refresh token
+   * and bails out when stale — its tokens belong to a now-discarded owner.
+   */
+  private isStale(gen: number): boolean {
+    return this.authGeneration !== gen;
+  }
+
   // ── auth (ARCHITECTURE §4) ──────────────────────────────────────────────────
 
   /**
@@ -237,7 +259,11 @@ export class WalletApiClient {
    */
   async signIn(): Promise<void> {
     if (this.authInFlight) return this.authInFlight;
-    const inFlight = this.signInInner().finally(() => {
+    // #583: bind this attempt to the CURRENT auth generation. A later
+    // setIdentity()/logout() bumps the generation; the attempt then self-cancels
+    // before mutating shared state (see `signInInner`/`tryRefresh`/`challengeSignIn`).
+    const gen = this.authGeneration;
+    const inFlight = this.signInInner(gen).finally(() => {
       // #583: only clear the slot if it still holds THIS promise. setIdentity()
       // may null `authInFlight` (abandoning a stale sign-in) and a fresh signIn()
       // may have stored a NEW promise; an unconditional clear here would clobber
@@ -248,9 +274,9 @@ export class WalletApiClient {
     return inFlight;
   }
 
-  private async signInInner(): Promise<void> {
-    if (await this.tryRefresh()) return;
-    await this.challengeSignIn();
+  private async signInInner(gen: number): Promise<void> {
+    if (await this.tryRefresh(gen)) return;
+    await this.challengeSignIn(gen);
   }
 
   /**
@@ -258,24 +284,34 @@ export class WalletApiClient {
    * 4xx (expired, revoked, rotation-reuse revocation) clears the stored token
    * and reports `false` — the caller falls back to a challenge cycle.
    */
-  private async tryRefresh(): Promise<boolean> {
-    const stored = await this.storage.get(this.refreshTokenKey());
+  private async tryRefresh(gen: number): Promise<boolean> {
+    // #583: capture the refresh-token key NOW. The whole attempt operates on
+    // THIS owner's key; a mid-flight identity switch repoints `refreshTokenKey()`
+    // at the new owner, so we must never read or write under the new key here.
+    const key = this.refreshTokenKey();
+    const stored = await this.storage.get(key);
     if (!stored) return false;
     const res = await this.rawFetch('POST', '/v1/auth/refresh', { refreshToken: stored });
+    // The identity may have moved on while the request was in flight — discard
+    // the result rather than caching the previous owner's JWT / refresh token.
+    if (this.isStale(gen)) return false;
     if (res.status === 200) {
       const tokens = parseAuthTokens(await this.readJson(res, 'auth/refresh'));
       this.jwt = tokens.jwt;
-      await this.storage.set(this.refreshTokenKey(), tokens.refreshToken);
+      await this.storage.set(key, tokens.refreshToken);
       return true;
     }
     // Stale/revoked/reused token — discard it; a fresh challenge cycle follows.
-    await this.storage.remove(this.refreshTokenKey());
+    await this.storage.remove(key);
     return false;
   }
 
   /** The challenge→verify cycle (§4 steps 1–3) with template verification (S1). */
-  private async challengeSignIn(): Promise<void> {
+  private async challengeSignIn(gen: number): Promise<void> {
     const identity = this.requireIdentity();
+    // #583: pin the refresh-token key to THIS owner up front (it is derived from
+    // the identity); a mid-flight switch must not write under the new owner's key.
+    const key = this.refreshTokenKey();
     const challengeRes = await this.rawFetch('POST', '/v1/auth/challenge', {
       pubkey: identity.chainPubkey,
     });
@@ -298,12 +334,20 @@ export class WalletApiClient {
     });
     if (verifyRes.status !== 200) throw await this.toError(verifyRes, 'auth/verify');
     const tokens = parseAuthTokens(await this.readJson(verifyRes, 'auth/verify'));
+    // The identity may have switched while challenge→verify was in flight —
+    // discard this owner's freshly-minted session instead of caching the JWT /
+    // persisting the refresh token under the new owner's storage key.
+    if (this.isStale(gen)) return;
     this.jwt = tokens.jwt;
-    await this.storage.set(this.refreshTokenKey(), tokens.refreshToken);
+    await this.storage.set(key, tokens.refreshToken);
   }
 
   /** Revoke the session server-side and drop all local credentials. */
   async logout(): Promise<void> {
+    // #583: invalidate any in-flight sign-in so it cannot re-cache a JWT or
+    // re-persist the refresh token after we have just dropped them.
+    this.authGeneration += 1;
+    this.authInFlight = null;
     if (this.jwt) {
       try {
         await this.rawFetch('POST', '/v1/auth/logout', {}, this.jwt);


### PR DESCRIPTION
## What

Durable architectural fix for the **address-switch bleed CLASS** (tracking issue **#583**). **Supersedes #580/#581's `rebindWalletApiIdentity` shim** — that was a leaf patch of a shared-single-client design; this fixes the root.

### The root
The wallet-api preset composed **ONE shared `WalletApiClient`** (single mutable identity+JWT) used by the token-storage provider, the mailbox/delivery provider, AND the `walletApi` session, across **all** per-address `PaymentsModule` instances. `switchToAddress` never quiesced the previous address's module, so its 30s poll pumps + self-healing wake supervisor kept driving the ONE shared client **after** it was rebound to the new owner.

### Four confirmed HIGH defects (each has a failing-first test, red on pre-fix → green post-fix)
1. **Silent incoming-token loss** — the orphaned previous-address delivery pump rejects + permanently marks-seen the new owner's legit mailbox entries. **Suspected root of #579's stranded 0.51 UCT — the test is the runtime re-confirmation of #579.**
2. **Wrong-owner wake routing** — the orphaned wake supervisor re-auths onto the new owner's wake streams via the shared client (one leaked socket per address).
3. **Payment-request bleed** — the stale PR pump surfaces the new owner's incoming PRs into the old module + poisons the PR cursor.
4. **Cross-owner spend corruption** — un-awaited `resumeOpenIntents` writes `applyDelta` (no owner pubkey in body) under the new owner's JWT after a concurrent switch.

## The fix — per-address client isolation
Each HD address binds its **OWN** identity-bound `WalletApiClient`, so an orphaned previous-address pump re-auths as ITS OWN owner (correct, harmless) — the whole class collapses.

- `WalletApiClient.clone()` — mint a fresh identity-less sibling from the same construction config; `setIdentity` also abandons `authInFlight` (race-safe clear via a same-promise guard in `signIn`).
- `createForAddress()` on **both** `WalletApiTokenStorageProvider` and `WalletApiMailboxProvider`; `DeliveryProvider` gains an optional `createForAddress()`. All of an address's wallet-api artifacts share **ONE** cloned client + one refresh-token lineage (separate siblings of the same owner+deviceId would trip the server's rotation-reuse revocation).
- `core/Sphere.ts` rewired: each per-address module set gets its OWN `delivery` + `walletApi` session + token storage; Sphere-level `_delivery`/`_walletApi` track the **active** address (so `walletApiSessionStatus` is the active owner's). **Retired** `rebindWalletApiIdentity` + the first-visit fallback `setIdentity`; **kept** the no-op-switch guard. Re-visit re-runs `startWalletApiSession` (session status + `resumeOpenIntents` E.3 retry).
- **Defense-in-depth owner guards** (mirror the existing `engine.isOwnedBy` guard): `surfaceIncomingPaymentRequest` skips wires whose `toPubkey !== owner`; `hydrateHistoryFromServer` gates the `_historyCache` overwrite on owner match.

## Tests (failing-first, no tautologies)
4 new fork-isolated files, each reproduces a finding red on pre-fix and green post-fix; the existing #580 re-visit + first-visit inventory-bleed tests still pass. Full unit suite green on **node:20 and node:22 (189 files / 3066 tests)**; `npm run build` + `npm run lint` clean (0 errors). New switch tests looped for determinism on both node versions.

Closes #583 (manual close — non-default base). Do not merge until reviewed.