### PR TITLE
feat(connect): add mint intent (+ mint:request scope)

### DIFF
--- a/connect/permissions.ts
+++ b/connect/permissions.ts
@@ -24,6 +24,7 @@ export const PERMISSION_SCOPES = {
   DM_MANAGE: 'dm:manage',
   PAYMENT_REQUEST: 'payment:request',
   SIGN_REQUEST: 'sign:request',
+  MINT_REQUEST: 'mint:request',
   INVOICE_READ: 'invoice:read',
   INVOICE_WRITE: 'invoice:write',
 } as const;
@@ -82,6 +83,7 @@ export const INTENT_PERMISSIONS: Record<string, PermissionScope> = {
   [INTENT_ACTIONS.SEND_INVOICE_RECEIPTS]: PERMISSION_SCOPES.INVOICE_WRITE,
   [INTENT_ACTIONS.SEND_CANCELLATION_NOTICES]: PERMISSION_SCOPES.INVOICE_WRITE,
   [INTENT_ACTIONS.SET_AUTO_RETURN]: PERMISSION_SCOPES.INVOICE_WRITE,
+  [INTENT_ACTIONS.MINT]: PERMISSION_SCOPES.MINT_REQUEST,
 };
 
 // =============================================================================

--- a/connect/protocol.ts
+++ b/connect/protocol.ts
@@ -66,6 +66,7 @@ export const INTENT_ACTIONS = {
   SEND_INVOICE_RECEIPTS: 'send_invoice_receipts',
   SEND_CANCELLATION_NOTICES: 'send_cancellation_notices',
   SET_AUTO_RETURN: 'set_auto_return',
+  MINT: 'mint',
 } as const;
 
 export type IntentAction = (typeof INTENT_ACTIONS)[keyof typeof INTENT_ACTIONS];

--- a/docs/CONNECT.md
+++ b/docs/CONNECT.md
@@ -426,6 +426,7 @@ The wallet's `onConnectionRequest` receives `silent=true` and must return `{ app
 | `send_invoice_receipts` | `invoiceId, memo?, includeZeroBalance?` |
 | `send_cancellation_notices` | `invoiceId, reason?, dealDescription?, includeZeroBalance?` |
 | `set_auto_return` | `invoiceId, enabled` |
+| `mint` | `coinId` (lowercase hex), `amount` (smallest units) |
 
 ### sign_message Intent
 
@@ -455,6 +456,22 @@ const isValid = verifySignedMessage(originalMessage, signature, expectedPubkey);
 - Recoverable signature — server can verify without storing the public key
 - Canonical signatures — prevents signature malleability attacks
 - The wallet displays the full message text for user review before signing
+
+### mint Intent
+
+The `mint` intent lets a dApp ask the connected wallet to **self-mint** a fungible token to the user's own wallet (the v2 replacement for the testnet faucet). The wallet always asks the user to confirm; minting is never silent.
+
+```typescript
+// dApp requests a self-mint (coinId is lowercase hex, amount in smallest units)
+const result = await client.intent('mint', {
+  coinId: '1111111111111111111111111111111111111111111111111111111111111111',
+  amount: '1000000',
+});
+
+// result = { tokenId: '…64-hex…', coinId: '…', amount: '1000000' }
+```
+
+Requires the `mint:request` permission scope. Minting only succeeds on networks that allow standalone self-mint (testnet2 today); on networks where it is unavailable the wallet returns an error from the token engine.
 
 ## Events (wallet → dApp push)
 
@@ -586,6 +603,7 @@ Permissions are requested during handshake and checked on every request:
 | `intent:payment_request` | `payment_request` intent |
 | `intent:receive` | `receive` intent |
 | `intent:sign_message` | `sign_message` intent |
+| `mint:request` | `mint` intent (self-mint a fungible token) |
 | `comms:read` | DM conversations |
 | `comms:write` | send DMs |
 | `invoice:read` | `sphere_getInvoices`, `sphere_getInvoiceStatus` |

--- a/tests/unit/connect/integration.test.ts
+++ b/tests/unit/connect/integration.test.ts
@@ -286,6 +286,30 @@ describe('Sphere Connect Integration', () => {
       expect(result.messageId).toBe('msg123');
     });
 
