### PR TITLE
Wave 6-P2-15: await ensureTokenEngine before background nametag mints

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -1600,6 +1600,10 @@ export class Sphere {
     if (sphere._identity?.nametag && !sphere._payments.hasNametag()) {
       progress?.({ step: 'registering_nametag', message: 'Restoring nametag token...' });
       logger.debug('Sphere', `Unicity ID @${sphere._identity.nametag} has no token, attempting to mint...`);
+      // Phase 6-P2-15: ensure v2 engine is ready before minting — this
+      // background retry runs off Sphere.init but predates the trust-base
+      // fetch settling on slow networks.
+      await sphere.ensureTokenEngine();
       try {
         const result = await sphere.mintNametag(sphere._identity.nametag);
         if (result.success) {

--- a/core/sphere-addresses.ts
+++ b/core/sphere-addresses.ts
@@ -498,6 +498,12 @@ export async function postSwitchSyncImpl(
 
     if (!host._payments.hasNametag()) {
       logger.debug('Sphere', `Minting nametag token for @${newNametag}...`);
+      // Phase 6-P2-15: ensure v2 token engine is ready before minting.
+      // `postSwitchSync` runs detached from `switchToAddress`, so it can
+      // race the async trust-base fetch on first init. Without this
+      // await the mint fires with `deps.tokenEngine === null` and
+      // returns "Token engine not available".
+      await host.ensureTokenEngine();
       try {
         const result = await host.mintNametag(newNametag);
         if (result.success) {
@@ -517,6 +523,8 @@ export async function postSwitchSyncImpl(
   } else if (host._identity?.nametag && !host._payments.hasNametag()) {
     // Existing address with nametag but missing token — mint it
     logger.debug('Sphere', `Unicity ID @${host._identity.nametag} has no token after switch, minting...`);
+    // Phase 6-P2-15: same rationale as above — ensure v2 engine ready.
+    await host.ensureTokenEngine();
     try {
       const result = await host.mintNametag(host._identity.nametag);
       if (result.success) {


### PR DESCRIPTION
**Fix:** 3 background nametag-mint sites in `core/Sphere.ts` and `core/sphere-addresses.ts` were racing the async trust-base fetch on cold init, resulting in `Could not mint nametag token: Token engine not available` warnings.

Uncovered while running trader-roundtrip against v2 — multi-wallet flows are especially prone to the race.

Each site now `await sphere.ensureTokenEngine()` (idempotent) before minting.

**No behavior change** on warm cache. Cold-start now waits instead of dropping the mint.