### PR TITLE
Adopt nostr-js-sdk 0.6.0 (UNIP-01 nametag resolution)

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -3479,8 +3479,9 @@ export class Sphere {
 
     // Register the nametag by publishing the Nostr identity binding (name ↔ chainPubkey).
     // D5: nametags are Nostr bindings only — there is no on-chain nametag token. Receive is
-    // always SignaturePredicate(chainPubkey); the binding is the sole registration act, and its
-    // first-seen-wins failure path below is the uniqueness guard.
+    // always SignaturePredicate(chainPubkey); the binding is the sole registration act. The
+    // binding carries the UNIP-01 marker, so the relay enforces single ownership — a publish
+    // for a name already owned by another key is rejected (the failure path below).
     if (this._transport.publishIdentityBinding) {
       const success = await this._transport.publishIdentityBinding(
         this._identity!.chainPubkey,
@@ -3599,7 +3600,7 @@ export class Sphere {
    * Check whether a nametag is available to register.
    *
    * D5: nametags are Nostr bindings (name ↔ chainPubkey), not on-chain tokens. Availability is
-   * first-seen-wins — a name is available iff no binding resolves for it.
+   * determined by UNIP-01 resolution — a name is available iff no binding resolves for it.
    *
    * @param nametag - The nametag to check (e.g., "alice" or "@alice")
    * @returns true if available, false if already taken

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@noble/ciphers": "^2.2.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.5.0",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
         "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
@@ -1991,9 +1991,9 @@
       }
     },
     "node_modules/@unicitylabs/nostr-js-sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.5.0.tgz",
-      "integrity": "sha512-v6qaZBkyuZzvfjyO/x+czqftYdAqxjyfBXipsB0QJIdqePBiWHR2aRs28zzJIhCMk1vP9HXzxGnpjRqlcnzroA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
+      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@noble/ciphers": "^2.2.0",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
-    "@unicitylabs/nostr-js-sdk": "^0.5.0",
+    "@unicitylabs/nostr-js-sdk": "^0.6.0",
     "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
     "bip39": "^3.1.0",
     "buffer": "^6.0.3",

--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -850,14 +850,16 @@ export class NostrTransportProvider implements TransportProvider {
 
   async resolveNametag(nametag: string): Promise<string | null> {
     await this.ensureConnectedForResolve();
-    // Delegate to nostr-js-sdk which implements first-seen-wins anti-hijacking
+    // Delegate to nostr-js-sdk, which resolves via UNIP-01 (prefers the
+    // relay-vetted single-owner binding; see unicity-tokens-relay/docs/UNIP-01.md)
     return this.nostrClient!.queryPubkeyByNametag(nametag);
   }
 
   async resolveNametagInfo(nametag: string): Promise<PeerInfo | null> {
     await this.ensureConnectedForResolve();
 
-    // Delegate to nostr-js-sdk which implements first-seen-wins anti-hijacking
+    // Delegate to nostr-js-sdk, which resolves via UNIP-01 (prefers the
+    // relay-vetted single-owner binding; see unicity-tokens-relay/docs/UNIP-01.md)
     const binding = await this.nostrClient!.queryBindingByNametag(nametag);
     if (!binding) {
       logger.debug('Nostr', `resolveNametagInfo: no binding events found for Unicity ID "${nametag}"`);
@@ -869,7 +871,7 @@ export class NostrTransportProvider implements TransportProvider {
 
   /**
    * Resolve a DIRECT:// or PROXY:// address to full peer info.
-   * Performs reverse lookup via nostr-js-sdk with first-seen-wins anti-hijacking.
+   * Performs reverse lookup via nostr-js-sdk (UNIP-01 marker-preferring resolution).
    */
   async resolveAddressInfo(address: string): Promise<PeerInfo | null> {
     await this.ensureConnectedForResolve();
@@ -1039,7 +1041,7 @@ export class NostrTransportProvider implements TransportProvider {
    * Without nametag: publishes base binding (chainPubkey, directAddress)
    * using a per-identity d-tag for address discovery.
    * With nametag: delegates to nostr-js-sdk's publishNametagBinding which handles
-   * conflict detection (first-seen-wins), encryption, and indexed tags.
+   * conflict detection (UNIP-01 single-owner), encryption, and indexed tags.
    *
    * @returns true if successful, false if nametag is taken by another pubkey
    */


### PR DESCRIPTION
## Summary

Bumps `@unicitylabs/nostr-js-sdk` `^0.5.0` → `^0.6.0` to adopt **UNIP-01** client support, so Sphere nametag resolution becomes deterministic and independent of self-asserted event timestamps. Relay spec: `unicity-tokens-relay/docs/UNIP-01.md` (enforcement already merged + deployed).

## What this brings in (from nostr-js-sdk 0.6.0)

- Binding events carry the NIP-32 `["L","unicity:nametag"]` marker, opting into relay-enforced single-owner semantics.
- Nametag resolution prefers the relay-vetted single-owner binding and **ignores `created_at`**; ambiguous (>1 marked owner) → unresolved; legacy fallback only when no marked binding exists (migration).

## sphere-sdk changes

- **Dependency bump only** for behavior — sphere-sdk delegates nametag resolution (`resolveNametag` / `resolveNametagInfo` / `resolveAddressInfo`) and registration (`publishIdentityBinding` → `publishNametagBinding`) to nostr-js-sdk, so it inherits the new resolution and marker emission with **no logic change**.
- The route-on-conflict guard already exists: an unresolved/ambiguous name returns `null` → `transport-resolver.ts` throws `INVALID_RECIPIENT`, aborting send / DM / payment-request / swap.
- Refreshed stale `"first-seen-wins anti-hijacking"` comments to UNIP-01 in `NostrTransportProvider` and `Sphere.registerNametag` / `isNametagAvailable`.

## Verification

- `tsc --noEmit`: clean.
- Nametag/transport tests: `NostrTransportProvider.nametag.test.ts` (22) + `nametag-roundtrip.test.ts` (7) pass.
- Lint clean on changed files.
- Full unit/integration suite: 2918 pass; the only failures (2 integration files) are a local-env artifact — pre-existing root-owned `.test-*` dirs that `rmdir` can't remove (`EACCES`), unrelated to this change; CI runs in a clean env.

## Rollout note

The direct `created_at`-based selections remaining in `NostrTransportProvider` (`resolveTransportPubkeyInfo`, `discoverAddresses`, `recoverNametag`) are scoped to a single known author (own/queried pubkey) — legitimate latest-wins, not a contested-name selection.