### PR TITLE
fix(transport)(sphere-sdk#559): re-export SendMessageOptions from top-level index

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -195,6 +195,7 @@ export type {
   TransportEvent,
   TransportEventType,
   TransportEventCallback,
+  SendMessageOptions,
 } from './transport';
 
 export type {


### PR DESCRIPTION
## Summary

PR #558 added the `SendMessageOptions` interface to `transport/transport-provider.ts` and the transport barrel (`transport/index.ts`) re-exports it via `export *`, but the explicit type allow-list in the top-level `index.ts` (lines 184-198) does not.

Consumers importing from `@unicitylabs/sphere-sdk` hit:

```
TS2459: Module '"@unicitylabs/sphere-sdk"' declares 'SendMessageOptions'
locally, but it is not exported.
```

Surfaced when wiring F3 (sphere-cli HMCP+ACP `selfWrap: false` opt-out) — the natural consumer of the new API.

## Change

One-line addition to the existing transport allow-list in `index.ts`. No behavior change.

```diff
   TransportEvent,
   TransportEventType,
   TransportEventCallback,
+  SendMessageOptions,
 } from './transport';
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] After merge: `npx tsc --noEmit` in sphere-cli on the F3 branch resolves the import without errors

## Related

- #555 — original investigation
- #559 — fresh-wallet backlog + F1 verdict
- PR #558 — M8 self-wrap opt-out (introduced `SendMessageOptions`)
- PR #582 — F1 instrumentation