### PR TITLE
fix(payments): recipient-side mailbox state must never fail the sender (§3.1, #621)

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -5263,34 +5263,55 @@ export class PaymentsModule {
 
     let changeOutput: SphereToken | null = null;
     if (payload.split) {
-      const blob = await provider.getToken(payload.split.tokenId);
-      const source = await engine.decodeToken(blob);
-      const selfChainPubkey = hexToBytes(this.deps!.identity.chainPubkey);
-      const { outputs } = await engine.split(
-        {
-          token: source,
-          outputs: [
+      // Split opIndex follows the direct ops — replayed from the intent's order (§8.1).
+      const splitOpIndex = payload.direct.length;
+      const existingSplit = journaled.get(splitOpIndex);
+      if (existingSplit) {
+        // #621/#622-review: the split already certified in the original send — re-deliver the journaled
+        // recipient blob, never re-run engine.split on the spent source (it would TransferConflictError
+        // and wedge). The change output is handled by the conflict path below / a resync.
+        await deliverBlob(existingSplit.tokenBlob, splitOpIndex);
+      } else {
+        try {
+          const blob = await provider.getToken(payload.split.tokenId);
+          const source = await engine.decodeToken(blob);
+          const selfChainPubkey = hexToBytes(this.deps!.identity.chainPubkey);
+          const { outputs } = await engine.split(
             {
-              recipientPubkey: recipientChainPubkey,
-              coinId: payload.coinId,
-              amount: BigInt(payload.split.splitAmount),
-              data: memoData,
+              token: source,
+              outputs: [
+                {
+                  recipientPubkey: recipientChainPubkey,
+                  coinId: payload.coinId,
+                  amount: BigInt(payload.split.splitAmount),
+                  data: memoData,
+                },
+                {
+                  recipientPubkey: selfChainPubkey,
+                  coinId: payload.coinId,
+                  amount: BigInt(payload.split.remainderAmount),
+                },
+              ],
             },
-            {
-              recipientPubkey: selfChainPubkey,
-              coinId: payload.coinId,
-              amount: BigInt(payload.split.remainderAmount),
-            },
-          ],
-        },
-        // Split opIndex follows the direct ops — replayed from the intent's order (§8.1).
-        { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId, opIndex: payload.direct.length }
-      );
-      changeOutput = outputs[1];
-      // critical (#515 F2): own-storage custody — persist-or-stay-open; a
-      // throw keeps the intent open and the next sign-in re-runs it.
-      if (!serverApply) await this.storeEngineToken(engine, changeOutput, { criticalSave: true });
-      await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(outputs[0]))), payload.direct.length);
+            { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId, opIndex: splitOpIndex }
+          );
+          changeOutput = outputs[1];
+          // critical (#515 F2): own-storage custody — persist-or-stay-open; a
+          // throw keeps the intent open and the next sign-in re-runs it.
+          if (!serverApply) await this.storeEngineToken(engine, changeOutput, { criticalSave: true });
+          await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(outputs[0]))), splitOpIndex);
+        } catch (err) {
+          // #622-review: mirror the direct-op path for split. The split source is already spent on-chain
+          // (a crash certified it before this resume) — record the spend instead of wedging on the
+          // re-certification conflict. KNOWN LIMITATION: the change output is NOT journaled and cannot be
+          // re-derived here (re-running engine.split conflicts), so a split that crashed between
+          // certification and applyDelta recovers its change token via a full inventory resync. Surfaced
+          // (inventory:conflict prompts that refresh) — never silently lost.
+          if (!(err instanceof TransferConflictError)) throw err;
+          logger.warn('Payments', `Resume split op already certified — recording the spend; change token (if any) recovers on the next inventory resync (§3.1):`, err);
+          this.deps!.emitEvent('inventory:conflict', { transferId, coinId: payload.coinId, error: err.message });
+        }
+      }
       spent.push(payload.split.tokenId);
     }
 
