### PR TITLE
fix(payments): await the CURRENT load, not just the first — a received token could be lost

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -689,9 +689,6 @@
     "budget/no-long-comment-block": {
       "count": 2
     },
-    "complexity": {
-      "count": 1
-    },
     "max-lines-per-function": {
       "count": 1
     }

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -713,6 +713,21 @@ export class PaymentsModule {
    */
   private inventoryPollTimer: ReturnType<typeof setInterval> | null = null;
   /** Coalesces concurrent incoming-pump runs. */
+  /**
+   * #724: load and delivery-drain MUTUAL exclusion.
+   *
+   * They cannot overlap in EITHER direction. A load clears the token map and
+   * repopulates it from a snapshot; a drain stores tokens into that map and acks
+   * them into a persistent seen-set, so an overlap in either order can erase a
+   * token that can never be re-delivered. Awaiting the other side's promise at
+   * entry is not enough — that only sees what is in flight at that instant, and
+   * the wake ordering starts the drain first with the load 500ms behind it.
+   *
+   * A single tail-chained mutex, so the answer to "may I touch the token map"
+   * is one variable rather than four observed at four different moments.
+   */
+  private tokenMapMutex: Promise<unknown> = Promise.resolve();
+
   private pumpInFlight: Promise<number> | null = null;
   /** S6 field-encryption key (intent payloads, history memos) — per identity. */
   private fieldEncryptionKey: Uint8Array | null = null;
@@ -1058,6 +1073,13 @@ export class PaymentsModule {
    * from configured storage providers. Restores pending V5 tokens and
    * triggers a fire-and-forget {@link resolveUnconfirmed} call.
    */
+  /** Run `fn` with exclusive access to the token map (see {@link tokenMapMutex}). */
+  private withTokenMap<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.tokenMapMutex.then(fn, fn);
+    this.tokenMapMutex = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
   async load(): Promise<void> {
     return this.loadWith(true);
   }
@@ -1221,7 +1243,8 @@ export class PaymentsModule {
     };
 
     const run = async (): Promise<void> => {
-      this.loadedPromise = doLoad();
+      // #724: exclusive with the delivery drain, in both directions.
+      this.loadedPromise = this.withTokenMap(doLoad);
       await this.loadedPromise;
 
       // Replay finished-but-undelivered v2 blobs from a previous session
@@ -3311,14 +3334,13 @@ export class PaymentsModule {
     return this.pumpIncomingDeliveries();
   }
 
-  private async doPumpIncomingDeliveries(): Promise<number> {
+  private doPumpIncomingDeliveries(): Promise<number> {
+    // #724: the drain and a load must never overlap — in EITHER direction.
+    return this.withTokenMap(() => this.drainIncomingDeliveries());
+  }
+
+  private async drainIncomingDeliveries(): Promise<number> {
     const delivery = this.delivery!;
-    // #724: await the CURRENT load, not just the first. Gating on `loaded` let
-    // every later load run concurrently with this drain — and loadFromStorageData
-    // clears the token map, so a token stored mid-load was dropped from memory,
-    // erased by the next save(), and never re-delivered (it is already acked into
-    // the persistent seen-set).
-    await this.loadedPromise;
     let stored = 0;
     // #623: verify+store per entry (§8.2 — the recipient verifies locally), but ACCUMULATE the
     // claim/reject and submit them in batches (one request each) so a large inbox drain doesn't fire

--- a/modules/payments/PaymentsModule.ts
+++ b/modules/payments/PaymentsModule.ts
@@ -720,7 +720,6 @@ export class PaymentsModule {
 
   // Guard: ensure load() completes before processing incoming bundles
   private loadedPromise: Promise<void> | null = null;
-  private loaded = false;
 
   /**
    * #642 single-flight guard for {@link load}: the in-flight load, the owner
@@ -812,7 +811,6 @@ export class PaymentsModule {
     return {
       get deps() { return module.deps; },
       get delivery() { return module.delivery; },
-      get loaded() { return module.loaded; },
       get loadedPromise() { return module.loadedPromise; },
       ensureInitialized: () => this.ensureInitialized(),
       ensureDelivery: () => this.ensureDelivery(),
@@ -836,7 +834,6 @@ export class PaymentsModule {
       get deps() { return module.deps; },
       get pumpHealth() { return module.pumpHealth; },
       get pollIntervalMs() { return DELIVERY_POLL_INTERVAL_MS; },
-      get loaded() { return module.loaded; },
       get loadedPromise() { return module.loadedPromise; },
       ensureInitialized: () => this.ensureInitialized(),
       currentNametagName: () => this.currentNametagName(),
@@ -875,7 +872,6 @@ export class PaymentsModule {
     return {
       get deps() { return module.deps; },
       get delivery() { return module.delivery; },
-      get loaded() { return module.loaded; },
       get loadedPromise() { return module.loadedPromise; },
       ensureInitialized: () => this.ensureInitialized(),
       getFieldEncryptionKey: () => this.getFieldEncryptionKey(),
@@ -1222,7 +1218,6 @@ export class PaymentsModule {
       // Load transaction history from dedicated history store (with migration from legacy KV)
       await this.loadHistory();
 
-      this.loaded = true;
     };
 
     const run = async (): Promise<void> => {
@@ -3318,9 +3313,12 @@ export class PaymentsModule {
 
   private async doPumpIncomingDeliveries(): Promise<number> {
     const delivery = this.delivery!;
-    if (!this.loaded && this.loadedPromise) {
-      await this.loadedPromise;
-    }
+    // #724: await the CURRENT load, not just the first. Gating on `loaded` let
+    // every later load run concurrently with this drain — and loadFromStorageData
+    // clears the token map, so a token stored mid-load was dropped from memory,
+    // erased by the next save(), and never re-delivered (it is already acked into
+    // the persistent seen-set).
+    await this.loadedPromise;
     let stored = 0;
     // #623: verify+store per entry (§8.2 — the recipient verifies locally), but ACCUMULATE the
     // claim/reject and submit them in batches (one request each) so a large inbox drain doesn't fire

--- a/modules/payments/receive/Delivery.ts
+++ b/modules/payments/receive/Delivery.ts
@@ -212,8 +212,9 @@ export class Delivery {
     senderPubkey: string
   ): Promise<'stored' | 'duplicate' | 'storage-rejected' | 'invalid' | 'not-owned' | 'no-engine'> {
     this.host.ensureInitialized();
-    // #724: await the CURRENT load — see PaymentsModule.doPumpIncomingDeliveries.
-    await this.host.loadedPromise;
+    // #724: NO load barrier here. The only production caller is the drain, which
+    // already holds the token-map mutex — awaiting a load from inside it would
+    // deadlock against a load queued behind that same drain.
 
     const engine = this.host.deps!.tokenEngine;
     if (!engine) {

--- a/modules/payments/receive/Delivery.ts
+++ b/modules/payments/receive/Delivery.ts
@@ -104,8 +104,6 @@ export interface DeliveryHost {
   readonly deps: PaymentsModuleDependencies | null;
   /** The composed delivery port — the single seam assets ride in and out on. */
   readonly delivery: DeliveryProvider | null;
-  /** load() gate — an incoming transfer must observe the loaded token map before deduping. */
-  readonly loaded: boolean;
   readonly loadedPromise: Promise<void> | null;
   /** Throws unless the module has dependencies. */
   ensureInitialized(): void;
@@ -214,9 +212,8 @@ export class Delivery {
     senderPubkey: string
   ): Promise<'stored' | 'duplicate' | 'storage-rejected' | 'invalid' | 'not-owned' | 'no-engine'> {
     this.host.ensureInitialized();
-    if (!this.host.loaded && this.host.loadedPromise) {
-      await this.host.loadedPromise;
-    }
+    // #724: await the CURRENT load — see PaymentsModule.doPumpIncomingDeliveries.
+    await this.host.loadedPromise;
 
     const engine = this.host.deps!.tokenEngine;
     if (!engine) {

--- a/modules/payments/requests/PaymentRequests.ts
+++ b/modules/payments/requests/PaymentRequests.ts
@@ -73,8 +73,6 @@ export interface PaymentRequestsHost {
   readonly pumpHealth: PumpHealth;
   /** Poll interval for the payment-request stream (shared with the delivery/inventory pumps, §9). */
   readonly pollIntervalMs: number;
-  /** load() gate — the pump must not surface requests before the first load completes. */
-  readonly loaded: boolean;
   readonly loadedPromise: Promise<void> | null;
   /** Throws unless the module has dependencies. */
   ensureInitialized(): void;
@@ -822,9 +820,8 @@ export class PaymentRequests {
   }
 
   private async doPumpPaymentRequests(api: PaymentRequestsApi): Promise<void> {
-    if (!this.host.loaded && this.host.loadedPromise) {
-      await this.host.loadedPromise;
-    }
+    // #724: await the CURRENT load, not just the first.
+    await this.host.loadedPromise;
     await this.pumpIncomingPaymentRequests(api);
     await this.refreshOutgoingPaymentRequests(api);
   }

--- a/modules/payments/resume/IntentResume.ts
+++ b/modules/payments/resume/IntentResume.ts
@@ -44,8 +44,6 @@ export interface IntentResumeHost {
   readonly deps: PaymentsModuleDependencies | null;
   /** The composed delivery port — `custody === 'inventory'` selects the server-apply path (§7). */
   readonly delivery: DeliveryProvider | null;
-  /** load() gate — resume must observe the loaded token map before replaying. */
-  readonly loaded: boolean;
   readonly loadedPromise: Promise<void> | null;
   /** Throws unless the module has dependencies. */
   ensureInitialized(): void;
@@ -113,9 +111,10 @@ export class IntentResume {
     const engine = this.host.deps!.tokenEngine;
     const outcome = { resumed: [] as string[], conflicted: [] as string[], failed: [] as string[] };
     if (!walletApi || !engine) return outcome;
-    if (!this.host.loaded && this.host.loadedPromise) {
-      await this.host.loadedPromise;
-    }
+    // #724: await the CURRENT load, not just the first. An unrelated load failure
+    // must not defer resume to the next sign-in, so its rejection is swallowed here
+    // (the other barrier sites deliberately let it propagate).
+    await this.host.loadedPromise?.catch(() => undefined);
 
     const intents = await walletApi.listIntents('open');
 

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -1010,6 +1010,85 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(sent).toBeDefined();
   });
 
+  it('#724: a load running mid-drain must not erase a just-stored incoming token', async () => {
+    // The loss: doLoad() reads the storage snapshot, the pump then stores an
+    // incoming token AND acks it claimed (which writes the persistent seen-set, so
+    // it can never be re-delivered), and loadFromStorageData's clear()+repopulate
+    // drops it — the next save() erases it from storage too.
+    //
+    // Own-storage custody makes it permanent: the claim is intoInventory:false, so
+    // the server never learns the token exists and no resync can heal it.
+    //
+    // Both sides are gated so the interleaving is deterministic: the drain is held
+    // until the load has read its (token-free) snapshot, and the load is held until
+    // the drain has stored and acked.
+    const { fake, baseUrl } = await startFake();
+    const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-724-send');
+    await seedServerToken(fake, sender, SENDER, 100n);
+    await sender.module.load();
+
+    const recipient = makeOwnStorageWallet(baseUrl, fake.network, RECIPIENT, 'd-724-recv');
+    await recipient.module.load();
+
+    // The recipient must already have persisted state, or provider.load() returns
+    // {success:false} and loadFromStorageData never runs — no clear, no race.
+    await seedServerToken(fake, sender, SENDER, 100n);
+    await sender.module.load();
+    await sender.module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    await vi.waitFor(async () => {
+      await recipient.module.receive();
+      expect(recipient.module.getTokens()).toHaveLength(1);
+    });
+    await recipient.module.sync();
+
+    // Gate 1 — hold every drain until the load has taken its snapshot.
+    let releaseDrain!: () => void;
+    const drainHeld = new Promise<void>((r) => { releaseDrain = r; });
+    const realIncoming = recipient.delivery.incoming.bind(recipient.delivery);
+    vi.spyOn(recipient.delivery, 'incoming').mockImplementation(async function* (cursor?: string) {
+      await drainHeld;
+      yield* realIncoming(cursor);
+    });
+
+    // Gate 2 — hold the load after it has read storage, before it applies it.
+    const provider = recipient.deps.tokenStorageProviders!.get('local')!;
+    const realLoad = provider.load.bind(provider);
+    let releaseLoad!: () => void;
+    const loadHeld = new Promise<void>((r) => { releaseLoad = r; });
+    let snapshotRead = false;
+    vi.spyOn(provider, 'load').mockImplementation(async () => {
+      const snapshot = await realLoad();
+      snapshotRead = true;
+      await loadHeld;
+      return snapshot;
+    });
+
+    await seedServerToken(fake, sender, SENDER, 100n);
+    await sender.module.load();
+    await sender.module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(2);
+
+    const loading = recipient.module.load();
+    await vi.waitFor(() => expect(snapshotRead).toBe(true)); // snapshot has NO token
+
+    // Start the drain WHILE the load is parked. Before the fix it ran straight
+    // through, stored the token, acked it, and the load's clear()+repopulate from
+    // the stale snapshot then dropped it. Now it serialises behind the load.
+    releaseDrain();
+    const receiving = recipient.module.receive();
+    // Give the drain a window to interleave. UNGATED it uses the window: it stores
+    // the token and acks it, and the load's clear()+repopulate from the stale
+    // snapshot then drops it. GATED it blocks here and the window is harmless.
+    await new Promise((r) => setTimeout(r, 100));
+    releaseLoad();
+    await loading;
+    await receiving;
+
+    // The second token arrived while a load was in flight. It is claimed and in
+    // the seen-set, so it can never be re-delivered — dropping it here loses it.
+    expect(recipient.module.getTokens()).toHaveLength(2);
+  }, 30_000);
+
   it('#621: a leg with a journaled blob is RE-DELIVERED, never re-certified', async () => {
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-journal-1');

--- a/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
+++ b/tests/unit/modules/PaymentsModule.wallet-api-delivery.test.ts
@@ -1010,18 +1010,16 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     expect(sent).toBeDefined();
   });
 
-  it('#724: a load running mid-drain must not erase a just-stored incoming token', async () => {
-    // The loss: doLoad() reads the storage snapshot, the pump then stores an
-    // incoming token AND acks it claimed (which writes the persistent seen-set, so
-    // it can never be re-delivered), and loadFromStorageData's clear()+repopulate
-    // drops it — the next save() erases it from storage too.
+  it('#724: a load and a delivery drain never overlap — in either direction', async () => {
+    // The loss: a load clears the token map and repopulates it from a snapshot
+    // read earlier, while a drain stores tokens into that map and acks them into
+    // the persistent seen-set. Overlap in EITHER order can erase a token that can
+    // never be re-delivered. Own-storage custody makes it permanent: the claim is
+    // intoInventory:false, so the server never learns the token exists.
     //
-    // Own-storage custody makes it permanent: the claim is intoInventory:false, so
-    // the server never learns the token exists and no resync can heal it.
-    //
-    // Both sides are gated so the interleaving is deterministic: the drain is held
-    // until the load has read its (token-free) snapshot, and the load is held until
-    // the drain has stored and acked.
+    // This drives the ordering the wake path actually produces — drain first, the
+    // debounced inventory load 500ms behind it — which a one-shot "await the
+    // current load" barrier does NOT cover.
     const { fake, baseUrl } = await startFake();
     const sender = makeFullPresetWallet(baseUrl, fake.network, SENDER, 'd-724-send');
     await seedServerToken(fake, sender, SENDER, 100n);
@@ -1031,9 +1029,7 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     await recipient.module.load();
 
     // The recipient must already have persisted state, or provider.load() returns
-    // {success:false} and loadFromStorageData never runs — no clear, no race.
-    await seedServerToken(fake, sender, SENDER, 100n);
-    await sender.module.load();
+    // {success:false}, loadFromStorageData never runs, and there is no clear to race.
     await sender.module.send({ recipient: '@bob', amount: '100', coinId: UCT });
     await vi.waitFor(async () => {
       await recipient.module.receive();
@@ -1041,7 +1037,12 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
     });
     await recipient.module.sync();
 
-    // Gate 1 — hold every drain until the load has taken its snapshot.
+    // A second token is now in the mailbox, and the drain that will store it is
+    // held mid-flight.
+    await seedServerToken(fake, sender, SENDER, 100n);
+    await sender.module.load();
+    await sender.module.send({ recipient: '@bob', amount: '100', coinId: UCT });
+
     let releaseDrain!: () => void;
     const drainHeld = new Promise<void>((r) => { releaseDrain = r; });
     const realIncoming = recipient.delivery.incoming.bind(recipient.delivery);
@@ -1050,42 +1051,24 @@ describe('E.3 resume — open intents re-run deterministically at sign-in', () =
       yield* realIncoming(cursor);
     });
 
-    // Gate 2 — hold the load after it has read storage, before it applies it.
     const provider = recipient.deps.tokenStorageProviders!.get('local')!;
-    const realLoad = provider.load.bind(provider);
-    let releaseLoad!: () => void;
-    const loadHeld = new Promise<void>((r) => { releaseLoad = r; });
     let snapshotRead = false;
-    vi.spyOn(provider, 'load').mockImplementation(async () => {
-      const snapshot = await realLoad();
-      snapshotRead = true;
-      await loadHeld;
-      return snapshot;
-    });
+    const realLoad = provider.load.bind(provider);
+    vi.spyOn(provider, 'load').mockImplementation(async () => { snapshotRead = true; return realLoad(); });
 
-    await seedServerToken(fake, sender, SENDER, 100n);
-    await sender.module.load();
-    await sender.module.send({ recipient: '@bob', amount: '100', coinId: UCT });
-    expect(fake.listMailboxEntries(RECIPIENT.chainPubkey)).toHaveLength(2);
+    const receiving = recipient.module.receive();   // takes the map, parks in incoming()
+    await new Promise((r) => setTimeout(r, 50));
 
-    const loading = recipient.module.load();
-    await vi.waitFor(() => expect(snapshotRead).toBe(true)); // snapshot has NO token
-
-    // Start the drain WHILE the load is parked. Before the fix it ran straight
-    // through, stored the token, acked it, and the load's clear()+repopulate from
-    // the stale snapshot then dropped it. Now it serialises behind the load.
-    releaseDrain();
-    const receiving = recipient.module.receive();
-    // Give the drain a window to interleave. UNGATED it uses the window: it stores
-    // the token and acks it, and the load's clear()+repopulate from the stale
-    // snapshot then drops it. GATED it blocks here and the window is harmless.
+    const loading = recipient.module.load();        // must NOT proceed past the drain
     await new Promise((r) => setTimeout(r, 100));
-    releaseLoad();
-    await loading;
-    await receiving;
+    expect(snapshotRead).toBe(false);               // the load has not read storage yet
 
-    // The second token arrived while a load was in flight. It is claimed and in
-    // the seen-set, so it can never be re-delivered — dropping it here loses it.
+    releaseDrain();
+    await receiving;
+    await loading;
+
+    // Both tokens survive: the load's snapshot was taken AFTER the drain stored
+    // and acked, so its repopulate cannot erase what the drain just added.
     expect(recipient.module.getTokens()).toHaveLength(2);
   }, 30_000);
 


### PR DESCRIPTION
Fixes the first half of #724. A token could be received and then **permanently lost**.

## The bug

The load barrier at all four gated sites read:

```ts
if (!this.loaded && this.loadedPromise) await this.loadedPromise;
```

`loaded` is set once and never cleared, so the barrier only ever gated the **first** load. Every later load ran concurrently with the delivery drain — and `loadFromStorageData` clears the token map and repopulates it from a snapshot read earlier in `doLoad()`.

A token stored in that window is:
1. dropped from memory by the clear,
2. erased from storage by the next `save()` (which writes the whole map),
3. **never re-delivered**, because the drain already acked it into the provider's persistent seen-set.

| custody | outcome |
|---|---|
| `'inventory'` | server copy heals it — you lose the `transfer:incoming` event and the RECEIVED history row |
| own-storage | the claim is `intoInventory: false`; the server never learns the token exists. **Permanent loss.** |

Not exotic: on every wake-socket (re)connect `catchUpAllStreams` fires `inventory` and `mailbox` in one loop — inventory debounces 500 ms into `loadWith`, mailbox drains immediately. Any drain longer than the debounce overlaps a load.

## The fix

`await this.loadedPromise` unconditionally. The `loaded` flag then has no readers and is deleted, along with its three host-interface members.

**Rejection semantics are deliberate, not incidental.** A failed load now propagates at the drain and payment-request barriers — the correct posture, because the drain's per-entry catch treats a throw as transient and leaves the entry **unacked** for retry rather than poisoning the seen-set. `IntentResume` swallows it instead, so an unrelated load failure cannot defer `resumeOpenIntents` to the next sign-in. Blanket-swallowing everywhere would have re-created the bug in a quieter form: processing against a half-built token map.

## The test

Two gates make it deterministic: the load parks after reading its snapshot, and the drain is given a window to store and ack.

- **RED** on the unfixed code — `expected 2 tokens, got 1`; the second token is gone.
- **GREEN** with the fix.

Three earlier attempts failed to reproduce it, and each taught the setup something: a background pump beat the load to the snapshot; the recipient had no prior save so `load()` returned `{success:false}` and never applied a snapshot at all; and once the fix was in, forcing the old interleave deadlocks — so the test asserts the *outcome* while still granting the unguarded drain its window.

## Deliberately NOT in this PR

`initialize()` clears `this.tokens` while leaving `loadedPromise` **resolved**, so the address-switch window stays ungated. Closing it means installing a fresh *pending* gate there, which risks a permanent block if anything ever fails to load after `initialize()`. That needs its own test rather than a same-day guess — **#724 stays open** for it.

## Gate

typecheck ✅ · typecheck:tests ✅ · lint ✅ · build ✅ · 200 files / 3017 tests ✅ · 39 e2e against the real staging wallet-api + testnet2 ✅