### PR TITLE
chore(tests): fix all 332 test type errors and gate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      # Tests were excluded from `typecheck` (`**/*.test.ts`), so 332 type errors
+      # had accumulated unseen — including doubles that no longer matched the
+      # interface they stood in for. Kept separate from `typecheck` so a break
+      # names which side it is on.
+      - name: Typecheck tests
+        run: npm run typecheck:tests
+
       - name: Lint
         run: npm run lint
 

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "test:e2e:live": "vitest run --config vitest.live.config.ts",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
+    "typecheck:tests": "tsc --noEmit -p tsconfig.tests.json",
     "verify:version": "node -e \"const p=require('./package.json');const s=require('fs').readFileSync('connect/version.ts','utf8');if(!s.includes(\\\"'\\\"+p.version+\\\"'\\\")){console.error('connect/version.ts is stale: expected SDK_VERSION '+p.version+'. Run: node scripts/gen-version.mjs && commit it.');process.exit(1)}console.log('connect/version.ts matches package.json '+p.version)\"",
     "cli": "echo 'The CLI has moved to @unicity-sphere/cli \u2014 install it with: npm install -g @unicity-sphere/cli' && exit 1",
     "lint:suppress": "eslint . --suppress-all",

--- a/tests/contract/wallet-api-mailbox-provider.contract.test.ts
+++ b/tests/contract/wallet-api-mailbox-provider.contract.test.ts
@@ -34,6 +34,13 @@ function hex(bytes: Uint8Array): string {
 
 interface Harness extends DeliveryProviderContractContext {
   fake: FakeWalletApi;
+  /**
+   * Narrowed from the port's `DeliveryProvider`: the provider-specific pins
+   * below reach for the concrete implementation's surface (`walletApiClient`,
+   * the nametag-carrying `setIdentity`, the non-optional `deliverBatch`), which
+   * the generic contract type deliberately keeps optional/absent.
+   */
+  sender: WalletApiMailboxProvider;
   recipientProvider: WalletApiMailboxProvider;
   recipientClient: WalletApiClient;
 }
@@ -311,7 +318,7 @@ describe('WalletApiMailboxProvider — provider-specific semantics', () => {
         transferId: 'tf-h4b',
         memo: 'note to self',
       });
-      const incoming = await drain(selfProvider as WalletApiMailboxProvider);
+      const incoming = await drain(selfProvider);
       const delivery = incoming.find((d) => d.deliveryId === deliveryId);
       expect(delivery).toBeDefined();
       expect(delivery!.memo).toBe('note to self');

--- a/tests/e2e/messaging-e2e.test.ts
+++ b/tests/e2e/messaging-e2e.test.ts
@@ -24,9 +24,9 @@ import type { DirectMessage } from '../../types';
 // Local helpers (the shared v1-era e2e helpers.ts died with the v1 cutover;
 // messaging needs no faucet/gateway — only temp dirs and random names).
 const rand = (n = 6): string => Math.random().toString(36).slice(2, 2 + n);
-function makeTempDirs(label: string): { dataDir: string; tokensDir: string } {
+function makeTempDirs(label: string): { base: string; dataDir: string; tokensDir: string } {
   const base = mkdtempSync(join(tmpdir(), `sphere-e2e-${label}-`));
-  return { dataDir: join(base, 'data'), tokensDir: join(base, 'tokens') };
+  return { base, dataDir: join(base, 'data'), tokensDir: join(base, 'tokens') };
 }
 
 // =============================================================================

--- a/tests/harness/live/live-address-switch-strand.test.ts
+++ b/tests/harness/live/live-address-switch-strand.test.ts
@@ -205,7 +205,7 @@ function startModule(binding: AddressBinding): Wallet {
     delivery: binding.delivery,
     walletApi: binding.client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, client: binding.client, engine: binding.engine, identity: binding.identity, delivery: binding.delivery };

--- a/tests/integration/address-switch-incoming-token-loss.test.ts
+++ b/tests/integration/address-switch-incoming-token-loss.test.ts
@@ -68,7 +68,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -153,7 +152,7 @@ function makeWallet(
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client, delivery };

--- a/tests/integration/market-module.test.ts
+++ b/tests/integration/market-module.test.ts
@@ -19,6 +19,7 @@ import { createBrowserProviders } from '../../impl/browser';
 import { createNodeProviders } from '../../impl/nodejs';
 import type { TransportProvider, OracleProvider } from '../../index';
 import type { ProviderStatus } from '../../types';
+import type { MarketModuleConfig } from '../../modules/market';
 import { TEST_NETWORK } from '../test-network';
 
 // =============================================================================
@@ -65,16 +66,38 @@ function createMockOracle(): OracleProvider {
   return {
     id: 'mock-oracle',
     name: 'Mock Oracle',
-    type: 'aggregator' as const,
+    // Same provider kind the real UnicityAggregatorProvider reports.
+    type: 'network' as const,
     connect: vi.fn().mockResolvedValue(undefined),
     disconnect: vi.fn().mockResolvedValue(undefined),
     isConnected: vi.fn().mockReturnValue(true),
     getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
     initialize: vi.fn().mockResolvedValue(undefined),
-    submitCommitment: vi.fn().mockResolvedValue({ requestId: 'test-id' }),
-    getProof: vi.fn().mockResolvedValue(null),
-    validate: vi.fn().mockResolvedValue({ valid: [], invalid: [] }),
-  } as OracleProvider;
+    // The v2 config surface is the whole oracle contract post-cutover. No trust
+    // base → Sphere skips building the token engine, which is what these
+    // market-only tests exercise (no money movement).
+    getTrustBaseJson: vi.fn().mockReturnValue(null),
+    getAggregatorUrl: vi.fn().mockReturnValue('https://mock-aggregator.invalid'),
+    getApiKey: vi.fn().mockReturnValue(undefined),
+  };
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * `BrowserProviders.market` / `NodeProviders.market` are declared
+ * `MarketModuleConfig | boolean` even though the factories always hand back the
+ * resolved OBJECT form (`resolveMarketConfig` returns
+ * `MarketModuleConfig | undefined`). Narrow to that object form so field
+ * assertions type-check; a `boolean` would read back as `undefined` and still
+ * fail the assertion, so nothing is hidden.
+ */
+function marketConfigOf(
+  market: MarketModuleConfig | boolean | undefined
+): MarketModuleConfig | undefined {
+  return typeof market === 'object' ? market : undefined;
 }
 
 // =============================================================================
@@ -619,7 +642,7 @@ describe('MarketModule integration with Sphere', () => {
       });
 
       expect(providers.market).toBeDefined();
-      expect(providers.market?.apiUrl).toBe('https://custom.market.api');
+      expect(marketConfigOf(providers.market)?.apiUrl).toBe('https://custom.market.api');
     });
 
     it('should resolve market: true to empty config (defaults applied by MarketModule)', () => {
@@ -665,7 +688,7 @@ describe('MarketModule integration with Sphere', () => {
       });
 
       expect(providers.market).toBeDefined();
-      expect(providers.market?.apiUrl).toBe('https://node-custom.market.api');
+      expect(marketConfigOf(providers.market)?.apiUrl).toBe('https://node-custom.market.api');
     });
 
     it('should resolve market: true to empty config (defaults applied by MarketModule)', () => {
@@ -689,7 +712,7 @@ describe('MarketModule integration with Sphere', () => {
       });
 
       expect(providers.market).toBeDefined();
-      expect(providers.market?.timeout).toBe(60000);
+      expect(marketConfigOf(providers.market)?.timeout).toBe(60000);
     });
   });
 
@@ -761,7 +784,7 @@ describe('MarketModule integration with Sphere', () => {
       expect(providers.market).toBeDefined();
 
       // Market should have custom URL
-      expect(providers.market?.apiUrl).toBe('https://test-node-market.api');
+      expect(marketConfigOf(providers.market)?.apiUrl).toBe('https://test-node-market.api');
     });
   });
 

--- a/tests/integration/nametag-roundtrip.test.ts
+++ b/tests/integration/nametag-roundtrip.test.ts
@@ -224,7 +224,9 @@ describe('Nametag roundtrip integration', () => {
 
     provider = new NostrTransportProvider({
       relays: ['wss://mock-relay.test'],
-      createWebSocket: (() => {}) as WebSocketFactory,
+      // Inert: the SDK's NostrClient (mocked here) owns its own sockets, so the
+      // factory is never invoked — it cannot return a real IWebSocket.
+      createWebSocket: (() => {}) as unknown as WebSocketFactory,
       timeout: 1000,
       autoReconnect: false,
     });

--- a/tests/integration/provider-disable-sync.test.ts
+++ b/tests/integration/provider-disable-sync.test.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { Sphere } from '../../core/Sphere';
 import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
 import { FileTokenStorageProvider } from '../../impl/nodejs/storage/FileTokenStorageProvider';
-import type { TransportProvider, OracleProvider, TokenStorageProvider, TxfStorageDataBase } from '../../index';
+import type { TransportProvider, OracleProvider, TokenStorageProvider, TxfStorageDataBase, InventoryView } from '../../index';
 import type { ProviderStatus } from '../../types';
 import { TEST_NETWORK } from '../test-network';
 
@@ -100,7 +100,19 @@ function createMockTokenStorage(id: string, name: string): TokenStorageProvider<
       removed: 0,
       conflicts: 0,
     })),
-    onEvent: vi.fn().mockReturnValue(() => {}),
+    // Lazy inventory port (sdk-changes S2). This double holds no blobs: the
+    // view is empty (so mergeLazyInventory is a no-op) and getToken has
+    // nothing to materialize.
+    listInventory: vi.fn(async (): Promise<InventoryView> => ({
+      cursor: 0n,
+      syncEpoch: 0n,
+      more: false,
+      items: [],
+    })),
+    getToken: vi.fn(async (tokenId: string) => {
+      throw new Error(`mock token storage holds no blob for ${tokenId}`);
+    }),
+    applyDelta: vi.fn(async () => {}),
   };
 }
 

--- a/tests/integration/self-send-multitoken.repro.test.ts
+++ b/tests/integration/self-send-multitoken.repro.test.ts
@@ -69,7 +69,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -143,7 +142,7 @@ function makeSelfWallet(baseUrl: string, network: string, deviceId: string): Wal
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client };

--- a/tests/integration/self-send-roundtrip.repro.test.ts
+++ b/tests/integration/self-send-roundtrip.repro.test.ts
@@ -64,7 +64,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -147,7 +146,7 @@ function makeWallet(
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client, identity };

--- a/tests/integration/self-send-variants.repro.test.ts
+++ b/tests/integration/self-send-variants.repro.test.ts
@@ -52,7 +52,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -126,7 +125,7 @@ function makeSelfWallet(baseUrl: string, network: string, deviceId: string): Wal
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client };

