### PR TITLE
fix(payments): make suspectedSpent demotion durable in wallet-api custody (SPHERE-4)

### DIFF
--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -237,10 +237,11 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
    * demoted client-side, but the server row is still `active` (no evidenced
    * tombstone), so `save()` carries nothing and a reload would re-serve the
    * phantom as spendable `confirmed` balance (SPHERE-4). We keep the tokenId in
-   * this per-device set and re-stamp it onto the active view every converge
-   * (see {@link snapshotView}); the set is pruned once the token leaves the
-   * active view (a real tombstone/spend or handoff), so it stays bounded and
-   * never shadows a legitimately re-added token.
+   * this per-device set and re-stamp it onto every returned view — full
+   * snapshot and delta page alike (see {@link applySuspectedSpentOverlay}); the
+   * set is pruned once the token leaves the active view (a real tombstone/spend
+   * or handoff) on either path, so it stays bounded and never shadows a
+   * legitimately re-added token.
    */
   private async readSuspectedSpent(): Promise<Set<string>> {
     const raw = await this.stateStore.get(this.stateKey('suspectedSpent'));
@@ -265,7 +266,8 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
    * (`PaymentsModule.demoteSuspectedSpent`) when a `TransferConflictError`
    * proves a source already spent on-chain. LOCAL only — the server view still
    * shows the row active, so this is the only place the flag can survive a
-   * reload. Re-applied to the view by {@link snapshotView}.
+   * reload. Re-applied to every returned view (full snapshot and delta) by
+   * {@link applySuspectedSpentOverlay}.
    */
   async markSuspectedSpent(tokenId: string): Promise<void> {
     const overlay = await this.readSuspectedSpent();
@@ -398,23 +400,47 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
         await this.persistSyncState(page.cursor, page.syncEpoch);
       }
     }
