### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sphere SDK
 
+[![Listed on TakoAPI](https://takoapi.com/api/badge/unicity-sphere-sphere-sdk)](https://takoapi.com/agents/unicity-sphere-sphere-sdk)
+
 A modular TypeScript SDK for Unicity wallet operations on Layer 3 (Unicity state transition network).
 
 ## Features


### PR DESCRIPTION
Hi! 👋 **sphere-sdk** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/unicity-sphere-sphere-sdk

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building sphere-sdk! 🙏