### PR TITLE
Concurrency money-safety: split-strand, payment double-pay, knownSpends poison (3 fixes)

### DIFF
--- a/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
+++ b/impl/shared/wallet-api/WalletApiTokenStorageProvider.ts
@@ -799,15 +799,22 @@ export class WalletApiTokenStorageProvider implements TokenStorageProvider<TxfSt
     // destroying it there is the fund-loss bug. A row whose stateHash the server does not
     // expose (pre-Unit-A backend) is skipped, never removed on tokenId alone (degrade to
     // prune-primary: the PaymentsModule stale-tombstone prune is the go-forward fix).
-    const spent: string[] = [];
+    // Capture the state we PROVE spent NOW, alongside the id. Recording the knownSpend from a
+    // post-await re-read of this.view (as this used to) keys it to whatever state a concurrent
+    // claim advanced the row to DURING applyInventoryDelta below — poisoning knownSpends with a
+    // never-spent state, which a later pushRemovals then treats as proof and uses to destroy the
+    // legitimately re-acquired token. (Same hazard applyDelta guards against by keying knownSpends
+    // off the caller's authoritative spentStates, never this.view.)
+    const spent: Array<{ id: string; stateHash: string }> = [];
     for (const id of tombstoneIds) {
       const row = this.view.get(id);
       if (row?.status !== 'active') continue;
-      if (this.provenSpentAtState(known, id, row.stateHash)) spent.push(id);
+      const st = row.stateHash;
+      if (st && this.provenSpentAtState(known, id, st)) spent.push({ id, stateHash: st });
     }
     if (spent.length === 0) return;
