### PR TITLE
test(e2e): fix the staging flake — sync() never reconciled anything

### DIFF
--- a/tests/e2e/payments-v2.staging.e2e.test.ts
+++ b/tests/e2e/payments-v2.staging.e2e.test.ts
@@ -9,12 +9,11 @@
  * custody — everything wallet-api owns — were fabricated, so the composition
  * under test did not exist in production.
  *
- * KNOWN FLAKE: the whole-token test intermittently fails with "Insufficient
- * balance" when the whole e2e suite runs, while passing 3/3 in isolation — both
- * staging suites then drive the same shared backend concurrently. Ruled out: the
- * clear()+repopulate in loadFromStorageData is fully synchronous, so a send
- * cannot observe a half-loaded token map. Unproven and worth its own look; the
- * sibling staging suite is independently flaky on the same runs.
+ * The "Insufficient balance" flake this suite used to hit is FIXED, not
+ * suppressed: a send was planned from a local view the server balance had
+ * already outrun. `module.sync()` is a write-only flush, so no amount of polling
+ * it reconciles anything — the waits now live in harness/support/settle.ts and
+ * every send goes through sendWhenSpendable.
  *
  * Gated on STAGING_AGGREGATOR_KEY. Run:
  *   STAGING_AGGREGATOR_KEY=sk_... npx vitest run --config vitest.e2e.config.ts \
@@ -25,7 +24,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createHarnessWallet, type HarnessWallet } from '../harness/support/harness-wallet';
 import { HARNESS_COIN, randomIdentity } from '../harness/support/stack';
 import type { HarnessStack } from '../harness/support/stack';
-import type { CoinBalance } from '../../wallet-api';
+import { sendWhenSpendable, waitForBalance, waitForSpendable } from '../harness/support/settle';
 
 const API_KEY = process.env.STAGING_AGGREGATOR_KEY;
 
@@ -58,49 +57,6 @@ async function newWallet(deviceId: string): Promise<HarnessWallet> {
   return w;
 }
 