-    return page;
+    // #679: the suspected-spent overlay is authoritative on the delta path too,
+    // not only in snapshotView — stamp any demoted active row this page carries
+    // (so a delta consumer never sees a demoted source as spendable) and prune
+    // ids this page tombstoned (so a stale overlay entry can't shadow a later
+    // re-add). Both paths converge on the SAME stamp/prune helper.
+    const items = await this.applySuspectedSpentOverlay(page.items);
+    return { ...page, items };
   }
 
   private async snapshotView(): Promise<InventoryView> {
     const active = [...this.view.values()].filter((i) => i.status === 'active');
-    // #679: re-apply (and prune) the durable suspected-spent overlay so a
-    // client-side demotion survives this reload — an active row in the overlay
-    // is stamped `suspectedSpent` and the consumer rebuilds it as a demoted,
-    // non-spendable token instead of resurrecting the phantom balance.
-    const overlay = await this.reconcileSuspectedSpent(active);
-    const items =
-      overlay.size === 0
-        ? active
-        : active.map((i) => (overlay.has(i.tokenId) ? { ...i, suspectedSpent: true } : i));
+    const items = await this.applySuspectedSpentOverlay(active);
     const cursor = (await this.readCursor()) ?? 0n;
     const syncEpoch = (await this.readSyncEpoch()) ?? 0n;
     return { cursor, syncEpoch, more: false, items };
+  }
+
+  /**
+   * #679: the SINGLE place the durable suspected-spent overlay is applied to
+   * inventory rows on their way to a consumer — used by BOTH return paths, the
+   * full snapshot ({@link snapshotView}) and the S2 delta page
+   * ({@link listInventory} with a cursor), so the two can never drift:
+   *  - a returned ACTIVE row whose tokenId is in the overlay is stamped
+   *    `suspectedSpent`, so a client-side demotion survives a reload AND a delta
+   *    consumer is never served a demoted source as spendable (the phantom
+   *    balance / re-spend guard, SPHERE-4);
+   *  - the overlay is pruned to the tokens still active in the WHOLE local view
+   *    — a tombstone arriving on EITHER path has already flipped its `this.view`
+   *    row to `removed`, so its id is dropped here, keeping the overlay bounded
+   *    and unable to shadow a later legitimately re-added token of the same id.
+   * Pruning is reconciled against the whole `this.view`, NOT just `rows`: a
+   * delta page is PARTIAL, so reconciling to only its rows would wrongly drop
+   * still-active overlay ids that simply did not change in this page.
+   */
+  private async applySuspectedSpentOverlay(rows: InventoryItem[]): Promise<InventoryItem[]> {
+    const active = [...this.view.values()].filter((i) => i.status === 'active');
+    const overlay = await this.reconcileSuspectedSpent(active);
+    if (overlay.size === 0) return rows;
+    return rows.map((i) =>
+      i.status === 'active' && overlay.has(i.tokenId) ? { ...i, suspectedSpent: true } : i
+    );
   }
 
   /** Fetch + decode one blob on demand via a short-lived signed GET (§5.1). */

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -262,6 +262,25 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
   }
 
   /**
+   * #679: serialize overlay read-modify-write. Both {@link markSuspectedSpent}
+   * and {@link reconcileSuspectedSpent} read the persisted overlay, mutate it,
+   * and write it back; without this a concurrent demotion (overlapping `send()`
+   * calls) could read a stale set and clobber another's write, dropping a
+   * `suspectedSpent` id so the phantom balance reappears after reload. A simple
+   * promise-chain mutex — each op runs after the previous settles, and a failing
+   * op never wedges the chain.
+   */
+  private overlayLock: Promise<unknown> = Promise.resolve();
+  private withOverlayLock<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.overlayLock.then(fn, fn);
+    this.overlayLock = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  /**
    * #679: durably record a client-side demotion. Called by the consumer
    * (`PaymentsModule.demoteSuspectedSpent`) when a `TransferConflictError`
    * proves a source already spent on-chain. LOCAL only — the server view still
@@ -270,10 +289,12 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
    * {@link applySuspectedSpentOverlay}.
    */
   async markSuspectedSpent(tokenId: string): Promise<void> {
-    const overlay = await this.readSuspectedSpent();
-    if (overlay.has(tokenId)) return;
-    overlay.add(tokenId);
-    await this.writeSuspectedSpent(overlay);
+    await this.withOverlayLock(async () => {
+      const overlay = await this.readSuspectedSpent();
+      if (overlay.has(tokenId)) return;
+      overlay.add(tokenId);
+      await this.writeSuspectedSpent(overlay);
+    });
   }
 
   /**
@@ -284,18 +305,20 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
    * (#679 lifecycle). Persists only when the set actually changed.
    */
   private async reconcileSuspectedSpent(active: InventoryItem[]): Promise<Set<string>> {
-    const overlay = await this.readSuspectedSpent();
-    if (overlay.size === 0) return overlay;
-    const activeIds = new Set(active.map((i) => i.tokenId));
-    let changed = false;
-    for (const id of overlay) {
-      if (!activeIds.has(id)) {
-        overlay.delete(id);
-        changed = true;
+    return this.withOverlayLock(async () => {
+      const overlay = await this.readSuspectedSpent();
+      if (overlay.size === 0) return overlay;
+      const activeIds = new Set(active.map((i) => i.tokenId));
+      let changed = false;
+      for (const id of overlay) {
+        if (!activeIds.has(id)) {
+          overlay.delete(id);
+          changed = true;
+        }
       }
-    }
-    if (changed) await this.writeSuspectedSpent(overlay);
-    return overlay;
+      if (changed) await this.writeSuspectedSpent(overlay);
+      return overlay;
+    });
   }
 
   // ── inventory sync (§5.1) ───────────────────────────────────────────────────

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -231,6 +231,71 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     await this.stateStore.set(this.stateKey('knownSpends'), JSON.stringify([...known]));
   }
 
