### PR TITLE
feat(payments): batch incoming mailbox claim/reject per page (#623)

### DIFF
--- a/impl/shared/wallet-api/WalletApiMailboxProvider.ts
+++ b/impl/shared/wallet-api/WalletApiMailboxProvider.ts
@@ -428,6 +428,31 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
     await this.addSeen([deliveryId]); // the persistent (tokenId, stateHash) seen-set (S7)
   }
 
+  /**
+   * Batch ack (#623): one `claimMailbox` + one `rejectMailbox` request for a whole page, instead of
+   * one per entry. Only entries that were acked successfully enter the seen-set, so a defensive-bucket
+   * claim failure leaves that entry un-seen for a later pump to retry (never throws on the batch for a
+   * single bad entry — the §16 defensive lineage bucket is unreachable in normal flows). Claim is
+   * idempotent (§6), so re-listing an un-seen entry re-claims safely.
+   */
+  async ackBatch(claimed: string[], rejected: string[]): Promise<void> {
+    const acked: string[] = [];
+    if (claimed.length > 0) {
+      const intoInventory = this.custody === 'inventory';
+      const result = await this.client.claimMailbox(claimed, intoInventory);
+      const failedIds = new Set(result.failed.map((f) => f.entryId));
+      for (const id of claimed) if (!failedIds.has(id)) acked.push(id);
+      if (failedIds.size > 0) {
+        logger.warn(TAG, `mailbox batch claim: ${String(failedIds.size)} entr(ies) in the defensive bucket — left un-seen for retry`);
+      }
+    }
+    if (rejected.length > 0) {
+      await this.client.rejectMailbox(rejected);
+      acked.push(...rejected);
+    }
+    if (acked.length > 0) await this.addSeen(acked);
+  }
+
   // ── wake (optional hook — §9: a nudge, never a correctness dependency) ──────
 
   // The wallet-api wake socket multiplexes all three owner streams; forward

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -4806,7 +4806,14 @@ export class PaymentsModule {
         );
       }
     }
-    await flush();
+    // A final-flush failure (transient claim/reject) is safe-by-replay — the entries are not in the
+    // seen-set, so the next pump re-lists and re-processes them. Degrade gracefully rather than
+    // propagating a pump crash (a 30s poll-restart).
+    try {
+      await flush();
+    } catch (err) {
+      logger.warn('Payments', 'Incoming ack flush failed — entries kept for the next pump (replay-safe):', err);
+    }
     return stored;
   }
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -4796,12 +4796,12 @@ export class PaymentsModule {
         }
         if (claimed.length + rejected.length >= INCOMING_ACK_BATCH_SIZE) await flush();
       } catch (err) {
-        // Transient (network, blob fetch) or no-engine: leave THIS entry unacked — the next poll
-        // retries; discovery of LATER entries continues. Already-verified entries stay buffered and
-        // flush at the next threshold / at the end.
+        // Transient (network, blob fetch / no-engine on THIS entry, or a threshold batch-flush
+        // failure): leave the affected entr(ies) unacked — they are not in the seen-set, so the next
+        // poll re-lists and re-processes them. Discovery of LATER entries continues.
         logger.warn(
           'Payments',
-          `Incoming delivery ${incoming.deliveryId.slice(0, 12)}… failed transiently (will retry):`,
+          `Incoming delivery ${incoming.deliveryId.slice(0, 12)}… (or its batch flush) failed transiently — left unacked, retried next poll:`,
           err
         );
       }

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -150,6 +150,9 @@ const DELIVERY_POLL_INTERVAL_MS = 30_000;
  */
 const DELIVERY_REPLAY_RETRIES = 2;
 const MAX_DELIVERY_REPLAY_ATTEMPTS = 6;
+/** #623: incoming claim/reject are submitted in batches of this size (one request each) so a large
+ * inbox drain doesn't fire one write per entry and trip the per-owner rate limit. */
+const INCOMING_ACK_BATCH_SIZE = 200;
 const DELIVERY_REPLAY_BASE_DELAY_MS = 1_000;
 const DELIVERY_REPLAY_MAX_DELAY_MS = 8_000;
 
