### PR TITLE
feat(connect): bump protocol version to 2.1 for the mint intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,13 @@ consumed exclusively through the `token-engine/` port. Consequences:
   `UnicityIdMintResult` (token-engine).
 
 ### Added
+- **Sphere Connect `mint` intent (#595):** the existing public
+  `PaymentsModule.mintFungibleToken` is now exposed as a `mint` Connect intent
+  (params `{ coinId, amount }`) behind a new `mint:request` permission scope, so a
+  connected dApp can request the user's wallet to self-mint a fungible token after
+  explicit approval (succeeds only where the network allows standalone self-mint,
+  e.g. testnet2). Connect protocol version bumped **2.0 → 2.1** (backward-compatible
+  MINOR); dApps that require it can set `minMinorVersion: 1`.
 - **Thin-wallet core (wallet-api program, sdk-changes S1/S2/S6/S7)** —
   - **`WalletApiClient`** (new `wallet-api/` module + `./wallet-api` subpath export): challenge→sign→JWT auth with mandatory challenge-template verification (`unicity:wallet-api:auth:v1\n` prefix, own-pubkey + plausible-timestamp checks — the spend key never signs unverified server text), rotating refresh tokens (`v1.<sessionId>.<secretHex>`) with rotation-reuse-revocation fallback to a fresh challenge cycle, logout; typed REST for the §16 inventory/intents/blob endpoints (amounts are decimal strings on the wire, `bigint` in types); WS wake channel via the single-use ticket flow; refresh token kept only in injected storage (never logged); non-loopback base URLs must be `https:`. The client keeps the normative LOCAL copy of open intents (E.3) and re-PUTs them on a `syncEpoch` change.
   - **S6 field encryption** (`core/field-encryption.ts`): `deriveFieldEncryptionKey` = HKDF-SHA256(wallet privkey, `sphere-fieldenc-v1`); XChaCha20-Poly1305 envelopes `"enc1." + base64(nonce ‖ ciphertext)`; `assertFieldEnvelopeShape` is the server-side prefix/base64/size-cap check (ARCHITECTURE §8.3). New dependency `@noble/ciphers`.

--- a/connect/protocol.ts
+++ b/connect/protocol.ts
@@ -10,7 +10,7 @@ import { majorOf } from './semver';
 // =============================================================================
 
 export const SPHERE_CONNECT_NAMESPACE = 'sphere-connect';
-export const SPHERE_CONNECT_VERSION = '2.0';   // Connect protocol version (semver MAJOR.MINOR)
+export const SPHERE_CONNECT_VERSION = '2.1';   // Connect protocol version (semver MAJOR.MINOR) — 2.1 adds the mint intent
 
 export { HOST_READY_TYPE, HOST_READY_TIMEOUT, SPHERE_NETWORKS } from '../constants';
 // Import for local use (e.g. SphereHandshake.network) AND re-export for connect consumers.

--- a/docs/CONNECT.md
+++ b/docs/CONNECT.md
@@ -4,7 +4,7 @@ Sphere Connect is a secure wallet-dApp communication protocol. It allows web app
 
 ## Protocol Version
 
-The current Connect protocol version is **`2.0`** (`SPHERE_CONNECT_VERSION = '2.0'`).
+The current Connect protocol version is **`2.1`** (`SPHERE_CONNECT_VERSION = '2.1'`). **2.1** added the `mint` intent (backward-compatible MINOR addition); a dApp that requires it can set `minMinorVersion: 1` so the handshake is rejected by wallets older than 2.1.
 
 ### Compatibility policy
 

--- a/tests/unit/connect/compatibility.test.ts
+++ b/tests/unit/connect/compatibility.test.ts
@@ -2,15 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { checkCompatibility } from '../../../connect/compatibility';
 import { ERROR_CODES, SPHERE_CONNECT_VERSION } from '../../../connect/protocol';
 
-const W = SPHERE_CONNECT_VERSION;     // '2.0'
+const W = SPHERE_CONNECT_VERSION;     // '2.1'
 const NET = 4;                        // testnet2
 
 describe('checkCompatibility', () => {
   it('ok when same MAJOR and matching network', () => {
     expect(checkCompatibility({ clientProtocol: '2.0', walletProtocol: W, clientNetwork: { id: NET }, walletNetworkId: NET }).ok).toBe(true);
   });
-  it('ok for a newer MINOR (2.1 client, 2.0 wallet)', () => {
-    expect(checkCompatibility({ clientProtocol: '2.1', walletProtocol: W, clientNetwork: { id: NET }, walletNetworkId: NET }).ok).toBe(true);
+  it('ok for a newer MINOR (2.2 client, 2.1 wallet)', () => {
+    expect(checkCompatibility({ clientProtocol: '2.2', walletProtocol: W, clientNetwork: { id: NET }, walletNetworkId: NET }).ok).toBe(true);
   });
   it('rejects a different MAJOR with UNSUPPORTED_PROTOCOL_VERSION', () => {
     const r = checkCompatibility({ clientProtocol: '1.0', walletProtocol: W, clientNetwork: { id: NET }, walletNetworkId: NET });

--- a/tests/unit/connect/protocol.test.ts
+++ b/tests/unit/connect/protocol.test.ts
@@ -85,8 +85,8 @@ describe('Protocol', () => {
 });
 
 describe('protocol v2 gate surface', () => {
-  it('Connect version is bumped to 2.0', () => {
-    expect(SPHERE_CONNECT_VERSION).toBe('2.0');
+  it('Connect version is bumped to 2.1', () => {
+    expect(SPHERE_CONNECT_VERSION).toBe('2.1');
   });
   it('has the new error codes', () => {
     expect(ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION).toBe(4007);


### PR DESCRIPTION
Follow-up to #602 (merged), which added the `mint` intent + `mint:request` scope but left the Connect protocol version at `2.0`.

Per the Connect versioning policy (CONNECT.md: "add method / intent / event -> MINOR"), a new backward-compatible intent warrants a MINOR bump. This bumps `SPHERE_CONNECT_VERSION` from 2.0 to 2.1 so:

- dApps can feature-detect mint support by version, and
- a dApp that requires mint can set `minMinorVersion: 1` (handshake rejected by wallets older than 2.1).

Includes: the version constant, the `protocol.test.ts` version assertion, the `compatibility.test.ts` newer-MINOR case + comment, the CONNECT.md version section, and a CHANGELOG entry. Connect unit suite: 118 passing.
