### PR TITLE
refactor!: remove the Nostr payment-request channel (6,912 → 6,747)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ This narrows the S7 covenant deliberately: payment requests are now wallet-api-o
 storage and delivery remain swappable interfaces with contract suites. Nostr is untouched
 elsewhere — it remains the rail for identity bindings, DMs and group chat.
 
+**Also removed — two payment-request fields that the wallet-api path never carried.**
+`PaymentRequest.recipientNametag` and `PaymentRequest.metadata` were only ever transmitted by the
+deleted Nostr wire; `sendWalletApiPaymentRequest` forwards assets, the encrypted memo envelope and
+`expiresAt` only. Leaving them declared would have meant a caller supplying them got `success:true`
+with the values silently dropped. `IncomingPaymentRequest.recipientNametag` / `.metadata` are gone
+for the same reason — `surfaceIncomingPaymentRequest` never set them, so they were permanently
+`undefined`. Removing them turns a silent loss into a compile error.
+`OutgoingPaymentRequest.recipientNametag` is unaffected — the wallet-api path still sets it.
+
 One test was re-pointed, not deleted: `PaymentsModule.payment-requests.test.ts` previously
 asserted "compositions WITHOUT wallet-api keep the Nostr payment-request path"; it now asserts
 that no transport subscriptions are installed and that sending is refused with a wallet-api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed — the Nostr payment-request channel
