### PR TITLE
Wave 6-P2-21: register invoice token in payments after createInvoice

### DIFF
--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -476,6 +476,37 @@ export class AccountingModule {
         token: Buffer.from(blob.token).toString('base64'),
       };
 
+      // Phase-6 UXF v2 fork: register the invoice token in payments so
+      // `sphere.payments.getToken(invoiceId)` returns it. This preserves
+      // the cross-process contract used by escrow-service (and any other
+      // module that treats the invoice as a first-class token) — without
+      // this registration, `payments.getToken(invoiceId)` returns
+      // undefined and the caller can't reach the sdkData envelope after
+      // createInvoice returns.
+      try {
+        const nowMs = Date.now();
+        const uiToken: import('../../types').Token = {
+          id: invoiceId,
+          coinId: '',
+          symbol: 'INVOICE',
+          name: 'Invoice',
+          decimals: 0,
+          amount: '0',
+          status: 'confirmed',
+          createdAt: nowMs,
+          updatedAt: nowMs,
+          sdkData: JSON.stringify(token),
+        };
+        await deps.payments.addToken(uiToken);
+      } catch (err) {
+        // Non-fatal — the invoice itself is minted successfully. Log
+        // and continue so callers still get the token via the return.
+        logger.warn(
+          LOG_TAG,
+          `createInvoice: failed to register invoice token in payments: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
       // Emit event and hand back result.
       deps.emitEvent('invoice:created', { invoiceId, confirmed: true });
 


### PR DESCRIPTION
Restores cross-process invoice access via `sphere.payments.getToken(invoiceId)`. Required for escrow-service to deliver deposit invoices to payer parties.

**Root cause:** v2 slim `createInvoice` returned the invoice but never registered it in payments.tokens. Escrow's `getDepositInvoiceToken()` looks it up via `payments.getToken(invoiceId)` → undefined → `deliver_deposit_invoice_no_token` → swap cancels.

**Fix:** post-mint, wrap the envelope in a v2 UI Token (coinId='', amount='0' as a data token) with sdkData=envelope JSON and register via `deps.payments.addToken()`.

Uncovered while running trader-roundtrip on v2 with a local v2-rebuilt escrow tenant.