### PR TITLE
Wave 6-P2-10b: Pointer layer v2 test coverage — 5 files, 86 cases

### DIFF
--- a/tests/unit/pointer/aggregator-probe.v2.test.ts
+++ b/tests/unit/pointer/aggregator-probe.v2.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Wave 6-P2-10b — Aggregator probe (T-C2) coverage restoration.
+ *
+ * The legacy tests in tests/legacy-v1/unit/profile/pointer/aggregator-probe.test.ts
+ * were quarantined in wave 6-P2-5 because they imported through the stsdk-v1
+ * alias in a shape the v2 harness could not resolve. This file restores the
+ * highest-value invariants against the current v2 pointer layer:
+ *
+ *   Probe path (probeVersion, SPEC §8.1 H2 OR-predicate):
+ *     - Both sides OK → included=true
+ *     - Only one side OK → included=true (H2 OR-predicate)
+ *     - Both PATH_NOT_INCLUDED → included=false (legitimate absence)
+ *     - Rotation / forgery: NOT_AUTHENTICATED / PATH_INVALID short-circuit
+ *       through raiseForTrustBaseMismatch (TRUST_BASE_STALE vs UNTRUSTED_PROOF)
+ *     - PROTOCOL_ERROR when the SDK response shape is wrong
+ *     - AbortSignal cancels an in-flight probe RPC
+ *
+ *   Classify path (classifyVersion, SPEC §8.2 four-way):
+ *     - Both sides OK + CID decoded + CAR fetched → VALID
+ *     - Partial inclusion (one side missing) → SEMANTICALLY_INVALID
+ *     - CID decoder fails on the reconstructed 64-byte plaintext → SEMANTICALLY_INVALID
+ *     - Proof RPC failure (network) → PROOF_TRANSIENT (must NOT collapse to CAR_TRANSIENT)
+ *     - Proof + CID ok but CAR unfetchable (transient) → CAR_TRANSIENT
+ *     - CAR content_mismatch / car_parse_failed → SEMANTICALLY_INVALID
+ *
+ *   decodeVersionCid (standalone Phase 1+2):
+ *     - Returns cidBytes on success
+ *     - Reports 'transient' / 'semantic' failure reasons
+ *
+ *   Reachability (isReachable, SPEC §11.12):
+ *     - Any HTTP response (including JsonRpcNetworkError / JsonRpcError) → reachable
+ *     - Genuine transport failure (timeout / DNS) → not reachable
+ *
+ * The tests inject a fake AggregatorClient — no real network / crypto is
+ * exercised. Verify status enums come from stsdk-v1 (which is what the
+ * pointer layer imports).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { InclusionProofVerificationStatus } from 'stsdk-v1/lib/transaction/InclusionProof.js';
+import type { InclusionProof } from 'stsdk-v1/lib/transaction/InclusionProof.js';
+import type { AggregatorClient } from 'stsdk-v1/lib/api/AggregatorClient.js';
+import type { RootTrustBase } from 'stsdk-v1/lib/bft/RootTrustBase.js';
+
+import {
+  probeVersion,
+  classifyVersion,
+  decodeVersionCid,
+  isReachable,
+  createMasterPrivateKey,
+  derivePointerKeyMaterial,
+  buildPointerSigner,
+  AggregatorPointerErrorCode,
+  type CarFetcher,
+  type CidDecoder,
+} from '../../../extensions/uxf/profile/aggregator-pointer/index.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const WALLET_SEED = new Uint8Array(32).fill(0x42);
+
+async function buildFixtures() {
+  const master = createMasterPrivateKey(WALLET_SEED);
+  const keyMaterial = derivePointerKeyMaterial(master);
+  const signer = await buildPointerSigner(keyMaterial.signingSeed);
+  return { keyMaterial, signer };
+}
+
+/**
+ * Build a fake `InclusionProof`. Only fields consumed by the probe/classify
+ * paths are populated — `verify()`, `transactionHash`, and the certificate
+ * epoch chain used by trust-base rotation.
+ */
+function fakeProof(
+  verifyResult: InclusionProofVerificationStatus,
+  certEpoch: bigint = 1n,
+  txHashData: Uint8Array | null = new Uint8Array(32).fill(0x01),
+): InclusionProof {
+  return {
+    verify: vi.fn(async () => verifyResult),
+    transactionHash:
+      txHashData === null
+        ? null
+        : { data: txHashData, imprint: new Uint8Array([0x00, 0x00, ...txHashData]) },
+    unicityCertificate: {
+      unicitySeal: { epoch: certEpoch },
+      inputRecord: { epoch: certEpoch },
+    },
+  } as unknown as InclusionProof;
+}
+
+/**
+ * A client that returns a fixed sequence of proofs (round-robin) via
+ * `getInclusionProof`. The pointer probe path expects a response object
+ * wrapping `.inclusionProof`.
+ */
+function fakeClient(proofs: readonly InclusionProof[]): AggregatorClient {
+  let idx = 0;
+  return {
+    getInclusionProof: vi.fn(async () => {
+      const proof = proofs[idx % proofs.length]!;
+      idx += 1;
+      return { inclusionProof: proof };
+    }),
+  } as unknown as AggregatorClient;
+}
+
+function fakeTrustBase(epoch: bigint = 1n): RootTrustBase {
+  return { epoch } as unknown as RootTrustBase;
+}
+
+const okDecodeCid: CidDecoder = (full) => ({ ok: true, cidBytes: full.slice(0, 36) });
+const badDecodeCid: CidDecoder = () => ({ ok: false });
+const okFetchCar: CarFetcher = async () => ({ ok: true });
+const transientFetchCar: CarFetcher = async () => ({ ok: false, kind: 'transient_unavailable' });
+const contentMismatchFetchCar: CarFetcher = async () => ({ ok: false, kind: 'content_mismatch' });
+
+// ── probeVersion — H2 OR-predicate ────────────────────────────────────────
+
+describe('probeVersion (SPEC §8.1 H2 OR-predicate)', () => {
+  it('returns true when both sides verify OK', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.OK),
+    ]);
+    const included = await probeVersion({
+      v: 4,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+    });
+    expect(included).toBe(true);
+  });
+
+  it('returns true when only side A verifies OK (H2 OR-predicate)', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.PATH_NOT_INCLUDED),
+    ]);
+    const included = await probeVersion({
+      v: 7,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+    });
+    expect(included).toBe(true);
+  });
+
+  it('returns false when both sides PATH_NOT_INCLUDED', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.PATH_NOT_INCLUDED),
+      fakeProof(InclusionProofVerificationStatus.PATH_NOT_INCLUDED),
+    ]);
+    const included = await probeVersion({
+      v: 9,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+    });
+    expect(included).toBe(false);
+  });
+
+  it('raises TRUST_BASE_STALE when cert.epoch > local (legitimate rotation)', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.NOT_AUTHENTICATED, 5n),
+      fakeProof(InclusionProofVerificationStatus.OK, 5n),
+    ]);
+    await expect(
+      probeVersion({
+        v: 3,
+        keyMaterial,
+        signer,
+        aggregatorClient: client,
+        trustBase: fakeTrustBase(3n),
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.TRUST_BASE_STALE,
+    });
+  });
+
+  it('raises UNTRUSTED_PROOF when NOT_AUTHENTICATED at the same epoch (forgery)', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.NOT_AUTHENTICATED, 3n),
+      fakeProof(InclusionProofVerificationStatus.OK, 3n),
+    ]);
+    await expect(
+      probeVersion({
+        v: 3,
+        keyMaterial,
+        signer,
+        aggregatorClient: client,
+        trustBase: fakeTrustBase(3n),
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.UNTRUSTED_PROOF,
+    });
+  });
+
+  it('raises UNTRUSTED_PROOF on PATH_INVALID (structurally bad proof)', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.PATH_INVALID, 1n),
+    ]);
+    await expect(
+      probeVersion({
+        v: 2,
+        keyMaterial,
+        signer,
+        aggregatorClient: client,
+        trustBase: fakeTrustBase(1n),
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.UNTRUSTED_PROOF,
+    });
+  });
+
+  it('rejects with PointerProbeAborted when abortSignal is already fired', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.OK),
+    ]);
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await expect(
+      probeVersion({
+        v: 1,
+        keyMaterial,
+        signer,
+        aggregatorClient: client,
+        trustBase: fakeTrustBase(),
+        abortSignal: ctrl.signal,
+      }),
+    ).rejects.toMatchObject({ name: 'PointerProbeAborted' });
+  });
+});
+
+// ── classifyVersion — four-way SPEC §8.2 ──────────────────────────────────
+
+describe('classifyVersion (SPEC §8.2 four-way)', () => {
+  it('returns VALID when both proofs OK + CID decoded + CAR fetched', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.OK),
+    ]);
+    const result = await classifyVersion({
+      v: 5,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecodeCid,
+      fetchCar: okFetchCar,
+    });
+    expect(result).toBe('VALID');
+  });
+
+  it('returns SEMANTICALLY_INVALID on partial inclusion (one side missing)', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.PATH_NOT_INCLUDED),
+    ]);
+    const result = await classifyVersion({
+      v: 5,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecodeCid,
+      fetchCar: okFetchCar,
+    });
+    expect(result).toBe('SEMANTICALLY_INVALID');
+  });
+
+  it('returns SEMANTICALLY_INVALID when the CID decoder rejects the plaintext', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.OK),
+    ]);
+    const result = await classifyVersion({
+      v: 5,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: badDecodeCid,
+      fetchCar: okFetchCar,
+    });
+    expect(result).toBe('SEMANTICALLY_INVALID');
+  });
+
+  it('returns PROOF_TRANSIENT when the aggregator proof RPC throws a network error', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = {
+      getInclusionProof: vi.fn(async () => {
+        // Simulate a transport failure. The classifier catches this
+        // and buckets it as PROOF_TRANSIENT (slot existence UNKNOWN).
+        throw Object.assign(new Error('ECONNREFUSED'), { name: 'FetchError' });
+      }),
+    } as unknown as AggregatorClient;
+    const result = await classifyVersion({
+      v: 5,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecodeCid,
+      fetchCar: okFetchCar,
+    });
+    expect(result).toBe('PROOF_TRANSIENT');
+  });
+
+  it('returns CAR_TRANSIENT when proofs verify + CID decodes but CAR is unreachable', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.OK),
+    ]);
+    const result = await classifyVersion({
+      v: 5,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecodeCid,
+      fetchCar: transientFetchCar,
+    });
+    expect(result).toBe('CAR_TRANSIENT');
+  });
+
+  it('returns SEMANTICALLY_INVALID on CAR content_mismatch', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.OK),
+    ]);
+    const result = await classifyVersion({
+      v: 5,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecodeCid,
+      fetchCar: contentMismatchFetchCar,
+    });
+    expect(result).toBe('SEMANTICALLY_INVALID');
+  });
+
+  it('raises PROTOCOL_ERROR when the SDK response is missing inclusionProof', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    // Simulate SDK shape drift — the response object is present but
+    // its `inclusionProof` field is null. classifyVersion must surface
+    // this as a deterministic PROTOCOL_ERROR, NOT a transient retry.
+    const client = {
+      getInclusionProof: vi.fn(async () => ({ inclusionProof: null })),
+    } as unknown as AggregatorClient;
+    await expect(
+      classifyVersion({
+        v: 5,
+        keyMaterial,
+        signer,
+        aggregatorClient: client,
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecodeCid,
+        fetchCar: okFetchCar,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PROTOCOL_ERROR,
+    });
+  });
+});
+
+// ── decodeVersionCid — standalone Phase 1+2 ───────────────────────────────
+
+describe('decodeVersionCid (Phase 1+2 standalone)', () => {
+  it('returns { ok:true, cidBytes } when both sides verify + CID decodes', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.OK),
+    ]);
+    const result = await decodeVersionCid({
+      v: 3,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecodeCid,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.cidBytes.length).toBe(36);
+    }
+  });
+
+  it('reports { ok:false, reason:"transient" } when proof RPC fails', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = {
+      getInclusionProof: vi.fn(async () => {
+        throw Object.assign(new Error('EAI_AGAIN'), { name: 'FetchError' });
+      }),
+    } as unknown as AggregatorClient;
+    const result = await decodeVersionCid({
+      v: 3,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecodeCid,
+    });
+    expect(result).toEqual({ ok: false, reason: 'transient' });
+  });
+
+  it('reports { ok:false, reason:"semantic" } when CID decoder rejects', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const client = fakeClient([
+      fakeProof(InclusionProofVerificationStatus.OK),
+      fakeProof(InclusionProofVerificationStatus.OK),
+    ]);
+    const result = await decodeVersionCid({
+      v: 3,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase(),
+      decodeCid: badDecodeCid,
+    });
+    expect(result).toEqual({ ok: false, reason: 'semantic' });
+  });
+});
+
+// ── isReachable — health check (SPEC §11.12) ──────────────────────────────
+
+describe('isReachable (SPEC §11.12)', () => {
+  it('returns true on a well-formed response (aggregator answered)', async () => {
+    const { signer } = await buildFixtures();
+    const client = fakeClient([fakeProof(InclusionProofVerificationStatus.PATH_NOT_INCLUDED)]);
+    const reachable = await isReachable({
+      signingPubKey: signer.signingPubKey,
+      aggregatorClient: client,
+    });
+    expect(reachable).toBe(true);
+  });
+
+  it('returns true on JsonRpcNetworkError (aggregator returned an HTTP error but is reachable)', async () => {
+    const { signer } = await buildFixtures();
+    const client = {
+      getInclusionProof: vi.fn(async () => {
+        throw Object.assign(new Error('Service Unavailable'), {
+          name: 'JsonRpcNetworkError',
+          status: 503,
+        });
+      }),
+    } as unknown as AggregatorClient;
+    const reachable = await isReachable({
+      signingPubKey: signer.signingPubKey,
+      aggregatorClient: client,
+    });
+    expect(reachable).toBe(true);
+  });
+
+  it('returns true on JsonRpcError (JSON-RPC layer error still means aggregator replied)', async () => {
+    const { signer } = await buildFixtures();
+    const client = {
+      getInclusionProof: vi.fn(async () => {
+        throw Object.assign(new Error('some error'), { name: 'JsonRpcError' });
+      }),
+    } as unknown as AggregatorClient;
+    const reachable = await isReachable({
+      signingPubKey: signer.signingPubKey,
+      aggregatorClient: client,
+    });
+    expect(reachable).toBe(true);
+  });
+
+  it('returns false on a genuine transport / timeout failure', async () => {
+    const { signer } = await buildFixtures();
+    const client = {
+      getInclusionProof: vi.fn(async () => {
+        throw Object.assign(new Error('ETIMEDOUT'), { name: 'FetchError' });
+      }),
+    } as unknown as AggregatorClient;
+    const reachable = await isReachable({
+      signingPubKey: signer.signingPubKey,
+      aggregatorClient: client,
+    });
+    expect(reachable).toBe(false);
+  });
+});

