### PR TITLE
feat(currency)!: strict parseTokenAmount/safeParseTokenAmount; remove toSmallestUnit (#611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `parseTokenAmount(value, decimals)` / `safeParseTokenAmount(value, decimals)` — strict
+  human-readable → smallest-units parsing with ethers `parseUnits` semantics. `parseTokenAmount`
+  throws `SphereError('INVALID_AMOUNT')` on empty/non-string input, non-decimal strings (sign,
+  scientific notation, hex), and fractional digits exceeding `decimals` (no silent truncation);
+  `safeParseTokenAmount` returns `null` instead of throwing (for live UI input). Adds the
+  `INVALID_AMOUNT` error code.
+
 ### Removed
+- **BREAKING:** Removed `toSmallestUnit` — it silently returned `0n` on invalid input and
+  truncated excess precision (a money-safety footgun). Use `parseTokenAmount` (strict) or
+  `safeParseTokenAmount` (UI input). Display helpers `toHumanReadable` / `formatAmount` are unchanged.
 - **BREAKING:** Removed the entire L1 (ALPHA blockchain) layer — `sphere.payments.l1`, the `L1` namespace, `L1Config`, `identity.l1Address`, the `sphere_l1GetBalance` / `sphere_l1GetHistory` Connect queries, the `l1_send` intent, and the `l1:read` / `l1:transfer` permission scopes. Wallets are now L3-only.
 
 ### Fixed — history disappears on reload (#549)

--- a/README.md
+++ b/README.md
@@ -668,9 +668,10 @@ import {
   getPublicKey, createKeyPair,
 
   // Currency conversion
-  toSmallestUnit,    // "1.5" → 1500000000000000000n
-  toHumanReadable,   // 1500000000000000000n → "1.5"
-  formatAmount,      // Format with decimals and symbol
+  parseTokenAmount,     // "1.5" → 1500000000000000000n (strict; throws on invalid input)
+  safeParseTokenAmount, // like parseTokenAmount but returns null instead of throwing
+  toHumanReadable,      // 1500000000000000000n → "1.5"
+  formatAmount,         // Format with decimals and symbol
 
   // Address encoding
   encodeBech32, decodeBech32,

--- a/core/currency.ts
+++ b/core/currency.ts
@@ -3,7 +3,7 @@
  * Conversion between human-readable amounts and smallest units (bigint)
  */
 
-import { logger } from './logger';
+import { SphereError } from './errors';
 
 // =============================================================================
 // Constants
@@ -17,28 +17,56 @@ export const DEFAULT_TOKEN_DECIMALS = 18;
 // =============================================================================
 
 /**
- * Convert human-readable amount to smallest unit (bigint)
+ * Parse a human-readable decimal amount into smallest units (bigint) — STRICT.
+ *
+ * Mirrors ethers `parseUnits`: throws `SphereError('INVALID_AMOUNT')` on invalid
+ * input rather than silently corrupting the value. Rejects empty/non-string
+ * values, non-decimal strings (sign, scientific notation, hex, junk), and more
+ * fractional digits than `decimals` (NO silent truncation). `'0'` is valid; the
+ * `> 0` business rule is the caller's responsibility.
+ *
+ * For money movement always use this (or {@link safeParseTokenAmount} for live UI
+ * input). Use {@link toHumanReadable} / {@link formatAmount} for display.
  *
  * @example
  * ```ts
- * toSmallestUnit('1.5', 18) // 1500000000000000000n
- * toSmallestUnit('100', 6)  // 100000000n
+ * parseTokenAmount('1.5', 18) // 1500000000000000000n
+ * parseTokenAmount('100', 6)  // 100000000n
+ * parseTokenAmount('1.5', 0)  // throws SphereError('INVALID_AMOUNT')
  * ```
  */
-export function toSmallestUnit(amount: number | string, decimals: number = DEFAULT_TOKEN_DECIMALS): bigint {
-  if (!amount) return 0n;
+export function parseTokenAmount(value: string, decimals: number = DEFAULT_TOKEN_DECIMALS): bigint {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new SphereError('Amount must be a non-empty string', 'INVALID_AMOUNT');
+  }
+  if (!Number.isInteger(decimals) || decimals < 0) {
+    throw new SphereError(`Invalid decimals: ${decimals}`, 'INVALID_AMOUNT');
+  }
+  const str = value.trim();
+  // Unsigned decimal only — no leading '-', no scientific notation, no hex.
+  if (!/^\d+(\.\d+)?$/.test(str)) {
+    throw new SphereError(`Invalid amount: "${value}"`, 'INVALID_AMOUNT');
+  }
+  const [integer, fraction = ''] = str.split('.');
+  if (fraction.length > decimals) {
+    throw new SphereError(`Amount "${value}" exceeds ${decimals} decimal place(s)`, 'INVALID_AMOUNT');
+  }
+  return BigInt(integer + fraction.padEnd(decimals, '0'));
+}
 
+/**
+ * Non-throwing variant of {@link parseTokenAmount} for live UI input: returns
+ * `null` when the value is not (yet) a valid amount. `null` is distinct from a
+ * genuine `0n`, so callers can tell "invalid / mid-typing" from "zero".
+ */
+export function safeParseTokenAmount(
+  value: string,
+  decimals: number = DEFAULT_TOKEN_DECIMALS,
+): bigint | null {
   try {
-    const str = amount.toString();
-    const [integer, fraction = ''] = str.split('.');
-
-    // Pad fraction to exact decimal places, truncate if longer
-    const paddedFraction = fraction.padEnd(decimals, '0').slice(0, decimals);
-
-    return BigInt(integer + paddedFraction);
-  } catch (err) {
-    logger.debug('Currency', 'toSmallestUnit conversion failed', err);
-    return 0n;
+    return parseTokenAmount(value, decimals);
+  } catch {
+    return null;
   }
 }
 
@@ -97,7 +125,8 @@ export function formatAmount(
 // =============================================================================
 
 export const CurrencyUtils = {
-  toSmallestUnit,
+  parseTokenAmount,
+  safeParseTokenAmount,
   toHumanReadable,
   format: formatAmount,
 };

--- a/core/errors.ts
+++ b/core/errors.ts
@@ -39,6 +39,7 @@ export type SphereErrorCode =
   | 'TRANSPORT_ERROR'
   | 'AGGREGATOR_ERROR'
   | 'VALIDATION_ERROR'
+  | 'INVALID_AMOUNT'
   | 'NETWORK_ERROR'
   | 'TIMEOUT'
   | 'DECRYPTION_ERROR'

--- a/docs/API.md
+++ b/docs/API.md
@@ -1492,9 +1492,14 @@ verifySignedMessage(message: string, signature: string, expectedPubkey: string):
 ### Currency Functions
 
 ```typescript
-// Convert human-readable to smallest unit
-toSmallestUnit(amount: number | string, decimals?: number): bigint
+// Parse a human-readable decimal string into smallest units — STRICT.
+// Throws SphereError('INVALID_AMOUNT') on invalid input / excess precision,
+// like ethers `parseUnits` (never silently returns 0n or truncates).
+parseTokenAmount(value: string, decimals?: number): bigint
 // "1.5" with 18 decimals → 1500000000000000000n
+
+// Non-throwing variant for live UI input — returns null (not 0n) when invalid.
+safeParseTokenAmount(value: string, decimals?: number): bigint | null
 
 // Convert smallest unit to human-readable
 toHumanReadable(amount: bigint | string, decimals?: number): string

--- a/index.ts
+++ b/index.ts
@@ -106,7 +106,8 @@ export {
   identityFromMnemonicSync,
   deriveAddressInfo,
   // Currency
-  toSmallestUnit,
+  parseTokenAmount,
+  safeParseTokenAmount,
   toHumanReadable,
   formatAmount,
   // Bech32

--- a/tests/unit/core/currency.test.ts
+++ b/tests/unit/core/currency.test.ts
@@ -5,69 +5,115 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  toSmallestUnit,
+  parseTokenAmount,
+  safeParseTokenAmount,
   toHumanReadable,
   formatAmount,
   DEFAULT_TOKEN_DECIMALS,
   CurrencyUtils,
 } from '../../../core/currency';
+import { SphereError } from '../../../core/errors';
 
 // =============================================================================
-// toSmallestUnit Tests
+// parseTokenAmount Tests (strict — throws on invalid input)
 // =============================================================================
 
-describe('toSmallestUnit()', () => {
+describe('parseTokenAmount()', () => {
   it('should convert integer amounts', () => {
-    expect(toSmallestUnit('1', 18)).toBe(1000000000000000000n);
-    expect(toSmallestUnit('100', 18)).toBe(100000000000000000000n);
+    expect(parseTokenAmount('1', 18)).toBe(1000000000000000000n);
+    expect(parseTokenAmount('100', 18)).toBe(100000000000000000000n);
   });
 
   it('should convert decimal amounts', () => {
-    expect(toSmallestUnit('1.5', 18)).toBe(1500000000000000000n);
-    expect(toSmallestUnit('0.1', 18)).toBe(100000000000000000n);
+    expect(parseTokenAmount('1.5', 18)).toBe(1500000000000000000n);
+    expect(parseTokenAmount('0.1', 18)).toBe(100000000000000000n);
   });
 
   it('should handle different decimal places', () => {
-    expect(toSmallestUnit('1.5', 6)).toBe(1500000n);
-    expect(toSmallestUnit('100', 6)).toBe(100000000n);
-    expect(toSmallestUnit('1.23', 2)).toBe(123n);
+    expect(parseTokenAmount('1.5', 6)).toBe(1500000n);
+    expect(parseTokenAmount('100', 6)).toBe(100000000n);
+    expect(parseTokenAmount('1.23', 2)).toBe(123n);
   });
 
-  it('should handle number input', () => {
-    expect(toSmallestUnit(1.5, 18)).toBe(1500000000000000000n);
-    expect(toSmallestUnit(100, 6)).toBe(100000000n);
+  it('should pad short fractions', () => {
+    expect(parseTokenAmount('1.5', 18)).toBe(1500000000000000000n);
+    expect(parseTokenAmount('1.05', 18)).toBe(1050000000000000000n);
   });
 
-  it('should truncate extra decimal places', () => {
-    // 1.123456789012345678901 with 18 decimals should truncate to 18
-    expect(toSmallestUnit('1.1234567890123456789', 18)).toBe(1123456789012345678n);
-  });
-
-  it('should pad short decimal places', () => {
-    expect(toSmallestUnit('1.5', 18)).toBe(1500000000000000000n);
-    expect(toSmallestUnit('1.05', 18)).toBe(1050000000000000000n);
-  });
-
-  it('should return 0n for empty/falsy input', () => {
-    expect(toSmallestUnit('', 18)).toBe(0n);
-    expect(toSmallestUnit(0, 18)).toBe(0n);
-  });
-
-  it('should handle zero amounts', () => {
-    expect(toSmallestUnit('0', 18)).toBe(0n);
-    expect(toSmallestUnit('0.0', 18)).toBe(0n);
+  it('should accept zero', () => {
+    expect(parseTokenAmount('0', 18)).toBe(0n);
+    expect(parseTokenAmount('0.0', 18)).toBe(0n);
   });
 
   it('should use default decimals (18)', () => {
-    expect(toSmallestUnit('1')).toBe(1000000000000000000n);
+    expect(parseTokenAmount('1')).toBe(1000000000000000000n);
   });
 
-  it('should handle very large amounts', () => {
-    expect(toSmallestUnit('1000000000', 18)).toBe(1000000000000000000000000000n);
+  it('should handle very large and very small amounts', () => {
+    expect(parseTokenAmount('1000000000', 18)).toBe(1000000000000000000000000000n);
+    expect(parseTokenAmount('0.000000000000000001', 18)).toBe(1n);
   });
 
-  it('should handle very small amounts', () => {
-    expect(toSmallestUnit('0.000000000000000001', 18)).toBe(1n);
+  // Strict behaviour: throw instead of silently returning 0n / truncating.
+
+  it('should throw on empty or whitespace input', () => {
+    expect(() => parseTokenAmount('')).toThrow(SphereError);
+    expect(() => parseTokenAmount('   ')).toThrow(SphereError);
+  });
+
+  it('should throw on non-decimal input', () => {
+    expect(() => parseTokenAmount('abc')).toThrow(SphereError);
+    expect(() => parseTokenAmount('1e18')).toThrow(SphereError);
+    expect(() => parseTokenAmount('0x10')).toThrow(SphereError);
+    expect(() => parseTokenAmount('1.')).toThrow(SphereError);
+    expect(() => parseTokenAmount('.5')).toThrow(SphereError);
+  });
+
+  it('should throw on negative amounts', () => {
+    expect(() => parseTokenAmount('-1', 18)).toThrow(SphereError);
+  });
+
+  it('should throw on excess precision instead of truncating', () => {
+    expect(() => parseTokenAmount('1.1234567890123456789', 18)).toThrow(SphereError);
+    expect(() => parseTokenAmount('1.5', 0)).toThrow(SphereError);
+  });
+
+  it('should throw on invalid decimals', () => {
+    expect(() => parseTokenAmount('1', -1)).toThrow(SphereError);
+    expect(() => parseTokenAmount('1', 1.5)).toThrow(SphereError);
+  });
+
+  it('should use the INVALID_AMOUNT error code', () => {
+    let caught: unknown;
+    try {
+      parseTokenAmount('nope');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SphereError);
+    expect((caught as SphereError).code).toBe('INVALID_AMOUNT');
+  });
+});
+
+// =============================================================================
+// safeParseTokenAmount Tests (non-throwing — null on invalid input)
+// =============================================================================
+
+describe('safeParseTokenAmount()', () => {
+  it('should return the parsed value for valid input', () => {
+    expect(safeParseTokenAmount('1.5', 18)).toBe(1500000000000000000n);
+    expect(safeParseTokenAmount('100', 6)).toBe(100000000n);
+  });
+
+  it('should return 0n for a genuine zero', () => {
+    expect(safeParseTokenAmount('0', 18)).toBe(0n);
+  });
+
+  it('should return null (not 0n) for invalid / mid-typing input', () => {
+    expect(safeParseTokenAmount('', 18)).toBeNull();
+    expect(safeParseTokenAmount('1.', 18)).toBeNull();
+    expect(safeParseTokenAmount('abc', 18)).toBeNull();
+    expect(safeParseTokenAmount('1.5', 0)).toBeNull();
   });
 });
 
@@ -180,8 +226,12 @@ describe('formatAmount()', () => {
 // =============================================================================
 
 describe('CurrencyUtils namespace', () => {
-  it('should export toSmallestUnit', () => {
-    expect(CurrencyUtils.toSmallestUnit('1', 18)).toBe(1000000000000000000n);
+  it('should export parseTokenAmount', () => {
+    expect(CurrencyUtils.parseTokenAmount('1', 18)).toBe(1000000000000000000n);
+  });
+
+  it('should export safeParseTokenAmount', () => {
+    expect(CurrencyUtils.safeParseTokenAmount('bad', 18)).toBeNull();
   });
 
   it('should export toHumanReadable', () => {
@@ -210,28 +260,28 @@ describe('DEFAULT_TOKEN_DECIMALS', () => {
 describe('Round-trip conversions', () => {
   it('should round-trip integer amounts', () => {
     const original = '123';
-    const smallest = toSmallestUnit(original, 18);
+    const smallest = parseTokenAmount(original, 18);
     const back = toHumanReadable(smallest, 18);
     expect(back).toBe(original);
   });
 
   it('should round-trip decimal amounts', () => {
     const original = '1.5';
-    const smallest = toSmallestUnit(original, 18);
+    const smallest = parseTokenAmount(original, 18);
     const back = toHumanReadable(smallest, 18);
     expect(back).toBe(original);
   });
 
   it('should round-trip with different decimals', () => {
     const original = '123.456';
-    const smallest = toSmallestUnit(original, 6);
+    const smallest = parseTokenAmount(original, 6);
     const back = toHumanReadable(smallest, 6);
     expect(back).toBe(original);
   });
 
   it('should round-trip zero', () => {
     const original = '0';
-    const smallest = toSmallestUnit(original, 18);
+    const smallest = parseTokenAmount(original, 18);
     const back = toHumanReadable(smallest, 18);
     expect(back).toBe(original);
   });


### PR DESCRIPTION
## What

Replaces the lenient `toSmallestUnit` with a strict, ethers-`parseUnits`-aligned amount parser. Part of #611 — track **S1**.

`toSmallestUnit` silently returned `0n` on invalid input and silently truncated excess precision — a money-safety footgun and a deviation from the ethers/web3 standard (which throw). It also conflated "zero" with "invalid".

## Changes

- **`core/currency.ts`**
  - `parseTokenAmount(value: string, decimals = 18): bigint` — strict. Throws `SphereError('INVALID_AMOUNT')` on: empty / non-string, non-decimal strings (sign, scientific notation, hex, junk), negative, and fractional digits `>` `decimals` (no silent truncation). `'0'` is valid; the `> 0` business rule stays with callers.
  - `safeParseTokenAmount(value: string, decimals = 18): bigint | null` — non-throwing variant for live UI input; `null` (≠ `0n`) when not a valid amount.
  - **Removed `toSmallestUnit`** (and its `CurrencyUtils.toSmallestUnit` member). `toHumanReadable` / `formatAmount` (display) are unchanged.
- **`core/errors.ts`** — adds the `INVALID_AMOUNT` error code.
- **`index.ts`** — exports `parseTokenAmount` / `safeParseTokenAmount`; removes the `toSmallestUnit` export.
- **Tests** — `tests/unit/core/currency.test.ts` rewritten for the strict contract (throw cases mirror ethers; `safeParse` null cases). 43 tests pass.
- **Docs** — `docs/API.md` + `README.md` currency section + `CHANGELOG.md`.

## Breaking

`toSmallestUnit` is removed (`feat!`). Consumers must migrate: `parseTokenAmount(x).toString()` for the smallest-unit string previously produced by `toSmallestUnit(x).toString()`, or `safeParseTokenAmount` for live UI input. The Sphere wallet migration is **S2** (separate PR); it stays on its current pinned SDK until then. `sphere-extension` is out of scope; `agentic-chatbot/chess-bot` pins `0.7.1` and is unaffected.

## Verification

- `npx vitest run tests/unit/core/currency.test.ts` → **43 passed**.
- `eslint` on changed files → clean.
- `typecheck`: the only error is a **pre-existing** one in `token-engine/SphereTokenEngine.ts:255` (a local `node_modules` SDK-rc skew, present on clean `main` without these changes; CI typechecks against the pinned SDK and is green). The currency/errors/index changes add no type errors.
