### PR TITLE
test(payments): deflake wake-reconnect — assert the drop, not the transient zero

### DIFF
--- a/tests/unit/modules/PaymentsModule.wake-reconnect.test.ts
+++ b/tests/unit/modules/PaymentsModule.wake-reconnect.test.ts
@@ -158,8 +158,11 @@ describe('wallet-api wake reconnect converges a window whose socket went dark (�
     await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 1, 'wake socket connected');
 
     // B's wake socket dies (proxy/idle/network kill) — unobserved by the bare handle.
+    // The drop itself is the observable — NOT the transient zero. The supervisor
+    // reconnects with full-jitter backoff, so `socketCount === 0` can close before
+    // any poll observes it; waiting for it made this test fail on loaded runners
+    // (main run 31192808625) while the product behaved correctly.
     expect(fake.dropSockets(OWNER.chainPubkey)).toBe(1);
-    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0, 'wake socket gone');
 
     // While B is DARK, window A tops up the shared inventory (+ the wake that
     // fires now reaches nobody — B has no socket; the server does not replay it).
@@ -184,8 +187,7 @@ describe('wallet-api wake reconnect converges a window whose socket went dark (�
     payer.module.onPaymentRequest((r) => surfaced.push(r));
 
     // The payer's socket dies.
-    fake.dropSockets(OWNER.chainPubkey);
-    await waitFor(() => fake.socketCount(OWNER.chainPubkey) === 0, 'wake socket gone');
+    expect(fake.dropSockets(OWNER.chainPubkey)).toBe(1);
 
     // The requester creates a PR while the payer is dark — its `payment_requests`
     // wake reaches no socket.


### PR DESCRIPTION
`main` went red on run 31192808625 (Node 22 job; Node 24 passed the same tree).

**Root cause — a real test bug, not slowness.** Both cases killed the wake socket and then waited for `socketCount === 0`. The session supervisor reconnects with full-jitter backoff, so that zero window can close *before any poll observes it* — the wait then times out at 20 s while the product did exactly the right thing. Load widens the miss window, which is why it surfaces on CI and never locally.

**Fix:** the drop is the observable. `dropSockets()` returns how many sockets it closed, so case 2 now **asserts it dropped exactly one** (it previously ignored the return value — strictly stronger than before), and neither case waits on a transient state. The reconnect-and-catch-up assertions that follow are untouched: a real convergence regression still fails this suite.

Verified 3/3 consecutive runs locally, typecheck:tests + eslint clean.

Note: this file is deleted by the P11 flip (#728) — this keeps `main` green in the meantime.