### PR TITLE
fix(payments): stop two send/resume double-pays (#676, #677)

### DIFF
--- a/core/errors.ts
+++ b/core/errors.ts
@@ -150,14 +150,16 @@ export class SphereError extends Error {
  * #677: a send that PARTIALLY completed before losing a source to a concurrent
  * transfer. At least one earlier leg certified on-chain and was journaled for
  * delivery (its {@link committedTokenIds}) — that value has irreversibly left
- * the wallet — but a LATER leg raised `TransferConflictError` (a lost race).
+ * the wallet — but a LATER leg raised `TransferConflictError` (a lost race), and
+ * `send()` could NOT cover the {@link remainingAmount} from the remaining live
+ * sources (the internal remainder re-plan is exhausted — this is the fallback).
  *
  * Distinct from `TransferConflictError` on purpose: a bare conflict makes the
  * caller re-send the FULL amount, paying the already-delivered leg a second
  * time. Catching THIS type (or `code === 'SEND_PARTIALLY_COMPLETED'`) tells the
  * caller/UI: the delivered legs are final, the conflicted intent has been
- * soft-aborted, and only the REMAINDER may be re-planned — under a NEW
- * transferId, never re-sending the whole amount.
+ * soft-aborted, and only the REMAINDER ({@link remainingAmount}) may be
+ * re-planned — under a NEW transferId, never re-sending the whole amount.
  *
  * NOT a subclass of `TransferConflictError` by design: existing conflict
  * handlers that re-send in full must NOT treat this as an ordinary conflict.
@@ -167,17 +169,59 @@ export class PartialSendConflictError extends SphereError {
   readonly transferId: string;
   /**
    * Source token ids whose spend already certified on-chain (and whose finished
-   * output blob is journaled for delivery). The remainder = the requested amount
-   * minus the value of these legs; re-plan only that, under a new transferId.
+   * output blob is journaled for delivery). Their value has already been
+   * delivered; NEVER re-send these.
    */
   readonly committedTokenIds: readonly string[];
+  /**
+   * The still-undelivered portion (base units, decimal string) — `send()` could
+   * not cover it from the remaining live sources. Re-plan ONLY this amount, under
+   * a new transferId; the delivered legs converge via the recipient's §6 claim.
+   */
+  readonly remainingAmount: string;
 
-  constructor(message: string, transferId: string, committedTokenIds: readonly string[], cause?: unknown) {
+  constructor(
+    message: string,
+    transferId: string,
+    committedTokenIds: readonly string[],
+    remainingAmount: string,
+    cause?: unknown,
+  ) {
     super(message, 'SEND_PARTIALLY_COMPLETED', cause);
     this.name = 'PartialSendConflictError';
     this.transferId = transferId;
     this.committedTokenIds = [...committedTokenIds];
+    this.remainingAmount = remainingAmount;
   }
+}
+
+/**
+ * Error codes for a send outcome where money has (or may have) already left the
+ * wallet on-chain, so the send is NOT a clean, re-sendable failure. A consumer
+ * that persists a "paid" flag (e.g. a payment request) must keep the request
+ * NON-payable on any of these — reverting to a re-payable state would double-pay
+ * (#441). Covers the post-commit mirror-sync-pending / keep-open certification
+ * states AND the partial-conflict outcome.
+ */
+const POSSIBLY_COMMITTED_SEND_CODES: ReadonlySet<SphereErrorCode> = new Set([
+  'SEND_SYNC_PENDING',
+  'CERTIFICATION_UNCONFIRMED',
+  'CHECKPOINT_PERSIST_FAILED',
+  'SPLIT_CHECKPOINT_LOST',
+  'CHECKPOINT_TRUSTBASE_MISMATCH',
+  'SEND_PARTIALLY_COMPLETED',
+]);
+
+/**
+ * #441: true when a send failed with an outcome where the payment has (or may
+ * have) irreversibly left the wallet — a post-commit sync-pending / keep-open
+ * certification state, or a `PartialSendConflictError`. Such a send completes (or
+ * has already partially completed) via resume/claim and MUST NOT be re-sent, so
+ * a persisted "paid" state must stay non-payable. A `false` result is a clean
+ * pre-commit failure — nothing left the wallet, safe to re-pay.
+ */
+export function isPossiblyCommittedSendOutcome(err: unknown): boolean {
+  return isSphereError(err) && POSSIBLY_COMMITTED_SEND_CODES.has(err.code);
 }
 
 /**

--- a/core/errors.ts
+++ b/core/errors.ts
@@ -52,6 +52,14 @@ export type SphereErrorCode =
   // #664). Surfaced distinctly so a UI can reassure ("sent — wallet catching
   // up") instead of showing a hard send failure.
   | 'SEND_SYNC_PENDING'
+  // #677: a multi-leg send lost a source to a concurrent transfer AFTER ≥1
+  // earlier leg had already certified on-chain AND been journaled/delivered.
+  // The delivered value has irreversibly left the wallet, so this is NOT a
+  // plain, re-sendable failure: surfacing a bare TransferConflictError makes
+  // the caller re-send the FULL amount and pay the delivered leg twice. Raised
+  // as PartialSendConflictError; the caller MUST re-plan ONLY the remainder
+  // under a NEW transferId, never the whole amount.
+  | 'SEND_PARTIALLY_COMPLETED'
   | 'TRANSPORT_ERROR'
   | 'AGGREGATOR_ERROR'
   | 'VALIDATION_ERROR'
@@ -135,6 +143,40 @@ export class SphereError extends Error {
     this.name = 'SphereError';
     this.code = code;
     this.cause = cause;
+  }
+}
+
+/**
+ * #677: a send that PARTIALLY completed before losing a source to a concurrent
+ * transfer. At least one earlier leg certified on-chain and was journaled for
+ * delivery (its {@link committedTokenIds}) — that value has irreversibly left
+ * the wallet — but a LATER leg raised `TransferConflictError` (a lost race).
+ *
+ * Distinct from `TransferConflictError` on purpose: a bare conflict makes the
+ * caller re-send the FULL amount, paying the already-delivered leg a second
+ * time. Catching THIS type (or `code === 'SEND_PARTIALLY_COMPLETED'`) tells the
+ * caller/UI: the delivered legs are final, the conflicted intent has been
+ * soft-aborted, and only the REMAINDER may be re-planned — under a NEW
+ * transferId, never re-sending the whole amount.
+ *
+ * NOT a subclass of `TransferConflictError` by design: existing conflict
+ * handlers that re-send in full must NOT treat this as an ordinary conflict.
+ */
+export class PartialSendConflictError extends SphereError {
+  /** The send's transferId — its intent was soft-aborted; the delivered legs are journaled under it. */
+  readonly transferId: string;
+  /**
+   * Source token ids whose spend already certified on-chain (and whose finished
+   * output blob is journaled for delivery). The remainder = the requested amount
+   * minus the value of these legs; re-plan only that, under a new transferId.
+   */
+  readonly committedTokenIds: readonly string[];
+
+  constructor(message: string, transferId: string, committedTokenIds: readonly string[], cause?: unknown) {
+    super(message, 'SEND_PARTIALLY_COMPLETED', cause);
+    this.name = 'PartialSendConflictError';
+    this.transferId = transferId;
+    this.committedTokenIds = [...committedTokenIds];
   }
 }
 

--- a/core/errors.ts
+++ b/core/errors.ts
@@ -151,8 +151,10 @@ export class SphereError extends Error {
  * transfer. At least one earlier leg certified on-chain and was journaled for
  * delivery (its {@link committedTokenIds}) — that value has irreversibly left
  * the wallet — but a LATER leg raised `TransferConflictError` (a lost race), and
- * `send()` could NOT cover the {@link remainingAmount} from the remaining live
- * sources (the internal remainder re-plan is exhausted — this is the fallback).
+ * `send()` could NOT COMPLETE the {@link remainingAmount} from the remaining live
+ * sources. This is the fallback after the internal remainder re-plan gave up —
+ * either insufficient funds OR a transient/transport error during the re-plan
+ * (the underlying reason is on `cause`), not necessarily an "out of funds" state.
  *
  * Distinct from `TransferConflictError` on purpose: a bare conflict makes the
  * caller re-send the FULL amount, paying the already-delivered leg a second
@@ -165,18 +167,25 @@ export class SphereError extends Error {
  * handlers that re-send in full must NOT treat this as an ordinary conflict.
  */
 export class PartialSendConflictError extends SphereError {
-  /** The send's transferId — its intent was soft-aborted; the delivered legs are journaled under it. */
+  /**
+   * The FIRST partial attempt's transferId — its intent was soft-aborted, and it
+   * is the §6 handoff anchor. NOTE: `send()` may re-plan the remainder across
+   * SEVERAL internal attempts before giving up, so {@link committedTokenIds} can
+   * span MULTIPLE transferIds — they do NOT all map to this single id.
+   */
   readonly transferId: string;
   /**
    * Source token ids whose spend already certified on-chain (and whose finished
    * output blob is journaled for delivery). Their value has already been
-   * delivered; NEVER re-send these.
+   * delivered; NEVER re-send these. May accumulate across several internal
+   * remainder-re-plan attempts (so not all are journaled under {@link transferId}).
    */
   readonly committedTokenIds: readonly string[];
   /**
    * The still-undelivered portion (base units, decimal string) — `send()` could
-   * not cover it from the remaining live sources. Re-plan ONLY this amount, under
-   * a new transferId; the delivered legs converge via the recipient's §6 claim.
+   * not COMPLETE it from the remaining live sources (insufficient funds or a
+   * transient error; see `cause`). Re-plan ONLY this amount, under a new
+   * transferId; the delivered legs converge via the recipient's §6 claim.
    */
   readonly remainingAmount: string;
 

--- a/core/index.ts
+++ b/core/index.ts
@@ -9,7 +9,7 @@ export * from './bech32';
 export * from './utils';
 export { logger } from './logger';
 export type { LogLevel, LogHandler, LoggerConfig } from './logger';
-export { SphereError, isSphereError } from './errors';
+export { SphereError, PartialSendConflictError, isSphereError } from './errors';
 export type { SphereErrorCode } from './errors';
 export { checkNetworkHealth } from './network-health';
 export type { CheckNetworkHealthOptions } from './network-health';

--- a/core/index.ts
+++ b/core/index.ts
@@ -9,7 +9,7 @@ export * from './bech32';
 export * from './utils';
 export { logger } from './logger';
 export type { LogLevel, LogHandler, LoggerConfig } from './logger';
-export { SphereError, PartialSendConflictError, isSphereError } from './errors';
+export { SphereError, PartialSendConflictError, isSphereError, isPossiblyCommittedSendOutcome } from './errors';
 export type { SphereErrorCode } from './errors';
 export { checkNetworkHealth } from './network-health';
 export type { CheckNetworkHealthOptions } from './network-health';

--- a/index.ts
+++ b/index.ts
@@ -48,7 +48,7 @@
 // Core
 // =============================================================================
 
-export { Sphere, createSphere, loadSphere, initSphere, getSphere, sphereExists, checkNetworkHealth, logger, SphereError, isSphereError } from './core';
+export { Sphere, createSphere, loadSphere, initSphere, getSphere, sphereExists, checkNetworkHealth, logger, SphereError, PartialSendConflictError, isSphereError } from './core';
 export { signMessage, verifySignedMessage, hashSignMessage, recoverPubkeyFromSignature, SIGN_MESSAGE_PREFIX } from './core/crypto';
 export type {
   SphereCreateOptions,

--- a/index.ts
+++ b/index.ts
@@ -48,7 +48,7 @@
 // Core
 // =============================================================================
 
-export { Sphere, createSphere, loadSphere, initSphere, getSphere, sphereExists, checkNetworkHealth, logger, SphereError, PartialSendConflictError, isSphereError } from './core';
+export { Sphere, createSphere, loadSphere, initSphere, getSphere, sphereExists, checkNetworkHealth, logger, SphereError, PartialSendConflictError, isSphereError, isPossiblyCommittedSendOutcome } from './core';
 export { signMessage, verifySignedMessage, hashSignMessage, recoverPubkeyFromSignature, SIGN_MESSAGE_PREFIX } from './core/crypto';
 export type {
   SphereCreateOptions,

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -82,7 +82,7 @@ import {
 } from '../../serialization/txf-serializer';
 import { TokenRegistry } from '../../registry';
 import { logger } from '../../core/logger';
-import { SphereError } from '../../core/errors';
+import { SphereError, PartialSendConflictError } from '../../core/errors';
 import { sha256, bytesToHex, hexToBytes } from '../../core/crypto';
 import { sleep } from '../../core/utils';
 import { PumpHealth } from './pump-health';
@@ -807,6 +807,18 @@ export interface PaymentsWalletApiPort {
   listIntents(status: 'open' | 'aborted'): Promise<
     { transferId: string; payload: string; status: 'open' | 'completed' | 'aborted'; createdAt: number }[]
   >;
+  /**
+   * #676: read the LOCAL intent disposition (status + the #516 `abortPending`
+   * flag) — OPTIONAL capability. Resume consults it before re-executing a
+   * server-`open` intent: a locally-`aborted` (or abort-pending) copy is a send
+   * the user already watched fail whose soft-abort never reached the server, so
+   * re-executing it would double-pay. A `null` result (or a port without a local
+   * copy that omits this method) leaves the server copy authoritative — correct
+   * for a fresh device.
+   */
+  getLocalIntent?(
+    transferId: string
+  ): Promise<{ status: 'open' | 'completed' | 'aborted'; abortPending: boolean } | null>;
   /** §5.2 checksum-bound presigned PUTs for spend outputs. */
   getUploadUrls(
     blobs: { sha256: string; size: number }[]
@@ -2355,6 +2367,26 @@ export class PaymentsModule {
         throw new SphereError(
           'Your payment was sent. Your wallet is syncing with the server and will catch up shortly.',
           'SEND_SYNC_PENDING',
+          error,
+        );
+      }
+
+      // #677: a lost race (TransferConflictError) AFTER ≥1 earlier leg already
+      // certified on-chain and was journaled/delivered is NOT a plain,
+      // re-sendable failure. The delivered value has irreversibly left the wallet
+      // (its source is terminal 'spent' above, its blob journaled for delivery),
+      // and the intent was already soft-aborted above. Surfacing a bare
+      // TransferConflictError would make the caller re-send the FULL amount and
+      // pay the delivered leg twice — so surface a DISTINCT partial outcome
+      // carrying the already-committed legs. The caller re-plans ONLY the
+      // remainder under a NEW transferId (the delivered legs converge via the
+      // recipient's claim handoff, §6). Do NOT emit transfer:failed: the
+      // delivered legs are not lost (mirrors the SEND_SYNC_PENDING contract).
+      if (error instanceof TransferConflictError && committedOnChainTokenIds.size > 0) {
+        throw new PartialSendConflictError(
+          'Part of your payment was already sent before a source token was spent by a concurrent transfer. Re-plan and send only the remaining amount — do NOT re-send the full amount.',
+          result.id,
+          [...committedOnChainTokenIds],
           error,
         );
       }
@@ -5621,6 +5653,32 @@ export class PaymentsModule {
 
     const intents = await walletApi.listIntents('open');
     for (const intent of intents) {
+      // #676: honor a LOCAL abort the server never learned about. A clean
+      // pre-certification send failure soft-aborts the intent best-effort; when
+      // that abort's server leg cannot land (dead backend), abortIntent flips
+      // the LOCAL copy to aborted+abortPending while the SERVER row stays 'open'.
+      // listIntents('open') (a plain server GET) hands that row back, and
+      // re-executing it would RE-SPEND sources the failure handler restored to
+      // 'confirmed' — paying the recipient a second time for a send the user
+      // already watched fail. So: if the local copy is aborted (or has a pending
+      // abort), do NOT resume; re-attempt the abort to converge the server and
+      // classify it with the conflicted (aborted, re-plan) bucket. A missing
+      // local copy (fresh device) leaves the server row authoritative and resume
+      // proceeds, unchanged.
+      const localIntent = await walletApi.getLocalIntent?.(intent.transferId);
+      if (localIntent && (localIntent.status === 'aborted' || localIntent.abortPending)) {
+        logger.warn(
+          'Payments',
+          `Intent ${intent.transferId.slice(0, 8)}… is locally aborted (the abort never reached the server) — converging, NOT resuming (#676)`,
+        );
+        try {
+          await walletApi.abortIntent(intent.transferId);
+        } catch (abortErr) {
+          logger.warn('Payments', 'abortIntent during resume-skip failed (retried next sign-in):', abortErr);
+        }
+        outcome.conflicted.push(intent.transferId);
+        continue;
+      }
       let payload: IntentPayloadV1;
       try {
         const plain = decryptField(this.getFieldEncryptionKey(), intent.payload);

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1787,7 +1787,7 @@ export class PaymentsModule {
         // WAS delivered and the shortfall still owed.
         if (deliveredSourceIds.length > 0) {
           throw new PartialSendConflictError(
-            'Part of your payment was sent, but the remaining amount could not be covered by your other funds. The delivered portion is final — re-plan only the shortfall, never the full amount.',
+            'Part of your payment was sent, but the remaining amount could not be completed (insufficient funds, or a transient error during the remainder re-plan — see cause). The delivered portion is final — re-plan only the shortfall, never the full amount.',
             primaryPartialTransferId!, // always set once a leg delivered (deliveredSourceIds is non-empty)
             deliveredSourceIds,
             currentRequest.amount,

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -82,7 +82,7 @@ import {
 } from '../../serialization/txf-serializer';
 import { TokenRegistry } from '../../registry';
 import { logger } from '../../core/logger';
-import { SphereError, PartialSendConflictError } from '../../core/errors';
+import { SphereError, PartialSendConflictError, isPossiblyCommittedSendOutcome } from '../../core/errors';
 import { sha256, bytesToHex, hexToBytes } from '../../core/crypto';
 import { sleep } from '../../core/utils';
 import { PumpHealth } from './pump-health';
@@ -808,17 +808,19 @@ export interface PaymentsWalletApiPort {
     { transferId: string; payload: string; status: 'open' | 'completed' | 'aborted'; createdAt: number }[]
   >;
   /**
-   * #676: read the LOCAL intent disposition (status + the #516 `abortPending`
-   * flag) — OPTIONAL capability. Resume consults it before re-executing a
+   * #676: read the LOCAL intent dispositions (status + the #516 `abortPending`
+   * flag) for EVERY known intent in ONE pass, keyed by transferId — OPTIONAL
+   * capability. Resume reads this ONCE before its loop and consults it per
    * server-`open` intent: a locally-`aborted` (or abort-pending) copy is a send
    * the user already watched fail whose soft-abort never reached the server, so
-   * re-executing it would double-pay. A `null` result (or a port without a local
-   * copy that omits this method) leaves the server copy authoritative — correct
-   * for a fresh device.
+   * re-executing it would double-pay. A transferId ABSENT from the map (or a port
+   * that omits this method) leaves the server copy authoritative — correct for a
+   * fresh device. Batched (PR #681 review): the per-intent read re-parsed the
+   * whole intents blob N times; this parses it once.
    */
-  getLocalIntent?(
-    transferId: string
-  ): Promise<{ status: 'open' | 'completed' | 'aborted'; abortPending: boolean } | null>;
+  getLocalIntentsMap?(): Promise<
+    Map<string, { status: 'open' | 'completed' | 'aborted'; abortPending: boolean }>
+  >;
   /** §5.2 checksum-bound presigned PUTs for spend outputs. */
   getUploadUrls(
     blobs: { sha256: string; size: number }[]
@@ -1708,24 +1710,42 @@ export class PaymentsModule {
    */
   /**
    * #625 — self-healing coin selection. If a selected source turns out already spent on-chain
-   * (`TransferConflictError`), demote it (durable `suspectedSpent` — kept in inventory, excluded from
-   * selection) and re-plan with the next candidate, bounded. A fixed plan (`instantSplitSend`) is not
-   * re-planned. Exhausting the live candidates surfaces a clean `SEND_INSUFFICIENT_BALANCE` (or the
-   * final conflict), never an endless loop.
+   * (`TransferConflictError`) with NOTHING certified yet, demote it (durable `suspectedSpent` — kept in
+   * inventory, excluded from selection) and re-plan with the next candidate, bounded. A fixed plan
+   * (`instantSplitSend`) is not re-planned. Exhausting the live candidates surfaces a clean
+   * `SEND_INSUFFICIENT_BALANCE`, never an endless loop.
+   *
+   * #677 — remainder re-plan. If a source is lost mid-send AFTER ≥1 leg already certified + delivered
+   * (`PartialSendConflictError`), a full-amount re-plan would double-pay the delivered leg — so re-plan
+   * ONLY the still-owed remainder (`X − already-delivered`) from the remaining live sources, under a
+   * NEW transferId. A send for X thus still delivers X even through a mid-send conflict; the certified
+   * legs converge via the recipient's §6 claim handoff. `PartialSendConflictError` reaches the CALLER
+   * only as the fallback — when that remainder genuinely cannot be covered by the other sources.
    */
   async send(
     request: TransferRequest,
     internal?: { existingReservationId?: string; existingSplitPlan?: SplitPlan },
   ): Promise<TransferResult> {
+    // #677: the running request shrinks to the still-owed REMAINDER across partial
+    // re-plans while the recipient must ultimately receive the full original amount.
+    let currentRequest = request;
+    let currentInternal = internal;
+    // Certified legs accumulated across partial attempts — carried into the fallback
+    // so it NEVER re-sends them; the first partial intent id anchors the §6 handoff.
+    const deliveredSourceIds: string[] = [];
+    let primaryPartialTransferId: string | undefined;
+
     for (let attempt = 0; ; attempt += 1) {
       try {
-        return await this.sendOnce(request, internal);
+        return await this.sendOnce(currentRequest, currentInternal);
       } catch (err) {
+        // #625 — self-healing full re-plan: a clean conflict with NOTHING certified
+        // in that attempt (safe to re-select the whole amount from the next candidate).
         const conflictedId = err instanceof TransferConflictError ? err.conflictedSourceId : undefined;
         if (
           conflictedId !== undefined &&
           attempt < MAX_RESELECT_ATTEMPTS &&
-          internal?.existingSplitPlan === undefined &&
+          currentInternal?.existingSplitPlan === undefined &&
           this.tokens.has(conflictedId)
         ) {
           await this.demoteSuspectedSpent(conflictedId);
@@ -1734,6 +1754,45 @@ export class PaymentsModule {
             `Source ${conflictedId} already spent on-chain — demoted, re-planning with the next candidate (#625, attempt ${attempt + 1}/${MAX_RESELECT_ATTEMPTS})`,
           );
           continue;
+        }
+
+        // #677 — a mid-send conflict AFTER ≥1 leg certified + delivered. Re-plan ONLY
+        // the remainder (never the full amount) from the remaining live sources, under
+        // a NEW transferId, so the recipient still receives the full amount.
+        if (err instanceof PartialSendConflictError && currentInternal?.existingSplitPlan === undefined) {
+          deliveredSourceIds.push(...err.committedTokenIds);
+          if (primaryPartialTransferId === undefined) primaryPartialTransferId = err.transferId;
+          const remaining = BigInt(err.remainingAmount);
+          if (remaining > 0n && attempt < MAX_RESELECT_ATTEMPTS) {
+            logger.warn(
+              'Payments',
+              `Partial send: ${err.committedTokenIds.length} leg(s) certified — re-planning ONLY the remaining ${remaining} under a NEW transferId (#677, attempt ${attempt + 1}/${MAX_RESELECT_ATTEMPTS})`,
+            );
+            currentRequest = { ...request, amount: remaining.toString() };
+            currentInternal = undefined; // fresh, coherent transfer for the remainder (new transferId + reservation)
+            continue;
+          }
+          // Remainder is 0 (defensive) or the attempt budget is exhausted — surface the
+          // accumulated partial so the caller re-plans only the shortfall, never the full amount.
+          throw new PartialSendConflictError(
+            err.message, primaryPartialTransferId, deliveredSourceIds, err.remainingAmount, err.cause,
+          );
+        }
+
+        // A clean, otherwise re-sendable failure that struck DURING a remainder re-plan
+        // (≥1 leg already delivered): the remainder could not be covered (e.g.
+        // SEND_INSUFFICIENT_BALANCE) or a transient error hit. Surfacing it bare would
+        // make the caller re-send the FULL amount and pay the delivered legs twice — so
+        // surface the partial outcome (the insufficient-remainder fallback) carrying what
+        // WAS delivered and the shortfall still owed.
+        if (deliveredSourceIds.length > 0) {
+          throw new PartialSendConflictError(
+            'Part of your payment was sent, but the remaining amount could not be covered by your other funds. The delivered portion is final — re-plan only the shortfall, never the full amount.',
+            primaryPartialTransferId!, // always set once a leg delivered (deliveredSourceIds is non-empty)
+            deliveredSourceIds,
+            currentRequest.amount,
+            err,
+          );
         }
         throw err;
       }
@@ -1782,6 +1841,12 @@ export class PaymentsModule {
     // this send. The failure handler must never restore these as 'confirmed' —
     // their state is consumed; the finished output blob is journaled separately.
     const committedOnChainTokenIds = new Set<string>();
+    // #677: value (base units) already DELIVERED to the recipient by the certified
+    // legs above — a direct leg delivers its whole token amount, a split leg
+    // delivers only its splitAmount. On a mid-send conflict the remainder that
+    // still owes the recipient is `request.amount − committedDeliveredAmount`;
+    // send() re-plans exactly that so a send for X still delivers X.
+    let committedDeliveredAmount = 0n;
     // §3.1 (#621): set when any leg's post-certification delivery is deferred (kept journaled).
     // Scoped to the whole send so the resolve path below can mark the result delivery-pending.
     let deliveryPending = false;
@@ -2034,6 +2099,7 @@ export class PaymentsModule {
           }
           // The source state is spent on-chain from here on.
           committedOnChainTokenIds.add(tw.uiToken.id);
+          committedDeliveredAmount += tw.amount; // #677: a direct leg delivers its whole amount
           // Journal the finished blob BEFORE delivery: a transport failure or a
           // crash must not lose the recipient's token (replayed on next load()).
           const tokenBlob = bytesToHex(encodeTokenBlob(engine.encodeToken(finished)));
@@ -2095,6 +2161,7 @@ export class PaymentsModule {
           // The split source is burnt on-chain from here on. Journal the
           // recipient's blob BEFORE the delivery attempt.
           committedOnChainTokenIds.add(splitPlan.tokenToSplit.uiToken.id);
+          committedDeliveredAmount += splitPlan.splitAmount ?? 0n; // #677: a split leg delivers only splitAmount
           const recipientBlob = bytesToHex(encodeTokenBlob(engine.encodeToken(outputs[0])));
           await this.savePendingV2Delivery({
             transferId: result.id,
@@ -2378,15 +2445,19 @@ export class PaymentsModule {
       // and the intent was already soft-aborted above. Surfacing a bare
       // TransferConflictError would make the caller re-send the FULL amount and
       // pay the delivered leg twice — so surface a DISTINCT partial outcome
-      // carrying the already-committed legs. The caller re-plans ONLY the
-      // remainder under a NEW transferId (the delivered legs converge via the
-      // recipient's claim handoff, §6). Do NOT emit transfer:failed: the
-      // delivered legs are not lost (mirrors the SEND_SYNC_PENDING contract).
+      // carrying the already-committed legs and the still-owed REMAINDER. send()
+      // catches this and re-plans ONLY the remainder under a NEW transferId (the
+      // delivered legs converge via the recipient's claim handoff, §6); this
+      // surfaces to the CALLER only when that remainder cannot be covered. Do NOT
+      // emit transfer:failed: the delivered legs are not lost (mirrors the
+      // SEND_SYNC_PENDING contract).
       if (error instanceof TransferConflictError && committedOnChainTokenIds.size > 0) {
+        const remaining = BigInt(request.amount) - committedDeliveredAmount;
         throw new PartialSendConflictError(
           'Part of your payment was already sent before a source token was spent by a concurrent transfer. Re-plan and send only the remaining amount — do NOT re-send the full amount.',
           result.id,
           [...committedOnChainTokenIds],
+          (remaining > 0n ? remaining : 0n).toString(),
           error,
         );
       }
@@ -2896,8 +2967,19 @@ export class PaymentsModule {
 
       return result;
     } catch (error) {
-      // Revert to pending on failure
-      this.updatePaymentRequestStatus(requestId, 'pending');
+      // #441/#442: reverting to 'pending' makes the request RE-PAYABLE (the guard
+      // above admits a re-pay when status is 'pending' OR 'accepted'). That is
+      // correct ONLY for a clean pre-commit failure where NOTHING left the wallet.
+      // For a possibly-committed outcome — a post-commit sync-pending / keep-open
+      // certification state, or a PartialSendConflictError (money already left,
+      // the intent completes via resume/claim) — reverting would double-pay. Mark
+      // it 'paid' (durably non-payable) instead and re-throw so the caller still
+      // learns it is pending/partial. This makes the request state durably correct
+      // for every consumer (the app's in-memory override becomes unnecessary).
+      this.updatePaymentRequestStatus(
+        requestId,
+        isPossiblyCommittedSendOutcome(error) ? 'paid' : 'pending',
+      );
       throw error;
     }
   }
@@ -5652,6 +5734,32 @@ export class PaymentsModule {
     }
 
     const intents = await walletApi.listIntents('open');
+
+    // #676 (PR #681 review): read EVERY local intent disposition ONCE before the
+    // loop (perf: one parse, not one per server-open intent). Best-effort — a
+    // storage read error must NOT abort the whole resume (Copilot robustness),
+    // but it also must NOT let us blindly resume: a server-`open` intent whose
+    // local copy is aborted would re-execute → double-pay. So when the local
+    // read is UNAVAILABLE (threw), we cannot prove any intent safe to resume and
+    // DEFER them all (classify failed, retry next sign-in) — erring toward not
+    // double-paying. A port without the capability (no local intent store) has
+    // no divergence to honor, so it resumes on the server row as before.
+    const localLookupSupported = typeof walletApi.getLocalIntentsMap === 'function';
+    let localIntents: Map<string, { status: 'open' | 'completed' | 'aborted'; abortPending: boolean }> | undefined;
+    let localReadFailed = false;
+    if (localLookupSupported) {
+      try {
+        localIntents = await walletApi.getLocalIntentsMap!();
+      } catch (err) {
+        localReadFailed = true;
+        logger.warn(
+          'Payments',
+          'Could not read local intent dispositions (#676) — deferring resume of all open intents this sign-in to avoid re-executing a locally-aborted send:',
+          err,
+        );
+      }
+    }
+
     for (const intent of intents) {
       // #676: honor a LOCAL abort the server never learned about. A clean
       // pre-certification send failure soft-aborts the intent best-effort; when
@@ -5660,24 +5768,33 @@ export class PaymentsModule {
       // listIntents('open') (a plain server GET) hands that row back, and
       // re-executing it would RE-SPEND sources the failure handler restored to
       // 'confirmed' — paying the recipient a second time for a send the user
-      // already watched fail. So: if the local copy is aborted (or has a pending
-      // abort), do NOT resume; re-attempt the abort to converge the server and
-      // classify it with the conflicted (aborted, re-plan) bucket. A missing
-      // local copy (fresh device) leaves the server row authoritative and resume
-      // proceeds, unchanged.
-      const localIntent = await walletApi.getLocalIntent?.(intent.transferId);
-      if (localIntent && (localIntent.status === 'aborted' || localIntent.abortPending)) {
-        logger.warn(
-          'Payments',
-          `Intent ${intent.transferId.slice(0, 8)}… is locally aborted (the abort never reached the server) — converging, NOT resuming (#676)`,
-        );
-        try {
-          await walletApi.abortIntent(intent.transferId);
-        } catch (abortErr) {
-          logger.warn('Payments', 'abortIntent during resume-skip failed (retried next sign-in):', abortErr);
+      // already watched fail.
+      if (localLookupSupported) {
+        if (localReadFailed) {
+          // Local disposition unknown (read threw) — cannot prove this intent is
+          // safe to resume, so defer it rather than risk re-executing a locally
+          // aborted send. The next sign-in retries once storage is healthy.
+          outcome.failed.push(intent.transferId);
+          continue;
         }
-        outcome.conflicted.push(intent.transferId);
-        continue;
+        const localIntent = localIntents!.get(intent.transferId);
+        // Local copy aborted (or abort pending) → do NOT resume; re-attempt the
+        // abort to converge the server and classify with the conflicted
+        // (aborted, re-plan) bucket. A missing local copy (fresh device) leaves
+        // the server row authoritative and resume proceeds, unchanged.
+        if (localIntent && (localIntent.status === 'aborted' || localIntent.abortPending)) {
+          logger.warn(
+            'Payments',
+            `Intent ${intent.transferId.slice(0, 8)}… is locally aborted (the abort never reached the server) — converging, NOT resuming (#676)`,
+          );
+          try {
+            await walletApi.abortIntent(intent.transferId);
+          } catch (abortErr) {
+            logger.warn('Payments', 'abortIntent during resume-skip failed (retried next sign-in):', abortErr);
+          }
+          outcome.conflicted.push(intent.transferId);
+          continue;
+        }
       }
       let payload: IntentPayloadV1;
       try {

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -31,6 +31,7 @@ import { WalletApiClient } from '../../../wallet-api';
 import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../../impl/shared/wallet-api';
 import { encodeTokenBlob } from '../../../token-engine/token-blob';
 import { hexToBytes } from '../../../core/crypto';
+import { SphereError, PartialSendConflictError } from '../../../core/errors';
 import { FIELD_ENVELOPE_PREFIX } from '../../../core/field-encryption';
 import { deriveDeliveryEncryptionKey, decryptDeliveryBundle } from '../../../core/delivery-envelope';
 
@@ -396,6 +397,65 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
       expect(requester.module.getTokens()).toContainEqual(
         expect.objectContaining({ amount: '1000', coinId: UCT, status: 'confirmed' })
       );
+    });
+  });
+
+  describe('#441/#442: a possibly-committed pay outcome keeps the request NON-payable (durable, no double-pay)', () => {
+    async function seedPendingRequest(deviceSuffix: string): Promise<{ payer: Wallet; reqId: string }> {
+      const { fake, baseUrl } = await startFake();
+      const requester = makeWalletApiWallet(baseUrl, fake.network, REQUESTER, `pr-441-r-${deviceSuffix}`);
+      const payer = makeWalletApiWallet(baseUrl, fake.network, PAYER, `pr-441-p-${deviceSuffix}`);
+      await seedServerToken(fake, payer, PAYER, 1000n);
+      await requester.module.load();
+      await payer.module.load();
+      await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '1000', coinId: UCT });
+      await payer.module.syncPaymentRequests();
+      const pending = payer.module.getPaymentRequests({ status: 'pending' });
+      expect(pending).toHaveLength(1);
+      return { payer, reqId: pending[0].id };
+    }
+
+    it('a possibly-committed keep-open failure (SEND_SYNC_PENDING) marks the request paid (NOT pending) — a re-pay is refused', async () => {
+      const { payer, reqId } = await seedPendingRequest('sync');
+
+      // The send committed on-chain; only the post-commit mirror sync is pending — the money has LEFT.
+      // Reverting to 'pending' (the old behavior) would let the request be re-paid → double-pay (#441).
+      vi.spyOn(payer.module, 'send').mockRejectedValue(new SphereError('sent — wallet catching up', 'SEND_SYNC_PENDING'));
+
+      await expect(payer.module.payPaymentRequest(reqId)).rejects.toMatchObject({ code: 'SEND_SYNC_PENDING' });
+
+      // Durably NON-payable: not pending/accepted, so the guard refuses a re-pay (survives reload — the
+      // status is the persisted record, not the app's in-memory override).
+      expect(payer.module.getPaymentRequests({ status: 'pending' })).toHaveLength(0);
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('paid');
+      await expect(payer.module.payPaymentRequest(reqId)).rejects.toThrow(/not pending or accepted/i);
+    });
+
+    it('a PartialSendConflictError (money left, remainder uncovered) also stays NON-payable', async () => {
+      const { payer, reqId } = await seedPendingRequest('partial');
+
+      vi.spyOn(payer.module, 'send').mockRejectedValue(
+        new PartialSendConflictError('part sent', 'tid-abc', ['v2_committed'], '500'),
+      );
+
+      await expect(payer.module.payPaymentRequest(reqId)).rejects.toBeInstanceOf(PartialSendConflictError);
+
+      expect(payer.module.getPaymentRequests({ status: 'pending' })).toHaveLength(0);
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('paid');
+      await expect(payer.module.payPaymentRequest(reqId)).rejects.toThrow(/not pending or accepted/i);
+    });
+
+    it('a genuine CLEAN pre-commit failure (nothing left the wallet) reverts to pending — safe to re-pay', async () => {
+      const { payer, reqId } = await seedPendingRequest('clean');
+
+      // Nothing committed on-chain (e.g. insufficient balance / a pre-cert error) — re-paying is safe.
+      vi.spyOn(payer.module, 'send').mockRejectedValue(new SphereError('not enough funds', 'SEND_INSUFFICIENT_BALANCE'));
+
+      await expect(payer.module.payPaymentRequest(reqId)).rejects.toMatchObject({ code: 'SEND_INSUFFICIENT_BALANCE' });
+
+      // Reverted to pending → re-payable (the request was not fulfilled).
+      expect(payer.module.getPaymentRequests({ status: 'pending' })).toHaveLength(1);
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('pending');
     });
   });
 

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -25,6 +25,7 @@ import type { OracleProvider } from '../../../oracle';
 import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, HistoryRecord } from '../../../storage';
 import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
 import { TransferConflictError, ProofUnconfirmedError, SplitCheckpointLostError } from '../../../token-engine';
+import { PartialSendConflictError } from '../../../core/errors';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
 import { WalletApiClient, WalletApiError } from '../../../wallet-api';
@@ -871,6 +872,71 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(sent).toBeDefined();
   });
 
+  it('#676: a locally-aborted intent whose server abort never landed is NOT re-executed on resume (double-pay guard)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-676');
+    const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // Reproduce the #516 unlanded-abort state a clean pre-cert send failure leaves behind against a
+    // dead backend: PUT the intent (server 'open' + local 'open'), then abort while the intent
+    // endpoint is down — abortIntent flips the LOCAL copy to aborted+abortPending and re-throws, but
+    // the SERVER row stays 'open'.
+    const transferId = crypto.randomUUID();
+    const payload = { v: 1, recipient: RECIPIENT.chainPubkey, coinId: UCT, amount: '1000', direct: [sourceTokenId] };
+    sender.client.setIdentity(SENDER);
+    await sender.client.putIntent(
+      transferId,
+      encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload)),
+    );
+    fake.setIntentFailure(true);
+    await expect(sender.client.abortIntent(transferId)).rejects.toThrow();
+    fake.setIntentFailure(false);
+
+    // Precondition: the server row is STILL 'open' (the double-pay hazard) while the local copy is
+    // aborted+abortPending — exactly the divergence resume must not re-execute.
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'open' });
+    expect(await sender.client.getLocalIntent(transferId)).toMatchObject({ status: 'aborted', abortPending: true });
+
+    const transferSpy = vi.spyOn(sender.engine, 'transfer');
+    const outcome = await sender.module.resumeOpenIntents();
+
+    // THE FIX: not resumed — the engine never re-ran, nothing was delivered, the source was never
+    // re-spent, and the server converges to 'aborted' instead of re-executing the failed send.
+    expect(outcome.resumed).not.toContain(transferId);
+    expect(outcome.conflicted).toContain(transferId);
+    expect(transferSpy).not.toHaveBeenCalled();
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);
+    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'active' });
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'aborted' });
+  });
+
+  it('#676: a server-open intent with NO local copy (fresh device) still resumes — the server copy stays authoritative', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-676-fresh');
+    const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    const transferId = crypto.randomUUID();
+    const payload = { v: 1, recipient: RECIPIENT.chainPubkey, coinId: UCT, amount: '1000', direct: [sourceTokenId] };
+    sender.client.setIdentity(SENDER);
+    await sender.client.putIntent(
+      transferId,
+      encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload)),
+    );
+    // Drop only the LOCAL backstop copy (server row stays 'open') — the fresh-device state where the
+    // server intent is the sole seed and the #516 local record is absent.
+    await sender.client.removeLocalIntent(transferId);
+    expect(await sender.client.getLocalIntent(transferId)).toBeNull();
+
+    const outcome = await sender.module.resumeOpenIntents();
+
+    // Resume proceeds unchanged: with no local record, the server copy is authoritative.
+    expect(outcome.resumed).toEqual([transferId]);
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(1);
+  });
+
   it('resume of an already-certified source records the spend instead of wedging on a conflict (§3.1 #621)', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-rs-621');
@@ -1207,10 +1273,11 @@ describe('stale-inventory conflict self-heals (#625) + is SURFACED (#517 item 2)
         : orig(...args);
     });
 
-    // The conflict is NOT self-healed (an earlier op already certified) — it propagates, and nothing
-    // is demoted (no retry).
+    // The conflict is NOT self-healed (an earlier op already certified) — nothing is demoted
+    // (no retry). #677: it surfaces as a PARTIAL outcome (not a bare TransferConflictError the caller
+    // would re-send in full) so only the remainder is re-planned.
     await expect(sender.module.send({ recipient: '@bob', amount: '2000', coinId: UCT }))
-      .rejects.toBeInstanceOf(TransferConflictError);
+      .rejects.toMatchObject({ code: 'SEND_PARTIALLY_COMPLETED' });
     expect(sender.module.getTokens().filter((t) => t.suspectedSpent)).toHaveLength(0);
   });
 
@@ -1226,6 +1293,62 @@ describe('stale-inventory conflict self-heals (#625) + is SURFACED (#517 item 2)
       .rejects.toThrow('engine boom');
 
     expect(sender.emitEvent.mock.calls.filter((c) => c[0] === 'inventory:conflict')).toHaveLength(0);
+  });
+});
+
+describe('#677: a partially-certified send is a partial outcome, never a re-sendable failure', () => {
+  it('op1 certifies+delivers, op2 conflicts → PartialSendConflictError (delivered leg spent, intent soft-aborted); the remainder re-plan does not re-send the delivered leg', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-677');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // amount 2000 → two direct legs. Leg 1 certifies + delivers; leg 2 loses its source to a
+    // concurrent transfer (TransferConflictError) AFTER leg 1's value has irreversibly left the wallet.
+    const orig = sender.engine.transfer.bind(sender.engine);
+    let calls = 0;
+    vi.spyOn(sender.engine, 'transfer').mockImplementation((...args: Parameters<typeof orig>) => {
+      calls += 1;
+      return calls === 2
+        ? Promise.reject(new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent'))
+        : orig(...args);
+    });
+
+    const thrown = await sender.module
+      .send({ recipient: '@bob', amount: '2000', coinId: UCT })
+      .then(() => { throw new Error('expected the partial send to reject'); }, (e) => e);
+
+    // THE FIX: a DISTINCT partial outcome — NOT a bare TransferConflictError the caller re-sends in
+    // full (which would pay the delivered leg twice).
+    expect(thrown).toBeInstanceOf(PartialSendConflictError);
+    expect(thrown).not.toBeInstanceOf(TransferConflictError);
+    const partial = thrown as PartialSendConflictError;
+    expect(partial.code).toBe('SEND_PARTIALLY_COMPLETED');
+    // It carries exactly the one already-committed leg so the caller re-plans ONLY the remainder.
+    expect(partial.committedTokenIds).toHaveLength(1);
+    expect(partial.transferId).toBeTruthy();
+
+    // Leg 1 delivered (one mailbox entry) and its source is terminal 'spent' locally — never restored.
+    const afterFirst = fake.listMailboxEntries(RECIPIENT.chainPubkey);
+    expect(afterFirst).toHaveLength(1);
+    const committedId = partial.committedTokenIds[0];
+    expect(sender.module.getTokens().find((t) => t.id === committedId)?.status).toBe('spent');
+    expect(`v2_${afterFirst[0].tokenId}`).toBe(committedId);
+
+    // Existing behavior preserved: the conflicted intent was soft-aborted; NO transfer:failed (the
+    // delivered leg is not lost — mirrors the SEND_SYNC_PENDING contract).
+    expect(fake.getIntent(SENDER.chainPubkey, partial.transferId)).toMatchObject({ status: 'aborted' });
+    expect(sender.emitEvent.mock.calls.filter((c) => c[0] === 'transfer:failed')).toHaveLength(0);
+
+    // The caller re-plans ONLY the remainder (1000) under a fresh transferId. The delivered leg's
+    // source is terminal 'spent', so the planner cannot pick it — the recipient gets exactly ONE more
+    // entry and the delivered leg is never re-sent.
+    const remainder = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT });
+    expect(remainder.status).toBe('completed');
+    const entries = fake.listMailboxEntries(RECIPIENT.chainPubkey);
+    expect(entries).toHaveLength(2);
+    expect(entries.filter((e) => `v2_${e.tokenId}` === committedId)).toHaveLength(1); // not duplicated
   });
 });
 

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -937,6 +937,62 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(1);
   });
 