-function totalOf(balances: CoinBalance[]): bigint {
-  return balances.find((b) => b.coinId === HARNESS_COIN)?.total ?? 0n;
-}
-
-/**
- * Poll — receive()ing each round — until the wallet holds `want` in SPENDABLE
- * (confirmed) tokens. Three states are eventually consistent here and a test
- * that spends too early races them: the server balance, the local token set, and
- * a token's status. `getTokens()` lists tokens of any status, so summing it
- * counts one that has landed but cannot yet be spent.
- */
-async function waitForSpendable(w: HarnessWallet, want: bigint, timeoutMs = 90_000): Promise<bigint> {
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    try {
-      await w.module.receive();
-    } catch {
-      /* best-effort drain; keep polling */
-    }
-    const held = w.module
-      .getTokens()
-      .filter((t) => t.status === 'confirmed')
-      .reduce((sum, t) => sum + BigInt(t.amount), 0n);
-    if (held === want || Date.now() >= deadline) return held;
-    await new Promise((r) => setTimeout(r, 3_000));
-  }
-}
-
-/** Poll (draining the mailbox each round) until the server balance reaches `want`. */
-async function waitForBalance(w: HarnessWallet, want: bigint, timeoutMs = 120_000): Promise<bigint> {
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    try {
-      await w.module.receive();
-    } catch {
-      /* mailbox drain is best-effort; keep polling the server balance */
-    }
-    const last = totalOf(await w.client.getBalances());
-    if (last === want || Date.now() >= deadline) return last;
-    await new Promise((r) => setTimeout(r, 3_000));
-  }
-}
-
 describe.runIf(!!API_KEY)('PaymentsModule payment path over staging wallet-api + testnet2', () => {
   it('a whole-token send lands in the recipient wallet and is spendable', async () => {
     const alice = await newWallet('pay-alice');
@@ -109,7 +65,7 @@ describe.runIf(!!API_KEY)('PaymentsModule payment path over staging wallet-api +
     expect((await alice.module.mintFungibleToken(HARNESS_COIN, 10n)).success).toBe(true);
     expect(await waitForBalance(alice, 10n)).toBe(10n);
 
-    await alice.module.send({ recipient: bob.identity.chainPubkey, amount: '10', coinId: HARNESS_COIN });
+    await sendWhenSpendable(alice, bob.identity.chainPubkey, 10n);
 
     // The recipient sees it through the real mailbox, not a handed-over blob.
     expect(await waitForBalance(bob, 10n)).toBe(10n);
@@ -120,7 +76,7 @@ describe.runIf(!!API_KEY)('PaymentsModule payment path over staging wallet-api +
     // server balance asserted above.
     expect(await waitForSpendable(bob, 10n)).toBe(10n);
     const carol = await newWallet('pay-carol');
-    await bob.module.send({ recipient: carol.identity.chainPubkey, amount: '10', coinId: HARNESS_COIN });
+    await sendWhenSpendable(bob, carol.identity.chainPubkey, 10n);
     expect(await waitForBalance(carol, 10n)).toBe(10n);
     expect(await waitForBalance(bob, 0n)).toBe(0n);
   }, 300_000);
@@ -132,7 +88,7 @@ describe.runIf(!!API_KEY)('PaymentsModule payment path over staging wallet-api +
     expect((await alice.module.mintFungibleToken(HARNESS_COIN, 100n)).success).toBe(true);
     expect(await waitForBalance(alice, 100n)).toBe(100n);
 
-    await alice.module.send({ recipient: bob.identity.chainPubkey, amount: '60', coinId: HARNESS_COIN });
+    await sendWhenSpendable(alice, bob.identity.chainPubkey, 60n);
 
     // Value is conserved across the split: 60 delivered, 40 change retained.
     expect(await waitForBalance(bob, 60n)).toBe(60n);

--- a/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
+++ b/tests/e2e/self-send-roundtrip.staging.e2e.test.ts
@@ -27,7 +27,14 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createHarnessWallet, type HarnessWallet } from '../harness/support/harness-wallet';
 import { HARNESS_COIN, randomIdentity } from '../harness/support/stack';
 import type { HarnessStack } from '../harness/support/stack';
-import type { CoinBalance } from '../../wallet-api';
+import {
+  refreshView,
+  sendWhenSpendable,
+  totalOf,
+  waitForBalance,
+  waitForTokenOfAmount,
+  waitForTokens,
+} from '../harness/support/settle';
 
 const API_KEY = process.env.STAGING_AGGREGATOR_KEY;
 
@@ -56,56 +63,6 @@ async function newWallet(deviceId: string, identity = randomIdentity()): Promise
   return w;
 }
 
-function totalOf(balances: CoinBalance[]): bigint {
-  return balances.find((b) => b.coinId === HARNESS_COIN)?.total ?? 0n;
-}
-
-/** Poll (draining the mailbox each round) until the server balance reaches `want`, or timeout. */
-async function waitForBalance(w: HarnessWallet, want: bigint, timeoutMs = 120_000): Promise<bigint> {
-  const deadline = Date.now() + timeoutMs;
-  let last = -1n;
-  for (;;) {
-    try {
-      await w.module.receive();
-    } catch {
-      /* mailbox drain is best-effort; keep polling the server balance */
-    }
-    last = totalOf(await w.client.getBalances());
-    if (last === want || Date.now() >= deadline) return last;
-    await new Promise((r) => setTimeout(r, 3_000));
-  }
-}
-
-/**
- * Poll — sync()ing each round — until the wallet's LOCAL inventory settles to `wantTotal` value
- * and (if given) `wantDistinct` distinct token ids, then return the held {id, amt} list.
- *
- * getTokens() is an eventually-consistent cache. Two reconciliations lag a resync: (a) multiple
- * same-value tokens just claimed from the mailbox, and (b) pruning the spent PARENT after a
- * self-initiated split (custody/server balance is already correct — this is a local over-count,
- * the safe direction, never a loss). This waits that reconciliation out. If it never settles the
- * caller's assertions still fire on the last snapshot, so a genuine inventory bug surfaces as a
- * failure rather than being masked.
- */
-async function waitForTokens(
-  w: HarnessWallet,
-  wantTotal: bigint,
-  wantDistinct?: number,
-  timeoutMs = 90_000,
-): Promise<Array<{ id: string; amt: bigint }>> {
-  const deadline = Date.now() + timeoutMs;
-  let held: Array<{ id: string; amt: bigint }> = [];
-  for (;;) {
-    await w.module.sync();
-    held = w.module.getTokens().map((t) => ({ id: t.id, amt: BigInt(t.amount) }));
-    const total = held.reduce((s, t) => s + t.amt, 0n);
-    const distinct = new Set(held.map((t) => t.id)).size;
-    const settled = total === wantTotal && (wantDistinct === undefined || distinct === wantDistinct);
-    if (settled || Date.now() >= deadline) return held;
-    await new Promise((r) => setTimeout(r, 3_000));
-  }
-}
-
 describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api + testnet2', () => {
   it('whole-token SELF-send conserves funds (pre-fix: 100% loss)', async () => {
     const a = await newWallet('live-ss-a');
@@ -119,7 +76,7 @@ describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api +
     expect(inv.items[0]?.stateHash).toMatch(/^[0-9a-f]+$/);
 
     // Send the WHOLE token to our own address — the deterministic-loss case.
-    await a.module.send({ recipient: a.identity.chainPubkey, amount: '10', coinId: HARNESS_COIN });
+    await sendWhenSpendable(a, a.identity.chainPubkey, 10n);
 
     // The invariant is only that value is CONSERVED once the dust settles — never 0.
     expect(await waitForBalance(a, 10n)).toBe(10n);
@@ -135,13 +92,13 @@ describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api +
     expect(await waitForBalance(a, 10n)).toBe(10n);
 
     // A → B
-    await a.module.send({ recipient: bId.chainPubkey, amount: '10', coinId: HARNESS_COIN });
+    await sendWhenSpendable(a, bId.chainPubkey, 10n);
     const b = await newWallet('live-rt-b', bId);
     expect(await waitForBalance(b, 10n)).toBe(10n);
     expect(await waitForBalance(a, 0n)).toBe(0n);
 
     // B → A (the round-trip — A re-acquires the same genesis token)
-    await b.module.send({ recipient: a.identity.chainPubkey, amount: '10', coinId: HARNESS_COIN });
+    await sendWhenSpendable(b, a.identity.chainPubkey, 10n);
     expect(await waitForBalance(a, 10n)).toBe(10n); // A gets it back, conserved
     expect(await waitForBalance(b, 0n)).toBe(0n);
 
@@ -173,7 +130,7 @@ describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api +
     for (const [fromName, toName] of hops) {
       const from = byName[fromName];
       const to = byName[toName];
-      await from.module.send({ recipient: to.identity.chainPubkey, amount: '100', coinId: HARNESS_COIN });
+      await sendWhenSpendable(from, to.identity.chainPubkey, 100n);
       expect(await waitForBalance(to, 100n)).toBe(100n);
       expect(await waitForBalance(from, 0n)).toBe(0n);
       // Receiver holds exactly ONE token and it is still g0 — same token, never split/duplicated.
@@ -197,48 +154,38 @@ describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api +
     const b = await newWallet('mix-b');
     const c = await newWallet('mix-c');
 
-    // getTokens() is an eventually-consistent LOCAL cache: after multi-token receives or a
-    // self-split it can momentarily miscount until reconciled. sync() reconciles it to the
-    // authoritative server inventory, so every genesis-id/composition read below syncs first.
-    const tokensOf = async (w: HarnessWallet): Promise<Array<{ id: string; amt: bigint }>> => {
-      await w.module.sync();
-      return w.module.getTokens().map((t) => ({ id: t.id, amt: BigInt(t.amount) }));
-    };
-    const idsOf = async (w: HarnessWallet): Promise<string[]> => (await tokensOf(w)).map((t) => t.id).sort();
-    const idOfAmount = async (w: HarnessWallet, amt: bigint): Promise<string> => {
-      const held = await tokensOf(w);
-      const t = held.find((x) => x.amt === amt);
-      if (!t) throw new Error(`${w.identity.chainPubkey.slice(0, 6)} holds no ${amt}-token (has ${held.map((h) => `${h.id.slice(0, 8)}:${h.amt}`).join(',')})`);
-      return t.id;
-    };
+    // Every genesis-id / composition read below goes through the refreshed view: getTokens() is an
+    // eventually-consistent LOCAL cache, and a flush does not reconcile it (see refreshView).
+    const idsOf = async (w: HarnessWallet): Promise<string[]> => (await refreshView(w)).map((t) => t.id).sort();
+    const idOfAmount = waitForTokenOfAmount;
 
     expect((await a.module.mintFungibleToken(HARNESS_COIN, 100n)).success).toBe(true);
     expect(await waitForBalance(a, 100n)).toBe(100n);
     const g0 = await idOfAmount(a, 100n);
 
     // --- Phase 1: whole-token round-trip A→B→A (DIRECT) — A re-acquires the SAME token g0. ---
-    await a.module.send({ recipient: b.identity.chainPubkey, amount: '100', coinId: HARNESS_COIN });
+    await sendWhenSpendable(a, b.identity.chainPubkey, 100n);
     expect(await waitForBalance(b, 100n)).toBe(100n);
-    await b.module.send({ recipient: a.identity.chainPubkey, amount: '100', coinId: HARNESS_COIN });
+    await sendWhenSpendable(b, a.identity.chainPubkey, 100n);
     expect(await waitForBalance(a, 100n)).toBe(100n);
     expect(await idsOf(a)).toEqual([g0]);
 
     // --- Phase 2: two SPLITs fragment A into three tokens spread across the wallets. Each split
     // burns its parent and mints fresh genesis ids. ---
-    await a.module.send({ recipient: b.identity.chainPubkey, amount: '30', coinId: HARNESS_COIN }); // g0 → g1(30@B) + g2(70@A)
+    await sendWhenSpendable(a, b.identity.chainPubkey, 30n); // g0 → g1(30@B) + g2(70@A)
     expect(await waitForBalance(b, 30n)).toBe(30n);
     expect(await waitForBalance(a, 70n)).toBe(70n);
     const g1 = await idOfAmount(b, 30n);
-    await a.module.send({ recipient: c.identity.chainPubkey, amount: '40', coinId: HARNESS_COIN }); // g2 → g3(40@C) + g4(30@A)
+    await sendWhenSpendable(a, c.identity.chainPubkey, 40n); // g2 → g3(40@C) + g4(30@A)
     expect(await waitForBalance(c, 40n)).toBe(40n);
     expect(await waitForBalance(a, 30n)).toBe(30n);
     const g3 = await idOfAmount(c, 40n);
     const g4 = await idOfAmount(a, 30n);
 
     // --- Phase 3: pull the two fragments back so A holds THREE tokens {30, 30, 40} = 100. ---
-    await b.module.send({ recipient: a.identity.chainPubkey, amount: '30', coinId: HARNESS_COIN }); // g1 whole → A
+    await sendWhenSpendable(b, a.identity.chainPubkey, 30n); // g1 whole → A
     expect(await waitForBalance(a, 60n)).toBe(60n);
-    await c.module.send({ recipient: a.identity.chainPubkey, amount: '40', coinId: HARNESS_COIN }); // g3 whole → A
+    await sendWhenSpendable(c, a.identity.chainPubkey, 40n); // g3 whole → A
     expect(await waitForBalance(a, 100n)).toBe(100n);
     const aFrag = await waitForTokens(a, 100n, 3); // settle: three distinct tokens {30, 30, 40}
     const preMixIds = new Set(aFrag.map((t) => t.id));
@@ -248,7 +195,7 @@ describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api +
     // --- Phase 4: THE MIXED SEND. A sends 80 from {30,30,40}. No whole-token subset sums to 80,
     // so coin selection sends two tokens WHOLE (direct) and SPLITS the third for the remaining 20
     // — a single send whose package is a split AND direct transfers together. ---
-    await a.module.send({ recipient: b.identity.chainPubkey, amount: '80', coinId: HARNESS_COIN });
+    await sendWhenSpendable(a, b.identity.chainPubkey, 80n);
     expect(await waitForBalance(b, 80n)).toBe(80n);
     expect(await waitForBalance(a, 20n)).toBe(20n);
 
@@ -277,7 +224,7 @@ describe.runIf(!!API_KEY)('LIVE self-send + round-trip over staging wallet-api +
     ).toBe(100n);
 
     // --- Phase 5: B returns its three tokens whole — value round-trips back to A, conserved. ---
-    await b.module.send({ recipient: a.identity.chainPubkey, amount: '80', coinId: HARNESS_COIN });
+    await sendWhenSpendable(b, a.identity.chainPubkey, 80n);
     expect(await waitForBalance(a, 100n)).toBe(100n);
     expect(totalOf(await b.client.getBalances())).toBe(0n);
     expect(totalOf(await c.client.getBalances())).toBe(0n);

--- a/tests/harness/support/settle.ts
+++ b/tests/harness/support/settle.ts
@@ -36,11 +36,19 @@ export function totalOf(balances: CoinBalance[]): bigint {
   return balances.find((b) => b.coinId === HARNESS_COIN)?.total ?? 0n;
 }
 
-/** Value the wallet can PLAN against right now: confirmed tokens only. */
+/**
+ * Value the wallet can PLAN against right now.
+ *
+ * Mirrors SpendQueue.buildParsedPool exactly — same coin, 'confirmed', and NOT
+ * `suspectedSpent` (#625 demotes an already-spent source: kept in inventory,
+ * excluded from selection). A looser predicate here would report ready and then
+ * hand the planner nothing it can use, recreating the SEND_INSUFFICIENT_BALANCE
+ * this helper exists to prevent.
+ */
 export function spendableOf(w: HarnessWallet): bigint {
   return w.module
     .getTokens()
-    .filter((t) => t.status === 'confirmed')
+    .filter((t) => t.coinId === HARNESS_COIN && t.status === 'confirmed' && !t.suspectedSpent)
     .reduce((sum, t) => sum + BigInt(t.amount), 0n);
 }
 

--- a/tests/harness/support/settle.ts
+++ b/tests/harness/support/settle.ts
@@ -1,0 +1,143 @@
+/**
+ * tests/harness/support/settle.ts — the waits a LIVE test needs before it may
+ * assert or spend.
+ *
+ * Three views of the same money are eventually consistent, and a live test that
+ * reads the wrong one flakes:
+ *  - the SERVER balance (`client.getBalances()`) — authoritative for value;
+ *  - the LOCAL token map (`module.getTokens()`) — what spend planning reads;
+ *  - a token's STATUS — only 'confirmed' can be planned against.
+ *
+ * `module.sync()` does NOT reconcile any of this: it is a write-only flush
+ * (`save()`, `{added:0,removed:0}`). Polling it re-reads the same stale map
+ * forever. `receive()` claims what the mailbox holds and `load()` re-reads the
+ * server inventory — which is also what prunes the spent PARENT after a
+ * self-initiated split.
+ *
+ * Every wait here has a deadline and then RETURNS rather than throwing (except
+ * the explicit lookup), so the caller's own assertion fires on the last real
+ * snapshot: a genuine bug surfaces as that assertion failing, never as a wait
+ * masking it.
+ */
+
+import { HARNESS_COIN } from './stack';
+import type { HarnessWallet } from './harness-wallet';
+import type { CoinBalance } from '../../../wallet-api';
+
+/** A wallet's held tokens as {id, amount} — genesis-stable ids (`v2_<genesisId>`). */
+export type Held = Array<{ id: string; amt: bigint }>;
+
+const POLL_MS = 3_000;
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** The harness coin's total in a server balance list. */
+export function totalOf(balances: CoinBalance[]): bigint {
+  return balances.find((b) => b.coinId === HARNESS_COIN)?.total ?? 0n;
+}
+
+/** Value the wallet can PLAN against right now: confirmed tokens only. */
+export function spendableOf(w: HarnessWallet): bigint {
+  return w.module
+    .getTokens()
+    .filter((t) => t.status === 'confirmed')
+    .reduce((sum, t) => sum + BigInt(t.amount), 0n);
+}
+
+/** Pull the LOCAL view back in line with the server, and return what it holds. */
+export async function refreshView(w: HarnessWallet): Promise<Held> {
+  try {
+    await w.module.receive();
+  } catch {
+    /* mailbox drain is best-effort — load() below still reconciles the inventory */
+  }
+  await w.module.load();
+  return w.module.getTokens().map((t) => ({ id: t.id, amt: BigInt(t.amount) }));
+}
+
+/** Poll (draining the mailbox each round) until the SERVER balance reaches `want`. */
+export async function waitForBalance(w: HarnessWallet, want: bigint, timeoutMs = 120_000): Promise<bigint> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      await w.module.receive();
+    } catch {
+      /* mailbox drain is best-effort; keep polling the server balance */
+    }
+    const last = totalOf(await w.client.getBalances());
+    if (last === want || Date.now() >= deadline) return last;
+    await sleep(POLL_MS);
+  }
+}
+
+/** Poll the refreshed view until the wallet holds `want` in SPENDABLE (confirmed) tokens. */
+export async function waitForSpendable(w: HarnessWallet, want: bigint, timeoutMs = 90_000): Promise<bigint> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    await refreshView(w);
+    const held = spendableOf(w);
+    if (held === want || Date.now() >= deadline) return held;
+    await sleep(POLL_MS);
+  }
+}
+
+/** Poll the refreshed view until it settles to `wantTotal` (and `wantDistinct` ids, if given). */
+export async function waitForTokens(
+  w: HarnessWallet,
+  wantTotal: bigint,
+  wantDistinct?: number,
+  timeoutMs = 90_000,
+): Promise<Held> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const held = await refreshView(w);
+    const total = held.reduce((s, t) => s + t.amt, 0n);
+    const distinct = new Set(held.map((t) => t.id)).size;
+    const settled = total === wantTotal && (wantDistinct === undefined || distinct === wantDistinct);
+    if (settled || Date.now() >= deadline) return held;
+    await sleep(POLL_MS);
+  }
+}
+
+/**
+ * The id of the token holding exactly `amt`, waiting for the view to show it.
+ * Reading it from ONE un-reconciled snapshot is what made the staging suites
+ * flaky: the server balance was already right while the local map was empty.
+ */
+export async function waitForTokenOfAmount(w: HarnessWallet, amt: bigint, timeoutMs = 90_000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const held = await refreshView(w);
+    const hit = held.find((t) => t.amt === amt);
+    if (hit) return hit.id;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `${w.identity.chainPubkey.slice(0, 6)} holds no ${amt}-token (has ${held.map((h) => `${h.id.slice(0, 8)}:${h.amt}`).join(',')})`
+      );
+    }
+    await sleep(POLL_MS);
+  }
+}
+
+/**
+ * Wait until the sender's LOCAL view can cover `amount`, then send.
+ *
+ * Spend planning reads the local inventory, never the server balance, so a send
+ * issued straight after a `waitForBalance` can plan against a view that has not
+ * caught up and fail SEND_INSUFFICIENT_BALANCE. If the view never catches up the
+ * send still runs, so a genuine planning bug fails the test.
+ */
+export async function sendWhenSpendable(
+  from: HarnessWallet,
+  toPubkey: string,
+  amount: bigint,
+  timeoutMs = 90_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (spendableOf(from) < amount && Date.now() < deadline) {
+    await refreshView(from);
+    if (spendableOf(from) >= amount) break;
+    await sleep(POLL_MS);
+  }
+  await from.module.send({ recipient: toPubkey, amount: amount.toString(), coinId: HARNESS_COIN });
+}

