### PR TITLE
feat(payments): keep the intent OPEN when an engine op may have certified (#631)

### DIFF
--- a/core/errors.ts
+++ b/core/errors.ts
@@ -35,6 +35,9 @@ export type SphereErrorCode =
   // The source state was consumed by a DIFFERENT transaction (lost race, not a
   // resume) — raised as TransferConflictError (token-engine/errors.ts, Part E.2).
   | 'TRANSFER_CONFLICT'
+  // The op's certification is INDETERMINATE (submit accepted / proof fetch
+  // inconclusive) — raised as ProofUnconfirmedError; keep the intent OPEN (#631).
+  | 'CERTIFICATION_UNCONFIRMED'
   | 'STORAGE_ERROR'
   | 'TRANSPORT_ERROR'
   | 'AGGREGATOR_ERROR'

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -30,7 +30,7 @@ import type {
 } from '../../types/txf';
 import type { SplitPlan, TokenWithAmount } from './TokenSplitCalculator';
 import type { ITokenEngine, SphereToken, TokenBlob } from '../../token-engine';
-import { TransferConflictError } from '../../token-engine';
+import { TransferConflictError, ProofUnconfirmedError } from '../../token-engine';
 import { WalletApiError } from '../../wallet-api';
 import { isV2TransferPayload, type V2TransferPayload } from '../../types/v2-transfer';
 import { TokenReservationLedger } from './TokenReservationLedger';
@@ -2011,13 +2011,22 @@ export class PaymentsModule {
       //    caller re-plans under a NEW transferId; soft abort keeps the row);
       //    any already-certified legs stay journaled for delivery replay and
       //    converge via the recipient's claim handoff (§6);
-      //  - a failure with NOTHING certified also aborts — an open intent would
-      //    silently re-execute the transfer at the next sign-in after the user
-      //    already saw it fail (and possibly retried it manually);
+      //  - a PROVEN clean pre-certification failure (nothing certified) also
+      //    aborts — an open intent would silently re-execute the transfer at the
+      //    next sign-in after the user already saw it fail (and possibly retried
+      //    it manually);
       //  - a partially-certified non-conflict failure keeps the intent OPEN:
-      //    forward completion via resume is the only exit (§7).
+      //    forward completion via resume is the only exit (§7);
+      //  - #631: a ProofUnconfirmedError (submit accepted / proof fetch
+      //    inconclusive) is NOT "nothing certified" — the source spend may be
+      //    on-chain under result.id, and the intent is the only resume seed. Keep
+      //    it OPEN even when committedOnChainTokenIds is still empty (the throw
+      //    beat the .add()). Resume re-derives the identical tx: it recovers the
+      //    proof + delivery, or records the spend if a foreign tx won — never a
+      //    second on-chain spend.
+      const mayHaveCertified = error instanceof ProofUnconfirmedError;
       if (this.deps?.walletApi) {
-        if (error instanceof TransferConflictError || committedOnChainTokenIds.size === 0) {
+        if (error instanceof TransferConflictError || (committedOnChainTokenIds.size === 0 && !mayHaveCertified)) {
           try {
             await this.deps.walletApi.abortIntent(result.id);
           } catch (abortErr) {

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -24,7 +24,7 @@ import type { TransportProvider } from '../../../transport';
 import type { OracleProvider } from '../../../oracle';
 import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../../storage';
 import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
-import { TransferConflictError } from '../../../token-engine';
+import { TransferConflictError, ProofUnconfirmedError } from '../../../token-engine';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
 import { WalletApiClient, WalletApiError } from '../../../wallet-api';
@@ -836,6 +836,65 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(outcome.conflicted).toEqual([]);
     expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'removed' });
     expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
+  });
+
+  it('#631: a proof-fetch failure AFTER certification keeps the intent OPEN (resume seed survives; no double-spend)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-631-open');
+    const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // The #631 window: the aggregator certifies (the source is consumed on-chain) but the
+    // inclusion-proof fetch THEN throws — modeled by running the REAL op (which marks the source
+    // spent → engine.isSpent(source) === true) and then throwing ProofUnconfirmedError.
+    const realTransfer = sender.engine.transfer.bind(sender.engine);
+    let transferId: string | undefined;
+    vi.spyOn(sender.engine, 'transfer').mockImplementationOnce(async (p, o) => {
+      transferId = o?.transferId;
+      const finished = await realTransfer(p, o); // consumes the source (certifies)
+      void finished;
+      throw new ProofUnconfirmedError('inclusion-proof fetch failed after certification');
+    });
+
+    await expect(
+      sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT, memo: 'lunch' }),
+    ).rejects.toBeInstanceOf(ProofUnconfirmedError);
+
+    // THE FIX: the intent is kept OPEN (was 'aborted' before #631) — the resume seed survives so
+    // resumeOpenIntents can replay the same transferId to recover the proof + delivery. (Resume
+    // convergence of an open intent is covered by the §3.1/#621 resume tests above.)
+    expect(fake.getIntent(SENDER.chainPubkey, transferId!)).toMatchObject({ status: 'open' });
+
+    // Money-safe: the source is terminal 'spent' locally (never restored to 'confirmed' — no
+    // phantom balance), via the restore loop's on-chain isSpent probe.
+    expect(sender.module.getTokens()[0].status).toBe('spent');
+
+    // Nothing committed server-side, nothing delivered: the throw beat applyDelta AND the
+    // blob-journal, so the source row is not removed and the recipient mailbox is empty. Only the
+    // resume SEED was ever at risk — and it now survives instead of being aborted.
+    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)?.status).not.toBe('removed');
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);
+  });
+
+  it('#631 regression: a clean pre-certification failure (plain error, source untouched) still aborts + restores', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-631-clean');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // A plain Error (NOT ProofUnconfirmedError) with NOTHING consumed — a proven clean
+    // pre-certification failure. The fix must leave this on the abort + restore path.
+    let transferId: string | undefined;
+    vi.spyOn(sender.engine, 'transfer').mockImplementationOnce((_p, o) => {
+      transferId = o?.transferId;
+      return Promise.reject(new Error('aggregator rejected — clean, nothing certified'));
+    });
+
+    await expect(sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT })).rejects.toThrow();
+
+    // Unchanged: the untouched source is restored to 'confirmed' and the intent is aborted.
+    expect(sender.module.getTokens()[0].status).toBe('confirmed');
+    expect(fake.getIntent(SENDER.chainPubkey, transferId!)).toMatchObject({ status: 'aborted' });
   });
 
   it('resume of an already-certified SPLIT source records the spend instead of wedging (#622 review)', async () => {

--- a/tests/unit/token-engine/recoverable-engine.test.ts
+++ b/tests/unit/token-engine/recoverable-engine.test.ts
@@ -18,7 +18,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { TransferConflictError } from '../../../token-engine/errors';
+import { TransferConflictError, ProofUnconfirmedError } from '../../../token-engine/errors';
 import { deriveRealization } from '../../../token-engine/realization';
 import {
   type CertificationData,
@@ -76,7 +76,8 @@ class CrashAfterBurnClient implements IAggregatorClient {
   }
 }
 
-/** Submit never reaches the aggregator — a genuine submit failure (no proof will exist). */
+/** Submit THROWS (unreachable / lost response) — INDETERMINATE: the POST may have been
+ * processed server-side, so this is not a proven clean reject (#631). */
 class SubmitUnreachableClient implements IAggregatorClient {
   public constructor(private readonly inner: TestAggregatorClient) {}
 
@@ -86,6 +87,50 @@ class SubmitUnreachableClient implements IAggregatorClient {
 
   public submitCertificationRequest(): Promise<CertificationResponse> {
     return Promise.reject(new Error('aggregator unreachable (simulated)'));
+  }
+}
+
+/** Submit LANDS (SUCCESS — the certification exists) but the PROOF FETCH throws: the
+ * canonical #631 window — the source is consumed on-chain, yet no verdict is available. */
+class GetInclusionProofThrowsClient implements IAggregatorClient {
+  public constructor(private readonly inner: TestAggregatorClient) {}
+
+  public submitCertificationRequest(certificationData: CertificationData): Promise<CertificationResponse> {
+    return this.inner.submitCertificationRequest(certificationData); // SUCCESS → certifies
+  }
+
+  public getInclusionProof(): Promise<InclusionProofResponse> {
+    return Promise.reject(new Error('inclusion-proof fetch failed: 503 unavailable'));
+  }
+}
+
+/** Submit resolves with a NON-VALIDATION status UNKNOWN to this SDK's enum (the transitional
+ * `STATE_ID_EXISTS` — "a certification may already exist"), then the proof fetch throws. E.2 is
+ * status-AGNOSTIC: this must be treated as possibly-certified (ProofUnconfirmedError), never a
+ * clean reject — #631. `status` is a plain string, so unknown values parse fine (per the SDK). */
+class UnknownStatusThenProofThrowsClient implements IAggregatorClient {
+  public constructor(private readonly inner: TestAggregatorClient) {}
+
+  public submitCertificationRequest(): Promise<CertificationResponse> {
+    return Promise.resolve({ status: 'STATE_ID_EXISTS' } as unknown as CertificationResponse);
+  }
+
+  public getInclusionProof(): Promise<InclusionProofResponse> {
+    return Promise.reject(new Error('proof fetch failed (transient)'));
+  }
+}
+
+/** Submit resolves with a KNOWN validation-reject status (nothing certified), then the proof fetch
+ * throws. E.2 must surface the clean submit error (→ abort + restore), NOT ProofUnconfirmedError. */
+class ValidationRejectThenProofThrowsClient implements IAggregatorClient {
+  public constructor(private readonly inner: TestAggregatorClient) {}
+
+  public submitCertificationRequest(): Promise<CertificationResponse> {
+    return Promise.resolve({ status: 'STATE_ID_MISMATCH' } as unknown as CertificationResponse);
+  }
+
+  public getInclusionProof(): Promise<InclusionProofResponse> {
+    return Promise.reject(new Error('proof fetch failed (transient)'));
   }
 }
 
@@ -237,10 +282,15 @@ describe('recoverable engine (Part E) — real adapter over in-memory aggregator
       { recipientPubkey: self, coinId: COIN, amount: 40n },
     ];
 
-    await expect(
+    const err = await crashing
       // Short proof-poll budget: the crashed mint submits leave no proof to find.
-      crashing.split({ token: src, outputs }, { transferId, signal: AbortSignal.timeout(2000) }),
-    ).rejects.toThrow('wallet crashed mid-split (simulated)');
+      .split({ token: src, outputs }, { transferId, signal: AbortSignal.timeout(2000) })
+      .then(() => null, (caught: unknown) => caught);
+    // #631: the mint submit crashed AFTER the burn certified — INDETERMINATE (the mint may have
+    // been processed server-side). The engine raises ProofUnconfirmedError (keep-open), preserving
+    // the crash as the cause; resume under the same transferId then completes (below).
+    expect(err).toBeInstanceOf(ProofUnconfirmedError);
+    expect(String((err as { cause?: unknown }).cause)).toContain('wallet crashed mid-split (simulated)');
 
     const resumed = await plain.split({ token: src, outputs }, { transferId });
     expect(resumed.outputs).toHaveLength(2);
@@ -305,9 +355,11 @@ describe('recoverable engine (Part E) — real adapter over in-memory aggregator
     expect((await plain.verify(finished)).ok).toBe(true);
   }, 20000);
 
-  // E.2 third arm: no certification ever landed AND the submit failed — the
-  // ORIGINAL submit error surfaces (a genuine failure, not a resume case).
-  it('E.2: a failed submit with no existing proof rethrows the original submit error', async () => {
+  // E.2 fourth arm (#631): a submit that THROWS (unreachable / lost response) is
+  // INDETERMINATE — it may have been processed server-side — so the engine raises a typed
+  // ProofUnconfirmedError (keep the intent OPEN + resume), preserving the submit error as
+  // the cause. Only a well-formed non-SUCCESS status is a PROVEN clean reject.
+  it('E.2 #631: a throwing/unreachable submit with no proof raises ProofUnconfirmedError (keep-open)', async () => {
     const aggregator = TestAggregatorClient.create();
     const walletKey = SigningService.generatePrivateKey();
     const plain = createTestEngine({ aggregator, privateKey: walletKey });
@@ -321,13 +373,93 @@ describe('recoverable engine (Part E) — real adapter over in-memory aggregator
       recipientPubkey: plain.getIdentity().chainPubkey,
       value: { assets: [{ coinId: COIN, amount: 1n }] },
     });
-    await expect(
-      dead.transfer(
+    const err = await dead
+      .transfer(
         { token: src, recipientPubkey: freshPubkey() },
         // Short proof-poll budget: with no certification the probe can only time out.
         { transferId: crypto.randomUUID(), signal: AbortSignal.timeout(500) },
-      ),
-    ).rejects.toThrow('aggregator unreachable (simulated)');
+      )
+      .then(() => null, (caught: unknown) => caught);
+    expect(err).toBeInstanceOf(ProofUnconfirmedError);
+    expect((err as ProofUnconfirmedError).code).toBe('CERTIFICATION_UNCONFIRMED');
+    expect((err as ProofUnconfirmedError).mayHaveCertified).toBe(true);
+    expect(String((err as { cause?: unknown }).cause)).toContain('aggregator unreachable');
+  }, 20000);
+
+  // #631 canonical window: submit SUCCESS (the certification lands — the source is consumed
+  // on-chain) but the proof FETCH throws. The engine must raise the typed keep-open signal
+  // (ProofUnconfirmedError) — NOT a raw error, NOT TransferConflictError — so the caller keeps
+  // the intent open and recovers via resume instead of orphaning a certified send.
+  it('E.2 #631: submit SUCCESS then a throwing proof fetch raises ProofUnconfirmedError (source is spent)', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const walletKey = SigningService.generatePrivateKey();
+    const plain = createTestEngine({ aggregator, privateKey: walletKey });
+    const flaky = createTestEngine({
+      aggregator,
+      privateKey: walletKey,
+      wireClient: new GetInclusionProofThrowsClient(aggregator),
+    });
+
+    const src = await plain.mint({
+      recipientPubkey: plain.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 7n }] },
+    });
+    const err = await flaky
+      .transfer({ token: src, recipientPubkey: freshPubkey() }, { transferId: crypto.randomUUID() })
+      .then(() => null, (caught: unknown) => caught);
+    expect(err).toBeInstanceOf(ProofUnconfirmedError);
+    expect((err as ProofUnconfirmedError).mayHaveCertified).toBe(true);
+    expect(err).not.toBeInstanceOf(TransferConflictError);
+    // the submit landed on the shared aggregator — the source IS spent on-chain, so a resume
+    // under the same transferId can recover the proof (this is exactly why we keep the intent open).
+    expect(await plain.isSpent(src)).toBe(true);
+  }, 20000);
+
+  // #631 status-agnostic classifier: an UNKNOWN/transitional non-SUCCESS status (e.g. STATE_ID_EXISTS
+  // — "a certification may already exist") + a throwing proof fetch is INDETERMINATE and MUST raise
+  // ProofUnconfirmedError (keep-open), NOT a clean abort. Guards against re-arming the #631 orphan on
+  // the submit-status classifier: `!== SUCCESS` is not "proven clean reject".
+  it('E.2 #631: an unknown non-SUCCESS submit status + throwing proof fetch → ProofUnconfirmedError (keep-open)', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const walletKey = SigningService.generatePrivateKey();
+    const plain = createTestEngine({ aggregator, privateKey: walletKey });
+    const flaky = createTestEngine({
+      aggregator,
+      privateKey: walletKey,
+      wireClient: new UnknownStatusThenProofThrowsClient(aggregator),
+    });
+    const src = await plain.mint({
+      recipientPubkey: plain.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 3n }] },
+    });
+    const err = await flaky
+      .transfer({ token: src, recipientPubkey: freshPubkey() }, { transferId: crypto.randomUUID(), signal: AbortSignal.timeout(500) })
+      .then(() => null, (caught: unknown) => caught);
+    expect(err).toBeInstanceOf(ProofUnconfirmedError);
+    expect((err as ProofUnconfirmedError).mayHaveCertified).toBe(true);
+  }, 20000);
+
+  // The other side of the classifier: a KNOWN validation-reject status PROVES nothing certified — it
+  // must surface the clean submit error (→ abort + restore), NEVER ProofUnconfirmedError.
+  it('E.2: a known validation-reject status + throwing proof fetch surfaces the clean submit error (abort)', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const walletKey = SigningService.generatePrivateKey();
+    const plain = createTestEngine({ aggregator, privateKey: walletKey });
+    const rejecting = createTestEngine({
+      aggregator,
+      privateKey: walletKey,
+      wireClient: new ValidationRejectThenProofThrowsClient(aggregator),
+    });
+    const src = await plain.mint({
+      recipientPubkey: plain.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 3n }] },
+    });
+    const err = await rejecting
+      .transfer({ token: src, recipientPubkey: freshPubkey() }, { transferId: crypto.randomUUID(), signal: AbortSignal.timeout(500) })
+      .then(() => null, (caught: unknown) => caught);
+    expect(err).not.toBeInstanceOf(ProofUnconfirmedError);
+    expect(err).not.toBeInstanceOf(TransferConflictError);
+    expect(String((err as Error).message)).toContain('STATE_ID_MISMATCH');
   }, 20000);
 
   // Pins the EXACT SDK error surface the engine maps to TransferConflictError:

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -14,7 +14,7 @@
 
 import { SphereError, type SphereErrorCode } from '../core/errors';
 import { randomUUID } from '../core/uuid';