@@ -4731,13 +4734,37 @@ export class PaymentsModule {
       await this.loadedPromise;
     }
     let stored = 0;
+    // #623: verify+store per entry (§8.2 — the recipient verifies locally), but ACCUMULATE the
+    // claim/reject and submit them in batches (one request each) so a large inbox drain doesn't fire
+    // one write per entry and trip the per-owner rate limit. Crash-safe: the seen-set (added only on a
+    // successful batch ack) is the replay guard and the cursor is the conservative §6 read pointer, so
+    // an un-flushed batch is simply re-listed and re-processed (idempotent claim, §6).
+    const claimed: string[] = [];
+    const rejected: string[] = [];
+    const flush = async (): Promise<void> => {
+      if (claimed.length === 0 && rejected.length === 0) return;
+      await this.flushIncomingAcks(delivery, claimed.splice(0), rejected.splice(0));
+    };
     for await (const incoming of delivery.incoming()) {
       try {
-        const accepted = await this.processIncomingDelivery(delivery, incoming);
-        if (accepted) stored++;
+        const verdict = await this.classifyIncomingDelivery(incoming);
+        if (verdict.disposition === 'claimed') {
+          claimed.push(incoming.deliveryId);
+          if (verdict.stored) stored++;
+        } else {
+          rejected.push(incoming.deliveryId);
+          // Surface as an invalid incoming payment (the actual reject is submitted in the flush).
+          this.deps!.emitEvent('transfer:invalid', {
+            deliveryId: incoming.deliveryId,
+            senderPubkey: incoming.senderPubkey,
+            reason: verdict.reason,
+          });
+        }
+        if (claimed.length + rejected.length >= INCOMING_ACK_BATCH_SIZE) await flush();
       } catch (err) {
-        // Transient (network, blob fetch): leave unacked — the next poll
-        // retries; discovery of LATER entries continues regardless.
+        // Transient (network, blob fetch) or no-engine: leave THIS entry unacked — the next poll
+        // retries; discovery of LATER entries continues. Already-verified entries stay buffered and
+        // flush at the next threshold / at the end.
         logger.warn(
           'Payments',
           `Incoming delivery ${incoming.deliveryId.slice(0, 12)}… failed transiently (will retry):`,
@@ -4745,53 +4772,60 @@ export class PaymentsModule {
         );
       }
     }
+    await flush();
     return stored;
   }
 