+
+Payment requests ride wallet-api (sdk-changes S4). The Nostr fallback is gone, so
+`PaymentsModule` no longer has two implementations of one concept.
+
+**Breaking:** a composition without the wallet-api payment-request capability can no longer
+send or receive payment requests. `sendPaymentRequest()` now returns
+`{ success: false, error: 'Payment requests require the wallet-api payment-request capability' }`
+instead of falling back to Nostr — an explicit refusal at the call site rather than a silent
+no-op. `transport.onPaymentRequest` / `onPaymentRequestResponse` subscriptions are no longer
+installed, and `sendPaymentRequestResponse` no longer has a transport leg.
+
+Removed with it: `handleIncomingPaymentRequest`, `handlePaymentRequestResponse`, the
+`unsubscribePaymentRequests` / `unsubscribePaymentRequestResponses` fields and their teardown.
+`dispatchPaymentRequestResponse` stays — it is shared, and the wallet-api channel uses it.
+
+This narrows the S7 covenant deliberately: payment requests are now wallet-api-only, while
+storage and delivery remain swappable interfaces with contract suites. Nostr is untouched
+elsewhere — it remains the rail for identity bindings, DMs and group chat.
+
+One test was re-pointed, not deleted: `PaymentsModule.payment-requests.test.ts` previously
+asserted "compositions WITHOUT wallet-api keep the Nostr payment-request path"; it now asserts
+that no transport subscriptions are installed and that sending is refused with a wallet-api
+error. No test was weakened.
+
 ### Removed — IPFS/IPNS token sync
 
 Sphere syncs tokens through wallet-api. The IPFS rail was opt-in

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -610,10 +610,10 @@
       "count": 1
     },
     "budget/no-long-comment-block": {
-      "count": 63
+      "count": 62
     },
     "complexity": {
-      "count": 12
+      "count": 11
     },
     "max-depth": {
       "count": 14
@@ -622,7 +622,7 @@
       "count": 1
     },
     "max-lines-per-function": {
-      "count": 18
+      "count": 17
     }
   },
   "modules/payments/SendOperations.ts": {

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -56,10 +56,6 @@ import type {
   TransportProvider,
   PeerInfo,
   IncomingTokenTransfer,
-  PaymentRequestPayload,
-  PaymentRequestResponsePayload,
-  IncomingPaymentRequest as TransportPaymentRequest,
-  IncomingPaymentRequestResponse as TransportPaymentRequestResponse,
 } from '../../transport';
 import type { DeliverOptions, DeliveryProvider, IncomingDelivery, WakeStream } from '../../transport/delivery-provider';
 import { TransportDeliveryAdapter } from './TransportDeliveryAdapter';
@@ -943,8 +939,6 @@ export class PaymentsModule {
 
   // Subscriptions
   private unsubscribeTransfers: (() => void) | null = null;
-  private unsubscribePaymentRequests: (() => void) | null = null;
-  private unsubscribePaymentRequestResponses: (() => void) | null = null;
 
   // Delivery port (sdk-changes S3/S7)
   /** The single delivery seam — an injected provider or the transport adapter. */
@@ -1175,10 +1169,6 @@ export class PaymentsModule {
     // Clean up previous subscriptions before re-initializing
     this.unsubscribeTransfers?.();
     this.unsubscribeTransfers = null;
-    this.unsubscribePaymentRequests?.();
-    this.unsubscribePaymentRequests = null;
-    this.unsubscribePaymentRequestResponses?.();
-    this.unsubscribePaymentRequestResponses = null;
     this.teardownDeliveryPump();
     this.teardownPaymentRequestPump();
 
@@ -1283,12 +1273,9 @@ export class PaymentsModule {
       );
     }
 
-    // Payment requests (sdk-changes S4): when the composed wallet-api port
-    // carries the §16 payment-request endpoints they ride wallet-api — the
-    // incoming `?since=<seq>` stream is polled (gap-free — §9; the poll is the
-    // correctness path) and the Nostr payment-request channel is NOT
-    // installed. Without the capability the transport subscriptions stay
-    // exactly as before (port selection, covenant §3.1-6).
+    // Payment requests ride wallet-api (sdk-changes S4). The incoming
+    // `?since=<seq>` stream is polled — gap-free per §9, and the poll is the
+    // correctness path.
     this.prBootstrapped = false;
     // #441: reset the deferred-paid journal so it reloads under the new identity's
     // storage key (the key bakes in chainPubkey). New mutations start a fresh
@@ -1302,20 +1289,6 @@ export class PaymentsModule {
       this.prPollTimer = setInterval(() => {
         this.pumpHealth.run('payment-requests', () => this.pumpPaymentRequests());
       }, DELIVERY_POLL_INTERVAL_MS);
-    } else {
-      // Subscribe to incoming payment requests (if supported)
-      if (deps.transport.onPaymentRequest) {
-        this.unsubscribePaymentRequests = deps.transport.onPaymentRequest((request) => {
-          this.handleIncomingPaymentRequest(request);
-        });
-      }
-
-      // Subscribe to payment request responses (if supported)
-      if (deps.transport.onPaymentRequestResponse) {
-        this.unsubscribePaymentRequestResponses = deps.transport.onPaymentRequestResponse((response) => {
-          this.handlePaymentRequestResponse(response);
-        });
-      }
     }
 
     // Subscribe to storage provider events (push-based sync)
@@ -1571,10 +1544,6 @@ export class PaymentsModule {
     }
     this.unsubscribeTransfers?.();
     this.unsubscribeTransfers = null;
-    this.unsubscribePaymentRequests?.();
-    this.unsubscribePaymentRequests = null;
-    this.unsubscribePaymentRequestResponses?.();
-    this.unsubscribePaymentRequestResponses = null;
     this.teardownDeliveryPump();
     this.teardownPaymentRequestPump();
     this.paymentRequestHandlers.clear();
@@ -2718,69 +2687,11 @@ export class PaymentsModule {
   ): Promise<PaymentRequestResult> {
     this.ensureInitialized();
 
-    // S4: with the wallet-api payment-request capability composed, the
-    // request rides the §16 endpoints — the Nostr channel is not used.
     const prApi = this.paymentRequestsApi();
-    if (prApi) {
-      return this.sendWalletApiPaymentRequest(prApi, recipientPubkeyOrNametag, request);
+    if (!prApi) {
+      return { success: false, error: 'Payment requests require the wallet-api payment-request capability' };
     }
-
-    if (!this.deps!.transport.sendPaymentRequest) {
-      return {
-        success: false,
-        error: 'Transport provider does not support payment requests',
-      };
-    }
-
-    try {
-      // Resolve recipient
-      const peerInfo = await this.deps!.transport.resolve?.(recipientPubkeyOrNametag) ?? null;
-      const recipientPubkey = this.resolveTransportPubkey(recipientPubkeyOrNametag, peerInfo);
-
-      // Build payload
-      const payload: PaymentRequestPayload = {
-        amount: request.amount,
-        coinId: request.coinId,
-        message: request.message,
-        recipientNametag: request.recipientNametag,
-        metadata: request.metadata,
-      };
-
-      // Send via transport
-      const eventId = await this.deps!.transport.sendPaymentRequest(recipientPubkey, payload);
-      const requestId = randomUUID();
-
-      // Track outgoing request
-      const outgoingRequest: OutgoingPaymentRequest = {
-        id: requestId,
-        eventId,
-        recipientPubkey,
-        recipientNametag: recipientPubkeyOrNametag.startsWith('@')
-          ? recipientPubkeyOrNametag.slice(1)
-          : undefined,
-        amount: request.amount,
-        coinId: request.coinId,
-        message: request.message,
-        createdAt: Date.now(),
-        status: 'pending',
-      };
-      this.outgoingPaymentRequests.set(requestId, outgoingRequest);
-
-      logger.debug('Payments', `Payment request sent: ${eventId}`);
-
-      return {
-        success: true,
-        requestId,
-        eventId,
-      };
-    } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      logger.debug('Payments', `Failed to send payment request: ${errorMsg}`);
-      return {
-        success: false,
-        error: errorMsg,
-      };
-    }
+    return this.sendWalletApiPaymentRequest(prApi, recipientPubkeyOrNametag, request);
   }
 
   /**
@@ -3088,50 +2999,6 @@ export class PaymentsModule {
     }
   }
 
-  private handleIncomingPaymentRequest(transportRequest: TransportPaymentRequest): void {
-    // Check for duplicates
-    if (this.paymentRequests.find((r) => r.id === transportRequest.id)) {
-      return;
-    }
-
-    // Convert transport request to IncomingPaymentRequest
-    const coinId = transportRequest.request.coinId;
-    const registry = TokenRegistry.getInstance();
-    const coinDef = registry.getDefinition(coinId);
-
-    const request: IncomingPaymentRequest = {
-      id: transportRequest.id,
-      senderPubkey: transportRequest.senderTransportPubkey,
-      senderNametag: transportRequest.senderNametag,
-      amount: transportRequest.request.amount,
-      coinId,
-      symbol: coinDef?.symbol || coinId.slice(0, 8),
-      message: transportRequest.request.message,
-      recipientNametag: transportRequest.request.recipientNametag,
-      requestId: transportRequest.request.requestId,
-      timestamp: transportRequest.timestamp,
-      status: 'pending',
-      metadata: transportRequest.request.metadata,
-    };
-
-    // Add to list (newest first)
-    this.paymentRequests.unshift(request);
-
-    // Emit event
-    this.deps?.emitEvent('payment_request:incoming', request);
-
-    // Notify handlers
-    for (const handler of this.paymentRequestHandlers) {
-      try {
-        handler(request);
-      } catch (error) {
-        logger.debug('Payments', 'Payment request handler error:', error);
-      }
-    }
-
-    logger.debug('Payments', `Incoming payment request: ${request.id} for ${request.amount} ${request.symbol}`);
-  }
-
   // ===========================================================================
   // Public API - Outgoing Payment Requests
   // ===========================================================================
@@ -3228,19 +3095,6 @@ export class PaymentsModule {
     }
   }
 
-  private handlePaymentRequestResponse(transportResponse: TransportPaymentRequestResponse): void {
-    // Convert transport response to PaymentRequestResponse
-    this.dispatchPaymentRequestResponse({
-      id: transportResponse.id,
-      responderPubkey: transportResponse.responderTransportPubkey,
-      requestId: transportResponse.response.requestId,
-      responseType: transportResponse.response.responseType,
-      message: transportResponse.response.message,
-      transferId: transportResponse.response.transferId,
-      timestamp: transportResponse.timestamp,
-    });
-  }
-
   /**
    * Fold a payment-request response into the outgoing surface and notify —
    * shared by the transport subscription and the wallet-api outgoing refresh
@@ -3304,42 +3158,23 @@ export class PaymentsModule {
     const request = this.paymentRequests.find((r) => r.id === requestId);
     if (!request) return;
 
-    // S4: respond via the §16 endpoint. 'accepted' is a LOCAL UI state — the
-    // backend models open → paid|declined|expired only, so nothing is sent
-    // until the actual decision. Unlike the best-effort transport leg below,
-    // server rejections (403 non-addressee / 409 non-open) propagate.
     const prApi = this.paymentRequestsApi();
-    if (prApi) {
-      if (responseType === 'accepted') return;
-      if (responseType === 'paid') {
-        if (transferId === undefined) {
-          throw new SphereError('A paid response requires the fulfilling transferId (§16)', 'VALIDATION_ERROR');
-        }
-        await prApi.respondPaymentRequest(request.requestId, { action: 'paid', transferId });
-      } else {
-        await prApi.respondPaymentRequest(request.requestId, { action: 'declined' });
+    if (!prApi) return;
+
+    // 'accepted' is a LOCAL UI state: the backend models open →
+    // paid|declined|expired, so nothing is sent until the real decision.
+    if (responseType === 'accepted') return;
+
+    // Server rejections (403 non-addressee, 409 non-open) propagate.
+    if (responseType === 'paid') {
+      if (transferId === undefined) {
+        throw new SphereError('A paid response requires the fulfilling transferId (§16)', 'VALIDATION_ERROR');
       }
-      logger.debug('Payments', `Responded to payment request via wallet-api: ${responseType} for ${requestId}`);
-      return;
+      await prApi.respondPaymentRequest(request.requestId, { action: 'paid', transferId });
+    } else {
+      await prApi.respondPaymentRequest(request.requestId, { action: 'declined' });
     }
-
-    if (!this.deps?.transport.sendPaymentRequestResponse) {
-      logger.debug('Payments', 'Transport does not support sendPaymentRequestResponse');
-      return;
-    }
-
-    try {
-      const payload: PaymentRequestResponsePayload = {
-        requestId: request.requestId, // Original request ID from sender
-        responseType,
-        transferId,
-      };
-
-      await this.deps.transport.sendPaymentRequestResponse(request.senderPubkey, payload);
-      logger.debug('Payments', `Sent payment request response: ${responseType} for ${requestId}`);
-    } catch (error) {
-      logger.debug('Payments', 'Failed to send payment request response:', error);
-    }
+    logger.debug('Payments', `Responded to payment request: ${responseType} for ${requestId}`);
   }
 
   // ===========================================================================

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -973,8 +973,8 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
   });
 });
 
-describe('compositions WITHOUT wallet-api keep the Nostr payment-request path (covenant §3.1-6)', () => {
-  it('installs the transport subscriptions and sends via the transport payload', async () => {
+describe('payment requests require wallet-api — there is no Nostr fallback', () => {
+  it('installs no transport subscriptions and refuses to send without the capability', async () => {
     const identity = fullIdentity(REQUESTER);
     const transport = mockTransport();
     const deps: PaymentsModuleDependencies = {
@@ -989,16 +989,16 @@ describe('compositions WITHOUT wallet-api keep the Nostr payment-request path (c
     module.initialize(deps);
     cleanups.push(() => module.destroy());
 
-    // The push subscriptions ARE installed on this path.
-    expect(transport.onPaymentRequest).toHaveBeenCalledTimes(1);
-    expect(transport.onPaymentRequestResponse).toHaveBeenCalledTimes(1);
+    expect(transport.onPaymentRequest).not.toHaveBeenCalled();
+    expect(transport.onPaymentRequestResponse).not.toHaveBeenCalled();
 
+    // Refused explicitly rather than silently doing nothing, so a caller
+    // composed without the capability finds out at the call site.
     const result = await module.sendPaymentRequest('@bob', { amount: '25', coinId: UCT, message: 'hi' });
-    expect(result.success).toBe(true);
-    expect(result.eventId).toBe('nostr-event-1');
-    expect(transport.sendPaymentRequest).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/wallet-api/);
+    expect(transport.sendPaymentRequest).not.toHaveBeenCalled();
 
-    // And the wallet-api pump surface is a no-op without the capability.
     await expect(module.syncPaymentRequests()).resolves.toBeUndefined();
   });
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -217,10 +217,6 @@ export interface PaymentRequest {
   readonly coinId: string;
   /** Optional message/memo */
   readonly message?: string;
-  /** Where tokens should be sent */
-  readonly recipientNametag?: string;
-  /** Custom metadata */
-  readonly metadata?: Record<string, unknown>;
   /** Expiration timestamp (ms) */
   readonly expiresAt?: number;
   /** Created timestamp */
@@ -245,16 +241,12 @@ export interface IncomingPaymentRequest {
   readonly symbol: string;
   /** Message from sender */
   readonly message?: string;
-  /** Requester's nametag (where tokens should be sent) */
-  readonly recipientNametag?: string;
   /** Original request ID from sender */
   readonly requestId: string;
   /** Timestamp */
   readonly timestamp: number;
   /** Current status */
   status: PaymentRequestStatus;
-  /** Custom metadata */
-  readonly metadata?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
Payment requests ride wallet-api (sdk-changes S4). The Nostr fallback is gone.

`PaymentsModule.ts` **6,912 → 6,747**. +31 / −196.

## Why this one first

The duplication analysis in `docs/PAYMENTS-ANALYSIS.md` flagged *"payment-request handling over transport vs over wallet-api — is one a divergent clone of the other?"* as a real finding. It was. Deleting the transport channel resolves it **by subtraction** instead of by building a shared abstraction over two things that only one of which is used.

It also touches no money path — requests are not transfers — which is why it's ahead of the send-path work in the safest-first order.

## Breaking

A composition without the wallet-api payment-request capability can no longer send or receive payment requests:

- `sendPaymentRequest()` returns `{ success: false, error: 'Payment requests require the wallet-api payment-request capability' }` rather than falling back to Nostr. **An explicit refusal at the call site beats a silent no-op.**
- `transport.onPaymentRequest` / `onPaymentRequestResponse` subscriptions are no longer installed.
- `sendPaymentRequestResponse` has no transport leg.

Removed: `handleIncomingPaymentRequest`, `handlePaymentRequestResponse`, the two `unsubscribe*` fields and their teardown, four now-unused transport type imports.

**Kept:** `dispatchPaymentRequestResponse` — it is shared, and the wallet-api channel uses it.

## Covenant note

This narrows S7 **deliberately**: payment requests are wallet-api-only now. Storage and delivery remain swappable interfaces with contract suites. Nostr is untouched elsewhere — identity bindings, DMs and group chat are unaffected.

## Readability

`sendPaymentRequestResponse` was rewritten rather than brace-patched. With one path left it sheds a nesting level and reads top-to-bottom:

```
const prApi = this.paymentRequestsApi();
if (!prApi) return;
if (responseType === 'accepted') return;   // local UI state
...
```

## Tests

One test **re-pointed, not deleted**. It previously asserted *"compositions WITHOUT wallet-api keep the Nostr payment-request path"*; it now asserts no transport subscriptions are installed and that sending is refused with a wallet-api error. No test was weakened.

## Ratchet

Suppressions pruned **837 → 834**. `PaymentsModule`'s `max-lines-per-function` ceiling drops **18 → 17** and `complexity` **12 → 11** — permanently.

## Verification (by exit code)

| Gate | Exit |
|---|---|
| typecheck | 0 |
| lint | 0 |
| build | 0 |
| unit + integration | 0 — **199 files / 3,117 tests** |
| live testnet2 e2e | 0 — **6 files / 35 tests** |