### PR TITLE
Concurrency money-safety: resume forward-completes delivered legs + surfaces the remainder (audit #4)

### DIFF
--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -5805,25 +5805,6 @@ export class PaymentsModule {
     return this.mutateSettlingJournal((m) => m.delete(requestId));
   }
 
-  /**
-   * Upgrade any settling link for `transferId` to `committed` (§7 partial completion). A committed
-   * link delivered value already, so reconcile must resolve it 'paid' and NEVER revert it to payable
-   * (re-paying the full amount would double-pay the delivered legs — {@link journalSettling}). No-op
-   * for a plain send with no linked request.
-   */
-  private markSettlingCommitted(transferId: string): Promise<void> {
-    return this.mutateSettlingJournal((m) => {
-      let changed = false;
-      for (const [requestId, entry] of m) {
-        if (entry.transferId === transferId && !entry.committed) {
-          m.set(requestId, { ...entry, committed: true });
-          changed = true;
-        }
-      }
-      return changed;
-    });
-  }
-
   // ── the pump ─────────────────────────────────────────────────────────────────
 
   /**
@@ -6212,12 +6193,13 @@ export class PaymentsModule {
           }
           outcome.conflicted.push(intent.transferId);
         } else if (err instanceof PartialSendConflictError) {
-          // §7 PARTIAL completion: ≥1 leg forward-completed (delivered + recorded) before a LATER
-          // source was lost to a foreign tx. resumeIntent has ALREADY, before closing the intent,
-          // durably marked any linked settling request COMMITTED (→ reconcile resolves 'paid', never
-          // reverts → no double-pay), written the delivered-amount SENT history, and emitted the
-          // 'send:partial-remainder' event. So this intent is DONE — classify it resumed; the app
-          // re-plans ONLY the shortfall under a NEW transferId (a background resume never auto-sends).
+          // §7 PARTIAL completion: ≥1 leg forward-completed (delivered + recorded, intent completed by
+          // applyDelta) before a LATER source was lost to a foreign tx. Classify it `resumed` — this is
+          // the durable no-double-pay guard: reconcileSettlingPaymentRequests resolves any linked
+          // request 'paid' via the `resumed || local-completed` branch and NEVER reverts it to payable,
+          // so the delivered legs are never re-paid. resumeIntent already wrote the delivered-amount SENT
+          // history and emitted 'send:partial-remainder'; the app re-plans ONLY the shortfall under a
+          // NEW transferId (a background resume never auto-sends).
           logger.warn(
             'Payments',
             `Intent ${intent.transferId.slice(0, 8)}… PARTIALLY completed — delivered legs final; ${err.remainingAmount} remainder owed (re-plan only the shortfall)`,
@@ -6596,19 +6578,20 @@ export class PaymentsModule {
       }
     }
 
-    // §7 PARTIAL completion: ≥1 leg delivered, then a LATER source was lost to a FOREIGN tx. Write
-    // ALL durable partial state BEFORE closing the intent, so a crash right after completeIntent
-    // cannot lose the shortfall (a completed intent never re-runs): (1) mark any linked settling
-    // request COMMITTED — reconcile resolves it 'paid' for the delivered value and NEVER reverts it to
-    // payable (the delivered legs are never re-paid = no double-pay); idempotent, a no-op for a plain
-    // send; (2) the SENT history for the DELIVERED amount only (never the full amount); (3) the
-    // remainder event so the app re-plans ONLY the shortfall under a NEW transferId (§7). THEN
-    // completeIntent (forward-complete, irreversible per §7; close the server row so listIntents('open')
-    // stops returning it) and surface the PartialSendConflictError.
+    // §7 PARTIAL completion: ≥1 leg delivered, then a LATER source was lost to a FOREIGN tx. The
+    // delivered legs' spends are already recorded by applyDelta above, which also COMPLETED the
+    // intent (server + local status 'completed', client.ts). No double-pay, durably: resumeOpenIntents
+    // classifies this transferId `resumed`, so reconcileSettlingPaymentRequests resolves any linked
+    // request 'paid' (via the `resumed || local-completed` branch) and NEVER reverts it to payable —
+    // the delivered legs are never re-paid. completeIntent FIRST (idempotent; the intent is already
+    // completed) so the best-effort SENT history / remainder event below can never wedge it open.
+    // The remainder event + PartialSendConflictError surface the shortfall so the app re-plans ONLY
+    // it under a NEW transferId (§7). NOTE: the event is a live-session hint; a crash-durable
+    // remainder re-plan (recipient made whole across restarts) is a tracked follow-up.
     if (conflicted) {
       const remaining = undeliveredAmount;
       const delivered = BigInt(payload.amount) - remaining;
-      await this.markSettlingCommitted(transferId);
+      await walletApi.completeIntent(transferId); // idempotent — applyDelta above usually already closed it
       await this.addToHistory({
         type: 'SENT',
         amount: (delivered > 0n ? delivered : 0n).toString(),
@@ -6626,7 +6609,6 @@ export class PaymentsModule {
         coinId: payload.coinId,
         recipient: payload.recipient,
       });
-      await walletApi.completeIntent(transferId);
       throw new PartialSendConflictError(
         'Resume: part of the payment was delivered before a source was consumed by a concurrent transfer — the delivered legs are final; re-plan ONLY the remainder.',
         transferId,

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -6213,22 +6213,15 @@ export class PaymentsModule {
           outcome.conflicted.push(intent.transferId);
         } else if (err instanceof PartialSendConflictError) {
           // §7 PARTIAL completion: ≥1 leg forward-completed (delivered + recorded) before a LATER
-          // source was lost to a foreign tx. resumeIntent already completed the intent server-side.
-          // Mark any linked settling request COMMITTED — reconcile then resolves it 'paid' (for the
-          // delivered value) and NEVER reverts it to payable, so the delivered legs are never re-paid
-          // (no double-pay). Surface the undelivered remainder for a re-plan under a NEW transferId
-          // (§7); a background resume does NOT auto-send it — the app re-plans ONLY the shortfall.
+          // source was lost to a foreign tx. resumeIntent has ALREADY, before closing the intent,
+          // durably marked any linked settling request COMMITTED (→ reconcile resolves 'paid', never
+          // reverts → no double-pay), written the delivered-amount SENT history, and emitted the
+          // 'send:partial-remainder' event. So this intent is DONE — classify it resumed; the app
+          // re-plans ONLY the shortfall under a NEW transferId (a background resume never auto-sends).
           logger.warn(
             'Payments',
             `Intent ${intent.transferId.slice(0, 8)}… PARTIALLY completed — delivered legs final; ${err.remainingAmount} remainder owed (re-plan only the shortfall)`,
           );
-          await this.markSettlingCommitted(intent.transferId);
-          this.deps!.emitEvent('send:partial-remainder', {
-            transferId: intent.transferId,
-            remainingAmount: err.remainingAmount,
-            coinId: payload.coinId,
-            recipient: payload.recipient,
-          });
           outcome.resumed.push(intent.transferId);
         } else if (err instanceof SplitCheckpointLostError || err instanceof CheckpointTrustbaseMismatchError) {
           // E.4: a burn-certified split is STUCK on an unrecoverable-for-now checkpoint error (lost
@@ -6420,23 +6413,21 @@ export class PaymentsModule {
     const spent: string[] = []; // DELIVERED legs only (§7 forward-completion)
     let conflicted = false; // ≥1 source was lost to a FOREIGN tx (§8.1) — that leg delivered nothing
     let firstConflict: TransferConflictError | undefined;
-    let deliveredAmount = 0n;
-    // A direct leg moves a WHOLE token, so its delivered value is that source's coin amount.
-    const legAmount = (genesisId: string, source?: SphereToken): bigint => {
-      const local = this.tokens.get(`v2_${genesisId}`)?.amount;
-      if (local !== undefined) return BigInt(local);
-      return source ? engine.balanceOf(source, payload.coinId) : 0n;
-    };
+    // The undelivered shortfall = Σ of the CONFLICTED legs' values. A conflicted leg is always FRESH
+    // (a journaled leg re-delivers, it never conflicts), so its `source` is decoded before the throw
+    // and its whole-token value is exact — computing the shortfall from the UNDELIVERED side avoids
+    // the delivered-side undercount (a journaled leg's source is already gone from this.tokens).
+    let undeliveredAmount = 0n;
     for (const [opIndex, genesisId] of payload.direct.entries()) {
       const existing = journaled.get(opIndex);
       if (existing) {
         await deliverBlob(existing.tokenBlob, opIndex);
         spent.push(genesisId);
-        deliveredAmount += legAmount(genesisId);
       } else {
+        // Decode the source OUTSIDE the try so it is in scope in the catch (a decode failure is a
+        // genuine error, not a conflict, and rethrows).
+        const source = await engine.decodeToken(await provider.getToken(genesisId));
         try {
-          const blob = await provider.getToken(genesisId);
-          const source = await engine.decodeToken(blob);
           const finished = await engine.transfer(
             { token: source, recipientPubkey: recipientChainPubkey, data: memoData },
             // (transferId, opIndex) pairing replayed from the intent's persisted order (§8.1)
@@ -6444,16 +6435,16 @@ export class PaymentsModule {
           );
           await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(finished))), opIndex);
           spent.push(genesisId);
-          deliveredAmount += legAmount(genesisId, source);
         } catch (err) {
           if (!(err instanceof TransferConflictError)) throw err;
           // §8.1: a resume TransferConflictError = a DIFFERENT (foreign) transaction consumed the
           // source. The engine returns the existing proof for OUR OWN resume (a hash-MATCH, no
           // throw — recoverable-engine AC-E1/E2 vs AC-E4), so this leg delivered NOTHING. NEVER
-          // record it as spent (that false-marks the intent PAID). Flag the partial; after the loops
-          // the delivered legs forward-complete and only the undelivered remainder is surfaced (§7).
+          // record it as spent (that false-marks the intent PAID). Flag the partial and add this
+          // WHOLE source token's value to the undelivered shortfall (§7).
           conflicted = true;
           firstConflict ??= err;
+          undeliveredAmount += engine.balanceOf(source, payload.coinId);
           logger.warn('Payments', `Resume op ${opIndex} lost its source to a concurrent transfer — not delivered (§8.1/#4):`, err);
         }
       }
@@ -6526,9 +6517,10 @@ export class PaymentsModule {
           if (err instanceof TransferConflictError) {
             // §8.1: the split SOURCE (burn leg) was consumed by a FOREIGN tx under a DIFFERENT
             // transferId — the split delivered NOTHING. Do NOT record it as spent (that false-marks
-            // the intent paid); flag the partial, handled after the loops like a direct-leg conflict.
+            // the intent paid); flag the partial and add the recipient portion to the shortfall (§7).
             conflicted = true;
             firstConflict ??= err;
+            undeliveredAmount += BigInt(payload.split.splitAmount);
             logger.warn('Payments', `Resume split: source lost to a concurrent transfer — not delivered (§8.1/#4):`, err);
           } else if (err instanceof SplitCheckpointLostError) {
             // LEGACY no-checkpoint residual: the mint leg already certified but there is no checkpoint
@@ -6543,7 +6535,6 @@ export class PaymentsModule {
       }
       if (splitDelivered) {
         spent.push(payload.split.tokenId);
-        deliveredAmount += BigInt(payload.split.splitAmount);
       }
     }
 
@@ -6605,21 +6596,22 @@ export class PaymentsModule {
       }
     }
 
-    // E.3 uniform close (idempotent; the apply above usually already did it). For a PARTIAL (below)
-    // this forward-completes the delivered legs — irreversible per §7 — and closes the server intent
-    // row so the next sign-in's listIntents('open') does not re-return it (no re-run wedge).
-    await walletApi.completeIntent(transferId);
-
-    // §7 PARTIAL completion: ≥1 leg delivered, then a LATER source was lost to a FOREIGN tx. The
-    // delivered legs are recorded + the intent completed (irreversible). Record the SENT history for
-    // the DELIVERED amount only, then surface the undelivered remainder as a PartialSendConflictError:
-    // resumeOpenIntents marks any linked settling request COMMITTED (resolve 'paid' for the delivered
-    // value, NEVER revert-to-payable → the delivered legs are never re-paid = no double-pay) and
-    // surfaces the remainder to re-plan under a NEW transferId (§7). NEVER write the full-amount SENT.
+    // §7 PARTIAL completion: ≥1 leg delivered, then a LATER source was lost to a FOREIGN tx. Write
+    // ALL durable partial state BEFORE closing the intent, so a crash right after completeIntent
+    // cannot lose the shortfall (a completed intent never re-runs): (1) mark any linked settling
+    // request COMMITTED — reconcile resolves it 'paid' for the delivered value and NEVER reverts it to
+    // payable (the delivered legs are never re-paid = no double-pay); idempotent, a no-op for a plain
+    // send; (2) the SENT history for the DELIVERED amount only (never the full amount); (3) the
+    // remainder event so the app re-plans ONLY the shortfall under a NEW transferId (§7). THEN
+    // completeIntent (forward-complete, irreversible per §7; close the server row so listIntents('open')
+    // stops returning it) and surface the PartialSendConflictError.
     if (conflicted) {
+      const remaining = undeliveredAmount;
+      const delivered = BigInt(payload.amount) - remaining;
+      await this.markSettlingCommitted(transferId);
       await this.addToHistory({
         type: 'SENT',
-        amount: deliveredAmount.toString(),
+        amount: (delivered > 0n ? delivered : 0n).toString(),
         coinId: payload.coinId,
         symbol: this.getCoinSymbol(payload.coinId),
         timestamp: Date.now(),
@@ -6628,7 +6620,13 @@ export class PaymentsModule {
         transferId,
         tokenId: spent[0] ? `v2_${spent[0]}` : undefined,
       });
-      const remaining = BigInt(payload.amount) - deliveredAmount;
+      this.deps!.emitEvent('send:partial-remainder', {
+        transferId,
+        remainingAmount: (remaining > 0n ? remaining : 0n).toString(),
+        coinId: payload.coinId,
+        recipient: payload.recipient,
+      });
+      await walletApi.completeIntent(transferId);
       throw new PartialSendConflictError(
         'Resume: part of the payment was delivered before a source was consumed by a concurrent transfer — the delivered legs are final; re-plan ONLY the remainder.',
         transferId,
@@ -6637,6 +6635,9 @@ export class PaymentsModule {
         firstConflict,
       );
     }
+
+    // E.3 uniform close (idempotent; the apply above usually already did it).
+    await walletApi.completeIntent(transferId);
 
     // §10: the SENT record — same dedupKey as the original attempt, so a
     // resume after the history POST is a no-op server-side.

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -6607,7 +6607,7 @@ export class PaymentsModule {
         transferId,
         remainingAmount: (remaining > 0n ? remaining : 0n).toString(),
         coinId: payload.coinId,
-        recipient: payload.recipient,
+        recipientPubkey: payload.recipient,
       });
       throw new PartialSendConflictError(
         'Resume: part of the payment was delivered before a source was consumed by a concurrent transfer — the delivered legs are final; re-plan ONLY the remainder.',

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -5805,6 +5805,25 @@ export class PaymentsModule {
     return this.mutateSettlingJournal((m) => m.delete(requestId));
   }
 
+  /**
+   * Upgrade any settling link for `transferId` to `committed` (§7 partial completion). A committed
+   * link delivered value already, so reconcile must resolve it 'paid' and NEVER revert it to payable
+   * (re-paying the full amount would double-pay the delivered legs — {@link journalSettling}). No-op
+   * for a plain send with no linked request.
+   */
+  private markSettlingCommitted(transferId: string): Promise<void> {
+    return this.mutateSettlingJournal((m) => {
+      let changed = false;
+      for (const [requestId, entry] of m) {
+        if (entry.transferId === transferId && !entry.committed) {
+          m.set(requestId, { ...entry, committed: true });
+          changed = true;
+        }
+      }
+      return changed;
+    });
+  }
+
   // ── the pump ─────────────────────────────────────────────────────────────────
 
   /**
@@ -6192,6 +6211,25 @@ export class PaymentsModule {
             logger.warn('Payments', 'abortIntent during resume failed:', abortErr);
           }
           outcome.conflicted.push(intent.transferId);
+        } else if (err instanceof PartialSendConflictError) {
+          // §7 PARTIAL completion: ≥1 leg forward-completed (delivered + recorded) before a LATER
+          // source was lost to a foreign tx. resumeIntent already completed the intent server-side.
+          // Mark any linked settling request COMMITTED — reconcile then resolves it 'paid' (for the
+          // delivered value) and NEVER reverts it to payable, so the delivered legs are never re-paid
+          // (no double-pay). Surface the undelivered remainder for a re-plan under a NEW transferId
+          // (§7); a background resume does NOT auto-send it — the app re-plans ONLY the shortfall.
+          logger.warn(
+            'Payments',
+            `Intent ${intent.transferId.slice(0, 8)}… PARTIALLY completed — delivered legs final; ${err.remainingAmount} remainder owed (re-plan only the shortfall)`,
+          );
+          await this.markSettlingCommitted(intent.transferId);
+          this.deps!.emitEvent('send:partial-remainder', {
+            transferId: intent.transferId,
+            remainingAmount: err.remainingAmount,
+            coinId: payload.coinId,
+            recipient: payload.recipient,
+          });
+          outcome.resumed.push(intent.transferId);
         } else if (err instanceof SplitCheckpointLostError || err instanceof CheckpointTrustbaseMismatchError) {
           // E.4: a burn-certified split is STUCK on an unrecoverable-for-now checkpoint error (lost
           // checkpoint, or a trust-base rotation). The intent stays OPEN (funds in-flight, never
@@ -6379,11 +6417,22 @@ export class PaymentsModule {
     // Re-running engine.transfer on the now-spent source would raise TransferConflictError — re-deliver
     // the stored blob instead (idempotent). Only run the engine op when nothing was journaled for it.
     const journaled = await this.journaledByOp(transferId);
-    const spent: string[] = [];
+    const spent: string[] = []; // DELIVERED legs only (§7 forward-completion)
+    let conflicted = false; // ≥1 source was lost to a FOREIGN tx (§8.1) — that leg delivered nothing
+    let firstConflict: TransferConflictError | undefined;
+    let deliveredAmount = 0n;
+    // A direct leg moves a WHOLE token, so its delivered value is that source's coin amount.
+    const legAmount = (genesisId: string, source?: SphereToken): bigint => {
+      const local = this.tokens.get(`v2_${genesisId}`)?.amount;
+      if (local !== undefined) return BigInt(local);
+      return source ? engine.balanceOf(source, payload.coinId) : 0n;
+    };
     for (const [opIndex, genesisId] of payload.direct.entries()) {
       const existing = journaled.get(opIndex);
       if (existing) {
         await deliverBlob(existing.tokenBlob, opIndex);
+        spent.push(genesisId);
+        deliveredAmount += legAmount(genesisId);
       } else {
         try {
           const blob = await provider.getToken(genesisId);
@@ -6394,15 +6443,20 @@ export class PaymentsModule {
             { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId, opIndex }
           );
           await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(finished))), opIndex);
+          spent.push(genesisId);
+          deliveredAmount += legAmount(genesisId, source);
         } catch (err) {
-          // #621: no journaled blob, but the source is already spent on-chain — the original send
-          // certified (and delivered) this op and only failed to close on a LATER step. Record the
-          // spend (applyDelta below) instead of wedging on a re-certification TransferConflictError.
           if (!(err instanceof TransferConflictError)) throw err;
-          logger.warn('Payments', `Resume op ${opIndex} already certified (source spent) — recording the spend, not re-certifying (§3.1):`, err);
+          // §8.1: a resume TransferConflictError = a DIFFERENT (foreign) transaction consumed the
+          // source. The engine returns the existing proof for OUR OWN resume (a hash-MATCH, no
+          // throw — recoverable-engine AC-E1/E2 vs AC-E4), so this leg delivered NOTHING. NEVER
+          // record it as spent (that false-marks the intent PAID). Flag the partial; after the loops
+          // the delivered legs forward-complete and only the undelivered remainder is surfaced (§7).
+          conflicted = true;
+          firstConflict ??= err;
+          logger.warn('Payments', `Resume op ${opIndex} lost its source to a concurrent transfer — not delivered (§8.1/#4):`, err);
         }
       }
-      spent.push(genesisId);
     }
 
     let changeOutput: SphereToken | null = null;
@@ -6416,9 +6470,11 @@ export class PaymentsModule {
       // legacy journaled shortcut (#634): that shortcut re-delivered the recipient blob but left the
       // change unpersisted, so the following applyDelta recorded the spend with an empty `added`.
       const checkpointStore = payload.v === 2 ? this.getCheckpointStore() : undefined;
+      let splitDelivered = false;
       if (checkpointStore === undefined && existingSplit) {
         // Legacy residual (no checkpoint): re-deliver only; the change recovers via inventory resync.
         await deliverBlob(existingSplit.tokenBlob, splitOpIndex);
+        splitDelivered = true;
       } else {
         try {
           const blob = await provider.getToken(payload.split.tokenId);
@@ -6453,6 +6509,7 @@ export class PaymentsModule {
           // throw keeps the intent open and the next sign-in re-runs it.
           if (!serverApply) await this.storeEngineToken(engine, changeOutput, { criticalSave: true });
           await deliverBlob(bytesToHex(encodeTokenBlob(engine.encodeToken(outputs[0]))), splitOpIndex);
+          splitDelivered = true;
         } catch (err) {
           if (err instanceof ProofUnconfirmedError) throw err; // #631 keep-open (indeterminate)
           // KEEP-OPEN with a checkpoint store (v:2): the burn is certified and a split-mint stateId is
@@ -6466,17 +6523,35 @@ export class PaymentsModule {
           ) {
             throw err;
           }
-          // Record the spend for: a genuine burn-leg foreign spend (TransferConflictError, §7 race
-          // under a DIFFERENT transferId), OR a LEGACY no-checkpoint split whose already-certified
-          // mint leg the engine now surfaces as SplitCheckpointLostError (there is no checkpoint to
-          // recover from — the v:1 residual: the change recovers via a full inventory resync).
-          if (!(err instanceof TransferConflictError) && !(err instanceof SplitCheckpointLostError)) throw err;
-          logger.warn('Payments', `Resume split: source already spent — recording the spend; change (if any) recovers on the next inventory resync (§3.1):`, err);
-          this.deps!.emitEvent('inventory:conflict', { transferId, coinId: payload.coinId, error: err.message });
+          if (err instanceof TransferConflictError) {
+            // §8.1: the split SOURCE (burn leg) was consumed by a FOREIGN tx under a DIFFERENT
+            // transferId — the split delivered NOTHING. Do NOT record it as spent (that false-marks
+            // the intent paid); flag the partial, handled after the loops like a direct-leg conflict.
+            conflicted = true;
+            firstConflict ??= err;
+            logger.warn('Payments', `Resume split: source lost to a concurrent transfer — not delivered (§8.1/#4):`, err);
+          } else if (err instanceof SplitCheckpointLostError) {
+            // LEGACY no-checkpoint residual: the mint leg already certified but there is no checkpoint
+            // to recover from — record the spend (the change recovers via a full inventory resync, v:1).
+            logger.warn('Payments', `Resume split (legacy no-checkpoint): recording the spend; change recovers on the next inventory resync (§3.1):`, err);
+            this.deps!.emitEvent('inventory:conflict', { transferId, coinId: payload.coinId, error: err.message });
+            splitDelivered = true;
+          } else {
+            throw err;
+          }
         }
       }
-      spent.push(payload.split.tokenId);
+      if (splitDelivered) {
+        spent.push(payload.split.tokenId);
+        deliveredAmount += BigInt(payload.split.splitAmount);
+      }
     }
+
+    // §7/§8.1: NOTHING was delivered — the (only/first) source was consumed by a FOREIGN tx. Surface
+    // the bare conflict: resumeOpenIntents soft-aborts the intent → the linked settling request
+    // reverts to payable and is re-paid IN FULL. Never applyDelta/complete an intent that delivered
+    // nothing (that is the #4 false-paid). The delivered case (≥1 leg) is handled after the tail.
+    if (conflicted && spent.length === 0) throw firstConflict!;
 
     if (serverApply) {
       const added: { tokenId: string; key: string }[] = [];
@@ -6530,8 +6605,38 @@ export class PaymentsModule {
       }
     }
 
-    // E.3 uniform close (idempotent; the apply above usually already did it).
+    // E.3 uniform close (idempotent; the apply above usually already did it). For a PARTIAL (below)
+    // this forward-completes the delivered legs — irreversible per §7 — and closes the server intent
+    // row so the next sign-in's listIntents('open') does not re-return it (no re-run wedge).
     await walletApi.completeIntent(transferId);
+
+    // §7 PARTIAL completion: ≥1 leg delivered, then a LATER source was lost to a FOREIGN tx. The
+    // delivered legs are recorded + the intent completed (irreversible). Record the SENT history for
+    // the DELIVERED amount only, then surface the undelivered remainder as a PartialSendConflictError:
+    // resumeOpenIntents marks any linked settling request COMMITTED (resolve 'paid' for the delivered
+    // value, NEVER revert-to-payable → the delivered legs are never re-paid = no double-pay) and
+    // surfaces the remainder to re-plan under a NEW transferId (§7). NEVER write the full-amount SENT.
+    if (conflicted) {
+      await this.addToHistory({
+        type: 'SENT',
+        amount: deliveredAmount.toString(),
+        coinId: payload.coinId,
+        symbol: this.getCoinSymbol(payload.coinId),
+        timestamp: Date.now(),
+        recipientPubkey: payload.recipient,
+        memo: payload.memo,
+        transferId,
+        tokenId: spent[0] ? `v2_${spent[0]}` : undefined,
+      });
+      const remaining = BigInt(payload.amount) - deliveredAmount;
+      throw new PartialSendConflictError(
+        'Resume: part of the payment was delivered before a source was consumed by a concurrent transfer — the delivered legs are final; re-plan ONLY the remainder.',
+        transferId,
+        spent, // the DELIVERED genesisIds — never the conflicted leg
+        (remaining > 0n ? remaining : 0n).toString(),
+        firstConflict,
+      );
+    }
 
     // §10: the SENT record — same dedupKey as the original attempt, so a
     // resume after the history POST is a no-op server-side.

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -1165,7 +1165,7 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     // The undelivered remainder (1000 − 600 = 400) is SURFACED for a re-plan under a new transferId —
     // never re-sent from here, never rolled into a full-amount re-pay.
     const evt = sender.emitEvent.mock.calls.find((c) => c[0] === 'send:partial-remainder');
-    expect(evt?.[1]).toMatchObject({ transferId, remainingAmount: '400', recipient: RECIPIENT.chainPubkey });
+    expect(evt?.[1]).toMatchObject({ transferId, remainingAmount: '400', recipientPubkey: RECIPIENT.chainPubkey });
   });
 
   it('legacy (v:1, no store): a resume that hits SplitCheckpointLostError records the spend, never wedges', async () => {

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -1001,7 +1001,7 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(fake.getRow(SENDER.chainPubkey, src)).toMatchObject({ status: 'active' }); // source not re-spent
   });
 
-  it('resume of an already-certified source records the spend instead of wedging on a conflict (§3.1 #621)', async () => {
+  it('audit#4: resume of a single source lost to a FOREIGN transfer ABORTS (conflicted) — never falsely completes (§8.1/§7; reverses #621)', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-rs-621');
     const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
@@ -1015,18 +1015,20 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
       encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload)),
     );
 
-    // The original send already certified (and delivered) this source — the intent only failed to
-    // close on a later step. Re-running the engine on the spent source raises TransferConflictError.
-    // Old behavior wedged (conflicted + re-certify forever); the fix records the spend and completes.
+    // §8.1: engine.transfer returns the existing proof for OUR OWN resume (a hash-MATCH, no throw);
+    // a TransferConflictError means a DIFFERENT (foreign) transaction consumed the source — this leg
+    // delivered NOTHING. With nothing delivered, resume must ABORT and re-plan the FULL amount (§7),
+    // NOT record the spend + complete (the #621 false-paid this reverses).
     vi.spyOn(sender.engine, 'transfer').mockRejectedValue(
       new TransferConflictError('TRANSACTION_HASH_MISMATCH: source already spent'),
     );
 
     const outcome = await sender.module.resumeOpenIntents();
-    expect(outcome.resumed).toEqual([transferId]);
-    expect(outcome.conflicted).toEqual([]);
-    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'removed' });
-    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
+    expect(outcome.conflicted).toContain(transferId);
+    expect(outcome.resumed).not.toContain(transferId);
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'aborted' });
+    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'active' }); // not falsely removed
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);
   });
 
   it('#631: a proof-fetch failure AFTER certification keeps the intent OPEN (resume seed survives; no double-spend)', async () => {
@@ -1088,7 +1090,7 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(fake.getIntent(SENDER.chainPubkey, transferId!)).toMatchObject({ status: 'aborted' });
   });
 
-  it('resume of an already-certified SPLIT source records the spend instead of wedging (#622 review)', async () => {
+  it('audit#4: resume of a split-only source lost to a FOREIGN transfer ABORTS (conflicted) — never falsely completes (§8.1/§7; reverses #622)', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-rs-split-621');
     const sourceTokenId = await seedServerToken(fake, sender, SENDER, 1000n);
@@ -1109,19 +1111,61 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
       encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload)),
     );
 
-    // The original send already certified the split — re-running engine.split conflicts. Without the
-    // #622-review fix this bubbles up, aborts, and wedges; the fix records the spend and completes.
+    // A TransferConflictError from engine.split = the split SOURCE was consumed by a DIFFERENT
+    // (foreign) transaction (§8.1). With no direct legs, NOTHING was delivered → resume must ABORT
+    // and re-plan the full amount (§7), never record the spend + complete (the #622 false-paid).
     vi.spyOn(sender.engine, 'split').mockRejectedValue(
       new TransferConflictError('TRANSACTION_HASH_MISMATCH: split source already spent'),
     );
 
     const outcome = await sender.module.resumeOpenIntents();
-    expect(outcome.resumed).toEqual([transferId]);
-    expect(outcome.conflicted).toEqual([]);
-    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'removed' });
+    expect(outcome.conflicted).toContain(transferId);
+    expect(outcome.resumed).not.toContain(transferId);
+    expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'aborted' });
+    expect(fake.getRow(SENDER.chainPubkey, sourceTokenId)).toMatchObject({ status: 'active' }); // not falsely removed
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);
+  });
+
+  it('audit#4 (Codex P1): MULTI-SOURCE partial — the delivered leg is retained (never double-paid); only the remainder is surfaced', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-rs-partial');
+    const g0 = await seedServerToken(fake, sender, SENDER, 600n); // leg 0 — delivers
+    const g1 = await seedServerToken(fake, sender, SENDER, 400n); // leg 1 — lost to a foreign tx
+    await sender.module.load();
+
+    const transferId = crypto.randomUUID();
+    const payload = { v: 1, recipient: RECIPIENT.chainPubkey, coinId: UCT, amount: '1000', direct: [g0, g1] };
+    sender.client.setIdentity(SENDER);
+    await sender.client.putIntent(
+      transferId,
+      encryptField(deriveFieldEncryptionKey(SENDER.privateKey), JSON.stringify(payload)),
+    );
+
+    // Resume: leg 0 (opIndex 0) transfers for real (delivers 600); leg 1 (opIndex 1) was consumed by
+    // a FOREIGN tx → engine.transfer conflicts (§8.1). This is exactly the case a bare abort would
+    // DOUBLE-PAY: aborting the whole intent makes a linked request payable and re-pays the delivered
+    // leg 0. The fix forward-completes leg 0 and surfaces ONLY the remainder.
+    const realTransfer = sender.engine.transfer.bind(sender.engine);
+    vi.spyOn(sender.engine, 'transfer').mockImplementation(async (p, o) => {
+      if (o?.opIndex === 1) throw new TransferConflictError('TRANSACTION_HASH_MISMATCH: leg 1 source lost');
+      return realTransfer(p, o);
+    });
+    const applySpy = vi.spyOn(sender.client, 'applyInventoryDelta');
+
+    const outcome = await sender.module.resumeOpenIntents();
+
+    // §7 forward-completion: the delivered leg is FINAL. The intent is RESUMED (completed), NEVER
+    // conflicted — so a linked settling request resolves 'paid' and is NEVER reverted to payable
+    // (no double-pay of leg 0). Only leg 0 (g0) is recorded spent — never the conflicted leg 1 (g1).
+    expect(outcome.resumed).toContain(transferId);
+    expect(outcome.conflicted).not.toContain(transferId);
+    const applyForT = applySpy.mock.calls.find((c) => (c[0] as { transferId?: string })?.transferId === transferId);
+    expect((applyForT?.[0] as { spent: string[] }).spent).toEqual([g0]); // delivered leg only — EXCLUDES the conflicted g1
     expect(fake.getIntent(SENDER.chainPubkey, transferId)).toMatchObject({ status: 'completed' });
-    // The change-token limitation is surfaced (prompts a resync) — never silently lost.
-    expect(sender.emitEvent.mock.calls.some((c) => c[0] === 'inventory:conflict')).toBe(true);
+    // The undelivered remainder (1000 − 600 = 400) is SURFACED for a re-plan under a new transferId —
+    // never re-sent from here, never rolled into a full-amount re-pay.
+    const evt = sender.emitEvent.mock.calls.find((c) => c[0] === 'send:partial-remainder');
+    expect(evt?.[1]).toMatchObject({ transferId, remainingAmount: '400', recipient: RECIPIENT.chainPubkey });
   });
 
   it('legacy (v:1, no store): a resume that hits SplitCheckpointLostError records the spend, never wedges', async () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -549,10 +549,10 @@ export interface SphereEventMap {
   /**
    * §7 partial completion: a resumed multi-source send delivered ≥1 leg, then a LATER source was
    * lost to a foreign tx. The delivered legs are final (recorded, request resolved 'paid'); the app
-   * should re-plan ONLY `remainingAmount` to `recipient` under a NEW transferId — never the full
+   * should re-plan ONLY `remainingAmount` to `recipientPubkey` under a NEW transferId — never the full
    * amount (that would double-pay the delivered legs).
    */
-  'send:partial-remainder': { transferId: string; remainingAmount: string; coinId: string; recipient: string };
+  'send:partial-remainder': { transferId: string; remainingAmount: string; coinId: string; recipientPubkey: string };
   /**
    * A journaled finished-but-undelivered v2 transfer blob (#517) has exhausted
    * its bounded replay budget and is now POISON: it stays journaled (the deposit

--- a/types/index.ts
+++ b/types/index.ts
@@ -423,6 +423,7 @@ export type SphereEventType =
   | 'storage:degraded'
   | 'inventory:conflict'
   | 'split:checkpoint-stuck'
+  | 'send:partial-remainder'
   | 'delivery:undeliverable'
   | 'delivery:deferred'
   | 'walletapi:session'
@@ -545,6 +546,13 @@ export interface SphereEventMap {
    * drain remedy), NOT a silent retry. Distinct from a transient resume failure.
    */
   'split:checkpoint-stuck': { transferId: string; code: string; error: string };
+  /**
+   * §7 partial completion: a resumed multi-source send delivered ≥1 leg, then a LATER source was
+   * lost to a foreign tx. The delivered legs are final (recorded, request resolved 'paid'); the app
+   * should re-plan ONLY `remainingAmount` to `recipient` under a NEW transferId — never the full
+   * amount (that would double-pay the delivered legs).
+   */
+  'send:partial-remainder': { transferId: string; remainingAmount: string; coinId: string; recipient: string };
   /**
    * A journaled finished-but-undelivered v2 transfer blob (#517) has exhausted
    * its bounded replay budget and is now POISON: it stays journaled (the deposit


### PR DESCRIPTION
## Summary

Fixes audit finding **#4** (resume false-paid), the one deferred from #688 because the first attempt had a Codex-flagged multi-source double-pay hole. This version is grounded in the wallet-api backend spec (`ARCHITECTURE.md` §7/§8.1/§10), not reverse-engineered.

**The bug.** `resumeIntent` swallowed every resume-time `TransferConflictError` as "my own certified send" and recorded the conflicted leg as spent → the intent was marked **paid** for a leg that delivered nothing. Per §8.1 the engine returns the existing proof for *our own* resume (a hash-**match**, no throw — recoverable-engine `AC-E1/E2` vs `AC-E4`); a `TransferConflictError` means a **different (foreign)** transaction consumed the source.

**Why the naive fix was worse.** Propagating a bare abort re-pays already-delivered legs in a multi-source resume (the linked request goes payable → re-pay). Codex P1.

## The fix (spec-mandated)

- **§8.1** — a resume conflict is a foreign spend; never apply the foreign proof.
- **§7, nothing certified (case i)** — a direct/split conflict with **0 delivered legs** rethrows the bare `TransferConflictError` → `resumeOpenIntents` soft-aborts → the linked request reverts to payable and is re-paid **in full**.
- **§7, "irreversible at the first certification; forward completion via resume is the only exit" (case ii)** — with **≥1 delivered leg**, record ONLY the delivered legs, `completeIntent` (forward-complete + close the server row so it never re-runs), then surface a `PartialSendConflictError`. `resumeOpenIntents` marks any linked settling request **committed** (reconcile resolves it `paid` and **NEVER reverts** → the delivered legs are never re-paid = no double-pay) and emits `send:partial-remainder` so the app re-plans ONLY the shortfall under a new `transferId`.

The per-leg `spent.push` is split so a conflicted leg is never recorded; the legacy no-checkpoint `SplitCheckpointLostError` residual stays classified delivered.

**Scope.** A background resume **surfaces** the remainder (event); it does **not** auto-send it. Auto-sending money on sign-in is a deliberate product decision, left as a follow-up (`send()`'s `#677` re-plan is the live-send path; whether resume should auto-complete a crashed payment is a separate call).

## Tests

- The `#621`/`#622` tests asserted the false-paid swallow → flipped to assert the spec abort (`§8.1/§7`).
- New deterministic **multi-source repro**: leg 0 delivers (600), leg 1 is a foreign loss (400) → asserts `spent==[g0]` (not `[g0,g1]`), intent **completed** (not conflicted → no revert/double-pay), remainder **400** surfaced. Fails without the fix (`expected [g0,g1] to equal [g0]`).

Full suite: **3144 pass**; `tsc --noEmit` clean.