### PR TITLE
feat(payments): self-healing coin selection — demote already-spent sources, re-plan (#625/P3)

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -154,6 +154,9 @@ const MAX_DELIVERY_REPLAY_ATTEMPTS = 6;
 /** #623: incoming claim/reject are submitted in batches of this size (one request each) so a large
  * inbox drain doesn't fire one write per entry and trip the per-owner rate limit. */
 const INCOMING_ACK_BATCH_SIZE = 200;
+/** #625: max times send() re-plans after demoting an already-spent source (self-healing selection).
+ * A backstop — each retry permanently demotes one stale source, so convergence is fast. */
+const MAX_RESELECT_ATTEMPTS = 8;
 /** §3.1 (#621): how long a recipient-quota (429) delivery is deferred before the next replay attempt. */
 const DELIVERY_DEFERRAL_MS = 60 * 60 * 1000; // 1h
 const DELIVERY_REPLAY_BASE_DELAY_MS = 1_000;
@@ -1519,7 +1522,58 @@ export class PaymentsModule {
    *   `existingReservationId` and `existingSplitPlan` allow callers (e.g. instantSplitSend)
    *   to pass an already-acquired reservation, skipping the planSend() critical section.
    */
+  /**
+   * #625 — self-healing coin selection. If a selected source turns out already spent on-chain
+   * (`TransferConflictError`), demote it (durable `suspectedSpent` — kept in inventory, excluded from
+   * selection) and re-plan with the next candidate, bounded. A fixed plan (`instantSplitSend`) is not
+   * re-planned. Exhausting the live candidates surfaces a clean `SEND_INSUFFICIENT_BALANCE` (or the
+   * final conflict), never an endless loop.
+   */
   async send(
+    request: TransferRequest,
+    internal?: { existingReservationId?: string; existingSplitPlan?: SplitPlan },
+  ): Promise<TransferResult> {
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        return await this.sendOnce(request, internal);
+      } catch (err) {
+        const conflictedId = err instanceof TransferConflictError ? err.conflictedSourceId : undefined;
+        if (
+          conflictedId !== undefined &&
+          attempt < MAX_RESELECT_ATTEMPTS &&
+          internal?.existingSplitPlan === undefined &&
+          this.tokens.has(conflictedId)
+        ) {
+          await this.demoteSuspectedSpent(conflictedId);
+          logger.warn(
+            'Payments',
+            `Source ${conflictedId} already spent on-chain — demoted, re-planning with the next candidate (#625, attempt ${attempt + 1}/${MAX_RESELECT_ATTEMPTS})`,
+          );
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
+
+  /**
+   * #625: mark a source token suspected-spent (a `TransferConflictError` proved its state consumed
+   * on-chain). It stays in inventory (visible, recoverable by a resync — never auto-removed) but is
+   * excluded from spend selection (SpendQueue) so coin-selection picks live tokens instead.
+   */
+  private async demoteSuspectedSpent(tokenId: string): Promise<void> {
+    const token = this.tokens.get(tokenId);
+    if (!token) return;
+    token.suspectedSpent = true;
+    this.tokens.set(tokenId, token);
+    try {
+      await this.save();
+    } catch (err) {
+      logger.warn('Payments', `Failed to persist suspectedSpent for ${tokenId} (re-derived on the next conflict):`, err);
+    }
+  }
+
+  private async sendOnce(
     request: TransferRequest,
     internal?: { existingReservationId?: string; existingSplitPlan?: SplitPlan },
   ): Promise<TransferResult> {
@@ -1722,16 +1776,23 @@ export class PaymentsModule {
         // so any device holding the wallet seed can rebuild the identical
         // transactions and resume (Part E).
         for (const [opIndex, tw] of splitPlan.tokensToTransferDirectly.entries()) {
-          const finished = await engine.transfer(
-            {
-              token: tw.sdkToken as SphereToken,
-              recipientPubkey: recipientChainPubkey,
-              data: memoData,
-            },
-            // opIndex = position in the persisted intent's `direct` order — the
-            // stable (transferId, opIndex) pairing resume replays (§8.1).
-            { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId: result.id, opIndex },
-          );
+          let finished;
+          try {
+            finished = await engine.transfer(
+              {
+                token: tw.sdkToken as SphereToken,
+                recipientPubkey: recipientChainPubkey,
+                data: memoData,
+              },
+              // opIndex = position in the persisted intent's `direct` order — the
+              // stable (transferId, opIndex) pairing resume replays (§8.1).
+              { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId: result.id, opIndex },
+            );
+          } catch (err) {
+            // #625: tag the conflicting source so the outer send() retry can demote it and re-plan.
+            if (err instanceof TransferConflictError) err.conflictedSourceId = tw.uiToken.id;
+            throw err;
+          }
           // The source state is spent on-chain from here on.
           committedOnChainTokenIds.add(tw.uiToken.id);
           // Journal the finished blob BEFORE delivery: a transport failure or a
@@ -1764,22 +1825,29 @@ export class PaymentsModule {
         let changeOutput: SphereToken | null = null;
         if (splitPlan.requiresSplit && splitPlan.tokenToSplit) {
           const selfChainPubkey = hexToBytes(this.deps.identity.chainPubkey);
-          const { outputs } = await engine.split(
-            {
-              token: splitPlan.tokenToSplit.sdkToken as SphereToken,
-              outputs: [
-                { recipientPubkey: recipientChainPubkey, coinId: request.coinId, amount: splitPlan.splitAmount!, data: memoData },
-                { recipientPubkey: selfChainPubkey, coinId: request.coinId, amount: splitPlan.remainderAmount! },
-              ],
-            },
-            // Same per-send seed; the split's opIndex follows the direct ops
-            // (stable across resume — it is derived from the intent's order).
-            {
-              signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS),
-              transferId: result.id,
-              opIndex: splitPlan.tokensToTransferDirectly.length,
-            },
-          );
+          let outputs;
+          try {
+            ({ outputs } = await engine.split(
+              {
+                token: splitPlan.tokenToSplit.sdkToken as SphereToken,
+                outputs: [
+                  { recipientPubkey: recipientChainPubkey, coinId: request.coinId, amount: splitPlan.splitAmount!, data: memoData },
+                  { recipientPubkey: selfChainPubkey, coinId: request.coinId, amount: splitPlan.remainderAmount! },
+                ],
+              },
+              // Same per-send seed; the split's opIndex follows the direct ops
+              // (stable across resume — it is derived from the intent's order).
+              {
+                signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS),
+                transferId: result.id,
+                opIndex: splitPlan.tokensToTransferDirectly.length,
+              },
+            ));
+          } catch (err) {
+            // #625: tag the conflicting split source so the outer send() retry can demote it and re-plan.
+            if (err instanceof TransferConflictError) err.conflictedSourceId = splitPlan.tokenToSplit.uiToken.id;
+            throw err;
+          }
           // The split source is burnt on-chain from here on. Journal the
           // recipient's blob BEFORE the delivery attempt.
           committedOnChainTokenIds.add(splitPlan.tokenToSplit.uiToken.id);

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -3073,6 +3073,9 @@ export class PaymentsModule {
     for (const token of this.tokens.values()) {
       // Skip spent and invalid tokens; transferring tokens are tracked separately.
       if (token.status === 'spent' || token.status === 'invalid') continue;
+      // #625: a suspected-spent source is excluded from spend selection, so it must not inflate the
+      // DISPLAYED spendable balance either (else the wallet shows a total it cannot actually send).
+      if (token.suspectedSpent) continue;
       if (coinId && token.coinId !== coinId) continue;
       this.accumulateToken(assetsMap, token);
     }

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1789,8 +1789,12 @@ export class PaymentsModule {
               { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId: result.id, opIndex },
             );
           } catch (err) {
-            // #625: tag the conflicting source so the outer send() retry can demote it and re-plan.
-            if (err instanceof TransferConflictError) err.conflictedSourceId = tw.uiToken.id;
+            // #625: tag for self-healing ONLY when nothing has certified yet in this attempt — re-planning
+            // the full amount is then safe. If an earlier op already certified, the certified value has
+            // left the wallet, so a full-amount re-plan would over-request; leave it untagged (no retry).
+            if (err instanceof TransferConflictError && committedOnChainTokenIds.size === 0) {
+              err.conflictedSourceId = tw.uiToken.id;
+            }
             throw err;
           }
           // The source state is spent on-chain from here on.
@@ -1844,8 +1848,11 @@ export class PaymentsModule {
               },
             ));
           } catch (err) {
-            // #625: tag the conflicting split source so the outer send() retry can demote it and re-plan.
-            if (err instanceof TransferConflictError) err.conflictedSourceId = splitPlan.tokenToSplit.uiToken.id;
+            // #625: tag for self-healing only when nothing certified yet this attempt (see the direct-op
+            // note) — a split after already-certified direct ops must not trigger a full-amount re-plan.
+            if (err instanceof TransferConflictError && committedOnChainTokenIds.size === 0) {
+              err.conflictedSourceId = splitPlan.tokenToSplit.uiToken.id;
+            }
             throw err;
           }
           // The split source is burnt on-chain from here on. Journal the

--- a/modules/payments/SpendQueue.ts
+++ b/modules/payments/SpendQueue.ts
@@ -117,6 +117,7 @@ export class SpendPlanner {
     for (const t of tokens) {
       if (t.coinId !== coinId) continue;
       if (t.status !== 'confirmed') continue;
+      if (t.suspectedSpent) continue; // #625: demoted (already-spent on-chain) — kept in inventory, not spendable
       if (!t.sdkData) {
         // Lazy inventory record (sdk-changes S2): plan from the value
         // metadata; the blob (and SphereToken handle) is fetched on demand by
@@ -640,9 +641,9 @@ export class SpendQueue {
 
     for (const [tokenId, entry] of pool) {
       if (entry.token.coinId !== coinId) continue;
-      // Skip tokens removed or no longer confirmed in the live wallet
+      // Skip tokens removed, no longer confirmed, or demoted as suspected-spent (#625) in the live wallet
       const liveToken = liveTokens.get(tokenId);
-      if (!liveToken || liveToken.status !== 'confirmed') continue;
+      if (!liveToken || liveToken.status !== 'confirmed' || liveToken.suspectedSpent) continue;
       const freeAmount = this.ledger.getFreeAmount(entry.token.id, entry.amount);
       // Only include fully-free tokens — partially reserved tokens cannot be
       // used for direct transfers and would cause INSUFFICIENT_FREE_AMOUNT

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -961,6 +961,31 @@ describe('stale-inventory conflict self-heals (#625) + is SURFACED (#517 item 2)
     expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(1);
   });
 
+  it('does NOT self-heal a conflict AFTER an earlier op certified — avoids a full-amount over-request re-plan (#625 safety)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-partial-1');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // amount 2000 needs BOTH sources (two direct ops). The first certifies; the second conflicts —
+    // so value has already left the wallet and a full-amount re-plan would over-request.
+    const orig = sender.engine.transfer.bind(sender.engine);
+    let calls = 0;
+    vi.spyOn(sender.engine, 'transfer').mockImplementation((...args: Parameters<typeof orig>) => {
+      calls += 1;
+      return calls === 2
+        ? Promise.reject(new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent'))
+        : orig(...args);
+    });
+
+    // The conflict is NOT self-healed (an earlier op already certified) — it propagates, and nothing
+    // is demoted (no retry).
+    await expect(sender.module.send({ recipient: '@bob', amount: '2000', coinId: UCT }))
+      .rejects.toBeInstanceOf(TransferConflictError);
+    expect(sender.module.getTokens().filter((t) => t.suspectedSpent)).toHaveLength(0);
+  });
+
   it('a plain (non-conflict) send failure does NOT emit inventory:conflict', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-conf-2');

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -912,30 +912,53 @@ describe('replay classifies recipient-quota (429) as deferred, never poison (§3
   });
 });
 
-describe('stale-inventory conflict is SURFACED, not silent (#517 item 2)', () => {
-  it('a send that loses the race on a stale source emits inventory:conflict (E.2 TransferConflictError)', async () => {
+describe('stale-inventory conflict self-heals (#625) + is SURFACED (#517 item 2)', () => {
+  it('the ONLY source being stale: demote it, re-plan, and surface a CLEAN SEND_INSUFFICIENT_BALANCE (not a raw conflict)', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-conf-1');
-    await seedServerToken(fake, sender, SENDER, 1000n);
+    const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
     await sender.module.load();
 
-    // Coin-selection planned from the lazy view, but another device already
-    // spent the source: the engine's match-verify raises TransferConflictError
-    // (Part E.2 — the predictable stale-view race the incident flagged).
+    // Another device already spent the only source: the engine's match-verify raises
+    // TransferConflictError on every certification attempt (Part E.2).
     vi.spyOn(sender.engine, 'transfer').mockRejectedValue(
       new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent')
     );
 
+    // #625: the send demotes the stale source and re-plans; with no live candidate left it exhausts to
+    // a CLEAN SEND_INSUFFICIENT_BALANCE — never an endless loop or a raw conflict to the caller.
     await expect(sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT }))
-      .rejects.toBeInstanceOf(TransferConflictError);
+      .rejects.toThrow(/insufficient balance/i);
 
-    // The recoverable condition is now OBSERVABLE — a distinct event, not just a
-    // generic transfer:failed buried in a string.
+    // The conflict is still surfaced (telemetry/UI awareness) — exactly once: the re-plan fails at
+    // SELECTION (the source is now excluded), not at certification, so no second conflict.
     const conflictCalls = sender.emitEvent.mock.calls.filter((c) => c[0] === 'inventory:conflict');
     expect(conflictCalls).toHaveLength(1);
-    expect(conflictCalls[0][1]).toMatchObject({ coinId: UCT });
-    expect(typeof conflictCalls[0][1].transferId).toBe('string');
     expect(conflictCalls[0][1].error).toContain('TRANSACTION_HASH_MISMATCH');
+
+    // The stale source is DEMOTED (suspectedSpent) but KEPT in inventory — never auto-removed.
+    const demoted = sender.module.getTokens().find((t) => t.id === `v2_${sourceTokenId}`);
+    expect(demoted?.suspectedSpent).toBe(true);
+  });
+
+  it('a stale source among live ones self-heals: demote the conflicted token, complete with the next candidate', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-heal-1');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await seedServerToken(fake, sender, SENDER, 1000n); // two interchangeable sources
+    await sender.module.load();
+
+    // The first-selected source is already spent: the engine conflicts ONCE, then certifies normally.
+    vi.spyOn(sender.engine, 'transfer').mockRejectedValueOnce(
+      new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent')
+    );
+
+    const result = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT });
+    expect(result.status).toBe('completed');
+
+    // Exactly one source demoted (the conflicted one); the delivery landed via the live source.
+    expect(sender.module.getTokens().filter((t) => t.suspectedSpent)).toHaveLength(1);
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(1);
   });
 
   it('a plain (non-conflict) send failure does NOT emit inventory:conflict', async () => {

--- a/token-engine/errors.ts
+++ b/token-engine/errors.ts
@@ -16,6 +16,12 @@ import { SphereError } from '../core/errors';
  * a NEW `transferId` (never reusing the old realization) — sdk-changes E.2.
  */
 export class TransferConflictError extends SphereError {
+  /**
+   * #625: the source token id (the caller's id, e.g. `v2_<genesis>`) whose state was already spent.
+   * Set by PaymentsModule at the engine call site so the self-healing retry can demote it and re-plan.
+   */
+  conflictedSourceId?: string;
+
   constructor(message: string, cause?: unknown) {
     super(message, 'TRANSFER_CONFLICT', cause);
     this.name = 'TransferConflictError';

--- a/types/index.ts
+++ b/types/index.ts
@@ -77,6 +77,13 @@ export interface Token {
    * (`getToken`) only when the token is selected for a spend.
    */
   readonly lazy?: boolean;
+  /**
+   * #625 (self-healing coin selection): a send selected this source but its state was already spent
+   * on-chain (`TransferConflictError`). It is KEPT in inventory (visible, recoverable by a resync —
+   * never auto-removed) but EXCLUDED from spend selection, so coin-selection picks live tokens and the
+   * send self-heals instead of wedging on a stale source.
+   */
+  suspectedSpent?: boolean;
 }
 
 export interface Asset {


### PR DESCRIPTION
Refs #625 (P3 — the headline follow-up from #621/#622).

## Why

A *fresh* send that coin-selects a stale-spent token (the source was consumed on-chain by another device / a prior attempt) raised `TransferConflictError`, surfaced `inventory:conflict`, and **failed** — recoverable, but the user had to manually refresh & retry. This is the send-time analog of the wedge #622 already fixed for *resume* (which now records-the-spend instead of re-certifying).

## What

`send()` now **self-heals**: on a `TransferConflictError` for a selected source, demote that source and re-plan with the next candidate, bounded.

- **`Token.suspectedSpent`** — a source proven spent on-chain. **Kept in inventory** (visible, recoverable by a resync — never auto-removed) but **excluded from spend selection** (`SpendQueue.buildParsedPool` + the live re-check). This is the "push to the end without removing" you asked for, realised as exclude-from-selection so an exhausted set yields a clean balance error rather than looping.
- **`TransferConflictError.conflictedSourceId`** — tagged at the `engine.transfer`/`engine.split` call site so the retry knows which source to demote.
- **`send()` is a thin retry wrapper** over `sendOnce()`: on a tagged conflict → demote + re-plan (`MAX_RESELECT_ATTEMPTS` backstop; a fixed `instantSplitSend` plan is never re-planned). Exhausting live candidates surfaces a **clean `SEND_INSUFFICIENT_BALANCE`** — never an endless loop or a raw conflict to the caller.

## Tests
- A stale source among live ones **self-heals** and completes via the next candidate (one source demoted, delivery lands).
- The only-source-stale case demotes and surfaces a clean `SEND_INSUFFICIENT_BALANCE` (the conflict is still surfaced once for telemetry; the demoted source stays in inventory).
- 1248 unit tests green, typecheck + lint clean.

Stacked on #624 (now merged); diff vs `main` is just P3. Remaining on #625: **P4** (activity-panel UI, sphere repo) and **wallet-api 429 subcodes**.