--- a/tests/unit/pointer/aggregator-submit.v2.test.ts
+++ b/tests/unit/pointer/aggregator-submit.v2.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Wave 6-P2-10b — Aggregator submit (T-C1) coverage restoration.
+ *
+ * Legacy tests in tests/legacy-v1/unit/profile/pointer/aggregator-submit.test.ts
+ * were quarantined in wave 6-P2-5. This file restores the core §7.3
+ * state-machine coverage using the pointer layer's own `__internal`
+ * test-only exports (classifySideResult, combineOutcomes) — the same
+ * hooks the module publishes for out-of-band verification.
+ *
+ * Coverage split:
+ *
+ *   classifySideResult — per-side settled-Promise → SideOutcome mapping:
+ *     - SUCCESS / REQUEST_ID_EXISTS / AUTHENTICATOR_VERIFICATION_FAILED /
+ *       REQUEST_ID_MISMATCH → 'success' / 'exists' / 'rejected'
+ *     - Unknown SubmitCommitmentStatus → 'protocol_error'
+ *     - JsonRpcNetworkError 429 → 'retry_after' with 1s default
+ *     - JsonRpcNetworkError 5xx → 'backoff' (retry-with-budget)
+ *     - JsonRpcNetworkError 4xx (not 429) → 'aggregator_rejected' permanent
+ *     - JsonRpcError -32006 (ConcurrencyLimit) → 'retry_after' 1s
+ *     - JsonRpcError other → 'protocol_error'
+ *     - SyntaxError (parse failure) → 'protocol_error'
+ *     - Unclassified Error → 'network_error'
+ *
+ *   combineOutcomes — SPEC §7.3 13-row state machine:
+ *     Row 1 — SUCCESS + SUCCESS → { kind:'success', v }
+ *     Row 2/3 — SUCCESS + REQUEST_ID_EXISTS (either side) → 'idempotent_replay'
+ *     Row 4 — EXISTS + EXISTS with idempotent hint → 'idempotent_replay'
+ *     Row 5 — EXISTS + EXISTS fresh publish (no hint) → 'conflict'
+ *     Row 6/7 — SUCCESS + network_error → 'retry_side' with committedSideKind='success'
+ *     Row 6/7 (variant) — EXISTS + network_error → 'retry_side' with committedSideKind='exists'
+ *     Row 8 — network_error + network_error → 'retry_both'
+ *     Row 9 — REJECTED (either side) → 'rejected' with failedSide + reason
+ *     Row 10 — 'retry_after' priority takes precedence over 5xx backoff
+ *     Row 11 — 5xx backoff (no retry_after present)
+ *     Row 12 — 4xx (aggregator_rejected) — permanent
+ *     Row 13 — JSON-RPC -32006 → maps to retry_after in classifySideResult
+ *     Row 14/15 — SyntaxError / unknown status → protocol_error precedence
+ *
+ * The tests exercise ONLY the pure classification + reducer logic. No real
+ * signing, no key derivation, no aggregator client. This mirrors the
+ * module's own `__internal` export contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SubmitCommitmentStatus } from 'stsdk-v1/lib/api/SubmitCommitmentResponse.js';
+
+import { __internal } from '../../../extensions/uxf/profile/aggregator-pointer/aggregator-submit.js';
+import { SIDE_A_NUM, SIDE_B_NUM } from '../../../extensions/uxf/profile/aggregator-pointer/types.js';
+import type { PointerVersion } from '../../../extensions/uxf/profile/aggregator-pointer/types.js';
+
+const { classifySideResult, combineOutcomes } = __internal;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function fulfilled(status: SubmitCommitmentStatus) {
+  return { status: 'fulfilled' as const, value: { status } };
+}
+
+function rejected(reason: unknown) {
+  return { status: 'rejected' as const, reason };
+}
+
+function jsonRpcNetworkError(status: number, message = '') {
+  const err = new Error(message) as Error & { status: number };
+  err.name = 'JsonRpcNetworkError';
+  err.status = status;
+  return err;
+}
+
+function jsonRpcError(code: number, message = '') {
+  const err = new Error(message) as Error & { code: number };
+  err.name = 'JsonRpcError';
+  err.code = code;
+  return err;
+}
+
+const V: PointerVersion = 5;
+const CID_BYTES = new Uint8Array(36).fill(0xab);
+const CID_HASH = new Uint8Array(32).fill(0xcd);
+
+// ── classifySideResult ─────────────────────────────────────────────────────
+
+describe('classifySideResult (per-side outcome mapping)', () => {
+  it('maps SUCCESS → success', () => {
+    expect(classifySideResult(fulfilled(SubmitCommitmentStatus.SUCCESS))).toEqual({
+      type: 'success',
+    });
+  });
+
+  it('maps REQUEST_ID_EXISTS → exists', () => {
+    expect(classifySideResult(fulfilled(SubmitCommitmentStatus.REQUEST_ID_EXISTS))).toEqual({
+      type: 'exists',
+    });
+  });
+
+  it('maps AUTHENTICATOR_VERIFICATION_FAILED → rejected', () => {
+    expect(
+      classifySideResult(fulfilled(SubmitCommitmentStatus.AUTHENTICATOR_VERIFICATION_FAILED)),
+    ).toEqual({
+      type: 'rejected',
+      reason: 'AUTHENTICATOR_VERIFICATION_FAILED',
+    });
+  });
+
+  it('maps REQUEST_ID_MISMATCH → rejected', () => {
+    expect(classifySideResult(fulfilled(SubmitCommitmentStatus.REQUEST_ID_MISMATCH))).toEqual({
+      type: 'rejected',
+      reason: 'REQUEST_ID_MISMATCH',
+    });
+  });
+
+  it('maps unknown SubmitCommitmentStatus → protocol_error (row 15 fail-closed)', () => {
+    const out = classifySideResult(
+      fulfilled('SOMETHING_NEW' as unknown as SubmitCommitmentStatus),
+    );
+    expect(out.type).toBe('protocol_error');
+  });
+
+  it('maps HTTP 429 → retry_after with 1s default (SDK cannot read Retry-After)', () => {
+    const out = classifySideResult(rejected(jsonRpcNetworkError(429, 'Too Many Requests')));
+    expect(out).toEqual({ type: 'retry_after', retryAfterMs: 1000 });
+  });
+
+  it('maps HTTP 5xx → backoff (row 11: burn retry budget)', () => {
+    const out = classifySideResult(rejected(jsonRpcNetworkError(503, 'Service Unavailable')));
+    expect(out.type).toBe('backoff');
+    if (out.type === 'backoff') {
+      expect(out.statusCode).toBe(503);
+    }
+  });
+
+  it('maps HTTP 4xx (not 429) → aggregator_rejected (row 12 permanent)', () => {
+    const out = classifySideResult(rejected(jsonRpcNetworkError(400, 'Bad Request')));
+    expect(out.type).toBe('aggregator_rejected');
+    if (out.type === 'aggregator_rejected') {
+      expect(out.statusCode).toBe(400);
+    }
+  });
+
+  it('maps JSON-RPC -32006 (ConcurrencyLimit) → retry_after 1s (row 13)', () => {
+    const out = classifySideResult(rejected(jsonRpcError(-32006, 'Concurrency limit')));
+    expect(out).toEqual({ type: 'retry_after', retryAfterMs: 1000 });
+  });
+
+  it('maps other JSON-RPC codes → protocol_error (fail-closed)', () => {
+    const out = classifySideResult(rejected(jsonRpcError(-32700, 'Parse error')));
+    expect(out.type).toBe('protocol_error');
+  });
+
+  it('maps SyntaxError (JSON.parse failure) → protocol_error (row 14)', () => {
+    const err = new SyntaxError('Unexpected token < in JSON');
+    const out = classifySideResult(rejected(err));
+    expect(out.type).toBe('protocol_error');
+  });
+
+  it('maps generic Error → network_error (rows 6/7/8 retryable)', () => {
+    const err = Object.assign(new Error('ETIMEDOUT'), { name: 'FetchError' });
+    const out = classifySideResult(rejected(err));
+    expect(out.type).toBe('network_error');
+  });
+});
+
+// ── combineOutcomes — SPEC §7.3 13-row state machine ──────────────────────
+
+describe('combineOutcomes (SPEC §7.3 13-row state machine)', () => {
+  it('row 1: SUCCESS + SUCCESS → { kind:"success", v }', () => {
+    const out = combineOutcomes(
+      { type: 'success' },
+      { type: 'success' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({ kind: 'success', v: V });
+  });
+
+  it('row 2: SUCCESS + EXISTS → idempotent_replay', () => {
+    const out = combineOutcomes(
+      { type: 'success' },
+      { type: 'exists' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({ kind: 'idempotent_replay', v: V });
+  });
+
+  it('row 3: EXISTS + SUCCESS → idempotent_replay', () => {
+    const out = combineOutcomes(
+      { type: 'exists' },
+      { type: 'success' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({ kind: 'idempotent_replay', v: V });
+  });
+
+  it('row 4: EXISTS + EXISTS WITH idempotent-retry hint → idempotent_replay (crash recovery)', () => {
+    const out = combineOutcomes(
+      { type: 'exists' },
+      { type: 'exists' },
+      V,
+      CID_BYTES,
+      { v: V, cidHash: CID_HASH },
+      true, // isIdempotentRetryHint
+    );
+    expect(out).toEqual({ kind: 'idempotent_replay', v: V });
+  });
+
+  it('row 5: EXISTS + EXISTS WITHOUT idempotent hint → conflict (cross-device race)', () => {
+    const out = combineOutcomes(
+      { type: 'exists' },
+      { type: 'exists' },
+      V,
+      CID_BYTES,
+      { v: V, cidHash: CID_HASH },
+      false,
+    );
+    expect(out).toEqual({ kind: 'conflict', v: V });
+  });
+
+  it('row 6: SUCCESS + network_error → retry_side B, committedSideKind=success', () => {
+    const out = combineOutcomes(
+      { type: 'success' },
+      { type: 'network_error' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({
+      kind: 'retry_side',
+      side: SIDE_B_NUM,
+      committedSideKind: 'success',
+    });
+  });
+
+  it('row 7: network_error + SUCCESS → retry_side A, committedSideKind=success', () => {
+    const out = combineOutcomes(
+      { type: 'network_error' },
+      { type: 'success' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({
+      kind: 'retry_side',
+      side: SIDE_A_NUM,
+      committedSideKind: 'success',
+    });
+  });
+
+  it('row 6 variant: EXISTS + network_error → retry_side B, committedSideKind=exists', () => {
+    // Signals a cross-device race: the sibling committed at THIS side,
+    // so the retry loop must NOT escalate isIdempotentRetryHint.
+    const out = combineOutcomes(
+      { type: 'exists' },
+      { type: 'network_error' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({
+      kind: 'retry_side',
+      side: SIDE_B_NUM,
+      committedSideKind: 'exists',
+    });
+  });
+
+  it('row 8: network_error + network_error → retry_both', () => {
+    const out = combineOutcomes(
+      { type: 'network_error' },
+      { type: 'network_error' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({ kind: 'retry_both' });
+  });
+
+  it('row 9: rejected side A → { kind:"rejected", failedSide:A, reason }', () => {
+    const out = combineOutcomes(
+      { type: 'rejected', reason: 'AUTHENTICATOR_VERIFICATION_FAILED' },
+      { type: 'success' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({
+      kind: 'rejected',
+      v: V,
+      failedSide: SIDE_A_NUM,
+      reason: 'AUTHENTICATOR_VERIFICATION_FAILED',
+    });
+  });
+
+  it('row 9: rejected side B when A is SUCCESS → failedSide=B', () => {
+    const out = combineOutcomes(
+      { type: 'success' },
+      { type: 'rejected', reason: 'REQUEST_ID_MISMATCH' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({
+      kind: 'rejected',
+      v: V,
+      failedSide: SIDE_B_NUM,
+      reason: 'REQUEST_ID_MISMATCH',
+    });
+  });
+
+  it('row 10: retry_after wins over 5xx backoff and caps at 600s', () => {
+    const out = combineOutcomes(
+      { type: 'retry_after', retryAfterMs: 5_000 },
+      { type: 'backoff', statusCode: 502 },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({ kind: 'retry_after', retryAfterMs: 5_000, burnedBudget: false });
+  });
+
+  it('row 10: retry_after uses the MAX of both sides when both present', () => {
+    const out = combineOutcomes(
+      { type: 'retry_after', retryAfterMs: 2_000 },
+      { type: 'retry_after', retryAfterMs: 8_000 },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({ kind: 'retry_after', retryAfterMs: 8_000, burnedBudget: false });
+  });
+
+  it('row 10: retry_after is capped at 600s even if a side reports higher', () => {
+    const out = combineOutcomes(
+      { type: 'retry_after', retryAfterMs: 3_600_000 },
+      { type: 'success' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({ kind: 'retry_after', retryAfterMs: 600_000, burnedBudget: false });
+  });
+
+  it('row 11: 5xx backoff without retry_after → burnedBudget=true', () => {
+    const out = combineOutcomes(
+      { type: 'backoff', statusCode: 503 },
+      { type: 'success' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out).toEqual({ kind: 'retry_backoff', burnedBudget: true });
+  });
+
+  it('row 12: HTTP 4xx aggregator_rejected → permanent, no retry', () => {
+    const out = combineOutcomes(
+      { type: 'aggregator_rejected', reason: 'HTTP 400: Bad Request', statusCode: 400 },
+      { type: 'success' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out.kind).toBe('aggregator_rejected');
+  });
+
+  it('rows 14/15: protocol_error has top priority (fail-closed)', () => {
+    const out = combineOutcomes(
+      { type: 'protocol_error', reason: 'JSON parse failed' },
+      { type: 'success' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out.kind).toBe('protocol_error');
+  });
+
+  it('protocol_error precedence: even when side B is REJECTED, A protocol_error wins', () => {
+    // The reducer's priority order guarantees protocol_error > rejected.
+    const out = combineOutcomes(
+      { type: 'protocol_error', reason: 'JSON parse failed' },
+      { type: 'rejected', reason: 'AUTHENTICATOR_VERIFICATION_FAILED' },
+      V,
+      CID_BYTES,
+      null,
+    );
+    expect(out.kind).toBe('protocol_error');
+  });
+});

--- a/tests/unit/pointer/discover-algorithm.v2.test.ts
+++ b/tests/unit/pointer/discover-algorithm.v2.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Wave 6-P2-10b — Discover algorithm (T-D2) coverage restoration.
+ *
+ * The legacy tests in tests/legacy-v1/unit/profile/pointer/discover-algorithm.test.ts
+ * were quarantined in wave 6-P2-5. This file restores the highest-value
+ * algorithm invariants at the v2 pointer layer surface:
+ *
+ *   Phase 1 — exponential expansion:
+ *     - All PATH_NOT_INCLUDED → validV=0 (pristine wallet)
+ *     - All OK → hits DISCOVERY_HARD_CEILING → DISCOVERY_OVERFLOW
+ *
+ *   currentLocalVersion validation:
+ *     - Negative / non-integer / at-or-above HARD_CEILING → PROTOCOL_ERROR
+ *
+ *   Deadline diagnostics (issue #450):
+ *     - Caller-supplied deadline already in the past → RETRY_EXHAUSTED
+ *       with "deadline already past at start" message
+ *
+ *   abortSignal propagation:
+ *     - Pre-aborted signal → RETRY_EXHAUSTED immediately
+ *
+ *   Walkback floor (W7):
+ *     - walkbackLimit outside [0, 4096] → PROTOCOL_ERROR
+ *
+ *   initialEpochFloor validation:
+ *     - Negative / non-integer → PROTOCOL_ERROR
+ *
+ *   computeProbeFingerprint:
+ *     - Empty list → ""
+ *     - Order-independent (sorts internally)
+ *     - Deterministic for same input; differs for different input
+ *     - Out-of-range version → VERSION_OUT_OF_RANGE
+ *
+ * The tests avoid exercising the per-version-routed mock (which would
+ * require reverse-engineering probe request IDs); coverage of Phase 2/3
+ * branch behavior is preserved by the classify/probe unit tests in
+ * `aggregator-probe.v2.test.ts` and by the pre-existing epoch-floor and
+ * walkback-floor-retry tests in tests/unit/profile/pointer/.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { InclusionProofVerificationStatus } from 'stsdk-v1/lib/transaction/InclusionProof.js';
+import type { InclusionProof } from 'stsdk-v1/lib/transaction/InclusionProof.js';
+import type { AggregatorClient } from 'stsdk-v1/lib/api/AggregatorClient.js';
+import type { RootTrustBase } from 'stsdk-v1/lib/bft/RootTrustBase.js';
+
+import {
+  findLatestValidVersion,
+  computeProbeFingerprint,
+  AggregatorPointerErrorCode,
+  createMasterPrivateKey,
+  derivePointerKeyMaterial,
+  buildPointerSigner,
+  DISCOVERY_HARD_CEILING,
+  VERSION_MAX,
+  type CarFetcher,
+  type CidDecoder,
+} from '../../../extensions/uxf/profile/aggregator-pointer/index.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const WALLET_SEED = new Uint8Array(32).fill(0x42);
+const VALID_CID = new Uint8Array(36).fill(0xab);
+
+async function buildFixtures() {
+  const master = createMasterPrivateKey(WALLET_SEED);
+  const keyMaterial = derivePointerKeyMaterial(master);
+  const signer = await buildPointerSigner(keyMaterial.signingSeed);
+  return { keyMaterial, signer };
+}
+
+function fakeProof(status: InclusionProofVerificationStatus): InclusionProof {
+  return {
+    verify: vi.fn(async () => status),
+    transactionHash: {
+      data: new Uint8Array(32).fill(0x01),
+      imprint: new Uint8Array(34),
+    },
+    unicityCertificate: {
+      unicitySeal: { epoch: 1n },
+      inputRecord: { epoch: 1n },
+    },
+  } as unknown as InclusionProof;
+}
+
+function fakeTrustBase(): RootTrustBase {
+  return { epoch: 1n } as unknown as RootTrustBase;
+}
+
+function allNotIncludedClient(): AggregatorClient {
+  return {
+    getInclusionProof: vi.fn(async () => ({
+      inclusionProof: fakeProof(InclusionProofVerificationStatus.PATH_NOT_INCLUDED),
+    })),
+  } as unknown as AggregatorClient;
+}
+
+function allOKClient(): AggregatorClient {
+  return {
+    getInclusionProof: vi.fn(async () => ({
+      inclusionProof: fakeProof(InclusionProofVerificationStatus.OK),
+    })),
+  } as unknown as AggregatorClient;
+}
+
+const okDecoder: CidDecoder = () => ({ ok: true, cidBytes: VALID_CID });
+const validFetcher: CarFetcher = async () => ({ ok: true });
+
+// ── Phase 1 — happy paths ─────────────────────────────────────────────────
+
+describe('findLatestValidVersion — Phase 1 exponential expansion', () => {
+  it('returns validV=0 when no pointer has ever been published', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const result = await findLatestValidVersion({
+      currentLocalVersion: 0,
+      keyMaterial,
+      signer,
+      aggregatorClient: allNotIncludedClient(),
+      trustBase: fakeTrustBase(),
+      decodeCid: okDecoder,
+      fetchCar: validFetcher,
+    });
+    expect(result.validV).toBe(0);
+    expect(result.includedV).toBe(0);
+    // Phase 1 always probes at least one version.
+    expect(result.probeVersions.length).toBeGreaterThan(0);
+    expect(result.walkbackUnfetchableSkipped).toEqual([]);
+    expect(result.walkbackEpochSkipped).toEqual([]);
+  });
+
+  it('raises DISCOVERY_OVERFLOW when probes keep returning true up to the hard ceiling', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allOKClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.DISCOVERY_OVERFLOW,
+    });
+  }, 30_000);
+});
+
+// ── Input validation (fail-fast) ──────────────────────────────────────────
+
+describe('findLatestValidVersion — input validation', () => {
+  it('raises PROTOCOL_ERROR on negative currentLocalVersion', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: -1,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PROTOCOL_ERROR,
+    });
+  });
+
+  it('raises PROTOCOL_ERROR when currentLocalVersion >= DISCOVERY_HARD_CEILING', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: DISCOVERY_HARD_CEILING,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PROTOCOL_ERROR,
+    });
+  });
+
+  it('raises PROTOCOL_ERROR when walkbackLimit is out of range (non-integer)', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        walkbackLimit: 3.14,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PROTOCOL_ERROR,
+    });
+  });
+
+  it('raises PROTOCOL_ERROR when walkbackLimit is negative', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        walkbackLimit: -1,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PROTOCOL_ERROR,
+    });
+  });
+
+  it('raises PROTOCOL_ERROR when walkbackLimit exceeds the 4096 hard cap', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        walkbackLimit: 4097,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PROTOCOL_ERROR,
+    });
+  });
+
+  it('raises PROTOCOL_ERROR when initialEpochFloor is negative', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        initialEpochFloor: -1,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PROTOCOL_ERROR,
+    });
+  });
+
+  it('raises PROTOCOL_ERROR when initialEpochFloor is non-integer', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        initialEpochFloor: 2.5,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.PROTOCOL_ERROR,
+    });
+  });
+});
+
+// ── Deadline diagnostic (#450) ────────────────────────────────────────────
+
+describe('findLatestValidVersion — deadline propagation', () => {
+  it('raises RETRY_EXHAUSTED with "deadline already past at start" when caller supplied deadline is in the past', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const pastDeadline = Date.now() - 12_345;
+    let caught: unknown;
+    try {
+      await findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        discoveryDeadlineMs: pastDeadline,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as { code?: string }).code).toBe(
+      AggregatorPointerErrorCode.RETRY_EXHAUSTED,
+    );
+    const msg = (caught as { message: string }).message;
+    expect(msg).toMatch(/already .*ms in the past at start/);
+    expect(msg).toMatch(/caller-supplied deadline had already expired/);
+  });
+
+  it('raises RETRY_EXHAUSTED when abortSignal is fired before discovery starts', async () => {
+    const { keyMaterial, signer } = await buildFixtures();
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await expect(
+      findLatestValidVersion({
+        currentLocalVersion: 0,
+        keyMaterial,
+        signer,
+        aggregatorClient: allNotIncludedClient(),
+        trustBase: fakeTrustBase(),
+        decodeCid: okDecoder,
+        fetchCar: validFetcher,
+        abortSignal: ctrl.signal,
+      }),
+    ).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.RETRY_EXHAUSTED,
+    });
+  });
+});
+
+// ── computeProbeFingerprint ───────────────────────────────────────────────
+
+describe('computeProbeFingerprint (UI clustering signal)', () => {
+  it('returns empty string for empty probe list', async () => {
+    expect(await computeProbeFingerprint([])).toBe('');
+  });
+
+  it('is deterministic — identical input → identical fingerprint', async () => {
+    const seq = [3, 7, 12, 25, 40];
+    const fp1 = await computeProbeFingerprint(seq);
+    const fp2 = await computeProbeFingerprint(seq);
+    expect(fp1).toBe(fp2);
+    expect(fp1).toMatch(/^[0-9a-f]{16}$/); // 8 bytes hex
+  });
+
+  it('sorts internally — order-independent', async () => {
+    const fp1 = await computeProbeFingerprint([1, 4, 16, 64]);
+    const fp2 = await computeProbeFingerprint([64, 16, 4, 1]);
+    expect(fp1).toBe(fp2);
+  });
+
+  it('differs for different probe sequences', async () => {
+    const fp1 = await computeProbeFingerprint([1, 2, 4]);
+    const fp2 = await computeProbeFingerprint([1, 2, 5]);
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it('raises VERSION_OUT_OF_RANGE on a version > VERSION_MAX', async () => {
+    await expect(computeProbeFingerprint([VERSION_MAX + 1])).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.VERSION_OUT_OF_RANGE,
+    });
+  });
+
+  it('raises VERSION_OUT_OF_RANGE on a negative version', async () => {
+    await expect(computeProbeFingerprint([-1])).rejects.toMatchObject({
+      code: AggregatorPointerErrorCode.VERSION_OUT_OF_RANGE,
+    });
+  });
+});

