### PR TITLE
feat(wallet-api): retry idempotent GETs on a transient NETWORK failure

### DIFF
--- a/tests/unit/wallet-api/client.retry.test.ts
+++ b/tests/unit/wallet-api/client.retry.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Transient NETWORK retry: a dropped/reset connection (e.g. a backend resetting mid-read under load —
+ * the swap-wallet inventory-sync ECONNRESET) should be retried for IDEMPOTENT GETs, but NEVER for
+ * writes (a lost-response retry could double-apply). Verified by injecting a flaky fetchFn.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { WalletApiClient, WalletApiError } from '../../../wallet-api';
+import { FakeWalletApi } from '../../support/fake-wallet-api';
+import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
+
+type FetchLike = (url: string | URL, init?: { method?: string }) => Promise<Response>;
+
+describe('WalletApiClient — transient NETWORK retry (GET only)', () => {
+  let fake: FakeWalletApi;
+  let baseUrl: string;
+  const identity = testIdentity(51);
+  const calls: { method: string; path: string }[] = [];
+
+  const realFetch: FetchLike = (u, init) =>
+    (globalThis as unknown as { fetch: FetchLike }).fetch(u, init);
+
+  function makeClient(fetchFn: FetchLike): WalletApiClient {
+    const client = new WalletApiClient({
+      baseUrl,
+      network: fake.network,
+      deviceId: 'dev-retry',
+      storage: new MemoryKeyValueStore(),
+      fetchFn: fetchFn as never,
+    });
+    client.setIdentity(identity);
+    return client;
+  }
+
+  beforeEach(async () => {
+    fake = new FakeWalletApi();
+    baseUrl = await fake.start();
+    calls.length = 0;
+  });
+  afterEach(async () => {
+    await fake.stop();
+  });
+
+  it('retries an idempotent GET on a transient NETWORK failure and succeeds', async () => {
+    let failInventory = 1; // drop the connection once, then let it through
+    const client = makeClient((u, init) => {
+      const method = init?.method ?? 'GET';
+      const path = String(u);
+      calls.push({ method, path });
+      if (method === 'GET' && path.includes('/v1/inventory') && failInventory-- > 0) {
+        return Promise.reject(new TypeError('fetch failed')); // ECONNRESET-style
+      }
+      return realFetch(u, init);
+    });
+
+    const page = await client.listInventory();
+    expect(page.items).toEqual([]); // empty inventory, but the call SUCCEEDED after the retry
+
+    const inventoryGets = calls.filter((c) => c.method === 'GET' && c.path.includes('/v1/inventory'));
+    expect(inventoryGets).toHaveLength(2); // first dropped → retried → succeeded
+  });
+
+  it('gives up after the bounded attempts when the GET keeps failing', async () => {
+    const client = makeClient((u, init) => {
+      const method = init?.method ?? 'GET';
+      const path = String(u);
+      calls.push({ method, path });
+      if (method === 'GET' && path.includes('/v1/inventory')) {
+        return Promise.reject(new TypeError('fetch failed'));
+      }
+      return realFetch(u, init);
+    });
+
+    await expect(client.listInventory()).rejects.toBeInstanceOf(WalletApiError);
+    const inventoryGets = calls.filter((c) => c.method === 'GET' && c.path.includes('/v1/inventory'));
+    expect(inventoryGets.length).toBeGreaterThan(1); // bounded retries were attempted
+    expect(inventoryGets.length).toBeLessThanOrEqual(3);
+  });
+
+  it('does NOT retry a write on a NETWORK failure — a lost-response retry could double-apply', async () => {
+    const client = makeClient((u, init) => {
+      const method = init?.method ?? 'GET';
+      const path = String(u);
+      calls.push({ method, path });
+      if (method === 'PUT' && path.includes('/v1/intents/')) {
+        return Promise.reject(new TypeError('fetch failed'));
+      }
+      return realFetch(u, init);
+    });
+
+    await expect(
+      client.putIntent('00000000-0000-0000-0000-000000000001', 'enc1.c2VlZA=='),
+    ).rejects.toBeInstanceOf(WalletApiError);
+
+    const intentPuts = calls.filter((c) => c.method === 'PUT' && c.path.includes('/v1/intents/'));
+    expect(intentPuts).toHaveLength(1); // attempted exactly once — writes are never retried
+  });
+});

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -145,6 +145,11 @@ function defaultWebSocketFactory(url: string): import('./types').WebSocketLike {
   return new Ctor(url);
 }
 
