### PR TITLE
fix(soak): trader-roundtrip §10 portfolio_balance — handle trailing log lines via JSONDecoder.raw_decode

### DIFF
--- a/manual-test-trader-roundtrip.sh
+++ b/manual-test-trader-roundtrip.sh
@@ -548,8 +548,14 @@ except Exception:
 m = re.search(r'(\{|\[)', raw)
 if not m:
     print("0"); sys.exit(0)
+# Use raw_decode so we only consume the FIRST complete JSON value and
+# tolerate trailing log lines (e.g. `[ipfs-client] WARN ...`) that tee
+# can append AFTER the portfolio JSON. Previous version used json.loads
+# which fails with "Extra data" on any trailing text and silently
+# returned 0 for every snapshot — yielding 0-delta in §10 even after a
+# real settlement.
 try:
-    data = json.loads(raw[m.start():])
+    data, _ = json.JSONDecoder().raw_decode(raw[m.start():])
 except Exception:
     print("0"); sys.exit(0)
 def find_balances(obj):


### PR DESCRIPTION
## Summary

After PR #615 unblocked the full soak by fixing the §4 pipefail bug, §10 (portfolio delta verification) failed every assertion with `delta=0`. The underlying trade settled correctly — alice received 4.25 ETH (exact midpoint of the [0.08, 0.09] band × 50 UCT) and bob received 50 UCT. The §10 parser silently returned 0 for every snapshot because `json.loads()` chokes on the trailing `[ipfs-client] WARN ...` log line that `tee` reliably appends after the JSON.

## Cause

`portfolio_balance()` reads each snapshot like:

```json
{
  "command_id": "...",
  "ok": true,
  "result": { ..., "balances": [ ... ] }
}
[2026-06-21T09:39:23.399Z] [WARN ] [ipfs-client] #370 capability probe ...
```

`json.loads()` is strict about extra data; it throws `JSONDecodeError: Extra data: line 20 column 1`. The outer `try/except` catches it and falls through to `print("0")`. Every snapshot reads as 0 → every delta computes 0 − 0 → every assertion fails.

## Fix

Use `json.JSONDecoder().raw_decode()` instead — parses the first complete JSON value and returns `(obj, end_index)`, tolerating anything after.

## Verification

Re-ran the fixed parser against the preserved workspace from the last soak:

| Source | UCT | ETH |
|---|---|---|
| alice baseline | 50e18 | 0 |
| alice final | 0 | 4.25e18 |
| bob baseline | 0 | 4.5e18 |
| bob final | 50e18 | 0.25e18 |

| Assertion | Result |
|---|---|
| alice UCT delta (sold) = expected 50e18 | ✅ |
| bob UCT delta (received) = expected 50e18 | ✅ |
| ETH symmetry (alice received == bob sold == 4.25e18) | ✅ |
| alice ETH delta ∈ [4e18, 4.5e18] | ✅ |

All §10 assertions pass with the parser fix.

## Companion to #615

This + #615 together unblock the full soak end-to-end. The underlying trade roundtrip protocol has been working correctly all along — both bugs were purely in the test harness.

## Test plan

- [x] Apply fix and re-validate against existing snapshots → all assertions pass
- [ ] (Follow-up) Run a fresh soak with both #615 and this PR landed to confirm green end-to-end