### PR TITLE
fix(ci): bump publish + CI to Node 24 LTS so npm@latest (npm 12) works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22]
+        # Supported range per package.json engines (>=22): the 22 LTS floor and
+        # the current 24 "Krypton" LTS. (20 is below the engine floor.)
+        node-version: [22, 24]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          # Current Node LTS (24 "Krypton"). Supports `npm@latest` (npm 12+,
+          # engine ^22.22.2 || ^24.15 || >=26); the old pin 22.14.0 broke publish
+          # with EBADENGINE once npm 12 shipped.
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
 


### PR DESCRIPTION
## Problem

`publish.yml` pins Node **22.14.0** and then runs `npm install -g npm@latest` (step *"Upgrade npm for OIDC trusted publishing"*). npm just released **12.0.0**, whose engine is `^22.22.2 || ^24.15 || >=26`. Node 22.14.0 no longer satisfies it → **EBADENGINE** → the publish job exits 1, blocking **every** release (hit trying to cut 0.11.6).

## Fix — move to the current toolchain (don't pin npm back)

- **publish.yml**: Node `22.14.0` → **`24`** (current "Krypton" LTS; satisfies npm 12's `^24.15`). Keeps `npm@latest` so OIDC trusted publishing stays on the newest npm.
- **ci.yml**: matrix `[20, 22]` → **`[22, 24]`** — aligns with `package.json` engines (`>=22.0.0`, so Node 20 was below the floor) and validates the current LTS that publish now uses.

Pure CI/release hardening — no product change. Node 24 is within the SDK's declared engine range, and the publish job runs the full test suite on it before publishing.