### PR TITLE
feat(payments): WalletApiCheckpointStore + checkpoint resume + #634 fix (sphere-sdk#501 E.4)

### DIFF
--- a/core/field-encryption.ts
+++ b/core/field-encryption.ts
@@ -131,12 +131,15 @@ export function deriveFieldEncryptionKey(privKeyHex: string): Uint8Array {
 // =============================================================================
 
 /**
- * Encrypt a plaintext field into the S6 wire envelope:
- * `"enc1." + base64(nonce ‖ ciphertext)` (XChaCha20-Poly1305, random 24-byte nonce).
+ * Encrypt BINARY plaintext into the S6 wire envelope, optionally bound to associated data (AAD):
+ * `"enc1." + base64(nonce ‖ ciphertext)` (XChaCha20-Poly1305, random 24-byte nonce). The AAD is
+ * authenticated but NOT stored in the envelope — the reader re-derives it from context, so a
+ * record decrypted against a different AAD fails the poly1305 tag (E.4: AAD = `transferId:opIndex`
+ * binds a checkpoint to its slot, defeating a mis-served / cross-intent replay at the crypto layer).
  */
-export function encryptField(key: Uint8Array, plaintext: string): string {
+export function encryptFieldBytes(key: Uint8Array, plaintext: Uint8Array, aad?: Uint8Array): string {
   const nonce = randomBytes(FIELD_ENVELOPE_NONCE_BYTES);
-  const ciphertext = xchacha20poly1305(key, nonce).encrypt(new TextEncoder().encode(plaintext));
+  const ciphertext = xchacha20poly1305(key, nonce, aad).encrypt(plaintext);
   const packed = new Uint8Array(nonce.length + ciphertext.length);
   packed.set(nonce, 0);
   packed.set(ciphertext, nonce.length);
@@ -144,11 +147,10 @@ export function encryptField(key: Uint8Array, plaintext: string): string {
 }
 
 /**
- * Decrypt an S6 wire envelope. Validates the prefix and shape, then opens the
- * XChaCha20-Poly1305 box; any tampering (nonce, ciphertext, or tag) throws a
- * `SphereError('DECRYPTION_ERROR')`.
+ * Decrypt an S6 wire envelope to BINARY bytes, requiring the same `aad` used at encrypt time.
+ * Any tampering, wrong key, OR wrong AAD throws `SphereError('DECRYPTION_ERROR')`.
  */
-export function decryptField(key: Uint8Array, envelope: string): string {
+export function decryptFieldBytes(key: Uint8Array, envelope: string, aad?: Uint8Array): Uint8Array {
   if (typeof envelope !== 'string' || !envelope.startsWith(FIELD_ENVELOPE_PREFIX)) {
     throw new SphereError('Invalid field envelope: missing "enc1." prefix', 'DECRYPTION_ERROR');
   }
@@ -159,11 +161,26 @@ export function decryptField(key: Uint8Array, envelope: string): string {
   const nonce = packed.slice(0, FIELD_ENVELOPE_NONCE_BYTES);
   const ciphertext = packed.slice(FIELD_ENVELOPE_NONCE_BYTES);
   try {
-    const plain = xchacha20poly1305(key, nonce).decrypt(ciphertext);
-    return new TextDecoder().decode(plain);
+    return xchacha20poly1305(key, nonce, aad).decrypt(ciphertext);
   } catch (err) {
-    throw new SphereError('Field envelope authentication failed (tampered or wrong key)', 'DECRYPTION_ERROR', err);
+    throw new SphereError('Field envelope authentication failed (tampered, wrong key, or wrong AAD)', 'DECRYPTION_ERROR', err);
   }
+}
+
+/**
+ * Encrypt a UTF-8 string field into the S6 wire envelope (AAD-less). Thin wrapper over
+ * {@link encryptFieldBytes} — the memo/nametag/intent-payload path.
+ */
+export function encryptField(key: Uint8Array, plaintext: string): string {
+  return encryptFieldBytes(key, new TextEncoder().encode(plaintext));
+}
+
+/**
+ * Decrypt an AAD-less S6 wire envelope to a UTF-8 string (memo/nametag/intent payload). Any
+ * tampering throws `SphereError('DECRYPTION_ERROR')`.
+ */
+export function decryptField(key: Uint8Array, envelope: string): string {
+  return new TextDecoder().decode(decryptFieldBytes(key, envelope));
 }
 
 /**

--- a/impl/shared/wallet-api/WalletApiCheckpointStore.ts
+++ b/impl/shared/wallet-api/WalletApiCheckpointStore.ts
@@ -1,0 +1,64 @@
+/**
+ * impl/shared/wallet-api/WalletApiCheckpointStore.ts — the E.4 split burn checkpoint store
+ * (sphere-sdk#501 option b) over the wallet-api §16 intent-progress endpoints.
+ *
+ * The engine's SplitCheckpointStore port deals in opaque PLAINTEXT bytes (the checkpoint CBOR).
+ * This adapter is the transport + crypto boundary: it AAD-encrypts the plaintext into the S6
+ * `enc1.` envelope (AAD = `transferId:opIndex`, binding a record to its slot so a mis-served /
+ * cross-intent record fails the poly1305 tag at decrypt), POSTs it via the client (signed,
+ * locally backed up, content-idempotent), and decrypts the AUTHORITATIVE stored envelope back to
+ * plaintext on get/put — so the engine mints from the winner's proof on a put race.
+ */
+
+import { decryptFieldBytes, encryptFieldBytes } from '../../../core/field-encryption';
+import { SphereError } from '../../../core/errors';
+import { SplitCheckpointLostError, type SplitCheckpointStore } from '../../../token-engine';
+
+/** The wallet-api §16 intent-progress surface this store needs (satisfied by WalletApiClient). */
+export interface CheckpointProgressPort {
+  /** Append the checkpoint envelope; returns the AUTHORITATIVE stored envelope (insert-once). */
+  postIntentProgress(transferId: string, opIndex: number, payloadEnvelope: string): Promise<string>;
+  /** The stored checkpoint records for the intent (ascending opIndex). */
+  getIntentProgress(transferId: string): Promise<readonly { opIndex: number; payload: string }[]>;
+}
+
+export class WalletApiCheckpointStore implements SplitCheckpointStore {
+  public constructor(
+    private readonly port: CheckpointProgressPort,
+    private readonly fieldKey: Uint8Array,
+  ) {}
+
+  /** Per-slot associated data — authenticated, never stored; both sides re-derive it from context. */
+  private aad(transferId: string, opIndex: number): Uint8Array {
+    return new TextEncoder().encode(`${transferId}:${String(opIndex)}`);
+  }
+
+  public async put(transferId: string, opIndex: number, bytes: Uint8Array): Promise<Uint8Array> {
+    const aad = this.aad(transferId, opIndex);
+    const envelope = encryptFieldBytes(this.fieldKey, bytes, aad);
+    const stored = await this.port.postIntentProgress(transferId, opIndex, envelope);
+    return this.open(stored, aad); // decode the winner's bytes (ours or a racing resumer's)
+  }
+
+  public async get(transferId: string, opIndex: number): Promise<Uint8Array | null> {
+    const record = (await this.port.getIntentProgress(transferId)).find((r) => r.opIndex === opIndex);
+    if (record === undefined) return null;
+    return this.open(record.payload, this.aad(transferId, opIndex));
+  }
+
+  /**
+   * Decrypt a stored envelope under the slot AAD. A decrypt failure means the record was tampered,
+   * mis-served for another slot, or otherwise unreadable — the checkpoint is effectively lost:
+   * surface the keep-open SplitCheckpointLostError (never a raw error the caller cannot dispose).
+   */
+  private open(envelope: string, aad: Uint8Array): Uint8Array {
+    try {
+      return decryptFieldBytes(this.fieldKey, envelope, aad);
+    } catch (err) {
+      if (err instanceof SphereError && err.code === 'DECRYPTION_ERROR') {
+        throw new SplitCheckpointLostError('split checkpoint record could not be decrypted (tampered or mis-served)', err);
+      }
+      throw err;
+    }
+  }
+}

--- a/impl/shared/wallet-api/index.ts
+++ b/impl/shared/wallet-api/index.ts
@@ -14,6 +14,9 @@ export {
 } from './WalletApiMailboxProvider';
 export type { WalletApiMailboxProviderConfig } from './WalletApiMailboxProvider';
 
+export { WalletApiCheckpointStore } from './WalletApiCheckpointStore';
+export type { CheckpointProgressPort } from './WalletApiCheckpointStore';
+
 export {
   createSphereProviders,
   createWalletApiProviders,

--- a/index.ts
+++ b/index.ts
@@ -198,6 +198,8 @@ export {
   deriveFieldEncryptionKey,
   encryptField,
   decryptField,
+  encryptFieldBytes,
+  decryptFieldBytes,
   assertFieldEnvelopeShape,
   FIELD_ENCRYPTION_HKDF_INFO,
   FIELD_ENVELOPE_PREFIX,

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -30,7 +30,15 @@ import type {
 } from '../../types/txf';
 import type { SplitPlan, TokenWithAmount } from './TokenSplitCalculator';
 import type { ITokenEngine, SphereToken, TokenBlob } from '../../token-engine';
-import { TransferConflictError, ProofUnconfirmedError } from '../../token-engine';
+import {
+  CheckpointPersistFailedError,
+  CheckpointTrustbaseMismatchError,
+  ProofUnconfirmedError,
+  type SplitCheckpointStore,
+  SplitCheckpointLostError,
+  TransferConflictError,
+} from '../../token-engine';
+import { WalletApiCheckpointStore } from '../../impl/shared/wallet-api/WalletApiCheckpointStore';
 import { WalletApiError } from '../../wallet-api';
 import { isV2TransferPayload, type V2TransferPayload } from '../../types/v2-transfer';
 import { TokenReservationLedger } from './TokenReservationLedger';
@@ -763,12 +771,23 @@ export interface WalletApiHistoryRecord {
  * module's responsibility: sdk-changes E.3 + S2 consumer update).
  */
 export interface PaymentsWalletApiPort {
-  /** E.3: persist the client-encrypted intent; MUST be awaited before the engine. */
-  putIntent(transferId: string, payloadEnvelope: string): Promise<void>;
-  /** E.3 uniform close — every finished send ends with this (idempotent). */
+  /**
+   * E.3: persist the client-encrypted intent; MUST be awaited before the engine. `requiresSeedClose`
+   * (E.4/#87) marks a split intent whose terminal close is seed-gated — set BEFORE the burn.
+   */
+  putIntent(transferId: string, payloadEnvelope: string, opts?: { requiresSeedClose?: boolean }): Promise<void>;
+  /** E.3 uniform close — every finished send ends with this (idempotent; signs the §87 close). */
   completeIntent(transferId: string): Promise<void>;
   /** E.2 lost-race cleanup (soft, recoverable). */
   abortIntent(transferId: string): Promise<void>;
+  /**
+   * E.4 burn checkpoint (sphere-sdk#501) — OPTIONAL capability. When present (the WalletApiClient
+   * provides them), a split's resume is checkpoint-protected via {@link WalletApiCheckpointStore};
+   * a composed port without them keeps today's residual (a split resumed after a certified mint
+   * cannot recover its change — surfaced via inventory resync).
+   */
+  postIntentProgress?(transferId: string, opIndex: number, payloadEnvelope: string): Promise<string>;
+  getIntentProgress?(transferId: string): Promise<readonly { opIndex: number; payload: string }[]>;
   /** E.3 resume: list open intents at sign-in (any device). */
   listIntents(status: 'open' | 'aborted'): Promise<
     { transferId: string; payload: string; status: 'open' | 'completed' | 'aborted'; createdAt: number }[]
@@ -833,9 +852,14 @@ type PaymentRequestsApi = Pick<PaymentsWalletApiPort, 'network'> &
     Pick<PaymentsWalletApiPort, 'createPaymentRequest' | 'listPaymentRequests' | 'respondPaymentRequest'>
   >;
 
-/** The decrypted E.3 intent payload (`{ sources, recipient, amounts }` concretized). */
+/**
+ * The decrypted E.3 intent payload (`{ sources, recipient, amounts }` concretized). `v:2` is the
+ * E.4 (sphere-sdk#501) variant: its split resumes from the durable burn checkpoint. `v:1` is the
+ * pre-E.4 legacy shape — resumed via the change-blind journaled shortcut, sunsetting one release
+ * after E.4 (a v:1 split that crashed mid-flight recovers its change via a full inventory resync).
+ */
 interface IntentPayloadV1 {
-  v: 1;
+  v: 1 | 2;
   /** Recipient chain pubkey (33-byte compressed, hex). */
   recipient: string;
   coinId: string;
@@ -1003,6 +1027,7 @@ export class PaymentsModule {
   private pumpInFlight: Promise<number> | null = null;
   /** S6 field-encryption key (intent payloads, history memos) — per identity. */
   private fieldEncryptionKey: Uint8Array | null = null;
+  private checkpointStore: SplitCheckpointStore | null = null;
 
   // wallet-api payment requests (sdk-changes S4 — §10/§16)
   private prPollTimer: ReturnType<typeof setInterval> | null = null;
@@ -1189,6 +1214,7 @@ export class PaymentsModule {
     this.deps = deps;
     this.priceProvider = deps.price ?? null;
     this.fieldEncryptionKey = null; // re-derived lazily per identity (S6)
+    this.checkpointStore = null; // rebuilt lazily — it captures the per-identity field key (E.4)
     // Path B: wire the engine into the planner (value reads use it when present).
     this.spendPlanner.setEngine(deps.tokenEngine);
 
@@ -1738,12 +1764,16 @@ export class PaymentsModule {
         // for a possibly-already-certified transfer; local-only persistence is
         // forbidden for the live path.
         if (walletApi) {
+          // E.4/#87: a split's terminal close is seed-gated — set requiresSeedClose here, BEFORE
+          // the burn, so the funds-critical window is guarded from intent creation (not only once
+          // the first checkpoint is appended).
           await walletApi.putIntent(
             result.id,
             encryptField(
               this.getFieldEncryptionKey(),
               JSON.stringify(this.buildIntentPayload(request, peerInfo.chainPubkey, splitPlan))
-            )
+            ),
+            splitPlan.requiresSplit ? { requiresSeedClose: true } : {}
           );
         }
 
@@ -1836,10 +1866,12 @@ export class PaymentsModule {
               },
               // Same per-send seed; the split's opIndex follows the direct ops
               // (stable across resume — it is derived from the intent's order).
+              // E.4: persist the burn checkpoint before the first mint (durable-ack gated).
               {
                 signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS),
                 transferId: result.id,
                 opIndex: splitPlan.tokensToTransferDirectly.length,
+                ...(this.getCheckpointStore() ? { checkpointStore: this.getCheckpointStore() } : {}),
               },
             ));
           } catch (err) {
@@ -2005,6 +2037,11 @@ export class PaymentsModule {
           error: error.message,
         });
       }
+      // E.4: a stuck checkpoint on the SEND path (lost/withheld record, or a trust-base rotation) —
+      // kept open, but surface the distinct loud signal (never a silent retry — needs the drain).
+      if (error instanceof SplitCheckpointLostError || error instanceof CheckpointTrustbaseMismatchError) {
+        this.deps!.emitEvent('split:checkpoint-stuck', { transferId: result.id, code: error.code, error: error.message });
+      }
 
       // Intent disposition on failure (E.2/E.3):
       //  - a TransferConflictError aborts (the prescribed recovery — the
@@ -2024,9 +2061,18 @@ export class PaymentsModule {
       //    beat the .add()). Resume re-derives the identical tx: it recovers the
       //    proof + delivery, or records the spend if a foreign tx won — never a
       //    second on-chain spend.
-      const mayHaveCertified = error instanceof ProofUnconfirmedError;
+      //  - E.4 (sphere-sdk#501): the split burn-checkpoint errors are ALL keep-open. The burn is
+      //    certified (or the source is untouched, for a leg-0 strand); a split-mint stateId is
+      //    HKDF-derived, so a mismatch is never a foreign spend. Aborting would orphan a
+      //    burn-certified split — resume under the same transferId (rebuilding from the stored
+      //    checkpoint) is the only exit. So keep-open even when committedOnChainTokenIds is empty.
+      const keepOpen =
+        error instanceof ProofUnconfirmedError ||
+        error instanceof CheckpointPersistFailedError ||
+        error instanceof SplitCheckpointLostError ||
+        error instanceof CheckpointTrustbaseMismatchError;
       if (this.deps?.walletApi) {
-        if (error instanceof TransferConflictError || (committedOnChainTokenIds.size === 0 && !mayHaveCertified)) {
+        if (error instanceof TransferConflictError || (committedOnChainTokenIds.size === 0 && !keepOpen)) {
           try {
             await this.deps.walletApi.abortIntent(result.id);
           } catch (abortErr) {
@@ -2152,6 +2198,28 @@ export class PaymentsModule {
   }
 
   /**
+   * The E.4 split burn checkpoint store (sphere-sdk#501), or undefined when the composed wallet-api
+   * port lacks the progress capability (own-storage / legacy compositions — the documented
+   * residual). Memoized. Passed into engine.split() so a split resumed after a certified mint
+   * rebuilds its outputs from the durable checkpoint instead of stranding them.
+   */
+  private getCheckpointStore(): SplitCheckpointStore | undefined {
+    const walletApi = this.deps?.walletApi;
+    if (!walletApi || typeof walletApi.postIntentProgress !== 'function' || typeof walletApi.getIntentProgress !== 'function') {
+      return undefined;
+    }
+    if (!this.checkpointStore) {
+      const post = walletApi.postIntentProgress.bind(walletApi);
+      const get = walletApi.getIntentProgress.bind(walletApi);
+      this.checkpointStore = new WalletApiCheckpointStore(
+        { postIntentProgress: post, getIntentProgress: get },
+        this.getFieldEncryptionKey(),
+      );
+    }
+    return this.checkpointStore;
+  }
+
+  /**
    * S2: materialize the SELECTED lazy sources — fetch each blob on demand via
    * the storage port's `getToken()` and decode it through the engine. Only
    * tokens the plan actually consumes are downloaded; coin-selection itself
@@ -2198,7 +2266,7 @@ export class PaymentsModule {
     const genesisIdOf = (tw: TokenWithAmount): string =>
       extractTokenIdFromSdkData(tw.uiToken.sdkData) ?? tw.uiToken.id.replace(/^v2_/, '');
     return {
-      v: 1,
+      v: 2, // E.4: new sends carry the checkpoint-aware resume contract (sphere-sdk#501)
       recipient: recipientChainPubkey,
       coinId: request.coinId,
       amount: request.amount,
@@ -5274,7 +5342,7 @@ export class PaymentsModule {
       try {
         const plain = decryptField(this.getFieldEncryptionKey(), intent.payload);
         payload = JSON.parse(plain) as IntentPayloadV1;
-        if (payload.v !== 1 || !Array.isArray(payload.direct)) {
+        if ((payload.v !== 1 && payload.v !== 2) || !Array.isArray(payload.direct)) {
           throw new SphereError('Unknown intent payload shape', 'VALIDATION_ERROR');
         }
       } catch (err) {
@@ -5296,6 +5364,18 @@ export class PaymentsModule {
             logger.warn('Payments', 'abortIntent during resume failed:', abortErr);
           }
           outcome.conflicted.push(intent.transferId);
+        } else if (err instanceof SplitCheckpointLostError || err instanceof CheckpointTrustbaseMismatchError) {
+          // E.4: a burn-certified split is STUCK on an unrecoverable-for-now checkpoint error (lost
+          // checkpoint, or a trust-base rotation). The intent stays OPEN (funds in-flight, never
+          // lost), but this is NOT a transient blip — emit a distinct LOUD signal so the operator
+          // can act (the drain remedy) rather than wait on a silent retry.
+          logger.warn('Payments', `Intent ${intent.transferId.slice(0, 8)}… split checkpoint STUCK (${err.code}) — kept open, needs attention:`, err);
+          this.deps!.emitEvent('split:checkpoint-stuck', {
+            transferId: intent.transferId,
+            code: err.code,
+            error: err.message,
+          });
+          outcome.failed.push(intent.transferId);
         } else {
           // Transient — the intent stays open; the next sign-in retries.
           logger.warn('Payments', `Intent ${intent.transferId.slice(0, 8)}… resume failed (stays open):`, err);
@@ -5383,10 +5463,14 @@ export class PaymentsModule {
       // Split opIndex follows the direct ops — replayed from the intent's order (§8.1).
       const splitOpIndex = payload.direct.length;
       const existingSplit = journaled.get(splitOpIndex);
-      if (existingSplit) {
-        // #621/#622-review: the split already certified in the original send — re-deliver the journaled
-        // recipient blob, never re-run engine.split on the spent source (it would TransferConflictError
-        // and wedge). The change output is handled by the conflict path below / a resync.
+      // E.4 (sphere-sdk#501): a v:2 split resumes THROUGH its burn checkpoint — engine.split()
+      // rebuilds BOTH outputs from the stored proof (already-certified legs match-verify), so the
+      // change is recovered even when the split already certified. This subsumes AND fixes the
+      // legacy journaled shortcut (#634): that shortcut re-delivered the recipient blob but left the
+      // change unpersisted, so the following applyDelta recorded the spend with an empty `added`.
+      const checkpointStore = payload.v === 2 ? this.getCheckpointStore() : undefined;
+      if (checkpointStore === undefined && existingSplit) {
+        // Legacy residual (no checkpoint): re-deliver only; the change recovers via inventory resync.
         await deliverBlob(existingSplit.tokenBlob, splitOpIndex);
       } else {
         try {
@@ -5410,7 +5494,12 @@ export class PaymentsModule {
                 },
               ],
             },
-            { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId, opIndex: splitOpIndex }
+            {
+              signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS),
+              transferId,
+              opIndex: splitOpIndex,
+              ...(checkpointStore ? { checkpointStore } : {}),
+            }
           );
           changeOutput = outputs[1];
           // critical (#515 F2): own-storage custody — persist-or-stay-open; a
@@ -5418,14 +5507,24 @@ export class PaymentsModule {
           if (!serverApply) await this.storeEngineToken(engine, changeOutput, { criticalSave: true });
           await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(outputs[0]))), splitOpIndex);
         } catch (err) {
-          // #622-review: mirror the direct-op path for split. The split source is already spent on-chain
-          // (a crash certified it before this resume) — record the spend instead of wedging on the
-          // re-certification conflict. KNOWN LIMITATION: the change output is NOT journaled and cannot be
-          // re-derived here (re-running engine.split conflicts), so a split that crashed between
-          // certification and applyDelta recovers its change token via a full inventory resync. Surfaced
-          // (inventory:conflict prompts that refresh) — never silently lost.
-          if (!(err instanceof TransferConflictError)) throw err;
-          logger.warn('Payments', `Resume split op already certified — recording the spend; change token (if any) recovers on the next inventory resync (§3.1):`, err);
+          if (err instanceof ProofUnconfirmedError) throw err; // #631 keep-open (indeterminate)
+          // KEEP-OPEN with a checkpoint store (v:2): the burn is certified and a split-mint stateId is
+          // HKDF-derived (never a foreign spend), so resume — rebuilding from the checkpoint — is the
+          // only exit. NEVER record the spend or abort.
+          if (
+            checkpointStore !== undefined &&
+            (err instanceof CheckpointPersistFailedError ||
+              err instanceof SplitCheckpointLostError ||
+              err instanceof CheckpointTrustbaseMismatchError)
+          ) {
+            throw err;
+          }
+          // Record the spend for: a genuine burn-leg foreign spend (TransferConflictError, §7 race
+          // under a DIFFERENT transferId), OR a LEGACY no-checkpoint split whose already-certified
+          // mint leg the engine now surfaces as SplitCheckpointLostError (there is no checkpoint to
+          // recover from — the v:1 residual: the change recovers via a full inventory resync).
+          if (!(err instanceof TransferConflictError) && !(err instanceof SplitCheckpointLostError)) throw err;
+          logger.warn('Payments', `Resume split: source already spent — recording the spend; change (if any) recovers on the next inventory resync (§3.1):`, err);
           this.deps!.emitEvent('inventory:conflict', { transferId, coinId: payload.coinId, error: err.message });
         }
       }

--- a/tests/support/fake-wallet-api.ts
+++ b/tests/support/fake-wallet-api.ts
@@ -43,6 +43,7 @@ import { randomBytes } from '@noble/hashes/utils.js';
 import { recoverPubkeyFromSignature } from '../../core/crypto';
 import { decodeTokenBlob } from '../../token-engine/token-blob';
 import { AUTH_CHALLENGE_PREFIX } from '../../wallet-api/challenge';
+import { completeSignMessage, progressSignMessage } from '../../wallet-api/intent-signing';
 import { assertFieldEnvelopeShape } from '../../core/field-encryption';
 
 // =============================================================================
@@ -113,7 +114,17 @@ interface OwnerState {
   cursor: bigint; // gap-free, commit-ordered per-owner counter (§9)
   rows: Map<string, InventoryRow>; // one row per (owner, token) (§5.1)
   appliedTransfers: Map<string, bigint>; // §5.3 step 1 idempotency record
-  intents: Map<string, { payload: string; status: 'open' | 'completed' | 'aborted'; createdAt: string }>;
+  intents: Map<
+    string,
+    {
+      payload: string;
+      status: 'open' | 'completed' | 'aborted';
+      createdAt: string;
+      requiresSeedClose?: boolean;
+      // §16/E.4 intent progress: insert-once per opIndex (the split burn checkpoint).
+      progress?: Map<number, { payload: string; createdAt: string }>;
+    }
+  >;
   /** Mailbox entries ADDRESSED TO this owner (§6), keyed by entry_id. */
   mailbox: Map<string, MailboxEntryRow>;
   /** Per-recipient monotonic mailbox seq counter (§6) — separate from `cursor`. */
@@ -250,6 +261,7 @@ export class FakeWalletApi {
   private readonly wsTicketTtlMs: number;
   private readonly maxBlobBytes: number;
   private readonly intentMaxBytes: number;
+  private readonly progressMaxBytes = 65536; // §5.5 PROGRESS_PAYLOAD_MAX_BYTES (E.4 checkpoint)
   private readonly mailboxUnclaimedCap: number;
   private readonly mailboxPerPairCap: number;
   private readonly maxPayerOpenRequests: number;
@@ -339,6 +351,11 @@ export class FakeWalletApi {
     if (opts.dropIntents) {
       for (const owner of this.owners.values()) owner.intents.clear();
     }
+  }
+
+  /** Drop a single intent (+ its progress) — a targeted PITR loss for the E.4 re-seed test. */
+  dropIntent(pubkey: string, transferId: string): void {
+    this.owner(pubkey).intents.delete(transferId);
   }
 
   /** Make the next auth challenge malformed — the client MUST refuse to sign it. */
@@ -670,7 +687,7 @@ export class FakeWalletApi {
     const respondMatch = path.match(/^\/v1\/payment-requests\/([^/]+)\/respond$/);
     if (method === 'POST' && respondMatch) return this.handlePaymentRequestRespond(req, res, respondMatch[1]);
 
-    const intentMatch = path.match(/^\/v1\/intents\/([^/]+)(\/(abort|complete))?$/);
+    const intentMatch = path.match(/^\/v1\/intents\/([^/]+)(\/(abort|complete|progress))?$/);
     if (intentMatch) return this.handleIntent(req, res, intentMatch[1], intentMatch[3]);
     if (method === 'GET' && path === '/v1/intents') return this.handleListIntents(req, res, url);
 
@@ -1981,9 +1998,15 @@ export class FakeWalletApi {
         throw new HttpError(422, 'VALIDATION', err instanceof Error ? err.message : 'bad intent payload');
       }
       const payload = body.payload as string;
+      const requiresSeedClose = body.requiresSeedClose === true; // §16/#87, honored on first insert
       const existing = owner.intents.get(transferId);
       if (!existing) {
-        owner.intents.set(transferId, { payload, status: 'open', createdAt: new Date().toISOString() });
+        owner.intents.set(transferId, {
+          payload,
+          status: 'open',
+          createdAt: new Date().toISOString(),
+          ...(requiresSeedClose ? { requiresSeedClose: true } : {}),
+        });
         this.json(res, 204, null);
         return;
       }
@@ -2017,15 +2040,86 @@ export class FakeWalletApi {
     if (method === 'POST' && action === 'complete') {
       const intent = owner.intents.get(transferId);
       if (!intent) throw new HttpError(404, 'NOT_FOUND', 'unknown intent');
-      // §16: idempotent; aborted → completed is legal (completion wins);
-      // completed never reverts. This is the uniform client-side close —
-      // storage-opt-out senders depend on it.
+      // §16/#87: a checkpoint-bearing (requires_seed_close) intent's terminal close needs a
+      // seed-holder signature. The fake does not verify secp256k1 — it only asserts one is present
+      // (the real backend recovers + checks the pubkey; cryptographic verification is covered by
+      // the wallet-api integration suite, M2.12).
+      if (intent.requiresSeedClose === true) {
+        const body = (await this.readJsonBody(req).catch(() => ({}))) as { signature?: unknown };
+        // §16/#87: recover the pubkey over the canonical close message and require the owner's — a
+        // faithful gate (the real backend does this) so a wrong-key/wrong-message signature fails.
+        this.assertSeedHolder(session.pubkey, completeSignMessage(transferId), body.signature, 403);
+      }
       intent.status = 'completed';
       this.json(res, 204, null);
       return;
     }
 
+    if (action === 'progress') return this.handleIntentProgress(req, res, owner, session.pubkey, transferId, method);
+
     throw new HttpError(404, 'NOT_FOUND', 'no such intent route');
+  }
+
+  /** §16/#87 seed-holder gate: the signature must recover to the intent owner over `message`. */
+  private assertSeedHolder(pubkey: string, message: string, signature: unknown, foreignStatus: number): void {
+    if (typeof signature !== 'string' || signature.length === 0) {
+      throw new HttpError(foreignStatus, 'FORBIDDEN', 'seed-holder signature required');
+    }
+    let recovered: string;
+    try {
+      recovered = recoverPubkeyFromSignature(message, signature);
+    } catch {
+      throw new HttpError(422, 'VALIDATION', 'seed-holder signature does not parse');
+    }
+    if (recovered.toLowerCase() !== pubkey.toLowerCase()) {
+      throw new HttpError(foreignStatus, 'FORBIDDEN', 'seed-holder signature is not the intent owner');
+    }
+  }
+
+  /** §16/E.4 intent progress — insert-once first-write-wins per (transferId, opIndex). */
+  private async handleIntentProgress(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    owner: OwnerState,
+    pubkey: string,
+    transferId: string,
+    method: string
+  ): Promise<void> {
+    const intent = owner.intents.get(transferId);
+    if (method === 'GET') {
+      if (!intent) throw new HttpError(404, 'NOT_FOUND', 'unknown intent');
+      const records = [...(intent.progress ?? new Map()).entries()]
+        .sort((a, b) => a[0] - b[0])
+        .map(([opIndex, r]) => ({ opIndex, payload: r.payload, createdAt: r.createdAt }));
+      this.json(res, 200, { records });
+      return;
+    }
+    if (method !== 'POST') throw new HttpError(404, 'NOT_FOUND', 'no such intent route');
+    if (!intent) throw new HttpError(404, 'NOT_FOUND', 'unknown intent');
+    if (intent.status !== 'open') throw new HttpError(409, 'CONFLICT', 'intent is not open');
+    if (intent.requiresSeedClose !== true) throw new HttpError(409, 'CONFLICT', 'intent is not requires_seed_close (§16/#87)');
+    const body = (await this.readJsonBody(req)) as { opIndex?: unknown; payload?: unknown; signature?: unknown };
+    try {
+      assertFieldEnvelopeShape(body.payload, this.progressMaxBytes);
+    } catch (err) {
+      throw new HttpError(422, 'VALIDATION', err instanceof Error ? err.message : 'bad progress payload');
+    }
+    const opIndex = Number(body.opIndex);
+    if (!Number.isInteger(opIndex) || opIndex < 0) throw new HttpError(422, 'VALIDATION', 'bad opIndex');
+    // §16/#87 seed-holder gate: recover the pubkey over the canonical progress message (bound to the
+    // EXACT envelope bytes) and require the owner's — the faithful gate the real backend runs.
+    this.assertSeedHolder(pubkey, progressSignMessage(transferId, opIndex, body.payload as string), body.signature, 403);
+    const progress = intent.progress ?? new Map<number, { payload: string; createdAt: string }>();
+    intent.progress = progress;
+    const existing = progress.get(opIndex);
+    if (existing) {
+      // insert-once: return the FIRST writer's record (adopt), 200.
+      this.json(res, 200, { record: { opIndex, payload: existing.payload, createdAt: existing.createdAt } });
+      return;
+    }
+    const record = { payload: body.payload as string, createdAt: new Date().toISOString() };
+    progress.set(opIndex, record);
+    this.json(res, 201, { record: { opIndex, payload: record.payload, createdAt: record.createdAt } });
   }
 
   private handleListIntents(req: http.IncomingMessage, res: http.ServerResponse, url: URL): void {

--- a/tests/unit/core/field-encryption.test.ts
+++ b/tests/unit/core/field-encryption.test.ts
@@ -7,8 +7,10 @@ import { describe, it, expect } from 'vitest';
 import {
   assertFieldEnvelopeShape,
   decryptField,
+  decryptFieldBytes,
   deriveFieldEncryptionKey,
   encryptField,
+  encryptFieldBytes,
   FIELD_ENVELOPE_MAX_BYTES,
   FIELD_ENVELOPE_PREFIX,
 } from '../../../core/field-encryption';
@@ -104,6 +106,45 @@ describe('field-encryption (S6)', () => {
       const big = encryptField(key, 'x'.repeat(FIELD_ENVELOPE_MAX_BYTES));
       expect(() => assertFieldEnvelopeShape(big)).toThrowError(/size cap/);
       expect(() => assertFieldEnvelopeShape(big, big.length)).not.toThrow();
+    });
+  });
+
+  describe('binary + AAD (E.4 checkpoint envelope)', () => {
+    const AAD_A = new TextEncoder().encode('transfer-a:0');
+    const AAD_B = new TextEncoder().encode('transfer-b:0');
+
+    it('round-trips arbitrary (non-UTF-8) binary bytes under matching AAD', () => {
+      const key = deriveFieldEncryptionKey(PRIV_A);
+      // 0xff 0xfe … is not valid UTF-8 — a string codec would corrupt it.
+      const plaintext = new Uint8Array([0xff, 0xfe, 0x00, 0x80, 0x13, 0x37, 0xc0]);
+      const envelope = encryptFieldBytes(key, plaintext, AAD_A);
+      expect(Array.from(decryptFieldBytes(key, envelope, AAD_A))).toEqual(Array.from(plaintext));
+    });
+
+    it('a wrong AAD fails the tag at decrypt (cross-slot replay is rejected)', () => {
+      const key = deriveFieldEncryptionKey(PRIV_A);
+      const envelope = encryptFieldBytes(key, new Uint8Array([1, 2, 3]), AAD_A);
+      // The SAME key + envelope, but a different slot's AAD — must not decrypt.
+      expect(() => decryptFieldBytes(key, envelope, AAD_B)).toThrowError(SphereError);
+      expect(() => decryptFieldBytes(key, envelope, AAD_B)).toThrowError(/authentication failed/);
+      // …and the correct AAD still opens it.
+      expect(Array.from(decryptFieldBytes(key, envelope, AAD_A))).toEqual([1, 2, 3]);
+    });
+
+    it('AAD is authenticated but NOT stored — omitting it entirely is a different context', () => {
+      const key = deriveFieldEncryptionKey(PRIV_A);
+      const withAad = encryptFieldBytes(key, new Uint8Array([9]), AAD_A);
+      expect(() => decryptFieldBytes(key, withAad)).toThrowError(/authentication failed/); // no AAD ≠ AAD_A
+      const noAad = encryptFieldBytes(key, new Uint8Array([9]));
+      expect(Array.from(decryptFieldBytes(key, noAad))).toEqual([9]); // AAD-less round-trips
+    });
+
+    it('the string wrappers are the AAD-less binary path (interop with encryptFieldBytes)', () => {
+      const key = deriveFieldEncryptionKey(PRIV_A);
+      const viaString = encryptField(key, 'hello');
+      expect(new TextDecoder().decode(decryptFieldBytes(key, viaString))).toBe('hello');
+      const viaBytes = encryptFieldBytes(key, new TextEncoder().encode('hello'));
+      expect(decryptField(key, viaBytes)).toBe('hello');
     });
   });
 });

--- a/tests/unit/impl/WalletApiCheckpointStore.test.ts
+++ b/tests/unit/impl/WalletApiCheckpointStore.test.ts
@@ -1,0 +1,111 @@
+/**
+ * WalletApiCheckpointStore (E.4, sphere-sdk#501) — the SplitCheckpointStore adapter over the
+ * wallet-api §16 intent-progress surface. Verifies the crypto/adopt boundary: AAD-bound
+ * encryption round-trips, a mis-served (cross-slot) record fails at decrypt as a keep-open
+ * SplitCheckpointLostError, insert-once put returns the WINNER's bytes (adopt), and get is null
+ * when the slot is empty.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { deriveFieldEncryptionKey, decryptFieldBytes } from '../../../core/field-encryption';
+import { SplitCheckpointLostError } from '../../../token-engine';
+import {
+  WalletApiCheckpointStore,
+  type CheckpointProgressPort,
+} from '../../../impl/shared/wallet-api/WalletApiCheckpointStore';
+
+const PRIV = 'a1'.repeat(32);
+
+/** An in-memory §16 progress backend: insert-once first-write-wins per (transferId, opIndex). */
+class InMemoryProgressPort implements CheckpointProgressPort {
+  public readonly slots = new Map<string, { opIndex: number; payload: string }[]>();
+
+  public postIntentProgress(transferId: string, opIndex: number, payloadEnvelope: string): Promise<string> {
+    const records = this.slots.get(transferId) ?? [];
+    this.slots.set(transferId, records);
+    const existing = records.find((r) => r.opIndex === opIndex);
+    if (existing) return Promise.resolve(existing.payload); // first-write-wins
+    records.push({ opIndex, payload: payloadEnvelope });
+    return Promise.resolve(payloadEnvelope);
+  }
+
+  public getIntentProgress(transferId: string): Promise<readonly { opIndex: number; payload: string }[]> {
+    return Promise.resolve(this.slots.get(transferId) ?? []);
+  }
+}
+
+describe('WalletApiCheckpointStore (E.4)', () => {
+  const key = deriveFieldEncryptionKey(PRIV);
+  const CKPT = new Uint8Array([0xca, 0xfe, 0x00, 0x80, 0x13, 0x37]); // non-UTF-8 checkpoint bytes
+
+  it('round-trips a checkpoint: put then get returns the exact plaintext bytes', async () => {
+    const port = new InMemoryProgressPort();
+    const store = new WalletApiCheckpointStore(port, key);
+
+    const put = await store.put('transfer-1', 0, CKPT);
+    expect(Array.from(put)).toEqual(Array.from(CKPT));
+
+    const got = await store.get('transfer-1', 0);
+    expect(got).not.toBeNull();
+    expect(Array.from(got as Uint8Array)).toEqual(Array.from(CKPT));
+
+    // What actually crossed the wire is an enc1. envelope, not the plaintext.
+    const stored = port.slots.get('transfer-1')![0].payload;
+    expect(stored.startsWith('enc1.')).toBe(true);
+  });
+
+  it('get returns null when the slot is empty', async () => {
+    const store = new WalletApiCheckpointStore(new InMemoryProgressPort(), key);
+    expect(await store.get('transfer-x', 0)).toBeNull();
+  });
+
+  it('binds the record to its slot: a record mis-served for a different opIndex fails at decrypt', async () => {
+    const port = new InMemoryProgressPort();
+    const store = new WalletApiCheckpointStore(port, key);
+    await store.put('transfer-1', 0, CKPT);
+
+    // Simulate a malicious/buggy server serving slot 0's envelope under slot 1 (opIndex 1).
+    const misServed = port.slots.get('transfer-1')![0].payload;
+    port.slots.set('transfer-1', [{ opIndex: 1, payload: misServed }]);
+
+    await expect(store.get('transfer-1', 1)).rejects.toBeInstanceOf(SplitCheckpointLostError);
+    await expect(store.get('transfer-1', 1)).rejects.toThrow(/could not be decrypted/);
+  });
+
+  it('a record mis-served for a different transferId also fails at decrypt (cross-intent replay)', async () => {
+    const portA = new InMemoryProgressPort();
+    const storeA = new WalletApiCheckpointStore(portA, key);
+    await storeA.put('transfer-A', 0, CKPT);
+    const aEnvelope = portA.slots.get('transfer-A')![0].payload;
+
+    // Serve intent A's envelope as intent B's slot 0.
+    const portB = new InMemoryProgressPort();
+    portB.slots.set('transfer-B', [{ opIndex: 0, payload: aEnvelope }]);
+    const storeB = new WalletApiCheckpointStore(portB, key);
+    await expect(storeB.get('transfer-B', 0)).rejects.toBeInstanceOf(SplitCheckpointLostError);
+  });
+
+  it('insert-once adopt: a second put with different bytes returns the FIRST writer bytes', async () => {
+    const port = new InMemoryProgressPort();
+    const store = new WalletApiCheckpointStore(port, key);
+
+    const winner = new Uint8Array([1, 2, 3]);
+    const loserBytes = new Uint8Array([9, 9, 9]);
+    await store.put('transfer-1', 0, winner);
+
+    // The loser encrypts DIFFERENT plaintext, but the server's first-write-wins returns the winner
+    // envelope; the adapter decrypts it → the loser must adopt the WINNER's bytes.
+    const adopted = await store.put('transfer-1', 0, loserBytes);
+    expect(Array.from(adopted)).toEqual(Array.from(winner));
+  });
+
+  it('encrypts once per put (a fresh random nonce) but the SAME plaintext decrypts identically', async () => {
+    const port = new InMemoryProgressPort();
+    const store = new WalletApiCheckpointStore(port, key);
+    await store.put('transfer-1', 0, CKPT);
+    const envelope = port.slots.get('transfer-1')![0].payload;
+    // AAD is transferId:opIndex — decrypting with the same AAD recovers the plaintext.
+    const aad = new TextEncoder().encode('transfer-1:0');
+    expect(Array.from(decryptFieldBytes(key, envelope, aad))).toEqual(Array.from(CKPT));
+  });
+});

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -24,7 +24,7 @@ import type { TransportProvider } from '../../../transport';
 import type { OracleProvider } from '../../../oracle';
 import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../../storage';
 import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
-import { TransferConflictError, ProofUnconfirmedError } from '../../../token-engine';
+import { TransferConflictError, ProofUnconfirmedError, SplitCheckpointLostError } from '../../../token-engine';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
 import { WalletApiClient, WalletApiError } from '../../../wallet-api';
@@ -931,6 +931,114 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
     // The change-token limitation is surfaced (prompts a resync) — never silently lost.
     expect(sender.emitEvent.mock.calls.some((c) => c[0] === 'inventory:conflict')).toBe(true);
+  });
+
+  it('legacy (v:1, no store): a resume that hits SplitCheckpointLostError records the spend, never wedges', async () => {
+    // The engine now maps a split-mint-leg mismatch to the keep-open SplitCheckpointLostError. A v:1
+    // intent has NO checkpoint store, so there is nothing to recover from — resume must fall back to
+    // the legacy residual (record the spend + surface a resync), NOT rethrow and wedge the intent.
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-legacy-lost');
+    const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    const transferId = crypto.randomUUID();
+    const payload = {
+      v: 1,
+      recipient: RECIPIENT.chainPubkey,
+      coinId: UCT,
+      amount: '300',
+      direct: [],
+      split: { tokenId: sourceTokenId, splitAmount: '300', remainderAmount: '700' },
+    };
+    sender.client.setIdentity(SENDER);
+    await sender.client.putIntent(
+      transferId,
+      encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload))
+    );
+    vi.spyOn(sender.engine, 'split').mockRejectedValue(
+      new SplitCheckpointLostError('a split mint leg no longer matches its certified leaf')
+    );
+
+    const outcome = await sender.module.resumeOpenIntents();
+    expect(outcome.resumed).toEqual([transferId]); // completed, not wedged
+    expect(outcome.failed).toEqual([]);
+    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'removed' });
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
+    expect(sender.emitEvent.mock.calls.some((c) => c[0] === 'inventory:conflict')).toBe(true);
+  });
+
+  it('#634: resume of a v:2 split re-runs the split THROUGH the checkpoint and recovers the change output', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-634-recover');
+    const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // A checkpoint-bearing (requiresSeedClose) v:2 split intent whose original send crashed after
+    // the split certified but before the change was applied server-side (the #634 window).
+    const transferId = crypto.randomUUID();
+    const payload = {
+      v: 2,
+      recipient: RECIPIENT.chainPubkey,
+      coinId: UCT,
+      amount: '300',
+      direct: [],
+      split: { tokenId: sourceTokenId, splitAmount: '300', remainderAmount: '700' },
+    };
+    sender.client.setIdentity(SENDER);
+    await sender.client.putIntent(
+      transferId,
+      encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload)),
+      { requiresSeedClose: true }
+    );
+    // CRUCIAL for #634: the original send JOURNALED the split's recipient blob (opIndex 0) before
+    // crashing. This is the exact state the old change-blind shortcut fired on — it re-delivered
+    // this blob and skipped re-deriving the change. The fix must re-run split() ANYWAY (via the
+    // checkpoint) so the change is recovered; without the fix the change row would be absent.
+    const splitOpIndex = 0; // direct.length
+    await (sender.module as unknown as {
+      savePendingV2Delivery(e: {
+        transferId: string;
+        recipientPubkey: string;
+        tokenBlob: string;
+        opIndex: number;
+        createdAt: number;
+      }): Promise<void>;
+    }).savePendingV2Delivery({
+      transferId,
+      recipientPubkey: RECIPIENT.chainPubkey,
+      tokenBlob: 'ab'.repeat(40),
+      opIndex: splitOpIndex,
+      createdAt: Date.now(),
+    });
+
+    // The engine recovers BOTH outputs from the stored checkpoint on resume (proven end-to-end by
+    // the engine's AC-E2). Here the FakeTokenEngine produces the outputs; we capture the options to
+    // assert the checkpoint store was threaded (the #634 fix re-runs split, not the change-blind
+    // shortcut) and the change output that resume must apply.
+    const realSplit = sender.engine.split.bind(sender.engine);
+    let splitOpts: Parameters<typeof sender.engine.split>[1];
+    let change: Awaited<ReturnType<typeof sender.engine.split>>['outputs'][1] | undefined;
+    vi.spyOn(sender.engine, 'split').mockImplementation(async (p, o) => {
+      splitOpts = o;
+      const result = await realSplit(p, o);
+      change = result.outputs[1];
+      return result;
+    });
+
+    const outcome = await sender.module.resumeOpenIntents();
+
+    expect(outcome.resumed).toEqual([transferId]);
+    expect(outcome.conflicted).toEqual([]);
+    // The #634 fix: engine.split WAS re-run WITH the checkpoint store (vs the old change-blind
+    // shortcut that never re-derived the change), and the source spend was applied.
+    expect(splitOpts?.checkpointStore).toBeDefined();
+    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'removed' });
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
+    // The change token (700) is now in the server inventory — RECOVERED, not lost, no resync prompt.
+    const changeId = sender.engine.tokenId(change!);
+    expect(fake.getRow(SENDER.chainPubkey, changeId)).toMatchObject({ status: 'active' });
+    expect(sender.emitEvent.mock.calls.some((c) => c[0] === 'inventory:conflict')).toBe(false);
   });
 });
 

