### PR TITLE
fix(wallet-api): make deterministic putIntent VALIDATION rejections terminal; isolate resync replay

### DIFF
--- a/core/field-encryption.ts
+++ b/core/field-encryption.ts
@@ -40,6 +40,9 @@ const POLY1305_TAG_BYTES = 16;
 /**
  * Default envelope size cap in bytes (UTF-8 length of the full `enc1.…`
  * string). Matches the intent-payload cap (≤ 4 KiB — ARCHITECTURE §7/§11).
+ * NOTE: the server-side INTENT cap is being raised (wallet-api#102); the SDK
+ * deliberately does NOT pre-flight-enforce it on sends (#670) — the server
+ * decides, and a deterministic 422 is handled as terminal by the send path.
  */
 export const FIELD_ENVELOPE_MAX_BYTES = 4096;
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -790,6 +790,12 @@ export interface PaymentsWalletApiPort {
   /** E.2 lost-race cleanup (soft, recoverable). */
   abortIntent(transferId: string): Promise<void>;
   /**
+   * #670: drop the local intent backstop copy — OPTIONAL capability, called only when the intent
+   * PUT was deterministically rejected (422 VALIDATION) with nothing on-chain, so keeping the copy
+   * would poison the resync replay forever. A port without a local copy has nothing to drop.
+   */
+  removeLocalIntent?(transferId: string): Promise<void>;
+  /**
    * E.4 burn checkpoint (sphere-sdk#501) — OPTIONAL capability. When present (the WalletApiClient
    * provides them), a split's resume is checkpoint-protected via {@link WalletApiCheckpointStore};
    * a composed port without them keeps today's residual (a split resumed after a certified mint
@@ -1779,6 +1785,12 @@ export class PaymentsModule {
     // normal failure.
     let onChainCommitComplete = false;
 
+    // #670: set when the intent PUT was deterministically rejected (422
+    // VALIDATION) — the local backstop copy is dropped at the rejection site
+    // and the failure-disposition abort below must be skipped (the server row
+    // never existed; an abort would only 404 and re-mark it abortPending).
+    let intentRejected = false;
+
     try {
       // Resolve recipient
       const peerInfo: PeerInfo | null = await this.deps!.transport.resolve?.(request.recipient) ?? null;
@@ -1923,14 +1935,44 @@ export class PaymentsModule {
           // E.4/#87: a split's terminal close is seed-gated — set requiresSeedClose here, BEFORE
           // the burn, so the funds-critical window is guarded from intent creation (not only once
           // the first checkpoint is appended).
-          await walletApi.putIntent(
-            result.id,
-            encryptField(
-              this.getFieldEncryptionKey(),
-              JSON.stringify(this.buildIntentPayload(request, peerInfo.chainPubkey, splitPlan))
-            ),
-            splitPlan.requiresSplit ? { requiresSeedClose: true } : {}
-          );
+          try {
+            await walletApi.putIntent(
+              result.id,
+              encryptField(
+                this.getFieldEncryptionKey(),
+                JSON.stringify(this.buildIntentPayload(request, peerInfo.chainPubkey, splitPlan))
+              ),
+              splitPlan.requiresSplit ? { requiresSeedClose: true } : {}
+            );
+          } catch (err) {
+            // #670: a 422 VALIDATION rejection is DETERMINISTIC — the server will
+            // never accept this payload (e.g. the intent envelope exceeds the
+            // service's size cap), so the #516 keep-and-replay backstop does not
+            // apply: nothing is on-chain yet (E.3 — the engine has not run) and
+            // the server row was never created. Drop the local copy (keeping it
+            // would poison resyncOpenIntents with an eternal 422) and surface a
+            // TYPED error the app can map instead of the raw wire text
+            // (WalletApiError is not a SphereError). Transient failures
+            // (NETWORK/5xx) rethrow unchanged and keep the backstop.
+            if (err instanceof WalletApiError && err.code === 'VALIDATION' && committedOnChainTokenIds.size === 0) {
+              intentRejected = true;
+              try {
+                await walletApi.removeLocalIntent?.(result.id);
+              } catch (removeErr) {
+                logger.warn('Payments', 'removeLocalIntent failed after intent VALIDATION rejection:', removeErr);
+              }
+              throw new SphereError(
+                // Matches both the server's "envelope exceeds N bytes (§8.3)"
+                // and the SDK checker's "exceeds size cap of N bytes" wording.
+                /exceeds .*bytes/.test(err.message)
+                  ? "The payment could not be registered with the wallet service because it exceeds the service's size limit. Try sending a smaller amount."
+                  : 'The wallet service rejected this payment as invalid.',
+                'VALIDATION_ERROR',
+                err
+              );
+            }
+            throw err;
+          }
         }
 
         // Deliver a journaled finished-token blob via the delivery port (S3:
@@ -2236,7 +2278,10 @@ export class PaymentsModule {
         error instanceof CheckpointPersistFailedError ||
         error instanceof SplitCheckpointLostError ||
         error instanceof CheckpointTrustbaseMismatchError;
-      if (this.deps?.walletApi) {
+      // #670: skip the abort when the intent PUT itself was deterministically
+      // rejected — the local copy is already dropped and the server row never
+      // existed (an abort would only 404 and re-mark the copy abortPending).
+      if (this.deps?.walletApi && !intentRejected) {
         if (error instanceof TransferConflictError || (committedOnChainTokenIds.size === 0 && !keepOpen)) {
           try {
             await this.deps.walletApi.abortIntent(result.id);

--- a/tests/unit/modules/PaymentsModule.fail-closed.test.ts
+++ b/tests/unit/modules/PaymentsModule.fail-closed.test.ts
@@ -13,6 +13,10 @@
  *   marks the LOCAL intent 'aborted'; after reconnect, `resumeOpenIntents`
  *   executes NOTHING and the resync lands the intent as aborted (no-op
  *   execution-wise).
+ * - #670 — a DETERMINISTIC `putIntent` 422 (oversized intent envelope) is
+ *   terminal: the send fails with a TYPED SphereError (VALIDATION_ERROR,
+ *   cause preserved), the local backstop copy is dropped (nothing on-chain),
+ *   and nothing is re-PUT on later sync epochs.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -24,7 +28,7 @@ import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, History
 import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
-import { WalletApiClient } from '../../../wallet-api';
+import { WalletApiClient, WalletApiError } from '../../../wallet-api';
 import type { FetchLike } from '../../../wallet-api';
 import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../../impl/shared/wallet-api';
 import { hexToBytes } from '../../../core/crypto';
@@ -335,5 +339,82 @@ describe('#516 — failed putIntent must NOT leave a re-executable open intent',
     expect(outcome2).toEqual({ resumed: [], conflicted: [], failed: [] });
     expect(transferSpy).not.toHaveBeenCalled();
     expect(module.getTokens()[0].status).toBe('confirmed'); // no double-spend of the source
+  });
+});
+
+describe('#670 — deterministic putIntent VALIDATION rejection is terminal', () => {
+  it('send fails with a TYPED SphereError (cause preserved); no local copy remains, nothing re-PUT on later epochs', async () => {
+    // A 64-byte fake intent cap deterministically 422s ANY real intent
+    // envelope — the production shape (a fragmented wallet whose envelope
+    // exceeds the §7 cap, Sentry SPHERE-R).
+    const fake = new FakeWalletApi({
+      decodeAssets: decodeFakeTokenAssets,
+      decodeTokenId: decodeFakeTokenId,
+      intentMaxBytes: 64,
+    });
+    const baseUrl = await fake.start();
+    cleanups.push(() => fake.stop());
+
+    const requests: string[] = [];
+    const fetchFn: FetchLike = (url, init) => {
+      requests.push(`${init?.method ?? 'GET'} ${String(url)}`);
+      return (globalThis.fetch as unknown as FetchLike)(url, init);
+    };
+    const kv = new MemoryKeyValueStore();
+    const client = new WalletApiClient({ baseUrl, network: fake.network, deviceId: 'd-670', storage: kv, fetchFn });
+    const delivery = new WalletApiMailboxProvider({ client, custody: 'external', stateStore: kv });
+    const engine = new FakeTokenEngine({ chainPubkey: hexToBytes(SENDER.chainPubkey) });
+    const emitEvent = vi.fn();
+    const deps: PaymentsModuleDependencies = {
+      identity: fullIdentity(SENDER),
+      storage: mockStorage(),
+      tokenStorageProviders: new Map([['local', mockLocalTokenStorage()]]),
+      transport: mockTransport(),
+      oracle: mockOracle(),
+      emitEvent,
+      tokenEngine: engine,
+      delivery,
+      walletApi: client,
+    };
+    const module = createPaymentsModule({ l1: null });
+    module.initialize(deps);
+    cleanups.push(() => module.destroy());
+
+    await module.load();
+    const mint = await module.mintFungibleToken(UCT, 1000n);
+    expect(mint.success).toBe(true);
+
+    const transferSpy = vi.spyOn(engine, 'transfer');
+    const putIntentSpy = vi.spyOn(client, 'putIntent');
+
+    // The app sees a TYPED error it can map — not the raw wire text.
+    let thrown: unknown;
+    try {
+      await module.send({ recipient: '@bob', amount: '1000', coinId: UCT });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(SphereError);
+    expect((thrown as SphereError).code).toBe('VALIDATION_ERROR');
+    expect((thrown as SphereError).message).toMatch(/size limit/);
+    const cause = (thrown as SphereError).cause;
+    expect(cause).toBeInstanceOf(WalletApiError);
+    expect((cause as WalletApiError).code).toBe('VALIDATION');
+
+    expect(transferSpy).not.toHaveBeenCalled(); // E.3: engine never ran
+    const transferId = putIntentSpy.mock.calls[0][0];
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toBeNull(); // row never created
+
+    // TERMINAL: the local backstop copy is dropped (nothing was on-chain) —
+    // later sync epochs make NO intent request (no repeated 422 stream) and
+    // resume has nothing to re-execute.
+    expect(await client.listLocalOpenIntents()).toEqual([]);
+    requests.length = 0;
+    await client.resyncOpenIntents();
+    expect(requests.filter((r) => r.includes('/v1/intents'))).toEqual([]);
+
+    // The source is restored and spendable; nothing reached the mailbox.
+    expect(module.getTokens()[0].status).toBe('confirmed');
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);
   });
 });

--- a/tests/unit/wallet-api/client.inventory.test.ts
+++ b/tests/unit/wallet-api/client.inventory.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { WalletApiClient, WalletApiError } from '../../../wallet-api';
+import type { FetchLike } from '../../../wallet-api';
 import { deriveFieldEncryptionKey, encryptField } from '../../../core/field-encryption';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { makeTestToken, MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
@@ -313,5 +314,98 @@ describe('WalletApiClient — intents (E.3, §16)', () => {
     // re-PUTs its locally-known open intents (idempotent).
     await client.listInventory();
     expect(fake.getIntent(identity.chainPubkey, tid)).toEqual({ payload, status: 'open' });
+  });
+});
+
+describe('WalletApiClient — #670 poisoned-intent self-heal (resyncOpenIntents)', () => {
+  let fake: FakeWalletApi;
+  let client: WalletApiClient;
+  let requests: string[];
+  /** When set, requests whose URL contains this id fail at the transport (NETWORK). */
+  let failFor: string | null;
+  const identity = testIdentity(52);
+  const fieldKey = deriveFieldEncryptionKey(identity.privateKey);
+
+  function envelope(content: string): string {
+    return encryptField(fieldKey, content);
+  }
+
+  beforeEach(async () => {
+    fake = new FakeWalletApi();
+    const baseUrl = await fake.start();
+    requests = [];
+    failFor = null;
+    const fetchFn: FetchLike = (url, init) => {
+      requests.push(`${init?.method ?? 'GET'} ${String(url)}`);
+      if (failFor && String(url).includes(failFor)) return Promise.reject(new TypeError('fetch failed'));
+      return (globalThis.fetch as unknown as FetchLike)(url, init);
+    };
+    client = new WalletApiClient({
+      baseUrl,
+      network: fake.network,
+      deviceId: 'dev-1',
+      storage: new MemoryKeyValueStore(),
+      fetchFn,
+    });
+    client.setIdentity(identity);
+  });
+
+  afterEach(async () => {
+    await fake.stop();
+  });
+
+  it('a poisoned abortPending intent (deterministic 422 re-PUT) is cleared instead of wedging; a later healthy intent still replays', async () => {
+    const tidBad = 'dddddddd-0000-4000-8000-000000000001';
+    const tidGood = 'dddddddd-0000-4000-8000-000000000002';
+    const oversize = envelope('x'.repeat(5000)); // > 4 KiB cap (§7) — deterministic 422
+
+    // The production wedge shape (Sentry SPHERE-R): the PUT 422s AFTER the
+    // local copy is written, the nothing-certified abort then 404s (the row
+    // was never created) → local 'aborted' + abortPending.
+    await expect(client.putIntent(tidBad, oversize)).rejects.toMatchObject({ code: 'VALIDATION' });
+    await expect(client.abortIntent(tidBad)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    // A healthy open intent queued BEHIND the poisoned one (insertion order),
+    // whose server row a restore then loses.
+    const goodPayload = envelope('healthy');
+    await client.putIntent(tidGood, goodPayload);
+    fake.dropIntent(identity.chainPubkey, tidGood);
+
+    await client.resyncOpenIntents();
+    // The healthy intent replayed despite the poisoned entry ahead of it…
+    expect(fake.getIntent(identity.chainPubkey, tidGood)).toEqual({ payload: goodPayload, status: 'open' });
+    // …and the poisoned entry's pending state is CLEARED: the next epoch
+    // makes no request for it (no recurring background 422 stream).
+    requests.length = 0;
+    await client.resyncOpenIntents();
+    expect(requests.filter((r) => r.includes(tidBad))).toEqual([]);
+    // The server never saw the poisoned intent; resume (status=open) has nothing to re-run.
+    expect(fake.getIntent(identity.chainPubkey, tidBad)).toBeNull();
+    expect((await client.listIntents('open')).map((i) => i.transferId)).toEqual([tidGood]);
+  });
+
+  it('#516 gate: a NETWORK failure on one entry is isolated — others replay, the failing entry stays pending', async () => {
+    const tidDown = 'dddddddd-0000-4000-8000-000000000003';
+    const tidUp = 'dddddddd-0000-4000-8000-000000000004';
+
+    // Two unlanded aborts (dead backend at send-failure cleanup — the #516 shape).
+    await client.putIntent(tidDown, envelope('down'));
+    await client.putIntent(tidUp, envelope('up'));
+    failFor = tidDown;
+    await expect(client.abortIntent(tidDown)).rejects.toMatchObject({ code: 'NETWORK' });
+    failFor = tidUp;
+    await expect(client.abortIntent(tidUp)).rejects.toMatchObject({ code: 'NETWORK' });
+
+    // Replay with tidDown STILL dark: tidUp's abort lands regardless (per-intent isolation).
+    failFor = tidDown;
+    await client.resyncOpenIntents();
+    expect(fake.getIntent(identity.chainPubkey, tidUp)).toMatchObject({ status: 'aborted' });
+    expect(fake.getIntent(identity.chainPubkey, tidDown)).toMatchObject({ status: 'open' }); // abort never landed
+
+    // The transient failure kept the #516 backstop: the entry stayed pending
+    // and converges once the transport heals.
+    failFor = null;
+    await client.resyncOpenIntents();
+    expect(fake.getIntent(identity.chainPubkey, tidDown)).toMatchObject({ status: 'aborted' });
   });
 });

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -30,6 +30,7 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 
 import { signMessage } from '../core/crypto';