+    it('requests a mint intent', async () => {
+      host.destroy();
+      transports = createMockTransportPair();
+      const onIntent = vi.fn().mockResolvedValue({
+        result: { tokenId: 'aa'.repeat(32), coinId: '11'.repeat(32), amount: '500' },
+      });
+      createHost({ onIntent });
+      createClient();
+      await client.connect();
+
+      const result = await client.intent<{ tokenId: string; coinId: string; amount: string }>(
+        INTENT_ACTIONS.MINT,
+        { coinId: '11'.repeat(32), amount: '500' },
+      );
+
+      expect(onIntent).toHaveBeenCalledWith(
+        'mint',
+        { coinId: '11'.repeat(32), amount: '500' },
+        expect.any(Object),
+      );
+      expect(result.tokenId).toBe('aa'.repeat(32));
+      expect(result.amount).toBe('500');
+    });
+
     it('handles user rejection', async () => {
       host.destroy();
       transports = createMockTransportPair();
@@ -377,6 +401,21 @@ describe('Sphere Connect Integration', () => {
 
       await expect(
         client.intent(INTENT_ACTIONS.SEND, { to: '@bob', amount: '1', coinId: 'UCT' }),
+      ).rejects.toThrow('Permission denied');
+    });
+
+    it('denies mint intent without mint:request', async () => {
+      createHost({
+        onConnectionRequest: vi.fn().mockResolvedValue({
+          approved: true,
+          grantedPermissions: [PERMISSION_SCOPES.TRANSFER_REQUEST] as PermissionScope[],
+        }),
+      });
+      createClient({ permissions: [PERMISSION_SCOPES.TRANSFER_REQUEST] });
+      await client.connect();
+
+      await expect(
+        client.intent(INTENT_ACTIONS.MINT, { coinId: '11'.repeat(32), amount: '500' }),
       ).rejects.toThrow('Permission denied');
     });
   });

--- a/tests/unit/connect/permissions.test.ts
+++ b/tests/unit/connect/permissions.test.ts
@@ -50,6 +50,16 @@ describe('Permissions', () => {
       expect(hasIntentPermission(granted, INTENT_ACTIONS.DM)).toBe(true);
     });
 
+    it('mint:request allows mint intent', () => {
+      const granted = new Set([PERMISSION_SCOPES.MINT_REQUEST]);
+      expect(hasIntentPermission(granted, INTENT_ACTIONS.MINT)).toBe(true);
+    });
+
+    it('transfer:request does NOT allow mint intent', () => {
+      const granted = new Set([PERMISSION_SCOPES.TRANSFER_REQUEST]);
+      expect(hasIntentPermission(granted, INTENT_ACTIONS.MINT)).toBe(false);
+    });
+
     it('returns false for unknown actions', () => {
       const granted = new Set(ALL_PERMISSIONS);
       expect(hasIntentPermission(granted, 'unknown_action')).toBe(false);
@@ -82,6 +92,14 @@ describe('Permissions', () => {
       for (const action of Object.values(INTENT_ACTIONS)) {
         expect(INTENT_PERMISSIONS[action]).toBeDefined();
       }
+    });
+
+    it('mint intent maps to mint:request scope', () => {
+      expect(INTENT_PERMISSIONS[INTENT_ACTIONS.MINT]).toBe(PERMISSION_SCOPES.MINT_REQUEST);
+    });
+
+    it('mint:request is a known scope', () => {
+      expect(ALL_PERMISSIONS).toContain(PERMISSION_SCOPES.MINT_REQUEST);
     });
 
     it('default permissions include identity:read', () => {


### PR DESCRIPTION
Closes #595.

Exposes the existing public `PaymentsModule.mintFungibleToken` over Sphere Connect as a new `mint` intent.

**Changes (protocol only):**
- `INTENT_ACTIONS.MINT = 'mint'`
- `PERMISSION_SCOPES.MINT_REQUEST = 'mint:request'`
- `INTENT_PERMISSIONS` maps `mint` -> `mint:request`
- Unit tests (scope/mapping/permission gate) + integration tests (intent delegation + permission denial)
- `docs/CONNECT.md`: intent row, scope row, and a `mint` intent subsection

**Design notes:**
- No new capability: `mintFungibleToken` is already public (bots/backends call it directly). This only lets a dApp *request* a self-mint behind explicit user approval.
- No network guard in Connect: where mint is unavailable the engine returns an error (testnet2 works; mainnet currently refuses to init). Counterfeiting protection on a future mainnet is a gateway/issuance-authorization concern, out of scope here.
- Wallet host UI (sphere) and the connect-example demo land in separate PRs.

Connect test suite: 119/119 passing.