### PR TITLE
fix(wallet-api): treat a lineage CONFLICT during token-storage save() as a benign no-op

### DIFF
--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -516,6 +516,23 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
       await this.syncInventory();
       return { success: true, timestamp: Date.now() };
     } catch (error) {
+      // A §5.3 lineage CONFLICT means the server already holds an equal/newer
+      // or evidenced-tombstoned state for a token we tried to push — the local
+      // snapshot is stale, NOT a failed save (recoverRemoved() treats the same
+      // CONFLICT as benign). Converge the view to server truth and report
+      // success: the mirror is already up to date, just not via our push.
+      // Surfacing this as a failure produced a red "storage degraded" toast and
+      // a Sentry error for a routine concurrency outcome, and left the stale
+      // view to re-conflict next cycle. Only genuine errors (network / protocol
+      // / auth) are a real degraded save.
+      if (error instanceof WalletApiError && error.code === 'CONFLICT') {
+        try {
+          await this.syncInventory();
+        } catch {
+          // Convergence is best-effort; the next save/sync cycle reconciles.
+        }
+        return { success: true, timestamp: Date.now() };
+      }
       return {
         success: false,
         error: error instanceof Error ? error.message : 'wallet-api save failed',

--- a/tests/contract/wallet-api-token-storage-provider.contract.test.ts
+++ b/tests/contract/wallet-api-token-storage-provider.contract.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { WalletApiClient } from '../../wallet-api';
+import { WalletApiClient, WalletApiError } from '../../wallet-api';
 import { WalletApiTokenStorageProvider } from '../../impl/shared/wallet-api/WalletApiTokenStorageProvider';
 import { deriveFieldEncryptionKey, encryptField } from '../../core/field-encryption';
 import type { FullIdentity } from '../../types';
@@ -100,6 +100,39 @@ describe('WalletApiTokenStorageProvider — S2 remote semantics', () => {
     const view = await provider.listInventory();
     expect(view.items).toHaveLength(5);
     expect(view.more).toBe(false);
+  });
+
+  it('a write-behind lineage CONFLICT is a benign no-op — save() converges and reports success (#663)', async () => {
+    const { client, provider } = makeDevice(fake, baseUrl, 22, 'dev-conflict');
+    await provider.initialize();
+
+    // Force the write-behind apply into a §5.3 lineage conflict (server holds
+    // an equal/newer or evidenced-tombstoned state). This is a routine
+    // concurrency outcome — the on-chain send already happened; the mirror is
+    // simply stale — so save() must treat it as success, not a degraded failure.
+    let applyCalls = 0;
+    client.applyInventoryDelta = async () => {
+      applyCalls += 1;
+      throw new WalletApiError(
+        'POST /v1/inventory/apply: CONFLICT lineage conflict for token [hex]',
+        'CONFLICT'
+      );
+    };
+
+    const result = await provider.save(buildTxfData([makeTestToken()]));
+    expect(result.success).toBe(true);
+    expect(applyCalls).toBeGreaterThan(0); // the push really attempted the apply
+  });
+
+  it('a genuine (non-CONFLICT) apply error still fails the save', async () => {
+    const { client, provider } = makeDevice(fake, baseUrl, 23, 'dev-neterr');
+    await provider.initialize();
+    client.applyInventoryDelta = async () => {
+      throw new WalletApiError('inventory/apply request failed', 'NETWORK');
+    };
+    const result = await provider.save(buildTxfData([makeTestToken()]));
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/apply request failed/);
   });
 
   it('a tombstoned delta converges a stale device (§5.1)', async () => {


### PR DESCRIPTION
Closes #663.

## Problem
`WalletApiTokenStorageProvider.save()` let a §5.3 lineage `CONFLICT` from `pushAdditions`/`pushRemovals` (`POST /v1/inventory/apply`) propagate to `{ success: false }` → a `storage:degraded` event → a red "Token storage degraded (wallet-api-token-storage)" toast + a Sentry error.

But a CONFLICT here is **benign**: the server already holds an equal/newer or evidenced-tombstoned state for a token we tried to push — the local snapshot is stale, and the on-chain send already happened. The sibling `recoverRemoved()` already treats the identical CONFLICT as benign (line ~436).

In production (org `unicity-labs`) this produced ~222 Sentry events across several fragmented issue groups — a routine concurrency outcome reported as an error, a scary red toast for the user, and (since the stale view was never reconciled on this path) a likely repeat conflict next cycle.

## Fix
Catch `WalletApiError` with `code === 'CONFLICT'` distinctly in `save()`: converge the local view to server truth (best-effort `syncInventory()`), and return `{ success: true }`. Only genuine NETWORK/PROTOCOL/AUTH errors remain a degraded save. Money-safe — conflicting additions are already accounted for server-side (or spent); removals are only ever pushed for confirmed spends; the re-sync converges the view.

## Tests
Two new contract tests drive the real save path (real upload/sync via the fake wallet-api) with the write-behind apply forced into (a) a `CONFLICT` → `save()` returns success and the apply was actually attempted; (b) a `NETWORK` error → `save()` still fails with the error surfaced. Full unit suite green (3035 tests); typecheck + lint clean.