+import { logger } from '../core/logger';
 import { timeoutSignal } from '../core/timeout';
 import { completeSignMessage, progressSignMessage } from './intent-signing';
 import { WalletApiError } from './errors';
@@ -864,11 +865,33 @@ export class WalletApiClient {
   }
 
   /**
+   * #670: drop the LOCAL intent copy. Only for a DETERMINISTIC server
+   * rejection of the payload (422 `VALIDATION`) on a send that committed
+   * nothing on-chain: the server row was never created and a re-PUT of the
+   * same bytes can never succeed, so keeping the copy would only poison
+   * {@link resyncOpenIntents} with an eternal 422 replay. NEVER call this for
+   * transient failures (NETWORK/5xx) — the local copy is the #516
+   * double-pay/restore backstop.
+   */
+  async removeLocalIntent(transferId: string): Promise<void> {
+    const intents = await this.readLocalIntents();
+    const intent = intents[transferId];
+    if (!intent) return;
+    // Only a still-'open' copy with no pending server abort is safe to drop:
+    // 'completed' never reverts (§16), and an 'aborted'+abortPending copy is a
+    // #516 backstop whose server row may still be open.
+    if (intent.status !== 'open' || intent.abortPending === true) return;
+    delete intents[transferId];
+    await this.writeLocalIntents(intents);
+  }
+
+  /**
    * Persist a (client-encrypted — S6) intent payload: LOCAL copy first, then
    * `PUT /v1/intents/{transferId}` and await the server ack (E.3 — the engine
    * MUST NOT be called before this resolves). A failed server PUT throws, but
    * the local copy stays as the restore backstop and is re-PUT by
-   * {@link resyncOpenIntents}.
+   * {@link resyncOpenIntents} — except a deterministic 422 `VALIDATION`, which
+   * the send path makes terminal via {@link removeLocalIntent} (#670).
    */
   async putIntent(
     transferId: string,
@@ -999,31 +1022,63 @@ export class WalletApiClient {
    * the row after a restore or a failed original PUT) then abort, so the
    * server row lands as 'aborted' instead of an 'open' intent that resume
    * would re-execute. Completed-wins is preserved server-side (§16).
+   *
+   * #670: replay is per-intent isolated (one failing entry logs and moves on
+   * instead of blocking the rest), and a deterministic 422 `VALIDATION` on the
+   * abortPending re-PUT clears the pending flag instead of retrying forever —
+   * the server will never accept those bytes.
    */
   async resyncOpenIntents(): Promise<void> {
     const intents = await this.readLocalIntents();
     for (const [transferId, intent] of Object.entries(intents)) {
-      if (intent.status === 'open') {
-        // Re-PUT with the SAME requiresSeedClose (the restore dropped the row), then re-POST every
-        // locally-held checkpoint byte-identically (E.4 — the two tables not blob-derivable).
-        await this.requestJson(
-          'PUT',
-          `/v1/intents/${transferId}`,
-          this.intentPutBody(intent.payload, intent.requiresSeedClose === true)
-        );
-        for (const [opIndex, envelope] of Object.entries(intent.progress ?? {})) {
-          // Reconcile to the authoritative record (a concurrent writer may have won the slot) so a
-          // later re-seed never re-POSTs stale losing bytes — the wedge Copilot flagged on #638.
-          await this.postProgressEnvelope(transferId, Number(opIndex), envelope);
+      try {
+        if (intent.status === 'open') {
+          // Re-PUT with the SAME requiresSeedClose (the restore dropped the row), then re-POST every
+          // locally-held checkpoint byte-identically (E.4 — the two tables not blob-derivable).
+          await this.requestJson(
+            'PUT',
+            `/v1/intents/${transferId}`,
+            this.intentPutBody(intent.payload, intent.requiresSeedClose === true)
+          );
+          for (const [opIndex, envelope] of Object.entries(intent.progress ?? {})) {
+            // Reconcile to the authoritative record (a concurrent writer may have won the slot) so a
+            // later re-seed never re-POSTs stale losing bytes — the wedge Copilot flagged on #638.
+            await this.postProgressEnvelope(transferId, Number(opIndex), envelope);
+          }
+        } else if (intent.status === 'aborted' && intent.abortPending === true) {
+          try {
+            await this.requestJson(
+              'PUT',
+              `/v1/intents/${transferId}`,
+              this.intentPutBody(intent.payload, intent.requiresSeedClose === true)
+            );
+          } catch (err) {
+            // #670: a 422 `VALIDATION` rejection is DETERMINISTIC — the server
+            // will never accept this payload, so the re-PUT can never land and
+            // retrying every sync epoch only streams 422s. But a 422 does NOT
+            // prove the row was never created (the server validates the payload
+            // before row existence), so settle the server side first: an abort
+            // that succeeds or 404s proves the row is closed/absent — only then
+            // clear the pending flag. Any other abort failure rethrows into the
+            // per-intent isolation catch and stays pending (#516 backstop).
+            if (!(err instanceof WalletApiError && err.code === 'VALIDATION')) throw err;
+            try {
+              await this.requestJson('POST', `/v1/intents/${transferId}/abort`);
+            } catch (abortErr) {
+              if (!(abortErr instanceof WalletApiError && abortErr.code === 'NOT_FOUND')) throw abortErr;
+            }
+            await this.setLocalIntentStatus(transferId, 'aborted'); // clears abortPending
+            continue;
+          }
+          await this.requestJson('POST', `/v1/intents/${transferId}/abort`);
+          await this.setLocalIntentStatus(transferId, 'aborted'); // clears abortPending
         }
-      } else if (intent.status === 'aborted' && intent.abortPending === true) {
-        await this.requestJson(
-          'PUT',
-          `/v1/intents/${transferId}`,
-          this.intentPutBody(intent.payload, intent.requiresSeedClose === true)
-        );
-        await this.requestJson('POST', `/v1/intents/${transferId}/abort`);
-        await this.setLocalIntentStatus(transferId, 'aborted'); // clears abortPending
+      } catch (err) {
+        // #670: per-intent isolation — one failing entry must not block the
+        // replay of the others (or become an unhandled rejection through the
+        // void-ed noteSyncEpoch callers). The entry keeps its local state and
+        // is retried on the next sync epoch.
+        logger.warn('WalletApi', `resyncOpenIntents: replay of intent ${transferId} failed (retried next epoch):`, err);
       }
     }
   }


### PR DESCRIPTION
Closes #670. Server-side companion: unicity-sphere/wallet-api#102.

## What

A 422 `VALIDATION` on the intent PUT is deterministic — re-PUTting the same bytes can never succeed — but the client treated it like a transient failure, poisoning itself (Sentry **SPHERE-R**: recurring background 422 streams from ~6 production wallets, wedged intent replay):

1. **`resyncOpenIntents` — per-intent isolation.** One failing entry now logs (`logger.warn`) and is retried next epoch instead of throwing out of the loop, which blocked replay of every later intent and became unhandled rejections through the void-ed `noteSyncEpoch` callers.
2. **`abortPending` replay — terminal handling of the deterministic 422.** On a `VALIDATION` re-PUT rejection, the server side is settled first: `POST /abort` succeeding or 404ing proves the row is closed/absent, and only then is the pending flag cleared. Any other abort failure keeps the entry pending (the #516 backstop). This self-heals wallets already wedged by the old behavior.
3. **Send path — typed, clean failure.** When the intent PUT itself is rejected with `VALIDATION` and nothing is committed on-chain (`committedOnChainTokenIds.size === 0`; putIntent precedes all engine ops per E.3), the fresh local copy is dropped via the new `removeLocalIntent` (guarded: only `open` + non-`abortPending` copies are deletable) and the error is rethrown as `SphereError('VALIDATION_ERROR')` with the original `WalletApiError` as `cause` — apps can map it instead of showing raw wire text (`PUT /v1/intents/<uuid>: VALIDATION_FAILED …`). The size-limit wording is keyed off the wire detail so a non-size 422 doesn't give misleading "send a smaller amount" advice.

**Unchanged by design:** NETWORK/5xx failures keep the exact keep-and-replay #516 double-pay/restore backstop; no client-side pre-flight size rejection; no coin-selection changes (dust growth is protocol-inherent — the server cap is being raised in wallet-api#102 to allow it).

## Tests

- New module-level integration test (real `WalletApiClient` against `FakeWalletApi` with `intentMaxBytes=64`, through the actual `module.send()` path): typed `VALIDATION_ERROR` with cause preserved; no local copy remains; nothing re-PUT on later sync epochs.
- Client tests: a poisoned `abortPending` entry is cleared by `resyncOpenIntents` (abort 404 → settled) while a healthy later intent in the same store still replays; NETWORK failure on putIntent keeps the backstop (regression guard for #516).
- `npx tsc --noEmit` clean; lint clean (only pre-existing warnings in untouched files); full unit suite 3045/3045.
