### PR TITLE
Batch mailbox deposit: one delivery call per send (#699)

### DIFF
--- a/impl/shared/wallet-api/WalletApiMailboxProvider.ts
+++ b/impl/shared/wallet-api/WalletApiMailboxProvider.ts
@@ -47,7 +47,7 @@ import {
   decryptDeliveryBundle,
 } from '../../../core/delivery-envelope';
 import { WalletApiClient, WalletApiError } from '../../../wallet-api';
-import type { KeyValueStore, MailboxEntry } from '../../../wallet-api';
+import type { KeyValueStore, MailboxDepositRequest, MailboxEntry } from '../../../wallet-api';
 import { logger } from '../../../core/logger';
 
 export interface WalletApiMailboxProviderConfig {
@@ -75,6 +75,13 @@ function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
 }
 
+/** One blob prepared for deposit: derived keys, unwrapped wire bytes, content hash (§5.2). */
+interface PreparedDelivery {
+  readonly keys: { tokenId: string; stateHash: string; deliveryId: string };
+  readonly wire: Uint8Array;
+  readonly sha: string;
+}
+
 const TAG = 'WalletApiMailbox';
 
 export class WalletApiMailboxProvider implements DeliveryProvider {
@@ -85,6 +92,9 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
   private deriveKeysFn: ((blobBytes: Uint8Array) => Promise<{ tokenId: string; stateHash: string }>) | null = null;
 
   private identity: { privateKey: string; chainPubkey: string; nametag?: string } | null = null;
+
+  /** True once a batch deposit 404'd (a pre-#111 deployment) — per instance; a re-sign-in re-probes. */
+  private batchDepositUnsupported = false;
 
   constructor(config: WalletApiMailboxProviderConfig) {
     this.client = config.client;
@@ -213,55 +223,121 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
    * (§6), which is what makes the sender's journal replay safe.
    */
   async deliver(recipientPubkey: string, blob: Uint8Array, options: DeliverOptions): Promise<DeliveryReceipt> {
+    const envelope = this.buildDeliveryEnvelope(recipientPubkey, options);
+    const prepared = await this.prepareBlob(blob);
+    const keyBySha = await this.uploadWires([prepared]);
+    return this.depositEntry(
+      this.toDepositRequest(prepared, { recipientPubkey, keyBySha, transferId: options.transferId, envelope }),
+      prepared.keys.deliveryId
+    );
+  }
+
+  /**
+   * Batch deliver (S7 #699): one send's committed blobs to ONE recipient —
+   * one `getUploadUrls` call, N content-addressed PUTs, one
+   * `POST /v1/mailbox/batch`. Receipts in request order. Fallbacks:
+   * - `404 NOT_FOUND` = a pre-#111 deployment — remembered per provider
+   *   instance, then (and on every later call) per-entry deposits over the
+   *   SAME already-uploaded keys;
+   * - `409` = the all-or-nothing batch failed on one conflicted entry (the
+   *   resume-rebuilt-proof case) — per-entry deposits let that one entry
+   *   absorb its own 409 idempotently (the S7 rule in {@link depositEntry})
+   *   while its siblings land;
+   * - anything else (network, 429, 5xx) rethrows — the caller's journal
+   *   replay converges per entry.
+   */
+  async deliverBatch(recipientPubkey: string, blobs: Uint8Array[], options: DeliverOptions): Promise<DeliveryReceipt[]> {
+    if (blobs.length === 0) return [];
+    const envelope = this.buildDeliveryEnvelope(recipientPubkey, options);
+    const prepared = await Promise.all(blobs.map(async (blob) => this.prepareBlob(blob)));
+    const keyBySha = await this.uploadWires(prepared);
+    const entries = prepared.map((p) =>
+      this.toDepositRequest(p, { recipientPubkey, keyBySha, transferId: options.transferId, envelope })
+    );
+    return this.depositBatch(entries, prepared.map((p) => p.keys.deliveryId));
+  }
+
+  private requireIdentity(): { privateKey: string; chainPubkey: string; nametag?: string } {
     if (!this.identity) {
       throw new WalletApiError('No identity set — call setIdentity() first', 'CONFIG');
     }
-    const keys = composeDeliveryKeys(await this.deriveKeys(blob));
+    return this.identity;
+  }
 
-    // S6: bundle the sender's nametag + memo into ONE recipient-addressed
-    // envelope. The key is the ECDH shared secret between the sender's private
-    // key and the RECIPIENT's chain pubkey (symmetric — the recipient
-    // re-derives it from its own key + this entry's senderPubkey), HKDF'd into
-    // the SAME `enc1.` XChaCha20-Poly1305 envelope the self-scoped field
-    // encryption uses (operator-blind, backend-valid — §8.3; no wire change).
-    // Attached whenever there is a nametag OR a memo (so the nametag travels
-    // even on a memo-less transfer); `undefined` ⇒ no `memo` field is sent.
-    const deliveryKey = deriveDeliveryEncryptionKey(this.identity.privateKey, recipientPubkey);
-    const envelope = encryptDeliveryBundle(deliveryKey, {
+  /**
+   * S6: bundle the sender's nametag + memo into ONE recipient-addressed
+   * envelope. The key is the ECDH shared secret between the sender's private
+   * key and the RECIPIENT's chain pubkey (symmetric — the recipient re-derives
+   * it from its own key + this entry's senderPubkey), HKDF'd into the SAME
+   * `enc1.` XChaCha20-Poly1305 envelope the self-scoped field encryption uses
+   * (operator-blind, backend-valid — §8.3; no wire change). Attached whenever
+   * there is a nametag OR a memo (so the nametag travels even on a memo-less
+   * transfer); `undefined` ⇒ no `memo` field is sent. One send = one
+   * recipient + one options set, so a batch computes this ONCE and attaches
+   * the same ciphertext to every entry (no per-entry binding exists; the
+   * entries are already publicly linked by their shared transferId).
+   */
+  private buildDeliveryEnvelope(recipientPubkey: string, options: DeliverOptions): string | undefined {
+    const identity = this.requireIdentity();
+    const deliveryKey = deriveDeliveryEncryptionKey(identity.privateKey, recipientPubkey);
+    return encryptDeliveryBundle(deliveryKey, {
       // The per-call nametag (threaded by PaymentsModule) wins; setIdentity's
       // nametag is the standalone fallback.
-      senderNametag: options.senderNametag ?? this.identity.nametag,
+      senderNametag: options.senderNametag ?? identity.nametag,
       memo: options.memo,
     });
+  }
 
-    // §5.2/§8.2: the wallet-api wire carries the RAW token bytes — the
-    // cross-port blob argument is the sphere envelope; unwrap at the boundary
-    // (the real backend content-addresses and Token.fromCBOR's exactly these
-    // bytes; the 39051 envelope never crosses the §16 API).
+  /**
+   * §5.2/§8.2: the wallet-api wire carries the RAW token bytes — the
+   * cross-port blob argument is the sphere envelope; unwrap at the boundary
+   * (the real backend content-addresses and Token.fromCBOR's exactly these
+   * bytes; the 39051 envelope never crosses the §16 API).
+   */
+  private async prepareBlob(blob: Uint8Array): Promise<PreparedDelivery> {
+    const keys = composeDeliveryKeys(await this.deriveKeys(blob));
     const wire = unwrapTokenBlobBytes(blob);
+    return { keys, wire, sha: bytesToHex(sha256(wire)) };
+  }
 
-    // Upload the finished blob (checksum-bound presigned PUT — §5.2).
-    const sha = bytesToHex(sha256(wire));
-    const urls = await this.client.getUploadUrls([{ sha256: sha, size: wire.length }]);
-    const upload = urls.find((u) => u.sha256 === sha);
-    if (!upload) {
-      throw new WalletApiError(`upload-urls response missing sha256 ${sha}`, 'PROTOCOL');
-    }
-    await this.client.uploadBlob(upload.putUrl, wire); // 412 = already present = success (§5.2)
+  /** Upload the finished blobs: ONE upload-urls request, then a checksum-bound PUT each (§5.2). */
+  private async uploadWires(prepared: readonly PreparedDelivery[]): Promise<Map<string, string>> {
+    const urls = await this.client.getUploadUrls(prepared.map((p) => ({ sha256: p.sha, size: p.wire.length })));
+    const uploads = prepared.map((p) => {
+      const upload = urls.find((u) => u.sha256 === p.sha);
+      if (!upload) {
+        throw new WalletApiError(`upload-urls response missing sha256 ${p.sha}`, 'PROTOCOL');
+      }
+      return { p, upload };
+    });
+    // 412 = already present = success (§5.2)
+    await Promise.all(uploads.map(async ({ p, upload }) => this.client.uploadBlob(upload.putUrl, p.wire)));
+    return new Map(uploads.map(({ p, upload }) => [p.sha, upload.key]));
+  }
 
-    // Deposit (idempotent by entry_id — §6). The nametag+memo envelope is
-    // ECDH-encrypted to the recipient BEFORE it leaves the device (§8.3): the
-    // operator never sees plaintext.
+  private toDepositRequest(
+    prepared: PreparedDelivery,
+    ctx: { recipientPubkey: string; keyBySha: Map<string, string>; transferId: string; envelope: string | undefined }
+  ): MailboxDepositRequest {
+    return {
+      recipientPubkey: ctx.recipientPubkey,
+      key: ctx.keyBySha.get(prepared.sha) ?? '',
+      transferId: ctx.transferId,
+      stateHash: prepared.keys.stateHash,
+      tokenId: prepared.keys.tokenId,
+      ...(ctx.envelope !== undefined ? { memo: ctx.envelope } : {}),
+    };
+  }
+
+  /**
+   * Deposit one entry (idempotent by entry_id — §6). The nametag+memo
+   * envelope is ECDH-encrypted to the recipient BEFORE it leaves the device
+   * (§8.3): the operator never sees plaintext.
+   */
+  private async depositEntry(entry: MailboxDepositRequest, deliveryId: string): Promise<DeliveryReceipt> {
     let entryId: string;
     try {
-      entryId = await this.client.depositMailbox({
-        recipientPubkey,
-        key: upload.key,
-        transferId: options.transferId,
-        stateHash: keys.stateHash,
-        tokenId: keys.tokenId,
-        ...(envelope !== undefined ? { memo: envelope } : {}),
-      });
+      entryId = await this.client.depositMailbox(entry);
     } catch (err) {
       // §6 CONFLICT = the backend already holds a record of EXACTLY this
       // (tokenId, stateHash) with different bytes. Reachable honestly in one
@@ -276,20 +352,63 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
       // conflict can never reach here: the engine's E.2 match-verify raises
       // TransferConflictError before anything is delivered.
       if (err instanceof WalletApiError && err.status === 409) {
-        return { deliveryId: keys.deliveryId };
+        return { deliveryId };
       }
       throw err;
     }
 
     // covenant §3.1-4: the id is CONTENT-DERIVED — computed client-side; a
     // backend returning anything else (e.g. a row id) is a protocol violation.
-    if (entryId !== keys.deliveryId) {
+    if (entryId !== deliveryId) {
       throw new WalletApiError(
-        `mailbox deposit returned a non-content-derived entryId (got ${entryId}, expected ${keys.deliveryId})`,
+        `mailbox deposit returned a non-content-derived entryId (got ${entryId}, expected ${deliveryId})`,
         'PROTOCOL'
       );
     }
-    return { deliveryId: keys.deliveryId };
+    return { deliveryId };
+  }
+
+  /** One batch deposit, falling back to per-entry on 404 (memoized) or 409 — see {@link deliverBatch}. */
+  private async depositBatch(entries: MailboxDepositRequest[], deliveryIds: string[]): Promise<DeliveryReceipt[]> {
+    if (!this.batchDepositUnsupported) {
+      try {
+        const results = await this.client.depositMailboxBatch(entries);
+        // covenant §3.1-4 per entry: content-derived ids, request order; the
+        // batch-only `seq` is data the provider deliberately ignores.
+        if (results.length !== entries.length) {
+          throw new WalletApiError(
+            `mailbox batch deposit returned ${String(results.length)} entries for ${String(entries.length)}`,
+            'PROTOCOL'
+          );
+        }
+        return results.map((result, i) => {
+          if (result.entryId !== deliveryIds[i]) {
+            throw new WalletApiError(
+              `mailbox batch deposit returned a non-content-derived entryId (got ${result.entryId}, expected ${String(deliveryIds[i])})`,
+              'PROTOCOL'
+            );
+          }
+          return { deliveryId: result.entryId };
+        });
+      } catch (err) {
+        if (err instanceof WalletApiError && err.code === 'NOT_FOUND') {
+          // pre-#111 deployment — remember and stop re-probing on this instance
+          this.batchDepositUnsupported = true;
+          logger.warn(TAG, 'POST /v1/mailbox/batch not deployed — falling back to per-entry deposits');
+        } else if (!(err instanceof WalletApiError && err.status === 409)) {
+          throw err;
+        }
+      }
+    }
+    // Per-entry fallback over the SAME already-uploaded keys (never a
+    // recursive deliver — no re-derive, no re-upload). Sequential to keep
+    // receipts in request order; any failure throws (the port contract —
+    // entries that DID land absorb idempotently on the caller's retry).
+    const receipts: DeliveryReceipt[] = [];
+    for (const [i, entry] of entries.entries()) {
+      receipts.push(await this.depositEntry(entry, deliveryIds[i] ?? ''));
+    }
+    return receipts;
   }
 
   // ── incoming (S3: mailbox pull) ─────────────────────────────────────────────

--- a/impl/shared/wallet-api/WalletApiMailboxProvider.ts
+++ b/impl/shared/wallet-api/WalletApiMailboxProvider.ts
@@ -46,8 +46,9 @@ import {
   encryptDeliveryBundle,
   decryptDeliveryBundle,
 } from '../../../core/delivery-envelope';
-import { WalletApiClient, WalletApiError } from '../../../wallet-api';
+import { WalletApiClient, WalletApiError, MAX_MAILBOX_BATCH_ENTRIES } from '../../../wallet-api';
 import type { KeyValueStore, MailboxDepositRequest, MailboxEntry } from '../../../wallet-api';
+import { MAX_SEND_OPERATION_CONCURRENCY } from '../../../modules/payments/SendOperations';
 import { logger } from '../../../core/logger';
 
 export interface WalletApiMailboxProviderConfig {
@@ -234,8 +235,9 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
 
   /**
    * Batch deliver (S7 #699): one send's committed blobs to ONE recipient —
-   * one `getUploadUrls` call, N content-addressed PUTs, one
-   * `POST /v1/mailbox/batch`. Receipts in request order. Fallbacks:
+   * one `getUploadUrls` call, N content-addressed PUTs (width-capped like
+   * every send fan-out), deposits chunked at the §16 entry cap. Receipts in
+   * request order. Fallbacks:
    * - `404 NOT_FOUND` = a pre-#111 deployment — remembered per provider
    *   instance, then (and on every later call) per-entry deposits over the
    *   SAME already-uploaded keys;
@@ -243,8 +245,12 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
    *   resume-rebuilt-proof case) — per-entry deposits let that one entry
    *   absorb its own 409 idempotently (the S7 rule in {@link depositEntry})
    *   while its siblings land;
+   * - `422` = the all-or-nothing batch failed validation on one entry —
+   *   per-entry deposits land the valid siblings; the bad entry throws its
+   *   own 422 and stays journaled;
    * - anything else (network, 429, 5xx) rethrows — the caller's journal
-   *   replay converges per entry.
+   *   replay converges per entry. A 429 deliberately never falls back:
+   *   per-entry deposits against a rate limiter would multiply requests.
    */
   async deliverBatch(recipientPubkey: string, blobs: Uint8Array[], options: DeliverOptions): Promise<DeliveryReceipt[]> {
     if (blobs.length === 0) return [];
@@ -310,8 +316,12 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
       }
       return { p, upload };
     });
-    // 412 = already present = success (§5.2)
-    await Promise.all(uploads.map(async ({ p, upload }) => this.client.uploadBlob(upload.putUrl, p.wire)));
+    // 412 = already present = success (§5.2). PUTs run at the same width as
+    // every other wallet-api send fan-out (certification, per-blob delivery).
+    for (let start = 0; start < uploads.length; start += MAX_SEND_OPERATION_CONCURRENCY) {
+      const batch = uploads.slice(start, start + MAX_SEND_OPERATION_CONCURRENCY);
+      await Promise.all(batch.map(async ({ p, upload }) => this.client.uploadBlob(upload.putUrl, p.wire)));
+    }
     return new Map(uploads.map(({ p, upload }) => [p.sha, upload.key]));
   }
 
@@ -368,8 +378,22 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
     return { deliveryId };
   }
 
-  /** One batch deposit, falling back to per-entry on 404 (memoized) or 409 — see {@link deliverBatch}. */
+  /** Batch deposit, chunked at the §16 entry cap; receipts in request order — see {@link depositChunk}. */
   private async depositBatch(entries: MailboxDepositRequest[], deliveryIds: string[]): Promise<DeliveryReceipt[]> {
+    const receipts: DeliveryReceipt[] = [];
+    for (let start = 0; start < entries.length; start += MAX_MAILBOX_BATCH_ENTRIES) {
+      receipts.push(
+        ...(await this.depositChunk(
+          entries.slice(start, start + MAX_MAILBOX_BATCH_ENTRIES),
+          deliveryIds.slice(start, start + MAX_MAILBOX_BATCH_ENTRIES)
+        ))
+      );
+    }
+    return receipts;
+  }
+
+  /** One batch deposit, falling back to per-entry on 404 (memoized), 409 or 422 — see {@link deliverBatch}. */
+  private async depositChunk(entries: MailboxDepositRequest[], deliveryIds: string[]): Promise<DeliveryReceipt[]> {
     if (!this.batchDepositUnsupported) {
       try {
         const results = await this.client.depositMailboxBatch(entries);
@@ -395,7 +419,7 @@ export class WalletApiMailboxProvider implements DeliveryProvider {
           // pre-#111 deployment — remember and stop re-probing on this instance
           this.batchDepositUnsupported = true;
           logger.warn(TAG, 'POST /v1/mailbox/batch not deployed — falling back to per-entry deposits');
-        } else if (!(err instanceof WalletApiError && err.status === 409)) {
+        } else if (!(err instanceof WalletApiError && (err.status === 409 || err.status === 422))) {
           throw err;
         }
       }

--- a/impl/shared/wallet-api/WalletApiMailboxProvider.ts
+++ b/impl/shared/wallet-api/WalletApiMailboxProvider.ts
@@ -39,7 +39,7 @@ import type {
   WakeStream,
   WakeChannelStatus,
 } from '../../../transport/delivery-provider';
-import { composeDeliveryKeys, computeDeliveryId } from '../../../transport/delivery-provider';
+import { composeDeliveryKeys } from '../../../transport/delivery-provider';
 import { unwrapTokenBlobBytes } from '../../../token-engine/token-blob';
 import {
   deriveDeliveryEncryptionKey,

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -61,7 +61,7 @@ import type {
   IncomingPaymentRequest as TransportPaymentRequest,
   IncomingPaymentRequestResponse as TransportPaymentRequestResponse,
 } from '../../transport';
-import type { DeliveryProvider, IncomingDelivery, WakeStream } from '../../transport/delivery-provider';
+import type { DeliverOptions, DeliveryProvider, IncomingDelivery, WakeStream } from '../../transport/delivery-provider';
 import { TransportDeliveryAdapter } from './TransportDeliveryAdapter';
 import { deriveFieldEncryptionKey, encryptField, decryptField } from '../../core/field-encryption';
 import {
@@ -2125,21 +2125,6 @@ export class PaymentsModule {
           }
         }
 
-        // Deliver a journaled finished-token blob via the delivery port (S3:
-        // the port replaced the direct relay leg; recipients are addressed by
-        // CHAIN pubkey — the canonical identity).
-        const deliverBlob = async (tokenBlob: string): Promise<void> => {
-          // Carry the sender's own CANONICAL nametag so the recipient renders
-          // "@name" instead of "Someone" — bundled with the memo in ONE
-          // recipient-addressed envelope (S6).
-          const nm = this.currentNametagName();
-          await delivery.deliver(recipientChainPubkeyHex, hexToBytes(tokenBlob), {
-            transferId: result.id,
-            memo: request.memo,
-            ...(nm !== undefined ? { senderNametag: nm } : {}),
-          });
-        };
-
         // Sources consumed by this send — the §7 step 6 apply (server path)
         // and the deferred local removals are driven from this list.
         // `sourceSdkData` = the source blob AS WE HELD IT (pre-spend). It is the single
@@ -2194,11 +2179,14 @@ export class PaymentsModule {
         }
         const selfChainPubkey = hexToBytes(this.deps.identity.chainPubkey);
 
-        // One operation: certify → journal → deliver. NEVER rejects (a mid-batch
-        // rejection would stop us observing still-in-flight siblings) and NEVER
-        // touches shared wallet state — this.tokens mutations and save() (an
-        // unlocked whole-map write) are not concurrency-safe; they belong to the
-        // sequential apply section below.
+        // One operation: certify → journal. Delivery is deliberately NOT here —
+        // it runs as one hoisted pass over the committed set below (#699), so a
+        // multi-source send can hand the whole set to the delivery port in one
+        // batched deposit. NEVER rejects (a mid-batch rejection would stop us
+        // observing still-in-flight siblings) and NEVER touches shared wallet
+        // state — this.tokens mutations and save() (an unlocked whole-map
+        // write) are not concurrency-safe; they belong to the sequential apply
+        // section below.
         const sendOperation = async (op: SendOperation): Promise<OperationOutcome> => {
           let finished: SphereToken;
           let changeOutput: SphereToken | undefined;
@@ -2243,8 +2231,9 @@ export class PaymentsModule {
           // reports certified: true so the accounting counts it even when a
           // local post-step fails.
           try {
-            // Journal the finished blob BEFORE delivery: a transport failure or a
-            // crash must not lose the recipient's token (replayed on next load()).
+            // Journal the finished blob BEFORE any delivery: the hoisted pass
+            // below (or the replay on next load()) hands it to the recipient —
+            // a delivery failure or a crash must not lose the recipient's token.
             const tokenBlob = bytesToHex(encodeTokenBlob(engine.encodeToken(finished)));
             await this.savePendingV2Delivery({
               transferId: result.id,
@@ -2254,9 +2243,7 @@ export class PaymentsModule {
               opIndex: op.opIndex,
               createdAt: Date.now(),
             });
-            // §3.1 (#621): a delivery failure after certification must NOT fail the sender.
-            const delivered = await this.tryDeliver(() => deliverBlob(tokenBlob), tokenBlob);
-            return { op, certified: true, delivered, ...(changeOutput !== undefined ? { changeOutput } : {}) };
+            return { op, certified: true, tokenBlob, ...(changeOutput !== undefined ? { changeOutput } : {}) };
           } catch (error) {
             return { op, certified: true, error, ...(changeOutput !== undefined ? { changeOutput } : {}) };
           }
@@ -2282,7 +2269,20 @@ export class PaymentsModule {
           if (outcomes.some((o) => o.error !== undefined)) break;
         }
         summary = summarizeOutcomes(outcomes);
-        deliveryPending = summary.deliveryPending;
+
+        // ── Delivery pass, hoisted out of the certification fan-out (#699):
+        // ONE batched mailbox deposit (when the port offers deliverBatch) or a
+        // per-blob loop over the SETTLED committed set. Runs on the failure
+        // path too — committed siblings of a failed batch get their delivery
+        // attempt before the throw below, exactly as the welded per-op era
+        // delivered them. Never throws (§3.1/#621): a deferred blob stays
+        // journaled and the send resolves delivery-pending.
+        deliveryPending = !(await this.deliverCommittedBlobs(
+          summary.committed.flatMap((o) => (o.tokenBlob === undefined ? [] : [o.tokenBlob])),
+          recipientChainPubkeyHex,
+          result.id,
+          request.memo,
+        ));
 
         // ── Sequential apply — the ONLY writer of shared wallet state. Runs for
         // committed ops even when another op failed: their spend is irreversible
@@ -6852,6 +6852,88 @@ export class PaymentsModule {
         await this.deps!.storage.set(STORAGE_KEYS_ADDRESS.PENDING_V2_DELIVERIES, JSON.stringify(filtered));
       }
     });
+  }
+
+  /**
+   * The hoisted send delivery pass (#699): hand a send's journaled committed
+   * blobs to ONE recipient — a single deliverBatch call when the port offers
+   * it and there is more than one blob, else per-blob deliver at the
+   * certification fan-out width. Returns true iff every blob was delivered
+   * (deferred blobs stay journaled). Never throws (§3.1).
+   */
+  private async deliverCommittedBlobs(
+    blobs: readonly string[],
+    recipientPubkey: string,
+    transferId: string,
+    memo?: string,
+  ): Promise<boolean> {
+    if (blobs.length === 0) return true;
+    // Carry the sender's own CANONICAL nametag so the recipient renders
+    // "@name" instead of "Someone" — bundled with the memo in ONE
+    // recipient-addressed envelope (S6). One send = one options set.
+    const nm = this.currentNametagName();
+    const options: DeliverOptions = {
+      transferId,
+      memo,
+      ...(nm !== undefined ? { senderNametag: nm } : {}),
+    };
+    // A single blob stays on the plain deliver path — byte-identical wire to
+    // the pre-batch era, and no batch probe for the dominant case.
+    if (this.delivery?.deliverBatch && blobs.length > 1) {
+      return this.tryDeliverBatch(blobs, recipientPubkey, options);
+    }
+    return this.deliverPerBlob(blobs, recipientPubkey, options);
+  }
+
+  /**
+   * Batch sibling of {@link tryDeliver}: success clears every journal entry;
+   * ANY failure keeps them ALL journaled (the deposit is idempotent by
+   * content-derived entry_id, so a replay absorbs entries that already
+   * landed). Never throws.
+   */
+  private async tryDeliverBatch(
+    blobs: readonly string[],
+    recipientPubkey: string,
+    options: DeliverOptions,
+  ): Promise<boolean> {
+    try {
+      await this.delivery!.deliverBatch!(recipientPubkey, blobs.map(hexToBytes), options);
+    } catch (err) {
+      logger.warn('Payments', 'Batch delivery deferred (all blobs kept journaled); sender not failed (§3.1):', err);
+      return false;
+    }
+    for (const tokenBlob of blobs) {
+      try {
+        await this.removePendingV2Delivery(tokenBlob);
+      } catch (err) {
+        logger.warn('Payments', 'Delivered, but journal cleanup failed (replay will re-remove):', err);
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Per-blob fallback (a batch-less port, or a single blob), chunked at
+   * MAX_SEND_OPERATION_CONCURRENCY so the pass keeps the certification
+   * fan-out era's delivery width. Never throws.
+   */
+  private async deliverPerBlob(
+    blobs: readonly string[],
+    recipientPubkey: string,
+    options: DeliverOptions,
+  ): Promise<boolean> {
+    const results: boolean[] = [];
+    for (let start = 0; start < blobs.length; start += MAX_SEND_OPERATION_CONCURRENCY) {
+      const chunk = blobs.slice(start, start + MAX_SEND_OPERATION_CONCURRENCY);
+      results.push(
+        ...(await Promise.all(
+          chunk.map((tokenBlob) =>
+            this.tryDeliver(() => this.delivery!.deliver(recipientPubkey, hexToBytes(tokenBlob), options), tokenBlob),
+          ),
+        )),
+      );
+    }
+    return results.every(Boolean);
   }
 
   /**

--- a/modules/payments/SendOperations.ts
+++ b/modules/payments/SendOperations.ts
@@ -3,10 +3,12 @@
  *
  * One send() fans out into N independent on-chain operations (0–N whole-token
  * transfers + at most one split, ARCHITECTURE §7). PaymentsModule certifies
- * them concurrently (bounded batches) and reduces the SETTLED outcomes here:
- * committed accounting plus the one error to surface. Everything in this file
- * is pure data + pure functions — no I/O, no wallet state — so the money-
- * critical failure semantics (#625/#677/#631) are table-testable in isolation
+ * them concurrently (bounded batches) — each op certifies and JOURNALS its
+ * recipient blob; delivery is a separate hoisted pass over the committed set
+ * (#699) — and reduces the SETTLED outcomes here: committed accounting plus
+ * the one error to surface. Everything in this file is pure data + pure
+ * functions — no I/O, no wallet state — so the money-critical failure
+ * semantics (#625/#677/#631) are table-testable in isolation
  * (tests/unit/modules/SendOperations.test.ts).
  */
 
@@ -71,8 +73,12 @@ export interface OperationOutcome {
    * spend may be on-chain (#631); resume settles the truth.
    */
   readonly certified: boolean;
-  /** tryDeliver result; false = deferred, blob stays journaled (§3.1/#621). Only present when certified. */
-  readonly delivered?: boolean;
+  /**
+   * Hex TokenBlob journaled for the recipient — present iff certified AND the
+   * journal write succeeded. Input to the hoisted delivery pass (#699); absent
+   * on a certified outcome ⇔ the blob was never journaled (resume re-derives).
+   */
+  readonly tokenBlob?: string;
   /** Split only: the change token minted back to this wallet (present once certified). */
   readonly changeOutput?: SphereToken;
   readonly error?: unknown;
@@ -90,8 +96,6 @@ export interface SendOutcomeSummary {
   readonly committedUiIds: Set<string>;
   /** Σ deliveredAmount over committed ops (#677). */
   readonly committedAmount: bigint;
-  /** True when any committed op's delivery was deferred (§3.1/#621). */
-  readonly deliveryPending: boolean;
   readonly changeOutput: SphereToken | null;
   /**
    * Every settled failure in plan (opIndex) order — certified-with-error ops
@@ -148,7 +152,6 @@ export function summarizeOutcomes(outcomes: readonly OperationOutcome[]): SendOu
     committed,
     committedUiIds: new Set(committed.map((o) => o.op.uiTokenId)),
     committedAmount: committed.reduce((sum, o) => sum + o.op.deliveredAmount, 0n),
-    deliveryPending: committed.some((o) => o.delivered === false),
     changeOutput: committed.find((o) => o.changeOutput !== undefined)?.changeOutput ?? null,
     failures,
   };

--- a/modules/payments/TransportDeliveryAdapter.ts
+++ b/modules/payments/TransportDeliveryAdapter.ts
@@ -22,6 +22,8 @@
  *   push subscription (`onTokenTransfer`) exactly as before — this adapter is
  *   the SEND seam, not a full mailbox. The S7 contract suite runs against
  *   real implementations, not this adapter.
+ * - `deliverBatch` is omitted like `ackBatch` (#699): the relay has no batch
+ *   primitive, so the module's delivery pass drives this adapter per blob.
  */
 
 import type {

--- a/tests/contract/wallet-api-mailbox-provider.contract.test.ts
+++ b/tests/contract/wallet-api-mailbox-provider.contract.test.ts
@@ -14,7 +14,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { FakeWalletApi } from '../support/fake-wallet-api';
 import { MemoryKeyValueStore, makeTestToken, testIdentity, fakeDeliveryKeys } from '../support/wallet-api-test-helpers';
-import { WalletApiClient } from '../../wallet-api';
+import { WalletApiClient, WalletApiError, MAX_MAILBOX_BATCH_ENTRIES } from '../../wallet-api';
+import { MAX_SEND_OPERATION_CONCURRENCY } from '../../modules/payments/SendOperations';
 import { WalletApiMailboxProvider } from '../../impl/shared/wallet-api';
 import type { DeliveryCustody, IncomingDelivery } from '../../transport/delivery-provider';
 import { FIELD_ENVELOPE_PREFIX } from '../../core/field-encryption';
@@ -342,6 +343,14 @@ describe('WalletApiMailboxProvider — provider-specific semantics', () => {
       return Array.from({ length: n }, () => h.makeBlob());
     }
 
+    /** The covenant §3.1-4 content-derived id: `hex(SHA-256(tokenId ‖ stateHash))`. */
+    function contentId(b: { tokenId: string; stateHash: string }): string {
+      return hex(sha256(Uint8Array.from([
+        ...Buffer.from(b.tokenId, 'hex'),
+        ...Buffer.from(b.stateHash, 'hex'),
+      ])));
+    }
+
     it('N blobs → ONE upload-urls call, ONE batch deposit, ZERO single deposits; receipts in order', async () => {
       const client = h.sender.walletApiClient;
       const uploadUrls = vi.spyOn(client, 'getUploadUrls');
@@ -360,12 +369,7 @@ describe('WalletApiMailboxProvider — provider-specific semantics', () => {
       expect(singleDeposit).not.toHaveBeenCalled();
 
       // request order, content-derived ids (covenant §3.1-4)
-      expect(receipts.map((r) => r.deliveryId)).toEqual(
-        blobs.map((b) => hex(sha256(Uint8Array.from([
-          ...Buffer.from(b.tokenId, 'hex'),
-          ...Buffer.from(b.stateHash, 'hex'),
-        ])))),
-      );
+      expect(receipts.map((r) => r.deliveryId)).toEqual(blobs.map(contentId));
       for (const r of receipts) {
         expect(h.fake.getMailboxEntry(h.recipientPubkey, r.deliveryId)).toMatchObject({ status: 'unclaimed' });
       }
@@ -432,11 +436,103 @@ describe('WalletApiMailboxProvider — provider-specific semantics', () => {
 
     it('a backend returning non-content-derived ids is a PROTOCOL violation (covenant §3.1-4)', async () => {
       const client = h.sender.walletApiClient;
-      vi.spyOn(client, 'depositMailboxBatch').mockResolvedValue([{ entryId: 'f'.repeat(64), seq: 1n }]);
-      const blob = h.makeBlob();
+      const blobs = makeBlobs(2);
+      // Correct count, correct FIRST id — only the second id is wrong, so the
+      // per-entry check (not the length guard) must be what catches it.
+      vi.spyOn(client, 'depositMailboxBatch').mockResolvedValue([
+        { entryId: contentId(blobs[0]), seq: 1n },
+        { entryId: 'f'.repeat(64), seq: 2n },
+      ]);
       await expect(
-        h.sender.deliverBatch(h.recipientPubkey, [blob.bytes, blob.bytes], { transferId: 'tf-b5' }),
+        h.sender.deliverBatch(h.recipientPubkey, blobs.map((b) => b.bytes), { transferId: 'tf-b5' }),
       ).rejects.toMatchObject({ code: 'PROTOCOL' });
+    });
+
+    it('a backend returning the wrong result count is a PROTOCOL violation (covenant §3.1-4)', async () => {
+      const client = h.sender.walletApiClient;
+      const blobs = makeBlobs(2);
+      vi.spyOn(client, 'depositMailboxBatch').mockResolvedValue([
+        { entryId: contentId(blobs[0]), seq: 1n },
+      ]);
+      await expect(
+        h.sender.deliverBatch(h.recipientPubkey, blobs.map((b) => b.bytes), { transferId: 'tf-b5c' }),
+      ).rejects.toMatchObject({ code: 'PROTOCOL' });
+    });
+
+    it('caps concurrent blob PUTs at MAX_SEND_OPERATION_CONCURRENCY', async () => {
+      const client = h.sender.walletApiClient;
+      const realUpload = client.uploadBlob.bind(client);
+      let inflight = 0;
+      let maxInflight = 0;
+      vi.spyOn(client, 'uploadBlob').mockImplementation(async (putUrl, bytes) => {
+        inflight += 1;
+        maxInflight = Math.max(maxInflight, inflight);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          return await realUpload(putUrl, bytes);
+        } finally {
+          inflight -= 1;
+        }
+      });
+
+      const blobs = makeBlobs(MAX_SEND_OPERATION_CONCURRENCY * 2 + 4);
+      const receipts = await h.sender.deliverBatch(h.recipientPubkey, blobs.map((b) => b.bytes), {
+        transferId: 'tf-b7',
+      });
+      expect(receipts).toHaveLength(blobs.length);
+      expect(maxInflight).toBe(MAX_SEND_OPERATION_CONCURRENCY);
+    });
+
+    it('deposits above MAX_MAILBOX_BATCH_ENTRIES are chunked; receipts stay in request order', async () => {
+      const client = h.sender.walletApiClient;
+      vi.spyOn(client, 'uploadBlob').mockResolvedValue(undefined);
+      const batchDeposit = vi
+        .spyOn(client, 'depositMailboxBatch')
+        .mockImplementation(async (entries) =>
+          entries.map((e, i) => ({ entryId: contentId(e), seq: BigInt(i + 1) }))
+        );
+
+      const blobs = makeBlobs(MAX_MAILBOX_BATCH_ENTRIES + 1);
+      const receipts = await h.sender.deliverBatch(h.recipientPubkey, blobs.map((b) => b.bytes), {
+        transferId: 'tf-b8',
+      });
+
+      expect(batchDeposit).toHaveBeenCalledTimes(2);
+      expect(batchDeposit.mock.calls[0][0]).toHaveLength(MAX_MAILBOX_BATCH_ENTRIES);
+      expect(batchDeposit.mock.calls[1][0]).toHaveLength(1);
+      expect(receipts.map((r) => r.deliveryId)).toEqual(blobs.map(contentId));
+    });
+
+    it('a batch 422 falls back per-entry so one bad entry cannot sink valid siblings', async () => {
+      const client = h.sender.walletApiClient;
+      vi.spyOn(client, 'depositMailboxBatch').mockRejectedValue(
+        WalletApiError.fromStatus(422, 'one bad entry')
+      );
+      const singleDeposit = vi.spyOn(client, 'depositMailbox');
+
+      const blobs = makeBlobs(2);
+      const receipts = await h.sender.deliverBatch(h.recipientPubkey, blobs.map((b) => b.bytes), {
+        transferId: 'tf-b9',
+      });
+      expect(singleDeposit).toHaveBeenCalledTimes(2);
+      expect(receipts.map((r) => r.deliveryId)).toEqual(blobs.map(contentId));
+      for (const r of receipts) {
+        expect(h.fake.getMailboxEntry(h.recipientPubkey, r.deliveryId)).toMatchObject({ status: 'unclaimed' });
+      }
+    });
+
+    it('a batch 429 rethrows — never a per-entry fallback against a rate limiter', async () => {
+      const client = h.sender.walletApiClient;
+      vi.spyOn(client, 'depositMailboxBatch').mockRejectedValue(
+        WalletApiError.fromStatus(429, 'rate limited')
+      );
+      const singleDeposit = vi.spyOn(client, 'depositMailbox');
+
+      const blobs = makeBlobs(2);
+      await expect(
+        h.sender.deliverBatch(h.recipientPubkey, blobs.map((b) => b.bytes), { transferId: 'tf-b10' }),
+      ).rejects.toMatchObject({ status: 429 });
+      expect(singleDeposit).not.toHaveBeenCalled();
     });
 
     it('an empty batch resolves to [] without touching the network', async () => {

--- a/tests/contract/wallet-api-mailbox-provider.contract.test.ts
+++ b/tests/contract/wallet-api-mailbox-provider.contract.test.ts
@@ -10,7 +10,7 @@
  * - S6 memo encryption: ciphertext on the wire, decryptable by the owner.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { FakeWalletApi } from '../support/fake-wallet-api';
 import { MemoryKeyValueStore, makeTestToken, testIdentity, fakeDeliveryKeys } from '../support/wallet-api-test-helpers';
@@ -330,6 +330,122 @@ describe('WalletApiMailboxProvider — provider-specific semantics', () => {
       const delivery = incoming.find((d) => d.deliveryId === deliveryId);
       expect(delivery).toBeDefined();
       await expect(delivery!.fetchBlob()).rejects.toThrow(/blobCollected|no fetchable blob/);
+    });
+  });
+
+  describe('deliverBatch — one deposit per send (#699)', () => {
+    beforeEach(async () => {
+      h = await makeHarness('external');
+    });
+
+    function makeBlobs(n: number): { bytes: Uint8Array; tokenId: string; stateHash: string }[] {
+      return Array.from({ length: n }, () => h.makeBlob());
+    }
+
+    it('N blobs → ONE upload-urls call, ONE batch deposit, ZERO single deposits; receipts in order', async () => {
+      const client = h.sender.walletApiClient;
+      const uploadUrls = vi.spyOn(client, 'getUploadUrls');
+      const batchDeposit = vi.spyOn(client, 'depositMailboxBatch');
+      const singleDeposit = vi.spyOn(client, 'depositMailbox');
+
+      const blobs = makeBlobs(3);
+      const receipts = await h.sender.deliverBatch(h.recipientPubkey, blobs.map((b) => b.bytes), {
+        transferId: 'tf-b1',
+      });
+
+      expect(uploadUrls).toHaveBeenCalledTimes(1);
+      expect(uploadUrls.mock.calls[0][0]).toHaveLength(3);
+      expect(batchDeposit).toHaveBeenCalledTimes(1);
+      expect(batchDeposit.mock.calls[0][0]).toHaveLength(3);
+      expect(singleDeposit).not.toHaveBeenCalled();
+
+      // request order, content-derived ids (covenant §3.1-4)
+      expect(receipts.map((r) => r.deliveryId)).toEqual(
+        blobs.map((b) => hex(sha256(Uint8Array.from([
+          ...Buffer.from(b.tokenId, 'hex'),
+          ...Buffer.from(b.stateHash, 'hex'),
+        ])))),
+      );
+      for (const r of receipts) {
+        expect(h.fake.getMailboxEntry(h.recipientPubkey, r.deliveryId)).toMatchObject({ status: 'unclaimed' });
+      }
+    });
+
+    it('equivalent to sequential deliver: a per-blob replay returns the identical receipts', async () => {
+      const blobs = makeBlobs(2);
+      const batched = await h.sender.deliverBatch(h.recipientPubkey, blobs.map((b) => b.bytes), {
+        transferId: 'tf-b2',
+      });
+      // deliver() of the same blobs is the idempotent replay — same ids, no duplicates
+      for (const [i, blob] of blobs.entries()) {
+        const single = await h.sender.deliver(h.recipientPubkey, blob.bytes, { transferId: 'tf-b2' });
+        expect(single.deliveryId).toBe(batched[i].deliveryId);
+      }
+      // a full re-batch is idempotent too
+      const again = await h.sender.deliverBatch(h.recipientPubkey, blobs.map((b) => b.bytes), {
+        transferId: 'tf-b2',
+      });
+      expect(again).toEqual(batched);
+    });
+
+    it('404 (pre-#111 deployment) falls back to per-entry deposits and never re-probes', async () => {
+      h.fake.setMailboxBatchRoute(false);
+      const client = h.sender.walletApiClient;
+      const batchDeposit = vi.spyOn(client, 'depositMailboxBatch');
+      const singleDeposit = vi.spyOn(client, 'depositMailbox');
+
+      const blobs = makeBlobs(2);
+      const receipts = await h.sender.deliverBatch(h.recipientPubkey, blobs.map((b) => b.bytes), {
+        transferId: 'tf-b3',
+      });
+      expect(receipts).toHaveLength(2);
+      expect(batchDeposit).toHaveBeenCalledTimes(1); // probed once, 404'd
+      expect(singleDeposit).toHaveBeenCalledTimes(2); // per-entry fallback landed both
+
+      // memoized: even with the route back (a fake convenience — real
+      // deployments don't hot-add routes), this instance never re-probes
+      h.fake.setMailboxBatchRoute(true);
+      const more = makeBlobs(2);
+      await h.sender.deliverBatch(h.recipientPubkey, more.map((b) => b.bytes), { transferId: 'tf-b3b' });
+      expect(batchDeposit).toHaveBeenCalledTimes(1);
+      expect(singleDeposit).toHaveBeenCalledTimes(4);
+    });
+
+    it('a batch 409 (one key-variant entry) falls back per-entry: the conflicted entry absorbs, siblings land', async () => {
+      // First deliver a blob, then tamper its stored key — the resume-rebuilt
+      // proof-bytes case (§6/S7). A batch containing it now 409s all-or-nothing.
+      const conflicted = h.makeBlob();
+      const first = await h.sender.deliver(h.recipientPubkey, conflicted.bytes, { transferId: 'tf-b4' });
+      h.fake.tamperMailboxEntryKey(h.recipientPubkey, first.deliveryId);
+
+      const fresh = h.makeBlob();
+      const receipts = await h.sender.deliverBatch(
+        h.recipientPubkey,
+        [conflicted.bytes, fresh.bytes],
+        { transferId: 'tf-b4' },
+      );
+      expect(receipts[0].deliveryId).toBe(first.deliveryId); // absorbed idempotently (S7)
+      expect(h.fake.getMailboxEntry(h.recipientPubkey, receipts[1].deliveryId)).toMatchObject({
+        status: 'unclaimed', // the fresh sibling landed despite the batch-level 409
+      });
+    });
+
+    it('a backend returning non-content-derived ids is a PROTOCOL violation (covenant §3.1-4)', async () => {
+      const client = h.sender.walletApiClient;
+      vi.spyOn(client, 'depositMailboxBatch').mockResolvedValue([{ entryId: 'f'.repeat(64), seq: 1n }]);
+      const blob = h.makeBlob();
+      await expect(
+        h.sender.deliverBatch(h.recipientPubkey, [blob.bytes, blob.bytes], { transferId: 'tf-b5' }),
+      ).rejects.toMatchObject({ code: 'PROTOCOL' });
+    });
+
+    it('an empty batch resolves to [] without touching the network', async () => {
+      const client = h.sender.walletApiClient;
+      const uploadUrls = vi.spyOn(client, 'getUploadUrls');
+      const batchDeposit = vi.spyOn(client, 'depositMailboxBatch');
+      await expect(h.sender.deliverBatch(h.recipientPubkey, [], { transferId: 'tf-b6' })).resolves.toEqual([]);
+      expect(uploadUrls).not.toHaveBeenCalled();
+      expect(batchDeposit).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/support/fake-wallet-api.ts
+++ b/tests/support/fake-wallet-api.ts
@@ -69,6 +69,16 @@ interface InventoryRow {
 }
 
 /** One mailbox entry (§6): append-only per recipient, content-derived id. */
+/** One deposit's validated wire fields — shared by the single and batch handlers (#111). */
+interface DepositEntryFields {
+  recipientPubkey: string;
+  key: string;
+  transferId: string;
+  tokenId: string;
+  stateHash: string;
+  memo?: string;
+}
+
 interface MailboxEntryRow {
   /** `hex(SHA-256(tokenId bytes ‖ stateHash bytes))` (§6). */
   entryId: string;
@@ -296,6 +306,7 @@ export class FakeWalletApi {
   private tamperChallenge: ((challenge: string) => string) | null = null;
   private failInventory = false;
   private failIntents = false;
+  private mailboxBatchEnabled = true;
 
   constructor(options: FakeWalletApiOptions = {}) {
     this.network = options.network ?? 'testnet2';
@@ -371,6 +382,11 @@ export class FakeWalletApi {
   /** Simulate an intent-endpoint outage (E.3 local-backstop tests). */
   setIntentFailure(fail: boolean): void {
     this.failIntents = fail;
+  }
+
+  /** Simulate a pre-#111 deployment: with false, POST /v1/mailbox/batch 404s like any unknown route. */
+  setMailboxBatchRoute(enabled: boolean): void {
+    this.mailboxBatchEnabled = enabled;
   }
 
   /** Force-expire all access tokens (drives the 401 → refresh path). */
@@ -675,6 +691,11 @@ export class FakeWalletApi {
     if (method === 'POST' && path === '/v1/inventory/apply') return this.handleApply(req, res);
 
     if (method === 'POST' && path === '/v1/mailbox') return this.handleMailboxDeposit(req, res);
+    if (method === 'POST' && path === '/v1/mailbox/batch' && this.mailboxBatchEnabled) {
+      // a pre-#111 deployment has no batch route — with the toggle off this
+      // falls through to the 404 below, exactly what the SDK's fallback probes
+      return this.handleMailboxBatchDeposit(req, res);
+    }
     if (method === 'GET' && path === '/v1/mailbox') return this.handleMailboxList(req, res, url);
     if (method === 'POST' && path === '/v1/mailbox/claim') return this.handleMailboxClaim(req, res);
     if (method === 'POST' && path === '/v1/mailbox/reject') return this.handleMailboxReject(req, res);
@@ -1260,22 +1281,83 @@ export class FakeWalletApi {
   private async handleMailboxDeposit(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
     const session = this.authenticate(req);
     const body = await this.readJsonBody(req);
-    const { recipientPubkey, key, transferId, stateHash, tokenId, memo } = body as {
+    const entry = this.parseDepositEntry(body, 'deposit');
+
+    // §6: deposit is idempotent by entry_id — an entry in ANY status returns
+    // 200 with the existing entryId and changes nothing, PROVIDED the
+    // request's recipient and key match the stored entry; a mismatch is 409,
+    // never a false success.
+    const existing = this.findExistingOrConflict(entry);
+    if (existing) {
+      this.json(res, 200, { entryId: existing.entryId });
+      return;
+    }
+    this.checkDepositCaps(entry.recipientPubkey, session.pubkey, 1);
+    const assets = this.validateDepositBlob(entry);
+
+    const { entryId } = this.appendMailboxEntry(session.pubkey, entry, assets);
+    this.wakeOwner(entry.recipientPubkey, 'mailbox'); // §9 wake nudge
+    this.json(res, 200, { entryId });
+  }
+
+  /**
+   * `POST /v1/mailbox/batch` (§6/§16, #111): up to 1000 entries for ONE
+   * recipient, ALL-OR-NOTHING — everything is validated (shape, idempotency
+   * mismatch → 409, §8.2 blob checks, caps over the FRESH count) before any
+   * entry is appended, so a failure mutates nothing. Duplicates succeed with
+   * their stored entryId+seq; fresh entries get a contiguous seq run in
+   * request order. One wake for the whole request.
+   */
+  private async handleMailboxBatchDeposit(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const session = this.authenticate(req);
+    const body = await this.readJsonBody(req);
+    const rawEntries = (body as { entries?: unknown }).entries;
+    if (!Array.isArray(rawEntries) || rawEntries.length < 1 || rawEntries.length > 1000) {
+      throw new HttpError(422, 'VALIDATION', 'entries must be an array of 1..1000 deposit entries');
+    }
+    const entries = rawEntries.map((raw, i) => this.parseDepositEntry(raw, `entries[${i}]`));
+    if (new Set(entries.map((e) => e.recipientPubkey)).size > 1) {
+      throw new HttpError(422, 'VALIDATION', 'all entries must share one recipientPubkey');
+    }
+    if (new Set(entries.map((e) => `${e.tokenId}:${e.stateHash}`)).size !== entries.length) {
+      throw new HttpError(422, 'VALIDATION', 'entries must be distinct (tokenId, stateHash) pairs');
+    }
+
+    // validation phase — request order, nothing stored yet
+    const resolved = entries.map((entry) => ({ entry, existing: this.findExistingOrConflict(entry) }));
+    const fresh = resolved.filter((r) => r.existing === null);
+    const recipientPubkey = entries[0].recipientPubkey;
+    this.checkDepositCaps(recipientPubkey, session.pubkey, fresh.length);
+    const freshAssets = new Map(fresh.map((r) => [r.entry, this.validateDepositBlob(r.entry)]));
+
+    // append phase — consecutive seqs in request order; one wake per request
+    const results = resolved.map(({ entry, existing }) => {
+      if (existing) return { entryId: existing.entryId, seq: existing.seq };
+      return this.appendMailboxEntry(session.pubkey, entry, freshAssets.get(entry) ?? []);
+    });
+    if (fresh.length > 0) this.wakeOwner(recipientPubkey, 'mailbox');
+    this.json(res, 200, {
+      entries: results.map((r) => ({ entryId: r.entryId, seq: r.seq.toString() })),
+    });
+  }
+
+  private parseDepositEntry(raw: unknown, where: string): DepositEntryFields {
+    const { recipientPubkey, key, transferId, stateHash, tokenId, memo } = (raw ?? {}) as {
       recipientPubkey?: unknown; key?: unknown; transferId?: unknown;
       stateHash?: unknown; tokenId?: unknown; memo?: unknown;
     };
     if (typeof recipientPubkey !== 'string' || !/^0[23][0-9a-f]{64}$/i.test(recipientPubkey)) {
-      throw new HttpError(422, 'VALIDATION', 'recipientPubkey must be a 33-byte compressed secp256k1 key (hex)');
+      throw new HttpError(422, 'VALIDATION', `${where}: recipientPubkey must be a 33-byte compressed secp256k1 key (hex)`);
     }
-    if (typeof key !== 'string' || key === '') throw new HttpError(422, 'VALIDATION', 'key is required');
+    if (typeof key !== 'string' || key === '') throw new HttpError(422, 'VALIDATION', `${where}: key is required`);
     if (typeof transferId !== 'string' || transferId === '') {
-      throw new HttpError(422, 'VALIDATION', 'transferId is required');
+      throw new HttpError(422, 'VALIDATION', `${where}: transferId is required`);
     }
     if (typeof tokenId !== 'string' || !/^[0-9a-f]{64}$/.test(tokenId)) {
-      throw new HttpError(422, 'VALIDATION', 'tokenId must be 64-hex');
+      throw new HttpError(422, 'VALIDATION', `${where}: tokenId must be 64-hex`);
     }
     if (typeof stateHash !== 'string' || !/^[0-9a-f]{64}$/.test(stateHash)) {
-      throw new HttpError(422, 'VALIDATION', 'stateHash must be 64-hex');
+      throw new HttpError(422, 'VALIDATION', `${where}: stateHash must be 64-hex`);
     }
     if (memo !== undefined) {
       // §8.3 wire mapping: the memo is an `enc1.` envelope, validated for
@@ -1286,48 +1368,52 @@ export class FakeWalletApi {
         throw new HttpError(422, 'VALIDATION', err instanceof Error ? err.message : 'bad memo envelope');
       }
     }
+    return { recipientPubkey, key, transferId, tokenId, stateHash, ...(memo !== undefined ? { memo: memo as string } : {}) };
+  }
 
-    // §6: deposit is idempotent by entry_id — an entry in ANY status returns
-    // 200 with the existing entryId and changes nothing, PROVIDED the
-    // request's recipient and key match the stored entry; a mismatch is 409,
-    // never a false success.
-    const entryId = this.entryIdFor(tokenId, stateHash);
-    const existing = this.findMailboxEntry(entryId);
-    if (existing) {
-      if (existing.recipientPubkey !== recipientPubkey || existing.s3Key !== key) {
-        throw new HttpError(409, 'CONFLICT', 'entry exists with a different recipient or key');
-      }
-      this.json(res, 200, { entryId });
-      return;
+  /** §6 idempotency: a stored entry (matching recipient+key) or null; a mismatch is 409, never a false success. */
+  private findExistingOrConflict(entry: DepositEntryFields): MailboxEntryRow | null {
+    const existing = this.findMailboxEntry(this.entryIdFor(entry.tokenId, entry.stateHash));
+    if (!existing) return null;
+    if (existing.recipientPubkey !== entry.recipientPubkey || existing.s3Key !== entry.key) {
+      throw new HttpError(409, 'CONFLICT', 'entry exists with a different recipient or key');
     }
+    return existing;
+  }
 
-    // §6/§5.5 caps — what bounds abuse is validation plus quotas, not token
-    // cost: the per-recipient unclaimed cap and the per-sender-pair sub-cap
-    // (so a third party cannot fill the whole inbox). A 429 after
-    // certification is not a loss — the blob is regenerable and the sender's
-    // resume keeps retrying.
+  /**
+   * §6/§5.5 caps — what bounds abuse is validation plus quotas, not token
+   * cost: the per-recipient unclaimed cap and the per-sender-pair sub-cap
+   * (so a third party cannot fill the whole inbox). A batch counts its FRESH
+   * entries: admit only when every one fits (all-or-nothing). A 429 after
+   * certification is not a loss — the blob is regenerable and the sender's
+   * resume keeps retrying.
+   */
+  private checkDepositCaps(recipientPubkey: string, senderPubkey: string, newCount: number): void {
     const recipient = this.owner(recipientPubkey); // accounts auto-provisioned on first touch (§4/§9)
     let unclaimed = 0;
     let unclaimedFromSender = 0;
     for (const e of recipient.mailbox.values()) {
       if (e.status !== 'unclaimed') continue;
       unclaimed++;
-      if (e.senderPubkey === session.pubkey) unclaimedFromSender++;
+      if (e.senderPubkey === senderPubkey) unclaimedFromSender++;
     }
-    if (unclaimed >= this.mailboxUnclaimedCap) {
+    if (unclaimed + newCount > this.mailboxUnclaimedCap) {
       throw new HttpError(429, 'RATE_LIMITED', 'recipient unclaimed-entry cap reached (§5.5)');
     }
-    if (unclaimedFromSender >= this.mailboxPerPairCap) {
+    if (unclaimedFromSender + newCount > this.mailboxPerPairCap) {
       throw new HttpError(429, 'RATE_LIMITED', 'per-sender-pair unclaimed sub-cap reached (§6)');
     }
+  }
 
-    // §8.2 deposit validation pipeline (nothing invalid is stored):
+  /** §8.2 deposit validation pipeline (nothing invalid is stored) — returns the decoded assets. */
+  private validateDepositBlob(entry: DepositEntryFields): FakeAsset[] {
     // step 1 — fetch the blob by key; size cap.
-    const bytes = this.blobStore.get(key);
-    if (!bytes) throw new HttpError(422, 'VALIDATION', `no blob stored at key ${key}`);
+    const bytes = this.blobStore.get(entry.key);
+    if (!bytes) throw new HttpError(422, 'VALIDATION', `no blob stored at key ${entry.key}`);
     if (bytes.length > this.maxBlobBytes) throw new HttpError(413, 'TOO_LARGE', 'blob exceeds MAX_BLOB_BYTES');
     // step 2 — recompute SHA-256; it MUST equal the content-addressed key (§5.2).
-    if (`${this.network}/t/${hex(sha256(bytes))}` !== key) {
+    if (`${this.network}/t/${hex(sha256(bytes))}` !== entry.key) {
       throw new HttpError(422, 'VALIDATION', 'blob bytes do not match the content-addressed key');
     }
     // step 3 — APPROXIMATION: the real server runs the SDK's three-service
@@ -1340,10 +1426,10 @@ export class FakeWalletApi {
     if (resolved.tokenId === null) {
       throw new HttpError(422, 'VALIDATION', 'blob does not decode to a token id');
     }
-    if (resolved.tokenId !== tokenId) {
+    if (resolved.tokenId !== entry.tokenId) {
       throw new HttpError(422, 'VALIDATION', 'decoded tokenId does not match the claimed tokenId');
     }
-    if (hex(sha256(resolved.inner)) !== stateHash) {
+    if (hex(sha256(resolved.inner)) !== entry.stateHash) {
       throw new HttpError(422, 'VALIDATION', 'decoded state hash does not match the claimed stateHash');
     }
     // step 5 — APPROXIMATION: recipient-ownership (predicate decode) is not
@@ -1354,26 +1440,34 @@ export class FakeWalletApi {
     if (assets === null) throw new HttpError(422, 'VALIDATION', 'token value does not decode');
     // step 7 (lineage) applies to inventory writes; the mailbox append itself
     // is replay-guarded by the content-derived entry_id above.
+    return assets;
+  }
 
-    // §6: assign a per-recipient monotonic seq and append; notify.
+  /** §6: assign the next per-recipient monotonic seq and append (caller wakes). */
+  private appendMailboxEntry(
+    senderPubkey: string,
+    entry: DepositEntryFields,
+    assets: FakeAsset[],
+  ): { entryId: string; seq: bigint } {
+    const recipient = this.owner(entry.recipientPubkey);
+    const entryId = this.entryIdFor(entry.tokenId, entry.stateHash);
     recipient.mailboxSeq += 1n;
     recipient.mailbox.set(entryId, {
       entryId,
       seq: recipient.mailboxSeq,
       status: 'unclaimed',
-      recipientPubkey,
-      senderPubkey: session.pubkey,
-      transferId,
-      tokenId,
-      stateHash,
-      s3Key: key,
+      recipientPubkey: entry.recipientPubkey,
+      senderPubkey,
+      transferId: entry.transferId,
+      tokenId: entry.tokenId,
+      stateHash: entry.stateHash,
+      s3Key: entry.key,
       assets,
-      ...(memo !== undefined ? { memo: memo as string } : {}),
+      ...(entry.memo !== undefined ? { memo: entry.memo } : {}),
       createdAt: new Date().toISOString(),
       blobCollected: false,
     });
-    this.wakeOwner(recipientPubkey, 'mailbox'); // §9 wake nudge
-    this.json(res, 200, { entryId });
+    return { entryId, seq: recipient.mailboxSeq };
   }
 
   private mailboxEntryToWire(entry: MailboxEntryRow): Record<string, unknown> {

--- a/tests/unit/modules/PaymentsModule.multi-token-send.test.ts
+++ b/tests/unit/modules/PaymentsModule.multi-token-send.test.ts
@@ -149,7 +149,11 @@ class SimulatedNetworkEngine extends FakeTokenEngine {
   private async certify(): Promise<void> {
     await this.clock.wait(PUBLISH_RTT_MS);
     await this.clock.wait(PROOF_WAIT_MS);
+    this.certifyEndMs.push(this.clock.now());
   }
+
+  /** Virtual-clock completion time of every successful certification (#699 hoisting pin). */
+  readonly certifyEndMs: number[] = [];
 }
 
 // ── Harness (mirrors PaymentsModule.v2-send-recovery.test.ts) ────────────────
@@ -197,9 +201,9 @@ function mockTokenStorage(): TokenStorageProvider<TxfStorageDataBase> {
 }
 
 /** Transport whose delivery pays one publish round trip on the virtual clock. */
-function mockTransport(clock: VirtualClock): TransportProvider {
+function mockTransport(clock: VirtualClock, deliveryStartMs: number[] = []): TransportProvider {
   return {
-    sendTokenTransfer: vi.fn(async () => { await clock.wait(DELIVER_MS); }),
+    sendTokenTransfer: vi.fn(async () => { deliveryStartMs.push(clock.now()); await clock.wait(DELIVER_MS); }),
     onTokenTransfer: vi.fn().mockReturnValue(() => {}),
     onPaymentRequest: vi.fn().mockReturnValue(() => {}),
     onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
@@ -225,10 +229,11 @@ function setup(
   engine: FakeTokenEngine,
   clock: VirtualClock,
   walletApi?: PaymentsModuleDependencies['walletApi'],
+  deliveryStartMs: number[] = [],
 ) {
   const tokenStorageProviders = new Map<string, TokenStorageProvider<TxfStorageDataBase>>();
   tokenStorageProviders.set('local', mockTokenStorage());
-  const transport = mockTransport(clock);
+  const transport = mockTransport(clock, deliveryStartMs);
   const deps: PaymentsModuleDependencies = {
     identity: mockIdentity(), storage: mockStorage(), tokenStorageProviders,
     transport, oracle: mockOracle(), emitEvent: vi.fn(), tokenEngine: engine,
@@ -271,13 +276,16 @@ interface SendTelemetry {
   deliveries: number;
   remainingConfirmed: number;
   virtualElapsedMs: number;
+  certifyEndMs: number[];
+  deliveryStartMs: number[];
 }
 
 async function runManyTokenSend(): Promise<SendTelemetry> {
   const clock = new VirtualClock();
   const certifications = new ConcurrencyGauge();
   const engine = new SimulatedNetworkEngine(clock, certifications);
-  const { module, transport } = setup(engine, clock);
+  const deliveryStartMs: number[] = [];
+  const { module, transport } = setup(engine, clock, undefined, deliveryStartMs);
   try {
     await seedWallet(module, engine, TOKEN_COUNT);
     const startMs = clock.now();
@@ -290,6 +298,8 @@ async function runManyTokenSend(): Promise<SendTelemetry> {
       deliveries: (transport.sendTokenTransfer as any).mock.calls.length,
       remainingConfirmed: module.getTokens().filter((t) => t.status === 'confirmed').length,
       virtualElapsedMs: clock.now() - startMs,
+      certifyEndMs: engine.certifyEndMs,
+      deliveryStartMs,
     };
   } finally {
     module.destroy();
@@ -360,10 +370,13 @@ describe(`single send() spending ${TOKEN_COUNT} source tokens`, () => {
   });
 
   it('parallel: certifications fan out at the send-operation cap', () => {
-    // CHARACTERIZATION of the batched fan-out: each batch of
-    // MAX_SEND_OPERATION_CONCURRENCY ops overlaps fully on the virtual clock
-    // (certify + deliver), and batches run back to back. The sequential-era
-    // baseline was maxConcurrent=1 at TOKEN_COUNT × 1100 = 110,000 ms.
+    // CHARACTERIZATION of the batched fan-out with the hoisted delivery pass
+    // (#699): certification batches of MAX_SEND_OPERATION_CONCURRENCY run back
+    // to back (batches × CERTIFY_MS), then the delivery pass walks the
+    // committed set at the same width (batches × DELIVER_MS on this batch-less
+    // transport port). The total is numerically the welded-era figure — the
+    // shape changed, the wall clock did not. Sequential-era baseline:
+    // maxConcurrent=1 at TOKEN_COUNT × 1100 = 110,000 ms.
     const batches = Math.ceil(TOKEN_COUNT / MAX_SEND_OPERATION_CONCURRENCY);
     const parallelTotalMs = batches * (CERTIFY_MS + DELIVER_MS);
 
@@ -376,6 +389,12 @@ describe(`single send() spending ${TOKEN_COUNT} source tokens`, () => {
         ` virtualWallClock=${formatDuration(t.virtualElapsedMs)}` +
         ` (${batches} batches; sequential-era baseline ${formatDuration(TOKEN_COUNT * (CERTIFY_MS + DELIVER_MS))})`,
     );
+  });
+
+  it('hoisted delivery (#699): no delivery starts until EVERY certification settled', () => {
+    expect(t.certifyEndMs).toHaveLength(TOKEN_COUNT);
+    expect(t.deliveryStartMs).toHaveLength(TOKEN_COUNT);
+    expect(Math.min(...t.deliveryStartMs)).toBeGreaterThanOrEqual(Math.max(...t.certifyEndMs));
   });
 });
 
@@ -393,9 +412,11 @@ describe('fail-fast: a failed operation stops later batches from launching', () 
     // when a batch fails in more than one way).
     expect((t.error as Error & { suppressedErrors?: unknown[] }).suppressedErrors).toBeUndefined();
     // Only the first batch launched (sequential-era fail-fast, at batch
-    // granularity): its siblings settled — certified + delivered — and no
-    // further batch started. Without the early exit this would be TOKEN_COUNT
-    // attempts over ceil(TOKEN_COUNT/MAX) batch round trips.
+    // granularity): its siblings settled certified, no further batch started,
+    // and the hoisted delivery pass (#699) then delivered the committed
+    // siblings — the failure path still hands certified value to the
+    // recipient. Without the early exit this would be TOKEN_COUNT attempts
+    // over ceil(TOKEN_COUNT/MAX) batch round trips.
     expect(t.certifications.count).toBe(MAX_SEND_OPERATION_CONCURRENCY);
     expect(t.deliveries).toBe(MAX_SEND_OPERATION_CONCURRENCY - 1);
     expect(t.virtualElapsedMs).toBe(CERTIFY_MS + DELIVER_MS);

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -371,6 +371,137 @@ describe('send — full wallet-api preset (S2 consumer + S3 + §7 pipeline)', ()
   });
 });
 
+describe('send — batched mailbox deposit (#699)', () => {
+  it('an N-source send issues ONE depositMailboxBatch (and ONE upload-urls) carrying all entries, not N', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-699-1');
+    const N = 3;
+    const sourceIds: string[] = [];
+    for (let i = 0; i < N; i += 1) sourceIds.push(await seedServerToken(fake, sender, SENDER, 100n));
+    await sender.module.load();
+
+    const batchDeposit = vi.spyOn(sender.client, 'depositMailboxBatch');
+    const singleDeposit = vi.spyOn(sender.client, 'depositMailbox');
+    const uploadUrls = vi.spyOn(sender.client, 'getUploadUrls');
+
+    const result = await sender.module.send({ recipient: '@bob', amount: '300', coinId: UCT });
+    expect(result.status).toBe('completed');
+    expect(result.deliveryPending).toBeFalsy();
+
+    expect(batchDeposit).toHaveBeenCalledTimes(1);
+    expect(batchDeposit.mock.calls[0][0]).toHaveLength(N);
+    expect(singleDeposit).not.toHaveBeenCalled();
+    expect(uploadUrls).toHaveBeenCalledTimes(1); // no split → no change upload; delivery is the only caller
+    expect(uploadUrls.mock.calls[0][0]).toHaveLength(N);
+
+    // All N entries landed under the send's transferId; the sources' removals
+    // are evidenced by those deposits (§5.3 — deposit still precedes apply).
+    const entries = fake.listMailboxEntries(RECIPIENT.chainPubkey);
+    expect(entries).toHaveLength(N);
+    expect(new Set(entries.map((e) => e.transferId))).toEqual(new Set([result.id]));
+    for (const tokenId of sourceIds) {
+      expect(fake.getRow(SENDER.chainPubkey, tokenId)).toMatchObject({ status: 'removed', removal: 'evidenced' });
+    }
+  });
+
+  it('a single-source send stays on the plain deposit path — the batch endpoint is never touched', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-699-2');
+    await seedServerToken(fake, sender, SENDER, 1000n);
+    await sender.module.load();
+
+    const batchDeposit = vi.spyOn(sender.client, 'depositMailboxBatch');
+    const singleDeposit = vi.spyOn(sender.client, 'depositMailbox');
+
+    const result = await sender.module.send({ recipient: '@bob', amount: '1000', coinId: UCT });
+    expect(result.status).toBe('completed');
+    expect(batchDeposit).not.toHaveBeenCalled();
+    expect(singleDeposit).toHaveBeenCalledTimes(1);
+  });
+
+  it('a pre-#111 deployment (batch 404) falls back to per-entry deposits; the probe is memoized', async () => {
+    const { fake, baseUrl } = await startFake();
+    fake.setMailboxBatchRoute(false);
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-699-3');
+    for (let i = 0; i < 4; i += 1) await seedServerToken(fake, sender, SENDER, 100n);
+    await sender.module.load();
+
+    const batchDeposit = vi.spyOn(sender.client, 'depositMailboxBatch');
+    const singleDeposit = vi.spyOn(sender.client, 'depositMailbox');
+
+    const first = await sender.module.send({ recipient: '@bob', amount: '200', coinId: UCT });
+    expect(first.status).toBe('completed');
+    expect(batchDeposit).toHaveBeenCalledTimes(1); // probed once → 404
+    expect(singleDeposit).toHaveBeenCalledTimes(2); // per-entry fallback landed both
+
+    const second = await sender.module.send({ recipient: '@bob', amount: '200', coinId: UCT });
+    expect(second.status).toBe('completed');
+    expect(batchDeposit).toHaveBeenCalledTimes(1); // memoized — never re-probed
+    expect(singleDeposit).toHaveBeenCalledTimes(4);
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(4);
+  });
+
+  it('a transient batch failure defers ALL legs (journaled, delivery-pending); the next load replays per entry', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-699-4');
+    const N = 3;
+    for (let i = 0; i < N; i += 1) await seedServerToken(fake, sender, SENDER, 100n);
+    await sender.module.load();
+
+    const batchDeposit = vi
+      .spyOn(sender.client, 'depositMailboxBatch')
+      .mockRejectedValue(new WalletApiError('mailbox down', 'NETWORK'));
+    const singleDeposit = vi.spyOn(sender.client, 'depositMailbox');
+
+    const result = await sender.module.send({ recipient: '@bob', amount: '300', coinId: UCT });
+    expect(result.status).not.toBe('failed');
+    expect(result.deliveryPending).toBe(true);
+    expect(result.deliveryState).toBe('pending-delivery');
+    const pendingEvents = sender.emitEvent.mock.calls.filter((c) => c[0] === 'transfer:delivery_pending');
+    expect(pendingEvents).toHaveLength(1);
+
+    // A batch failure is NOT a per-entry fallback trigger — everything stays
+    // journaled instead (the all-or-nothing endpoint may have landed none).
+    expect(singleDeposit).not.toHaveBeenCalled();
+    expect(JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]')).toHaveLength(N);
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(0);
+
+    // "Restart" with the endpoint healthy again: load()'s replay converges the
+    // journal per entry (replayOneDelivery — deliberately not batched, #699).
+    batchDeposit.mockRestore();
+    const second = createPaymentsModule({ l1: null });
+    second.initialize({ ...sender.deps });
+    cleanups.push(() => second.destroy());
+    await second.load();
+    await vi.waitFor(() => {
+      expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(N);
+    });
+    expect(JSON.parse(sender.storage.map.get('pending_v2_deliveries') ?? '[]')).toHaveLength(0);
+  });
+
+  it('a batch-level 409 falls back to per-entry deposits inside the provider — the send still completes', async () => {
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-699-5');
+    for (let i = 0; i < 2; i += 1) await seedServerToken(fake, sender, SENDER, 100n);
+    await sender.module.load();
+
+    // The all-or-nothing endpoint 409s (one conflicted entry — the
+    // resume-rebuilt-proof case); per-entry deposits let each entry settle
+    // itself (the provider-level contract suite pins the real-conflict absorb).
+    const batchDeposit = vi
+      .spyOn(sender.client, 'depositMailboxBatch')
+      .mockRejectedValue(WalletApiError.fromStatus(409, 'entry exists with a different recipient or key'));
+    const singleDeposit = vi.spyOn(sender.client, 'depositMailbox');
+
+    const result = await sender.module.send({ recipient: '@bob', amount: '200', coinId: UCT });
+    expect(result.status).toBe('completed');
+    expect(result.deliveryPending).toBeFalsy();
+    expect(batchDeposit).toHaveBeenCalledTimes(1);
+    expect(singleDeposit).toHaveBeenCalledTimes(2);
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(2);
+  });
+});
+
 describe('incoming — claim/reject batched per page (#623)', () => {
   it('receive() of N entries issues ONE claimMailbox call carrying all ids, not N', async () => {
     const { fake, baseUrl } = await startFake();

--- a/tests/unit/modules/SendOperations.test.ts
+++ b/tests/unit/modules/SendOperations.test.ts
@@ -43,7 +43,7 @@ function splitOp(opIndex: number, splitAmount: bigint, remainderAmount: bigint):
 }
 
 function certified(op: SendOperation, extra: Partial<OperationOutcome> = {}): OperationOutcome {
-  return { op, certified: true, delivered: true, ...extra };
+  return { op, certified: true, tokenBlob: `journal-${String(op.opIndex)}`, ...extra };
 }
 
 function failed(op: SendOperation, error: unknown): OperationOutcome {
@@ -57,7 +57,6 @@ describe('summarizeOutcomes — accounting', () => {
     expect(s.conflictTagSourceId).toBeUndefined();
     expect(s.committedUiIds).toEqual(new Set(['ui-0', 'ui-1']));
     expect(s.committedAmount).toBe(50n);
-    expect(s.deliveryPending).toBe(false);
     expect(s.changeOutput).toBeNull();
     expect(s.failures).toEqual([]);
   });
@@ -65,13 +64,6 @@ describe('summarizeOutcomes — accounting', () => {
   it('committed ops are returned in plan (opIndex) order regardless of settle order', () => {
     const s = summarizeOutcomes([certified(directOp(2, 1n)), certified(directOp(0, 1n)), certified(directOp(1, 1n))]);
     expect(s.committed.map((o) => o.op.opIndex)).toEqual([0, 1, 2]);
-  });
-
-  it('a deferred delivery flips deliveryPending without failing anything (§3.1/#621)', () => {
-    const s = summarizeOutcomes([certified(directOp(0, 1n)), certified(directOp(1, 1n), { delivered: false })]);
-    expect(s.deliveryPending).toBe(true);
-    expect(s.primaryError).toBeUndefined();
-    expect(s.committedAmount).toBe(2n);
   });
 
   it('a split op contributes only splitAmount and propagates its change token (#677)', () => {

--- a/tests/unit/wallet-api/client.mailbox-batch.test.ts
+++ b/tests/unit/wallet-api/client.mailbox-batch.test.ts
@@ -1,0 +1,161 @@
+/**
+ * `WalletApiClient.depositMailboxBatch` (§6/§16, #111): one request deposits a
+ * whole send's blobs to one recipient — all-or-nothing on the server, results
+ * in request order, idempotent by the entries' content-derived entry_ids (so
+ * NETWORK/503 retry is safe — pinned here like inventory/apply's, #664). A
+ * pre-#111 deployment answers 404 NOT_FOUND, the callers' fallback signal.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { WalletApiClient, WalletApiError, type MailboxDepositRequest } from '../../../wallet-api';
+import { FakeWalletApi } from '../../support/fake-wallet-api';
+import { MemoryKeyValueStore, makeTestToken, testIdentity, type TestToken } from '../../support/wallet-api-test-helpers';
+
+type FetchLike = (url: string | URL, init?: { method?: string }) => Promise<Response>;
+
+function sha256Hex(bytes: Uint8Array): string {
+  return Array.from(sha256(bytes), (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+const TRANSFER_ID = '00000000-0000-0000-0000-000000000699';
+
+describe('WalletApiClient — depositMailboxBatch (§16 #111)', () => {
+  let fake: FakeWalletApi;
+  let baseUrl: string;
+  const sender = testIdentity(61);
+  const recipient = testIdentity(62);
+  const calls: { method: string; path: string }[] = [];
+  let flaky: ((method: string, path: string) => Response | 'drop' | null) | null = null;
+
+  const realFetch: FetchLike = (u, init) =>
+    (globalThis as unknown as { fetch: FetchLike }).fetch(u, init);
+
+  let client: WalletApiClient;
+
+  beforeEach(async () => {
+    fake = new FakeWalletApi();
+    baseUrl = await fake.start();
+    calls.length = 0;
+    flaky = null;
+    client = new WalletApiClient({
+      baseUrl,
+      network: fake.network,
+      deviceId: 'dev-batch',
+      storage: new MemoryKeyValueStore(),
+      fetchFn: ((u: string | URL, init?: { method?: string }) => {
+        const method = init?.method ?? 'GET';
+        const path = String(u);
+        calls.push({ method, path });
+        const intercepted = flaky?.(method, path);
+        if (intercepted === 'drop') return Promise.reject(new TypeError('fetch failed'));
+        if (intercepted) return Promise.resolve(intercepted);
+        return realFetch(u, init as never);
+      }) as never,
+    });
+    client.setIdentity(sender);
+  });
+  afterEach(async () => {
+    await fake.stop();
+  });
+
+  /** Upload a token's WIRE (inner) bytes and build its batch entry. */
+  async function uploadedEntry(token: TestToken): Promise<MailboxDepositRequest> {
+    const wire = token.blob.token;
+    const [url] = await client.getUploadUrls([{ sha256: sha256Hex(wire), size: wire.length }]);
+    await client.uploadBlob(url.putUrl, wire);
+    return {
+      recipientPubkey: recipient.chainPubkey,
+      key: url.key,
+      transferId: TRANSFER_ID,
+      stateHash: sha256Hex(wire),
+      tokenId: token.tokenId,
+    };
+  }
+
+  it('serializes entries verbatim (memo omitted when absent) and parses request-ordered results', async () => {
+    const entries = [await uploadedEntry(makeTestToken()), await uploadedEntry(makeTestToken())];
+
+    const results = await client.depositMailboxBatch(entries);
+    expect(results).toHaveLength(2);
+    // request order, content-derived ids, seq parsed to bigint
+    results.forEach((r, i) => {
+      const expectedId = sha256Hex(
+        Uint8Array.from([
+          ...Buffer.from(entries[i].tokenId, 'hex'),
+          ...Buffer.from(entries[i].stateHash, 'hex'),
+        ]),
+      );
+      expect(r.entryId).toBe(expectedId);
+      expect(r.seq).toBe(BigInt(i + 1));
+    });
+
+    const batchPosts = calls.filter((c) => c.method === 'POST' && c.path.includes('/v1/mailbox/batch'));
+    expect(batchPosts).toHaveLength(1);
+  });
+
+  it('a full replay returns the identical results — idempotent by entry_id, no seq consumed', async () => {
+    const entries = [await uploadedEntry(makeTestToken()), await uploadedEntry(makeTestToken())];
+    const first = await client.depositMailboxBatch(entries);
+    const replay = await client.depositMailboxBatch(entries);
+    expect(replay).toEqual(first);
+  });
+
+  it('DOES retry on a transient NETWORK failure — idempotent by content-derived entry_ids', async () => {
+    const entries = [await uploadedEntry(makeTestToken())];
+    let drops = 1;
+    flaky = (method, path) =>
+      method === 'POST' && path.includes('/v1/mailbox/batch') && drops-- > 0 ? 'drop' : null;
+
+    const results = await client.depositMailboxBatch(entries);
+    expect(results).toHaveLength(1); // succeeded AFTER the retry
+
+    const batchPosts = calls.filter((c) => c.method === 'POST' && c.path.includes('/v1/mailbox/batch'));
+    expect(batchPosts).toHaveLength(2); // first dropped → retried → succeeded
+  });
+
+  it('DOES retry on a 503, honoring the idempotent-write policy', async () => {
+    const entries = [await uploadedEntry(makeTestToken())];
+    let unavailable = 1;
+    flaky = (method, path) =>
+      method === 'POST' && path.includes('/v1/mailbox/batch') && unavailable-- > 0
+        ? new Response(JSON.stringify({ error: { code: 'SERVICE_UNAVAILABLE', message: 'restarting' } }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          })
+        : null;
+
+    const results = await client.depositMailboxBatch(entries);
+    expect(results).toHaveLength(1);
+    const batchPosts = calls.filter((c) => c.method === 'POST' && c.path.includes('/v1/mailbox/batch'));
+    expect(batchPosts).toHaveLength(2);
+  });
+
+  it('surfaces a pre-#111 deployment as NOT_FOUND — the callers’ per-entry fallback signal', async () => {
+    fake.setMailboxBatchRoute(false);
+    const entries = [await uploadedEntry(makeTestToken())];
+    const err = await client.depositMailboxBatch(entries).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(WalletApiError);
+    expect((err as WalletApiError).code).toBe('NOT_FOUND');
+  });
+
+  it('a malformed response (missing entryId) is a PROTOCOL error', async () => {
+    const entries = [await uploadedEntry(makeTestToken())];
+    flaky = (method, path) =>
+      method === 'POST' && path.includes('/v1/mailbox/batch')
+        ? new Response(JSON.stringify({ entries: [{ seq: '1' }] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        : null;
+
+    const err = await client.depositMailboxBatch(entries).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(WalletApiError);
+    expect((err as WalletApiError).code).toBe('PROTOCOL');
+  });
+});

--- a/transport/delivery-provider.ts
+++ b/transport/delivery-provider.ts
@@ -185,6 +185,23 @@ export interface DeliveryProvider {
   ackBatch?(claimed: string[], rejected: string[]): Promise<void>;
 
   /**
+   * Optional batch deliver (#699): hand N finished blobs to ONE recipient with a single deposit
+   * request (and one upload-urls request) instead of N — a multi-source send then costs O(1)
+   * against the backend's deposit rate limit regardless of fragmentation. Optional like
+   * {@link ackBatch}: the port must not preclude the relay transport or a future federated one,
+   * and neither has a batch primitive — callers probe and fall back to per-blob {@link deliver}.
+   *
+   * Semantically equivalent to awaiting {@link deliver} once per blob, in order:
+   * - receipts return in REQUEST order; each `deliveryId` is the content-derived entry id
+   *   (covenant §3.1-4 — NEVER the batch endpoint's server-assigned seq);
+   * - idempotent per (token, state) exactly like {@link deliver};
+   * - `options` apply to every blob (one send = one transferId/memo/senderNametag);
+   * - throws when ANY blob could not be deposited — blobs that DID land are absorbed
+   *   idempotently when the caller retries, batched or per-blob.
+   */
+  deliverBatch?(recipientPubkey: string, blobs: Uint8Array[], options: DeliverOptions): Promise<DeliveryReceipt[]>;
+
+  /**
    * Optional wake hook: `callback` fires with the {@link WakeStream} that was
    * nudged when new data may be available on it (e.g. a WS nudge — never a
    * correctness dependency, ARCHITECTURE §9). The wallet-api wake socket

--- a/wallet-api/client.ts
+++ b/wallet-api/client.ts
@@ -47,6 +47,7 @@ import {
   parseBalances,
   parseBlobUrls,
   parseClaimResult,
+  parseBatchDepositResult,
   parseDepositResult,
   parseHistoryPage,
   parseIntents,
@@ -74,6 +75,7 @@ import type {
   InventoryPage,
   KeyValueStore,
   ListPaymentRequestsParams,
+  MailboxBatchDepositResult,
   MailboxClaimResult,
   MailboxDepositRequest,
   MailboxPage,
@@ -722,6 +724,36 @@ export class WalletApiClient {
         // existing entry in ANY status replays to 200 with its id, so a
         // lost-response retry / 503 retry cannot double-deposit (the 8-wide
         // send fan-out makes 503s likelier).
+        { idempotent: true }
+      )
+    );
+  }
+
+  /**
+   * `POST /v1/mailbox/batch` — deposit a whole send's already-uploaded blobs
+   * to ONE recipient in a single request (§6/§16, #111). ALL-OR-NOTHING: any
+   * per-entry 409/422/429 fails the request with full rollback, while
+   * already-present entries succeed inside a batch, returning their stored
+   * `entryId` + `seq` (request order). Idempotent by the entries'
+   * content-derived entry_ids — a full replay returns the identical result —
+   * so NETWORK/503 retry is safe. A 404 `NOT_FOUND` means a pre-#111
+   * deployment: callers fall back to per-entry {@link depositMailbox}.
+   */
+  async depositMailboxBatch(entries: MailboxDepositRequest[]): Promise<MailboxBatchDepositResult[]> {
+    return parseBatchDepositResult(
+      await this.requestJson(
+        'POST',
+        '/v1/mailbox/batch',
+        {
+          entries: entries.map((req) => ({
+            recipientPubkey: req.recipientPubkey,
+            key: req.key,
+            transferId: req.transferId,
+            stateHash: req.stateHash,
+            tokenId: req.tokenId,
+            ...(req.memo !== undefined ? { memo: req.memo } : {}),
+          })),
+        },
         { idempotent: true }
       )
     );

--- a/wallet-api/codec.ts
+++ b/wallet-api/codec.ts
@@ -18,6 +18,7 @@ import type {
   HistoryWireRecord,
   IntentRecord,
   InventoryPage,
+  MailboxBatchDepositResult,
   MailboxClaimResult,
   MailboxEntry,
   MailboxPage,
@@ -201,6 +202,18 @@ export function parseProgressRecords(body: unknown): ProgressRecord[] {
 export function parseDepositResult(body: unknown): string {
   const rec = asRecord(body, 'mailbox deposit response');
   return asString(rec.entryId, 'mailbox deposit response .entryId');
+}
+
+/** `POST /v1/mailbox/batch` → {@link MailboxBatchDepositResult}[] in request order (§16, #111). */
+export function parseBatchDepositResult(body: unknown): MailboxBatchDepositResult[] {
+  const rec = asRecord(body, 'mailbox batch deposit response');
+  return asArray(rec.entries, 'mailbox batch deposit response .entries').map((raw, i) => {
+    const entry = asRecord(raw, `entries[${i}]`);
+    return {
+      entryId: asString(entry.entryId, `entries[${i}].entryId`),
+      seq: parseCounter(entry.seq, `entries[${i}].seq`),
+    };
+  });
 }
 
 function parseMailboxEntry(raw: unknown, what: string): MailboxEntry {

--- a/wallet-api/index.ts
+++ b/wallet-api/index.ts
@@ -31,6 +31,7 @@ export type {
   ApplyDeltaRequest,
   IntentRecord,
   MailboxDepositRequest,
+  MailboxBatchDepositResult,
   MailboxEntry,
   MailboxEntryStatus,
   MailboxPage,

--- a/wallet-api/index.ts
+++ b/wallet-api/index.ts
@@ -10,6 +10,7 @@ export { WalletApiClient } from './client';
 export { WalletApiError, ChallengeTemplateError } from './errors';
 export type { WalletApiErrorCode } from './errors';
 export { AUTH_CHALLENGE_PREFIX, verifyChallengeTemplate } from './challenge';
+export { MAX_MAILBOX_BATCH_ENTRIES } from './types';
 export { completeSignMessage, progressSignMessage } from './intent-signing';
 export type { ChallengeExpectation } from './challenge';
 

--- a/wallet-api/types.ts
+++ b/wallet-api/types.ts
@@ -231,6 +231,13 @@ export interface MailboxDepositRequest {
 }
 
 /**
+ * The §16 batch-deposit entry cap: `POST /v1/mailbox/batch` 422s above 1000
+ * entries. Callers chunk at this bound so a legal send of any size never
+ * emits a request the backend rejects outright.
+ */
+export const MAX_MAILBOX_BATCH_ENTRIES = 1000;
+
+/**
  * One `POST /v1/mailbox/batch` result (§6/§16, #111): the content-derived
  * entry id plus the entry's per-recipient seq (newly on the wire — the single
  * deposit returns `{ entryId }` only), in request order. `seq` is data, never

--- a/wallet-api/types.ts
+++ b/wallet-api/types.ts
@@ -230,6 +230,17 @@ export interface MailboxDepositRequest {
   memo?: string;
 }
 
+/**
+ * One `POST /v1/mailbox/batch` result (§6/§16, #111): the content-derived
+ * entry id plus the entry's per-recipient seq (newly on the wire — the single
+ * deposit returns `{ entryId }` only), in request order. `seq` is data, never
+ * an id: the S7 deliveryId stays content-derived.
+ */
+export interface MailboxBatchDepositResult {
+  entryId: string;
+  seq: bigint;
+}
+
 export type MailboxEntryStatus = 'unclaimed' | 'claimed' | 'rejected'; // §11/§16 wire values
 
 /** One `GET /v1/mailbox` entry (§16). */


### PR DESCRIPTION
Closes #699. Stacks on #698 (base: `concurrent-send`); retarget to `main` after #698 merges. Server half: unicity-sphere/wallet-api#113.

## What

An N-source send now makes **one** `POST /v1/tokens/upload-urls` and **one** `POST /v1/mailbox/batch` instead of N of each — and delivery is hoisted out of the per-op certification closure (the structural request from #698's review), which is what makes the batch call site possible.

- **Delivery hoisting** — `sendOperation` is pure certify → journal (`OperationOutcome` carries the journaled `tokenBlob`; `delivered`/`deliveryPending` leave the reducer). One `deliverCommittedBlobs` pass runs over the settled committed set, before the `primaryError` throw so committed siblings of a failed batch still get their delivery attempt. Batch failure defers ALL blobs to the journal (the all-or-nothing endpoint may have landed none); the per-blob fallback keeps the 8-wide width, so the multi-token-send virtual-clock totals are unchanged. New pin: no delivery starts until every certification settled.
- **Port** — optional `deliverBatch?(recipientPubkey, blobs, options)` on `DeliveryProvider` (S7 text landed in wallet-api#113). `TransportDeliveryAdapter` omits it like `ackBatch`; the module probes and falls back per blob.
- **Client** — `depositMailboxBatch()` with `{ idempotent: true }` (content-derived entry_ids make NETWORK/503 retry safe; pinned). 404 `NOT_FOUND` = pre-batch deployment.
- **Provider** — `deliver` decomposes into shared helpers; `deliverBatch` = one upload-urls + N PUTs + one batch deposit. Fallbacks: 404 memoized per instance → per-entry deposits over the same uploaded keys; batch-level 409 → per-entry so the one conflicted entry absorbs its own 409 under the existing S7 rule.
- **Out of scope** (per the issue): `replayOneDelivery` and resume's per-op delivery stay per-entry.

## Tests

Client retry/wire pins; provider contract additions (one-call pins, sequential-deliver equivalence, idempotent re-batch, 404 memoization, real-conflict 409 absorb, covenant entryId check, empty batch); module end-to-end (ONE batch call for N ops with §5.3 evidence preserved, single-source unchanged, old-server fallback + memoization, transient-failure → journal → per-entry replay convergence, batch-409 → completes). Full suite: 3172 tests green; existing journal-replay / #677 / resume suites untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)