### PR TITLE
feat(oracle): setOracleApiKey — re-key the live token engine without a full re-init

### DIFF
--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -1568,6 +1568,29 @@ export class Sphere {
   }
 
   /**
+   * Apply a new gateway API key to the LIVE oracle + token engine WITHOUT a full
+   * Sphere rebuild (transport / realtime socket / discovery stay up). Use this to
+   * inject a per-wallet subscription key provisioned AFTER init, or a per-address
+   * key on an address switch, so the next money operation authenticates with it.
+   *
+   * Money-safety: the running token engine is snapshotted per-operation (the
+   * payments module reads `deps.tokenEngine` into a local at op start), so an
+   * in-flight send/mint completes on the OLD key (submit + proof stay paired on
+   * one client) and only operations started AFTER this call use the new key.
+   * Only the ACTIVE address's engine is rebuilt — other tracked addresses re-key
+   * on their next switch/build. No-op-safe if the engine can't be built (the
+   * modules fall back to their legacy path, same as init).
+   */
+  async setOracleApiKey(apiKey: string): Promise<void> {
+    this._oracle.setApiKey?.(apiKey);
+    // Rebuild ONLY the token engine (buildTokenEngine reads getApiKey() fresh)
+    // and swap it into the live payments module — no transport/socket/storage
+    // teardown, unlike a full re-init.
+    this._tokenEngine = await this.buildTokenEngine();
+    this._payments.setTokenEngine(this._tokenEngine);
+  }
+
+  /**
    * Check if wallet has BIP32 master key for HD derivation
    */
   hasMasterKey(): boolean {

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1201,6 +1201,18 @@ export class PaymentsModule {
   // ===========================================================================
 
   /**
+   * Swap the live token engine WITHOUT re-initializing the module — used by
+   * `Sphere.setOracleApiKey()` after it rebuilds the engine with a new gateway
+   * key. Operations snapshot `this.deps.tokenEngine` into a local at their start
+   * (see send/mint/split), so an in-flight op finishes on the PREVIOUS engine
+   * (submit + proof stay paired); only ops started after this use the new one.
+   */
+  setTokenEngine(engine?: ITokenEngine): void {
+    if (this.deps) this.deps.tokenEngine = engine;
+    this.spendPlanner.setEngine(engine);
+  }
+
+  /**
    * Initialize module with dependencies
    */
   initialize(deps: PaymentsModuleDependencies): void {

--- a/oracle/UnicityAggregatorProvider.ts
+++ b/oracle/UnicityAggregatorProvider.ts
@@ -108,6 +108,17 @@ export class UnicityAggregatorProvider implements OracleProvider {
     return this.config.apiKey || undefined;
   }
 
+  /**
+   * Update the API key on this live provider. The v2 token engine snapshots the
+   * key at build time, so this alone does NOT change money operations already
+   * wired into a running engine — `Sphere.setOracleApiKey()` rebuilds the engine
+   * for that. Paths that read `getApiKey()` fresh (e.g. the Unicity-ID minter)
+   * pick up the new value immediately.
+   */
+  setApiKey(apiKey: string): void {
+    this.config.apiKey = apiKey ?? '';
+  }
+
   // ===========================================================================
   // BaseProvider Implementation
   // ===========================================================================

--- a/oracle/oracle-provider.ts
+++ b/oracle/oracle-provider.ts
@@ -45,6 +45,15 @@ export interface OracleProvider extends BaseProvider {
 
   /** Gateway API key, when the gateway requires one (e.g. testnet2). */
   getApiKey(): string | undefined;
+
+  /**
+   * Update the gateway API key on a LIVE provider (optional). Lets a consumer
+   * swap the key (e.g. a per-wallet subscription key provisioned after init)
+   * WITHOUT rebuilding the whole Sphere. Note: the token engine snapshots the
+   * key when it is built, so the caller must rebuild the engine for the change
+   * to reach money operations — use `Sphere.setOracleApiKey()`, which does both.
+   */
+  setApiKey?(apiKey: string): void;
 }
 
 // =============================================================================

--- a/tests/unit/oracle/UnicityAggregatorProvider.test.ts
+++ b/tests/unit/oracle/UnicityAggregatorProvider.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { UnicityAggregatorProvider } from '../../../oracle/UnicityAggregatorProvider';
+
+/**
+ * Runtime API-key swap on the oracle (feat: oracle-api-key-setter). Lets a
+ * consumer inject a per-wallet subscription key provisioned AFTER init without
+ * rebuilding the whole Sphere. (Sphere.setOracleApiKey() rebuilds the token
+ * engine so the change also reaches money ops — covered by Sphere/PaymentsModule
+ * tests; here we lock the provider-level accessor.)
+ */
+describe('UnicityAggregatorProvider.setApiKey', () => {
+  const make = (apiKey?: string) =>
+    new UnicityAggregatorProvider({ url: 'https://gateway.example', apiKey });
+
+  it('updates the live key read by getApiKey()', () => {
+    const p = make('sk_old');
+    expect(p.getApiKey()).toBe('sk_old');
+    p.setApiKey('sk_new');
+    expect(p.getApiKey()).toBe('sk_new');
+  });
+
+  it('can set a key on a provider that started without one', () => {
+    const p = make();
+    expect(p.getApiKey()).toBeUndefined();
+    p.setApiKey('sk_first');
+    expect(p.getApiKey()).toBe('sk_first');
+  });
+
+  it('an empty key clears back to undefined (no auth header)', () => {
+    const p = make('sk_old');
+    p.setApiKey('');
+    expect(p.getApiKey()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Part of the Sphere keyless-send-window fix (layer 5). Lets the wallet apply a
per-wallet subscription key provisioned AFTER init **without rebuilding the whole
Sphere** (transport / realtime socket / discovery stay up).

## Why

The token engine snapshots the gateway API key at build time — `AggregatorClient.key`
is `readonly`. So today a consumer that provisions a subscription key post-init must
full-re-init the Sphere just to apply it (transport/socket/discovery churn).

## What

- `OracleProvider.setApiKey?(key)` (impl in `UnicityAggregatorProvider`) — mutates the
  held key; paths that read `getApiKey()` fresh (e.g. the Unicity-ID minter) pick it up.
- `PaymentsModule.setTokenEngine(engine)` — swap the live engine without re-init.
- `Sphere.setOracleApiKey(key)` — sets the provider key, rebuilds **only** the token
  engine (`buildTokenEngine` reads `getApiKey()` fresh) and swaps it into payments.

## Money-safety

Operations snapshot `deps.tokenEngine` into a local at op start (send/mint/split), so
an **in-flight op finishes on the previous engine** (submit + proof stay paired on one
client); only ops started **after** the swap use the new key. Only the active address's
engine is rebuilt — other tracked addresses re-key on their next switch/build.

## Test plan

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `UnicityAggregatorProvider.setApiKey` unit test — passing
- `npm run build` — OK (dist + DTS)

## ⚠️ Do not merge yet

Part of a two-repo feature — hold until the Sphere consumer (replacing 4 full re-inits
with `setOracleApiKey`) is done and both are validated together.