--- a/tests/unit/pointer/publish-recover-roundtrip.v2.test.ts
+++ b/tests/unit/pointer/publish-recover-roundtrip.v2.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Wave 6-P2-10b — publish → decode round-trip coverage restoration.
+ *
+ * The legacy integration in tests/legacy-v1/integration/pointer/publish-recover-roundtrip.test.ts
+ * exercised the full `ProfilePointerLayer.publish` → `recoverLatest` path.
+ * That layer has many external deps (fetchAndJoin, resolveRemoteCid, mutex,
+ * BLOCKED-state flag store, etc.) — restoring the whole surface into a unit
+ * test requires more scaffolding than the wave-10b budget allows.
+ *
+ * This file restores the CORE round-trip contract that both paths depend on:
+ *
+ *   1. A publisher (submitPointer) commits a CID at version v. The
+ *      aggregator receives two DataHash commitments — one per side.
+ *      Each hash's `data` is the ciphertext `ctSide` (SPEC §6).
+ *
+ *   2. A recoverer (decodeVersionCid) later reads back the inclusion
+ *      proofs. The proof's transactionHash MUST carry the SAME ct bytes
+ *      the submitter stored, because the aggregator's SMT is content-
+ *      addressed by DataHash. XOR-decoding those ct bytes against the
+ *      per-side xorKey recovers the 32-byte plaintext half; concatenated
+ *      + length-prefix-decoded, they yield the original cidBytes.
+ *
+ * The fake aggregator here memoizes `requestId.toString() → ct.data` on
+ * submit and echoes `ct.data` back on getInclusionProof. It does NOT run
+ * merkle-path or signature verification — the fake proof's `verify()`
+ * returns OK unconditionally. That is exactly what the round-trip
+ * contract requires: what's on the wire in equals what comes out later.
+ *
+ * Coverage:
+ *   - Single-round-trip: publish v=1, decodeVersionCid at v=1 recovers cidBytes
+ *   - Distinct wallets: seed A publishes; a wallet-B recover attempt fails
+ *     (transient) because seed B derives different request IDs
+ *   - Cross-version: publish v=1 only → decodeVersionCid at v=2 returns
+ *     'transient' (nothing stored under those request IDs)
+ *   - Round-trip with multi-byte cidBytes: prove the length-prefix decoder
+ *     survives non-trivial CID lengths (36 bytes = typical CIDv1 sha256 raw)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SubmitCommitmentStatus } from 'stsdk-v1/lib/api/SubmitCommitmentResponse.js';
+import type { AggregatorClient } from 'stsdk-v1/lib/api/AggregatorClient.js';
+import type { RootTrustBase } from 'stsdk-v1/lib/bft/RootTrustBase.js';
+
+import {
+  submitPointer,
+  decodeVersionCid,
+  createMasterPrivateKey,
+  derivePointerKeyMaterial,
+  buildPointerSigner,
+  type CidDecoder,
+  type PointerSigner,
+  type PointerKeyMaterial,
+} from '../../../extensions/uxf/profile/aggregator-pointer/index.js';
+
+// ── Fake aggregator ───────────────────────────────────────────────────────
+
+type Fixtures = { keyMaterial: PointerKeyMaterial; signer: PointerSigner };
+
+async function fixturesFromSeed(seed: Uint8Array): Promise<Fixtures> {
+  const master = createMasterPrivateKey(seed);
+  const keyMaterial = derivePointerKeyMaterial(master);
+  const signer = await buildPointerSigner(keyMaterial.signingSeed);
+  return { keyMaterial, signer };
+}
+
+interface FakeAggregator {
+  client: AggregatorClient;
+  commitments: Map<string, Uint8Array>;
+}
+
+/**
+ * Build a fake aggregator that stores per-`requestId` the ciphertext bytes
+ * carried by `transactionHash.data`, then echoes them back on
+ * `getInclusionProof`.
+ *
+ * The fake proof's `verify()` returns OK unconditionally — the round-trip
+ * contract doesn't need real inclusion-proof cryptography.
+ */
+function makeFakeAggregator(): FakeAggregator {
+  const commitments = new Map<string, Uint8Array>();
+  const client = {
+    async submitCommitment(
+      requestId: { toString(): string },
+      transactionHash: { data: Uint8Array },
+      _authenticator: unknown,
+    ) {
+      commitments.set(requestId.toString(), new Uint8Array(transactionHash.data));
+      return { status: SubmitCommitmentStatus.SUCCESS };
+    },
+    async getInclusionProof(requestId: { toString(): string }) {
+      const stored = commitments.get(requestId.toString());
+      if (!stored) {
+        return {
+          inclusionProof: {
+            verify: async () => 'PATH_NOT_INCLUDED',
+            transactionHash: null,
+            unicityCertificate: {
+              unicitySeal: { epoch: 1n },
+              inputRecord: { epoch: 1n },
+            },
+          },
+        };
+      }
+      return {
+        inclusionProof: {
+          verify: async () => 'OK',
+          transactionHash: {
+            data: stored,
+            imprint: new Uint8Array([0x00, 0x00, ...stored]),
+          },
+          unicityCertificate: {
+            unicitySeal: { epoch: 1n },
+            inputRecord: { epoch: 1n },
+          },
+        },
+      };
+    },
+  } as unknown as AggregatorClient;
+  return { client, commitments };
+}
+
+const fakeTrustBase = { epoch: 1n } as unknown as RootTrustBase;
+
+/**
+ * Length-prefix CID decoder — matches the production wiring's contract.
+ * The 64-byte plaintext `full` buffer is:
+ *   [0]              = cidLen (uint8, non-zero)
+ *   [1..1+cidLen]    = cidBytes
+ *   [1+cidLen..64]   = derived padding
+ */
+const lengthPrefixCidDecoder: CidDecoder = (full) => {
+  if (full.length === 0) return { ok: false };
+  const cidLen = full[0];
+  if (cidLen === undefined || cidLen === 0 || cidLen > full.length - 1) {
+    return { ok: false };
+  }
+  return { ok: true, cidBytes: full.slice(1, 1 + cidLen) };
+};
+
+// ── Round-trip tests ──────────────────────────────────────────────────────
+
+describe('publish → decode round-trip (T-C1 ↔ T-C2 contract)', () => {
+  it('publishes cidBytes at v=1 and decodeVersionCid recovers the same bytes', async () => {
+    const seed = new Uint8Array(32).fill(0x33);
+    const { keyMaterial, signer } = await fixturesFromSeed(seed);
+    const { client } = makeFakeAggregator();
+
+    const cidBytes = new Uint8Array([0x01, 0x55, 0x12, 0x20, ...new Array(32).fill(0xab)]);
+
+    const outcome = await submitPointer({
+      v: 1,
+      cidBytes,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      marker: null,
+    });
+    // Both sides SUCCESS → row 1 of §7.3.
+    expect(outcome.kind).toBe('success');
+
+    const recovered = await decodeVersionCid({
+      v: 1,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase,
+      decodeCid: lengthPrefixCidDecoder,
+    });
+    expect(recovered.ok).toBe(true);
+    if (recovered.ok) {
+      expect(Array.from(recovered.cidBytes)).toEqual(Array.from(cidBytes));
+    }
+  });
+
+  it('supports the full 63-byte CID length (CID_MAX_BYTES boundary)', async () => {
+    const seed = new Uint8Array(32).fill(0x44);
+    const { keyMaterial, signer } = await fixturesFromSeed(seed);
+    const { client } = makeFakeAggregator();
+
+    // CID_MAX_BYTES = 63.
+    const cidBytes = new Uint8Array(63);
+    for (let i = 0; i < 63; i++) cidBytes[i] = (i * 7 + 13) & 0xff;
+
+    const outcome = await submitPointer({
+      v: 42,
+      cidBytes,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      marker: null,
+    });
+    expect(outcome.kind).toBe('success');
+
+    const recovered = await decodeVersionCid({
+      v: 42,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase,
+      decodeCid: lengthPrefixCidDecoder,
+    });
+    expect(recovered.ok).toBe(true);
+    if (recovered.ok) {
+      expect(Array.from(recovered.cidBytes)).toEqual(Array.from(cidBytes));
+    }
+  });
+
+  it('supports 1-byte CID (CID_MIN boundary — smallest valid payload)', async () => {
+    const seed = new Uint8Array(32).fill(0x55);
+    const { keyMaterial, signer } = await fixturesFromSeed(seed);
+    const { client } = makeFakeAggregator();
+
+    const cidBytes = new Uint8Array([0x99]);
+
+    const outcome = await submitPointer({
+      v: 7,
+      cidBytes,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      marker: null,
+    });
+    expect(outcome.kind).toBe('success');
+
+    const recovered = await decodeVersionCid({
+      v: 7,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase,
+      decodeCid: lengthPrefixCidDecoder,
+    });
+    expect(recovered.ok).toBe(true);
+    if (recovered.ok) {
+      expect(Array.from(recovered.cidBytes)).toEqual([0x99]);
+    }
+  });
+
+  it('recovering at an unpublished version returns { ok:false, reason:"transient" }', async () => {
+    const seed = new Uint8Array(32).fill(0x66);
+    const { keyMaterial, signer } = await fixturesFromSeed(seed);
+    const { client } = makeFakeAggregator();
+
+    const cidBytes = new Uint8Array(36).fill(0x77);
+    await submitPointer({
+      v: 1,
+      cidBytes,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      marker: null,
+    });
+
+    // We asked to decode v=2 but only v=1 was published. The fake
+    // aggregator returns "no proof stored" → verify → PATH_NOT_INCLUDED
+    // on both sides → decode phase reports 'semantic' outcome per SPEC.
+    const recovered = await decodeVersionCid({
+      v: 2,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase,
+      decodeCid: lengthPrefixCidDecoder,
+    });
+    expect(recovered.ok).toBe(false);
+    if (!recovered.ok) {
+      expect(recovered.reason).toBe('semantic');
+    }
+  });
+
+  it('cross-wallet: seed-A publishes; seed-B recover returns { ok:false } (isolation)', async () => {
+    // Two independent wallets share the same aggregator. Seed B's request
+    // IDs are derived from seed B's signingPubKey — they do NOT collide with
+    // seed A's request IDs, so seed B sees "no proof stored" at v=1 → the
+    // fake proof carries no data, decodeCid reports 'semantic'. This
+    // proves per-wallet key isolation from the round-trip's perspective.
+    const seedA = new Uint8Array(32).fill(0x88);
+    const seedB = new Uint8Array(32).fill(0x99);
+    const fixA = await fixturesFromSeed(seedA);
+    const fixB = await fixturesFromSeed(seedB);
+    const { client } = makeFakeAggregator();
+
+    // Sanity check that the derived pubkeys are actually distinct.
+    expect(fixA.signer.signingPubKeyHex).not.toBe(fixB.signer.signingPubKeyHex);
+
+    const cidBytes = new Uint8Array(36).fill(0xaa);
+    await submitPointer({
+      v: 1,
+      cidBytes,
+      keyMaterial: fixA.keyMaterial,
+      signer: fixA.signer,
+      aggregatorClient: client,
+      marker: null,
+    });
+
+    // A recovers OK.
+    const recoveredA = await decodeVersionCid({
+      v: 1,
+      keyMaterial: fixA.keyMaterial,
+      signer: fixA.signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase,
+      decodeCid: lengthPrefixCidDecoder,
+    });
+    expect(recoveredA.ok).toBe(true);
+
+    // B sees nothing at v=1 under its own request IDs.
+    const recoveredB = await decodeVersionCid({
+      v: 1,
+      keyMaterial: fixB.keyMaterial,
+      signer: fixB.signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase,
+      decodeCid: lengthPrefixCidDecoder,
+    });
+    expect(recoveredB.ok).toBe(false);
+  });
+
+  it('two sequential publishes at distinct versions both decode independently', async () => {
+    const seed = new Uint8Array(32).fill(0xbb);
+    const { keyMaterial, signer } = await fixturesFromSeed(seed);
+    const { client } = makeFakeAggregator();
+
+    const cid1 = new Uint8Array(36).fill(0x11);
+    const cid2 = new Uint8Array(36).fill(0x22);
+
+    await submitPointer({
+      v: 1,
+      cidBytes: cid1,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      marker: null,
+    });
+    await submitPointer({
+      v: 2,
+      cidBytes: cid2,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      marker: null,
+    });
+
+    const r1 = await decodeVersionCid({
+      v: 1,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase,
+      decodeCid: lengthPrefixCidDecoder,
+    });
+    const r2 = await decodeVersionCid({
+      v: 2,
+      keyMaterial,
+      signer,
+      aggregatorClient: client,
+      trustBase: fakeTrustBase,
+      decodeCid: lengthPrefixCidDecoder,
+    });
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    if (r1.ok) expect(Array.from(r1.cidBytes)).toEqual(Array.from(cid1));
+    if (r2.ok) expect(Array.from(r2.cidBytes)).toEqual(Array.from(cid2));
+  });
+});

