### PR TITLE
feat(payments): tag a post-commit mirror-sync failure SEND_SYNC_PENDING (reassuring UX)

### DIFF
--- a/core/errors.ts
+++ b/core/errors.ts
@@ -46,6 +46,12 @@ export type SphereErrorCode =
   // a byte-bound checkpoint proof no longer verifies against the current trust base (validator rotation).
   | 'CHECKPOINT_TRUSTBASE_MISMATCH'
   | 'STORAGE_ERROR'
+  // #665: the on-chain spend committed but the post-commit wallet-api mirror
+  // sync (inventory apply / blob upload / save) failed. NOT a lost payment —
+  // the intent is kept open and resume converges the mirror (idempotent apply,
+  // #664). Surfaced distinctly so a UI can reassure ("sent — wallet catching
+  // up") instead of showing a hard send failure.
+  | 'SEND_SYNC_PENDING'
   | 'TRANSPORT_ERROR'
   | 'AGGREGATOR_ERROR'
   | 'VALIDATION_ERROR'

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1767,13 +1767,16 @@ export class PaymentsModule {
     // §3.1 (#621): set when any leg's post-certification delivery is deferred (kept journaled).
     // Scoped to the whole send so the resolve path below can mark the result delivery-pending.
     let deliveryPending = false;
-    // #665: set once every on-chain submit has certified, right before the
-    // wallet-api persistence (inventory apply / blob upload / save). A failure
-    // AFTER this point means the money already moved on-chain and only the
-    // server-mirror sync failed — the intent stays open and resume converges
-    // it (idempotent apply, #664). We still throw (keep-open + resume is the
-    // exit), but re-tag the error SEND_SYNC_PENDING so the UI can reassure the
-    // user ("sent — wallet catching up") instead of showing a scary failure.
+    // #665: set inside the wallet-api-inventory-custody branch below, once every
+    // on-chain submit has certified and right before the server-mirror
+    // persistence (inventory apply / blob upload / save). A failure AFTER this
+    // means the money already moved on-chain and only the server-MIRROR sync
+    // failed — the intent stays open and resume converges it (idempotent apply,
+    // #664). We still throw (keep-open + resume is the exit), but re-tag the
+    // error SEND_SYNC_PENDING so the UI can reassure the user ("sent — wallet
+    // catching up"). Deliberately NOT set for own-storage / no-wallet-api sends:
+    // there is no server mirror, so a post-commit local failure there stays a
+    // normal failure.
     let onChainCommitComplete = false;
 
     try {
@@ -2074,11 +2077,16 @@ export class PaymentsModule {
           if (!serverApply) await this.removeToken(splitPlan.tokenToSplit.uiToken.id, result.id);
         }
 
-        // #665: all on-chain submits have certified by here — everything that
-        // follows (wallet-api apply / blob upload / save) is post-commit.
-        onChainCommitComplete = true;
-
         if (serverApply) {
+          // #665: SCOPED to wallet-api inventory custody. Every on-chain submit
+          // has certified by here, and the wallet-api persistence that follows
+          // (blob upload / apply / the save below) is post-commit — a failure is
+          // a server-MIRROR sync-pending, converged by resume. Setting the flag
+          // only inside this branch keeps own-storage / no-wallet-api sends OUT
+          // of the SEND_SYNC_PENDING path: there is no server mirror to catch up,
+          // so a local post-commit save failure there stays a normal failure
+          // (Copilot review, PR #669).
+          onChainCommitComplete = true;
           // §7 steps 4+6: upload the change output, then record the whole
           // spend in ONE idempotent apply carrying the send's transferId. The
           // backend evidence-checks the removals against the mailbox deposit

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1767,6 +1767,14 @@ export class PaymentsModule {
     // §3.1 (#621): set when any leg's post-certification delivery is deferred (kept journaled).
     // Scoped to the whole send so the resolve path below can mark the result delivery-pending.
     let deliveryPending = false;
+    // #665: set once every on-chain submit has certified, right before the
+    // wallet-api persistence (inventory apply / blob upload / save). A failure
+    // AFTER this point means the money already moved on-chain and only the
+    // server-mirror sync failed — the intent stays open and resume converges
+    // it (idempotent apply, #664). We still throw (keep-open + resume is the
+    // exit), but re-tag the error SEND_SYNC_PENDING so the UI can reassure the
+    // user ("sent — wallet catching up") instead of showing a scary failure.
+    let onChainCommitComplete = false;
 
     try {
       // Resolve recipient
@@ -2066,6 +2074,10 @@ export class PaymentsModule {
           if (!serverApply) await this.removeToken(splitPlan.tokenToSplit.uiToken.id, result.id);
         }
 
+        // #665: all on-chain submits have certified by here — everything that
+        // follows (wallet-api apply / blob upload / save) is post-commit.
+        onChainCommitComplete = true;
+
         if (serverApply) {
           // §7 steps 4+6: upload the change output, then record the whole
           // spend in ONE idempotent apply carrying the send's transferId. The
@@ -2276,6 +2288,23 @@ export class PaymentsModule {
 
       // Notify queue AFTER cache is rebuilt so queued entries see restored tokens
       this.spendQueue.notifyChange(request.coinId);
+
+      // #665: a failure AFTER the on-chain commit is a mirror-sync-pending
+      // outcome, not a lost payment — the spend landed on-chain, the intent is
+      // kept open, and resume converges the server mirror (idempotent apply,
+      // #664). Do NOT emit transfer:failed (nothing was lost); throw a
+      // re-tagged SEND_SYNC_PENDING so the send caller can reassure the user
+      // instead of showing a hard failure. Excludes a genuine lost race
+      // (TransferConflictError) and the keep-open certification states
+      // (ProofUnconfirmed / split-checkpoint), which are pre-mirror and have
+      // their own handling.
+      if (onChainCommitComplete && !(error instanceof TransferConflictError) && !keepOpen) {
+        throw new SphereError(
+          'Your payment was sent. Your wallet is syncing with the server and will catch up shortly.',
+          'SEND_SYNC_PENDING',
+          error,
+        );
+      }
 
       this.deps!.emitEvent('transfer:failed', result);
       throw error;

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -255,6 +255,48 @@ describe('send — full wallet-api preset (S2 consumer + S3 + §7 pipeline)', ()
     expect(sent!.memo).not.toContain('lunch');
   });
 
+  it('a post-commit apply failure surfaces as SEND_SYNC_PENDING, not a hard failure (#665)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-665');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // The on-chain spend certifies first; then fail the post-commit wallet-api
+    // apply (persistently — outlasting the #664 retry). The money already
+    // moved on-chain, only the server-mirror sync failed.
+    const cause = new WalletApiError('inventory/apply failed', 'NETWORK');
+    sender.client.applyInventoryDelta = async () => {
+      throw cause;
+    };
+
+    await expect(
+      sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT }),
+    ).rejects.toMatchObject({ code: 'SEND_SYNC_PENDING', cause });
+
+    // Not a lost payment: transfer:failed must NOT be emitted for a sync-pending.
+    const failed = sender.emitEvent.mock.calls.filter((c) => c[0] === 'transfer:failed');
+    expect(failed).toHaveLength(0);
+  });
+
+  it('a PRE-commit failure is still a hard failure (transfer:failed), not sync-pending', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-665b');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // putIntent runs FIRST, before any on-chain submit — a failure here is a
+    // genuine pre-commit send failure and must NOT be re-tagged sync-pending.
+    sender.client.putIntent = async () => {
+      throw new WalletApiError('putIntent failed', 'NETWORK');
+    };
+
+    await expect(
+      sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT }),
+    ).rejects.not.toMatchObject({ code: 'SEND_SYNC_PENDING' });
+    const failed = sender.emitEvent.mock.calls.filter((c) => c[0] === 'transfer:failed');
+    expect(failed.length).toBeGreaterThan(0);
+  });
+
   it('a split send uploads the change output and applies it in the SAME delta (700 stays)', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-send-2');

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -297,6 +297,25 @@ describe('send — full wallet-api preset (S2 consumer + S3 + §7 pipeline)', ()
     expect(failed.length).toBeGreaterThan(0);
   });
 
