### PR TITLE
Concurrency money-safety: serialize local-intents blob RMW (root cause A)

### DIFF
--- a/tests/unit/wallet-api/client.inventory.test.ts
+++ b/tests/unit/wallet-api/client.inventory.test.ts
@@ -203,6 +203,21 @@ describe('WalletApiClient — intents (E.3, §16)', () => {
     expect(await client.getLocalIntent(tidZ)).not.toBeNull();
   });
 
+  it('audit: a queued intent mutation writes to the SUBMITTING identity, not one setIdentity() switched to mid-flight', async () => {
+    const other = testIdentity(52);
+    // A submits putIntent; the mutex DEFERS the local RMW to a microtask. The identity then switches
+    // to B before that RMW runs. The write must land in A's blob (the submitter) — deriving the key
+    // at run time would put A's intent into B's blob (A loses its restore backstop; B's is polluted).
+    const pending = client.putIntent(tid, envelope('{"a":1}')).catch(() => undefined); // the post-switch PUT may fail; ignore
+    client.setIdentity(other);
+    await pending;
+
+    client.setIdentity(other);
+    expect(await client.getLocalIntent(tid)).toBeNull(); // NOT in B's blob (pre-fix: present)
+    client.setIdentity(identity);
+    expect(await client.getLocalIntent(tid)).not.toBeNull(); // in A's blob (the submitter)
+  });
+
   it('the server rejects a non-envelope or oversize intent payload (§8.3)', async () => {
     await expect(client.putIntent(tid, 'plaintext — not an envelope')).rejects.toMatchObject({
       code: 'VALIDATION',

--- a/tests/unit/wallet-api/client.inventory.test.ts
+++ b/tests/unit/wallet-api/client.inventory.test.ts
@@ -187,6 +187,22 @@ describe('WalletApiClient — intents (E.3, §16)', () => {
     expect(fake.getIntent(identity.chainPubkey, tid)).toEqual({ payload, status: 'open' });
   });
 
+  it('audit#5: concurrent putIntent must not clobber each other locally (the restore/double-pay backstop survives)', async () => {
+    const tidY = 'bbbbbbbb-0000-4000-8000-00000000000a';
+    const tidZ = 'bbbbbbbb-0000-4000-8000-00000000000b';
+    // Two intents PUT concurrently. putIntent does a read-modify-write of the WHOLE local-intents
+    // blob (get → add the key → set) with an await in between; without the mutex both read the same
+    // snapshot and the second's set clobbers the first — dropping one intent's LOCAL copy, which is
+    // the #516/E.3 restore + double-pay backstop (a dropped copy = an un-restorable committed send).
+    await Promise.all([
+      client.putIntent(tidY, envelope('{"y":1}')),
+      client.putIntent(tidZ, envelope('{"z":1}')),
+    ]);
+
+    expect(await client.getLocalIntent(tidY)).not.toBeNull(); // pre-fix: one of these is null (clobbered)
+    expect(await client.getLocalIntent(tidZ)).not.toBeNull();
+  });
+
   it('the server rejects a non-envelope or oversize intent payload (§8.3)', async () => {
     await expect(client.putIntent(tid, 'plaintext — not an envelope')).rejects.toMatchObject({
       code: 'VALIDATION',

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -854,21 +854,42 @@ export class WalletApiClient {
     await this.storage.set(this.intentsKey(), JSON.stringify(intents));
   }
 
+  /**
+   * Serialize every read-modify-write of the whole local-intents blob. Each mutator (putIntent,
+   * setLocalIntentStatus, removeLocalIntent, backstopProgress) does get→parse→mutate→set with an
+   * await in between; run concurrently they each start from the SAME snapshot and the last writer
+   * clobbers the others' entries — dropping, e.g., a split's freshly-persisted burn checkpoint
+   * (→ SplitCheckpointLostError / stranded funds after a restore). A promise-chain mutex (like the
+   * provider's overlayLock) runs each RMW after the previous settles; a failure never wedges the
+   * chain. Wrap ONLY the local RMW — never a network call — so the lock is held briefly.
+   */
+  private intentsLock: Promise<unknown> = Promise.resolve();
+  private withIntentsLock<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.intentsLock.then(fn, fn);
+    this.intentsLock = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
   private async setLocalIntentStatus(
     transferId: string,
     status: LocalIntent['status'],
     opts: { abortPending?: boolean } = {}
   ): Promise<void> {
-    const intents = await this.readLocalIntents();
-    const intent = intents[transferId];
-    if (!intent) return;
-    if (intent.status === 'completed') return; // completed never reverts (§16)
-    const abortPending = opts.abortPending === true;
-    if (intent.status === status && (intent.abortPending === true) === abortPending) return;
-    intent.status = status;
-    if (abortPending) intent.abortPending = true;
-    else delete intent.abortPending;
-    await this.writeLocalIntents(intents);
+    return this.withIntentsLock(async () => {
+      const intents = await this.readLocalIntents();
+      const intent = intents[transferId];
+      if (!intent) return;
+      if (intent.status === 'completed') return; // completed never reverts (§16)
+      const abortPending = opts.abortPending === true;
+      if (intent.status === status && (intent.abortPending === true) === abortPending) return;
+      intent.status = status;
+      if (abortPending) intent.abortPending = true;
+      else delete intent.abortPending;
+      await this.writeLocalIntents(intents);
+    });
   }
 
   /**
@@ -881,15 +902,17 @@ export class WalletApiClient {
    * double-pay/restore backstop.
    */
   async removeLocalIntent(transferId: string): Promise<void> {
-    const intents = await this.readLocalIntents();
-    const intent = intents[transferId];
-    if (!intent) return;
-    // Only a still-'open' copy with no pending server abort is safe to drop:
-    // 'completed' never reverts (§16), and an 'aborted'+abortPending copy is a
-    // #516 backstop whose server row may still be open.
-    if (intent.status !== 'open' || intent.abortPending === true) return;
-    delete intents[transferId];
-    await this.writeLocalIntents(intents);
+    return this.withIntentsLock(async () => {
+      const intents = await this.readLocalIntents();
+      const intent = intents[transferId];
+      if (!intent) return;
+      // Only a still-'open' copy with no pending server abort is safe to drop:
+      // 'completed' never reverts (§16), and an 'aborted'+abortPending copy is a
+      // #516 backstop whose server row may still be open.
+      if (intent.status !== 'open' || intent.abortPending === true) return;
+      delete intents[transferId];
+      await this.writeLocalIntents(intents);
+    });
   }
 
   /**
@@ -906,16 +929,18 @@ export class WalletApiClient {
     opts: { requiresSeedClose?: boolean } = {}
   ): Promise<void> {
     const requiresSeedClose = opts.requiresSeedClose === true;
-    const intents = await this.readLocalIntents();
-    if (!intents[transferId]) {
-      intents[transferId] = {
-        payload: payloadEnvelope,
-        status: 'open',
-        createdAt: this.now(),
-        ...(requiresSeedClose ? { requiresSeedClose: true } : {}),
-      };
-      await this.writeLocalIntents(intents);
-    }
+    await this.withIntentsLock(async () => {
+      const intents = await this.readLocalIntents();
+      if (!intents[transferId]) {
+        intents[transferId] = {
+          payload: payloadEnvelope,
+          status: 'open',
+          createdAt: this.now(),
+          ...(requiresSeedClose ? { requiresSeedClose: true } : {}),
+        };
+        await this.writeLocalIntents(intents);
+      }
+    });
     await this.requestJson('PUT', `/v1/intents/${transferId}`, this.intentPutBody(payloadEnvelope, requiresSeedClose));
   }
 
@@ -964,13 +989,15 @@ export class WalletApiClient {
 
   /** Persist the exact envelope locally before the first POST (dual persistence — E.3/E.4). */
   private async backstopProgress(transferId: string, opIndex: number, payloadEnvelope: string): Promise<void> {
-    const intents = await this.readLocalIntents();
-    const intent = intents[transferId];
-    if (!intent) return; // no local intent (fresh-device append) — the server row is the seed
-    const progress = intent.progress ?? {};
-    if (progress[opIndex] === payloadEnvelope) return;
-    intent.progress = { ...progress, [opIndex]: payloadEnvelope };
-    await this.writeLocalIntents(intents);
+    return this.withIntentsLock(async () => {
+      const intents = await this.readLocalIntents();
+      const intent = intents[transferId];
+      if (!intent) return; // no local intent (fresh-device append) — the server row is the seed
+      const progress = intent.progress ?? {};
+      if (progress[opIndex] === payloadEnvelope) return;
+      intent.progress = { ...progress, [opIndex]: payloadEnvelope };
+      await this.writeLocalIntents(intents);
+    });
   }
 
   /** `GET /v1/intents?status=` — server-side intent list. */

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -840,8 +840,13 @@ export class WalletApiClient {
     return this.scopedKey('intents');
   }
 
-  private async readLocalIntents(): Promise<Record<string, LocalIntent>> {
-    const raw = await this.storage.get(this.intentsKey());
+  // Every RMW BINDS the intents key at submission (the caller passes the key captured before the
+  // op was queued). The mutex defers the callback, and read/write re-deriving this.intentsKey()
+  // would read the CURRENT identity — so a setIdentity() between submit and run could make a
+  // queued putIntent write owner A's intent into owner B's blob (A loses its restore backstop, B's
+  // record corrupted). Binding the key also closes the pre-existing read-vs-write double-derive.
+  private async readLocalIntents(key: string = this.intentsKey()): Promise<Record<string, LocalIntent>> {
+    const raw = await this.storage.get(key);
     if (!raw) return {};
     try {
       return JSON.parse(raw) as Record<string, LocalIntent>;
@@ -850,8 +855,8 @@ export class WalletApiClient {
     }
   }
 
-  private async writeLocalIntents(intents: Record<string, LocalIntent>): Promise<void> {
-    await this.storage.set(this.intentsKey(), JSON.stringify(intents));
+  private async writeLocalIntents(intents: Record<string, LocalIntent>, key: string = this.intentsKey()): Promise<void> {
+    await this.storage.set(key, JSON.stringify(intents));
   }
 
   /**
@@ -878,8 +883,9 @@ export class WalletApiClient {
     status: LocalIntent['status'],
     opts: { abortPending?: boolean } = {}
   ): Promise<void> {
+    const key = this.intentsKey(); // bind the owner NOW, before the mutex defers the RMW
     return this.withIntentsLock(async () => {
-      const intents = await this.readLocalIntents();
+      const intents = await this.readLocalIntents(key);
       const intent = intents[transferId];
       if (!intent) return;
       if (intent.status === 'completed') return; // completed never reverts (§16)
@@ -888,7 +894,7 @@ export class WalletApiClient {
       intent.status = status;
       if (abortPending) intent.abortPending = true;
       else delete intent.abortPending;
-      await this.writeLocalIntents(intents);
+      await this.writeLocalIntents(intents, key);
     });
   }
 
@@ -902,8 +908,9 @@ export class WalletApiClient {
    * double-pay/restore backstop.
    */
   async removeLocalIntent(transferId: string): Promise<void> {
+    const key = this.intentsKey(); // bind the owner NOW, before the mutex defers the RMW
     return this.withIntentsLock(async () => {
-      const intents = await this.readLocalIntents();
+      const intents = await this.readLocalIntents(key);
       const intent = intents[transferId];
       if (!intent) return;
       // Only a still-'open' copy with no pending server abort is safe to drop:
@@ -911,7 +918,7 @@ export class WalletApiClient {
       // #516 backstop whose server row may still be open.
       if (intent.status !== 'open' || intent.abortPending === true) return;
       delete intents[transferId];
-      await this.writeLocalIntents(intents);
+      await this.writeLocalIntents(intents, key);
     });
   }
 
@@ -929,8 +936,9 @@ export class WalletApiClient {
     opts: { requiresSeedClose?: boolean } = {}
   ): Promise<void> {
     const requiresSeedClose = opts.requiresSeedClose === true;
+    const key = this.intentsKey(); // bind the owner NOW, before the mutex defers the RMW
     await this.withIntentsLock(async () => {
-      const intents = await this.readLocalIntents();
+      const intents = await this.readLocalIntents(key);
       if (!intents[transferId]) {
         intents[transferId] = {
           payload: payloadEnvelope,
@@ -938,7 +946,7 @@ export class WalletApiClient {
           createdAt: this.now(),
           ...(requiresSeedClose ? { requiresSeedClose: true } : {}),
         };
-        await this.writeLocalIntents(intents);
+        await this.writeLocalIntents(intents, key);
       }
     });
     await this.requestJson('PUT', `/v1/intents/${transferId}`, this.intentPutBody(payloadEnvelope, requiresSeedClose));
@@ -989,14 +997,15 @@ export class WalletApiClient {
 
   /** Persist the exact envelope locally before the first POST (dual persistence — E.3/E.4). */
   private async backstopProgress(transferId: string, opIndex: number, payloadEnvelope: string): Promise<void> {
+    const key = this.intentsKey(); // bind the owner NOW, before the mutex defers the RMW
     return this.withIntentsLock(async () => {
-      const intents = await this.readLocalIntents();
+      const intents = await this.readLocalIntents(key);
       const intent = intents[transferId];
       if (!intent) return; // no local intent (fresh-device append) — the server row is the seed
       const progress = intent.progress ?? {};
       if (progress[opIndex] === payloadEnvelope) return;
       intent.progress = { ...progress, [opIndex]: payloadEnvelope };
-      await this.writeLocalIntents(intents);
+      await this.writeLocalIntents(intents, key);
     });
   }
 


### PR DESCRIPTION
## Summary

First fix of **root cause A** from the wallet-api concurrency audit: no mutex over the whole-blob read-modify-writes.

Every mutator of the local-intents blob — `putIntent`, `setLocalIntentStatus`, `removeLocalIntent`, `backstopProgress` — does `get → parse → mutate → set` with an await in between. Run concurrently they each start from the SAME snapshot and the last writer clobbers the others' entries:
- a concurrent write drops another intent's LOCAL copy (the #516/E.3 restore + double-pay backstop → an un-restorable committed send), or
- a split's freshly-persisted burn checkpoint (→ `SplitCheckpointLostError` / stranded funds on a later restore).

Fix: a per-client promise-chain mutex (like the provider's `overlayLock`) runs each RMW after the previous settles; the network PUT stays outside the lock.

## Regression

Two concurrent `putIntent` must both persist locally — fails `expected null not to be null` without the mutex (one copy clobbered), passes with it.

Full suite: 3142 tests pass; `tsc --noEmit` clean.

## Follow-ups

Root cause A also covers the provider-side blob RMWs (`this.view` under `applySuspectedSpentOverlay`, `persistSyncState` — audit findings #7/#10); those are tracked separately.