### PR TITLE
refactor!: remove the last v1 token remnants (7,025 → 6,912)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,56 @@ thing never shown.
   SDK floor already published `requiredSdk` / `actualSdk`; those are unchanged.
 - Nothing else moved: same error codes, same `reason` values, same wire shape. Any UI that
   prints `error.message` gains the versions with no code change.
+### Removed — the last v1 token remnants
+
+The v2 cutover left v1 code paths behind to keep stored v1 TXF tokens *displayable*.
+Those paths are now gone. Stored v1 tokens are unspendable (and have been since the
+cutover); they are no longer parsed for display, no longer validated, and report as
+`UNKNOWN` if surfaced.
+
+**Breaking:**
+
+- **`OracleProvider.validateToken()`** — removed from the interface and from
+  `UnicityAggregatorProvider`. Token verification is entirely the engine's job
+  (`engine.verify` + `engine.isSpent`). Custom `OracleProvider` implementations no
+  longer need to supply it. The `ValidationResult` type it returned is removed with it,
+  including its re-export from the root entry point. **This also deletes a latent data
+  bug** rather than fixing it: `validateToken` caught *all* errors — including network
+  failures — and returned `{valid: false}` instead of throwing, so a single gateway
+  outage during `validate()` durably marked **every** stored v1 token `'invalid'` and
+  persisted it, while the v2 branch fifteen lines above had an explicit
+  "never invalidate funds on an outage" guard.
+- With `validateToken` gone the oracle issues **no JSON-RPC calls at all** — it is now
+  purely a network-config provider, as its own docstring already claimed. The internal
+  `rpcCall`/`ensureConnected` plumbing and the spent-state cache are removed.
+
+**Behavior:**
+
+- `payments.validate()` is v2-only. A stored v1 relic is neither reported valid nor
+  marked invalid — it is left untouched, because the engine cannot read it and guessing
+  corrupts the user's view of their legacy holdings.
+- `parseTokenInfo()` no longer contains the v1 TXF JSON display parser (this also
+  removes a 37-line literal clone between its `genesis.coinData` and `state.coinData`
+  branches).
+- `load()` no longer terminalizes orphaned pending-V5 tokens into `'invalid'`; that
+  migration ran on every load since the cutover and has served its purpose. The legacy
+  `PENDING_V5_TOKENS` key is still dropped so it does not linger.
+
+**Deliberately kept:** the non-blob key-derivation branch in `parseSdkDataCached`.
+Despite reading the legacy JSON shape it is **not** a v1 feature — tombstone and journal
+dedup are storage-level and version-agnostic, keyed by `(tokenId, stateHash)`, and the
+tombstone suite covers both stored shapes on purpose. Removing it would have silently
+weakened dedup in the money path.
+
+**Also kept:** the archived/forked `TxfToken` stores. They look like v1 remnants but
+have four live consumers in `AccountingModule` (invoice payment attribution) and no real
+test coverage — they are Stage 10 of `docs/PAYMENTS-REFACTOR.md`, which requires
+characterization tests first.
+
+Verified: typecheck and lint clean, 210 test files / 3,329 tests green, and the **live
+testnet2 e2e suite green** (6 files / 35 tests — including `payments-v2.testnet2` and
+`token-engine.testnet2`), identical to the pre-change baseline.
+
 ### Removed — dead code in `PaymentsModule` (no behavior change)
 
 Verified-unreachable code removed from `modules/payments/PaymentsModule.ts` (**7,179 → 7,025

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -734,19 +734,19 @@
       "count": 1
     },
     "budget/no-long-comment-block": {
-      "count": 64
+      "count": 63
     },
     "complexity": {
-      "count": 13
+      "count": 12
     },
     "max-depth": {
-      "count": 16
+      "count": 14
     },
     "max-lines": {
       "count": 1
     },
     "max-lines-per-function": {
-      "count": 19
+      "count": 18
     }
   },
   "modules/payments/SendOperations.ts": {

--- a/index.ts
+++ b/index.ts
@@ -240,7 +240,6 @@ export type {
 export type {
   // Oracle (Aggregator) — v2: network-config provider for the token engine
   OracleProvider,
-  ValidationResult,
   OracleEvent,
   OracleEventType,
   OracleEventCallback,

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -341,91 +341,13 @@ export async function parseTokenInfo(tokenData: unknown, engine?: ITokenEngine):
       return { ...defaultInfo, tokenId: engine.tokenId(token) };
     } catch (error) {
       logger.warn('Payments', 'Failed to parse token info via engine:', error);
-      // fall through to legacy parsing
     }
   }
 
-  try {
-    // If it's a string, try to parse as JSON
-    const data = typeof tokenData === 'string' ? JSON.parse(tokenData) : tokenData;
-
-    // Manual extraction from legacy v1 TXF JSON (display-only — the v1 engine is
-    // gone, so stored TXF tokens are parsed as plain JSON, never via an SDK).
-    if (data.genesis?.data) {
-      const genesis = data.genesis.data;
-      if (genesis.coinData) {
-        // coinData can be: [[coinIdHex, amount]] or {coinIdHex: amount}
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const coinData = genesis.coinData as any;
-        if (Array.isArray(coinData) && coinData.length > 0) {
-          const firstEntry = coinData[0];
-          if (Array.isArray(firstEntry) && firstEntry.length === 2) {
-            const [coinIdHex, amount] = firstEntry;
-            return enrichWithRegistry({
-              coinId: String(coinIdHex),
-              symbol: String(coinIdHex).slice(0, 8),
-              name: `Token ${String(coinIdHex).slice(0, 8)}`,
-              decimals: 0,
-              amount: String(amount),
-              tokenId: genesis.tokenId,
-            });
-          }
-        } else if (typeof coinData === 'object') {
-          const coinEntries = Object.entries(coinData);
-          if (coinEntries.length > 0) {
-            const [coinId, amount] = coinEntries[0] as [string, unknown];
-            return enrichWithRegistry({
-              coinId,
-              symbol: coinId.slice(0, 8),
-              name: `Token ${coinId.slice(0, 8)}`,
-              decimals: 0,
-              amount: String(amount),
-              tokenId: genesis.tokenId,
-            });
-          }
-        }
-      }
-      if (genesis.tokenId) {
-        defaultInfo.tokenId = genesis.tokenId;
-      }
-    }
-
-    // Try to extract from state if available
-    if (data.state?.coinData) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const coinData = data.state.coinData as any;
-      if (Array.isArray(coinData) && coinData.length > 0) {
-        const firstEntry = coinData[0];
-        if (Array.isArray(firstEntry) && firstEntry.length === 2) {
-          const [coinIdHex, amount] = firstEntry;
-          return enrichWithRegistry({
-            coinId: String(coinIdHex),
-            symbol: String(coinIdHex).slice(0, 8),
-            name: `Token ${String(coinIdHex).slice(0, 8)}`,
-            decimals: 0,
-            amount: String(amount),
-            tokenId: defaultInfo.tokenId,
-          });
-        }
-      } else if (typeof coinData === 'object') {
-        const coinEntries = Object.entries(coinData);
-        if (coinEntries.length > 0) {
-          const [coinId, amount] = coinEntries[0] as [string, unknown];
-          return enrichWithRegistry({
-            coinId,
-            symbol: coinId.slice(0, 8),
-            name: `Token ${coinId.slice(0, 8)}`,
-            decimals: 0,
-            amount: String(amount),
-            tokenId: defaultInfo.tokenId,
-          });
-        }
-      }
-    }
-  } catch (error) {
-    logger.warn('Payments', 'Failed to parse token info:', error);
-  }
-
+  // v2-only: anything that is not an engine blob is a stored v1 TXF relic. The
+  // v1 JSON display parser was removed with the rest of the v1 stack, so such a
+  // token reports as UNKNOWN rather than being decoded by a format we no longer
+  // support.
   return defaultInfo;
 }
 