-import { TransferConflictError } from './errors';
+import { TransferConflictError, ProofUnconfirmedError } from './errors';
 import { deriveDirectAddress, UNICITY_TOKEN_TYPE_HEX } from './identity';
 import { deriveDeliveryKeys } from './blob-keys';
 import { deriveRealization } from './realization';
@@ -83,6 +83,26 @@ export interface EngineDeps {
 
 /** Canonical lowercase UUID — the spec's `transferId` wire form (sdk-changes E.1). */
 const TRANSFER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * The KNOWN validation-reject submit statuses: a well-formed rejection that PROVES the
+ * state was never certified (a byte-identical resume of a *valid* tx never later returns
+ * a format/signature/state/shard-mismatch failure). E.2 is status-AGNOSTIC for everything
+ * else: an UNKNOWN or transitional non-SUCCESS status (e.g. the gateway's transitional
+ * `STATE_ID_EXISTS`) means "a certification for this state MAY already exist" — it must be
+ * treated as possibly-certified (keep the intent OPEN — #631), NEVER a clean abort. Any
+ * status outside this set therefore falls through to `ProofUnconfirmedError`.
+ */
+const CLEAN_REJECT_STATUSES: ReadonlySet<string> = new Set([
+  CertificationStatus.STATE_ID_MISMATCH,
+  CertificationStatus.SIGNATURE_VERIFICATION_FAILED,
+  CertificationStatus.INVALID_SIGNATURE_FORMAT,
+  CertificationStatus.INVALID_PUBLIC_KEY_FORMAT,
+  CertificationStatus.INVALID_SOURCE_STATE_HASH_FORMAT,
+  CertificationStatus.INVALID_TRANSACTION_HASH_FORMAT,
+  CertificationStatus.UNSUPPORTED_ALGORITHM,
+  CertificationStatus.INVALID_SHARD,
+]);
 
 export class SphereTokenEngine implements ITokenEngine {
   /** Hex form of the wallet key — deriveRealization's ikm input (Part E.1). */
@@ -418,10 +438,16 @@ export class SphereTokenEngine implements ITokenEngine {
     options?: EngineOpOptions,
   ): Promise<InclusionProof> {
     let submitError: unknown = null;
+    // true ONLY for a KNOWN validation-reject status — a PROVEN clean pre-certification
+    // reject (nothing on-chain). Status-agnostic otherwise (E.2): an UNKNOWN/transitional
+    // non-SUCCESS status may have certified, and a THROWN submit POST may have been
+    // processed server-side — both stay INDETERMINATE (keep-open, #631).
+    let submitRejectedCleanly = false;
     try {
       const response = await this.deps.client.submitCertificationRequest(certificationData);
       if (response.status !== CertificationStatus.SUCCESS) {
         submitError = new SphereError(`${failLabel}: ${response.status}`, failCode);
+        submitRejectedCleanly = CLEAN_REJECT_STATUSES.has(response.status);
       }
     } catch (err) {
       submitError = err ?? new SphereError(`${failLabel}: submit failed`, failCode);
@@ -450,9 +476,20 @@ export class SphereTokenEngine implements ITokenEngine {
           err,
         );
       }
-      // No certification materialized and the submit itself had failed.
-      if (submitError !== null) throw submitError;
-      throw err;
+      // A PROVEN clean pre-certification reject (well-formed non-SUCCESS status)
+      // → the state was genuinely never certified; surface the original error so
+      // the caller aborts + restores the untouched source.
+      if (submitRejectedCleanly) throw submitError;
+      // Otherwise INDETERMINATE (#631): the submit returned SUCCESS (submitError
+      // === null) and the proof fetch threw, OR the submit POST itself threw (may
+      // have been processed server-side). The source spend MAY be on-chain under
+      // THIS transferId — surface a typed keep-open signal so the caller keeps the
+      // intent OPEN and resumes under the same transferId instead of aborting.
+      throw new ProofUnconfirmedError(
+        `${failLabel}: certification unconfirmed — the source spend may be on-chain; ` +
+          'keep the intent open and resume under the same transferId',
+        submitError ?? err,
+      );
     }
   }
 

--- a/token-engine/errors.ts
+++ b/token-engine/errors.ts
@@ -27,3 +27,26 @@ export class TransferConflictError extends SphereError {
     this.name = 'TransferConflictError';
   }
 }
+
+/**
+ * The op's certification is INDETERMINATE: the submit was accepted (`SUCCESS`)
+ * or failed ambiguously (a thrown submit POST that may have been processed
+ * server-side), and the inclusion-proof fetch/verify returned NO verdict — a
+ * transient network/timeout error, NOT a matching proof and NOT
+ * `TRANSACTION_HASH_MISMATCH`. The source's spend MAY already be on-chain under
+ * THIS `transferId`.
+ *
+ * Unlike {@link TransferConflictError} (a foreign tx won — abort + re-plan under
+ * a NEW id), the caller MUST keep the intent OPEN: resume re-derives the
+ * byte-identical transaction from `(seed, transferId, opIndex)` and recovers the
+ * certified proof + recipient blob, or records the spend if a foreign tx won the
+ * race — never a second on-chain spend (sdk-changes E.2/E.3, #631).
+ */
+export class ProofUnconfirmedError extends SphereError {
+  readonly mayHaveCertified = true as const;
+
+  constructor(message: string, cause?: unknown) {
+    super(message, 'CERTIFICATION_UNCONFIRMED', cause);
+    this.name = 'ProofUnconfirmedError';
+  }
+}

--- a/token-engine/index.ts
+++ b/token-engine/index.ts
@@ -44,7 +44,7 @@ export { createSphereTokenEngine } from './factory';
 // Typed conflict surface of the recoverable engine (Part E.2): the source state
 // was consumed by a DIFFERENT transaction — a lost race, not a resume. Callers
 // abort the intent and re-plan under a new transferId.
-export { TransferConflictError } from './errors';
+export { TransferConflictError, ProofUnconfirmedError } from './errors';
 
 // Self-issued Unicity ID (nametag) token mint — the v2 analog of the v1
 // nametag mint, stored at registration but unused at runtime (D5 + user


### PR DESCRIPTION
## What

`payments.send` aborted the intent whenever `committedOnChainTokenIds` was empty. But a **proof-fetch failure that occurs *after* the aggregator certifies** throws *before* that set is populated (the throw beats the `.add()`), so a **possibly-certified send was aborted** and its recipient delivery **orphaned** — the recipient never receives a token the sender already paid for, and resume can't recover an aborted intent. Not a double-spend (the restore loop's `isSpent` probe still marks a truly-spent source terminal `'spent'`), but a real recipient-delivery-loss.