-  /** Returns true when the delivery stored a new token. */
-  private async processIncomingDelivery(
-    delivery: DeliveryProvider,
+  /**
+   * Verify + store an incoming delivery (§8.2 — local), returning the ack disposition WITHOUT acking
+   * — the pump batches the claim/reject (#623). A `duplicate` still claims (idempotent §6, advances
+   * the read pointer); `no-engine` throws so the entry is left unacked for a later pump.
+   */
+  private async classifyIncomingDelivery(
     incoming: IncomingDelivery
-  ): Promise<boolean> {
+  ): Promise<{ disposition: 'claimed'; stored: boolean } | { disposition: 'rejected'; reason: string }> {
     const bytes = await incoming.fetchBlob();
     const payload: V2TransferPayload = {
       type: 'V2_TRANSFER',
       version: '2.0',
       tokenBlob: bytesToHex(bytes),
-      // memo + senderNametag both ride the recipient-addressed delivery
-      // envelope (S6) the provider already decrypted — the nametag is the
-      // PRIMARY counterparty identity (no Nostr lookup; fixes "Someone").
+      // memo + senderNametag both ride the recipient-addressed delivery envelope (S6) the provider
+      // already decrypted — the nametag is the PRIMARY counterparty identity (no Nostr lookup).
       memo: incoming.memo,
       ...(incoming.senderNametag !== undefined ? { senderNametag: incoming.senderNametag } : {}),
     };
     const verdict = await this.handleV2Transfer(payload, incoming.senderPubkey ?? '');
     switch (verdict) {
       case 'stored':
-        await delivery.ack(incoming.deliveryId, 'claimed');
-        return true;
+        return { disposition: 'claimed', stored: true };
       case 'duplicate':
-        // Idempotent re-delivery (e.g. claimed race with another device) —
-        // claim so the read pointer advances (claim is idempotent, §6).
-        await delivery.ack(incoming.deliveryId, 'claimed');
-        return false;
+        return { disposition: 'claimed', stored: false };
       case 'invalid':
       case 'not-owned':
       case 'storage-rejected':
-        // Local verification failed (or the state is stale/tombstoned here):
-        // reject — terminal for DISCOVERY only; the entry stays claimable and
-        // its blob retained (§6), retryable after an app update (e.g. a
-        // trustbase fix). Surface as an invalid incoming payment.
-        await delivery.ack(incoming.deliveryId, 'rejected');
-        this.deps!.emitEvent('transfer:invalid', {
-          deliveryId: incoming.deliveryId,
-          senderPubkey: incoming.senderPubkey,
-          reason: verdict,
-        });
-        return false;
+        // Local verification failed (or the state is stale/tombstoned here): reject — terminal for
+        // DISCOVERY only; the entry stays claimable and its blob retained (§6).
+        return { disposition: 'rejected', reason: verdict };
       case 'no-engine':
-        // Not a verdict on the token at all — leave unacked for a later pump.
         throw new SphereError('Token engine unavailable for incoming delivery', 'AGGREGATOR_ERROR');
     }
+  }
+
+  /**
+   * Submit a batch of claims/rejects via the provider's batch ack (#623), falling back to per-entry
+   * ack for a provider without it (e.g. the relay no-op).
+   */
+  private async flushIncomingAcks(
+    delivery: DeliveryProvider,
+    claimed: string[],
+    rejected: string[]
+  ): Promise<void> {
+    if (delivery.ackBatch) {
+      await delivery.ackBatch(claimed, rejected);
+      return;
+    }
+    for (const id of claimed) await delivery.ack(id, 'claimed');
+    for (const id of rejected) await delivery.ack(id, 'rejected');
   }
 
   // ===========================================================================

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -301,6 +301,63 @@ describe('send — full wallet-api preset (S2 consumer + S3 + §7 pipeline)', ()
   });
 });
 
