### PR TITLE
docs(connect): correct CONNECT.md to match the SDK; mark invoicing experimental (Closes #608)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,9 +184,9 @@ Typed RPC layer for dApp ↔ wallet communication. Full guide: [`docs/CONNECT.md
 
 **Queries (16):** `sphere_getIdentity`, `sphere_getBalance`, `sphere_getAssets`, `sphere_getFiatBalance`, `sphere_getTokens`, `sphere_getHistory`, `sphere_resolve`, `sphere_subscribe`, `sphere_unsubscribe`, `sphere_disconnect`, `sphere_getConversations`, `sphere_getMessages`, `sphere_getDMUnreadCount`, `sphere_markAsRead`, `sphere_getInvoices`, `sphere_getInvoiceStatus`.
 
-**Intents (14):** `send`, `dm`, `payment_request`, `receive`, `sign_message`, `create_invoice`, `close_invoice`, `cancel_invoice`, `pay_invoice`, `return_invoice_payment`, `import_invoice`, `send_invoice_receipts`, `send_cancellation_notices`, `set_auto_return`.
+**Intents (15):** `send`, `dm`, `payment_request`, `receive`, `sign_message`, `create_invoice`, `close_invoice`, `cancel_invoice`, `pay_invoice`, `return_invoice_payment`, `import_invoice`, `send_invoice_receipts`, `send_cancellation_notices`, `set_auto_return`, `mint`. (The invoice/accounting intents are experimental and not enabled in the Sphere wallet — see `docs/CONNECT.md`.)
 
-**Permission scopes (14):** `identity:read`, `balance:read`, `tokens:read`, `history:read`, `events:subscribe`, `resolve:peer`, `transfer:request`, `dm:request`, `dm:read`, `dm:manage`, `payment:request`, `sign:request`, `invoice:read`, `invoice:write`.
+**Permission scopes (15):** `identity:read`, `balance:read`, `tokens:read`, `history:read`, `events:subscribe`, `resolve:peer`, `transfer:request`, `dm:request`, `dm:read`, `dm:manage`, `payment:request`, `sign:request`, `mint:request`, `invoice:read`, `invoice:write`.
 
 **Silent mode:** `new ConnectClient({ ..., silent: true })` — fast-check approved list without UI popup.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A modular TypeScript SDK for Unicity wallet operations on Layer 3 (Unicity state
 
 - **Wallet Management** - BIP39/BIP32 key derivation, AES-256 encryption
 - **L3 Payments** - Token transfers via the v2 state-transition token engine, concurrent-send safety (SpendQueue)
-- **Invoicing / Accounting** - On-chain invoice lifecycle with payment attribution, auto-return, privacy-preserving hashed invoice IDs; invoices travel as v2 data-token blobs (hex strings) — `createInvoice()` returns the blob, `importInvoice()` accepts it
+- **Invoicing / Accounting** *(experimental — not production-ready, not enabled in the Sphere wallet)* - On-chain invoice lifecycle with payment attribution, auto-return, privacy-preserving hashed invoice IDs; invoices travel as v2 data-token blobs (hex strings) — `createInvoice()` returns the blob, `importInvoice()` accepts it
 - **Token Swaps** - P2P atomic swaps via escrow with DM-based negotiation protocol
 - **Payment Requests** - Request payments with async response tracking
 - **Market (Intents)** - Signed intent bulletin board with semantic search and live feed

--- a/docs/API.md
+++ b/docs/API.md
@@ -2130,6 +2130,11 @@ Sync Flow:
 
 ## AccountingModule (Invoicing)
 
+> **⚠️ Experimental — not production-ready.** Invoicing/accounting is implemented and
+> unit-tested, but it has no live/e2e verification, is used by no shipped app, and is **not
+> enabled in the Sphere wallet** (nor supported over Connect — see [CONNECT.md](CONNECT.md)).
+> NFT line-items and external delivery methods are placeholders. Treat the API as unstable.
+
 Access via `sphere.accounting` (once registered on the `Sphere` instance).
 
 Manages the full invoice lifecycle: creation, import, payment attribution, status tracking, balance computation, auto-return, and receipt/cancellation-notice delivery. Persists invoice tokens, terminal-state sets, frozen balances, and an incremental invoice-transfer index (§5.4).

--- a/docs/CONNECT.md
+++ b/docs/CONNECT.md
@@ -246,7 +246,7 @@ const result = await autoConnect({
 
 // Use the client
 const balance = await result.client.query('sphere_getBalance');
-await result.client.intent('send', { recipient: '@alice', amount: '1000000', coinId: 'UCT' });
+await result.client.intent('send', { to: '@alice', amount: '10', coinId: '<lowercase 64-hex coin id>' });
 result.client.on('transfer:incoming', (data) => console.log(data));
 
 // Disconnect
@@ -348,9 +348,9 @@ const assets  = await client.query('sphere_getAssets');
 
 // Intents — wallet opens UI for user confirmation
 const txResult = await client.intent('send', {
-  recipient: '@alice',
-  amount: 100,
-  coinId: 'USDC',
+  to: '@alice',
+  amount: '10',                          // whole-token amount, as a string
+  coinId: '<lowercase 64-hex coin id>',
 });
 
 // Sign a message (e.g. challenge-response auth)
@@ -399,31 +399,36 @@ The wallet's `onConnectionRequest` receives `silent=true` and must return `{ app
 | `sphere_getTokens` | `coinId?` | token array |
 | `sphere_getHistory` | — | transaction history |
 | `sphere_resolve` | `identifier` | resolved address info |
-| `sphere_getInvoices` | `state?, createdByMe?, targetingMe?, limit?, offset?, sortBy?, sortOrder?` | `InvoiceRef[]` |
-| `sphere_getInvoiceStatus` | `invoiceId` | `InvoiceStatus` |
+| `sphere_getConversations` | — | DM conversation list |
+| `sphere_getMessages` | `peerPubkey, limit?, before?` | DM message page |
+| `sphere_getDMUnreadCount` | `peerPubkey?` | unread count |
+| `sphere_markAsRead` | `messageIds` | acknowledgement |
 | `sphere_subscribe` | `event` | `{ subscribed, event }` |
 | `sphere_unsubscribe` | `event` | `{ unsubscribed, event }` |
 | `sphere_disconnect` | — | `{ disconnected }` |
+
+> Invoice queries (`sphere_getInvoices`, `sphere_getInvoiceStatus`) exist in the protocol but
+> are experimental and not enabled in the Sphere wallet — see [Experimental](#experimental--not-supported-by-the-sphere-wallet).
 
 ## Intent Actions (require user confirmation)
 
 | Action | Params |
 |--------|--------|
-| `send` | `recipient, amount, coinId` |
-| `dm` | `recipient, content` |
-| `payment_request` | `amount, coinId, description?` |
-| `receive` | `coinId?` |
+| `send` | `to, amount, coinId` |
+| `dm` | `to, message` |
+| `payment_request` | `to, amount, coinId, message?` |
+| `receive` | — |
 | `sign_message` | `message` |
-| `create_invoice` | `targets, dueDate?, memo?, deliveryMethods?, anonymous?` |
-| `close_invoice` | `invoiceId, autoReturn?` |
-| `cancel_invoice` | `invoiceId, autoReturn?` |
-| `pay_invoice` | `invoiceId, targetIndex, assetIndex?, amount?, freeText?, refundAddress?, contact?` |
-| `return_invoice_payment` | `invoiceId, recipient, amount, coinId, freeText?` |
-| `import_invoice` | `token` |
-| `send_invoice_receipts` | `invoiceId, memo?, includeZeroBalance?` |
-| `send_cancellation_notices` | `invoiceId, reason?, dealDescription?, includeZeroBalance?` |
-| `set_auto_return` | `invoiceId, enabled` |
 | `mint` | `coinId` (lowercase hex), `amount` (smallest units) |
+
+> **Amount units:** for `send` and `payment_request`, `amount` is the **whole-token display
+> amount** (what the wallet shows). For `mint`, `amount` is in **smallest units**. Both differ
+> from the token engine's `mintFungibleToken(coinId, amount: bigint)`, which takes base units.
+> `coinId` is always the canonical lowercase 64-hex id (a symbol like `UCT` is rejected).
+>
+> Invoice/accounting intents (`create_invoice` … `set_auto_return`) exist in the protocol but
+> are experimental and not enabled in the Sphere wallet — see
+> [Experimental](#experimental--not-supported-by-the-sphere-wallet).
 
 ### sign_message Intent
 
@@ -470,16 +475,32 @@ const result = await client.intent('mint', {
 
 Requires the `mint:request` permission scope. Minting only succeeds on networks that allow standalone self-mint (testnet2 today); on networks where it is unavailable the wallet returns an error from the token engine.
 
+## Experimental — not supported by the Sphere wallet
+
+Invoicing/accounting is **defined in the protocol** for forward-compatibility but is
+**experimental and not enabled in the Sphere wallet**: it is implemented in the SDK and
+unit-tested, but has no live/e2e verification and is not wired into the wallet. The wallet
+rejects these intents with `METHOD_NOT_FOUND`, and the invoice queries error with
+`MODULE_NOT_AVAILABLE`. **Do not use them yet.**
+
+- **Intents** (scope `invoice:write`, or `transfer:request` for the paying ones):
+  `create_invoice`, `close_invoice`, `cancel_invoice`, `pay_invoice`,
+  `return_invoice_payment`, `import_invoice`, `send_invoice_receipts`,
+  `send_cancellation_notices`, `set_auto_return`.
+- **Queries** (scope `invoice:read`): `sphere_getInvoices`, `sphere_getInvoiceStatus`.
+
 ## Events (wallet → dApp push)
 
-| Event | Payload |
-|-------|---------|
-| `transfer:incoming` | token transfer received |
-| `transfer:confirmed` | transfer confirmed on chain |
-| `transfer:failed` | transfer failed |
-| `balance:updated` | balance changed |
-| `identity:updated` | identity info changed |
-| `session:expired` | session TTL reached |
+| Event | Payload | Delivery |
+|-------|---------|----------|
+| `transfer:incoming` | token transfer received | via `sphere_subscribe` |
+| `transfer:confirmed` | transfer confirmed on chain | via `sphere_subscribe` |
+| `transfer:failed` | transfer failed | via `sphere_subscribe` |
+| `wallet:locked` | wallet locked / logged out | auto-pushed (no subscribe) |
+| `identity:changed` | active identity changed | auto-pushed (no subscribe) |
+
+> Session expiry is **not** an event — the next request after the TTL is rejected with
+> error `4004 SESSION_EXPIRED`.
 
 ### Wallet Lock Handling
 
@@ -501,14 +522,14 @@ client.on('wallet:locked', async () => {
 
 #### Extension / iframe mode (P1, P2)
 
-The wallet's background service worker or parent frame stays alive. Instead of disconnecting, set a `isWalletLocked` flag and wait for the user to unlock. When the wallet is unlocked, the host calls `updateSphere(newSphere)` and fires an `identity:updated` event, which signals the dApp to resume:
+The wallet's background service worker or parent frame stays alive. Instead of disconnecting, set a `isWalletLocked` flag and wait for the user to unlock. When the wallet is unlocked, the host calls `updateSphere(newSphere)` and fires an `identity:changed` event, which signals the dApp to resume:
 
 ```typescript
 client.on('wallet:locked', () => {
   setIsWalletLocked(true);
 });
 
-client.on('identity:updated', (identity) => {
+client.on('identity:changed', (identity) => {
   setIsWalletLocked(false);
   // Refresh UI with new identity if it changed
 });
@@ -587,22 +608,21 @@ Permissions are requested during handshake and checked on every request:
 
 | Scope | Grants access to |
 |-------|-----------------|
-| `identity:read` | `sphere_getIdentity` |
-| `balance:read` | `sphere_getBalance`, `sphere_getFiatBalance` |
-| `assets:read` | `sphere_getAssets` |
+| `identity:read` | `sphere_getIdentity`, `receive` intent (always granted) |
+| `balance:read` | `sphere_getBalance`, `sphere_getFiatBalance`, `sphere_getAssets` |
 | `tokens:read` | `sphere_getTokens` |
 | `history:read` | `sphere_getHistory` |
-| `events:subscribe` | `sphere_subscribe/unsubscribe` |
-| `intent:send` | `send` intent |
-| `intent:dm` | `dm` intent |
-| `intent:payment_request` | `payment_request` intent |
-| `intent:receive` | `receive` intent |
-| `intent:sign_message` | `sign_message` intent |
+| `events:subscribe` | `sphere_subscribe`, `sphere_unsubscribe` |
+| `resolve:peer` | `sphere_resolve` |
+| `transfer:request` | `send` intent |
+| `dm:request` | `dm` intent |
+| `dm:read` | `sphere_getConversations`, `sphere_getMessages`, `sphere_getDMUnreadCount` |
+| `dm:manage` | `sphere_markAsRead` |
+| `payment:request` | `payment_request` intent |
+| `sign:request` | `sign_message` intent |
 | `mint:request` | `mint` intent (self-mint a fungible token) |
-| `comms:read` | DM conversations |
-| `comms:write` | send DMs |
-| `invoice:read` | `sphere_getInvoices`, `sphere_getInvoiceStatus` |
-| `invoice:write` | `create_invoice`, `close_invoice`, `cancel_invoice`, `import_invoice`, `send_invoice_receipts`, `send_cancellation_notices`, `set_auto_return` intents |
+| `invoice:read` | invoice queries (experimental — see above) |
+| `invoice:write` | invoice intents (experimental — see above) |
 
 ---
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -747,6 +747,11 @@ await sphere.communications.broadcast('Hello world!', ['general']);
 
 ## Invoicing / Accounting
 
+> **⚠️ Experimental — not production-ready.** Invoicing/accounting is implemented and
+> unit-tested, but it has no live/e2e verification, is used by no shipped app, and is **not
+> enabled in the Sphere wallet** (nor supported over Connect — see [CONNECT.md](CONNECT.md)).
+> NFT line-items and external delivery methods are placeholders. Treat the API as unstable.
+
 The `AccountingModule` manages the full lifecycle of on-chain invoices: creation, sharing, payment attribution, status tracking, returns, and receipts. An invoice is a v2 **data token** minted via the token engine on the Unicity gateway. Its terms (payment targets, amounts, due date, memo) are embedded in the token's genesis data, making them tamper-evident and independently verifiable by any party who holds the token.
 
 > Invoice creation and import **require the v2 token engine** (oracle with a v2 trust base +

--- a/docs/QUICKSTART-BROWSER.md
+++ b/docs/QUICKSTART-BROWSER.md
@@ -412,6 +412,10 @@ await sphere.communications.sendDM('@alice', 'Hello from the browser!');
 
 ### Invoicing
 
+> **⚠️ Experimental — not production-ready.** Invoicing/accounting is implemented and
+> unit-tested, but it has no live/e2e verification, is used by no shipped app, and is **not
+> enabled in the Sphere wallet** (nor supported over Connect). Treat the API as unstable.
+
 Enable the accounting module when initializing the wallet:
 
 ```typescript

--- a/docs/QUICKSTART-NODEJS.md
+++ b/docs/QUICKSTART-NODEJS.md
@@ -533,6 +533,10 @@ unsubscribe(); // Stop listening
 
 ## Invoicing
 
+> **⚠️ Experimental — not production-ready.** Invoicing/accounting is implemented and
+> unit-tested, but it has no live/e2e verification, is used by no shipped app, and is **not
+> enabled in the Sphere wallet** (nor supported over Connect). Treat the API as unstable.
+
 The `AccountingModule` handles the full invoice lifecycle — creation, status queries, payment, and closing. Enable it by passing `accounting: true` to `Sphere.init()`.
 
 > **Note:** The accounting module requires the Oracle provider (v2 gateway config), which is included by default with `createNodeProviders()`. Invoices are minted as data tokens via the v2 token engine.


### PR DESCRIPTION
## What

Rewrites the Connect docs to match the actual SDK source (`connect/protocol.ts` + `connect/permissions.ts`) and fixes the original #608 field-name / amount-unit issues.

**Closes #608.** Part of the #609 audit (track B1).

## `docs/CONNECT.md`

- **Permission Scopes table** — replaced 8 non-existent scopes (`assets:read`, `intent:send`, `intent:dm`, `intent:payment_request`, `intent:receive`, `intent:sign_message`, `comms:read`, `comms:write`) with the real 15 from `PERMISSION_SCOPES`, mapped correctly (`resolve:peer`, `transfer:request`, `dm:request`, `dm:read`, `dm:manage`, `payment:request`, `sign:request`, `mint:request`, …). `balance:read` now includes `sphere_getAssets`.
- **RPC table** — added the 4 DM query methods (`sphere_getConversations`, `sphere_getMessages`, `sphere_getDMUnreadCount`, `sphere_markAsRead`).
- **Events table** — removed the 3 events that don't exist (`balance:updated`, `identity:updated`, `session:expired`); added the 2 real auto-pushed events (`wallet:locked`, `identity:changed`); noted session expiry is error `4004`, not an event.
- **Wallet-unlock flow** — `identity:updated` → `identity:changed` (the real event) in prose and the snippet (the documented resume flow was non-functional).
- **Intent params (#608)** — `recipient`→`to`, `content`→`message`, `description?`→`message?`; examples use `to` and string amounts. Added an **Amount units** note: `send`/`payment_request` `amount` is the whole-token display amount, `mint` is smallest units, and `coinId` is the canonical lowercase 64-hex id (a symbol like `UCT` is rejected by the wallet — see sphere PR #381).
- **Experimental section** — invoice/accounting intents + the 2 invoice queries are moved out of the usable tables into an "Experimental — not supported by the Sphere wallet" section (per the #609 gate decision: invoicing is implemented + unit-tested but has no live/e2e proof, is used by no app, and is not wired into the wallet).

## `CLAUDE.md`

- "Intents (14)" → **15** (added `mint`); "Permission scopes (14)" → **15** (added `mint:request`).

## Verification

- `grep` for the removed bad tokens (`recipient`, `comms:*`, `intent:*`, `identity:updated`, `balance:updated`, `session:expired`, `assets:read`, `coinId: 'UCT'/'USDC'`) in `docs/CONNECT.md` → no matches.
- Docs-only change (no build).