--- a/tests/integration/sphere-network-isolation.e2e.test.ts
+++ b/tests/integration/sphere-network-isolation.e2e.test.ts
@@ -116,7 +116,6 @@ async function buildWallet(network: NetworkType): Promise<Sphere> {
     network,
     dataDir: SHARED_DATA_DIR,
     tokensDir: SHARED_TOKENS_DIR,
-    l1: undefined,
   });
   const { sphere } = await Sphere.init({
     ...providers,

--- a/tests/integration/token-storage-network.test.ts
+++ b/tests/integration/token-storage-network.test.ts
@@ -64,7 +64,7 @@ function createTxfData(tokenIds: string[]): TxfStorageDataBase {
     },
   };
   for (const id of tokenIds) {
-    (data as Record<string, unknown>)[`_${id}`] = {
+    data[`_${id}`] = {
       version: '2.0',
       state: { tokenId: id },
       transactions: [],
@@ -81,7 +81,7 @@ function countTokens(data: TxfStorageDataBase): number {
 }
 
 function hasToken(data: TxfStorageDataBase, id: string): boolean {
-  return (data as Record<string, unknown>)[`_${id}`] !== undefined;
+  return data[`_${id}`] !== undefined;
 }
 
 // =============================================================================

--- a/tests/integration/wallet-clear-indexeddb.test.ts
+++ b/tests/integration/wallet-clear-indexeddb.test.ts
@@ -59,7 +59,7 @@ function createTxfData(address: string, tokenIds: string[]): TxfStorageDataBase 
     },
   };
   for (const id of tokenIds) {
-    (data as Record<string, unknown>)[`_${id}`] = {
+    data[`_${id}`] = {
       version: '2.0',
       state: { tokenId: id, coinId: 'UCT', amount: '1000000' },
       transactions: [],

--- a/tests/integration/wallet-clear.test.ts
+++ b/tests/integration/wallet-clear.test.ts
@@ -286,7 +286,7 @@ describe('Sphere.clear() integration', () => {
       // Verify tokens actually exist by reading them back via load()
       const loadResult = await tokenStorage.load();
       expect(loadResult.success).toBe(true);
-      const loadedData = loadResult.data as Record<string, unknown>;
+      const loadedData = loadResult.data!;
       expect(loadedData._token1).toBeDefined();
       expect((loadedData._token1 as Record<string, unknown>).coinId).toBe('UCT');
       expect(loadedData._nametagToken).toBeDefined();
@@ -304,7 +304,7 @@ describe('Sphere.clear() integration', () => {
       // Verify tokens are gone - by loading
       const loadResultAfter = await tokenStorage.load();
       if (loadResultAfter.success && loadResultAfter.data) {
-        const dataAfter = loadResultAfter.data as Record<string, unknown>;
+        const dataAfter = loadResultAfter.data;
         expect(dataAfter._token1).toBeUndefined();
         expect(dataAfter._nametagToken).toBeUndefined();
       }
@@ -440,7 +440,7 @@ describe('Sphere.clear() integration', () => {
       // Verify tokens exist by loading
       const loadResult = await tokenStorage.load();
       expect(loadResult.success).toBe(true);
-      const loadedData = loadResult.data as Record<string, unknown>;
+      const loadedData = loadResult.data!;
       expect(loadedData._token001).toBeDefined();
       expect(loadedData._token002).toBeDefined();
 
@@ -452,7 +452,7 @@ describe('Sphere.clear() integration', () => {
       // Verify all tokens are gone
       const loadAfterClear = await tokenStorage.load();
       if (loadAfterClear.success && loadAfterClear.data) {
-        const dataAfter = loadAfterClear.data as Record<string, unknown>;
+        const dataAfter = loadAfterClear.data;
         // Only _meta should remain (or nothing)
         const tokenKeysAfter = Object.keys(dataAfter).filter(k => !k.startsWith('_'));
         expect(tokenKeysAfter.length).toBe(0);

--- a/tests/support/fake-wallet-api.ts
+++ b/tests/support/fake-wallet-api.ts
@@ -1012,6 +1012,9 @@ export class FakeWalletApi {
       // signature when they are absent or differ. Enforced here because the
       // phase-2 harness caught exactly this drift on first contact with real
       // MinIO (the fake had validated only the body, never the headers).
+      if (entry.sha256 === undefined) {
+        throw new HttpError(500, 'INTERNAL', 'fake: upload entry has no sha256 to check against');
+      }
       const expectedChecksum = Buffer.from(entry.sha256, 'hex').toString('base64');
       if (req.headers['x-amz-checksum-sha256'] !== expectedChecksum) {
         throw new HttpError(403, 'FORBIDDEN', 'x-amz-checksum-sha256 signed header missing or mismatched');

--- a/tests/support/preset-wallet.ts
+++ b/tests/support/preset-wallet.ts
@@ -28,7 +28,7 @@ import {
   type PaymentsModuleDependencies,
 } from '../../modules/payments/PaymentsModule';
 import type { FullIdentity } from '../../types';
-import type { TransportProvider } from '../../transport';
+import type { PeerInfo, TransportProvider } from '../../transport';
 import type { OracleProvider } from '../../oracle';
 import type { StorageProvider } from '../../storage';
 import { FakeTokenEngine, decodeFakeTokenAssets, decodeFakeTokenId, type FakeEngineConfig } from '../unit/token-engine/FakeTokenEngine';
@@ -51,7 +51,22 @@ export function fullIdentity(who: TestKeypair): FullIdentity {
     chainPubkey: who.chainPubkey,
     privateKey: who.privateKey,
     directAddress: `DIRECT://${who.chainPubkey.slice(0, 12)}`,
+  };
+}
+
+/**
+ * What a transport `resolve()` would return for `who`. Distinct from
+ * {@link fullIdentity} on purpose: an Identity has no `transportPubkey` — that
+ * belongs to a PEER description, and conflating them is how a test ends up
+ * asserting on a field the wallet never had.
+ */
+export function peerInfoOf(who: TestKeypair, nametag?: string): PeerInfo {
+  return {
+    chainPubkey: who.chainPubkey,
     transportPubkey: who.chainPubkey.slice(2),
+    directAddress: `DIRECT://${who.chainPubkey.slice(0, 12)}`,
+    timestamp: 0,
+    ...(nametag !== undefined ? { nametag } : {}),
   };
 }
 

--- a/tests/unit/connect/gate.test.ts
+++ b/tests/unit/connect/gate.test.ts
@@ -31,7 +31,7 @@ describe('ConnectClient gate', () => {
     const h = makeClientHarness();
     void h.client.connect();
     await Promise.resolve();
-    const req = h.sent[0] as Record<string, unknown>;
+    const req = h.sent[0] as unknown as Record<string, unknown>;
     expect((req.network as { id: number }).id).toBe(WALLET_NET);
     expect(typeof req.sdkVersion).toBe('string');
     expect(req.v).toBe(SPHERE_CONNECT_VERSION);
@@ -90,13 +90,15 @@ function makeHostHarness(opts?: { minMinorVersion?: number }) {
   const onConnectionRejected = vi.fn();
   const onConnectionRequest = vi.fn(async () => ({ approved: true, grantedPermissions: [PERMISSION_SCOPES.IDENTITY_READ] }));
   const host = new ConnectHost({ sphere, transport, onConnectionRequest, onConnectionRejected, onIntent: vi.fn(), ...opts });
-  const send = (msg: Partial<SphereConnectMessage> & Record<string, unknown>) =>
-    clientHandler?.({ ns: SPHERE_CONNECT_NAMESPACE, type: 'handshake', direction: 'request', permissions: [], ...msg } as SphereConnectMessage);
+  // Deliberately UNTYPED wire input: these tests hand the host off-version handshakes
+  // (v: '1.0'), which `SphereConnectMessage` cannot express by construction.
+  const send = (msg: Record<string, unknown>) =>
+    clientHandler?.({ ns: SPHERE_CONNECT_NAMESPACE, type: 'handshake', direction: 'request', permissions: [], ...msg } as unknown as SphereConnectMessage);
   return { host, sent, send, onConnectionRejected, onConnectionRequest };
 }
 
 const handshakeResponses = (sent: SphereConnectMessage[]) =>
-  sent.filter((m) => m.type === 'handshake' && (m as { direction?: string }).direction === 'response') as Array<Record<string, unknown>>;
+  sent.filter((m) => m.type === 'handshake' && (m as { direction?: string }).direction === 'response') as unknown as Array<Record<string, unknown>>;
 
 describe('ConnectHost gate', () => {
   it('rejects a v1 client with UNSUPPORTED_PROTOCOL_VERSION and does not call onConnectionRequest', async () => {

--- a/tests/unit/connect/integration.test.ts
+++ b/tests/unit/connect/integration.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ConnectHost } from '../../../connect/host/ConnectHost';
 import { ConnectClient } from '../../../connect/client/ConnectClient';
-import type { ConnectTransport, SphereConnectMessage } from '../../../connect/types';
+import type {
+  ConnectTransport,
+  SphereConnectMessage,
+  ConnectHostConfig,
+  ConnectClientConfig,
+} from '../../../connect/types';
 import { PERMISSION_SCOPES } from '../../../connect/permissions';
 import { ERROR_CODES, RPC_METHODS, INTENT_ACTIONS } from '../../../connect/protocol';
 import type { PermissionScope } from '../../../connect/permissions';
@@ -104,7 +109,7 @@ describe('Sphere Connect Integration', () => {
     mockSphere = createMockSphere();
   });
 
-  function createHost(overrides?: Partial<Parameters<typeof ConnectHost['prototype']['constructor']>[0]>) {
+  function createHost(overrides?: Partial<ConnectHostConfig>) {
     host = new ConnectHost({
       sphere: mockSphere,
       transport: transports.host,
@@ -114,19 +119,17 @@ describe('Sphere Connect Integration', () => {
       }),
       onIntent: vi.fn().mockResolvedValue({ result: { success: true } }),
       ...overrides,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any);
+    });
     return host;
   }
 
-  function createClient(overrides?: Partial<Parameters<typeof ConnectClient['prototype']['constructor']>[0]>) {
+  function createClient(overrides?: Partial<ConnectClientConfig>) {
     client = new ConnectClient({
       transport: transports.client,
       dapp: defaultDapp,
       network: { id: 4 },
       ...overrides,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any);
+    });
     return client;
   }
 

--- a/tests/unit/connect/lock.test.ts
+++ b/tests/unit/connect/lock.test.ts
@@ -72,15 +72,24 @@ function createMockTransportPair(): MockPair {
 // Mock Sphere
 // ===========================================================================
 
+/** Mirrors `Sphere.identity`, which is `Identity | null`. Absent-able on purpose: the
+ *  lock-edge tests model a wallet whose identity is already gone when the snapshot freezes,
+ *  and the host's `if (!id)` treats null and undefined identically. */
+type MockSphereIdentity =
+  | { chainPubkey: string; directAddress: string; nametag: string }
+  | null
+  | undefined;
+
 function createMockSphere(overrides?: { chainPubkey?: string; networkId?: number }) {
   const eventHandlers = new Map<string, Set<(data: unknown) => void>>();
 
   return {
+    // Widened to MockSphereIdentity (not narrowed to the literal) so tests can clear it.
     identity: {
       chainPubkey: overrides?.chainPubkey ?? '02abc123',
       directAddress: 'DIRECT://test',
       nametag: 'alice',
-    },
+    } as MockSphereIdentity,
     networkId: overrides?.networkId ?? 4,
     payments: {
       getBalance: vi.fn().mockReturnValue([{ coinId: 'UCT', totalAmount: '1000000' }]),
@@ -186,7 +195,7 @@ function eventsOfType(sent: SphereConnectMessage[], event: string) {
 function handshakeResponses(sent: SphereConnectMessage[]) {
   return sent.filter(
     (m) => m.type === 'handshake' && (m as { direction?: string }).direction === 'response',
-  ) as Array<Record<string, unknown>>;
+  ) as unknown as Array<Record<string, unknown>>;
 }
 
 function subscribeCalls(sent: SphereConnectMessage[]): string[] {
@@ -2042,7 +2051,7 @@ describe('lock-edge guards fail closed', () => {
 
     expect(h.host.walletState).toBe('locked');
     expect(h.host.getSession()).not.toBeNull();
-    const err = await h.client.query(RPC_METHODS.GET_BALANCE).catch((e) => e as ConnectError);
+    const err = (await h.client.query(RPC_METHODS.GET_BALANCE).catch((e) => e)) as ConnectError;
     // Still a typed lock refusal — not -32603 forever.
     expect(err.code).toBe(ERROR_CODES.WALLET_LOCKED);
   });

--- a/tests/unit/connect/protocol.test.ts
+++ b/tests/unit/connect/protocol.test.ts
@@ -70,7 +70,9 @@ describe('Protocol', () => {
     it('defines RPC methods', () => {
       expect(RPC_METHODS.GET_IDENTITY).toBe('sphere_getIdentity');
       expect(RPC_METHODS.GET_BALANCE).toBe('sphere_getBalance');
-      expect(RPC_METHODS.SEND).toBeUndefined();
+      // `send` is an INTENT, never an RPC method — assert its runtime absence through an
+      // index signature, since the const object's type (correctly) has no SEND member.
+      expect((RPC_METHODS as Record<string, string | undefined>).SEND).toBeUndefined();
     });
 
     it('defines intent actions', () => {

--- a/tests/unit/core/Sphere.clear.test.ts
+++ b/tests/unit/core/Sphere.clear.test.ts
@@ -7,7 +7,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Sphere } from '../../../core/Sphere';
 import type { StorageProvider } from '../../../storage';
-import type { TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import type { InventoryView, TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import type { TokenBlob } from '../../../token-engine';
 import type { ProviderStatus } from '../../../types';
 
 // =============================================================================
@@ -63,6 +64,16 @@ function createMockTokenStorage(): TokenStorageProvider<TxfStorageDataBase> & { 
       removed: 0,
       conflicts: 0,
     })),
+    // S2 lazy-inventory surface: present so the double really satisfies the
+    // TokenStorageProvider port. An empty view and a loud getToken are the
+    // honest stand-ins for a store that holds nothing.
+    listInventory: vi.fn(async (): Promise<InventoryView> => ({
+      items: [], cursor: 0n, syncEpoch: 0n, more: false,
+    })),
+    getToken: vi.fn(async (tokenId: string): Promise<TokenBlob> => {
+      throw new Error(`mock token storage: no blob for ${tokenId}`);
+    }),
+    applyDelta: vi.fn(async (): Promise<void> => undefined),
     clear: vi.fn(async () => true),
   };
 }

--- a/tests/unit/core/Sphere.nametag-sync.test.ts
+++ b/tests/unit/core/Sphere.nametag-sync.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import type { StorageProvider, OracleProvider, TransportProvider } from '../../../index';
-import type { FullIdentity, ProviderStatus } from '../../../types';
+import type { FullIdentity, ProviderStatus, TrackedAddressEntry } from '../../../types';
 
 // =============================================================================
 // Mock Providers
@@ -52,6 +52,8 @@ function _createMockStorage(): StorageProvider & { _data: Map<string, string> } 
       }
       return Promise.resolve();
     }),
+    saveTrackedAddresses: vi.fn(async () => {}),
+    loadTrackedAddresses: vi.fn(async (): Promise<TrackedAddressEntry[]> => []),
     _data: data,
   };
 }

--- a/tests/unit/core/Sphere.network-delegation.test.ts
+++ b/tests/unit/core/Sphere.network-delegation.test.ts
@@ -67,13 +67,12 @@ describe('Sphere.init network → TokenRegistry delegation (regression guard)', 
 
   it('Test A: fresh wallet (create path) fetches testnet2 registry, not testnet', async () => {
     const fetched = stubFetchRecording();
-    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: false });
+    const { storage, transport, oracle } = makeMockProviders({ walletExists: false });
 
     const { sphere, created } = await Sphere.init({
       storage,
       transport,
       oracle,
-      l1,
       network: TEST_NETWORK,
       autoGenerate: true,
     });
@@ -96,13 +95,12 @@ describe('Sphere.init network → TokenRegistry delegation (regression guard)', 
 
   it('Test B: existing wallet (load path) fetches testnet2 registry, not testnet', async () => {
     const fetched = stubFetchRecording();
-    const { storage, transport, oracle, l1 } = makeMockProviders({ walletExists: true });
+    const { storage, transport, oracle } = makeMockProviders({ walletExists: true });
 
     const { sphere, created } = await Sphere.init({
       storage,
       transport,
       oracle,
-      l1,
       network: TEST_NETWORK,
     });
 

--- a/tests/unit/core/Sphere.providers.test.ts
+++ b/tests/unit/core/Sphere.providers.test.ts
@@ -73,7 +73,8 @@ class MockTokenStorageProvider implements TokenStorageProvider<TxfStorageDataBas
       data: this.data ?? {
         _meta: {
           version: 1,
-          address: this.identity?.address ?? '',
+          // Mirrors the real providers: _meta.address carries the chain pubkey.
+          address: this.identity?.chainPubkey ?? '',
           formatVersion: '2.0',
           updatedAt: Date.now(),
         },
@@ -155,8 +156,8 @@ describe('TokenStorageProvider Management', () => {
 
       const identity: FullIdentity = {
         privateKey: 'a'.repeat(64),
-        publicKey: 'b'.repeat(64),
-        address: '02abtest',
+        chainPubkey: `02${'b'.repeat(64)}`,
+        directAddress: 'DIRECT://test',
         ipnsName: '12D3KooWtest',
       };
 

--- a/tests/unit/core/Sphere.registerNametag.test.ts
+++ b/tests/unit/core/Sphere.registerNametag.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import type { ITokenEngine } from '../../../token-engine';
 import { Sphere } from '../../../core/Sphere';
 import { FileStorageProvider } from '../../../impl/nodejs/storage/FileStorageProvider';
 import { FileTokenStorageProvider } from '../../../impl/nodejs/storage/FileTokenStorageProvider';
@@ -50,6 +51,20 @@ function createMockTransport(): TransportProvider {
   } as TransportProvider;
 }
 
+/** Minimal single-node trust base: parses, dials nothing. */
+const TRUST_BASE_JSON = {
+  changeRecordHash: null,
+  epoch: '0',
+  epochStartRound: '0',
+  networkId: 4,
+  previousEntryHash: null,
+  quorumThreshold: '1',
+  rootNodes: [{ nodeId: 'NODE', sigKey: '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', stake: '1' }],
+  signatures: {},
+  stateHash: '00',
+  version: '1',
+};
+
 function createMockOracle(): OracleProvider {
   return {
     id: 'mock-oracle',
@@ -60,11 +75,12 @@ function createMockOracle(): OracleProvider {
     isConnected: vi.fn().mockReturnValue(true),
     getStatus: vi.fn().mockReturnValue('connected' as ProviderStatus),
     initialize: vi.fn().mockResolvedValue(undefined),
-    submitCommitment: vi.fn().mockResolvedValue({ requestId: 'test-id' }),
-    getProof: vi.fn().mockResolvedValue(null),
-    waitForProof: vi.fn().mockResolvedValue({ proof: 'mock' }),
-    validateToken: vi.fn().mockResolvedValue({ valid: true }),
-    mintToken: vi.fn().mockResolvedValue({ success: true, token: { id: 'mock-token' } }),
+    // The three config accessors ARE the post-cutover oracle surface, and they
+    // are what lets Sphere build a token engine here — without one, the
+    // "never mints" guard below would have nothing to watch.
+    getTrustBaseJson: () => TRUST_BASE_JSON,
+    getAggregatorUrl: () => 'https://127.0.0.1:1/never-called',
+    getApiKey: () => undefined,
   } as unknown as OracleProvider;
 }
 
@@ -106,7 +122,14 @@ describe('Sphere.registerNametag() — Nostr-binding only (D5, no on-chain mint)
     });
 
     (transport.publishIdentityBinding as ReturnType<typeof vi.fn>).mockClear();
-    (oracle.submitCommitment as ReturnType<typeof vi.fn>).mockClear();
+
+    // Watch the ONLY surface a nametag mint could go through today. The old
+    // guard watched `oracle.submitCommitment`, which the v1 cutover deleted from
+    // OracleProvider — nothing could call it, so the assertion could not fail.
+    const engine = (sphere as unknown as { _tokenEngine?: ITokenEngine })._tokenEngine;
+    expect(engine).toBeDefined();
+    const mint = vi.spyOn(engine!, 'mint');
+    const mintDataToken = vi.spyOn(engine!, 'mintDataToken');
 
     await sphere.registerNametag('alice');
 
@@ -118,8 +141,9 @@ describe('Sphere.registerNametag() — Nostr-binding only (D5, no on-chain mint)
     );
     // …updated local state…
     expect(sphere.identity!.nametag).toBe('alice');
-    // …and performed NO on-chain mint: registration never touches the aggregator.
-    expect(oracle.submitCommitment).not.toHaveBeenCalled();
+    // …and performed NO on-chain mint: registration is a Nostr binding, nothing more.
+    expect(mint).not.toHaveBeenCalled();
+    expect(mintDataToken).not.toHaveBeenCalled();
 
     await sphere.destroy();
   });

--- a/tests/unit/core/Sphere.status.test.ts
+++ b/tests/unit/core/Sphere.status.test.ts
@@ -4,12 +4,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import type { InventoryView, StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import type { TokenBlob } from '../../../token-engine';
 import type { TransportProvider } from '../../../transport';
 import type { OracleProvider } from '../../../oracle';
+import type { PricePlatform, TokenPrice } from '../../../price';
 import type { ProviderStatus, SphereEventMap } from '../../../types';
 
-import { Sphere } from '../../../core/Sphere';
+import { Sphere, type SphereInitOptions } from '../../../core/Sphere';
 import { TEST_NETWORK } from '../../test-network';
 
 // =============================================================================
@@ -125,7 +127,16 @@ function createMockTokenStorage(id: string, name: string): TokenStorageProvider<
       removed: 0,
       conflicts: 0,
     })),
-    onEvent: vi.fn().mockReturnValue(() => {}),
+    // S2 lazy-inventory surface: present so the double really satisfies the
+    // TokenStorageProvider port. An empty view and a loud getToken are the
+    // honest stand-ins for a store that holds nothing.
+    listInventory: vi.fn(async (): Promise<InventoryView> => ({
+      items: [], cursor: 0n, syncEpoch: 0n, more: false,
+    })),
+    getToken: vi.fn(async (tokenId: string): Promise<TokenBlob> => {
+      throw new Error(`mock token storage: no blob for ${tokenId}`);
+    }),
+    applyDelta: vi.fn(async (): Promise<void> => undefined),
   };
 }
 
@@ -157,9 +168,9 @@ describe('Sphere Status & Provider Management', () => {
   });
 
   async function initSphere(options?: {
-    price?: { platform: string };
+    price?: { platform: PricePlatform };
   }) {
-    const initOpts: Record<string, unknown> = {
+    const initOpts: SphereInitOptions = {
       storage,
       transport: transport as unknown as TransportProvider,
       oracle: oracle as unknown as OracleProvider,
@@ -170,12 +181,12 @@ describe('Sphere Status & Provider Management', () => {
     if (options?.price) {
       initOpts.price = {
         platform: options.price.platform,
-        getPrices: vi.fn().mockResolvedValue(new Map()),
-        getPrice: vi.fn().mockResolvedValue(null),
+        getPrices: vi.fn(async (): Promise<Map<string, TokenPrice>> => new Map()),
+        getPrice: vi.fn(async (): Promise<TokenPrice | null> => null),
         clearCache: vi.fn(),
       };
     }
-    const { sphere } = await Sphere.init(initOpts as Parameters<typeof Sphere.init>[0]);
+    const { sphere } = await Sphere.init(initOpts);
     return sphere;
   }
 

--- a/tests/unit/core/Sphere.walletapi-session.test.ts
+++ b/tests/unit/core/Sphere.walletapi-session.test.ts
@@ -6,7 +6,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import type { InventoryView, StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import type { TokenBlob } from '../../../token-engine';
 import type { TransportProvider } from '../../../transport';
 import type { OracleProvider } from '../../../oracle';
 import type { ProviderStatus, SphereEventMap } from '../../../types';
@@ -91,7 +92,16 @@ function createMockTokenStorage(): TokenStorageProvider<TxfStorageDataBase> {
     sync: vi.fn(async (localData: TxfStorageDataBase) => ({
       success: true, merged: localData, added: 0, removed: 0, conflicts: 0,
     })),
-    onEvent: vi.fn().mockReturnValue(() => {}),
+    // S2 lazy-inventory surface: present so the double really satisfies the
+    // TokenStorageProvider port. An empty view and a loud getToken are the
+    // honest stand-ins for a store that holds nothing.
+    listInventory: vi.fn(async (): Promise<InventoryView> => ({
+      items: [], cursor: 0n, syncEpoch: 0n, more: false,
+    })),
+    getToken: vi.fn(async (tokenId: string): Promise<TokenBlob> => {
+      throw new Error(`mock token storage: no blob for ${tokenId}`);
+    }),
+    applyDelta: vi.fn(async (): Promise<void> => undefined),
   };
 }
 

--- a/tests/unit/core/network-fail-loud.test.ts
+++ b/tests/unit/core/network-fail-loud.test.ts
@@ -22,9 +22,10 @@ import { getEmbeddedTrustBase } from '../../../impl/shared/trustbase-loader';
 describe('fail-loud: network required (no silent defaults)', () => {
   describe('createBrowserProviders', () => {
     it('throws when network is omitted', () => {
-      // @ts-expect-error network is required
+      // `network` is optional in the CONFIG TYPE (so `createBrowserProviders()`
+      // compiles) — the requirement is enforced at runtime, which is what this
+      // asserts.
       expect(() => createBrowserProviders({})).toThrow(/network/i);
-      // @ts-expect-error network is required
       expect(() => createBrowserProviders({})).toThrow(SphereError);
     });
 
@@ -35,9 +36,10 @@ describe('fail-loud: network required (no silent defaults)', () => {
 
   describe('createNodeProviders', () => {
     it('throws when network is omitted', () => {
-      // @ts-expect-error network is required
+      // `network` is optional in the CONFIG TYPE (so `createNodeProviders()`
+      // compiles) — the requirement is enforced at runtime, which is what this
+      // asserts.
       expect(() => createNodeProviders({})).toThrow(/network/i);
-      // @ts-expect-error network is required
       expect(() => createNodeProviders({})).toThrow(SphereError);
     });
 

--- a/tests/unit/core/support/mock-providers.ts
+++ b/tests/unit/core/support/mock-providers.ts
@@ -10,7 +10,8 @@
  */
 
 import { vi } from 'vitest';
-import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../../storage';
+import type { InventoryView, StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../../storage';
+import type { TokenBlob } from '../../../../token-engine';
 import type { TransportProvider } from '../../../../transport';
 import type { OracleProvider } from '../../../../oracle';
 import type { ProviderStatus } from '../../../../types';
@@ -140,7 +141,13 @@ function createMockTokenStorage(id: string, name: string): TokenStorageProvider<
       removed: 0,
       conflicts: 0,
     })),
-    onEvent: vi.fn().mockReturnValue(() => {}),
+    // S2 lazy-inventory surface: present so the mock really satisfies the
+    // contract. An empty view and a loud getToken are the honest stand-ins.
+    listInventory: vi.fn(async (): Promise<InventoryView> => ({ items: [], cursor: 0n, syncEpoch: 0n, more: false })),
+    getToken: vi.fn(async (tokenId: string): Promise<TokenBlob> => {
+      throw new Error(`mock token storage: no blob for ${tokenId}`);
+    }),
+    applyDelta: vi.fn(async (): Promise<void> => undefined),
   };
 }
 

--- a/tests/unit/impl/browser/IndexedDBTokenStorageProvider.history.test.ts
+++ b/tests/unit/impl/browser/IndexedDBTokenStorageProvider.history.test.ts
@@ -41,7 +41,6 @@ function createIdentity(): FullIdentity {
 function makeEntry(overrides: Partial<HistoryRecord> & { dedupKey: string }): HistoryRecord {
   return {
     id: crypto.randomUUID(),
-    dedupKey: overrides.dedupKey,
     type: 'RECEIVED',
     amount: '1000',
     coinId: 'UCT',

--- a/tests/unit/impl/browser/IndexedDBTokenStorageProvider.test.ts
+++ b/tests/unit/impl/browser/IndexedDBTokenStorageProvider.test.ts
@@ -50,7 +50,7 @@ function createTxfData(tokenIds: string[]): TxfStorageDataBase {
     },
   };
   for (const id of tokenIds) {
-    (data as Record<string, unknown>)[`_${id}`] = {
+    data[`_${id}`] = {
       version: '2.0',
       state: { tokenId: id },
       transactions: [],

--- a/tests/unit/impl/nodejs/FileTokenStorageProvider.history.test.ts
+++ b/tests/unit/impl/nodejs/FileTokenStorageProvider.history.test.ts
@@ -40,7 +40,6 @@ function createIdentity(): FullIdentity {
 function makeEntry(overrides: Partial<HistoryRecord> & { dedupKey: string }): HistoryRecord {
   return {
     id: crypto.randomUUID(),
-    dedupKey: overrides.dedupKey,
     type: 'RECEIVED',
     amount: '1000',
     coinId: 'UCT',

--- a/tests/unit/modules/AccountingModule.autoTerminate.test.ts
+++ b/tests/unit/modules/AccountingModule.autoTerminate.test.ts
@@ -13,7 +13,7 @@
  * Test IDs: UT-AUTOTERM-001 through UT-AUTOTERM-005
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import {
   createTestAccountingModule,
   createTestTransfer,
@@ -25,6 +25,13 @@ import type { IncomingTransfer } from '../../../types/index.js';
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Recorded-call shape of the injected `deps.emitEvent` vi.fn(): `(type, data)`.
+ * Typing the spy this way makes the `mock.calls` filters below type-check
+ * without per-callback tuple annotations.
+ */
+type EmitEventMock = Mock<(type: string, data: Record<string, unknown>) => void>;
 
 function makeTerms(
   targetAddress = 'DIRECT://test_target_address_abc123',
@@ -119,7 +126,7 @@ describe('AccountingModule — autoTerminateOnReturn', () => {
       config: { autoTerminateOnReturn: true },
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    const emitEvent = (module as unknown as { deps?: { emitEvent?: EmitEventMock } }).deps?.emitEvent as EmitEventMock;
     await module.load();
 
     const terms = makeTerms();
@@ -138,7 +145,7 @@ describe('AccountingModule — autoTerminateOnReturn', () => {
     // The invoice should be marked as closed
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const closedInvoices = (module as any).closedInvoices as Set<string>;
-    const closedCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:closed');
+    const closedCalls = emitEvent.mock.calls.filter(([evt]) => evt === 'invoice:closed');
     expect(closedCalls.length).toBeGreaterThan(0);
     expect(closedCalls[0][1]).toMatchObject({ invoiceId, explicit: false });
     expect(closedInvoices.has(invoiceId)).toBe(true);
@@ -154,7 +161,7 @@ describe('AccountingModule — autoTerminateOnReturn', () => {
       config: { autoTerminateOnReturn: true },
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    const emitEvent = (module as unknown as { deps?: { emitEvent?: EmitEventMock } }).deps?.emitEvent as EmitEventMock;
     await module.load();
 
     const terms = makeTerms();
@@ -169,7 +176,7 @@ describe('AccountingModule — autoTerminateOnReturn', () => {
     // The invoice should be marked as cancelled
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cancelledInvoices = (module as any).cancelledInvoices as Set<string>;
-    const cancelledCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:cancelled');
+    const cancelledCalls = emitEvent.mock.calls.filter(([evt]) => evt === 'invoice:cancelled');
     expect(cancelledCalls.length).toBeGreaterThan(0);
     expect(cancelledCalls[0][1]).toMatchObject({ invoiceId });
     expect(cancelledInvoices.has(invoiceId)).toBe(true);
@@ -186,7 +193,7 @@ describe('AccountingModule — autoTerminateOnReturn', () => {
       config: { autoTerminateOnReturn: false },
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    const emitEvent = (module as unknown as { deps?: { emitEvent?: EmitEventMock } }).deps?.emitEvent as EmitEventMock;
     await module.load();
 
     const terms = makeTerms();
@@ -212,10 +219,10 @@ describe('AccountingModule — autoTerminateOnReturn', () => {
     expect(cancelledInvoices.has(invoiceId)).toBe(false);
 
     // invoice:return_received SHOULD fire (sender is valid), but no close/cancel
-    const returnCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:return_received');
+    const returnCalls = emitEvent.mock.calls.filter(([evt]) => evt === 'invoice:return_received');
     expect(returnCalls.length).toBeGreaterThan(0);
-    const closedCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:closed');
-    const cancelledCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:cancelled');
+    const closedCalls = emitEvent.mock.calls.filter(([evt]) => evt === 'invoice:closed');
+    const cancelledCalls = emitEvent.mock.calls.filter(([evt]) => evt === 'invoice:cancelled');
     expect(closedCalls.length).toBe(0);
     expect(cancelledCalls.length).toBe(0);
 
@@ -284,7 +291,7 @@ describe('AccountingModule — autoTerminateOnReturn', () => {
       config: { autoTerminateOnReturn: true },
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    const emitEvent = (module as unknown as { deps?: { emitEvent?: EmitEventMock } }).deps?.emitEvent as EmitEventMock;
     await module.load();
 
     // Create invoice with a DIFFERENT target that does NOT match identity.directAddress.
@@ -306,7 +313,7 @@ describe('AccountingModule — autoTerminateOnReturn', () => {
     // The sender (identity.directAddress) is NOT a target, so unauthorized_return fires
     expect(closedInvoices.has(invoiceId)).toBe(false);
     const unauthorizedCalls = emitEvent.mock.calls.filter(
-      ([evt, p]: [string, any]) =>
+      ([evt, p]) =>
         evt === 'invoice:irrelevant' && p.reason === 'unauthorized_return',
     );
     expect(unauthorizedCalls.length).toBeGreaterThan(0);

--- a/tests/unit/modules/AccountingModule.bug002-fixes.test.ts
+++ b/tests/unit/modules/AccountingModule.bug002-fixes.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
 import {
   createTestAccountingModule,
   createTestTransferRef,
@@ -75,8 +76,16 @@ function addLedgerEntry(
   (module as any).balanceCache.delete(invoiceId);
 }
 
-function getEmitEvent(module: AccountingModule): ReturnType<typeof vi.fn> {
-  return (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+/**
+ * The injected `emitEvent` dependency is a `vi.fn()` (see
+ * `createTestAccountingModule`). Typing it as a mock of the real
+ * `(type, data) => void` signature makes `.mock.calls` a `[string, unknown]`
+ * tuple list instead of `any[]`.
+ */
+type EmitEventMock = MockInstance<(type: string, data: unknown) => void>;
+
+function getEmitEvent(module: AccountingModule): EmitEventMock {
+  return (module as unknown as { deps?: { emitEvent?: EmitEventMock } }).deps?.emitEvent as EmitEventMock;
 }
 
 // =============================================================================
@@ -166,7 +175,7 @@ describe('BUG-002 Fix 3: _executeTerminationReturns per-send timeout', () => {
 
     // Verify auto_return_failed was emitted for the timed-out send
     const failedCalls = emitEvent.mock.calls.filter(
-      ([evt]: [string]) => evt === 'invoice:auto_return_failed',
+      ([evt]) => evt === 'invoice:auto_return_failed',
     );
     expect(failedCalls.length).toBeGreaterThan(0);
     expect(failedCalls[0][1]).toMatchObject({
@@ -212,7 +221,7 @@ describe('BUG-002 Fix 3: _executeTerminationReturns per-send timeout', () => {
 
     // No auto_return_failed event should have fired
     const failedCalls = emitEvent.mock.calls.filter(
-      ([evt]: [string]) => evt === 'invoice:auto_return_failed',
+      ([evt]) => evt === 'invoice:auto_return_failed',
     );
     expect(failedCalls.length).toBe(0);
 

--- a/tests/unit/modules/AccountingModule.closeCancel.test.ts
+++ b/tests/unit/modules/AccountingModule.closeCancel.test.ts
@@ -203,7 +203,7 @@ function buildNonTargetTerms(): InvoiceTerms {
 
 /** Get the emitEvent mock fn from a module's injected deps. */
 function getEmitEvent(module: AccountingModule): ReturnType<typeof vi.fn> {
-  return (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+  return (module as unknown as { deps?: { emitEvent?: ReturnType<typeof vi.fn> } }).deps?.emitEvent as ReturnType<typeof vi.fn>;
 }
 
 /** Compute storage key as the module does internally (uses condensed addressId). */
@@ -650,8 +650,11 @@ describe('AccountingModule close/cancel: storage write ordering', () => {
 
     // Track storage.set call order
     const setOrder: string[] = [];
-    const originalSet = mocks.storage.set.getMockImplementation();
-    mocks.storage.set.mockImplementation(async (key: string, value: string) => {
+    // `storage.set` is declared by StorageProvider as a plain method; the mock
+    // provider backs it with a vi.fn(), so recover the spy surface.
+    const storageSet = vi.mocked(mocks.storage.set);
+    const originalSet = storageSet.getMockImplementation();
+    storageSet.mockImplementation(async (key: string, value: string) => {
       setOrder.push(key);
       if (originalSet) {
         return originalSet(key, value);
@@ -680,8 +683,10 @@ describe('AccountingModule close/cancel: storage write ordering', () => {
     seedInvoice(module, invoiceId, terms);
 
     const setOrder: string[] = [];
-    const originalSet = mocks.storage.set.getMockImplementation();
-    mocks.storage.set.mockImplementation(async (key: string, value: string) => {
+    // See above: recover the vi.fn() spy surface behind StorageProvider.set.
+    const storageSet = vi.mocked(mocks.storage.set);
+    const originalSet = storageSet.getMockImplementation();
+    storageSet.mockImplementation(async (key: string, value: string) => {
       setOrder.push(key);
       if (originalSet) {
         return originalSet(key, value);

--- a/tests/unit/modules/AccountingModule.createInvoice.test.ts
+++ b/tests/unit/modules/AccountingModule.createInvoice.test.ts
@@ -72,7 +72,7 @@ describe('UT-CREATE-001: simple single-target, single-asset creation', () => {
     expect(typeof result.invoiceId).toBe('string');
     expect(result.invoiceId).toHaveLength(64);
     expect(result.terms).toBeDefined();
-    expect(result.terms.targets).toHaveLength(1);
+    expect(result.terms!.targets).toHaveLength(1);
   });
 });
 
@@ -89,7 +89,7 @@ describe('UT-CREATE-002: anonymous invoice omits creator', () => {
   it('does not include creator field when anonymous: true', async () => {
     const result = await module.createInvoice({ ...validRequest(), anonymous: true });
 
-    expect(result.terms.creator).toBeUndefined();
+    expect(result.terms!.creator).toBeUndefined();
   });
 });
 
@@ -106,7 +106,7 @@ describe('UT-CREATE-003: non-anonymous invoice includes creator pubkey', () => {
   it('sets creator to the wallet chainPubkey when anonymous: false', async () => {
     const result = await module.createInvoice({ ...validRequest(), anonymous: false });
 
-    expect(result.terms.creator).toBe(mocks.identity.chainPubkey);
+    expect(result.terms!.creator).toBe(mocks.identity.chainPubkey);
   });
 
   it('sets creator when anonymous is omitted (default is non-anonymous)', async () => {
@@ -114,7 +114,7 @@ describe('UT-CREATE-003: non-anonymous invoice includes creator pubkey', () => {
     // anonymous is not set — default behaviour is non-anonymous
     const result = await module.createInvoice(req);
 
-    expect(result.terms.creator).toBe(mocks.identity.chainPubkey);
+    expect(result.terms!.creator).toBe(mocks.identity.chainPubkey);
   });
 });
 
@@ -134,7 +134,7 @@ describe('UT-CREATE-004: createdAt set to Date.now() at creation time', () => {
 
     const result = await module.createInvoice(validRequest());
 
-    expect(result.terms.createdAt).toBe(frozenNow);
+    expect(result.terms!.createdAt).toBe(frozenNow);
   });
 });
 
@@ -153,7 +153,7 @@ describe('UT-CREATE-005: dueDate in the future is accepted', () => {
     const result = await module.createInvoice({ ...validRequest(), dueDate: 2000 });
 
     expect(result.success).toBe(true);
-    expect(result.terms.dueDate).toBe(2000);
+    expect(result.terms!.dueDate).toBe(2000);
   });
 });
 
@@ -627,7 +627,7 @@ describe('UT-CREATE-023: multi-target, multi-asset creation succeeds', () => {
     });
 
     expect(result.success).toBe(true);
-    expect(result.terms.targets).toHaveLength(2);
+    expect(result.terms!.targets).toHaveLength(2);
   });
 });
 
@@ -644,7 +644,7 @@ describe('UT-CREATE-024: more than 100 targets is rejected', () => {
   it('throws INVOICE_TOO_MANY_TARGETS for 101 targets', async () => {
     const targets = Array.from({ length: 101 }, (_, i) => ({
       address: `DIRECT://target_${i}`,
-      assets: [{ coin: ['UCT', '100'] }],
+      assets: [{ coin: ['UCT', '100'] as [string, string] }],
     }));
 
     await expect(
@@ -668,13 +668,13 @@ describe('UT-CREATE-025: exactly 100 targets succeeds', () => {
   it('creates invoice with exactly 100 targets', async () => {
     const targets = Array.from({ length: 100 }, (_, i) => ({
       address: `DIRECT://target_${i}`,
-      assets: [{ coin: ['UCT', '100'] }],
+      assets: [{ coin: ['UCT', '100'] as [string, string] }],
     }));
 
     const result = await module.createInvoice({ targets });
 
     expect(result.success).toBe(true);
-    expect(result.terms.targets).toHaveLength(100);
+    expect(result.terms!.targets).toHaveLength(100);
   });
 });
 
@@ -763,7 +763,7 @@ describe('UT-CREATE-029: memo exactly 4096 chars succeeds', () => {
     const result = await module.createInvoice({ ...validRequest(), memo: 'x'.repeat(4096) });
 
     expect(result.success).toBe(true);
-    expect(result.terms.memo).toHaveLength(4096);
+    expect(result.terms!.memo).toHaveLength(4096);
   });
 });
 

--- a/tests/unit/modules/AccountingModule.deliveryOrders.test.ts
+++ b/tests/unit/modules/AccountingModule.deliveryOrders.test.ts
@@ -15,7 +15,7 @@
  * Test IDs: UT-DELIVERY-001 through UT-DELIVERY-050
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import {
   createTestAccountingModule,
   createTestTransfer,
@@ -29,7 +29,14 @@ import type { IncomingTransfer } from '../../../types/index.js';
 // suite self-contained — every test should be readable in isolation)
 // ---------------------------------------------------------------------------
 
-const TARGET = DEFAULT_TEST_IDENTITY.directAddress; // wallet under test
+/**
+ * Recorded-call shape of the injected `deps.emitEvent` vi.fn(): `(type, data)`.
+ * Typing the spy this way makes the `mock.calls` filters below type-check
+ * without per-callback tuple annotations.
+ */
+type EmitEventMock = Mock<(type: string, data: Record<string, unknown>) => void>;
+
+const TARGET = DEFAULT_TEST_IDENTITY.directAddress!; // wallet under test
 
 function makeTerms(overrides?: Partial<InvoiceTerms>): InvoiceTerms {
   return {
@@ -140,14 +147,14 @@ function tokenInvoiceMapEntriesFor(
 describe('AccountingModule — payment/invoice delivery ordering', () => {
   let module: ReturnType<typeof createTestAccountingModule>['module'];
   let mocks: ReturnType<typeof createTestAccountingModule>['mocks'];
-  let emitEvent: ReturnType<typeof vi.fn>;
+  let emitEvent: EmitEventMock;
 
   beforeEach(async () => {
     const built = createTestAccountingModule();
     module = built.module;
     mocks = built.mocks;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    emitEvent = (module as unknown as { deps?: { emitEvent?: EmitEventMock } }).deps?.emitEvent as EmitEventMock;
     await module.load();
   });
 
@@ -176,7 +183,7 @@ describe('AccountingModule — payment/invoice delivery ordering', () => {
     );
     // No unknown_reference fired in the happy path.
     const unknownCalls = emitEvent.mock.calls.filter(
-      ([evt]: [string]) => evt === 'invoice:unknown_reference',
+      ([evt]) => evt === 'invoice:unknown_reference',
     );
     expect(unknownCalls).toHaveLength(0);
   });
@@ -195,7 +202,7 @@ describe('AccountingModule — payment/invoice delivery ordering', () => {
 
     // unknown_reference fires — observability preserved.
     const unknownCalls = emitEvent.mock.calls.filter(
-      ([evt]: [string]) => evt === 'invoice:unknown_reference',
+      ([evt]) => evt === 'invoice:unknown_reference',
     );
     expect(unknownCalls).toHaveLength(1);
 
@@ -234,7 +241,7 @@ describe('AccountingModule — payment/invoice delivery ordering', () => {
     expect(forwardSum(module, invoiceId)).toBe(10000000n);
 
     const paymentCalls = emitEvent.mock.calls.filter(
-      ([evt]: [string]) => evt === 'invoice:payment',
+      ([evt]) => evt === 'invoice:payment',
     );
     expect(paymentCalls.length).toBeGreaterThanOrEqual(2); // one per transfer
 
@@ -256,7 +263,7 @@ describe('AccountingModule — payment/invoice delivery ordering', () => {
 
     // Both unknown_reference events fired.
     const unknownCalls = emitEvent.mock.calls.filter(
-      ([evt]: [string]) => evt === 'invoice:unknown_reference',
+      ([evt]) => evt === 'invoice:unknown_reference',
     );
     expect(unknownCalls).toHaveLength(2);
 
@@ -403,7 +410,7 @@ describe('AccountingModule — payment/invoice delivery ordering', () => {
 
     // unknown_reference fired for B (orphan), NOT for A.
     const unknownCalls = emitEvent.mock.calls.filter(
-      ([evt]: [string]) => evt === 'invoice:unknown_reference',
+      ([evt]) => evt === 'invoice:unknown_reference',
     );
     expect(unknownCalls).toHaveLength(1);
     expect(unknownCalls[0][1]).toMatchObject({ invoiceId: invoiceB });

--- a/tests/unit/modules/AccountingModule.errors.test.ts
+++ b/tests/unit/modules/AccountingModule.errors.test.ts
@@ -361,9 +361,9 @@ describe('Error: MODULE_DESTROYED', () => {
     ];
 
     for (const method of methods) {
-      const err = await (method() as Promise<unknown>).catch((e) => e);
+      const err = await (method() as Promise<unknown>).catch((e: unknown) => e);
       expect(err).toBeInstanceOf(SphereError);
-      expect(err.code).toBe('MODULE_DESTROYED');
+      expect((err as SphereError).code).toBe('MODULE_DESTROYED');
     }
   });
 });

--- a/tests/unit/modules/AccountingModule.events.test.ts
+++ b/tests/unit/modules/AccountingModule.events.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
 import {
   createTestAccountingModule,
   createTestTransfer,
@@ -19,6 +20,15 @@ import type { IncomingTransfer } from '../../../types/index.js';
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * One recorded `deps.emitEvent(type, payload)` call: the event name plus the
+ * payload object the module emits with it.
+ */
+type EmittedEvent = [type: string, payload: Record<string, unknown>];
+
+/** Recorded-call view of the `emitEvent: vi.fn()` the test harness injects. */
+type EmitEventMock = Mock<(...args: EmittedEvent) => void>;
 
 /** Returns minimal InvoiceTerms targeting the default wallet address. */
 function makeTerms(overrides?: Partial<InvoiceTerms>): InvoiceTerms {
@@ -103,7 +113,7 @@ function makeIncomingTransfer(
 describe('AccountingModule — Events', () => {
   let module: ReturnType<typeof createTestAccountingModule>['module'];
   let mocks: ReturnType<typeof createTestAccountingModule>['mocks'];
-  let emitEvent: ReturnType<typeof vi.fn>;
+  let emitEvent: EmitEventMock;
 
   beforeEach(async () => {
     const built = createTestAccountingModule();
@@ -112,7 +122,7 @@ describe('AccountingModule — Events', () => {
     // deps.emitEvent is injected as vi.fn() — extract it directly from the module's
     // internal deps reference, which is accessible via the private field.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    emitEvent = (module as any).deps?.emitEvent as ReturnType<typeof vi.fn>;
+    emitEvent = (module as unknown as { deps?: { emitEvent?: EmitEventMock } }).deps?.emitEvent as EmitEventMock;
     await module.load();
   });
 
@@ -197,7 +207,7 @@ describe('AccountingModule — Events', () => {
     mocks.payments._emit('transfer:incoming', transfer);
     await new Promise((r) => setTimeout(r, 30));
 
-    const assetCoveredCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:asset_covered');
+    const assetCoveredCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:asset_covered');
     expect(assetCoveredCalls.length).toBeGreaterThan(0);
     expect(assetCoveredCalls[0][1]).toMatchObject({
       invoiceId,
@@ -234,7 +244,7 @@ describe('AccountingModule — Events', () => {
     mocks.payments._emit('transfer:incoming', transfer);
     await new Promise((r) => setTimeout(r, 30));
 
-    const targetCoveredCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:target_covered');
+    const targetCoveredCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:target_covered');
     expect(targetCoveredCalls.length).toBeGreaterThan(0);
     expect(targetCoveredCalls[0][1]).toMatchObject({
       invoiceId,
@@ -270,7 +280,7 @@ describe('AccountingModule — Events', () => {
     mocks.payments._emit('transfer:incoming', transfer);
     await new Promise((r) => setTimeout(r, 30));
 
-    const coveredCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:covered');
+    const coveredCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:covered');
     expect(coveredCalls.length).toBeGreaterThan(0);
     expect(coveredCalls[0][1]).toMatchObject({ invoiceId });
   });
@@ -307,7 +317,7 @@ describe('AccountingModule — Events', () => {
     await module.getInvoiceStatus(invoiceId);
 
     // Implicit close must fire with explicit: false
-    const closedCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:closed');
+    const closedCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:closed');
     expect(closedCalls.length).toBeGreaterThan(0);
     expect(closedCalls[0][1]).toMatchObject({ invoiceId, explicit: false });
   });
@@ -356,7 +366,7 @@ describe('AccountingModule — Events', () => {
     mocks.payments._emit('transfer:incoming', transfer);
     await new Promise((r) => setTimeout(r, 30));
 
-    const overpaymentCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:overpayment');
+    const overpaymentCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:overpayment');
     expect(overpaymentCalls.length).toBeGreaterThan(0);
     expect(overpaymentCalls[0][1]).toMatchObject({ invoiceId });
   });
@@ -444,10 +454,10 @@ describe('AccountingModule — Events', () => {
     mocks.payments._emit('transfer:incoming', transfer);
     await new Promise((r) => setTimeout(r, 30));
 
-    const irrelevantCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:irrelevant');
+    const irrelevantCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:irrelevant');
     expect(irrelevantCalls.length).toBeGreaterThan(0);
-    const reasons = irrelevantCalls.map(([, p]: [string, any]) => p.reason);
-    expect(reasons.some((r: string) => r === 'unknown_address' || r === 'unknown_address_and_asset')).toBe(true);
+    const reasons = irrelevantCalls.map(([, p]: EmittedEvent) => p.reason);
+    expect(reasons.some((r) => r === 'unknown_address' || r === 'unknown_address_and_asset')).toBe(true);
   });
 
   // -------------------------------------------------------------------------
@@ -530,9 +540,9 @@ describe('AccountingModule — Events', () => {
     mocks.payments._emit('transfer:incoming', transfer);
     await new Promise((r) => setTimeout(r, 30));
 
-    const irrelevantCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:irrelevant');
+    const irrelevantCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:irrelevant');
     const unknownAssetCalls = irrelevantCalls.filter(
-      ([, p]: [string, any]) => p.reason === 'unknown_asset',
+      ([, p]: EmittedEvent) => p.reason === 'unknown_asset',
     );
     expect(unknownAssetCalls.length).toBeGreaterThan(0);
   });
@@ -602,7 +612,7 @@ describe('AccountingModule — Events', () => {
     );
 
     // auto_return_failed must fire since send() was rejected
-    const failedCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:auto_return_failed');
+    const failedCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:auto_return_failed');
     expect(failedCalls.length).toBeGreaterThan(0);
     expect(failedCalls[0][1]).toMatchObject({ invoiceId });
   });
@@ -627,7 +637,7 @@ describe('AccountingModule — Events', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Events may fire multiple times (idempotency is on ledger, not events)
-    const paymentCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:payment');
+    const paymentCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:payment');
     expect(paymentCalls.length).toBeGreaterThanOrEqual(1);
 
     // Ledger should not double-count: dedup key prevents it.
@@ -770,7 +780,7 @@ describe('AccountingModule — Events', () => {
     mocks.payments._emit('transfer:incoming', transfer);
     await new Promise((r) => setTimeout(r, 30));
 
-    const unknownCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:unknown_reference');
+    const unknownCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:unknown_reference');
     expect(unknownCalls.length).toBeGreaterThan(0);
     expect(unknownCalls[0][1]).toMatchObject({ invoiceId: unknownInvoiceId });
   });
@@ -805,7 +815,7 @@ describe('AccountingModule — Events', () => {
 
     // unknown_reference still fires (preserves backward-compat observability)
     const unknownCalls = emitEvent.mock.calls.filter(
-      ([evt]: [string]) => evt === 'invoice:unknown_reference',
+      ([evt]: EmittedEvent) => evt === 'invoice:unknown_reference',
     );
     expect(unknownCalls.length).toBeGreaterThan(0);
     expect(unknownCalls[0][1]).toMatchObject({ invoiceId: lateInvoiceId });
@@ -884,7 +894,7 @@ describe('AccountingModule — Events', () => {
     await new Promise((r) => setTimeout(r, 30));
 
     // over_refund_warning must fire since returned (6 UCT) > forwarded (5 UCT)
-    const warnCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:over_refund_warning');
+    const warnCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:over_refund_warning');
     expect(warnCalls.length).toBeGreaterThan(0);
     expect(warnCalls[0][1]).toMatchObject({ invoiceId });
   });
@@ -943,10 +953,9 @@ describe('AccountingModule — Events', () => {
     // Since it's a "back" direction (return), and senderPubkey can't be resolved to a
     // target address, it should fire unauthorized_return (same pattern as UT-EVENTS-003b).
     // The key assertion is that the pipeline did NOT treat this as a forward payment.
-    const paymentCalls = emitEvent.mock.calls.filter(([evt]: [string]) => evt === 'invoice:payment');
+    const paymentCalls = emitEvent.mock.calls.filter(([evt]: EmittedEvent) => evt === 'invoice:payment');
     const forwardPayments = paymentCalls.filter(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ([, payload]: [string, any]) => payload.paymentDirection === 'forward',
+      ([, payload]: EmittedEvent) => payload.paymentDirection === 'forward',
     );
     // No forward payment events should have fired — the on-chain "back" overrides memo "F"
     expect(forwardPayments.length).toBe(0);

--- a/tests/unit/modules/AccountingModule.lifecycle.test.ts
+++ b/tests/unit/modules/AccountingModule.lifecycle.test.ts
@@ -274,7 +274,7 @@ describe('UT-LIFECYCLE-005: destroy() unsubscribes from events', () => {
 
     // Capture the call count of the actual emitEvent mock BEFORE emitting
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const countBefore = (module as any).deps?.emitEvent?.mock?.calls?.length ?? 0;
+    const countBefore = (module as unknown as { deps?: { emitEvent?: ReturnType<typeof vi.fn> } }).deps?.emitEvent?.mock?.calls?.length ?? 0;
 
     // Re-emit a transfer event — the destroyed module should ignore it
     mocks.payments._emit('transfer:incoming', {
@@ -285,7 +285,7 @@ describe('UT-LIFECYCLE-005: destroy() unsubscribes from events', () => {
 
     // emitEvent should not have been called again after destroy
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const countAfter = (module as any).deps?.emitEvent?.mock?.calls?.length ?? 0;
+    const countAfter = (module as unknown as { deps?: { emitEvent?: ReturnType<typeof vi.fn> } }).deps?.emitEvent?.mock?.calls?.length ?? 0;
     expect(countAfter).toBe(countBefore);
   });
 });
@@ -397,8 +397,8 @@ describe('UT-LIFECYCLE-007: I/O methods throw MODULE_DESTROYED after destroy', (
   it('payInvoice() throws MODULE_DESTROYED', async () => {
     await expectModuleDestroyed(() =>
       module.payInvoice('a'.repeat(64), {
-        targetAddress: 'DIRECT://alice',
-        assets: [{ coin: ['UCT', '100'] }],
+        targetIndex: 0,
+        amount: '100',
       }),
     );
   });
@@ -406,9 +406,9 @@ describe('UT-LIFECYCLE-007: I/O methods throw MODULE_DESTROYED after destroy', (
   it('returnInvoicePayment() throws MODULE_DESTROYED', async () => {
     await expectModuleDestroyed(() =>
       module.returnInvoicePayment('a'.repeat(64), {
-        targetAddress: 'DIRECT://alice',
-        senderAddress: 'DIRECT://sender',
-        assets: [{ coin: ['UCT', '100'] }],
+        recipient: 'DIRECT://sender',
+        amount: '100',
+        coinId: 'UCT',
       }),
     );
   });

--- a/tests/unit/modules/AccountingModule.minting.test.ts
+++ b/tests/unit/modules/AccountingModule.minting.test.ts
@@ -81,7 +81,9 @@ describe('UT-MINT-001: createInvoice mints via engine.mintDataToken', () => {
     expect(bytesToHex(params.tokenType!)).toBe(INVOICE_TOKEN_TYPE_HEX);
 
     // Mint payload = the canonical serialization of the returned terms.
-    expect(new TextDecoder().decode(params.data)).toBe(canonicalSerialize(result.terms));
+    // `terms` is optional on CreateInvoiceResult (absent only on failure); a
+    // successful createInvoice always populates it.
+    expect(new TextDecoder().decode(params.data)).toBe(canonicalSerialize(result.terms!));
 
     // Deterministic salt: 32 bytes (SHA-256 over signing key || serialized terms).
     expect(params.salt).toBeInstanceOf(Uint8Array);
@@ -143,15 +145,15 @@ describe('UT-MINT-008: stored engine blob carries the canonical serialized terms
     const result = await module.createInvoice(request);
 
     // Returned terms reflect the request.
-    expect(result.terms.memo).toBe('test memo');
-    expect(result.terms.targets).toEqual(request.targets);
+    expect(result.terms!.memo).toBe('test memo');
+    expect(result.terms!.targets).toEqual(request.targets);
 
     // Decode the stored blob via the SAME engine instance and read the data back.
     const added = (mocks.payments as any).addToken.mock.calls.at(-1)[0];
     const token = await engine.decodeToken(decodeTokenBlob(hexToBytes(added.sdkData)));
     const dataBytes = engine.readTokenData(token);
     expect(dataBytes).not.toBeNull();
-    expect(new TextDecoder().decode(dataBytes!)).toBe(canonicalSerialize(result.terms));
+    expect(new TextDecoder().decode(dataBytes!)).toBe(canonicalSerialize(result.terms!));
   });
 
   it('result.token is the transmittable engine-blob hex matching the stored sdkData', async () => {

--- a/tests/unit/modules/AccountingModule.payInvoice-provisional.test.ts
+++ b/tests/unit/modules/AccountingModule.payInvoice-provisional.test.ts
@@ -364,9 +364,13 @@ describe('AccountingModule.payInvoice() — provisional reservation (BUG-002 Fix
     mocks.payments._tokens = [makeInvoiceToken(terms)];
     await module.load();
 
+    // `storage.set` is declared by StorageProvider as a plain method; the mock
+    // provider backs it with a vi.fn(), so recover the spy surface.
+    const storageSet = vi.mocked(mocks.storage.set);
+
     // Snapshot storage.set call count before payInvoice — load() may have
     // written some bookkeeping entries during initialization.
-    const setCallsBefore = mocks.storage.set.mock.calls.length;
+    const setCallsBefore = storageSet.mock.calls.length;
 
     const result = await module.payInvoice(INVOICE_ID, {
       targetIndex: 0,
@@ -375,7 +379,7 @@ describe('AccountingModule.payInvoice() — provisional reservation (BUG-002 Fix
 
     // Storage MUST have been written to during the payInvoice call — specifically,
     // the inv_ledger:{invoiceId} entry containing the provisional forward ref.
-    const setCallsDuring = mocks.storage.set.mock.calls.slice(setCallsBefore);
+    const setCallsDuring = storageSet.mock.calls.slice(setCallsBefore);
     const ledgerWrites = setCallsDuring.filter(([key]) =>
       typeof key === 'string' && key.includes(`inv_ledger:${INVOICE_ID}`),
     );
@@ -418,9 +422,12 @@ describe('AccountingModule.payInvoice() — provisional reservation (BUG-002 Fix
     // Reject the FIRST `inv_ledger:` storage write that occurs during payInvoice.
     // We must let earlier load()-time writes (and any pre-payInvoice setup writes)
     // pass through — only fail the per-invoice ledger persistence.
-    const realSet = mocks.storage.set.getMockImplementation();
+    // `storage.set` is declared by StorageProvider as a plain method; the mock
+    // provider backs it with a vi.fn(), so recover the spy surface.
+    const storageSet = vi.mocked(mocks.storage.set);
+    const realSet = storageSet.getMockImplementation();
     let rejected = false;
-    mocks.storage.set.mockImplementation((key: string, value: string): Promise<void> => {
+    storageSet.mockImplementation((key: string, value: string): Promise<void> => {
       if (!rejected && key.includes(`inv_ledger:${INVOICE_ID}`)) {
         rejected = true;
         return Promise.reject(new Error('mock storage failure: disk full'));

--- a/tests/unit/modules/AccountingModule.v2-createInvoice.test.ts
+++ b/tests/unit/modules/AccountingModule.v2-createInvoice.test.ts
@@ -69,7 +69,7 @@ describe('importInvoice — v2 engine path (B2)', () => {
     // A fresh importer (same engine fixture) decodes + verifies + stores it.
     const importer = createTestAccountingModule({ tokenEngine: engine });
     (importer.mocks.payments as any).addToken = vi.fn().mockResolvedValue(undefined);
-    const terms = await importer.module.importInvoice(created.token);
+    const terms = await importer.module.importInvoice(created.token!);
 
     expect(terms.memo).toBe('round-trip');
     // Stored under the same genesis-stable id with the blob as sdkData.
@@ -90,7 +90,7 @@ describe('importInvoice — v2 engine path (B2)', () => {
     const importer = createTestAccountingModule({ tokenEngine: badEngine });
     (importer.mocks.payments as any).addToken = vi.fn().mockResolvedValue(undefined);
 
-    await expect(importer.module.importInvoice(created.token)).rejects.toThrow(/proof is invalid/i);
+    await expect(importer.module.importInvoice(created.token!)).rejects.toThrow(/proof is invalid/i);
   });
 });
 

--- a/tests/unit/modules/CommunicationsModule.resolve.test.ts
+++ b/tests/unit/modules/CommunicationsModule.resolve.test.ts
@@ -119,8 +119,8 @@ describe('CommunicationsModule — resolvePeerNametag', () => {
 
   it('should return undefined when transport does not support resolveTransportPubkeyInfo', async () => {
     const transport = createMockTransport();
-    // Ensure resolveTransportPubkeyInfo is not defined
-    delete (transport as Record<string, unknown>).resolveTransportPubkeyInfo;
+    // Ensure resolveTransportPubkeyInfo is not defined (it is an optional member)
+    delete transport.resolveTransportPubkeyInfo;
     mod.initialize(createDeps({ transport }));
 
     const result = await mod.resolvePeerNametag(PEER_PUBKEY);

--- a/tests/unit/modules/CommunicationsModule.storage.test.ts
+++ b/tests/unit/modules/CommunicationsModule.storage.test.ts
@@ -254,7 +254,7 @@ describe('CommunicationsModule — storage & pagination', () => {
 
       const transport1 = createMockTransport();
       (transport1.onMessage as ReturnType<typeof vi.fn>).mockReturnValue(unsub1);
-      (transport1 as Record<string, unknown>).onComposing = vi.fn().mockReturnValue(unsub2);
+      transport1.onComposing = vi.fn().mockReturnValue(unsub2);
 
       const deps1 = createDeps({ transport: transport1 });
       mod.initialize(deps1);

--- a/tests/unit/modules/MarketModule.test.ts
+++ b/tests/unit/modules/MarketModule.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { MarketModule, createMarketModule, DEFAULT_MARKET_API_URL } from '../../../modules/market/MarketModule';
 import type { FullIdentity } from '../../../types';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
@@ -61,7 +62,10 @@ function createRegisteredModule(config?: Parameters<typeof createMarketModule>[0
 // =============================================================================
 
 describe('MarketModule', () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // Typed as a spy of the real `fetch` so `fetchSpy.mock.calls[n]` keeps its
+  // `[input, init?: RequestInit]` shape (untyped `ReturnType<typeof vi.spyOn>`
+  // erases the arguments to `unknown[]`).
+  let fetchSpy: MockInstance<typeof globalThis.fetch>;
 
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({}));

--- a/tests/unit/modules/PaymentsModule.concurrent-send.test.ts
+++ b/tests/unit/modules/PaymentsModule.concurrent-send.test.ts
@@ -39,8 +39,13 @@ import { testIdentity } from '../../support/wallet-api-test-helpers';
 import { FakeTokenEngine } from '../token-engine/FakeTokenEngine';
 import type { FakeWalletApi } from '../../support/fake-wallet-api';
 import type { TransportProvider } from '../../../transport';
-import type { SphereToken } from '../../../token-engine';
-import type { EngineOpOptions, SplitParams, SplitResult, TransferParams } from '../../../token-engine/engine';
+import type {
+  EngineOpOptions,
+  SphereToken,
+  SplitParams,
+  SplitResult,
+  TransferParams,
+} from '../../../token-engine';
 
 const UCT = '11'.repeat(32);
 const SELF = testIdentity(41);

--- a/tests/unit/modules/PaymentsModule.fail-closed.test.ts
+++ b/tests/unit/modules/PaymentsModule.fail-closed.test.ts
@@ -47,7 +47,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -165,7 +164,7 @@ function makeDeps(
 }
 
 function initModule(deps: PaymentsModuleDependencies) {
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return module;
@@ -194,7 +193,7 @@ describe('#515 F1 — fail-closed composition invariant (S7 legality matrix)', (
 
   it("delivery custody 'inventory' without walletApi throws INVALID_CONFIG", () => {
     const parts = makeParts();
-    const module = createPaymentsModule({ l1: null });
+    const module = createPaymentsModule();
     let thrown: unknown;
     try {
       module.initialize(makeDeps(parts, { storage: parts.localStorage, custody: 'inventory' }));
@@ -208,7 +207,7 @@ describe('#515 F1 — fail-closed composition invariant (S7 legality matrix)', (
 
   it('an active thin storage provider without walletApi throws INVALID_CONFIG (any delivery)', () => {
     const parts = makeParts();
-    const module = createPaymentsModule({ l1: null });
+    const module = createPaymentsModule();
     let thrown: unknown;
     try {
       module.initialize(makeDeps(parts, { storage: parts.thinStorage }));
@@ -222,7 +221,7 @@ describe('#515 F1 — fail-closed composition invariant (S7 legality matrix)', (
 
   it('the full degraded incident composition (thin storage + inventory delivery, no client) throws', () => {
     const parts = makeParts();
-    const module = createPaymentsModule({ l1: null });
+    const module = createPaymentsModule();
     expect(() =>
       module.initialize(makeDeps(parts, { storage: parts.thinStorage, custody: 'inventory' }))
     ).toThrow(SphereError);
@@ -296,7 +295,7 @@ describe('#516 — failed putIntent must NOT leave a re-executable open intent',
       delivery,
       walletApi: client,
     };
-    const module = createPaymentsModule({ l1: null });
+    const module = createPaymentsModule();
     module.initialize(deps);
     cleanups.push(() => module.destroy());
 
@@ -376,7 +375,7 @@ describe('#670 — deterministic putIntent VALIDATION rejection is terminal', ()
       delivery,
       walletApi: client,
     };
-    const module = createPaymentsModule({ l1: null });
+    const module = createPaymentsModule();
     module.initialize(deps);
     cleanups.push(() => module.destroy());
 

--- a/tests/unit/modules/PaymentsModule.history-hydration.test.ts
+++ b/tests/unit/modules/PaymentsModule.history-hydration.test.ts
@@ -23,7 +23,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -105,7 +104,7 @@ function makeDeps(who: { privateKey: string; chainPubkey: string }, walletApi: P
 }
 
 function makeModule(deps: PaymentsModuleDependencies): PaymentsModule {
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return module;

--- a/tests/unit/modules/PaymentsModule.history-integration.test.ts
+++ b/tests/unit/modules/PaymentsModule.history-integration.test.ts
@@ -65,7 +65,6 @@ function createMockIdentity(): FullIdentity {
     chainPubkey: ALICE.chainPubkey,
     directAddress: 'DIRECT://testaddr',
     privateKey: ALICE.privateKey,
-    transportPubkey: 'dd'.repeat(32),
   };
 }
 

--- a/tests/unit/modules/PaymentsModule.history-sync.test.ts
+++ b/tests/unit/modules/PaymentsModule.history-sync.test.ts
@@ -138,7 +138,9 @@ function createMockDeps() {
     onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
   } as unknown as TransportProvider;
 
-  // Post-cutover oracle surface: network config + legacy-TXF validateToken only.
+  // Post-cutover oracle surface: network config only. The legacy v1
+  // `validateToken` RPC was removed from OracleProvider (verification is the
+  // engine's job now), so there is nothing else to stub here.
   const mockOracle: OracleProvider = {
     id: 'mock-oracle',
     name: 'Mock Oracle',
@@ -148,7 +150,6 @@ function createMockDeps() {
     isConnected: vi.fn().mockReturnValue(true),
     getStatus: vi.fn().mockReturnValue('connected' as const),
     initialize: vi.fn().mockResolvedValue(undefined),
-    validateToken: vi.fn().mockResolvedValue({ valid: true, spent: false }),
     getTrustBaseJson: vi.fn().mockReturnValue(null),
     getAggregatorUrl: vi.fn().mockReturnValue('https://aggregator.test'),
     getApiKey: vi.fn().mockReturnValue(undefined),

--- a/tests/unit/modules/PaymentsModule.history.test.ts
+++ b/tests/unit/modules/PaymentsModule.history.test.ts
@@ -41,7 +41,6 @@ function mockIdentity(): FullIdentity {
     chainPubkey: FAKE_PUBKEY,
     directAddress: 'DIRECT://testaddress',
     privateKey: FAKE_PRIVATE_KEY,
-    transportPubkey: 'c'.repeat(64),
   };
 }
 

--- a/tests/unit/modules/PaymentsModule.journey-backlog.test.ts
+++ b/tests/unit/modules/PaymentsModule.journey-backlog.test.ts
@@ -62,7 +62,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -173,7 +172,7 @@ function makeFullPresetWallet(
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client, emitEvent, storage, deps };
@@ -360,7 +359,7 @@ function makeOfflineCapableWallet(
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client, emitEvent, storage, deps };

--- a/tests/unit/modules/PaymentsModule.load-coalescing.test.ts
+++ b/tests/unit/modules/PaymentsModule.load-coalescing.test.ts
@@ -24,7 +24,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -105,7 +104,7 @@ function makeModule(provider: TokenStorageProvider<TxfStorageDataBase>): {
   emitEvent: ReturnType<typeof vi.fn>;
 } {
   const deps = makeDeps(provider);
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, emitEvent: deps.emitEvent as ReturnType<typeof vi.fn> };

--- a/tests/unit/modules/PaymentsModule.multi-token-send.test.ts
+++ b/tests/unit/modules/PaymentsModule.multi-token-send.test.ts
@@ -34,7 +34,6 @@ import { FakeTokenEngine } from '../token-engine/FakeTokenEngine';
 import { decodeTokenBlob, encodeTokenBlob } from '../../../token-engine/token-blob';
 import { bytesToHex, hexToBytes } from '../../../core/crypto';
 import type { V2TransferPayload } from '../../../types/v2-transfer';
-import { createMemoryDelivery } from '../../support/memory-delivery';
 
 // ── Scenario ─────────────────────────────────────────────────────────────────
 
@@ -162,7 +161,7 @@ class SimulatedNetworkEngine extends FakeTokenEngine {
 function mockIdentity(): FullIdentity {
   return {
     chainPubkey: FAKE_PUBKEY, directAddress: 'DIRECT://x',
-    privateKey: FAKE_PRIVATE_KEY, transportPubkey: 'dd'.repeat(32),
+    privateKey: FAKE_PRIVATE_KEY,
   };
 }
 

--- a/tests/unit/modules/PaymentsModule.payment-requests.test.ts
+++ b/tests/unit/modules/PaymentsModule.payment-requests.test.ts
@@ -44,7 +44,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -177,7 +176,7 @@ function makeWalletApiWallet(
     walletApi: client,
     ...(getCurrentNametag !== undefined ? { getCurrentNametag } : {}),
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client, transport, emitEvent, storage, deps };
@@ -529,7 +528,7 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
       // durable journal and hold it settling instead.
       expect(fake.getPaymentRequest(reqId)).toMatchObject({ status: 'open' });
 
-      const reopened = createPaymentsModule({ l1: null });
+      const reopened = createPaymentsModule();
       reopened.initialize({ ...payer.deps });
       cleanups.push(() => reopened.destroy());
       const reNotified: IncomingPaymentRequest[] = [];
@@ -646,7 +645,7 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
       // A fresh module over the same storage must LOAD + PUMP without throwing.
       // Without the JSON.parse guard, ensureSettlingJournalLoaded throws and wedges
       // the whole payment-request pump / resume path.
-      const reopened = createPaymentsModule({ l1: null });
+      const reopened = createPaymentsModule();
       reopened.initialize({ ...payer.deps });
       cleanups.push(() => reopened.destroy());
       await reopened.load();
@@ -802,7 +801,7 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     // in-memory — pre-#556 only the still-open `openReq` survived, and the
     // resolved paid/declined requests VANISHED. The #556 full `since=0`
     // hydration must rebuild the CURRENT state of ALL incoming requests.
-    const reopened = createPaymentsModule({ l1: null });
+    const reopened = createPaymentsModule();
     reopened.initialize({ ...payer.deps });
     cleanups.push(() => reopened.destroy());
     const reNotified: IncomingPaymentRequest[] = [];
@@ -948,7 +947,7 @@ describe('payment requests ride wallet-api (S4 AC: create → notify → respond
     vi.spyOn(payer.client, 'listPaymentRequests').mockImplementationOnce(() =>
       Promise.reject(new Error('simulated outage'))
     );
-    const restarted = createPaymentsModule({ l1: null });
+    const restarted = createPaymentsModule();
     restarted.initialize({ ...payer.deps });
     cleanups.push(() => restarted.destroy());
 
@@ -985,7 +984,7 @@ describe('payment requests require wallet-api — there is no Nostr fallback', (
       oracle: mockOracle(),
       emitEvent: vi.fn(),
     };
-    const module = createPaymentsModule({ l1: null });
+    const module = createPaymentsModule();
     module.initialize(deps);
     cleanups.push(() => module.destroy());
 

--- a/tests/unit/modules/PaymentsModule.receive-fresh-pump.test.ts
+++ b/tests/unit/modules/PaymentsModule.receive-fresh-pump.test.ts
@@ -56,7 +56,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -213,7 +212,7 @@ function makeWallet(
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, delivery };

--- a/tests/unit/modules/PaymentsModule.storage-guard-migration.test.ts
+++ b/tests/unit/modules/PaymentsModule.storage-guard-migration.test.ts
@@ -35,7 +35,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -132,7 +131,7 @@ function makeDeps(local: LocalProvider): PaymentsModuleDependencies {
 }
 
 function initModule(deps: PaymentsModuleDependencies) {
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return module;

--- a/tests/unit/modules/PaymentsModule.tokenTransfers.test.ts
+++ b/tests/unit/modules/PaymentsModule.tokenTransfers.test.ts
@@ -25,6 +25,7 @@ import type { FakeWalletApi } from '../../support/fake-wallet-api';
 import { testIdentity } from '../../support/wallet-api-test-helpers';
 import {
   fullIdentity,
+  peerInfoOf,
   makeFullPresetWallet,
   seedServerToken,
   startFakeWalletApi,
@@ -36,7 +37,7 @@ const UCT = '11'.repeat(32); // v2 coin ids are lowercase hex
 const ALICE = testIdentity(21); // the wallet under test (real keypair — the backend verifies signatures)
 const BOB = testIdentity(22); // the recipient
 /** Bob's transport-layer coordinates, as the transport would publish them. */
-const BOB_PEER = fullIdentity(BOB);
+const BOB_PEER = peerInfoOf(BOB, 'bob');
 
 /** Bob is reachable AND has published a chain identity — the happy peer. */
 function mockTransport(): TransportProvider {

--- a/tests/unit/modules/PaymentsModule.tombstone.test.ts
+++ b/tests/unit/modules/PaymentsModule.tombstone.test.ts
@@ -19,13 +19,20 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createPaymentsModule, type PaymentsModuleDependencies } from '../../../modules/payments/PaymentsModule';
-import type { Token, FullIdentity } from '../../../types';
+import type { Token, FullIdentity, TrackedAddressEntry } from '../../../types';
 import type { TombstoneEntry } from '../../../types/txf';
-import type { StorageProvider, TokenStorageProvider, TxfStorageDataBase } from '../../../storage';
+import type {
+  ApplyDeltaAdded,
+  ApplyDeltaOptions,
+  InventoryView,
+  StorageProvider,
+  TokenStorageProvider,
+  TxfStorageDataBase,
+} from '../../../storage';
 import type { TransportProvider } from '../../../transport';
 import type { OracleProvider } from '../../../oracle';
 import { FakeTokenEngine } from '../token-engine/FakeTokenEngine';
-import type { SphereToken } from '../../../token-engine';
+import type { SphereToken, TokenBlob } from '../../../token-engine';
 import { encodeTokenBlob } from '../../../token-engine/token-blob';
 import { sha256, bytesToHex } from '../../../core/crypto';
 
@@ -152,6 +159,8 @@ function createMockDeps(engine: FakeTokenEngine): PaymentsModuleDependencies {
     has: vi.fn().mockResolvedValue(false),
     keys: vi.fn().mockResolvedValue([]),
     clear: vi.fn().mockResolvedValue(undefined),
+    saveTrackedAddresses: vi.fn(async (_entries: TrackedAddressEntry[]): Promise<void> => {}),
+    loadTrackedAddresses: vi.fn(async (): Promise<TrackedAddressEntry[]> => []),
   };
 
   const mockTokenStorage: TokenStorageProvider<TxfStorageDataBase> = {
@@ -168,6 +177,21 @@ function createMockDeps(engine: FakeTokenEngine): PaymentsModuleDependencies {
     save: vi.fn().mockResolvedValue({ success: true, timestamp: Date.now() }),
     load: vi.fn().mockResolvedValue({ success: false, source: 'local' as const, timestamp: Date.now() }),
     sync: vi.fn().mockResolvedValue({ success: true, added: 0, removed: 0, conflicts: 0 }),
+    // Lazy-inventory port (S2). This double holds nothing, so the view is empty
+    // and getToken() takes the documented "unknown token" throw. The tombstone
+    // paths under test (addToken/removeToken/mergeTombstones) only ever save().
+    listInventory: vi.fn(async (_since?: bigint): Promise<InventoryView> => ({
+      cursor: 0n, syncEpoch: 0n, more: false, items: [],
+    })),
+    getToken: vi.fn(async (tokenId: string): Promise<TokenBlob> => {
+      throw new Error(`Unknown token: ${tokenId}`);
+    }),
+    applyDelta: vi.fn(async (
+      _transferId: string,
+      _spent: string[],
+      _added: ApplyDeltaAdded[],
+      _opts?: ApplyDeltaOptions,
+    ): Promise<void> => {}),
   };
 
   const tokenStorageProviders = new Map<string, TokenStorageProvider<TxfStorageDataBase>>();
@@ -190,7 +214,8 @@ function createMockDeps(engine: FakeTokenEngine): PaymentsModuleDependencies {
     onPaymentRequestResponse: vi.fn().mockReturnValue(() => {}),
   } as unknown as TransportProvider;
 
-  // Post-cutover oracle surface: network config + legacy-TXF validateToken only.
+  // Post-cutover oracle surface: network config ONLY. `validateToken` was
+  // removed with the v1 stack — verification is the engine's job now.
   const mockOracle: OracleProvider = {
     id: 'mock-oracle',
     name: 'Mock Oracle',
@@ -200,7 +225,6 @@ function createMockDeps(engine: FakeTokenEngine): PaymentsModuleDependencies {
     isConnected: vi.fn().mockReturnValue(true),
     getStatus: vi.fn().mockReturnValue('connected' as const),
     initialize: vi.fn().mockResolvedValue(undefined),
-    validateToken: vi.fn().mockResolvedValue({ valid: true, spent: false }),
     getTrustBaseJson: vi.fn().mockReturnValue(null),
     getAggregatorUrl: vi.fn().mockReturnValue('https://aggregator.test'),
     getApiKey: vi.fn().mockReturnValue(undefined),

--- a/tests/unit/modules/PaymentsModule.v2-receive.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-receive.test.ts
@@ -45,7 +45,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -181,7 +180,7 @@ async function makeWallet(
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   await module.load();

--- a/tests/unit/modules/PaymentsModule.v2-send-recovery.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-send-recovery.test.ts
@@ -52,7 +52,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: 'dd'.repeat(32),
   };
 }
 

--- a/tests/unit/modules/PaymentsModule.v2-validate.test.ts
+++ b/tests/unit/modules/PaymentsModule.v2-validate.test.ts
@@ -24,7 +24,7 @@ const UCT = '11'.repeat(32);
 function mockIdentity(): FullIdentity {
   return {
     chainPubkey: FAKE_PUBKEY, directAddress: 'DIRECT://x',
-    privateKey: FAKE_PRIVATE_KEY, transportPubkey: 'dd'.repeat(32),
+    privateKey: FAKE_PRIVATE_KEY,
   };
 }
 

--- a/tests/unit/modules/PaymentsModule.wake-consumers.test.ts
+++ b/tests/unit/modules/PaymentsModule.wake-consumers.test.ts
@@ -44,7 +44,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -143,7 +142,7 @@ function makeWallet(
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client, emitEvent, storage };

--- a/tests/unit/modules/PaymentsModule.wake-reconnect.test.ts
+++ b/tests/unit/modules/PaymentsModule.wake-reconnect.test.ts
@@ -36,7 +36,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -120,7 +119,7 @@ function makeWallet(baseUrl: string, network: string, who: { privateKey: string;
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client };

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -44,7 +44,6 @@ function fullIdentity(id: { privateKey: string; chainPubkey: string }): FullIden
     chainPubkey: id.chainPubkey,
     privateKey: id.privateKey,
     directAddress: `DIRECT://${id.chainPubkey.slice(0, 12)}`,
-    transportPubkey: id.chainPubkey.slice(2),
   };
 }
 
@@ -166,7 +165,7 @@ function makeFullPresetWallet(
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client, delivery, emitEvent, storage, deps };
@@ -197,7 +196,7 @@ function makeOwnStorageWallet(
     delivery,
     walletApi: client,
   };
-  const module = createPaymentsModule({ l1: null });
+  const module = createPaymentsModule();
   module.initialize(deps);
   cleanups.push(() => module.destroy());
   return { module, engine, client, delivery, emitEvent, storage, deps };
@@ -315,7 +314,7 @@ describe('send — full wallet-api preset (S2 consumer + S3 + §7 pipeline)', ()
     await sender.module.load();
     await sender.module.mintFungibleToken(UCT, 1000n); // token exists BEFORE we break save
 
-    const local = sender.deps.tokenStorageProviders.get('local')!;
+    const local = sender.deps.tokenStorageProviders!.get('local')!;
     local.save = vi.fn(async () => ({ success: false, error: 'local save failed', timestamp: 0 }));
 
     await expect(
@@ -469,7 +468,7 @@ describe('send — batched mailbox deposit (#699)', () => {
     // "Restart" with the endpoint healthy again: load()'s replay converges the
     // journal per entry (replayOneDelivery — deliberately not batched, #699).
     batchDeposit.mockRestore();
-    const second = createPaymentsModule({ l1: null });
+    const second = createPaymentsModule();
     second.initialize({ ...sender.deps });
     cleanups.push(() => second.destroy());
     await second.load();
@@ -678,7 +677,7 @@ describe('interrupted deposit — journal replay on next load (S3 AC)', () => {
 
     // "Restart": a fresh module over the SAME storage + providers replays the
     // journal from load() — the deposit lands.
-    const second = createPaymentsModule({ l1: null });
+    const second = createPaymentsModule();
     second.initialize({ ...sender.deps });
     cleanups.push(() => second.destroy());
     await second.load();

--- a/tests/unit/modules/SpendQueue.starvation.test.ts
+++ b/tests/unit/modules/SpendQueue.starvation.test.ts
@@ -11,7 +11,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 import {
   SpendQueue,
   SpendPlanner,
@@ -28,6 +28,9 @@ import type { SplitPlan, TokenWithAmount } from '../../../modules/payments/Token
 // =============================================================================
 // Test helpers
 // =============================================================================
+
+/** The candidate free-view list the planner is called with. */
+type SplitCandidates = Parameters<SpendPlanner['calculateOptimalSplitSync']>[0];
 
 let tokenCounter = 0;
 
@@ -114,7 +117,7 @@ describe('SpendQueue Starvation Protection', () => {
   let parsedCache: Map<string, ParsedTokenEntry>;
 
   // We spy on calculateOptimalSplitSync to control when plans succeed/fail
-  let calculateSpy: ReturnType<typeof vi.spyOn>;
+  let calculateSpy: MockInstance<SpendPlanner['calculateOptimalSplitSync']>;
 
   // Shared tokens used across tests — large enough pool to support various scenarios
   let smallToken: Token;
@@ -236,7 +239,7 @@ describe('SpendQueue Starvation Protection', () => {
       parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
 
       // large fails, small succeeds
-      calculateSpy.mockImplementation((_candidates: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_candidates: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 1_000_000n) return null;
         return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
       });
@@ -305,7 +308,7 @@ describe('SpendQueue Starvation Protection', () => {
       parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
       parsedCache.set(smallToken2.id, makeParsedEntry(smallToken2, 100_000n));
       let smallCallCount = 0;
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 1_000_000n) return null;
         smallCallCount++;
         if (smallCallCount === 1) return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
@@ -324,7 +327,7 @@ describe('SpendQueue Starvation Protection', () => {
       parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
 
       let largeCanPlan = false;
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 1_000_000n) {
           if (!largeCanPlan) return null;
           return makeDirectPlan([{ token: largeToken, amount: 1_000_000n }], 1_000_000n);
@@ -356,7 +359,7 @@ describe('SpendQueue Starvation Protection', () => {
       parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
 
       let largeCanPlan = false;
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 1_000_000n) {
           if (!largeCanPlan) return null;
           return makeDirectPlan([{ token: largeToken, amount: 1_000_000n }], 1_000_000n);
@@ -428,7 +431,7 @@ describe('SpendQueue Starvation Protection', () => {
 
       // Make 'behind' plannable — queue continues past blocker and serves it
       parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 1_000_000n) return null;
         return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
       });
@@ -442,7 +445,7 @@ describe('SpendQueue Starvation Protection', () => {
     it('successfully planned entry is removed without affecting others', () => {
       const coinId = 'UCT';
 
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 500_000n) return null;
         return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
       });
@@ -465,7 +468,7 @@ describe('SpendQueue Starvation Protection', () => {
       const tokB = makeToken('COIN_B', 100_000n, 'b-tok');
       parsedCache.set(tokB.id, makeParsedEntry(tokB, 100_000n));
 
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 1_000_000n) return null; // COIN_A large
         return makeDirectPlan([{ token: tokB, amount: 100_000n }], 100_000n);
       });
@@ -498,7 +501,7 @@ describe('SpendQueue Starvation Protection', () => {
       const tokB = makeToken('COIN_B', 100_000n, 'b-tok-2');
       parsedCache.set(tokB.id, makeParsedEntry(tokB, 100_000n));
 
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 1_000_000n) return null;
         return makeDirectPlan([{ token: tokB, amount: 100_000n }], 100_000n);
       });
@@ -529,7 +532,7 @@ describe('SpendQueue Starvation Protection', () => {
       parsedCache.set(tinyTok.id, makeParsedEntry(tinyTok, 50_000n));
 
       // large and small fail, tiny succeeds
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 50_000n) {
           return makeDirectPlan([{ token: tinyTok, amount: 50_000n }], 50_000n);
         }
@@ -569,7 +572,7 @@ describe('SpendQueue Starvation Protection', () => {
       parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
 
       let largeCanPlan = false;
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 1_000_000n) {
           if (!largeCanPlan) return null;
           return makeDirectPlan([{ token: largeToken, amount: 1_000_000n }], 1_000_000n);
@@ -678,7 +681,7 @@ describe('SpendQueue Starvation Protection', () => {
       const coinId = 'UCT';
       parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
 
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 1_000_000n) return null; // impossible
         return makeDirectPlan([{ token: smallToken, amount: targetAmount }], targetAmount);
       });
@@ -757,7 +760,7 @@ describe('SpendQueue Starvation Protection', () => {
 
       let allowLarge = false;
       let smallIdx = 0;
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount >= 1_000_000n) {
           if (!allowLarge) return null;
           return makeDirectPlan([{ token: largeToken, amount: 1_000_000n }], 1_000_000n);
@@ -802,7 +805,7 @@ describe('SpendQueue Starvation Protection', () => {
       const coinId = 'UCT';
       parsedCache.set(smallToken.id, makeParsedEntry(smallToken, 100_000n));
 
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 999_999n) return null;
         return makeDirectPlan([{ token: smallToken, amount: 100_000n }], 100_000n);
       });
@@ -918,7 +921,7 @@ describe('SpendQueue Starvation Protection', () => {
       // Round 2: first entry succeeds, second entry fails
       // Round 3: second entry succeeds
       let round = 0;
-      calculateSpy.mockImplementation((_c: any, targetAmount: bigint) => {
+      calculateSpy.mockImplementation((_c: SplitCandidates, targetAmount: bigint) => {
         if (targetAmount === 200_000n) {
           if (round >= 2) return makeDirectPlan([{ token: smallToken, amount: 200_000n }], 200_000n);
           return null;

--- a/tests/unit/modules/SwapModule.lifecycle.test.ts
+++ b/tests/unit/modules/SwapModule.lifecycle.test.ts
@@ -182,7 +182,7 @@ describe('SwapModule Lifecycle', () => {
     injectSwapRef(module, swapRef);
 
     // Clear storage set calls so far
-    mocks.storage.set.mockClear();
+    vi.mocked(mocks.storage.set).mockClear();
 
     await module.destroy();
 
@@ -190,7 +190,7 @@ describe('SwapModule Lifecycle', () => {
     expect(mocks.storage.set).toHaveBeenCalled();
 
     // Verify that the index was persisted
-    const setCalls = mocks.storage.set.mock.calls;
+    const setCalls = vi.mocked(mocks.storage.set).mock.calls;
     const indexCallFound = setCalls.some((call: any[]) => {
       const key = call[0] as string;
       return key.includes(STORAGE_KEYS_ADDRESS.SWAP_INDEX);

--- a/tests/unit/modules/SwapModule.proposeSwap.test.ts
+++ b/tests/unit/modules/SwapModule.proposeSwap.test.ts
@@ -86,7 +86,7 @@ describe('SwapModule.proposeSwap()', () => {
     await module.proposeSwap(deal);
 
     // resolve called with @alice and @bob (plus escrow)
-    const resolveArgs = mocks.resolve.mock.calls.map((c: unknown[]) => c[0]);
+    const resolveArgs = vi.mocked(mocks.resolve).mock.calls.map((c: unknown[]) => c[0]);
     expect(resolveArgs).toContain('@alice');
     expect(resolveArgs).toContain('@bob');
   });

--- a/tests/unit/modules/SwapModule.storage.test.ts
+++ b/tests/unit/modules/SwapModule.storage.test.ts
@@ -71,18 +71,18 @@ describe('SwapModule Storage', () => {
     injectSwapRef(module, swapRef);
 
     // Clear storage mocks so we can track new writes
-    mocks.storage.set.mockClear();
+    vi.mocked(mocks.storage.set).mockClear();
 
     // acceptSwap transitions proposed -> accepted, which triggers persistSwap
     await module.acceptSwap(swapRef.swapId);
 
     // Verify storage.set was called with the swap record key
-    const setCallKeys = mocks.storage.set.mock.calls.map((c: any[]) => c[0] as string);
+    const setCallKeys = vi.mocked(mocks.storage.set).mock.calls.map((c: any[]) => c[0] as string);
     const expectedKey = swapRecordKey(addressId, swapRef.swapId);
     expect(setCallKeys).toContain(expectedKey);
 
     // Verify the stored JSON contains the updated progress
-    const swapRecordCall = mocks.storage.set.mock.calls.find(
+    const swapRecordCall = vi.mocked(mocks.storage.set).mock.calls.find(
       (c: any[]) => (c[0] as string) === expectedKey,
     );
     expect(swapRecordCall).toBeDefined();
@@ -149,7 +149,7 @@ describe('SwapModule Storage', () => {
     injectSwapRef(module, swapRef);
 
     // Clear storage calls from inject/load
-    mocks.storage.set.mockClear();
+    vi.mocked(mocks.storage.set).mockClear();
 
     await module.destroy();
 
@@ -157,7 +157,7 @@ describe('SwapModule Storage', () => {
     expect(mocks.storage.set).toHaveBeenCalled();
 
     const indexKey = swapIndexKey(addressId);
-    const indexCall = mocks.storage.set.mock.calls.find(
+    const indexCall = vi.mocked(mocks.storage.set).mock.calls.find(
       (c: any[]) => (c[0] as string) === indexKey,
     );
     expect(indexCall).toBeDefined();
@@ -238,7 +238,7 @@ describe('SwapModule Storage', () => {
     );
 
     // Clear remove calls
-    mocks.storage.remove.mockClear();
+    vi.mocked(mocks.storage.remove).mockClear();
 
     await module.load();
 
@@ -247,7 +247,7 @@ describe('SwapModule Storage', () => {
     expect(swaps.length).toBe(0);
 
     // storage.remove should have been called for the purged swap's record key
-    const removeCallKeys = mocks.storage.remove.mock.calls.map((c: any[]) => c[0] as string);
+    const removeCallKeys = vi.mocked(mocks.storage.remove).mock.calls.map((c: any[]) => c[0] as string);
     const expectedPurgeKey = swapRecordKey(addressId, completedSwapId);
     expect(removeCallKeys).toContain(expectedPurgeKey);
   });

--- a/tests/unit/modules/accounting-test-helpers.ts
+++ b/tests/unit/modules/accounting-test-helpers.ts
@@ -20,7 +20,8 @@ import type {
 import type { FullIdentity, TrackedAddress, TransferResult, Token, Asset, DirectMessage } from '../../../types/index.js';
 import type { TxfToken, TxfInclusionProof } from '../../../types/txf.js';
 import type { StorageProvider } from '../../../storage/storage-provider.js';
-import type { TokenStorageProvider, LoadResult, SaveResult, SyncResult } from '../../../storage/storage-provider.js';
+import type { InventoryView, TokenStorageProvider, LoadResult, SaveResult, SyncResult } from '../../../storage/storage-provider.js';
+import type { TokenBlob } from '../../../token-engine/index.js';
 import { SphereError } from '../../../core/errors.js';
 import { getAddressId } from '../../../constants.js';
 
@@ -372,6 +373,15 @@ export function createMockTokenStorageProvider(): MockTokenStorageProvider {
 
     addHistoryEntry: vi.fn().mockResolvedValue(undefined),
     getHistoryEntries: vi.fn().mockResolvedValue([]),
+
+    // S2 lazy-inventory surface. Present so this mock actually satisfies the
+    // provider contract; accounting never drives coin selection, so an empty
+    // view and a loud getToken are the honest stand-ins.
+    listInventory: vi.fn(async (): Promise<InventoryView> => ({ items: [], cursor: 0n, syncEpoch: 0n, more: false })),
+    getToken: vi.fn(async (tokenId: string): Promise<TokenBlob> => {
+      throw new Error(`mock token storage: no blob for ${tokenId}`);
+    }),
+    applyDelta: vi.fn(async (): Promise<void> => undefined),
 
     // Test helper: backing token map (for direct assertion in tests)
     _tokens: tokens,
@@ -827,8 +837,6 @@ export function createTestAccountingModule(overrides?: {
   communications?: MockCommunicationsModule;
   identity?: FullIdentity;
   trackedAddresses?: TrackedAddress[];
-  // C6-R17: Allow overriding trustBase for security tests (null/empty = rejection)
-  trustBase?: unknown;
   // Path B: inject a token engine to exercise the v2 mint/read paths.
   tokenEngine?: AccountingModuleDependencies['tokenEngine'];
 }): {
@@ -850,7 +858,6 @@ export function createTestAccountingModule(overrides?: {
     payments: payments as unknown as AccountingModuleDependencies['payments'],
     tokenStorage: tokenStorage as unknown as AccountingModuleDependencies['tokenStorage'],
     oracle: oracle as unknown as AccountingModuleDependencies['oracle'],
-    trustBase: overrides?.trustBase !== undefined ? overrides.trustBase : new Uint8Array([1, 2, 3]),
     identity,
     tokenEngine: overrides?.tokenEngine,
     getActiveAddresses: vi.fn().mockReturnValue(trackedAddresses),

--- a/tests/unit/price/CoinGeckoPriceProvider.test.ts
+++ b/tests/unit/price/CoinGeckoPriceProvider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 import { CoinGeckoPriceProvider } from '../../../price/CoinGeckoPriceProvider';
 import type { StorageProvider } from '../../../storage';
 import { STORAGE_KEYS_GLOBAL } from '../../../constants';
@@ -16,7 +16,7 @@ function createMockStorage(): StorageProvider {
 }
 
 describe('CoinGeckoPriceProvider', () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSpy: MockInstance<typeof globalThis.fetch>;
 
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, 'fetch');

--- a/tests/unit/registry/TokenRegistry.test.ts
+++ b/tests/unit/registry/TokenRegistry.test.ts
@@ -977,9 +977,9 @@ describe('StorageProvider Cache', () => {
     await registry.refreshFromRemote();
 
     // storage.set should NOT have been called with cache keys
-    const setCalls = (storage.set as ReturnType<typeof vi.fn>).mock.calls;
+    const setCalls = vi.mocked(storage.set).mock.calls;
     const cacheSetCalls = setCalls.filter(
-      ([key]: [string]) => key === STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE,
+      ([key]) => key === STORAGE_KEYS_GLOBAL.TOKEN_REGISTRY_CACHE,
     );
     expect(cacheSetCalls).toHaveLength(0);
   });

--- a/tests/unit/serialization/txf-serializer.test.ts
+++ b/tests/unit/serialization/txf-serializer.test.ts
@@ -407,7 +407,7 @@ describe('buildTxfStorageData()', () => {
       version: '2.0',
     };
 
-    const result = await buildTxfStorageData([], meta, { nametag });
+    const result = await buildTxfStorageData([], meta, { nametags: [nametag] });
 
     // Nametag is no longer saved in TXF to avoid duplication
     // It's saved separately via saveNametagToFileStorage() as nametag-{name}.json

--- a/tests/unit/support/mock-token-engine.ts
+++ b/tests/unit/support/mock-token-engine.ts
@@ -5,7 +5,7 @@ import type {
 
 /** Build a SphereToken stand-in for interaction tests (sdkToken/blob are inert). */
 export function mockSphereToken(value: SphereValue | null = { assets: [] }): SphereToken {
-  const blob: TokenBlob = { v: 1, network: 2, token: new Uint8Array() };
+  const blob: TokenBlob = { v: 1, network: 2, tokenId: '00'.repeat(32), token: new Uint8Array() };
   return { sdkToken: {} as SphereToken['sdkToken'], blob, value };
 }
 
@@ -17,7 +17,13 @@ export function createMockTokenEngine(overrides: Partial<ITokenEngine> = {}): IT
   const base: ITokenEngine = {
     getIdentity: vi.fn((): EngineIdentity => ({ chainPubkey: new Uint8Array(identity.chainPubkey) })),
     deriveIdentityAddress: vi.fn((pubkey?: Uint8Array) => Promise.resolve(`DIRECT://${hex(pubkey ?? identity.chainPubkey)}`)),
+    tokenId: vi.fn((t: SphereToken) => t.blob.tokenId),
     readValue: vi.fn((t: SphereToken) => t.value),
+    readMemo: vi.fn((_t: SphereToken) => null),
+    readTokenData: vi.fn((_t: SphereToken) => null),
+    mintDataToken: vi.fn(async () => mockSphereToken(null)),
+    isOwnedBy: vi.fn((_t: SphereToken, _pubkey: Uint8Array) => true),
+    deliveryKeys: vi.fn(async () => ({ tokenId: '00'.repeat(32), stateHash: '11'.repeat(32) })),
     balanceOf: vi.fn((_t: SphereToken, _c: CoinId) => 0n),
     mint: vi.fn(async () => mockSphereToken()),
     transfer: vi.fn(async () => mockSphereToken()),

--- a/tests/unit/transport/MultiAddressTransportMux.sharedClient.test.ts
+++ b/tests/unit/transport/MultiAddressTransportMux.sharedClient.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { NostrClient } from '@unicitylabs/nostr-js-sdk';
 
 const mockSubscribe = vi.fn().mockReturnValue('mock-sub-id');
 const mockUnsubscribe = vi.fn();
@@ -136,7 +137,7 @@ describe('MultiAddressTransportMux shared-NostrClient (#123)', () => {
     // inside its own connect(). To support the case where the Mux is
     // configured before that happens, the API accepts a getter.
     let lazyClient: ReturnType<typeof makeStub> | null = null;
-    const getter = vi.fn(() => lazyClient);
+    const getter = vi.fn((): NostrClient | null => asClient(lazyClient));
 
     NostrClientCtor.mockClear();
 
@@ -168,7 +169,7 @@ describe('MultiAddressTransportMux shared-NostrClient (#123)', () => {
     // runtime). The Mux must adopt the new client and re-issue its
     // wallet/chat subs.
     let currentClient = makeStub();
-    const getter = vi.fn(() => currentClient);
+    const getter = vi.fn((): NostrClient | null => asClient(currentClient));
 
     const mux = new MultiAddressTransportMux({
       relays: ['wss://relay1.test'],
@@ -532,7 +533,7 @@ describe('MultiAddressTransportMux shared-NostrClient (#123)', () => {
       createWebSocket: (() => {}) as any,
       timeout: 100,
       autoReconnect: false,
-      sharedNostrClient: () => activeClient,
+      sharedNostrClient: () => asClient(activeClient),
     });
 
     await mux.addAddress(0, TEST_IDENTITY);
@@ -554,7 +555,7 @@ describe('MultiAddressTransportMux shared-NostrClient (#123)', () => {
       createWebSocket: (() => {}) as any,
       timeout: 100,
       autoReconnect: false,
-      sharedNostrClient: () => activeClient,
+      sharedNostrClient: () => asClient(activeClient),
     });
 
     await mux.addAddress(0, TEST_IDENTITY);
@@ -609,6 +610,16 @@ describe('MultiAddressTransportMux shared-NostrClient (#123)', () => {
     expect(NostrClientCtor).toHaveBeenCalledTimes(2);
   });
 });
+
+/**
+ * The stubs are deliberately partial doubles of the SDK's NostrClient — only the
+ * members the Mux actually touches. The Mux config demands the real class type,
+ * so cast at that single boundary (the stub itself stays vi.fn-typed so the tests
+ * can assert on `.mock`).
+ */
+function asClient(stub: ReturnType<typeof makeStub> | null): NostrClient | null {
+  return stub as unknown as NostrClient | null;
+}
 
 function makeStub() {
   return {

--- a/tests/unit/transport/NostrTransportProvider.chatReady.test.ts
+++ b/tests/unit/transport/NostrTransportProvider.chatReady.test.ts
@@ -61,7 +61,9 @@ const { NostrTransportProvider } = await import('../../../transport/NostrTranspo
 function createProvider() {
   return new NostrTransportProvider({
     relays: ['wss://relay1.test'],
-    createWebSocket: (() => {}) as WebSocketFactory,
+    // Inert: the SDK's NostrClient (mocked here) owns its own sockets, so the
+    // factory is never invoked — it cannot return a real IWebSocket.
+    createWebSocket: (() => {}) as unknown as WebSocketFactory,
     timeout: 5000,
     autoReconnect: false,
   });

--- a/tests/unit/transport/NostrTransportProvider.nametag.test.ts
+++ b/tests/unit/transport/NostrTransportProvider.nametag.test.ts
@@ -199,7 +199,9 @@ const TEST_NAMETAG = 'alice';
 function createProvider() {
   return new NostrTransportProvider({
     relays: ['wss://test.relay'],
-    createWebSocket: (() => {}) as WebSocketFactory,
+    // Inert: the SDK's NostrClient (mocked here) owns its own sockets, so the
+    // factory is never invoked — it cannot return a real IWebSocket.
+    createWebSocket: (() => {}) as unknown as WebSocketFactory,
     timeout: 1000,
     autoReconnect: false,
   });

--- a/tests/unit/validation/TokenValidator.test.ts
+++ b/tests/unit/validation/TokenValidator.test.ts
@@ -15,7 +15,7 @@ import type { SphereToken } from '../../../token-engine';
 function tok(id: number): SphereToken {
   return {
     sdkToken: {} as SphereToken['sdkToken'],
-    blob: { v: 1, network: 2, token: new Uint8Array([id]) },
+    blob: { v: 1, network: 2, tokenId: id.toString(16).padStart(64, '0'), token: new Uint8Array([id]) },
     value: { assets: [] },
   };
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["tests/**/*.ts", "vitest.config.ts", "vitest.e2e.config.ts", "vitest.relay.config.ts", "vitest.daemon.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
`npm run typecheck` excluded `**/*.test.ts`, so **no test file had ever been typechecked**. 332 errors across 74 files had accumulated. This clears them all and adds `npm run typecheck:tests` to CI.

The reason this matters more than a tidy-up: most errors were **doubles that had drifted from the interface they stand in for**, and a mock missing a method cannot catch a caller of it.

## What the errors actually were

| pattern | what the test believed | what production does |
|---|---|---|
| `{ l1: null }` in 20+ `createPaymentsModule` calls | disabling the L1 rail | L1 was deleted in #604; `PaymentsModuleConfig` has no such key, the constructor drops it — **including in the file whose subject is the L1-removal storage guard** |
| `transportPubkey` on a wallet `FullIdentity`, 15+ fixtures | the wallet identity carries a transport pubkey | it belongs to `PeerInfo` (a *resolved peer*); no production code reads it off an identity |
| oracle doubles stubbing `submitCommitment`/`getProof`/`waitForProof`/`mintToken`/`validateToken` | the oracle still has a commitment/mint surface | all removed at the v2 cutover; the port is network-config only |
| `payInvoice({ targetAddress, assets })`, `returnInvoicePayment({ senderAddress, assets })` | selecting a target by address, passing an asset list | params are `targetIndex`/`assetIndex` and `recipient`/`amount`/`coinId` — **every property passed was ignored** |
| `buildTxfStorageData(…, { nametag })` | feeding a nametag in, to prove it is not written to the blob | the option is `nametags` (plural); the key was dropped, so the assertion held vacuously |
| `vi.fn(() => …)`, `ReturnType<typeof vi.spyOn>` | a typed spy | signature erased, so `mock.calls[n][1]` was `{}` and every recorded-request read was unchecked (50 of the errors, one root cause) |

Two that were outright bugs rather than fictions:

- **`makeTempDirs()` never returned the `base` it computed**, so every `messaging-e2e` run called `rmSync(undefined)` inside a swallowing `catch` — no temp dir was ever deleted, every run leaked wallet dirs under `os.tmpdir()`.
- **A dead import** of `tests/support/memory-delivery`, deleted with the Nostr delivery rail. Type-only, so it never failed at runtime.

## The one that needed a real decision

`Sphere.registerNametag`'s *"performs no on-chain mint"* guard asserted `expect(oracle.submitCommitment).not.toHaveBeenCalled()` — on a method the v1 cutover deleted from `OracleProvider`. **Nothing could call it, so the assertion could not fail**, and no other test covered the invariant. Deleting it would have left a hole, so it now watches `engine.mint` / `engine.mintDataToken` — where such a regression would actually go.

## Nothing was weakened

- **3127 tests over 202 files, before and after** — identical count;
- zero `.skip`/`.only` added, zero tests removed or renamed;
- the 22 touched `expect(` lines are the same assertions with the same expected values, re-anchored through `!` once the optional they read was typed honestly. I diffed every one.

## How it was done

13 parallel agents, split by file, each verifying its own files (filtered `tsc` + running its suites) before reporting — and each instructed to report rather than paper over any case where a type error revealed a test asserting on a fiction. That is where the table above comes from: **54 findings**. The shared helpers, the vacuous mint guard, and the final audit were done centrally.

## Gate

typecheck ✅ · **typecheck:tests ✅ (new, wired into CI)** · lint 0 errors ✅ · 202 files / 3127 tests ✅ · 39 e2e against the real staging wallet-api + testnet2 ✅