+describe('incoming — claim/reject batched per page (#623)', () => {
+  it('receive() of N entries issues ONE claimMailbox call carrying all ids, not N', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-batch-1');
+    const N = 5;
+    for (let i = 0; i < N; i += 1) await seedServerToken(fake, sender, SENDER, 100n);
+    await sender.module.load();
+    for (let i = 0; i < N; i += 1) await sender.module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(N);
+
+    const recipient = makeFullPresetWallet(baseUrl, fake.network, RECIPIENT, 'd-batch-2');
+    await recipient.module.load();
+    const claimSpy = vi.spyOn(recipient.client, 'claimMailbox');
+
+    const { transfers } = await recipient.module.receive();
+    expect(transfers).toHaveLength(N);
+
+    // The whole page is claimed in ONE request carrying all N ids (was N requests of 1 before #623).
+    expect(claimSpy).toHaveBeenCalledTimes(1);
+    expect(claimSpy.mock.calls[0][0]).toHaveLength(N);
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey).every((e) => e.status === 'claimed')).toBe(true);
+  });
+
+  it('a mixed page batches valid claims and invalid rejects into one request each', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-mix-1');
+    await seedServerToken(fake, sender, SENDER, 100n);
+    await seedServerToken(fake, sender, SENDER, 100n);
+    await sender.module.load();
+    await sender.module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    await sender.module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    // A stranger deposits a token locked to ITSELF → the recipient can't verify ownership → rejected.
+    const stranger = makeFullPresetWallet(baseUrl, fake.network, STRANGER, 'd-mix-str');
+    const strangerToken = await stranger.engine.mint({
+      recipientPubkey: stranger.engine.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: UCT, amount: 100n }] },
+    });
+    const badBytes = encodeTokenBlob(stranger.engine.encodeToken(strangerToken));
+    stranger.delivery.setIdentity(STRANGER);
+    await stranger.delivery.deliver(RECIPIENT.chainPubkey, badBytes, { transferId: crypto.randomUUID() });
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(3);
+
+    const recipient = makeFullPresetWallet(baseUrl, fake.network, RECIPIENT, 'd-mix-2');
+    await recipient.module.load();
+    const claimSpy = vi.spyOn(recipient.client, 'claimMailbox');
+    const rejectSpy = vi.spyOn(recipient.client, 'rejectMailbox');
+
+    await recipient.module.receive();
+
+    expect(claimSpy).toHaveBeenCalledTimes(1);
+    expect(claimSpy.mock.calls[0][0]).toHaveLength(2); // two valid
+    expect(rejectSpy).toHaveBeenCalledTimes(1);
+    expect(rejectSpy.mock.calls[0][0]).toHaveLength(1); // one invalid
+    expect(recipient.emitEvent.mock.calls.some((c) => c[0] === 'transfer:invalid')).toBe(true);
+  });
+});
+
 describe('incoming — mailbox pull feeds handleV2Transfer (S3)', () => {
   it('receive(): fetch → local verify → store → ack claimed (handoff) → RECEIVED history POST carrying the sender nametag + memo', async () => {
     const { fake, baseUrl } = await startFake();

--- a/transport/delivery-provider.ts
+++ b/transport/delivery-provider.ts
@@ -175,6 +175,16 @@ export interface DeliveryProvider {
   ack(deliveryId: string, disposition: DeliveryDisposition): Promise<void>;
 
   /**
+   * Optional batch acknowledge (#623): claim and reject whole pages of incoming deliveries in a
+   * single request each, instead of one per entry — so draining a large inbox (a long-offline or
+   * service wallet) doesn't fire thousands of writes and trip the per-owner rate limit. Same
+   * semantics as {@link ack}: the seen-set records only entries that were acked successfully, so a
+   * partial/failed batch is re-listed and re-processed (idempotent claim, §6). A provider that does
+   * not implement it (e.g. the relay no-op) is driven via per-entry {@link ack}.
+   */
+  ackBatch?(claimed: string[], rejected: string[]): Promise<void>;
+
+  /**
    * Optional wake hook: `callback` fires with the {@link WakeStream} that was
    * nudged when new data may be available on it (e.g. a WS nudge — never a
    * correctness dependency, ARCHITECTURE §9). The wallet-api wake socket


### PR DESCRIPTION
Closes #623.

## Why

The incoming pump claimed/rejected **one entry per request** (`claimMailbox([deliveryId])`), so a wallet draining a large backlog (a long-offline or service wallet — the swap wallet coming online with 10k+ entries) fired 10k+ writes and tripped the per-owner write rate limit:

```
POST /v1/tokens/upload-urls: RATE_LIMITED write rate limit exceeded (120/min)
```

The backend already accepts batch `claimMailbox(entryIds[])` / `rejectMailbox(entryIds[])`, pages the list (`PAGE_LIMIT`=1000), and rate-limits **per request** — so one batch of N is **1 request, not N**. The gap was purely client-side.

## What

- Add optional **`DeliveryProvider.ackBatch(claimed[], rejected[])`**; `WalletApiMailboxProvider` implements it (one `claimMailbox` + one `rejectMailbox`; the seen-set records only successfully-acked entries). The relay no-op provider falls back to per-entry `ack`.
- The pump verifies+stores **per entry** (§8.2 — the recipient verifies locally; not batchable) but **accumulates** the claim/reject and flushes in batches of `INCOMING_ACK_BATCH_SIZE` (and at end).

10k entries → ~10 batch requests instead of 10k.

## Crash-safety (unchanged at-least-once semantics)

`incoming()`'s cursor is the **conservative list-time §6 read pointer** (persisted before any claims), the **seen-set is the replay guard** (added only on a *successful* batch ack), and claim is **idempotent** (§6). So an un-flushed batch (crash mid-pump) is simply re-listed and re-processed (`duplicate` verdict → idempotent re-claim) — nothing lost or double-stored.

## Tests
`receive()` of N entries issues **one** `claimMailbox` call carrying all ids; a mixed page batches valid claims and invalid rejects into one request each. 1242 unit tests green, typecheck + lint clean.

Pairs with wallet-api #82 (rate limits disableable) and the infra scaling — batching lowers the scaling bar by ~100×.