+  it('an OWN-STORAGE post-commit failure stays a hard failure, NOT SEND_SYNC_PENDING (#665 scope, Copilot #669)', async () => {
+    // No wallet-api inventory mirror in own-storage custody, so a post-commit
+    // LOCAL persistence failure must NOT be re-tagged sync-pending (there is no
+    // server mirror to "catch up") — it stays a normal failure.
+    const { fake, baseUrl } = await startFake();
+    const sender = makeOwnStorageWallet(baseUrl, fake.network, SENDER, 'd-665c');
+    await sender.module.load();
+    await sender.module.mintFungibleToken(UCT, 1000n); // token exists BEFORE we break save
+
+    const local = sender.deps.tokenStorageProviders.get('local')!;
+    local.save = vi.fn(async () => ({ success: false, error: 'local save failed', timestamp: 0 }));
+
+    await expect(
+      sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT }),
+    ).rejects.not.toMatchObject({ code: 'SEND_SYNC_PENDING' });
+    const failed = sender.emitEvent.mock.calls.filter((c) => c[0] === 'transfer:failed');
+    expect(failed.length).toBeGreaterThan(0);
+  });
+
   it('a split send uploads the change output and applies it in the SAME delta (700 stays)', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-send-2');


### PR DESCRIPTION
Closes #665.

## What
When the on-chain spend is already committed but the post-commit wallet-api persistence (inventory apply / blob upload / save) fails, the send threw a generic `STORAGE_ERROR` → the UI showed a hard "send failed", even though the money moved on-chain and resume converges the mirror.

This is a **messaging-only** improvement — the money-path behavior (keep the intent open, mark sources spent, resume converges) is **unchanged**:
- Set `onChainCommitComplete` once every submit has certified, right before the wallet-api persistence block.
- In the failure catch, re-tag a post-commit failure with a distinct **`SEND_SYNC_PENDING`** code (original error preserved as `cause`) and **suppress `transfer:failed`** (nothing was lost). A UI maps that code to "your payment was sent — your wallet is syncing and will catch up shortly."
- Excludes genuine pre-commit failures and a lost race (`TransferConflictError`), and the keep-open certification states (`ProofUnconfirmed` / split-checkpoint) — all pre-mirror with their own handling.

Why not the original "pending-success" conversion: #664 already fixed the transient case; a resolved-success result would show a wrong balance until resync (the change token isn't stored locally if `applyDelta` failed) and would change what `transfer:confirmed`/`failed` mean. See #665 for the full rationale.

## Tests
`PaymentsModule.wallet-api-delivery.test.ts`: a post-commit `applyInventoryDelta` failure → the send rejects with `code: 'SEND_SYNC_PENDING'` (cause preserved) and **no** `transfer:failed` event; a **pre-commit** `putIntent` failure still fails hard (not re-tagged, `transfer:failed` emitted). Full unit suite green (3041); typecheck + lint clean.

Follow-up: the sphere app maps `SEND_SYNC_PENDING` to the reassuring message (separate PR).