### PR TITLE
fix(groupchat): stop NIP-29 connect from freezing the UI on large groups

### DIFF
--- a/modules/groupchat/GroupChatModule.ts
+++ b/modules/groupchat/GroupChatModule.ts
@@ -395,12 +395,18 @@ export class GroupChatModule {
     //  - Moderation events must not be missed (e.g., kicks that occurred while offline)
     const sinceTimestamp = this.getLatestKnownTimestamp(groupIds);
 
-    // Subscribe to group messages
+    // Subscribe to group messages.
+    // `limit` bounds the stored-event backlog the relay replays on (re)connect:
+    // without it, a busy global group dumps its ENTIRE history in one burst
+    // (observed: 1000 events), and each one runs synchronously through
+    // handleGroupEvent + two emitEvent fan-outs, freezing the UI. Older history
+    // is loaded on demand via fetchMessages()/getMessagesPage().
     this.trackSubscription(
       createNip29Filter({
         kinds: [NIP29_KINDS.CHAT_MESSAGE, NIP29_KINDS.THREAD_ROOT, NIP29_KINDS.THREAD_REPLY],
         '#h': groupIds,
         ...(sinceTimestamp ? { since: sinceTimestamp } : {}),
+        limit: this.config.defaultMessageLimit,
       }),
       { onEvent: (event: Event) => this.handleGroupEvent(event) },
     );
@@ -429,11 +435,14 @@ export class GroupChatModule {
 
     const sinceTimestamp = this.getLatestKnownTimestamp([groupId]);
 
+    // See subscribeToJoinedGroups(): `limit` bounds the replayed backlog so a
+    // busy group can't freeze the UI by dumping its full history on connect.
     this.trackSubscription(
       createNip29Filter({
         kinds: [NIP29_KINDS.CHAT_MESSAGE, NIP29_KINDS.THREAD_ROOT, NIP29_KINDS.THREAD_REPLY],
         '#h': [groupId],
         ...(sinceTimestamp ? { since: sinceTimestamp } : {}),
+        limit: this.config.defaultMessageLimit,
       }),
       { onEvent: (event: Event) => this.handleGroupEvent(event) },
     );
@@ -1369,26 +1378,29 @@ export class GroupChatModule {
       this.fetchGroupAdminsInternal(groupId),
     ]);
 
+    // De-dupe by pubkey in O(n) via a Map, then assign the array once.
+    // saveMemberToMemory() does a linear findIndex per insert, so calling it in
+    // a loop over a member list is O(n^2): for a global group with tens of
+    // thousands of members that is a multi-second synchronous main-thread freeze
+    // (so severe the page can't even open DevTools). Merge with whatever is
+    // already in memory so existing entries aren't dropped.
+    const adminSet = new Set(adminPubkeys);
+    const byPubkey = new Map<string, GroupMemberData>();
+    for (const existing of this.members.get(groupId) ?? []) {
+      byPubkey.set(existing.pubkey, existing);
+    }
     for (const member of members) {
-      if (adminPubkeys.includes(member.pubkey)) {
-        member.role = GroupRoleEnum.ADMIN;
-      }
-      this.saveMemberToMemory(member);
+      if (adminSet.has(member.pubkey)) member.role = GroupRoleEnum.ADMIN;
+      byPubkey.set(member.pubkey, member);
     }
-
-    // Save admins not in member list
+    // Admins not present in the member list.
     for (const pubkey of adminPubkeys) {
-      const existing = (this.members.get(groupId) || []).find((m) => m.pubkey === pubkey);
-      if (!existing) {
-        this.saveMemberToMemory({
-          pubkey,
-          groupId,
-          role: GroupRoleEnum.ADMIN,
-          joinedAt: Date.now(),
-        });
+      if (!byPubkey.has(pubkey)) {
+        byPubkey.set(pubkey, { pubkey, groupId, role: GroupRoleEnum.ADMIN, joinedAt: Date.now() });
       }
     }
 
+    this.members.set(groupId, Array.from(byPubkey.values()));
     this.schedulePersist();
   }
 

--- a/tests/relay/groupchat-backlog-freeze.test.ts
+++ b/tests/relay/groupchat-backlog-freeze.test.ts
@@ -1,0 +1,227 @@
+/**
+ * GroupChatModule — global-chat backlog freeze reproduction (relay e2e)
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Enabling group chat in the Sphere wallet froze the UI: on first connect the
+ * client auto-joins the pinned global groups (`announcements`, `general`) and
+ * `subscribeToJoinedGroups()` issues a NIP-29 message REQ with **no `limit`**
+ * (and no `since`, because nothing is stored yet). A busy global group then
+ * replays its ENTIRE history in one burst, and every event runs synchronously
+ * through `handleGroupEvent` (JSON.parse + saveMessageToMemory + two emitEvent
+ * fan-outs) on the main thread with no chunking/yielding. Backlog volume × the
+ * per-event synchronous work = a dead UI until the dump finishes.
+ *
+ * This test reproduces that against the REAL relay so we can SEE what stalls,
+ * then locks in the fix contract: the initial backlog must be BOUNDED, not the
+ * whole history.
+ *
+ * HOW TO RUN
+ * ----------
+ *   npm run test:relay -- groupchat-backlog-freeze
+ *   # or point at another relay:
+ *   RELAY_URL=wss://sphere-relay.unicity.network npm run test:relay -- groupchat-backlog-freeze
+ *
+ * Defaults to the real production relay because the freeze only manifests
+ * against a group that actually has a large stored history (an empty Docker
+ * relay can't reproduce it).
+ */
+import { describe, it, expect } from 'vitest';
+import { monitorEventLoopDelay } from 'node:perf_hooks';
+import { NostrKeyManager } from '@unicitylabs/nostr-js-sdk';
+
+import { GroupChatModule } from '../../modules/groupchat/GroupChatModule';
+import { GroupVisibility } from '../../modules/groupchat/types';
+import type { GroupData } from '../../modules/groupchat/types';
+import type { StorageProvider } from '../../storage';
+import type {
+  FullIdentity,
+  SphereEventType,
+  SphereEventMap,
+  TrackedAddressEntry,
+  ProviderStatus,
+} from '../../types';
+import { STORAGE_KEYS_ADDRESS, STORAGE_KEYS_GLOBAL } from '../../constants';
+
+// =============================================================================
+// Config
+// =============================================================================
+
+/** The real global chat lives here; override with RELAY_URL to target another. */
+const RELAY_URL = process.env.RELAY_URL ?? 'wss://sphere-relay.unicity.network';
+
+/** The busiest pinned global group — the one that actually has a big backlog. */
+const GLOBAL_GROUP_ID = process.env.GROUP_ID ?? 'general';
+
+/**
+ * The fix contract: the first connect must request a BOUNDED backlog
+ * (config.defaultMessageLimit, currently 50), not the entire history.
+ * Allow a small margin for live messages that land during the quiet window.
+ */
+const DEFAULT_MESSAGE_LIMIT = 50;
+const LIVE_TRAFFIC_TOLERANCE = 25;
+const MAX_INITIAL_BACKLOG = DEFAULT_MESSAGE_LIMIT + LIVE_TRAFFIC_TOLERANCE;
+
+/** Treat the backlog as drained once no new message arrives for this long. */
+const QUIET_MS = 2500;
+/** Hard cap on how long we wait for the backlog burst to settle. */
+const SETTLE_HARD_CAP_MS = 90_000;
+
+// A fixed, valid (non-zero, < n) secp256k1 scalar for the read-only test user.
+const TEST_PRIVATE_KEY = '00000000000000000000000000000000000000000000000000000000000000a1';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+class InMemoryStorageProvider implements StorageProvider {
+  readonly id = 'memory';
+  readonly name = 'Memory';
+  readonly type = 'local' as const;
+  private data = new Map<string, string>();
+
+  async connect(): Promise<void> {}
+  async disconnect(): Promise<void> {}
+  isConnected(): boolean { return true; }
+  getStatus(): ProviderStatus { return 'connected'; }
+  setIdentity(): void {}
+  async get(key: string): Promise<string | null> { return this.data.get(key) ?? null; }
+  async set(key: string, value: string): Promise<void> { this.data.set(key, value); }
+  async remove(key: string): Promise<void> { this.data.delete(key); }
+  async has(key: string): Promise<boolean> { return this.data.has(key); }
+  async keys(prefix?: string): Promise<string[]> {
+    const all: string[] = [];
+    this.data.forEach((_, k) => all.push(k));
+    return prefix ? all.filter((k) => k.startsWith(prefix)) : all;
+  }
+  async clear(prefix?: string): Promise<void> {
+    if (!prefix) { this.data.clear(); return; }
+    const toDelete: string[] = [];
+    this.data.forEach((_, k) => { if (k.startsWith(prefix)) toDelete.push(k); });
+    toDelete.forEach((k) => this.data.delete(k));
+  }
+  async saveTrackedAddresses(): Promise<void> {}
+  async loadTrackedAddresses(): Promise<TrackedAddressEntry[]> { return []; }
+}
+
+function getXOnlyPubkey(privateKeyHex: string): string {
+  const km = NostrKeyManager.fromPrivateKey(Buffer.from(privateKeyHex, 'hex'));
+  return km.getPublicKeyHex();
+}
+
+/**
+ * Seed storage so the module already "knows" the global group, forcing the
+ * production `subscribeToJoinedGroups()` path (groups.size > 0) rather than the
+ * relay-restore path. Also seed the relay URL so checkAndClearOnRelayChange()
+ * doesn't wipe the seeded group.
+ */
+async function seedGlobalGroup(storage: InMemoryStorageProvider): Promise<void> {
+  const group: GroupData = {
+    id: GLOBAL_GROUP_ID,
+    relayUrl: RELAY_URL,
+    name: GLOBAL_GROUP_ID,
+    visibility: GroupVisibility.PUBLIC,
+    createdAt: 1,
+  };
+  await storage.set(STORAGE_KEYS_ADDRESS.GROUP_CHAT_GROUPS, JSON.stringify([group]));
+  await storage.set(STORAGE_KEYS_GLOBAL.GROUP_CHAT_RELAY_URL, RELAY_URL);
+}
+
+async function connectWithRetry(module: GroupChatModule, maxAttempts = 15): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      await module.connect();
+      if (module.getConnectionStatus()) return;
+    } catch { /* swallow and retry */ }
+    await sleep(1000);
+  }
+  throw new Error(`Failed to connect to relay ${RELAY_URL} after retries`);
+}
+
+// =============================================================================
+// Test
+// =============================================================================
+
+describe('GroupChatModule — global-chat backlog freeze', () => {
+  it(
+    'bounds the initial backlog instead of replaying the entire global history',
+    async () => {
+      const storage = new InMemoryStorageProvider();
+      await seedGlobalGroup(storage);
+
+      const identity: FullIdentity = {
+        privateKey: TEST_PRIVATE_KEY,
+        chainPubkey: '02' + getXOnlyPubkey(TEST_PRIVATE_KEY),
+        l1Address: 'alpha1testdummy',
+      };
+
+      const events: Array<{ type: string; data: unknown }> = [];
+      const emitEvent = <T extends SphereEventType>(type: T, data: SphereEventMap[T]): void => {
+        events.push({ type, data });
+      };
+
+      const module = new GroupChatModule({ relays: [RELAY_URL] });
+      module.initialize({ identity, storage, emitEvent });
+      await module.load();
+
+      // --- Instrument: count ingested messages + max main-thread (event-loop) stall.
+      let count = 0;
+      let firstAt = 0;
+      let lastAt = 0;
+      const unsub = module.onMessage(() => {
+        count++;
+        const now = Date.now();
+        if (count === 1) firstAt = now;
+        lastAt = now;
+      });
+
+      const eld = monitorEventLoopDelay({ resolution: 1 });
+      eld.enable();
+      const connectStart = Date.now();
+
+      await connectWithRetry(module);
+
+      // Wait until the backlog burst drains (quiet window) or we hit the cap.
+      const waitStart = Date.now();
+      while (Date.now() - waitStart < SETTLE_HARD_CAP_MS) {
+        await sleep(250);
+        if (count > 0 && Date.now() - lastAt > QUIET_MS) break;
+      }
+
+      eld.disable();
+      unsub();
+      module.destroy?.();
+
+      const ingestMs = firstAt && lastAt ? lastAt - firstAt : 0;
+      const report = {
+        relay: RELAY_URL,
+        group: GLOBAL_GROUP_ID,
+        backlogMessages: count,
+        connectToFirstMsgMs: firstAt ? firstAt - connectStart : null,
+        backlogIngestMs: ingestMs,
+        eventLoopMaxMs: +(eld.max / 1e6).toFixed(1),
+        eventLoopP99Ms: +(eld.percentile(99) / 1e6).toFixed(1),
+        eventLoopMeanMs: +(eld.mean / 1e6).toFixed(2),
+        groupchatMessageEmits: events.filter((e) => e.type === 'groupchat:message').length,
+      };
+      // Always surface the numbers so we can SEE what stalls, pass or fail.
+      console.log('[backlog-freeze] ' + JSON.stringify(report, null, 2));
+
+      // Sanity: we actually received the backlog (0 ⇒ relay needs auth/membership;
+      // that's a different finding worth failing loudly on).
+      expect(count, 'received no messages — relay may require auth/membership to read').toBeGreaterThan(0);
+
+      // FIX CONTRACT (red until the subscription is bounded): the initial load
+      // must NOT stream the entire global history.
+      expect(
+        count,
+        `initial backlog of ${count} msgs exceeds the bounded limit — global history is being fully replayed on connect`,
+      ).toBeLessThanOrEqual(MAX_INITIAL_BACKLOG);
+    },
+    SETTLE_HARD_CAP_MS + 60_000,
+  );
+});