@@ -5488,12 +5509,18 @@ export class PaymentsModule {
   private async tryDeliver(deliver: () => Promise<unknown>, tokenBlob: string): Promise<boolean> {
     try {
       await deliver();
-      await this.removePendingV2Delivery(tokenBlob);
-      return true;
     } catch (err) {
       logger.warn('Payments', 'Delivery deferred (kept journaled); sender not failed (§3.1):', err);
       return false;
     }
+    // Delivered. Clearing the journal is best-effort — a failure here is harmless (the idempotent
+    // replay re-removes it) and must NOT flip the result to delivery-pending (#622 review).
+    try {
+      await this.removePendingV2Delivery(tokenBlob);
+    } catch (err) {
+      logger.warn('Payments', 'Delivered, but journal cleanup failed (replay will re-remove):', err);
+    }
+    return true;
   }
 
   /**

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1522,6 +1522,9 @@ export class PaymentsModule {
     // this send. The failure handler must never restore these as 'confirmed' —
     // their state is consumed; the finished output blob is journaled separately.
     const committedOnChainTokenIds = new Set<string>();
+    // §3.1 (#621): set when any leg's post-certification delivery is deferred (kept journaled).
+    // Scoped to the whole send so the resolve path below can mark the result delivery-pending.
+    let deliveryPending = false;
 
     try {
       // Resolve recipient
@@ -1719,8 +1722,8 @@ export class PaymentsModule {
             memo: request.memo,
             createdAt: Date.now(),
           });
-          await deliverBlob(tokenBlob);
-          await this.removePendingV2Delivery(tokenBlob);
+          // §3.1 (#621): a delivery failure after certification must NOT fail the sender.
+          if (!(await this.tryDeliver(() => deliverBlob(tokenBlob), tokenBlob))) deliveryPending = true;
           result.tokenTransfers.push({ sourceTokenId: tw.uiToken.id, method: 'direct' });
           consumedSources.push({
             uiTokenId: tw.uiToken.id,
@@ -1779,8 +1782,8 @@ export class PaymentsModule {
             await this.storeEngineToken(engine, changeOutput, { criticalSave: true });
           }
 
-          await deliverBlob(recipientBlob);
-          await this.removePendingV2Delivery(recipientBlob);
+          // §3.1 (#621): a delivery failure after certification must NOT fail the sender.
+          if (!(await this.tryDeliver(() => deliverBlob(recipientBlob), recipientBlob))) deliveryPending = true;
 
           result.tokenTransfers.push({ sourceTokenId: splitPlan.tokenToSplit.uiToken.id, method: 'split' });
           consumedSources.push({
@@ -1870,7 +1873,17 @@ export class PaymentsModule {
       // Commit reservation — all tokens have been sent on-chain and removed.
       this.reservationLedger.commit(result.id);
 
-      this.deps!.emitEvent('transfer:confirmed', result);
+      // §3.1 (#621): the spend is final regardless of delivery. If any leg's delivery was
+      // deferred (recipient-side 429 / transient outage), resolve as delivery-pending — the
+      // blob stays journaled for (re-)delivery — rather than failing the sender.
+      if (deliveryPending) {
+        result.deliveryPending = true;
+        result.deliveryState = 'pending-delivery';
+      } else {
+        result.deliveryState = 'landed';
+      }
+
+      this.deps!.emitEvent(deliveryPending ? 'transfer:delivery_pending' : 'transfer:confirmed', result);
       return result;
     } catch (error) {
       // Cancel reservation — free reserved amounts for other sends
@@ -5406,6 +5419,25 @@ export class PaymentsModule {
         await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(filtered));
       }
     });
+  }
+
+  /**
+   * Covenant §3.1 (#621): once the source is certified on-chain, a delivery failure must NEVER
+   * fail the sender. Recipient-side conditions (a full mailbox / 429 from a never-claiming recipient)
+   * and transient delivery-infra failures (5xx/network) both leave the finished blob JOURNALED for
+   * (re-)delivery — the send resolves as delivery-pending and the sender moves on. The blob is already
+   * journaled (savePendingV2Delivery ran before this); on success we clear the journal, on any failure
+   * we keep it. Returns true if delivered, false if deferred. Never throws.
+   */
+  private async tryDeliver(deliver: () => Promise<void>, tokenBlob: string): Promise<boolean> {
+    try {
+      await deliver();
+      await this.removePendingV2Delivery(tokenBlob);
+      return true;
+    } catch (err) {
+      logger.warn('Payments', 'Delivery deferred (kept journaled); sender not failed (§3.1):', err);
+      return false;
+    }
   }
 
   /**

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -31,6 +31,7 @@ import type {
 import type { SplitPlan, TokenWithAmount } from './TokenSplitCalculator';
 import type { ITokenEngine, SphereToken, TokenBlob } from '../../token-engine';
 import { TransferConflictError } from '../../token-engine';
+import { WalletApiError } from '../../wallet-api';
 import { isV2TransferPayload, type V2TransferPayload } from '../../types/v2-transfer';
 import { TokenReservationLedger } from './TokenReservationLedger';
 import { SpendPlanner, SpendQueue, type ParsedTokenEntry, type ParsedTokenPool } from './SpendQueue';
@@ -150,6 +151,8 @@ const DELIVERY_POLL_INTERVAL_MS = 30_000;
  */
 const DELIVERY_REPLAY_RETRIES = 2;
 const MAX_DELIVERY_REPLAY_ATTEMPTS = 6;
+/** §3.1 (#621): how long a recipient-quota (429) delivery is deferred before the next replay attempt. */
+const DELIVERY_DEFERRAL_MS = 60 * 60 * 1000; // 1h
 const DELIVERY_REPLAY_BASE_DELAY_MS = 1_000;
 const DELIVERY_REPLAY_MAX_DELAY_MS = 8_000;
 
@@ -174,6 +177,20 @@ interface PendingV2Delivery {
   attempts?: number;
   /** Set once the entry is surfaced as poison; it stays journaled but is no longer auto-retried. */
   undeliverable?: boolean;
+  /**
+   * (transferId, opIndex) pairing (§8.1) — the op's position in the intent's persisted order.
+   * Lets resume RE-DELIVER this already-certified blob instead of re-running the engine op
+   * (which would raise TransferConflictError on the spent source). Absent on legacy entries.
+   */
+  opIndex?: number;
+  /**
+   * §3.1 (#621): a recipient-side 429 (full mailbox / never-claimer) is NOT poison — it self-heals
+   * when the recipient drains. Such entries are deferred (kept journaled, never auto-poisoned) and
+   * retried no sooner than this epoch-ms; the count does not consume the case-A poison budget.
+   */
+  deferredUntil?: number;
+  /** Why the entry is deferred (observability) — e.g. 'recipient-quota'. */
+  deferredReason?: string;
 }
 
 /** Running per-coin totals folded by {@link PaymentsModule.aggregateTokens}. */
@@ -1022,6 +1039,8 @@ export class PaymentsModule {
    * waiting real time — never mutated in production.
    */
   private replayBackoffBaseMs = DELIVERY_REPLAY_BASE_DELAY_MS;
+  /** Deferral window for recipient-quota (429) deliveries (#621). Overridable in tests. */
+  private deliveryDeferralMs = DELIVERY_DEFERRAL_MS;
   /**
    * #517: serializes {@link replayPendingV2Deliveries}. `load()` kicks replay
    * off fire-and-forget and `receive()` calls `load()`, so two passes can
@@ -1720,6 +1739,7 @@ export class PaymentsModule {
             recipientPubkey: recipientChainPubkeyHex,
             tokenBlob,
             memo: request.memo,
+            opIndex,
             createdAt: Date.now(),
           });
           // §3.1 (#621): a delivery failure after certification must NOT fail the sender.
@@ -1766,6 +1786,7 @@ export class PaymentsModule {
             recipientPubkey: recipientChainPubkeyHex,
             tokenBlob: recipientBlob,
             memo: request.memo,
+            opIndex: splitPlan.tokensToTransferDirectly.length,
             createdAt: Date.now(),
           });
           changeOutput = outputs[1];
@@ -5187,33 +5208,56 @@ export class PaymentsModule {
       parseInvoiceMemoForOnChain(payload.memo, payload.invoiceRefundAddress, payload.invoiceContact) ??
       undefined;
 
-    const deliverBlob = async (tokenBlobHex: string): Promise<void> => {
+    const deliverBlob = async (tokenBlobHex: string, opIndex: number): Promise<void> => {
       await this.savePendingV2Delivery({
         transferId,
         recipientPubkey: payload.recipient,
         tokenBlob: tokenBlobHex,
         memo: payload.memo,
+        opIndex,
         createdAt: Date.now(),
       });
       const nm = this.currentNametagName();
-      await delivery.deliver(payload.recipient, hexToBytes(tokenBlobHex), {
-        transferId,
-        memo: payload.memo,
-        ...(nm !== undefined ? { senderNametag: nm } : {}),
-      });
-      await this.removePendingV2Delivery(tokenBlobHex);
+      // §3.1 (#621): non-fatal — a recipient-side/transient delivery failure must NOT throw out of
+      // resume (applyDelta below must still reconcile the server); the blob stays journaled for replay.
+      await this.tryDeliver(
+        () => delivery.deliver(payload.recipient, hexToBytes(tokenBlobHex), {
+          transferId,
+          memo: payload.memo,
+          ...(nm !== undefined ? { senderNametag: nm } : {}),
+        }),
+        tokenBlobHex,
+      );
     };
 
+    // #621: re-deliver, never re-certify. A journaled blob for (transferId, opIndex) means the op
+    // already certified in the original send (the intent stayed open on a LATER failure, e.g. applyDelta).
+    // Re-running engine.transfer on the now-spent source would raise TransferConflictError — re-deliver
+    // the stored blob instead (idempotent). Only run the engine op when nothing was journaled for it.
+    const journaled = await this.journaledByOp(transferId);
     const spent: string[] = [];
     for (const [opIndex, genesisId] of payload.direct.entries()) {
-      const blob = await provider.getToken(genesisId);
-      const source = await engine.decodeToken(blob);
-      const finished = await engine.transfer(
-        { token: source, recipientPubkey: recipientChainPubkey, data: memoData },
-        // (transferId, opIndex) pairing replayed from the intent's persisted order (§8.1)
-        { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId, opIndex }
-      );
-      await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(finished))));
+      const existing = journaled.get(opIndex);
+      if (existing) {
+        await deliverBlob(existing.tokenBlob, opIndex);
+      } else {
+        try {
+          const blob = await provider.getToken(genesisId);
+          const source = await engine.decodeToken(blob);
+          const finished = await engine.transfer(
+            { token: source, recipientPubkey: recipientChainPubkey, data: memoData },
+            // (transferId, opIndex) pairing replayed from the intent's persisted order (§8.1)
+            { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId, opIndex }
+          );
+          await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(finished))), opIndex);
+        } catch (err) {
+          // #621: no journaled blob, but the source is already spent on-chain — the original send
+          // certified (and delivered) this op and only failed to close on a LATER step. Record the
+          // spend (applyDelta below) instead of wedging on a re-certification TransferConflictError.
+          if (!(err instanceof TransferConflictError)) throw err;
+          logger.warn('Payments', `Resume op ${opIndex} already certified (source spent) — recording the spend, not re-certifying (§3.1):`, err);
+        }
+      }
       spent.push(genesisId);
     }
 
@@ -5246,7 +5290,7 @@ export class PaymentsModule {
       // critical (#515 F2): own-storage custody — persist-or-stay-open; a
       // throw keeps the intent open and the next sign-in re-runs it.
       if (!serverApply) await this.storeEngineToken(engine, changeOutput, { criticalSave: true });
-      await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(outputs[0]))));
+      await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(outputs[0]))), payload.direct.length);
       spent.push(payload.split.tokenId);
     }
 
@@ -5394,6 +5438,18 @@ export class PaymentsModule {
     return data ? (JSON.parse(data) as PendingV2Delivery[]) : [];
   }
 
+  /**
+   * #621: journaled finished blobs for an intent, keyed by op position. opIndex when present,
+   * else positional among the intent's entries (legacy entries journaled in op order). Resume
+   * uses this to re-deliver an already-certified op instead of re-running the engine on its spent source.
+   */
+  private async journaledByOp(transferId: string): Promise<Map<number, PendingV2Delivery>> {
+    const mine = (await this.loadPendingV2Deliveries()).filter((e) => e.transferId === transferId);
+    const byOp = new Map<number, PendingV2Delivery>();
+    mine.forEach((e, i) => byOp.set(e.opIndex ?? i, e));
+    return byOp;
+  }
+
   /** #517: run a journal read-modify-write atomically against all other journal mutations. */
   private withJournalLock<T>(fn: () => Promise<T>): Promise<T> {
     const run = this.journalMutation.then(fn, fn);
@@ -5429,7 +5485,7 @@ export class PaymentsModule {
    * journaled (savePendingV2Delivery ran before this); on success we clear the journal, on any failure
    * we keep it. Returns true if delivered, false if deferred. Never throws.
    */
-  private async tryDeliver(deliver: () => Promise<void>, tokenBlob: string): Promise<boolean> {
+  private async tryDeliver(deliver: () => Promise<unknown>, tokenBlob: string): Promise<boolean> {
     try {
       await deliver();
       await this.removePendingV2Delivery(tokenBlob);
@@ -5462,7 +5518,11 @@ export class PaymentsModule {
     if (this.replayInFlight) return;
     this.replayInFlight = true;
     try {
-      const entries = (await this.loadPendingV2Deliveries()).filter((e) => !e.undeliverable);
+      // #621: skip poison and recipient-quota entries still inside their deferral window.
+      const now = Date.now();
+      const entries = (await this.loadPendingV2Deliveries()).filter(
+        (e) => !e.undeliverable && (e.deferredUntil === undefined || e.deferredUntil <= now),
+      );
       if (entries.length === 0) return;
       logger.warn('Payments', `${entries.length} undelivered v2 transfer(s) journaled from a previous session — replaying`);
       for (const e of entries) {
@@ -5481,6 +5541,13 @@ export class PaymentsModule {
       await this.removePendingV2Delivery(entry.tokenBlob);
       logger.debug('Payments', `Replayed undelivered v2 transfer ${tag}...`);
     } catch (err) {
+      // §3.1 (#621): a recipient-side 429 (full mailbox / never-claimer) is NOT poison — it
+      // self-heals when the recipient drains. Defer it (kept journaled, never consumes the case-A
+      // poison budget, retried after the deferral window), distinct from a genuine delivery failure.
+      if (err instanceof WalletApiError && err.status === 429) {
+        await this.deferDelivery(entry, err.message);
+        return;
+      }
       const attempts = (entry.attempts ?? 0) + 1;
       const message = err instanceof Error ? err.message : String(err);
       if (attempts >= MAX_DELIVERY_REPLAY_ATTEMPTS) {
@@ -5490,6 +5557,26 @@ export class PaymentsModule {
       await this.bumpDeliveryAttempts(entry.tokenBlob, attempts);
       logger.warn('Payments', `Replay of undelivered v2 transfer ${tag}... failed (attempt ${attempts}/${MAX_DELIVERY_REPLAY_ATTEMPTS}, kept for next load):`, err);
     }
+  }
+
+  /**
+   * §3.1 (#621): defer a recipient-quota (429) delivery — keep it journaled, never poison it (it
+   * self-heals when the recipient claims), and retry no sooner than the deferral window. Surfaced
+   * distinctly (delivery:deferred) so a UI can show "recipient's mailbox is full — will retry".
+   */
+  private async deferDelivery(entry: PendingV2Delivery, error: string): Promise<void> {
+    const deferredUntil = Date.now() + this.deliveryDeferralMs;
+    await this.updatePendingV2Delivery(entry.tokenBlob, (e) => {
+      e.deferredUntil = deferredUntil;
+      e.deferredReason = 'recipient-quota';
+    });
+    logger.warn('Payments', `Undelivered v2 transfer ${entry.transferId.slice(0, 8)}... deferred — recipient mailbox full (429); kept journaled, retried after the deferral window (§3.1):`, error);
+    this.deps!.emitEvent('delivery:deferred', {
+      transferId: entry.transferId,
+      recipientPubkey: entry.recipientPubkey,
+      reason: 'recipient-quota',
+      deferredUntil,
+    });
   }
 
   /** One delivery with in-pass exponential backoff; throws the last error if all attempts fail. */

--- a/tests/unit/modules/PaymentsModule.v2-send-recovery.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-send-recovery.test.ts
@@ -145,17 +145,18 @@ function journal(storage: { map: Map<string, string> }): Array<{ transferId: str
 }
 
 describe('send() — failure recovery (v2)', () => {
-  it('transport failure AFTER engine.transfer: source is spent (never confirmed), blob journaled, restore persisted', async () => {
-    const { module, engine, transport, storage, tokenStorage } = setup();
+  it('transport failure AFTER engine.transfer (§3.1 #621): send resolves delivery-pending, source consumed, blob journaled', async () => {
+    const { module, engine, transport, storage } = setup();
     await deliver(module, await v2Payload(engine, 100n));
     (transport.sendTokenTransfer as any).mockRejectedValueOnce(new Error('relay down'));
 
-    await expect(module.send({ recipient: '@bob', amount: '100', coinId: UCT })).rejects.toThrow('relay down');
+    // Covenant: a post-certification delivery failure must NOT fail the sender.
+    const result = await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    expect(result.status).not.toBe('failed');
+    expect(result.deliveryPending).toBe(true);
 
-    // Source token was certified on-chain — terminal 'spent', NOT confirmed.
-    const tokens = module.getTokens();
-    expect(tokens).toHaveLength(1);
-    expect(tokens[0].status).toBe('spent');
+    // Source was certified on-chain — consumed, never left spendable.
+    expect(module.getTokens().some((t) => t.status === 'confirmed')).toBe(false);
 
     // The finished blob is journaled for replay. Since S3 the journal records
     // the recipient's CHAIN pubkey — the delivery port's canonical addressing
@@ -163,18 +164,14 @@ describe('send() — failure recovery (v2)', () => {
     const entries = journal(storage);
     expect(entries).toHaveLength(1);
     expect(entries[0].recipientPubkey).toBe(BOB_CHAIN_PUBKEY);
-
-    // The restore was persisted (a crash now must not resurrect 'transferring').
-    expect(tokenStorage.save).toHaveBeenCalled();
-    const persisted = tokenStorage.savedData();
-    expect(JSON.stringify(persisted)).toContain('"spent"');
   });
 
   it('replayPendingV2Deliveries delivers the journaled blob and clears the journal', async () => {
     const { module, engine, transport, storage } = setup();
     await deliver(module, await v2Payload(engine, 100n));
     (transport.sendTokenTransfer as any).mockRejectedValueOnce(new Error('relay down'));
-    await expect(module.send({ recipient: '@bob', amount: '100', coinId: UCT })).rejects.toThrow();
+    const result = await module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    expect(result.deliveryPending).toBe(true);
     expect(journal(storage)).toHaveLength(1);
     const journaledBlob = journal(storage)[0].tokenBlob;
 
@@ -192,14 +189,15 @@ describe('send() — failure recovery (v2)', () => {
     await deliver(module, await v2Payload(engine, 1000n));
     (transport.sendTokenTransfer as any).mockRejectedValueOnce(new Error('relay down'));
 
-    await expect(module.send({ recipient: '@bob', amount: '300', coinId: UCT })).rejects.toThrow('relay down');
+    // Covenant §3.1 (#621): delivery failure must not fail the sender.
+    const result = await module.send({ recipient: '@bob', amount: '300', coinId: UCT });
+    expect(result.deliveryPending).toBe(true);
 
     const tokens = module.getTokens();
-    // Change token (700) survived as confirmed; the split source is terminal 'spent'.
+    // Change token (700) survived as confirmed; the split source was consumed on-chain.
     const change = tokens.find((t) => t.amount === '700');
     expect(change?.status).toBe('confirmed');
-    const source = tokens.find((t) => t.amount === '1000');
-    expect(source?.status).toBe('spent');
+    expect(tokens.some((t) => t.amount === '1000' && t.status === 'confirmed')).toBe(false);
     // Recipient's 300 blob is journaled for replay.
     expect(journal(storage)).toHaveLength(1);
   });

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -752,6 +752,71 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     const sent = fake.getHistoryRecords(SENDER.chainPubkey).find((r) => r.dedupKey === `SENT_transfer_${transferId}`);
     expect(sent).toBeDefined();
   });
+
+  it('resume of an already-certified source records the spend instead of wedging on a conflict (§3.1 #621)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-rs-621');
+    const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    const transferId = crypto.randomUUID();
+    const payload = { v: 1, recipient: RECIPIENT.chainPubkey, coinId: UCT, amount: '1000', direct: [sourceTokenId] };
+    sender.client.setIdentity(SENDER);
+    await sender.client.putIntent(
+      transferId,
+      encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload)),
+    );
+
+    // The original send already certified (and delivered) this source — the intent only failed to
+    // close on a later step. Re-running the engine on the spent source raises TransferConflictError.
+    // Old behavior wedged (conflicted + re-certify forever); the fix records the spend and completes.
+    vi.spyOn(sender.engine, 'transfer').mockRejectedValue(
+      new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent'),
+    );
+
+    const outcome = await sender.module.resumeOpenIntents();
+    expect(outcome.resumed).toEqual([transferId]);
+    expect(outcome.conflicted).toEqual([]);
+    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'removed' });
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
+  });
+});
+
+describe('replay classifies recipient-quota (429) as deferred, never poison (§3.1 #621)', () => {
+  it('a recipient-full 429 blob is deferred (kept journaled, never poison) and lands once the recipient drains', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-defer-621');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (sender.module as any).deliveryDeferralMs = 0; // re-eligible immediately — no real wait
+    (sender.module as any).replayBackoffBaseMs = 0;
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    const realDeliver = sender.delivery.deliver.bind(sender.delivery);
+    let recipientFull = true;
+    vi.spyOn(sender.delivery, 'deliver').mockImplementation((a, b, c) =>
+      recipientFull ? Promise.reject(new WalletApiError('quota (§5.5)', 'RATE_LIMITED', 429)) : realDeliver(a, b, c),
+    );
+
+    const result = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT });
+    expect(result.deliveryPending).toBe(true);
+
+    // Drive far past the case-A poison budget (6) while the recipient stays full — never poison.
+    for (let i = 0; i < 8; i++) await (sender.module as any).replayPendingV2Deliveries();
+    const journaled = JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]');
+    expect(journaled).toHaveLength(1);
+    expect(journaled[0].undeliverable).toBeUndefined();
+    expect(journaled[0].deferredReason).toBe('recipient-quota');
+    expect(sender.emitEvent.mock.calls.some((c) => c[0] === 'delivery:deferred')).toBe(true);
+    expect(sender.emitEvent.mock.calls.some((c) => c[0] === 'delivery:undeliverable')).toBe(false);
+
+    // Recipient drains → next replay lands and clears the journal.
+    recipientFull = false;
+    await (sender.module as any).replayPendingV2Deliveries();
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(1);
+    expect(JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]')).toHaveLength(0);
+  });
 });
 
 describe('stale-inventory conflict is SURFACED, not silent (#517 item 2)', () => {

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -27,7 +27,7 @@ import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../to
 import { TransferConflictError } from '../../../token-engine';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
-import { WalletApiClient } from '../../../wallet-api';
+import { WalletApiClient, WalletApiError } from '../../../wallet-api';
 import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../../impl/shared/wallet-api';
 import { encodeTokenBlob } from '../../../token-engine/token-blob';
 import { bytesToHex, hexToBytes } from '../../../core/crypto';
@@ -399,14 +399,18 @@ describe('interrupted deposit — journal replay on next load (S3 AC)', () => {
     await seedServerToken(fake, sender, SENDER, 1000n);
     await sender.module.load();
 
-    // Deliver fails once (mailbox outage) AFTER the engine certified.
+    // Deliver fails once (mailbox outage) AFTER the engine certified. Covenant §3.1 (#621):
+    // a post-certification delivery failure must NOT fail the sender — the send resolves
+    // delivery-pending and the journaled blob lands on the next load's replay.
     const realDeliver = sender.delivery.deliver.bind(sender.delivery);
     let failures = 1;
     vi.spyOn(sender.delivery, 'deliver').mockImplementation((a, b, c) =>
       failures-- > 0 ? Promise.reject(new Error('mailbox down')) : realDeliver(a, b, c)
     );
 
-    await expect(sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT })).rejects.toThrow('mailbox down');
+    const result = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT });
+    expect(result.status).not.toBe('failed');
+    expect(result.deliveryPending).toBe(true);
 
     // The finished blob is journaled; nothing reached the mailbox yet; the
     // source is terminal 'spent' locally (certified on-chain).
@@ -466,6 +470,60 @@ describe('interrupted deposit — journal replay on next load (S3 AC)', () => {
     expect(JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]')).toHaveLength(0);
     expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(1);
     expect(fake.getMailboxEntry(RECIPIENT.chainPubkey, entry.entryId)).toMatchObject({ status: 'claimed' });
+  });
+});
+
+describe('recipient-side 429 must NOT fail the sender (covenant §3.1 — issue #621)', () => {
+  it('a recipient unclaimed-cap 429 after certification RESOLVES the send (deliveryPending), source spent, blob journaled', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-quota-1');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // The recipient's mailbox is FULL (§5.5 unclaimed cap). The deposit 429s AFTER the
+    // engine certified — exactly the recipient-side condition that must never fail the sender.
+    vi.spyOn(sender.delivery, 'deliver').mockRejectedValue(
+      new WalletApiError('per-recipient unclaimed+rejected entries exceed (§5.5)', 'RATE_LIMITED', 429),
+    );
+
+    // Covenant: the sender certified, the token is the recipient's on-chain — the send RESOLVES.
+    const result = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT });
+    expect(result.status).not.toBe('failed');
+    expect(result.deliveryPending).toBe(true);
+
+    // Source is terminally spent (never re-spendable); the finished blob stays journaled for re-delivery;
+    // nothing reached the recipient's mailbox yet.
+    const lazy = sender.module.getTokens();
+    expect(lazy.some((t) => t.status === 'confirmed')).toBe(false);
+    expect(JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]')).toHaveLength(1);
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);
+  });
+
+  it('after the recipient drains, a journal replay deposits the blob and clears the journal', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-quota-2');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    const realDeliver = sender.delivery.deliver.bind(sender.delivery);
+    let quotaFull = true;
+    vi.spyOn(sender.delivery, 'deliver').mockImplementation((a, b, c) =>
+      quotaFull
+        ? Promise.reject(new WalletApiError('quota (§5.5)', 'RATE_LIMITED', 429))
+        : realDeliver(a, b, c),
+    );
+
+    const result = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT });
+    expect(result.deliveryPending).toBe(true);
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);
+
+    // Recipient drains → the deferred blob lands on the next replay; journal clears.
+    quotaFull = false;
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    await (sender.module as any).replayPendingV2Deliveries();
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(1);
+    expect(JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]')).toHaveLength(0);
   });
 });
 

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -780,6 +780,42 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'removed' });
     expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
   });