--- a/tests/unit/wallet-api/client.inventory.test.ts
+++ b/tests/unit/wallet-api/client.inventory.test.ts
@@ -196,6 +196,41 @@ describe('WalletApiClient — intents (E.3, §16)', () => {
     );
   });
 
+  it('intent progress (E.4): append is insert-once, readable, and gated on requiresSeedClose', async () => {
+    const ckpt = envelope('{"checkpoint":"burn-proof"}');
+    // A checkpoint append requires the intent to be requiresSeedClose (§16/#87).
+    await client.putIntent(tid, envelope('unguarded'));
+    await expect(client.postIntentProgress(tid, 0, ckpt)).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    // A seed-close split intent accepts the signed append; the response is the AUTHORITATIVE stored
+    // envelope, insert-once (a re-POST of the same slot returns the first record byte-identically).
+    const splitTid = 'cccccccc-0000-4000-8000-000000000001';
+    await client.putIntent(splitTid, envelope('split'), { requiresSeedClose: true });
+    expect(await client.postIntentProgress(splitTid, 0, ckpt)).toBe(ckpt); // 201 → our bytes
+    expect(await client.postIntentProgress(splitTid, 0, envelope('other'))).toBe(ckpt); // 200 → first wins
+    const records = await client.getIntentProgress(splitTid);
+    expect(records).toMatchObject([{ opIndex: 0, payload: ckpt }]);
+
+    // The signed uniform close succeeds for the checkpoint-bearing intent (the fake requires a sig).
+    await client.completeIntent(splitTid);
+    expect(fake.getIntent(identity.chainPubkey, splitTid)?.status).toBe('completed');
+  });
+
+  it('progress records ride the E.3 re-seed: resync re-POSTs the local backstop after a restore', async () => {
+    const splitTid = 'cccccccc-0000-4000-8000-000000000002';
+    const ckpt = envelope('{"checkpoint":"x"}');
+    await client.putIntent(splitTid, envelope('split'), { requiresSeedClose: true });
+    await client.postIntentProgress(splitTid, 0, ckpt);
+
+    // Simulate a server restore that dropped the rows; the client re-seeds from its local backstop.
+    fake.dropIntent(identity.chainPubkey, splitTid);
+    expect(fake.getIntent(identity.chainPubkey, splitTid)).toBeNull();
+    await client.resyncOpenIntents();
+
+    expect(fake.getIntent(identity.chainPubkey, splitTid)?.status).toBe('open');
+    expect(await client.getIntentProgress(splitTid)).toMatchObject([{ opIndex: 0, payload: ckpt }]);
+  });
+
   it('PUT is write-once while open: a different payload is a no-op (§16)', async () => {
     const p1 = envelope('one');
     const p2 = envelope('two');

--- a/tests/unit/wallet-api/intent-signing.test.ts
+++ b/tests/unit/wallet-api/intent-signing.test.ts
@@ -1,0 +1,24 @@
+/**
+ * E.4/#87 seed-holder message vectors (sphere-sdk#501). These EXACT literals are the cross-repo
+ * contract — the wallet-api backend recovers + verifies signatures over the same strings
+ * (`tests/integration/intents.test.ts` M2.11/M2.12 pins the identical vectors). Any drift here or
+ * there wedges checkpointing, loudly and pre-mint. Keep both sides in lock-step.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { completeSignMessage, progressSignMessage } from '../../../wallet-api/intent-signing';
+
+const TID = '00000000-0000-4000-8000-000000000000';
+
+describe('intent-signing message vectors (E.4/#87 cross-repo contract)', () => {
+  it('pins the progress-append message (sha256-hex of the exact envelope bytes)', () => {
+    // sha256('enc1.AAAA') = 67ca…ff805 — byte-identical to the wallet-api M2.11 vector.
+    expect(progressSignMessage(TID, 3, 'enc1.AAAA')).toBe(
+      `wallet-api.progress.v1:${TID}:3:67ca567f7d63debafac96df43259ec03a8e84dbf8b116e7ba9a6493dc40ff805`
+    );
+  });
+
+  it('pins the terminal-close message', () => {
+    expect(completeSignMessage(TID)).toBe(`wallet-api.complete.v1:${TID}`);
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -421,6 +421,7 @@ export type SphereEventType =
   | 'sync:error'
   | 'storage:degraded'
   | 'inventory:conflict'
+  | 'split:checkpoint-stuck'
   | 'delivery:undeliverable'
   | 'delivery:deferred'
   | 'walletapi:session'
@@ -528,6 +529,14 @@ export interface SphereEventMap {
    * "refresh and retry". `transferId` is the aborted send's id.
    */
   'inventory:conflict': { transferId: string; coinId: string; error: string };
+  /**
+   * E.4 (sphere-sdk#501): a burn-certified split is stuck on a keep-open checkpoint error — the
+   * stored checkpoint is lost/unreadable (`SPLIT_CHECKPOINT_LOST`) or no longer verifies against the
+   * current trust base (`CHECKPOINT_TRUSTBASE_MISMATCH`, a validator rotation). The intent stays
+   * OPEN (never aborted — funds are in-flight, not lost), but this needs operator attention (the
+   * drain remedy), NOT a silent retry. Distinct from a transient resume failure.
+   */
+  'split:checkpoint-stuck': { transferId: string; code: string; error: string };
   /**
    * A journaled finished-but-undelivered v2 transfer blob (#517) has exhausted
    * its bounded replay budget and is now POISON: it stays journaled (the deposit

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -862,18 +862,21 @@ export class WalletApiClient {
    */
   async postIntentProgress(transferId: string, opIndex: number, payloadEnvelope: string): Promise<string> {
     await this.backstopProgress(transferId, opIndex, payloadEnvelope);
-    const signature = this.signProgress(transferId, opIndex, payloadEnvelope);
-    const body = await this.requestJson('POST', `/v1/intents/${transferId}/progress`, {
-      opIndex,
-      payload: payloadEnvelope,
-      signature,
-    });
-    // Insert-once first-write-wins: a 200 returns the WINNER's envelope, which may differ from ours
-    // if a racing device wrote first. Reconcile the local backstop to the AUTHORITATIVE bytes so a
-    // later syncEpoch re-seed re-POSTs the winner's proof — never our stale losing bytes (which
-    // would make our proof authoritative and mismatch the leg the winner already certified).
+    return this.postProgressEnvelope(transferId, opIndex, payloadEnvelope);
+  }
+
+  /**
+   * POST one checkpoint envelope (signed) and RECONCILE the local backstop to the AUTHORITATIVE
+   * returned envelope. Insert-once first-write-wins: a 200 returns the WINNER's envelope, which may
+   * differ from ours if a racing device wrote first — so re-seeding (or a retry) must carry the
+   * winner's proof, never our stale losing bytes (which would make our proof authoritative and
+   * mismatch the leg the winner already certified). Shared by the append and the syncEpoch re-seed.
+   */
+  private async postProgressEnvelope(transferId: string, opIndex: number, envelope: string): Promise<string> {
+    const signature = this.signProgress(transferId, opIndex, envelope);
+    const body = await this.requestJson('POST', `/v1/intents/${transferId}/progress`, { opIndex, payload: envelope, signature });
     const authoritative = parseProgressRecord(body).payload;
-    if (authoritative !== payloadEnvelope) await this.backstopProgress(transferId, opIndex, authoritative);
+    if (authoritative !== envelope) await this.backstopProgress(transferId, opIndex, authoritative);
     return authoritative;
   }
 
@@ -967,11 +970,9 @@ export class WalletApiClient {
           this.intentPutBody(intent.payload, intent.requiresSeedClose === true)
         );
         for (const [opIndex, envelope] of Object.entries(intent.progress ?? {})) {
-          await this.requestJson('POST', `/v1/intents/${transferId}/progress`, {
-            opIndex: Number(opIndex),
-            payload: envelope,
-            signature: this.signProgress(transferId, Number(opIndex), envelope),
-          });
+          // Reconcile to the authoritative record (a concurrent writer may have won the slot) so a
+          // later re-seed never re-POSTs stale losing bytes — the wedge Copilot flagged on #638.
+          await this.postProgressEnvelope(transferId, Number(opIndex), envelope);
         }
       } else if (intent.status === 'aborted' && intent.abortPending === true) {
         await this.requestJson(

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -30,6 +30,7 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 
 import { signMessage } from '../core/crypto';
+import { completeSignMessage, progressSignMessage } from './intent-signing';
 import { WalletApiError } from './errors';
 import { verifyChallengeTemplate } from './challenge';
 import {
@@ -47,6 +48,8 @@ import {
   parseDepositResult,
   parseHistoryPage,
   parseIntents,
+  parseProgressRecord,
+  parseProgressRecords,
   parseInventoryPage,
   parseMailboxPage,
   parsePaymentRequestRecord,
@@ -74,6 +77,7 @@ import type {
   MailboxPage,
   PaymentRequestRecord,
   PaymentRequestsPage,
+  ProgressRecord,
   RespondPaymentRequestInput,
   SupervisedWakeSocketHandle,
   SuperviseWakeOptions,
@@ -99,6 +103,17 @@ interface LocalIntent {
    * resume re-executing a send the user watched fail.
    */
   abortPending?: boolean;
+  /**
+   * E.4/#87: a split intent whose terminal close needs a seed-holder signature. Set at PUT (before
+   * the burn); re-PUT with the same flag on a syncEpoch re-seed; the close is signed when it is set.
+   */
+  requiresSeedClose?: boolean;
+  /**
+   * E.4 burn-checkpoint backstop: the exact enc1. envelope(s) POSTed to
+   * `/v1/intents/{id}/progress`, keyed by opIndex. Persisted BEFORE the first POST and re-POSTed
+   * byte-identically on retry / syncEpoch re-seed (content-idempotent; re-encryption is forbidden).
+   */
+  progress?: Record<number, string>;
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -813,13 +828,74 @@ export class WalletApiClient {
    * the local copy stays as the restore backstop and is re-PUT by
    * {@link resyncOpenIntents}.
    */
-  async putIntent(transferId: string, payloadEnvelope: string): Promise<void> {
+  async putIntent(
+    transferId: string,
+    payloadEnvelope: string,
+    opts: { requiresSeedClose?: boolean } = {}
+  ): Promise<void> {
+    const requiresSeedClose = opts.requiresSeedClose === true;
     const intents = await this.readLocalIntents();
     if (!intents[transferId]) {
-      intents[transferId] = { payload: payloadEnvelope, status: 'open', createdAt: this.now() };
+      intents[transferId] = {
+        payload: payloadEnvelope,
+        status: 'open',
+        createdAt: this.now(),
+        ...(requiresSeedClose ? { requiresSeedClose: true } : {}),
+      };
       await this.writeLocalIntents(intents);
     }
-    await this.requestJson('PUT', `/v1/intents/${transferId}`, { payload: payloadEnvelope });
+    await this.requestJson('PUT', `/v1/intents/${transferId}`, this.intentPutBody(payloadEnvelope, requiresSeedClose));
+  }
+
+  /** §16/#87: requiresSeedClose is honored only on first insert (write-once); omit it when false. */
+  private intentPutBody(payloadEnvelope: string, requiresSeedClose: boolean): Record<string, unknown> {
+    return requiresSeedClose ? { payload: payloadEnvelope, requiresSeedClose: true } : { payload: payloadEnvelope };
+  }
+
+  // ── intent progress: the E.4 burn checkpoint (sphere-sdk#501) ────────────────
+
+  /**
+   * `POST /v1/intents/{id}/progress` — append the split burn checkpoint envelope for `opIndex`,
+   * signed with the wallet chain key (§16/#87). Returns the AUTHORITATIVE stored envelope
+   * (insert-once first-write-wins: our bytes on 201, the winner's on 200 — the caller adopts it).
+   * The envelope is backed up locally BEFORE the POST and re-POSTed byte-identically on retry.
+   */
+  async postIntentProgress(transferId: string, opIndex: number, payloadEnvelope: string): Promise<string> {
+    await this.backstopProgress(transferId, opIndex, payloadEnvelope);
+    const signature = this.signProgress(transferId, opIndex, payloadEnvelope);
+    const body = await this.requestJson('POST', `/v1/intents/${transferId}/progress`, {
+      opIndex,
+      payload: payloadEnvelope,
+      signature,
+    });
+    // Insert-once first-write-wins: a 200 returns the WINNER's envelope, which may differ from ours
+    // if a racing device wrote first. Reconcile the local backstop to the AUTHORITATIVE bytes so a
+    // later syncEpoch re-seed re-POSTs the winner's proof — never our stale losing bytes (which
+    // would make our proof authoritative and mismatch the leg the winner already certified).
+    const authoritative = parseProgressRecord(body).payload;
+    if (authoritative !== payloadEnvelope) await this.backstopProgress(transferId, opIndex, authoritative);
+    return authoritative;
+  }
+
+  /** `GET /v1/intents/{id}/progress` → the stored checkpoint records (ascending opIndex). */
+  async getIntentProgress(transferId: string): Promise<ProgressRecord[]> {
+    return parseProgressRecords(await this.requestJson('GET', `/v1/intents/${transferId}/progress`));
+  }
+
+  /** The E.4 seed-holder append signature over the exact stored-envelope bytes. */
+  private signProgress(transferId: string, opIndex: number, payloadEnvelope: string): string {
+    return signMessage(this.requireIdentity().privateKey, progressSignMessage(transferId, opIndex, payloadEnvelope));
+  }
+
+  /** Persist the exact envelope locally before the first POST (dual persistence — E.3/E.4). */
+  private async backstopProgress(transferId: string, opIndex: number, payloadEnvelope: string): Promise<void> {
+    const intents = await this.readLocalIntents();
+    const intent = intents[transferId];
+    if (!intent) return; // no local intent (fresh-device append) — the server row is the seed
+    const progress = intent.progress ?? {};
+    if (progress[opIndex] === payloadEnvelope) return;
+    intent.progress = { ...progress, [opIndex]: payloadEnvelope };
+    await this.writeLocalIntents(intents);
   }
 
   /** `GET /v1/intents?status=` — server-side intent list. */
@@ -847,9 +923,15 @@ export class WalletApiClient {
     await this.setLocalIntentStatus(transferId, 'aborted');
   }
 
-  /** `POST /v1/intents/{id}/complete` — the uniform client-side close (E.3). */
+  /**
+   * `POST /v1/intents/{id}/complete` — the uniform client-side close (E.3). Always carries the
+   * seed-holder signature over `wallet-api.complete.v1:{transferId}` (§16/#87): a checkpoint-bearing
+   * intent REQUIRES it, and a valid own-key signature is harmlessly accepted for any other intent —
+   * so a fresh-device close (no local flag) still works.
+   */
   async completeIntent(transferId: string): Promise<void> {
-    await this.requestJson('POST', `/v1/intents/${transferId}/complete`);
+    const signature = signMessage(this.requireIdentity().privateKey, completeSignMessage(transferId));
+    await this.requestJson('POST', `/v1/intents/${transferId}/complete`, { signature });
     await this.setLocalIntentStatus(transferId, 'completed');
   }
 
@@ -877,9 +959,26 @@ export class WalletApiClient {
     const intents = await this.readLocalIntents();
     for (const [transferId, intent] of Object.entries(intents)) {
       if (intent.status === 'open') {
-        await this.requestJson('PUT', `/v1/intents/${transferId}`, { payload: intent.payload });
+        // Re-PUT with the SAME requiresSeedClose (the restore dropped the row), then re-POST every
+        // locally-held checkpoint byte-identically (E.4 — the two tables not blob-derivable).
+        await this.requestJson(
+          'PUT',
+          `/v1/intents/${transferId}`,
+          this.intentPutBody(intent.payload, intent.requiresSeedClose === true)
+        );
+        for (const [opIndex, envelope] of Object.entries(intent.progress ?? {})) {
+          await this.requestJson('POST', `/v1/intents/${transferId}/progress`, {
+            opIndex: Number(opIndex),
+            payload: envelope,
+            signature: this.signProgress(transferId, Number(opIndex), envelope),
+          });
+        }
       } else if (intent.status === 'aborted' && intent.abortPending === true) {
-        await this.requestJson('PUT', `/v1/intents/${transferId}`, { payload: intent.payload });
+        await this.requestJson(
+          'PUT',
+          `/v1/intents/${transferId}`,
+          this.intentPutBody(intent.payload, intent.requiresSeedClose === true)
+        );
         await this.requestJson('POST', `/v1/intents/${transferId}/abort`);
         await this.setLocalIntentStatus(transferId, 'aborted'); // clears abortPending
       }

--- a/wallet-api/codec.ts
+++ b/wallet-api/codec.ts
@@ -23,6 +23,7 @@ import type {
   MailboxPage,
   PaymentRequestRecord,
   PaymentRequestsPage,
+  ProgressRecord,
   UploadUrlEntry,
 } from './types';
 
@@ -165,6 +166,29 @@ export function parseIntents(body: unknown): IntentRecord[] {
       createdAt,
     };
   });
+}
+
+function parseProgressEntry(raw: unknown, where: string): ProgressRecord {
+  const it = asRecord(raw, where);
+  const opIndex = Number(it.opIndex);
+  if (!Number.isInteger(opIndex) || opIndex < 0) throw protocolError(`${where}.opIndex is not a non-negative integer`);
+  const createdAt = Date.parse(asString(it.createdAt, `${where}.createdAt`));
+  if (Number.isNaN(createdAt)) throw protocolError(`${where}.createdAt is not a timestamp`);
+  return { opIndex, payload: asString(it.payload, `${where}.payload`), createdAt };
+}
+
+/** `POST /v1/intents/{id}/progress` → the stored record (§16/E.4; 201 created or 200 first-write-wins). */
+export function parseProgressRecord(body: unknown): ProgressRecord {
+  const rec = asRecord(body, 'progress response');
+  return parseProgressEntry(rec.record, 'progress response .record');
+}
+
+/** `GET /v1/intents/{id}/progress` → the stored records, ascending opIndex (§16/E.4). */
+export function parseProgressRecords(body: unknown): ProgressRecord[] {
+  const rec = asRecord(body, 'progress list response');
+  return asArray(rec.records, 'progress list response .records').map((raw, i) =>
+    parseProgressEntry(raw, `progress records[${i}]`)
+  );
 }
 
 // ── mailbox (§6/§16) ──────────────────────────────────────────────────────────

--- a/wallet-api/index.ts
+++ b/wallet-api/index.ts
@@ -10,6 +10,7 @@ export { WalletApiClient } from './client';
 export { WalletApiError, ChallengeTemplateError } from './errors';
 export type { WalletApiErrorCode } from './errors';
 export { AUTH_CHALLENGE_PREFIX, verifyChallengeTemplate } from './challenge';
+export { completeSignMessage, progressSignMessage } from './intent-signing';
 export type { ChallengeExpectation } from './challenge';
 
 export type {

--- a/wallet-api/intent-signing.ts
+++ b/wallet-api/intent-signing.ts
@@ -1,0 +1,20 @@
+/**
+ * wallet-api/intent-signing.ts — the E.4/#87 seed-holder message formats (sphere-sdk#501).
+ *
+ * These EXACT strings are the cross-repo contract: the client signs them with the wallet chain
+ * key, and the wallet-api backend recovers the pubkey and verifies it (ARCHITECTURE §16). A drift
+ * between the two repos wedges checkpointing (loudly, pre-mint) — so both sides pin the same
+ * literal vectors (sphere-sdk here + `tests/integration/intents.test.ts` M2.11/M2.12 in wallet-api).
+ */
+
+import { sha256 } from '../core/crypto';
+
+/** The §16 progress-append message: signed over the EXACT stored-envelope bytes (E.4). */
+export function progressSignMessage(transferId: string, opIndex: number, payloadEnvelope: string): string {
+  return `wallet-api.progress.v1:${transferId}:${opIndex}:${sha256(payloadEnvelope, 'utf8')}`;
+}
+
+/** The §16/#87 terminal-close message for a checkpoint-bearing intent. */
+export function completeSignMessage(transferId: string): string {
+  return `wallet-api.complete.v1:${transferId}`;
+}

--- a/wallet-api/types.ts
+++ b/wallet-api/types.ts
@@ -189,6 +189,13 @@ export interface IntentRecord {
   createdAt: number;
 }
 
+/** One intent-progress record (§16/E.4): a split burn checkpoint. `payload` is the enc1. envelope. */
+export interface ProgressRecord {
+  opIndex: number;
+  payload: string;
+  createdAt: number;
+}
+
 // ── mailbox (§6/§16) ──────────────────────────────────────────────────────────
 
 /** `POST /v1/mailbox` request (§16). `memo` is the S6 `enc1.` envelope, verbatim. */


### PR DESCRIPTION
## Why

sphere-sdk#501, the **orchestration leg** — the last piece that makes the split-resume fix work on
the live path. The engine leg (#636) added the `SplitCheckpointStore` port + checkpoint-resume
`split()`; this PR wires it to wallet-api and reworks PaymentsModule resume. It also closes
sphere-sdk#634. Contract: `../wallet-api/sdk-changes.md` E.4 (+ #87 for the seed-gated close).

## What

- **`WalletApiCheckpointStore`** (`impl/shared/wallet-api/`) — the `SplitCheckpointStore` adapter
  over the wallet-api §16 intent-progress endpoints. AAD-encrypts the plaintext checkpoint (AAD =
  `transferId:opIndex` — a mis-served or cross-intent record fails the poly1305 tag at decrypt and
  surfaces as keep-open `SplitCheckpointLostError`), and decrypts the authoritative stored record on
  `get`/`put` so a put-race loser adopts the winner's bytes.
- **`core/field-encryption`** — binary+AAD `encryptFieldBytes`/`decryptFieldBytes` (the string
  `encryptField`/`decryptField` become AAD-less wrappers over them). The checkpoint is binary CBOR up
  to ~64 KiB, not a UTF-8 string, and needs the slot binding — the existing helper had neither.
- **`wallet-api/client`** — `postIntentProgress`/`getIntentProgress` (signed append over
  `wallet-api.progress.v1:{transferId}:{opIndex}:{sha256-hex(payload)}`, local backstop persisted
  before the first POST, content-idempotent re-POST of the identical envelope); `requiresSeedClose`
  on the intent PUT (before the burn); the uniform close now signs `wallet-api.complete.v1:{transferId}`
  (always — a valid own-key signature is harmlessly accepted for a non-flagged intent, so a
  fresh-device close still works); and the syncEpoch re-seed re-POSTs the backstopped checkpoints.
- **`PaymentsModule`** — threads the store into both `engine.split()` sites; sets
  `requiresSeedClose:true` at the split PUT; keeps the intent OPEN on the three checkpoint errors
  (never abort); a v:1/v:2 payload gate; and **the sphere-sdk#634 fix**: a v:2 split resumes THROUGH
  the checkpoint — the engine rebuilds both outputs, so the change is recovered. The old change-blind
  journaled shortcut re-delivered the recipient blob but left the change unpersisted, so applyDelta
  recorded the spend with an empty `added`. v:1 legacy intents keep the old path (sunsetting) — and a
  v:1 split whose engine now surfaces a mint-leg mismatch as the keep-open `SplitCheckpointLostError`
  records the spend (legacy residual) instead of wedging.

## Tests

- `field-encryption`: binary/AAD round-trip, cross-slot rejection, string wrappers still round-trip.
- `WalletApiCheckpointStore`: AAD round-trip, cross-slot AND cross-intent decrypt rejection →
  `SplitCheckpointLostError`, insert-once adopt (a losing put returns the winner's bytes).
- Client progress wire round-trip against the fake backend: insert-once, the not-guarded
  (requires_seed_close) gate, the signed close, and the E.3 re-seed re-POST.
- PaymentsModule end-to-end over the real client + fake backend: the **#634** recovery (a v:2 split
  resume re-runs `split()` with the store and the change lands active in inventory, no resync prompt),
  and the **legacy-regression pin** (a v:1 split hitting `SplitCheckpointLostError` records the spend,
  never wedges) — with the pre-existing v:1 `TransferConflictError` residual kept as a control.

## Review hardening (adversarial pass over the diff before this PR)

- **HIGH / money-safety — backstop reconcile:** `postIntentProgress` now reconciles the local
  backstop to the AUTHORITATIVE returned envelope after an insert-once adopt. Without it, a losing
  put-race writer kept its own (losing) burn-proof bytes locally, and a later syncEpoch re-seed would
  re-POST them — making the wrong proof authoritative and permanently wedging the burn-certified split.
- **Loud alert:** a genuinely-stuck split (`SplitCheckpointLostError` / `CheckpointTrustbaseMismatchError`)
  now emits a distinct `split:checkpoint-stuck` event on both the send and resume paths (the E.4
  "alert loudly, operator drain" requirement), instead of being silently bucketed with transient blips.
- **Test falsification:** the #634 test now journals the split delivery first (so `existingSplit` is
  present — the exact state the change-blind shortcut fired on), so it genuinely falsifies the fix; the
  fake's seed-holder gate now actually recovers the pubkey over the canonical message (was a
  tautological presence-check), and a cross-repo message-vector pin (`intent-signing.test.ts`) matches
  the wallet-api M2.11/M2.12 literals.
- Reset the memoized checkpoint store on identity change (it captures the per-identity field key).

## Verification

- `npm run typecheck` + `lint` (0 errors) + the full unit suite green.
- The adversarial review's findings were all fixed; a re-run confirms the affected suites pass.

Closes #637 and sphere-sdk#634. Part of the #501 train (only the PR 5 live-drill un-scope remains).