+  it('#676 (PR #681 review): the local intent dispositions are read ONCE for all open intents (batched), not once per intent', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-676-batch');
+    const src1 = await seedServerToken(fake, sender, SENDER, 1000n);
+    const src2 = await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    // Two independent server-`open` intents (each with a local copy from putIntent).
+    sender.client.setIdentity(SENDER);
+    const putIntent = async (src: string): Promise<string> => {
+      const tid = crypto.randomUUID();
+      const payload = { v: 1, recipient: RECIPIENT.chainPubkey, coinId: UCT, amount: '1000', direct: [src] };
+      await sender.client.putIntent(tid, encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload)));
+      return tid;
+    };
+    const t1 = await putIntent(src1);
+    const t2 = await putIntent(src2);
+
+    const mapSpy = vi.spyOn(sender.client, 'getLocalIntentsMap');
+    const outcome = await sender.module.resumeOpenIntents();
+
+    // ONE batched read regardless of the open-intent count (was one full parse per intent before the
+    // PR #681 review fix). Both intents still resume (their local copies are 'open').
+    expect(mapSpy).toHaveBeenCalledTimes(1);
+    expect(outcome.resumed).toEqual(expect.arrayContaining([t1, t2]));
+  });
+
+  it('#676 (PR #681 review): a FAILING local-intent read does not abort resume and does NOT resume any intent — money-safe defer (no double-pay)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-676-throw');
+    const src = await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    const transferId = crypto.randomUUID();
+    const payload = { v: 1, recipient: RECIPIENT.chainPubkey, coinId: UCT, amount: '1000', direct: [src] };
+    sender.client.setIdentity(SENDER);
+    await sender.client.putIntent(
+      transferId,
+      encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload)),
+    );
+
+    // The local-disposition read throws (storage error). A server-`open` intent could be locally
+    // aborted (the #676 divergence), so re-executing it would double-pay. Resume must NOT crash AND
+    // must NOT resume — it DEFERS the intent (retry next sign-in), erring toward not double-paying.
+    vi.spyOn(sender.client, 'getLocalIntentsMap').mockRejectedValue(new Error('storage unavailable'));
+    const transferSpy = vi.spyOn(sender.engine, 'transfer');
+
+    const outcome = await sender.module.resumeOpenIntents(); // resolves — the loop is not aborted
+
+    expect(outcome.resumed).not.toContain(transferId);
+    expect(outcome.failed).toContain(transferId);                              // deferred
+    expect(transferSpy).not.toHaveBeenCalled();                               // never re-executed
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);   // nothing delivered → no double-pay
+    expect(fake.getRow(SENDER.chainPubkey, src)).toMatchObject({ status: 'active' }); // source not re-spent
+  });
+
   it('resume of an already-certified source records the spend instead of wedging on a conflict (§3.1 #621)', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-rs-621');
@@ -1255,7 +1311,7 @@ describe('stale-inventory conflict self-heals (#625) + is SURFACED (#517 item 2)
     expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(1);
   });
 