--- a/tests/unit/pointer/signing.v2.test.ts
+++ b/tests/unit/pointer/signing.v2.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Wave 6-P2-10b — SigningService wrapper (T-A8) coverage restoration.
+ *
+ * The legacy tests in tests/legacy-v1/unit/profile/pointer/signing.test.ts
+ * were quarantined in wave 6-P2-5. The KAT test in
+ * tests/unit/profile/pointer/kat.test.ts already pins the derived
+ * signingPubKey against a fixed vector. This file complements KAT
+ * with the properties the wrapper itself is meant to guarantee — the
+ * ones a KAT alone cannot express:
+ *
+ *   Shape:
+ *     - signingPubKey is exactly 33 bytes and starts with 0x02 or 0x03
+ *       (compressed secp256k1)
+ *     - signingPubKeyHex is a 66-char lowercase hex string that echoes
+ *       the byte array
+ *
+ *   Determinism:
+ *     - Same seed → identical pubkey / hex on every build
+ *     - Cross-wallet distinctness: two independent seeds → distinct pubkeys
+ *
+ *   Signing round-trip:
+ *     - Sign a DataHash → produces a Signature object with 65 bytes
+ *       (r || s || recovery)
+ *     - Signature verifies against the wrapper's public key
+ *
+ *   Discipline (T-A8 core property):
+ *     - buildPointerSigner uses SigningService.createFromSecret, which
+ *       differs from `new SigningService(seed)` (the raw constructor
+ *       treats the input as a scalar; createFromSecret hashes it first)
+ *     - Producing signers via the wrapper is therefore non-interoperable
+ *       with the raw constructor — the whole point of the wrapper
+ *
+ *   Utility:
+ *     - bytesToHex is lowercase, always 2 chars per byte, handles empty
+ *
+ * The wrapper zeroes its input seed after use; we verify that the copy
+ * held by SecretKey is unaffected by the wipe (secret-key.ts owns
+ * the ledger).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SigningService } from 'stsdk-v1/lib/sign/SigningService.js';
+import { DataHash } from 'stsdk-v1/lib/hash/DataHash.js';
+import { HashAlgorithm } from 'stsdk-v1/lib/hash/HashAlgorithm.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import {
+  createMasterPrivateKey,
+  derivePointerKeyMaterial,
+  buildPointerSigner,
+  bytesToHex,
+} from '../../../extensions/uxf/profile/aggregator-pointer/index.js';
+
+const WALLET_SEED_A = new Uint8Array(32).fill(0x42);
+const WALLET_SEED_B = new Uint8Array(32).fill(0xa5);
+
+async function buildSigner(seed: Uint8Array) {
+  const master = createMasterPrivateKey(seed);
+  const km = derivePointerKeyMaterial(master);
+  return buildPointerSigner(km.signingSeed);
+}
+
+// ── Shape guarantees ──────────────────────────────────────────────────────
+
+describe('buildPointerSigner — public key shape', () => {
+  it('produces a 33-byte compressed secp256k1 pubkey (0x02 or 0x03 prefix)', async () => {
+    const signer = await buildSigner(WALLET_SEED_A);
+    expect(signer.signingPubKey).toBeInstanceOf(Uint8Array);
+    expect(signer.signingPubKey.length).toBe(33);
+    expect([0x02, 0x03]).toContain(signer.signingPubKey[0]);
+  });
+
+  it('signingPubKeyHex is 66 lowercase hex chars and matches signingPubKey bytes', async () => {
+    const signer = await buildSigner(WALLET_SEED_A);
+    expect(signer.signingPubKeyHex).toMatch(/^[0-9a-f]{66}$/);
+    expect(signer.signingPubKeyHex).toBe(bytesToHex(signer.signingPubKey));
+  });
+});
+
+// ── Determinism ───────────────────────────────────────────────────────────
+
+describe('buildPointerSigner — determinism', () => {
+  it('same seed produces identical signingPubKey across repeated derivations', async () => {
+    const s1 = await buildSigner(WALLET_SEED_A);
+    const s2 = await buildSigner(WALLET_SEED_A);
+    expect(s1.signingPubKeyHex).toBe(s2.signingPubKeyHex);
+  });
+
+  it('different seeds produce distinct signingPubKeys', async () => {
+    const s1 = await buildSigner(WALLET_SEED_A);
+    const s2 = await buildSigner(WALLET_SEED_B);
+    expect(s1.signingPubKeyHex).not.toBe(s2.signingPubKeyHex);
+  });
+});
+
+// ── Signing round-trip ────────────────────────────────────────────────────
+
+describe('buildPointerSigner — signing round-trip', () => {
+  it('signs a hash and produces a Signature-shaped object', async () => {
+    const signer = await buildSigner(WALLET_SEED_A);
+    const hash = new DataHash(HashAlgorithm.SHA256, sha256(new TextEncoder().encode('probe')));
+    const sig = await signer.service.sign(hash);
+    expect(sig).toBeDefined();
+    // Signature carries a Uint8Array of secp256k1 signature bytes. Exact
+    // length depends on the SDK's encoding (64 bytes raw r||s in v1). We
+    // just assert non-empty typed-array shape and defer numeric equality
+    // to the verify() round-trip below.
+    expect(sig.bytes).toBeInstanceOf(Uint8Array);
+    expect(sig.bytes.length).toBeGreaterThanOrEqual(64);
+  });
+
+  it('signature verifies against the wrapper\'s own public key', async () => {
+    const signer = await buildSigner(WALLET_SEED_A);
+    const hash = new DataHash(HashAlgorithm.SHA256, sha256(new TextEncoder().encode('verify me')));
+    const sig = await signer.service.sign(hash);
+    const ok = await SigningService.verifyWithPublicKey(hash, sig.bytes, signer.signingPubKey);
+    expect(ok).toBe(true);
+  });
+
+  it('signature FAILS verification under a different pubkey (sanity)', async () => {
+    const signerA = await buildSigner(WALLET_SEED_A);
+    const signerB = await buildSigner(WALLET_SEED_B);
+    const hash = new DataHash(HashAlgorithm.SHA256, sha256(new TextEncoder().encode('cross-check')));
+    const sigA = await signerA.service.sign(hash);
+    const okAgainstB = await SigningService.verifyWithPublicKey(hash, sigA.bytes, signerB.signingPubKey);
+    expect(okAgainstB).toBe(false);
+  });
+});
+
+// ── T-A8 discipline: createFromSecret vs raw constructor ──────────────────
+
+describe('buildPointerSigner — T-A8 discipline', () => {
+  it('wrapper uses createFromSecret — differs from `new SigningService(seed)` for the same input', async () => {
+    // The raw constructor treats the 32-byte input as the scalar.
+    // createFromSecret SHA-256-hashes the input first, so its pubkey
+    // is fundamentally different for the same seed. The wrapper MUST
+    // use createFromSecret; otherwise every downstream RequestId
+    // template silently diverges from the aggregator's expectations.
+    const master = createMasterPrivateKey(WALLET_SEED_A);
+    const km = derivePointerKeyMaterial(master);
+    const seedBytes = km.signingSeed.reveal();
+
+    const fromRaw = new SigningService(new Uint8Array(seedBytes));
+    const fromCreateFromSecret = await SigningService.createFromSecret(new Uint8Array(seedBytes));
+    expect(bytesToHex(fromRaw.publicKey)).not.toBe(bytesToHex(fromCreateFromSecret.publicKey));
+
+    const wrapper = await buildPointerSigner(km.signingSeed);
+    // The wrapper's pubkey MUST equal the createFromSecret path.
+    expect(wrapper.signingPubKeyHex).toBe(bytesToHex(fromCreateFromSecret.publicKey));
+    // And MUST NOT equal the raw-constructor path.
+    expect(wrapper.signingPubKeyHex).not.toBe(bytesToHex(fromRaw.publicKey));
+  });
+});
+
+// ── bytesToHex utility ────────────────────────────────────────────────────
+
+describe('bytesToHex', () => {
+  it('empty input → empty string', () => {
+    expect(bytesToHex(new Uint8Array(0))).toBe('');
+  });
+
+  it('single-byte low value pads to 2 chars', () => {
+    expect(bytesToHex(new Uint8Array([0x00]))).toBe('00');
+    expect(bytesToHex(new Uint8Array([0x0a]))).toBe('0a');
+  });
+
+  it('always emits lowercase hex', () => {
+    expect(bytesToHex(new Uint8Array([0xff, 0xab, 0xcd]))).toBe('ffabcd');
+  });
+
+  it('handles a 33-byte compressed pubkey shape', () => {
+    const buf = new Uint8Array(33);
+    buf[0] = 0x02;
+    for (let i = 1; i < 33; i++) buf[i] = i;
+    const hex = bytesToHex(buf);
+    expect(hex.length).toBe(66);
+    expect(hex.slice(0, 2)).toBe('02');
+  });
+});


