### PR TITLE
Wave 6-P2-9: quick wins — .env.example + soak-invoice-return + docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# sphere-sdk e2e / soak configuration — copy to `.env` (gitignored).
+
+# Unicity testnet2 v2 gateway (state-transition aggregator).
+TESTNET2_GATEWAY=https://gateway.testnet2.unicity.network
+
+# testnet2 gateway API key — NOT a secret: testnet2 keys are safe to
+# commit here and in docs.
+TESTNET2_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
+
+# Root trust base JSON URL (testnet2 = networkId 4).
+TESTNET2_TRUSTBASE_URL=https://raw.githubusercontent.com/unicitynetwork/unicity-ids/main/bft-trustbase.testnet2.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,11 @@ Typed RPC layer for dApp ↔ wallet communication. Full guide: [`docs/CONNECT.md
 | `sphere.swap.acceptSwap(swapId)` | `void` | Accept a swap proposal |
 | `sphere.swap.deposit(swapId)` | `TransferResult` | Deposit into a swap |
 | `sphere.swap.getSwaps(filter?)` | `SwapRef[]` | List swaps with filter |
+| `sphere.tokenEngine.mint(params, options?)` | `SphereToken` | v2 engine: mint a token (testnet2 only; `null` on v1 networks) |
+| `sphere.tokenEngine.transfer(params, options?)` | `SphereToken` | v2 engine: transfer a token to a new predicate |
+| `sphere.tokenEngine.split(params, options?)` | `SplitResult` | v2 engine: burn-then-mint split into outputs |
+| `sphere.tokenEngine.verify(token, options?)` | `EngineVerifyResult` | v2 engine: verify token state + proofs |
+| `sphere.tokenEngine.isSpent(token, options?)` | `boolean` | v2 engine: check if the token's current state is spent |
 
 ### Key Events
 
@@ -466,7 +471,14 @@ Abstract interfaces for platform independence:
 |---------|------------|-------------|----------|
 | mainnet | aggregator.unicity.network | relay.unicity.network | fulcrum.alpha.unicity.network |
 | testnet | goggregator-test.unicity.network | nostr-relay.testnet.unicity.network | fulcrum.alpha.testnet.unicity.network |
+| testnet2 | gateway.testnet2.unicity.network (v2) | nostr-relay.testnet.unicity.network | fulcrum.alpha.testnet.unicity.network |
 | dev | dev-aggregator.dyndns.org | nostr-relay.testnet.unicity.network | fulcrum.alpha.testnet.unicity.network |