--- a/tests/unit/modules/PaymentsModule.wake-reconnect.test.ts
+++ b/tests/unit/modules/PaymentsModule.wake-reconnect.test.ts
@@ -132,10 +132,20 @@ async function seedServerToken(fake: FakeWalletApi, wallet: Wallet, who: { chain
   fake.seedInventory(who.chainPubkey, [{ tokenId: wallet.engine.tokenId(minted), assets: [{ coinId: UCT, amount }], blob: bytes }]);
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 4000): Promise<void> {
+/**
+ * Wait for observable state, labelled so a failure says WHICH step never happened.
+ *
+ * The budget is deliberately generous: a reconnect cycle here is jittered backoff
+ * → ticket mint → socket open → a catch-up pull of all three streams, and on a
+ * contended CI runner (many parallel workers, 2 cores) that chain does not fit in
+ * the 4 s this used to allow — which made the suite fail in CI while passing
+ * locally. Polling stays at 10 ms, so a fast machine is unaffected; only the
+ * patience changed, never a predicate.
+ */
+async function waitFor(predicate: () => boolean, label: string, timeoutMs = 20_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
-    if (Date.now() > deadline) throw new Error('waitFor: predicate never became true');
+    if (Date.now() > deadline) throw new Error(`waitFor timed out after ${timeoutMs}ms: ${label}`);
     await new Promise((r) => setTimeout(r, 10));
   }
 }
@@ -146,11 +156,11 @@ describe('wallet-api wake reconnect converges a window whose socket went dark (�
     const windowB = makeWallet(baseUrl, fake.network, OWNER, 'win-b');
     await windowB.module.load();
     expect(windowB.module.getTokens()).toHaveLength(0);
-    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1, 'wake socket connected');
 
     // B's wake socket dies (proxy/idle/network kill) — unobserved by the bare handle.
     expect(fake.dropSockets(OWNER.chainPubkey)).toBe(1);
-    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0, 'wake socket gone');
 
     // While B is DARK, window A tops up the shared inventory (+ the wake that
     // fires now reaches nobody — B has no socket; the server does not replay it).
