### PR TITLE
feat(engine): SplitCheckpointStore port + split() checkpoint resume (sphere-sdk#501 option b, E.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ ref_materials/
 # CLI wallet profiles and test wallets
 .sphere-cli*/
 
-# Integration test data
-tests/integration/.test-*/
+# Test-run data dirs (any suite that writes a wallet/token fixture under tests/)
+tests/**/.test-*/
 .claude/
 
 # Superpowers specs/plans — local only, never committed

--- a/core/errors.ts
+++ b/core/errors.ts
@@ -38,6 +38,13 @@ export type SphereErrorCode =
   // The op's certification is INDETERMINATE (submit accepted / proof fetch
   // inconclusive) — raised as ProofUnconfirmedError; keep the intent OPEN (#631).
   | 'CERTIFICATION_UNCONFIRMED'
+  // Split burn checkpoint (sdk-changes E.4, sphere-sdk#501) — all keep-open (token-engine/errors.ts):
+  // burn certified but the checkpoint could not be persisted (no mint submitted);
+  | 'CHECKPOINT_PERSIST_FAILED'
+  // a certified mint leaf has no reproducing stored bytes, or a stored checkpoint fails byte-binding;
+  | 'SPLIT_CHECKPOINT_LOST'
+  // a byte-bound checkpoint proof no longer verifies against the current trust base (validator rotation).
+  | 'CHECKPOINT_TRUSTBASE_MISMATCH'
   | 'STORAGE_ERROR'
   | 'TRANSPORT_ERROR'
   | 'AGGREGATOR_ERROR'

--- a/tests/unit/token-engine/recoverable-engine.test.ts
+++ b/tests/unit/token-engine/recoverable-engine.test.ts
@@ -18,9 +18,16 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { TransferConflictError, ProofUnconfirmedError } from '../../../token-engine/errors';
+import type { SplitCheckpointStore } from '../../../token-engine/engine';
+import {
+  CheckpointPersistFailedError,
+  ProofUnconfirmedError,
+  SplitCheckpointLostError,
+  TransferConflictError,
+} from '../../../token-engine/errors';
 import { deriveRealization } from '../../../token-engine/realization';
 import {
+  CborSerializer,
   type CertificationData,
   type CertificationResponse,
   HexConverter,
@@ -133,6 +140,116 @@ class ValidationRejectThenProofThrowsClient implements IAggregatorClient {
     return Promise.reject(new Error('proof fetch failed (transient)'));
   }
 }
+
+/** In-memory SplitCheckpointStore (E.4): insert-once, first-write-wins — the wallet-api §16
+ * intent-progress contract the engine builds against. `raw`/`putCalls` are test observers. */
+class InMemoryCheckpointStore implements SplitCheckpointStore {
+  public putCalls = 0;
+  private readonly slots = new Map<string, Uint8Array>();
+
+  private key(transferId: string, opIndex: number): string {
+    return `${transferId}:${String(opIndex)}`;
+  }
+
+  public put(transferId: string, opIndex: number, bytes: Uint8Array): Promise<Uint8Array> {
+    this.putCalls++;
+    const k = this.key(transferId, opIndex);
+    const existing = this.slots.get(k);
+    if (existing !== undefined) return Promise.resolve(existing); // first-write-wins
+    this.slots.set(k, bytes);
+    return Promise.resolve(bytes);
+  }
+
+  public get(transferId: string, opIndex: number): Promise<Uint8Array | null> {
+    return Promise.resolve(this.slots.get(this.key(transferId, opIndex)) ?? null);
+  }
+
+  public raw(transferId: string, opIndex: number): Uint8Array | undefined {
+    return this.slots.get(this.key(transferId, opIndex));
+  }
+}
+
+/** `put` always rejects — the durable-ack gate must fail BEFORE any mint submit (E.4). */
+class PersistFailingStore implements SplitCheckpointStore {
+  public get(): Promise<Uint8Array | null> {
+    return Promise.resolve(null);
+  }
+
+  public put(): Promise<Uint8Array> {
+    return Promise.reject(new Error('checkpoint store 503 (simulated)'));
+  }
+}
+
+/** `get` serves corrupt bytes — a store may serve a non-array blob OR a well-framed 5-array whose
+ * inner fields are wrong-typed (a bit-flip / tolerant re-encode that still parses as an array). */
+class PoisonedStore implements SplitCheckpointStore {
+  public constructor(private readonly poison: Uint8Array) {}
+
+  public get(): Promise<Uint8Array | null> {
+    return Promise.resolve(this.poison);
+  }
+
+  public put(_transferId: string, _opIndex: number, bytes: Uint8Array): Promise<Uint8Array> {
+    return Promise.resolve(bytes);
+  }
+}
+
+/** `get` null, but `put` returns a DIFFERENT authoritative record (a racing resumer won the slot). */
+class AdoptStore implements SplitCheckpointStore {
+  public constructor(private readonly winner: Uint8Array) {}
+
+  public get(): Promise<Uint8Array | null> {
+    return Promise.resolve(null);
+  }
+
+  public put(): Promise<Uint8Array> {
+    return Promise.resolve(this.winner); // first-write-wins: the caller MUST adopt these bytes
+  }
+}
+
+/** `get` always returns the same fixed record (a device resuming from a server-stored checkpoint). */
+class FixedGetStore implements SplitCheckpointStore {
+  public constructor(private readonly record: Uint8Array) {}
+
+  public get(): Promise<Uint8Array | null> {
+    return Promise.resolve(this.record);
+  }
+
+  public put(_transferId: string, _opIndex: number, bytes: Uint8Array): Promise<Uint8Array> {
+    return Promise.resolve(bytes);
+  }
+}
+
+/** A non-4-byte, structurally-valid 5-element CBOR array whose version field is a TEXT string
+ * (wrong major type) — parses as array(5) but the per-field decode throws a raw CborError. */
+const WRONG_TYPED_CHECKPOINT = CborSerializer.encodeArray(
+  CborSerializer.encodeTextString('not-an-int'), // field[0] should be a uint version
+  CborSerializer.encodeTextString('sdk'),
+  CborSerializer.encodeByteString(new Uint8Array([1])),
+  CborSerializer.encodeByteString(new Uint8Array([2])),
+  CborSerializer.encodeByteString(new Uint8Array([3])),
+);
+
+/** Counts submits so a test can prove ZERO mint legs were submitted (only the burn). */
+class SubmitCountingClient implements IAggregatorClient {
+  public submits = 0;
+
+  public constructor(private readonly inner: IAggregatorClient) {}
+
+  public getInclusionProof(stateId: StateId): Promise<InclusionProofResponse> {
+    return this.inner.getInclusionProof(stateId);
+  }
+
+  public submitCertificationRequest(certificationData: CertificationData): Promise<CertificationResponse> {
+    this.submits++;
+    return this.inner.submitCertificationRequest(certificationData);
+  }
+}
+
+const SPLIT_OUTPUTS = (self: Uint8Array) => [
+  { recipientPubkey: freshPubkey(), coinId: COIN, amount: 70n },
+  { recipientPubkey: self, coinId: COIN, amount: 30n },
+];
 
 describe('recoverable engine (Part E) — real adapter over in-memory aggregator', () => {
   // AC-E1 (transfer leg) + the AC-E2 mock-resume shape: the duplicate submit is
@@ -300,24 +417,59 @@ describe('recoverable engine (Part E) — real adapter over in-memory aggregator
     }
   }, 40000);
 
-  // KNOWN GAP sphere-sdk#501, pinned: a FULL re-run after the mint legs
-  // certified cannot recover. The aggregator rebuilds inclusion proofs from
-  // the live tree per request (st-sdk#126 — only CertificationData is
-  // stable), so the rebuilt mint transactions embed a byte-different burn
-  // proof; their transactionHashes mismatch the certified leaves and E.2's
-  // match-verify throws TransferConflictError. FLIP this test to assert
-  // recovery once the #501 persistence design (durable burn-certified split
-  // progress) lands.
-  it('split full re-run after certified mints throws TransferConflictError (#501 known gap)', async () => {
+  // AC-E2 (split leg, sphere-sdk#501 FIXED via E.4): a FULL re-run after the
+  // mint legs certified RECOVERS when a checkpoint store is supplied. The
+  // aggregator rebuilds inclusion proofs from the live tree per request
+  // (st-sdk#126 — only CertificationData is stable), so a refetched burn proof
+  // is byte-different; recovery therefore CANNOT come from a refetch — it comes
+  // from the stored burn checkpoint. The control below (no store → still
+  // conflicts, same aggregator) proves the checkpoint is what flips the outcome.
+  it('AC-E2: split full re-run after certified mints RECOVERS from the checkpoint (no funds lost)', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const store = new InMemoryCheckpointStore();
+    const engine = createTestEngine({ aggregator });
+    const self = engine.getIdentity().chainPubkey;
+    const src = await engine.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+    const transferId = crypto.randomUUID();
+    const outputs = SPLIT_OUTPUTS(self);
+
+    const first = await engine.split({ token: src, outputs }, { transferId, checkpointStore: store });
+    expect(first.outputs).toHaveLength(2);
+    // The checkpoint was persisted exactly once (before the first mint), and holds real bytes.
+    expect(store.putCalls).toBe(1);
+    const stored = store.raw(transferId, 0);
+    expect(stored).toBeInstanceOf(Uint8Array);
+    const storedHex = HexConverter.encode(stored as Uint8Array);
+
+    // Full re-run with the same transferId + the same store: the mint justification is rebuilt
+    // from the STORED burn proof, so the already-certified legs match-verify and every output is
+    // recovered — decimal-exact, fully verifying — NOT a TransferConflictError.
+    const resumed = await engine.split({ token: src, outputs }, { transferId, checkpointStore: store });
+    expect(resumed.outputs).toHaveLength(2);
+    expect(resumed.outputs.map((o) => engine.balanceOf(o, COIN))).toEqual([70n, 30n]);
+    expect(resumed.outputs.map((o) => engine.tokenId(o))).toEqual(first.outputs.map((o) => engine.tokenId(o)));
+    for (const o of resumed.outputs) {
+      expect((await engine.verify(o)).ok).toBe(true);
+    }
+    // Insert-once: the resume read the checkpoint, never re-persisted it (still one put, same bytes).
+    expect(store.putCalls).toBe(1);
+    expect(HexConverter.encode(store.raw(transferId, 0) as Uint8Array)).toBe(storedHex);
+  }, 40000);
+
+  // The residual for fully-local compositions (no checkpoint store), pinned: a FULL re-run after
+  // the mint legs certified does NOT recover — the refetched burn proof is byte-different (the
+  // aggregator regenerates per request), so the rebuilt mint transactions mismatch the certified
+  // leaves. It surfaces as the keep-open SplitCheckpointLostError (a mint-leg mismatch is NEVER a
+  // foreign spend — its stateId is HKDF-derived — so never the abort-y TransferConflictError). This
+  // is the SAME aggregator as the recovery test above; the ONLY difference is the presence of the
+  // checkpoint — the proof that recovery came from stored bytes, not accidental refetch stability.
+  it('residual: split full re-run WITHOUT a checkpoint store cannot recover (SplitCheckpointLostError)', async () => {
     const aggregator = TestAggregatorClient.create();
     const engine = createTestEngine({ aggregator });
     const self = engine.getIdentity().chainPubkey;
     const src = await engine.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
     const transferId = crypto.randomUUID();
-    const outputs = [
-      { recipientPubkey: freshPubkey(), coinId: COIN, amount: 70n },
-      { recipientPubkey: self, coinId: COIN, amount: 30n },
-    ];
+    const outputs = SPLIT_OUTPUTS(self);
 
     const first = await engine.split({ token: src, outputs }, { transferId });
     expect(first.outputs).toHaveLength(2);
@@ -326,8 +478,145 @@ describe('recoverable engine (Part E) — real adapter over in-memory aggregator
       () => null,
       (caught: unknown) => caught,
     );
-    expect(err).toBeInstanceOf(TransferConflictError);
-    expect((err as TransferConflictError).code).toBe('TRANSFER_CONFLICT');
+    expect(err).toBeInstanceOf(SplitCheckpointLostError);
+    expect((err as SplitCheckpointLostError).code).toBe('SPLIT_CHECKPOINT_LOST');
+    expect(err).not.toBeInstanceOf(TransferConflictError);
+  }, 40000);
+
+  // AC-E6(a) — the durable-ack ordering gate: if the checkpoint cannot be persisted after the
+  // burn certifies, the engine raises CheckpointPersistFailedError (keep-open) and submits ZERO
+  // mint legs (only the burn reached the aggregator). Funds are in-flight, not lost.
+  it('AC-E6: a checkpoint persist failure raises CheckpointPersistFailedError and submits no mint leg', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const counting = new SubmitCountingClient(aggregator);
+    const engine = createTestEngine({ aggregator, wireClient: counting });
+    const self = engine.getIdentity().chainPubkey;
+    const src = await engine.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+    const submitsAfterMint = counting.submits; // the source mint
+
+    const err = await engine
+      .split({ token: src, outputs: SPLIT_OUTPUTS(self) }, { transferId: crypto.randomUUID(), checkpointStore: new PersistFailingStore() })
+      .then(() => null, (caught: unknown) => caught);
+
+    expect(err).toBeInstanceOf(CheckpointPersistFailedError);
+    expect((err as CheckpointPersistFailedError).code).toBe('CHECKPOINT_PERSIST_FAILED');
+    expect((err as CheckpointPersistFailedError).mayHaveCertified).toBe(true);
+    expect(String((err as { cause?: unknown }).cause)).toContain('checkpoint store 503');
+    // exactly one submit after the source mint — the burn — and NO mint leg.
+    expect(counting.submits).toBe(submitsAfterMint + 1);
+  }, 40000);
+
+  // AC-E6(b) — leg-0 pre-flight: a certified mint leaf with NO checkpoint (server data loss /
+  // withholding) is genuinely unrecoverable. Resume with an empty store probes leg-0 (certified
+  // on the shared aggregator) and raises SplitCheckpointLostError BEFORE any re-burn — never a
+  // foreign-conflict, never a silent re-mint.
+  it('AC-E6: a certified leg with a missing checkpoint raises SplitCheckpointLostError (leg-0 probe)', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const engine = createTestEngine({ aggregator });
+    const self = engine.getIdentity().chainPubkey;
+    const src = await engine.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+    const transferId = crypto.randomUUID();
+    const outputs = SPLIT_OUTPUTS(self);
+
+    await engine.split({ token: src, outputs }, { transferId, checkpointStore: new InMemoryCheckpointStore() });
+
+    // Resume under the same transferId but with a FRESH (empty) store — the checkpoint is gone.
+    const err = await engine
+      .split({ token: src, outputs }, { transferId, checkpointStore: new InMemoryCheckpointStore() })
+      .then(() => null, (caught: unknown) => caught);
+    expect(err).toBeInstanceOf(SplitCheckpointLostError);
+    expect((err as SplitCheckpointLostError).code).toBe('SPLIT_CHECKPOINT_LOST');
+  }, 40000);
+
+  // AC-E6(c) — a corrupt / mis-served checkpoint record must never be minted from: decoding fails
+  // and the engine raises SplitCheckpointLostError (keep-open), never a wrong-bytes mint. BOTH
+  // corruption shapes are covered: a non-array blob, AND a well-framed 5-array with a wrong-typed
+  // inner field (the field decoders throw a raw CborError that must still surface as the typed
+  // keep-open error — a bit-flip / tolerant re-encode that this plaintext layer cannot pre-reject).
+  it.each([
+    ['non-array blob', new Uint8Array([0xff, 0x00, 0x13, 0x37])],
+    ['5-array, wrong-typed version field', WRONG_TYPED_CHECKPOINT],
+  ])('AC-E6: a poisoned checkpoint record (%s) raises SplitCheckpointLostError, never mints', async (_label, poison) => {
+    const aggregator = TestAggregatorClient.create();
+    const counting = new SubmitCountingClient(aggregator);
+    const engine = createTestEngine({ aggregator, wireClient: counting });
+    const self = engine.getIdentity().chainPubkey;
+    const src = await engine.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+    const submitsAfterMint = counting.submits;
+
+    const err = await engine
+      .split({ token: src, outputs: SPLIT_OUTPUTS(self) }, { transferId: crypto.randomUUID(), checkpointStore: new PoisonedStore(poison) })
+      .then(() => null, (caught: unknown) => caught);
+    expect(err).toBeInstanceOf(SplitCheckpointLostError);
+    // get() returned poison up front — nothing was submitted (no burn, no mint).
+    expect(counting.submits).toBe(submitsAfterMint);
+  }, 40000);
+
+  // AC-E6(e) — insert-once ADOPT: two devices race the no-checkpoint path; the loser's put() gets
+  // the WINNER's authoritative bytes back and MUST mint from those (decode-from-stored), not its
+  // own pre-store burnt token — else the two devices would embed byte-different burn proofs and
+  // diverge. Construction: engine A burns + checkpoints but crashes before minting (no leg
+  // certified, checkpoint C captured); the tree is advanced so a fresh burn refetch is
+  // byte-different; the loser adopts C via put() and mints; a reference device resuming from C
+  // (get-path) mints the same legs — the outputs are byte-identical, proving the loser used C.
+  it('AC-E6: a resumer that loses the put race adopts the winner checkpoint and converges', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const walletKey = SigningService.generatePrivateKey();
+    const capture = new InMemoryCheckpointStore();
+    const crashing = createTestEngine({ aggregator, privateKey: walletKey, wireClient: new CrashAfterBurnClient(aggregator) });
+    const plain = createTestEngine({ aggregator, privateKey: walletKey });
+
+    const self = plain.getIdentity().chainPubkey;
+    const src = await plain.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+    const transferId = crypto.randomUUID();
+    const outputs = SPLIT_OUTPUTS(self);
+
+    // A: burn certifies + checkpoint persists, then the mint submit crashes — no leg certified.
+    await crashing
+      .split({ token: src, outputs }, { transferId, checkpointStore: capture, signal: AbortSignal.timeout(2000) })
+      .then(() => null, () => null);
+    const winner = capture.raw(transferId, 0);
+    expect(winner).toBeInstanceOf(Uint8Array);
+    // Advance the tree so a fresh burn-proof refetch is byte-different from the captured one.
+    await plain.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 1n }] } });
+
+    // The LOSER: get() sees nothing, but put() returns the winner's bytes — it must mint from those.
+    // It mints FIRST here, certifying the legs with whichever burn proof it used.
+    const loser = await plain.split({ token: src, outputs }, { transferId, checkpointStore: new AdoptStore(winner as Uint8Array) });
+    expect(loser.outputs.map((o) => plain.balanceOf(o, COIN))).toEqual([70n, 30n]);
+    for (const o of loser.outputs) {
+      expect((await plain.verify(o)).ok).toBe(true);
+    }
+
+    // The discriminator: a reference device resuming DIRECTLY from the winner checkpoint rebuilds
+    // the winner's mint justification and re-submits the legs. It match-verifies (dup-OK) ONLY if
+    // the loser certified them with the winner's burn proof — i.e. adopted it. Had the loser minted
+    // from its OWN (byte-different, tree-advanced) burn proof, this resume would hit a mint-leg hash
+    // mismatch and throw SplitCheckpointLostError. That it recovers is the proof of adoption.
+    const reference = await plain.split({ token: src, outputs }, { transferId, checkpointStore: new FixedGetStore(winner as Uint8Array) });
+    expect(reference.outputs.map((o) => plain.tokenId(o))).toEqual(loser.outputs.map((o) => plain.tokenId(o)));
+    for (const o of reference.outputs) {
+      expect((await plain.verify(o)).ok).toBe(true);
+    }
+  }, 40000);
+
+  // AC-E6(d) — the happy path with a store: a first-time split persists the checkpoint (before the
+  // first mint) and completes; every output verifies. Proves the store is written on the fresh
+  // path, not only on resume.
+  it('AC-E6: a first-time split with a checkpoint store completes and persists the checkpoint', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const store = new InMemoryCheckpointStore();
+    const engine = createTestEngine({ aggregator });
+    const self = engine.getIdentity().chainPubkey;
+    const src = await engine.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN, amount: 100n }] } });
+    const transferId = crypto.randomUUID();
+
+    const { outputs } = await engine.split({ token: src, outputs: SPLIT_OUTPUTS(self) }, { transferId, checkpointStore: store });
+    expect(outputs.map((o) => engine.balanceOf(o, COIN))).toEqual([70n, 30n]);
+    for (const o of outputs) {
+      expect((await engine.verify(o)).ok).toBe(true);
+    }
+    expect(store.raw(transferId, 0)).toBeInstanceOf(Uint8Array);
   }, 40000);
 
   // E.2 status-agnostic submit: a submit that THROWS (response-parse failure)

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -14,10 +14,16 @@
 
 import { SphereError, type SphereErrorCode } from '../core/errors';
 import { randomUUID } from '../core/uuid';