+
+`testnet2` is Phase 6's v2 state-transition SDK network — it auto-fetches
+the root trust base from `NETWORKS.testnet2.trustBaseUrl` and exposes the
+new engine at `sphere.tokenEngine`. See `.env.example` at the repo root
+and [`docs/QUICKSTART-NODEJS.md`](docs/QUICKSTART-NODEJS.md#testnet2-v2-state-transition-sdk)
+for the config shape.
 
 ## Common Commands
 

--- a/docs/QUICKSTART-NODEJS.md
+++ b/docs/QUICKSTART-NODEJS.md
@@ -246,6 +246,52 @@ const providers = createNodeProviders({
 });
 ```
 
+## testnet2 (v2 state-transition SDK)
+
+Phase 6 migrates the L3 aggregator to v2 (`gateway.testnet2.unicity.network`).
+The `testnet2` network key wires the v2 gateway and root trust base for the
+new engine.
+
+```typescript
+import { Sphere } from '@unicitylabs/sphere-sdk';
+import { createNodeProviders } from '@unicitylabs/sphere-sdk/impl/nodejs';
+
+const providers = createNodeProviders({
+  network: 'testnet2',
+  // testnet2 API key — NOT a secret, safe to embed. Copy from .env.example.
+  oracle: { apiKey: process.env.TESTNET2_API_KEY! },
+  dataDir: './wallet-data',
+  tokensDir: './tokens-data',
+});
+
+const { sphere } = await Sphere.init({
+  ...providers,
+  network: 'testnet2',
+  tokenEngine: { apiKey: process.env.TESTNET2_API_KEY! },
+  autoGenerate: true,
+});
+
+// v2-only surface — the anti-corruption engine port:
+if (sphere.tokenEngine) {
+  const token = await sphere.tokenEngine.mint({ /* ... */ });
+  const moved = await sphere.tokenEngine.transfer({ /* ... */ });
+  const { outputs } = await sphere.tokenEngine.split({ /* ... */ });
+  const verified = await sphere.tokenEngine.verify(token);
+  const spent = await sphere.tokenEngine.isSpent(token);
+}
+```
+
+Notes:
+
+- The root trust base is fetched lazily on first engine construction from
+  the `trustBaseUrl` configured for the network (see `constants.ts` →
+  `NETWORKS.testnet2.trustBaseUrl`). No manual `trustBasePath` needed.
+- `sphere.tokenEngine` is `null` on v1-only networks (`mainnet`, `testnet`,
+  `dev`); the slim `PaymentsModule` / `AccountingModule` throw an
+  "engine not configured" error on any call that requires it.
+- The testnet2 API key is safe to commit — see `.env.example` at the repo
+  root for the current value and other testnet2 defaults.
+
 ## IPFS Token Sync (Optional)
 
 Enable decentralized token backup to IPFS/IPNS. No extra packages needed — uses built-in HTTP API.

--- a/scripts/soak-invoice-return.ts
+++ b/scripts/soak-invoice-return.ts
@@ -1,0 +1,253 @@
+/**
+ * Extended soak: invoice auto-return / manual return validation
+ * (Wave 6-P2-9).
+ *
+ * Wallet A (issuer) creates an invoice, Wallet B (payer) mints funds and
+ * pays it, then Wallet A initiates a return of the collected payment
+ * back to Wallet B. We verify:
+ *
+ *   - `createInvoice` mints the invoice token (v2 slim path).
+ *   - `payInvoice` delivers funds from B → A.
+ *   - `returnAllInvoicePayments(invoiceId)` (the public API on the slim
+ *     rebuild) sends the collected amount back to B. `setAutoReturn` is
+ *     the flag-toggle sibling; the imperative refund is
+ *     `returnAllInvoicePayments`.
+ *   - Wallet B observes the refund via `transfer:incoming` within 30s.
+ *   - Wallet B's confirmed UCT balance is restored (starting mint minus
+ *     any residual on-chain overhead — the returned amount should equal
+ *     the paid amount).
+ *
+ * If the refund path is not fully wired end-to-end on the slim rebuild
+ * (a runtime bug the parent may need to follow up on), this soak still
+ * validates the API surface and prints the precise failure step.
+ *
+ * Run:
+ *   npx tsx scripts/soak-invoice-return.ts
+ */
+
+import type { IncomingTransfer } from '../types';
+import {
+  TESTNET2_GATEWAY,
+  UCT_COIN_ID,
+  log,
+  initFreshWallet,
+  sleep,
+  waitForEvent,
+  forceExit,
+  reportPass,
+  reportFail,
+} from './soak-helpers';
+
+const TAG = 'soak-invoice-return';
+const MINT_AMOUNT_B = 5000n;
+const INVOICE_AMOUNT = 1000n;
+
+async function main(): Promise<void> {
+  const baseDir = process.env.SOAK_DATA_DIR ?? '/tmp/sphere-soak-invoice-return';
+  log(TAG, 'start', { gateway: TESTNET2_GATEWAY, baseDir });
+
+  const walletA = await initFreshWallet({
+    tag: `${TAG}:A`,
+    dataDir: `${baseDir}/wallet-a`,
+    accounting: true,
+  });
+  const walletB = await initFreshWallet({
+    tag: `${TAG}:B`,
+    dataDir: `${baseDir}/wallet-b`,
+    accounting: true,
+  });
+  const sphereA = walletA.sphere;
+  const sphereB = walletB.sphere;
+  const identityA = sphereA.identity!;
+  const identityB = sphereB.identity!;
+
+  if (!sphereA.accounting || !sphereB.accounting) {
+    throw new Error('accounting module not enabled on one or both wallets');
+  }
+
+  // Step 1: Wallet B mints UCT (payer funds).
+  log(TAG, 'B: minting UCT (payer funds)', { amount: MINT_AMOUNT_B.toString() });
+  const mintRes = await sphereB.payments.mintFungibleToken(UCT_COIN_ID, MINT_AMOUNT_B);
+  if (!mintRes.success) {
+    throw new Error(`B mint failed: ${mintRes.error}`);
+  }
+  log(TAG, 'B: minted', { tokenId: mintRes.tokenId });
+
+  await sleep(1000);
+
+  // Record B's pre-payment confirmed balance for the round-trip check.
+  const bPreBalance = sumConfirmedUct(sphereB);
+  log(TAG, 'B: pre-payment UCT confirmed balance', { balance: bPreBalance.toString() });
+
+  // Step 2: Wallet A creates the invoice targeting itself.
+  log(TAG, 'A: createInvoice', {
+    target: identityA.directAddress,
+    coinId: UCT_COIN_ID,
+    amount: INVOICE_AMOUNT.toString(),
+  });
+  const invoiceRes = await sphereA.accounting.createInvoice({
+    targets: [
+      {
+        address: identityA.directAddress!,
+        assets: [{ coin: [UCT_COIN_ID, INVOICE_AMOUNT.toString()] }],
+      },
+    ],
+    memo: 'soak-invoice-return',
+  });
+  log(TAG, 'A: createInvoice result', {
+    success: invoiceRes.success,
+    invoiceId: invoiceRes.invoiceId,
+    error: invoiceRes.error,
+  });
+  if (!invoiceRes.success || !invoiceRes.invoiceId || !invoiceRes.token) {
+    throw new Error(
+      `A createInvoice failed: ${invoiceRes.error ?? '(no error)'} — see also ` +
+        `soak-invoice-lifecycle for the coinId-validation gotcha.`,
+    );
+  }
+  const invoiceId: string = invoiceRes.invoiceId;
+  const invoiceToken = invoiceRes.token;
+
+  // Step 3: Wallet B imports the invoice token so it can pay it.
+  log(TAG, 'B: importInvoice');
+  await sphereB.accounting.importInvoice(invoiceToken);
+
+  // Step 4: pre-arm A's incoming-transfer waiter (the paying leg).
+  const aIncomingPromise = waitForEvent<IncomingTransfer>(
+    sphereA,
+    'transfer:incoming',
+    60_000,
+    (t) => t.tokens.some((tok) => tok.coinId === UCT_COIN_ID),
+  );
+
+  // Step 5: Wallet B pays the invoice.
+  log(TAG, 'B: payInvoice', { invoiceId, amount: INVOICE_AMOUNT.toString() });
+  const payResult = await sphereB.accounting.payInvoice(invoiceId, {
+    targetIndex: 0,
+    amount: INVOICE_AMOUNT.toString(),
+  });
+  log(TAG, 'B: payInvoice result', {
+    id: payResult.id,
+    status: payResult.status,
+    tokens: payResult.tokens.length,
+    error: payResult.error,
+  });
+  if (payResult.status !== 'delivered') {
+    throw new Error(
+      `payInvoice did not reach 'delivered': status=${payResult.status} error=${payResult.error ?? '(none)'}`,
+    );
+  }
+
+  // Step 6: Wallet A observes the incoming transfer (the paying leg).
+  log(TAG, 'A: awaiting transfer:incoming (payment leg)');
+  const aIncoming = await aIncomingPromise;
+  log(TAG, 'A: transfer:incoming', {
+    senderPubkey: aIncoming.senderPubkey,
+    tokens: aIncoming.tokens.length,
+  });
+
+  // Wait briefly for A's accounting bookkeeping to record the ledger entry
+  // (invoice status → COVERED / PARTIAL), otherwise `returnAllInvoicePayments`
+  // has nothing to refund yet.
+  await sleep(1500);
+  const midStatus = await sphereA.accounting.getInvoiceStatus(invoiceId);
+  log(TAG, 'A: post-pay invoice status', { state: midStatus.state });
+
+  // Step 7: pre-arm B's incoming-transfer waiter (the refund leg).
+  const bIncomingPromise = waitForEvent<IncomingTransfer>(
+    sphereB,
+    'transfer:incoming',
+    45_000,
+    (t) => t.tokens.some((tok) => tok.coinId === UCT_COIN_ID),
+  );
+
+  // Step 8: Wallet A returns all collected payments on this invoice.
+  //
+  // `returnAllInvoicePayments(invoiceId)` is the imperative refund API on
+  // the slim rebuild (AccountingModule.ts §returnAllInvoicePayments,
+  // ~line 1085). `setAutoReturn(invoiceId, true)` is the persistent flag
+  // that arms auto-return on subsequent close/cancel; it does NOT
+  // retroactively refund what's already been paid, so we call the
+  // imperative one for this soak.
+  log(TAG, 'A: returnAllInvoicePayments', { invoiceId });
+  const returnRes = await sphereA.accounting.returnAllInvoicePayments(invoiceId);
+  log(TAG, 'A: returnAllInvoicePayments result', {
+    returned: returnRes.returned,
+    failed: returnRes.failed,
+    errorsCount: returnRes.errors.length,
+    firstError: returnRes.errors[0],
+  });
+  if (returnRes.returned === 0) {
+    throw new Error(
+      `No payments were returned. failed=${returnRes.failed}, ` +
+        `firstError=${returnRes.errors[0]?.error ?? '(none)'} — likely the ` +
+        `refund path or ledger attribution is incomplete on the slim rebuild.`,
+    );
+  }
+
+  // Step 9: Wallet B observes the refund via transfer:incoming.
+  log(TAG, 'B: awaiting transfer:incoming (refund leg)');
+  const bIncoming = await bIncomingPromise;
+  log(TAG, 'B: transfer:incoming (refund)', {
+    senderPubkey: bIncoming.senderPubkey,
+    tokens: bIncoming.tokens.length,
+  });
+
+  // Step 10: allow B's payments module to finalize the incoming refund,
+  // then verify B's UCT confirmed balance is restored to the pre-payment
+  // value (net-zero round trip).
+  await sleep(2000);
+  const bPostBalance = sumConfirmedUct(sphereB);
+  log(TAG, 'B: post-refund UCT confirmed balance', {
+    pre: bPreBalance.toString(),
+    post: bPostBalance.toString(),
+    delta: (bPostBalance - bPreBalance).toString(),
+  });
+
+  // A successful round trip should restore B to at least the pre-payment
+  // balance. Some flows may momentarily leave the refund unconfirmed —
+  // accept "restored" as `post >= pre - INVOICE_AMOUNT + returned-tokens`;
+  // strictly, `post` should equal `pre` once the refund lands & finalizes.
+  if (bPostBalance < bPreBalance) {
+    throw new Error(
+      `B balance not restored: pre=${bPreBalance} post=${bPostBalance} ` +
+        `— refund arrived (${bIncoming.tokens.length} tokens) but ` +
+        `balance is short by ${(bPreBalance - bPostBalance).toString()}.`,
+    );
+  }
+
+  await sphereA.destroy();
+  await sphereB.destroy();
+
+  log(TAG, 'SOAK PASSED');
+  reportPass({
+    gateway: TESTNET2_GATEWAY,
+    invoiceId,
+    walletA_chainPubkey: identityA.chainPubkey,
+    walletB_chainPubkey: identityB.chainPubkey,
+    paidAmount: INVOICE_AMOUNT.toString(),
+    returned: returnRes.returned,
+    bPreBalance: bPreBalance.toString(),
+    bPostBalance: bPostBalance.toString(),
+  });
+  forceExit(0);
+}
+
+function sumConfirmedUct(sphere: import('../core/Sphere').Sphere): bigint {
+  const assets = sphere.payments.getBalance(UCT_COIN_ID);
+  let total = 0n;
+  for (const asset of assets) {
+    if (asset.coinId !== UCT_COIN_ID) continue;
+    total += BigInt(asset.confirmedAmount);
+  }
+  return total;
+}
+
+main().catch((err) => {
+  log(TAG, 'SOAK FAILED', {
+    error: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? err.stack?.split('\n').slice(0, 5).join(' | ') : undefined,
+  });
+  reportFail('invoice-return', err);
+  forceExit(1);
+});


### PR DESCRIPTION
## Summary

Three low-risk deliverables for Wave 6-P2-9 (Phase-6 v1→v2 SDK migration):

1. **`.env.example`** — repo-root defaults for testnet2 e2e/soak flows
   (`TESTNET2_GATEWAY`, `TESTNET2_API_KEY`, `TESTNET2_TRUSTBASE_URL`). The
   testnet2 API key is not a secret; `.env` is already gitignored.
   Referenced by `token-engine/factory.ts:40`.

2. **`scripts/soak-invoice-return.ts`** — empirical auto-return validation:
   B mints 5000 UCT → A creates a 1000 UCT invoice → B pays → A calls
   `sphere.accounting.returnAllInvoicePayments(invoiceId)` (the
   imperative refund API on the slim rebuild; `setAutoReturn` is the
   persistent flag-toggle sibling) → B observes `transfer:incoming`
   refund within 45s → B's confirmed UCT balance restored to
   pre-payment. If the refund path is incomplete on the slim rebuild
   the soak reports the exact failure step for a follow-up wave — the
   soak script itself is well-formed even if the runtime path isn't
   complete.

3. **Docs**
   - `docs/QUICKSTART-NODEJS.md` — new `## testnet2` section with the
     `createNodeProviders({ network: 'testnet2', oracle: { apiKey } })`
     usage, `sphere.tokenEngine` accessor, and trust-base auto-fetch
     note.
   - `CLAUDE.md` — adds a `testnet2` row to the Network Configuration
     table and the five `sphere.tokenEngine.mint/transfer/split/verify/isSpent`
     entries to the Key API Methods Reference.

## Constraints preserved

- `npx tsc --noEmit` — 0 errors.
- `npm run test:run` — 7,036 pass / 6 skip unchanged.

## Soak run

Not executed against live testnet2 in this wave — the script is a
well-formed harness ready to be run empirically once the slim
rebuild's refund path (or its known follow-ups) is resolved. Run
locally with:

```
TESTNET2_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590 \
  npx tsx scripts/soak-invoice-return.ts
```

## Test plan

- [x] `npx tsc --noEmit` green
- [x] `npm run test:run` green (7,036 pass / 6 skip)
- [ ] Optional: run `soak-invoice-return` against testnet2 to
      confirm the refund path is wired end-to-end.