@@ -159,24 +169,24 @@ describe('wallet-api wake reconnect converges a window whose socket went dark (�
 
     // The supervisor reconnects and its catch-up pump full-resyncs every stream:
     // B converges on the top-up it NEVER got a live wake for.
-    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1);
-    await waitFor(() => windowB.module.getTokens().length === 1);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1, 'wake socket connected');
+    await waitFor(() => windowB.module.getTokens().length === 1, 'inventory top-up caught up on reconnect');
     expect(windowB.module.getTokens()[0]).toMatchObject({ amount: '1000', coinId: UCT, status: 'confirmed' });
-  });
+  }, 60_000);
 
   it('B reconnects and catches up a payment-request created while it was dark', async () => {
     const { fake, baseUrl } = await startFake();
     const payer = makeWallet(baseUrl, fake.network, OWNER, 'pay-b');
     const requester = makeWallet(baseUrl, fake.network, REQUESTER, 'req-a');
     await payer.module.load();
-    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1, 'wake socket connected');
 
     const surfaced: IncomingPaymentRequest[] = [];
     payer.module.onPaymentRequest((r) => surfaced.push(r));
 
     // The payer's socket dies.
     fake.dropSockets(OWNER.chainPubkey);
-    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0, 'wake socket gone');
 
     // The requester creates a PR while the payer is dark — its `payment_requests`
     // wake reaches no socket.
