### PR TITLE
fix(payments): defer payment-request 'paid' until the transfer completes (no reload double-pay)

### DIFF
--- a/core/errors.ts
+++ b/core/errors.ts
@@ -137,6 +137,14 @@ export type SphereErrorCode =
 export class SphereError extends Error {
   readonly code: SphereErrorCode;
   readonly cause?: unknown;
+  /**
+   * #441 deferred-paid linkage: the transferId of the possibly-committed send,
+   * stamped by `sendOnce` before the error leaves so a payment-request consumer
+   * can durably journal request→transfer and resolve 'paid' only when that
+   * transfer actually completes (never optimistically). Present ONLY on
+   * possibly-committed outcomes ({@link isPossiblyCommittedSendOutcome}).
+   */
+  transferId?: string;
 
   constructor(message: string, code: SphereErrorCode, cause?: unknown) {
     super(message);

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1093,7 +1093,7 @@ export class PaymentsModule {
    * promise (the #679/#680 lesson: an unserialized RMW drops entries under
    * concurrency = a re-payable request = the double-pay this fix prevents).
    */
-  private settlingJournal: Map<string, { transferId: string; createdAt: number }> | null = null;
+  private settlingJournal: Map<string, { transferId: string; createdAt: number; committed?: boolean }> | null = null;
   private settlingJournalLoad: Promise<void> | null = null;
   private settlingJournalWrite: Promise<void> = Promise.resolve();
   /** #441: guard overlapping resume reconciles (resumeOpenIntents has 2 fire-and-forget call sites). */
@@ -3060,10 +3060,17 @@ export class PaymentsModule {
         // there is no reload re-surface to double-pay), keep the prior durable
         // 'paid' behavior instead of holding an unresolvable 'settling'.
         if (linkedTransferId && this.paymentRequestsApi()) {
+          // A PartialSendConflictError means ≥1 leg ALREADY certified + delivered
+          // and the anchor intent was soft-aborted — so resume will report it
+          // aborted, but value DID leave the wallet. Journal it as `committed` so
+          // the reconcile resolves it 'paid' and NEVER reverts to payable (a
+          // re-pay would double-pay the delivered leg). Every other keep-open code
+          // is a non-committed link that resume may complete or genuinely abort.
+          const committed = error instanceof PartialSendConflictError;
           // Order is load-bearing: journal PERSISTS before the in-memory status
           // flip, so a crash in between leaves the durable link (reload re-applies
           // settling) — never a lost link (which would re-surface payable).
-          await this.journalSettling(requestId, linkedTransferId);
+          await this.journalSettling(requestId, linkedTransferId, committed);
           this.updatePaymentRequestStatus(requestId, 'settling');
         } else {
           // Either a Nostr-only composition (no wallet-api PR port — no deferral
@@ -5583,7 +5590,7 @@ export class PaymentsModule {
     return (this.settlingJournalLoad ??= (async () => {
       const raw = await this.deps!.storage.get(this.prSettlingKey());
       this.settlingJournal = new Map(
-        raw ? Object.entries(JSON.parse(raw) as Record<string, { transferId: string; createdAt: number }>) : []
+        raw ? Object.entries(JSON.parse(raw) as Record<string, { transferId: string; createdAt: number; committed?: boolean }>) : []
       );
     })());
   }
@@ -5595,7 +5602,7 @@ export class PaymentsModule {
    * when the Map changed and must be persisted.
    */
   private mutateSettlingJournal(
-    fn: (m: Map<string, { transferId: string; createdAt: number }>) => boolean
+    fn: (m: Map<string, { transferId: string; createdAt: number; committed?: boolean }>) => boolean
   ): Promise<void> {
     this.settlingJournalWrite = this.settlingJournalWrite.catch(() => {}).then(async () => {
       await this.ensureSettlingJournalLoaded();
@@ -5609,9 +5616,19 @@ export class PaymentsModule {
     return this.settlingJournalWrite;
   }
 
-  private journalSettling(requestId: string, transferId: string): Promise<void> {
+  /**
+   * #441: link a request to its in-flight transfer. `committed` marks a
+   * DEFINITE spend whose anchor intent is soft-aborted and will NOT resume-
+   * complete — a `PartialSendConflictError` (≥1 leg already delivered). The
+   * reconcile must resolve such a link 'paid' and NEVER revert it to payable
+   * (re-paying the full amount would double-pay the delivered leg). A
+   * non-`committed` link is a keep-open outcome that resume may still complete
+   * OR abort (e.g. CERTIFICATION_UNCONFIRMED losing to a foreign tx delivers
+   * nothing) — those DO revert to payable on abort.
+   */
+  private journalSettling(requestId: string, transferId: string, committed = false): Promise<void> {
     return this.mutateSettlingJournal((m) => {
-      m.set(requestId, { transferId, createdAt: Date.now() });
+      m.set(requestId, { transferId, createdAt: Date.now(), ...(committed ? { committed: true } : {}) });
       return true;
     });
   }
@@ -6086,7 +6103,13 @@ export class PaymentsModule {
         }
         const local = localIntents?.get(transferId);
 
-        if (resumed.has(transferId) || local?.status === 'completed') {
+        // A `committed` link (PartialSendConflictError) delivered value already;
+        // its anchor intent is soft-aborted, so it will show aborted/conflicted —
+        // but it must NEVER revert to payable (that re-pays the delivered leg).
+        // Resolve it 'paid' unconditionally (retry the response until it lands).
+        if (entry.committed) {
+          await this.resolveSettledPaid(requestId, transferId);
+        } else if (resumed.has(transferId) || local?.status === 'completed') {
           await this.resolveSettledPaid(requestId, transferId);
         } else if (conflicted.has(transferId) || local?.status === 'aborted' || local?.abortPending === true) {
           await this.revertSettlingToPayable(requestId);

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -2985,9 +2985,13 @@ export class PaymentsModule {
   }
 
   /**
-   * Remove all non-pending incoming payment requests from memory.
+   * Remove resolved incoming payment requests from memory.
    *
-   * Keeps only requests with status `'pending'`.
+   * Keeps requests with status `'pending'` OR `'settling'` (#441). A `'settling'`
+   * request is UNRESOLVED — its linked transfer is still in-flight — so evicting
+   * it would drop the in-memory hold that keeps it non-payable until the journal
+   * re-surfaces it. Only terminal statuses (`'paid'`/`'rejected'`/`'expired'`)
+   * are removed.
    */
   clearProcessedPaymentRequests(): void {
     // #441: a 'settling' request is UNRESOLVED (its linked transfer is still
@@ -5591,7 +5595,13 @@ export class PaymentsModule {
    */
   private ensureSettlingJournalLoaded(): Promise<void> {
     return (this.settlingJournalLoad ??= (async () => {
-      const raw = await this.deps!.storage.get(this.prSettlingKey());
+      const keyAtLoad = this.prSettlingKey();
+      const raw = await this.deps!.storage.get(keyAtLoad);
+      // Identity switched during the load await (initialize() reset the journal
+      // for a new key): do NOT clobber the NEW identity's settlingJournal with
+      // this stale load. The fresh identity's ensureSettlingJournalLoaded (its
+      // memo was reset to null) loads the correct journal.
+      if (this.prSettlingKey() !== keyAtLoad) return;
       try {
         this.settlingJournal = new Map(
           raw ? Object.entries(JSON.parse(raw) as Record<string, { transferId: string; createdAt: number; committed?: boolean }>) : []
@@ -5625,6 +5635,10 @@ export class PaymentsModule {
     this.settlingJournalWrite = this.settlingJournalWrite.catch(() => {}).then(async () => {
       if (this.prSettlingKey() !== keyAtEnqueue) return; // identity changed — drop the stale mutation
       await this.ensureSettlingJournalLoaded();
+      // Re-check after the load await: if the identity switched WHILE loading, the
+      // load skipped its assignment (guard above) — bail so we never mutate under
+      // the wrong identity, and so `settlingJournal!` is provably non-null here.
+      if (this.prSettlingKey() !== keyAtEnqueue) return;
       if (fn(this.settlingJournal!)) {
         await this.deps!.storage.set(keyAtEnqueue, JSON.stringify(Object.fromEntries(this.settlingJournal!)));
       }

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -102,6 +102,15 @@ import { parseInvoiceMemoForOnChain } from '../accounting/memo.js';
 export type TransactionHistoryEntry = import('../../storage').HistoryRecord;
 
 /**
+ * #441: a wallet-api `respondPaymentRequest` rejection meaning the request is
+ * NOT open (already resolved / expired) — a 409 CONFLICT. Safe to swallow when
+ * replaying a deferred 'paid' (idempotent); any OTHER error must be retried.
+ */
+function isNonOpenConflict(err: unknown): boolean {
+  return err instanceof WalletApiError && (err.code === 'CONFLICT' || err.status === 409);
+}
+
+/**
  * Compute a dedup key for a history entry.
  * - SENT + transferId → groups multi-token sends into a single entry
  * - type + tokenId → one entry per token per direction
@@ -1073,6 +1082,23 @@ export class PaymentsModule {
    */
   private prBootstrapped = false;
 
+  /**
+   * #441 deferred-paid journal (durable, per network+identity): links a payment
+   * request to the in-flight transfer of a possibly-committed pay so the request
+   * is held NON-payable ('settling') until that transfer completes (→ 'paid',
+   * server told) or aborts (→ payable, journal cleared). Keyed by request wire id
+   * (== requestId for wallet-api-surfaced requests). The in-memory Map is the
+   * synchronous source of truth used by the reload re-apply seam; it is
+   * single-flight loaded and every read-modify-write is serialized through a tail
+   * promise (the #679/#680 lesson: an unserialized RMW drops entries under
+   * concurrency = a re-payable request = the double-pay this fix prevents).
+   */
+  private settlingJournal: Map<string, { transferId: string; createdAt: number }> | null = null;
+  private settlingJournalLoad: Promise<void> | null = null;
+  private settlingJournalWrite: Promise<void> = Promise.resolve();
+  /** #441: guard overlapping resume reconciles (resumeOpenIntents has 2 fire-and-forget call sites). */
+  private reconcileInFlight = false;
+
   // Guard: ensure load() completes before processing incoming bundles
   private loadedPromise: Promise<void> | null = null;
   private loaded = false;
@@ -1358,6 +1384,11 @@ export class PaymentsModule {
     // installed. Without the capability the transport subscriptions stay
     // exactly as before (port selection, covenant §3.1-6).
     this.prBootstrapped = false;
+    // #441: reset the deferred-paid journal so it reloads under the new identity's
+    // storage key (the key bakes in chainPubkey). The pending write chain flushes
+    // its in-flight old-key write naturally.
+    this.settlingJournal = null;
+    this.settlingJournalLoad = null;
     if (this.paymentRequestsApi()) {
       this.prPollTimer = setInterval(() => {
         this.pumpHealth.run('payment-requests', () => this.pumpPaymentRequests());
@@ -2451,11 +2482,16 @@ export class PaymentsModule {
       // (ProofUnconfirmed / split-checkpoint), which are pre-mirror and have
       // their own handling.
       if (onChainCommitComplete && !(error instanceof TransferConflictError) && !keepOpen) {
-        throw new SphereError(
+        // #441 deferred-paid linkage: stamp the committing attempt's own transferId
+        // so a payment-request consumer can journal request→transfer and resolve
+        // 'paid' only once resumeOpenIntents actually completes this transfer.
+        const pending = new SphereError(
           'Your payment was sent. Your wallet is syncing with the server and will catch up shortly.',
           'SEND_SYNC_PENDING',
           error,
         );
+        pending.transferId = result.id;
+        throw pending;
       }
 
       // #677: a lost race (TransferConflictError) AFTER ≥1 earlier leg already
@@ -2480,6 +2516,15 @@ export class PaymentsModule {
           (remaining > 0n ? remaining : 0n).toString(),
           error,
         );
+      }
+
+      // #441 deferred-paid linkage: the keep-open certification codes
+      // (CERTIFICATION_UNCONFIRMED / CHECKPOINT_PERSIST_FAILED / SPLIT_CHECKPOINT_LOST /
+      // CHECKPOINT_TRUSTBASE_MISMATCH) reach the caller via the terminal throw below.
+      // Stamp this attempt's transferId so a payment-request consumer can journal
+      // request→transfer (idempotent; only fills a possibly-committed keep-open code).
+      if (error instanceof SphereError && isPossiblyCommittedSendOutcome(error)) {
+        error.transferId ??= result.id;
       }
 
       this.deps!.emitEvent('transfer:failed', result);
@@ -2942,7 +2987,12 @@ export class PaymentsModule {
    * Keeps only requests with status `'pending'`.
    */
   clearProcessedPaymentRequests(): void {
-    this.paymentRequests = this.paymentRequests.filter((r) => r.status === 'pending');
+    // #441: a 'settling' request is UNRESOLVED (its linked transfer is still
+    // in-flight) — it must NOT be evicted, or the reload re-apply loses its
+    // in-memory hold before the journal re-surfaces it.
+    this.paymentRequests = this.paymentRequests.filter(
+      (r) => r.status === 'pending' || r.status === 'settling'
+    );
   }
 
   /**
@@ -2995,16 +3045,46 @@ export class PaymentsModule {
       // #441/#442: reverting to 'pending' makes the request RE-PAYABLE (the guard
       // above admits a re-pay when status is 'pending' OR 'accepted'). That is
       // correct ONLY for a clean pre-commit failure where NOTHING left the wallet.
-      // For a possibly-committed outcome — a post-commit sync-pending / keep-open
-      // certification state, or a PartialSendConflictError (money already left,
-      // the intent completes via resume/claim) — reverting would double-pay. Mark
-      // it 'paid' (durably non-payable) instead and re-throw so the caller still
-      // learns it is pending/partial. This makes the request state durably correct
-      // for every consumer (the app's in-memory override becomes unnecessary).
-      this.updatePaymentRequestStatus(
-        requestId,
-        isPossiblyCommittedSendOutcome(error) ? 'paid' : 'pending',
-      );
+      if (isPossiblyCommittedSendOutcome(error)) {
+        // Money has (or may have) left the wallet on-chain. Do NOT tell the server
+        // 'paid' yet — resumeOpenIntents may still ABORT this transfer. Durably
+        // journal request→transfer and hold the request NON-payable ('settling')
+        // until the linked transfer actually completes (resolves 'paid') or aborts
+        // (returns to payable). Reverting to 'pending' here — or telling the server
+        // 'paid' now — would double-pay after a RELOAD.
+        const linkedTransferId =
+          error instanceof SphereError && error.transferId ? error.transferId : undefined;
+        // Deferral requires the wallet-api resume + respond mechanism. Without a
+        // wallet-api PR port (a Nostr-only composition — where a possibly-committed
+        // outcome does not actually arise, and requests are in-memory push-only, so
+        // there is no reload re-surface to double-pay), keep the prior durable
+        // 'paid' behavior instead of holding an unresolvable 'settling'.
+        if (linkedTransferId && this.paymentRequestsApi()) {
+          // Order is load-bearing: journal PERSISTS before the in-memory status
+          // flip, so a crash in between leaves the durable link (reload re-applies
+          // settling) — never a lost link (which would re-surface payable).
+          await this.journalSettling(requestId, linkedTransferId);
+          this.updatePaymentRequestStatus(requestId, 'settling');
+        } else {
+          // Either a Nostr-only composition (no wallet-api PR port — no deferral
+          // mechanism, no reload re-surface) or — defensively — a possibly-committed
+          // code with NO stamped transferId (should be impossible after the sendOnce
+          // stamps). Either way FAIL CLOSED to the pre-fix behavior (durably
+          // non-payable) rather than re-surface payable or hold an unresolvable
+          // 'settling'.
+          if (!linkedTransferId) {
+            logger.error(
+              'Payments',
+              `Possibly-committed send for ${requestId} carried no transferId — marking paid (fail-closed)`,
+            );
+          }
+          this.updatePaymentRequestStatus(requestId, 'paid');
+        }
+      } else {
+        // Clean pre-commit failure — nothing left the wallet; re-payable.
+        await this.clearSettling(requestId); // defensive: drop any stale link
+        this.updatePaymentRequestStatus(requestId, 'pending');
+      }
       throw error;
     }
   }
@@ -3019,7 +3099,8 @@ export class PaymentsModule {
       if (eventType === 'payment_request:accepted' ||
           eventType === 'payment_request:rejected' ||
           eventType === 'payment_request:paid' ||
-          eventType === 'payment_request:expired') {
+          eventType === 'payment_request:expired' ||
+          eventType === 'payment_request:settling') {
         this.deps?.emitEvent(eventType, request);
       }
     }
@@ -5486,6 +5567,59 @@ export class PaymentsModule {
     );
   }
 
+  // ── #441 deferred-paid journal (per network + identity — mirrors prCursor) ──
+
+  private prSettlingKey(): string {
+    const network = this.paymentRequestsApi()?.network ?? 'default';
+    return `wallet-api-pr:settling:${network}:${this.deps!.identity.chainPubkey}`;
+  }
+
+  /**
+   * Single-flight load: concurrent callers (the pump's reload re-apply, resume's
+   * reconcile, a live pay catch) share ONE storage.get + ONE Map instance so a
+   * lazy read never overwrites another context's in-memory mutation.
+   */
+  private ensureSettlingJournalLoaded(): Promise<void> {
+    return (this.settlingJournalLoad ??= (async () => {
+      const raw = await this.deps!.storage.get(this.prSettlingKey());
+      this.settlingJournal = new Map(
+        raw ? Object.entries(JSON.parse(raw) as Record<string, { transferId: string; createdAt: number }>) : []
+      );
+    })());
+  }
+
+  /**
+   * Serialize every read-modify-write through a tail-promise chain so two
+   * concurrent mutations can't lose an entry (the #679/#680 mutex lesson — a
+   * dropped entry is a re-payable request is a double-pay). `fn` returns true
+   * when the Map changed and must be persisted.
+   */
+  private mutateSettlingJournal(
+    fn: (m: Map<string, { transferId: string; createdAt: number }>) => boolean
+  ): Promise<void> {
+    this.settlingJournalWrite = this.settlingJournalWrite.catch(() => {}).then(async () => {
+      await this.ensureSettlingJournalLoaded();
+      if (fn(this.settlingJournal!)) {
+        await this.deps!.storage.set(
+          this.prSettlingKey(),
+          JSON.stringify(Object.fromEntries(this.settlingJournal!))
+        );
+      }
+    });
+    return this.settlingJournalWrite;
+  }
+
+  private journalSettling(requestId: string, transferId: string): Promise<void> {
+    return this.mutateSettlingJournal((m) => {
+      m.set(requestId, { transferId, createdAt: Date.now() });
+      return true;
+    });
+  }
+
+  private clearSettling(requestId: string): Promise<void> {
+    return this.mutateSettlingJournal((m) => m.delete(requestId));
+  }
+
   // ── the pump ─────────────────────────────────────────────────────────────────
 
   /**
@@ -5540,6 +5674,12 @@ export class PaymentsModule {
    * picks up live updates from the resume point.
    */
   private async pumpIncomingPaymentRequests(api: PaymentRequestsApi): Promise<void> {
+    // #441: the deferred-paid journal must be present in memory BEFORE the first
+    // hydration surfaces any wire — surfaceIncomingPaymentRequest reads it
+    // synchronously to hold a settling request non-payable instead of re-surfacing
+    // it as payable. Single-flight, so ordering vs. resumeOpenIntents is irrelevant.
+    await this.ensureSettlingJournalLoaded();
+
     const persisted = await this.readPrCursorState();
 
     if (!this.prBootstrapped) {
@@ -5630,7 +5770,24 @@ export class PaymentsModule {
       return;
     }
 
-    const status = PaymentsModule.PR_WIRE_STATUS[wire.status];
+    let status = PaymentsModule.PR_WIRE_STATUS[wire.status];
+
+    // #441 reload re-apply: a request linked to an in-flight transfer (durable
+    // journal, loaded before hydration) must NOT be re-surfaced as payable. Read
+    // the SYNCHRONOUS in-memory journal (loaded in pumpIncomingPaymentRequests /
+    // resumeOpenIntents before any surface call).
+    const settling = this.settlingJournal?.get(wire.id);
+    if (settling) {
+      if (wire.status === 'open') {
+        // Hold non-payable; suppresses the new-incoming notify below.
+        status = 'settling';
+      } else {
+        // Server already resolved (paid/declined/expired) — our deferred tell
+        // landed in a prior session, or it expired. Drop the stale link and let
+        // the terminal status flow.
+        void this.clearSettling(wire.id);
+      }
+    }
 
     // §16 upsert: a request re-surfaces in the incoming ?since= delta at a higher seq when it is
     // resolved (paid/declined) or expired — on another device OR by THIS wallet's other session.
@@ -5866,7 +6023,120 @@ export class PaymentsModule {
         }
       }
     }
+
+    // #441: drive deferred-paid resolution off the DURABLE journal (not in-memory
+    // request presence) — this is the sole seam where a settling transfer
+    // completes (resumed), aborts (conflicted), or stays open (failed).
+    await this.reconcileSettlingPaymentRequests(
+      outcome,
+      new Set(intents.map((i) => i.transferId)),
+      localIntents,
+      localReadFailed,
+    );
+
     return outcome;
+  }
+
+  /**
+   * #441: resolve every journaled settling payment request against a resume
+   * outcome. Completed → send the deferred 'paid' response (server now told) and
+   * resolve 'paid'. Aborted (nothing delivered) → clear journal, return to
+   * payable. Still open → leave it. For an id accounted for by NONE of those
+   * (a crash between resume-complete and the local write), consult the server
+   * `listIntents('aborted')` authority: aborted → payable; else → paid (a
+   * completed row the server GC'd). Direction-of-error is deliberate: the only
+   * residual false-paid is a transfer that aborted server-side AND whose local
+   * 'aborted' write was lost AND whose server aborted-row was later GC'd — it is
+   * treated as paid, erring toward PAID-NEVER-RE-PAYABLE (no double-pay), the
+   * invariant this fix exists to protect.
+   */
+  private async reconcileSettlingPaymentRequests(
+    outcome: { resumed: string[]; conflicted: string[]; failed: string[] },
+    openIntentIds: Set<string>,
+    localIntents: Map<string, { status: 'open' | 'completed' | 'aborted'; abortPending: boolean }> | undefined,
+    localReadFailed: boolean,
+  ): Promise<void> {
+    if (this.reconcileInFlight) return; // an overlapping resume is already reconciling
+    await this.ensureSettlingJournalLoaded();
+    if (this.settlingJournal!.size === 0) return;
+    if (localReadFailed) return; // #676 posture: dispositions unknown → leave settling, retry next sign-in
+    this.reconcileInFlight = true;
+    try {
+      const resumed = new Set(outcome.resumed);
+      const conflicted = new Set(outcome.conflicted); // aborted THIS run — nothing delivered
+
+      // Server ABORTED authority — fetched lazily, only when a journaled id is
+      // unaccounted-for by the cheap checks below (closes the false-paid crash gap
+      // without a local-absence guess).
+      let abortedIds: Set<string> | null = null;
+      const abortedAuthority = async (): Promise<Set<string>> => {
+        if (abortedIds) return abortedIds;
+        const aborted = await this.deps!.walletApi!.listIntents('aborted');
+        abortedIds = new Set(aborted.map((i) => i.transferId));
+        return abortedIds;
+      };
+
+      for (const [requestId, entry] of [...this.settlingJournal!]) {
+        const { transferId, createdAt } = entry;
+        if (Date.now() - createdAt > 7 * 864e5) {
+          logger.warn(
+            'Payments',
+            `Settling link ${requestId}→${transferId.slice(0, 8)}… is >7d old (stuck transfer?)`,
+          );
+        }
+        const local = localIntents?.get(transferId);
+
+        if (resumed.has(transferId) || local?.status === 'completed') {
+          await this.resolveSettledPaid(requestId, transferId);
+        } else if (conflicted.has(transferId) || local?.status === 'aborted' || local?.abortPending === true) {
+          await this.revertSettlingToPayable(requestId);
+        } else if (openIntentIds.has(transferId)) {
+          // Still open (transient/stuck) → leave journal, retry next sign-in.
+        } else {
+          // Not resumed this run, not locally decided, not in the open list —
+          // consult the server aborted authority.
+          try {
+            const aborted = await abortedAuthority();
+            if (aborted.has(transferId)) await this.revertSettlingToPayable(requestId);
+            else await this.resolveSettledPaid(requestId, transferId); // server GC'd a completed row
+          } catch (e) {
+            logger.warn(
+              'Payments',
+              `listIntents(aborted) failed during reconcile — deferring ${requestId} to next sign-in:`,
+              e,
+            );
+          }
+        }
+      }
+    } finally {
+      this.reconcileInFlight = false;
+    }
+  }
+
+  /** #441: the linked transfer completed — tell the server 'paid' and resolve 'paid'. */
+  private async resolveSettledPaid(requestId: string, transferId: string): Promise<void> {
+    const api = this.paymentRequestsApi();
+    if (!api || typeof api.respondPaymentRequest !== 'function') return; // only wallet-api ports journal
+    try {
+      await api.respondPaymentRequest(requestId, { action: 'paid', transferId });
+    } catch (err) {
+      // Idempotent replay / expiry race: a 409 CONFLICT ('non-open') means the
+      // request is already resolved server-side → swallow and clear. Any OTHER
+      // error (network / 5xx) → leave the journal, retry next sign-in.
+      if (!isNonOpenConflict(err)) {
+        logger.warn('Payments', `Deferred paid response failed for ${requestId} (retried next sign-in):`, err);
+        return;
+      }
+    }
+    await this.clearSettling(requestId);
+    this.updatePaymentRequestStatus(requestId, 'paid'); // reconcile in-memory if surfaced; else next pump sees wire 'paid'
+  }
+
+  /** #441: the linked transfer aborted — nothing was paid; clear the link and return to payable. */
+  private async revertSettlingToPayable(requestId: string): Promise<void> {
+    await this.clearSettling(requestId);
+    // No-op if not in memory; the next pump re-surfaces the open wire as 'pending'.
+    this.updatePaymentRequestStatus(requestId, 'pending');
   }
 
   /**

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1385,10 +1385,13 @@ export class PaymentsModule {
     // exactly as before (port selection, covenant §3.1-6).
     this.prBootstrapped = false;
     // #441: reset the deferred-paid journal so it reloads under the new identity's
-    // storage key (the key bakes in chainPubkey). The pending write chain flushes
-    // its in-flight old-key write naturally.
+    // storage key (the key bakes in chainPubkey). New mutations start a fresh
+    // write chain; any still-queued old-identity mutation is dropped by the
+    // per-mutation key guard in mutateSettlingJournal (it can't pollute the new
+    // identity's journal).
     this.settlingJournal = null;
     this.settlingJournalLoad = null;
+    this.settlingJournalWrite = Promise.resolve();
     if (this.paymentRequestsApi()) {
       this.prPollTimer = setInterval(() => {
         this.pumpHealth.run('payment-requests', () => this.pumpPaymentRequests());
@@ -5589,9 +5592,18 @@ export class PaymentsModule {
   private ensureSettlingJournalLoaded(): Promise<void> {
     return (this.settlingJournalLoad ??= (async () => {
       const raw = await this.deps!.storage.get(this.prSettlingKey());
-      this.settlingJournal = new Map(
-        raw ? Object.entries(JSON.parse(raw) as Record<string, { transferId: string; createdAt: number; committed?: boolean }>) : []
-      );
+      try {
+        this.settlingJournal = new Map(
+          raw ? Object.entries(JSON.parse(raw) as Record<string, { transferId: string; createdAt: number; committed?: boolean }>) : []
+        );
+      } catch (err) {
+        // A corrupt blob (partial write / manual clear / older format) must NOT
+        // wedge the whole resume + payment-request pump. Fail open to an empty
+        // journal (a settling request may re-surface payable — a rare, bounded
+        // risk) rather than throw and break ALL resume for the session.
+        logger.error('Payments', 'Settling journal unreadable — treating as empty:', err);
+        this.settlingJournal = new Map();
+      }
     })());
   }
 
@@ -5604,13 +5616,17 @@ export class PaymentsModule {
   private mutateSettlingJournal(
     fn: (m: Map<string, { transferId: string; createdAt: number; committed?: boolean }>) => boolean
   ): Promise<void> {
+    // Capture the identity's storage key at ENQUEUE time. If the identity
+    // switches before this queued mutation runs, prSettlingKey() will have
+    // changed — skip, so a stale old-identity mutation cannot reload + rewrite
+    // the NEW identity's journal (resetting the chain pointer alone does not
+    // cancel an already-queued .then).
+    const keyAtEnqueue = this.prSettlingKey();
     this.settlingJournalWrite = this.settlingJournalWrite.catch(() => {}).then(async () => {
+      if (this.prSettlingKey() !== keyAtEnqueue) return; // identity changed — drop the stale mutation
       await this.ensureSettlingJournalLoaded();
       if (fn(this.settlingJournal!)) {
-        await this.deps!.storage.set(
-          this.prSettlingKey(),
-          JSON.stringify(Object.fromEntries(this.settlingJournal!))
-        );
+        await this.deps!.storage.set(keyAtEnqueue, JSON.stringify(Object.fromEntries(this.settlingJournal!)));
       }
     });
     return this.settlingJournalWrite;
@@ -5801,8 +5817,11 @@ export class PaymentsModule {
       } else {
         // Server already resolved (paid/declined/expired) — our deferred tell
         // landed in a prior session, or it expired. Drop the stale link and let
-        // the terminal status flow.
-        void this.clearSettling(wire.id);
+        // the terminal status flow. Fire-and-forget (surface is sync), but attach
+        // a .catch so a storage I/O failure can't raise an unhandled rejection.
+        void this.clearSettling(wire.id).catch((err) =>
+          logger.warn('Payments', `Failed to clear stale settling link for ${wire.id}:`, err),
+        );
       }
     }
 

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -647,6 +647,45 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
       expect(bJournal?.has('reqA') ?? false).toBe(false);
     });
 
+    it('(identity switch during load, load-bearing) an in-flight load under A does NOT overwrite B journal (Copilot)', async () => {
+      const { fake, payer } = await seedPendingRequest('idload');
+      // Seed identity A's journal on disk.
+      payer.storage.map.set(
+        SETTLING_KEY(fake.network),
+        JSON.stringify({ reqA: { transferId: 'tidA', createdAt: Date.now() } }),
+      );
+
+      // Block the next settling-key storage.get so a load stays in-flight.
+      let release!: () => void;
+      const gate = new Promise<void>((r) => { release = r; });
+      const map = payer.storage.map;
+      (payer.storage.provider.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        async (k: string) => {
+          if (k.includes(':settling:')) await gate;
+          return map.get(k) ?? null;
+        },
+      );
+
+      // Force a fresh load under identity A and start it (do not await — it blocks).
+      (payer.module as unknown as { settlingJournalLoad: Promise<void> | null }).settlingJournalLoad = null;
+      const loadP = (
+        payer.module as unknown as { ensureSettlingJournalLoaded(): Promise<void> }
+      ).ensureSettlingJournalLoaded();
+
+      // Switch to identity B while A's load is blocked.
+      const B = testIdentity(7777);
+      payer.module.initialize({ ...payer.deps, identity: B });
+
+      // Release → A's load resolves AFTER the switch. Its key guard must drop it.
+      release();
+      await loadP.catch(() => {});
+
+      // B's in-memory journal must NOT have been clobbered with A's data.
+      const j = (payer.module as unknown as { settlingJournal: Map<string, unknown> | null })
+        .settlingJournal;
+      expect(j?.has('reqA') ?? false).toBe(false);
+    });
+
     it('(idempotent respond) a 409 CONFLICT on the deferred paid response is swallowed → journal cleared, status paid; a NETWORK error retains the journal', async () => {
       const { fake, payer, reqId, sourceTokenId } = await seedPendingRequest('idem');
       const transferId = crypto.randomUUID();

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -601,6 +601,52 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
       await expect(payer.module.payPaymentRequest(reqId)).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
     });
 
+    it('(corrupt journal) an unreadable settling blob loads as empty and does NOT wedge the pump (Copilot)', async () => {
+      const { fake, payer, reqId, sourceTokenId } = await seedPendingRequest('corrupt');
+      const transferId = crypto.randomUUID();
+      await putOpenIntent(payer, transferId, sourceTokenId);
+      await paySettling(payer, reqId, transferId); // writes a valid journal
+      // Corrupt the persisted blob (partial write / manual clear / older format).
+      payer.storage.map.set(SETTLING_KEY(fake.network), '{ not valid json');
+
+      // A fresh module over the same storage must LOAD + PUMP without throwing.
+      // Without the JSON.parse guard, ensureSettlingJournalLoaded throws and wedges
+      // the whole payment-request pump / resume path.
+      const reopened = createPaymentsModule({ l1: null });
+      reopened.initialize({ ...payer.deps });
+      cleanups.push(() => reopened.destroy());
+      await reopened.load();
+      await reopened.syncPaymentRequests(); // would REJECT here without the fix
+
+      // Fail-open: journal treated as empty → the request re-surfaces per server
+      // state (open → pending) rather than the pump being wedged.
+      expect(reopened.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('pending');
+    });
+
+    it('(identity switch, load-bearing) a journal mutation queued under identity A does NOT pollute identity B (Copilot)', async () => {
+      const { fake, payer } = await seedPendingRequest('idswitch');
+
+      // Enqueue a journal mutation under identity A but do NOT await it…
+      const pA = (
+        payer.module as unknown as { journalSettling(r: string, t: string, c?: boolean): Promise<void> }
+      ).journalSettling('reqA', 'tidA');
+
+      // …then synchronously switch to identity B (a distinct chainPubkey). The
+      // queued mutation's .then runs AFTER the switch; the enqueue-time key guard
+      // must drop it so it can't reload + rewrite identity B's journal.
+      const B = testIdentity(4242);
+      payer.module.initialize({ ...payer.deps, identity: B });
+
+      await pA.catch(() => {});
+
+      // reqA must NOT have leaked into identity B's IN-MEMORY journal. Without the
+      // key guard the queued mutation reloads B's (empty) journal, injects reqA,
+      // and persists — polluting B's session state with a prior identity's link.
+      const bJournal = (payer.module as unknown as { settlingJournal: Map<string, unknown> | null })
+        .settlingJournal;
+      expect(bJournal?.has('reqA') ?? false).toBe(false);
+    });
+
     it('(idempotent respond) a 409 CONFLICT on the deferred paid response is swallowed → journal cleared, status paid; a NETWORK error retains the journal', async () => {
       const { fake, payer, reqId, sourceTokenId } = await seedPendingRequest('idem');
       const transferId = crypto.randomUUID();

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -27,12 +27,12 @@ import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase, History
 import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId } from '../token-engine/FakeTokenEngine';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
-import { WalletApiClient } from '../../../wallet-api';
+import { WalletApiClient, WalletApiError } from '../../../wallet-api';
 import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../../impl/shared/wallet-api';
 import { encodeTokenBlob } from '../../../token-engine/token-blob';
 import { hexToBytes } from '../../../core/crypto';
 import { SphereError, PartialSendConflictError } from '../../../core/errors';
-import { FIELD_ENVELOPE_PREFIX } from '../../../core/field-encryption';
+import { FIELD_ENVELOPE_PREFIX, deriveFieldEncryptionKey, encryptField } from '../../../core/field-encryption';
 import { deriveDeliveryEncryptionKey, decryptDeliveryBundle } from '../../../core/delivery-envelope';
 
 const UCT = '11'.repeat(32);
@@ -400,62 +400,226 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     });
   });
 
-  describe('#441/#442: a possibly-committed pay outcome keeps the request NON-payable (durable, no double-pay)', () => {
-    async function seedPendingRequest(deviceSuffix: string): Promise<{ payer: Wallet; reqId: string }> {
+  describe('#441 deferred-paid: a possibly-committed pay HOLDS the request settling until the transfer resolves (no double-pay on reload)', () => {
+    const SETTLING_KEY = (net: string) => `wallet-api-pr:settling:${net}:${PAYER.chainPubkey}`;
+
+    interface Ctx {
+      fake: FakeWalletApi;
+      baseUrl: string;
+      requester: Wallet;
+      payer: Wallet;
+      reqId: string;
+      sourceTokenId: string;
+    }
+
+    async function seedPendingRequest(deviceSuffix: string): Promise<Ctx> {
       const { fake, baseUrl } = await startFake();
       const requester = makeWalletApiWallet(baseUrl, fake.network, REQUESTER, `pr-441-r-${deviceSuffix}`);
       const payer = makeWalletApiWallet(baseUrl, fake.network, PAYER, `pr-441-p-${deviceSuffix}`);
-      await seedServerToken(fake, payer, PAYER, 1000n);
+      const sourceTokenId = await seedServerToken(fake, payer, PAYER, 1000n);
       await requester.module.load();
       await payer.module.load();
       await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '1000', coinId: UCT });
       await payer.module.syncPaymentRequests();
       const pending = payer.module.getPaymentRequests({ status: 'pending' });
       expect(pending).toHaveLength(1);
-      return { payer, reqId: pending[0].id };
+      return { fake, baseUrl, requester, payer, reqId: pending[0].id, sourceTokenId };
     }
 
-    it('a possibly-committed keep-open failure (SEND_SYNC_PENDING) marks the request paid (NOT pending) — a re-pay is refused', async () => {
-      const { payer, reqId } = await seedPendingRequest('sync');
-
-      // The send committed on-chain; only the post-commit mirror sync is pending — the money has LEFT.
-      // Reverting to 'pending' (the old behavior) would let the request be re-paid → double-pay (#441).
-      vi.spyOn(payer.module, 'send').mockRejectedValue(new SphereError('sent — wallet catching up', 'SEND_SYNC_PENDING'));
-
-      await expect(payer.module.payPaymentRequest(reqId)).rejects.toMatchObject({ code: 'SEND_SYNC_PENDING' });
-
-      // Durably NON-payable: not pending/accepted, so the guard refuses a re-pay (survives reload — the
-      // status is the persisted record, not the app's in-memory override).
-      expect(payer.module.getPaymentRequests({ status: 'pending' })).toHaveLength(0);
-      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('paid');
-      await expect(payer.module.payPaymentRequest(reqId)).rejects.toThrow(/not pending or accepted/i);
-    });
-
-    it('a PartialSendConflictError (money left, remainder uncovered) also stays NON-payable', async () => {
-      const { payer, reqId } = await seedPendingRequest('partial');
-
-      vi.spyOn(payer.module, 'send').mockRejectedValue(
-        new PartialSendConflictError('part sent', 'tid-abc', ['v2_committed'], '500'),
+    /** Put a REAL open intent on the server (the id resume will complete/abort), matching this pay. */
+    async function putOpenIntent(payer: Wallet, transferId: string, sourceTokenId: string): Promise<void> {
+      payer.client.setIdentity(PAYER);
+      const payload = { v: 1, recipient: REQUESTER.chainPubkey, coinId: UCT, amount: '1000', direct: [sourceTokenId] };
+      await payer.client.putIntent(
+        transferId,
+        encryptField(deriveFieldEncryptionKey(PAYER.privateKey), JSON.stringify(payload)),
       );
+    }
 
-      await expect(payer.module.payPaymentRequest(reqId)).rejects.toBeInstanceOf(PartialSendConflictError);
+    /** Drive payPaymentRequest into 'settling' by mocking send to throw a stamped possibly-committed error. */
+    async function paySettling(payer: Wallet, reqId: string, transferId: string, code = 'SEND_SYNC_PENDING'): Promise<void> {
+      const err = new SphereError('sent — wallet catching up', code as never);
+      err.transferId = transferId;
+      vi.spyOn(payer.module, 'send').mockRejectedValueOnce(err);
+      await expect(payer.module.payPaymentRequest(reqId)).rejects.toMatchObject({ code });
+    }
 
+    it('(write site) a possibly-committed pay → status settling, journal links request→transfer, server NOT told paid, error re-thrown', async () => {
+      const { fake, payer, reqId, sourceTokenId } = await seedPendingRequest('write');
+      const transferId = crypto.randomUUID();
+      await putOpenIntent(payer, transferId, sourceTokenId);
+
+      const respondSpy = vi.spyOn(payer.client, 'respondPaymentRequest');
+      await paySettling(payer, reqId, transferId);
+
+      // Held NON-payable: 'settling', not 'paid', not 'pending'.
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('settling');
       expect(payer.module.getPaymentRequests({ status: 'pending' })).toHaveLength(0);
-      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('paid');
+      // Durable journal links request→transfer.
+      const journal = JSON.parse(payer.storage.map.get(SETTLING_KEY(fake.network))!);
+      expect(journal[reqId]).toMatchObject({ transferId });
+      // Server was NOT told 'paid' (the whole point — resume may still abort).
+      expect(respondSpy).not.toHaveBeenCalled();
+      expect(fake.getPaymentRequest(reqId)).toMatchObject({ status: 'open', transferId: null });
+    });
+
+    it('(write site) a PartialSendConflictError links its NATIVE primary transferId → settling', async () => {
+      const { fake, payer, reqId } = await seedPendingRequest('partial');
+      // PartialSendConflictError.transferId is set natively (not via the sendOnce stamp).
+      vi.spyOn(payer.module, 'send').mockRejectedValueOnce(
+        new PartialSendConflictError('part sent', 'tid-primary', ['v2_committed'], '500'),
+      );
+      await expect(payer.module.payPaymentRequest(reqId)).rejects.toBeInstanceOf(PartialSendConflictError);
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('settling');
+      const journal = JSON.parse(payer.storage.map.get(SETTLING_KEY(fake.network))!);
+      expect(journal[reqId]).toMatchObject({ transferId: 'tid-primary' });
+    });
+
+    it('(pay guard) a settling request is auto NON-payable — a tapped re-pay throws VALIDATION_ERROR', async () => {
+      const { payer, reqId, sourceTokenId } = await seedPendingRequest('guard');
+      const transferId = crypto.randomUUID();
+      await putOpenIntent(payer, transferId, sourceTokenId);
+      await paySettling(payer, reqId, transferId);
+      await expect(payer.module.payPaymentRequest(reqId)).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
       await expect(payer.module.payPaymentRequest(reqId)).rejects.toThrow(/not pending or accepted/i);
     });
 
-    it('a genuine CLEAN pre-commit failure (nothing left the wallet) reverts to pending — safe to re-pay', async () => {
-      const { payer, reqId } = await seedPendingRequest('clean');
+    it('(RELOAD, load-bearing) a settling request is NOT re-surfaced as payable — a fresh module over the SAME storage+server holds it settling, no re-notify', async () => {
+      const { fake, payer, reqId, sourceTokenId } = await seedPendingRequest('reload');
+      const transferId = crypto.randomUUID();
+      await putOpenIntent(payer, transferId, sourceTokenId);
+      await paySettling(payer, reqId, transferId);
 
-      // Nothing committed on-chain (e.g. insufficient balance / a pre-cert error) — re-paying is safe.
-      vi.spyOn(payer.module, 'send').mockRejectedValue(new SphereError('not enough funds', 'SEND_INSUFFICIENT_BALANCE'));
+      // The server PR is STILL open (never told paid). Pre-fix, a reload re-hydrated
+      // it OPEN → payable → the exact double-pay. A fresh module must re-apply the
+      // durable journal and hold it settling instead.
+      expect(fake.getPaymentRequest(reqId)).toMatchObject({ status: 'open' });
+
+      const reopened = createPaymentsModule({ l1: null });
+      reopened.initialize({ ...payer.deps });
+      cleanups.push(() => reopened.destroy());
+      const reNotified: IncomingPaymentRequest[] = [];
+      reopened.onPaymentRequest((r) => reNotified.push(r));
+      await reopened.load();
+      await reopened.syncPaymentRequests();
+
+      const req = reopened.getPaymentRequests().find((r) => r.id === reqId);
+      expect(req?.status).toBe('settling');
+      expect(reopened.getPaymentRequests({ status: 'pending' })).toHaveLength(0);
+      // Never re-fires the actionable 'new incoming' notify for a settling request.
+      expect(reNotified.map((r) => r.id)).not.toContain(reqId);
+      expect(payer.emitEvent.mock.calls.some((c) => c[0] === 'payment_request:incoming' && (c[1] as IncomingPaymentRequest).id === reqId)).toBe(true); // only the ORIGINAL surface notified
+    });
+
+    it('(resolution, load-bearing) when the linked transfer COMPLETES via resume → paid response sent to the server exactly once, request resolves paid, journal cleared', async () => {
+      const { fake, payer, reqId, sourceTokenId } = await seedPendingRequest('resolve');
+      const transferId = crypto.randomUUID();
+      await putOpenIntent(payer, transferId, sourceTokenId);
+      await paySettling(payer, reqId, transferId);
+      vi.restoreAllMocks(); // drop the send mock — resume uses the real engine
+      const respondSpy = vi.spyOn(payer.client, 'respondPaymentRequest');
+
+      const outcome = await payer.module.resumeOpenIntents();
+      expect(outcome.resumed).toContain(transferId);
+
+      // Deferred 'paid' now told to the server EXACTLY once, with the linking transferId.
+      const paidCalls = respondSpy.mock.calls.filter((c) => (c[1] as { action: string }).action === 'paid');
+      expect(paidCalls).toHaveLength(1);
+      expect(paidCalls[0]).toEqual([reqId, { action: 'paid', transferId }]);
+      expect(fake.getPaymentRequest(reqId)).toMatchObject({ status: 'paid', transferId });
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('paid');
+      // Journal cleared.
+      expect(payer.storage.map.get(SETTLING_KEY(fake.network))).toBe('{}');
+
+      // Idempotent: a second resume does not re-respond (journal already empty).
+      respondSpy.mockClear();
+      await payer.module.resumeOpenIntents();
+      expect(respondSpy).not.toHaveBeenCalled();
+    });
+
+    it('(abort, load-bearing) when the linked transfer ABORTS via resume → journal clears, server never told paid, request returns to payable', async () => {
+      const { fake, payer, reqId, sourceTokenId } = await seedPendingRequest('abort');
+      const transferId = crypto.randomUUID();
+      await putOpenIntent(payer, transferId, sourceTokenId);
+      await paySettling(payer, reqId, transferId);
+      vi.restoreAllMocks();
+
+      // Reproduce the #676 locally-aborted-but-server-open divergence: resume must
+      // NOT re-execute it and classifies it conflicted (aborted, nothing delivered).
+      fake.setIntentFailure(true);
+      await expect(payer.client.abortIntent(transferId)).rejects.toThrow();
+      fake.setIntentFailure(false);
+      expect(await payer.client.getLocalIntent(transferId)).toMatchObject({ status: 'aborted', abortPending: true });
+
+      const respondSpy = vi.spyOn(payer.client, 'respondPaymentRequest');
+      const outcome = await payer.module.resumeOpenIntents();
+      expect(outcome.conflicted).toContain(transferId);
+      expect(outcome.resumed).not.toContain(transferId);
+
+      // Nothing was paid: server never told 'paid', journal cleared, request re-payable.
+      expect(respondSpy.mock.calls.filter((c) => (c[1] as { action: string }).action === 'paid')).toHaveLength(0);
+      expect(fake.getPaymentRequest(reqId)).toMatchObject({ status: 'open' });
+      expect(payer.storage.map.get(SETTLING_KEY(fake.network))).toBe('{}');
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('pending');
+      // And a re-pay is admitted again (the request was NOT fulfilled).
+      expect(payer.module.getPaymentRequests({ status: 'pending' }).map((r) => r.id)).toContain(reqId);
+    });
+
+    it('(idempotent respond) a 409 CONFLICT on the deferred paid response is swallowed → journal cleared, status paid; a NETWORK error retains the journal', async () => {
+      const { fake, payer, reqId, sourceTokenId } = await seedPendingRequest('idem');
+      const transferId = crypto.randomUUID();
+      await putOpenIntent(payer, transferId, sourceTokenId);
+      await paySettling(payer, reqId, transferId);
+      vi.restoreAllMocks();
+
+      // First resume: the respond hits a transient NETWORK error → journal RETAINED, still settling.
+      const respondSpy = vi.spyOn(payer.client, 'respondPaymentRequest')
+        .mockRejectedValueOnce(new WalletApiError('flaky', 'NETWORK'));
+      await payer.module.resumeOpenIntents();
+      expect(payer.storage.map.get(SETTLING_KEY(fake.network))).toContain(reqId);
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('settling');
+
+      // Next resume: the respond returns 409 CONFLICT (already resolved server-side) → swallowed,
+      // journal cleared, status paid.
+      respondSpy.mockRejectedValueOnce(new WalletApiError('non-open', 'CONFLICT', 409));
+      await payer.module.resumeOpenIntents();
+      expect(payer.storage.map.get(SETTLING_KEY(fake.network))).toBe('{}');
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('paid');
+    });
+
+    it('(clean pre-commit failure) nothing left the wallet → reverts to pending, journal untouched, re-payable', async () => {
+      const { fake, payer, reqId } = await seedPendingRequest('clean');
+      vi.spyOn(payer.module, 'send').mockRejectedValueOnce(new SphereError('not enough funds', 'SEND_INSUFFICIENT_BALANCE'));
 
       await expect(payer.module.payPaymentRequest(reqId)).rejects.toMatchObject({ code: 'SEND_INSUFFICIENT_BALANCE' });
 
-      // Reverted to pending → re-payable (the request was not fulfilled).
-      expect(payer.module.getPaymentRequests({ status: 'pending' })).toHaveLength(1);
+      expect(payer.module.getPaymentRequests({ status: 'pending' }).map((r) => r.id)).toContain(reqId);
       expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('pending');
+      expect(payer.storage.map.get(SETTLING_KEY(fake.network)) ?? '{}').toBe('{}');
+    });
+
+    it('(concurrency RMW) two journalSettling for distinct requests racing from cold both survive (no dropped entry = no re-payable double-pay)', async () => {
+      const { fake, payer } = await seedPendingRequest('rmw');
+      const mod = payer.module as unknown as {
+        journalSettling(requestId: string, transferId: string): Promise<void>;
+      };
+      // Race both writes from the null-loaded state — the serialized RMW + single-flight load must
+      // keep BOTH (a lost entry would re-surface that request payable = double-pay, the #679/#680 lesson).
+      await Promise.all([mod.journalSettling('req-A', 'tid-A'), mod.journalSettling('req-B', 'tid-B')]);
+      const journal = JSON.parse(payer.storage.map.get(SETTLING_KEY(fake.network))!);
+      expect(journal['req-A']).toMatchObject({ transferId: 'tid-A' });
+      expect(journal['req-B']).toMatchObject({ transferId: 'tid-B' });
+    });
+
+    it('(clearProcessedPaymentRequests) keeps settling (and pending), evicts paid/rejected/expired', async () => {
+      const { payer, reqId, sourceTokenId } = await seedPendingRequest('clearproc');
+      const transferId = crypto.randomUUID();
+      await putOpenIntent(payer, transferId, sourceTokenId);
+      await paySettling(payer, reqId, transferId);
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('settling');
+      payer.module.clearProcessedPaymentRequests();
+      // The settling request is UNRESOLVED — it must survive the eviction.
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('settling');
     });
   });
 

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -565,6 +565,42 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
       expect(payer.module.getPaymentRequests({ status: 'pending' }).map((r) => r.id)).toContain(reqId);
     });
 
+    it('(partial commit, load-bearing) a PartialSendConflictError whose anchor intent ABORTS stays PAID — never reverts to payable (Codex P1)', async () => {
+      const { fake, payer, reqId, sourceTokenId } = await seedPendingRequest('partial-abort');
+      const transferId = crypto.randomUUID();
+      await putOpenIntent(payer, transferId, sourceTokenId);
+
+      // Pay ends in a PartialSendConflictError: ≥1 leg already certified + delivered,
+      // the anchor intent (transferId) soft-aborted. Value LEFT the wallet.
+      const partial = new PartialSendConflictError('part sent', transferId, ['v2_committed'], '500');
+      vi.spyOn(payer.module, 'send').mockRejectedValueOnce(partial);
+      await expect(payer.module.payPaymentRequest(reqId)).rejects.toBeInstanceOf(PartialSendConflictError);
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('settling');
+      // Journaled as committed — the discriminator that stops the revert.
+      expect(JSON.parse(payer.storage.map.get(SETTLING_KEY(fake.network))!)[reqId]).toMatchObject({
+        transferId, committed: true,
+      });
+      vi.restoreAllMocks();
+
+      // The anchor intent aborts on resume (exactly the #676 divergence). WITHOUT the
+      // committed flag the reconcile would read "aborted → nothing paid → revert to
+      // pending" and a re-pay would double-pay the delivered leg. It must resolve PAID.
+      fake.setIntentFailure(true);
+      await expect(payer.client.abortIntent(transferId)).rejects.toThrow();
+      fake.setIntentFailure(false);
+
+      const respondSpy = vi.spyOn(payer.client, 'respondPaymentRequest');
+      const outcome = await payer.module.resumeOpenIntents();
+      expect(outcome.conflicted).toContain(transferId); // the anchor DID abort…
+
+      // …yet the request is resolved PAID and NON-payable, journal cleared.
+      expect(respondSpy.mock.calls.filter((c) => (c[1] as { action: string }).action === 'paid')).toHaveLength(1);
+      expect(payer.storage.map.get(SETTLING_KEY(fake.network))).toBe('{}');
+      expect(payer.module.getPaymentRequests().find((r) => r.id === reqId)?.status).toBe('paid');
+      // A re-pay is REFUSED (delivered value must not be paid twice).
+      await expect(payer.module.payPaymentRequest(reqId)).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    });
+
     it('(idempotent respond) a 409 CONFLICT on the deferred paid response is swallowed → journal cleared, status paid; a NETWORK error retains the journal', async () => {
       const { fake, payer, reqId, sourceTokenId } = await seedPendingRequest('idem');
       const transferId = crypto.randomUUID();

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -270,9 +270,17 @@ describe('send — full wallet-api preset (S2 consumer + S3 + §7 pipeline)', ()
       throw cause;
     };
 
-    await expect(
-      sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT }),
-    ).rejects.toMatchObject({ code: 'SEND_SYNC_PENDING', cause });
+    const err = await sender.module
+      .send({ recipient: '@bob', amount: '1000', coinId: UCT })
+      .then(() => { throw new Error('expected send to reject'); }, (e: unknown) => e);
+    expect(err).toMatchObject({ code: 'SEND_SYNC_PENDING', cause });
+
+    // #441 stamp: the possibly-committed error carries the committing attempt's
+    // transferId, and it names a real OPEN intent on the server (the id resume
+    // will complete). A payment-request consumer journals this link.
+    const stampedId = (err as { transferId?: string }).transferId;
+    expect(typeof stampedId).toBe('string');
+    expect(fake.getIntent(SENDER.chainPubkey, stampedId!)).toMatchObject({ status: 'open' });
 
     // Not a lost payment: transfer:failed must NOT be emitted for a sync-pending.
     const failed = sender.emitEvent.mock.calls.filter((c) => c[0] === 'transfer:failed');

--- a/types/index.ts
+++ b/types/index.ts
@@ -203,7 +203,7 @@ export interface IncomingTransfer {
 // Payment Request Types
 // =============================================================================
 
-export type PaymentRequestStatus = 'pending' | 'accepted' | 'rejected' | 'paid' | 'expired';
+export type PaymentRequestStatus = 'pending' | 'accepted' | 'rejected' | 'paid' | 'expired' | 'settling';
 
 /**
  * Outgoing payment request (requesting payment from someone)
@@ -409,6 +409,7 @@ export type SphereEventType =
   | 'payment_request:rejected'
   | 'payment_request:paid'
   | 'payment_request:expired'
+  | 'payment_request:settling'
   | 'payment_request:response'
   | 'message:dm'
   | 'message:read'
@@ -503,6 +504,13 @@ export interface SphereEventMap {
   'payment_request:rejected': IncomingPaymentRequest;
   'payment_request:paid': IncomingPaymentRequest;
   'payment_request:expired': IncomingPaymentRequest;
+  /**
+   * #441: a possibly-committed pay linked the request to an in-flight transfer.
+   * The request is held NON-payable until that transfer completes (resolves
+   * 'paid') or aborts (returns to payable). Distinct from 'paid' — money may
+   * have left but the server has NOT yet been told 'paid'.
+   */
+  'payment_request:settling': IncomingPaymentRequest;
   'payment_request:response': PaymentRequestResponse;
   'message:dm': DirectMessage;
   'message:read': { messageIds: string[]; peerPubkey: string };


### PR DESCRIPTION
## The bug (verified against source)

Paying an incoming payment request could **double-pay after a RELOAD**.

`PaymentsModule.payPaymentRequest` marked the request `'paid'` **in memory only** on a possibly-committed send outcome (`isPossiblyCommittedSendOutcome` → `SEND_SYNC_PENDING` / `CERTIFICATION_UNCONFIRMED` / `CHECKPOINT_PERSIST_FAILED` / `SPLIT_CHECKPOINT_LOST` / `CHECKPOINT_TRUSTBASE_MISMATCH` / `SEND_PARTIALLY_COMPLETED`) and never told the server. On reload, `pumpIncomingPaymentRequests` re-hydrates all incoming requests from the server (`since=0`, no status filter); the request came back **OPEN → payable again → the user taps Pay → double-pay** (the original transfer completes via `resumeOpenIntents`, plus the re-pay).

## The fix

On a possibly-committed pay, do **not** optimistically tell the server `'paid'`. Instead:

1. **Stamp** the committing attempt's own `transferId` onto the error at the two possibly-committed exits in `sendOnce` (`SEND_SYNC_PENDING` throw + the keep-open certification codes before the terminal throw). `PartialSendConflictError` already carries `.transferId`.
2. **Durably journal** `requestId → transferId` (per network+identity, mirroring `prCursor`) and hold the request in a new NON-payable **`'settling'`** status.
3. **Resolve on completion, not optimistically**: `resumeOpenIntents` — the sole seam where a deferred transfer finishes/aborts — reconciles off the durable journal:
   - completed (`resumed` / local `completed`) → send the deferred `'paid'` (server now told) and resolve `'paid'`.
   - aborted (`conflicted` / local `aborted`/`abortPending`) → clear the journal, return to payable (nothing was paid).
   - crash gap (not open, not locally decided) → consult the server `listIntents('aborted')` authority; errs toward **paid-never-re-payable** (no double-pay).
4. **Reload re-apply**: the journal is loaded before hydration and `surfaceIncomingPaymentRequest` holds a journaled request `'settling'` (never re-surfaced payable, never re-notified).

### Money-safety details
- The journal read-modify-write is **serialized** through a tail-promise chain with a **single-flight load** (the #679/#680 mutex lesson: a dropped entry = a re-payable request = the double-pay this fixes).
- Journal persists **before** the in-memory status flip (a crash in between leaves the durable link, never a lost one).
- `'settling'` is auto non-payable (the pay guard admits only `pending`/`accepted`), excluded from `PR_TERMINAL` (a later server `paid` still advances it; an open re-surface never downgrades it), and kept by `clearProcessedPaymentRequests`.
- Idempotent deferred respond: a `409 CONFLICT` is swallowed + journal cleared; any other error retries next sign-in.
- Nostr-only compositions (no wallet-api PR port) keep the prior durable `'paid'` behavior.

## Seams changed
- `core/errors.ts`: optional `SphereError.transferId` linkage field.
- `types/index.ts`: `'settling'` `PaymentRequestStatus` + `payment_request:settling` event.
- `modules/payments/PaymentsModule.ts`: stamp sites in `sendOnce`; durable journal (`prSettlingKey` / single-flight load / serialized `mutateSettlingJournal` / `journalSettling` / `clearSettling`); `payPaymentRequest` catch rewrite; `reconcileSettlingPaymentRequests` + `resolveSettledPaid` + `revertSettlingToPayable` driven at the end of `resumeOpenIntents`; reload re-apply in `surfaceIncomingPaymentRequest`; journal load atop `pumpIncomingPaymentRequests`; journal reset on identity switch; `clearProcessedPaymentRequests` keeps `settling`; `isNonOpenConflict` helper.

## Tests (load-bearing — fail without the fix)
Extended `tests/unit/modules/PaymentsModule.payment-requests.test.ts` with a `#441 deferred-paid` suite and a stamp assertion in `PaymentsModule.wallet-api-delivery.test.ts`:
- **RELOAD**: a settling request is NOT re-surfaced payable by a fresh module over the same storage+server (the double-pay guard).
- **Resolution**: the linked transfer completing via real `resumeOpenIntents` sends `'paid'` to the server **exactly once** and resolves `'paid'`, journal cleared.
- **Abort**: the linked transfer aborting clears the journal, server never told paid, request returns to payable.
- **Clean pre-commit failure**: reverts to `pending`, journal untouched (unchanged).
- Plus: write-site (SEND_SYNC_PENDING + PartialSendConflictError), pay guard, idempotent respond (409 vs NETWORK), concurrency RMW, `clearProcessedPaymentRequests`, and the real `sendOnce` stamp names an OPEN server intent.

## Verification
- `npx tsc --noEmit`: clean.
- `eslint` touched files: 0 errors (4 pre-existing warnings, none in changed lines).
- `npm run test:run`: **3123 passed / 202 files**.