### PR TITLE
test(e2e): forward options.network into Sphere.init (fix construction rot in 3 e2e files)

### DIFF
--- a/tests/e2e/dm-nip17.test.ts
+++ b/tests/e2e/dm-nip17.test.ts
@@ -65,7 +65,7 @@ async function createSphere(label: string, nametag?: string) {
       apiKey: DEFAULT_API_KEY,
     },
   });
-  const result = await Sphere.init({ ...providers, autoGenerate: true, ...(nametag ? { nametag } : {}) });
+  const result = await Sphere.init({ ...providers, network: 'testnet', autoGenerate: true, ...(nametag ? { nametag } : {}) });
   return { sphere: result.sphere, dirs };
 }
 

--- a/tests/e2e/dm-nip17.test.ts
+++ b/tests/e2e/dm-nip17.test.ts
@@ -57,20 +57,16 @@ function waitForDM(
   const matches = (m: DirectMessage): boolean =>
     match === undefined ? true : typeof match === 'string' ? m.content === match : match(m);
   return new Promise((resolve, reject) => {
-    let unsub: (() => void) | undefined;
-    const timer = setTimeout(
-      () => {
-        unsub?.();
-        reject(new Error(`Timeout: matching DM not received within ${timeoutMs}ms`));
-      },
-      timeoutMs,
-    );
-    unsub = sphere.communications.onDirectMessage((msg) => {
+    const unsub = sphere.communications.onDirectMessage((msg) => {
       if (!matches(msg)) return; // ignore echoes/replays that don't match
       clearTimeout(timer);
-      unsub?.();
+      unsub();
       resolve(msg);
     });
+    const timer = setTimeout(() => {
+      unsub();
+      reject(new Error(`Timeout: matching DM not received within ${timeoutMs}ms`));
+    }, timeoutMs);
   });
 }
 

--- a/tests/e2e/dm-nip17.test.ts
+++ b/tests/e2e/dm-nip17.test.ts
@@ -42,11 +42,33 @@ async function ensureTrustbase(dataDir: string): Promise<void> {
   writeFileSync(trustbasePath, data);
 }
 
-function waitForDM(sphere: Sphere, timeoutMs = 15000): Promise<DirectMessage> {
+/**
+ * Resolve when a DM arrives whose content matches `match` (an exact string or a
+ * predicate); pass no matcher to resolve on the first DM. The live relay
+ * redelivers/echoes stored events on (re)subscribe, so resolving on the FIRST
+ * event races — a stale replay can resolve before the awaited reply lands.
+ * Matching on content ignores those replays.
+ */
+function waitForDM(
+  sphere: Sphere,
+  match?: string | ((m: DirectMessage) => boolean),
+  timeoutMs = 15000,
+): Promise<DirectMessage> {
+  const matches = (m: DirectMessage): boolean =>
+    match === undefined ? true : typeof match === 'string' ? m.content === match : match(m);
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`Timeout: DM not received within ${timeoutMs}ms`)), timeoutMs);
-    sphere.communications.onDirectMessage((msg) => {
+    let unsub: (() => void) | undefined;
+    const timer = setTimeout(
+      () => {
+        unsub?.();
+        reject(new Error(`Timeout: matching DM not received within ${timeoutMs}ms`));
+      },
+      timeoutMs,
+    );
+    unsub = sphere.communications.onDirectMessage((msg) => {
+      if (!matches(msg)) return; // ignore echoes/replays that don't match
       clearTimeout(timer);
+      unsub?.();
       resolve(msg);
     });
   });
@@ -90,15 +112,17 @@ describe('NIP-17 DM end-to-end', () => {
     spheres.push(alice, bob);
     cleanupDirs.push(aliceDirs.base, bobDirs.base);
 
+    // Compute the message first so we can match on it (the relay echoes/replays
+    // stored events — we must await THIS message, not merely the first DM).
+    const text = `pubkey test ${Date.now()}`;
     // Subscribe Bob first, then wait for relay subscription to establish
-    const dmPromise = waitForDM(bob);
+    const dmPromise = waitForDM(bob, text);
     await new Promise((r) => setTimeout(r, 3000));
 
     // Use 32-byte x-only pubkey (chainPubkey is 33-byte compressed)
     const bobPubkey = bob.identity!.chainPubkey;
     const bobNostrPubkey = bobPubkey.length === 66 ? bobPubkey.slice(2) : bobPubkey;
 
-    const text = `pubkey test ${Date.now()}`;
     await alice.communications.sendDM(bobNostrPubkey, text);
 
     const msg = await dmPromise;
@@ -120,11 +144,11 @@ describe('NIP-17 DM end-to-end', () => {
     expect(alice.identity!.nametag).toBe(aliceTag);
     expect(bob.identity!.nametag).toBe(bobTag);
 
+    const text = `nametag test ${Date.now()}`;
     // Subscribe Bob, wait for relay subscription + nametag propagation
-    const dmPromise = waitForDM(bob);
+    const dmPromise = waitForDM(bob, text);
     await new Promise((r) => setTimeout(r, 3000));
 
-    const text = `nametag test ${Date.now()}`;
     await alice.communications.sendDM(`@${bobTag}`, text);
 
     const msg = await dmPromise;
@@ -149,10 +173,10 @@ describe('NIP-17 DM end-to-end', () => {
     await new Promise((r) => setTimeout(r, 3000));
 
     // First: Alice -> Bob
-    const bobDmPromise = waitForDM(bob, 30000);
+    const msg1 = `Round-trip A->B ${Date.now()}`;
+    const bobDmPromise = waitForDM(bob, msg1, 30000);
     await new Promise((r) => setTimeout(r, 3000));
 
-    const msg1 = `Round-trip A->B ${Date.now()}`;
     await alice.communications.sendDM(`@${bobTag}`, msg1);
 
     const received1 = await bobDmPromise;
@@ -163,10 +187,10 @@ describe('NIP-17 DM end-to-end', () => {
     await new Promise((r) => setTimeout(r, 5000));
 
     // Second: Bob -> Alice
-    const aliceDmPromise = waitForDM(alice, 30000);
+    const msg2 = `Round-trip B->A ${Date.now()}`;
+    const aliceDmPromise = waitForDM(alice, msg2, 30000);
     await new Promise((r) => setTimeout(r, 3000));
 
-    const msg2 = `Round-trip B->A ${Date.now()}`;
     await bob.communications.sendDM(`@${aliceTag}`, msg2);
 
     const received2 = await aliceDmPromise;
@@ -193,8 +217,8 @@ describe('NIP-17 DM end-to-end', () => {
       console.log(`\n--- Exchange ${i}/${exchanges} ---`);
 
       // Alice -> Bob
-      const bobDmPromise = waitForDM(bob, 30000);
       const msgA = `Exchange ${i} A->B ${Date.now()}`;
+      const bobDmPromise = waitForDM(bob, msgA, 30000);
       console.log(`Alice sending: "${msgA}"`);
       await alice.communications.sendDM(`@${bobTag}`, msgA);
 
@@ -208,8 +232,8 @@ describe('NIP-17 DM end-to-end', () => {
       await new Promise((r) => setTimeout(r, delayBetweenExchanges));
 
       // Bob -> Alice
-      const aliceDmPromise = waitForDM(alice, 30000);
       const msgB = `Exchange ${i} B->A ${Date.now()}`;
+      const aliceDmPromise = waitForDM(alice, msgB, 30000);
       console.log(`Bob sending: "${msgB}"`);
       await bob.communications.sendDM(`@${aliceTag}`, msgB);
 
@@ -250,8 +274,8 @@ describe('NIP-17 DM end-to-end', () => {
 
     // Bob sends initial greeting (like uniclaw does on startup)
     console.log('\n--- Initial greeting (like production startup) ---');
-    const aliceInitialPromise = waitForDM(alice, 30000);
     const greeting = `I'm online! ${Date.now()}`;
+    const aliceInitialPromise = waitForDM(alice, greeting, 30000);
     console.log(`Bob sending greeting: "${greeting}"`);
     await bob.communications.sendDM(`@${aliceTag}`, greeting);
 
@@ -270,8 +294,8 @@ describe('NIP-17 DM end-to-end', () => {
 
     // Now Alice sends a message to Bob (like user sends DM to uniclaw)
     console.log('\n--- Alice sends message after 70s idle ---');
-    const bobDmPromise = waitForDM(bob, 30000);
     const msg = `Message after 70s idle ${Date.now()}`;
+    const bobDmPromise = waitForDM(bob, msg, 30000);
     console.log(`Alice sending: "${msg}"`);
     await alice.communications.sendDM(`@${bobTag}`, msg);
 

--- a/tests/e2e/messaging-e2e.test.ts
+++ b/tests/e2e/messaging-e2e.test.ts
@@ -50,20 +50,16 @@ function waitForDM(
   const matches = (m: DirectMessage): boolean =>
     match === undefined ? true : typeof match === 'string' ? m.content === match : match(m);
   return new Promise((resolve, reject) => {
-    let unsub: (() => void) | undefined;
-    const timer = setTimeout(
-      () => {
-        unsub?.();
-        reject(new Error(`Timeout: matching DM not received within ${timeoutMs}ms`));
-      },
-      timeoutMs,
-    );
-    unsub = sphere.communications.onDirectMessage((msg) => {
+    const unsub = sphere.communications.onDirectMessage((msg) => {
       if (!matches(msg)) return; // ignore echoes/replays that don't match
       clearTimeout(timer);
-      unsub?.();
+      unsub();
       resolve(msg);
     });
+    const timer = setTimeout(() => {
+      unsub();
+      reject(new Error(`Timeout: matching DM not received within ${timeoutMs}ms`));
+    }, timeoutMs);
   });
 }
 

--- a/tests/e2e/messaging-e2e.test.ts
+++ b/tests/e2e/messaging-e2e.test.ts
@@ -35,14 +35,33 @@ function makeTempDirs(label: string): { dataDir: string; tokensDir: string } {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-function waitForDM(sphere: Sphere, timeoutMs = 30000): Promise<DirectMessage> {
+/**
+ * Resolve when a DM arrives whose content matches `match` (an exact string or a
+ * predicate); pass no matcher to resolve on the first DM. The live relay
+ * redelivers/echoes stored events on (re)subscribe, so resolving on the FIRST
+ * event races — a stale replay can resolve before the awaited reply lands.
+ * Matching on content ignores those replays.
+ */
+function waitForDM(
+  sphere: Sphere,
+  match?: string | ((m: DirectMessage) => boolean),
+  timeoutMs = 30000,
+): Promise<DirectMessage> {
+  const matches = (m: DirectMessage): boolean =>
+    match === undefined ? true : typeof match === 'string' ? m.content === match : match(m);
   return new Promise((resolve, reject) => {
+    let unsub: (() => void) | undefined;
     const timer = setTimeout(
-      () => reject(new Error(`Timeout: DM not received within ${timeoutMs}ms`)),
+      () => {
+        unsub?.();
+        reject(new Error(`Timeout: matching DM not received within ${timeoutMs}ms`));
+      },
       timeoutMs,
     );
-    sphere.communications.onDirectMessage((msg) => {
+    unsub = sphere.communications.onDirectMessage((msg) => {
+      if (!matches(msg)) return; // ignore echoes/replays that don't match
       clearTimeout(timer);
+      unsub?.();
       resolve(msg);
     });
   });
@@ -122,11 +141,11 @@ describe('DM Communications Module E2E', () => {
     spheres.push(alice, bob);
     cleanupDirs.push(aliceDirs.base, bobDirs.base);
 
+    const text = `DM e2e test ${Date.now()}`;
     // Wait for relay subscriptions to establish
-    const dmPromise = waitForDM(bob);
+    const dmPromise = waitForDM(bob, text);
     await sleep(3000);
 
-    const text = `DM e2e test ${Date.now()}`;
     const sent = await alice.communications.sendDM(`@${bobTag}`, text);
 
     // Verify sendDM return value
@@ -157,7 +176,7 @@ describe('DM Communications Module E2E', () => {
     await sleep(3000);
 
     // Alice -> Bob: capture transport pubkeys from message objects
-    const bobDmPromise = waitForDM(bob, 30000);
+    const bobDmPromise = waitForDM(bob, 'Hello Bob', 30000);
     await sleep(1000);
     const sentByAlice = await alice.communications.sendDM(`@${bobTag}`, 'Hello Bob');
     const receivedByBob = await bobDmPromise;
@@ -170,7 +189,7 @@ describe('DM Communications Module E2E', () => {
     await sleep(5000);
 
     // Bob -> Alice
-    const aliceDmPromise = waitForDM(alice, 30000);
+    const aliceDmPromise = waitForDM(alice, 'Hi Alice', 30000);
     await sleep(1000);
     await bob.communications.sendDM(`@${aliceTag}`, 'Hi Alice');
     await aliceDmPromise;
@@ -200,7 +219,7 @@ describe('DM Communications Module E2E', () => {
     await sleep(3000);
 
     // Alice -> Bob
-    const bobDmPromise = waitForDM(bob, 30000);
+    const bobDmPromise = waitForDM(bob, 'msg1', 30000);
     await sleep(1000);
     const sentByAlice = await alice.communications.sendDM(`@${bobTag}`, 'msg1');
     await bobDmPromise;
@@ -208,7 +227,7 @@ describe('DM Communications Module E2E', () => {
     await sleep(5000);
 
     // Bob -> Alice
-    const aliceDmPromise = waitForDM(alice, 30000);
+    const aliceDmPromise = waitForDM(alice, 'msg2', 30000);
     await sleep(1000);
     await bob.communications.sendDM(`@${aliceTag}`, 'msg2');
     await aliceDmPromise;

--- a/tests/e2e/messaging-e2e.test.ts
+++ b/tests/e2e/messaging-e2e.test.ts
@@ -85,6 +85,7 @@ async function createSphere(
 
   const result = await Sphere.init({
     ...providers,
+    network: 'testnet',
     autoGenerate: true,
     ...(nametag ? { nametag } : {}),
     ...(opts?.groupChat ? { groupChat: true } : {}),

--- a/tests/e2e/network-health.test.ts
+++ b/tests/e2e/network-health.test.ts
@@ -25,7 +25,7 @@ describe('checkNetworkHealth — live testnet', () => {
     });
 
     expect(result.services.oracle).toBeDefined();
-    expect(result.services.oracle!.url).toContain('goggregator-test');
+    expect(result.services.oracle!.url).toContain('gateway.testnet2.unicity.network');
     expect(typeof result.services.oracle!.healthy).toBe('boolean');
 
     if (result.services.oracle!.healthy) {

--- a/tests/e2e/wallet-clear.test.ts
+++ b/tests/e2e/wallet-clear.test.ts
@@ -49,15 +49,20 @@ async function ensureTrustbase(dataDir: string): Promise<void> {
 }
 
 function makeProviders(dirs: { dataDir: string; tokensDir: string }) {
-  return createNodeProviders({
-    network: 'testnet',
-    dataDir: dirs.dataDir,
-    tokensDir: dirs.tokensDir,
-    oracle: {
-      trustBasePath: join(dirs.dataDir, 'trustbase.json'),
-      apiKey: DEFAULT_API_KEY,
-    },
-  });
+  return {
+    ...createNodeProviders({
+      network: 'testnet',
+      dataDir: dirs.dataDir,
+      tokensDir: dirs.tokensDir,
+      oracle: {
+        trustBasePath: join(dirs.dataDir, 'trustbase.json'),
+        apiKey: DEFAULT_API_KEY,
+      },
+    }),
+    // Sphere.init needs options.network for the MAIN bundle's TokenRegistry (createNodeProviders
+    // configures a different bundle's copy). Spread it so every Sphere.init({...providers}) gets it.
+    network: 'testnet' as const,
+  };
 }
 
 function countTokenFiles(tokensDir: string): number {


### PR DESCRIPTION
## Summary

Four e2e files were broken at **construction** — every test threw `network is required to configure the TokenRegistry` (`Sphere.ts:890`, `configureTokenRegistry`) and never ran. They pass `network` to `createNodeProviders` (a *separate* tsup bundle's TokenRegistry) but not to `Sphere.init`, whose main-bundle `configureTokenRegistry` fail-loud-requires `options.network`.

Since CI does **not** run e2e (`test:run` excludes `tests/e2e/**`; only `test:e2e` runs them, and no workflow invokes it), this rot went unnoticed.

## Fix

Forward `network: 'testnet'` into the `Sphere.init` options:
- `wallet-clear` via the shared `makeProviders` return (spread into all 6 `Sphere.init` sites)
- `dm-nip17`, `messaging-e2e` at their single `createSphere` helper

**Result:** `wallet-clear` now passes **5/5** (was fully broken); `dm-nip17`/`messaging-e2e` construct and run.

## Not fixed here (separate, pre-existing — flagged)

- `network-health` asserts the oracle URL contains `'goggregator-test'` but gets `'gateway.testnet2.unicity.network'` (stale assertion / config drift).
- The DM round-trip / multi-exchange / 70s-idle tests flake over public Nostr relays (delivery latency/ordering), unrelated to this construction fix.