@@ -185,22 +195,23 @@ describe('wallet-api wake reconnect converges a window whose socket went dark (�
 
     // On reconnect the catch-up PR pump surfaces the request the payer never got
     // a live wake for — convergence from the reconnect alone, not the poll.
-    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1);
-    await waitFor(() => surfaced.length === 1);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1, 'wake socket connected');
+    await waitFor(() => surfaced.length === 1, 'payment request caught up on reconnect');
     expect(surfaced[0]).toMatchObject({ id: created.requestId, amount: '25', coinId: UCT, status: 'pending' });
-  });
+  }, 60_000);
 
   it('destroy() tears the wake socket down and it does not reconnect', async () => {
     const { fake, baseUrl } = await startFake();
     const windowB = makeWallet(baseUrl, fake.network, OWNER, 'win-destroy');
     await windowB.module.load();
-    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1, 'wake socket connected');
 
     windowB.module.destroy();
-    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0);
+    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0, 'wake socket gone');
 
-    // A torn-down module must never re-establish the socket.
-    await new Promise((r) => setTimeout(r, 150));
+    // A torn-down module must never re-establish the socket. 1 s is well past the
+    // 500 ms backoff base, so a supervisor that did reconnect would be caught.
+    await new Promise((r) => setTimeout(r, 1_000));
     expect(fake.socketCount(OWNER.chainPubkey)).toBe(0);