@@ -473,7 +395,11 @@ function parseSdkDataCached(sdkData: string): { tokenId: string | null; stateHas
     looksLikeTokenBlob(sdkData) ? tryParseBlobKeys(sdkData) : null;
 
   if (!entry) {
-    // Legacy v1 TXF JSON.
+    // NOT a v1 feature: tombstone/journal dedup is storage-level and
+    // version-agnostic, keyed by (tokenId, stateHash). This branch derives those
+    // keys for any non-blob stored shape — including the legacy TXF JSON still
+    // sitting in old wallets — so a re-delivery can still be deduped. It stays
+    // after the v1 removal deliberately; losing it would silently weaken dedup.
     let tokenId: string | null = null;
     let stateHash = '';
     try {
@@ -1531,45 +1457,15 @@ export class PaymentsModule {
       const loadedTokens = Array.from(this.tokens.values()).map(t => `${t.id.slice(0, 12)}(${t.status})`);
       logger.debug('Payments', `load(): from TXF providers: ${this.tokens.size} tokens [${loadedTokens.join(', ')}]`);
 
-      // v1 cutover: orphaned pending-V5 tokens (saved by the removed instant-split
-      // receiver) can never confirm — their finalization path was v1-only. Move
-      // them to the terminal 'invalid' state instead of leaving phantom
-      // 'submitted' balance forever. sdkData is kept intact for audit.
-      // They lived in the legacy PENDING_V5_TOKENS KV key (TXF never persisted
-      // them), so this is a one-time KV migration; the in-map sweep below covers
-      // any stragglers that did land in token storage.
-      let terminalized = 0;
+      // v1 cutover: drop the legacy PENDING_V5_TOKENS KV key if a pre-cutover
+      // wallet still carries one. The orphaned-token terminalization it fed ran
+      // for every load since the cutover and has served its purpose; with the v1
+      // stack gone there is nothing left to terminalize, so this is now only a
+      // one-time key cleanup.
       try {
-        const legacyPendingV5 = await this.deps!.storage.get(STORAGE_KEYS_ADDRESS.PENDING_V5_TOKENS);
-        if (legacyPendingV5) {
-          const v5Tokens = JSON.parse(legacyPendingV5) as Token[];
-          for (const t of v5Tokens) {
-            if (this.tokens.has(t.id)) continue;
-            t.status = 'invalid';
-            t.updatedAt = Date.now();
-            this.tokens.set(t.id, t);
-            terminalized++;
-          }
-          await this.deps!.storage.remove(STORAGE_KEYS_ADDRESS.PENDING_V5_TOKENS);
-        }
+        await this.deps!.storage.remove(STORAGE_KEYS_ADDRESS.PENDING_V5_TOKENS);
       } catch (err) {
-        logger.warn('Payments', 'load(): failed to migrate legacy PENDING_V5_TOKENS:', err);
-      }
-      for (const [, t] of this.tokens) {
-        if (t.status !== 'submitted') continue;
-        const isPendingV5 = t.id.startsWith('v5split_')
-          || (t.sdkData?.startsWith('{') && (() => {
-            try { return '_pendingFinalization' in JSON.parse(t.sdkData!); } catch { return false; }
-          })());
-        if (isPendingV5) {
-          t.status = 'invalid';
-          t.updatedAt = Date.now();
-          terminalized++;
-        }
-      }
-      if (terminalized > 0) {
-        logger.warn('Payments', `load(): terminalized ${terminalized} orphaned pending-V5 token(s) (v1 finalization removed)`);
-        await this.save();
+        logger.warn('Payments', 'load(): failed to drop legacy PENDING_V5_TOKENS:', err);
       }
 
       // Crash recovery: tokens persisted mid-send stay 'transferring' forever —
@@ -5130,36 +5026,27 @@ export class PaymentsModule {
 
     const engine = this.deps?.tokenEngine;
     for (const token of this.tokens.values()) {
-      // v2 blob tokens are verified via the engine (local proof check + on-chain
-      // spent-status); the oracle's validateToken only understands v1 TXF.
-      if (engine && token.sdkData && looksLikeTokenBlob(token.sdkData)) {
-        try {
-          const sphereToken = await engine.decodeToken(decodeTokenBlob(hexToBytes(token.sdkData)));
-          const verdict = await engine.verify(sphereToken);
-          const spent = verdict.ok ? await engine.isSpent(sphereToken) : false;
-          if (verdict.ok && !spent) {
-            valid.push(token);
-          } else {
-            token.status = 'invalid';
-            this.parsedTokenCache.delete(token.id);
-            invalid.push(token);
-          }
-        } catch (err) {
-          // Transient failure (decode/network) — do NOT invalidate funds on an
-          // outage; skip this token for this run.
-          logger.warn('Payments', `validate: engine check failed for ${token.id}, skipping:`, err);
+      // v2-only: tokens are verified via the engine (local proof check + on-chain
+      // spent-status). Anything that is not an engine blob is a stored v1 TXF
+      // relic — unspendable since the cutover and no longer inspected here, so it
+      // is left untouched rather than judged by a validator that cannot read it.
+      if (!engine || !token.sdkData || !looksLikeTokenBlob(token.sdkData)) continue;
+
+      try {
+        const sphereToken = await engine.decodeToken(decodeTokenBlob(hexToBytes(token.sdkData)));
+        const verdict = await engine.verify(sphereToken);
+        const spent = verdict.ok ? await engine.isSpent(sphereToken) : false;
+        if (verdict.ok && !spent) {
+          valid.push(token);
+        } else {
+          token.status = 'invalid';
+          this.parsedTokenCache.delete(token.id);
+          invalid.push(token);
         }
-        continue;
-      }
-
-      const result = await this.deps!.oracle.validateToken(token.sdkData);
-
-      if (result.valid && !result.spent) {
-        valid.push(token);
-      } else {
-        token.status = 'invalid';
-        this.parsedTokenCache.delete(token.id);
-        invalid.push(token);
+      } catch (err) {
+        // Transient failure (decode/network) — do NOT invalidate funds on an
+        // outage; skip this token for this run.
+        logger.warn('Payments', `validate: engine check failed for ${token.id}, skipping:`, err);
       }
     }
 

--- a/oracle/UnicityAggregatorProvider.ts
+++ b/oracle/UnicityAggregatorProvider.ts
@@ -6,9 +6,6 @@
  * and exposes the gateway URL + API key. The engine (token-engine/) builds its
  * own SDK clients from these — no state-transition SDK objects live here.
  *
- * `validateToken` remains as a best-effort JSON-RPC check for LEGACY v1 TXF
- * tokens still present in storage (display-path only).
- *
  * TrustBaseLoader is injected for platform-specific loading:
  * - Browser: fetch from URL
  * - Node.js: read from file
@@ -18,13 +15,11 @@ import { logger } from '../core/logger';
 import type { ProviderStatus } from '../types';
 import type {
   OracleProvider,
-  ValidationResult,
   OracleEvent,
   OracleEventCallback,
   TrustBaseLoader,
 } from './oracle-provider';
 import { DEFAULT_AGGREGATOR_TIMEOUT } from '../constants';
-import { SphereError } from '../core/errors';
 
 // =============================================================================
 // Configuration
@@ -46,17 +41,6 @@ export interface UnicityAggregatorProviderConfig {
 }
 
 // =============================================================================
-// RPC Response Types
-// =============================================================================
-
-interface RpcValidateResponse {
-  valid?: boolean;
-  spent?: boolean;
-  stateHash?: string;
-  error?: string;
-}
-
-// =============================================================================
 // Implementation
 // =============================================================================
 
@@ -75,8 +59,6 @@ export class UnicityAggregatorProvider implements OracleProvider {
   /** Raw trust-base JSON as loaded (the v2 token engine parses it itself). */
   private trustBaseJson: unknown | null = null;
 
-  // Cache for spent states reported by validateToken (immutable once spent)
-  private spentCache: Map<string, boolean> = new Map();
 
   constructor(config: UnicityAggregatorProviderConfig) {
     this.config = {
@@ -170,45 +152,6 @@ export class UnicityAggregatorProvider implements OracleProvider {
     this.log('Initialized with trust base JSON:', !!this.trustBaseJson);
   }
 
-  /**
-   * Best-effort RPC validation for LEGACY v1 TXF tokens (display path only).
-   * v2 blob tokens are verified via the token engine and never reach this.
-   */
-  async validateToken(tokenData: unknown): Promise<ValidationResult> {
-    this.ensureConnected();
-
-    try {
-      const response = await this.rpcCall<RpcValidateResponse>('validateToken', { token: tokenData });
-
-      const valid = response.valid ?? false;
-      const spent = response.spent ?? false;
-
-      this.emitEvent({
-        type: 'validation:completed',
-        timestamp: Date.now(),
-        data: { valid },
-      });
-
-      // Cache spent state if spent
-      if (response.stateHash && spent) {
-        this.spentCache.set(response.stateHash, true);
-      }
-
-      return {
-        valid,
-        spent,
-        stateHash: response.stateHash,
-        error: response.error,
-      };
-    } catch (error) {
-      return {
-        valid: false,
-        spent: false,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
   // ===========================================================================
   // Event Subscription
   // ===========================================================================
@@ -219,53 +162,8 @@ export class UnicityAggregatorProvider implements OracleProvider {
   }
 
   // ===========================================================================
-  // Private: RPC
-  // ===========================================================================
-
-  private async rpcCall<T>(method: string, params: unknown): Promise<T> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.config.timeout);
-
-    try {
-      const response = await fetch(this.config.url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: Date.now(),
-          method,
-          params,
-        }),
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        throw new SphereError(`HTTP ${response.status}: ${response.statusText}`, 'AGGREGATOR_ERROR');
-      }
-
-      const result = await response.json();
-
-      if (result.error) {
-        throw new SphereError(result.error.message ?? 'RPC error', 'AGGREGATOR_ERROR');
-      }
-
-      return (result.result ?? {}) as T;
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-
-  // ===========================================================================
   // Private: Helpers
   // ===========================================================================
-
-  private ensureConnected(): void {
-    if (this.status !== 'connected') {
-      throw new SphereError('UnicityAggregatorProvider not connected', 'NOT_INITIALIZED');
-    }
-  }
 
   private emitEvent(event: OracleEvent): void {
     for (const callback of this.eventCallbacks) {

--- a/oracle/oracle-provider.ts
+++ b/oracle/oracle-provider.ts
@@ -7,9 +7,9 @@
  * engine (token-engine/) builds its own aggregator clients from these — no
  * SDK client objects cross this boundary anymore.
  *
- * `validateToken` survives as a best-effort JSON-RPC check for LEGACY v1 TXF
- * tokens still present in storage (display-path only); v2 blob tokens are
- * verified via the engine (`engine.verify` + `engine.isSpent`).
+ * Token verification is entirely the engine's job (`engine.verify` +
+ * `engine.isSpent`); the legacy v1 `validateToken` RPC was removed with the
+ * rest of the v1 stack.
  */
 
 import type { BaseProvider } from '../types';
@@ -26,12 +26,6 @@ export interface OracleProvider extends BaseProvider {
    * @param trustBaseJson - Optional raw trust-base JSON (overrides the loader).
    */
   initialize(trustBaseJson?: unknown): Promise<void>;
-
-  /**
-   * Validate a LEGACY v1 TXF token against the aggregator (best-effort RPC).
-   * v2 blob tokens never reach this — they are verified via the token engine.
-   */
-  validateToken(tokenData: unknown): Promise<ValidationResult>;
 
   // ── v2 token-engine config surface ─────────────────────────────────────────
   // Sphere.buildTokenEngine reads exactly these three accessors; the engine
@@ -59,13 +53,6 @@ export interface OracleProvider extends BaseProvider {
 // =============================================================================
 // Validation Types
 // =============================================================================
-
-export interface ValidationResult {
-  valid: boolean;
-  spent: boolean;
-  error?: string;
-  stateHash?: string;
-}
 
 // =============================================================================
 // Oracle Events

--- a/tests/unit/modules/PaymentsModule.v2-send-recovery.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-send-recovery.test.ts
@@ -273,8 +273,8 @@ describe('handleV2Transfer — storage rejection gates events (v2)', () => {
   });
 });
 
-describe('load() — orphaned pending-V5 terminalization', () => {
-  it("migrates the legacy PENDING_V5_TOKENS KV key: tokens become terminal 'invalid', key removed", async () => {
+describe('load() — legacy PENDING_V5_TOKENS cleanup', () => {
+  it('drops the legacy KV key without materializing its tokens', async () => {
     const { module, storage } = setup();
     // Inject the key exactly as the removed v1 receiver persisted it.
     storage.map.set(STORAGE_KEYS_ADDRESS.PENDING_V5_TOKENS, JSON.stringify([{
@@ -285,11 +285,10 @@ describe('load() — orphaned pending-V5 terminalization', () => {
 
     await module.load();
 
-    const v5 = module.getTokens({ status: 'invalid' });
-    expect(v5).toHaveLength(1);
-    expect(v5[0].id).toBe('v5split_abc');
-    // Not counted as confirmed balance, and the legacy key is gone.
-    expect(module.getTokens({ status: 'confirmed' })).toHaveLength(0);
+    // v1 removal: the terminalize-into-'invalid' migration is gone. These tokens
+    // were never spendable and are no longer surfaced at all — the only remaining
+    // obligation is that the legacy key does not linger.
+    expect(module.getTokens()).toHaveLength(0);
     expect(storage.map.has(STORAGE_KEYS_ADDRESS.PENDING_V5_TOKENS)).toBe(false);
   });
 });

--- a/tests/unit/modules/PaymentsModule.v2-validate.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-validate.test.ts
@@ -175,13 +175,20 @@ describe('validate() — v2 engine branch', () => {
     expect(module.getTokens().find((t) => t.id === token.id)?.status).toBe('confirmed');
   });
 
-  it('routes legacy v1 TXF JSON tokens through oracle.validateToken', async () => {
-    const { module, oracle } = setup();
+  it('leaves legacy v1 TXF JSON tokens untouched — never judged, never invalidated', async () => {
+    const { module } = setup();
     const token = await storeLegacyToken(module);
+    const statusBefore = module.getTokens().find((t) => t.id === token.id)?.status;
 
-    const { valid } = await module.validate();
+    const { valid, invalid } = await module.validate();
 
-    expect(oracle.validateToken).toHaveBeenCalledWith(token.sdkData);
-    expect(valid.map((t) => t.id)).toContain(token.id);
+    // v1 removal: the oracle's legacy validateToken RPC is gone. A stored v1 relic
+    // is neither reported valid nor marked invalid — the engine cannot read it, and
+    // guessing would durably corrupt the user's view of their legacy holdings
+    // (the pre-removal branch marked them 'invalid' on any gateway outage, because
+    // validateToken returns {valid:false} rather than throwing on a network error).
+    expect(valid.map((t) => t.id)).not.toContain(token.id);
+    expect(invalid.map((t) => t.id)).not.toContain(token.id);
+    expect(module.getTokens().find((t) => t.id === token.id)?.status).toBe(statusBefore);
   });
 });


### PR DESCRIPTION
**Stacked on #702** — review/merge that first; this PR's base is `chore/payments-module-refactor`, and its diff is v1-removal only.

## What

The v2 cutover left v1 code paths behind to keep stored v1 TXF tokens *displayable*. Those paths are now gone. `PaymentsModule.ts` **6,862 → 6,749**; `UnicityAggregatorProvider` **−102 lines**.

## Breaking

- **`OracleProvider.validateToken()`** removed from the interface and the implementation. Verification is entirely the engine's job (`engine.verify` + `engine.isSpent`). Custom `OracleProvider` implementations no longer supply it. `ValidationResult` goes with it, including its root re-export.
- With it gone, **the oracle makes no JSON-RPC calls at all** — it is now purely a network-config provider, exactly as its own docstring already claimed. `rpcCall`/`ensureConnected` and the spent-state cache are removed.

## This deletes a latent data bug rather than fixing it

`validateToken` caught **all** errors — including network failures — and returned `{valid: false}` instead of throwing (`UnicityAggregatorProvider.ts`). The legacy branch in `validate()` then marked **every** stored v1 token `'invalid'` and **persisted it** via `save()`. One gateway outage durably corrupted the user's view of their legacy holdings.

The v2 branch fifteen lines above had exactly the right guard, commented *"do NOT invalidate funds on an outage"*. The legacy branch never got it — textbook drift from the cutover.

`validate()` is now v2-only and leaves v1 relics **untouched — neither valid nor invalid** — because the engine cannot read them and guessing is what caused the bug.

## Deliberately kept (both would have looked like wins)

- **The non-blob branch in `parseSdkDataCached`.** It reads the legacy JSON shape, but it is *not* a v1 feature: tombstone/journal dedup is storage-level and version-agnostic, keyed by `(tokenId, stateHash)`, and the tombstone suite covers both stored shapes on purpose. I removed it, **9 tombstone tests failed**, and I reverted it — silently weakening dedup in the money path to save 25 lines is a bad trade.
- **The archived/forked `TxfToken` stores.** They look like v1 remnants but have **4 live consumers in `AccountingModule`** (invoice payment attribution) and no real coverage — `AccountingModule`'s calls are `vi.fn()`-stubbed in the test helpers. That is Stage 10 of `docs/PAYMENTS-REFACTOR.md`, which requires characterization tests first.

## Tests: re-pointed, not weakened

Two tests covered behavior this PR removes. Both now pin the **new** contract:
- the `validate()` legacy-routing test asserts a v1 relic is left untouched, and documents the outage bug in a comment;
- the pending-V5 test asserts the legacy key is dropped without materializing its tokens.

## Verification

- typecheck clean; lint clean with **no new warnings** (confirmed by diffing against a stashed tree)
- **210 test files / 3,329 tests** green
- **Live testnet2 e2e green — identical to the pre-change baseline**: 6 files / 35 tests passed, 1 file / 4 skipped, including `payments-v2.testnet2.e2e` and `token-engine.testnet2.e2e`

## Not included

IPFS token-sync removal was also requested and is **not** in this PR — it is a separate concern (~3,216 lines plus the published `./impl/browser/ipfs` subpath export) and deserves its own reviewable diff.