### PR TITLE
test(connect): protocol-surface guard against unversioned changes

### DIFF
--- a/docs/CONNECT.md
+++ b/docs/CONNECT.md
@@ -686,6 +686,8 @@ Connect uses semver MAJOR.MINOR. The rules:
 | Change or remove an existing message / field | MAJOR | Breaking — requires a deprecation window |
 | Behaviour fix with no wire change | PATCH (no Connect bump) | Invisible to peers |
 
+**Enforced in CI:** `tests/unit/connect/protocol-surface.test.ts` snapshots the full wire surface (intents, scopes, methods) + `SPHERE_CONNECT_VERSION`. Any change to the surface fails that test until you bump the version and update its snapshot — so the bump can't be forgotten.
+
 **Deprecation window for MAJOR changes:** announce the upcoming MAJOR → soft-warn via the handshake response `warning` field (non-fatal, logged by the client) → reject (MAJOR bumped). Never a flag-day cut except the current v1 → v2 migration (v1 peers are genuinely incompatible — no transition period is possible).
 
 The `warning` field in `SphereHandshake` is reserved for this deprecation flow. No call site emits one yet.

--- a/tests/unit/connect/protocol-surface.test.ts
+++ b/tests/unit/connect/protocol-surface.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { INTENT_ACTIONS, RPC_METHODS, SPHERE_CONNECT_VERSION } from '../../../connect/protocol';
+import { PERMISSION_SCOPES } from '../../../connect/permissions';
+
+/**
+ * Connect protocol-surface guard.
+ *
+ * The "surface" — every intent action, permission scope and RPC method, plus the
+ * protocol version — is the wire contract dApps depend on. Per docs/CONNECT.md:
+ *   - add an intent / method / scope            -> bump MINOR (e.g. 2.0 -> 2.1)
+ *   - remove / rename / change an existing one  -> bump MAJOR (e.g. 2.0 -> 3.0)
+ *
+ * When this test fails: read the diff, decide MINOR vs MAJOR, update
+ * SPHERE_CONNECT_VERSION, then update EXPECTED below to match.
+ */
+
+const BUMP_REMINDER =
+  '\nConnect wire surface changed.\n' +
+  'Per docs/CONNECT.md: add intent/method/scope -> MINOR; remove/rename/change -> MAJOR.\n' +
+  'Bump SPHERE_CONNECT_VERSION, then update EXPECTED in this file to match.\n';
+
+// Committed snapshot of the wire surface. CHANGE ONLY TOGETHER WITH A VERSION BUMP.
+const EXPECTED = {
+  version: '2.0',
+  intents: [
+    'send', 'dm', 'payment_request', 'receive', 'sign_message',
+    'create_invoice', 'close_invoice', 'cancel_invoice', 'pay_invoice',
+    'return_invoice_payment', 'import_invoice', 'send_invoice_receipts',
+    'send_cancellation_notices', 'set_auto_return', 'mint',
+  ],
+  scopes: [
+    'identity:read', 'balance:read', 'tokens:read', 'history:read',
+    'events:subscribe', 'resolve:peer', 'transfer:request', 'dm:request',
+    'dm:read', 'dm:manage', 'payment:request', 'sign:request', 'mint:request',
+    'invoice:read', 'invoice:write',
+  ],
+  methods: [
+    'sphere_getIdentity', 'sphere_getBalance', 'sphere_getAssets',
+    'sphere_getFiatBalance', 'sphere_getTokens', 'sphere_getHistory',
+    'sphere_resolve', 'sphere_subscribe', 'sphere_unsubscribe', 'sphere_disconnect',
+    'sphere_getConversations', 'sphere_getMessages', 'sphere_getDMUnreadCount',
+    'sphere_markAsRead', 'sphere_getInvoices', 'sphere_getInvoiceStatus',
+  ],
+};
+
+/** Order-independent canonical form so reordering a registry never trips the guard. */
+function canonical(s: { version: string; intents: string[]; scopes: string[]; methods: string[] }) {
+  return {
+    version: s.version,
+    intents: [...s.intents].sort(),
+    scopes: [...s.scopes].sort(),
+    methods: [...s.methods].sort(),
+  };
+}
+
+describe('Connect protocol surface guard', () => {
+  it('wire surface is unchanged (else bump SPHERE_CONNECT_VERSION + update EXPECTED)', () => {
+    const live = {
+      version: SPHERE_CONNECT_VERSION,
+      intents: Object.values(INTENT_ACTIONS),
+      scopes: Object.values(PERMISSION_SCOPES),
+      methods: Object.values(RPC_METHODS),
+    };
+    expect(canonical(live), BUMP_REMINDER).toEqual(canonical(EXPECTED));
+  });
+});


### PR DESCRIPTION
Adds a guard test that snapshots the Sphere Connect wire surface — every intent action, permission scope, and RPC method, plus `SPHERE_CONNECT_VERSION` — and fails on any change with a message reminding the bump rule (add -> MINOR, remove/rename/change -> MAJOR; see docs/CONNECT.md).

Why: the version bump was silently forgotten twice — the mint intent (#602) and the L1 removal (#604) both changed the surface without touching `SPHERE_CONNECT_VERSION`. This test would have caught both. The snapshot is pinned at version 2.0 with the current surface (incl. mint / mint:request), so it also codifies the decision to stay at 2.0.

- `tests/unit/connect/protocol-surface.test.ts` — live-vs-snapshot, order-normalized, `BUMP_REMINDER` as the failure message. Verified it fails-with-reminder when the surface changes, then passes once snapshot+version are updated.
- `docs/CONNECT.md` — one line under the versioning rules pointing at the guard.

CI cost: ~2ms test execution (pure in-memory comparison, no IO) — negligible.

Out of scope (possible follow-ups): a version->surface map that forces a new version entry, and a CI git-diff check requiring the version line to change.
