### PR TITLE
State-aware inventory reconciliation for tokens re-acquired after being spent

### DIFF
--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -569,12 +569,19 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     // advanced the view's state before this call). A legacy caller with no spentStates
     // falls back to a bare tokenId record (state-agnostic).
     const spentState = new Map((opts?.spentStates ?? []).map((s) => [s.tokenId, s.stateHash]));
-    await this.addKnownSpends(
-      spent.map((id) => {
+    // Record a COMPOSITE (tokenId, protocolState) knownSpend for each source whose spent
+    // state the caller supplied. Do NOT fall back to a BARE tokenId when it is absent: a
+    // bare record makes recoverRemoved's `mayHaveSpent` SKIP a token whose row a claim later
+    // reactivated (round-trip / legacy-payload resume), blocking recovery of legitimately-
+    // held funds. Absent a precise spent state, recoverRemoved's fail-closed on-chain
+    // `isSpent` gate is the protection instead.
+    const knownSpendKeys = spent
+      .map((id) => {
         const s = spentState.get(id);
-        return s !== undefined && s !== '' ? this.knownSpendKey(id, s) : id;
+        return s !== undefined && s !== '' ? this.knownSpendKey(id, s) : null;
       })
-    );
+      .filter((k): k is string => k !== null);
+    await this.addKnownSpends(knownSpendKeys);
     await this.syncInventory();
   }
 

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -604,14 +604,24 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
         result.skipped.push(item.tokenId);
         continue;
       }
-      // I4 gate: a wiped/second device has an EMPTY knownSpends, so the skip above can't
-      // protect it — ask the aggregator whether this blob's state is already consumed and
-      // NEVER resurrect a genuinely-spent token (belt-and-suspenders to the server 409).
-      if (this.isSpentOnChain && (await this.isSpentBlob(item.tokenId, blobBytes))) {
+      // I4 FAIL-CLOSED gate. Reactivating a removed row can resurrect a genuinely-spent
+      // token: the server reactivates an UNEVIDENCED tombstone (validation/lineage), and
+      // the evidence-free write-behind removal produces exactly those. A wiped/second
+      // device has an EMPTY knownSpends, so the (tokenId, state) filter above cannot
+      // protect it. Therefore reactivate ONLY when an ON-CHAIN check POSITIVELY confirms
+      // the state is UNSPENT. Without that check (isSpent not wired at composition) we
+      // cannot prove it — so we DO NOT reactivate (skip). This makes recoverRemoved a safe
+      // no-op absent an engine, rather than a phantom-balance / re-spend hazard.
+      if (!this.isSpentOnChain) {
+        result.skipped.push(item.tokenId);
+        continue;
+      }
+      if (await this.isSpentBlob(item.tokenId, blobBytes)) {
         result.spent.push(item.tokenId);
         if (item.stateHash) await this.addKnownSpends([this.knownSpendKey(item.tokenId, item.stateHash)]);
         continue;
       }
+      // On-chain check confirmed UNSPENT — safe to reactivate.
       // Content-addressed key of the exact bytes we verified (§5.2).
       const key = `${this.client.network}/t/${bytesToHex(sha256(blobBytes))}`;
       try {

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -566,8 +566,7 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     });
     // Record knownSpends keyed by (tokenId, PROTOCOL spent state) from the caller's
     // AUTHORITATIVE spentStates — never from this.view (a concurrent claim can have
-    // advanced the view's state before this call). A legacy caller with no spentStates
-    // falls back to a bare tokenId record (state-agnostic).
+    // advanced the view's state before this call).
     const spentState = new Map((opts?.spentStates ?? []).map((s) => [s.tokenId, s.stateHash]));
     // Record a COMPOSITE (tokenId, protocolState) knownSpend for each source whose spent
     // state the caller supplied. Do NOT fall back to a BARE tokenId when it is absent: a

--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -66,6 +66,17 @@ export interface WalletApiTokenStorageConfig {
    * and matches its tokenId.
    */
   verifyToken?: (blob: TokenBlob) => Promise<boolean>;
+  /**
+   * Optional ON-CHAIN spent check used by `recoverRemoved()` before reactivating a
+   * tombstoned blob. A wiped/second device has an EMPTY knownSpends set — the exact
+   * cohort recoverRemoved serves — so the local (tokenId, state) skip cannot protect it;
+   * this asks the aggregator whether the blob's current state is already consumed, so a
+   * genuinely-spent token is never resurrected (a re-spend would be blocked on-chain
+   * anyway, but we must not surface phantom balance). Wire the engine's `isSpent` here at
+   * composition; when unset, recoverRemoved relies on knownSpends + the server's evidenced
+   * -tombstone 409 alone (its prior behavior).
+   */
+  isSpent?: (blob: TokenBlob) => Promise<boolean>;
 }
 
 function bytesToHex(bytes: Uint8Array): string {
@@ -105,6 +116,7 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
   private readonly client: WalletApiClient;
   private readonly stateStore: KeyValueStore;
   private readonly verifyToken?: (blob: TokenBlob) => Promise<boolean>;
+  private readonly isSpentOnChain?: (blob: TokenBlob) => Promise<boolean>;
 
   private status: ProviderStatus = 'disconnected';
   private identity: FullIdentity | null = null;
@@ -124,6 +136,7 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     this.client = config.client;
     this.stateStore = config.stateStore;
     this.verifyToken = config.verifyToken;
+    this.isSpentOnChain = config.isSpent;
   }
 
   // ── provider lifecycle ──────────────────────────────────────────────────────
@@ -161,6 +174,7 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
       client,
       stateStore: this.stateStore,
       verifyToken: this.verifyToken,
+      isSpent: this.isSpentOnChain,
     });
   }
 
@@ -213,7 +227,13 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     await this.stateStore.set(this.stateKey('syncEpoch'), syncEpoch.toString());
   }
 
-  /** TokenIds this provider itself spent — `recoverRemoved()` skips these. */
+  /**
+   * States this provider itself spent, so `recoverRemoved()`/`pushRemovals()` can tell
+   * "a state we spent" from "a state a claim reactivated". Entries are composite
+   * `${tokenId}:${protocolStateHash}` keys (the PROTOCOL imprint — same space as the
+   * server row `state_hash`). Legacy builds wrote a BARE `${tokenId}`; those are tolerated
+   * on read as state-agnostic records (see {@link mayHaveSpent}).
+   */
   private async readKnownSpends(): Promise<Set<string>> {
     const raw = await this.stateStore.get(this.stateKey('knownSpends'));
     if (!raw) return new Set();
@@ -224,11 +244,36 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     }
   }
 
