### PR TITLE
chore(crypto): migrate elliptic to @noble/curves (#674)

### DIFF
--- a/core/crypto.ts
+++ b/core/crypto.ts
@@ -5,16 +5,14 @@
  * Platform-independent - no browser-specific APIs.
  */
 
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 import * as bip39 from 'bip39';
 import CryptoJS from 'crypto-js';
-import elliptic from 'elliptic';
 import { SphereError } from './errors';
 
 // =============================================================================
 // Constants
 // =============================================================================
-
-const ec = new elliptic.ec('secp256k1');
 
 /** secp256k1 curve order */
 const CURVE_ORDER = BigInt(
@@ -154,8 +152,7 @@ export function deriveChildKey(
     data = '00' + parentPrivKey + indexHex;
   } else {
     // Non-hardened derivation: compressedPubKey || index
-    const keyPair = ec.keyFromPrivate(parentPrivKey, 'hex');
-    const compressedPubKey = keyPair.getPublic(true, 'hex');
+    const compressedPubKey = getPublicKey(parentPrivKey, true);
     const indexHex = index.toString(16).padStart(8, '0');
     data = compressedPubKey + indexHex;
   }
@@ -239,8 +236,9 @@ export function deriveKeyAtPath(
  * @param compressed - Return compressed public key (default: true)
  */
 export function getPublicKey(privateKey: string, compressed: boolean = true): string {
-  const keyPair = ec.keyFromPrivate(privateKey, 'hex');
-  return keyPair.getPublic(compressed, 'hex');
+  // SEC1 encoding: compressed = 02/03 prefix + x (33 bytes),
+  // uncompressed = 04 prefix + x + y (65 bytes) — identical to elliptic's output.
+  return bytesToHex(secp256k1.getPublicKey(hexToBytes(privateKey), compressed));
 }
 
 /**
@@ -481,30 +479,20 @@ export function hashSignMessage(message: string): string {
  * @param message       - plaintext message to sign
  */
 export function signMessage(privateKeyHex: string, message: string): string {
-  const keyPair = ec.keyFromPrivate(privateKeyHex, 'hex');
   const hashHex = hashSignMessage(message);
-  const hashBytes = Buffer.from(hashHex, 'hex');
-  const sig = keyPair.sign(hashBytes, { canonical: true });
+  // prehash:false — the message is already hashed (double-SHA256 above);
+  // lowS:true — canonical low-S signatures (same as elliptic's {canonical:true});
+  // format:'recovered' — recoveryId(1) || r(32) || s(32), RFC6979-deterministic.
+  const sigBytes = secp256k1.sign(hexToBytes(hashHex), hexToBytes(privateKeyHex), {
+    prehash: false,
+    lowS: true,
+    format: 'recovered',
+  });
 
-  // Find recovery parameter
-  const pub = keyPair.getPublic();
-  let recoveryParam = -1;
-  for (let i = 0; i < 4; i++) {
-    try {
-      if (ec.recoverPubKey(hashBytes, sig, i).eq(pub)) {
-        recoveryParam = i;
-        break;
-      }
-    } catch { /* try next */ }
-  }
-  if (recoveryParam === -1) {
-    throw new SphereError('Could not find recovery parameter', 'SIGNING_ERROR');
-  }
-
+  const recoveryParam = sigBytes[0];
   const v = (31 + recoveryParam).toString(16).padStart(2, '0');
-  const r = sig.r.toString('hex').padStart(64, '0');
-  const s = sig.s.toString('hex').padStart(64, '0');
-  return v + r + s;
+  // r and s are fixed-width 32-byte big-endian — already left-padded.
+  return v + bytesToHex(sigBytes.subarray(1));
 }
 
 /**
@@ -529,12 +517,13 @@ export function verifySignedMessage(
   if (v < 0 || v > 3) return false;
 
   const hashHex = hashSignMessage(message);
-  const hashBytes = Buffer.from(hashHex, 'hex');
 
   try {
-    const recovered = ec.recoverPubKey(hashBytes, { r, s }, v);
-    const recoveredHex = recovered.encode('hex', true); // compressed
-    return recoveredHex === expectedPubkey;
+    const recovered = secp256k1.Signature
+      .fromHex(r + s, 'compact')
+      .addRecoveryBit(v)
+      .recoverPublicKey(hexToBytes(hashHex));
+    return recovered.toHex(true) === expectedPubkey; // compressed
   } catch {
     return false;
   }
@@ -573,11 +562,10 @@ export function recoverPubkeyFromSignature(message: string, signature: string): 
   }
 
   const hashHex = hashSignMessage(message);
-  const hashBytes = Buffer.from(hashHex, 'hex');
 
-  const recovered = ec.recoverPubKey(hashBytes, { r, s }, v);
-  return recovered.encode('hex', true);
+  const recovered = secp256k1.Signature
+    .fromHex(r + s, 'compact')
+    .addRecoveryBit(v)
+    .recoverPublicKey(hexToBytes(hashHex));
+  return recovered.toHex(true); // compressed
 }
-
-// Re-export elliptic instance for advanced use cases
-export { ec };

--- a/core/crypto.ts
+++ b/core/crypto.ts
@@ -19,6 +19,26 @@ const CURVE_ORDER = BigInt(
   '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141'
 );
 
+/** A secp256k1 private key is exactly 32 bytes — 64 hex chars. */
+const PRIVKEY_HEX_RE = /^[0-9a-fA-F]{64}$/;
+
+/**
+ * Reject a malformed private key BEFORE it reaches the curve (#674 review).
+ * `hexToBytes` coerces any non-hex character to a zero byte
+ * (`parseInt('gg', 16)` → NaN → 0), so a right-length string with a stray
+ * non-hex char would otherwise derive/sign with a DIFFERENT valid key and no
+ * error — silently signing with an unintended key. secp256k1 already rejects
+ * wrong-*length* input; this closes the same-length-wrong-chars hole.
+ */
+function assertPrivKeyHex(privateKeyHex: string): void {
+  if (!PRIVKEY_HEX_RE.test(privateKeyHex)) {
+    throw new SphereError(
+      `Invalid private key: expected 64 hex chars, got ${privateKeyHex.length}`,
+      'VALIDATION_ERROR',
+    );
+  }
+}
+
 /** Default derivation path for Unicity (BIP44) */
 export const DEFAULT_DERIVATION_PATH = "m/44'/0'/0'";
 
@@ -236,6 +256,7 @@ export function deriveKeyAtPath(
  * @param compressed - Return compressed public key (default: true)
  */
 export function getPublicKey(privateKey: string, compressed: boolean = true): string {
+  assertPrivKeyHex(privateKey);
   // SEC1 encoding: compressed = 02/03 prefix + x (33 bytes),
   // uncompressed = 04 prefix + x + y (65 bytes) — identical to elliptic's output.
   return bytesToHex(secp256k1.getPublicKey(hexToBytes(privateKey), compressed));
@@ -479,6 +500,7 @@ export function hashSignMessage(message: string): string {
  * @param message       - plaintext message to sign
  */
 export function signMessage(privateKeyHex: string, message: string): string {
+  assertPrivKeyHex(privateKeyHex);
   const hashHex = hashSignMessage(message);
   // prehash:false — the message is already hashed (double-SHA256 above);
   // lowS:true — canonical low-S signatures (same as elliptic's {canonical:true});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
         "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0",
-        "elliptic": "^6.6.1"
+        "crypto-js": "^4.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -27,7 +26,6 @@
         "@libp2p/interface": "^3.1.0",
         "@libp2p/peer-id": "^6.0.4",
         "@types/crypto-js": "^4.2.2",
-        "@types/elliptic": "^6.4.18",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.54.0",
@@ -1620,14 +1618,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@types/bn.js": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/crypto-js": {
       "version": "4.2.2",
       "dev": true,
@@ -1654,14 +1644,6 @@
         "@types/docker-modem": "*",
         "@types/node": "*",
         "@types/ssh2": "*"
-      }
-    },
-    "node_modules/@types/elliptic": {
-      "version": "6.4.18",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/bn.js": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -2586,10 +2568,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/bn.js": {
-      "version": "4.12.2",
-      "license": "MIT"
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "dev": true,
@@ -2598,10 +2576,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "license": "MIT"
     },
     "node_modules/buffer": {
       "version": "6.0.3",
@@ -3031,19 +3005,6 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/elliptic": {
-      "version": "6.6.1",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3624,27 +3585,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hashlru": {
       "version": "2.3.0",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -3711,6 +3655,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/interface-datastore": {
@@ -4075,14 +4020,6 @@
       "version": "1.0.1",
       "devOptional": true,
       "license": "Apache-2.0 OR MIT"
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "license": "ISC"
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -150,8 +150,7 @@
     "bip39": "^3.1.0",
     "buffer": "^6.0.3",
     "canonicalize": "^3.0.0",
-    "crypto-js": "^4.2.0",
-    "elliptic": "^6.6.1"
+    "crypto-js": "^4.2.0"
   },
   "optionalDependencies": {
     "@libp2p/crypto": "^5.1.13",
@@ -166,7 +165,6 @@
     "@libp2p/interface": "^3.1.0",
     "@libp2p/peer-id": "^6.0.4",
     "@types/crypto-js": "^4.2.2",
-    "@types/elliptic": "^6.4.18",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.54.0",

--- a/tests/unit/core/chainPubkey-stability.test.ts
+++ b/tests/unit/core/chainPubkey-stability.test.ts
@@ -3,9 +3,10 @@
  *
  * `chainPubkey` is the wallet's identity anchor (Nostr npub and the L3
  * recipient predicate both hang off it). The v1→v2 migration must NOT change it. sphere
- * derives it with `elliptic` (core/crypto); the v2 state-transition SDK derives signing
- * keys with `@noble/curves`. This test locks that, for a fixed private key, both produce
- * the BYTE-IDENTICAL 33-byte compressed secp256k1 public key — so chainPubkey is stable
+ * derives it in core/crypto (formerly `elliptic`, now `@noble/curves` — see #674); the
+ * v2 state-transition SDK derives signing keys through its own `@noble/curves` path.
+ * This test locks that, for a fixed private key, both code paths produce the
+ * BYTE-IDENTICAL 33-byte compressed secp256k1 public key — so chainPubkey is stable
  * across the engine swap regardless of which library computes it.
  *
  * SDK-side import goes through token-engine/sdk (the single SDK boundary), exactly as the
@@ -24,8 +25,8 @@ const PRIVATE_KEYS: readonly string[] = [
   'f0e1d2c3b4a5968778695a4b3c2d1e0ff0e1d2c3b4a5968778695a4b3c2d1e0f',
 ];
 
-describe('chainPubkey stability (D9) — sphere elliptic ≡ v2 SDK @noble', () => {
-  it('getPublicKey (elliptic) === SigningService.publicKey (@noble) for each key', () => {
+describe('chainPubkey stability (D9) — sphere core/crypto ≡ v2 SDK @noble', () => {
+  it('getPublicKey (core/crypto) === SigningService.publicKey (v2 SDK) for each key', () => {
     for (const priv of PRIVATE_KEYS) {
       const sphereCompressed = getPublicKey(priv).toLowerCase();
       const sdkCompressed = HexConverter.encode(new SigningService(hexToBytes(priv)).publicKey).toLowerCase();

--- a/tests/unit/core/crypto-noble-equivalence.test.ts
+++ b/tests/unit/core/crypto-noble-equivalence.test.ts
@@ -211,3 +211,67 @@ describe('crypto noble equivalence — golden vectors captured from elliptic v0.
     });
   });
 });
+
+describe('recovery-id v-byte wiring — all four values [0..3] exercised (#674 review)', () => {
+  // signMessage cannot naturally emit recoveryId 2/3 (needs R.x >= n, probability
+  // ~2^-128 under RFC6979), so no golden signMessage vector can cover them. But
+  // verify/recover ACCEPT external v in [0..3], so decode wiring for 2/3 must
+  // still be exercised: take the privkey=1 vector (recoveryId 1, v=0x20) and
+  // tamper the v byte to every other value, driving addRecoveryBit(0/2/3) for
+  // real. A wiring bug that mapped 2/3 onto 0/1 would let a wrong byte recover
+  // the signer — these assertions would catch it.
+  const v = GOLDEN_VECTORS[0];
+  const signer = v.recovered;
+  const rs = v.signature.slice(2); // r||s (128 hex), v byte stripped
+
+  it('v = 31 + recoveryId is a bijection over [0..3]', () => {
+    for (const rec of [0, 1, 2, 3]) {
+      const vByte = (31 + rec).toString(16).padStart(2, '0');
+      expect(parseInt(vByte, 16) - 31).toBe(rec);
+    }
+  });
+
+  it('only the correct recovery byte (0x20) recovers the signer; 0x1f/0x21/0x22 do not', () => {
+    const tryRecover = (vByte: string): string | null => {
+      try {
+        return recoverPubkeyFromSignature(v.message, vByte + rs);
+      } catch {
+        return null; // no valid point for this recovery id — acceptable
+      }
+    };
+    expect(tryRecover('20')).toBe(signer); // recoveryId 1
+    for (const vByte of ['1f', '21', '22']) {
+      // recoveryId 0, 2, 3 — must reach noble and never return the signer
+      expect(tryRecover(vByte)).not.toBe(signer);
+    }
+  });
+
+  it('verifySignedMessage accepts only the correct recovery byte', () => {
+    expect(verifySignedMessage(v.message, '20' + rs, signer)).toBe(true);
+    for (const vByte of ['1f', '21', '22']) {
+      expect(verifySignedMessage(v.message, vByte + rs, signer)).toBe(false);
+    }
+  });
+});
+
+describe('private-key input validation (#674 review)', () => {
+  const VALID = '0000000000000000000000000000000000000000000000000000000000000001';
+
+  it('getPublicKey rejects a right-length key with a non-hex char (no silent zero-coercion)', () => {
+    // 'gg' would coerce to 0x00 in hexToBytes → a different valid key, no error.
+    expect(() => getPublicKey('gg' + VALID.slice(2))).toThrow(/expected 64 hex/);
+  });
+
+  it('getPublicKey rejects wrong-length keys', () => {
+    expect(() => getPublicKey('0102')).toThrow(/expected 64 hex/);
+    expect(() => getPublicKey('')).toThrow(/expected 64 hex/);
+  });
+
+  it('signMessage rejects a right-length key with a non-hex char', () => {
+    expect(() => signMessage('gg' + VALID.slice(2), 'msg')).toThrow(/expected 64 hex/);
+  });
+
+  it('a valid key still succeeds unchanged', () => {
+    expect(getPublicKey(VALID)).toBe(GOLDEN_VECTORS[0].compressed);
+  });
+});

--- a/tests/unit/core/crypto-noble-equivalence.test.ts
+++ b/tests/unit/core/crypto-noble-equivalence.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Golden-vector equivalence tests for the elliptic → @noble/curves migration (#674).
+ *
+ * The expected values below were captured from the elliptic-based implementation
+ * (v0.11.11, commit facaca6e) BEFORE the migration. They encode the cross-language
+ * signature contract: the aggregator-subscription proxy verifies these exact bytes
+ * server-side in Java/BouncyCastle (`SphereSignedMessage.java`) for SGW auth —
+ * v = 31 + recoveryId (0..3), r and s as 32-byte big-endian hex (low-S,
+ * RFC6979-deterministic), pubkeys as 33-byte compressed SEC1 lowercase hex.
+ *
+ * DO NOT update these literals to make a failing implementation pass. A mismatch
+ * means the implementation regressed — byte-drift here breaks wallet auth against
+ * deployed verifiers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getPublicKey,
+  hashSignMessage,
+  signMessage,
+  verifySignedMessage,
+  recoverPubkeyFromSignature,
+  deriveChildKey,
+  deriveAddressInfo,
+  entropyToMnemonic,
+  identityFromMnemonicSync,
+  DEFAULT_DERIVATION_PATH,
+} from '../../../core/crypto';
+
+/** secp256k1 half order — signatures must be low-S (canonical / BTC-compatible). */
+const HALF_ORDER = BigInt(
+  '0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0'
+);
+
+interface GoldenVector {
+  name: string;
+  privateKey: string;
+  message: string;
+  compressed: string;
+  uncompressed: string;
+  hash: string;
+  signature: string;
+  recovered: string;
+}
+
+// 560-byte message — exercises the 3-byte varint (0xfd) length-prefix path.
+const LONG_MESSAGE = 'sphere-golden-'.repeat(40);
+
+const GOLDEN_VECTORS: GoldenVector[] = [
+  {
+    name: 'privkey=1 (30 leading zero bytes), empty message',
+    privateKey: '0000000000000000000000000000000000000000000000000000000000000001',
+    message: '',
+    compressed: '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    uncompressed:
+      '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
+    hash: 'f06f7738d0de178c64ab309c40ce34bd31031f7295a53ce8bb287baf2104d3a6',
+    signature:
+      '20760a3ce2064403629e85c70f238c952806b6039fdc8af7190360dff7d4c5ec13795533d2baab2b9c8eb5e0204bb5cd47d1ef8a633efc7355f4ff400f67d81338',
+    recovered: '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+  },
+  {
+    name: 'leading-zero-byte key, unicode message',
+    privateKey: '00a1b2c3d4e5f60718293a4b5c6d7e8f9091a2b3c4d5e6f708192a3b4c5d6e7f',
+    message: 'héllo ⚡ ünïcode 日本語 🚀',
+    compressed: '030c0557c356f97ce5745d75a8eaf80d4ddffdb42223a4de66a7e75fa4b7b2488b',
+    uncompressed:
+      '040c0557c356f97ce5745d75a8eaf80d4ddffdb42223a4de66a7e75fa4b7b2488bd5e64ee33890f71f5ff7bcf80b638c219dda42e8f7a0890ae2bd0feeed31ee11',
+    hash: 'a4560ce2c8d28581fd0a41c9ad89db2e51d92cff356936fb12a3cbc8722cd6ba',
+    signature:
+      '2089de3618c2d700698989f1a37fa4fa408901e39159b1523670bd6ce28151a92915d0a363e25fdb7c2ea9e70b3f2cc3f32a9c326e07c8b440a612b0ee52ceb7ee',
+    recovered: '030c0557c356f97ce5745d75a8eaf80d4ddffdb42223a4de66a7e75fa4b7b2488b',
+  },
+  {
+    name: "24-word-derived key (m/44'/0'/0'/0/0 of all-zero entropy), ascii message",
+    privateKey: 'cb4793fa23e98437e2d37655eaaa59cf03a0637ea890f85a85d91946e9214c64',
+    message: 'SGW auth challenge 42',
+    compressed: '0342d943b8dba93a4ce29b858479c67f1e4f1110eecbe1f83dc01b455eb8b123b3',
+    uncompressed:
+      '0442d943b8dba93a4ce29b858479c67f1e4f1110eecbe1f83dc01b455eb8b123b372ff98e283aebf0b5209a6546a47db8fbc307ba4d3c2146d31179a9de6464693',
+    hash: '9621f61f90b57aa1790b7f0bbbdb2f26583a8eb150e430075409c379a77b17d8',
+    signature:
+      '1fb44295d43e99c69270e69746ca5751b934c6fc1ff1606bb9826754f6ea529b0e47a2e287b3542e32e6b0a7ff0015835c00b3b7f1bc9dadd85e8121fbd04cfadd',
+    recovered: '0342d943b8dba93a4ce29b858479c67f1e4f1110eecbe1f83dc01b455eb8b123b3',
+  },
+  {
+    name: 'n-1 private key, short message',
+    privateKey: 'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140',
+    message: 'test',
+    compressed: '0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    uncompressed:
+      '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777',
+    hash: 'cf21516be50d2c5fffc8818f37e785bfbf6f702dfcd54a42a8a3c4b6e69e84a8',
+    signature:
+      '20f4da5417bf62f23531e9eb95ba2fcb9c033690f5a2a274e2274a76822f0c1a362b156433a5b3b356040210fcd241ee6ee835be59e9b90e7e336e1e17b7712d75',
+    recovered: '0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+  },
+  {
+    name: 'mid-range key, long message (>252 bytes, 3-byte varint path)',
+    privateKey: '4242424242424242424242424242424242424242424242424242424242424242',
+    message: LONG_MESSAGE,
+    compressed: '0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c',
+    uncompressed:
+      '0424653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c119fc5009a032aa9fe47f5e149bb8442f71f884ccb516590686d8ff6ab91c613',
+    hash: '11b343b6165986e28395a81d01c0808992f7d1dbe21e86624e6f707075b443f3',
+    signature:
+      '20a414dacddb5b83b7c3b951ba141c7bed366adeb96b724a5af7ba2887a63078dd387e66205ae3766b81b79af07b3d5956b589f039b4eb105f9fb5e4154507ab87',
+    recovered: '0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c',
+  },
+];
+
+describe('crypto noble equivalence — golden vectors captured from elliptic v0.11.11', () => {
+  describe.each(GOLDEN_VECTORS)('$name', (v) => {
+    it('getPublicKey — compressed (33-byte, 02/03 prefix)', () => {
+      const pub = getPublicKey(v.privateKey, true);
+      expect(pub).toBe(v.compressed);
+      expect(pub).toMatch(/^0[23][0-9a-f]{64}$/);
+    });
+
+    it('getPublicKey — uncompressed (65-byte, 04 prefix)', () => {
+      const pub = getPublicKey(v.privateKey, false);
+      expect(pub).toBe(v.uncompressed);
+      expect(pub).toMatch(/^04[0-9a-f]{128}$/);
+    });
+
+    it('getPublicKey — default is compressed', () => {
+      expect(getPublicKey(v.privateKey)).toBe(v.compressed);
+    });
+
+    it('hashSignMessage — double-SHA256 varint digest', () => {
+      expect(hashSignMessage(v.message)).toBe(v.hash);
+    });
+
+    it('signMessage — byte-identical v+r+s (RFC6979 deterministic)', () => {
+      expect(signMessage(v.privateKey, v.message)).toBe(v.signature);
+    });
+
+    it('signMessage — SphereSignedMessage.java format contract (130 lowercase hex, v=31+recId, low-S)', () => {
+      const sig = signMessage(v.privateKey, v.message);
+      // Java: SIGNATURE_PATTERN = ^[0-9a-f]{130}$
+      expect(sig).toMatch(/^[0-9a-f]{130}$/);
+      // Java: recoveryId = v - 31, must be in [0..3]
+      const recoveryId = parseInt(sig.slice(0, 2), 16) - 31;
+      expect(recoveryId).toBeGreaterThanOrEqual(0);
+      expect(recoveryId).toBeLessThanOrEqual(3);
+      // Canonical low-S (elliptic {canonical:true} ≡ noble lowS default)
+      const s = BigInt('0x' + sig.slice(66, 130));
+      expect(s <= HALF_ORDER).toBe(true);
+    });
+
+    it('verifySignedMessage — accepts the golden signature', () => {
+      expect(verifySignedMessage(v.message, v.signature, v.compressed)).toBe(true);
+    });
+
+    it('verifySignedMessage — rejects a tampered signature', () => {
+      // Flip the last nibble of s
+      const last = v.signature.slice(-1);
+      const flipped = (parseInt(last, 16) ^ 0x1).toString(16);
+      const tampered = v.signature.slice(0, -1) + flipped;
+      expect(verifySignedMessage(v.message, tampered, v.compressed)).toBe(false);
+    });
+
+    it('recoverPubkeyFromSignature — recovers the golden compressed pubkey', () => {
+      expect(recoverPubkeyFromSignature(v.message, v.signature)).toBe(v.recovered);
+    });
+  });
+
+  describe('EC-dependent BIP32 derivation (non-hardened branch uses the compressed pubkey)', () => {
+    // 24-word mnemonic from all-zero 256-bit entropy (standard BIP39 test vector)
+    const MNEMONIC_24 = entropyToMnemonic('00'.repeat(32));
+
+    it('all-zero-entropy 24-word mnemonic is stable', () => {
+      expect(MNEMONIC_24).toBe(
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon ' +
+          'abandon abandon abandon abandon abandon abandon abandon abandon abandon ' +
+          'abandon abandon abandon abandon abandon art'
+      );
+    });
+
+    it('master key from 24-word mnemonic is byte-identical', () => {
+      const master = identityFromMnemonicSync(MNEMONIC_24);
+      expect(master.privateKey).toBe(
+        '235b34cd7c9f6d7e4595ffe9ae4b1cb5606df8aca2b527d20a07c8f56b2342f4'
+      );
+      expect(master.chainCode).toBe(
+        'f40eaad21641ca7cb5ac00f9ce21cac9ba070bb673a237f7bce57acda54386a4'
+      );
+    });
+
+    it('non-hardened deriveChildKey (index 0) is byte-identical', () => {
+      const master = identityFromMnemonicSync(MNEMONIC_24);
+      const child = deriveChildKey(master.privateKey, master.chainCode, 0);
+      expect(child.privateKey).toBe(
+        'da44d2b30836e1ca7c38b2b32fb5f62e07209364248e8a3eb86ffa2aa2ff3af1'
+      );
+      expect(child.chainCode).toBe(
+        '720f054103868ffcccf40da0f9002350d6deffd0b2e88ec5a8f4231d6db7f155'
+      );
+    });
+
+    it("deriveAddressInfo at m/44'/0'/0'/0/0 is byte-identical", () => {
+      const master = identityFromMnemonicSync(MNEMONIC_24);
+      const addr = deriveAddressInfo(master, DEFAULT_DERIVATION_PATH, 0);
+      expect(addr.privateKey).toBe(
+        'cb4793fa23e98437e2d37655eaaa59cf03a0637ea890f85a85d91946e9214c64'
+      );
+      expect(addr.publicKey).toBe(
+        '0342d943b8dba93a4ce29b858479c67f1e4f1110eecbe1f83dc01b455eb8b123b3'
+      );
+      expect(addr.path).toBe("m/44'/0'/0'/0/0");
+    });
+  });
+});

--- a/tests/unit/core/crypto.test.ts
+++ b/tests/unit/core/crypto.test.ts
@@ -4,7 +4,6 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ec as EC } from 'elliptic';
 import {
   generateMnemonic,
   validateMnemonic,
@@ -615,17 +614,15 @@ describe('Message Signing', () => {
 // =============================================================================
 
 describe('recoverPubkeyFromSignature', () => {
-  const ec = new EC('secp256k1');
   const PRIVKEY_HEX = '0000000000000000000000000000000000000000000000000000000000000001';
-
-  function pubkeyFor(privkeyHex: string): string {
-    return ec.keyFromPrivate(privkeyHex, 'hex').getPublic().encode('hex', true);
-  }
+  // Compressed SEC1 encoding of the secp256k1 generator point G — the public key
+  // of private key 1. Well-known constant, independent of any crypto library.
+  const PUBKEY_OF_ONE = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
 
   it('returns compressed pubkey of the signer', () => {
     const message = 'hello sphere';
     const signature = signMessage(PRIVKEY_HEX, message);
-    expect(recoverPubkeyFromSignature(message, signature)).toBe(pubkeyFor(PRIVKEY_HEX));
+    expect(recoverPubkeyFromSignature(message, signature)).toBe(PUBKEY_OF_ONE);
   });
 
   it('is deterministic', () => {


### PR DESCRIPTION
> [!WARNING]
> **CRYPTO CHANGE — needs careful review; do NOT merge on mainnet-launch day without a second reviewer confirming signature-format equivalence.**

Resolves #674 (advisory GHSA-848j-6mx2-7j84 against `elliptic`).

## Scope — elliptic only, crypto-js deliberately untouched

Exactly the three elliptic ECDSA operations in `core/crypto.ts` move to `@noble/curves` (already a dependency, used elsewhere in the SDK):

1. **`getPublicKey`** (and the non-hardened branch of `deriveChildKey`, which now calls it): `secp256k1.getPublicKey(priv, compressed)` — same SEC1 encodings as elliptic: compressed `02/03` + x (33 bytes), uncompressed `04` + x + y (65 bytes), lowercase hex.
2. **`signMessage`**: `secp256k1.sign(hash, priv, { prehash: false, lowS: true, format: 'recovered' })`. `prehash:false` because the digest is already the double-SHA256 varint scheme; `lowS:true` is exactly elliptic's `{canonical:true}`; noble's `'recovered'` format carries the recovery id directly, so the old brute-force `ec.recoverPubKey` loop is deleted. Output stays the exact **130-char hex `v(=31+recoveryId) + r(64) + s(64)`**, RFC6979-deterministic (both libraries implement RFC6979 with HMAC-SHA256, so r/s are bit-for-bit identical — proven by the golden vectors below).
3. **`verifySignedMessage` / `recoverPubkeyFromSignature`**: `secp256k1.Signature.fromHex(r+s, 'compact').addRecoveryBit(v).recoverPublicKey(hash).toHex(true)` (noble supports recovery ids 0–3, matching elliptic).

Also removed: the dead `export { ec }` escape hatch (no in-repo consumers; never re-exported from the package index), and `elliptic` + `@types/elliptic` from `package.json`/lockfile.

**`crypto-js` is NOT touched.** It is not part of the advisory, and in `core/crypto.ts` it performs the consensus-critical BIP32 HMAC-SHA512 key derivation and message hashing — changing it would alter every derived address and digest. Every `CryptoJS.*` call is exactly as before.

## Byte-exactness guarantee and how it's verified

This is not just an internal refactor: the signature bytes are a **cross-language, on-chain-adjacent contract**. The aggregator-subscription proxy verifies sphere `signMessage` output server-side in Java/BouncyCastle (`SphereSignedMessage.java`: `v = 31 + recoveryId`, `^[0-9a-f]{130}$`, compressed-pubkey recovery over the double-SHA256 varint digest) for SGW auth — signature drift breaks mainnet wallet auth against deployed verifiers.

New test: **`tests/unit/core/crypto-noble-equivalence.test.ts`** (49 tests). The expected literals were captured from the **elliptic implementation at v0.11.11 (facaca6e) before the migration**, then the migration had to reproduce them bit-for-bit:

- 5 (privateKey, message) golden vectors: privkey=1 (30 leading zero bytes) + empty message, leading-zero-byte key + unicode message, 24-word-mnemonic-derived key (`m/44'/0'/0'/0/0`), n−1 key, and a 560-byte message (exercises the 3-byte varint path).
- For each: compressed + uncompressed pubkey, `hashSignMessage` digest, full `signMessage` output, `verifySignedMessage` (accept + tamper-reject), `recoverPubkeyFromSignature`, plus the Java format contract (130 lowercase hex, recovery id ∈ [0,3], low-S ≤ n/2).
- EC-dependent BIP32 derivation locked too: master key from the 24-word vector, non-hardened `deriveChildKey`, `deriveAddressInfo`.

**All 49 assertions reproduce byte-identically on the noble implementation — zero drift.** The recovery ids exercised cover both 0 (`v=1f`) and 1 (`v=20`); all captured signatures are low-S, confirming elliptic `canonical:true` ≡ noble `lowS:true`.

The pre-existing `chainPubkey-stability.test.ts` (sphere `getPublicKey` ≡ state-transition SDK `SigningService.publicKey`) still passes and now cross-checks two independent noble call paths; `crypto.test.ts` had its one elliptic test helper replaced with the well-known SEC1 generator-point constant.

## Verification results

- `tests/unit/core/crypto-noble-equivalence.test.ts`: **49/49** ✅ (passes against BOTH the old elliptic implementation and the new noble one)
- Targeted run — `crypto.test.ts` + `chainPubkey-stability.test.ts` + `wallet-api/intent-signing.test.ts` + `core/encryption.test.ts` + equivalence: **160/160** ✅
- Full unit suite (`npm run test:run`): **3094/3094 tests, 202 files** ✅ (one unrelated timing flake in `PaymentsModule.wake-reconnect.test.ts` under CPU contention; passes in isolation and in the clean full run)
- `npm run typecheck` (`tsc --noEmit`): ✅
- `npm run build` (tsup): ✅ — no `elliptic` package code in `dist/`
- `npx eslint` on touched files: ✅
- `npm ls elliptic`: **(empty)** — gone from the entire dependency tree; `npm audit` no longer reports GHSA-848j-6mx2-7j84

## Review focus

- `core/crypto.ts` `signMessage`: confirm `prehash: false` (we pass a precomputed digest) and `format: 'recovered'` layout (`recoveryId || r || s`, fixed-width 32-byte big-endian r/s).
- Confirm the golden-vector literals in the new test were NOT edited after capture (they encode the deployed Java verifier contract — a failing implementation must never be "fixed" by updating vectors).