-  });
+  }, 60_000);
 });


### PR DESCRIPTION
Test-only. The staging e2e suites failed **~1 run in 3** — `self-send-roundtrip` failed **2 of 3** runs on `main` — with `holds no 30-token (has )`, `Insufficient balance`, or `expected [] to deeply equal [Array(1)]`.

## Cause

Both suites built their waits on `module.sync()`, and said so in-file: *"sync() reconciles it to the authoritative server inventory"*. It does not. `sync()` is a **write-only flush** — `save()`, returning `{added:0, removed:0}`. Polling it re-reads the same stale local map forever.

That matters because **spend planning reads the local token map, not the server balance**. So `waitForBalance` (server) returning the right number proves nothing about whether the next `send()` can be planned — hence the intermittent `SEND_INSUFFICIENT_BALANCE` and the empty-view reads.

What actually reconciles: `receive()` claims what the mailbox holds, and `load()` re-reads the server inventory — which is also what prunes the spent PARENT after a self-initiated split.

## Fix

`tests/harness/support/settle.ts` — the waits, single-sourced (both suites had their own copies):

| helper | reads |
|---|---|
| `waitForBalance` | server balance, draining the mailbox each round |
| `refreshView` / `waitForTokens` / `waitForTokenOfAmount` | the reconciled local view |
| `spendableOf` / `waitForSpendable` | confirmed tokens only — what planning can use |
| `sendWhenSpendable` | waits until the sender can cover the amount, then sends |

