### PR TITLE
feat(payments-v2): connectionStatus() getter — late subscribers can seed (sphere#473 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `payments.connectionStatus()` (sphere#473 P1)
+
+The current wallet-api connection status is now readable at any time, not only observable at
+transition: `sphere.payments.connectionStatus()` returns `'connected' | 'degraded' | 'offline'`
+(never null; `'offline'` while the vertical is unstarted). `connection:status` stays the change
+notification — a component mounting after a transition (the header indicator vs. an `offline`
+sign-in during `Sphere.init`, where a persistent outage produces no further transition) seeds from
+the getter. Both read the session's one status value (`FacadeSession.status()` is now REQUIRED),
+so the getter and the event cannot disagree. This replaces the pre-flip `sphere.walletApiSessionStatus`
+getter, which the flip deleted without a replacement.
+
 ### Changed — P11 flip (BREAKING): the payments-v2 vertical is the ONLY money path
 
 `sphere.payments` now IS the §4 facade (`assets()`, `tokens()`, `history()`, `send()`, `mint()`,

--- a/docs/MIGRATION-PAYMENTS-V2.md
+++ b/docs/MIGRATION-PAYMENTS-V2.md
@@ -57,6 +57,7 @@ sphere.payments.send({ recipient: '@bob', amount: '1000', coinId: 'UCT' });
 | `rejectPaymentRequest(id)` | `requests.decline(id)` — 403/409 now propagate |
 | `clearProcessedPaymentRequests()` | `requests.dismissProcessed()` |
 | `sync()` / `validate()` | gone — the server is the record; nothing to flush |
+| `sphere.walletApiSessionStatus` (getter, deleted at the flip) | `payments.connectionStatus()` — readable at any time; `connection:status` stays the change notification (sphere#473) |
 | ~25 further members | gone (zero consumers existed; see design doc §4) |
 
 Events: `transfer:incoming` unchanged. `transfer:confirmed` +

--- a/docs/PAYMENTS-V2-DESIGN.md
+++ b/docs/PAYMENTS-V2-DESIGN.md
@@ -125,6 +125,9 @@ interface Payments {
   pendingTransfers(): Promise<PendingTransfer[]>; // on-read view over the intent backstop + delivery journal (+ #690 shortfalls, surfaced distinctly) — never a cached mirror
   resumeNow(): Promise<void>;                     // immediate resume pass; coalesces with a running one and reschedules the heartbeat from its outcome   // explicit drain-now
 
+  // connection (sphere#473)
+  connectionStatus(): 'connected' | 'degraded' | 'offline'; // the session's CURRENT status, read through — never null, 'offline' while unstarted
+
   // payment requests (wallet-api S4 streams only)
   requests: {
     create(to: string, terms: { coinId: string; amount: string; memo?: string }): Promise<PaymentRequest>;
@@ -156,6 +159,13 @@ from `transfer:updated{status:'failed'}`),
 `payment_request:incoming`, `payment_request:updated`, `connection:status`
 (`connected|degraded|offline`; replaces `realtime:status` + `storage:degraded` — the server IS
 storage).
+
+**Connection-status invariant:** the current status is **readable at any time** via
+`connectionStatus()`; `connection:status` is only the CHANGE notification. A component mounting
+after a transition (the header indicator vs. an offline sign-in during init, sphere#473 — during a
+persistent outage no further transition ever comes) seeds from the getter. Both read the session's
+one status value, so they can never disagree; unstarted reads 'offline' (no session, no
+connectivity claim), never null.
 
 **Kept verbatim (consumed contracts, not legacy):** the typed error family and exact codes —
 `CERTIFICATION_UNCONFIRMED`, `SEND_SYNC_PENDING`, `CHECKPOINT_PERSIST_FAILED`,

--- a/modules/payments-v2/PaymentsFacade.ts
+++ b/modules/payments-v2/PaymentsFacade.ts
@@ -16,7 +16,7 @@ import type { MintParams, SphereToken } from '../../token-engine/types';
 import { TOKEN_BLOB_VERSION } from '../../token-engine/token-blob';
 import type { Asset, IncomingTransfer, Token, TokenTransferDetail, TransferResult } from '../../types';
 
-import type { HistoryPage, MintResult, PaymentsV2, PendingTransfer, SendRequest } from './api';
+import type { ConnectionStatus, HistoryPage, MintResult, PaymentsV2, PendingTransfer, SendRequest } from './api';
 import { SerialChain, SingleFlight } from './async';
 import { ConvergenceHeartbeat, Converger, derivePendingTransfers } from './convergence';
 import { reseedAndReset, type RestoreDeps } from './restore';
@@ -211,6 +211,11 @@ export class PaymentsFacade implements PaymentsV2 {
 
   history(page?: { before?: string; limit?: number }): Promise<HistoryPage> {
     return this.historyStore.page(page ?? {});
+  }
+
+  /** §4: read through to the session — the same value `connection:status` carries (sphere#473). No session ⇒ 'offline'. */
+  connectionStatus(): ConnectionStatus {
+    return this.started ? this.deps.session.status() : 'offline';
   }
 
   /** §4 pending-transfers UI surface — derived on read, never cached (convergence.ts). */
@@ -774,20 +779,13 @@ export class PaymentsFacade implements PaymentsV2 {
 
   private toUiToken(tokenId: string, coinId: string, amount: bigint): Token {
     const now = this.nowMs();
-    return toToken(
-      tokenId,
-      { assets: [], createdAt: now, updatedAt: now },
-      { coinId, amount: amount.toString() },
-      this.deps.registry,
-      { transferring: true, suspectedSpent: false }
-    );
+    const snapshot = { assets: [], createdAt: now, updatedAt: now };
+    const flags = { transferring: true, suspectedSpent: false };
+    return toToken(tokenId, snapshot, { coinId, amount: amount.toString() }, this.deps.registry, flags);
   }
 
   private track<T>(op: Promise<T>): Promise<T> {
-    const settled = op.then(
-      () => undefined,
-      () => undefined
-    );
+    const settled = op.then(() => undefined, () => undefined);
     this.pendingOps.add(settled);
     void settled.finally(() => this.pendingOps.delete(settled));
     return op;

--- a/modules/payments-v2/api.ts
+++ b/modules/payments-v2/api.ts
@@ -89,6 +89,8 @@ export interface PendingTransfer {
   createdAt: number;
 }
 
+export type ConnectionStatus = 'connected' | 'degraded' | 'offline';
+
 export interface PaymentsV2 {
   assets(coinId?: string): Promise<Asset[]>;
   tokens(filter?: { coinId?: string }): Token[];
@@ -103,6 +105,10 @@ export interface PaymentsV2 {
   pendingTransfers(): Promise<PendingTransfer[]>;
   resumeNow(): Promise<void>;
 
+  // Readable at ANY time (a late-mounting indicator seeds it, sphere#473);
+  // `connection:status` is only the change notification. 'offline' unstarted.
+  connectionStatus(): ConnectionStatus;
+
   readonly requests: PaymentsRequestsApi;
 }
 
@@ -116,5 +122,5 @@ export interface PaymentsV2Events {
   'history:updated': HistoryEntry;
   'payment_request:incoming': PaymentRequestView;
   'payment_request:updated': { id: string; status: PaymentRequestStatus };
-  'connection:status': { status: 'connected' | 'degraded' | 'offline' };
+  'connection:status': { status: ConnectionStatus };
 }

--- a/modules/payments-v2/compose.ts
+++ b/modules/payments-v2/compose.ts
@@ -6,7 +6,7 @@ import { decryptField, encryptField } from '../../core/field-encryption';
 import type { ITokenEngine, SplitCheckpointStore } from '../../token-engine/engine';
 import type { TransferResult } from '../../types';
 
-import type { SendRequest } from './api';
+import type { ConnectionStatus, SendRequest } from './api';
 import type { DeliveryPort, StoragePort } from './ports';
 import type { ScopedKV } from './stores';
 import { History, type HistoryClient } from './history/History';
@@ -58,11 +58,16 @@ export interface FacadeSession {
    */
   subscribeEpochChange(handler: (epoch: string) => Promise<void>): () => void;
   /**
+   * The session's CURRENT status — REQUIRED, and the ONE source `connectionStatus()`
+   * and `connection:status` both come from ('offline' before first contact).
+   */
+  status(): ConnectionStatus;
+  /**
    * Optional connection-status feed (same wiring pattern as the streams; the
    * emission point is the session's existing `connection:status` transition).
    * The facade's heartbeat resets its backoff on a 'connected' recovery.
    */
-  subscribeStatus?(handler: (status: 'connected' | 'degraded' | 'offline') => void): () => void;
+  subscribeStatus?(handler: (status: ConnectionStatus) => void): () => void;
 }
 
 /**

--- a/modules/payments-v2/index.ts
+++ b/modules/payments-v2/index.ts
@@ -1,4 +1,4 @@
-export type { PaymentsV2, PaymentsV2Events, SendRequest, MintResult, HistoryEntry, HistoryPage, PaymentRequestView, PaymentRequestStatus, PaymentsRequestsApi, PendingTransfer } from './api';
+export type { PaymentsV2, PaymentsV2Events, ConnectionStatus, SendRequest, MintResult, HistoryEntry, HistoryPage, PaymentRequestView, PaymentRequestStatus, PaymentsRequestsApi, PendingTransfer } from './api';
 export type { StoragePort, DeliveryPort, InventoryItem, InventoryPage, InventoryAsset, ApplyDeltaResult, DeliveryReceipt, IncomingDelivery, DeliverOptions } from './ports';
 export type { IntentPayload, PlannedOp, OpOutcome, OutcomeClass } from './machine/types';
 export * from './stores';

--- a/tests/integration/sphere-payments-v2-wiring.test.ts
+++ b/tests/integration/sphere-payments-v2-wiring.test.ts
@@ -141,6 +141,8 @@ function makeWorld(network: string = NET) {
     network,
     paymentsV2Transport: (args: PaymentsV2TransportArgs): PaymentsV2Transport => {
       const session = new FakeSession();
+      // As WalletApiSession does: ONE transition writes the status cell and feeds the bus.
+      session.emitStatus = args.emitStatus;
       const caller: FakeCaller = { chainPubkey: args.identity.chainPubkey, network: args.network };
       const client = new FakeWalletApiV2Client(api, caller, { decodeBlob });
       transports.push({ session, client, args });
@@ -325,9 +327,11 @@ describe('Sphere payments wiring — defaults (P11 flip: the vertical is default
     sphere.on('connection:status', (payload) => statuses.push(payload));
     sphere.on('inventory:updated', (payload) => inventoryPings.push(payload));
 
-    // connection:status rides the emitStatus plumbing wired into the session.
-    world.transports[0]!.args.emitStatus('degraded');
+    // connection:status rides the emitStatus plumbing wired into the session,
+    // and sphere.payments.connectionStatus() reads that same value (sphere#473).
+    world.transports[0]!.session.setStatus('degraded');
     expect(statuses).toEqual([{ status: 'degraded' }]);
+    expect(sphere.payments.connectionStatus()).toBe('degraded');
 
     // inventory:updated fires when the view applies a server delta.
     await seedInventory(world, world.transports[0]!, 15n);

--- a/tests/unit/payments-v2/connection-status.test.ts
+++ b/tests/unit/payments-v2/connection-status.test.ts
@@ -1,0 +1,69 @@
+// §4 connectionStatus(): the current connection status is READABLE at any time,
+// not only observable at transition (sphere#473 — the header indicator mounts
+// after an offline sign-in and, during a persistent outage, no further
+// transition ever comes). The getter reads the session; the event is only the
+// change notification, so the two can never disagree.
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { cleanupWorlds, eventsOf, flushTail, makeWorld } from './facade-harness';
+
+afterEach(cleanupWorlds);
+
+describe('PaymentsFacade — connectionStatus()', () => {
+  it("unstarted → 'offline', and a stopped facade goes back to 'offline' (no session, no connectivity claim)", async () => {
+    const world = makeWorld();
+
+    expect(world.facade.connectionStatus()).toBe('offline');
+
+    await world.facade.start();
+    world.session.setStatus('connected');
+    expect(world.facade.connectionStatus()).toBe('connected');
+
+    await world.facade.stop();
+    expect(world.facade.connectionStatus()).toBe('offline');
+  });
+
+  it('tracks the last emitted status across connected → degraded → offline', async () => {
+    const world = makeWorld();
+    await world.facade.start();
+
+    world.session.setStatus('connected');
+    expect(world.facade.connectionStatus()).toBe('connected');
+
+    world.session.setStatus('degraded');
+    expect(world.facade.connectionStatus()).toBe('degraded');
+
+    world.session.setStatus('offline');
+    expect(world.facade.connectionStatus()).toBe('offline');
+  });
+
+  it('#473: a status emitted BEFORE any subscriber exists is still readable — the late mount seeds the outage', async () => {
+    const world = makeWorld();
+    await world.facade.start();
+
+    // Sign-in fails during init: the transition happens with nobody listening.
+    world.session.setStatus('offline');
+    const emittedByNow = eventsOf(world, 'connection:status').length;
+
+    // The indicator mounts HERE. A persistent outage produces no further event…
+    await flushTail();
+    expect(eventsOf(world, 'connection:status').length).toBe(emittedByNow);
+
+    // …yet the current status is readable, so the warning can render.
+    expect(world.facade.connectionStatus()).toBe('offline');
+  });
+
+  it('getter and event never disagree across a run of transitions', async () => {
+    const world = makeWorld();
+    await world.facade.start();
+
+    const run = ['connected', 'degraded', 'offline', 'degraded', 'connected', 'offline'] as const;
+    for (const status of run) {
+      world.session.setStatus(status);
+      const emitted = eventsOf(world, 'connection:status').at(-1) as { status: string };
+      expect(emitted.status).toBe(status);
+      expect(world.facade.connectionStatus()).toBe(status);
+    }
+  });
+});

--- a/tests/unit/payments-v2/facade-harness.ts
+++ b/tests/unit/payments-v2/facade-harness.ts
@@ -189,6 +189,7 @@ export function makeWorld(options: { engine?: RealizationEngine } = {}): World {
   const hooks: Hooks = {};
   const counters: Counters = { putIntent: 0, listOpen: 0 };
   const events: { event: string; payload: unknown }[] = [];
+  session.emitStatus = (status) => events.push({ event: 'connection:status', payload: { status } });
   const gates: Gate[] = [];
   const resolveMap = new Map<string, RecipientInfo | null>([
     ['@peer', { chainPubkey: PEER_PUB, network: NET }],

--- a/tests/unit/payments-v2/support.ts
+++ b/tests/unit/payments-v2/support.ts
@@ -72,6 +72,8 @@ export class FakeSession implements FacadeSession {
   private readonly statusHandlers = new Set<(status: 'connected' | 'degraded' | 'offline') => void>();
   private readonly epochHandlers = new Set<(epoch: string) => Promise<void>>();
   epoch = '1';
+  /** The one status cell: status() reads it, setStatus() writes it then notifies (as the real session does). */
+  private lastStatus: 'connected' | 'degraded' | 'offline' = 'offline';
   startCalls = 0;
   stopCalls = 0;
   async start(): Promise<void> {
@@ -100,6 +102,9 @@ export class FakeSession implements FacadeSession {
     this.statusHandlers.add(handler);
     return () => this.statusHandlers.delete(handler);
   }
+  status(): 'connected' | 'degraded' | 'offline' {
+    return this.lastStatus;
+  }
   fire(stream: string): void {
     for (const handler of this.handlers.get(stream) ?? []) handler();
   }
@@ -110,8 +115,13 @@ export class FakeSession implements FacadeSession {
     for (const handler of [...this.epochHandlers]) await handler(epoch);
     for (const stream of ['inventory', 'mailbox', 'payment_requests']) this.fire(stream);
   }
-  /** Test hook: push a connection-status transition to subscribers. */
+  /** Bus sink, wired as core/payments-v2-wiring.ts does: session transition → `connection:status`. */
+  emitStatus: ((status: 'connected' | 'degraded' | 'offline') => void) | null = null;
+  /** Test hook: push a connection-status transition (status cell first, then the feeds). */
   setStatus(status: 'connected' | 'degraded' | 'offline'): void {
+    if (this.lastStatus === status) return;
+    this.lastStatus = status;
+    this.emitStatus?.(status);
     for (const handler of this.statusHandlers) handler(status);
   }
 }


### PR DESCRIPTION
## The gap (sphere PR #473 P1, verified real)

`connection:status` is **event-only**. The wallet-api sign-in can emit `offline` *during*
`Sphere.init`, so any component mounting afterwards — the header
`WalletApiSessionIndicator`, via `useRealtimeStatus()` — subscribes too late and sits at
`null` forever. During a persistent outage no further transition ever comes, so the required
"Wallet API offline" warning never appears: the wallet looks fine while server custody
(inventory + mailbox) is unreachable.

The pre-flip code had `sphere.walletApiSessionStatus` as a getter precisely to seed this
case. The P11 flip deleted it **without a replacement** (the frontend hook even documents
the hole: *"null until the first `connection:status` event arrives (no SDK getter)"*). Same
class as the old consumed-surface note "realtime:status has no getter".

## The invariant

> The current connection status is **readable at any time**, not only observable at
> transition. Late subscribers seed from the getter; the event remains the change
> notification.

One source of truth: `connectionStatus()` **reads through** to the session's live status —
the same value its `connection:status` transitions carry — so the getter and the event
cannot disagree. No cached copy the facade maintains, no new durable store, no new sampled
state. Never `null`/`undefined`: a nullable getter would just move the problem.

**Semantics.** Before `start()` / while unstarted (and after `stop()`) → `'offline'` —
honest: no session, so no connectivity claim. After `start()` → the session's live view.

## Changes

- `PaymentsV2.connectionStatus(): ConnectionStatus` (`'connected' | 'degraded' | 'offline'`)
  on `modules/payments-v2/api.ts` + `PaymentsFacade` — reachable as
  `sphere.payments.connectionStatus()`, which is what the frontend header needs. No
  Sphere-level duplicate.
- `FacadeSession.status()` is now **REQUIRED** (it was already implemented and unconsumed on
  `WalletApiSession`, returning its existing `lastStatus ?? 'offline'`) — a session that
  emits transitions it cannot report is now a compile error.
- Docs: design §4 gains the member + the invariant line; the migration API map gains the
  `walletApiSessionStatus` → `payments.connectionStatus()` row; CHANGELOG entry.
- Two small formatting condensations in `PaymentsFacade.ts` to stay inside the 800-line
  budget (`toUiToken`, `track`) — no behaviour change.

## Tests

`tests/unit/payments-v2/connection-status.test.ts` (through the facade with the fake session):

- unstarted facade returns `'offline'`, and a stopped one returns to `'offline'`;
- the getter tracks `connected → degraded → offline`;
- **the #473 scenario**: a status emitted BEFORE any subscriber exists is still readable
  afterwards, with no further event arriving;
- getter and event never disagree across a run of six transitions.

`tests/integration/sphere-payments-v2-wiring.test.ts` now drives the status through the
session (as `WalletApiSession` does — one transition writes the cell and feeds the bus)
and asserts `sphere.payments.connectionStatus()` agrees with the emitted event end-to-end.

## Gates

`vitest run tests/unit/payments-v2/` (321 ✓) · typecheck · typecheck:tests · eslint (0
errors) · build · `npm run test:run` (1926 ✓ / 109 files) · `npm run test:mutation` 22/22
probes KILLED (no probe added — the guard is pinned by the unstarted/stopped test).