--- a/tests/unit/modules/GroupChatModule.members.test.ts
+++ b/tests/unit/modules/GroupChatModule.members.test.ts
@@ -1,0 +1,122 @@
+/**
+ * GroupChatModule — member-list ingestion scaling.
+ *
+ * Reproduces the global-chat freeze: on fresh import the wallet restores/joins
+ * the pinned global group `general` (which everyone is a member of), and
+ * fetchAndSaveMembers() inserts every member via saveMemberToMemory(), which
+ * does a linear `findIndex` dedup per member — O(n^2) over the whole member
+ * list. For a global group with tens of thousands of members this is a ~30s
+ * synchronous main-thread block (so hard the page can't even open DevTools).
+ *
+ * This drives the REAL fetchAndSaveMembers() with a large synthetic member set
+ * (no relay, no publish) and asserts ingestion stays O(n) — fast enough to not
+ * freeze the UI.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { monitorEventLoopDelay } from 'node:perf_hooks';
+import { GroupChatModule } from '../../../modules/groupchat/GroupChatModule';
+import { NIP29_KINDS } from '../../../constants';
+import type { StorageProvider } from '../../../storage';
+import type { FullIdentity } from '../../../types';
+
+const GROUP_ID = 'general';
+const MEMBER_COUNT = 30_000;
+// Generous ceiling: O(n) ingestion of 30k members is a few ms; the O(n^2)
+// regression is multiple seconds. 1500ms cleanly separates the two.
+const MAX_INGEST_MS = 1500;
+
+function createMockStorage(): StorageProvider {
+  const store = new Map<string, string>();
+  return {
+    id: 'mock', name: 'Mock', type: 'local' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected'),
+    setIdentity: vi.fn(),
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+    has: vi.fn().mockResolvedValue(false),
+    keys: vi.fn().mockResolvedValue([]),
+    clear: vi.fn().mockResolvedValue(undefined),
+    saveTrackedAddresses: vi.fn().mockResolvedValue(undefined),
+    loadTrackedAddresses: vi.fn().mockResolvedValue([]),
+  } as unknown as StorageProvider;
+}
+
+interface FakeEvent { id: string; pubkey: string; created_at: number; kind: number; content: string; tags: string[][]; }
+
+function makeMembersEvent(pubkeys: string[]): FakeEvent {
+  return {
+    id: 'members', pubkey: 'relay', created_at: 1000, kind: NIP29_KINDS.GROUP_MEMBERS, content: '',
+    tags: [['d', GROUP_ID], ...pubkeys.map((pk) => ['p', pk, '', 'member'])],
+  };
+}
+function makeAdminsEvent(pubkeys: string[]): FakeEvent {
+  return {
+    id: 'admins', pubkey: 'relay', created_at: 1000, kind: NIP29_KINDS.GROUP_ADMINS, content: '',
+    tags: [['d', GROUP_ID], ...pubkeys.map((pk) => ['p', pk, '', 'admin'])],
+  };
+}
+
+/** Minimal NostrClient stand-in: serves the members/admins events then EOSE. */
+function makeMockClient(membersEvt: FakeEvent, adminsEvt: FakeEvent) {
+  let n = 0;
+  return {
+    subscribe(filter: { kinds?: number[] }, handlers: { onEvent: (e: FakeEvent) => void; onEndOfStoredEvents?: () => void }) {
+      const id = 'sub' + n++;
+      const kinds = filter.kinds ?? [];
+      setTimeout(() => {
+        if (kinds.includes(NIP29_KINDS.GROUP_MEMBERS)) handlers.onEvent(membersEvt);
+        else if (kinds.includes(NIP29_KINDS.GROUP_ADMINS)) handlers.onEvent(adminsEvt);
+        handlers.onEndOfStoredEvents?.();
+      }, 0);
+      return id;
+    },
+    unsubscribe() {},
+  };
+}
+
+describe('GroupChatModule — member ingestion scaling', () => {
+  it('ingests a huge global-group member list without an O(n^2) main-thread stall', async () => {
+    const pubkeys = Array.from({ length: MEMBER_COUNT }, (_, i) => i.toString(16).padStart(64, '0'));
+    const adminPk = 'f'.repeat(64);
+
+    const identity: FullIdentity = {
+      privateKey: '01'.padStart(64, '0'),
+      chainPubkey: '02' + 'a'.repeat(64),
+      l1Address: 'alpha1testdummy',
+    };
+
+    const mod = new GroupChatModule();
+    mod.initialize({ identity, storage: createMockStorage(), emitEvent: vi.fn() });
+    // Inject mock client so we exercise fetchAndSaveMembers without a real relay.
+    (mod as unknown as { client: unknown }).client = makeMockClient(
+      makeMembersEvent(pubkeys),
+      makeAdminsEvent([adminPk]),
+    );
+
+    const eld = monitorEventLoopDelay({ resolution: 1 });
+    eld.enable();
+    const t0 = performance.now();
+    await (mod as unknown as { fetchAndSaveMembers(id: string): Promise<void> }).fetchAndSaveMembers(GROUP_ID);
+    const durationMs = performance.now() - t0;
+    eld.disable();
+
+    const stored = mod.getMembers(GROUP_ID);
+    // eslint-disable-next-line no-console
+    console.log(`[member-freeze] members=${stored.length} ingestMs=${Math.round(durationMs)} eldMaxMs=${(eld.max / 1e6).toFixed(0)}`);
+
+    // Correctness: every member (+ the extra admin) is stored, deduped.
+    expect(stored.length).toBe(MEMBER_COUNT + 1);
+
+    // Freeze gate: ingestion must be O(n), not the original O(n^2) dedup
+    // (saveMemberToMemory's per-member findIndex) which was a multi-second
+    // synchronous main-thread block for a global group's full member list.
+    expect(
+      durationMs,
+      `member ingestion took ${Math.round(durationMs)}ms — O(n^2) dedup is freezing the main thread`,
+    ).toBeLessThan(MAX_INGEST_MS);
+  });
+});


### PR DESCRIPTION
Connecting to big NIP-29 groups (e.g. the global general/announcements channels with ~60-70k members) froze the wallet's main thread for tens of seconds — so hard the page could not even open DevTools. Two causes:

1. Member ingestion was O(n^2). fetchAndSaveMembers() inserted every member via saveMemberToMemory(), which does a linear findIndex dedup per member, so a group's full member list cost ~n^2 comparisons on the main thread (~3.7s for 30k members, ~10-20s for 70k). Build the member list in O(n) with a Map keyed by pubkey and assign it once.

2. The group message subscription had no `limit`, so a busy group replayed its entire stored history in one burst (observed: 1000 events) — each event runs synchronously through handleGroupEvent + two emitEvent fan-outs. Bound the backlog with `limit: defaultMessageLimit`; older messages still load on demand via fetchMessages()/getMessagesPage().

Tests:
- tests/unit/modules/GroupChatModule.members.test.ts: 30k-member ingest drops from ~3.7s to ~20ms (O(n) gate).
- tests/relay/groupchat-backlog-freeze.test.ts: initial message backlog is bounded against a real relay.