+
+  it('resume of an already-certified SPLIT source records the spend instead of wedging (#622 review)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-rs-split-621');
+    const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    const transferId = crypto.randomUUID();
+    const payload = {
+      v: 1,
+      recipient: RECIPIENT.chainPubkey,
+      coinId: UCT,
+      amount: '300',
+      direct: [],
+      split: { tokenId: sourceTokenId, splitAmount: '300', remainderAmount: '700' },
+    };
+    sender.client.setIdentity(SENDER);
+    await sender.client.putIntent(
+      transferId,
+      encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload)),
+    );
+
+    // The original send already certified the split — re-running engine.split conflicts. Without the
+    // #622-review fix this bubbles up, aborts, and wedges; the fix records the spend and completes.
+    vi.spyOn(sender.engine, 'split').mockRejectedValue(
+      new TransferConflictError('TRANSACTION_HASH_MISMATCH: split source already spent'),
+    );
+
+    const outcome = await sender.module.resumeOpenIntents();
+    expect(outcome.resumed).toEqual([transferId]);
+    expect(outcome.conflicted).toEqual([]);
+    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'removed' });
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
+    // The change-token limitation is surfaced (prompts a resync) — never silently lost.
+    expect(sender.emitEvent.mock.calls.some((c) => c[0] === 'inventory:conflict')).toBe(true);
+  });
 });
 
 describe('replay classifies recipient-quota (429) as deferred, never poison (§3.1 #621)', () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -415,6 +415,7 @@ export type SphereEventType =
   | 'storage:degraded'
   | 'inventory:conflict'
   | 'delivery:undeliverable'
+  | 'delivery:deferred'
   | 'walletapi:session'
   | 'realtime:status'
   | 'connection:changed'
@@ -530,6 +531,12 @@ export interface SphereEventMap {
    * is higher. Surfacing trips once `attempts` reaches the bounded budget.
    */
   'delivery:undeliverable': { transferId: string; recipientPubkey: string; attempts: number; error: string };
+  /**
+   * §3.1 (#621): a delivery was deferred because the recipient's mailbox is full (429 — a never-claimer
+   * or quota). NOT poison: kept journaled and retried after `deferredUntil`. UI: "recipient can't receive
+   * yet — will retry". The sender is NOT failed; the token is the recipient's on-chain.
+   */
+  'delivery:deferred': { transferId: string; recipientPubkey: string; reason: string; deferredUntil: number };
   /**
    * wallet-api session state change (#515 F3): 'offline' = sign-in failed and
    * the wallet runs degraded (no intents barrier, no server custody writes);

--- a/types/index.ts
+++ b/types/index.ts
@@ -172,6 +172,15 @@ export interface TransferResult {
   /** Per-token transfer details — one entry per source token consumed */
   readonly tokenTransfers: TokenTransferDetail[];
   error?: string;
+  /**
+   * True when the send certified on-chain but the recipient-side delivery did not land
+   * (covenant §3.1 — issue #621): the source is terminally spent, the finished blob is
+   * journaled, and the sender is NOT failed. Distinguishes "sent, delivery deferred" from
+   * a real send failure. See {@link deliveryState}.
+   */
+  deliveryPending?: boolean;
+  /** 'landed' = delivered to the recipient's mailbox; 'pending-delivery' = certified, journaled, awaiting (re-)delivery. */
+  deliveryState?: 'landed' | 'pending-delivery';
 }
 
 export interface IncomingTransfer {
@@ -386,6 +395,7 @@ export type SphereEventType =
   | 'transfer:incoming'
   | 'transfer:confirmed'
   | 'transfer:failed'
+  | 'transfer:delivery_pending'
   | 'transfer:invalid'
   | 'payment_request:incoming'
   | 'payment_request:accepted'
@@ -466,6 +476,12 @@ export interface SphereEventMap {
   'transfer:incoming': IncomingTransfer;
   'transfer:confirmed': TransferResult;
   'transfer:failed': TransferResult;
+  /**
+   * Covenant §3.1 (#621): the send certified on-chain but recipient-side delivery did not land
+   * (a full mailbox / 429, or a transient outage). The source is spent, the finished blob is
+   * journaled for (re-)delivery, and the sender is NOT failed. UI renders "sent — delivery pending".
+   */
+  'transfer:delivery_pending': TransferResult;
   /**
    * An incoming delivery failed LOCAL verification and was rejected back to
    * the delivery rail (sdk-changes S3): terminal for discovery only — the


### PR DESCRIPTION
Closes #621 (SDK core — increments 1 & 2 of 3; see "Follow-ups").

## Why

Covenant §3.1: once the engine **certifies** a transfer, the source is the recipient's on-chain and the sender must move on. A recipient-side condition — a full mailbox (`429 QUOTA_EXCEEDED` from a never-claiming recipient, e.g. the Sphere swap wallet) — must never block or fail the sender. Today a `429` escapes `send()` (`deliverBlob` at `PaymentsModule.ts:1722/1782`), failing the sender's send, wedging `SwapModule.deposit`, and on the next sign-in `resumeIntent` re-certifies the already-spent source → `TransferConflictError` ("source state already consumed"). One non-claiming recipient wedges every sender.

This came from a prod incident: the swap wallet hit the §5.5 unclaimed cap → swaps stopped. The cap was unblocked (`MAX_RECIPIENT_ENTRIES=0`); this PR fixes the underlying covenant violation so it can't recur (and holds for mainnet, where caps return, and for any third-party recipient).

## What

**Two-tier delivery handling, SDK-owned.** Classify the error reaching the delivery seam:

| Error | Class | Behavior |
|---|---|---|
| `5xx` / network / timeout | infra (A) | bounded replay → poison (unchanged — retry is right) |
| `429 QUOTA_EXCEEDED` | recipient-side (B) | **soft-success**: send resolves `deliveryPending`, source consumed, blob journaled & **deferred** (never poison), `delivery:deferred` event |
| `403/422` | poison | surfaced, not hammered |
| `409` | idempotent | success |

Cross-cutting: **any post-certification delivery failure resolves the send.** `send()` rejects only for the two cases a never-claiming recipient can't trigger — pre-certification failure and `TransferConflictError`.

- **Increment 1 (send-side):** in-loop delivery is non-fatal (`tryDeliver`) → blob stays journaled, `deliveryPending` set, **`applyDelta` still runs** so the server learns the source is consumed (closes the inventory-custody resurrection gap). New `TransferResult.deliveryPending`/`deliveryState` + `transfer:delivery_pending` event.
- **Increment 2 (resume + replay):** `resumeIntent` re-delivers a journaled blob (by `(transferId, opIndex)`) instead of re-certifying; if none is journaled but the source is already spent, it **records the spend** (`applyDelta`) instead of wedging on a conflict. Replay classifies `429` as **deferred, never poison** (`delivery:deferred`), preserving the bounded `5xx` replay→poison path.

## Tests
Recipient-`429` resolves + journals + replay-lands; resume of an already-certified source completes (no wedge); `429` deferred past the poison budget then lands on drain. The pinned post-certification "send throws on delivery failure" tests (relay + wallet-api) updated to the covenant-correct resolve — alignment, not weakening (they still assert journaling + replay; now also that the sender isn't failed). **1244 unit tests green**, typecheck + lint clean.

## Follow-ups (tracked on #621)
- **P3 — self-healing coin selection** (a *fresh* send that selects a stale-spent token: demote-to-end with durable `suspectedSpent`, try next candidate, bounded → clean `SEND_INSUFFICIENT_BALANCE`). Deferred as its own PR — it restructures `send()`'s coin-selection and warrants focused review. Today that case is already surfaced (not silent) via `inventory:conflict` for a UI "refresh & retry".
- **P4 — activity-panel UI** (sphere): render spent-elsewhere vs delivery-pending distinctly off the new events.
- **wallet-api**: distinct subcodes for per-recipient vs per-pair `429` (observability); spec edits (ARCHITECTURE §3.1/§5.5/§6, sdk-changes S3).