+/** GET-only retry on a transient NETWORK failure (a dropped/reset connection — e.g. a backend under
+ * load resetting mid-read). Total attempts and exponential-backoff base. */
+const GET_RETRY_ATTEMPTS = 3;
+const GET_RETRY_BASE_MS = 200;
+
 export class WalletApiClient {
   /** Network name (also the blob-key prefix `<network>/t/<sha256>` — §5.2). */
   readonly network: string;
@@ -408,16 +413,41 @@ export class WalletApiClient {
   }
 
   /**
+   * GET-only retry on a transient NETWORK failure (a dropped/reset connection — e.g. a backend under
+   * load resetting mid-read). GETs are idempotent, so re-issuing is safe; non-GET methods are NEVER
+   * retried here because a lost-response retry could double-apply a write. Non-NETWORK outcomes (any
+   * HTTP status) come back as a response and are handled by the caller. Bounded exponential backoff.
+   */
+  private async rawFetchWithReadRetry(
+    method: string,
+    path: string,
+    body: unknown,
+    jwt: string
+  ): Promise<FetchResponseLike> {
+    const attempts = method === 'GET' ? GET_RETRY_ATTEMPTS : 1;
+    for (let attempt = 1; ; attempt += 1) {
+      try {
+        return await this.rawFetch(method, path, body, jwt);
+      } catch (err) {
+        const transient = err instanceof WalletApiError && err.code === 'NETWORK';
+        if (!transient || attempt >= attempts) throw err;
+        await new Promise((resolve) => setTimeout(resolve, GET_RETRY_BASE_MS * 2 ** (attempt - 1)));
+      }
+    }
+  }
+
+  /**
    * Authenticated JSON request. A 401 triggers one silent re-auth
-   * (refresh → challenge fallback) and one retry.
+   * (refresh → challenge fallback) and one retry; idempotent GETs additionally retry a transient
+   * NETWORK failure (rawFetchWithReadRetry) so a single dropped connection doesn't fail the call.
    */
   private async requestJson(method: string, path: string, body?: unknown): Promise<unknown> {
     if (!this.jwt) await this.signIn();
-    let res = await this.rawFetch(method, path, body, this.jwt!);
+    let res = await this.rawFetchWithReadRetry(method, path, body, this.jwt!);
     if (res.status === 401) {
       this.jwt = null;
       await this.signIn();
-      res = await this.rawFetch(method, path, body, this.jwt!);
+      res = await this.rawFetchWithReadRetry(method, path, body, this.jwt!);
     }
     if (res.status === 204) return null;
     if (!res.ok) throw await this.toError(res, `${method} ${path}`);


### PR DESCRIPTION
## Why

The swap wallet surfaced:
```
token storage degraded: Failed to save to provider wallet-api-token-storage:
wallet-api request failed: GET /v1/inventory?since=4738
```
That's a **`NETWORK`-code** error (no HTTP status) — `cause: TypeError: fetch failed … ECONNRESET`: the backend **reset the connection** mid-read under load (the same connection-drop pattern as the staging-degradation handoff; reads are un-throttled, so it's not rate-limiting). `WalletApiTokenStorageProvider.save()` runs a `syncInventory()` delta GET before+after pushing, so one dropped connection on that idempotent read failed the **whole save** and emitted `storage:degraded`.

## What

`requestJson` now retries **GETs** on a `NETWORK` failure with bounded exponential backoff (`rawFetchWithReadRetry` — 3 attempts, 200 ms base). A single dropped connection is ridden out transparently instead of degrading the wallet.

**Scoped to GET only.** Writes are never retried here — a lost-response retry of a non-idempotent write could double-apply. (Auth POSTs go through `rawFetch` directly and are unaffected.)

## Scope note
This is **client resilience**, not the root fix — the connection drops are infra-side (backend under the swap wallet's load); scaling is in progress separately. This stops transient drops from surfacing as `storage:degraded` in the meantime.

## Tests
A GET retries once and succeeds; a persistently-failing GET gives up after the bounded attempts; a `PUT` write is attempted **exactly once** (never retried). 54 client tests green.