### PR TITLE
fix(wallet-api): retry POST /v1/inventory/apply on transient network failure (idempotent by transferId)

### DIFF
--- a/tests/unit/wallet-api/client.retry.test.ts
+++ b/tests/unit/wallet-api/client.retry.test.ts
@@ -76,7 +76,7 @@ describe('WalletApiClient — transient NETWORK retry (GET only)', () => {
     expect(inventoryGets.length).toBeLessThanOrEqual(3);
   });
 
-  it('does NOT retry a write on a NETWORK failure — a lost-response retry could double-apply', async () => {
+  it('does NOT retry a NON-idempotent write on a NETWORK failure — a lost-response retry could double-apply', async () => {
     const client = makeClient((u, init) => {
       const method = init?.method ?? 'GET';
       const path = String(u);
@@ -92,6 +92,49 @@ describe('WalletApiClient — transient NETWORK retry (GET only)', () => {
     ).rejects.toBeInstanceOf(WalletApiError);
 
     const intentPuts = calls.filter((c) => c.method === 'PUT' && c.path.includes('/v1/intents/'));
-    expect(intentPuts).toHaveLength(1); // attempted exactly once — writes are never retried
+    expect(intentPuts).toHaveLength(1); // attempted exactly once — non-idempotent writes are not retried
+  });
+
+  it('DOES retry inventory/apply on a NETWORK failure — idempotent by transferId, safe to replay (#664)', async () => {
+    let failApply = 1; // drop the connection once, then let it through
+    const client = makeClient((u, init) => {
+      const method = init?.method ?? 'GET';
+      const path = String(u);
+      calls.push({ method, path });
+      if (method === 'POST' && path.includes('/v1/inventory/apply') && failApply-- > 0) {
+        return Promise.reject(new TypeError('fetch failed')); // ECONNRESET-style on the write
+      }
+      return realFetch(u, init);
+    });
+
+    // An empty apply is a no-op that still exercises the write path + retry.
+    const cursor = await client.applyInventoryDelta({
+      transferId: '00000000-0000-0000-0000-000000000664',
+      spent: [],
+      added: [],
+    });
+    expect(typeof cursor).toBe('bigint'); // succeeded AFTER the retry
+
+    const applies = calls.filter((c) => c.method === 'POST' && c.path.includes('/v1/inventory/apply'));
+    expect(applies).toHaveLength(2); // first dropped → retried → succeeded
+  });
+
+  it('gives up on inventory/apply after the bounded attempts when it keeps failing', async () => {
+    const client = makeClient((u, init) => {
+      const method = init?.method ?? 'GET';
+      const path = String(u);
+      calls.push({ method, path });
+      if (method === 'POST' && path.includes('/v1/inventory/apply')) {
+        return Promise.reject(new TypeError('fetch failed'));
+      }
+      return realFetch(u, init);
+    });
+
+    await expect(
+      client.applyInventoryDelta({ transferId: '00000000-0000-0000-0000-000000000665', spent: [], added: [] }),
+    ).rejects.toBeInstanceOf(WalletApiError);
+    const applies = calls.filter((c) => c.method === 'POST' && c.path.includes('/v1/inventory/apply'));
+    expect(applies.length).toBeGreaterThan(1);
+    expect(applies.length).toBeLessThanOrEqual(3); // bounded
   });
 });

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -493,11 +493,14 @@ export class WalletApiClient {
   /**
    * Retry transient REST failures with bounded exponential backoff + jitter:
    * - a thrown transient `NETWORK` failure (dropped/reset connection, DNS blip)
-   *   retries on **idempotent GETs only** — a lost-response retry of a write
-   *   could double-apply;
+   *   retries on **idempotent requests** — every GET, plus a write the caller
+   *   marked `idempotentWrite` (the server replays it as a no-op, so a
+   *   lost-response retry cannot double-apply; today only `inventory/apply`,
+   *   idempotent by transferId — #664). A non-idempotent write is single-attempt;
    * - a `429` response retries on **any** method (a 429 is rejected before the
    *   handler runs — the write never executed), honoring the server `Retry-After`;
-   * - a `503` response retries on **GETs only** (a write may have started).
+   * - a `503` response retries on **idempotent requests only** (a non-idempotent
+   *   write may have started).
    * Every other outcome (2xx, or a non-retryable status) is returned to the
    * caller, which maps a non-2xx to a typed {@link WalletApiError}.
    */
@@ -505,9 +508,15 @@ export class WalletApiClient {
     method: string,
     path: string,
     body: unknown,
-    jwt: string
+    jwt: string,
+    idempotentWrite = false
   ): Promise<FetchResponseLike> {
-    const idempotent = method === 'GET';
+    // GETs are idempotent by method; a write is retry-safe only when the caller
+    // explicitly declares it so (idempotentWrite) — i.e. the server makes a
+    // re-applied request a no-op replay, so a lost-response retry cannot double
+    // apply. Today that is `POST /v1/inventory/apply` (idempotent by transferId;
+    // #664).
+    const idempotent = method === 'GET' || idempotentWrite;
     for (let attempt = 1; ; attempt += 1) {
       let res: FetchResponseLike;
       try {
@@ -532,8 +541,8 @@ export class WalletApiClient {
 
   /**
    * Delay before retrying a non-2xx response, or `null` to not retry. `429`
-   * retries on any method (rejected before execution); `503` on idempotent GETs.
-   * Honors a capped `Retry-After` when present, else falls back to backoff.
+   * retries on any method (rejected before execution); `503` on idempotent
+   * requests only. Honors a capped `Retry-After` when present, else backoff.
    */
   private retryDelayForStatus(res: FetchResponseLike, idempotent: boolean, attempt: number): number | null {
     const retryable = res.status === 429 || (res.status === 503 && idempotent);
@@ -564,16 +573,23 @@ export class WalletApiClient {
    * Authenticated JSON request. A 401 triggers one silent re-auth
    * (refresh → challenge fallback) and one retry; {@link rawFetchWithRetry}
    * additionally rides out transient failures — a dropped connection on an
-   * idempotent GET, or a `429`/`503` with `Retry-After` — so a single blip or a
-   * brief rate-limit window doesn't fail the call.
+   * idempotent request (any GET, or a write flagged `opts.idempotent`), or a
+   * `429`/`503` with `Retry-After` — so a single blip or a brief rate-limit
+   * window doesn't fail the call.
    */
-  private async requestJson(method: string, path: string, body?: unknown): Promise<unknown> {
+  private async requestJson(
+    method: string,
+    path: string,
+    body?: unknown,
+    opts?: { idempotent?: boolean }
+  ): Promise<unknown> {
+    const idempotent = opts?.idempotent ?? false;
     if (!this.jwt) await this.signIn();
-    let res = await this.rawFetchWithRetry(method, path, body, this.jwt!);
+    let res = await this.rawFetchWithRetry(method, path, body, this.jwt!, idempotent);
     if (res.status === 401) {
       this.jwt = null;
       await this.signIn();
-      res = await this.rawFetchWithRetry(method, path, body, this.jwt!);
+      res = await this.rawFetchWithRetry(method, path, body, this.jwt!, idempotent);
     }
     if (res.status === 204) return null;
     if (!res.ok) throw await this.toError(res, `${method} ${path}`);
@@ -611,12 +627,20 @@ export class WalletApiClient {
    */
   async applyInventoryDelta(req: ApplyDeltaRequest): Promise<bigint> {
     const cursor = parseApplyResult(
-      await this.requestJson('POST', '/v1/inventory/apply', {
-        transferId: req.transferId,
-        spent: req.spent,
-        added: req.added,
-        ...(req.externalDelivery !== undefined ? { externalDelivery: req.externalDelivery } : {}),
-      })
+      await this.requestJson(
+        'POST',
+        '/v1/inventory/apply',
+        {
+          transferId: req.transferId,
+          spent: req.spent,
+          added: req.added,
+          ...(req.externalDelivery !== undefined ? { externalDelivery: req.externalDelivery } : {}),
+        },
+        // Idempotent by transferId — the server replays a re-applied transferId
+        // to the same cursor (beginApplied), so a lost-response retry on a flaky
+        // link is safe and won't double-apply (#664).
+        { idempotent: true }
+      )
     );
     await this.setLocalIntentStatus(req.transferId, 'completed');
     return cursor;


### PR DESCRIPTION
Closes #664. Depends on the backend idempotency contract tracked in unicity-sphere/wallet-api#100.

## Problem
`rawFetchWithRetry` gated retries on `method === 'GET'`, so the send-path write `POST /v1/inventory/apply` was **single-attempt**. A dropped connection / timeout on that write hard-failed the send — the dominant genuine slow/unstable-connection "cannot send" failure in production.

## Why it's now safe
`/v1/inventory/apply` is **idempotent by `transferId`** server-side: `applyTx` (`wallet-api` `src/inventory/service.ts`) calls `beginApplied(ownerId, transferId)` and, on a replay, returns the recorded cursor and mutates nothing (§5.3 step 1). Tested at `inventory.test.ts:396` ("idempotent replay") and `:436` ("late replay never resurrects a spent change token"). So a lost-response retry **replays** — it cannot double-apply. This dependency is filed as a stable-contract heads-up in wallet-api#100.

## Change
- Thread an explicit `idempotent` flag `requestJson` → `rawFetchWithRetry` (`idempotent = method === 'GET' || idempotentWrite`).
- Set `{ idempotent: true }` **only** on `applyInventoryDelta`. Every other write (incl. `putIntent`) stays single-attempt — the existing "non-idempotent writes are never retried" contract test is unchanged and still green.
- A transient `NETWORK` throw and a `503` now retry for the apply, bounded by the existing backoff/jitter/`maxAttempts` policy.

## Tests
`client.retry.test.ts`: apply retried once on a NETWORK drop → succeeds (2 apply POSTs); apply gives up after bounded attempts; the non-idempotent write (`putIntent`) still attempts exactly once. Full wallet-api unit suite green (72); typecheck + lint clean.