-  private async addKnownSpends(tokenIds: string[]): Promise<void> {
-    if (tokenIds.length === 0) return;
+  private async addKnownSpends(keys: string[]): Promise<void> {
+    if (keys.length === 0) return;
     const known = await this.readKnownSpends();
-    for (const id of tokenIds) known.add(id);
+    for (const k of keys) known.add(k);
     await this.stateStore.set(this.stateKey('knownSpends'), JSON.stringify([...known]));
+  }
+
+  private knownSpendKey(tokenId: string, stateHash: string): string {
+    return `${tokenId}:${stateHash}`;
+  }
+
+  /**
+   * PROVEN spend: we authoritatively recorded spending this token AT EXACTLY this
+   * protocol state. Authorizes an evidence-free removal ({@link pushRemovals}) — STRICT,
+   * so a legacy bare (state-agnostic) entry never authorizes destroying a row that a
+   * claim may have reactivated at a different state. An absent/empty state is never a
+   * proof.
+   */
+  private provenSpentAtState(known: Set<string>, tokenId: string, stateHash: string | undefined): boolean {
+    return stateHash !== undefined && stateHash !== '' && known.has(this.knownSpendKey(tokenId, stateHash));
+  }
+
+  /**
+   * CONSERVATIVE: did we record spending this token — this exact state, OR (a legacy
+   * bare entry) any state? Used to SKIP recovery ({@link recoverRemoved}); errs toward
+   * NOT resurrecting a token we may have transferred away.
+   */
+  private mayHaveSpent(known: Set<string>, tokenId: string, stateHash: string | undefined): boolean {
+    if (known.has(tokenId)) return true; // legacy bare entry — state-agnostic
+    return this.provenSpentAtState(known, tokenId, stateHash);
   }
 
   /**
@@ -519,7 +564,17 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
       added,
       ...(opts?.externalDelivery !== undefined ? { externalDelivery: opts.externalDelivery } : {}),
     });
-    await this.addKnownSpends(spent);
+    // Record knownSpends keyed by (tokenId, PROTOCOL spent state) from the caller's
+    // AUTHORITATIVE spentStates — never from this.view (a concurrent claim can have
+    // advanced the view's state before this call). A legacy caller with no spentStates
+    // falls back to a bare tokenId record (state-agnostic).
+    const spentState = new Map((opts?.spentStates ?? []).map((s) => [s.tokenId, s.stateHash]));
+    await this.addKnownSpends(
+      spent.map((id) => {
+        const s = spentState.get(id);
+        return s !== undefined && s !== '' ? this.knownSpendKey(id, s) : id;
+      })
+    );
     await this.syncInventory();
   }
 
@@ -537,13 +592,24 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     const knownSpends = await this.readKnownSpends();
     const result: RecoverRemovedResult = { recovered: [], spent: [], skipped: [] };
 
+    // State-scoped skip: reactivate a tombstone UNLESS we recorded spending this token
+    // (this exact protocol state, or a legacy state-agnostic entry). This lets a bogus
+    // (claim-reactivated) removal be undone while never reviving a state we truly spent.
     const candidates = [...this.view.values()].filter(
-      (i) => i.status === 'removed' && !knownSpends.has(i.tokenId)
+      (i) => i.status === 'removed' && !this.mayHaveSpent(knownSpends, i.tokenId, i.stateHash)
     );
     for (const item of candidates) {
       const blobBytes = await this.fetchRemovedBlob(item.tokenId);
       if (blobBytes === null || !(await this.locallyValid(item.tokenId, blobBytes))) {
         result.skipped.push(item.tokenId);
+        continue;
+      }
+      // I4 gate: a wiped/second device has an EMPTY knownSpends, so the skip above can't
+      // protect it — ask the aggregator whether this blob's state is already consumed and
+      // NEVER resurrect a genuinely-spent token (belt-and-suspenders to the server 409).
+      if (this.isSpentOnChain && (await this.isSpentBlob(item.tokenId, blobBytes))) {
+        result.spent.push(item.tokenId);
+        if (item.stateHash) await this.addKnownSpends([this.knownSpendKey(item.tokenId, item.stateHash)]);
         continue;
       }
       // Content-addressed key of the exact bytes we verified (§5.2).
@@ -557,9 +623,12 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
         result.recovered.push(item.tokenId);
       } catch (err) {
         if (err instanceof WalletApiError && err.code === 'CONFLICT') {
-          // Evidenced tombstone (or the token moved on) — actually spent (§5.3).
+          // Evidenced tombstone (or the token moved on) — actually spent (§5.3). Record
+          // the exact state the server 409'd so recovery stays scoped to that state.
           result.spent.push(item.tokenId);
-          await this.addKnownSpends([item.tokenId]);
+          await this.addKnownSpends([
+            item.stateHash ? this.knownSpendKey(item.tokenId, item.stateHash) : item.tokenId,
+          ]);
         } else {
           throw err;
         }
@@ -586,6 +655,12 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     if (blob.tokenId !== tokenId) return false;
     if (this.verifyToken) return this.verifyToken(blob);
     return true;
+  }
+
+  /** True when the aggregator reports this blob's current state already consumed. */
+  private async isSpentBlob(tokenId: string, bytes: Uint8Array): Promise<boolean> {
+    if (!this.isSpentOnChain) return false;
+    return this.isSpentOnChain(this.wrapWireBlob(tokenId, bytes));
   }
 
   // ── whole-blob surface (thin: the hot path is the lazy port above) ──────────
@@ -700,10 +775,23 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     // successful inventory load; a spent token is removed only against a
     // confirmed on-chain spend (a tombstone), never mere absence.
     if (!this.hadSuccessfulLoad || tombstoneIds.size === 0) return;
-    const spent = [...tombstoneIds].filter((id) => this.view.get(id)?.status === 'active');
+    const known = await this.readKnownSpends();
+    // FAIL-CLOSED + state-scoped. Push an evidence-free removal (fresh transferId, no
+    // deposit) ONLY for a row the server still shows ACTIVE at EXACTLY the protocol state
+    // we authoritatively spent (provenSpentAtState). A row active at a DIFFERENT state was
+    // reactivated by a claim (self-send / A→B→A round-trip) and is legitimately ours —
+    // destroying it there is the fund-loss bug. A row whose stateHash the server does not
+    // expose (pre-Unit-A backend) is skipped, never removed on tokenId alone (degrade to
+    // prune-primary: the PaymentsModule stale-tombstone prune is the go-forward fix).
+    const spent: string[] = [];
+    for (const id of tombstoneIds) {
+      const row = this.view.get(id);
+      if (row?.status !== 'active') continue;
+      if (this.provenSpentAtState(known, id, row.stateHash)) spent.push(id);
+    }
     if (spent.length === 0) return;
     await this.client.applyInventoryDelta({ transferId: newTransferId(), spent, added: [] });
-    await this.addKnownSpends(spent);
+    await this.addKnownSpends(spent.map((id) => this.knownSpendKey(id, this.view.get(id)!.stateHash!)));
   }
 
   async sync(localData: TxfStorageDataBase): Promise<SyncResult<TxfStorageDataBase>> {

--- a/impl/shared/wallet-api/composition.ts
+++ b/impl/shared/wallet-api/composition.ts
@@ -103,6 +103,9 @@ export interface WalletApiCompositionConfig {
   webSocketFactory?: WebSocketFactoryLike;
   /** Local token verification for `recoverRemoved()` (wire the engine here). */
   verifyToken?: (blob: TokenBlob) => Promise<boolean>;
+  /** On-chain spent check for `recoverRemoved()` — wire the engine's `isSpent` here so a
+   *  wiped/second device never resurrects a genuinely-spent tombstone (I4 belt-and-suspenders). */
+  isSpent?: (blob: TokenBlob) => Promise<boolean>;
   /** Transient-failure retry policy for the §16 REST path (default-on; `false` disables). */
   retry?: WalletApiRetryConfig | false;
   /** Per-request timeout in ms for the §16 REST path (#642; default 30 000, `0` disables). */
@@ -159,6 +162,7 @@ export function createWalletApiProviders<B extends SphereBaseProviders>(
     client,
     stateStore,
     verifyToken: config.verifyToken,
+    isSpent: config.isSpent,
   });
   const delivery = new WalletApiMailboxProvider({ client, custody: 'inventory', stateStore });
   return { ...base, tokenStorage, delivery, walletApi: client };

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -116,8 +116,13 @@ function isNonOpenConflict(err: unknown): boolean {
  * - type + tokenId → one entry per token per direction
  * - fallback → UUID (no dedup possible)
  */
-function computeHistoryDedupKey(type: string, tokenId?: string, transferId?: string): string {
+function computeHistoryDedupKey(type: string, tokenId?: string, transferId?: string, stateHash?: string): string {
   if (type === 'SENT' && transferId) return `${type}_transfer_${transferId}`;
+  // A genesis token can be RECEIVED more than once at DIFFERENT states (a self-send or an
+  // A→B→A round-trip re-acquires it). Include the received state so each leg is a distinct
+  // receipt instead of upserting the same `RECEIVED_v2_<genesisId>` key — otherwise repeated
+  // re-acquires undercount received history and stop netting against their SENT records.
+  if (tokenId && stateHash) return `${type}_${tokenId}_${stateHash}`;
   if (tokenId) return `${type}_${tokenId}`;
   return `${type}_${randomUUID()}`;
 }
@@ -4314,7 +4319,7 @@ export class PaymentsModule {
   async addToHistory(entry: Omit<TransactionHistoryEntry, 'id' | 'dedupKey'>): Promise<void> {
     this.ensureInitialized();
 
-    const dedupKey = computeHistoryDedupKey(entry.type, entry.tokenId, entry.transferId);
+    const dedupKey = computeHistoryDedupKey(entry.type, entry.tokenId, entry.transferId, entry.stateHash);
     const historyEntry: TransactionHistoryEntry = {
       id: randomUUID(),
       dedupKey,
@@ -5293,26 +5298,35 @@ export class PaymentsModule {
       return 'not-owned';
     }
 
-    // Dedup by (tokenId, stateHash) — NOT genesis-id alone. A re-delivered IDENTICAL
-    // state is ignored, but a NEW state of a token we already hold (a self-send or A→B→A
-    // round-trip direct leg returning at a new state) MUST still be received and recorded,
-    // or the wallet keeps the funds but drops the RECEIVED history. The incoming state
-    // hash is taken via the engine-canonical encoding so it lands in the SAME local-sha256
-    // space as stored tokens' state keys; storeEngineToken→addToken below re-checks the
-    // exact duplicate, tombstones, and older-state replacement authoritatively.
+    // Dedup by (tokenId, stateHash) — NOT genesis-id alone. A re-delivered IDENTICAL state
+    // is ignored, but a NEW state of a token we already hold (a self-send or A→B→A round-trip
+    // direct leg returning at a new state) MUST still be received and recorded, or the wallet
+    // keeps the funds but drops the RECEIVED history. v2 tokens are keyed by `v2_<genesisId>`,
+    // so the currently-held state (if any) is an O(1) lookup.
     const genesisId = engine.tokenId(token);
     const id = `v2_${genesisId}`;
     const incomingStateHash = extractStateHashFromSdkData(bytesToHex(encodeTokenBlob(engine.encodeToken(token))));
-    const alreadyHeldSameState =
-      incomingStateHash !== '' &&
-      [...this.tokens.values()].some(
-        (t) =>
-          extractTokenIdFromSdkData(t.sdkData) === genesisId &&
-          extractStateHashFromSdkData(t.sdkData) === incomingStateHash
-      );
-    if (alreadyHeldSameState) {
-      logger.debug('Payments', `V2 transfer ${id.slice(0, 16)}... (same state) already present, skipping`);
-      return 'duplicate';
+    const held = this.tokens.get(id);
+    if (held) {
+      const heldStateHash = extractStateHashFromSdkData(held.sdkData);
+      if (incomingStateHash !== '' && incomingStateHash === heldStateHash) {
+        logger.debug('Payments', `V2 transfer ${id.slice(0, 16)}... (same state) already present, skipping`);
+        return 'duplicate';
+      }
+      // A DIFFERENT state of a token we ALREADY hold. Accepting it means addToken will
+      // REPLACE the held state (CASE 2). That is correct for a legitimate re-acquire (the
+      // incoming state is the live unspent tip), but a delayed/replayed OLDER, already-spent
+      // state would otherwise swap the spendable state for a phantom spent one — and
+      // mergeLazyInventory won't repair it (it skips genesis ids already in memory). verify()
+      // is cryptographic only; isSpent() is the on-chain unspent check. So gate the replacement:
+      // reject the incoming state if it is already consumed on-chain (Codex P1 on #687).
+      if (await engine.isSpent(token)) {
+        logger.warn(
+          'Payments',
+          `V2 transfer ${id.slice(0, 16)}... is an already-spent state of a held token — rejecting stale/replayed delivery`
+        );
+        return 'duplicate';
+      }
     }
 
     const { uiToken, added } = await this.storeEngineToken(engine, token);
@@ -5350,6 +5364,9 @@ export class PaymentsModule {
       ...(senderNametag !== undefined ? { senderNametag } : {}),
       memo: payload.memo,
       tokenId: id,
+      // Per-state receipt key (Codex #687 P2): a genesis token re-acquired at multiple
+      // states (self-send / round-trip) records each leg instead of upserting one key.
+      ...(incomingStateHash !== '' ? { stateHash: incomingStateHash } : {}),
     });
     return 'stored';
   }

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -2123,7 +2123,12 @@ export class PaymentsModule {
 
         // Sources consumed by this send — the §7 step 6 apply (server path)
         // and the deferred local removals are driven from this list.
-        const consumedSources: { uiTokenId: string; genesisId: string }[] = [];
+        // `sourceSdkData` = the source blob AS WE HELD IT (pre-spend). It is the single
+        // authoritative source for both spent-state derivations — the LOCAL sha256 (for the
+        // state-aware local removeToken, M2) and the PROTOCOL imprint (deliveryKeys → the
+        // server's state_hash, for knownSpends, M3) — so neither is ever read back from a
+        // live view a concurrent claim may have advanced.
+        const consumedSources: { uiTokenId: string; genesisId: string; sourceSdkData: string }[] = [];
 
         // Whole-token direct transfers. ONE realization seed per SEND
         // (ARCHITECTURE §7/§8.1): the intent transferId seeds every engine op,
@@ -2171,11 +2176,16 @@ export class PaymentsModule {
           consumedSources.push({
             uiTokenId: tw.uiToken.id,
             genesisId: extractTokenIdFromSdkData(tw.uiToken.sdkData) ?? tw.uiToken.id.replace(/^v2_/, ''),
+            sourceSdkData: tw.uiToken.sdkData ?? '',
           });
           // Server path: the removal is recorded by the single applyDelta
           // below (its evidence is the deposit just made); locally the source
           // is removed right away on the non-server path (unchanged behavior).
-          if (!serverApply) await this.removeToken(tw.uiToken.id, result.id);
+          // M2: pass the LOCAL state we spent so removeToken never tombstones a state a
+          // concurrent claim already advanced the map entry to.
+          if (!serverApply) {
+            await this.removeToken(tw.uiToken.id, result.id, extractStateHashFromSdkData(tw.uiToken.sdkData));
+          }
         }
 
         // Value-conserving split: recipient gets splitAmount, this wallet keeps
@@ -2248,8 +2258,15 @@ export class PaymentsModule {
             genesisId:
               extractTokenIdFromSdkData(splitPlan.tokenToSplit.uiToken.sdkData) ??
               splitPlan.tokenToSplit.uiToken.id.replace(/^v2_/, ''),
+            sourceSdkData: splitPlan.tokenToSplit.uiToken.sdkData ?? '',
           });
-          if (!serverApply) await this.removeToken(splitPlan.tokenToSplit.uiToken.id, result.id);
+          if (!serverApply) {
+            await this.removeToken(
+              splitPlan.tokenToSplit.uiToken.id,
+              result.id,
+              extractStateHashFromSdkData(splitPlan.tokenToSplit.uiToken.sdkData)
+            );
+          }
         }
 
         if (serverApply) {
@@ -2276,15 +2293,30 @@ export class PaymentsModule {
           if (!storage) {
             throw new SphereError('No token storage provider available for applyDelta', 'STORAGE_ERROR');
           }
+          // M3: derive each source's PROTOCOL spent state (deliveryKeys imprint = the
+          // server's row state_hash) from the source blob we HELD — never from the live
+          // view — so the server records knownSpends as (tokenId, exact spent state).
+          // Derived here (server path only), in parallel, off the hot send loop.
+          const spentStates = await Promise.all(
+            consumedSources.map(async (s) => ({
+              tokenId: s.genesisId,
+              stateHash: s.sourceSdkData ? (await engine.deliveryKeys(hexToBytes(s.sourceSdkData))).stateHash : '',
+            }))
+          );
           await storage.applyDelta(
             result.id,
             consumedSources.map((s) => s.genesisId),
-            added
+            added,
+            { spentStates }
           );
           // Local bookkeeping AFTER the server apply (see the ordering note
-          // above): store the change, then drop the consumed sources.
+          // above): store the change, then drop the consumed sources. M2: each
+          // removeToken carries the LOCAL state we spent, so a source the pump
+          // already reactivated to a new state is KEPT, not re-tombstoned.
           if (changeOutput) await this.storeEngineToken(engine, changeOutput);
-          for (const s of consumedSources) await this.removeToken(s.uiTokenId, result.id);
+          for (const s of consumedSources) {
+            await this.removeToken(s.uiTokenId, result.id, extractStateHashFromSdkData(s.sourceSdkData));
+          }
         }
       }
 
@@ -3889,12 +3921,51 @@ export class PaymentsModule {
    *
    * @param tokenId - Local UUID of the token to remove.
    */
-  async removeToken(tokenId: string, excludeReservationId?: string): Promise<void> {
+  /**
+   * Remove a token we spent. `expectedStateHash` (LOCAL sha256 — the state the caller
+   * actually burned) makes this STATE-AWARE (M2): we always tombstone the SPENT state
+   * (so a re-delivery of that exact state is deduped), but if the map entry has since
+   * advanced to a DIFFERENT state — a concurrent claim reactivated this tokenId (a
+   * self-send or A→B→A round-trip direct leg returning at a new state) — that token is
+   * legitimately ours, so we KEEP it instead of deleting it. When `expectedStateHash` is
+   * omitted (legacy callers) or equals the current state, behavior is byte-identical to
+   * before: tombstone the current state and delete.
+   */
+  async removeToken(tokenId: string, excludeReservationId?: string, expectedStateHash?: string): Promise<void> {
     this.ensureInitialized();
 
     const token = this.tokens.get(tokenId);
     if (!token) return;
 
+    const currentStateHash = extractStateHashFromSdkData(token.sdkData);
+    // The state we actually spent: the caller's expected state, else the current state.
+    const spentHash = expectedStateHash !== undefined && expectedStateHash !== '' ? expectedStateHash : currentStateHash;
+    const genesisId = extractTokenIdFromSdkData(token.sdkData);
+
+    // Tombstone the SPENT state (never a reactivated newer state).
+    if (genesisId && spentHash) {
+      const key = `${genesisId}:${spentHash}`;
+      if (!this.tombstoneKeySet.has(key)) {
+        this.tombstones.push({ tokenId: genesisId, stateHash: spentHash, timestamp: Date.now() });
+        this.tombstoneKeySet.add(key);
+        logger.debug('Payments', `Created tombstone for ${genesisId.slice(0, 8)}..._${spentHash.slice(0, 8)}...`);
+      }
+    } else {
+      logger.debug('Payments', `Warning: Could not create tombstone for token ${tokenId.slice(0, 8)}... (missing tokenId or stateHash)`);
+    }
+
+    // M2: the map entry has advanced past the state we spent → a claim reactivated it →
+    // keep the reactivated token; only the spent-state tombstone above stands.
+    if (expectedStateHash !== undefined && expectedStateHash !== '' && currentStateHash !== expectedStateHash) {
+      logger.debug(
+        'Payments',
+        `removeToken kept ${tokenId.slice(0, 8)}...: live state ≠ spent state (reactivated by a concurrent claim)`
+      );
+      await this.save();
+      return;
+    }
+
+    // The state we spent is (still) the one in the map — remove it.
     // Spend Queue: cancel any OTHER active reservations referencing this token.
     // excludeReservationId prevents cancelling the caller's own in-flight reservation.
     this.reservationLedger.cancelForToken(tokenId, excludeReservationId);
@@ -3902,21 +3973,6 @@ export class PaymentsModule {
 
     // Archive before removing
     await this.archiveToken(token);
-
-    // Create tombstone with exact (tokenId, stateHash) - requires both
-    const tombstone = createTombstoneFromToken(token);
-    if (tombstone) {
-      const key = `${tombstone.tokenId}:${tombstone.stateHash}`;
-      if (!this.tombstoneKeySet.has(key)) {
-        this.tombstones.push(tombstone);
-        this.tombstoneKeySet.add(key);
-        logger.debug('Payments', `Created tombstone for ${tombstone.tokenId.slice(0, 8)}..._${tombstone.stateHash.slice(0, 8)}...`);
-      }
-    } else {
-      // No valid tombstone could be created (missing tokenId or stateHash)
-      // Token will still be removed but may be re-synced later
-      logger.debug('Payments', `Warning: Could not create tombstone for token ${tokenId.slice(0, 8)}... (missing tokenId or stateHash)`);
-    }
 
     // Remove from active tokens
     this.tokens.delete(tokenId);
@@ -5214,10 +5270,25 @@ export class PaymentsModule {
       return 'not-owned';
     }
 
-    // Dedup by genesis-stable id (a re-delivered identical token is ignored).
-    const id = `v2_${engine.tokenId(token)}`;
-    if (this.tokens.has(id)) {
-      logger.debug('Payments', `V2 transfer ${id.slice(0, 16)}... already present, skipping`);
+    // Dedup by (tokenId, stateHash) — NOT genesis-id alone. A re-delivered IDENTICAL
+    // state is ignored, but a NEW state of a token we already hold (a self-send or A→B→A
+    // round-trip direct leg returning at a new state) MUST still be received and recorded,
+    // or the wallet keeps the funds but drops the RECEIVED history. The incoming state
+    // hash is taken via the engine-canonical encoding so it lands in the SAME local-sha256
+    // space as stored tokens' state keys; storeEngineToken→addToken below re-checks the
+    // exact duplicate, tombstones, and older-state replacement authoritatively.
+    const genesisId = engine.tokenId(token);
+    const id = `v2_${genesisId}`;
+    const incomingStateHash = extractStateHashFromSdkData(bytesToHex(encodeTokenBlob(engine.encodeToken(token))));
+    const alreadyHeldSameState =
+      incomingStateHash !== '' &&
+      [...this.tokens.values()].some(
+        (t) =>
+          extractTokenIdFromSdkData(t.sdkData) === genesisId &&
+          extractStateHashFromSdkData(t.sdkData) === incomingStateHash
+      );
+    if (alreadyHeldSameState) {
+      logger.debug('Payments', `V2 transfer ${id.slice(0, 16)}... (same state) already present, skipping`);
       return 'duplicate';
     }
 

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -910,6 +910,15 @@ interface IntentPayloadV1 {
   direct: string[];
   /** The at-most-one split (ARCHITECTURE §7). */
   split?: { tokenId: string; splitAmount: string; remainderAmount: string };
+  /**
+   * M7: the state each consumed source was SPENT at, keyed by genesis token id, so an
+   * interrupted-send resume is STATE-AWARE without re-reading a live view a concurrent
+   * claim may have advanced. `local` = sha256-over-bytes (for removeToken's keep-guard);
+   * `protocol` = the deliveryKeys imprint = the server state_hash (for the spend's
+   * knownSpends record). Absent on legacy (pre-M7) payloads — resume then falls back to
+   * the fail-closed path (no state-aware keep, no composite knownSpends).
+   */
+  spentStates?: Record<string, { local: string; protocol: string }>;
 }
 
 // =============================================================================
@@ -2071,7 +2080,7 @@ export class PaymentsModule {
               result.id,
               encryptField(
                 this.getFieldEncryptionKey(),
-                JSON.stringify(this.buildIntentPayload(request, peerInfo.chainPubkey, splitPlan))
+                JSON.stringify(await this.buildIntentPayload(request, peerInfo.chainPubkey, splitPlan))
               ),
               splitPlan.requiresSplit ? { requiresSeedClose: true } : {}
             );
@@ -2688,13 +2697,26 @@ export class PaymentsModule {
    * the realization plan, so a resume on ANY device rebuilds byte-identical
    * transactions (same transferId + same inputs + same output order).
    */
-  private buildIntentPayload(
+  private async buildIntentPayload(
     request: TransferRequest,
     recipientChainPubkey: string,
     splitPlan: SplitPlan
-  ): IntentPayloadV1 {
+  ): Promise<IntentPayloadV1> {
+    const engine = this.deps!.tokenEngine!;
     const genesisIdOf = (tw: TokenWithAmount): string =>
       extractTokenIdFromSdkData(tw.uiToken.sdkData) ?? tw.uiToken.id.replace(/^v2_/, '');
+    // M7: capture each source's spent state (BOTH spaces) from the source blob as we hold
+    // it now — so a later resume is state-aware without re-reading a claim-advanced view.
+    const spentStates: Record<string, { local: string; protocol: string }> = {};
+    const recordState = async (tw: TokenWithAmount): Promise<void> => {
+      const sdkData = tw.uiToken.sdkData ?? '';
+      spentStates[genesisIdOf(tw)] = {
+        local: extractStateHashFromSdkData(sdkData),
+        protocol: sdkData ? (await engine.deliveryKeys(hexToBytes(sdkData))).stateHash : '',
+      };
+    };
+    for (const tw of splitPlan.tokensToTransferDirectly) await recordState(tw);
+    if (splitPlan.requiresSplit && splitPlan.tokenToSplit) await recordState(splitPlan.tokenToSplit);
     return {
       v: 2, // E.4: new sends carry the checkpoint-aware resume contract (sphere-sdk#501)
       recipient: recipientChainPubkey,
@@ -2715,6 +2737,7 @@ export class PaymentsModule {
             },
           }
         : {}),
+      ...(Object.keys(spentStates).length > 0 ? { spentStates } : {}),
     };
   }
 
@@ -6417,15 +6440,23 @@ export class PaymentsModule {
         const changeBytes = encodeTokenBlob(engine.encodeToken(changeOutput));
         added.push({ tokenId: engine.tokenId(changeOutput), key: await this.uploadOutputBlob(changeBytes) });
       }
-      await provider.applyDelta(transferId, spent, added);
+      // M7: replay the spend with the PROTOCOL states persisted at send time, so knownSpends
+      // records the exact spent state (→ M4 can repair a stuck-active server row instead of
+      // leaving a phantom). Legacy payloads (no spentStates) fall back to bare knownSpends.
+      await provider.applyDelta(transferId, spent, added, {
+        spentStates: spent.map((id) => ({ tokenId: id, stateHash: payload.spentStates?.[id]?.protocol ?? '' })),
+      });
       if (changeOutput) await this.storeEngineToken(engine, changeOutput);
     }
 
-    // Drop any local records of the consumed sources (present when resuming
-    // on the originating device).
+    // Drop any local records of the consumed sources (present when resuming on the
+    // originating device). M7: pass the LOCAL state we spent so removeToken's keep-guard
+    // fires — if a concurrent claim reactivated the source to a new state (self-send /
+    // round-trip on resume), it is KEPT, not destroyed. Legacy payloads (no spentStates)
+    // pass undefined and fall back to the prior unconditional drop.
     for (const genesisId of spent) {
       const local = this.tokens.get(`v2_${genesisId}`);
-      if (local) await this.removeToken(local.id, transferId);
+      if (local) await this.removeToken(local.id, transferId, payload.spentStates?.[genesisId]?.local);
     }
 
     // E.3 uniform close (idempotent; the apply above usually already did it).

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -6452,11 +6452,38 @@ export class PaymentsModule {
     // Drop any local records of the consumed sources (present when resuming on the
     // originating device). M7: pass the LOCAL state we spent so removeToken's keep-guard
     // fires — if a concurrent claim reactivated the source to a new state (self-send /
-    // round-trip on resume), it is KEPT, not destroyed. Legacy payloads (no spentStates)
-    // pass undefined and fall back to the prior unconditional drop.
+    // round-trip on resume), it is KEPT, not destroyed.
     for (const genesisId of spent) {
       const local = this.tokens.get(`v2_${genesisId}`);
-      if (local) await this.removeToken(local.id, transferId, payload.spentStates?.[genesisId]?.local);
+      if (!local) continue;
+      const spentLocal = payload.spentStates?.[genesisId]?.local;
+      if (spentLocal !== undefined && spentLocal !== '') {
+        await this.removeToken(local.id, transferId, spentLocal);
+        continue;
+      }
+      // LEGACY payload (no persisted spent state — an in-flight intent from before M7,
+      // hit during a rolling deploy). removeToken cannot state-gate, so a self-send /
+      // round-trip source reactivated by the pump would be destroyed (permanent on
+      // own-storage). FAIL-CLOSED: only drop the source if the aggregator confirms its
+      // CURRENT state is spent; a reactivated (unspent) source is KEPT. Unverifiable →
+      // keep (never destroy value we cannot prove is spent).
+      let spentOnChain = false;
+      try {
+        if (local.sdkData) {
+          const decoded = await engine.decodeToken(decodeTokenBlob(hexToBytes(local.sdkData)));
+          spentOnChain = await engine.isSpent(decoded);
+        }
+      } catch {
+        spentOnChain = false;
+      }
+      if (spentOnChain) {
+        await this.removeToken(local.id, transferId, extractStateHashFromSdkData(local.sdkData));
+      } else {
+        logger.warn(
+          'Payments',
+          `Resume(legacy): source ${genesisId.slice(0, 8)}... is unspent on-chain — keeping (reactivated), not dropping`
+        );
+      }
     }
 
     // E.3 uniform close (idempotent; the apply above usually already did it).

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -78,6 +78,9 @@ export interface HistoryRecord {
   transferId?: string;
   /** Genesis tokenId this entry relates to (used for dedup) */
   tokenId?: string;
+  /** RECEIVED only: the received state (local hash) — makes the dedup key per-state, so a
+   *  genesis token re-acquired at multiple states records each receipt instead of colliding. */
+  stateHash?: string;
   // Sender info (for RECEIVED)
   senderPubkey?: string;
   senderAddress?: string;
@@ -176,8 +179,11 @@ export interface ApplyDeltaOptions {
    * NEVER read from a live inventory view (a concurrent claim can advance the view to a
    * new state before this call). Lets the provider record `knownSpends` as
    * `(tokenId, spentState)`, so a later removal/recovery can distinguish "the state we
-   * spent" from "a state a claim reactivated". Absent for legacy callers → `knownSpends`
-   * falls back to a tokenId-only (state-agnostic) record.
+   * spent" from "a state a claim reactivated". When a token's spent state is absent, the
+   * wallet-api provider records NO knownSpend for it (never a bare tokenId-only record —
+   * that would wrongly block recovery of a reactivated row); its fail-closed on-chain
+   * `isSpent` gate in `recoverRemoved` is the protection instead. Other providers MAY choose
+   * differently, but MUST NOT record a state-agnostic spend that shadows a reactivation.
    */
   spentStates?: { tokenId: string; stateHash: string }[];
 }

--- a/storage/storage-provider.ts
+++ b/storage/storage-provider.ts
@@ -113,6 +113,14 @@ export interface InventoryItem {
   /** Genesis-stable 64-hex token id. */
   tokenId: string;
   status: 'active' | 'removed';
+  /**
+   * The row's CURRENT protocol state hash (DataHash imprint, hex) — the same value
+   * wallet-api stores (§8.2 pipeline `stateHashHex`) and `ITokenEngine.deliveryKeys`
+   * derives. Additive: present only when the server exposes it; a pre-exposure server
+   * omits it, and state-aware removal reconciliation degrades safely to absent. This is
+   * the PROTOCOL hash — never the local sha256-over-bytes journal key.
+   */
+  stateHash?: string;
   /** Decoded value; absent when unknown (e.g. a tombstone). */
   assets?: InventoryAsset[];
   /** Owner change-cursor value at this row's last change (`?since=` deltas). */
@@ -161,6 +169,17 @@ export interface ApplyDeltaOptions {
    * server records them as `external` (never-collected blob retention).
    */
   externalDelivery?: boolean;
+  /**
+   * The PROTOCOL state hash (DataHash imprint, hex — the SAME space as the server's
+   * inventory `state_hash` and `ITokenEngine.deliveryKeys`) of each spent token AS IT
+   * WAS SPENT. Computed authoritatively by the caller from the SOURCE token it burned —
+   * NEVER read from a live inventory view (a concurrent claim can advance the view to a
+   * new state before this call). Lets the provider record `knownSpends` as
+   * `(tokenId, spentState)`, so a later removal/recovery can distinguish "the state we
+   * spent" from "a state a claim reactivated". Absent for legacy callers → `knownSpends`
+   * falls back to a tokenId-only (state-agnostic) record.
+   */
+  spentStates?: { tokenId: string; stateHash: string }[];
 }
 
 /** Result of an explicit `recoverRemoved()` maintenance run (sdk-changes S2). */

--- a/tests/contract/wallet-api-token-storage-provider.contract.test.ts
+++ b/tests/contract/wallet-api-token-storage-provider.contract.test.ts
@@ -14,6 +14,7 @@ import { WalletApiClient, WalletApiError } from '../../wallet-api';
 import { WalletApiTokenStorageProvider } from '../../impl/shared/wallet-api/WalletApiTokenStorageProvider';
 import { deriveFieldEncryptionKey, encryptField } from '../../core/field-encryption';
 import type { FullIdentity } from '../../types';
+import type { TokenBlob } from '../../token-engine/types';
 import { FakeWalletApi } from '../support/fake-wallet-api';
 import {
   buildTxfData,
@@ -32,7 +33,14 @@ function makeDevice(
   fake: FakeWalletApi,
   baseUrl: string,
   identityIndex: number,
-  deviceId: string
+  deviceId: string,
+  /**
+   * The on-chain spent oracle recoverRemoved fail-closes on (mirrors the engine's
+   * `isSpent`, wired at composition in prod / the harness). A test supplies a set of
+   * tokenIds it considers spent-on-chain; recoverRemoved reactivates only tokens NOT in it.
+   * When omitted, recoverRemoved is a safe no-op (never reactivates) — the unwired default.
+   */
+  spentOnChain?: ReadonlySet<string>
 ): {
   client: WalletApiClient;
   provider: WalletApiTokenStorageProvider;
@@ -50,6 +58,9 @@ function makeDevice(
   const provider = new WalletApiTokenStorageProvider({
     client,
     stateStore,
+    ...(spentOnChain
+      ? { isSpent: (blob: TokenBlob): Promise<boolean> => Promise.resolve(spentOnChain.has(blob.tokenId)) }
+      : {}),
   });
   provider.setIdentity({
     privateKey: identity.privateKey,
@@ -199,7 +210,9 @@ describe('WalletApiTokenStorageProvider — S2 remote semantics', () => {
 
   it('a tombstone arriving on the DELTA path prunes the overlay — a later re-add is NOT shadowed (#679)', async () => {
     const deviceA = makeDevice(fake, baseUrl, 41, 'dev-a');
-    const deviceB = makeDevice(fake, baseUrl, 41, 'dev-b'); // same owner, second device
+    // t1's removal here is an unevidenced (reactivatable) flip, not a genuine on-chain
+    // spend — so isSpent reports it UNSPENT and recoverRemoved may re-add it.
+    const deviceB = makeDevice(fake, baseUrl, 41, 'dev-b', new Set()); // same owner, second device
     const t1 = makeTestToken();
     await seedVia(deviceA.provider, [t1]);
 
@@ -282,11 +295,29 @@ describe('WalletApiTokenStorageProvider — S2 remote semantics', () => {
     expect(fake.getRow(pubkey, t.tokenId)?.status).toBe('active');
   });
 
-  it('a confirmed-spend tombstone IS pushed after a successful load', async () => {
-    const { provider, pubkey } = makeDevice(fake, baseUrl, 25, 'dev-a');
+  it('a confirmed-spend tombstone IS pushed after a successful load (evidence-race desync repair)', async () => {
+    const { provider, pubkey, client } = makeDevice(fake, baseUrl, 25, 'dev-a');
     const t = makeTestToken();
     await seedVia(provider, [t]);
 
+    // The row's current protocol state — the value pushRemovals matches the spend against.
+    const rowStateHash = (await provider.listInventory()).items.find((i) => i.tokenId === t.tokenId)!.stateHash!;
+    expect(rowStateHash).toBeTruthy();
+
+    // Record an AUTHORITATIVE (composite) spend for t at that exact state, WITHOUT removing
+    // the server row: the client apply is a no-op, simulating the evidence-race desync where
+    // the spend's server removal did not stick and the row is left ACTIVE.
+    const realApply = client.applyInventoryDelta.bind(client);
+    client.applyInventoryDelta = (async () => 0n) as typeof client.applyInventoryDelta;
+    await provider.applyDelta('55555555-5555-4555-8555-555555555555', [t.tokenId], [], {
+      spentStates: [{ tokenId: t.tokenId, stateHash: rowStateHash }],
+    });
+    client.applyInventoryDelta = realApply;
+    expect(fake.getRow(pubkey, t.tokenId)?.status).toBe('active'); // the desync: still active
+
+    // A save with the local tombstone repairs it: pushRemovals PROVES the spend (the composite
+    // knownSpend matches the active row's state) and pushes the removal — a token-id-only or
+    // unproven tombstone would be skipped (fail-closed).
     const data = buildTxfData([]);
     data._tombstones = [{ tokenId: t.tokenId, stateHash: '', timestamp: Date.now() }];
     const result = await provider.save(data);
@@ -298,7 +329,8 @@ describe('WalletApiTokenStorageProvider — S2 remote semantics', () => {
   });
 
   it('recoverRemoved() restores a wiped-but-unspent token (§5.3 recovery)', async () => {
-    const { provider, pubkey } = makeDevice(fake, baseUrl, 26, 'dev-a');
+    // isSpent (wired at composition in prod) reports t1 UNSPENT → recoverRemoved reactivates.
+    const { provider, pubkey } = makeDevice(fake, baseUrl, 26, 'dev-a', new Set());
     const t1 = makeTestToken();
     const t2 = makeTestToken();
     await seedVia(provider, [t1, t2]);
@@ -330,8 +362,11 @@ describe('WalletApiTokenStorageProvider — S2 remote semantics', () => {
   });
 
   it('recoverRemoved() keeps an evidenced tombstone — server 409 = actually spent (§5.3)', async () => {
-    const deviceA = makeDevice(fake, baseUrl, 27, 'dev-a');
+    // t is genuinely spent below → isSpent reports it spent → recoverRemoved keeps it as spent.
+    const spentOnChain27 = new Set<string>();
+    const deviceA = makeDevice(fake, baseUrl, 27, 'dev-a', spentOnChain27);
     const t = makeTestToken();
+    spentOnChain27.add(t.tokenId);
     const change = makeTestToken();
     await seedVia(deviceA.provider, [t]);
 
@@ -361,9 +396,13 @@ describe('WalletApiTokenStorageProvider — S2 remote semantics', () => {
     expect(view.items.map((i) => i.tokenId)).toEqual([change.tokenId]);
   });
 
-  it('recoverRemoved() skips the provider’s own known spends', async () => {
-    const { provider, pubkey } = makeDevice(fake, baseUrl, 28, 'dev-a');
+  it('recoverRemoved() never resurrects the provider’s own on-chain spends', async () => {
+    // The provider spends t1 itself; the fail-closed isSpent gate confirms it consumed
+    // on-chain and records it as spent — never reactivating it (I4).
+    const spentOnChain28 = new Set<string>();
+    const { provider, pubkey } = makeDevice(fake, baseUrl, 28, 'dev-a', spentOnChain28);
     const t1 = makeTestToken();
+    spentOnChain28.add(t1.tokenId);
     const t2 = makeTestToken();
     await seedVia(provider, [t1, t2]);
 
@@ -371,7 +410,7 @@ describe('WalletApiTokenStorageProvider — S2 remote semantics', () => {
 
     const result = await provider.recoverRemoved();
     expect(result.recovered).toEqual([]);
-    expect(result.spent).toEqual([]);
+    expect(result.spent).toEqual([t1.tokenId]);
     expect(result.skipped).toEqual([]);
     expect(fake.getRow(pubkey, t1.tokenId)?.status).toBe('removed');
   });

--- a/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
+++ b/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
@@ -118,4 +118,60 @@ describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api +
     expect(aTotal + bTotal).toBe(10n);
     expect(aTotal).toBe(10n);
   }, 420_000);
+
+  it('multi-wallet path a→b→c→b→a→c→a→b→a with DIRECT + SPLIT transfers conserves value at every hop', async () => {
+    const a = await newWallet('mrt-a');
+    const b = await newWallet('mrt-b');
+    const c = await newWallet('mrt-c');
+    const byName: Record<'a' | 'b' | 'c', HarnessWallet> = { a, b, c };
+
+    const MINT = 100n;
+    expect((await a.module.mintFungibleToken(HARNESS_COIN, MINT)).success).toBe(true);
+    expect(await waitForBalance(a, MINT)).toBe(MINT);
+
+    // The a→b→c→b→a→c→a→b→a path, with amounts chosen so the run exercises EVERY transfer
+    // shape: whole-token DIRECT, multi-token DIRECT (spending fragmented change), and SPLIT
+    // (a partial amount → sent leg + change), while the same genesis lineage is re-acquired
+    // repeatedly across three independent wallets.
+    //   kind  = the transfer shape the sender's holding forces at that amount (documentation).
+    // Traced with smallest-first coin selection (fragment values are selection-dependent, but
+    // the split-vs-direct classification is deterministic: a hop SPLITs iff no whole-token
+    // subset of the sender's holding sums to the amount). Sender holdings per hop:
+    //   1 A{100}  2 B{100}  3 C{60}  4 B{40,60}  5 A{40,60}  6 C{40,30}  7 A{30,40,30}  8 B{30,40,30}
+    const hops: Array<{ from: 'a' | 'b' | 'c'; to: 'a' | 'b' | 'c'; amt: bigint; kind: string }> = [
+      { from: 'a', to: 'b', amt: 100n, kind: 'direct — whole 100-token' },
+      { from: 'b', to: 'c', amt: 60n, kind: 'SPLIT — 60 of a 100-token (60 sent + 40 change)' },
+      { from: 'c', to: 'b', amt: 60n, kind: 'direct — whole 60-token (B re-acquires)' },
+      { from: 'b', to: 'a', amt: 100n, kind: 'direct multi-token — both change tokens (40 + 60)' },
+      { from: 'a', to: 'c', amt: 70n, kind: 'SPLIT — 70 of {40,60}; no whole subset = 70, so a source splits' },
+      { from: 'c', to: 'a', amt: 70n, kind: 'direct multi-token — both received tokens (40 + 30) (A re-acquires)' },
+      { from: 'a', to: 'b', amt: 100n, kind: 'direct multi-token — all held tokens (30 + 40 + 30)' },
+      { from: 'b', to: 'a', amt: 100n, kind: 'direct multi-token — all held tokens (30 + 40 + 30)' },
+    ];
+
+    const bal: Record<'a' | 'b' | 'c', bigint> = { a: MINT, b: 0n, c: 0n };
+    for (const hop of hops) {
+      const from = byName[hop.from];
+      const to = byName[hop.to];
+      await from.module.send({ recipient: to.identity.chainPubkey, amount: hop.amt.toString(), coinId: HARNESS_COIN });
+      bal[hop.from] -= hop.amt;
+      bal[hop.to] += hop.amt;
+      // Both endpoints settle to their exact expected balances (a split leaves the sender its
+      // change; a whole/multi-token send leaves it at its remaining total).
+      expect(await waitForBalance(to, bal[hop.to])).toBe(bal[hop.to]);
+      expect(await waitForBalance(from, bal[hop.from])).toBe(bal[hop.from]);
+      // Conservation across ALL THREE wallets at EVERY hop — no value vanishes mid-path.
+      const total =
+        totalOf(await a.client.getBalances()) +
+        totalOf(await b.client.getBalances()) +
+        totalOf(await c.client.getBalances());
+      expect(total).toBe(MINT);
+    }
+
+    // Path ends at A with the full value, real and spendable; B and C empty.
+    expect(await waitForBalance(a, MINT)).toBe(MINT);
+    expect(totalOf(await b.client.getBalances())).toBe(0n);
+    expect(totalOf(await c.client.getBalances())).toBe(0n);
+    expect(a.module.getTokens().reduce((s, t) => s + BigInt(t.amount), 0n)).toBe(MINT);
+  }, 600_000);
 });

--- a/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
+++ b/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
@@ -1,0 +1,116 @@
+/**
+ * LIVE money-loss repro — self-send + A→B→A round-trip over the REAL staging
+ * wallet-api and the REAL testnet2 aggregator, with REAL (testnet) transactions.
+ *
+ * This is the only test that can validate the fix end-to-end: the fakes return
+ * certificationData AND inclusionCertificate together (like today's aggregator),
+ * so no fake can exercise the ExclusionCert / isSpent discriminator, and no fake
+ * reproduces the real mailbox/inventory timing. Here the token is minted, sent,
+ * claimed, and sent BACK across two real wallets, and we assert value is conserved.
+ *
+ * Verified 2026-07-19: on `main` the whole-token SELF-send LOSES 100% (server
+ * balance stays 0), and this test conserves it on the fix branch — same test,
+ * real staging + testnet2. (The A→B→A round-trip is the timing-dependent variant:
+ * it conserves here and does not reproduce on every live run, unlike the
+ * deterministic self-send; the integration repros cover it deterministically.)
+ *
+ * NOTE: staging wallet-api is PRE-Unit-A (no per-row state_hash), so this exercises
+ * the DEGRADED path (M2 local keep-guard + M4 skip, no server-side repair) — i.e.
+ * exactly what production hits today.
+ *
+ * Gated on STAGING_AGGREGATOR_KEY. Run:
+ *   STAGING_AGGREGATOR_KEY=sk_... npx vitest run --config vitest.e2e.config.ts \
+ *     tests/e2e/self-send-roundtrip.staging.e2e.test.ts
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createHarnessWallet, type HarnessWallet } from '../harness/support/harness-wallet';
+import { HARNESS_COIN, randomIdentity } from '../harness/support/stack';
+import type { HarnessStack } from '../harness/support/stack';
+import type { CoinBalance } from '../../wallet-api';
+
+const API_KEY = process.env.STAGING_AGGREGATOR_KEY;
+
+const STACK: HarnessStack = {
+  baseUrl: process.env.STAGING_WALLET_API ?? 'https://wallet-api.staging.unicity.network',
+  aggregatorUrl: process.env.STAGING_AGGREGATOR ?? 'https://gateway.testnet2.unicity.network',
+  network: 'testnet2',
+  ...(API_KEY ? { aggregatorApiKey: API_KEY } : {}),
+  trustbaseUrl:
+    process.env.STAGING_TRUSTBASE ??
+    'https://raw.githubusercontent.com/unicitynetwork/unicity-ids/main/bft-trustbase.testnet2.json',
+};
+
+const wallets: HarnessWallet[] = [];
+afterEach(() => {
+  while (wallets.length) wallets.pop()?.destroy();
+});
+
+async function newWallet(deviceId: string, identity = randomIdentity()): Promise<HarnessWallet> {
+  const w = await createHarnessWallet({ stack: STACK, identity, deviceId, custody: 'inventory' });
+  wallets.push(w);
+  await w.module.load();
+  return w;
+}
+
+function totalOf(balances: CoinBalance[]): bigint {
+  return balances.find((b) => b.coinId === HARNESS_COIN)?.total ?? 0n;
+}
+
+/** Poll (draining the mailbox each round) until the server balance reaches `want`, or timeout. */
+async function waitForBalance(w: HarnessWallet, want: bigint, timeoutMs = 120_000): Promise<bigint> {
+  const deadline = Date.now() + timeoutMs;
+  let last = -1n;
+  for (;;) {
+    try {
+      await w.module.receive();
+    } catch {
+      /* mailbox drain is best-effort; keep polling the server balance */
+    }
+    last = totalOf(await w.client.getBalances());
+    if (last === want || Date.now() >= deadline) return last;
+    await new Promise((r) => setTimeout(r, 3_000));
+  }
+}
+
+describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api + testnet2', () => {
+  it('whole-token SELF-send conserves funds (pre-fix: 100% loss)', async () => {
+    const a = await newWallet('live-ss-a');
+
+    expect((await a.module.mintFungibleToken(HARNESS_COIN, 10n)).success).toBe(true);
+    expect(await waitForBalance(a, 10n)).toBe(10n);
+
+    // Send the WHOLE token to our own address — the deterministic-loss case.
+    await a.module.send({ recipient: a.identity.chainPubkey, amount: '10', coinId: HARNESS_COIN });
+
+    // The invariant is only that value is CONSERVED once the dust settles — never 0.
+    expect(await waitForBalance(a, 10n)).toBe(10n);
+    // and it is a real, spendable token (not a phantom lazy row)
+    expect(a.module.getTokens().reduce((s, t) => s + BigInt(t.amount), 0n)).toBe(10n);
+  }, 300_000);
+
+  it('A→B→A round-trip conserves A funds (pre-fix: permanent loss)', async () => {
+    const a = await newWallet('live-rt-a');
+    const bId = randomIdentity();
+
+    expect((await a.module.mintFungibleToken(HARNESS_COIN, 10n)).success).toBe(true);
+    expect(await waitForBalance(a, 10n)).toBe(10n);
+
+    // A → B
+    await a.module.send({ recipient: bId.chainPubkey, amount: '10', coinId: HARNESS_COIN });
+    const b = await newWallet('live-rt-b', bId);
+    expect(await waitForBalance(b, 10n)).toBe(10n);
+    expect(await waitForBalance(a, 0n)).toBe(0n);
+
+    // B → A (the round-trip — A re-acquires the same genesis token)
+    await b.module.send({ recipient: a.identity.chainPubkey, amount: '10', coinId: HARNESS_COIN });
+    expect(await waitForBalance(a, 10n)).toBe(10n); // A gets it back, conserved
+    expect(await waitForBalance(b, 0n)).toBe(0n);
+
+    // Total across both wallets is conserved (no token vanished).
+    const aTotal = totalOf(await a.client.getBalances());
+    const bTotal = totalOf(await b.client.getBalances());
+    expect(aTotal + bTotal).toBe(10n);
+    expect(aTotal).toBe(10n);
+  }, 420_000);
+});

--- a/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
+++ b/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
@@ -47,7 +47,10 @@ afterEach(() => {
 });
 
 async function newWallet(deviceId: string, identity = randomIdentity()): Promise<HarnessWallet> {
-  const w = await createHarnessWallet({ stack: STACK, identity, deviceId, custody: 'inventory' });
+  // Namespace local storage by the (random) identity so runs never inherit a prior run's
+  // stale local tokens/journal — otherwise leftover state contaminates id-composition checks.
+  const uniqueDeviceId = `${deviceId}-${identity.chainPubkey.slice(2, 14)}`;
+  const w = await createHarnessWallet({ stack: STACK, identity, deviceId: uniqueDeviceId, custody: 'inventory' });
   wallets.push(w);
   await w.module.load();
   return w;
@@ -69,6 +72,36 @@ async function waitForBalance(w: HarnessWallet, want: bigint, timeoutMs = 120_00
     }
     last = totalOf(await w.client.getBalances());
     if (last === want || Date.now() >= deadline) return last;
+    await new Promise((r) => setTimeout(r, 3_000));
+  }
+}
+
+/**
+ * Poll — sync()ing each round — until the wallet's LOCAL inventory settles to `wantTotal` value
+ * and (if given) `wantDistinct` distinct token ids, then return the held {id, amt} list.
+ *
+ * getTokens() is an eventually-consistent cache. Two reconciliations lag a resync: (a) multiple
+ * same-value tokens just claimed from the mailbox, and (b) pruning the spent PARENT after a
+ * self-initiated split (custody/server balance is already correct — this is a local over-count,
+ * the safe direction, never a loss). This waits that reconciliation out. If it never settles the
+ * caller's assertions still fire on the last snapshot, so a genuine inventory bug surfaces as a
+ * failure rather than being masked.
+ */
+async function waitForTokens(
+  w: HarnessWallet,
+  wantTotal: bigint,
+  wantDistinct?: number,
+  timeoutMs = 90_000,
+): Promise<Array<{ id: string; amt: bigint }>> {
+  const deadline = Date.now() + timeoutMs;
+  let held: Array<{ id: string; amt: bigint }> = [];
+  for (;;) {
+    await w.module.sync();
+    held = w.module.getTokens().map((t) => ({ id: t.id, amt: BigInt(t.amount) }));
+    const total = held.reduce((s, t) => s + t.amt, 0n);
+    const distinct = new Set(held.map((t) => t.id)).size;
+    const settled = total === wantTotal && (wantDistinct === undefined || distinct === wantDistinct);
+    if (settled || Date.now() >= deadline) return held;
     await new Promise((r) => setTimeout(r, 3_000));
   }
 }
@@ -119,69 +152,135 @@ describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api +
     expect(aTotal).toBe(10n);
   }, 420_000);
 
-  it('round-trips the SAME genesis token (direct) AND a split output (direct) — re-acquired at A, proven by id', async () => {
-    const a = await newWallet('mrt-a');
-    const b = await newWallet('mrt-b');
-    const c = await newWallet('mrt-c');
-
-    // A wallet's held token IDs (v2_<genesisId>) — genesis-stable across transfers, so a
-    // re-acquired token keeps the SAME id. This is what makes it a genuine round-trip of the
-    // SAME token (the actual bug), not a value coincidence.
+  it('a→b→c→b→a→c→a→b→a round-trips ONE token with NO splits — same genesis id the whole way', async () => {
+    const a = await newWallet('rt1-a');
+    const b = await newWallet('rt1-b');
+    const c = await newWallet('rt1-c');
+    const byName: Record<'a' | 'b' | 'c', HarnessWallet> = { a, b, c };
+    // Held token ids (v2_<genesisId>) are genesis-stable across transfers.
     const idsOf = (w: HarnessWallet): string[] => w.module.getTokens().map((t) => t.id).sort();
-    const idOfAmount = (w: HarnessWallet, amt: bigint): string => {
-      const t = w.module.getTokens().find((x) => BigInt(x.amount) === amt);
-      if (!t) throw new Error(`${w.identity.chainPubkey.slice(0, 6)} holds no ${amt}-token (has ${idsOf(w).join(',')})`);
+
+    expect((await a.module.mintFungibleToken(HARNESS_COIN, 100n)).success).toBe(true);
+    expect(await waitForBalance(a, 100n)).toBe(100n);
+    const g0 = idsOf(a)[0]!; // the one and only token — it never changes identity below
+
+    // Every hop moves the WHOLE token (amount == full value), so every transfer is DIRECT and
+    // preserves the genesis id. The one token visits all three wallets and is re-acquired at A
+    // three times (hops 4, 6, 8). Nothing ever splits, so the id stays g0 for the entire path.
+    const hops: Array<['a' | 'b' | 'c', 'a' | 'b' | 'c']> = [
+      ['a', 'b'], ['b', 'c'], ['c', 'b'], ['b', 'a'], ['a', 'c'], ['c', 'a'], ['a', 'b'], ['b', 'a'],
+    ];
+    for (const [fromName, toName] of hops) {
+      const from = byName[fromName];
+      const to = byName[toName];
+      await from.module.send({ recipient: to.identity.chainPubkey, amount: '100', coinId: HARNESS_COIN });
+      expect(await waitForBalance(to, 100n)).toBe(100n);
+      expect(await waitForBalance(from, 0n)).toBe(0n);
+      // Receiver holds exactly ONE token and it is still g0 — same token, never split/duplicated.
+      expect(idsOf(to)).toEqual([g0]);
+      const total =
+        totalOf(await a.client.getBalances()) +
+        totalOf(await b.client.getBalances()) +
+        totalOf(await c.client.getBalances());
+      expect(total).toBe(100n);
+    }
+
+    // Ends back at A holding exactly the original token, whole.
+    expect(idsOf(a)).toEqual([g0]);
+    expect(await waitForBalance(a, 100n)).toBe(100n);
+    expect(totalOf(await b.client.getBalances())).toBe(0n);
+    expect(totalOf(await c.client.getBalances())).toBe(0n);
+  }, 600_000);
+
+  it('MIXED send (direct + split in one package) mid-path, with same-token re-acquire, conserves', async () => {
+    const a = await newWallet('mix-a');
+    const b = await newWallet('mix-b');
+    const c = await newWallet('mix-c');
+
+    // getTokens() is an eventually-consistent LOCAL cache: after multi-token receives or a
+    // self-split it can momentarily miscount until reconciled. sync() reconciles it to the
+    // authoritative server inventory, so every genesis-id/composition read below syncs first.
+    const tokensOf = async (w: HarnessWallet): Promise<Array<{ id: string; amt: bigint }>> => {
+      await w.module.sync();
+      return w.module.getTokens().map((t) => ({ id: t.id, amt: BigInt(t.amount) }));
+    };
+    const idsOf = async (w: HarnessWallet): Promise<string[]> => (await tokensOf(w)).map((t) => t.id).sort();
+    const idOfAmount = async (w: HarnessWallet, amt: bigint): Promise<string> => {
+      const held = await tokensOf(w);
+      const t = held.find((x) => x.amt === amt);
+      if (!t) throw new Error(`${w.identity.chainPubkey.slice(0, 6)} holds no ${amt}-token (has ${held.map((h) => `${h.id.slice(0, 8)}:${h.amt}`).join(',')})`);
       return t.id;
     };
 
     expect((await a.module.mintFungibleToken(HARNESS_COIN, 100n)).success).toBe(true);
     expect(await waitForBalance(a, 100n)).toBe(100n);
-    const g0 = idOfAmount(a, 100n); // the minted token
+    const g0 = await idOfAmount(a, 100n);
 
-    // --- Phase 1: round-trip the WHOLE minted token A→B→A (DIRECT). Genesis id is preserved,
-    // so A re-acquires the SAME token g0. (Pre-fix this is where A loses it.) ---
+    // --- Phase 1: whole-token round-trip A→B→A (DIRECT) — A re-acquires the SAME token g0. ---
     await a.module.send({ recipient: b.identity.chainPubkey, amount: '100', coinId: HARNESS_COIN });
     expect(await waitForBalance(b, 100n)).toBe(100n);
-    expect(idOfAmount(b, 100n)).toBe(g0); // same token now at B
     await b.module.send({ recipient: a.identity.chainPubkey, amount: '100', coinId: HARNESS_COIN });
     expect(await waitForBalance(a, 100n)).toBe(100n);
-    expect(idsOf(a)).toEqual([g0]); // ← A re-acquired the SAME genesis token
+    expect(await idsOf(a)).toEqual([g0]);
 
-    // --- Phase 2: SPLIT it (60 to B + 40 change at A). This BURNS g0 and mints two NEW genesis
-    // tokens: g1 (60, at B) and g2 (40, A's change). ---
-    await a.module.send({ recipient: b.identity.chainPubkey, amount: '60', coinId: HARNESS_COIN });
-    expect(await waitForBalance(b, 60n)).toBe(60n);
-    expect(await waitForBalance(a, 40n)).toBe(40n);
-    const g1 = idOfAmount(b, 60n); // split output sent to B
-    const g2 = idOfAmount(a, 40n); // split change kept at A
-    expect(new Set([g0, g1, g2]).size).toBe(3); // split minted brand-new genesis ids
-
-    // --- Phase 3: round-trip the SPLIT OUTPUT g1 (60) whole B→C→A (DIRECT) — A re-acquires g1. ---
-    await b.module.send({ recipient: c.identity.chainPubkey, amount: '60', coinId: HARNESS_COIN });
-    expect(await waitForBalance(c, 60n)).toBe(60n);
-    expect(idOfAmount(c, 60n)).toBe(g1);
-    await c.module.send({ recipient: a.identity.chainPubkey, amount: '60', coinId: HARNESS_COIN });
-    expect(await waitForBalance(a, 100n)).toBe(100n); // A now holds g2(40) + g1(60)
-    expect(idOfAmount(a, 60n)).toBe(g1); // ← A re-acquired the SAME split-output token g1
-    expect(idsOf(a)).toEqual([g1, g2].sort());
-
-    // --- Phase 4: round-trip the OTHER split output g2 (40) whole A→C→A (DIRECT) — A re-acquires g2. ---
-    await a.module.send({ recipient: c.identity.chainPubkey, amount: '40', coinId: HARNESS_COIN });
+    // --- Phase 2: two SPLITs fragment A into three tokens spread across the wallets. Each split
+    // burns its parent and mints fresh genesis ids. ---
+    await a.module.send({ recipient: b.identity.chainPubkey, amount: '30', coinId: HARNESS_COIN }); // g0 → g1(30@B) + g2(70@A)
+    expect(await waitForBalance(b, 30n)).toBe(30n);
+    expect(await waitForBalance(a, 70n)).toBe(70n);
+    const g1 = await idOfAmount(b, 30n);
+    await a.module.send({ recipient: c.identity.chainPubkey, amount: '40', coinId: HARNESS_COIN }); // g2 → g3(40@C) + g4(30@A)
     expect(await waitForBalance(c, 40n)).toBe(40n);
-    expect(idOfAmount(c, 40n)).toBe(g2);
-    await c.module.send({ recipient: a.identity.chainPubkey, amount: '40', coinId: HARNESS_COIN });
-    expect(await waitForBalance(a, 100n)).toBe(100n);
-    expect(idOfAmount(a, 40n)).toBe(g2); // ← A re-acquired the SAME split-output token g2
+    expect(await waitForBalance(a, 30n)).toBe(30n);
+    const g3 = await idOfAmount(c, 40n);
+    const g4 = await idOfAmount(a, 30n);
 
-    // End: A holds exactly the two split outputs (60 + 40 = 100); B and C empty; conserved.
-    expect(idsOf(a)).toEqual([g1, g2].sort());
-    expect(a.module.getTokens().reduce((s, t) => s + BigInt(t.amount), 0n)).toBe(100n);
+    // --- Phase 3: pull the two fragments back so A holds THREE tokens {30, 30, 40} = 100. ---
+    await b.module.send({ recipient: a.identity.chainPubkey, amount: '30', coinId: HARNESS_COIN }); // g1 whole → A
+    expect(await waitForBalance(a, 60n)).toBe(60n);
+    await c.module.send({ recipient: a.identity.chainPubkey, amount: '40', coinId: HARNESS_COIN }); // g3 whole → A
+    expect(await waitForBalance(a, 100n)).toBe(100n);
+    const aFrag = await waitForTokens(a, 100n, 3); // settle: three distinct tokens {30, 30, 40}
+    const preMixIds = new Set(aFrag.map((t) => t.id));
+    expect(preMixIds).toEqual(new Set([g4, g1, g3])); // A re-acquired g1 and g3 whole
+    const known = new Set([g0, g1, g3, g4]); // every genesis id seen so far (g2 already burned)
+
+    // --- Phase 4: THE MIXED SEND. A sends 80 from {30,30,40}. No whole-token subset sums to 80,
+    // so coin selection sends two tokens WHOLE (direct) and SPLITS the third for the remaining 20
+    // — a single send whose package is a split AND direct transfers together. ---
+    await a.module.send({ recipient: b.identity.chainPubkey, amount: '80', coinId: HARNESS_COIN });
+    expect(await waitForBalance(b, 80n)).toBe(80n);
+    expect(await waitForBalance(a, 20n)).toBe(20n);
+
+    // The RECIPIENT's view is the authoritative proof of the package's shape: B receives exactly
+    // three tokens — two arriving WHOLE (their pre-mix genesis ids preserved = DIRECT legs) and
+    // one with a fresh genesis id (the SPLIT leg). Both transfer kinds in ONE send.
+    const bTokens = await waitForTokens(b, 80n, 3); // settle: three legs totaling 80
+    const directLegs = bTokens.filter((t) => preMixIds.has(t.id)); // arrived WHOLE — genesis preserved
+    const splitLegs = bTokens.filter((t) => !known.has(t.id)); // fresh genesis minted by the split
+    expect(directLegs).toHaveLength(2); // two DIRECT transfers in the package
+    expect(splitLegs).toHaveLength(1); // one SPLIT leg in the SAME package
+
+    // The SENDER keeps only the split's change. After a self-initiated split the local inventory
+    // over-lists the spent parent until an inventory resync prunes it (server balance is already
+    // 20 — waitForBalance above). waitForTokens settles the local view to the one change leg.
+    const aTokens = await waitForTokens(a, 20n, 1);
+    expect(aTokens).toHaveLength(1); // just the change leg, once the spent parent is pruned
+    expect(aTokens[0]?.amt).toBe(20n);
+    expect(known.has(aTokens[0]?.id ?? '')).toBe(false); // change is a fresh genesis (parent was burned)
+
+    // conservation on the server immediately after the mixed send
+    expect(
+      totalOf(await a.client.getBalances()) +
+        totalOf(await b.client.getBalances()) +
+        totalOf(await c.client.getBalances()),
+    ).toBe(100n);
+
+    // --- Phase 5: B returns its three tokens whole — value round-trips back to A, conserved. ---
+    await b.module.send({ recipient: a.identity.chainPubkey, amount: '80', coinId: HARNESS_COIN });
+    expect(await waitForBalance(a, 100n)).toBe(100n);
     expect(totalOf(await b.client.getBalances())).toBe(0n);
     expect(totalOf(await c.client.getBalances())).toBe(0n);
-    const total =
-      totalOf(await a.client.getBalances()) +
-      totalOf(await b.client.getBalances()) +
-      totalOf(await c.client.getBalances());
-    expect(total).toBe(100n);
+    expect((await waitForTokens(a, 100n)).reduce((s, t) => s + t.amt, 0n)).toBe(100n);
   }, 600_000);
 });

--- a/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
+++ b/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
@@ -80,6 +80,11 @@ describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api +
     expect((await a.module.mintFungibleToken(HARNESS_COIN, 10n)).success).toBe(true);
     expect(await waitForBalance(a, 10n)).toBe(10n);
 
+    // Prove staging exposes per-row state_hash (Unit A) — else this would silently test the
+    // degraded (skip-primary) path instead of M4's real state-scoped reconciliation.
+    const inv = await a.client.listInventory();
+    expect(inv.items[0]?.stateHash).toMatch(/^[0-9a-f]+$/);
+
     // Send the WHOLE token to our own address — the deterministic-loss case.
     await a.module.send({ recipient: a.identity.chainPubkey, amount: '10', coinId: HARNESS_COIN });
 

--- a/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
+++ b/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
@@ -119,59 +119,69 @@ describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api +
     expect(aTotal).toBe(10n);
   }, 420_000);
 
-  it('multi-wallet path a→b→c→b→a→c→a→b→a with DIRECT + SPLIT transfers conserves value at every hop', async () => {
+  it('round-trips the SAME genesis token (direct) AND a split output (direct) — re-acquired at A, proven by id', async () => {
     const a = await newWallet('mrt-a');
     const b = await newWallet('mrt-b');
     const c = await newWallet('mrt-c');
-    const byName: Record<'a' | 'b' | 'c', HarnessWallet> = { a, b, c };
 
-    const MINT = 100n;
-    expect((await a.module.mintFungibleToken(HARNESS_COIN, MINT)).success).toBe(true);
-    expect(await waitForBalance(a, MINT)).toBe(MINT);
+    // A wallet's held token IDs (v2_<genesisId>) — genesis-stable across transfers, so a
+    // re-acquired token keeps the SAME id. This is what makes it a genuine round-trip of the
+    // SAME token (the actual bug), not a value coincidence.
+    const idsOf = (w: HarnessWallet): string[] => w.module.getTokens().map((t) => t.id).sort();
+    const idOfAmount = (w: HarnessWallet, amt: bigint): string => {
+      const t = w.module.getTokens().find((x) => BigInt(x.amount) === amt);
+      if (!t) throw new Error(`${w.identity.chainPubkey.slice(0, 6)} holds no ${amt}-token (has ${idsOf(w).join(',')})`);
+      return t.id;
+    };
 
-    // The a→b→c→b→a→c→a→b→a path, with amounts chosen so the run exercises EVERY transfer
-    // shape: whole-token DIRECT, multi-token DIRECT (spending fragmented change), and SPLIT
-    // (a partial amount → sent leg + change), while the same genesis lineage is re-acquired
-    // repeatedly across three independent wallets.
-    //   kind  = the transfer shape the sender's holding forces at that amount (documentation).
-    // Traced with smallest-first coin selection (fragment values are selection-dependent, but
-    // the split-vs-direct classification is deterministic: a hop SPLITs iff no whole-token
-    // subset of the sender's holding sums to the amount). Sender holdings per hop:
-    //   1 A{100}  2 B{100}  3 C{60}  4 B{40,60}  5 A{40,60}  6 C{40,30}  7 A{30,40,30}  8 B{30,40,30}
-    const hops: Array<{ from: 'a' | 'b' | 'c'; to: 'a' | 'b' | 'c'; amt: bigint; kind: string }> = [
-      { from: 'a', to: 'b', amt: 100n, kind: 'direct — whole 100-token' },
-      { from: 'b', to: 'c', amt: 60n, kind: 'SPLIT — 60 of a 100-token (60 sent + 40 change)' },
-      { from: 'c', to: 'b', amt: 60n, kind: 'direct — whole 60-token (B re-acquires)' },
-      { from: 'b', to: 'a', amt: 100n, kind: 'direct multi-token — both change tokens (40 + 60)' },
-      { from: 'a', to: 'c', amt: 70n, kind: 'SPLIT — 70 of {40,60}; no whole subset = 70, so a source splits' },
-      { from: 'c', to: 'a', amt: 70n, kind: 'direct multi-token — both received tokens (40 + 30) (A re-acquires)' },
-      { from: 'a', to: 'b', amt: 100n, kind: 'direct multi-token — all held tokens (30 + 40 + 30)' },
-      { from: 'b', to: 'a', amt: 100n, kind: 'direct multi-token — all held tokens (30 + 40 + 30)' },
-    ];
+    expect((await a.module.mintFungibleToken(HARNESS_COIN, 100n)).success).toBe(true);
+    expect(await waitForBalance(a, 100n)).toBe(100n);
+    const g0 = idOfAmount(a, 100n); // the minted token
 
-    const bal: Record<'a' | 'b' | 'c', bigint> = { a: MINT, b: 0n, c: 0n };
-    for (const hop of hops) {
-      const from = byName[hop.from];
-      const to = byName[hop.to];
-      await from.module.send({ recipient: to.identity.chainPubkey, amount: hop.amt.toString(), coinId: HARNESS_COIN });
-      bal[hop.from] -= hop.amt;
-      bal[hop.to] += hop.amt;
-      // Both endpoints settle to their exact expected balances (a split leaves the sender its
-      // change; a whole/multi-token send leaves it at its remaining total).
-      expect(await waitForBalance(to, bal[hop.to])).toBe(bal[hop.to]);
-      expect(await waitForBalance(from, bal[hop.from])).toBe(bal[hop.from]);
-      // Conservation across ALL THREE wallets at EVERY hop — no value vanishes mid-path.
-      const total =
-        totalOf(await a.client.getBalances()) +
-        totalOf(await b.client.getBalances()) +
-        totalOf(await c.client.getBalances());
-      expect(total).toBe(MINT);
-    }
+    // --- Phase 1: round-trip the WHOLE minted token A→B→A (DIRECT). Genesis id is preserved,
+    // so A re-acquires the SAME token g0. (Pre-fix this is where A loses it.) ---
+    await a.module.send({ recipient: b.identity.chainPubkey, amount: '100', coinId: HARNESS_COIN });
+    expect(await waitForBalance(b, 100n)).toBe(100n);
+    expect(idOfAmount(b, 100n)).toBe(g0); // same token now at B
+    await b.module.send({ recipient: a.identity.chainPubkey, amount: '100', coinId: HARNESS_COIN });
+    expect(await waitForBalance(a, 100n)).toBe(100n);
+    expect(idsOf(a)).toEqual([g0]); // ← A re-acquired the SAME genesis token
 
-    // Path ends at A with the full value, real and spendable; B and C empty.
-    expect(await waitForBalance(a, MINT)).toBe(MINT);
+    // --- Phase 2: SPLIT it (60 to B + 40 change at A). This BURNS g0 and mints two NEW genesis
+    // tokens: g1 (60, at B) and g2 (40, A's change). ---
+    await a.module.send({ recipient: b.identity.chainPubkey, amount: '60', coinId: HARNESS_COIN });
+    expect(await waitForBalance(b, 60n)).toBe(60n);
+    expect(await waitForBalance(a, 40n)).toBe(40n);
+    const g1 = idOfAmount(b, 60n); // split output sent to B
+    const g2 = idOfAmount(a, 40n); // split change kept at A
+    expect(new Set([g0, g1, g2]).size).toBe(3); // split minted brand-new genesis ids
+
+    // --- Phase 3: round-trip the SPLIT OUTPUT g1 (60) whole B→C→A (DIRECT) — A re-acquires g1. ---
+    await b.module.send({ recipient: c.identity.chainPubkey, amount: '60', coinId: HARNESS_COIN });
+    expect(await waitForBalance(c, 60n)).toBe(60n);
+    expect(idOfAmount(c, 60n)).toBe(g1);
+    await c.module.send({ recipient: a.identity.chainPubkey, amount: '60', coinId: HARNESS_COIN });
+    expect(await waitForBalance(a, 100n)).toBe(100n); // A now holds g2(40) + g1(60)
+    expect(idOfAmount(a, 60n)).toBe(g1); // ← A re-acquired the SAME split-output token g1
+    expect(idsOf(a)).toEqual([g1, g2].sort());
+
+    // --- Phase 4: round-trip the OTHER split output g2 (40) whole A→C→A (DIRECT) — A re-acquires g2. ---
+    await a.module.send({ recipient: c.identity.chainPubkey, amount: '40', coinId: HARNESS_COIN });
+    expect(await waitForBalance(c, 40n)).toBe(40n);
+    expect(idOfAmount(c, 40n)).toBe(g2);
+    await c.module.send({ recipient: a.identity.chainPubkey, amount: '40', coinId: HARNESS_COIN });
+    expect(await waitForBalance(a, 100n)).toBe(100n);
+    expect(idOfAmount(a, 40n)).toBe(g2); // ← A re-acquired the SAME split-output token g2
+
+    // End: A holds exactly the two split outputs (60 + 40 = 100); B and C empty; conserved.
+    expect(idsOf(a)).toEqual([g1, g2].sort());
+    expect(a.module.getTokens().reduce((s, t) => s + BigInt(t.amount), 0n)).toBe(100n);
     expect(totalOf(await b.client.getBalances())).toBe(0n);
     expect(totalOf(await c.client.getBalances())).toBe(0n);
-    expect(a.module.getTokens().reduce((s, t) => s + BigInt(t.amount), 0n)).toBe(MINT);
+    const total =
+      totalOf(await a.client.getBalances()) +
+      totalOf(await b.client.getBalances()) +
+      totalOf(await c.client.getBalances());
+    expect(total).toBe(100n);
   }, 600_000);
 });

--- a/tests/harness/support/harness-wallet.ts
+++ b/tests/harness/support/harness-wallet.ts
@@ -245,6 +245,7 @@ export async function createHarnessWallet(opts: HarnessWalletOptions): Promise<H
     ...(opts.webSocketFactory ? { webSocketFactory: opts.webSocketFactory } : {}),
     verifyToken: async (blob: TokenBlob): Promise<boolean> =>
       (await engine.verify(await engine.decodeToken(blob))).ok,
+    isSpent: async (blob: TokenBlob): Promise<boolean> => engine.isSpent(await engine.decodeToken(blob)),
   };
   const providers =
     opts.custody === 'inventory'

--- a/tests/integration/self-send-multitoken.repro.test.ts
+++ b/tests/integration/self-send-multitoken.repro.test.ts
@@ -35,7 +35,8 @@
  *     just-claimed ACTIVE row to removed/unevidenced. Balance drops by 2 and
  *     addKnownSpends() blocks recoverRemoved() from ever resurrecting it.
  *
- * Both tests are EXPECTED TO FAIL on the current code — they are bug repros.
+ * Both tests reproduce the bug: they FAIL on the pre-fix revision (main) and PASS on the
+ * state-aware inventory reconciliation fix. They are regression guards, not xfail tests.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';

--- a/tests/integration/self-send-multitoken.repro.test.ts
+++ b/tests/integration/self-send-multitoken.repro.test.ts
@@ -1,0 +1,310 @@
+/**
+ * REPRO — multi-token SELF-send over the wallet-api mailbox rail (field report,
+ * sphere app @ sdk 0.11.14/0.11.15-dev.1):
+ *
+ *   Wallet holds 58 UCT as three tokens [5, 51, 2]. User sends 6 UCT to their
+ *   OWN nametag. Coin selection (smallest-first) plans:
+ *     - DIRECT-transfer the 2-token  (SAME genesis tokenId, new state), and
+ *     - SPLIT the 5-token into 4 (sent, fresh tokenId) + 1 change.
+ *   Reported: history shows only −6 / +4 (the +2 leg is missing, net −2);
+ *   colleagues additionally report ACTUAL balance loss.
+ *
+ * Mechanism exercised here (deterministically):
+ *   A self-send deposits into the wallet's OWN mailbox. The server fires a §9
+ *   wake at deposit time, so in production the wallet's own incoming pump runs
+ *   DURING the still-executing send (the on-chain split takes seconds). This
+ *   test simulates that wake by draining the mailbox (module.receive()) right
+ *   before the engine.split step — i.e. after the direct leg's deposit but
+ *   before the send's applyDelta/removeToken bookkeeping.
+ *
+ *   - HISTORY loss: handleV2Transfer dedups incoming tokens by genesis id only
+ *     (PaymentsModule.ts ~5218: `this.tokens.has('v2_<id>')`) — the old state
+ *     of the 2-token is still in the map (status 'transferring'), so the
+ *     incoming NEW state is classified 'duplicate', CLAIMED, seen-set forever:
+ *     no RECEIVED +2 history, ever.
+ *   - FUND loss: the claim (intoInventory:true) reactivates the server row for
+ *     the 2-token at its NEW state. The real wallet-api (post-#70, d3c68c9)
+ *     then treats the send's own applyDelta spend of that token as a noop
+ *     (row is at the same-transfer deposit's final state) — this test shims
+ *     that server rule onto the fake, which predates #70 and would otherwise
+ *     tombstone the row one step earlier (same net loss, different line).
+ *     But removeToken() then tombstones the token locally (state-blind), and
+ *     the NEXT provider save's pushRemovals (WalletApiTokenStorageProvider.ts
+ *     ~698-707) pushes spent=[tokenId] — tokenId-matched, no state check —
+ *     under a FRESH transferId with zero deposit evidence, flipping the
+ *     just-claimed ACTIVE row to removed/unevidenced. Balance drops by 2 and
+ *     addKnownSpends() blocks recoverRemoved() from ever resurrecting it.
+ *
+ * Both tests are EXPECTED TO FAIL on the current code — they are bug repros.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  createPaymentsModule,
+  type PaymentsModule,
+  type PaymentsModuleDependencies,
+} from '../../modules/payments/PaymentsModule';
+import type { FullIdentity } from '../../types';
+import type { TransportProvider } from '../../transport';
+import type { OracleProvider } from '../../oracle';
+import type { StorageProvider } from '../../storage';
+import {
+  FakeTokenEngine,
+  decodeFakeTokenAssets,
+  decodeFakeTokenId,
+} from '../unit/token-engine/FakeTokenEngine';
+import { FakeWalletApi } from '../support/fake-wallet-api';
+import { MemoryKeyValueStore, testIdentity } from '../support/wallet-api-test-helpers';
+import { WalletApiClient, type ApplyDeltaRequest } from '../../wallet-api';
+import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../impl/shared/wallet-api';
+import { encodeTokenBlob } from '../../token-engine/token-blob';
+import { hexToBytes } from '../../core/crypto';
+
+const UCT = '11'.repeat(32);
+const SELF = testIdentity(21);
+
+function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIdentity {
+  return {
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
+    transportPubkey: id.chainPubkey.slice(2),
+  };
+}
+
+function mockStorage(): StorageProvider {
+  const s = new Map<string, string>();
+  return {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+}
+
+/** Transport that resolves EVERY recipient to this wallet's own identity — the self-send. */
+function selfTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue({
+      chainPubkey: SELF.chainPubkey,
+      transportPubkey: SELF.chainPubkey.slice(2),
+      directAddress: `DIRECT://${SELF.chainPubkey.slice(0, 12)}`,
+      nametag: 'me',
+    }),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    isDevMode: () => false,
+  } as unknown as OracleProvider;
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!();
+});
+
+interface Wallet {
+  module: PaymentsModule;
+  engine: FakeTokenEngine;
+  client: WalletApiClient;
+}
+
+/** FULL wallet-api preset (custody 'inventory') — the sphere app's composition. */
+function makeSelfWallet(baseUrl: string, network: string, deviceId: string): Wallet {
+  const identity = fullIdentity(SELF);
+  const kv = new MemoryKeyValueStore();
+  const client = new WalletApiClient({ baseUrl, network, deviceId, storage: kv });
+  const tokenStorage = new WalletApiTokenStorageProvider({ client, stateStore: kv });
+  tokenStorage.setIdentity(identity);
+  const delivery = new WalletApiMailboxProvider({ client, custody: 'inventory', stateStore: kv });
+  const engine = new FakeTokenEngine({ chainPubkey: hexToBytes(SELF.chainPubkey) });
+  const deps: PaymentsModuleDependencies = {
+    identity,
+    storage: mockStorage(),
+    tokenStorageProviders: new Map([[tokenStorage.id, tokenStorage]]),
+    transport: selfTransport(),
+    oracle: mockOracle(),
+    emitEvent: vi.fn(),
+    tokenEngine: engine,
+    delivery,
+    walletApi: client,
+  };
+  const module = createPaymentsModule({ l1: null });
+  module.initialize(deps);
+  cleanups.push(() => module.destroy());
+  return { module, engine, client };
+}
+
+async function seedServerToken(fake: FakeWalletApi, wallet: Wallet, amount: bigint): Promise<string> {
+  const minted = await wallet.engine.mint({
+    recipientPubkey: wallet.engine.getIdentity().chainPubkey,
+    value: { assets: [{ coinId: UCT, amount }] },
+  });
+  const bytes = encodeTokenBlob(wallet.engine.encodeToken(minted));
+  const tokenId = wallet.engine.tokenId(minted);
+  fake.seedInventory(SELF.chainPubkey, [{ tokenId, assets: [{ coinId: UCT, amount }], blob: bytes }]);
+  return tokenId;
+}
+
+/**
+ * Shim the wallet-api#70 (d3c68c9) server rule onto the fake, which predates
+ * it: an inventory apply's spend of a token is a NOOP when that token has a
+ * mailbox deposit under the SAME transferId that was already claimed into
+ * inventory (the row sits at the deposit's final state). Without this shim the
+ * fake tombstones the claim-reactivated row at the send's own applyDelta —
+ * same 2-UCT loss, just one step earlier than the real backend.
+ */
+function shimServerNoopForClaimedSameTransferSpends(fake: FakeWalletApi, wallet: Wallet): void {
+  const orig = wallet.client.applyInventoryDelta.bind(wallet.client);
+  wallet.client.applyInventoryDelta = async (req: ApplyDeltaRequest) => {
+    const spent = req.spent.filter((tokenId) => {
+      const entry = fake
+        .listMailboxEntries(SELF.chainPubkey)
+        .find((e) => e.transferId === req.transferId && e.tokenId === tokenId);
+      if (!entry) return true; // no same-transfer deposit → genuine spend
+      const full = fake.getMailboxEntry(SELF.chainPubkey, entry.entryId);
+      const claimedIntoInventory = full?.status === 'claimed' && full.intoInventory === true;
+      if (claimedIntoInventory) {
+        console.log(`[#70 shim] apply(${req.transferId.slice(0, 8)}…): spend of ${tokenId.slice(0, 8)}… is a noop (claimed same-transfer deposit)`);
+      }
+      return !claimedIntoInventory;
+    });
+    // Trace every apply so the row-killing call is visible in the output.
+    if (spent.length > 0 || req.added.length > 0) {
+      console.log(
+        `[apply] transferId=${req.transferId.slice(0, 8)}… spent=[${spent.map((s) => `…${s.slice(-4)}`).join(',')}] added=[${req.added.map((a) => `…${a.tokenId.slice(-4)}`).join(',')}]`
+      );
+    }
+    return orig({ ...req, spent });
+  };
+}
+
+interface ScenarioResult {
+  fake: FakeWalletApi;
+  wallet: Wallet;
+  tokenIds: { t5: string; t51: string; t2: string };
+  sendResult: Awaited<ReturnType<PaymentsModule['send']>>;
+}
+
+async function runSelfSendScenario(deviceId: string): Promise<ScenarioResult> {
+  const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
+  const baseUrl = await fake.start();
+  cleanups.push(() => fake.stop());
+
+  const wallet = makeSelfWallet(baseUrl, fake.network, deviceId);
+  const t5 = await seedServerToken(fake, wallet, 5n);
+  const t51 = await seedServerToken(fake, wallet, 51n);
+  const t2 = await seedServerToken(fake, wallet, 2n);
+  await wallet.module.load();
+
+  // Sanity: 58 across three tokens before the send.
+  expect(await wallet.client.getBalances()).toEqual([{ coinId: UCT, total: 58n, tokenCount: 3 }]);
+
+  shimServerNoopForClaimedSameTransferSpends(fake, wallet);
+
+  // Pin the §9 wake ordering: the direct leg's mailbox deposit (to SELF) has
+  // already landed when engine.split starts; the server wakes this same
+  // wallet's pump immediately and the pump runs during the multi-second
+  // on-chain split. NOTE: this race also fires NATURALLY in this harness —
+  // PaymentsModule.initialize installs the wake subscription
+  // (PaymentsModule.ts ~1354-1360 → handleWake 'mailbox' →
+  // pumpIncomingDeliveries), and the fake's WS wake lands during the send's
+  // own awaits (verified: with SELF_SEND_REPRO_NO_WAKE=1 skipping this hook,
+  // both tests still fail identically). The explicit drain below only makes
+  // the ordering deterministic so the repro cannot rot into flakiness.
+  const origSplit = wallet.engine.split.bind(wallet.engine);
+  const splitSpy = vi.spyOn(wallet.engine, 'split').mockImplementation(async (args, opts) => {
+    if (process.env.SELF_SEND_REPRO_NO_WAKE === '1') return origSplit(args, opts); // natural-race baseline
+    const { transfers } = await wallet.module.receive();
+    console.log(
+      `[wake-during-split] pump stored ${transfers.length} transfer(s); ` +
+      `mailbox=${JSON.stringify(fake.listMailboxEntries(SELF.chainPubkey).map((e) => ({ token: e.tokenId.slice(0, 8), status: e.status })))}`
+    );
+    return origSplit(args, opts);
+  });
+
+  const sendResult = await wallet.module.send({ recipient: '@me', amount: '6', coinId: UCT });
+  splitSpy.mockRestore();
+  expect(sendResult.status).toBe('completed');
+
+  // LOAD-BEARING plan check: the field scenario requires exactly
+  // [direct 2-token, split 5-token → 4 + 1 change]. If selection changed, the
+  // repro would silently test a different shape.
+  const plan = sendResult.tokenTransfers.map((t) => ({ method: t.method, sourceTokenId: t.sourceTokenId }));
+  console.log('[plan]', JSON.stringify(plan));
+  expect(plan).toEqual([
+    { method: 'direct', sourceTokenId: `v2_${t2}` },
+    { method: 'split', sourceTokenId: `v2_${t5}` },
+  ]);
+
+  // Post-send settle: drain the remaining mailbox legs (the split output).
+  await wallet.module.receive();
+  await wallet.module.receive(); // second pass: nothing may remain unprocessed
+
+  return { fake, wallet, tokenIds: { t5, t51, t2 }, sendResult };
+}
+
+function sumHistory(fake: FakeWalletApi, type: 'SENT' | 'RECEIVED'): bigint {
+  return fake
+    .getHistoryRecords(SELF.chainPubkey)
+    .filter((r) => r.type === type)
+    .flatMap((r) => (r.assets as { coinId: string; amount: string }[] | undefined) ?? [])
+    .filter((a) => a.coinId === UCT)
+    .reduce((s, a) => s + BigInt(a.amount), 0n);
+}
+
+describe('self-send of 6 from [5, 51, 2] over the wallet-api mailbox rail (field repro)', () => {
+  it('Test A (history): the transfer nets to 0 in history — a −6 SENT matched by +6 of incoming records', async () => {
+    const { fake } = await runSelfSendScenario('d-selfsend-history');
+
+    const records = fake.getHistoryRecords(SELF.chainPubkey).map((r) => ({
+      type: r.type,
+      dedupKey: r.dedupKey,
+      assets: r.assets,
+    }));
+    console.log('[history]', JSON.stringify(records, null, 2));
+
+    const sent = sumHistory(fake, 'SENT');
+    const received = sumHistory(fake, 'RECEIVED');
+    console.log(`[history] sent=${sent} received=${received} net=${received - sent}`);
+
+    expect(sent).toBe(6n); // the aggregate −6 SENT record (works today)
+    // FIELD BUG: only +4 (split leg) is recorded; the +2 direct leg is
+    // swallowed by the genesis-id-only 'duplicate' verdict → net history −2.
+    expect(received).toBe(6n);
+  });
+
+  it('Test B (funds): inventory still holds 58 and the direct-leg 2-token is present and spendable', async () => {
+    const { fake, wallet, tokenIds } = await runSelfSendScenario('d-selfsend-funds');
+
+    const row2 = fake.getRow(SELF.chainPubkey, tokenIds.t2);
+    const localTotal = wallet.module
+      .getTokens()
+      .filter((t) => t.coinId === UCT)
+      .reduce((s, t) => s + BigInt(t.amount || '0'), 0n);
+    const balances = await wallet.client.getBalances();
+    console.log('[inventory] row2 =', JSON.stringify(row2));
+    console.log('[inventory] server balances =', JSON.stringify(balances, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)));
+    console.log('[inventory] local token total =', localTotal.toString());
+
+    // FIELD BUG (fund loss): the wallet's own pushRemovals (state-blind,
+    // fresh transferId, no deposit evidence) re-kills the claim-reactivated
+    // row of the direct leg → server flips it removed/unevidenced, balance 56.
+    expect(row2).toMatchObject({ status: 'active' });
+    expect(balances).toEqual([{ coinId: UCT, total: 58n, tokenCount: expect.any(Number) }]);
+    expect(localTotal).toBe(58n);
+  });
+});

--- a/tests/integration/self-send-roundtrip.repro.test.ts
+++ b/tests/integration/self-send-roundtrip.repro.test.ts
@@ -1,0 +1,284 @@
+/**
+ * BLAST-RADIUS PROBE — is the multi-token SELF-send fund-loss bug
+ * (tests/integration/self-send-multitoken.repro.test.ts) STRICTLY confined to
+ * self-sends, or does a NON-self round-trip A→B→A trigger the identical
+ * state-blind, evidence-free pushRemovals kill?
+ *
+ * The confirmed self-send loss chain (sdk 0.11.14, wallet-api inventory custody):
+ *   1. send() DIRECT-transfers a token X (same genesis tokenId, new state) and
+ *      calls removeToken(X) → a LOCAL tombstone (X.tokenId, X.oldStateHash) that
+ *      lives in PaymentsModule.tombstones (PaymentsModule.ts:2287, :3892-3913).
+ *   2. X's server inventory row is REACTIVATED to 'active' (a mailbox claim that
+ *      handed X back — self-send: own pump; round-trip: the return claim —
+ *      fake-wallet-api.ts performClaimHandoff :1538-1556).
+ *   3. The NEXT save() serializes tombstones into data._tombstones
+ *      (PaymentsModule.ts:6695) and WalletApiTokenStorageProvider.save()
+ *      →pushRemovals (:698-706) DROPS the stateHash (:636) and pushes
+ *      spent=[X.tokenId] under a FRESH newTransferId() with ZERO deposit
+ *      evidence, because it matches X by tokenId ONLY and sees the server row is
+ *      'active'. The fake flips it removed/'unevidenced'
+ *      (fake-wallet-api.ts removalFor :1086-1090) → permanent loss;
+ *      addKnownSpends (:706) then blocks recoverRemoved (:540-541).
+ *
+ * THE OPEN QUESTION probed here: A sends X to a DIFFERENT wallet B (ordinary
+ * direct transfer; X keeps its genesis tokenId). Later B sends the same X back
+ * to A. When A re-claims X, A's inventory row for X reactivates. A's STALE local
+ * tombstone for X — left from A's original outbound send, never reconciled in a
+ * single session — is still in PaymentsModule.tombstones. Does the next save()
+ * collide it with the reactivated 'active' row and fire the same kill?
+ *
+ * The scenario below drives A→B→A with two distinct wallets over ONE shared
+ * FakeWalletApi (real mailbox/inventory between them), then FORCES a save() on A
+ * and asserts A's server row for X and A's balance. The assertions encode the
+ * NO-LOSS expectation, so a FAILURE here means the loss is NOT self-send-specific.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  createPaymentsModule,
+  type PaymentsModule,
+  type PaymentsModuleDependencies,
+} from '../../modules/payments/PaymentsModule';
+import type { FullIdentity } from '../../types';
+import type { TransportProvider, PeerInfo } from '../../transport';
+import type { OracleProvider } from '../../oracle';
+import type { StorageProvider } from '../../storage';
+import {
+  FakeTokenEngine,
+  decodeFakeTokenAssets,
+  decodeFakeTokenId,
+} from '../unit/token-engine/FakeTokenEngine';
+import { FakeWalletApi } from '../support/fake-wallet-api';
+import { MemoryKeyValueStore, testIdentity } from '../support/wallet-api-test-helpers';
+import { WalletApiClient } from '../../wallet-api';
+import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../impl/shared/wallet-api';
+import { encodeTokenBlob } from '../../token-engine/token-blob';
+import { hexToBytes } from '../../core/crypto';
+
+const UCT = '11'.repeat(32);
+const A = testIdentity(31);
+const B = testIdentity(32);
+
+function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIdentity {
+  return {
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
+    transportPubkey: id.chainPubkey.slice(2),
+  };
+}
+
+function mockStorage(): StorageProvider {
+  const s = new Map<string, string>();
+  return {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+}
+
+/** Transport that resolves EVERY recipient to a FIXED target identity (A→B, B→A). */
+function transportTo(target: { chainPubkey: string }): TransportProvider {
+  const peer: PeerInfo = {
+    chainPubkey: target.chainPubkey,
+    transportPubkey: target.chainPubkey.slice(2),
+    directAddress: `DIRECT://${target.chainPubkey.slice(0, 12)}`,
+    nametag: 'peer',
+    timestamp: Date.now(),
+  };
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue(peer),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    isDevMode: () => false,
+  } as unknown as OracleProvider;
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!();
+});
+
+interface Wallet {
+  module: PaymentsModule;
+  engine: FakeTokenEngine;
+  client: WalletApiClient;
+  identity: FullIdentity;
+}
+
+/** FULL wallet-api preset (custody 'inventory') — the sphere app's composition. */
+function makeWallet(
+  baseUrl: string,
+  network: string,
+  deviceId: string,
+  who: { privateKey: string; chainPubkey: string },
+  target: { chainPubkey: string },
+): Wallet {
+  const identity = fullIdentity(who);
+  const kv = new MemoryKeyValueStore();
+  const client = new WalletApiClient({ baseUrl, network, deviceId, storage: kv });
+  const tokenStorage = new WalletApiTokenStorageProvider({ client, stateStore: kv });
+  tokenStorage.setIdentity(identity);
+  const delivery = new WalletApiMailboxProvider({ client, custody: 'inventory', stateStore: kv });
+  const engine = new FakeTokenEngine({ chainPubkey: hexToBytes(who.chainPubkey) });
+  const deps: PaymentsModuleDependencies = {
+    identity,
+    storage: mockStorage(),
+    tokenStorageProviders: new Map([[tokenStorage.id, tokenStorage]]),
+    transport: transportTo(target),
+    oracle: mockOracle(),
+    emitEvent: vi.fn(),
+    tokenEngine: engine,
+    delivery,
+    walletApi: client,
+  };
+  const module = createPaymentsModule({ l1: null });
+  module.initialize(deps);
+  cleanups.push(() => module.destroy());
+  return { module, engine, client, identity };
+}
+
+async function seedServerToken(fake: FakeWalletApi, wallet: Wallet, amount: bigint): Promise<string> {
+  const minted = await wallet.engine.mint({
+    recipientPubkey: wallet.engine.getIdentity().chainPubkey,
+    value: { assets: [{ coinId: UCT, amount }] },
+  });
+  const bytes = encodeTokenBlob(wallet.engine.encodeToken(minted));
+  const tokenId = wallet.engine.tokenId(minted);
+  fake.seedInventory(wallet.identity.chainPubkey, [{ tokenId, assets: [{ coinId: UCT, amount }], blob: bytes }]);
+  return tokenId;
+}
+
+function balanceOf(client: WalletApiClient): Promise<{ coinId: string; total: bigint; tokenCount: number }[]> {
+  return client.getBalances();
+}
+
+describe('A→B→A round-trip of a single direct-transferable token over the wallet-api mailbox rail', () => {
+  it('does NOT lose funds: A re-claims X, and a forced save() must not re-kill the reactivated row', async () => {
+    const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
+    const baseUrl = await fake.start();
+    cleanups.push(() => fake.stop());
+
+    const walletA = makeWallet(baseUrl, fake.network, 'd-rt-A', A, B);
+    const walletB = makeWallet(baseUrl, fake.network, 'd-rt-B', B, A);
+
+    // Trace EVERY inventory apply A issues, so the killing call is visible in the
+    // output: its transferId is a FRESH uuid (not A's send transferId) and it
+    // carries spent=[X] with added=[] and zero mailbox deposit → the fake scores
+    // the removal 'unevidenced' (fake-wallet-api.ts removalFor :1086-1090).
+    const applies: { transferId: string; spent: string[]; added: number }[] = [];
+    const origApply = walletA.client.applyInventoryDelta.bind(walletA.client);
+    walletA.client.applyInventoryDelta = async (req) => {
+      applies.push({ transferId: req.transferId, spent: [...req.spent], added: req.added.length });
+      if (req.spent.length > 0 || req.added.length > 0) {
+        console.log(
+          `[A apply] transferId=${req.transferId.slice(0, 8)}… spent=[${req.spent.map((s) => `…${s.slice(-4)}`).join(',')}] added=${req.added.length}`
+        );
+      }
+      return origApply(req);
+    };
+
+    // A holds a single 10-UCT token X (direct-transferable — exact-amount send
+    // takes the DIRECT path, so X keeps its genesis tokenId through the trip).
+    const X = await seedServerToken(fake, walletA, 10n);
+    await walletA.module.load();
+    await walletB.module.load();
+
+    expect(await balanceOf(walletA.client)).toEqual([{ coinId: UCT, total: 10n, tokenCount: 1 }]);
+    expect(await balanceOf(walletB.client)).toEqual([]);
+    console.log(`[setup] X=${X.slice(0, 12)}… A=${A.chainPubkey.slice(0, 10)}… B=${B.chainPubkey.slice(0, 10)}…`);
+
+    // ── Leg 1: A sends X to @B (direct). ──────────────────────────────────────
+    const sendAB = await walletA.module.send({ recipient: '@B', amount: '10', coinId: UCT });
+    expect(sendAB.status).toBe('completed');
+    const planAB = sendAB.tokenTransfers.map((t) => ({ method: t.method, sourceTokenId: t.sourceTokenId }));
+    console.log('[leg1 A→B plan]', JSON.stringify(planAB));
+    expect(planAB).toEqual([{ method: 'direct', sourceTokenId: `v2_${X}` }]); // load-bearing: must be a DIRECT transfer of X
+
+    // A's tombstone for X is created HERE (removeToken after the server apply,
+    // PaymentsModule.ts:2287) and — the crux of this probe — is never reconciled
+    // away in a single session.
+    const tombstonesAfterLeg1 = walletA.module.getTombstones().map((t) => t.tokenId);
+    console.log('[leg1] A tombstones =', JSON.stringify(tombstonesAfterLeg1.map((t) => t.slice(0, 12))));
+    expect(tombstonesAfterLeg1).toContain(X);
+
+    console.log('[leg1] A row(X) =', JSON.stringify(fake.getRow(A.chainPubkey, X)));
+
+    // ── B claims X. ───────────────────────────────────────────────────────────
+    await walletB.module.receive();
+    await walletB.module.receive(); // settle
+    console.log('[leg1] B row(X) =', JSON.stringify(fake.getRow(B.chainPubkey, X)));
+    expect(await balanceOf(walletB.client)).toEqual([{ coinId: UCT, total: 10n, tokenCount: 1 }]);
+    expect(await balanceOf(walletA.client)).toEqual([]); // A gave X away
+
+    // ── Leg 2: B sends X back to @A (direct — same genesis tokenId, new state). ─
+    const sendBA = await walletB.module.send({ recipient: '@A', amount: '10', coinId: UCT });
+    expect(sendBA.status).toBe('completed');
+    const planBA = sendBA.tokenTransfers.map((t) => ({ method: t.method, sourceTokenId: t.sourceTokenId }));
+    console.log('[leg2 B→A plan]', JSON.stringify(planBA));
+    expect(planBA).toEqual([{ method: 'direct', sourceTokenId: `v2_${X}` }]);
+
+    // ── A re-claims X (return trip). This REACTIVATES A's inventory row for X. ─
+    await walletA.module.receive();
+    await walletA.module.receive(); // settle
+
+    const rowBeforeSave = fake.getRow(A.chainPubkey, X);
+    const balBeforeSave = await balanceOf(walletA.client);
+    const tombstonesBeforeSave = walletA.module.getTombstones().map((t) => t.tokenId);
+    console.log('[return] A row(X) BEFORE forced save =', JSON.stringify(rowBeforeSave));
+    console.log('[return] A balances BEFORE forced save =', JSON.stringify(balBeforeSave, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)));
+    console.log('[return] A still tombstones X? =', tombstonesBeforeSave.includes(X), JSON.stringify(tombstonesBeforeSave.map((t) => t.slice(0, 12))));
+
+    // Precondition for the probe: X came back (row reactivated) AND A still
+    // carries the stale tombstone for X.tokenId. If either is false the probe is
+    // vacuous — assert both so a fixture accident cannot masquerade as "no loss".
+    expect(rowBeforeSave).toMatchObject({ status: 'active' });
+    expect(balBeforeSave).toEqual([{ coinId: UCT, total: 10n, tokenCount: 1 }]);
+    expect(tombstonesBeforeSave).toContain(X);
+
+    // ── Force ONE more save() on A — the same private persist the module runs
+    // after every mutation (createStorageData → provider.save → syncInventory →
+    // pushRemovals). If the round-trip shares the self-send mechanism, THIS is
+    // where the state-blind, evidence-free spent=[X] push fires.
+    await (walletA.module as unknown as { save(): Promise<void> }).save();
+
+    const rowAfterSave = fake.getRow(A.chainPubkey, X);
+    const balAfterSave = await balanceOf(walletA.client);
+
+    // The killing apply: the LAST spent=[X] push. Show it is a fresh transferId,
+    // distinct from A's original leg-1 send apply (evidence-free re-kill).
+    const spendsOfX = applies.filter((a) => a.spent.includes(X));
+    console.log('[return] A applies that spent X =', JSON.stringify(spendsOfX.map((a) => ({ tid: a.transferId.slice(0, 8), added: a.added }))));
+    console.log('[return] A row(X) AFTER forced save =', JSON.stringify(rowAfterSave));
+    console.log('[return] A balances AFTER forced save =', JSON.stringify(balAfterSave, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)));
+
+    // Conservation across the two wallets (X lives in exactly one place).
+    const bBal = await balanceOf(walletB.client);
+    const total =
+      (balAfterSave.find((x) => x.coinId === UCT)?.total ?? 0n) +
+      (bBal.find((x) => x.coinId === UCT)?.total ?? 0n);
+    console.log(`[return] conserved total across A+B = ${total} (expect 10)`);
+
+    // NO-LOSS expectation: X ends ACTIVE under A, A's balance is 10, total conserved.
+    // A FAILURE here (row removed/'unevidenced', balance 0) proves the loss is
+    // NOT confined to self-sends.
+    expect(rowAfterSave).toMatchObject({ status: 'active' });
+    expect(balAfterSave).toEqual([{ coinId: UCT, total: 10n, tokenCount: 1 }]);
+    expect(total).toBe(10n);
+  });
+});

--- a/tests/integration/self-send-variants.repro.test.ts
+++ b/tests/integration/self-send-variants.repro.test.ts
@@ -1,0 +1,396 @@
+/**
+ * REPRO — BLAST-RADIUS map of the self-send money-loss bug (sdk 0.11.14).
+ *
+ * The confirmed bug (tests/integration/self-send-multitoken.repro.test.ts): a
+ * MULTI-token self-send (6 from [5,51,2]) loses the whole-token DIRECT leg. The
+ * direct leg reuses the SAME genesis tokenId (new state), is deposited to the
+ * wallet's OWN mailbox, the wallet's own pump claims it back REACTIVATING the
+ * server row at the new state, and then a state-blind, evidence-free
+ * pushRemovals (WalletApiTokenStorageProvider.ts:698-707; the stateHash is
+ * dropped at :636) re-kills the just-reactivated row under a fresh transferId.
+ * recoverRemoved is then blocked by the tokenId-keyed knownSpends (:541,:706).
+ *
+ * This file maps which OTHER self-send shapes lose funds, reusing the exact
+ * multitoken harness (FakeWalletApi, custody 'inventory', transport.resolve
+ * pinned to SELF, the #70 server-noop shim). Variants:
+ *
+ *   V1  — single-token WHOLE self-send (hold [10], send 10, pure direct, NO split)
+ *   V2  — partial single-token self-send (hold [10], send 4 → split 10→4+6)
+ *   V3  — repeated self-send round-trip (a self-send, settle, then a SECOND one)
+ *
+ * For each: assert (a) balance conserved and (b) no inventory row ends
+ * removed/unevidenced. A FAILING assertion == the loss reproduced.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  createPaymentsModule,
+  type PaymentsModule,
+  type PaymentsModuleDependencies,
+} from '../../modules/payments/PaymentsModule';
+import type { FullIdentity } from '../../types';
+import type { TransportProvider } from '../../transport';
+import type { OracleProvider } from '../../oracle';
+import type { StorageProvider } from '../../storage';
+import {
+  FakeTokenEngine,
+  decodeFakeTokenAssets,
+  decodeFakeTokenId,
+} from '../unit/token-engine/FakeTokenEngine';
+import { FakeWalletApi } from '../support/fake-wallet-api';
+import { MemoryKeyValueStore, testIdentity } from '../support/wallet-api-test-helpers';
+import { WalletApiClient, type ApplyDeltaRequest } from '../../wallet-api';
+import { WalletApiMailboxProvider, WalletApiTokenStorageProvider } from '../../impl/shared/wallet-api';
+import { encodeTokenBlob } from '../../token-engine/token-blob';
+import { hexToBytes } from '../../core/crypto';
+
+const UCT = '11'.repeat(32);
+const SELF = testIdentity(21);
+
+function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIdentity {
+  return {
+    chainPubkey: id.chainPubkey,
+    privateKey: id.privateKey,
+    directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
+    transportPubkey: id.chainPubkey.slice(2),
+  };
+}
+
+function mockStorage(): StorageProvider {
+  const s = new Map<string, string>();
+  return {
+    id: 's', name: 's', type: 'local', connect: vi.fn(), disconnect: vi.fn(),
+    isConnected: () => true, getStatus: () => 'connected', setIdentity: vi.fn(),
+    get: vi.fn(async (k: string) => s.get(k) ?? null),
+    set: vi.fn(async (k: string, v: string) => { s.set(k, v); }),
+    remove: vi.fn(async (k: string) => { s.delete(k); }),
+    has: vi.fn(async (k: string) => s.has(k)),
+    keys: vi.fn(async () => [...s.keys()]),
+    clear: vi.fn(async () => { s.clear(); }),
+  } as unknown as StorageProvider;
+}
+
+/** Transport that resolves EVERY recipient to this wallet's own identity — the self-send. */
+function selfTransport(): TransportProvider {
+  return {
+    sendTokenTransfer: vi.fn().mockResolvedValue(undefined),
+    onTokenTransfer: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequest: vi.fn().mockReturnValue(() => {}),
+    onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
+    resolve: vi.fn().mockResolvedValue({
+      chainPubkey: SELF.chainPubkey,
+      transportPubkey: SELF.chainPubkey.slice(2),
+      directAddress: `DIRECT://${SELF.chainPubkey.slice(0, 12)}`,
+      nametag: 'me',
+    }),
+    resolveTransportPubkeyInfo: vi.fn().mockResolvedValue(null),
+    connect: vi.fn().mockResolvedValue(undefined), disconnect: vi.fn(), isConnected: () => true,
+  } as unknown as TransportProvider;
+}
+
+function mockOracle(): OracleProvider {
+  return {
+    validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    isDevMode: () => false,
+  } as unknown as OracleProvider;
+}
+
+const cleanups: (() => Promise<void> | void)[] = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()!();
+});
+
+interface Wallet {
+  module: PaymentsModule;
+  engine: FakeTokenEngine;
+  client: WalletApiClient;
+}
+
+/** FULL wallet-api preset (custody 'inventory') — the sphere app's composition. */
+function makeSelfWallet(baseUrl: string, network: string, deviceId: string): Wallet {
+  const identity = fullIdentity(SELF);
+  const kv = new MemoryKeyValueStore();
+  const client = new WalletApiClient({ baseUrl, network, deviceId, storage: kv });
+  const tokenStorage = new WalletApiTokenStorageProvider({ client, stateStore: kv });
+  tokenStorage.setIdentity(identity);
+  const delivery = new WalletApiMailboxProvider({ client, custody: 'inventory', stateStore: kv });
+  const engine = new FakeTokenEngine({ chainPubkey: hexToBytes(SELF.chainPubkey) });
+  const deps: PaymentsModuleDependencies = {
+    identity,
+    storage: mockStorage(),
+    tokenStorageProviders: new Map([[tokenStorage.id, tokenStorage]]),
+    transport: selfTransport(),
+    oracle: mockOracle(),
+    emitEvent: vi.fn(),
+    tokenEngine: engine,
+    delivery,
+    walletApi: client,
+  };
+  const module = createPaymentsModule({ l1: null });
+  module.initialize(deps);
+  cleanups.push(() => module.destroy());
+  return { module, engine, client };
+}
+
+async function seedServerToken(fake: FakeWalletApi, wallet: Wallet, amount: bigint): Promise<string> {
+  const minted = await wallet.engine.mint({
+    recipientPubkey: wallet.engine.getIdentity().chainPubkey,
+    value: { assets: [{ coinId: UCT, amount }] },
+  });
+  const bytes = encodeTokenBlob(wallet.engine.encodeToken(minted));
+  const tokenId = wallet.engine.tokenId(minted);
+  fake.seedInventory(SELF.chainPubkey, [{ tokenId, assets: [{ coinId: UCT, amount }], blob: bytes }]);
+  return tokenId;
+}
+
+/**
+ * Shim the wallet-api#70 (d3c68c9) server rule onto the fake, which predates
+ * it: an inventory apply's spend of a token is a NOOP when that token has a
+ * mailbox deposit under the SAME transferId that was already claimed into
+ * inventory (the row sits at the deposit's final state). Optionally also drains
+ * the mailbox ONCE right before the send's own apply — reproducing the §9
+ * wake's incoming pump claiming the direct-leg deposit DURING the still-running
+ * send (the multitoken repro pins the identical ordering inside engine.split;
+ * a whole self-send has no split to hook, so we hook the apply instead).
+ */
+function shimServer(
+  fake: FakeWalletApi,
+  wallet: Wallet,
+  opts: { drainBeforeFirstSpendApply?: boolean } = {}
+): void {
+  const orig = wallet.client.applyInventoryDelta.bind(wallet.client);
+  let drained = false;
+  wallet.client.applyInventoryDelta = async (req: ApplyDeltaRequest) => {
+    // One-shot pre-apply drain: only before the send's OWN apply (it carries
+    // spent tokens); pushRemovals/pushAdditions applies carry no spent+deposit.
+    if (opts.drainBeforeFirstSpendApply && !drained && req.spent.length > 0) {
+      drained = true; // set BEFORE receive() so a reentrant apply cannot re-drain
+      const { transfers } = await wallet.module.receive();
+      console.log(
+        `[wake-before-apply] pump stored ${transfers.length}; ` +
+        `mailbox=${JSON.stringify(fake.listMailboxEntries(SELF.chainPubkey).map((e) => ({ token: e.tokenId.slice(0, 6), status: e.status })))}`
+      );
+    }
+    const spent = req.spent.filter((tokenId) => {
+      const entry = fake
+        .listMailboxEntries(SELF.chainPubkey)
+        .find((e) => e.transferId === req.transferId && e.tokenId === tokenId);
+      if (!entry) return true; // no same-transfer deposit → genuine spend
+      const full = fake.getMailboxEntry(SELF.chainPubkey, entry.entryId);
+      const claimedIntoInventory = full?.status === 'claimed' && full.intoInventory === true;
+      if (claimedIntoInventory) {
+        console.log(`[#70 shim] apply(${req.transferId.slice(0, 8)}…): spend of ${tokenId.slice(0, 6)}… is a noop (claimed same-transfer deposit)`);
+      }
+      return !claimedIntoInventory;
+    });
+    if (spent.length > 0 || req.added.length > 0) {
+      console.log(
+        `[apply] transferId=${req.transferId.slice(0, 8)}… spent=[${spent.map((s) => `…${s.slice(-4)}`).join(',')}] added=[${req.added.map((a) => `…${a.tokenId.slice(-4)}`).join(',')}]`
+      );
+    }
+    return orig({ ...req, spent });
+  };
+}
+
+/** Pin the §9 wake into the middle of engine.split (like the multitoken repro). */
+function drainDuringSplit(wallet: Wallet): void {
+  const origSplit = wallet.engine.split.bind(wallet.engine);
+  vi.spyOn(wallet.engine, 'split').mockImplementation(async (args, options) => {
+    const { transfers } = await wallet.module.receive();
+    console.log(`[wake-during-split] pump stored ${transfers.length} transfer(s)`);
+    return origSplit(args, options);
+  });
+}
+
+function sumHistory(fake: FakeWalletApi, type: 'SENT' | 'RECEIVED'): bigint {
+  return fake
+    .getHistoryRecords(SELF.chainPubkey)
+    .filter((r) => r.type === type)
+    .flatMap((r) => (r.assets as { coinId: string; amount: string }[] | undefined) ?? [])
+    .filter((a) => a.coinId === UCT)
+    .reduce((s, a) => s + BigInt(a.amount), 0n);
+}
+
+async function balances(wallet: Wallet): Promise<{ coinId: string; total: bigint; tokenCount: number }[]> {
+  return wallet.client.getBalances();
+}
+
+function localTotal(wallet: Wallet): bigint {
+  return wallet.module
+    .getTokens()
+    .filter((t) => t.coinId === UCT)
+    .reduce((s, t) => s + BigInt(t.amount || '0'), 0n);
+}
+
+/** Every server row's status/removal — the inventory-truth we assert against. */
+function serverRows(fake: FakeWalletApi, tokenIds: string[]): Record<string, { status: string; removal?: string } | null> {
+  const out: Record<string, { status: string; removal?: string } | null> = {};
+  for (const id of tokenIds) out[id.slice(0, 8)] = fake.getRow(SELF.chainPubkey, id);
+  return out;
+}
+
+// =============================================================================
+// V1 — single-token WHOLE self-send (pure direct transfer, NO split)
+// =============================================================================
+
+describe('V1 — WHOLE single-token self-send (hold [10], send 10; pure direct, no split)', () => {
+  async function setup(deviceId: string, drainBeforeFirstSpendApply: boolean) {
+    const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
+    const baseUrl = await fake.start();
+    cleanups.push(() => fake.stop());
+    const wallet = makeSelfWallet(baseUrl, fake.network, deviceId);
+    const t10 = await seedServerToken(fake, wallet, 10n);
+    await wallet.module.load();
+    expect(await balances(wallet)).toEqual([{ coinId: UCT, total: 10n, tokenCount: 1 }]);
+    shimServer(fake, wallet, { drainBeforeFirstSpendApply });
+
+    const sendResult = await wallet.module.send({ recipient: '@me', amount: '10', coinId: UCT });
+    expect(sendResult.status).toBe('completed');
+
+    // LOAD-BEARING plan check: pure whole-token direct, NO split.
+    const plan = sendResult.tokenTransfers.map((t) => ({ method: t.method, sourceTokenId: t.sourceTokenId }));
+    console.log('[V1 plan]', JSON.stringify(plan));
+    expect(plan).toEqual([{ method: 'direct', sourceTokenId: `v2_${t10}` }]);
+
+    // Row status the instant send() returns (before any post-send drain): tells
+    // us whether the kill landed DURING the send (natural mid-send wake) or only
+    // once the post-send drain reactivates + re-kills the row.
+    console.log('[V1 right after send()] row =', JSON.stringify(fake.getRow(SELF.chainPubkey, t10)),
+      'mailbox =', JSON.stringify(fake.listMailboxEntries(SELF.chainPubkey).map((e) => ({ t: e.tokenId.slice(0, 6), s: e.status }))));
+
+    // Post-send settle: drain the direct-leg deposit back into inventory.
+    await wallet.module.receive();
+    console.log('[V1 after receive#1] row =', JSON.stringify(fake.getRow(SELF.chainPubkey, t10)));
+    await wallet.module.receive();
+
+    console.log('[V1] server rows =', JSON.stringify(serverRows(fake, [t10])));
+    console.log('[V1] balances =', JSON.stringify(await balances(wallet), (_k, v) => (typeof v === 'bigint' ? v.toString() : v)));
+    console.log('[V1] localTotal =', localTotal(wallet).toString());
+    console.log(`[V1] history SENT=${sumHistory(fake, 'SENT')} RECEIVED=${sumHistory(fake, 'RECEIVED')}`);
+    return { fake, wallet, t10 };
+  }
+
+  // NB: empirically the natural §9 wake pump claims the direct-leg deposit
+  // DURING the send (the row is already removed/unevidenced the instant send()
+  // returns — see the "[V1 right after send()]" log), so this needs NO
+  // test-imposed drain to reproduce. That is the field condition.
+  it('V1a (natural §9 wake — no test-imposed drain): funds conserved, row not removed/unevidenced', async () => {
+    const { fake, wallet, t10 } = await setup('v1a-natural', false);
+    const row = fake.getRow(SELF.chainPubkey, t10);
+    expect(row).not.toMatchObject({ status: 'removed', removal: 'unevidenced' });
+    expect(await balances(wallet)).toEqual([{ coinId: UCT, total: 10n, tokenCount: expect.any(Number) }]);
+    expect(localTotal(wallet)).toBe(10n);
+  });
+
+  it('V1b (§9 wake claims DURING the send — mid-send ordering): funds conserved, row not removed/unevidenced', async () => {
+    const { fake, wallet, t10 } = await setup('v1b-midsend', true);
+    const row = fake.getRow(SELF.chainPubkey, t10);
+    expect(row).not.toMatchObject({ status: 'removed', removal: 'unevidenced' });
+    expect(await balances(wallet)).toEqual([{ coinId: UCT, total: 10n, tokenCount: expect.any(Number) }]);
+    expect(localTotal(wallet)).toBe(10n);
+  });
+});
+
+// =============================================================================
+// V2 — partial single-token self-send (split 10 → 4 sent + 6 change; NO direct)
+// =============================================================================
+
+describe('V2 — PARTIAL single-token self-send (hold [10], send 4 → split 10→4+6; no direct leg)', () => {
+  it('funds conserved, no row removed/unevidenced, and the +4 split leg IS recorded in history', async () => {
+    const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
+    const baseUrl = await fake.start();
+    cleanups.push(() => fake.stop());
+    const wallet = makeSelfWallet(baseUrl, fake.network, 'v2-partial');
+    const t10 = await seedServerToken(fake, wallet, 10n);
+    await wallet.module.load();
+    expect(await balances(wallet)).toEqual([{ coinId: UCT, total: 10n, tokenCount: 1 }]);
+    shimServer(fake, wallet);
+    drainDuringSplit(wallet); // §9 wake pump runs during the on-chain split (faithful ordering)
+
+    const sendResult = await wallet.module.send({ recipient: '@me', amount: '4', coinId: UCT });
+    expect(sendResult.status).toBe('completed');
+
+    // LOAD-BEARING plan check: a PURE split (no whole-token direct leg).
+    const plan = sendResult.tokenTransfers.map((t) => ({ method: t.method, sourceTokenId: t.sourceTokenId }));
+    console.log('[V2 plan]', JSON.stringify(plan));
+    expect(plan).toEqual([{ method: 'split', sourceTokenId: `v2_${t10}` }]);
+
+    // Post-send settle: claim the +4 split-output leg from own mailbox.
+    await wallet.module.receive();
+    await wallet.module.receive();
+
+    const bals = await balances(wallet);
+    console.log('[V2] server row(source) =', JSON.stringify(fake.getRow(SELF.chainPubkey, t10)));
+    console.log('[V2] balances =', JSON.stringify(bals, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)));
+    console.log('[V2] localTotal =', localTotal(wallet).toString());
+    const received = sumHistory(fake, 'RECEIVED');
+    console.log(`[V2] history SENT=${sumHistory(fake, 'SENT')} RECEIVED=${received}`);
+
+    // No server row ends removed/unevidenced; funds conserved.
+    expect(fake.getRow(SELF.chainPubkey, t10)).not.toMatchObject({ status: 'removed', removal: 'unevidenced' });
+    expect(await balances(wallet)).toEqual([{ coinId: UCT, total: 10n, tokenCount: expect.any(Number) }]);
+    expect(localTotal(wallet)).toBe(10n);
+    // The +4 self-claim must be recorded (fresh split-output tokenId — not swallowed as a genesis-id duplicate).
+    expect(received).toBe(4n);
+  });
+});
+
+// =============================================================================
+// V3 — repeated self-send round-trip: a multi-token self-send, settle/drain,
+// then a SECOND self-send reusing the now-current (round-tripped, fresh-id)
+// tokens. Does the second send lose its whole-token direct legs too?
+// =============================================================================
+
+/** Genesis id of every ACTIVE local token → its server row status. */
+function localRows(fake: FakeWalletApi, wallet: Wallet): Record<string, { status: string; removal?: string } | null> {
+  const out: Record<string, { status: string; removal?: string } | null> = {};
+  for (const t of wallet.module.getTokens()) {
+    const genesis = t.id.startsWith('v2_') ? t.id.slice(3) : t.id;
+    out[`${genesis.slice(0, 6)}(${t.amount})`] = fake.getRow(SELF.chainPubkey, genesis);
+  }
+  return out;
+}
+
+describe('V3 — REPEATED self-send (multi-token self-send, settle, then self-send the survivors)', () => {
+  it('a second self-send of the round-tripped tokens loses its whole-direct legs too (compounding loss)', async () => {
+    const fake = new FakeWalletApi({ decodeAssets: decodeFakeTokenAssets, decodeTokenId: decodeFakeTokenId });
+    const baseUrl = await fake.start();
+    cleanups.push(() => fake.stop());
+    const wallet = makeSelfWallet(baseUrl, fake.network, 'v3-repeated');
+    await seedServerToken(fake, wallet, 5n);
+    await seedServerToken(fake, wallet, 51n);
+    await seedServerToken(fake, wallet, 2n);
+    await wallet.module.load();
+    expect(await balances(wallet)).toEqual([{ coinId: UCT, total: 58n, tokenCount: 3 }]);
+    shimServer(fake, wallet);
+    drainDuringSplit(wallet); // faithful §9-wake ordering, as in the multitoken repro
+
+    // ── First self-send: 6 from [5,51,2] (direct 2 + split 5→4+1) — the known loss ─
+    const first = await wallet.module.send({ recipient: '@me', amount: '6', coinId: UCT });
+    expect(first.status).toBe('completed');
+    console.log('[V3 first plan]', JSON.stringify(first.tokenTransfers.map((t) => ({ method: t.method }))));
+    await wallet.module.receive();
+    await wallet.module.receive();
+    const afterFirst = await balances(wallet);
+    console.log('[V3 after first] balances =', JSON.stringify(afterFirst, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)),
+      'localTotal =', localTotal(wallet).toString(), 'rows =', JSON.stringify(localRows(fake, wallet)));
+
+    // ── Second self-send: 4 from the survivors — reuses the round-tripped +4
+    // self-claim (a fresh-id token the FIRST send delivered into inventory) as a
+    // WHOLE-DIRECT leg. Single leg → deterministic, like V1. ─────────────────────
+    const second = await wallet.module.send({ recipient: '@me', amount: '4', coinId: UCT });
+    expect(second.status).toBe('completed');
+    console.log('[V3 second plan]', JSON.stringify(second.tokenTransfers.map((t) => ({ method: t.method, id: t.sourceTokenId.slice(0, 10) }))));
+    await wallet.module.receive();
+    await wallet.module.receive();
+
+    const afterSecond = await balances(wallet);
+    console.log('[V3 after second] balances =', JSON.stringify(afterSecond, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)),
+      'localTotal =', localTotal(wallet).toString(), 'rows =', JSON.stringify(localRows(fake, wallet)));
+    console.log(`[V3] history SENT=${sumHistory(fake, 'SENT')} RECEIVED=${sumHistory(fake, 'RECEIVED')}`);
+
+    // The wallet only ever moved money to ITSELF: the balance must still be 58.
+    expect(afterSecond).toEqual([{ coinId: UCT, total: 58n, tokenCount: expect.any(Number) }]);
+    expect(localTotal(wallet)).toBe(58n);
+  });
+});

--- a/tests/support/fake-wallet-api.ts
+++ b/tests/support/fake-wallet-api.ts
@@ -842,6 +842,10 @@ export class FakeWalletApi {
     return {
       tokenId: row.tokenId,
       status: row.status,
+      // Per-row protocol state hash (mirrors the wallet-api inventory state_hash
+      // exposure): carried for active AND removed rows so the client can reconcile a
+      // removal against the row's CURRENT state, not its token id alone.
+      stateHash: row.stateHash,
       // Amounts are decimal strings in every JSON body (§11); asset rows are
       // deleted at the spend, so tombstones carry no assets (§5.3 step 4).
       ...(row.status === 'active' && row.assets

--- a/tests/unit/wallet-api/client.auth.test.ts
+++ b/tests/unit/wallet-api/client.auth.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { WalletApiClient, ChallengeTemplateError, WalletApiError, verifyChallengeTemplate, AUTH_CHALLENGE_PREFIX } from '../../../wallet-api';
+import { WalletApiClient, ChallengeTemplateError, WalletApiError, verifyChallengeTemplate, AUTH_CHALLENGE_PREFIX, type FetchLike } from '../../../wallet-api';
 import { FakeWalletApi } from '../../support/fake-wallet-api';
 import { MemoryKeyValueStore, testIdentity } from '../../support/wallet-api-test-helpers';
 
@@ -103,6 +103,47 @@ describe('WalletApiClient — auth (§4)', () => {
     // §4 rotation: the stored refresh token changed.
     expect(storedRefreshToken()).not.toBe(firstRefresh);
     expect(fake.challengeRequests).toBe(1); // no second challenge cycle needed
+  });
+
+  it('concurrent requests after ONE expiry drive EXACTLY one refresh — a peer reuses the rotated JWT, never re-refreshes or clobbers it', async () => {
+    // Regression for the auth double-refresh race (it surfaced as the flaky
+    // G3/J6 idle-resume test: load()'s fire-and-forget pumps race the resume op,
+    // so several authed requests carry the same stale JWT). Force the exact
+    // interleaving deterministically: two authed GETs are dispatched bearing the
+    // SAME stale JWT; the FIRST's 401 → /auth/refresh → retry completes BEFORE
+    // the SECOND's 401 is processed. A correct client makes the second REUSE the
+    // peer's freshly-rotated token — ONE refresh for one expiry — and must NOT
+    // null that fresh token (which would send the retry unauthenticated → a
+    // spurious UNAUTHORIZED). Pre-fix this drove a redundant second refresh.
+    const liveFetch: FetchLike = (u, init) => (globalThis as unknown as { fetch: FetchLike }).fetch(u, init);
+    let releaseSecond!: () => void;
+    const firstRefreshLanded = new Promise<void>((r) => { releaseSecond = r; });
+    let authedGets = 0;
+    const gatedFetch: FetchLike = async (u, init) => {
+      const isAuthedGet = (init?.method ?? 'GET') === 'GET' && !!init?.headers?.['authorization'];
+      // Hold the SECOND authed GET until the first request's refresh has landed,
+      // so its 401 is handled with the client's JWT ALREADY rotated by the peer.
+      if (isAuthedGet && ++authedGets === 2) await firstRefreshLanded;
+      const res = await liveFetch(u, init);
+      if (u.endsWith('/v1/auth/refresh')) releaseSecond();
+      return res;
+    };
+
+    const raced = new WalletApiClient({
+      baseUrl, network: fake.network, deviceId: 'dev-1', storage: new MemoryKeyValueStore(), fetchFn: gatedFetch,
+    });
+    raced.setIdentity(identity);
+    await raced.signIn(); // challenge→verify (POSTs); jwt = J0. Not counted as an authed GET.
+    const refreshesBefore = fake.refreshRequests;
+    fake.expireAccessTokens(); // J0 is now stale on the server
+
+    // Two authed GETs fired concurrently — both capture the stale J0 before any refresh.
+    const [a, b] = await Promise.all([raced.getBalances(), raced.getBalances()]);
+
+    expect(a).toEqual([]);
+    expect(b).toEqual([]); // both succeed — the peer's rotated token was reused, not clobbered
+    expect(fake.refreshRequests - refreshesBefore).toBe(1); // ONE refresh for one expiry, not two
+    expect(fake.challengeRequests).toBe(1); // and no challenge→verify fallback
   });
 
   it('rotation-reuse revocation falls back to a fresh challenge cycle (§4 reuse detection)', async () => {

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -477,7 +477,12 @@ export class SphereTokenEngine implements ITokenEngine {
         const data = await SpherePaymentData.create(leg.assets, ctx.params.outputs[i].data ?? null).encode();
         const probe = await MintTransaction.create(leg.networkId, leg.recipient, data, leg.tokenType, leg.salt, null);
         const response = await this.deps.client.getInclusionProof(await StateId.fromTransaction(probe));
-        if (response.inclusionProof.inclusionCertificate !== null) {
+        // Inclusion (leaf certified on-chain) is discriminated by `certificationData`, NOT
+        // by the certificate bytes: the aggregator's non-inclusion response carries a
+        // certificate too (an ExclusionCert once non-inclusion proofs ship), so
+        // `inclusionCertificate` is not a reliable "certified" signal (aggregator
+        // types.go: CertificationData != nil ⟺ inclusion).
+        if (response.inclusionProof.certificationData !== null) {
           throw new SplitCheckpointLostError(
             'a split mint leaf is certified on-chain but no burn checkpoint exists — outputs are unrecoverable',
           );
@@ -563,8 +568,14 @@ export class SphereTokenEngine implements ITokenEngine {
     );
     const stateId = await StateId.fromTransaction(probe);
     const response = await this.deps.client.getInclusionProof(stateId);
-    // A present inclusion certificate means the state has already been consumed on-chain.
-    return response.inclusionProof.inclusionCertificate !== null;
+    // A state is consumed on-chain iff the aggregator returns CERTIFICATION DATA for its
+    // stateId — that is the aggregator's own inclusion/non-inclusion discriminator
+    // (types.go: `CertificationData != nil` ⟺ inclusion). Do NOT test
+    // `inclusionCertificate`: a non-inclusion response also carries a certificate (an
+    // ExclusionCert, once non-inclusion proofs are implemented), so a non-null certificate
+    // does NOT imply the state was spent — testing it would report an UNSPENT state as
+    // spent and (via the fail-closed resume/recovery gates) destroy a live token.
+    return response.inclusionProof.certificationData !== null;
   }
 
   // ── serialization ────────────────────────────────────────────────────────────

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -586,10 +586,17 @@ export class WalletApiClient {
   ): Promise<unknown> {
     const idempotent = opts?.idempotent ?? false;
     if (!this.jwt) await this.signIn();
+    const usedJwt = this.jwt;
     let res = await this.rawFetchWithRetry(method, path, body, this.jwt!, idempotent);
     if (res.status === 401) {
-      this.jwt = null;
-      await this.signIn();
+      // A concurrent request may already have refreshed the JWT since ours went
+      // out. Only drive a (re-)auth if `this.jwt` is still the token we used (or
+      // a peer's in-flight refresh nulled it — `signIn()` then coalesces onto
+      // that same refresh); if a peer already rotated it to a fresh token, reuse
+      // that token and retry once. This avoids a redundant second /auth/refresh
+      // and never nulls a peer's freshly-obtained JWT.
+      if (this.jwt === usedJwt) this.jwt = null;
+      if (!this.jwt) await this.signIn();
       res = await this.rawFetchWithRetry(method, path, body, this.jwt!, idempotent);
     }
     if (res.status === 204) return null;

--- a/wallet-api/codec.ts
+++ b/wallet-api/codec.ts
@@ -83,6 +83,10 @@ function parseInventoryItem(raw: unknown, what: string): InventoryItem {
     status,
     assets: parseAssets(rec.assets, `${what}.assets`),
     seq: parseCounter(rec.seq, `${what}.seq`),
+    // Additive (wallet-api inventory state_hash exposure): the row's current protocol
+    // state hash. Optional so a pre-exposure server (no field) parses fine and the
+    // client degrades to prune-primary rather than mis-firing state-aware removals.
+    ...(rec.stateHash === undefined ? {} : { stateHash: asString(rec.stateHash, `${what}.stateHash`) }),
   };
 }
 


### PR DESCRIPTION
## Summary

Makes wallet-api inventory reconciliation STATE-AWARE. Under a specific concurrent-claim ordering, a transfer that hands a whole token to an address which re-acquires the same token in the same session (a self-transfer, or an A→B→A round-trip) could reconcile a removal against a row already advanced to a new state, recording the leg's history and inventory inconsistently. The on-chain state is retained throughout.

## What changed

Two hash spaces are kept cleanly separated (the codebase already warns against mixing them):

**Local** (`extractStateHashFromSdkData`, sha256-over-bytes) — the module's journal/dedup:
- incoming dedup keys on (tokenId, state), so a new state of a held token is received + recorded rather than dropped as a duplicate;
- `removeToken(expectedStateHash)` tombstones the SPENT state and keeps a token the map has advanced to a reactivated state.

**Protocol** (`deliveryKeys` = the server `state_hash`) — the wallet-api provider:
- `knownSpends` re-keyed to (tokenId, spentState), fed authoritatively from the source token (never a live view a claim can advance);
- `pushRemovals` is fail-closed: it reconciles an evidence-free removal only for a row the server shows active at exactly the state we can prove we spent; a reactivated state is left alone; an unexposed state hash degrades to skip;
- `recoverRemoved` is state-keyed and gated on an on-chain `isSpent` check (fail-closed — reactivates only what it can prove unspent).

**Resume** (`resumeIntent`) is state-aware: the intent payload persists each source's spent state; legacy in-flight payloads fall back to a fail-closed on-chain check.

**Inclusion check**: `isSpent` now discriminates on `certificationData` (the aggregator's own inclusion discriminator) rather than the certificate bytes, which also carry a non-inclusion (Exclusion) certificate.

## Validation

- Deterministic reproductions (`tests/integration/self-send-{multitoken,roundtrip,variants}.repro.test.ts`) fail before, pass after.
- A live e2e (`tests/e2e/self-send-roundtrip.staging.e2e.test.ts`, gated on `STAGING_AGGREGATOR_KEY`) exercises the real staging wallet-api + testnet2 aggregator with real transactions.
- Full suite: 3138 unit/contract/integration tests.

## Deploy dependency

Needs the additive wallet-api `state_hash` inventory field (unicity-sphere/wallet-api#108) deployed first for full correctness; degrades safely (skip-primary) if the SDK races ahead. `recoverRemoved`'s `isSpent` gate must be wired at composition (like `verifyToken`); unwired it is a safe no-op. No change to ordinary cross-party transfers.

## Also in this PR

**Expanded e2e money-safety coverage** (`tests/e2e/self-send-roundtrip.staging.e2e.test.ts`, live staging + testnet2):
- whole-token `a→b→c→b→a→c→a→b→a` round-trip — the SAME genesis token bounces through three wallets and is re-acquired at A three times, its id asserted unchanged (no splits);
- a mid-path MIXED send — a wallet holding `{30,30,40}` sends 80, so two tokens go DIRECT (whole) and the third is SPLIT for the remainder in one package; proven at the recipient (two preserved-id legs + one fresh-genesis split leg);
- id-composition reads are resync-safe: `getTokens()` is an eventually-consistent local cache (a self-split's spent parent is pruned only after an inventory resync; the server balance is already correct), so the tests `sync()` + poll until the view settles before asserting — a real inventory bug would still fail them.

**Auth: no redundant second `/auth/refresh` on a concurrent 401** (`wallet-api/client.ts`). Root-caused from a flaky auth test this PR's CI surfaced. `requestJson`'s 401 handler nulled the JWT and re-signed-in unconditionally, so when several authed requests carried the same stale token into one expiry (e.g. `load()`'s fire-and-forget pumps racing a resume op), a later request drove a second refresh and could clobber a peer's freshly-rotated token → spurious `UNAUTHORIZED`. Now it captures the token the request used and only re-auths if a peer hasn't already rotated it (else reuses that token for the single retry). A deterministic regression (`client.auth.test.ts`) forces the interleaving — fails `expected 2 to be 1` without the fix, passes with it.
