### PR TITLE
fix(payments): stop the heavy-wallet request storm — single-flight load(), incremental history hydration, client request timeout (#642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — heavy-wallet request storm (#642)
+- **`PaymentsModule.load()` is single-flight:** the 30s inventory poll backstop and the
+  `inventory` wakes funnel into `load()` via `resyncInventory()`; on a wallet whose load outlives
+  the poll interval, uncoalesced calls stacked concurrent full loads — each with its own complete
+  history hydration. Same-owner concurrent callers now share the in-flight load (plus exactly one
+  trailing re-run so a wake that raced a load still converges); a different-owner call (re-init
+  mid-load) serializes behind the stale load and runs fresh.
+- **Incremental history hydration:** after one completed hydration per owner, later pulls page
+  newest-first only until the first non-empty page with nothing new, and MERGE into the cache
+  (also preserving local entries whose §10 POST hasn't landed yet). Before, every resync
+  re-paginated from page 0 — on a wallet whose history overflows `MAX_HISTORY_HYDRATION_PAGES`
+  that was 100 `GET /v1/history` pages every 30 seconds, forever (measured: 2,646 requests in
+  8 minutes from one idle tab, 84% history pages). A pull cut off by the page cap still replaces
+  the cache (merging would hide the gap).
+- **Per-request timeout in the wallet-api client:** `WalletApiClientConfig.requestTimeoutMs`
+  (default 30 000 ms, `0` disables; plumbed through `WalletApiCompositionConfig`). A stalled
+  request aborts via `timeoutSignal()` (the #617 older-WebView guard, NOT bare
+  `AbortSignal.timeout`) and surfaces as the transient `NETWORK` class, so the #630 retry policy
+  applies unchanged (GETs retry, writes don't). Without it, requests starved by a connection-pool
+  pile-up hung indefinitely and eventually failed the background token-storage save — the
+  `storage:degraded` red-toast storm. Blob transfers and the wake socket are not governed by
+  this timeout.
+
 ### Added
 - **wallet-api client resilience (#630):** the §16 REST client now rides out transient failures
   instead of surfacing them raw. Idempotent GETs retry a dropped/reset connection (a DNS /

--- a/impl/shared/wallet-api/composition.ts
+++ b/impl/shared/wallet-api/composition.ts
@@ -105,6 +105,8 @@ export interface WalletApiCompositionConfig {
   verifyToken?: (blob: TokenBlob) => Promise<boolean>;
   /** Transient-failure retry policy for the §16 REST path (default-on; `false` disables). */
   retry?: WalletApiRetryConfig | false;
+  /** Per-request timeout in ms for the §16 REST path (#642; default 30 000, `0` disables). */
+  requestTimeoutMs?: number;
 }
 
 /** What the wallet-api presets add to the base bundle. */
@@ -138,6 +140,7 @@ function buildClient(base: SphereBaseProviders, config: WalletApiCompositionConf
       fetchFn: config.fetchFn,
       webSocketFactory: config.webSocketFactory,
       ...(config.retry !== undefined ? { retry: config.retry } : {}),
+      ...(config.requestTimeoutMs !== undefined ? { requestTimeoutMs: config.requestTimeoutMs } : {}),
     });
   return { client, stateStore };
 }

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1604,10 +1604,17 @@ export class PaymentsModule {
         // and re-init can cancel it even after the flag was consumed, and run
         // under the inventory pump health so a failure is classified
         // (quiet-then-escalate) instead of an unhandled rejection.
+        //
+        // rerunOnCoalesce=false: the re-run IS the convergence pass. If, when
+        // its macrotask fires, another load is already in flight (e.g. a poll
+        // tick started one in the gap), coalescing onto it already observes
+        // the change — requesting yet another re-run would chain into gapless
+        // back-to-back loads under slow-load regimes, the exact behavior the
+        // poll opt-out prevents.
         this.loadRerunRequested = false;
         this.loadRerunTimer = setTimeout(() => {
           this.loadRerunTimer = null;
-          this.pumpHealth.run('inventory', () => this.resyncInventory());
+          this.pumpHealth.run('inventory', () => this.resyncInventory(false));
         }, 0);
       }
     });
@@ -5009,8 +5016,10 @@ export class PaymentsModule {
 
   /**
    * Debounced inventory resync driven by an `inventory` wake — coalesces a
-   * burst of wakes into one pull. Runs the same {@link resyncInventory} as the
-   * poll backstop: a wake just makes it fire sooner.
+   * burst of wakes into one pull. Unlike the poll backstop, a wake DOES want
+   * the trailing re-run (rerunOnCoalesce=true): if it coalesces onto a load
+   * that started before the wake's change, that re-run is what converges it
+   * without waiting for the next poll tick.
    */
   private debouncedInventorySyncFromWake(): void {
     if (this.syncDebounceTimer) {
@@ -5018,7 +5027,7 @@ export class PaymentsModule {
     }
     this.syncDebounceTimer = setTimeout(() => {
       this.syncDebounceTimer = null;
-      this.pumpHealth.run('inventory', () => this.resyncInventory());
+      this.pumpHealth.run('inventory', () => this.resyncInventory(true));
     }, PaymentsModule.SYNC_DEBOUNCE_MS);
   }
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -125,6 +125,15 @@ const MAX_SYNCED_HISTORY_ENTRIES = 5000;
 const MAX_HISTORY_HYDRATION_PAGES = 100;
 
 /**
+ * Force a FULL history re-pull every N incremental pulls (#642). The
+ * incremental stop condition assumes the server's keyset order matches arrival
+ * order (append-only log); if a row ever lands "behind" already-pulled pages
+ * (backdated ts, cross-device clock skew), the periodic full pull bounds how
+ * long it can stay invisible (~N × the 30s poll interval).
+ */
+const FULL_HISTORY_REPULL_EVERY = 20;
+
+/**
  * Cap on the number of gap-free `?since=` pages pulled when rebuilding the
  * incoming payment-request view from the server on reload (the wallet-api
  * composition — the #556 reload fix). At the §16 page limit this bounds a
@@ -1048,6 +1057,36 @@ export class PaymentsModule {
   private loadedPromise: Promise<void> | null = null;
   private loaded = false;
 
+  /**
+   * #642 single-flight guard for {@link load}: the in-flight load, the owner
+   * (chainPubkey) it runs for, and whether a coalesced caller asked for one
+   * trailing re-run once it completes. The 30s inventory poll backstop and the
+   * `inventory` wakes both funnel into load() via {@link resyncInventory}; on a
+   * heavy wallet one load can outlive the poll interval, and uncoalesced calls
+   * would stack concurrent full loads — each with its own history hydration.
+   * The re-run is scheduled on a tracked macrotask (`loadRerunTimer`) so
+   * destroy()/re-init can cancel it even after the flag was consumed.
+   */
+  private loadInFlight: Promise<void> | null = null;
+  private loadInFlightOwner: string | null = null;
+  private loadRerunRequested = false;
+  private loadRerunTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Owner (chainPubkey) whose server history hydration last completed —
+   * enables the #642 incremental fast path in {@link hydrateHistoryFromServer}.
+   * Reset on re-init (address switch). `serverSeenHistoryKeys` holds only
+   * dedupKeys actually PULLED from the server (never locally-POSTed ones), so
+   * the incremental stop condition can't be masked by our own fresh POSTs;
+   * `incrementalHistoryPulls` forces a periodic full re-pull to bound the
+   * staleness window if server keyset order ever diverges from arrival order.
+   * `hydrationEpoch` guards a pull racing a same-owner re-init.
+   */
+  private historyHydratedFor: string | null = null;
+  private serverSeenHistoryKeys = new Set<string>();
+  private incrementalHistoryPulls = 0;
+  private hydrationEpoch = 0;
+
   // Storage event subscriptions (push-based sync)
   private storageEventUnsubscribers: (() => void)[] = [];
   private syncDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1198,6 +1237,15 @@ export class PaymentsModule {
     this.archivedTokens.clear();
     this.forkedTokens.clear();
     this._historyCache = [];
+    this.historyHydratedFor = null;
+    this.serverSeenHistoryKeys = new Set();
+    this.incrementalHistoryPulls = 0;
+    this.hydrationEpoch++;
+    this.loadRerunRequested = false;
+    if (this.loadRerunTimer !== null) {
+      clearTimeout(this.loadRerunTimer);
+      this.loadRerunTimer = null;
+    }
     this.nametags = [];
 
     // Reset spend queue state
@@ -1258,8 +1306,11 @@ export class PaymentsModule {
       }, DELIVERY_POLL_INTERVAL_MS);
       // Inventory poll backstop (§9): converges the owned-token set even if an
       // `inventory` wake is missed, mirroring the delivery/PR pumps' interval.
+      // rerunOnCoalesce=false: the poll's next tick IS its retry — requesting
+      // the #642 trailing re-run here would turn any load slower than the poll
+      // interval into gapless back-to-back loads.
       this.inventoryPollTimer = setInterval(() => {
-        this.pumpHealth.run('inventory', () => this.resyncInventory());
+        this.pumpHealth.run('inventory', () => this.resyncInventory(false));
       }, DELIVERY_POLL_INTERVAL_MS);
     } else {
       // Subscribe to incoming transfers
@@ -1307,7 +1358,50 @@ export class PaymentsModule {
    * triggers a fire-and-forget {@link resolveUnconfirmed} call.
    */
   async load(): Promise<void> {
+    return this.loadWith(true);
+  }
+
+  /**
+   * #642: like {@link load}, but the caller must observe storage as of NOW —
+   * it must never coalesce onto a load that began before the caller's writes
+   * (the shared snapshot would omit them, and its `loadFromStorageData` would
+   * drop them from the in-memory map). Serializes behind any in-flight load
+   * (whose failure is not this caller's) and then runs fresh.
+   */
+  private async loadFresh(): Promise<void> {
+    while (this.loadInFlight) {
+      await this.loadInFlight.catch(() => {});
+    }
+    return this.loadWith(true);
+  }
+
+  /**
+   * @param rerunOnCoalesce whether a call coalesced onto an in-flight load
+   *   should schedule the trailing re-run. The wake path and direct callers
+   *   want it (converge now, not at the next tick); the 30s poll backstop
+   *   passes `false` — its next tick IS the retry, and re-running on its
+   *   behalf would turn any load slower than the poll interval into gapless
+   *   back-to-back loads.
+   */
+  private async loadWith(rerunOnCoalesce: boolean): Promise<void> {
     this.ensureInitialized();
+
+    // #642 single-flight: coalesce same-owner callers onto the in-flight load
+    // instead of stacking concurrent full loads (each with its own history
+    // hydration — on a heavy wallet that is a 100-page storm per caller). A
+    // coalesced call schedules exactly ONE trailing re-run, so an `inventory`
+    // wake that raced a load still converges without waiting for the next
+    // 30s poll tick. A DIFFERENT-owner call (re-init mid-load) serializes
+    // behind the stale load and then runs fresh — its data must not come from
+    // a load started for the previous address.
+    const owner = this.deps!.identity.chainPubkey;
+    while (this.loadInFlight) {
+      if (this.loadInFlightOwner === owner) {
+        if (rerunOnCoalesce) this.loadRerunRequested = true;
+        return this.loadInFlight;
+      }
+      await this.loadInFlight.catch(() => {});
+    }
 
     // Expose a promise that incoming transfer handlers can await to ensure
     // the token map is populated before running dedup checks.
@@ -1475,25 +1569,49 @@ export class PaymentsModule {
       this.loaded = true;
     };
 
-    this.loadedPromise = doLoad();
-    await this.loadedPromise;
+    const run = async (): Promise<void> => {
+      this.loadedPromise = doLoad();
+      await this.loadedPromise;
 
-    // Replay finished-but-undelivered v2 blobs from a previous session
-    // (fire-and-forget; failures are kept journaled for the next load).
-    void this.replayPendingV2Deliveries().catch((err) =>
-      logger.warn('Payments', 'Pending v2 delivery replay failed:', err));
+      // Replay finished-but-undelivered v2 blobs from a previous session
+      // (fire-and-forget; failures are kept journaled for the next load).
+      void this.replayPendingV2Deliveries().catch((err) =>
+        logger.warn('Payments', 'Pending v2 delivery replay failed:', err));
 
-    // S3: drain the delivery port's incoming feed once at load (poll + wake
-    // keep it drained afterwards).
-    if (this.injectedDelivery) {
-      this.pumpHealth.run('delivery', () => this.pumpIncomingDeliveries());
-    }
+      // S3: drain the delivery port's incoming feed once at load (poll + wake
+      // keep it drained afterwards).
+      if (this.injectedDelivery) {
+        this.pumpHealth.run('delivery', () => this.pumpIncomingDeliveries());
+      }
 
-    // S4: drain the payment-request `?since=` stream once at load (the poll
-    // keeps it drained afterwards).
-    if (this.paymentRequestsApi()) {
-      this.pumpHealth.run('payment-requests', () => this.pumpPaymentRequests());
-    }
+      // S4: drain the payment-request `?since=` stream once at load (the poll
+      // keeps it drained afterwards).
+      if (this.paymentRequestsApi()) {
+        this.pumpHealth.run('payment-requests', () => this.pumpPaymentRequests());
+      }
+    };
+
+    this.loadInFlightOwner = owner;
+    this.loadInFlight = run().finally(() => {
+      this.loadInFlight = null;
+      this.loadInFlightOwner = null;
+      if (this.loadRerunRequested) {
+        // One trailing re-run on behalf of the coalesced callers, routed
+        // through resyncInventory() so the convergence it brings emits
+        // `sync:remote-update` with the re-run's actual delta (a bare load()
+        // would merge new tokens silently and the UI would not refresh until
+        // the next poll tick). Scheduled on a TRACKED macrotask so destroy()
+        // and re-init can cancel it even after the flag was consumed, and run
+        // under the inventory pump health so a failure is classified
+        // (quiet-then-escalate) instead of an unhandled rejection.
+        this.loadRerunRequested = false;
+        this.loadRerunTimer = setTimeout(() => {
+          this.loadRerunTimer = null;
+          this.pumpHealth.run('inventory', () => this.resyncInventory());
+        }, 0);
+      }
+    });
+    return this.loadInFlight;
   }
 
   /**
@@ -1503,6 +1621,14 @@ export class PaymentsModule {
    * no longer needed.
    */
   destroy(): void {
+    // A load still in flight may finish after teardown — make sure its
+    // trailing re-run (#642) does not restart work on a destroyed module,
+    // whether the flag is still pending or already consumed into the timer.
+    this.loadRerunRequested = false;
+    if (this.loadRerunTimer !== null) {
+      clearTimeout(this.loadRerunTimer);
+      this.loadRerunTimer = null;
+    }
     this.unsubscribeTransfers?.();
     this.unsubscribeTransfers = null;
     this.unsubscribePaymentRequests?.();
@@ -2974,7 +3100,9 @@ export class PaymentsModule {
     // Handlers save tokens during processing (with potentially different IDs for
     // V5 pending tokens vs finalized tokens). load() clears the in-memory map
     // and reloads from TXF + pending V5 storage, ensuring no duplicates.
-    await this.load();
+    // loadFresh (#642): must observe the handlers' saves — coalescing onto a
+    // load that started BEFORE them would drop the just-received tokens.
+    await this.loadFresh();
 
     // Identify newly added tokens
     const received: IncomingTransfer[] = [];
@@ -3900,6 +4028,13 @@ export class PaymentsModule {
    * session must not double-list). The S6 `memo` / `counterpartyNametag`
    * envelopes are decrypted with the owner's own field key on the way in.
    *
+   * #642 incremental fast path: after one completed hydration for this owner,
+   * later pulls stop at the first non-empty page holding nothing new — the
+   * §10 log is append-only (newest-first keyset), so everything past a fully
+   * known page is already cached. The steady-state 30s inventory resync then
+   * costs ONE history page instead of a full re-pagination (which on a wallet
+   * whose history overflows the page cap was 100 pages, every tick, forever).
+   *
    * Best-effort, like the §10 history POST: history is untrusted DISPLAY data,
    * so a backend outage during hydration must NEVER fail `load()` (the money
    * path) — the in-session cache is left intact and the pull retries next load.
@@ -3911,28 +4046,73 @@ export class PaymentsModule {
     // client per owner so this can't normally happen; the guard ensures a stale
     // pull never replaces the active owner's history with another owner's.
     const owner = this.deps!.identity.chainPubkey;
+    // Also guard against a SAME-owner re-init racing this pull (the epoch is
+    // bumped by initialize()): a truncated incremental prefix written after
+    // the re-init cleared the cache would otherwise be pinned as "hydrated".
+    const epoch = this.hydrationEpoch;
+    // Incremental only against dedupKeys actually PULLED from the server —
+    // a locally-POSTed key must not make a page look "fully known" before the
+    // pull has ever seen the server's copy. Bounded by the periodic full
+    // re-pull (see FULL_HISTORY_REPULL_EVERY).
+    const known = this.historyHydratedFor === owner &&
+      this.serverSeenHistoryKeys.size > 0 &&
+      this.incrementalHistoryPulls < FULL_HISTORY_REPULL_EVERY
+      ? this.serverSeenHistoryKeys
+      : null;
     const byDedupKey = new Map<string, TransactionHistoryEntry>();
+    const pulledKeys = new Set<string>();
+    // True when the pull is CONTIGUOUS with what we already hold — it reached
+    // the log's end or a fully-known page. Only then may the pulled prefix be
+    // merged into the cache; a pull cut off by the page cap must replace it
+    // instead (merging would hide the gap between the prefix and the cache).
+    let contiguous = false;
     try {
       let before: string | undefined;
       for (let page = 0; page < MAX_HISTORY_HYDRATION_PAGES; page++) {
         const result = await api.listHistory(before !== undefined ? { before } : {});
+        let unknown = 0;
         for (const wire of result.records) {
+          pulledKeys.add(wire.dedupKey);
+          if (known && !known.has(wire.dedupKey)) unknown++;
           if (!byDedupKey.has(wire.dedupKey)) {
             byDedupKey.set(wire.dedupKey, this.historyEntryFromWire(wire));
           }
         }
-        if (!result.more || result.cursor === null) break;
+        if (known && result.records.length > 0 && unknown === 0) {
+          contiguous = true;
+          break;
+        }
+        if (!result.more || result.cursor === null) {
+          contiguous = true;
+          break;
+        }
         before = result.cursor;
       }
     } catch (err) {
       logger.warn('Payments', 'history hydration from server failed (kept in-memory; retries next load):', err);
       return;
     }
-    if (this.deps!.identity.chainPubkey !== owner) {
-      logger.warn('Payments', 'history hydration owner changed mid-pull — discarding stale result (owner guard)');
+    if (this.deps!.identity.chainPubkey !== owner || this.hydrationEpoch !== epoch) {
+      logger.warn('Payments', 'history hydration owner/epoch changed mid-pull — discarding stale result (owner guard)');
       return;
     }
+    if (known && contiguous) {
+      // Merge: keep cached entries the pull stopped short of (older pages) and
+      // local-only entries whose §10 POST hasn't landed server-side yet.
+      // Display order is unaffected — getHistory() sorts by timestamp.
+      for (const e of this._historyCache) {
+        if (!byDedupKey.has(e.dedupKey)) byDedupKey.set(e.dedupKey, e);
+      }
+      this.incrementalHistoryPulls++;
+      for (const k of pulledKeys) this.serverSeenHistoryKeys.add(k);
+    } else {
+      // Full pull (or an incremental one cut off by the page cap, which
+      // degenerates to a replace): the server view IS the pulled set.
+      this.incrementalHistoryPulls = 0;
+      this.serverSeenHistoryKeys = pulledKeys;
+    }
     this._historyCache = [...byDedupKey.values()];
+    this.historyHydratedFor = owner;
   }
 
   /**
@@ -4852,9 +5032,9 @@ export class PaymentsModule {
    * `sync()` reports none). Used by BOTH the `inventory` wake and the poll
    * backstop, so convergence never depends on a wake arriving.
    */
-  private async resyncInventory(): Promise<void> {
+  private async resyncInventory(rerunOnCoalesce = true): Promise<void> {
     const before = this.tokens.size;
-    await this.load();
+    await this.loadWith(rerunOnCoalesce);
     const after = this.tokens.size;
     this.deps?.emitEvent('sync:remote-update', {
       providerId: 'wallet-api',

--- a/tests/unit/modules/PaymentsModule.history-hydration.test.ts
+++ b/tests/unit/modules/PaymentsModule.history-hydration.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Incremental history hydration (#642): the first hydration for an owner pages
+ * the §10 server log to the end; steady-state re-hydrations (the 30s inventory
+ * resync) stop at the first non-empty page holding nothing new and MERGE into
+ * the cache. Before this, every resync re-paginated from page 0 — on a wallet
+ * whose history overflows MAX_HISTORY_HYDRATION_PAGES that was 100 pages of
+ * GET /v1/history every 30 seconds, forever (the swap-wallet request storm).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createPaymentsModule, type PaymentsModule, type PaymentsModuleDependencies, type WalletApiHistoryRecord, type PaymentsWalletApiPort } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity } from '../../../types';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import { testIdentity } from '../../support/wallet-api-test-helpers';
+
+const UCT = '11'.repeat(32);
+const OWNER_A = testIdentity(81);
+const OWNER_B = testIdentity(82);
+
+function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIdentity {
+  return {
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
+    transportPubkey: id.chainPubkey.slice(2),
+  };
+}
+
+function mockStorage(): StorageProvider {
+  const s = new Map<string, string>();
+  return {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+}
+
+function mockTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn(), onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue(null), resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn(), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return { validateToken: vi.fn().mockResolvedValue({ valid: true }), isDevMode: () => false } as unknown as OracleProvider;
+}
+
+function mockLocalTokenStorage(): TokenStorageProvider<TxfStorageDataBase> {
+  return {
+    id: 'local', name: 'local', type: 'local',
+    connect: vi.fn(), disconnect: vi.fn(), isConnected: () => true,
+    getStatus: () => 'connected', setIdentity: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(true), shutdown: vi.fn(),
+    save: vi.fn(async () => ({ success: true, timestamp: 0 })),
+    load: vi.fn(async () => ({ success: false, source: 'local', timestamp: 0 })),
+    sync: vi.fn(async () => ({ success: true, added: 0, removed: 0, conflicts: 0 })),
+  } as unknown as TokenStorageProvider<TxfStorageDataBase>;
+}
+
+function record(n: number): WalletApiHistoryRecord {
+  return {
+    dedupKey: `dk-${n}`,
+    id: `h-${n}`,
+    type: 'RECEIVED',
+    ts: new Date(1_700_000_000_000 + n * 1000).toISOString(),
+    assets: [{ coinId: UCT, amount: String(n) }],
+  };
+}
+
+/**
+ * A §10 log stub paging NEWEST-FIRST over `records[0..]` with an index-based
+ * keyset cursor — exactly the listHistory contract the client provides.
+ * Prepend new records to the FRONT of `records` (newest first).
+ */
+function pagedWalletApi(records: WalletApiHistoryRecord[], pageSize: number) {
+  const listHistory = vi.fn(async (options?: { before?: string }) => {
+    const start = options?.before !== undefined ? Number(options.before) : 0;
+    const page = records.slice(start, start + pageSize);
+    const more = start + pageSize < records.length;
+    return { records: page, more, cursor: more ? String(start + pageSize) : null, syncEpoch: 0n };
+  });
+  return { listHistory, port: { listHistory } as unknown as PaymentsWalletApiPort };
+}
+
+function makeDeps(who: { privateKey: string; chainPubkey: string }, walletApi: PaymentsWalletApiPort): PaymentsModuleDependencies {
+  return {
+    identity: fullIdentity(who),
+    storage: mockStorage(),
+    tokenStorageProviders: new Map([['local', mockLocalTokenStorage()]]),
+    transport: mockTransport(),
+    oracle: mockOracle(),
+    emitEvent: vi.fn(),
+    walletApi,
+  };
+}
+
+function makeModule(deps: PaymentsModuleDependencies): PaymentsModule {
+  const module = createPaymentsModule({ l1: null });
+  module.initialize(deps);
+  cleanups.push(() => module.destroy());
+  return module;
+}
+
+const cleanups: (() => void)[] = [];
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!();
+});
+
+describe('hydrateHistoryFromServer — incremental fast path (#642)', () => {
+  it('first hydration pages to the end; a no-change resync stops at page 0', async () => {
+    const records = [5, 4, 3, 2, 1].map(record); // newest first
+    const { listHistory, port } = pagedWalletApi(records, 2);
+    const module = makeModule(makeDeps(OWNER_A, port));
+
+    await module.load();
+    expect(listHistory).toHaveBeenCalledTimes(3); // 2+2+1, paged to the end
+    expect(module.getHistory()).toHaveLength(5);
+
+    await module.load();
+    expect(listHistory).toHaveBeenCalledTimes(4); // ONE page: all known → stop
+    expect(module.getHistory()).toHaveLength(5);
+  });
+
+  it('a resync after new records pulls only until the first fully-known page and merges', async () => {
+    const records = [5, 4, 3, 2, 1].map(record);
+    const { listHistory, port } = pagedWalletApi(records, 2);
+    const module = makeModule(makeDeps(OWNER_A, port));
+    await module.load(); // 3 calls
+
+    records.unshift(record(6)); // one new entry lands server-side
+    await module.load();
+    // page 0 (dk-6, dk-5) has something new → continue; page 1 (dk-4, dk-3)
+    // fully known → stop. NOT a full re-pagination.
+    expect(listHistory).toHaveBeenCalledTimes(3 + 2);
+    const history = module.getHistory();
+    expect(history).toHaveLength(6);
+    expect(history[0].dedupKey).toBe('dk-6'); // newest first (getHistory sorts)
+  });
+
+  it('merging keeps local-only entries whose §10 POST has not landed server-side', async () => {
+    const records = [3, 2, 1].map(record);
+    const { port } = pagedWalletApi(records, 2);
+    const module = makeModule(makeDeps(OWNER_A, port));
+    await module.load();
+
+    // A local entry not (yet) on the server — e.g. its history POST failed.
+    (module as unknown as { _historyCache: unknown[] })._historyCache.push({
+      id: 'h-local', dedupKey: 'dk-local', type: 'SENT', amount: '9',
+      coinId: UCT, symbol: 'UCT', timestamp: 1_700_000_099_000,
+    });
+
+    await module.load(); // incremental resync (nothing new server-side)
+    const keys = module.getHistory().map((e) => e.dedupKey);
+    expect(keys).toContain('dk-local'); // merge preserved it
+    expect(keys).toHaveLength(4);
+  });
+
+  it('an owner switch re-initializes the fast path — the new owner gets a full hydration', async () => {
+    const recordsA = [2, 1].map(record);
+    const apiA = pagedWalletApi(recordsA, 2);
+    const module = makeModule(makeDeps(OWNER_A, apiA.port));
+    await module.load();
+    expect(apiA.listHistory).toHaveBeenCalledTimes(1);
+
+    const recordsB = [12, 11, 10].map(record);
+    const apiB = pagedWalletApi(recordsB, 1);
+    module.initialize(makeDeps(OWNER_B, apiB.port)); // address switch resets per-address state
+    await module.load();
+    expect(apiB.listHistory).toHaveBeenCalledTimes(3); // FULL pagination for the new owner
+    expect(module.getHistory()).toHaveLength(3);
+  });
+
+  it('a pull cut off by the page cap replaces (no silent gap), and the next resync is cheap again', async () => {
+    // 250 records, page size 1 → the first pull stops at the 100-page cap.
+    const records = Array.from({ length: 250 }, (_, i) => record(250 - i));
+    const { listHistory, port } = pagedWalletApi(records, 1);
+    const module = makeModule(makeDeps(OWNER_A, port));
+
+    await module.load();
+    expect(listHistory).toHaveBeenCalledTimes(100); // capped
+    expect(module.getHistory()).toHaveLength(100); // newest cap window, like before
+
+    await module.load(); // steady state: page 0 known → stop
+    expect(listHistory).toHaveBeenCalledTimes(101);
+    expect(module.getHistory()).toHaveLength(100); // merge kept the window intact
+  });
+
+  it('every 20th incremental pull is forced back to a FULL re-pull (staleness bound)', async () => {
+    const records = [5, 4, 3, 2, 1].map(record);
+    const { listHistory, port } = pagedWalletApi(records, 2);
+    const module = makeModule(makeDeps(OWNER_A, port));
+
+    await module.load(); // full: 3 pages
+    expect(listHistory).toHaveBeenCalledTimes(3);
+
+    for (let i = 0; i < 20; i++) await module.load(); // incremental: 1 page each
+    expect(listHistory).toHaveBeenCalledTimes(3 + 20);
+
+    await module.load(); // 21st resync: counter exhausted → FULL re-pagination
+    expect(listHistory).toHaveBeenCalledTimes(3 + 20 + 3);
+
+    await module.load(); // ...and the fast path resumes
+    expect(listHistory).toHaveBeenCalledTimes(3 + 20 + 3 + 1);
+  });
+
+  it('a hydration failure keeps the cache and stays on the full-pull path for the next load', async () => {
+    const records = [2, 1].map(record);
+    const { listHistory, port } = pagedWalletApi(records, 2);
+    const failing = {
+      listHistory: vi.fn(async () => { throw new Error('backend down'); }),
+    } as unknown as PaymentsWalletApiPort;
+
+    const module = makeModule(makeDeps(OWNER_A, failing));
+    await module.load(); // hydration fails, load() itself must not
+    expect(module.getHistory()).toHaveLength(0);
+
+    // Swap in a working port (same module/owner) — still a FULL pull, because
+    // the failed one never completed.
+    module.initialize(makeDeps(OWNER_A, port));
+    await module.load();
+    expect(listHistory).toHaveBeenCalledTimes(1);
+    expect(module.getHistory()).toHaveLength(2);
+  });
+});

--- a/tests/unit/modules/PaymentsModule.load-coalescing.test.ts
+++ b/tests/unit/modules/PaymentsModule.load-coalescing.test.ts
@@ -155,6 +155,25 @@ describe('PaymentsModule.load() — single-flight (#642)', () => {
     });
   });
 
+  it('the trailing re-run calls resyncInventory(false) so it cannot chain into back-to-back loads (sphere-sdk#646 review)', async () => {
+    const { provider, release } = gatedTokenStorage();
+    const { module } = makeModule(provider);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const resyncSpy = vi.spyOn(module as any, 'resyncInventory');
+
+    const p1 = module.load();
+    const p2 = module.load(); // coalesces → arms the trailing re-run
+    release();
+    await Promise.all([p1, p2]);
+
+    // The re-run is the only resyncInventory caller here (no poll timer without
+    // an injected delivery). If it fired without an explicit `false`, a re-run
+    // that coalesces onto an in-flight load would request YET another re-run —
+    // the gapless back-to-back loads the poll opt-out exists to prevent.
+    await vi.waitFor(() => expect(resyncSpy).toHaveBeenCalled());
+    expect(resyncSpy).toHaveBeenCalledWith(false);
+  });
+
   it('does not coalesce sequential calls — each load runs fresh', async () => {
     const { provider, stats, release } = gatedTokenStorage();
     const { module } = makeModule(provider);

--- a/tests/unit/modules/PaymentsModule.load-coalescing.test.ts
+++ b/tests/unit/modules/PaymentsModule.load-coalescing.test.ts
@@ -1,0 +1,237 @@
+/**
+ * load() single-flight (#642): the 30s inventory poll backstop and the
+ * `inventory` wakes call load() via resyncInventory(); on a heavy wallet one
+ * load can outlive the poll interval, and uncoalesced calls stacked concurrent
+ * full loads — each re-running the complete history hydration (the swap-wallet
+ * request storm: 84% of ~2,600 requests in 8 minutes were history pages).
+ *
+ * Same-owner concurrent calls now share the in-flight load, plus exactly ONE
+ * trailing re-run so a wake that raced a load still converges.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createPaymentsModule, type PaymentsModule, type PaymentsModuleDependencies } from '../../../modules/payments/PaymentsModule';
+import type { FullIdentity } from '../../../types';
+import type { TransportProvider } from '../../../transport';
+import type { OracleProvider } from '../../../oracle';
+import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import { testIdentity } from '../../support/wallet-api-test-helpers';
+
+const WHO = testIdentity(71);
+const OTHER = testIdentity(72);
+
+function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIdentity {
+  return {
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
+    transportPubkey: id.chainPubkey.slice(2),
+  };
+}
+
+function mockStorage(): StorageProvider {
+  const s = new Map<string, string>();
+  return {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+}
+
+function mockTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn(), onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue(null), resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn(), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return { validateToken: vi.fn().mockResolvedValue({ valid: true }), isDevMode: () => false } as unknown as OracleProvider;
+}
+
+/**
+ * A local token-storage provider whose load() blocks until `release()` —
+ * concurrency is observable through `loadCalls`/`maxConcurrent`.
+ */
+function gatedTokenStorage() {
+  let releaseAll: (() => void) | null = null;
+  const gate = new Promise<void>((resolve) => { releaseAll = resolve; });
+  const stats = { loadCalls: 0, inFlight: 0, maxConcurrent: 0 };
+  const provider = {
+    id: 'local', name: 'local', type: 'local',
+    connect: vi.fn(), disconnect: vi.fn(), isConnected: () => true,
+    getStatus: () => 'connected', setIdentity: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(true), shutdown: vi.fn(),
+    save: vi.fn(async () => ({ success: true, timestamp: 0 })),
+    load: vi.fn(async () => {
+      stats.loadCalls++;
+      stats.inFlight++;
+      stats.maxConcurrent = Math.max(stats.maxConcurrent, stats.inFlight);
+      await gate;
+      stats.inFlight--;
+      return { success: false, source: 'local', timestamp: 0 };
+    }),
+    sync: vi.fn(async () => ({ success: true, added: 0, removed: 0, conflicts: 0 })),
+    getHistoryEntries: vi.fn(async () => []),
+    addHistoryEntry: vi.fn(), hasHistoryEntry: vi.fn(async () => false),
+    clearHistory: vi.fn(), importHistoryEntries: vi.fn(async () => 0),
+  } as unknown as TokenStorageProvider<TxfStorageDataBase>;
+  return { provider, stats, release: () => releaseAll!() };
+}
+
+function makeDeps(
+  provider: TokenStorageProvider<TxfStorageDataBase>,
+  who: { privateKey: string; chainPubkey: string } = WHO,
+): PaymentsModuleDependencies {
+  return {
+    identity: fullIdentity(who),
+    storage: mockStorage(),
+    tokenStorageProviders: new Map([['local', provider]]),
+    transport: mockTransport(),
+    oracle: mockOracle(),
+    emitEvent: vi.fn(),
+  };
+}
+
+function makeModule(provider: TokenStorageProvider<TxfStorageDataBase>): {
+  module: PaymentsModule;
+  emitEvent: ReturnType<typeof vi.fn>;
+} {
+  const deps = makeDeps(provider);
+  const module = createPaymentsModule({ l1: null });
+  module.initialize(deps);
+  cleanups.push(() => module.destroy());
+  return { module, emitEvent: deps.emitEvent as ReturnType<typeof vi.fn> };
+}
+
+const cleanups: (() => void)[] = [];
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!();
+});
+
+describe('PaymentsModule.load() — single-flight (#642)', () => {
+  it('coalesces concurrent same-owner calls onto one provider load, never overlapping', async () => {
+    const { provider, stats, release } = gatedTokenStorage();
+    const { module } = makeModule(provider);
+
+    const p1 = module.load();
+    const p2 = module.load();
+    const p3 = module.load();
+    release();
+    await Promise.all([p1, p2, p3]);
+
+    expect(stats.maxConcurrent).toBe(1); // never two provider loads at once
+    // The coalesced callers scheduled exactly ONE trailing re-run.
+    await vi.waitFor(() => expect(stats.loadCalls).toBe(2));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stats.loadCalls).toBe(2); // ...and no more after it
+  });
+
+  it('the trailing re-run converges through resyncInventory — sync:remote-update fires after it', async () => {
+    const { provider, stats, release } = gatedTokenStorage();
+    const { module, emitEvent } = makeModule(provider);
+
+    const p1 = module.load();
+    const p2 = module.load(); // coalesced → requests the re-run
+    release();
+    await Promise.all([p1, p2]);
+    expect(emitEvent).not.toHaveBeenCalledWith('sync:remote-update', expect.anything());
+
+    // The re-run goes through resyncInventory(), which emits AFTER converging —
+    // a bare load() would merge silently and the UI would miss the wake.
+    await vi.waitFor(() => {
+      expect(stats.loadCalls).toBe(2);
+      expect(emitEvent).toHaveBeenCalledWith(
+        'sync:remote-update',
+        expect.objectContaining({ providerId: 'wallet-api', name: 'inventory' }),
+      );
+    });
+  });
+
+  it('does not coalesce sequential calls — each load runs fresh', async () => {
+    const { provider, stats, release } = gatedTokenStorage();
+    const { module } = makeModule(provider);
+    release(); // no gating needed here
+
+    await module.load();
+    await module.load();
+    expect(stats.loadCalls).toBe(2);
+  });
+
+  it('a coalesced caller resolves with the shared load completed (loaded state visible)', async () => {
+    const { provider, release } = gatedTokenStorage();
+    const { module } = makeModule(provider);
+
+    const p1 = module.load();
+    const p2 = module.load();
+    let p2Done = false;
+    void p2.then(() => { p2Done = true; });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(p2Done).toBe(false); // blocked on the shared in-flight load
+
+    release();
+    await Promise.all([p1, p2]);
+    expect(module.getTokens()).toEqual([]); // load completed for both callers
+  });
+
+  it('a different-owner call serializes behind the stale load and runs fresh', async () => {
+    const gatedA = gatedTokenStorage();
+    const { module } = makeModule(gatedA.provider);
+
+    const pA = module.load(); // OWNER A's load, gated
+    // Let A's load actually reach its (gated) provider call before switching.
+    await vi.waitFor(() => expect(gatedA.stats.loadCalls).toBe(1));
+
+    // Address switch mid-load: re-init with owner B and B's own provider.
+    const providerB = gatedTokenStorage();
+    providerB.release(); // B's loads answer immediately
+    module.initialize(makeDeps(providerB.provider, OTHER));
+
+    const pB = module.load();
+    let pBDone = false;
+    void pB.then(() => { pBDone = true; });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(pBDone).toBe(false); // B waits behind A's stale in-flight load
+
+    gatedA.release();
+    await Promise.all([pA, pB]);
+    expect(providerB.stats.loadCalls).toBeGreaterThanOrEqual(1); // fresh run under B
+  });
+
+  it('destroy() cancels a pending trailing re-run', async () => {
+    const { provider, stats, release } = gatedTokenStorage();
+    const { module } = makeModule(provider);
+
+    const p1 = module.load();
+    const p2 = module.load(); // marks the trailing re-run
+    module.destroy();
+    cleanups.pop(); // already destroyed
+    release();
+    await Promise.all([p1, p2]);
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stats.loadCalls).toBe(1); // no re-run fired after destroy
+  });
+
+  it('destroy() right after a completed load cancels the already-scheduled re-run (consumed flag)', async () => {
+    const { provider, stats, release } = gatedTokenStorage();
+    const { module } = makeModule(provider);
+
+    const p1 = module.load();
+    const p2 = module.load(); // marks the trailing re-run
+    release();
+    await Promise.all([p1, p2]); // finally has consumed the flag into the timer
+    module.destroy();
+    cleanups.pop(); // already destroyed
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stats.loadCalls).toBe(1); // the timer was cleared — no zombie load
+  });
+});

--- a/tests/unit/modules/PaymentsModule.wake-consumers.test.ts
+++ b/tests/unit/modules/PaymentsModule.wake-consumers.test.ts
@@ -206,7 +206,12 @@ describe('wallet-api wake streams converge a second session (§9 cross-session s
     await windowB.module.load();
     await waitFor(() => fake.socketCount(OWNER.chainPubkey) >= 1);
 
-    const loadSpy = vi.spyOn(windowB.module, 'load');
+    // #642: the wake resync runs through the internal single-flight loadWith()
+    // (public load() is now a thin wrapper) — spy where the pull actually runs.
+    const loadSpy = vi.spyOn(
+      windowB.module as unknown as { loadWith: (...args: unknown[]) => Promise<void> },
+      'loadWith',
+    );
     await seedServerToken(fake, windowB, OWNER, 500n);
     // A rapid burst — they MUST collapse to a single trailing resync.
     fake.wakeOwner(OWNER.chainPubkey, 'inventory');

--- a/tests/unit/wallet-api/client.timeout.test.ts
+++ b/tests/unit/wallet-api/client.timeout.test.ts
@@ -111,16 +111,18 @@ describe('WalletApiClient — per-request timeout (#642)', () => {
   it('still aborts on runtimes without AbortSignal.timeout (the #617 older-WebView guard)', async () => {
     // iOS 15 / older Android WebViews lack AbortSignal.timeout — the client
     // must fall back to timeoutSignal's AbortController path, not crash.
+    // Use defineProperty (not bare assignment): AbortSignal.timeout can be a
+    // non-writable own property on some runtimes, where `= undefined` throws.
+    // Mirrors tests/unit/core/timeout.test.ts.
     const original = AbortSignal.timeout;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (AbortSignal as any).timeout = undefined;
+    Object.defineProperty(AbortSignal, 'timeout', { value: undefined, configurable: true, writable: true });
     try {
       const seen: { signal?: AbortSignal }[] = [];
       const client = makeClient(stallingFetch('/v1/inventory', seen), 100);
       await expect(client.listInventory()).rejects.toMatchObject({ code: 'NETWORK' });
       expect(seen[0]?.signal).toBeInstanceOf(AbortSignal); // fallback signal supplied
     } finally {
-      AbortSignal.timeout = original;
+      Object.defineProperty(AbortSignal, 'timeout', { value: original, configurable: true, writable: true });
     }
   });
 

--- a/tests/unit/wallet-api/client.timeout.test.ts
+++ b/tests/unit/wallet-api/client.timeout.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Per-request timeout (#642): a stalled REST request must abort instead of
+ * hanging until the browser/OS gives up (during the swap-wallet request storm
+ * the starved background-save requests hung indefinitely). The abort surfaces
+ * as the transient `NETWORK` error class, so the existing retry policy applies
+ * unchanged: idempotent GETs retry, writes fail fast.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { WalletApiClient, WalletApiError } from '../../../wallet-api';
+import { FakeWalletApi } from '../../support/fake-wallet-api';
+import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
+
+type FetchLike = (
+  url: string | URL,
+  init?: { method?: string; signal?: AbortSignal }
+) => Promise<Response>;
+
+describe('WalletApiClient — per-request timeout (#642)', () => {
+  let fake: FakeWalletApi;
+  let baseUrl: string;
+  const identity = testIdentity(61);
+
+  const realFetch: FetchLike = (u, init) =>
+    (globalThis as unknown as { fetch: FetchLike }).fetch(u, init);
+
+  /** A fetch that never answers on `stallPath` but honors the abort signal —
+   *  exactly how native fetch behaves on a stalled socket. */
+  function stallingFetch(stallPath: string, seen: { signal?: AbortSignal }[]): FetchLike {
+    return (u, init) => {
+      if (String(u).includes(stallPath)) {
+        seen.push({ signal: init?.signal });
+        return new Promise((_, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(init.signal!.reason), { once: true });
+        });
+      }
+      return realFetch(u, init);
+    };
+  }
+
+  function makeClient(fetchFn: FetchLike, requestTimeoutMs?: number): WalletApiClient {
+    const client = new WalletApiClient({
+      baseUrl,
+      network: fake.network,
+      deviceId: 'dev-timeout',
+      storage: new MemoryKeyValueStore(),
+      fetchFn: fetchFn as never,
+      ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
+      retry: false, // isolate the timeout behavior from the retry policy
+    });
+    client.setIdentity(identity);
+    return client;
+  }
+
+  beforeEach(async () => {
+    fake = new FakeWalletApi();
+    baseUrl = await fake.start();
+  });
+  afterEach(async () => {
+    await fake.stop();
+  });
+
+  it('aborts a stalled GET after the configured timeout and surfaces NETWORK', async () => {
+    const seen: { signal?: AbortSignal }[] = [];
+    const client = makeClient(stallingFetch('/v1/inventory', seen), 100);
+
+    const started = Date.now();
+    await expect(client.listInventory()).rejects.toMatchObject({ code: 'NETWORK' });
+    expect(Date.now() - started).toBeLessThan(5_000); // aborted, not hung
+    expect(seen[0]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('retries a timed-out GET like any transient NETWORK failure', async () => {
+    let stalls = 1; // stall the first attempt, answer the second
+    const seen: { signal?: AbortSignal }[] = [];
+    const stalling = stallingFetch('/v1/inventory', seen);
+    const fetchFn: FetchLike = (u, init) => {
+      if (String(u).includes('/v1/inventory') && stalls-- > 0) return stalling(u, init);
+      return realFetch(u, init);
+    };
+    const client = new WalletApiClient({
+      baseUrl,
+      network: fake.network,
+      deviceId: 'dev-timeout-retry',
+      storage: new MemoryKeyValueStore(),
+      fetchFn: fetchFn as never,
+      requestTimeoutMs: 100,
+      retry: { maxAttempts: 2, baseMs: 1, capMs: 1 },
+    });
+    client.setIdentity(identity);
+
+    const page = await client.listInventory();
+    expect(page.items).toEqual([]); // recovered on the retry
+  });
+
+  it('passes no signal when the timeout is disabled (0)', async () => {
+    const seen: { signal?: AbortSignal }[] = [];
+    let answered = false;
+    const fetchFn: FetchLike = (u, init) => {
+      if (String(u).includes('/v1/inventory') && !answered) {
+        answered = true;
+        seen.push({ signal: init?.signal });
+      }
+      return realFetch(u, init);
+    };
+    const client = makeClient(fetchFn, 0);
+
+    await client.listInventory();
+    expect(seen[0]?.signal).toBeUndefined();
+  });
+
+  it('still aborts on runtimes without AbortSignal.timeout (the #617 older-WebView guard)', async () => {
+    // iOS 15 / older Android WebViews lack AbortSignal.timeout — the client
+    // must fall back to timeoutSignal's AbortController path, not crash.
+    const original = AbortSignal.timeout;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (AbortSignal as any).timeout = undefined;
+    try {
+      const seen: { signal?: AbortSignal }[] = [];
+      const client = makeClient(stallingFetch('/v1/inventory', seen), 100);
+      await expect(client.listInventory()).rejects.toMatchObject({ code: 'NETWORK' });
+      expect(seen[0]?.signal).toBeInstanceOf(AbortSignal); // fallback signal supplied
+    } finally {
+      AbortSignal.timeout = original;
+    }
+  });
+
+  it('sanitizes a nonsensical timeout back to the default instead of hanging or throwing', async () => {
+    // NaN must not silently disable the timeout (NaN > 0 is false — it would).
+    const seen: { signal?: AbortSignal }[] = [];
+    const fetchFn: FetchLike = (u, init) => {
+      if (String(u).includes('/v1/inventory') && seen.length === 0) {
+        seen.push({ signal: init?.signal });
+      }
+      return realFetch(u, init);
+    };
+    const client = makeClient(fetchFn, Number.NaN);
+
+    await client.listInventory();
+    expect(seen[0]?.signal).toBeInstanceOf(AbortSignal); // default applied
+  });
+});

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -30,6 +30,7 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 
 import { signMessage } from '../core/crypto';
+import { timeoutSignal } from '../core/timeout';
 import { completeSignMessage, progressSignMessage } from './intent-signing';
 import { WalletApiError } from './errors';
 import { verifyChallengeTemplate } from './challenge';
@@ -184,6 +185,13 @@ const DEFAULT_RETRY: ResolvedRetryConfig = {
   maxRetryAfterMs: 60_000,
 };
 
+/**
+ * Default per-request timeout for the §16 REST path (#642). Generous — a JSON
+ * page normally answers in well under a second; this only cuts off requests
+ * that would otherwise hang indefinitely on a stalled socket.
+ */
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
 /** A finite number ≥ `min`, else `fallback` — sanitizes the public retry config. */
 function finiteAtLeast(value: number | undefined, fallback: number, min: number): number {
   return typeof value === 'number' && Number.isFinite(value) && value >= min ? value : fallback;
@@ -219,6 +227,8 @@ export class WalletApiClient {
   private readonly wsFactory: WebSocketFactoryLike;
   private readonly now: () => number;
   private readonly retry: ResolvedRetryConfig;
+  /** Per-request timeout in ms for the §16 REST path (#642); `0` disables. */
+  private readonly requestTimeoutMs: number;
 
   private identity: WalletApiIdentity | null = null;
   private jwt: string | null = null;
@@ -255,6 +265,7 @@ export class WalletApiClient {
     this.wsFactory = config.webSocketFactory ?? defaultWebSocketFactory;
     this.now = config.now ?? (() => Date.now());
     this.retry = resolveRetry(config.retry);
+    this.requestTimeoutMs = finiteAtLeast(config.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS, 0);
     this.config = config;
   }
 
@@ -445,6 +456,13 @@ export class WalletApiClient {
         method,
         headers,
         body: body !== undefined ? JSON.stringify(body) : undefined,
+        // #642: a stalled request must not hang until the browser/OS gives up
+        // (under a connection-pool pile-up that is effectively forever). The
+        // abort lands in the catch below as the transient NETWORK class, so
+        // the retry policy applies unchanged (GETs retry, writes don't).
+        // timeoutSignal, NOT bare AbortSignal.timeout — the #617 older-WebView
+        // guard (iOS 15 / older Android WebViews lack AbortSignal.timeout).
+        signal: this.requestTimeoutMs > 0 ? timeoutSignal(this.requestTimeoutMs) : undefined,
       });
     } catch (err) {
       throw new WalletApiError(`wallet-api request failed: ${method} ${path}`, 'NETWORK', undefined, err);

--- a/wallet-api/types.ts
+++ b/wallet-api/types.ts
@@ -28,6 +28,12 @@ export type FetchLike = (url: string, init?: {
   method?: string;
   headers?: Record<string, string>;
   body?: string | Uint8Array;
+  /**
+   * Request-timeout abort (#642). Native `fetch` honors it; a test double that
+   * ignores it simply behaves like a pre-timeout client (hangs), so doubles
+   * exercising timeout behavior MUST observe it.
+   */
+  signal?: AbortSignal;
 }) => Promise<FetchResponseLike>;
 
 /**
@@ -99,6 +105,16 @@ export interface WalletApiClientConfig {
    * `false` to disable (a single attempt). See {@link WalletApiRetryConfig}.
    */
   retry?: WalletApiRetryConfig | false;
+  /**
+   * Per-request timeout for the §16 REST path in ms (#642; default 30 000,
+   * `0` disables). Without it a stalled request hangs until the browser/OS
+   * gives up — under a connection-pool pile-up that is effectively forever. A
+   * timeout aborts the fetch and surfaces as the transient `NETWORK` error
+   * class, so the retry policy applies unchanged (GETs retry, writes don't).
+   * Blob transfers (presigned S3 URLs) and the wake socket are NOT governed by
+   * this — large blobs may legitimately stream longer.
+   */
+  requestTimeoutMs?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #642.

## What

Three changes, one per defect in the issue's causal chain:

1. **`PaymentsModule.load()` is single-flight.** Same-owner concurrent callers coalesce onto the in-flight load instead of stacking full loads. A coalesced caller schedules exactly **one** trailing re-run — on a tracked macrotask (cancelled by `destroy()` and re-init, even after the flag is consumed) and routed through `resyncInventory()` so the convergence it brings emits `sync:remote-update` with the re-run's actual delta (a bare `load()` would merge new tokens silently and the UI wouldn't refresh until the next tick). The 30s poll backstop opts out of the re-run — its next tick *is* the retry; requesting one would turn any load slower than the poll interval into gapless back-to-back loads. A **different-owner** call (re-init mid-load) serializes behind the stale load and runs fresh. `receive()` uses a never-coalescing `loadFresh()` — it must observe the handlers' just-saved tokens, and coalescing onto a load that began before them would drop them from its result.

2. **Incremental history hydration.** After one completed hydration per owner, later pulls page newest-first only until the first non-empty page containing no *server-unseen* dedupKeys, then **merge** into the cache (preserving local entries whose §10 POST hasn't landed). The stop set is only dedupKeys actually **pulled** from the server — a locally-POSTed key must not mask never-pulled records from another device. A pull cut off by the page cap still **replaces** (merging would hide the gap). A full re-pull is forced every 20 incremental pulls, bounding staleness if server keyset order ever diverges from arrival order (backdated rows). A hydration epoch (bumped on re-init) extends the #583 owner guard to same-owner re-init races.

3. **Per-request timeout in `WalletApiClient`.** `requestTimeoutMs` (default 30 000 ms, `0` disables; plumbed through `WalletApiCompositionConfig`), implemented with `timeoutSignal()` — the **#617 older-WebView guard**, not bare `AbortSignal.timeout` (iOS 15 / older Android WebViews lack it). A timeout surfaces as the transient `NETWORK` class, so the #630 retry policy applies unchanged (GETs retry, writes don't). Blob transfers (presigned S3) and the wake socket are intentionally not governed by it.

## Why (measured)

Restoring a real testnet2 wallet whose history overflows `MAX_HISTORY_HYDRATION_PAGES` (instrumented Chromium against production wallet-api): **2,646 requests in 8 minutes from one idle tab, 84% `GET /v1/history`** — a fresh 100-page hydration burst every 30.0s forever, with bursts of 200–300 pages where 2–3 uncoalesced loads overlapped. Under production latency the storm starves the per-token background saves into socket-level failures (`wallet-api request failed: GET /v1/inventory?since=…`, no HTTP status), and each failed save emits `storage:degraded` — the 2026-07-07 red-toast/Sentry storm (sphere SPHERE-2/-3). With this PR the steady-state resync costs ~1 history page instead of 100, loads never stack, and a starved request aborts into the existing retry policy instead of hanging.

## Test plan

- `npm run test:run` — 200 files, 3,029 tests green (typecheck, lint, build also green).
- New: `PaymentsModule.load-coalescing.test.ts` (7 — coalescing, never-overlapping, re-run emits `sync:remote-update` after convergence, sequential no-coalesce, different-owner serialization, destroy cancels the re-run both before and after flag consumption), `PaymentsModule.history-hydration.test.ts` (7 — full-then-incremental page counts, merge with new records, local-only preservation, owner-switch reset, page-cap replace, periodic full re-pull, failure keeps cache), `client.timeout.test.ts` (5 — abort surfaces NETWORK, timed-out GET retries, `0` disables, NaN sanitized to default, `AbortSignal.timeout`-less runtime falls back).
- Updated: `PaymentsModule.wake-consumers.test.ts` burst-debounce spy targets the internal `loadWith()` (public `load()` is now a wrapper); assertion strength unchanged.
- One pre-existing behavior intentionally kept: a first hydration cut by the 100-page cap still truncates to the newest window (now it at least stops re-downloading it every 30s).

## Notes

- `resyncInventory()` still runs a full `load()` per tick; with hydration now incremental that's ~a handful of requests. Making the poll a pure inventory delta (skipping provider `load()`/crash-recovery re-scan) is a possible follow-up, tracked in #642's follow-up list along with batching the per-incoming-token save pipeline and edge-triggering `storage:degraded`.
