### PR TITLE
Wave 6-P2-11: runtime gap fixes — waitForProof audit + uxf-cid receive

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -103,6 +103,13 @@ import { SphereError } from '../../core/errors';
 // SDK-shaped).
 import { encodeTransferPayload, decodeNostrEventContent } from '../../extensions/uxf/bundle/transfer-payload';
 import { isUxfTransferPayloadCar, isUxfTransferPayloadCid } from '../../extensions/uxf/types/uxf-transfer';
+import type { UxfTransferPayloadCid } from '../../extensions/uxf/types/uxf-transfer';
+// CID-fetch pipeline — wave 6-P2-11 wires the recipient side of the
+// `kind: 'uxf-cid'` envelope. `fetchCarByCid` walks the configured
+// gateway list, verifies the CAR root CID matches the requested
+// bundleCid, and returns the bytes on success.
+import { fetchCarByCid } from '../../extensions/uxf/pipeline/cid-fetcher';
+import { CarReader } from '@ipld/car';
 
 // SpendQueue is retained per the wave brief but its stsdk-v1-based
 // parser is not on the hot path in the v2 slim rebuild; we re-export
@@ -1064,6 +1071,88 @@ export class PaymentsModule {
   }
 
   /**
+   * Wave 6-P2-11 — Fetch a `uxf-cid` bundle from configured IPFS gateways
+   * and extract the inline token blobs the receive tail expects.
+   *
+   * Returns `null` on any failure (empty gateway list, transient fetch
+   * failure, structural CAR issue). The caller treats `null` as
+   * "retention required" and reports back to the transport so the event
+   * can be retried.
+   *
+   * Success returns an array of raw token blob bytes (possibly empty if
+   * the CAR's root block is a well-formed envelope containing no tokens
+   * — that's a peer-side sender bug, not a delivery failure, so no
+   * retention).
+   *
+   * **Never expose gateway URLs in logs.** `fetchCarByCid` carries the
+   * gateway list on the `SphereError.cause`, but we only surface the
+   * error message which is bounded to `"fetchCarByCid: …"` shape by
+   * construction. Downstream fetch errors surface via their message and
+   * are truncated defensively.
+   */
+  private async fetchAndExtractCidBundle(
+    payload: UxfTransferPayloadCid,
+    senderTransportPubkey: string,
+  ): Promise<Uint8Array[] | null> {
+    const gateways = this.deps?.cidFetchGateways;
+    if (!gateways || gateways.length === 0) {
+      logger.warn(
+        'Payments',
+        `Ignoring uxf-cid payload (${payload.bundleCid.slice(0, 16)}...); no cidFetchGateways configured`,
+      );
+      return null;
+    }
+    let carBytes: Uint8Array;
+    try {
+      const result = await fetchCarByCid(payload.bundleCid, {
+        gateways,
+        senderTransportPubkey,
+      });
+      carBytes = result.carBytes;
+    } catch (err) {
+      // Bound message to avoid accidentally leaking a gateway URL that
+      // slipped into a nested `cause`.
+      const raw = err instanceof Error ? err.message : String(err);
+      const safe = raw.length > 200 ? raw.slice(0, 200) + '…' : raw;
+      logger.warn(
+        'Payments',
+        `uxf-cid fetch failed for ${payload.bundleCid.slice(0, 16)}...: ${safe}`,
+      );
+      return null;
+    }
+    // Parse the CAR and extract the root block. In the slim receive path
+    // the root block bytes carry the same JSON envelope the inline
+    // `uxf-car` path packs into `carBase64` — we re-run the shared
+    // decoder so the downstream "same tail" (isOwnedBy → verify →
+    // persist) is bit-identical.
+    try {
+      const reader = await CarReader.fromBytes(carBytes);
+      const roots = await reader.getRoots();
+      if (roots.length !== 1) {
+        logger.warn(
+          'Payments',
+          `uxf-cid CAR has ${roots.length} roots; expected exactly 1`,
+        );
+        return null;
+      }
+      const rootBlock = await reader.get(roots[0]);
+      if (!rootBlock) {
+        logger.warn('Payments', 'uxf-cid CAR root block missing from CAR');
+        return null;
+      }
+      const envelopeBase64 = Buffer.from(rootBlock.bytes).toString('base64');
+      return extractInlineTokenBlobs(envelopeBase64);
+    } catch (err) {
+      logger.warn(
+        'Payments',
+        `uxf-cid CAR decode failed for ${payload.bundleCid.slice(0, 16)}...:`,
+        err,
+      );
+      return null;
+    }
+  }
+
+  /**
    * Handle an incoming transport transfer event. Returns `true` when the
    * event is durably persisted (advances the transport's `since` cursor).
    */
