### PR TITLE
fix(soak): trader-roundtrip §4 ACP probe — pipefail+SIGPIPE race masked every success as timeout

### DIFF
--- a/manual-test-trader-roundtrip.sh
+++ b/manual-test-trader-roundtrip.sh
@@ -487,20 +487,35 @@ create_intent_with_shim() {
 wait_for_tenant_running() {
   local peer="$1" wallet="$2" instance="$3" tenant_nt="$4" log="$5" timeout_s="$6"
   local deadline=$(( $(date +%s) + timeout_s ))
+  local iter=0
   cd "$peer"
   sphere wallet use "$wallet"
+  # BUG FIX (2026-06-21): previous version used a pipeline
+  #   `sphere ... 2>&1 | tee "$log" | grep -qE '"balances"|balances'`
+  # which under `set -o pipefail` (set at the top of this script) ALWAYS
+  # returned non-zero because `grep -q` exits on the first match,
+  # triggering SIGPIPE upstream → tee/sphere die with rc=141 → pipefail
+  # surfaces 141 → the `if` evaluates false. Every probe iteration
+  # SUCCEEDED at the ACP level (the tenant responded with a valid
+  # `"balances": []` JSON payload) but the harness interpreted every
+  # response as a failure, then asserted FAIL at the 180s deadline.
+  # Rewriting to a temp-file pattern eliminates the SIGPIPE race.
+  : > "$log"  # truncate at start of loop
   while (( $(date +%s) < deadline )); do
-    if sphere trader portfolio --tenant "@$tenant_nt" --timeout 20000 \
-         2>&1 | tee "$log" \
-         | grep -qE '"balances"|balances'; then
-      echo "INFO: $instance accepted ACP probe (portfolio)"
+    iter=$(( iter + 1 ))
+    echo "===== probe iter #${iter} at $(date +%H:%M:%S) ($(date +%s)) =====" >> "$log"
+    local iter_out
+    iter_out=$(sphere trader portfolio --tenant "@$tenant_nt" --timeout 20000 2>&1) || true
+    printf '%s\n' "$iter_out" >> "$log"
+    if printf '%s' "$iter_out" | grep -qE '"balances"|balances'; then
+      echo "INFO: $instance accepted ACP probe (portfolio) at iter #${iter}"
       return 0
     fi
-    echo "  $instance ACP probe not ready yet — sleeping 5 s…"
+    echo "  $instance ACP probe not ready yet (iter #${iter}) — sleeping 5 s…"
     sleep 5
   done
-  echo "ASSERT FAIL (tenant-running): $instance did not pass ACP probe within ${timeout_s}s" >&2
-  tail -30 "$log" >&2 || true
+  echo "ASSERT FAIL (tenant-running): $instance did not pass ACP probe within ${timeout_s}s (iters=${iter})" >&2
+  tail -60 "$log" >&2 || true
   return 1
 }
 


### PR DESCRIPTION
## Summary

`manual-test-trader-roundtrip.sh` always failed at Section 4 ("ACP smoke probe each tenant") with `ASSERT FAIL (tenant-running) ... did not pass ACP probe within 180s` — despite tenants being fully responsive in 2-3 seconds per probe.

Root cause: `set -o pipefail` + `grep -q` SIGPIPE race in `wait_for_tenant_running()`. Every probe succeeded; the script interpreted every success as a timeout.

## Cause in detail

```bash
if sphere trader portfolio ... 2>&1 | tee "$log" | grep -qE '"balances"|balances'; then
```

`grep -q` exits on first match → closes stdin → SIGPIPE upstream → `sphere` exits 141 → pipefail surfaces 141 → `if` evaluates false → "not ready" branch fires → repeat for 180s.

Verified with this minimal reproducer:

```bash
set -eo pipefail
if sphere trader portfolio ... 2>&1 | tee log | grep -qE '"balances"'; then
  echo MATCH
else
  echo "NO MATCH (rc=$?)"   # prints "NO MATCH (rc=141)"
fi
set +o pipefail
if sphere trader portfolio ... 2>&1 | tee log | grep -qE '"balances"'; then
  echo MATCH                # prints MATCH
fi
```

## Fix

Capture probe output to a variable (no pipe → no SIGPIPE → no pipefail surfacing), append to log, then grep the variable.

## Verification — full trader-roundtrip soak completed

This is the **first time any soak run has progressed past §4** in the recent investigation history.

| Section | Result |
|---|---|
| §4 ACP probe | ✅ both tenants accepted on iter #1 |
| §5 deposits | ✅ UCT and ETH confirmed in both tenant portfolios |
| §6 / §7 intents | ✅ alice SELL + bob BUY posted and listed |
| §8 autonomous settlement | ✅ deal-completed both sides |
| §9 rate sanity | ✅ agreed rate=0.0849… (midpoint of 0.08–0.09 band) |
| §10 portfolio delta | ⚠️ delta=0 (portfolio reflection lag — separate issue, unrelated to settlement) |
| §11 hygiene | ✅ no FAILED deals, no poison-pill |

## Related

The bug masquerading as a transport issue in [sphere-sdk#559](https://github.com/unicity-sphere/sphere-sdk/issues/559) was always this script bug at the §4 layer. The genuine relay-pollution findings from #559's F1 measurement (the per-spawn new-event count + the §3 buffered count) remain valid and unaffected — those measurements were on the spawn-flow side, not on the §4 probe.

## Test plan

- [x] Reproduce the SIGPIPE+pipefail interaction in isolation
- [x] Apply fix and re-run the full soak end-to-end
- [x] Confirm §4 passes on iter #1 + §8 settles
- [ ] (Follow-up) Investigate §10 portfolio-delta lag — separate issue