### PR TITLE
fix(compat): route bare crypto.randomUUID() through a browser-safe helper (#619)

### DIFF
--- a/core/utils.ts
+++ b/core/utils.ts
@@ -191,14 +191,8 @@ export function randomHex(byteLength: number): string {
 }
 
 /**
- * Generate random UUID v4
+ * Generate a v4 UUID. Re-exported from {@link ./uuid} — a browser-safe,
+ * dependency-free implementation (native `crypto.randomUUID` with a
+ * `crypto.getRandomValues` fallback; no node:crypto require). See sphere-sdk#619.
  */
-export function randomUUID(): string {
-  if (typeof globalThis.crypto !== 'undefined' && globalThis.crypto.randomUUID) {
-    return globalThis.crypto.randomUUID();
-  }
-  // Fallback
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const nodeCrypto = require('crypto');
-  return nodeCrypto.randomUUID();
-}
+export { randomUUID } from './uuid';

--- a/core/uuid.ts
+++ b/core/uuid.ts
@@ -1,0 +1,30 @@
+/**
+ * Browser-safe UUID v4 generation.
+ *
+ * Kept dependency-free (no node:crypto require, unlike core/utils.ts) so it is
+ * safe to import from the platform:'browser' bundles and the token-engine
+ * subpath without dragging a Node builtin into them.
+ */
+
+/**
+ * Generate a v4 UUID.
+ *
+ * Prefers `crypto.randomUUID()` (secure context; Safari 15.4+, Chrome 92+,
+ * Node 19+). Falls back to deriving one from `crypto.getRandomValues()`, which
+ * is available in every browser — including insecure / non-HTTPS contexts and
+ * older WebViews — and in Node 20+. This avoids
+ * `crypto.randomUUID is not a function` on sub-15.4 / insecure-context runtimes
+ * (sphere-sdk#619), with no node:crypto fallback that would break browser bundles.
+ */
+export function randomUUID(): string {
+  const c = globalThis.crypto;
+  if (typeof c !== 'undefined' && typeof c.randomUUID === 'function') {
+    return c.randomUUID();
+  }
+  // RFC 4122 v4 from CSPRNG bytes.
+  const b = c.getRandomValues(new Uint8Array(16));
+  b[6] = (b[6] & 0x0f) | 0x40; // version 4
+  b[8] = (b[8] & 0x3f) | 0x80; // variant 10xx
+  const h = Array.from(b, (x) => x.toString(16).padStart(2, '0'));
+  return `${h[0]}${h[1]}${h[2]}${h[3]}-${h[4]}${h[5]}-${h[6]}${h[7]}-${h[8]}${h[9]}-${h[10]}${h[11]}${h[12]}${h[13]}${h[14]}${h[15]}`;
+}

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -30,6 +30,8 @@
  */
 
 import { sha256 } from '@noble/hashes/sha2.js';
+
+import { randomUUID } from '../../../core/uuid';
 import type {
   ApplyDeltaAdded,
   ApplyDeltaOptions,
@@ -77,7 +79,7 @@ function hexToBytes(hex: string): Uint8Array {
 }
 
 function newTransferId(): string {
-  return (globalThis as { crypto: { randomUUID(): string } }).crypto.randomUUID();
+  return randomUUID();
 }
 
 /** A stored v2 token entry (the UI token record with a hex CBOR blob). */

--- a/impl/shared/wallet-api/composition.ts
+++ b/impl/shared/wallet-api/composition.ts
@@ -34,6 +34,7 @@ import type { DeliveryProvider } from '../../../transport/delivery-provider';
 import type { OracleProvider } from '../../../oracle';
 import type { TokenBlob } from '../../../token-engine/types';
 import { WalletApiClient } from '../../../wallet-api';
+import { randomUUID } from '../../../core/uuid';
 import type { FetchLike, KeyValueStore, WebSocketFactoryLike } from '../../../wallet-api';
 import { WalletApiTokenStorageProvider } from './WalletApiTokenStorageProvider';
 import { WalletApiMailboxProvider } from './WalletApiMailboxProvider';
@@ -130,7 +131,7 @@ function buildClient(base: SphereBaseProviders, config: WalletApiCompositionConf
     new WalletApiClient({
       baseUrl: config.baseUrl,
       network: config.network,
-      deviceId: config.deviceId ?? `sphere-${crypto.randomUUID()}`,
+      deviceId: config.deviceId ?? `sphere-${randomUUID()}`,
       storage: stateStore,
       fetchFn: config.fetchFn,
       webSocketFactory: config.webSocketFactory,

--- a/modules/communications/CommunicationsModule.ts
+++ b/modules/communications/CommunicationsModule.ts
@@ -5,6 +5,7 @@
 
 import { logger } from '../../core/logger';
 import { SphereError } from '../../core/errors';
+import { randomUUID } from '../../core/uuid';
 import { createTransportAddressResolver, type TransportAddressResolver } from '../../core/transport-resolver';
 import type {
   DirectMessage,
@@ -482,7 +483,7 @@ export class CommunicationsModule {
     const eventId = await this.deps!.transport.publishBroadcast?.(content, tags);
 
     const message: BroadcastMessage = {
-      id: eventId ?? crypto.randomUUID(),
+      id: eventId ?? randomUUID(),
       authorPubkey: this.deps!.identity.chainPubkey,
       authorNametag: this.deps!.identity.nametag,
       content,

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -77,6 +77,7 @@ import { SphereError } from '../../core/errors';
 import { sha256, bytesToHex, hexToBytes } from '../../core/crypto';
 import { sleep } from '../../core/utils';
 import { timeoutSignal } from '../../core/timeout';
+import { randomUUID } from '../../core/uuid';
 import { decodeTokenBlob, encodeTokenBlob, unwrapTokenBlobBytes, TOKEN_BLOB_VERSION } from '../../token-engine/token-blob';
 import { parseInvoiceMemoForOnChain } from '../accounting/memo.js';
 
@@ -99,7 +100,7 @@ export type TransactionHistoryEntry = import('../../storage').HistoryRecord;
 function computeHistoryDedupKey(type: string, tokenId?: string, transferId?: string): string {
   if (type === 'SENT' && transferId) return `${type}_transfer_${transferId}`;
   if (tokenId) return `${type}_${tokenId}`;
-  return `${type}_${crypto.randomUUID()}`;
+  return `${type}_${randomUUID()}`;
 }
 
 /** Maximum number of history entries to include in IPFS-synced TXF data */
@@ -1511,7 +1512,7 @@ export class PaymentsModule {
 
     // Use mutable result for building the transfer
     const result: { -readonly [K in keyof TransferResult]: TransferResult[K] } = {
-      id: internal?.existingReservationId ?? crypto.randomUUID(),
+      id: internal?.existingReservationId ?? randomUUID(),
       status: 'pending',
       tokens: [],
       tokenTransfers: [],
@@ -2210,7 +2211,7 @@ export class PaymentsModule {
 
       // Send via transport
       const eventId = await this.deps!.transport.sendPaymentRequest(recipientPubkey, payload);
-      const requestId = crypto.randomUUID();
+      const requestId = randomUUID();
 
       // Track outgoing request
       const outgoingRequest: OutgoingPaymentRequest = {
@@ -3586,7 +3587,7 @@ export class PaymentsModule {
 
     const dedupKey = computeHistoryDedupKey(entry.type, entry.tokenId, entry.transferId);
     const historyEntry: TransactionHistoryEntry = {
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       dedupKey,
       ...entry,
     };
@@ -3626,7 +3627,7 @@ export class PaymentsModule {
         await walletApi.postHistoryRecords([
           {
             dedupKey: historyEntry.dedupKey,
-            id: crypto.randomUUID(),
+            id: randomUUID(),
             type: historyEntry.type,
             ts: new Date(historyEntry.timestamp).toISOString(),
             assets: [{ coinId: historyEntry.coinId, amount: historyEntry.amount }],

--- a/tests/unit/core/uuid.test.ts
+++ b/tests/unit/core/uuid.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for core/uuid.ts (browser-safe randomUUID).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from '../../../core/uuid';
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('randomUUID()', () => {
+  it('returns a valid v4 UUID on the native fast-path', () => {
+    expect(randomUUID()).toMatch(UUID_V4);
+  });
+
+  it('returns distinct values', () => {
+    expect(randomUUID()).not.toBe(randomUUID());
+  });
+
+  // sphere-sdk#619: sub-15.4 / insecure-context (non-HTTPS) WebViews expose
+  // `crypto` but not `crypto.randomUUID`. The bare call sites threw
+  // "crypto.randomUUID is not a function"; the getRandomValues fallback fixes it.
+  describe('fallback path (crypto.getRandomValues only)', () => {
+    beforeEach(() => {
+      // Shadow the prototype method so the helper sees randomUUID as absent.
+      Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        value: undefined,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      // Remove the own shadow, restoring the prototype's randomUUID.
+      delete (globalThis.crypto as { randomUUID?: unknown }).randomUUID;
+    });
+
+    it('derives a valid v4 UUID from getRandomValues when randomUUID is absent', () => {
+      expect(typeof globalThis.crypto.randomUUID).not.toBe('function');
+      expect(randomUUID()).toMatch(UUID_V4);
+    });
+
+    it('still returns distinct values via the fallback', () => {
+      expect(randomUUID()).not.toBe(randomUUID());
+    });
+  });
+});

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -13,6 +13,7 @@
  */
 
 import { SphereError, type SphereErrorCode } from '../core/errors';
+import { randomUUID } from '../core/uuid';
 import { TransferConflictError } from './errors';
 import { deriveDirectAddress, UNICITY_TOKEN_TYPE_HEX } from './identity';
 import { deriveDeliveryKeys } from './blob-keys';
@@ -380,7 +381,7 @@ export class SphereTokenEngine implements ITokenEngine {
   }
 
   private resolveTransferId(options?: EngineOpOptions): string {
-    const transferId = options?.transferId ?? crypto.randomUUID();
+    const transferId = options?.transferId ?? randomUUID();
     if (!TRANSFER_ID_RE.test(transferId)) {
       throw new SphereError(
         `transferId must be a canonical lowercase UUID string, got "${transferId}"`,


### PR DESCRIPTION
Closes #619 — follow-up from the browser-compat audit (#617).

## Problem

`crypto.randomUUID()` needs Safari 15.4 / Chrome 92 / Node 19+ **and a secure (HTTPS) context**. Several sites called it **bare** (no feature-detect, no fallback). On sub-15.4 in-app/WebView browsers, or non-HTTPS/insecure-context origins where `crypto` exists but `crypto.randomUUID` is `undefined`, the spend/transfer path throws `crypto.randomUUID is not a function`. (This is *not* the #617 crash — that was `AbortSignal.timeout`, Safari 16 — but the same class of old-browser hazard.)

## Fix

New `core/uuid.ts` — a dependency-free `randomUUID()`:
- native `crypto.randomUUID()` when present,
- else derives a v4 UUID from `crypto.getRandomValues()` (available in every browser incl. insecure contexts, and Node 20+).

It carries **no `node:crypto` require**, so it is safe to import from the `platform:'browser'` bundles and the `token-engine` subpath — unlike `core/utils.ts`, whose `require('crypto')` cannot resolve there (the build break that bit #618).

Routed the **9 bare sites** through it:
- `PaymentsModule` ×5
- `token-engine/SphereTokenEngine.ts` `resolveTransferId` — the random source is only used when no `transferId` is supplied; when one is (the normal send path), it's untouched, so **§8.1 resume determinism is unaffected**
- `impl/shared/wallet-api/WalletApiTokenStorageProvider.ts` (`newTransferId`)
- `impl/shared/wallet-api/composition.ts` (`deviceId`)
- `modules/communications/CommunicationsModule.ts`

`connect/protocol.ts` already feature-detects — left as-is. `core/utils.randomUUID` now re-exports the browser-safe helper, dropping its node-only `require('crypto')` fallback.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` (changed files) — 0 errors (2 pre-existing warnings)
- `npx vitest run` core/uuid + core/utils — 44 passed, incl. a regression test that stubs `crypto.randomUUID = undefined` and asserts the `getRandomValues` fallback yields a valid v4 UUID
- Bundled all 11 tsup entries (every platform) to a temp outDir — no `Could not resolve "crypto"`

## Scope

No contract/API/schema change. Behavior is identical on modern runtimes (native fast-path); only the fallback path changes (was broken in browsers, now works).