@@ -1079,14 +1168,21 @@ export class PaymentsModule {
       if (isUxfTransferPayloadCar(payload)) {
         blobs = extractInlineTokenBlobs(payload.carBase64);
       } else if (isUxfTransferPayloadCid(payload)) {
-        // CID-by-reference — v2 slim rebuild does not fetch CARs. Log and
-        // return false so the transport retains the event for a fatter
-        // consumer.
-        logger.warn(
-          'Payments',
-          `Ignoring uxf-cid payload (${payload.bundleCid}); CID-fetch not wired in v2 slim receive`,
+        // Wave 6-P2-11 — CID-by-reference receive. `fetchAndExtractCidBundle`
+        // walks `deps.cidFetchGateways` in order, verifies the CAR root
+        // CID matches `payload.bundleCid`, and extracts the same JSON-
+        // envelope token blobs the inline `uxf-car` path consumes. On any
+        // failure (empty gateway list, transient fetch failure, structural
+        // CAR issue) it returns null and we hand back `false` so the
+        // transport retains the event for retry.
+        const fetched = await this.fetchAndExtractCidBundle(
+          payload,
+          transfer.senderTransportPubkey,
         );
-        return false;
+        if (fetched === null) {
+          return false;
+        }
+        blobs = fetched;
       } else {
         logger.debug('Payments', 'Ignoring non-UXF transfer payload (legacy shape)');
         return false;

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1110,10 +1110,11 @@ export class PaymentsModule {
       });
       carBytes = result.carBytes;
     } catch (err) {
-      // Bound message to avoid accidentally leaking a gateway URL that
-      // slipped into a nested `cause`.
+      // Never surface gateway URLs to logs — strip any URL-looking
+      // token from the raw message and bound the length.
       const raw = err instanceof Error ? err.message : String(err);
-      const safe = raw.length > 200 ? raw.slice(0, 200) + '…' : raw;
+      const stripped = raw.replace(/https?:\/\/[^\s"',<>]+/gi, '[gateway-redacted]');
+      const safe = stripped.length > 200 ? stripped.slice(0, 200) + '…' : stripped;
       logger.warn(
         'Payments',
         `uxf-cid fetch failed for ${payload.bundleCid.slice(0, 16)}...: ${safe}`,

--- a/tests/unit/modules/payments/PaymentsModule.receive.v2.test.ts
+++ b/tests/unit/modules/payments/PaymentsModule.receive.v2.test.ts
@@ -412,7 +412,12 @@ describe('PaymentsModule.receive (v2 slim)', () => {
     expect(h.module.getTokens()).toHaveLength(0);
   });
 
-  it('rejects a uxf-cid payload (slim receive does not fetch CARs by CID)', async () => {
+  it('rejects a uxf-cid payload when no cidFetchGateways are configured (retention)', async () => {
+    // Wave 6-P2-11 wired the uxf-cid receive path, but the harness here
+    // omits `deps.cidFetchGateways`. With no gateways to walk, the module
+    // still returns `false` so the transport retains the event for retry
+    // once gateways are configured. Full happy-path coverage lives in
+    // PaymentsModule.uxfCid.v2.test.ts.
     const h = await makeHarness();
     const cid: IncomingTokenTransfer = {
       id: 'nostr-cid',
@@ -428,8 +433,6 @@ describe('PaymentsModule.receive (v2 slim)', () => {
       timestamp: Date.now(),
     };
     const durable = await h.handler(cid);
-    // Slim rebuild returns false so the transport can keep the event and
-    // hand it to a fatter consumer later.
     expect(durable).toBe(false);
     expect(h.module.getTokens()).toHaveLength(0);
   });

--- a/tests/unit/modules/payments/PaymentsModule.uxfCid.v2.test.ts
+++ b/tests/unit/modules/payments/PaymentsModule.uxfCid.v2.test.ts
@@ -1,0 +1,498 @@
+/**
+ * PaymentsModule receive path — `kind: 'uxf-cid'` (wave 6-P2-11).
+ *
+ * The wave-6-P2-4b slim rebuild rejected every uxf-cid envelope, returning
+ * `false` so the transport retained the event for a fatter consumer that
+ * never arrived. Wave 6-P2-11 wires the recipient side:
+ *
+ *   1. Empty/null `deps.cidFetchGateways` → still returns `false`
+ *      (retention). Operators must configure gateways to enable CID mode.
+ *   2. `fetchCarByCid` walks gateways in order, verifies CAR root CID
+ *      matches `payload.bundleCid`, returns bytes on success.
+ *   3. Recipient extracts the CAR's single root block, treats its bytes
+ *      as the same JSON envelope the inline `uxf-car` path consumes,
+ *      and runs the shared decoder → isOwnedBy → verify → persist tail.
+ *   4. Any failure downstream of the fetch (empty gateway list, all-
+ *      gateways-failed, CAR structural error) → `false` for retention.
+ *
+ * Test strategy: mock `fetchCarByCid` at the module boundary so we can
+ * return known CAR bytes (built with `@ipld/car`'s CarWriter) or force a
+ * transient error. The receive tail is exercised end-to-end.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CarWriter } from '@ipld/car';
+import { CID } from 'multiformats/cid';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+// ---------------------------------------------------------------------------
+// Mock fetchCarByCid at module boundary
+// ---------------------------------------------------------------------------
+
+const fetchCarByCidMock = vi.fn();
+vi.mock('../../../../extensions/uxf/pipeline/cid-fetcher', () => ({
+  fetchCarByCid: (...args: unknown[]) => fetchCarByCidMock(...args),
+}));
+
+// TokenRegistry — same stub as the sibling receive test.
+vi.mock('../../../../registry', () => ({
+  TokenRegistry: {
+    getInstance: () => ({
+      getDefinition: () => null,
+      getIconUrl: () => null,
+      getSymbol: (id: string) => id,
+      getName: (id: string) => id,
+      getDecimals: () => 8,
+    }),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import {
+  createPaymentsModule,
+  type PaymentsModuleDependencies,
+} from '../../../../modules/payments/PaymentsModule';
+import type {
+  FullIdentity,
+  SphereEventType,
+  SphereEventMap,
+} from '../../../../types';
+import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../../storage';
+import type {
+  TransportProvider,
+  IncomingTokenTransfer,
+  TokenTransferHandler,
+} from '../../../../transport';
+import type { OracleProvider } from '../../../../oracle';
+import type {
+  ITokenEngine,
+  SphereToken,
+  TokenBlob,
+  EngineIdentity,
+} from '../../../../token-engine';
+
+type MutableFullIdentity = { -readonly [K in keyof FullIdentity]: FullIdentity[K] };
+
+// ---------------------------------------------------------------------------
+// Fake engine (mirrors PaymentsModule.receive.v2.test.ts shape)
+// ---------------------------------------------------------------------------
+
+let tokenSeq = 0;
+function makeSphereToken(coinId: string, amount: bigint, ownerHex: string): SphereToken {
+  tokenSeq++;
+  const tokenId = `token-${tokenSeq.toString().padStart(4, '0')}`;
+  const blob: TokenBlob = {
+    v: 1,
+    network: 2,
+    tokenId,
+    token: new TextEncoder().encode(
+      JSON.stringify({ tokenId, coinId, amount: amount.toString(), owner: ownerHex }),
+    ),
+  };
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sdkToken: { tokenId, coinId, amount, ownerHex } as any,
+    blob,
+    value: { assets: [{ coinId, amount }] },
+  };
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.replace(/^0x/, '').toLowerCase();
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function makeFakeEngine(identity: EngineIdentity): ITokenEngine {
+  return {
+    getIdentity: () => identity,
+    deriveIdentityAddress: async (pubkey?: Uint8Array) =>
+      `DIRECT://${bytesToHex(pubkey ?? identity.chainPubkey).slice(0, 20)}`,
+    tokenId: (t) => t.blob.tokenId,
+    readValue: (t) => t.value,
+    balanceOf: (t, coinId) => {
+      if (!t.value) return 0n;
+      const a = t.value.assets.find((x) => x.coinId === coinId);
+      return a ? a.amount : 0n;
+    },
+    readMemo: () => null,
+    readTokenData: () => null,
+    mint: async () => { throw new Error('unused'); },
+    mintDataToken: async () => { throw new Error('unused'); },
+    transfer: async () => { throw new Error('unused'); },
+    split: async () => ({ outputs: [] }),
+    verify: async () => ({ ok: true }),
+    isSpent: async () => false,
+    isOwnedBy: (t, pubkey) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (t.sdkToken as any).ownerHex === bytesToHex(pubkey);
+    },
+    encodeToken: (t) => t.blob,
+    decodeToken: async (blob) => {
+      const parsed = JSON.parse(new TextDecoder().decode(blob.token)) as {
+        tokenId: string;
+        coinId: string;
+        amount: string;
+        owner: string;
+      };
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        sdkToken: { tokenId: parsed.tokenId, coinId: parsed.coinId, amount: BigInt(parsed.amount), ownerHex: parsed.owner } as any,
+        blob: { ...blob, tokenId: parsed.tokenId },
+        value: { assets: [{ coinId: parsed.coinId, amount: BigInt(parsed.amount) }] },
+      };
+    },
+    deliveryKeys: async (blobBytes) => {
+      const hex = bytesToHex(blobBytes).slice(0, 64).padEnd(64, '0');
+      return { tokenId: hex, stateHash: hex };
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// CAR builder — wraps a JSON envelope (same shape as inline uxf-car path
+// carBase64) as the sole block of a single-root CARv1.
+// ---------------------------------------------------------------------------
+
+const RAW_CODEC = 0x55; // multiformats raw codec
+const SHA256_CODE = 0x12;
+
+function createSha256Digest(hash: Uint8Array): { code: 0x12; size: number; digest: Uint8Array; bytes: Uint8Array } {
+  const size = hash.length;
+  const bytes = new Uint8Array(2 + size);
+  bytes[0] = SHA256_CODE;
+  bytes[1] = size;
+  bytes.set(hash, 2);
+  return { code: SHA256_CODE, size, digest: hash, bytes };
+}
+
+/**
+ * Build a real single-root CARv1 whose sole block is the JSON envelope
+ * bytes. Returns `{ carBytes, bundleCid }` — bundleCid is the CIDv1
+ * base32 (`b...`) of the block, computed as sha256(bytes) wrapped in
+ * `raw` codec.
+ */
+async function buildSingleBlockCar(envelopeBytes: Uint8Array): Promise<{
+  carBytes: Uint8Array;
+  bundleCid: string;
+}> {
+  const digest = createSha256Digest(sha256(envelopeBytes));
+  const cid = CID.createV1(RAW_CODEC, digest);
+  const { writer, out } = CarWriter.create([cid]);
+  const chunks: Uint8Array[] = [];
+  const collect = (async () => {
+    for await (const c of out) chunks.push(c);
+  })();
+  await writer.put({ cid, bytes: envelopeBytes });
+  await writer.close();
+  await collect;
+  let total = 0;
+  for (const c of chunks) total += c.length;
+  const carBytes = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    carBytes.set(c, offset);
+    offset += c.length;
+  }
+  return { carBytes, bundleCid: cid.toString() };
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const RECEIVER_PUBKEY_HEX = '02' + 'a'.repeat(64);
+const SENDER_TRANSPORT_PUBKEY = 'e'.repeat(64);
+const SENDER_DIRECT_ADDRESS = 'DIRECT://sender-original';
+
+interface Harness {
+  module: ReturnType<typeof createPaymentsModule>;
+  events: Array<{ type: SphereEventType; data: unknown }>;
+  handler: TokenTransferHandler;
+}
+
+async function makeHarness(opts: {
+  cidFetchGateways?: ReadonlyArray<string>;
+} = {}): Promise<Harness> {
+  const identity: MutableFullIdentity = {
+    chainPubkey: RECEIVER_PUBKEY_HEX,
+    directAddress: 'DIRECT://receiver-abc',
+    privateKey: '0x' + 'c'.repeat(64),
+  };
+  const storage: StorageProvider = {
+    id: 'mock-storage',
+    name: 'Mock Storage',
+    type: 'local',
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected'),
+    setIdentity: vi.fn(),
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+    has: vi.fn().mockResolvedValue(false),
+    keys: vi.fn().mockResolvedValue([]),
+    clear: vi.fn().mockResolvedValue(undefined),
+    saveTrackedAddresses: vi.fn().mockResolvedValue(undefined),
+    loadTrackedAddresses: vi.fn().mockResolvedValue([]),
+  };
+
+  let capturedHandler: TokenTransferHandler | null = null;
+  const resolveTransportPubkeyInfo = vi.fn().mockResolvedValue({
+    chainPubkey: '02' + 'e'.repeat(64),
+    transportPubkey: SENDER_TRANSPORT_PUBKEY,
+    directAddress: SENDER_DIRECT_ADDRESS,
+    timestamp: Date.now(),
+  });
+
+  const transport = {
+    id: 'mock-transport',
+    name: 'Mock Transport',
+    type: 'p2p' as const,
+    setIdentity: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as const),
+    sendMessage: vi.fn(),
+    onMessage: vi.fn().mockReturnValue(() => {}),
+    sendTokenTransfer: vi.fn(),
+    onTokenTransfer: vi.fn((h: TokenTransferHandler) => {
+      capturedHandler = h;
+      return () => { capturedHandler = null; };
+    }),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolveTransportPubkeyInfo,
+  } as unknown as TransportProvider;
+
+  const oracle = {
+    id: 'mock-oracle',
+    name: 'Mock Oracle',
+    type: 'aggregator' as const,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    getStatus: vi.fn().mockReturnValue('connected' as const),
+    initialize: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OracleProvider;
+
+  const events: Array<{ type: SphereEventType; data: unknown }> = [];
+  const emitEvent = vi.fn(<T extends SphereEventType>(type: T, data: SphereEventMap[T]) => {
+    events.push({ type, data });
+  });
+
+  const engine = makeFakeEngine({ chainPubkey: hexToBytes(RECEIVER_PUBKEY_HEX) });
+  const module = createPaymentsModule();
+  const tokenStorageProviders = new Map<string, TokenStorageProvider<TxfStorageDataBase>>();
+  const deps: PaymentsModuleDependencies = {
+    identity: identity as FullIdentity,
+    storage,
+    tokenStorageProviders,
+    transport,
+    oracle,
+    emitEvent,
+    tokenEngine: engine,
+    ...(opts.cidFetchGateways !== undefined
+      ? { cidFetchGateways: opts.cidFetchGateways }
+      : {}),
+  };
+  module.initialize(deps);
+  if (!capturedHandler) throw new Error('handler was not captured');
+  return { module, events, handler: capturedHandler };
+}
+
+function buildEnvelopeForToken(ownerHex: string): { envelopeBytes: Uint8Array; tokenId: string } {
+  const st = makeSphereToken('UCT', 100n, ownerHex);
+  const encoded = [
+    {
+      v: st.blob.v,
+      network: st.blob.network,
+      tokenId: st.blob.tokenId,
+      token: Buffer.from(st.blob.token).toString('base64'),
+    },
+  ];
+  const envelopeBytes = new TextEncoder().encode(JSON.stringify({ tokens: encoded }));
+  return { envelopeBytes, tokenId: st.blob.tokenId };
+}
+
+function buildCidIncoming(bundleCid: string, tokenIds: string[], memo?: string): IncomingTokenTransfer {
+  return {
+    id: 'nostr-cid-' + Math.random().toString(36).slice(2, 8),
+    senderTransportPubkey: SENDER_TRANSPORT_PUBKEY,
+    payload: {
+      kind: 'uxf-cid',
+      version: '1.0',
+      mode: 'instant',
+      bundleCid,
+      tokenIds,
+      sender: {
+        transportPubkey: '02' + 'e'.repeat(64),
+        nametag: 'alice',
+      },
+      ...(memo !== undefined ? { memo } : {}),
+    },
+    timestamp: Date.now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PaymentsModule receive — uxf-cid path (wave 6-P2-11)', () => {
+  beforeEach(() => {
+    tokenSeq = 0;
+    fetchCarByCidMock.mockReset();
+  });
+
+  it('happy path — fetches CAR, extracts root envelope, persists owned token', async () => {
+    const h = await makeHarness({
+      cidFetchGateways: ['https://ipfs.example', 'https://backup.example'],
+    });
+    const { envelopeBytes, tokenId } = buildEnvelopeForToken(RECEIVER_PUBKEY_HEX);
+    const { carBytes, bundleCid } = await buildSingleBlockCar(envelopeBytes);
+    fetchCarByCidMock.mockResolvedValue({ carBytes, gatewayUsed: 'https://ipfs.example' });
+
+    const durable = await h.handler(buildCidIncoming(bundleCid, [tokenId], 'INV:hash:A'));
+
+    expect(durable).toBe(true);
+    expect(fetchCarByCidMock).toHaveBeenCalledTimes(1);
+    expect(fetchCarByCidMock).toHaveBeenCalledWith(
+      bundleCid,
+      expect.objectContaining({
+        gateways: ['https://ipfs.example', 'https://backup.example'],
+        senderTransportPubkey: SENDER_TRANSPORT_PUBKEY,
+      }),
+    );
+    const tokens = h.module.getTokens();
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].coinId).toBe('UCT');
+    expect(tokens[0].amount).toBe('100');
+
+    // memo + senderNametag ride through the same tail.
+    const incoming = h.events.find((e) => e.type === 'transfer:incoming');
+    expect(incoming).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((incoming!.data as any).memo).toBe('INV:hash:A');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((incoming!.data as any).senderNametag).toBe('alice');
+  });
+
+  it('empty cidFetchGateways → returns false (retention); no fetch attempted', async () => {
+    const h = await makeHarness({ cidFetchGateways: [] });
+
+    const durable = await h.handler(buildCidIncoming('bogus-cid', ['t1']));
+
+    expect(durable).toBe(false);
+    expect(fetchCarByCidMock).not.toHaveBeenCalled();
+    expect(h.module.getTokens()).toHaveLength(0);
+  });
+
+  it('undefined cidFetchGateways (never wired) → returns false (retention)', async () => {
+    const h = await makeHarness({}); // cidFetchGateways omitted from deps entirely
+
+    const durable = await h.handler(buildCidIncoming('bogus-cid', ['t1']));
+
+    expect(durable).toBe(false);
+    expect(fetchCarByCidMock).not.toHaveBeenCalled();
+  });
+
+  it('all-gateways-failed error → returns false (retention); no crash', async () => {
+    const h = await makeHarness({
+      cidFetchGateways: ['https://ipfs.example', 'https://backup.example'],
+    });
+    fetchCarByCidMock.mockRejectedValue(
+      new Error('fetchCarByCid: all 2 gateway(s) failed for bfake123'),
+    );
+
+    const durable = await h.handler(buildCidIncoming('bfake123', ['t1']));
+
+    expect(durable).toBe(false);
+    expect(fetchCarByCidMock).toHaveBeenCalledTimes(1);
+    expect(h.module.getTokens()).toHaveLength(0);
+  });
+
+  it('CID-mismatch (bundleCid does not match CAR root) → returns false (retention)', async () => {
+    const h = await makeHarness({ cidFetchGateways: ['https://ipfs.example'] });
+    // Build a CAR whose root CID != the bundleCid we claim. Since we
+    // mock `fetchCarByCid` (which encapsulates the mismatch reject
+    // upstream), model the mismatch as fetchCarByCid throwing — which
+    // is how the real CID-mismatch path surfaces (`all-gateways-failed`
+    // classification per §9.2).
+    fetchCarByCidMock.mockRejectedValue(
+      new Error('fetchCarByCid: all 1 gateway(s) failed for bmismatch (cid-mismatch)'),
+    );
+
+    const durable = await h.handler(buildCidIncoming('bmismatch', ['t1']));
+
+    expect(durable).toBe(false);
+    expect(h.module.getTokens()).toHaveLength(0);
+  });
+
+  it('CAR with zero roots → returns false (retention)', async () => {
+    // Build a mostly-valid CAR then swap its root count via a hand-
+    // crafted invalid CAR. Simpler: mock fetchCarByCid to hand back
+    // a byte sequence that CarReader parses as multi-root (dropping to
+    // the mismatch-shaped classification is more work than the value).
+    // Instead we hand back a truncated CAR — parse throws inside our
+    // helper's try/catch, we return null → false.
+    const h = await makeHarness({ cidFetchGateways: ['https://ipfs.example'] });
+    fetchCarByCidMock.mockResolvedValue({
+      carBytes: new Uint8Array([0x00, 0x00, 0x00]), // truncated garbage
+      gatewayUsed: 'https://ipfs.example',
+    });
+
+    const durable = await h.handler(buildCidIncoming('bcid', ['t1']));
+
+    expect(durable).toBe(false);
+    expect(h.module.getTokens()).toHaveLength(0);
+  });
+
+  it('CAR root block whose bytes are not a JSON envelope → returns true (no retention, no tokens)', async () => {
+    // Successful fetch + parseable CAR whose root block contains bytes
+    // that do NOT decode as `{ tokens: [...] }`. `extractInlineTokenBlobs`
+    // returns [] on parse failure, the tail loop is a no-op, so we
+    // report `true` — the peer sent junk, retention won't fix it.
+    const h = await makeHarness({ cidFetchGateways: ['https://ipfs.example'] });
+    const junk = new TextEncoder().encode('not-a-json-envelope-at-all');
+    const { carBytes, bundleCid } = await buildSingleBlockCar(junk);
+    fetchCarByCidMock.mockResolvedValue({ carBytes, gatewayUsed: 'https://ipfs.example' });
+
+    const durable = await h.handler(buildCidIncoming(bundleCid, ['t1']));
+
+    expect(durable).toBe(true);
+    expect(h.module.getTokens()).toHaveLength(0);
+  });
+
+  it('never surfaces gateway URLs in log output on failure', async () => {
+    const h = await makeHarness({
+      cidFetchGateways: ['https://internal-sensitive.example/ipfs'],
+    });
+    // Tap the logger.warn output to assert URL redaction directly.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const longMsg = 'https://internal-sensitive.example/ipfs/bafybe... failed: '
+      + 'x'.repeat(300);
+    fetchCarByCidMock.mockRejectedValue(new Error(longMsg));
+
+    const durable = await h.handler(buildCidIncoming('bcid', ['t1']));
+
+    expect(durable).toBe(false);
+    // Ensure the transfer:incoming event did NOT fire (nothing accepted).
+    const incoming = h.events.find((e) => e.type === 'transfer:incoming');
+    expect(incoming).toBeUndefined();
+
+    // Assert no log call carries a `https://` gateway URL substring.
+    for (const call of warnSpy.mock.calls) {
+      const flat = call.map((c) => String(c)).join(' ');
+      expect(flat).not.toMatch(/https?:\/\/internal-sensitive\.example/);
+    }
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/unit/oracle/UnicityAggregatorProvider.waitForProof.v2.test.ts
+++ b/tests/unit/oracle/UnicityAggregatorProvider.waitForProof.v2.test.ts
@@ -1,0 +1,166 @@
+/**
+ * UnicityAggregatorProvider.waitForProof — Phase 6 wave-6-P2-11 coverage.
+ *
+ * Wave 6-P2-7 flagged the `waitForProof` polling loop for verification
+ * after the wave-6-P2-4a shrink dropped the v1-shaped `waitForProofSdk`
+ * twin. The loop MUST:
+ *
+ *   1. Return immediately when `getProof` yields a canonical
+ *      inclusion proof on the first call (no unnecessary sleep).
+ *   2. Poll on `pollInterval` cadence until a proof arrives or the
+ *      timeout expires — the polling loop, not the aggregator's
+ *      atomic `submitCertificationRequest` return, is the recipient's
+ *      only route to the proof for pending requestIds.
+ *   3. Throw `SphereError('TIMEOUT')` when the wall-clock deadline
+ *      elapses without a proof.
+ *   4. Emit `proof:received` on success so telemetry pickers observe
+ *      terminal transitions.
+ *   5. Invoke the optional `onPoll` callback with a 1-indexed attempt
+ *      counter that increments on every getProof() call.
+ *
+ * Test strategy: mock the SDK boundary and stub `getProof` directly on
+ * the provider so we can control per-call return values without wiring
+ * fake HTTP responses.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../../token-engine/sdk', () => {
+  class AggregatorClient {
+    getLatestBlockNumber = vi.fn().mockResolvedValue(1n);
+  }
+  class StateTransitionClient {
+    constructor(public readonly aggregator: unknown) {}
+  }
+  class RootTrustBase {
+    static fromJSON(json: unknown): RootTrustBase {
+      return new RootTrustBase(json);
+    }
+    constructor(public readonly source: unknown) {}
+  }
+  return { AggregatorClient, StateTransitionClient, RootTrustBase };
+});
+
+import { UnicityAggregatorProvider } from '../../../oracle/UnicityAggregatorProvider';
+import type { InclusionProof } from '../../../oracle/oracle-provider';
+
+function canonicalProof(requestId: string, round = 7): InclusionProof {
+  return {
+    requestId,
+    roundNumber: round,
+    proof: {
+      authenticator: { sig: 'x' },
+      merkleTreePath: { steps: [] },
+      transactionHash: '0xabc',
+      unicityCertificate: { cert: 'y' },
+    },
+    timestamp: Date.now(),
+  };
+}
+
+describe('UnicityAggregatorProvider.waitForProof (v2 slim, wave-6-P2-11)', () => {
+  let p: UnicityAggregatorProvider;
+
+  beforeEach(async () => {
+    p = new UnicityAggregatorProvider({
+      url: 'https://aggregator.example',
+      // Keep timeout low enough that fake-timer advances don't lag behind
+      // Date.now() cadence in the runner.
+      timeout: 5000,
+    });
+    await p.initialize({});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns immediately when getProof resolves on the first poll', async () => {
+    const getProof = vi
+      .spyOn(p, 'getProof')
+      .mockResolvedValue(canonicalProof('req-fast'));
+    const onPoll = vi.fn();
+
+    const proof = await p.waitForProof('req-fast', { onPoll });
+
+    expect(proof.requestId).toBe('req-fast');
+    expect(proof.roundNumber).toBe(7);
+    expect(getProof).toHaveBeenCalledTimes(1);
+    expect(onPoll).toHaveBeenCalledTimes(1);
+    expect(onPoll).toHaveBeenCalledWith(1);
+  });
+
+  it('emits proof:received on successful return', async () => {
+    vi.spyOn(p, 'getProof').mockResolvedValue(canonicalProof('req-emit'));
+    const events: string[] = [];
+    p.onEvent((e) => events.push(e.type));
+
+    await p.waitForProof('req-emit');
+
+    expect(events).toContain('proof:received');
+  });
+
+  it('polls until a proof arrives and increments attempt on every getProof call', async () => {
+    vi.useFakeTimers();
+    let callCount = 0;
+    vi.spyOn(p, 'getProof').mockImplementation(async () => {
+      callCount++;
+      if (callCount < 3) return null;
+      return canonicalProof('req-poll');
+    });
+    const onPoll = vi.fn();
+
+    const proofPromise = p.waitForProof('req-poll', {
+      timeout: 10_000,
+      pollInterval: 100,
+      onPoll,
+    });
+
+    // Two sleeps at 100 ms each between the 3 getProof calls.
+    await vi.advanceTimersByTimeAsync(250);
+    const proof = await proofPromise;
+
+    expect(proof.requestId).toBe('req-poll');
+    expect(callCount).toBe(3);
+    expect(onPoll).toHaveBeenNthCalledWith(1, 1);
+    expect(onPoll).toHaveBeenNthCalledWith(2, 2);
+    expect(onPoll).toHaveBeenNthCalledWith(3, 3);
+  });
+
+  it('throws SphereError(TIMEOUT) when the deadline elapses without a proof', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(p, 'getProof').mockResolvedValue(null);
+
+    const proofPromise = p.waitForProof('req-timeout', {
+      timeout: 200,
+      pollInterval: 50,
+    });
+    // Attach a catch handler up front so the unresolved rejection during
+    // timer advancement doesn't trip vitest's unhandled-rejection guard.
+    const settled = proofPromise.catch((e: unknown) => e);
+
+    await vi.advanceTimersByTimeAsync(500);
+    const err = await settled;
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/Timeout waiting for proof|req-timeout/);
+    // Include a defensive check against the SphereError code name.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((err as any).code ?? '').toMatch(/TIMEOUT/);
+  });
+
+  it('propagates unexpected sync throws from getProof as loop termination', async () => {
+    // Wave 6-P2-11 audit: `getProof` catches errors internally and returns
+    // null. But defensively, if a caller passes a monkey-patched getProof
+    // that throws, the polling loop MUST NOT swallow it silently — the
+    // promise should reject with the underlying error so operators see
+    // the diagnostic surface rather than an ambiguous timeout.
+    const boom = new Error('unexpected getProof exception');
+    vi.spyOn(p, 'getProof').mockRejectedValue(boom);
+
+    await expect(p.waitForProof('req-throws', { timeout: 5000 })).rejects.toThrow(
+      /unexpected getProof exception/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes 2 runtime gaps that wave 6-P2-7's coverage report flagged in the slim v2 rebuilds:

1. **`UnicityAggregatorProvider.waitForProof` polling loop** — audited, verified correct against v2's atomic `submitCertificationRequest` semantics (the polling loop is still the sole recipient path for pending requestIds). No fix required. Adds 5 unit tests locking down: immediate return, `proof:received` event emission, multi-poll cadence with `onPoll` counter, `SphereError(TIMEOUT)` on deadline, and propagation of unexpected exceptions from `getProof`.

2. **`PaymentsModule` `uxf-cid` receive path** — was rejecting every CID-by-reference envelope with `return false`, forcing the transport to retain events for a fatter consumer that never arrived. Wired the recipient side against `deps.cidFetchGateways`.

## uxf-cid receive path

- Empty/null `deps.cidFetchGateways` → keep returning `false` (retention). Operators must configure gateways to enable CID mode. **No silent drop-to-error.**
- `fetchCarByCid` (existing tested pipeline module) walks gateways in order and verifies CAR root CID matches `payload.bundleCid`.
- On successful fetch: parse CAR with `CarReader.fromBytes`, extract single root block bytes, feed through the same `extractInlineTokenBlobs` decoder the inline `uxf-car` path uses — so the downstream isOwnedBy → verify → persist tail is bit-identical.
- Fetch failures → return `false` (retention, matches existing transport contract).
- Structural CAR errors after successful fetch → return `false` (retention) so a re-fetch can retry against a healthier gateway.
- Gateway URLs are **never surfaced to logs** — error messages are URL-redacted (`https?://…` → `[gateway-redacted]`) and length-bounded before hitting `logger.warn`. Enforced by test assertion.

## Test coverage delta

- `tests/unit/oracle/UnicityAggregatorProvider.waitForProof.v2.test.ts` — 5 new tests
- `tests/unit/modules/payments/PaymentsModule.uxfCid.v2.test.ts` — 8 new tests

Total: **+13 tests**. Full suite: **441 files, 7,119 passed + 6 skipped, 0 failures**. `npx tsc --noEmit` clean.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run test:run` — 7,119 pass, 0 fail
- [x] waitForProof: happy path + multi-poll + timeout + error propagation
- [x] uxf-cid: happy path (real CAR built with `@ipld/car`), empty gateways reject, undefined gateways reject, all-gateways-failed retention, CID-mismatch retention, structural CAR failure retention, junk-envelope drop, URL redaction assertion
- [ ] Manual verification against testnet2 — deferred; recipient-side CID mode requires a sender publishing a real CID-referenced bundle