### PR TITLE
fix(wallet-api): validate auth challenge against server timestamps only, not the device clock

### DIFF
--- a/tests/unit/wallet-api/client.auth.test.ts
+++ b/tests/unit/wallet-api/client.auth.test.ts
@@ -79,14 +79,18 @@ describe('WalletApiClient — auth (§4)', () => {
     expect(fake.verifyRequests).toBe(0);
   });
 
-  it('refuses a challenge with implausible timestamps', async () => {
+  it('signs a challenge whose (server) timestamps are far from the device clock (#662)', async () => {
+    // A device clock skewed by decades vs the server-issued timestamps must NOT
+    // block sign-in: the window is well-formed and the server is authoritative
+    // on expiry. Previously this threw a client-side "expired" and locked the
+    // user out of every send.
     fake.tamperNextChallenge((c) =>
       c
         .replace(/"issuedAt":"[^"]*"/, '"issuedAt":"1970-01-01T00:00:00.000Z"')
         .replace(/"expiresAt":"[^"]*"/, '"expiresAt":"1970-01-01T00:05:00.000Z"')
     );
-    await expect(client.signIn()).rejects.toThrowError(/expired/);
-    expect(fake.verifyRequests).toBe(0);
+    await expect(client.signIn()).resolves.toBeUndefined();
+    expect(fake.verifyRequests).toBe(1); // proceeded to verify; server decides expiry
   });
 
   it('silently refreshes (with rotation) when the access token expires', async () => {
@@ -175,6 +179,24 @@ describe('verifyChallengeTemplate — direct edge cases (S1)', () => {
   it('rejects an implausible validity window', () => {
     const longWindow = challengeJson({ expiresAt: '2026-06-13T12:00:00.000Z' });
     expect(() => verifyChallengeTemplate(longWindow, expect4)).toThrowError(/window/);
+  });
+
+  it('accepts server timestamps regardless of device clock skew (#662)', () => {
+    // Device clock 10 min FAST (nowMs well past expiresAt): must NOT throw
+    // "expired" — the server enforces expiry, not the device.
+    const fast = { ...expect4, nowMs: Date.parse('2026-06-11T12:14:00.000Z') };
+    expect(() => verifyChallengeTemplate(valid, fast)).not.toThrow();
+    // Device clock 10 min SLOW (issuedAt appears "in the future"): must NOT throw.
+    const slow = { ...expect4, nowMs: Date.parse('2026-06-11T11:49:00.000Z') };
+    expect(() => verifyChallengeTemplate(valid, slow)).not.toThrow();
+    // nowMs omitted entirely: still fine (field is deprecated/ignored).
+    const noClock = { pubkey: identity.chainPubkey, nonce: 'abc123', network: 'testnet2' };
+    expect(() => verifyChallengeTemplate(valid, noClock)).not.toThrow();
+  });
+
+  it('still rejects a non-positive validity window using server timestamps only', () => {
+    const inverted = challengeJson({ issuedAt: '2026-06-11T12:04:00.000Z', expiresAt: '2026-06-11T12:00:00.000Z' });
+    expect(() => verifyChallengeTemplate(inverted, expect4)).toThrowError(/window/);
   });
 
   it('throws the typed error', () => {

--- a/wallet-api/challenge.ts
+++ b/wallet-api/challenge.ts
@@ -7,8 +7,18 @@
  *   1. begins with the fixed domain-separation prefix
  *      `unicity:wallet-api:auth:v1\n`;
  *   2. embeds the client's OWN pubkey (and the nonce returned alongside it);
- *   3. carries plausible timestamps (`issuedAt` near now, `expiresAt` in the
- *      future, a sane validity window).
+ *   3. carries a structurally sane validity window (`issuedAt < expiresAt`,
+ *      window ≤ `MAX_VALIDITY_WINDOW_MS`), using ONLY the server's own
+ *      timestamps — NOT the local device clock (#662).
+ *
+ * Why not gate on the device clock: the challenge is fetched and signed
+ * immediately, and the server authoritatively enforces expiry on
+ * `/v1/auth/verify`. Comparing the server's `issuedAt`/`expiresAt` against the
+ * device's `now` only produced false rejections — a clock off by more than a
+ * few minutes (dead RTC, wrong date, bad NTP) failed EVERY sign-in with
+ * "Challenge is already expired", a hard send blocker with no security
+ * benefit. The anti-forgery property ("never sign arbitrary server text")
+ * comes entirely from the prefix + pubkey + nonce + network binding below.
  *
  * The accepted grammar matches the REAL backend (wallet-api M1,
  * src/auth/service.ts): the prefix followed by a single-line JSON object with
@@ -23,9 +33,6 @@ import { ChallengeTemplateError } from './errors';
 /** Fixed domain-separation prefix (ARCHITECTURE §4 step 1). */
 export const AUTH_CHALLENGE_PREFIX = 'unicity:wallet-api:auth:v1\n';
 
-/** Allowed clock skew between client and server (ms). */
-const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
-
 /** Maximum plausible challenge validity window (server default: NONCE_TTL = 5 min). */
 const MAX_VALIDITY_WINDOW_MS = 60 * 60 * 1000;
 
@@ -36,8 +43,13 @@ export interface ChallengeExpectation {
   nonce: string;
   /** The client's network — refused if the challenge names a different one. */
   network: string;
-  /** Current time, ms since epoch. */
-  nowMs: number;
+  /**
+   * @deprecated Ignored since #662. The challenge is validated against the
+   * server's own timestamps only; the device clock is never used (a skewed
+   * clock previously produced false "expired" rejections). Retained so the
+   * exported signature stays source-compatible for existing callers.
+   */
+  nowMs?: number;
 }
 
 function parseFields(body: string): Map<string, string> {
@@ -105,12 +117,9 @@ export function verifyChallengeTemplate(challenge: string, expect: ChallengeExpe
   const issuedAt = parseTimestamp(requireField(fields, 'issuedAt'), 'issuedAt');
   const expiresAt = parseTimestamp(requireField(fields, 'expiresAt'), 'expiresAt');
 
-  if (issuedAt > expect.nowMs + MAX_CLOCK_SKEW_MS) {
-    throw new ChallengeTemplateError('Challenge issuedAt is in the future');
-  }
-  if (expiresAt <= expect.nowMs - MAX_CLOCK_SKEW_MS) {
-    throw new ChallengeTemplateError('Challenge is already expired');
-  }
+  // Server timestamps only — no device-clock comparison (#662). A well-formed
+  // challenge has a positive, bounded validity window; actual expiry is the
+  // server's authoritative call on /v1/auth/verify.
   if (expiresAt <= issuedAt || expiresAt - issuedAt > MAX_VALIDITY_WINDOW_MS) {
     throw new ChallengeTemplateError('Challenge validity window is implausible');
   }


### PR DESCRIPTION
Closes #662.

## Problem
`verifyChallengeTemplate` (`wallet-api/challenge.ts`) compared the server-issued `issuedAt`/`expiresAt` against the **device clock** (`expect.nowMs`, from `client.ts:397`). A device clock off by more than the 5-min skew tolerance (dead RTC, wrong date, bad NTP) failed **every** sign-in with `Challenge is already expired` (or `issuedAt is in the future`) — thrown on the client *before* `/v1/auth/verify`, so it never reached the server and couldn't self-heal.

In production (org `unicity-labs`) this is a hard send blocker: ~63 Sentry events `Token storage save failed (wallet-api-token-storage): Challenge is already expired`, and the event breadcrumbs show the gateway requests returning **200 in ~200ms** — it's clock skew, not latency.

## Fix
The challenge is fetched and signed immediately, and the server authoritatively enforces expiry on verify — so the device-clock comparison had no security value (the prefix + pubkey + nonce + network binding is what prevents signing foreign/replayed text). This drops both device-clock checks and keeps the **server-timestamp-only** window check (`issuedAt < expiresAt`, window ≤ `MAX_VALIDITY_WINDOW_MS`). `nowMs` stays on `ChallengeExpectation` as optional + `@deprecated` for source compatibility.

## Tests
- Rewrote the "implausible timestamps" sign-in test: a challenge with decades-off (server) timestamps but a valid window is now **accepted** and proceeds to verify (server decides expiry) — the exact case that previously locked users out.
- Added direct `verifyChallengeTemplate` cases: device clock 10 min fast, 10 min slow, and `nowMs` omitted — all accepted; a non-positive/oversized window is still rejected using server timestamps only.
- Full wallet-api unit suite green (70 tests); typecheck + lint clean.