## Fix

- **Engine (`submitAndAwaitProof`)** raises a typed **`ProofUnconfirmedError`** (`mayHaveCertified`, code `CERTIFICATION_UNCONFIRMED`) when certification is **indeterminate** — submit accepted (`SUCCESS`), submit thrown, or an **unknown/transitional non-`SUCCESS` status** — followed by an inconclusive proof fetch.
- **`sendOnce`** keeps the intent **OPEN** on that signal (`... || (committedOnChainTokenIds.size === 0 && !mayHaveCertified)`), so resume replays the **same `transferId`** and recovers the proof + delivery (or records the spend if a foreign tx won). Only a **proven clean reject** and a `TransferConflictError` still abort.
- **Status-agnostic (E.2):** the clean-reject classifier is an **allow-list of known validation statuses**, *not* `!== SUCCESS`. `CertificationResponse.status` is a tolerant `string` — an unknown status (e.g. the transitional `STATE_ID_EXISTS`) may have certified, so it keeps-open.

## Adversarial verification (3 hostile reviewers + synthesis)

- **Fund-safety: PASS.** No double-spend / double-credit / durable phantom is constructible. Resume re-runs the **same `transferId`** (one `StateId`, single-occupancy, `TRANSACTION_HASH_MISMATCH`-never-applied) and never re-selects a source → at most one on-chain spend, under every interleaving (manual retry, concurrent-device resume, restore-loop race).
- **Caught + fixed a latent defect (now in this PR):** the first cut used `!== SUCCESS` for the clean-reject classifier, which would treat `STATE_ID_EXISTS` as a clean reject and **re-arm the exact #631 orphan** on the classifier. Fixed with the allow-list above + two engine tests locking both sides.

