### PR TITLE
fix(payments): incident follow-ups — replay backoff+poison, stale-inventory surfacing, in-flight balance (#517)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -283,13 +283,14 @@ interface Asset {
   readonly name: string;         // e.g., 'Unicity'
   readonly decimals: number;     // e.g., 18
   readonly iconUrl?: string;     // Token icon URL
-  readonly totalAmount: string;  // Sum of all token amounts (smallest units)
-  readonly tokenCount: number;   // Number of tokens aggregated
+  readonly totalAmount: string;  // Spendable balance: confirmed + unconfirmed (in-flight EXCLUDED), smallest units
+  readonly tokenCount: number;   // Number of confirmed + unconfirmed tokens aggregated
   readonly confirmedAmount: string;     // Confirmed token amounts
-  readonly unconfirmedAmount: string;   // Unconfirmed token amounts
+  readonly unconfirmedAmount: string;   // Unconfirmed token amounts (NOT in-flight)
   readonly confirmedTokenCount: number; // Number of confirmed tokens
   readonly unconfirmedTokenCount: number; // Number of unconfirmed tokens
-  readonly transferringTokenCount: number; // Number of tokens currently being sent
+  readonly transferringTokenCount: number; // Number of in-flight tokens (NOT spendable)
+  readonly transferringAmount: string;  // Sum of in-flight token amounts — excluded from totalAmount
   readonly priceUsd: number | null;     // Price per unit in USD
   readonly priceEur: number | null;     // Price per unit in EUR
   readonly change24h: number | null;    // 24h price change %
@@ -454,8 +455,9 @@ if (result.success) {
 Get token balances grouped by coin type. **Synchronous** (no await needed) — returns the same
 `Asset` shape as `getAssets()` but with all price fields `null` (use `getAssets()` for prices).
 
-Skips tokens with status `'spent'` or `'invalid'`. Tokens with status `'transferring'` remain
-visible (counted in `unconfirmedAmount` and `transferringTokenCount`).
+Skips tokens with status `'spent'` or `'invalid'`. In-flight (`'transferring'`) tokens are NOT
+counted toward the spendable balance (`totalAmount`/`confirmedAmount`/`unconfirmedAmount`) — they
+are reported only via `transferringTokenCount`/`transferringAmount` for a "Sending" badge.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -1245,6 +1247,8 @@ type SphereEventType =
   | 'sync:provider'
   | 'sync:error'
   | 'sync:remote-update'
+  | 'inventory:conflict'
+  | 'delivery:undeliverable'
   | 'connection:changed'
   | 'nametag:registered'
   | 'nametag:recovered'
@@ -1279,6 +1283,10 @@ interface SphereEventMap {
   'sync:provider': { providerId: string; success: boolean; added?: number; removed?: number; error?: string };
   'sync:error': { source: string; error: string };
   'sync:remote-update': { providerId: string; name: string; sequence: number; cid: string; added: number; removed: number };
+  // A send lost a race on a stale-inventory source (Part E.2 TransferConflictError) — surfaced so a UI can prompt refresh+retry.
+  'inventory:conflict': { transferId: string; coinId: string; error: string };
+  // A journaled undelivered transfer blob exhausted its bounded replay budget — surfaced as poison (kept journaled, no longer auto-retried).
+  'delivery:undeliverable': { transferId: string; recipientPubkey: string; attempts: number; error: string };
   'connection:changed': { provider: string; connected: boolean; status?: ProviderStatus; enabled?: boolean; error?: string };
   'nametag:registered': { nametag: string; addressIndex: number };
   'nametag:recovered': { nametag: string };

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1030,6 +1030,14 @@ export class PaymentsModule {
    * waiting real time — never mutated in production.
    */
   private replayBackoffBaseMs = DELIVERY_REPLAY_BASE_DELAY_MS;
+  /**
+   * #517: serializes {@link replayPendingV2Deliveries}. `load()` kicks replay
+   * off fire-and-forget and `receive()` calls `load()`, so two passes can
+   * overlap — duplicating delivery attempts and clobbering each other's
+   * `attempts` increments (both read the same stale value, both write N+1,
+   * delaying poison surfacing). Only one pass runs per module instance at a time.
+   */
+  private replayInFlight = false;
 
   constructor(config?: PaymentsModuleConfig) {
     this.moduleConfig = {
@@ -5419,11 +5427,21 @@ export class PaymentsModule {
    * so a journaled blob never sits undelivered invisibly.
    */
   private async replayPendingV2Deliveries(): Promise<void> {
-    const entries = (await this.loadPendingV2Deliveries()).filter((e) => !e.undeliverable);
-    if (entries.length === 0) return;
-    logger.warn('Payments', `${entries.length} undelivered v2 transfer(s) journaled from a previous session — replaying`);
-    for (const e of entries) {
-      await this.replayOneDelivery(e);
+    // #517: drop an overlapping pass — a replay started while one is in flight
+    // would read the same journal snapshot, re-deliver the same entries, and
+    // race the per-entry `attempts` read/modify/write. Dropped entries stay
+    // journaled and replay on the next load(), so nothing is lost.
+    if (this.replayInFlight) return;
+    this.replayInFlight = true;
+    try {
+      const entries = (await this.loadPendingV2Deliveries()).filter((e) => !e.undeliverable);
+      if (entries.length === 0) return;
+      logger.warn('Payments', `${entries.length} undelivered v2 transfer(s) journaled from a previous session — replaying`);
+      for (const e of entries) {
+        await this.replayOneDelivery(e);
+      }
+    } finally {
+      this.replayInFlight = false;
     }
   }
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1038,6 +1038,14 @@ export class PaymentsModule {
    * delaying poison surfacing). Only one pass runs per module instance at a time.
    */
   private replayInFlight = false;
+  /**
+   * #517: serializes every read-modify-write of the PENDING_V2_DELIVERIES journal.
+   * save/remove/update each load → mutate → store the WHOLE blob, so a replay
+   * (fire-and-forget from load()) overlapping a send()'s journal write could
+   * clobber a newly-saved undelivered entry and lose it — defeating the crash-
+   * safety guarantee. A promise-chain mutex makes each whole RMW atomic.
+   */
+  private journalMutation: Promise<unknown> = Promise.resolve();
 
   constructor(config?: PaymentsModuleConfig) {
     this.moduleConfig = {
@@ -5396,20 +5404,31 @@ export class PaymentsModule {
     return data ? (JSON.parse(data) as PendingV2Delivery[]) : [];
   }
 
+  /** #517: run a journal read-modify-write atomically against all other journal mutations. */
+  private withJournalLock<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.journalMutation.then(fn, fn);
+    this.journalMutation = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
   private async savePendingV2Delivery(entry: PendingV2Delivery): Promise<void> {
-    const all = await this.loadPendingV2Deliveries();
-    if (!all.some((e) => e.tokenBlob === entry.tokenBlob)) {
-      all.push(entry);
-      await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(all));
-    }
+    await this.withJournalLock(async () => {
+      const all = await this.loadPendingV2Deliveries();
+      if (!all.some((e) => e.tokenBlob === entry.tokenBlob)) {
+        all.push(entry);
+        await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(all));
+      }
+    });
   }
 
   private async removePendingV2Delivery(tokenBlob: string): Promise<void> {
-    const all = await this.loadPendingV2Deliveries();
-    const filtered = all.filter((e) => e.tokenBlob !== tokenBlob);
-    if (filtered.length !== all.length) {
-      await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(filtered));
-    }
+    await this.withJournalLock(async () => {
+      const all = await this.loadPendingV2Deliveries();
+      const filtered = all.filter((e) => e.tokenBlob !== tokenBlob);
+      if (filtered.length !== all.length) {
+        await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(filtered));
+      }
+    });
   }
 
   /**
@@ -5505,11 +5524,13 @@ export class PaymentsModule {
 
   /** Mutate one journaled entry in place (keyed by tokenBlob) and persist. No-op if gone. */
   private async updatePendingV2Delivery(tokenBlob: string, mutate: (e: PendingV2Delivery) => void): Promise<void> {
-    const all = await this.loadPendingV2Deliveries();
-    const target = all.find((e) => e.tokenBlob === tokenBlob);
-    if (!target) return;
-    mutate(target);
-    await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(all));
+    await this.withJournalLock(async () => {
+      const all = await this.loadPendingV2Deliveries();
+      const target = all.find((e) => e.tokenBlob === tokenBlob);
+      if (!target) return;
+      mutate(target);
+      await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(all));
+    });
   }
 
   private async createStorageData(): Promise<TxfStorageDataBase> {

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -142,8 +142,8 @@ const DELIVERY_POLL_INTERVAL_MS = 30_000;
  * Bounded replay budget for journaled finished-but-undelivered v2 blobs (#517
  * item 1). Each load()'s replay pass makes at most {@link DELIVERY_REPLAY_RETRIES}
  * + 1 attempts per entry with exponential backoff; the cumulative failed-attempt
- * count is journaled across loads. Once it crosses
- * {@link MAX_DELIVERY_REPLAY_ATTEMPTS} the entry is surfaced as poison
+ * count is journaled across loads. Once it reaches
+ * {@link MAX_DELIVERY_REPLAY_ATTEMPTS} (inclusive) the entry is surfaced as poison
  * (`delivery:undeliverable`) and left journaled but no longer auto-retried —
  * the deposit is idempotent, so a later app version may still land it.
  */
@@ -167,7 +167,7 @@ interface PendingV2Delivery {
   createdAt: number;
   /**
    * Cumulative failed replay attempts across load()s. Surfaced as poison and
-   * marked `undeliverable` once it crosses {@link MAX_DELIVERY_REPLAY_ATTEMPTS}
+   * marked `undeliverable` once it reaches {@link MAX_DELIVERY_REPLAY_ATTEMPTS}
    * so journaled blobs never sit undelivered invisibly (#517).
    */
   attempts?: number;

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -76,6 +76,7 @@ import { TokenRegistry } from '../../registry';
 import { logger } from '../../core/logger';
 import { SphereError } from '../../core/errors';
 import { sha256, bytesToHex, hexToBytes } from '../../core/crypto';
+import { sleep } from '../../core/utils';
 import { decodeTokenBlob, encodeTokenBlob, unwrapTokenBlobBytes, TOKEN_BLOB_VERSION } from '../../token-engine/token-blob';
 import { parseInvoiceMemoForOnChain } from '../accounting/memo.js';
 
@@ -138,6 +139,20 @@ const SEND_ENGINE_OP_TIMEOUT_MS = 60_000;
 const DELIVERY_POLL_INTERVAL_MS = 30_000;
 
 /**
+ * Bounded replay budget for journaled finished-but-undelivered v2 blobs (#517
+ * item 1). Each load()'s replay pass makes at most {@link DELIVERY_REPLAY_RETRIES}
+ * + 1 attempts per entry with exponential backoff; the cumulative failed-attempt
+ * count is journaled across loads. Once it crosses
+ * {@link MAX_DELIVERY_REPLAY_ATTEMPTS} the entry is surfaced as poison
+ * (`delivery:undeliverable`) and left journaled but no longer auto-retried —
+ * the deposit is idempotent, so a later app version may still land it.
+ */
+const DELIVERY_REPLAY_RETRIES = 2;
+const MAX_DELIVERY_REPLAY_ATTEMPTS = 6;
+const DELIVERY_REPLAY_BASE_DELAY_MS = 1_000;
+const DELIVERY_REPLAY_MAX_DELAY_MS = 8_000;
+
+/**
  * A FINISHED v2 token blob awaiting transport delivery. Journaled the moment
  * the transfer/split output is certified on-chain (the source is already
  * spent) and removed after successful delivery, so a transport failure or a
@@ -150,6 +165,29 @@ interface PendingV2Delivery {
   tokenBlob: string;
   memo?: string;
   createdAt: number;
+  /**
+   * Cumulative failed replay attempts across load()s. Surfaced as poison and
+   * marked `undeliverable` once it crosses {@link MAX_DELIVERY_REPLAY_ATTEMPTS}
+   * so journaled blobs never sit undelivered invisibly (#517).
+   */
+  attempts?: number;
+  /** Set once the entry is surfaced as poison; it stays journaled but is no longer auto-retried. */
+  undeliverable?: boolean;
+}
+
+/** Running per-coin totals folded by {@link PaymentsModule.aggregateTokens}. */
+interface AssetAccumulator {
+  coinId: string;
+  symbol: string;
+  name: string;
+  decimals: number;
+  iconUrl?: string;
+  confirmedAmount: bigint;
+  unconfirmedAmount: bigint;
+  transferringAmount: bigint;
+  confirmedTokenCount: number;
+  unconfirmedTokenCount: number;
+  transferringTokenCount: number;
 }
 
 // =============================================================================
@@ -986,6 +1024,12 @@ export class PaymentsModule {
   private spendQueue: SpendQueue;
   /** Cache of parsed SdkToken data for synchronous queue re-evaluation */
   private readonly parsedTokenCache: Map<string, ParsedTokenEntry> = new Map();
+  /**
+   * Base delay (ms) for the journaled-delivery replay backoff (#517 item 1).
+   * A field, not a const, so tests can drive the bounded retry loop without
+   * waiting real time — never mutated in production.
+   */
+  private replayBackoffBaseMs = DELIVERY_REPLAY_BASE_DELAY_MS;
 
   constructor(config?: PaymentsModuleConfig) {
     this.moduleConfig = {
@@ -1848,6 +1892,19 @@ export class PaymentsModule {
       result.error = error instanceof TransferConflictError
         ? `Send conflicted: a source token was already spent by a concurrent transfer — re-plan and retry (${error.message})`
         : error instanceof Error ? error.message : String(error);
+
+      // #517 item 2: a TransferConflictError here is the predictable stale-view
+      // race — coin-selection planned from a lazy-inventory view that missed
+      // another device's spend. It is handled (abort + reconcile below) but was
+      // otherwise SILENT; surface it as a distinct, recoverable signal so a UI
+      // can prompt "refresh and retry" instead of just showing a generic failure.
+      if (error instanceof TransferConflictError) {
+        this.deps!.emitEvent('inventory:conflict', {
+          transferId: result.id,
+          coinId: request.coinId,
+          error: error.message,
+        });
+      }
 
       // Intent disposition on failure (E.2/E.3):
       //  - a TransferConflictError aborts (the prescribed recovery — the
@@ -2813,8 +2870,11 @@ export class PaymentsModule {
    * Get token balances grouped by coin type.
    *
    * Returns an array of {@link Asset} objects, one per coin type held.
-   * Each entry includes confirmed and unconfirmed breakdowns. Tokens with
-   * status `'spent'`, `'invalid'`, or `'transferring'` are excluded.
+   * Each entry includes confirmed and unconfirmed breakdowns. `'spent'` and
+   * `'invalid'` tokens are excluded entirely. In-flight (`'transferring'`)
+   * tokens are NOT counted toward the spendable balance (`totalAmount`,
+   * `confirmedAmount`, `unconfirmedAmount`) — they are reported only in the
+   * `transferring*` fields (#517 item 3).
    *
    * This is synchronous — no price data is included. Use {@link getAssets}
    * for the async version with fiat pricing.
@@ -2828,7 +2888,10 @@ export class PaymentsModule {
 
   /**
    * Get aggregated assets (tokens grouped by coinId) with price data.
-   * Includes both confirmed and unconfirmed tokens with breakdown.
+   * Confirmed + unconfirmed tokens make up the spendable balance; in-flight
+   * (`'transferring'`) tokens are reported only in the `transferring*` fields
+   * and excluded from `totalAmount` (#517 item 3). Fiat value derives from
+   * `totalAmount`, so it likewise excludes in-flight value.
    */
   async getAssets(coinId?: string): Promise<Asset[]> {
     const rawAssets = this.aggregateTokens(coinId);
@@ -2890,82 +2953,79 @@ export class PaymentsModule {
   }
 
   /**
-   * Aggregate tokens by coinId with confirmed/unconfirmed breakdown.
+   * Aggregate tokens by coinId with confirmed/unconfirmed/transferring breakdown.
    * Excludes tokens with status 'spent' or 'invalid'.
-   * Tokens with status 'transferring' are counted as unconfirmed (visible in UI as "Sending").
+   *
+   * In-flight (`'transferring'`) tokens are LEAVING the wallet during an active
+   * send, so they are NOT counted as spendable: they are tracked in their own
+   * `transferring*` fields and excluded from `totalAmount`/`unconfirmedAmount`.
+   * Counting them as balance would show the user value they cannot spend (the
+   * #517 incident follow-up).
    */
   private aggregateTokens(coinId?: string): Asset[] {
-    const assetsMap = new Map<string, {
-      coinId: string;
-      symbol: string;
-      name: string;
-      decimals: number;
-      iconUrl?: string;
-      confirmedAmount: bigint;
-      unconfirmedAmount: bigint;
-      confirmedTokenCount: number;
-      unconfirmedTokenCount: number;
-      transferringTokenCount: number;
-    }>();
+    const assetsMap = new Map<string, AssetAccumulator>();
 
     for (const token of this.tokens.values()) {
-      // Skip spent and invalid tokens; transferring tokens remain visible
+      // Skip spent and invalid tokens; transferring tokens are tracked separately.
       if (token.status === 'spent' || token.status === 'invalid') continue;
       if (coinId && token.coinId !== coinId) continue;
-
-      const key = token.coinId;
-      const amount = BigInt(token.amount);
-      const isConfirmed = token.status === 'confirmed';
-      const isTransferring = token.status === 'transferring';
-      const existing = assetsMap.get(key);
-
-      if (existing) {
-        if (isConfirmed) {
-          existing.confirmedAmount += amount;
-          existing.confirmedTokenCount++;
-        } else {
-          existing.unconfirmedAmount += amount;
-          existing.unconfirmedTokenCount++;
-        }
-        if (isTransferring) existing.transferringTokenCount++;
-      } else {
-        assetsMap.set(key, {
-          coinId: token.coinId,
-          symbol: token.symbol,
-          name: token.name,
-          decimals: token.decimals,
-          iconUrl: token.iconUrl,
-          confirmedAmount: isConfirmed ? amount : 0n,
-          unconfirmedAmount: isConfirmed ? 0n : amount,
-          confirmedTokenCount: isConfirmed ? 1 : 0,
-          unconfirmedTokenCount: isConfirmed ? 0 : 1,
-          transferringTokenCount: isTransferring ? 1 : 0,
-        });
-      }
+      this.accumulateToken(assetsMap, token);
     }
 
-    return Array.from(assetsMap.values()).map((raw) => {
-      const totalAmount = (raw.confirmedAmount + raw.unconfirmedAmount).toString();
-      return {
-        coinId: raw.coinId,
-        symbol: raw.symbol,
-        name: raw.name,
-        decimals: raw.decimals,
-        iconUrl: raw.iconUrl,
-        totalAmount,
-        tokenCount: raw.confirmedTokenCount + raw.unconfirmedTokenCount,
-        confirmedAmount: raw.confirmedAmount.toString(),
-        unconfirmedAmount: raw.unconfirmedAmount.toString(),
-        confirmedTokenCount: raw.confirmedTokenCount,
-        unconfirmedTokenCount: raw.unconfirmedTokenCount,
-        transferringTokenCount: raw.transferringTokenCount,
-        priceUsd: null,
-        priceEur: null,
-        change24h: null,
-        fiatValueUsd: null,
-        fiatValueEur: null,
-      };
-    });
+    return Array.from(assetsMap.values()).map((raw) => ({
+      coinId: raw.coinId,
+      symbol: raw.symbol,
+      name: raw.name,
+      decimals: raw.decimals,
+      iconUrl: raw.iconUrl,
+      // Spendable + soon-spendable holdings ONLY — the in-flight token is omitted.
+      totalAmount: (raw.confirmedAmount + raw.unconfirmedAmount).toString(),
+      tokenCount: raw.confirmedTokenCount + raw.unconfirmedTokenCount,
+      confirmedAmount: raw.confirmedAmount.toString(),
+      unconfirmedAmount: raw.unconfirmedAmount.toString(),
+      confirmedTokenCount: raw.confirmedTokenCount,
+      unconfirmedTokenCount: raw.unconfirmedTokenCount,
+      transferringTokenCount: raw.transferringTokenCount,
+      transferringAmount: raw.transferringAmount.toString(),
+      priceUsd: null,
+      priceEur: null,
+      change24h: null,
+      fiatValueUsd: null,
+      fiatValueEur: null,
+    }));
+  }
+
+  /** Fold one token into its coin's running totals (see {@link aggregateTokens}). */
+  private accumulateToken(assetsMap: Map<string, AssetAccumulator>, token: Token): void {
+    const acc = assetsMap.get(token.coinId) ?? this.newAssetAccumulator(token);
+    assetsMap.set(token.coinId, acc);
+    const amount = BigInt(token.amount);
+    if (token.status === 'transferring') {
+      acc.transferringAmount += amount;
+      acc.transferringTokenCount++;
+    } else if (token.status === 'confirmed') {
+      acc.confirmedAmount += amount;
+      acc.confirmedTokenCount++;
+    } else {
+      acc.unconfirmedAmount += amount;
+      acc.unconfirmedTokenCount++;
+    }
+  }
+
+  private newAssetAccumulator(token: Token): AssetAccumulator {
+    return {
+      coinId: token.coinId,
+      symbol: token.symbol,
+      name: token.name,
+      decimals: token.decimals,
+      iconUrl: token.iconUrl,
+      confirmedAmount: 0n,
+      unconfirmedAmount: 0n,
+      transferringAmount: 0n,
+      confirmedTokenCount: 0,
+      unconfirmedTokenCount: 0,
+      transferringTokenCount: 0,
+    };
   }
 
   /**
@@ -5345,31 +5405,93 @@ export class PaymentsModule {
   }
 
   /**
-   * Replay journaled finished-but-undelivered v2 blobs (kicked fire-and-forget
-   * from load()) through the delivery port (sdk-changes S3). Idempotent end to
-   * end: the mailbox deposit is idempotent by the content-derived entry_id —
-   * it succeeds even after the recipient claimed (§6) — and the relay path's
-   * recipient dedups by the genesis-stable token id. Entries that still fail
-   * to send are kept for the next load.
+   * Replay journaled finished-but-undelivered v2 blobs (kicked from load())
+   * through the delivery port (sdk-changes S3). Idempotent end to end: the
+   * mailbox deposit is idempotent by the content-derived entry_id — it succeeds
+   * even after the recipient claimed (§6) — and the relay path's recipient
+   * dedups by the genesis-stable token id.
+   *
+   * #517 item 1: instead of a silent unbounded fire-and-forget, each entry is
+   * retried with bounded exponential backoff, its cumulative failed-attempt
+   * count is journaled across loads, and an entry that exhausts
+   * {@link MAX_DELIVERY_REPLAY_ATTEMPTS} is SURFACED as poison
+   * (`delivery:undeliverable`) and left journaled but no longer auto-retried —
+   * so a journaled blob never sits undelivered invisibly.
    */
   private async replayPendingV2Deliveries(): Promise<void> {
-    const entries = await this.loadPendingV2Deliveries();
+    const entries = (await this.loadPendingV2Deliveries()).filter((e) => !e.undeliverable);
     if (entries.length === 0) return;
     logger.warn('Payments', `${entries.length} undelivered v2 transfer(s) journaled from a previous session — replaying`);
     for (const e of entries) {
+      await this.replayOneDelivery(e);
+    }
+  }
+
+  /** Replay a single journaled entry: backoff retries → success/removal, or → bounded poison. */
+  private async replayOneDelivery(entry: PendingV2Delivery): Promise<void> {
+    const tag = entry.transferId.slice(0, 8);
+    try {
+      await this.attemptDeliveryWithBackoff(entry);
+      await this.removePendingV2Delivery(entry.tokenBlob);
+      logger.debug('Payments', `Replayed undelivered v2 transfer ${tag}...`);
+    } catch (err) {
+      const attempts = (entry.attempts ?? 0) + 1;
+      const message = err instanceof Error ? err.message : String(err);
+      if (attempts >= MAX_DELIVERY_REPLAY_ATTEMPTS) {
+        await this.markDeliveryPoison(entry, attempts, message);
+        return;
+      }
+      await this.bumpDeliveryAttempts(entry.tokenBlob, attempts);
+      logger.warn('Payments', `Replay of undelivered v2 transfer ${tag}... failed (attempt ${attempts}/${MAX_DELIVERY_REPLAY_ATTEMPTS}, kept for next load):`, err);
+    }
+  }
+
+  /** One delivery with in-pass exponential backoff; throws the last error if all attempts fail. */
+  private async attemptDeliveryWithBackoff(entry: PendingV2Delivery): Promise<void> {
+    const nm = this.currentNametagName();
+    let lastErr: unknown;
+    for (let attempt = 0; attempt <= DELIVERY_REPLAY_RETRIES; attempt++) {
+      if (attempt > 0) {
+        const delay = Math.min(this.replayBackoffBaseMs * 2 ** (attempt - 1), DELIVERY_REPLAY_MAX_DELAY_MS);
+        if (delay > 0) await sleep(delay);
+      }
       try {
-        const nm = this.currentNametagName();
-        await this.delivery!.deliver(e.recipientPubkey, hexToBytes(e.tokenBlob), {
-          transferId: e.transferId,
-          memo: e.memo,
+        await this.delivery!.deliver(entry.recipientPubkey, hexToBytes(entry.tokenBlob), {
+          transferId: entry.transferId,
+          memo: entry.memo,
           ...(nm !== undefined ? { senderNametag: nm } : {}),
         });
-        await this.removePendingV2Delivery(e.tokenBlob);
-        logger.debug('Payments', `Replayed undelivered v2 transfer ${e.transferId.slice(0, 8)}...`);
+        return;
       } catch (err) {
-        logger.warn('Payments', `Replay of undelivered v2 transfer ${e.transferId.slice(0, 8)}... failed (kept for next load):`, err);
+        lastErr = err;
       }
     }
+    throw lastErr;
+  }
+
+  /** Mark a journal entry poison (keep it, stop retrying) and surface it (#517 item 1). */
+  private async markDeliveryPoison(entry: PendingV2Delivery, attempts: number, error: string): Promise<void> {
+    await this.updatePendingV2Delivery(entry.tokenBlob, (e) => { e.attempts = attempts; e.undeliverable = true; });
+    logger.error('Payments', `Undelivered v2 transfer ${entry.transferId.slice(0, 8)}... is POISON after ${attempts} attempts — surfaced, kept journaled, no longer auto-retried:`, error);
+    this.deps!.emitEvent('delivery:undeliverable', {
+      transferId: entry.transferId,
+      recipientPubkey: entry.recipientPubkey,
+      attempts,
+      error,
+    });
+  }
+
+  private async bumpDeliveryAttempts(tokenBlob: string, attempts: number): Promise<void> {
+    await this.updatePendingV2Delivery(tokenBlob, (e) => { e.attempts = attempts; });
+  }
+
+  /** Mutate one journaled entry in place (keyed by tokenBlob) and persist. No-op if gone. */
+  private async updatePendingV2Delivery(tokenBlob: string, mutate: (e: PendingV2Delivery) => void): Promise<void> {
+    const all = await this.loadPendingV2Deliveries();
+    const target = all.find((e) => e.tokenBlob === tokenBlob);
+    if (!target) return;
+    mutate(target);
+    await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(all));
   }
 
   private async createStorageData(): Promise<TxfStorageDataBase> {

--- a/tests/unit/modules/PaymentsModule.test.ts
+++ b/tests/unit/modules/PaymentsModule.test.ts
@@ -705,7 +705,7 @@ describe('getAssets()', () => {
     expect(assets[0]?.totalAmount).toBe('1000000000000000000');
   });
 
-  it('should include confirmed, unconfirmed, and transferring tokens but exclude spent/invalid', async () => {
+  it('counts confirmed + unconfirmed as balance; transferring (in-flight) is tracked separately, NOT spendable', async () => {
     const module = createModuleWithTokens([
       { id: 't1', coinId: '0xaaa', symbol: 'UCT', name: 'Unicity', decimals: 18, amount: '1000', status: 'confirmed' },
       { id: 't2', coinId: '0xaaa', symbol: 'UCT', name: 'Unicity', decimals: 18, amount: '2000', status: 'pending' },
@@ -716,13 +716,18 @@ describe('getAssets()', () => {
 
     const assets = await module.getAssets();
     expect(assets.length).toBe(1);
-    expect(assets[0]?.totalAmount).toBe('6000'); // 1000 confirmed + 2000 pending + 3000 transferring
-    expect(assets[0]?.tokenCount).toBe(3); // t1 + t2 + t3
-    expect(assets[0]?.confirmedAmount).toBe('1000');
-    expect(assets[0]?.unconfirmedAmount).toBe('5000'); // 2000 pending + 3000 transferring
+    // totalAmount is the wallet's holdings — confirmed (1000) + unconfirmed (2000).
+    // The 3000 in-flight token is LEAVING the wallet, so it must NOT inflate the
+    // balance the user sees as theirs.
+    expect(assets[0]?.totalAmount).toBe('3000'); // 1000 confirmed + 2000 pending; NOT the 3000 transferring
+    expect(assets[0]?.tokenCount).toBe(2); // t1 + t2 (transferring not counted in tokenCount)
+    expect(assets[0]?.confirmedAmount).toBe('1000'); // spendable
+    expect(assets[0]?.unconfirmedAmount).toBe('2000'); // pending only — NOT the transferring token
     expect(assets[0]?.confirmedTokenCount).toBe(1);
-    expect(assets[0]?.unconfirmedTokenCount).toBe(2); // pending + transferring
+    expect(assets[0]?.unconfirmedTokenCount).toBe(1); // pending only
+    // The in-flight token is surfaced on its own field for the "Sending" UI badge.
     expect(assets[0]?.transferringTokenCount).toBe(1);
+    expect(assets[0]?.transferringAmount).toBe('3000');
   });
 
   it('should filter by coinId when provided', async () => {

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -24,6 +24,7 @@ import type { TransportProvider } from '../../../transport';
 import type { OracleProvider } from '../../../oracle';
 import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../../storage';
 import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
+import { TransferConflictError } from '../../../token-engine';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
 import { WalletApiClient } from '../../../wallet-api';
@@ -469,6 +470,95 @@ describe('interrupted deposit — journal replay on next load (S3 AC)', () => {
   });
 });
 
+describe('journaled-delivery replay: bounded backoff + poison surfacing (#517 item 1)', () => {
+  it('a persistently-undeliverable blob is SURFACED as poison after the bounded budget, then no longer auto-retried', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-poison-1');
+    await sender.module.load();
+
+    // Drive the backoff loop without waiting real time.
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (sender.module as any).replayBackoffBaseMs = 0;
+
+    // A journaled finished blob whose delivery ALWAYS fails (a wrong/rotated
+    // recipient key, a permanently-rejecting rail — the "poison" class).
+    const deliverSpy = vi.spyOn(sender.delivery, 'deliver').mockRejectedValue(new Error('rail rejects: bad recipient'));
+    await (sender.module as any).savePendingV2Delivery({
+      transferId: 'poison-tx',
+      recipientPubkey: RECIPIENT.chainPubkey,
+      tokenBlob: 'aa'.repeat(40),
+      createdAt: Date.now(),
+    });
+
+    // Each replay pass bumps the cumulative attempt count by 1; the entry stays
+    // journaled (un-poisoned) and NOT surfaced until the budget is crossed.
+    const budget = 6; // MAX_DELIVERY_REPLAY_ATTEMPTS
+    for (let i = 0; i < budget - 1; i++) {
+      await (sender.module as any).replayPendingV2Deliveries();
+      const journal = JSON.parse(sender.storage.map.get('pending_v2_deliveries')!);
+      expect(journal).toHaveLength(1);
+      expect(journal[0].undeliverable).toBeUndefined();
+      expect(journal[0].attempts).toBe(i + 1);
+    }
+    expect(sender.emitEvent.mock.calls.filter((c) => c[0] === 'delivery:undeliverable')).toHaveLength(0);
+
+    // The pass that crosses the budget surfaces it as poison — ONE event,
+    // entry kept journaled but flagged so it does not sit undelivered invisibly.
+    await (sender.module as any).replayPendingV2Deliveries();
+    const poisonCalls = sender.emitEvent.mock.calls.filter((c) => c[0] === 'delivery:undeliverable');
+    expect(poisonCalls).toHaveLength(1);
+    expect(poisonCalls[0][1]).toMatchObject({ transferId: 'poison-tx', recipientPubkey: RECIPIENT.chainPubkey, attempts: budget });
+    expect(poisonCalls[0][1].error).toContain('rail rejects');
+    const poisoned = JSON.parse(sender.storage.map.get('pending_v2_deliveries')!);
+    expect(poisoned).toHaveLength(1);
+    expect(poisoned[0]).toMatchObject({ undeliverable: true, attempts: budget });
+
+    // Poison is terminal for auto-replay: a further pass touches the rail no more
+    // and emits no duplicate surfacing.
+    const deliverCallsBefore = deliverSpy.mock.calls.length;
+    await (sender.module as any).replayPendingV2Deliveries();
+    expect(deliverSpy.mock.calls.length).toBe(deliverCallsBefore);
+    expect(sender.emitEvent.mock.calls.filter((c) => c[0] === 'delivery:undeliverable')).toHaveLength(1);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  });
+
+  it('a blob that recovers within the budget is delivered and the journal is cleared — no poison event', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-poison-2');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (sender.module as any).replayBackoffBaseMs = 0;
+
+    // Capture a REAL deliverable blob by sending once, then re-journal it and
+    // make delivery fail twice (transient outage) before recovering.
+    let captured: Uint8Array | null = null;
+    const realDeliver = sender.delivery.deliver.bind(sender.delivery);
+    let failures = 2;
+    vi.spyOn(sender.delivery, 'deliver').mockImplementation((a, b, c) => {
+      captured = b;
+      return failures-- > 0 ? Promise.reject(new Error('mailbox flapping')) : realDeliver(a, b, c);
+    });
+    const result = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT })
+      .catch(() => null);
+    // The send itself failed mid-deliver, journaling the finished blob.
+    expect(captured).not.toBeNull();
+    const journalAfterSend = JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]');
+    expect(journalAfterSend).toHaveLength(1);
+    void result;
+
+    // failures is now 1 → the next replay pass retries within-pass (backoff) and
+    // recovers; the blob lands and the journal clears with NO poison event.
+    await (sender.module as any).replayPendingV2Deliveries();
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    expect(JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]')).toHaveLength(0);
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(1);
+    expect(sender.emitEvent.mock.calls.filter((c) => c[0] === 'delivery:undeliverable')).toHaveLength(0);
+  });
+});
+
 describe('own-storage + wallet-api delivery (S7 AC: delivery-only composition)', () => {
   it('sender: deposits without EVER calling apply; the send closes via intents/complete alone', async () => {
     const { fake, baseUrl } = await startFake();
@@ -550,6 +640,47 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
     const sent = fake.getHistoryRecords(SENDER.chainPubkey).find((r) => r.dedupKey === `SENT_transfer_${transferId}`);
     expect(sent).toBeDefined();
+  });
+});
+
+describe('stale-inventory conflict is SURFACED, not silent (#517 item 2)', () => {
+  it('a send that loses the race on a stale source emits inventory:conflict (E.2 TransferConflictError)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-conf-1');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // Coin-selection planned from the lazy view, but another device already
+    // spent the source: the engine's match-verify raises TransferConflictError
+    // (Part E.2 — the predictable stale-view race the incident flagged).
+    vi.spyOn(sender.engine, 'transfer').mockRejectedValue(
+      new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent')
+    );
+
+    await expect(sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT }))
+      .rejects.toBeInstanceOf(TransferConflictError);
+
+    // The recoverable condition is now OBSERVABLE — a distinct event, not just a
+    // generic transfer:failed buried in a string.
+    const conflictCalls = sender.emitEvent.mock.calls.filter((c) => c[0] === 'inventory:conflict');
+    expect(conflictCalls).toHaveLength(1);
+    expect(conflictCalls[0][1]).toMatchObject({ coinId: UCT });
+    expect(typeof conflictCalls[0][1].transferId).toBe('string');
+    expect(conflictCalls[0][1].error).toContain('TRANSACTION_HASH_MISMATCH');
+  });
+
+  it('a plain (non-conflict) send failure does NOT emit inventory:conflict', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-conf-2');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    vi.spyOn(sender.engine, 'transfer').mockRejectedValue(new Error('engine boom'));
+
+    await expect(sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT }))
+      .rejects.toThrow('engine boom');
+
+    expect(sender.emitEvent.mock.calls.filter((c) => c[0] === 'inventory:conflict')).toHaveLength(0);
   });
 });
 

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -553,6 +553,29 @@ describe('journaled-delivery replay: bounded backoff + poison surfacing (#517 it
     expect(JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]')).toHaveLength(0);
   });
 
+  it('concurrent journal mutations do NOT clobber each other — the journal lock serializes RMW', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-journal-lock-1');
+    await sender.module.load();
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const m = sender.module as any;
+    // Two journal writes kicked WITHOUT awaiting between them — mirrors a send()
+    // journaling a finished blob while a fire-and-forget replay mutates the journal.
+    // Without the lock both read the same snapshot, mutate, and the last write wins.
+    await Promise.all([
+      m.savePendingV2Delivery({ transferId: 'tx-A', recipientPubkey: RECIPIENT.chainPubkey, tokenBlob: 'aa'.repeat(40), createdAt: Date.now() }),
+      m.savePendingV2Delivery({ transferId: 'tx-B', recipientPubkey: RECIPIENT.chainPubkey, tokenBlob: 'bb'.repeat(40), createdAt: Date.now() }),
+    ]);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    // BOTH entries survive. RED without the lock: 1 — the second save reads the
+    // pre-first snapshot and clobbers the first entry (the crash-safety blob is lost).
+    const journal = JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]');
+    expect(journal).toHaveLength(2);
+    expect(journal.map((e: { transferId: string }) => e.transferId).sort()).toEqual(['tx-A', 'tx-B']);
+  });
+
   it('a blob that recovers within the budget is delivered and the journal is cleared — no poison event', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-poison-2');

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -522,6 +522,37 @@ describe('journaled-delivery replay: bounded backoff + poison surfacing (#517 it
     /* eslint-enable @typescript-eslint/no-explicit-any */
   });
 
+  it('two overlapping replay passes deliver each journaled entry ONCE — the in-flight guard serializes them', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-concurrent-1');
+    await sender.module.load();
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    // One journaled finished blob; delivery resolves so a pass delivers + clears it.
+    const deliverSpy = vi
+      .spyOn(sender.delivery, 'deliver')
+      .mockResolvedValue({ deliveryId: 'concurrent-d1' } as any);
+    await (sender.module as any).savePendingV2Delivery({
+      transferId: 'concurrent-tx',
+      recipientPubkey: RECIPIENT.chainPubkey,
+      tokenBlob: 'bb'.repeat(40),
+      createdAt: Date.now(),
+    });
+
+    // Kick TWO passes WITHOUT awaiting between them — mirrors load()'s fire-and-
+    // forget replay racing a receive()→load(). The guard (set synchronously before
+    // the first await) must drop the second pass.
+    const p1 = (sender.module as any).replayPendingV2Deliveries();
+    const p2 = (sender.module as any).replayPendingV2Deliveries();
+    await Promise.all([p1, p2]);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    // Delivered exactly once. RED without the guard: 2 — both passes read the same
+    // journal snapshot and re-deliver (and race the per-entry attempts RMW).
+    expect(deliverSpy.mock.calls).toHaveLength(1);
+    expect(JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]')).toHaveLength(0);
+  });
+
   it('a blob that recovers within the budget is delivered and the journal is cleared — no poison event', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-poison-2');

--- a/types/index.ts
+++ b/types/index.ts
@@ -97,8 +97,16 @@ export interface Asset {
   readonly confirmedTokenCount: number;
   /** Number of unconfirmed tokens aggregated */
   readonly unconfirmedTokenCount: number;
-  /** Number of tokens currently being sent */
+  /** Number of tokens currently being sent (in-flight, NOT spendable) */
   readonly transferringTokenCount: number;
+  /**
+   * Sum of in-flight (`'transferring'`) token amounts (smallest units). These
+   * tokens are LEAVING the wallet during an active send, so they are excluded
+   * from {@link totalAmount}, {@link confirmedAmount}, and
+   * {@link unconfirmedAmount} — surfaced here so a UI can still show a "Sending"
+   * badge without inflating the spendable balance.
+   */
+  readonly transferringAmount: string;
   /** Price per whole unit in USD (null if PriceProvider not configured) */
   readonly priceUsd: number | null;
   /** Price per whole unit in EUR (null if PriceProvider not configured) */
@@ -399,6 +407,8 @@ export type SphereEventType =
   | 'sync:provider'
   | 'sync:error'
   | 'storage:degraded'
+  | 'inventory:conflict'
+  | 'delivery:undeliverable'
   | 'walletapi:session'
   | 'realtime:status'
   | 'connection:changed'
@@ -489,6 +499,23 @@ export interface SphereEventMap {
    * emitting this.
    */
   'storage:degraded': { providerId: string; error: string };
+  /**
+   * A send lost a race on a source token (#517): coin-selection planned from a
+   * lazy-inventory view that was stale (missing another device's spend), so the
+   * engine raised `TransferConflictError` (Part E.2 — `TRANSACTION_HASH_MISMATCH`).
+   * The send fails cleanly and the conflicted source is reconciled to 'spent';
+   * this surfaces the otherwise-silent recoverable condition so a UI can prompt
+   * "refresh and retry". `transferId` is the aborted send's id.
+   */
+  'inventory:conflict': { transferId: string; coinId: string; error: string };
+  /**
+   * A journaled finished-but-undelivered v2 transfer blob (#517) has exhausted
+   * its bounded replay budget and is now POISON: it stays journaled (the deposit
+   * is idempotent, so a later app version may still land it) but is no longer
+   * auto-retried, so it does not sit undelivered invisibly. `attempts` is the
+   * cumulative failed-replay count that tripped the surfacing.
+   */
+  'delivery:undeliverable': { transferId: string; recipientPubkey: string; attempts: number; error: string };
   /**
    * wallet-api session state change (#515 F3): 'offline' = sign-in failed and
    * the wallet runs degraded (no intents barrier, no server custody writes);

--- a/types/index.ts
+++ b/types/index.ts
@@ -515,7 +515,7 @@ export interface SphereEventMap {
    * auto-retried, so it does not sit undelivered invisibly. `attempts` counts
    * failed replay PASSES (one per `load()`), NOT underlying delivery calls — each
    * pass internally retries with backoff, so the real number of delivery attempts
-   * is higher. Surfacing trips once `attempts` crosses the bounded budget.
+   * is higher. Surfacing trips once `attempts` reaches the bounded budget.
    */
   'delivery:undeliverable': { transferId: string; recipientPubkey: string; attempts: number; error: string };
   /**

--- a/types/index.ts
+++ b/types/index.ts
@@ -512,8 +512,10 @@ export interface SphereEventMap {
    * A journaled finished-but-undelivered v2 transfer blob (#517) has exhausted
    * its bounded replay budget and is now POISON: it stays journaled (the deposit
    * is idempotent, so a later app version may still land it) but is no longer
-   * auto-retried, so it does not sit undelivered invisibly. `attempts` is the
-   * cumulative failed-replay count that tripped the surfacing.
+   * auto-retried, so it does not sit undelivered invisibly. `attempts` counts
+   * failed replay PASSES (one per `load()`), NOT underlying delivery calls — each
+   * pass internally retries with backoff, so the real number of delivery attempts
+   * is higher. Surfacing trips once `attempts` crosses the bounded budget.
    */
   'delivery:undeliverable': { transferId: string; recipientPubkey: string; attempts: number; error: string };
   /**


### PR DESCRIPTION
Closes #517 — the three lower-severity hazards from the 2026-06-12 incident workflow. All three are **observability or balance-correctness only**: no server-side transfer coordination, no aggregator calls from the backend, no port-contract changes (§19 respected). Branched off `feat/wallet-api-integration` (the #585 tip).

Each change has its **own failing-first test** (RED proven against the base branch, GREEN after the fix).

---

### 1. Replay backoff + poison surfacing — `modules/payments/PaymentsModule.ts` `replayPendingV2Deliveries` (≈ :5409)
`replayPendingV2Deliveries` was a silent unbounded fire-and-forget: a journaled finished-but-undelivered blob just got one deliver attempt per load forever, with no surfacing. Now:
- bounded **exponential backoff** per entry within a pass (`DELIVERY_REPLAY_RETRIES` + 1 attempts);
- a cumulative `attempts` count **journaled across loads** (new `PendingV2Delivery.attempts`);
- once an entry crosses `MAX_DELIVERY_REPLAY_ATTEMPTS` it is marked `undeliverable` and **surfaced** via a new `delivery:undeliverable` event — it stays journaled (the deposit is idempotent by the content-derived entry_id, so a later app version may still land it) but is **no longer auto-retried**, so blobs never sit undelivered invisibly.

**Failing-first test** (`tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts`, describe `journaled-delivery replay: bounded backoff + poison surfacing (#517 item 1)`):
- `a persistently-undeliverable blob is SURFACED as poison after the bounded budget, then no longer auto-retried`
- `a blob that recovers within the budget is delivered and the journal is cleared — no poison event`

**RED (base branch):** poison test → `attempts` never set, no `delivery:undeliverable` emitted; recovery test → base does only ONE deliver attempt per pass (no in-pass backoff retry), so the journal is not cleared (`expected [ {…} ] to have a length of +0 but got 1`).
**GREEN (this branch):** both pass.

### 2. Stale-inventory tolerance/surfacing — `send` `TransferConflictError` path (≈ :1898)
Coin-selection can plan from a lazy-inventory view that is stale (missing another device's spend); the engine then raises `TransferConflictError` (Part E.2 — `TRANSACTION_HASH_MISMATCH`). Handling is **unchanged** (abort intent + reconcile the source to `'spent'`); now it **also emits a distinct `inventory:conflict` event** so the recoverable race is observable instead of buried in a generic `transfer:failed` string. A UI can prompt "refresh and retry".

**Failing-first test** (same file, describe `stale-inventory conflict is SURFACED, not silent (#517 item 2)`):
- `a send that loses the race on a stale source emits inventory:conflict (E.2 TransferConflictError)`
- `a plain (non-conflict) send failure does NOT emit inventory:conflict` (guards over-surfacing)

**RED (pre-emit):** `expected [] to have a length of 1 but got +0`.
**GREEN:** both pass.

### 3. In-flight balance — `aggregateTokens` (≈ :2953)
`'transferring'` tokens were counted into `unconfirmedAmount` and `totalAmount` — i.e. shown as spendable. They are **leaving** the wallet during an active send, so they must not inflate the balance. Now they are tracked in their own bucket: `transferringTokenCount` + a new `Asset.transferringAmount`, and **excluded** from `totalAmount`/`confirmedAmount`/`unconfirmedAmount`. Fiat value derives from `totalAmount`, so `getFiatBalance` likewise excludes in-flight value. Amounts stay decimal-string / `BigInt` end-to-end (no JS numbers). Coin-selection is unaffected — it plans over `this.tokens`, not over the `Asset` aggregation.

**Failing-first test** (`tests/unit/modules/PaymentsModule.test.ts`, `getAssets()` → `counts confirmed + unconfirmed as balance; transferring (in-flight) is tracked separately, NOT spendable`). The prior test encoded the buggy behavior; it is replaced with the correct semantics.

**RED:** `expected '6000' to be '3000'` (the 3000 in-flight token inflated `totalAmount`).
**GREEN:** `totalAmount` = 3000 (1000 confirmed + 2000 pending), `transferringAmount` = 3000.

---

### Spec / docs
No `§16 API` / `§11 schema` / port-contract change (those specs live in the wallet-api repo; these are internal SDK module changes). `docs/API.md` updated for the new `Asset.transferringAmount` field, the corrected balance semantics on `getBalance`/`getAssets`, and the two new `SphereEventType`/`SphereEventMap` entries.

### Verification (node:22, DooD)
- Full unit suite: **190 files, 3073 tests, all pass**.
- `tsc --noEmit`: clean (exit 0).
- `eslint` on changed files: **0 errors** (2 pre-existing warnings unrelated to this diff).
- Live suite NOT run (needs secrets + network; out of scope here).