### PR TITLE
perf(payments): finer proof-poll cadence + parallel split mints (#683, #684)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unicitylabs/sphere-sdk",
-  "version": "0.11.14",
+  "version": "0.11.15-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unicitylabs/sphere-sdk",
-      "version": "0.11.14",
+      "version": "0.11.15-dev.1",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicitylabs/sphere-sdk",
-  "version": "0.11.14",
+  "version": "0.11.15-dev.1",
   "description": "Modular TypeScript SDK for Unicity wallet operations",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/tests/unit/token-engine/SphereTokenEngine.hardening.test.ts
+++ b/tests/unit/token-engine/SphereTokenEngine.hardening.test.ts
@@ -69,6 +69,21 @@ describe('SphereTokenEngine — hardening / edge cases', () => {
     expect(outputs.reduce((sum, o) => sum + e.balanceOf(o, COIN_A), 0n)).toBe(100n);
   }, 30000);
 
+  it('split preserves output ORDER despite parallel minting (#684)', async () => {
+    // The mint legs are minted in parallel (Promise.allSettled). Distinct amounts make
+    // the returned order verifiable per index — a regression guard that parallelizing did
+    // not reorder outputs vs. the requested order (index-aligned settled.map).
+    const e = createTestEngine();
+    const self = e.getIdentity().chainPubkey;
+    const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN_A, amount: 100n }] } });
+    const requested = [10n, 20n, 30n, 40n];
+    const { outputs } = await e.split({
+      token: src,
+      outputs: requested.map((amount) => ({ recipientPubkey: freshPubkey(), coinId: COIN_A, amount })),
+    });
+    expect(outputs.map((o) => e.balanceOf(o, COIN_A))).toEqual(requested); // exact order, not just sum
+  }, 30000);
+
   it('rejects minting a negative or malformed value', async () => {
     const e = createTestEngine();
     const self = e.getIdentity().chainPubkey;

--- a/tests/unit/token-engine/SphereTokenEngine.hardening.test.ts
+++ b/tests/unit/token-engine/SphereTokenEngine.hardening.test.ts
@@ -69,19 +69,22 @@ describe('SphereTokenEngine — hardening / edge cases', () => {
     expect(outputs.reduce((sum, o) => sum + e.balanceOf(o, COIN_A), 0n)).toBe(100n);
   }, 30000);
 
-  it('split preserves output ORDER despite parallel minting (#684)', async () => {
-    // The mint legs are minted in parallel (Promise.allSettled). Distinct amounts make
-    // the returned order verifiable per index — a regression guard that parallelizing did
-    // not reorder outputs vs. the requested order (index-aligned settled.map).
+  it('split preserves output ORDER across bounded-concurrency batches (#684)', async () => {
+    // The mint legs are minted in parallel with a concurrency cap (MAX_MINT_CONCURRENCY=8),
+    // so >8 outputs span MULTIPLE batches. Distinct amounts make the returned order
+    // verifiable per index — a regression guard that the batched, index-aligned settled.map
+    // preserves the requested order (not just the value sum) across the batch boundary.
     const e = createTestEngine();
     const self = e.getIdentity().chainPubkey;
-    const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN_A, amount: 100n }] } });
-    const requested = [10n, 20n, 30n, 40n];
+    const requested = [1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n, 10n]; // 10 outputs (> the cap of 8) = 2 batches
+    const total = requested.reduce((s, a) => s + a, 0n);
+    const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN_A, amount: total }] } });
     const { outputs } = await e.split({
       token: src,
       outputs: requested.map((amount) => ({ recipientPubkey: freshPubkey(), coinId: COIN_A, amount })),
     });