-  it('does NOT self-heal a conflict AFTER an earlier op certified — avoids a full-amount over-request re-plan (#625 safety)', async () => {
+  it('a conflict AFTER an earlier op certified re-plans ONLY the remainder (not the full amount) — delivers X, never over-requests (#677)', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-partial-1');
     await seedServerToken(fake, sender, SENDER, 1000n);
@@ -1263,7 +1319,7 @@ describe('stale-inventory conflict self-heals (#625) + is SURFACED (#517 item 2)
     await sender.module.load();
 
     // amount 2000 needs BOTH sources (two direct ops). The first certifies; the second conflicts —
-    // so value has already left the wallet and a full-amount re-plan would over-request.
+    // so value has already left the wallet and a FULL-amount re-plan would over-request (send 3000).
     const orig = sender.engine.transfer.bind(sender.engine);
     let calls = 0;
     vi.spyOn(sender.engine, 'transfer').mockImplementation((...args: Parameters<typeof orig>) => {
@@ -1273,11 +1329,12 @@ describe('stale-inventory conflict self-heals (#625) + is SURFACED (#517 item 2)
         : orig(...args);
     });
 
-    // The conflict is NOT self-healed (an earlier op already certified) — nothing is demoted
-    // (no retry). #677: it surfaces as a PARTIAL outcome (not a bare TransferConflictError the caller
-    // would re-send in full) so only the remainder is re-planned.
-    await expect(sender.module.send({ recipient: '@bob', amount: '2000', coinId: UCT }))
-      .rejects.toMatchObject({ code: 'SEND_PARTIALLY_COMPLETED' });
+    // #677: send() re-plans ONLY the remaining 1000 (the conflict freed the second source, which was
+    // not actually spent), so the recipient receives the full 2000 across exactly TWO legs — never a
+    // third over-request leg. Nothing is demoted: the certified-then-reused source completed cleanly.
+    const result = await sender.module.send({ recipient: '@bob', amount: '2000', coinId: UCT });
+    expect(result.status).toBe('completed');
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(2); // full amount, NOT 3 legs
     expect(sender.module.getTokens().filter((t) => t.suspectedSpent)).toHaveLength(0);
   });
 
@@ -1296,59 +1353,85 @@ describe('stale-inventory conflict self-heals (#625) + is SURFACED (#517 item 2)
   });
 });
 