+  /**
+   * #679 durable suspected-spent overlay — DURABLE LOCAL demotions, never on
+   * the server. A source proven spent on-chain (`TransferConflictError`) is
+   * demoted client-side, but the server row is still `active` (no evidenced
+   * tombstone), so `save()` carries nothing and a reload would re-serve the
+   * phantom as spendable `confirmed` balance (SPHERE-4). We keep the tokenId in
+   * this per-device set and re-stamp it onto the active view every converge
+   * (see {@link snapshotView}); the set is pruned once the token leaves the
+   * active view (a real tombstone/spend or handoff), so it stays bounded and
+   * never shadows a legitimately re-added token.
+   */
+  private async readSuspectedSpent(): Promise<Set<string>> {
+    const raw = await this.stateStore.get(this.stateKey('suspectedSpent'));
+    if (!raw) return new Set();
+    try {
+      return new Set(JSON.parse(raw) as string[]);
+    } catch {
+      return new Set();
+    }
+  }
+
+  private async writeSuspectedSpent(ids: Set<string>): Promise<void> {
+    if (ids.size === 0) {
+      await this.stateStore.remove(this.stateKey('suspectedSpent'));
+      return;
+    }
+    await this.stateStore.set(this.stateKey('suspectedSpent'), JSON.stringify([...ids]));
+  }
+
+  /**
+   * #679: durably record a client-side demotion. Called by the consumer
+   * (`PaymentsModule.demoteSuspectedSpent`) when a `TransferConflictError`
+   * proves a source already spent on-chain. LOCAL only — the server view still
+   * shows the row active, so this is the only place the flag can survive a
+   * reload. Re-applied to the view by {@link snapshotView}.
+   */
+  async markSuspectedSpent(tokenId: string): Promise<void> {
+    const overlay = await this.readSuspectedSpent();
+    if (overlay.has(tokenId)) return;
+    overlay.add(tokenId);
+    await this.writeSuspectedSpent(overlay);
+  }
+
+  /**
+   * Prune the durable suspected-spent overlay to the tokens still ACTIVE in the
+   * given view and return the surviving set. Any overlay id that is no longer
+   * active — legitimately tombstoned/spent, handed off, or vanished — is
+   * dropped, so the overlay cannot grow unbounded or shadow a re-added token
+   * (#679 lifecycle). Persists only when the set actually changed.
+   */
+  private async reconcileSuspectedSpent(active: InventoryItem[]): Promise<Set<string>> {
+    const overlay = await this.readSuspectedSpent();
+    if (overlay.size === 0) return overlay;
+    const activeIds = new Set(active.map((i) => i.tokenId));
+    let changed = false;
+    for (const id of overlay) {
+      if (!activeIds.has(id)) {
+        overlay.delete(id);
+        changed = true;
+      }
+    }
+    if (changed) await this.writeSuspectedSpent(overlay);
+    return overlay;
+  }
+
   // ── inventory sync (§5.1) ───────────────────────────────────────────────────
 
   private applyItems(items: InventoryItem[]): void {
@@ -337,7 +402,16 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
   }
 
   private async snapshotView(): Promise<InventoryView> {
-    const items = [...this.view.values()].filter((i) => i.status === 'active');
+    const active = [...this.view.values()].filter((i) => i.status === 'active');
+    // #679: re-apply (and prune) the durable suspected-spent overlay so a
+    // client-side demotion survives this reload — an active row in the overlay
+    // is stamped `suspectedSpent` and the consumer rebuilds it as a demoted,
+    // non-spendable token instead of resurrecting the phantom balance.
+    const overlay = await this.reconcileSuspectedSpent(active);
+    const items =
+      overlay.size === 0
+        ? active
+        : active.map((i) => (overlay.has(i.tokenId) ? { ...i, suspectedSpent: true } : i));
     const cursor = (await this.readCursor()) ?? 0n;
     const syncEpoch = (await this.readSyncEpoch()) ?? 0n;
     return { cursor, syncEpoch, more: false, items };

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1738,6 +1738,26 @@ export class PaymentsModule {
     if (!token) return;
     token.suspectedSpent = true;
     this.tokens.set(tokenId, token);
+    // #679: write the demotion through to any provider that keeps a DURABLE
+    // suspected-spent overlay (the wallet-api thin provider). Its save() below
+    // pushes only additions + confirmed-spend tombstones, so a suspectedSpent
+    // flag on an otherwise-active row is dropped and the phantom resurfaces as
+    // spendable `confirmed` on the next reload (SPHERE-4). The overlay is keyed
+    // by the genesis tokenId; a lazy record carries no sdkData, so derive it
+    // from the `v2_` id. Local whole-blob providers persist the flag via save()
+    // and don't implement this hook.
+    const genesisId =
+      extractTokenIdFromSdkData(token.sdkData) ?? (token.id.startsWith('v2_') ? token.id.slice(3) : null);
+    if (genesisId) {
+      for (const [, provider] of this.getTokenStorageProviders()) {
+        if (typeof provider.markSuspectedSpent !== 'function') continue;
+        try {
+          await provider.markSuspectedSpent(genesisId);
+        } catch (err) {
+          logger.warn('Payments', `Failed to persist suspectedSpent overlay for ${genesisId}:`, err);
+        }
+      }
+    }
     try {
       await this.save();
     } catch (err) {
@@ -2567,6 +2587,11 @@ export class PaymentsModule {
         createdAt: Date.now(),
         updatedAt: Date.now(),
         lazy: true,
+        // #679: the provider re-applied its durable suspected-spent overlay to
+        // this server-active row (a source proven spent on-chain). Rebuild it
+        // demoted so the reload does NOT re-serve the phantom as spendable —
+        // getSpendableTokens/coin-selection and aggregateTokens skip it.
+        ...(item.suspectedSpent ? { suspectedSpent: true } : {}),
       };
       this.tokens.set(token.id, token);
       merged++;

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -117,6 +117,17 @@ export interface InventoryItem {
   assets?: InventoryAsset[];
   /** Owner change-cursor value at this row's last change (`?since=` deltas). */
   seq: bigint;
+  /**
+   * #679 client-local demotion overlay: the server still reports this row as
+   * `active`, but a prior `TransferConflictError` proved its state consumed
+   * on-chain (a "suspected spent" source). It is stamped here so the consumer
+   * (`PaymentsModule.mergeLazyInventory`) rebuilds the token as `suspectedSpent`
+   * — kept in inventory, excluded from spendable balance and coin-selection —
+   * and the demotion survives a reload. Providers with server-side custody keep
+   * this flag in DURABLE LOCAL state (never pushed to the server); local
+   * whole-blob providers omit it (they persist the whole token record).
+   */
+  suspectedSpent?: boolean;
 }
 
 /** Result of {@link TokenStorageProvider.listInventory}. */
@@ -289,6 +300,20 @@ export interface TokenStorageProvider<TData = unknown> extends BaseProvider {
    * Only meaningful for providers with server-side tombstones.
    */
   recoverRemoved?(): Promise<RecoverRemovedResult>;
+
+  /**
+   * #679 durable client-side demotion. Record that `tokenId` was proven spent
+   * on-chain (a `TransferConflictError`) even though the server view still
+   * reports its row `active` — so the demotion survives a reload instead of
+   * being re-served as spendable `confirmed` balance every session (the
+   * SPHERE-4 phantom-balance bug). Providers with server-side custody persist
+   * it in DURABLE LOCAL state and re-stamp it onto `listInventory()`
+   * (`InventoryItem.suspectedSpent`); the overlay is never pushed to the server
+   * and is pruned once the token leaves the active view (a real spend/tombstone
+   * or handoff). Local whole-blob providers persist `suspectedSpent` inside the
+   * saved token record and omit this hook.
+   */
+  markSuspectedSpent?(tokenId: string): Promise<void>;
 
   /**
    * Check if data exists

--- a/tests/contract/wallet-api-token-storage-provider.contract.test.ts
+++ b/tests/contract/wallet-api-token-storage-provider.contract.test.ts
@@ -33,7 +33,12 @@ function makeDevice(
   baseUrl: string,
   identityIndex: number,
   deviceId: string
-): { client: WalletApiClient; provider: WalletApiTokenStorageProvider; pubkey: string } {
+): {
+  client: WalletApiClient;
+  provider: WalletApiTokenStorageProvider;
+  pubkey: string;
+  stateStore: MemoryKeyValueStore;
+} {
   const identity = testIdentity(identityIndex);
   const client = new WalletApiClient({
     baseUrl,
@@ -41,15 +46,16 @@ function makeDevice(
     deviceId,
     storage: new MemoryKeyValueStore(),
   });
+  const stateStore = new MemoryKeyValueStore();
   const provider = new WalletApiTokenStorageProvider({
     client,
-    stateStore: new MemoryKeyValueStore(),
+    stateStore,
   });
   provider.setIdentity({
     privateKey: identity.privateKey,
     chainPubkey: identity.chainPubkey,
   } as FullIdentity);
-  return { client, provider, pubkey: identity.chainPubkey };
+  return { client, provider, pubkey: identity.chainPubkey, stateStore };
 }
 
 async function seedVia(provider: WalletApiTokenStorageProvider, tokens: TestToken[]): Promise<void> {
@@ -158,6 +164,68 @@ describe('WalletApiTokenStorageProvider — S2 remote semantics', () => {
     // And B's converged active view drops it.
     const after = await deviceB.provider.listInventory();
     expect(after.items.map((i) => i.tokenId)).toEqual([t2.tokenId]);
+  });
+
+  // #679 SPHERE-4: the durable suspected-spent overlay is authoritative on the
+  // DELTA path too, not just the full snapshot (snapshotView). Before the fix a
+  // delta page (`listInventory(cursor)`) was applied to the view and returned
+  // RAW, so a demoted source could be served as spendable and a delta tombstone
+  // never pruned the overlay key.
+  const overlayKey = (identityIndex: number): string =>
+    `wallet-api-storage:suspectedSpent:${fake.network}:${testIdentity(identityIndex).chainPubkey}`;
+
+  it('a demoted token served on a DELTA page is stamped suspectedSpent, not spendable (#679)', async () => {
+    const deviceA = makeDevice(fake, baseUrl, 40, 'dev-a');
+    const deviceB = makeDevice(fake, baseUrl, 40, 'dev-b'); // same owner, second device
+    const t1 = makeTestToken();
+    await seedVia(deviceA.provider, [t1]);
+
+    // Device B converges — t1 is active and NOT demoted yet.
+    const before = await deviceB.provider.listInventory();
+    expect(before.items.find((i) => i.tokenId === t1.tokenId)?.suspectedSpent).toBeUndefined();
+
+    // A #625 client-side demotion on device B (a TransferConflictError proved
+    // the source spent on-chain): recorded on the durable per-device overlay.
+    await deviceB.provider.markSuspectedSpent(t1.tokenId);
+
+    // A consumer replaying a delta that re-carries t1 as an ACTIVE row (a
+    // lagging device draining from an older cursor) must see it STAMPED — the
+    // overlay is authoritative on the delta path, exactly like the snapshot.
+    const delta = await deviceB.provider.listInventory(0n);
+    const row = delta.items.find((i) => i.tokenId === t1.tokenId);
+    expect(row?.status).toBe('active');
+    expect(row?.suspectedSpent).toBe(true); // raw delta row before the fix → undefined
+  });
+
+  it('a tombstone arriving on the DELTA path prunes the overlay — a later re-add is NOT shadowed (#679)', async () => {
+    const deviceA = makeDevice(fake, baseUrl, 41, 'dev-a');
+    const deviceB = makeDevice(fake, baseUrl, 41, 'dev-b'); // same owner, second device
+    const t1 = makeTestToken();
+    await seedVia(deviceA.provider, [t1]);
+
+    // Device B converges and demotes t1 client-side (durable overlay).
+    const before = await deviceB.provider.listInventory();
+    await deviceB.provider.markSuspectedSpent(t1.tokenId);
+    expect(await deviceB.stateStore.get(overlayKey(41))).toBe(JSON.stringify([t1.tokenId]));
+
+    // Device A legitimately spends t1 (its other device) → a real tombstone.
+    // Device B learns it ONLY via a delta page — the overlay must be pruned
+    // there (t1 left the active view), or it would shadow a later re-add.
+    await deviceA.provider.applyDelta('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', [t1.tokenId], []);
+    const delta = await deviceB.provider.listInventory(before.cursor);
+    expect(delta.items.find((i) => i.tokenId === t1.tokenId)?.status).toBe('removed');
+    expect(await deviceB.stateStore.get(overlayKey(41))).toBeNull(); // overlay kept t1 before the fix
+
+    // t1 is later legitimately re-added (recovery/reactivation). With the
+    // overlay pruned it returns SPENDABLE — the stale demotion no longer
+    // shadows it. Before the fix the un-pruned overlay re-stamps it on the next
+    // full snapshot, re-hiding a healthy token forever.
+    const recovered = await deviceB.provider.recoverRemoved();
+    expect(recovered.recovered).toContain(t1.tokenId);
+    const restored = await deviceB.provider.listInventory();
+    const row = restored.items.find((i) => i.tokenId === t1.tokenId);
+    expect(row?.status).toBe('active');
+    expect(row?.suspectedSpent).toBeFalsy();
   });
 
   it('syncEpoch change → discard cursors, full pull, re-PUT open intents (§5.4/E.3)', async () => {

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -1281,6 +1281,123 @@ describe('reload (tab refresh) — durable cursor, rebuilt view (#521)', () => {
   });
 });
 
+describe('suspected-spent demotion is DURABLE across a reload (SPHERE-4 phantom balance, #679)', () => {
+  const overlayKey = () => `wallet-api-storage:suspectedSpent:${'testnet2'}:${SENDER.chainPubkey}`;
+
+  it('a #625 demotion survives a tab refresh — the phantom is NOT re-served as spendable confirmed balance', async () => {
+    const { fake, baseUrl } = await startFake();
+    const kv = new MemoryKeyValueStore(); // the SHARED persisted stateStore — survives the "refresh"
+
+    // Session 1 — the only source is already spent on-chain: every certification
+    // attempt raises TransferConflictError, so #625 demotes it and the send
+    // exhausts to a clean SEND_INSUFFICIENT_BALANCE.
+    const tab1 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-679', kv);
+    const sourceTokenId = await seedServerToken(fake, tab1, SENDER, 1000n);
+    await tab1.module.load();
+    expect(tab1.module.getBalance(UCT)).toEqual([
+      expect.objectContaining({ coinId: UCT, confirmedAmount: '1000' }),
+    ]);
+
+    vi.spyOn(tab1.engine, 'transfer').mockRejectedValue(
+      new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent'),
+    );
+    await expect(tab1.module.send({ recipient: '@bob', amount: '1000', coinId: UCT })).rejects.toThrow(
+      /insufficient balance/i,
+    );
+
+    // In-session: demoted, kept in inventory, excluded from spendable balance…
+    expect(tab1.module.getTokens().find((t) => t.id === `v2_${sourceTokenId}`)?.suspectedSpent).toBe(true);
+    expect(tab1.module.getBalance(UCT)).toEqual([]);
+    // …and the demotion is now on the DURABLE overlay (client-local, never the server).
+    expect(await kv.get(overlayKey())).toBe(JSON.stringify([sourceTokenId]));
+    // The server row is still ACTIVE — the demotion was never pushed (no wire change).
+    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)?.status).toBe('active');
+
+    // Session 2 — a NEW provider+module instance over the SAME persisted store
+    // (the tab refresh). Before #679 mergeLazyInventory re-stamped the still-active
+    // server row as spendable `confirmed` and the phantom returned every session.
+    const tab2 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-679', kv);
+    await tab2.module.load();
+
+    // The token is kept (visible/recoverable) but DEMOTED — not phantom-confirmed.
+    const reloaded = tab2.module.getTokens().find((t) => t.id === `v2_${sourceTokenId}`);
+    expect(reloaded).toBeDefined();
+    expect(reloaded?.suspectedSpent).toBe(true);
+    // NOT presented as spendable confirmed balance.
+    expect(tab2.module.getBalance(UCT)).toEqual([]);
+    // NOT selectable by coin-selection — the fresh engine has NO conflict spy, so a
+    // broken overlay would let this real send proceed; the demotion blocks it at
+    // selection instead.
+    await expect(tab2.module.send({ recipient: '@bob', amount: '1000', coinId: UCT })).rejects.toThrow(
+      /insufficient balance/i,
+    );
+  });
+
+  it('the overlay is selective: a non-demoted active token stays spendable after reload', async () => {
+    const { fake, baseUrl } = await startFake();
+    const kv = new MemoryKeyValueStore();
+
+    // Two sources: a 1000 (which a 1000-send selects, then finds conflicted) and a
+    // 500 that is too small to cover the send, so it is never touched.
+    const tab1 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-679-sel', kv);
+    const bigId = await seedServerToken(fake, tab1, SENDER, 1000n);
+    await seedServerToken(fake, tab1, SENDER, 500n);
+    await tab1.module.load();
+
+    vi.spyOn(tab1.engine, 'transfer').mockRejectedValue(
+      new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent'),
+    );
+    await expect(tab1.module.send({ recipient: '@bob', amount: '1000', coinId: UCT })).rejects.toThrow(
+      /insufficient balance/i,
+    );
+    expect(await kv.get(overlayKey())).toBe(JSON.stringify([bigId]));
+
+    // Reload: only the demoted 1000 is excluded; the untouched 500 is still spendable.
+    const tab2 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-679-sel', kv);
+    await tab2.module.load();
+    expect(tab2.module.getTokens().find((t) => t.id === `v2_${bigId}`)?.suspectedSpent).toBe(true);
+    expect(tab2.module.getBalance(UCT)).toEqual([
+      expect.objectContaining({ coinId: UCT, confirmedAmount: '500', confirmedTokenCount: 1 }),
+    ]);
+  });
+
+  it('a legitimately-tombstoned token clears from the overlay (bounded, never shadows a re-add)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const kv = new MemoryKeyValueStore();
+
+    // Demote the only source (as above) → it lands on the durable overlay.
+    const tab1 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-679-tomb', kv);
+    const sourceTokenId = await seedServerToken(fake, tab1, SENDER, 1000n);
+    await tab1.module.load();
+    vi.spyOn(tab1.engine, 'transfer').mockRejectedValue(
+      new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent'),
+    );
+    await expect(tab1.module.send({ recipient: '@bob', amount: '1000', coinId: UCT })).rejects.toThrow(
+      /insufficient balance/i,
+    );
+    expect(await kv.get(overlayKey())).toBe(JSON.stringify([sourceTokenId]));
+
+    // The token is now LEGITIMATELY spent on-chain (the owner's other device):
+    // the server row becomes a real tombstone. On the next converge the overlay
+    // must drop it — it left the active view, so it can neither grow unbounded
+    // nor shadow a legitimately re-added token later.
+    const other = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-679-other');
+    await other.client.applyInventoryDelta({
+      transferId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      spent: [sourceTokenId],
+      added: [],
+    });
+    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)?.status).toBe('removed');
+
+    const tab2 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-679-tomb', kv);
+    await tab2.module.load();
+
+    // The demoted token is gone (spent), and the overlay is pruned empty.
+    expect(tab2.module.getTokens().find((t) => t.id === `v2_${sourceTokenId}`)).toBeUndefined();
+    expect(await kv.get(overlayKey())).toBeNull();
+  });
+});
+
 describe('history reload (tab refresh) — rebuilt from the server log (J4/J5, #549)', () => {
   it('J4: send → reload → the SENT record is hydrated from the server with its memo decrypted (no loss, no dupes)', async () => {
     const { fake, baseUrl } = await startFake();

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -1282,7 +1282,8 @@ describe('reload (tab refresh) — durable cursor, rebuilt view (#521)', () => {
 });
 
 describe('suspected-spent demotion is DURABLE across a reload (SPHERE-4 phantom balance, #679)', () => {
-  const overlayKey = () => `wallet-api-storage:suspectedSpent:${'testnet2'}:${SENDER.chainPubkey}`;
+  const overlayKey = (network: string) =>
+    `wallet-api-storage:suspectedSpent:${network}:${SENDER.chainPubkey}`;
 
   it('a #625 demotion survives a tab refresh — the phantom is NOT re-served as spendable confirmed balance', async () => {
     const { fake, baseUrl } = await startFake();
@@ -1309,7 +1310,7 @@ describe('suspected-spent demotion is DURABLE across a reload (SPHERE-4 phantom 
     expect(tab1.module.getTokens().find((t) => t.id === `v2_${sourceTokenId}`)?.suspectedSpent).toBe(true);
     expect(tab1.module.getBalance(UCT)).toEqual([]);
     // …and the demotion is now on the DURABLE overlay (client-local, never the server).
-    expect(await kv.get(overlayKey())).toBe(JSON.stringify([sourceTokenId]));
+    expect(await kv.get(overlayKey(fake.network))).toBe(JSON.stringify([sourceTokenId]));
     // The server row is still ACTIVE — the demotion was never pushed (no wire change).
     expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)?.status).toBe('active');
 
@@ -1350,7 +1351,7 @@ describe('suspected-spent demotion is DURABLE across a reload (SPHERE-4 phantom 
     await expect(tab1.module.send({ recipient: '@bob', amount: '1000', coinId: UCT })).rejects.toThrow(
       /insufficient balance/i,
     );
-    expect(await kv.get(overlayKey())).toBe(JSON.stringify([bigId]));
+    expect(await kv.get(overlayKey(fake.network))).toBe(JSON.stringify([bigId]));
 
     // Reload: only the demoted 1000 is excluded; the untouched 500 is still spendable.
     const tab2 = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-679-sel', kv);
@@ -1375,7 +1376,7 @@ describe('suspected-spent demotion is DURABLE across a reload (SPHERE-4 phantom 
     await expect(tab1.module.send({ recipient: '@bob', amount: '1000', coinId: UCT })).rejects.toThrow(
       /insufficient balance/i,
     );
-    expect(await kv.get(overlayKey())).toBe(JSON.stringify([sourceTokenId]));
+    expect(await kv.get(overlayKey(fake.network))).toBe(JSON.stringify([sourceTokenId]));
 
     // The token is now LEGITIMATELY spent on-chain (the owner's other device):
     // the server row becomes a real tombstone. On the next converge the overlay
@@ -1394,7 +1395,26 @@ describe('suspected-spent demotion is DURABLE across a reload (SPHERE-4 phantom 
 
     // The demoted token is gone (spent), and the overlay is pruned empty.
     expect(tab2.module.getTokens().find((t) => t.id === `v2_${sourceTokenId}`)).toBeUndefined();
-    expect(await kv.get(overlayKey())).toBeNull();
+    expect(await kv.get(overlayKey(fake.network))).toBeNull();
+  });
+
+  it('concurrent demotions do not clobber the overlay (serialized read-modify-write, #679)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const kv = new MemoryKeyValueStore();
+    const client = new WalletApiClient({ baseUrl, network: fake.network, deviceId: 'd-679-race', storage: kv });
+    const provider = new WalletApiTokenStorageProvider({ client, stateStore: kv });
+    provider.setIdentity(fullIdentity(SENDER));
+
+    // Fire many demotions at once. Each markSuspectedSpent read-modify-writes the
+    // persisted overlay; WITHOUT serialization concurrent calls read the same
+    // stale set and the last write clobbers the rest, dropping suspectedSpent ids
+    // (the phantom returns after reload). The mutex must retain ALL of them.
+    const ids = Array.from({ length: 20 }, (_, i) => `race-tok-${i.toString().padStart(2, '0')}`);
+    await Promise.all(ids.map((id) => provider.markSuspectedSpent(id)));
+
+    const persisted = new Set(JSON.parse((await kv.get(overlayKey(fake.network)))!) as string[]);
+    expect(persisted.size).toBe(ids.length);
+    for (const id of ids) expect(persisted.has(id)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## SPHERE-4 phantom-balance bug (Sentry P0)

In the wallet-api custody composition (the production/hosted wallet), a token proven spent on-chain via `TransferConflictError` is demoted with `suspectedSpent`, but the demotion **does not survive a reload** — so it is re-served as spendable `confirmed` balance every session, inflating the displayed balance and surfacing as `SEND_INSUFFICIENT_BALANCE` when the user tries to spend value that isn't really there.

### Mechanism (confirmed in source)
- `PaymentsModule.demoteSuspectedSpent` sets `token.suspectedSpent = true` and calls `save()`.
- `WalletApiTokenStorageProvider.save()` persists **only** unknown-token additions and confirmed-spend `_tombstones`. A `suspectedSpent` token stays `active` in the server inventory view, so it is neither an addition nor a tombstone — the flag is silently dropped. `load()` returns only `_meta` + `_tombstones` (no per-token flags).
- On reload, `mergeLazyInventory` rebuilds the token map from the server view and stamps every server-`active` row `status:'confirmed'` with no `suspectedSpent`. The phantom is resurrected.

The `demoteSuspectedSpent` comment calls the demotion "durable" — true for local whole-blob custody (the whole token record is saved), false for the wallet-api thin provider (prod).

### Fix: durable client-local `suspectedSpent` overlay (client-only)

`wallet-api` is aggregator-independent by design, so this fix adds **no** server round-trip, chain reconciliation, or wire/protocol change.

- **Where it's persisted:** a per-device set of `suspectedSpent` tokenIds in the thin provider's base key-value `stateStore` — the same durable-local mechanism it already uses for `cursor` / `syncEpoch` / `knownSpends`, keyed per `(network, chainPubkey)` (`wallet-api-storage:suspectedSpent:<network>:<chainPubkey>`). **Never pushed to the server.**
- **Write-through:** `demoteSuspectedSpent` calls a new optional `TokenStorageProvider.markSuspectedSpent(tokenId)` hook (keyed by the genesis tokenId, derived from the lazy record's `v2_` id). Local whole-blob providers don't implement it and keep persisting the flag inside the saved token record.
- **Re-application:** `snapshotView()` re-applies the overlay — a server-`active` row in the overlay is stamped `InventoryItem.suspectedSpent`, and `mergeLazyInventory` rebuilds it demoted. Exclusion from spendable balance (`aggregateTokens`) and coin-selection (`SpendQueue`) already keys off `suspectedSpent`, so no change is needed there — it matches a live-session demotion exactly.
- **Lifecycle / cleanup:** on every converge the overlay is pruned to the tokens still active in the view. A legitimately tombstoned/spent, handed-off, or vanished token drops out — so the set stays bounded and can never shadow a legitimately re-added token.

### Why no server change
The server view is the source of truth for custody; a `suspectedSpent` demotion is a purely client-side, per-device belief ("this source already lost a race on-chain") that must not mutate the shared server inventory. Keeping it in the provider's local `stateStore` and re-stamping it onto the rendered view preserves the wallet-api aggregator-independence invariant.

### Files
- `storage/storage-provider.ts` — `InventoryItem.suspectedSpent?` + optional `TokenStorageProvider.markSuspectedSpent?()`.
- `impl/shared/wallet-api/WalletApiTokenStorageProvider.ts` — durable overlay read/write, `markSuspectedSpent()`, `reconcileSuspectedSpent()` prune, and overlay re-application in `snapshotView()`.
- `modules/payments/PaymentsModule.ts` — `demoteSuspectedSpent` write-through; `mergeLazyInventory` stamps `suspectedSpent` from the view.
- `tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts` — regression tests.

### Verification
- Regression tests (over the wallet-api provider composition, reload = fresh module+provider over the same persisted `stateStore`): a demoted token survives a reload — **not** presented as spendable `confirmed`, **not** selectable by coin-selection; a non-demoted active token stays spendable; a legitimately-tombstoned token clears from the overlay. Verified **load-bearing** — all 3 fail without the fix.
- `npm run typecheck`: clean.
- `npm run lint` (touched files): 0 errors (only pre-existing warnings, none in new code).
- `npm run test:run`: **202 files, 3104 tests, all passing.**

Closes #679