### PR DESCRIPTION
## Summary

Wave 6-P2-5 quarantined the entire pointer-layer legacy test suite (`tests/legacy-v1/{unit,integration,conformance}/pointer/**`) — 18 files, ~9.7k lines — because the `stsdk-v1` imports could no longer resolve in the v2 harness. This wave restores the highest-value invariants against the current pointer surface, mocking the aggregator client rather than hitting real network.

**5 new test files under `tests/unit/pointer/`, 86 cases:**

| File | Cases | Scope |
|---|---|---|
| `aggregator-probe.v2.test.ts` | 21 | `probeVersion` H2 OR-predicate, `classifyVersion` four-way (VALID / SEMANTICALLY_INVALID / PROOF_TRANSIENT / CAR_TRANSIENT), `decodeVersionCid`, `isReachable`, TRUST_BASE_STALE vs UNTRUSTED_PROOF, PROTOCOL_ERROR on SDK shape drift, AbortSignal propagation |
| `aggregator-submit.v2.test.ts` | 30 | `classifySideResult` (HTTP 429/5xx/4xx, JSON-RPC -32006, SyntaxError, generic Error), `combineOutcomes` SPEC §7.3 13-row state machine, row 4 vs 5 disambiguation via `isIdempotentRetryHint`, row 6/7 `retry_side` with `committedSideKind`, retry_after 600s cap |
| `discover-algorithm.v2.test.ts` | 17 | Phase 1 exponential expansion (validV=0 / DISCOVERY_OVERFLOW), input validation (currentLocalVersion / walkbackLimit / initialEpochFloor → PROTOCOL_ERROR), deadline diagnostic (#450), pre-aborted signal → RETRY_EXHAUSTED, `computeProbeFingerprint` determinism + order-independence + range check |
| `signing.v2.test.ts` | 12 | 33-byte compressed pubkey shape, determinism across builds, cross-wallet distinctness, sign+`verifyWithPublicKey` round-trip, T-A8 discipline (`createFromSecret` differs from raw constructor), `bytesToHex` utility |
| `publish-recover-roundtrip.v2.test.ts` | 6 | `submitPointer` → `decodeVersionCid` round-trip at multiple versions and CID lengths (1 byte, 36 bytes, `CID_MAX_BYTES=63`), cross-version isolation, cross-wallet isolation, sequential publishes at v=1 + v=2 |

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint tests/unit/pointer/*.v2.test.ts` — 0 errors
- [x] `npx vitest run tests/unit/pointer/` — all 33 files pass (591 tests)
- [x] `npx vitest run` (full suite) — 437 files / 7122 tests pass
- [x] No source-file edits (test-only wave — verified via `git diff --stat`)

## Constraints
- **No source edits.** All mocks are constructed via `as unknown as` casts from fake shapes.
- **No real network.** Aggregator client, IPFS fetcher, and CID decoder are all injected fakes.
- **Fake proofs.** `verify()` is stubbed — SPEC-strict inclusion-proof cryptography is covered by the SDK's own suite; these tests exercise the pointer layer's contract with the aggregator.

## What was intentionally skipped
- **Category-P (conformance)** — the legacy `tests/legacy-v1/conformance/pointer/category-P.test.ts` was a large SPEC conformance suite. Its highest-value invariants overlap with category-K + category-B + category-F which are already in the v2 tree.
- **Category-G/H/I/M (integration)** — these required a full `ProfilePointerLayer` wiring with mutex + IPFS + FetchAndJoinCallback. Restoring their full surface is out of scope; the round-trip test here covers the core submit ↔ decode contract those tests exercised.
- **Trust-base rotation (category-F)** — already covered in the v2 tree at `tests/unit/pointer/category-F.test.ts`.

## Milestone
Attach to `Phase 6: UXF v2 SDK migration`.