### PR TITLE
fix(connect): name the versions in compatibility-gate refusals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — compatibility-gate refusals now name the versions
+
+A rejected handshake said `SDK version below the required minimum` and stopped there. The
+numbers were in `error.data` all along, but every UI in the fleet renders `error.message` and
+nothing else, so the one thing a developer needed — *which* version to move to — was the one
+thing never shown.
+
+- `checkCompatibility` now quotes both sides in `message`:
+  `SDK version 0.11.9 is below the required minimum 0.12.0`,
+  `Connect protocol 2.0 is below the required minimum 2.1`,
+  `Incompatible Connect protocol version: app speaks 1.0, wallet speaks 2.1`.
+  A client that sent no `sdkVersion` reads `SDK version unknown (not reported) is below …` —
+  a distinct failure from an old version, and one a developer would otherwise chase in the
+  wrong place.
+- New `data.requiredProtocol` on a MINOR-floor refusal (the floor the wallet demands). The
+  SDK floor already published `requiredSdk` / `actualSdk`; those are unchanged.
+- Nothing else moved: same error codes, same `reason` values, same wire shape. Any UI that
+  prints `error.message` gains the versions with no code change.
+
 ### Added — `ERROR_CODES.INTENT_OUTCOME_UNKNOWN` (4201), and a rule about what a host may claim
 
 **Read this before upgrading if your dApp spends.** Once `onIntent` has been called, a host may

--- a/connect/compatibility.ts
+++ b/connect/compatibility.ts
@@ -31,6 +31,12 @@ function fail(
  * (protocol MAJOR → optional MINOR floor → optional SDK floor → network) and
  * returns {ok:true} or {ok:false, error}. A malformed clientProtocol (NaN MAJOR)
  * is treated as protocol-incompatible.
+ *
+ * Every refusal message NAMES the versions involved. The same numbers are also in
+ * `error.data` for anything that wants to branch on them, but `data` alone is not
+ * enough: the whole fleet renders `error.message` and nothing else, so a floor that
+ * only said "below the required minimum" told a developer to upgrade without ever
+ * saying to what.
  */
 export function checkCompatibility(input: CompatInput): CompatResult {
   const { clientProtocol, walletProtocol, minMinor, clientSdkVersion, minSdkVersion } = input;
@@ -38,21 +44,28 @@ export function checkCompatibility(input: CompatInput): CompatResult {
   // 1. Protocol MAJOR must match.
   if (majorOf(clientProtocol) !== majorOf(walletProtocol)) {
     return fail(ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION, 'protocol_incompatible',
-      'Incompatible Connect protocol version', { walletProtocol, clientProtocol });
+      `Incompatible Connect protocol version: app speaks ${clientProtocol}, wallet speaks ${walletProtocol}`,
+      { walletProtocol, clientProtocol });
   }
 
   const walletMajor = majorOf(walletProtocol);
 
   // 2. Optional MINOR floor within the MAJOR.
   if (minMinor !== undefined && compareSemver(clientProtocol, `${walletMajor}.${minMinor}`) < 0) {
+    const requiredProtocol = `${walletMajor}.${minMinor}`;
     return fail(ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION, 'protocol_incompatible',
-      'Connect protocol below the required minimum', { walletProtocol, clientProtocol });
+      `Connect protocol ${clientProtocol} is below the required minimum ${requiredProtocol}`,
+      { walletProtocol, clientProtocol, requiredProtocol });
   }
 
   // 3. Optional secondary npm-SDK floor (rarely used).
   if (minSdkVersion !== undefined && (!clientSdkVersion || compareSemver(clientSdkVersion, minSdkVersion) < 0)) {
+    // A client that reported nothing is a distinct failure from one that reported an old
+    // version — say which it was, or the developer checks a version that was never sent.
+    const actual = clientSdkVersion ?? 'unknown (not reported)';
     return fail(ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION, 'protocol_incompatible',
-      'SDK version below the required minimum', { walletProtocol, clientProtocol, requiredSdk: minSdkVersion, actualSdk: clientSdkVersion ?? null });
+      `SDK version ${actual} is below the required minimum ${minSdkVersion}`,
+      { walletProtocol, clientProtocol, requiredSdk: minSdkVersion, actualSdk: clientSdkVersion ?? null });
   }
 
   // 4. Network must match (a missing network is treated as a mismatch).