-    await this.client.applyInventoryDelta({ transferId: newTransferId(), spent, added: [] });
-    await this.addKnownSpends(spent.map((id) => this.knownSpendKey(id, this.view.get(id)!.stateHash!)));
+    await this.client.applyInventoryDelta({ transferId: newTransferId(), spent: spent.map((s) => s.id), added: [] });
+    await this.addKnownSpends(spent.map((s) => this.knownSpendKey(s.id, s.stateHash)));
   }
 
   async sync(localData: TxfStorageDataBase): Promise<SyncResult<TxfStorageDataBase>> {

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -1163,6 +1163,15 @@ export class PaymentsModule {
   // Token Spend Queue — concurrent send race condition prevention
   private readonly reservationLedger = new TokenReservationLedger();
   private readonly spendPlanner = new SpendPlanner();
+  /**
+   * Per-request single-flight for {@link payPaymentRequest}. The pay flow flips the request to
+   * 'accepted' before it awaits send(), and the status guard re-admits 'accepted' (intended for a
+   * sequential retry-after-failure) — so a concurrent double-tap / second session would otherwise
+   * enter send() a second time and DOUBLE-PAY (each send picks a different token; the reservation
+   * ledger is coin-scoped, not request-scoped). Concurrent calls for the same requestId coalesce
+   * onto the first in-flight pay; the entry is cleared when it settles, so a later retry is unaffected.
+   */
+  private readonly payInFlight = new Map<string, Promise<TransferResult>>();
   private spendQueue: SpendQueue;
   /** Cache of parsed SdkToken data for synchronous queue re-evaluation */
   private readonly parsedTokenCache: Map<string, ParsedTokenEntry> = new Map();
@@ -3076,6 +3085,21 @@ export class PaymentsModule {
    * Convenience method that accepts, sends, and marks as paid
    */
   async payPaymentRequest(requestId: string, memo?: string): Promise<TransferResult> {
+    // Single-flight: a concurrent second call for the same request coalesces onto the first pay
+    // instead of issuing a second send (double-pay). Cleared in the inner's finally so a later
+    // sequential retry — the reason the status guard re-admits 'accepted' — still proceeds.
+    const inFlight = this.payInFlight.get(requestId);
+    if (inFlight) return inFlight;
+    const pay = this.payPaymentRequestInner(requestId, memo);
+    this.payInFlight.set(requestId, pay);
+    try {
+      return await pay;
+    } finally {
+      this.payInFlight.delete(requestId);
+    }
+  }
+
+  private async payPaymentRequestInner(requestId: string, memo?: string): Promise<TransferResult> {
     const request = this.paymentRequests.find((r) => r.id === requestId);
     if (!request) {
       throw new SphereError(`Payment request not found: ${requestId}`, 'VALIDATION_ERROR');

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -3088,6 +3088,9 @@ export class PaymentsModule {
     // Single-flight: a concurrent second call for the same request coalesces onto the first pay
     // instead of issuing a second send (double-pay). Cleared in the inner's finally so a later
     // sequential retry — the reason the status guard re-admits 'accepted' — still proceeds.
+    // NOTE: a coalesced caller receives the FIRST caller's result, so if concurrent callers pass
+    // different `memo` values only the first is used — memo is per-request, not per-call, under
+    // concurrency (a distinct memo needs a distinct request, or a sequential call).
     const inFlight = this.payInFlight.get(requestId);
     if (inFlight) return inFlight;
     const pay = this.payPaymentRequestInner(requestId, memo);

--- a/tests/contract/wallet-api-token-storage-provider.contract.test.ts
+++ b/tests/contract/wallet-api-token-storage-provider.contract.test.ts
@@ -328,6 +328,57 @@ describe('WalletApiTokenStorageProvider — S2 remote semantics', () => {
     expect(view.items).toEqual([]);
   });
 
+  it('audit#3: pushRemovals keys the knownSpend to the PROVEN-spent state, not a post-await re-read — a round-trip re-acquisition survives', async () => {
+    const A = makeDevice(fake, baseUrl, 90, 'dev-a3');
+    const B = makeDevice(fake, baseUrl, 90, 'dev-b3'); // same owner, 2nd device = the round-trip claimant
+    const t1 = makeTestToken({ amount: 1000n });
+    await seedVia(A.provider, [t1]);
+    const s1 = (await A.provider.listInventory()).items.find((i) => i.tokenId === t1.tokenId)!.stateHash!;
+    expect(s1).toBeTruthy();
+
+    // Authoritative knownSpend for t1 @ S1 (no-op server apply → the row stays active: the
+    // evidence-race desync). S1 is the ONLY state we ever proved spent.
+    const noop = (async () => 0n) as typeof A.client.applyInventoryDelta;
+    const realApply = A.client.applyInventoryDelta.bind(A.client);
+    A.client.applyInventoryDelta = noop;
+    await A.provider.applyDelta('33333333-3333-4333-8333-333333333333', [t1.tokenId], [], {
+      spentStates: [{ tokenId: t1.tokenId, stateHash: s1 }],
+    });
+    A.client.applyInventoryDelta = realApply;
+
+    // Cycle 1 — drive pushRemovals via a tombstone save, and GATE its applyInventoryDelta: AFTER
+    // the removal applies, device B re-acquires t1 at a NEW state S2 (the A→B→A round-trip) and
+    // device A syncs it in. That is the concurrent claim advancing this.view between the spend
+    // decision and the knownSpend write.
+    const t2 = makeTestToken({ tokenId: t1.tokenId, amount: 1000n }); // same id, fresh state S2
+    let raced = false;
+    A.client.applyInventoryDelta = (async (delta: never) => {
+      const r = await realApply(delta);
+      if (!raced) {
+        raced = true;
+        await seedVia(B.provider, [t2]); // server row t1 → active @ S2 (re-acquired)
+        await A.provider.listInventory(); // A.view advances t1 → active @ S2 mid-reconcile
+      }
+      return r;
+    }) as typeof A.client.applyInventoryDelta;
+    const c1 = buildTxfData([]);
+    c1._tombstones = [{ tokenId: t1.tokenId, stateHash: '', timestamp: Date.now() }];
+    await A.provider.save(c1);
+    A.client.applyInventoryDelta = realApply;
+
+    // The round-trip token is back and live at S2 after cycle 1.
+    expect(fake.getRow(A.pubkey, t1.tokenId)?.status).toBe('active');
+
+    // Cycle 2 — a later stale tombstone triggers pushRemovals again. knownSpends must still prove
+    // ONLY S1, so the re-acquired S2 is left alone. Pre-fix, cycle 1's post-await re-read poisoned
+    // knownSpends with t1@S2, so this SECOND pushRemovals destroys the live re-acquisition.
+    const c2 = buildTxfData([]);
+    c2._tombstones = [{ tokenId: t1.tokenId, stateHash: '', timestamp: Date.now() }];
+    await A.provider.save(c2);
+
+    expect(fake.getRow(A.pubkey, t1.tokenId)?.status).toBe('active'); // preserved (pre-fix: 'removed')
+  });
+
   it('recoverRemoved() restores a wiped-but-unspent token (§5.3 recovery)', async () => {
     // isSpent (wired at composition in prod) reports t1 UNSPENT → recoverRemoved reactivates.
     const { provider, pubkey } = makeDevice(fake, baseUrl, 26, 'dev-a', new Set());

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -400,6 +400,40 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     });
   });
 
+  it('audit#2: two concurrent payPaymentRequest calls must NOT double-pay (payer spends the amount ONCE)', async () => {
+    const { fake, baseUrl } = await startFake();
+    const requester = makeWalletApiWallet(baseUrl, fake.network, REQUESTER, 'pr-dbl-1');
+    const payer = makeWalletApiWallet(baseUrl, fake.network, PAYER, 'pr-dbl-2');
+    // Payer holds TWO whole 1000-tokens (2000 total). Two concurrent sends can each pick a
+    // DIFFERENT token — the reservation ledger only blocks two sends selecting the SAME coin,
+    // never two coins fulfilling one request.
+    await seedServerToken(fake, payer, PAYER, 1000n);
+    await seedServerToken(fake, payer, PAYER, 1000n);
+    await requester.module.load();
+    await payer.module.load();
+    const uct = async (w: Wallet): Promise<bigint> =>
+      (await w.client.getBalances()).find((b) => b.coinId === UCT)?.total ?? 0n;
+    expect(await uct(payer)).toBe(2000n);
+
+    const created = await requester.module.sendPaymentRequest(PAYER.chainPubkey, { amount: '1000', coinId: UCT });
+    await payer.module.syncPaymentRequests();
+    expect(payer.module.getPaymentRequests({ status: 'pending' })).toHaveLength(1);
+
+    // Double-tap / two sessions: fire the SAME request twice concurrently. payPaymentRequest flips
+    // the request to 'accepted' SYNCHRONOUSLY before it awaits send(), and the guard re-admits
+    // 'accepted' (intended for retry-after-failure), so pre-fix BOTH calls enter send() and each
+    // spends a different token — the payer is charged twice for one request.
+    await Promise.allSettled([
+      payer.module.payPaymentRequest(created.requestId!),
+      payer.module.payPaymentRequest(created.requestId!),
+    ]);
+
+    // Money invariant (fix-agnostic): ONE request paid ONCE — the payer spends exactly 1000 and
+    // keeps the other 1000-token. Pre-fix this is 0n (both tokens spent = double-pay).
+    expect(await uct(payer)).toBe(1000n);
+    expect(fake.getPaymentRequest(created.requestId!)?.status).toBe('paid');
+  });
+
   describe('#441 deferred-paid: a possibly-committed pay HOLDS the request settling until the transfer resolves (no double-pay on reload)', () => {
     const SETTLING_KEY = (net: string) => `wallet-api-pr:settling:${net}:${PAYER.chainPubkey}`;
 

--- a/tests/unit/token-engine/SphereTokenEngine.hardening.test.ts
+++ b/tests/unit/token-engine/SphereTokenEngine.hardening.test.ts
@@ -140,7 +140,7 @@ describe('SphereTokenEngine — hardening / edge cases', () => {
     await expect(e.split({ token: src, outputs: twoOutputs(self) })).rejects.toBeInstanceOf(SplitCheckpointLostError);
   }, 30000);
 
-  it('parallel split: when EVERY leg fails cleanly (nothing certified) surfaces the lowest-index clean error — no spurious keep-open (#684)', async () => {
+  it('parallel split: when EVERY mint leg fails cleanly after the burn CERTIFIED, keep the intent OPEN — aborting would strand the burnt source (audit#1)', async () => {
     const e = createTestEngine();
     const self = e.getIdentity().chainPubkey;
     const src = await e.mint({ recipientPubkey: self, value: { assets: [{ coinId: COIN_A, amount: 100n }] } });
@@ -148,12 +148,19 @@ describe('SphereTokenEngine — hardening / edge cases', () => {
     let call = 0;
     vi.spyOn(proto, 'mintSplitOutput').mockImplementation(function (this: unknown) {
       call += 1;
+      // Both mint legs clean-reject; NOTHING mints. But the burn already certified (below).
       return Promise.reject(new SphereError(`leg-${call - 1} failed`, call === 1 ? 'AGGREGATOR_ERROR' : 'TRANSPORT_ERROR'));
     });
-    // No leg committed → the split genuinely failed → surface the lowest-index CLEAN error and
-    // let PaymentsModule abort. Guards against over-correcting into a keep-open that would strand
-    // a genuinely-failed intent open forever.
-    await expect(e.split({ token: src, outputs: twoOutputs(self) })).rejects.toMatchObject({ code: 'AGGREGATOR_ERROR' });
+    // The burn commits on-chain BEFORE the mint fan-out (resolveBurntToken). Previously this case
+    // surfaced the abortable clean error on the theory "no leg committed → the split failed" — but
+    // that ignores the BURN: the source is already spent. Surfacing an abortable error lets
+    // PaymentsModule abort the intent and STRAND the entire source (the burn cannot be undone, an
+    // aborted intent never re-runs). Every post-burn failure must be keep-open so resume re-runs the
+    // mints from the burn checkpoint — funds recoverable, not lost.
+    await expect(e.split({ token: src, outputs: twoOutputs(self) })).rejects.toBeInstanceOf(ProofUnconfirmedError);
+    // Proof the burn really committed (this is exactly why an abort here would strand the funds):
+    // the source is now spent on-chain even though no mint certified.
+    expect(await e.isSpent(src)).toBe(true);
   }, 30000);
 
   it('rejects minting a negative or malformed value', async () => {

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -386,13 +386,14 @@ export class SphereTokenEngine implements ITokenEngine {
     //  1. If ANY leg rejected keep-open (ProofUnconfirmed / SplitCheckpointLost / the E.4 pair),
     //     surface that verbatim (lowest-index) so its specific keep-open type drives
     //     PaymentsModule's classification exactly as before.
-    //  2. Else if ANY leg CERTIFIED (fulfilled) while another failed cleanly, convert to a
-    //     keep-open ProofUnconfirmedError (cause = the clean failure): the burn is certified +
-    //     checkpointed, so resume re-runs ALL legs and recovers the certified one idempotently
-    //     (HKDF-deterministic stateId → the aggregator returns the existing proof; #631/E.2/E.3).
-    //  3. Else (every rejection is clean AND nothing certified) surface the lowest-index clean
-    //     rejection — nothing is committed, so aborting is safe and the net outcome matches the
-    //     sequential loop.
+    //  2. Else (ANY clean rejection, whether or not a sibling certified) the BURN is already
+    //     committed + checkpointed (resolveBurntToken, above), so the source is spent on-chain.
+    //     Convert to a keep-open ProofUnconfirmedError (cause = the clean failure): a plain
+    //     abortable error would let PaymentsModule abort the intent and STRAND the whole source
+    //     value (the burn cannot be undone; an aborted intent never re-runs). Keep-open so resume
+    //     re-runs ALL legs idempotently from the burn checkpoint (HKDF-deterministic stateId → the
+    //     aggregator returns the existing proof; #631/E.2/E.3). A clean mint reject after a valid,
+    //     value-conserving burn is transient (e.g. a shard reconfiguration), never permanent.
     const keepOpenRejection = settled.find(
       (r): r is PromiseRejectedResult => r.status === 'rejected' && isKeepOpenSplitError(r.reason),
     );

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -402,14 +402,22 @@ export class SphereTokenEngine implements ITokenEngine {
     const firstRejected = settled.findIndex((r) => r.status === 'rejected');
     if (firstRejected !== -1) {
       const cleanReason = (settled[firstRejected] as PromiseRejectedResult).reason;
-      if (settled.some((r) => r.status === 'fulfilled')) {
-        throw new ProofUnconfirmedError(
-          'a split mint leg certified while a sibling leg failed — keep the intent open; resume ' +
-            'completes all legs idempotently from the burn checkpoint (#684 parallel fan-out)',
-          cleanReason,
-        );
-      }
-      throw cleanReason;
+      //  3. Else (every rejection is clean — none keep-open) the burn is STILL committed +
+      //     checkpointed (resolveBurntToken, above), whether or not a sibling certified. Surfacing
+      //     a plain abortable clean error would let PaymentsModule abort the intent and STRAND the
+      //     entire source value — the burn cannot be undone and an aborted intent never re-runs. So
+      //     EVERY post-burn mint failure is keep-open: resume re-runs all legs idempotently from the
+      //     burn checkpoint. (A clean mint reject after a valid, value-conserving burn is transient —
+      //     e.g. a shard reconfiguration — not a permanent validation failure; keep-open leaves the
+      //     funds RECOVERABLE, abort loses them.)
+      throw new ProofUnconfirmedError(
+        settled.some((r) => r.status === 'fulfilled')
+          ? 'a split mint leg certified while a sibling leg failed — keep the intent open; resume ' +
+              'completes all legs idempotently from the burn checkpoint (#684 parallel fan-out)'
+          : 'every split mint leg failed after the burn certified — keep the intent open; resume ' +
+              're-runs all legs idempotently from the burn checkpoint (post-burn must never abort)',
+        cleanReason,
+      );
     }
     const outputs = settled.map((r) => (r as PromiseFulfilledResult<SphereToken>).value);
     return { outputs };


### PR DESCRIPTION
## Summary

Three confirmed money-safety bugs found by an adversarial concurrency/state-authority audit of the wallet-api surface. Each is fixed with a **deterministic regression that fails on `main` and passes after the fix** — the interleaving/fault is forced (gated apply, spied engine), so the bug is demonstrated every run rather than probabilistically. Full suite: 3141 tests pass; `tsc --noEmit` clean.

## The fixes

**1 — Split strands the entire source when every mint leg fails after the burn** (`token-engine/SphereTokenEngine.ts`)
`split()` burns the source on-chain and persists the burn checkpoint *before* fanning out the mint legs. If every leg then clean-rejected with none certified, the aggregation threw an abortable clean error; PaymentsModule's committed-source set is still empty there, so it aborted the intent — and an aborted intent never re-runs, so the burn checkpoint is orphaned and neither output is ever minted. The full source value is irreversibly stranded. The old premise ("no leg committed → the split failed") ignored the burn. Fix: every post-burn mint failure is keep-open (`ProofUnconfirmedError`), so resume re-runs all legs idempotently from the checkpoint. Regression asserts keep-open **and** that the burn committed (`isSpent(src) === true`).

**2 — Concurrent `payPaymentRequest` double-pays** (`modules/payments/PaymentsModule.ts`)
The pay flow flips the request to `'accepted'` synchronously before awaiting `send()`, and the status guard re-admits `'accepted'` (for retry-after-failure) — so a double-tap / second session enters `send()` again and spends a *different* token (the reservation ledger is coin-scoped, not request-scoped). Fix: a per-requestId single-flight coalesces the concurrent call onto the first pay; cleared in a finally so a sequential retry is unaffected. Regression: two concurrent pays on a payer holding two tokens — payer must spend the amount once (fails `expected 0n to be 1000n`).

**3 — `pushRemovals` poisons the state-scope guard** (`impl/shared/wallet-api/WalletApiTokenStorageProvider.ts`)
It decided the spend from a synchronous snapshot, then after `await applyInventoryDelta` re-read `this.view.get(id).stateHash` for the knownSpend key. A concurrent claim (the 30s poll, or an A→B→A round-trip) that reactivated the row during the await advanced the view to a new state, so the knownSpend was recorded against a state that was never spent — and a later pushRemovals then treats it as proof and destroys the re-acquired token. Fix: capture the proven-spent state at decision time (mirroring the protection `applyDelta` already documents). Regression: a two-cycle repro where the re-acquired token must survive (`expected 'removed' to be 'active'`).

## Deferred / tracked follow-ups

Two more audit findings need a larger change and are NOT in this PR:

- **Resume false-paid (finding #4)** — `resumeIntent` swallows a `TransferConflictError` (a foreign spend) as if it were our own certified resume, falsely marking the intent paid. The fix reverses the prior #621/#622 behavior, but review (Codex) correctly flagged that a bare abort would **double-pay already-delivered legs** in a *multi-source* resume; it must retain the committed legs and re-plan only the undelivered remainder (like `PartialSendConflictError`). Deferred to its own PR.
- **Cross-session double-pay** — the finding-#2 single-flight is instance-local; two tabs/devices with the same identity still race. A full fix needs a server-backed claim (wallet-api support). Deferred.
- Audit findings #6–#14 (phantom balance, stranded funds, cross-account JWT, DoS) reduce to two more root causes and are tracked separately.