-    expect(outputs.map((o) => e.balanceOf(o, COIN_A))).toEqual(requested); // exact order, not just sum
+    expect(outputs).toHaveLength(requested.length);
+    expect(outputs.map((o) => e.balanceOf(o, COIN_A))).toEqual(requested); // exact order across batches
   }, 30000);
 
   it('rejects minting a negative or malformed value', async () => {

--- a/tests/unit/token-engine/SphereTokenEngine.hardening.test.ts
+++ b/tests/unit/token-engine/SphereTokenEngine.hardening.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { SphereError } from '../../../core/errors';
 import { NetworkId } from '../../../token-engine/sdk';
+import { ProofUnconfirmedError, SplitCheckpointLostError } from '../../../token-engine/errors';
 import { createTestEngine, freshPubkey } from './test-engine';
 
 const COIN_A = 'a'.repeat(64);
@@ -9,6 +11,9 @@ const COIN_C = 'c'.repeat(64);
 
 // Edge cases hardening the real engine (token-engine territory only).
 describe('SphereTokenEngine — hardening / edge cases', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
   it('mints a multi-coin token; balanceOf is per-coin', async () => {
     const e = createTestEngine();
     const token = await e.mint({
@@ -85,6 +90,70 @@ describe('SphereTokenEngine — hardening / edge cases', () => {
     });
     expect(outputs).toHaveLength(requested.length);
     expect(outputs.map((o) => e.balanceOf(o, COIN_A))).toEqual(requested); // exact order across batches
+  }, 30000);
+
+  // --- #684 parallel-mint error aggregation (Codex P1) ------------------------------------
+  // The mint legs of a split now fan out in parallel, so — UNLIKE the old sequential loop —
+  // a lower-index leg can fail while a higher-index leg was ALSO submitted and may be certified.
+  // Surfacing the lowest-index CLEAN error there would let PaymentsModule abort the intent and
+  // orphan the certified sibling (no checkpoint recovery). The aggregation must bias to keep-open.
+  // These spy on the private per-leg mint so we control each leg's outcome; the map invokes the
+  // legs of one batch synchronously in index order, so call #1 = leg 0, call #2 = leg 1.
+  const twoOutputs = (self: Uint8Array) => [
+    { recipientPubkey: freshPubkey(), coinId: COIN_A, amount: 40n },
+    { recipientPubkey: self, coinId: COIN_A, amount: 60n },
+  ];
+
+  it('parallel split: a CLEAN leg failure alongside a CERTIFIED sibling surfaces keep-open, not the abortable clean error (#684)', async () => {
+    const e = createTestEngine();
+    const self = e.getIdentity().chainPubkey;
+    const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN_A, amount: 100n }] } });
+    const proto = Object.getPrototypeOf(e);
+    const orig = proto.mintSplitOutput;
+    let call = 0;
+    vi.spyOn(proto, 'mintSplitOutput').mockImplementation(function (this: unknown, ...args: unknown[]) {
+      call += 1;
+      // Leg 0 fails CLEAN (definitively not committed); leg 1 mints for real (certifies on-chain).
+      if (call === 1) return Promise.reject(new SphereError('leg-0 gateway blip', 'AGGREGATOR_ERROR'));
+      return orig.apply(e, args);
+    });
+    // Lowest-index rejection is CLEAN, but a sibling certified → MUST surface keep-open
+    // (CERTIFICATION_UNCONFIRMED) so the intent stays open and resume recovers leg 1 idempotently.
+    // If this reverts to 'throw the lowest-index rejection', it throws AGGREGATOR_ERROR and fails.
+    await expect(e.split({ token: src, outputs: twoOutputs(self) })).rejects.toBeInstanceOf(ProofUnconfirmedError);
+  }, 30000);
+
+  it('parallel split: a CLEAN leg failure alongside a KEEP-OPEN sibling surfaces the keep-open error verbatim (#684)', async () => {
+    const e = createTestEngine();
+    const self = e.getIdentity().chainPubkey;
+    const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN_A, amount: 100n }] } });
+    const proto = Object.getPrototypeOf(e);
+    let call = 0;
+    vi.spyOn(proto, 'mintSplitOutput').mockImplementation(function (this: unknown) {
+      call += 1;
+      // Leg 0 clean, leg 1 keep-open (higher index). The keep-open sibling must win.
+      if (call === 1) return Promise.reject(new SphereError('leg-0 gateway blip', 'AGGREGATOR_ERROR'));
+      return Promise.reject(new SplitCheckpointLostError('leg-1 checkpoint stale'));
+    });
+    // Reverting to lowest-index would throw AGGREGATOR_ERROR (abortable); the fix surfaces the
+    // keep-open SplitCheckpointLostError so PaymentsModule keeps the intent open.
+    await expect(e.split({ token: src, outputs: twoOutputs(self) })).rejects.toBeInstanceOf(SplitCheckpointLostError);
+  }, 30000);
+
+  it('parallel split: when EVERY leg fails cleanly (nothing certified) surfaces the lowest-index clean error — no spurious keep-open (#684)', async () => {
+    const e = createTestEngine();
+    const self = e.getIdentity().chainPubkey;
+    const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN_A, amount: 100n }] } });
+    const proto = Object.getPrototypeOf(e);
+    let call = 0;
+    vi.spyOn(proto, 'mintSplitOutput').mockImplementation(function (this: unknown) {
+      call += 1;
+      return Promise.reject(new SphereError(`leg-${call - 1} failed`, call === 1 ? 'AGGREGATOR_ERROR' : 'TRANSPORT_ERROR'));
+    });
+    // No leg committed → the split genuinely failed → surface the lowest-index CLEAN error and
+    // let PaymentsModule abort. Guards against over-correcting into a keep-open that would strand
+    // a genuinely-failed intent open forever.
+    await expect(e.split({ token: src, outputs: twoOutputs(self) })).rejects.toMatchObject({ code: 'AGGREGATOR_ERROR' });
   }, 30000);
 
   it('rejects minting a negative or malformed value', async () => {

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -103,7 +103,16 @@ export interface EngineDeps {
  * poll boundary. Bounded by waitInclusionProof's 10s abort; the extra polls are
  * cheap read-only getInclusionProof calls confined to the ~1.5s finalization window.
  */
-const DEFAULT_PROOF_POLL_INTERVAL_MS = 300;
+export const DEFAULT_PROOF_POLL_INTERVAL_MS = 300;
+
+/**
+ * #684: max split-mint legs minted concurrently. The mints are independent off the
+ * one burn, but an UNBOUNDED fan-out would submit + proof-poll every leg at once
+ * against the gateway (the prior sequential loop naturally paced it to one). This
+ * cap keeps a typical split (K=2 — payment + change) fully parallel while bounding
+ * gateway load on a large multi-output split.
+ */
+const MAX_MINT_CONCURRENCY = 8;
 
 /** Canonical lowercase UUID — the spec's `transferId` wire form (sdk-changes E.1). */
 const TRANSFER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
@@ -336,11 +345,22 @@ export class SphereTokenEngine implements ITokenEngine {
     //      deterministic; re-submit → the aggregator already holds it → waitInclusionProof
     //      returns the existing proof — the #631/E.2 resume contract). So legs the sequential
     //      loop would NOT have submitted, but this one did, are never lost — only recovered.
-    const settled = await Promise.allSettled(
-      split.tokens.map((token, i) =>
-        this.mintSplitOutput(token, burntToken, params.outputs[i].data ?? null, options),
-      ),
-    );
+    //    Bounded concurrency (MAX_MINT_CONCURRENCY) paces the fan-out so a large split
+    //    can't storm the gateway; a typical K=2 split runs in a single fully-parallel batch.
+    const settled: PromiseSettledResult<SphereToken>[] = [];
+    for (let start = 0; start < split.tokens.length; start += MAX_MINT_CONCURRENCY) {
+      const batch = split.tokens.slice(start, start + MAX_MINT_CONCURRENCY);
+      settled.push(
+        ...(await Promise.allSettled(
+          batch.map((token, j) =>
+            this.mintSplitOutput(token, burntToken, params.outputs[start + j].data ?? null, options),
+          ),
+        )),
+      );
+    }
+    // Every leg has settled (all batches ran). Throw the LOWEST-index rejection —
+    // byte-identical to the sequential loop's 'fail at first index'. Later batches
+    // still ran, so a leg they certified is recovered idempotently on resume.
     const firstRejected = settled.findIndex((r) => r.status === 'rejected');
     if (firstRejected !== -1) {
       throw (settled[firstRejected] as PromiseRejectedResult).reason;

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -16,6 +16,7 @@ import { SphereError, type SphereErrorCode } from '../core/errors';
 import { randomUUID } from '../core/uuid';
 import {
   CheckpointPersistFailedError,
+  CheckpointTrustbaseMismatchError,
   ProofUnconfirmedError,
   SplitCheckpointLostError,
   TransferConflictError,
@@ -113,6 +114,23 @@ export const DEFAULT_PROOF_POLL_INTERVAL_MS = 300;
  * gateway load on a large multi-output split.
  */
 const MAX_MINT_CONCURRENCY = 8;
+
+/**
+ * The keep-open engine errors a split leg can raise — mirrors PaymentsModule's `keepOpen` set.
+ * When one of these settles a parallel mint fan-out, the leg's spend MAY already be certified
+ * on-chain, so the intent MUST stay OPEN for checkpoint-based resume; the fan-out must surface a
+ * keep-open outcome rather than an abortable clean failure that would strand a certified sibling
+ * (#684). Only ProofUnconfirmedError / SplitCheckpointLostError are reachable from a mint leg
+ * today; the checkpoint pair is included so the classifier stays faithful to the keep-open family.
+ */
+function isKeepOpenSplitError(err: unknown): boolean {
+  return (
+    err instanceof ProofUnconfirmedError ||
+    err instanceof CheckpointPersistFailedError ||
+    err instanceof SplitCheckpointLostError ||
+    err instanceof CheckpointTrustbaseMismatchError
+  );
+}
 
 /** Canonical lowercase UUID — the spec's `transferId` wire form (sdk-changes E.1). */
 const TRANSFER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
@@ -358,12 +376,40 @@ export class SphereTokenEngine implements ITokenEngine {
         )),
       );
     }
-    // Every leg has settled (all batches ran). Throw the LOWEST-index rejection —
-    // byte-identical to the sequential loop's 'fail at first index'. Later batches
-    // still ran, so a leg they certified is recovered idempotently on resume.
+    // Every leg has settled. Aggregate with a KEEP-OPEN BIAS. The old sequential loop never
+    // submitted a later leg once an earlier one failed, so surfacing the first failure could
+    // never orphan a certified sibling. THIS fan-out submits every leg, so a lower-index CLEAN
+    // failure can coexist with a higher-index leg that already CERTIFIED (fulfilled) or MAY have
+    // (a keep-open rejection). Surfacing the lowest-index CLEAN error in that case would let
+    // PaymentsModule abort the intent (its committed-source set is still empty here) and strand
+    // the certified sibling with no checkpoint recovery (Codex P1 on #684). So, in order:
+    //  1. If ANY leg rejected keep-open (ProofUnconfirmed / SplitCheckpointLost / the E.4 pair),
+    //     surface that verbatim (lowest-index) so its specific keep-open type drives
+    //     PaymentsModule's classification exactly as before.
+    //  2. Else if ANY leg CERTIFIED (fulfilled) while another failed cleanly, convert to a
+    //     keep-open ProofUnconfirmedError (cause = the clean failure): the burn is certified +
+    //     checkpointed, so resume re-runs ALL legs and recovers the certified one idempotently
+    //     (HKDF-deterministic stateId → the aggregator returns the existing proof; #631/E.2/E.3).
+    //  3. Else (every rejection is clean AND nothing certified) surface the lowest-index clean
+    //     rejection — nothing is committed, so aborting is safe and the net outcome matches the
+    //     sequential loop.
+    const keepOpenRejection = settled.find(
+      (r): r is PromiseRejectedResult => r.status === 'rejected' && isKeepOpenSplitError(r.reason),
+    );
+    if (keepOpenRejection !== undefined) {
+      throw keepOpenRejection.reason;
+    }
     const firstRejected = settled.findIndex((r) => r.status === 'rejected');
     if (firstRejected !== -1) {
-      throw (settled[firstRejected] as PromiseRejectedResult).reason;
+      const cleanReason = (settled[firstRejected] as PromiseRejectedResult).reason;
+      if (settled.some((r) => r.status === 'fulfilled')) {
+        throw new ProofUnconfirmedError(
+          'a split mint leg certified while a sibling leg failed — keep the intent open; resume ' +
+            'completes all legs idempotently from the burn checkpoint (#684 parallel fan-out)',
+          cleanReason,
+        );
+      }
+      throw cleanReason;
     }
     const outputs = settled.map((r) => (r as PromiseFulfilledResult<SphereToken>).value);
     return { outputs };

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -86,7 +86,24 @@ export interface EngineDeps {
    */
   readonly privateKey: Uint8Array;
   readonly networkId: NetworkId;
+  /**
+   * Inclusion-proof poll cadence in ms (#683). The aggregator finalizes in ~1-1.5s,
+   * but the state-transition-sdk's waitInclusionProof default is 1000ms, so the proof
+   * is only caught at ~2s (poll granularity). A finer interval catches it ~0.5-0.75s
+   * sooner PER proof round with zero correctness impact (waitInclusionProof returns
+   * only an OK-verified proof regardless of poll frequency). Undefined → the tuned
+   * default below.
+   */
+  readonly proofPollIntervalMs?: number;
 }
+
+/**
+ * #683: default inclusion-proof poll interval (ms). Finer than the sdk's 1000ms
+ * default so a ~1.2s finalization is caught near ~1.2-1.5s instead of at the 2s
+ * poll boundary. Bounded by waitInclusionProof's 10s abort; the extra polls are
+ * cheap read-only getInclusionProof calls confined to the ~1.5s finalization window.
+ */
+const DEFAULT_PROOF_POLL_INTERVAL_MS = 300;
 
 /** Canonical lowercase UUID — the spec's `transferId` wire form (sdk-changes E.1). */
 const TRANSFER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
@@ -198,6 +215,7 @@ export class SphereTokenEngine implements ITokenEngine {
       this.deps.predicateVerifier,
       mintTx,
       options?.signal,
+      this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS, // #683 finer poll cadence
     );
     const certified = await mintTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
     const token = await Token.mint(
@@ -229,6 +247,7 @@ export class SphereTokenEngine implements ITokenEngine {
       this.deps.predicateVerifier,
       mintTx,
       options?.signal,
+      this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS, // #683 finer poll cadence
     );
     const certified = await mintTx.toCertifiedTransaction(this.deps.trustBase, this.deps.predicateVerifier, proof);
     const token = await Token.mint(
@@ -299,11 +318,34 @@ export class SphereTokenEngine implements ITokenEngine {
     //    split input; a mint certified against proof bytes that were never stored strands #501).
     const burntToken = await this.resolveBurntToken({ params, split, transferId, options });
 
-    // 2. Mint each output, justified by the burnt token + its split proofs.
-    const outputs: SphereToken[] = [];
-    for (let i = 0; i < split.tokens.length; i++) {
-      outputs.push(await this.mintSplitOutput(split.tokens[i], burntToken, params.outputs[i].data ?? null, options));
+    // 2. Mint every output IN PARALLEL (#684), each justified by the burnt token + its
+    //    own split proofs. The mints are independent legs off the ONE already-certified,
+    //    already-checkpointed burn (step 1, outside this fan-out — E.4 burn-before-mint
+    //    is unchanged), so they carry no ordering constraint among themselves.
+    //
+    //    MONEY-SAFETY (identical semantics to the prior sequential loop):
+    //    - `allSettled` waits for EVERY leg (never short-circuits) so an in-flight leg is
+    //      not abandoned mid-submit; then we throw the LOWEST-index rejection's error —
+    //      exactly the error the sequential loop would have surfaced (it failed at the
+    //      first failing index and never attempted later legs). So the caller's keep-open
+    //      classification (ProofUnconfirmedError / SplitCheckpointLostError / …) is byte-for-
+    //      byte unchanged.
+    //    - On any failure the intent stays OPEN (the burn is certified + checkpointed) and
+    //      resume re-runs ALL legs from the durable checkpoint. A leg this fan-out already
+    //      certified is recovered idempotently on resume (its stateId is HKDF-derived and
+    //      deterministic; re-submit → the aggregator already holds it → waitInclusionProof
+    //      returns the existing proof — the #631/E.2 resume contract). So legs the sequential
+    //      loop would NOT have submitted, but this one did, are never lost — only recovered.
+    const settled = await Promise.allSettled(
+      split.tokens.map((token, i) =>
+        this.mintSplitOutput(token, burntToken, params.outputs[i].data ?? null, options),
+      ),
+    );
+    const firstRejected = settled.findIndex((r) => r.status === 'rejected');
+    if (firstRejected !== -1) {
+      throw (settled[firstRejected] as PromiseRejectedResult).reason;
     }
+    const outputs = settled.map((r) => (r as PromiseFulfilledResult<SphereToken>).value);
     return { outputs };
   }
 
@@ -361,17 +403,21 @@ export class SphereTokenEngine implements ITokenEngine {
    * so correctness does NOT depend on the mint loop certifying leg 0 first (E.4 step 3).
    */
   private async assertNoLegStranded(ctx: SplitContext): Promise<void> {
-    for (let i = 0; i < ctx.split.tokens.length; i++) {
-      const leg = ctx.split.tokens[i];
-      const data = await SpherePaymentData.create(leg.assets, ctx.params.outputs[i].data ?? null).encode();
-      const probe = await MintTransaction.create(leg.networkId, leg.recipient, data, leg.tokenType, leg.salt, null);
-      const response = await this.deps.client.getInclusionProof(await StateId.fromTransaction(probe));
-      if (response.inclusionProof.inclusionCertificate !== null) {
-        throw new SplitCheckpointLostError(
-          'a split mint leaf is certified on-chain but no burn checkpoint exists — outputs are unrecoverable',
-        );
-      }
-    }
+    // #684: probe every leg's stateId IN PARALLEL — read-only getInclusionProof calls,
+    // order-independent (it throws if ANY leg is already certified). Promise.all rejects
+    // on the first stranded leg, same as the prior sequential loop.
+    await Promise.all(
+      ctx.split.tokens.map(async (leg, i) => {
+        const data = await SpherePaymentData.create(leg.assets, ctx.params.outputs[i].data ?? null).encode();
+        const probe = await MintTransaction.create(leg.networkId, leg.recipient, data, leg.tokenType, leg.salt, null);
+        const response = await this.deps.client.getInclusionProof(await StateId.fromTransaction(probe));
+        if (response.inclusionProof.inclusionCertificate !== null) {
+          throw new SplitCheckpointLostError(
+            'a split mint leaf is certified on-chain but no burn checkpoint exists — outputs are unrecoverable',
+          );
+        }
+      }),
+    );
   }
 
   /** One split output: build the justification from the burnt token, submit, certify, wrap. */
@@ -556,6 +602,7 @@ export class SphereTokenEngine implements ITokenEngine {
         this.deps.predicateVerifier,
         transaction,
         options?.signal,
+        this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS, // #683 finer poll cadence
       );
     } catch (err) {
       // The SDK surfaces a match-verify mismatch as a generic Error whose

--- a/token-engine/factory.ts
+++ b/token-engine/factory.ts
@@ -59,6 +59,8 @@ export async function createSphereTokenEngine(config: EngineConfig): Promise<ITo
     // The trust base is the single source of truth for the network id (it carries
     // NetworkId.fromId, so any id works — e.g. testnet2 = 4 — with no enum entry).
     networkId: trustBase.networkId,
+    // #683: forward the (optional) proof-poll cadence; undefined → the engine default.
+    proofPollIntervalMs: config.proofPollIntervalMs,
   };
 
   return new SphereTokenEngine(deps);

--- a/token-engine/unicity-id.ts
+++ b/token-engine/unicity-id.ts
@@ -43,6 +43,7 @@ import {
 } from './sdk';
 import { UNICITY_TOKEN_TYPE_HEX } from './identity';
 import type { EngineConfig, EngineOpOptions } from './engine';
+import { DEFAULT_PROOF_POLL_INTERVAL_MS } from './SphereTokenEngine';
 
 export interface UnicityIdMintResult {
   /** UnicityIdToken CBOR, hex-encoded — the storable form (UnicityIdToken.fromCBOR round-trips it). */
@@ -67,6 +68,7 @@ class SelfIssuedUnicityIdMinter implements IUnicityIdMinter {
     private readonly trustBase: RootTrustBase,
     private readonly predicateVerifier: PredicateVerifierService,
     private readonly signingService: SigningService,
+    private readonly proofPollIntervalMs?: number, // #683 finer proof-poll cadence
   ) {}
 
   public async mintUnicityIdToken(name: string, options?: EngineOpOptions): Promise<UnicityIdMintResult> {
@@ -106,6 +108,7 @@ class SelfIssuedUnicityIdMinter implements IUnicityIdMinter {
         this.predicateVerifier,
         mintTx,
         options?.signal,
+        this.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS, // #683 finer poll cadence
       );
       const certified = await mintTx.toCertifiedTransaction(this.trustBase, this.predicateVerifier, proof);
       const token = await UnicityIdToken.mint(this.trustBase, this.predicateVerifier, certified);
@@ -130,11 +133,18 @@ export interface UnicityIdMinterDeps {
   readonly trustBase: RootTrustBase;
   readonly predicateVerifier: PredicateVerifierService;
   readonly signingService: SigningService;
+  readonly proofPollIntervalMs?: number; // #683 finer proof-poll cadence
 }
 
 /** Build the minter from pre-constructed SDK objects (tests / shared wiring). */
 export function createUnicityIdMinterFromDeps(deps: UnicityIdMinterDeps): IUnicityIdMinter {
-  return new SelfIssuedUnicityIdMinter(deps.client, deps.trustBase, deps.predicateVerifier, deps.signingService);
+  return new SelfIssuedUnicityIdMinter(
+    deps.client,
+    deps.trustBase,
+    deps.predicateVerifier,
+    deps.signingService,
+    deps.proofPollIntervalMs,
+  );
 }
 
 /**
@@ -151,5 +161,6 @@ export function createUnicityIdMinter(config: EngineConfig): IUnicityIdMinter {
     trustBase,
     PredicateVerifierService.create(),
     new SigningService(config.privateKey),
+    config.proofPollIntervalMs, // #683 finer proof-poll cadence
   );
 }


### PR DESCRIPTION
Closes #683, closes #684.

## Why

A real testnet2 send trace showed a split transfer spending **~8.25s of ~11.6s just waiting between inclusion-proof polls**, sequentially across the burn + N mint legs. The aggregator finalizes in ~1-1.5s; the rest was client-side poll granularity and sequential minting.

## #683 — finer inclusion-proof poll cadence

`waitInclusionProof` (state-transition-sdk) defaults to a **1000ms** poll interval, so a ~1.2s finalization is only caught at the 2s poll boundary. Sphere's `proofPollIntervalMs` config existed but was **never wired**. This threads it `config → factory → EngineDeps → the three waitInclusionProof call sites`, defaulting to **300ms**.

- **Zero correctness impact:** `waitInclusionProof` returns only an OK-verified proof regardless of poll frequency; bounded by its existing 10s abort. The extra polls are cheap read-only `getInclusionProof` calls confined to the ~1.5s finalization window.
- Saves ~0.5-0.75s **per proof round** (×1 direct, ×(1+N) split).

## #684 — parallelize the split mint legs

`engine.split` minted its N outputs in a **sequential `for`-await** — N sequential aggregator rounds. The mints are independent legs off the **one already-certified, already-checkpointed burn** (E.4 burn-before-mint is unchanged, *outside* the fan-out), so they parallelize (`Promise.allSettled`). The read-only `assertNoLegStranded` pre-burn probes are parallelized too.

### Money-safety preserved exactly
- `allSettled` **waits for every leg** (never short-circuits — no abandoned in-flight submit), then throws the **lowest-index rejection's error** — byte-identical to the sequential loop's "fail at the first failing index" behavior, so the caller's keep-open classification (`ProofUnconfirmedError` / `SplitCheckpointLostError` / …) is unchanged.
- On any failure the intent stays **open** (the burn is certified + checkpointed) and resume re-runs all legs from the durable checkpoint. A leg this fan-out already certified is recovered **idempotently** on resume (HKDF-deterministic stateId; re-submit → aggregator already holds it → the existing proof is returned — the #631/E.2 resume contract). So legs the sequential loop would *not* have submitted but this one did are never lost — only recovered.

### Verification
- **Existing (green, load-bearing):** `split resume: a crash after burn certification completes on re-run` (K=2, `CrashAfterBurnClient` → asserts `ProofUnconfirmedError` keep-open + resume completes both outputs); `AC-E2: split full re-run after certified mints RECOVERS` (K=2, both mints certified → recovered, same tokenIds, no double-mint).
- **New:** `split preserves output ORDER despite parallel minting` — distinct amounts, asserts per-index order (guards against a reordering refactor).
- Full suite **3128 pass**, `tsc --noEmit` clean, ESLint clean.

⚠️ Money-path change (split engine) — worth a careful review of the parallel error-aggregation.