### PR TITLE
fix(core): consistent wrong-password error + de-flake wallet-password test (#592)

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -4280,7 +4280,14 @@ export class Sphere {
 
     if (encryptedMnemonic) {
       const mnemonic = this.decrypt(encryptedMnemonic);
-      if (!mnemonic) {
+      // A wrong password can decrypt to non-empty GARBAGE: `decryptSimple` uses
+      // unauthenticated AES-CBC, so ~1/256 of wrong keys produce byte-valid PKCS#7
+      // padding and a non-null result instead of throwing. A wallet is only ever
+      // persisted with a VALID BIP39 phrase, so a decrypted value that fails BIP39
+      // validation deterministically means wrong-password / corruption — surface
+      // the SAME "Failed to decrypt mnemonic" instead of leaking a misleading
+      // "Invalid mnemonic phrase" from downstream identity init.
+      if (!mnemonic || !validateBip39Mnemonic(mnemonic)) {
         throw new SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR');
       }
       this._mnemonic = mnemonic;

--- a/tests/integration/wallet-password.test.ts
+++ b/tests/integration/wallet-password.test.ts
@@ -218,6 +218,44 @@ describe('Wallet password encryption', () => {
       ).rejects.toThrow('Failed to decrypt mnemonic');
     });
 
+    // De-flake regression: an unauthenticated AES-CBC decrypt with the WRONG
+    // password yields, ~1/256 of the time, byte-valid PKCS#7 padding → a
+    // non-empty GARBAGE string instead of a clean failure. Previously that
+    // garbage flowed into BIP39 init and surfaced the misleading
+    // 'Invalid mnemonic phrase'. This fixture is a hand-found (ciphertext,
+    // wrong-password) pair that DETERMINISTICALLY hits that path: the wrong
+    // password decrypts to a 2-char garbage string. The wallet MUST still report
+    // the consistent 'Failed to decrypt mnemonic'. (RED before the fix:
+    // 'Invalid mnemonic phrase'.)
+    it('reports "Failed to decrypt mnemonic" even when a wrong password decrypts to garbage', async () => {
+      // ciphertext = encryptMnemonic('legal winner thank year wave sausage worth
+      //   useful legal winner thank yellow', 'correct-horse-battery-staple');
+      // decryptSimple(ciphertext, 'wrong-password-20') === <2-char garbage> (non-empty, not BIP39)
+      const GARBAGE_CIPHERTEXT =
+        'U2FsdGVkX18hJUu5YmclTG/FlK5AU7fZj+/kD6u1b1HQjqeQl+ZTIQG2W1Y7Rk9J3orcy25Tvg3zvsT90LVwT8Ya3y2cg6xpLE/ljAz+vs03rCj5eirJHBrR9pKahd5b';
+      const WRONG_PASSWORD_YIELDING_GARBAGE = 'wrong-password-20';
+
+      writeWalletJson(DATA_DIR, {
+        [STORAGE_KEYS_GLOBAL.MNEMONIC]: GARBAGE_CIPHERTEXT,
+        [STORAGE_KEYS_GLOBAL.WALLET_EXISTS]: 'true',
+        [STORAGE_KEYS_GLOBAL.WALLET_SOURCE]: 'mnemonic',
+      });
+
+      const storage = new FileStorageProvider({ dataDir: DATA_DIR });
+      const tokenStorage = new FileTokenStorageProvider({ tokensDir: TOKENS_DIR });
+
+      await expect(
+        Sphere.init({
+          storage,
+          tokenStorage,
+          transport: createMockTransport(),
+          oracle: createMockOracle(),
+          network: TEST_NETWORK,
+          password: WRONG_PASSWORD_YIELDING_GARBAGE,
+        })
+      ).rejects.toThrow('Failed to decrypt mnemonic');
+    });
+
     it('should fail without password when wallet is encrypted', async () => {
       await createAndDestroy({ password: TEST_PASSWORD });
 


### PR DESCRIPTION
Closes #592.

## Problem
`wallet-password.test.ts > should fail with wrong password` flakes (~1/256, seen on #588 CI): expected `Failed to decrypt mnemonic` but got `Invalid mnemonic phrase`.

**Root cause:** mnemonics are stored with **unauthenticated AES-CBC** (CryptoJS passphrase mode, no MAC). A wrong password yields byte-valid PKCS#7 padding ~1/256 of the time → a non-empty **garbage** plaintext instead of a clean failure. That garbage skipped the `!mnemonic` guard in `Sphere.loadIdentityFromStorage` and flowed into BIP39 init → the misleading `Invalid mnemonic phrase`. So it's also a minor **product bug** (wrong password sometimes reports a corrupt-wallet error).

## Fix
`core/Sphere.ts`: validate the decrypted value as BIP39 at the decrypt site. A wallet is only ever persisted with a valid phrase, so a decrypted value that fails BIP39 validation deterministically means wrong-password/corruption — surface the consistent `Failed to decrypt mnemonic`. One line, no format/storage change.

## Test (deterministic failing-first)
New case in `wallet-password.test.ts` seeds a hand-found `(ciphertext, wrong-password)` fixture that ALWAYS decrypts to a 2-char garbage string (the flaky path, made deterministic). **RED** before the guard (`Invalid mnemonic phrase`), **GREEN** after. This also de-flakes the existing wrong-password test (the guard converts the garbage path too). 16/16 in the file; 10/10 loop with zero `Invalid mnemonic` leaks; tsc + eslint clean.

## Not in this PR (tracked on #592)
- The `encryptedMasterKey` sibling path has the same latent shape (no repro yet).
- Deeper fix: migrate to AEAD (AES-GCM) for cryptographically deterministic wrong-password detection — needs a stored-format migration, separate issue.