## Spec-first

`wallet-api/docs/sdk-changes.md` E.2 "fourth arm" + S3 updated (committed to wallet-api `main` — docs-only).

## Tests

- Send-path: keep-open on the #631 window (was `aborted`, now `open`) + regression that a **clean** pre-cert failure still aborts + restores. Confirmed **failing-first**.
- Engine: proof-fetch-throws → `ProofUnconfirmedError`; unreachable/thrown submit → `ProofUnconfirmedError`; **unknown status** → keep-open; **known validation-reject** → clean abort; crash-after-burn resume completes.
- `npm run typecheck` + `npm run lint` clean; `npm run test:run` — **2939 pass** (the 48 local failures are the pre-existing root-owned `.test-*` scratch-dir `EACCES`, unrelated; CI's clean container is unaffected).

## Two judgment calls for you (deliberate, not defects)

1. **Thrown/unreachable submit → keep-open (UX change).** A submit that *throws* is now indeterminate (kept open + resumed) rather than clean-aborted. The asymmetry is decisive — a stuck-open intent loses nothing (source stays spendable, conflict-guards any reuse), whereas an aborted-but-certified send loses funds — so biasing to keep-open is the spec-mandated call. Cost: a permanently-throwing submit leaks an open intent (liveness, retried each sign-in), and §7 "surprise-completion" on a send the user abandoned. Both money-safe.
2. **App-facing observability (worth deciding before apps build retry UX).** A kept-open `ProofUnconfirmedError` still surfaces `send()` as a *reject* / `transfer:failed` with no distinct "resumable/pending" signal. The **SDK** cannot double-spend, but an **app** that reacts to the reject by re-issuing the payment as a *fresh* transfer (new source) can double-**pay** the recipient. Consider emitting a distinct `transfer:pending_resume` / `deliveryState` so apps can distinguish "deferred, resuming" from "failed, safe to re-send". (Follow-up, not blocking.)

## Residuals (out of scope, not worsened)

Post-proof *realization* throws (an even narrower same-class window), sustained outage through the restore probe, and a permanently-*thrown* submit leaking an open intent — all money-safe (resume is byte-identical, never re-selects a source). Noted for a follow-up test that a *permanent* rejection surfaces as a non-`SUCCESS` **status** (aborts) rather than a throw (leaks).

Closes #631
