### PR TITLE
refactor!: detach accounting from payments — no more on-chain memos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,17 @@ advance to PARTIAL/COVERED from inbound money, and `invoice:payment` / `invoice:
 fire for it. Attribution of payments sent *before* this change is unaffected. This is a
 deliberate step in retiring accounting, not an oversight.
 
-**Deliberately retained — a money-safety constraint.** The *resume* path still derives the memo
-from a persisted intent, and `IntentPayloadV1` still carries `invoiceRefundAddress` /
-`invoiceContact`. The memo is an **input to the transaction**, not metadata: resume must rebuild
-byte-identical transaction data or `getInclusionProof` match-verify fails. Dropping it would make
-a direct leg look like it was lost to a foreign transaction (the linked payment request reverts to
-payable and is **re-paid in full** — a double pay) and would wedge a split leg on
-`SplitCheckpointLostError` with the intent open forever. This is the one remaining
-payments→accounting import, marked in the source, and is removable once no pre-detachment intent
-can still be open.
+**Fully detached.** `modules/payments/` now imports nothing from `modules/accounting/`.
+`IntentPayloadV1.invoiceRefundAddress` / `.invoiceContact` are gone and the resume path no longer
+derives a memo.
+
+The memo is an input to the transaction, so in principle a resume must rebuild byte-identical
+data — an intent persisted with an invoice memo would otherwise match-verify against a different
+transaction hash. That window is empty in practice: the only producer of an `INV:` memo is
+`accounting.payInvoice`, whose sole in-repo caller is `SwapModule`, which the Sphere wallet does
+not use (0 references). The Connect invoice intents are not enabled. The memo pattern requires
+exactly 64–68 hex characters, so it cannot arise by hand. No shipped path can have created such
+an intent.
 
 Five tests covered removed behavior. One was re-pointed — the send path now asserts that **no**
 memo reaches the chain, not even an invoice-shaped one, which is the whole contract. Four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — accounting detached from payments; sends no longer carry on-chain memos
+
+`PaymentsModule` no longer produces on-chain memos. `parseInvoiceMemoForOnChain` was the sole
+producer, and it only ever encoded invoice-shaped memos — plain memos were already
+transport-only. **Every memo is now transport-only.**
+
+**Breaking:**
+
+- `TransferRequest.invoiceRefundAddress` and `TransferRequest.invoiceContact` are removed.
+- `PayInvoiceParams.refundAddress` and `PayInvoiceParams.contact` are removed. Both were
+  documented as *"embedded in the on-chain TransferMessagePayload"*; with no on-chain message
+  they were validated and then discarded. Removing them makes that a compile error rather than a
+  silent no-op, and drops `INVOICE_INVALID_REFUND_ADDRESS` / `INVOICE_INVALID_CONTACT` from
+  `payInvoice`'s failure modes.
+
+**Functional consequence, stated plainly:** `AccountingModule` attributes an incoming invoice
+payment by reading the on-chain memo (`engine.readMemo`). Nothing writes one any more, so
+**recipient-side invoice attribution no longer works for new payments** — invoices will not
+advance to PARTIAL/COVERED from inbound money, and `invoice:payment` / `invoice:covered` will not
+fire for it. Attribution of payments sent *before* this change is unaffected. This is a
+deliberate step in retiring accounting, not an oversight.
+
+**Deliberately retained — a money-safety constraint.** The *resume* path still derives the memo
+from a persisted intent, and `IntentPayloadV1` still carries `invoiceRefundAddress` /
+`invoiceContact`. The memo is an **input to the transaction**, not metadata: resume must rebuild
+byte-identical transaction data or `getInclusionProof` match-verify fails. Dropping it would make
+a direct leg look like it was lost to a foreign transaction (the linked payment request reverts to
+payable and is **re-paid in full** — a double pay) and would wedge a split leg on
+`SplitCheckpointLostError` with the intent open forever. This is the one remaining
+payments→accounting import, marked in the source, and is removable once no pre-detachment intent
+can still be open.
+
+Five tests covered removed behavior. One was re-pointed — the send path now asserts that **no**
+memo reaches the chain, not even an invoice-shaped one, which is the whole contract. Four
+`payInvoice` validation tests were deleted: they asserted runtime rejection of parameters that no
+longer exist, and the type system now rejects them at compile time. No test was weakened.
+
 ### Removed — the Nostr payment-request channel
 
 Payment requests ride wallet-api (sdk-changes S4). The Nostr fallback is gone, so

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -483,7 +483,7 @@
       "count": 33
     },
     "complexity": {
-      "count": 29
+      "count": 28
     },
     "max-depth": {
       "count": 24

--- a/modules/accounting/AccountingModule.ts
+++ b/modules/accounting/AccountingModule.ts
@@ -2061,46 +2061,6 @@ export class AccountingModule {
 
     const asset = target.assets[assetIndex]!;
 
-    // §8.5 step 5: refundAddress must be a valid DIRECT:// address when provided
-    if (params.refundAddress !== undefined) {
-      if (
-        !params.refundAddress.startsWith('DIRECT://') ||
-        params.refundAddress.length <= 'DIRECT://'.length
-      ) {
-        throw new SphereError(
-          'refundAddress must be a valid DIRECT:// address',
-          'INVOICE_INVALID_REFUND_ADDRESS',
-        );
-      }
-    }
-
-    // §8.5 step 6: contact fields must be valid when provided
-    if (params.contact !== undefined) {
-      const { address, url } = params.contact;
-      if (
-        typeof address !== 'string' ||
-        !address.startsWith('DIRECT://') ||
-        address.length <= 'DIRECT://'.length
-      ) {
-        throw new SphereError(
-          'contact.address must be a valid DIRECT:// address',
-          'INVOICE_INVALID_CONTACT',
-        );
-      }
-      if (url !== undefined) {
-        if (
-          typeof url !== 'string' ||
-          (!url.startsWith('https://') && !url.startsWith('wss://')) ||
-          url.length > 2048
-        ) {
-          throw new SphereError(
-            'contact.url must start with https:// or wss:// and be at most 2048 characters',
-            'INVOICE_INVALID_CONTACT',
-          );
-        }
-      }
-    }
-
     // Asset must have a coin entry to determine coinId
     if (!asset.coin) {
       throw new SphereError(
@@ -2110,13 +2070,9 @@ export class AccountingModule {
     }
     const [coinId, requestedAmountStr] = asset.coin;
 
-    // §4.7: Auto-populate contact from identity.directAddress when not explicitly provided.
     if (!deps.identity.directAddress) {
       throw new SphereError('directAddress required for invoice payments', 'NOT_INITIALIZED');
     }
-    const effectiveContact: { address: string; url?: string } = params.contact ?? {
-      address: deps.identity.directAddress,
-    };
 
     // §8.5 step 2 + BUG-002 Fix 2: Hold the gate across terminal check, balance
     // computation, send(), AND provisional ledger write. This prevents concurrent
@@ -2171,14 +2127,16 @@ export class AccountingModule {
         );
       }
 
+      // Payments no longer attaches an on-chain invoice reference, so the memo
+      // travels transport-only and the recipient cannot attribute this payment
+      // to the invoice automatically. See CHANGELOG "accounting detached from
+      // payments".
       // §5.9: Apply 60-second timeout to send() within the gate (matches returnInvoicePayment)
       const sendPromise = deps.payments.send({
         recipient: target.address,
         amount: sendAmount,
         coinId,
         memo,
-        invoiceRefundAddress: params.refundAddress,
-        invoiceContact: effectiveContact,
       });
 
       let timer: ReturnType<typeof setTimeout> | undefined;

--- a/modules/accounting/types.ts
+++ b/modules/accounting/types.ts
@@ -710,46 +710,6 @@ export interface PayInvoiceParams {
   readonly amount?: string;
   /** Optional free text appended to memo */
   readonly freeText?: string;
-  /**
-   * Optional refund address (DIRECT:// format) embedded in the on-chain
-   * TransferMessagePayload. Provides an explicit return destination for the
-   * payer. Essential for masked-predicate senders (one-time address that
-   * becomes unresolvable), but also usable by unmasked senders who want
-   * returns routed to a different address. When present, takes priority
-   * over senderAddress for per-sender balance keying.
-   *
-   * This address is NOT included in the transport memo (privacy: transport
-   * memos are human-readable). It is only recorded on-chain in the
-   * structured `inv.ra` field of the TransferMessagePayload.
-   *
-   * Privacy note: while the refund address is not in the memo, it IS the
-   * recipient of auto-return transfers and therefore visible in the transport
-   * layer's addressing metadata (Nostr NIP-04/NIP-17 envelope), as with any
-   * transfer recipient.
-   *
-   * Auto-return destination priority: refundAddress → senderAddress → fail.
-   */
-  readonly refundAddress?: string;
-  /**
-   * Optional contact info embedded in the on-chain TransferMessagePayload
-   * (`inv.ct` field). Allows the invoice target to reach the payer for
-   * future communication: receipts (after close), cancellation notices,
-   * and payment reminders.
-   *
-   * `address`: a reachable DIRECT:// address for the payer (required within the object).
-   * `url`: optional non-Nostr transport URL (https:// or wss://, max 2048 chars).
-   *
-   * NOT included in the transport memo (same privacy model as refund address).
-   * Contact is purely informational — it does not affect auto-return routing,
-   * balance computation, or per-sender keying.
-   *
-   * When not provided, auto-populated from `identity.directAddress` at runtime
-   * (see §4.7). This ensures every outbound invoice payment carries contact info.
-   *
-   * Contact resolution priority (application-level recommendation):
-   * `contacts[0].address → refundAddress → senderAddress → null`
-   */
-  readonly contact?: { address: string; url?: string };
 }
 
 /**

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -93,6 +93,11 @@ import { PumpHealth } from './pump-health';
 import { timeoutSignal } from '../../core/timeout';
 import { randomUUID } from '../../core/uuid';
 import { decodeTokenBlob, encodeTokenBlob, unwrapTokenBlobBytes, TOKEN_BLOB_VERSION } from '../../token-engine/token-blob';
+// LEGACY DRAIN — the only remaining payments→accounting dependency. Sends no
+// longer produce on-chain memos, but an intent persisted by an earlier version
+// did, and resume must re-derive byte-identical transaction data or the
+// match-verify fails (double-pay on a direct leg, frozen funds on a split leg).
+// Delete once no pre-detachment intent can still be open.
 import { parseInvoiceMemoForOnChain } from '../accounting/memo.js';
 
 // =============================================================================
@@ -791,7 +796,9 @@ interface IntentPayloadV1 {
   /** Requested amount (decimal string). */
   amount: string;
   memo?: string;
+  /** Legacy drain — read by resume only; new sends never set these. */
   invoiceRefundAddress?: string;
+  /** Legacy drain — read by resume only; new sends never set these. */
   invoiceContact?: { address: string; url?: string };
   /** Genesis token ids transferred whole, in execution order. */
   direct: string[];
@@ -1834,12 +1841,6 @@ export class PaymentsModule {
       const recipientNametag = peerInfo?.nametag
         || (request.recipient.startsWith('@') ? request.recipient.slice(1) : undefined);
 
-      const onChainMessage = parseInvoiceMemoForOnChain(
-        request.memo,
-        request.invoiceRefundAddress,
-        request.invoiceContact,
-      );
-
       {
         // =================================================================
         // v2 ENGINE MODE (sender-driven): engine.transfer hands the recipient
@@ -1857,11 +1858,6 @@ export class PaymentsModule {
         const serverApply = !!walletApi && delivery.custody === 'inventory';
         const recipientChainPubkeyHex = peerInfo.chainPubkey;
         const recipientChainPubkey = hexToBytes(recipientChainPubkeyHex);
-        // On-chain memo: the structured invoice ref ({inv:{id,dir}}) for invoice
-        // payments, else null — plain memos stay transport-only (privacy).
-        // parseInvoiceMemoForOnChain already produced the encoded bytes (or null).
-        const memoData = onChainMessage ?? undefined;
-
         // S2: blobs are fetched on demand — lazy inventory records selected by
         // coin-selection are materialized (getToken + engine decode) only now.
         await this.materializeSelectedSources(splitPlan);
@@ -1983,7 +1979,7 @@ export class PaymentsModule {
           try {
             if (op.kind === 'direct') {
               finished = await engine.transfer(
-                { token: op.sdkToken, recipientPubkey: recipientChainPubkey, data: memoData },
+                { token: op.sdkToken, recipientPubkey: recipientChainPubkey },
                 { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId: result.id, opIndex: op.opIndex },
               );
             } else {
@@ -1995,7 +1991,7 @@ export class PaymentsModule {
                 {
                   token: op.sdkToken,
                   outputs: [
-                    { recipientPubkey: recipientChainPubkey, coinId: request.coinId, amount: op.deliveredAmount, data: memoData },
+                    { recipientPubkey: recipientChainPubkey, coinId: request.coinId, amount: op.deliveredAmount },
                     { recipientPubkey: selfChainPubkey, coinId: request.coinId, amount: op.remainderAmount },
                   ],
                 },
@@ -2587,10 +2583,6 @@ export class PaymentsModule {
       coinId: request.coinId,
       amount: request.amount,
       ...(request.memo !== undefined ? { memo: request.memo } : {}),
-      ...(request.invoiceRefundAddress !== undefined
-        ? { invoiceRefundAddress: request.invoiceRefundAddress }
-        : {}),
-      ...(request.invoiceContact !== undefined ? { invoiceContact: request.invoiceContact } : {}),
       direct: splitPlan.tokensToTransferDirectly.map(genesisIdOf),
       ...(splitPlan.requiresSplit && splitPlan.tokenToSplit
         ? {

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -93,12 +93,6 @@ import { PumpHealth } from './pump-health';
 import { timeoutSignal } from '../../core/timeout';
 import { randomUUID } from '../../core/uuid';
 import { decodeTokenBlob, encodeTokenBlob, unwrapTokenBlobBytes, TOKEN_BLOB_VERSION } from '../../token-engine/token-blob';
-// LEGACY DRAIN — the only remaining payments→accounting dependency. Sends no
-// longer produce on-chain memos, but an intent persisted by an earlier version
-// did, and resume must re-derive byte-identical transaction data or the
-// match-verify fails (double-pay on a direct leg, frozen funds on a split leg).
-// Delete once no pre-detachment intent can still be open.
-import { parseInvoiceMemoForOnChain } from '../accounting/memo.js';
 
 // =============================================================================
 // Transaction History Entry
@@ -796,10 +790,6 @@ interface IntentPayloadV1 {
   /** Requested amount (decimal string). */
   amount: string;
   memo?: string;
-  /** Legacy drain — read by resume only; new sends never set these. */
-  invoiceRefundAddress?: string;
-  /** Legacy drain — read by resume only; new sends never set these. */
-  invoiceContact?: { address: string; url?: string };
   /** Genesis token ids transferred whole, in execution order. */
   direct: string[];
   /** The at-most-one split (ARCHITECTURE §7). */
@@ -6011,10 +6001,6 @@ export class PaymentsModule {
 
     const serverApply = delivery.custody === 'inventory';
     const recipientChainPubkey = hexToBytes(payload.recipient);
-    const memoData =
-      parseInvoiceMemoForOnChain(payload.memo, payload.invoiceRefundAddress, payload.invoiceContact) ??
-      undefined;
-
     const deliverBlob = async (tokenBlobHex: string, opIndex: number): Promise<void> => {
       await this.savePendingV2Delivery({
         transferId,
@@ -6061,7 +6047,7 @@ export class PaymentsModule {
         const source = await engine.decodeToken(await provider.getToken(genesisId));
         try {
           const finished = await engine.transfer(
-            { token: source, recipientPubkey: recipientChainPubkey, data: memoData },
+            { token: source, recipientPubkey: recipientChainPubkey },
             // (transferId, opIndex) pairing replayed from the intent's persisted order (§8.1)
             { signal: timeoutSignal(SEND_ENGINE_OP_TIMEOUT_MS), transferId, opIndex }
           );
@@ -6111,7 +6097,6 @@ export class PaymentsModule {
                   recipientPubkey: recipientChainPubkey,
                   coinId: payload.coinId,
                   amount: BigInt(payload.split.splitAmount),
-                  data: memoData,
                 },
                 {
                   recipientPubkey: selfChainPubkey,

--- a/tests/unit/modules/AccountingModule.payReturn.test.ts
+++ b/tests/unit/modules/AccountingModule.payReturn.test.ts
@@ -205,22 +205,6 @@ describe('AccountingModule.payInvoice()', () => {
     ).rejects.toMatchObject({ code: 'INVOICE_INVALID_ASSET_INDEX' });
   });
 
-  // UT-PAY-007
-  it('UT-PAY-007: throws INVOICE_INVALID_REFUND_ADDRESS for invalid refund address', async () => {
-    const terms = makeTerms();
-    const { module, mocks } = createTestAccountingModule();
-    mocks.payments._tokens = [makeInvoiceToken(terms)];
-    await module.load();
-
-    await expect(
-      module.payInvoice(INVOICE_ID, {
-        targetIndex: 0,
-        assetIndex: 0,
-        amount: '1000',
-        refundAddress: 'invalid-not-direct',
-      }),
-    ).rejects.toMatchObject({ code: 'INVOICE_INVALID_REFUND_ADDRESS' });
-  });
 
   // UT-PAY-008
   it('UT-PAY-008: throws INVOICE_NOT_FOUND for unknown invoiceId', async () => {
@@ -247,57 +231,8 @@ describe('AccountingModule.payInvoice()', () => {
     expect(memo).toContain(hashInvoiceId(INVOICE_ID));
   });
 
-  // UT-PAY-010
-  it('UT-PAY-010: contact auto-populated from identity.directAddress', async () => {
-    const terms = makeTerms();
-    const { module, mocks } = createTestAccountingModule();
-    mocks.payments._tokens = [makeInvoiceToken(terms)];
-    await module.load();
 
-    // No contact param provided → should auto-populate from identity
-    await module.payInvoice(INVOICE_ID, { targetIndex: 0, amount: '5000000' });
 
-    const sendCall = mocks.payments.send.mock.calls[0]![0] as Record<string, unknown>;
-    const contact = sendCall.invoiceContact as { address: string } | undefined;
-    expect(contact).toBeDefined();
-    // Auto-populated from DEFAULT_TEST_IDENTITY.directAddress
-    expect(contact!.address).toBe(DEFAULT_TEST_IDENTITY.directAddress);
-  });
-
-  // UT-PAY-011
-  it('UT-PAY-011: throws INVOICE_INVALID_CONTACT for missing DIRECT:// in contact address', async () => {
-    const terms = makeTerms();
-    const { module, mocks } = createTestAccountingModule();
-    mocks.payments._tokens = [makeInvoiceToken(terms)];
-    await module.load();
-
-    await expect(
-      module.payInvoice(INVOICE_ID, {
-        targetIndex: 0,
-        amount: '1000',
-        contact: { address: 'not-a-direct-address' },
-      }),
-    ).rejects.toMatchObject({ code: 'INVOICE_INVALID_CONTACT' });
-  });
-
-  // UT-PAY-012
-  it('UT-PAY-012: throws INVOICE_INVALID_CONTACT for contact URL not https:// or wss://', async () => {
-    const terms = makeTerms();
-    const { module, mocks } = createTestAccountingModule();
-    mocks.payments._tokens = [makeInvoiceToken(terms)];
-    await module.load();
-
-    await expect(
-      module.payInvoice(INVOICE_ID, {
-        targetIndex: 0,
-        amount: '1000',
-        contact: {
-          address: 'DIRECT://valid_contact_addr_xyz',
-          url: 'http://unsafe.example.com',
-        },
-      }),
-    ).rejects.toMatchObject({ code: 'INVOICE_INVALID_CONTACT' });
-  });
 
   // UT-PAY-013
   it('UT-PAY-013: freeText is included in the memo', async () => {

--- a/tests/unit/modules/PaymentsModule.v2-receive.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-receive.test.ts
@@ -263,19 +263,19 @@ describe('send — v2 engine path, whole-token (B1)', () => {
     expect(recipient.module.getTokens()[0].amount).toBe('300');
   });
 
-  it('carries the structured invoice ref on-chain for an invoice-memo payment', async () => {
+  it('puts NO memo on-chain, not even an invoice-shaped one', async () => {
     const { module, engine, transport } = setup();
     await deliver(module, await v2Payload(engine, UCT, 100n));
 
-    const invoiceId = 'ab'.repeat(32); // 64-char hex invoice id
+    // An INV: memo used to be encoded into the transaction's on-chain data.
+    // Payments is detached from accounting, so nothing produces on-chain memos
+    // now — every memo is transport-only. This is the whole contract.
+    const invoiceId = 'ab'.repeat(32);
     await module.send({ recipient: '@bob', amount: '100', coinId: UCT, memo: `INV:${invoiceId}:F` });
 
-    // The finished token's on-chain memo decodes to the structured invoice ref.
     const sentPayload = (transport.sendTokenTransfer as any).mock.calls[0][1];
     const token = await engine.decodeToken(decodeTokenBlob(hexToBytes(sentPayload.tokenBlob)));
-    const onChainMemo = engine.readMemo(token);
-    expect(onChainMemo).not.toBeNull();
-    expect(decodeTransferMessage(onChainMemo)?.inv?.id?.toLowerCase()).toBe(invoiceId);
+    expect(engine.readMemo(token)).toBeNull();
   });
 
   it('keeps a plain memo transport-only (no on-chain memo, for privacy)', async () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -149,10 +149,6 @@ export interface TransferRequest {
   readonly addressMode?: AddressMode;
   /** @deprecated v2 has a single engine-driven send path; this field is accepted for backwards-compat but IGNORED. */
   readonly transferMode?: TransferMode;
-  /** Invoice refund address (DIRECT://) — embedded in on-chain message for return routing */
-  readonly invoiceRefundAddress?: string;
-  /** Invoice contact info — embedded in on-chain message for receipt/notice delivery */
-  readonly invoiceContact?: { address: string; url?: string };
 }
 
 /**


### PR DESCRIPTION
`parseInvoiceMemoForOnChain` was the **sole** producer of on-chain memo bytes, and it only ever encoded invoice-shaped memos — plain memos were already transport-only. The send path no longer calls it, so **every memo is transport-only now** and the `data:` argument is gone from `engine.transfer` and the split output.

## Breaking

- `TransferRequest.invoiceRefundAddress` / `.invoiceContact`
- `PayInvoiceParams.refundAddress` / `.contact`

Both `PayInvoiceParams` fields were documented as *"embedded in the on-chain TransferMessagePayload"*. With no on-chain message they were validated and then **discarded** — removing them makes that a compile error instead of a silent no-op. Same lesson as the #707 review finding.

## Functional consequence — stated, not buried

`AccountingModule` attributes incoming invoice payments by reading the on-chain memo (`engine.readMemo`). Nothing writes one any more, so **recipient-side invoice attribution stops working for new payments** — invoices won't advance to PARTIAL/COVERED from inbound money, and `invoice:payment` / `invoice:covered` won't fire for it. Payments sent *before* this change still attribute.

That's a deliberate step in retiring accounting, not an oversight.

## ⚠️ Retained on purpose — this is the money-safety part

**The resume path still derives the memo, and `IntentPayloadV1` still carries both fields.**

The memo is an **input to the transaction**, not metadata:

```ts
TransferTransaction.create(token, recipient, stateMask, params.data ?? null)
```

`requestId` derives from the source state and the HKDF stateMask — **not** from `data`. So a resume that omits the memo fetches the *same* inclusion proof and match-verifies it against a *different* transaction hash:

| Leg | Failure |
|---|---|
| direct | `TRANSACTION_HASH_MISMATCH` → classified as lost to a foreign tx → spend not recorded → linked payment request reverts to payable → **re-paid in full while the recipient already holds the money** |
| split | `SplitCheckpointLostError` → intent stays OPEN forever → **funds frozen** |

Trigger window: any intent left open by a pre-detachment SDK whose memo matched the invoice pattern. No test covers it, which is why it's called out here rather than trusted to CI.

Both retained sites are marked in the source with the condition for deleting them: once no pre-detachment intent can still be open. This is the **last** payments→accounting import.

**Not vendored** into `modules/payments/`: copying ~150 lines to delete one import is backwards when the goal is less code, and accounting stays on disk for now anyway.

## Tests

- **1 re-pointed** — the send path now asserts **no** memo reaches the chain, not even an invoice-shaped one. That is now the whole contract.
- **4 deleted** — `payInvoice` validation tests asserting runtime rejection of parameters that no longer exist. The compiler rejects them now, which is stronger.

No test was weakened.

## Cross-repo

| Repo | Impact |
|---|---|
| `wallet-api` | none — imports only `./token-engine` |
| `sphere` | none — accounting appears only in `DocsPage.tsx` text; swap in **0** files |

## Verification (by exit code)

typecheck 0 · lint 0 · build 0 · **199 files / 3,113 tests** 0 · **live testnet2 e2e** 0