-import { TransferConflictError, ProofUnconfirmedError } from './errors';
+import {
+  CheckpointPersistFailedError,
+  ProofUnconfirmedError,
+  SplitCheckpointLostError,
+  TransferConflictError,
+} from './errors';
 import { deriveDirectAddress, UNICITY_TOKEN_TYPE_HEX } from './identity';
 import { deriveDeliveryKeys } from './blob-keys';
 import { deriveRealization } from './realization';
+import { burntTokenFromCheckpoint, encodeCheckpoint } from './split-checkpoint';
 import {
   CborDeserializer,
   CertificationData,
@@ -37,6 +43,7 @@ import {
   SignaturePredicateUnlockScript,
   type SigningService,
   SplitMintJustification,
+  type SplitToken,
   SplitTokenRequest,
   StateId,
   type StateTransitionClient,
@@ -103,6 +110,17 @@ const CLEAN_REJECT_STATUSES: ReadonlySet<string> = new Set([
   CertificationStatus.UNSUPPORTED_ALGORITHM,
   CertificationStatus.INVALID_SHARD,
 ]);
+
+/** The deterministic split plan (burn leg + per-output mint requests) — `TokenSplit.split`'s result. */
+type SplitPlan = Awaited<ReturnType<typeof TokenSplit.split>>;
+
+/** Threaded through the E.4 burnt-token resolution so its helpers stay within the max-params bound. */
+interface SplitContext {
+  readonly params: SplitParams;
+  readonly split: SplitPlan;
+  readonly transferId: string;
+  readonly options?: EngineOpOptions | undefined;
+}
 
 export class SphereTokenEngine implements ITokenEngine {
   /** Hex form of the wallet key — deriveRealization's ikm input (Part E.1). */
@@ -276,55 +294,133 @@ export class SphereTokenEngine implements ITokenEngine {
       deriveRealization(this.privateKeyHex, transferId, this.resolveOpIndex(options), 'burn'),
     );
 
-    // 1. Burn the source: certify the burn transfer and append it -> burntToken.
-    const burnUnlock = await SignaturePredicateUnlockScript.create(split.burn.transaction, this.deps.signingService);
-    const burnCert = await CertificationData.fromTransaction(split.burn.transaction, burnUnlock);
-    const burnProof = await this.submitAndAwaitProof(
-      burnCert,
-      split.burn.transaction,
-      'Split burn failed',
-      'TRANSFER_FAILED',
-      options,
-    );
-    const burnCertified = await split.burn.transaction.toCertifiedTransaction(
-      this.deps.trustBase,
-      this.deps.predicateVerifier,
-      burnProof,
-    );
-    const burntToken = await params.token.sdkToken.transfer(
-      this.deps.trustBase,
-      this.deps.predicateVerifier,
-      burnCertified,
-    );
+    // 1. Resolve the burnt token: from a durable checkpoint on resume, else burn now and persist
+    //    the checkpoint BEFORE any mint submit (E.4 — the burn proof is the one non-re-derivable
+    //    split input; a mint certified against proof bytes that were never stored strands #501).
+    const burntToken = await this.resolveBurntToken({ params, split, transferId, options });
 
     // 2. Mint each output, justified by the burnt token + its split proofs.
     const outputs: SphereToken[] = [];
     for (let i = 0; i < split.tokens.length; i++) {
-      const splitToken = split.tokens[i];
-      // split.tokens preserves requests order, so the per-output memo maps by index.
-      const data = await SpherePaymentData.create(splitToken.assets, params.outputs[i].data ?? null).encode();
-      const justification = SplitMintJustification.create(burntToken, splitToken.proofs).toCBOR();
-      const mintTx = await MintTransaction.create(
-        splitToken.networkId,
-        splitToken.recipient,
-        data,
-        splitToken.tokenType,
-        splitToken.salt,
-        justification,
-      );
-      const certData = await CertificationData.fromMintTransaction(mintTx);
-      const proof = await this.submitAndAwaitProof(certData, mintTx, 'Split mint failed', 'AGGREGATOR_ERROR', options);
-      const certified = await mintTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
-      const token = await Token.mint(
-        this.deps.trustBase,
-        this.deps.predicateVerifier,
-        this.deps.mintJustificationVerifier,
-        certified,
-      );
-      outputs.push(this.wrapToken(token));
+      outputs.push(await this.mintSplitOutput(split.tokens[i], burntToken, params.outputs[i].data ?? null, options));
     }
-
     return { outputs };
+  }
+
+  /**
+   * E.4 burnt-token resolution. With a checkpoint store: `get` → rebuild from the STORED proof on
+   * resume; else a leg-0 pre-flight probe (a certified leaf with no checkpoint is unrecoverable),
+   * then burn, persist the checkpoint (durable-ack gated), and adopt the authoritative stored
+   * bytes. Without a store: burn as before (a documented residual for fully-local compositions).
+   */
+  private async resolveBurntToken(ctx: SplitContext): Promise<Token> {
+    const store = ctx.options?.checkpointStore;
+    const opIndex = this.resolveOpIndex(ctx.options);
+    const source = ctx.params.token.sdkToken;
+    if (store === undefined) {
+      return (await this.burnSource(ctx)).burntToken;
+    }
+    const stored = await store.get(ctx.transferId, opIndex);
+    if (stored !== null) {
+      return burntTokenFromCheckpoint(this.deps, stored, ctx.split.burn.transaction, source);
+    }
+    await this.assertNoLegStranded(ctx);
+    const { burntToken, burnProof } = await this.burnSource(ctx);
+    const envelope = await encodeCheckpoint(ctx.split.burn.transaction, burnProof, burntToken);
+    // The durable-ack gate: `put` resolving IS the ack, and NO mint has been submitted yet.
+    let authoritative: Uint8Array;
+    try {
+      authoritative = await store.put(ctx.transferId, opIndex, envelope);
+    } catch (err) {
+      throw new CheckpointPersistFailedError(
+        'split burn certified but its checkpoint could not be persisted — keep the intent open and resume',
+        err,
+      );
+    }
+    // Decode-from-stored discipline: mint from the AUTHORITATIVE bytes (ours, or a racing resumer's
+    // that won the slot), never the pre-store in-memory burnt token — so concurrent resumers agree.
+    return burntTokenFromCheckpoint(this.deps, authoritative, ctx.split.burn.transaction, source);
+  }
+
+  /** Burn the source: certify the burn transfer and append it -> burntToken (+ its proof). */
+  private async burnSource(ctx: SplitContext): Promise<{ burntToken: Token; burnProof: InclusionProof }> {
+    const burnTx = ctx.split.burn.transaction;
+    const burnUnlock = await SignaturePredicateUnlockScript.create(burnTx, this.deps.signingService);
+    const burnCert = await CertificationData.fromTransaction(burnTx, burnUnlock);
+    const burnProof = await this.submitAndAwaitProof(burnCert, burnTx, 'Split burn failed', 'TRANSFER_FAILED', ctx.options);
+    const burnCertified = await burnTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, burnProof);
+    const burntToken = await ctx.params.token.sdkToken.transfer(this.deps.trustBase, this.deps.predicateVerifier, burnCertified);
+    return { burntToken, burnProof };
+  }
+
+  /**
+   * Pre-flight (no-checkpoint path): if ANY mint leaf is already certified on-chain while the
+   * checkpoint is missing, the burn proof is genuinely unrecoverable — fail BEFORE any re-burn. A
+   * mint's stateId is justification-INDEPENDENT (only the source state hash + salt-derived mask),
+   * so a probe mint with a null justification derives the true on-chain key. Every leg is probed,
+   * so correctness does NOT depend on the mint loop certifying leg 0 first (E.4 step 3).
+   */
+  private async assertNoLegStranded(ctx: SplitContext): Promise<void> {
+    for (let i = 0; i < ctx.split.tokens.length; i++) {
+      const leg = ctx.split.tokens[i];
+      const data = await SpherePaymentData.create(leg.assets, ctx.params.outputs[i].data ?? null).encode();
+      const probe = await MintTransaction.create(leg.networkId, leg.recipient, data, leg.tokenType, leg.salt, null);
+      const response = await this.deps.client.getInclusionProof(await StateId.fromTransaction(probe));
+      if (response.inclusionProof.inclusionCertificate !== null) {
+        throw new SplitCheckpointLostError(
+          'a split mint leaf is certified on-chain but no burn checkpoint exists — outputs are unrecoverable',
+        );
+      }
+    }
+  }
+
+  /** One split output: build the justification from the burnt token, submit, certify, wrap. */
+  private async mintSplitOutput(
+    splitToken: SplitToken,
+    burntToken: Token,
+    memo: Uint8Array | null,
+    options?: EngineOpOptions,
+  ): Promise<SphereToken> {
+    const data = await SpherePaymentData.create(splitToken.assets, memo).encode();
+    const justification = SplitMintJustification.create(burntToken, splitToken.proofs).toCBOR();
+    const mintTx = await MintTransaction.create(
+      splitToken.networkId,
+      splitToken.recipient,
+      data,
+      splitToken.tokenType,
+      splitToken.salt,
+      justification,
+    );
+    const certData = await CertificationData.fromMintTransaction(mintTx);
+    const proof = await this.submitSplitMintLeg(certData, mintTx, options);
+    const certified = await mintTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
+    const token = await Token.mint(this.deps.trustBase, this.deps.predicateVerifier, this.deps.mintJustificationVerifier, certified);
+    return this.wrapToken(token);
+  }
+
+  /**
+   * Submit one split-mint leg. A `TRANSACTION_HASH_MISMATCH` on a mint leg is NOT a foreign spend
+   * (its stateId is HKDF-derived from `(seed, transferId)`, so only a seed-holder under THIS
+   * transferId could have certified a different leaf): the stored checkpoint no longer reproduces
+   * the certified leaf → keep-open `SplitCheckpointLostError`, never the abort-and-re-plan
+   * `TransferConflictError` (E.2/E.4 split-mint arm).
+   */
+  private async submitSplitMintLeg(
+    certData: CertificationData,
+    mintTx: MintTransaction,
+    options?: EngineOpOptions,
+  ): Promise<InclusionProof> {
+    try {
+      return await this.submitAndAwaitProof(certData, mintTx, 'Split mint failed', 'AGGREGATOR_ERROR', options);
+    } catch (err) {
+      if (err instanceof TransferConflictError) {
+        throw new SplitCheckpointLostError(
+          'a split mint leg no longer matches its certified leaf — the burn checkpoint is stale or lost',
+          err,
+        );
+      }
+      throw err;
+    }
   }
 
   // ── verification ─────────────────────────────────────────────────────────────

--- a/token-engine/engine.ts
+++ b/token-engine/engine.ts
@@ -21,10 +21,42 @@ import type {
   EngineVerifyResult,
 } from './types';
 
+/**
+ * Durable, any-device store for a split's burn checkpoint (sdk-changes E.4, sphere-sdk#501
+ * option b). The engine passes opaque PLAINTEXT bytes; a transport adapter (the wallet-api
+ * provider) is responsible for AAD-encryption and the wallet-api §16 intent-progress round-trip.
+ *
+ * The store is the resume seed for the one split input the engine cannot re-derive — the burn's
+ * aggregator-issued inclusion proof — so the mint justification is rebuilt from stored bytes, not
+ * a refetch (the aggregator regenerates proofs per request).
+ */
+export interface SplitCheckpointStore {
+  /**
+   * Insert-once, first-write-wins. MUST resolve only AFTER the store acked durability, and MUST
+   * resolve with the AUTHORITATIVE stored bytes — the caller's own on a fresh write, or the FIRST
+   * writer's when the slot `(transferId, opIndex)` was already taken (the caller adopts those and
+   * mints from them, so concurrent resumers converge on one burn proof).
+   */
+  put(transferId: string, opIndex: number, bytes: Uint8Array): Promise<Uint8Array>;
+  /** The stored bytes for the slot, or `null` when none exists. */
+  get(transferId: string, opIndex: number): Promise<Uint8Array | null>;
+}
+
 /** Options common to the long-running, network-bound operations. */
 export interface EngineOpOptions {
   /** Cancels the operation (including inclusion-proof polling). */
   readonly signal?: AbortSignal;
+  /**
+   * Durable burn-checkpoint store for a resumable split (sdk-changes E.4, sphere-sdk#501). When
+   * present, `split()` persists the burn's certified proof AND awaits its durable ack BEFORE
+   * submitting any mint leg, and rebuilds the mint justification from the stored bytes on resume —
+   * so a split resumed after any mint leg certified recovers instead of stranding its outputs.
+   *
+   * Absent keeps today's behavior (a fresh burn proof per attempt): fine for a mid-split resume
+   * with no mint yet certified, but a split resumed AFTER a mint certified cannot recover — a
+   * documented residual for fully-local compositions; the live path MUST supply the store.
+   */
+  readonly checkpointStore?: SplitCheckpointStore;
   /**
    * Realization seed for deterministic transfer/split (Part E, sdk-changes E.1/E.3):
    * a client-generated UUIDv4 in canonical lowercase string form. Every value the

--- a/token-engine/errors.ts
+++ b/token-engine/errors.ts
@@ -50,3 +50,58 @@ export class ProofUnconfirmedError extends SphereError {
     this.name = 'ProofUnconfirmedError';
   }
 }
+
+/**
+ * A split's burn certified but its checkpoint (sdk-changes E.4, sphere-sdk#501) could NOT be
+ * durably persisted — the `SplitCheckpointStore.put` rejected (network / 5xx / timeout / quota) —
+ * so NO mint leg was submitted. The burn is on-chain (funds in-flight, not lost); the outputs are
+ * fully recoverable on resume.
+ *
+ * Keep-open family (like {@link ProofUnconfirmedError}): the caller MUST keep the intent OPEN and
+ * resume under the SAME `transferId` — the next attempt re-derives the byte-identical burn,
+ * re-persists the checkpoint (content-idempotent), and mints. NEVER abort.
+ */
+export class CheckpointPersistFailedError extends SphereError {
+  readonly mayHaveCertified = true as const;
+
+  constructor(message: string, cause?: unknown) {
+    super(message, 'CHECKPOINT_PERSIST_FAILED', cause);
+    this.name = 'CheckpointPersistFailedError';
+  }
+}
+
+/**
+ * A split cannot be rebuilt from its checkpoint, in a way that is NOT a lost race: either a mint
+ * leaf is already certified on-chain but no stored bytes reproduce its certified transactionHash
+ * (server data loss / withholding, or a pre-E.4 legacy intent), or a stored checkpoint fails its
+ * byte-binding checks (the re-derived burn tx ≠ the stored bytes — cross-version derivation drift
+ * — or a corrupt stored proof, or a burnt-token re-encode mismatch).
+ *
+ * Distinct from {@link TransferConflictError}: a split-mint stateId is HKDF-derived from
+ * `(seed, transferId)`, so only a seed-holder under THIS `transferId` can have certified it — this
+ * is never a foreign spend. Keep-open, alert loudly: the caller MUST NOT abort, NOT complete, and
+ * NOT record the source as foreign-spent (sdk-changes E.4).
+ */
+export class SplitCheckpointLostError extends SphereError {
+  constructor(message: string, cause?: unknown) {
+    super(message, 'SPLIT_CHECKPOINT_LOST', cause);
+    this.name = 'SplitCheckpointLostError';
+  }
+}
+
+/**
+ * A stored split checkpoint (sdk-changes E.4) is authentic and byte-bound to the re-derived burn
+ * transaction, but its inclusion proof no longer verifies against the CURRENT trust base
+ * (`INVALID_TRUSTBASE`) — a validator-set / quorum rotation while the intent was open. The bytes
+ * are NOT wrong; re-burning would strand the certified split, so the engine never falls through to
+ * a re-burn.
+ *
+ * Keep-open, distinct signal: the operational remedy is to drain open split intents BEFORE a
+ * validator rotation (the SDK has no epoch map — single-epoch trust base, ARCHITECTURE §8.2/§19).
+ */
+export class CheckpointTrustbaseMismatchError extends SphereError {
+  constructor(message: string, cause?: unknown) {
+    super(message, 'CHECKPOINT_TRUSTBASE_MISMATCH', cause);
+    this.name = 'CheckpointTrustbaseMismatchError';
+  }
+}

--- a/token-engine/index.ts
+++ b/token-engine/index.ts
@@ -14,6 +14,7 @@ export type {
   ITokenEngine,
   EngineConfig,
   EngineOpOptions,
+  SplitCheckpointStore,
   CreateTokenEngine,
 } from './engine';
 
@@ -41,10 +42,18 @@ export { deriveDirectAddress } from './identity';
 // The concrete adapter factory (A4) — the public way to obtain an ITokenEngine.
 export { createSphereTokenEngine } from './factory';
 
-// Typed conflict surface of the recoverable engine (Part E.2): the source state
-// was consumed by a DIFFERENT transaction — a lost race, not a resume. Callers
-// abort the intent and re-plan under a new transferId.
-export { TransferConflictError, ProofUnconfirmedError } from './errors';
+// Typed error surface of the recoverable engine (Part E.2/E.4). TransferConflictError = the source
+// was consumed by a DIFFERENT transaction (lost race — abort + re-plan). The rest are KEEP-OPEN
+// (never abort): ProofUnconfirmedError (#631 indeterminate certification), and the split burn
+// checkpoint family (sphere-sdk#501/E.4) that the wallet-api adapter + PaymentsModule must catch
+// and dispose — CheckpointPersistFailedError, SplitCheckpointLostError, CheckpointTrustbaseMismatchError.
+export {
+  CheckpointPersistFailedError,
+  CheckpointTrustbaseMismatchError,
+  ProofUnconfirmedError,
+  SplitCheckpointLostError,
+  TransferConflictError,
+} from './errors';
 
 // Self-issued Unicity ID (nametag) token mint — the v2 analog of the v1
 // nametag mint, stored at registration but unused at runtime (D5 + user

--- a/token-engine/split-checkpoint.ts
+++ b/token-engine/split-checkpoint.ts
@@ -1,0 +1,165 @@
+/**
+ * token-engine/split-checkpoint.ts — the split burn checkpoint (sdk-changes E.4, sphere-sdk#501
+ * option b). Encodes/decodes the one split-resume input the engine cannot re-derive — the burn's
+ * aggregator-issued inclusion proof — and rebuilds the burnt token from STORED bytes so every
+ * mint justification is byte-stable across a resume (the aggregator regenerates proofs per
+ * request; only `CertificationData` is stable).
+ *
+ * Payload (strict-canonical CBOR array): `[v, sdkVersion, burnTx.toCBOR(), burnProof.toCBOR(),
+ * sha256(burntToken.toCBOR())]`. Storing the burn-tx bytes turns any cross-version derivation
+ * drift into a LOUD byte-inequality; the burnt-token hash catches a tolerant-decode wire migration
+ * on resume. The engine passes PLAINTEXT through the `SplitCheckpointStore` port; AAD-encryption is
+ * the transport adapter's concern.
+ */
+
+import { SplitCheckpointLostError, CheckpointTrustbaseMismatchError } from './errors';
+import {
+  CborDeserializer,
+  CborSerializer,
+  DataHasher,
+  HashAlgorithm,
+  InclusionProof,
+  InclusionProofVerificationStatus,
+  type PredicateVerifierService,
+  type RootTrustBase,
+  Token,
+  type TransferTransaction,
+} from './sdk';
+
+/** Checkpoint payload version (the CBOR array's first element). */
+const CHECKPOINT_VERSION = 1;
+/**
+ * The base-SDK pin whose CBOR wire form governs byte-stability — recorded for a LOUD drift
+ * diagnosis only (byte-inequality of the stored burn tx is the actual guard). Bump with the pin.
+ */
+const CHECKPOINT_SDK_VERSION = '@unicitylabs/state-transition-sdk@2.0.0-rc.68bc1e5';
+
+export interface CheckpointDeps {
+  readonly trustBase: RootTrustBase;
+  readonly predicateVerifier: PredicateVerifierService;
+}
+
+/** Constant-length-agnostic byte-equality (no early-exit timing concern — these are public bytes). */
+export function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
+  return (await new DataHasher(HashAlgorithm.SHA256).update(bytes).digest()).imprint;
+}
+
+/**
+ * Encode the checkpoint for `store.put`. `burntToken` is the freshly-built burnt token whose hash
+ * pins the resume-side re-encode equality check.
+ */
+export async function encodeCheckpoint(
+  burnTx: TransferTransaction,
+  burnProof: InclusionProof,
+  burntToken: Token,
+): Promise<Uint8Array> {
+  return CborSerializer.encodeArray(
+    CborSerializer.encodeUnsignedInteger(CHECKPOINT_VERSION),
+    CborSerializer.encodeTextString(CHECKPOINT_SDK_VERSION),
+    CborSerializer.encodeByteString(burnTx.toCBOR()),
+    CborSerializer.encodeByteString(burnProof.toCBOR()),
+    CborSerializer.encodeByteString(await sha256(burntToken.toCBOR())),
+  );
+}
+
+interface DecodedCheckpoint {
+  readonly sdkVersion: string;
+  readonly burnTxBytes: Uint8Array;
+  readonly burnProofBytes: Uint8Array;
+  readonly burntTokenHash: Uint8Array;
+}
+
+/**
+ * Decode a stored checkpoint; ANY malformed/unknown-version record is a lost checkpoint (never
+ * mint). The FULL decode (array framing AND every inner field) is guarded — a well-framed 5-array
+ * with a wrong-typed/non-canonical inner field throws a raw `CborError` from the per-field decoders,
+ * which must still surface as the typed keep-open error, not escape `split()` untyped (AC-E6(c)).
+ */
+function decodeCheckpoint(bytes: Uint8Array): DecodedCheckpoint {
+  try {
+    const fields = CborDeserializer.decodeArray(bytes, 5);
+    const version = Number(CborDeserializer.decodeUnsignedInteger(fields[0]));
+    if (version !== CHECKPOINT_VERSION) {
+      throw new SplitCheckpointLostError(`split checkpoint version ${String(version)} is not supported`);
+    }
+    return {
+      sdkVersion: CborDeserializer.decodeTextString(fields[1]),
+      burnTxBytes: CborDeserializer.decodeByteString(fields[2]),
+      burnProofBytes: CborDeserializer.decodeByteString(fields[3]),
+      burntTokenHash: CborDeserializer.decodeByteString(fields[4]),
+    };
+  } catch (err) {
+    if (err instanceof SplitCheckpointLostError) throw err;
+    throw new SplitCheckpointLostError('split checkpoint is malformed (cannot decode)', err);
+  }
+}
+
+/** Classify a `toCertifiedTransaction` failure: only INVALID_TRUSTBASE is a keep-open drain case. */
+function isTrustbaseFailure(err: unknown): boolean {
+  const status = (err as { verificationResult?: { status?: unknown } })?.verificationResult?.status;
+  return status === InclusionProofVerificationStatus.INVALID_TRUSTBASE;
+}
+
+/**
+ * Rebuild the burnt token from a stored checkpoint (resume, or adopt-after-put). NEVER refetches
+ * the burn proof — it applies the STORED proof to the re-derived burn tx, so the mint
+ * justification is byte-stable. Throws (never returns a wrong burnt token):
+ * - stored burn tx ≠ re-derived (cross-version drift)      → SplitCheckpointLostError (names sdkVersion)
+ * - stored proof fails ONLY the current trust base         → CheckpointTrustbaseMismatchError
+ * - stored proof otherwise invalid / corrupt               → SplitCheckpointLostError
+ * - rebuilt burnt token re-encodes to a different hash      → SplitCheckpointLostError (wire migration)
+ */
+export async function burntTokenFromCheckpoint(
+  deps: CheckpointDeps,
+  storedBytes: Uint8Array,
+  reDerivedBurnTx: TransferTransaction,
+  sourceToken: Token,
+): Promise<Token> {
+  const decoded = decodeCheckpoint(storedBytes);
+  if (!bytesEqual(decoded.burnTxBytes, reDerivedBurnTx.toCBOR())) {
+    throw new SplitCheckpointLostError(
+      `split checkpoint burn tx does not match the re-derived burn (stored under ${decoded.sdkVersion}) — derivation drift`,
+    );
+  }
+  // The burn-proof field is the most transit-exposed value; parsing corrupt bytes throws a raw
+  // CborError, which must surface as the typed keep-open error (not escape split() untyped).
+  let burnProof: InclusionProof;
+  try {
+    burnProof = InclusionProof.fromCBOR(decoded.burnProofBytes);
+  } catch (err) {
+    throw new SplitCheckpointLostError('split checkpoint proof is malformed (cannot decode)', err);
+  }
+  let burnCertified;
+  try {
+    burnCertified = await reDerivedBurnTx.toCertifiedTransaction(deps.trustBase, deps.predicateVerifier, burnProof);
+  } catch (err) {
+    if (isTrustbaseFailure(err)) {
+      throw new CheckpointTrustbaseMismatchError(
+        'split checkpoint proof no longer verifies against the current trust base (validator rotation)',
+        err,
+      );
+    }
+    throw new SplitCheckpointLostError('split checkpoint proof is invalid', err);
+  }
+  // Defense-in-depth: the inputs are pre-validated (byte-equal burn tx + trustbase-verified proof),
+  // so this application is effectively unreachable-throwing — but keep the whole resume path free of
+  // raw-error escapes (a future wire migration must still surface the typed keep-open error).
+  let burntToken: Token;
+  try {
+    burntToken = await sourceToken.transfer(deps.trustBase, deps.predicateVerifier, burnCertified);
+  } catch (err) {
+    throw new SplitCheckpointLostError('split checkpoint could not rebuild the burnt token', err);
+  }
+  if (!bytesEqual(await sha256(burntToken.toCBOR()), decoded.burntTokenHash)) {
+    throw new SplitCheckpointLostError('split checkpoint burnt-token hash mismatch (wire re-encoding drift)');
+  }
+  return burntToken;
+}


### PR DESCRIPTION
## Why

sphere-sdk#501: a split resumed after any mint leg certified cannot rebuild byte-stable mint
transactions — the aggregator regenerates inclusion proofs per request (only `CertificationData`
is stable), so a refetched burn proof is byte-different and the rebuilt `SplitMintJustification`
no longer hashes to the certified leaves → `TransferConflictError` thrown before any output
exists. The source is already burned. Money lost.

Decided as **option (b)** (see the issue + `../wallet-api/sdk-changes.md` **E.4**): persist the
burn's certified proof durably, before the first mint submit, and rebuild every mint justification
from the **stored** bytes on resume. The wallet-api leg is merged (durable store + close gate:
unicity-sphere/wallet-api#89, #90). This is the **engine leg**.

## What

- **Port** (`token-engine/engine.ts`): `SplitCheckpointStore { get, put }` over opaque plaintext
  bytes, added as the optional `EngineOpOptions.checkpointStore`. `ITokenEngine`'s surface stays
  frozen. `put` is insert-once/first-write-wins and returns the authoritative stored bytes.
- **Typed errors** (`token-engine/errors.ts`, + 3 codes in `core/errors.ts`), all keep-open:
  `CheckpointPersistFailedError` (burn certified, checkpoint not durable, zero mints submitted),
  `SplitCheckpointLostError` (a certified leaf with no reproducing stored bytes; byte-binding
  failure; corrupt proof — never a foreign conflict, since a split-mint stateId is HKDF-derived
  from `(seed, transferId)`), `CheckpointTrustbaseMismatchError` (byte-bound proof fails the
  current trustbase — validator rotation).
- **`split()` restructure** (`token-engine/SphereTokenEngine.ts`): the burnt token is now resolved
  via `resolveBurntToken` — with a store, `get` → rebuild from the stored proof on resume; else a
  leg-0 pre-flight probe (a certified leaf with no checkpoint is unrecoverable — fail before any
  re-burn), then burn, persist the checkpoint (durable-ack gated — `put` resolving IS the ack, and
  no mint has been submitted), and **adopt** the authoritative returned bytes (decode-from-stored
  discipline, so concurrent resumers converge on one burn proof). The mint loop is unchanged; a
  mint tx hash is stable, so already-certified legs match-verify under E.2 while unsubmitted legs
  go first-time. Extracted `burnSource`/`assertLegZeroNotStranded`/`mintSplitOutput` to keep every
  function within the §15 structure limits.
- **Checkpoint codec** (`token-engine/split-checkpoint.ts`): strict-canonical CBOR
  `[v, sdkVersion, burnTx.toCBOR(), burnProof.toCBOR(), sha256(burntToken.toCBOR())]`. Storing the
  burn-tx bytes turns cross-version derivation drift into a loud byte-inequality; the burnt-token
  hash catches a tolerant-decode wire migration on resume. `burntTokenFromCheckpoint` verifies the
  stored proof via `toCertifiedTransaction` (classifying `INVALID_TRUSTBASE` vs a corrupt proof)
  and rebuilds from the stored proof — never a refetch. The engine deals in plaintext through the
  port; AAD-encryption is the (later) adapter's concern.

## Tests

**Flipped** the pinned `#501` gap test in `recoverable-engine.test.ts`: **AC-E2** now asserts a
full re-run after certified mints **recovers** (2 outputs, decimal-exact `[70n, 30n]`, matching
tokenIds, `verify().ok`), persisting the checkpoint exactly once. The **control** — the same
scenario against the same proof-regenerating aggregator but **without** a store — is kept and still
throws `TransferConflictError`; that delta is the proof that recovery comes from the stored bytes,
not accidental refetch stability (the vendored `TestAggregatorClient` rebuilds proofs from the live
SMT per request). Added **AC-E6**: the persist-failure zero-mint gate (asserts exactly one submit
— the burn — after the failure), the leg-0 probe (`SplitCheckpointLostError` before any re-burn), a
poisoned record (`SplitCheckpointLostError`, nothing submitted), and the first-time-with-store
happy path.

## Review hardening (adversarial pass over the diff before this PR)

A multi-finder review (verified against the vendored SDK) caught and this diff fixes:

- **Untyped-error escapes:** `decodeCheckpoint` now guards the *whole* decode (a well-framed
  5-array with a wrong-typed inner field threw a raw `CborError` that escaped `split()` untyped),
  and `InclusionProof.fromCBOR` on the stored proof is now inside the guard — both surface as the
  keep-open `SplitCheckpointLostError` per the E.4 contract. New AC-E6(c) case covers the
  wrong-typed record (the old poison test only hit the non-array branch).
- **Mint-leg disposition:** a split-mint-leg `TRANSACTION_HASH_MISMATCH` now maps to keep-open
  `SplitCheckpointLostError` (via `submitSplitMintLeg`), not the abort-y `TransferConflictError` —
  a mint stateId is HKDF-derived from `(seed, transferId)`, so it is never a foreign spend. The
  burn leg and whole-token transfers still throw `TransferConflictError` (AC-E4 unchanged). The
  no-store residual control was updated accordingly (it now surfaces the keep-open error).
- **Probe robustness:** the pre-flight probe (`assertNoLegStranded`) now probes **every** leg, so
  correctness no longer depends on the mint loop certifying leg 0 first (E.4 step-3 concern
  removed rather than merely documented).
- **Adopt coverage:** a new AC-E6(e) test falsifies the insert-once adopt path — a losing put-race
  resumer must mint from `put()`'s authoritative return, proven via a reference device that only
  match-verifies (dup-OK) if the loser adopted the winner's burn proof.
- **Hygiene:** removed two accidentally-staged test artifacts and broadened `.gitignore` to
  `tests/**/.test-*/`.

## Verification

- `npm run typecheck` + `lint` (0 errors) + `build` green; the full token-engine unit suite passes
  (14 files / 111 tests; `recoverable-engine.test.ts` 20). A fresh verification pass confirmed the
  fixes closed the findings with no regression.

Out of scope (later PRs): the `WalletApiCheckpointStore` adapter + AAD encryption, the
PaymentsModule resume rework (incl. sphere-sdk#634) + `requiresSeedClose` PUT wiring + signed
close, and the live-drill un-scope.

Closes #635. Part of the sphere-sdk#501 train.