--- a/docs/CONNECT.md
+++ b/docs/CONNECT.md
@@ -682,7 +682,10 @@ try {
     showWrongNetwork((e as ConnectError).data);
   } else if (code === ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION) {
     // data.reason = 'protocol_incompatible'
-    // data.walletProtocol = '2.0', data.clientProtocol = '1.0' (for example)
+    // data.walletProtocol = '2.1', data.clientProtocol = '1.0' (for example)
+    // A version floor also sends what it demanded: data.requiredProtocol, or
+    // data.requiredSdk + data.actualSdk. `e.message` already names both sides —
+    // showing it verbatim is enough if you have no custom copy.
     showUpdateRequired((e as ConnectError).data);
   } else {
     showGenericError();
@@ -715,8 +718,15 @@ Rejection `.data` for the two gate errors:
 // UNSUPPORTED_PROTOCOL_VERSION (4007)
 {
   reason: 'protocol_incompatible';
-  walletProtocol: string;  // e.g. '2.0'
+  walletProtocol: string;  // e.g. '2.1'
   clientProtocol: string;  // e.g. '1.0'
+
+  // Only on the optional MINOR floor — the MINOR the wallet demands, e.g. '2.1'.
+  requiredProtocol?: string;
+
+  // Only on the optional npm-SDK floor.
+  requiredSdk?: string;         // e.g. '0.12.0'
+  actualSdk?: string | null;    // null when the dApp reported no sdkVersion
 }
 
 // INCOMPATIBLE_NETWORK (4008)

--- a/tests/unit/connect/compatibility.test.ts
+++ b/tests/unit/connect/compatibility.test.ts
@@ -61,3 +61,51 @@ describe('checkCompatibility', () => {
     if (!r.ok) expect(r.error.code).toBe(ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION);
   });
 });
+
+/**
+ * The refusal a human actually sees.
+ *
+ * `error.data` has carried the versions all along, but every UI in the fleet renders
+ * `error.message` and nothing else — so a version floor read as "SDK version below the
+ * required minimum" with no hint of WHICH version to move to. The numbers belong in the
+ * message; `data` stays authoritative for anything that wants to branch on them.
+ */
+describe('checkCompatibility — refusal messages name the versions', () => {
+  const base = { walletProtocol: W, clientNetwork: { id: NET }, walletNetworkId: NET } as const;
+
+  it('names both SDK versions on the sdk floor', () => {
+    const r = checkCompatibility({ ...base, clientProtocol: '2.0', clientSdkVersion: '0.9.0', minSdkVersion: '0.10.0' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.message).toBe('SDK version 0.9.0 is below the required minimum 0.10.0');
+      expect(r.error.data).toMatchObject({ requiredSdk: '0.10.0', actualSdk: '0.9.0' });
+    }
+  });
+
+  it('still names the required SDK version when the client reported none', () => {
+    const r = checkCompatibility({ ...base, clientProtocol: '2.0', minSdkVersion: '0.10.0' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.message).toBe('SDK version unknown (not reported) is below the required minimum 0.10.0');
+      expect(r.error.data).toMatchObject({ requiredSdk: '0.10.0', actualSdk: null });
+    }
+  });
+
+  it('names both protocol versions on the MINOR floor, and publishes requiredProtocol', () => {
+    const r = checkCompatibility({ ...base, clientProtocol: '2.0', minMinor: 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.message).toBe('Connect protocol 2.0 is below the required minimum 2.1');
+      expect(r.error.data).toMatchObject({ clientProtocol: '2.0', requiredProtocol: '2.1' });
+    }
+  });
+
+  it('names both protocol versions on a MAJOR mismatch', () => {
+    const r = checkCompatibility({ ...base, clientProtocol: '1.0' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.message).toBe(`Incompatible Connect protocol version: app speaks 1.0, wallet speaks ${W}`);
+      expect(r.error.data).toMatchObject({ walletProtocol: W, clientProtocol: '1.0' });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

A refused handshake told the developer to upgrade without saying to what:

> SDK version below the required minimum

The versions were in `error.data` (`requiredSdk` / `actualSdk`) all along — but every UI in the fleet renders `error.message` and nothing else, so the one fact that made the error actionable was the one fact never shown.

## Change

`checkCompatibility` now quotes both sides in the message:

- `SDK version 0.11.9 is below the required minimum 0.12.0`
- `Connect protocol 2.0 is below the required minimum 2.1`
- `Incompatible Connect protocol version: app speaks 1.0, wallet speaks 2.1`

A client that sent no `sdkVersion` reads `SDK version unknown (not reported) is below …` — a distinct failure from an old version, and one a developer would otherwise chase in the wrong place.

New `data.requiredProtocol` on a MINOR-floor refusal. `requiredSdk` / `actualSdk` are unchanged.

## Compatibility

Error codes, `reason` values and wire shape are untouched. No consumer branches on the message text (the one place that could — `connectErrors.ts` in connect-example — is explicit that coded errors never consult it). Any UI printing `error.message` gains the versions with no code change.

## Tests

4 new cases in `tests/unit/connect/compatibility.test.ts` pinning each message. `tests/unit/connect` 310/310, `tsc --noEmit` clean, lint 0 errors.

## Related

- unicity-sphere/sphere — wallet-side copy for the same refusal
- unicity-sphere/sphere-sdk-connect-example — dApp-side banner