-describe('#677: a partially-certified send is a partial outcome, never a re-sendable failure', () => {
-  it('op1 certifies+delivers, op2 conflicts → PartialSendConflictError (delivered leg spent, intent soft-aborted); the remainder re-plan does not re-send the delivered leg', async () => {
+describe('#677: a mid-send conflict re-plans the remainder inside send() and still delivers the full amount', () => {
+  it('a mid-SPLIT conflict after a certified leg re-plans the remainder — the recipient receives the FULL amount X across a NEW transferId', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-677-split');
+    await seedServerToken(fake, sender, SENDER, 1500n);
+    await seedServerToken(fake, sender, SENDER, 1500n);
+    await sender.module.load();
+
+    // amount 2000 from two 1500s → a direct leg (1500) + a SPLIT leg (500 to recipient, 1000 change).
+    // The direct leg certifies + delivers; the split leg loses its source to a concurrent transfer the
+    // FIRST time (AFTER 1500 has irreversibly left the wallet), then succeeds on the remainder re-plan.
+    const origSplit = sender.engine.split.bind(sender.engine);
+    let splitCalls = 0;
+    vi.spyOn(sender.engine, 'split').mockImplementation((...args: Parameters<typeof origSplit>) => {
+      splitCalls += 1;
+      return splitCalls === 1
+        ? Promise.reject(new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent'))
+        : origSplit(...args);
+    });
+
+    // THE FIX: send() re-plans ONLY the still-owed 500 under a NEW transferId and RESOLVES successfully
+    // — a send for 2000 delivers 2000, never re-sending the certified 1500 leg.
+    const result = await sender.module.send({ recipient: '@bob', amount: '2000', coinId: UCT });
+    expect(result.status).toBe('completed');
+
+    // The recipient receives the full 2000 (1500 direct + 500 split) across the two legs.
+    const recipient = makeFullPresetWallet(baseUrl, fake.network, RECIPIENT, 'd-677-recv');
+    await recipient.module.load();
+    const { transfers } = await recipient.module.receive();
+    const received = transfers.flatMap((t) => t.tokens).reduce((sum, tok) => sum + BigInt(tok.amount), 0n);
+    expect(received).toBe(2000n);
+  });
+
+  it('op1 certifies+delivers, op2 conflicts and the remainder CANNOT be covered → PartialSendConflictError carrying the delivered leg + the shortfall (never a re-sendable failure)', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-677');
     await seedServerToken(fake, sender, SENDER, 1000n);
     await seedServerToken(fake, sender, SENDER, 1000n);
     await sender.module.load();
 
-    // amount 2000 → two direct legs. Leg 1 certifies + delivers; leg 2 loses its source to a
-    // concurrent transfer (TransferConflictError) AFTER leg 1's value has irreversibly left the wallet.
+    // amount 2000 → two direct legs. Leg 1 certifies + delivers; every subsequent op conflicts, so the
+    // second source is exhausted (demoted after its own clean conflict) and the remainder cannot be
+    // covered — the insufficient-remainder fallback.
     const orig = sender.engine.transfer.bind(sender.engine);
     let calls = 0;
     vi.spyOn(sender.engine, 'transfer').mockImplementation((...args: Parameters<typeof orig>) => {
       calls += 1;
-      return calls === 2
-        ? Promise.reject(new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent'))
-        : orig(...args);
+      return calls === 1
+        ? orig(...args)
+        : Promise.reject(new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent'));
     });
 
     const thrown = await sender.module
       .send({ recipient: '@bob', amount: '2000', coinId: UCT })
       .then(() => { throw new Error('expected the partial send to reject'); }, (e) => e);
 
-    // THE FIX: a DISTINCT partial outcome — NOT a bare TransferConflictError the caller re-sends in
+    // THE FALLBACK: a DISTINCT partial outcome — NOT a bare TransferConflictError the caller re-sends in
     // full (which would pay the delivered leg twice).
     expect(thrown).toBeInstanceOf(PartialSendConflictError);
     expect(thrown).not.toBeInstanceOf(TransferConflictError);
     const partial = thrown as PartialSendConflictError;
     expect(partial.code).toBe('SEND_PARTIALLY_COMPLETED');
-    // It carries exactly the one already-committed leg so the caller re-plans ONLY the remainder.
+    // It carries exactly the one already-committed leg + the still-owed shortfall (1000) so the caller
+    // re-plans ONLY the remainder, never the whole amount.
     expect(partial.committedTokenIds).toHaveLength(1);
+    expect(partial.remainingAmount).toBe('1000');
     expect(partial.transferId).toBeTruthy();
 
-    // Leg 1 delivered (one mailbox entry) and its source is terminal 'spent' locally — never restored.
-    const afterFirst = fake.listMailboxEntries(RECIPIENT.chainPubkey);
-    expect(afterFirst).toHaveLength(1);
+    // Leg 1 delivered (exactly one mailbox entry — the delivered leg is never re-sent) and its source
+    // is terminal 'spent' locally, never restored.
+    const entries = fake.listMailboxEntries(RECIPIENT.chainPubkey);
+    expect(entries).toHaveLength(1);
     const committedId = partial.committedTokenIds[0];
     expect(sender.module.getTokens().find((t) => t.id === committedId)?.status).toBe('spent');
-    expect(`v2_${afterFirst[0].tokenId}`).toBe(committedId);
+    expect(`v2_${entries[0].tokenId}`).toBe(committedId);
 
-    // Existing behavior preserved: the conflicted intent was soft-aborted; NO transfer:failed (the
-    // delivered leg is not lost — mirrors the SEND_SYNC_PENDING contract).
+    // Existing behavior preserved: the conflicted intent was soft-aborted (the delivered leg is not
+    // lost — mirrors the SEND_SYNC_PENDING contract).
     expect(fake.getIntent(SENDER.chainPubkey, partial.transferId)).toMatchObject({ status: 'aborted' });
-    expect(sender.emitEvent.mock.calls.filter((c) => c[0] === 'transfer:failed')).toHaveLength(0);
-
-    // The caller re-plans ONLY the remainder (1000) under a fresh transferId. The delivered leg's
-    // source is terminal 'spent', so the planner cannot pick it — the recipient gets exactly ONE more
-    // entry and the delivered leg is never re-sent.
-    const remainder = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT });
-    expect(remainder.status).toBe('completed');
-    const entries = fake.listMailboxEntries(RECIPIENT.chainPubkey);
-    expect(entries).toHaveLength(2);
-    expect(entries.filter((e) => `v2_${e.tokenId}` === committedId)).toHaveLength(1); // not duplicated
   });
 });
 

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -1012,6 +1012,29 @@ export class WalletApiClient {
   }
 
   /**
+   * #676: the LOCAL disposition of one intent — its status and the #516
+   * `abortPending` flag — or `null` when no local copy exists.
+   *
+   * Resume ({@link PaymentsModule.resumeOpenIntents}) consults this BEFORE
+   * re-executing a server-`open` intent. A clean pre-certification send failure
+   * soft-aborts the intent best-effort; when that abort's server leg cannot land
+   * (dead backend), {@link abortIntent} flips the LOCAL copy to
+   * `aborted`+`abortPending` and re-throws — leaving the SERVER row `open`.
+   * `listIntents('open')` (a plain server GET) would then hand that row back and
+   * resume would RE-EXECUTE a send the user already watched fail: a double-pay.
+   * A `null` result (fresh device — no local copy) leaves the server row
+   * authoritative, so resume correctly proceeds.
+   */
+  async getLocalIntent(
+    transferId: string
+  ): Promise<{ status: 'open' | 'completed' | 'aborted'; abortPending: boolean } | null> {
+    const intents = await this.readLocalIntents();
+    const intent = intents[transferId];
+    if (!intent) return null;
+    return { status: intent.status, abortPending: intent.abortPending === true };
+  }
+
+  /**
    * Re-PUT every locally-known open intent (idempotent — the server PUT is
    * write-once while open/completed). Called after a `syncEpoch` change
    * (server restore — §5.4): intents are the one server table not

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -1035,6 +1035,27 @@ export class WalletApiClient {
   }
 
   /**
+   * #676 (PR #681 review): the LOCAL disposition of EVERY known intent, keyed by
+   * transferId, read + parsed in ONE pass. {@link PaymentsModule.resumeOpenIntents}
+   * consults the local record before re-executing each server-`open` intent (see
+   * {@link getLocalIntent}); calling the per-intent read once per server-open
+   * intent re-parses the whole intents blob N times. This batch read parses it
+   * ONCE so resume is O(1) reads regardless of the open-intent count. A `transferId`
+   * absent from the map has no local copy (fresh device) → the server row is
+   * authoritative and resume proceeds.
+   */
+  async getLocalIntentsMap(): Promise<
+    Map<string, { status: 'open' | 'completed' | 'aborted'; abortPending: boolean }>
+  > {
+    const intents = await this.readLocalIntents();
+    const map = new Map<string, { status: 'open' | 'completed' | 'aborted'; abortPending: boolean }>();
+    for (const [transferId, intent] of Object.entries(intents)) {
+      map.set(transferId, { status: intent.status, abortPending: intent.abortPending === true });
+    }
+    return map;
+  }
+
+  /**
    * Re-PUT every locally-known open intent (idempotent — the server PUT is
    * write-once while open/completed). Called after a `syncEpoch` change
    * (server restore — §5.4): intents are the one server table not


### PR DESCRIPTION
Two verified **CRITICAL double-pay** bugs in the send / open-intent resume state machine. Both matched the reported mechanism exactly.

## #676 — `resumeOpenIntents` re-executes a send whose soft-abort never reached the server

**Mechanism.** On a clean pre-certification send failure the handler calls `walletApi.abortIntent(result.id)` best-effort. When the abort's server leg cannot land (dead backend), `abortIntent` (`wallet-api/client.ts`) catches, flips the **LOCAL** intent copy to `aborted` + `abortPending`, and re-throws — so the **server row stays `open`**. The only path that converges the server (`resyncOpenIntents`) runs solely on a `syncEpoch` change (server restore), never at a normal sign-in. At sign-in `Sphere` calls `payments.resumeOpenIntents()`, which iterates `walletApi.listIntents('open')` (a plain server GET) and **never consulted the local copy / `abortPending`**. So it re-ran the intent — re-spending the sources the failure handler had restored to `confirmed` → the recipient is paid twice.

**Fix.** Expose `WalletApiClient.getLocalIntent(transferId)` → `{ status, abortPending } | null`, surfaced via a new optional `PaymentsWalletApiPort.getLocalIntent`. `resumeOpenIntents` now consults the local record before resuming each server-`open` intent:
- local copy is `aborted` **or** `abortPending` → do **not** resume; re-attempt `abortIntent` to converge the server, classify with the `conflicted` (aborted, re-plan) bucket, and skip.
- local copy `open` → resume unchanged.
- **no** local copy (fresh device) → `getLocalIntent` returns `null`, the server row stays authoritative, resume proceeds (correct).

Idempotent and safe if the local record is missing. This is the robust, self-contained fix (it converges the server via the re-abort), so no `resyncOpenIntents()` call was added to sign-in.

## #677 — a partially-certified send reported as a flat, re-sendable failure

**Mechanism.** In the send-failure catch, the `SEND_SYNC_PENDING` reassurance is thrown only when `onChainCommitComplete && !(error instanceof TransferConflictError) && !keepOpen`. A `TransferConflictError` raised on op2 *after* op1 already certified + delivered (marked `spent`, journaled) falls through to `emitEvent('transfer:failed'); throw error` — the caller sees a bare conflict and re-sends the **FULL** amount, paying the already-delivered leg again.

**Fix / chosen contract.** When a send fails with a conflict and `committedOnChainTokenIds` is non-empty, throw the new typed **`PartialSendConflictError`** (SphereError, `code: 'SEND_PARTIALLY_COMPLETED'`) carrying:
- `transferId` — the (soft-aborted) intent id the delivered legs are journaled under;
- `committedTokenIds: readonly string[]` — the source ids already certified/delivered, so the caller can compute + re-plan the remainder.

Deliberately **not** a subclass of `TransferConflictError`, so existing conflict handlers that re-send in full do not catch it — the app maps the distinct type/`code` and re-plans **only the remainder under a NEW transferId**, never the whole amount. The existing soft-abort of the conflicted intent and all keep-open / `SEND_SYNC_PENDING` behavior are unchanged; no `transfer:failed` is emitted (the delivered leg is not lost — mirrors the `SEND_SYNC_PENDING` contract). Exported from the package root alongside `SphereError`.

## Code changes
- `core/errors.ts` — add `SEND_PARTIALLY_COMPLETED` code + `PartialSendConflictError` class; `core/index.ts` + root `index.ts` export it.
- `wallet-api/client.ts` — add `getLocalIntent(transferId)`.
- `modules/payments/PaymentsModule.ts` — add optional `getLocalIntent` to `PaymentsWalletApiPort`; `sendOnce` catch throws `PartialSendConflictError` for the partial-conflict case (#677); `resumeOpenIntents` consults the local disposition and skips/converges a locally-aborted intent (#676).

## Regression tests
`tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts` (real `WalletApiClient` over the in-process fake backend):
- **#676** — `putIntent` then a failing `abortIntent` (server stays `open`, local `abortPending`); assert resume does **not** re-run the engine / deliver, the source stays active, and the server converges to `aborted`. Plus: a fresh-device intent with no local copy still resumes.
- **#677** — a 2-op send where op1 certifies+delivers and op2 conflicts throws `PartialSendConflictError` (`SEND_PARTIALLY_COMPLETED`, one `committedTokenIds`), the delivered leg's source is terminal `spent`, the intent is soft-aborted, no `transfer:failed`; a remainder re-plan delivers exactly one more entry and never re-sends the delivered leg. The prior `#625-safety` test was updated to the new partial contract.

## Verification
- `npm run typecheck` — clean
- `npm run lint` (touched files) — 0 errors (only pre-existing warnings)
- `npm run test:run` — **202 files, 3104 tests, all passing** (the target file: 38 passing, incl. 3 new + 1 updated)

Closes #676
Closes #677

---

## Update (13c029aa) — hardening + a materially changed #677 contract

Three follow-ups. **The #677 caller contract changed** (see below).

### #676 — PR review (robustness + perf)
`resumeOpenIntents` no longer calls a per-intent `getLocalIntent()` inside the loop. It reads all local dispositions **once** via a new batched `getLocalIntentsMap()` (client + optional port method) before the loop, then does in-memory lookups — O(1) reads regardless of the open-intent count. The read is best-effort: a storage error no longer aborts the whole resume, and it does **not** blindly resume (a locally-aborted intent would re-execute → double-pay) — it **defers all** open intents that sign-in (retry next time), erring toward not double-paying. A port without the capability resumes on the server row as before.

### #677 — now re-plans the remainder inside `send()` (was: typed error only)
Previously a partial conflict threw `PartialSendConflictError` and left the remainder to the **caller**. Now **`send()` re-plans the remainder itself**: on a mid-send conflict after ≥1 leg certified + delivered, it delivers `X − already-delivered` from the remaining live sources under a **new** transferId, so **a send for X still delivers X** (the certified legs converge via the recipient's §6 claim handoff). `sendOnce` carries the still-owed `remainingAmount` on the error for the internal re-plan.

**Contract change:** `PartialSendConflictError` is now the **fallback**, surfaced to the caller **only when the remainder genuinely cannot be covered** by the other sources — not on every partial conflict. It still must never be re-sent in full; it now also carries `remainingAmount` (the shortfall still owed). The `#625` demote+reselect loop, keep-open and `SEND_SYNC_PENDING` paths are untouched.

### #441 — `payPaymentRequest` must not revert to `pending` on a possibly-committed outcome
The catch reverted to `'pending'` on **any** failure; since the guard admits a re-pay when `pending` **or** `accepted`, a possibly-committed outcome became re-payable → double-pay. It now classifies via the new exported `isPossiblyCommittedSendOutcome()` (the pending-commit codes + `SEND_PARTIALLY_COMPLETED`): a possibly-committed outcome marks the request `'paid'` (durably non-payable) and re-throws; only a clean pre-commit failure reverts to `'pending'`. This makes the request state durably correct for every consumer (the app's in-memory override — PR #442 P1 — becomes unnecessary, its removal a separate release-gated follow-up).

### Tests / verification
New/updated tests (real `WalletApiClient` over the fake backend): the batched read happens once + a throwing read defers all (no double-pay); a mid-SPLIT conflict re-plans the remainder and the recipient receives the **full** amount, with `PartialSendConflictError` only when the remainder can't be covered; `payPaymentRequest` keeps a possibly-committed / partial outcome non-payable while a clean failure reverts to pending. `npm run typecheck` + `npm run lint` clean (pre-existing warnings only); `npm run test:run` — **3110 passing**.