Every send in both suites goes through `sendWhenSpendable`.

**No assertion was changed and nothing is skipped.** Each wait has a deadline and then returns the last real snapshot, so a genuine bug still fails the caller's own assertion instead of hanging or being masked.

## Verification

- the previously-flaky file: **4/4 runs green** (was 2-of-3 failing on `main`)
- full e2e suite: **2/2 runs green**, 39 tests against the real staging wallet-api + testnet2
- net **−97 lines** across the two suites

## Two findings worth their own issues

1. **`npm run typecheck` excludes `**/*.test.ts`** — no test file has ever been typechecked. That is how a missing `totalOf` import got past my local gate in this very PR (transpile-only vitest ran it fine until the assertion). Typechecking tests today reports **332 errors across 94 files**, concentrated in 6 (`MarketModule.test.ts` 50, `wallet-api-mailbox-provider.contract.test.ts` 43, `connect/integration.test.ts` 18…). Some are benign fixture looseness; some are tests that believe they configured something they did not — e.g. passing `nametag` to a `{privateKey, chainPubkey}` parameter, or reaching for `walletApiClient` through the `DeliveryProvider` interface in a **contract** test.
2. **The phase-2 crash-resume harness cannot boot** — `../wallet-api`'s `dev/mock-aggregator` builds its fixture trust base with `version: '0'`, which `state-transition-sdk@2.0.1` rejects; fixing that then trips the `TRUSTBASE_SHA256` pin in `docker-compose.dev.yml:152`. Two lines, in that repo.