### PR TITLE
fix(payments-v2)!: the cross-network recipient guard was unfalsifiable — prove the network or signal it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ wallets. An unproven recipient therefore **proceeds** and emits
 `ATTENTION_RECIPIENT_NETWORK_UNVERIFIED`). #734 tracks putting the field on the publish side and
 tightening this to a hard refusal.
 
+Reading the claim is **per-route**, and the limitation is stated where it bites: sphere parses it
+off the raw signed event on the routes that own the parse (`resolveTransportPubkeyInfo`,
+`discoverAddresses`), where a proven foreign network is refused end to end. `@nametag` and
+`DIRECT://` resolve through nostr-js-sdk's `queryBindingBy*`, whose `parseBindingInfo` whitelists
+the network away and never returns the selected signed event, so those two recipients can only be
+SIGNALLED until #734 lands upstream — `bindingInfoToPeerInfo` carries no network at all rather
+than a read that cannot fire, and `tests/unit/payments-v2/recipient-network.transport.test.ts`
+drives relay → transport → resolver → gate per route to keep both halves honest.
+
 ### Added — `payments.connectionStatus()` (sphere#473 P1)
 
 The current wallet-api connection status is now readable at any time, not only observable at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (BREAKING, money) — the cross-network recipient guard was unfalsifiable (#733)
+
+`resolveRecipientInfo` stamped the LOCAL session network onto every `RecipientInfo`, so
+`PaymentsFacade`'s §5.6 guard compared the session network with a copy of itself and could never
+fire; its only test injected a fake resolver. All networks share Nostr relays, so a
+foreign-network peer resolves fine, the deposit is keyed under the SENDER's network, the server
+answers 200, and the delivery-journal row — the sender's only copy of the obligation — is dropped
+while the recipient never sees the entry.
+
+`RecipientInfo.network` is now `string | null` (**breaking** for anyone constructing one) and
+carries only what the identifier proves: a bare chain pubkey stays session-stamped (typing one
+into this session is the caller asserting it), a resolved peer reports `PeerInfo.network ?? null`.
+`PeerInfo` gains an optional `network`, parsed from the identity binding wherever one declares it
+and invented nowhere. The guard refuses a PROVEN foreign network with `INVALID_RECIPIENT` before
+any reserve/intent/engine work.
+
+Transition posture (#734): no identity binding published so far declares a network — nostr-js-sdk's
+binding builders whitelist the content fields, so the claim cannot ride today's publish API at all
+— and refusing every unproven recipient would stop nametag/`DIRECT://` sends between current
+wallets. An unproven recipient therefore **proceeds** and emits
+`transfer:attention { code: 'recipient:network-unverified' }` (exported as
+`ATTENTION_RECIPIENT_NETWORK_UNVERIFIED`). #734 tracks putting the field on the publish side and
+tightening this to a hard refusal.
+
 ### Added — `payments.connectionStatus()` (sphere#473 P1)
 
 The current wallet-api connection status is now readable at any time, not only observable at

--- a/core/payments-v2-wiring.ts
+++ b/core/payments-v2-wiring.ts
@@ -251,15 +251,14 @@ export interface PaymentsV2Host {
 
 const CHAIN_PUBKEY_RE = /^0[23][0-9a-f]{64}$/i;
 
-/**
- * Non-pubkey identifiers ride the same transport resolution the old send path
- * used; the recipient's network is pinned to the SESSION network (§5.6).
- */
-async function resolveRecipientInfo(
+/** §5.6: the recipient's network is what the identifier PROVES, else `null`
+ *  — stamping the session network made the guard compare it with itself (#733). */
+export async function resolveRecipientInfo(
   identifier: string,
   network: string,
   resolvePeer: (identifier: string) => Promise<PeerInfo | null>
 ): Promise<RecipientInfo | null> {
+  // Typing a bare pubkey into THIS session is the caller asserting it — stamped.
   if (CHAIN_PUBKEY_RE.test(identifier)) {
     return { chainPubkey: identifier.toLowerCase(), network };
   }
@@ -267,7 +266,8 @@ async function resolveRecipientInfo(
   if (!peer?.chainPubkey) return null;
   return {
     chainPubkey: peer.chainPubkey,
-    network,
+    // Only what the binding declares (blank declares nothing) — never a local stamp.
+    network: peer.network || null,
     ...(peer.nametag !== undefined ? { nametag: peer.nametag } : {}),
   };
 }

--- a/docs/PAYMENTS-V2-DESIGN.md
+++ b/docs/PAYMENTS-V2-DESIGN.md
@@ -401,7 +401,25 @@ ride today's publish API at all, and the transport layer (relays are shared acro
 not know its own network either. Refusing every unproven recipient would therefore refuse every
 nametag/`DIRECT://` send between current wallets. Sphere parses the claim wherever a binding
 carries one and invents it nowhere; **#734** tracks putting it on the publish side and then
-tightening this row to a hard refusal.
+tightening this row to a hard refusal. It also owes the comparison a **canonical network name**
+before any publisher ships: row 1 is an exact string compare, and this repo already aliases
+`testnet` → `testnet2`, so an alias or case mismatch between the word a binding declares and the
+session's would refuse a *same-network* send. Normalize both sides when the publish side lands —
+never by loosening the compare afterwards.
+
+**Reading it is per-route, and two routes cannot (#734).** `resolveTransportPubkeyInfo` and
+`discoverAddresses` parse the raw signed binding event, so a declaration there IS read and row 1
+fires end to end. `@nametag` and `DIRECT://` resolve through nostr-js-sdk's
+`queryBindingByNametag`/`queryBindingByAddress`, which hardcode `parseBindingInfo` inside a
+**private** resolver: sphere never sees the signed event that UNIP-01 resolution selected, and the
+parse has already dropped every content field outside its whitelist. Re-querying raw would mean
+re-deriving ownership ourselves (marker preference, cross-author first-seen-wins, ambiguity→null,
+multi-relay settle — all private), and a second resolver that can disagree with the SDK's is worse
+than a missing field on a money guard. So for those two routes §5.6 can only ever land on row 3
+today; `bindingInfoToPeerInfo` therefore carries **no** network at all rather than a value that
+merely looks read. The limitation is pinned by
+`tests/unit/payments-v2/recipient-network.transport.test.ts` (relay → transport → resolver →
+gate, per route), which goes red the day upstream carries the field.
 
 ### 5.7 `Receive`
 

--- a/docs/PAYMENTS-V2-DESIGN.md
+++ b/docs/PAYMENTS-V2-DESIGN.md
@@ -373,11 +373,35 @@ content-derived `hex(SHA-256(tokenId ‖ stateHash))` via the engine's `delivery
 never a server row id or seq. Two more Delivery-owned rules: **cross-network misdirection is the
 sender's to prevent** — a deposit keys the recipient under the *sender's* network, the server
 does not remap, and it returns 200 for an entry the recipient will never query; so the
-recipient's network is pinned at resolve time and a recipient not verifiably on the session
-network is refused **before certification** (deposit 200 ≠ reachability — otherwise the journal
-entry is removed while the recipient never sees the entry). And **memo encryption is owned
-here**: the delivery memo is the recipient-ECDH `sphere-deliveryenc-v1` bundle
-(`core/delivery-envelope.ts`, shared with Requests); the server rejects non-`enc1.` envelopes.
+recipient's network is settled at resolve time, **before certification** (deposit 200 ≠
+reachability — otherwise the journal entry is removed while the recipient never sees the entry).
+And **memo encryption is owned here**: the delivery memo is the recipient-ECDH
+`sphere-deliveryenc-v1` bundle (`core/delivery-envelope.ts`, shared with Requests); the server
+rejects non-`enc1.` envelopes.
+
+**Proving the recipient's network (#733/#734).** `RecipientInfo.network` is `string | null` and
+carries only what the identifier **proves**: a bare chain pubkey is session-stamped (typing one
+into this session *is* the caller asserting a recipient on it), a resolved peer reports
+`PeerInfo.network ?? null` — never a local stamp. That distinction is the whole guard: until
+#733 the resolver stamped the session network onto *every* recipient, so
+`requireSameNetworkRecipient` compared the session network with a copy of itself and could not
+fire, and its only test injected a fake resolver, proving nothing about the shipped path.
+Guard posture, both outcomes ahead of any reserve/intent/engine work:
+
+| recipient network | outcome |
+|---|---|
+| proves a different network | refuse, `INVALID_RECIPIENT` naming both networks |
+| proves the session network | proceed |
+| proves nothing (`null`) | **proceed**, `transfer:attention { code: 'recipient:network-unverified' }` |
+
+The third row is a deliberate **transition** posture, not the target. No identity binding
+published so far declares a network — the nostr-js-sdk binding builders whitelist the content
+fields (`public_key`/`l1_address`/`direct_address`/`proxy_address`), so a `network` claim cannot
+ride today's publish API at all, and the transport layer (relays are shared across networks) does
+not know its own network either. Refusing every unproven recipient would therefore refuse every
+nametag/`DIRECT://` send between current wallets. Sphere parses the claim wherever a binding
+carries one and invents it nowhere; **#734** tracks putting it on the publish side and then
+tightening this row to a hard refusal.
 
 ### 5.7 `Receive`
 

--- a/modules/payments-v2/PaymentsFacade.ts
+++ b/modules/payments-v2/PaymentsFacade.ts
@@ -19,6 +19,7 @@ import type { Asset, IncomingTransfer, Token, TokenTransferDetail, TransferResul
 import type { ConnectionStatus, HistoryPage, MintResult, PaymentsV2, PendingTransfer, SendRequest } from './api';
 import { SerialChain, SingleFlight } from './async';
 import { ConvergenceHeartbeat, Converger, derivePendingTransfers } from './convergence';
+import { requireSameNetworkRecipient } from './recipient';
 import { reseedAndReset, type RestoreDeps } from './restore';
 import type { MintJournalEntry, ShortfallEntry } from './stores';
 import type { History } from './history/History';
@@ -36,7 +37,6 @@ import {
   supportsDeterministicMint,
   type HeldStateCache,
   type PaymentsFacadeDeps,
-  type RecipientInfo,
 } from './compose';
 
 export {
@@ -49,6 +49,7 @@ export {
   type RecipientInfo,
 } from './compose';
 export { ATTENTION_RESEED_REJECTED } from './restore';
+export { ATTENTION_RECIPIENT_NETWORK_UNVERIFIED } from './recipient';
 
 /** Max re-plans after a conflicted attempt (#625/#677 parity with the old send loop). */
 export const MAX_RESELECT = 8;
@@ -305,7 +306,7 @@ export class PaymentsFacade implements PaymentsV2 {
   }
 
   private async sendWithPolicy(request: SendRequest, run: SendRun): Promise<TransferResult> {
-    const recipient = await this.requireSameNetworkRecipient(request.recipient);
+    const recipient = await requireSameNetworkRecipient(this.deps, request.recipient);
     for (let attempt = 0; ; attempt++) {
       let ctx: AttemptCtx;
       try {
@@ -327,21 +328,6 @@ export class PaymentsFacade implements PaymentsV2 {
       const surfaced = await this.consumePartial(ctx, disposition, run, attempt);
       if (surfaced !== null) return surfaced;
     }
-  }
-
-  /** §5.6 cross-network deposit trap: refused BEFORE any reserve/certification. */
-  private async requireSameNetworkRecipient(identifier: string): Promise<RecipientInfo> {
-    const recipient = await this.deps.resolveRecipient(identifier);
-    if (recipient === null || recipient.chainPubkey === '') {
-      throw new SphereError(`Recipient ${identifier} has no published chain pubkey`, 'INVALID_RECIPIENT');
-    }
-    if (recipient.network !== this.deps.network) {
-      throw new SphereError(
-        `Recipient ${identifier} is on network "${recipient.network}" but this session is on "${this.deps.network}" — a cross-network deposit is unrecoverable`,
-        'INVALID_RECIPIENT'
-      );
-    }
-    return recipient;
   }
 
   private async runAttempt(ctx: AttemptCtx): Promise<AttemptDisposition> {

--- a/modules/payments-v2/compose.ts
+++ b/modules/payments-v2/compose.ts
@@ -38,7 +38,8 @@ export function supportsDeterministicMint(
 
 export interface RecipientInfo {
   chainPubkey: string;
-  network: string;
+  /** The recipient's PROVEN network — `null` when nothing proved one (§5.6). */
+  network: string | null;
   nametag?: string;
 }
 

--- a/modules/payments-v2/index.ts
+++ b/modules/payments-v2/index.ts
@@ -6,6 +6,7 @@ export {
   PaymentsFacade,
   MAX_RESELECT,
   ATTENTION_MINT_UNRESOLVED,
+  ATTENTION_RECIPIENT_NETWORK_UNVERIFIED,
   ATTENTION_RESEED_REJECTED,
   supportsDeterministicMint,
 } from './PaymentsFacade';

--- a/modules/payments-v2/recipient.ts
+++ b/modules/payments-v2/recipient.ts
@@ -1,0 +1,41 @@
+// §5.6 recipient gate (facade policy in its own file, like restore.ts): the
+// cross-network deposit trap — a deposit keys the recipient under the SENDER's
+// network and the server 200s an entry the recipient never queries. TRANSITION
+// (#734): unproven is not foreign — see docs/PAYMENTS-V2-DESIGN.md §5.6.
+
+import { SphereError } from '../../core/errors';
+
+import type { RecipientInfo } from './compose';
+
+export const ATTENTION_RECIPIENT_NETWORK_UNVERIFIED = 'recipient:network-unverified';
+
+export interface RecipientGateDeps {
+  resolveRecipient: (identifier: string) => Promise<RecipientInfo | null>;
+  network: string;
+  emit: (event: string, payload: unknown) => void;
+}
+
+export async function requireSameNetworkRecipient(
+  deps: RecipientGateDeps,
+  identifier: string
+): Promise<RecipientInfo> {
+  const recipient = await deps.resolveRecipient(identifier);
+  if (recipient === null || recipient.chainPubkey === '') {
+    throw new SphereError(`Recipient ${identifier} has no published chain pubkey`, 'INVALID_RECIPIENT');
+  }
+  if (recipient.network === null) {
+    deps.emit('transfer:attention', {
+      transferId: '', // the gate precedes plan allocation — no transferId exists yet
+      code: ATTENTION_RECIPIENT_NETWORK_UNVERIFIED,
+      detail: `could not verify the network of recipient ${identifier} — assuming this session's "${deps.network}"`,
+    });
+    return recipient;
+  }
+  if (recipient.network !== deps.network) {
+    throw new SphereError(
+      `Recipient ${identifier} is on network "${recipient.network}" but this session is on "${deps.network}" — a cross-network deposit is unrecoverable`,
+      'INVALID_RECIPIENT'
+    );
+  }
+  return recipient;
+}

--- a/modules/payments-v2/recipient.ts
+++ b/modules/payments-v2/recipient.ts
@@ -1,7 +1,6 @@
-// §5.6 recipient gate (facade policy in its own file, like restore.ts): the
-// cross-network deposit trap — a deposit keys the recipient under the SENDER's
-// network and the server 200s an entry the recipient never queries. TRANSITION
-// (#734): unproven is not foreign — see docs/PAYMENTS-V2-DESIGN.md §5.6.
+// §5.6 recipient gate: the cross-network deposit trap — a deposit keys the
+// recipient under the SENDER's network and the server 200s an entry the
+// recipient never queries. TRANSITION (#734) — docs/PAYMENTS-V2-DESIGN.md §5.6.
 
 import { SphereError } from '../../core/errors';
 
@@ -31,6 +30,7 @@ export async function requireSameNetworkRecipient(
     });
     return recipient;
   }
+  // #734 owes this compare a canonical name (`testnet` aliases `testnet2`) — §5.6.
   if (recipient.network !== deps.network) {
     throw new SphereError(
       `Recipient ${identifier} is on network "${recipient.network}" but this session is on "${deps.network}" — a cross-network deposit is unrecoverable`,

--- a/tests/integration/sphere-payments-v2-wiring.test.ts
+++ b/tests/integration/sphere-payments-v2-wiring.test.ts
@@ -24,7 +24,7 @@ import { SphereError } from '../../core/errors';
 import { getPublicKey, hexToBytes } from '../../core/crypto';
 import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
 import { TRUSTBASE_TESTNET2 } from '../../assets/trustbase';
-import type { TransportProvider } from '../../transport';
+import type { PeerInfo, TransportProvider } from '../../transport';
 import type { OracleProvider } from '../../oracle';
 import type { ProviderStatus } from '../../types';
 import type { ITokenEngine } from '../../token-engine';
@@ -46,7 +46,7 @@ const COIN = 'aa'.repeat(32);
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-function createMockTransport(): TransportProvider {
+function createMockTransport(peers: Record<string, PeerInfo> = {}): TransportProvider {
   return {
     id: 'mock-transport',
     name: 'Mock Transport',
@@ -62,7 +62,7 @@ function createMockTransport(): TransportProvider {
     subscribeToBroadcast: vi.fn().mockReturnValue(() => {}),
     publishBroadcast: vi.fn().mockResolvedValue('broadcast-id'),
     onEvent: vi.fn().mockReturnValue(() => {}),
-    resolve: vi.fn().mockResolvedValue(null),
+    resolve: vi.fn(async (identifier: string) => peers[identifier] ?? null),
     resolveNametag: vi.fn().mockResolvedValue(null),
     publishIdentityBinding: vi.fn().mockResolvedValue(true),
     recoverNametag: vi.fn().mockResolvedValue(null),
@@ -170,6 +170,19 @@ async function seedInventory(world: World, record: TransportRecord, amount: bigi
   return token;
 }
 
+const PEER_PUB = getPublicKey('22'.repeat(32));
+
+/** A resolved Nostr identity binding; `network` omitted = the binding declares none. */
+function peerBinding(overrides: Partial<PeerInfo> = {}): PeerInfo {
+  return {
+    transportPubkey: PEER_PUB.slice(2),
+    chainPubkey: PEER_PUB,
+    directAddress: 'DIRECT://peer',
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
 const cleanups: (() => Promise<void>)[] = [];
 afterEach(async () => {
   for (const cleanup of cleanups.splice(0)) {
@@ -180,6 +193,7 @@ afterEach(async () => {
 interface BuildOptions {
   paymentsV2?: boolean;
   walletApi: WalletApiTransportConfig;
+  peers?: Record<string, PeerInfo>;
 }
 
 async function buildSphere(options: BuildOptions): Promise<Sphere> {
@@ -187,7 +201,7 @@ async function buildSphere(options: BuildOptions): Promise<Sphere> {
   const storage = new FileStorageProvider({ dataDir });
   const { sphere } = await Sphere.init({
     storage,
-    transport: createMockTransport(),
+    transport: createMockTransport(options.peers),
     oracle: createEngineOracle(),
     mnemonic: MNEMONIC,
     // #728 single-network invariant: the Sphere network must equal walletApi.network.
@@ -303,6 +317,43 @@ describe('Sphere payments wiring — defaults (P11 flip: the vertical is default
     });
     const assets = await sphere.payments.assets(COIN);
     expect(assets[0]?.totalAmount).toBe('40');
+  }, 20_000);
+
+  // #733: proves composePaymentsV2 wires the resolver that reports the PEER's
+  // network — a session stamp anywhere on this path makes the §5.6 guard dead.
+  it('#733 cross-network guard on the composed path: a peer declaring another network is refused, one declaring none is signalled', async () => {
+    const world = makeWorld();
+    const sphere = await buildSphere({
+      walletApi: world.walletApi,
+      peers: { '@mars': peerBinding({ network: 'mars' }), '@ghost': peerBinding() },
+    });
+    await seedInventory(world, world.transports[0]!, 40n);
+    world.transports[0]!.session.fire('inventory');
+    await vi.waitFor(() => {
+      expect(sphere.payments.tokens()).toHaveLength(1);
+    });
+    const attention: unknown[] = [];
+    sphere.on('transfer:attention', (payload) => attention.push(payload));
+
+    await expect(
+      sphere.payments.send({ recipient: '@mars', amount: '10', coinId: COIN })
+    ).rejects.toMatchObject({ code: 'INVALID_RECIPIENT' });
+    expect(attention).toEqual([]);
+
+    // A binding declaring nothing is every wallet in the fleet today: signalled, not
+    // refused — the send gets PAST the guard (and then dies materializing this world's
+    // fake-minted blob against the REAL engine, which is not the guard's business).
+    const outcome = await sphere.payments
+      .send({ recipient: '@ghost', amount: '10', coinId: COIN })
+      .catch((err: unknown) => err);
+    expect((outcome as SphereError).code).not.toBe('INVALID_RECIPIENT');
+    expect(attention).toEqual([
+      {
+        transferId: '',
+        code: 'recipient:network-unverified',
+        detail: expect.stringContaining('@ghost') as unknown,
+      },
+    ]);
   }, 20_000);
 
   it('`paymentsV2: true` and `paymentsV2: false` are both tolerated no-ops (one release)', async () => {

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -174,5 +174,13 @@
     "find": "    await ctx.machine.resumeIntent({\n      transferId: job.transferId,",
     "replace": "    await ctx.machine.resumeIntent({\n      transferId: `${job.transferId}:reissued`,",
     "tests": ["tests/unit/payments-v2/heartbeat.test.ts"]
+  },
+  {
+    "name": "wiring-stamps-session-network-on-peer",
+    "note": "#733: the peer branch reports only what the binding PROVES — stamping the session network makes the §5.6 guard compare it with itself, i.e. unfalsifiable (facade.test.ts network-guard asserts)",
+    "file": "core/payments-v2-wiring.ts",
+    "find": "    network: peer.network || null,",
+    "replace": "    network,",
+    "tests": ["tests/unit/payments-v2/facade.test.ts"]
   }
 ]

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -182,5 +182,21 @@
     "find": "    network: peer.network || null,",
     "replace": "    network,",
     "tests": ["tests/unit/payments-v2/facade.test.ts"]
+  },
+  {
+    "name": "transport-drops-network-from-raw-event",
+    "note": "#735 review: the transport-pubkey route is the ONE recipient route that can prove a network today — it must read the raw signed event, not lose it (recipient-network.transport.test.ts refuses a relay-declared foreign network end to end)",
+    "file": "transport/NostrTransportProvider.ts",
+    "find": "      const network = declaredNetwork(bindingEvent);",
+    "replace": "      const network = undefined as string | undefined;",
+    "tests": ["tests/unit/payments-v2/recipient-network.transport.test.ts"]
+  },
+  {
+    "name": "transport-invents-network-on-parsed-binding",
+    "note": "#735 review: the SDK-parsed @nametag/DIRECT:// routes cannot prove a network (parseBindingInfo whitelists it away) and must NOT invent one — a stamp silences the recipient:network-unverified signal, which is the #733 bug wearing a new hat (recipient-network.transport.test.ts LIMITATION asserts)",
+    "file": "transport/NostrTransportProvider.ts",
+    "find": "    return {\n      nametag: nametag || binding.nametag,",
+    "replace": "    return {\n      network: 'testnet2',\n      nametag: nametag || binding.nametag,",
+    "tests": ["tests/unit/payments-v2/recipient-network.transport.test.ts"]
   }
 ]

--- a/tests/unit/payments-v2/facade-harness.ts
+++ b/tests/unit/payments-v2/facade-harness.ts
@@ -170,7 +170,16 @@ export function peerBinding(overrides: Partial<PeerInfo> = {}): PeerInfo {
 }
 
 export function makeWorld(
-  options: { engine?: RealizationEngine; peers?: Record<string, PeerInfo | null> } = {}
+  options: {
+    engine?: RealizationEngine;
+    peers?: Record<string, PeerInfo | null>;
+    /**
+     * Replaces the in-memory `peers` directory with a real peer lookup — used by
+     * the transport-driven §5.6 tests, which run identifiers through a real
+     * NostrTransportProvider over a fake relay instead of an injected PeerInfo.
+     */
+    resolvePeer?: (identifier: string) => Promise<PeerInfo | null>;
+  } = {}
 ): World {
   const engine = options.engine ?? new RealizationEngine({ chainPubkey: hexToBytes(OWN_PUB) });
   const engines = [engine];
@@ -230,7 +239,11 @@ export function makeWorld(
       events.push({ event, payload });
     },
     resolveRecipient: (identifier) =>
-      resolveRecipientInfo(identifier, NET, async (id) => peers.get(id) ?? null),
+      resolveRecipientInfo(
+        identifier,
+        NET,
+        options.resolvePeer ?? (async (id) => peers.get(id) ?? null)
+      ),
     signComplete: async (transferId) => fakeSeedSignature(OWN_PUB, completeMessageFor(transferId)),
     fieldKey: new Uint8Array(32).fill(7),
     network: NET,

--- a/tests/unit/payments-v2/facade-harness.ts
+++ b/tests/unit/payments-v2/facade-harness.ts
@@ -5,15 +5,13 @@
  */
 
 import { getPublicKey, hexToBytes } from '../../../core/crypto';
+import { resolveRecipientInfo } from '../../../core/payments-v2-wiring';
+import type { PeerInfo } from '../../../transport';
 import type { SphereToken } from '../../../token-engine';
 import { WalletApiStoragePort } from '../../../impl/wallet-api-v2/storage';
 import { WalletApiDeliveryPort } from '../../../impl/wallet-api-v2/mailbox';
 import type { DeliveryPort, StoragePort } from '../../../modules/payments-v2/ports';
-import {
-  PaymentsFacade,
-  type FacadeClient,
-  type RecipientInfo,
-} from '../../../modules/payments-v2/PaymentsFacade';
+import { PaymentsFacade, type FacadeClient } from '../../../modules/payments-v2/PaymentsFacade';
 import { RealizationEngine, fakeDecodeBlobFor } from './machine-harness';
 import {
   FakeSession,
@@ -143,7 +141,8 @@ export interface World {
   counters: Counters;
   events: { event: string; payload: unknown }[];
   gates: Gate[];
-  resolveMap: Map<string, RecipientInfo | null>;
+  /** The fake transport directory the production resolver reads (identifier → binding). */
+  peers: Map<string, PeerInfo | null>;
   seed(amount: bigint): Promise<SphereToken>;
   peerDeliver(token: SphereToken, transferId: string): Promise<void>;
   gate(name: 'putIntent' | 'deliver' | 'listOpen' | 'applyDelta'): Gate;
@@ -159,7 +158,20 @@ export async function cleanupWorlds(): Promise<void> {
   }
 }
 
-export function makeWorld(options: { engine?: RealizationEngine } = {}): World {
+/** A Nostr identity binding as PeerInfo; `network` omitted = the binding declares none. */
+export function peerBinding(overrides: Partial<PeerInfo> = {}): PeerInfo {
+  return {
+    transportPubkey: PEER_PUB.slice(2),
+    chainPubkey: PEER_PUB,
+    directAddress: 'DIRECT://peer',
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+export function makeWorld(
+  options: { engine?: RealizationEngine; peers?: Record<string, PeerInfo | null> } = {}
+): World {
   const engine = options.engine ?? new RealizationEngine({ chainPubkey: hexToBytes(OWN_PUB) });
   const engines = [engine];
   const decodeBlob = (bytes: Uint8Array): FakeBlobMeta => {
@@ -191,10 +203,10 @@ export function makeWorld(options: { engine?: RealizationEngine } = {}): World {
   const events: { event: string; payload: unknown }[] = [];
   session.emitStatus = (status) => events.push({ event: 'connection:status', payload: { status } });
   const gates: Gate[] = [];
-  const resolveMap = new Map<string, RecipientInfo | null>([
-    ['@peer', { chainPubkey: PEER_PUB, network: NET }],
-    ['@mars', { chainPubkey: PEER_PUB, network: 'mars' }],
-  ]);
+  // Fake only the TRANSPORT lookup; recipient resolution is the PRODUCTION
+  // resolveRecipientInfo, so the §5.6 guard can never be proven by a fake (#733).
+  const peers = new Map<string, PeerInfo | null>([['@peer', peerBinding({ network: NET })]]);
+  Object.entries(options.peers ?? {}).forEach(([id, peer]) => peers.set(id, peer));
 
   let ids = 0;
   const facade = new PaymentsFacade({
@@ -217,11 +229,8 @@ export function makeWorld(options: { engine?: RealizationEngine } = {}): World {
     emit: (event, payload) => {
       events.push({ event, payload });
     },
-    resolveRecipient: async (identifier) => {
-      if (resolveMap.has(identifier)) return resolveMap.get(identifier)!;
-      if (/^0[23][0-9a-f]{64}$/.test(identifier)) return { chainPubkey: identifier, network: NET };
-      return null;
-    },
+    resolveRecipient: (identifier) =>
+      resolveRecipientInfo(identifier, NET, async (id) => peers.get(id) ?? null),
     signComplete: async (transferId) => fakeSeedSignature(OWN_PUB, completeMessageFor(transferId)),
     fieldKey: new Uint8Array(32).fill(7),
     network: NET,
@@ -244,7 +253,7 @@ export function makeWorld(options: { engine?: RealizationEngine } = {}): World {
     counters,
     events,
     gates,
-    resolveMap,
+    peers,
     seed: async (amount: bigint) => {
       const token = await engine.mint({
         recipientPubkey: hexToBytes(OWN_PUB),

--- a/tests/unit/payments-v2/facade.test.ts
+++ b/tests/unit/payments-v2/facade.test.ts
@@ -13,6 +13,7 @@ import { STORE_KEYS, type MintJournalEntry } from '../../../modules/payments-v2/
 import { createMachineStores } from '../../../modules/payments-v2/machine/journal';
 import {
   ATTENTION_MINT_UNRESOLVED,
+  ATTENTION_RECIPIENT_NETWORK_UNVERIFIED,
   type DeterministicMintCapable,
 } from '../../../modules/payments-v2/PaymentsFacade';
 import { RealizationEngine } from './machine-harness';
@@ -25,6 +26,7 @@ import {
   flushTail,
   makeWorld,
   ownCaller,
+  peerBinding,
   peerCaller,
 } from './facade-harness';
 
@@ -95,14 +97,21 @@ describe('PaymentsFacade — send policy', () => {
     expect(assets[0]?.totalAmount).toBe('300');
   });
 
-  it('cross-network recipient is refused BEFORE any reserve (no putIntent, no engine op, pool untouched)', async () => {
-    const world = makeWorld();
+  // §5.6 network guard — through the PRODUCTION resolveRecipientInfo over a fake
+  // transport directory. The pre-#733 guard stamped the session network onto
+  // every recipient and compared it with itself, so an injected-fake test proved
+  // nothing about the shipped path.
+  it('a peer whose binding declares a DIFFERENT network is refused BEFORE any reserve (no putIntent, no engine op, pool untouched)', async () => {
+    const world = makeWorld({ peers: { '@mars': peerBinding({ network: 'mars' }) } });
     await world.seed(100n);
     await world.facade.start();
 
     await expect(
       world.facade.send({ recipient: '@mars', amount: '100', coinId: COIN })
-    ).rejects.toMatchObject({ code: 'INVALID_RECIPIENT' });
+    ).rejects.toMatchObject({
+      code: 'INVALID_RECIPIENT',
+      message: expect.stringContaining('is on network "mars" but this session is on "testnet2"') as unknown,
+    });
 
     expect(world.counters.putIntent).toBe(0);
     expect(world.engine.transferCalls).toHaveLength(0);
@@ -110,6 +119,54 @@ describe('PaymentsFacade — send policy', () => {
     // The full balance is still plannable — nothing stayed reserved.
     const ok = await world.facade.send({ recipient: '@peer', amount: '100', coinId: COIN });
     expect(ok.status).toBe('delivered');
+  });
+
+  it('a peer whose binding declares the SESSION network proceeds, unsignalled', async () => {
+    const world = makeWorld();
+    await world.seed(100n);
+    await world.facade.start();
+
+    const result = await world.facade.send({ recipient: '@peer', amount: '100', coinId: COIN });
+
+    expect(result.status).toBe('delivered');
+    expect(eventsOf(world, 'transfer:attention')).toEqual([]);
+  });
+
+  it('#734 transition: a binding declaring NO network — or a blank one — proceeds AND is signalled', async () => {
+    const world = makeWorld({
+      peers: { '@peer': peerBinding(), '@blank': peerBinding({ network: '' }) },
+    });
+    await world.seed(50n);
+    await world.seed(50n);
+    await world.facade.start();
+
+    const first = await world.facade.send({ recipient: '@peer', amount: '50', coinId: COIN });
+    const second = await world.facade.send({ recipient: '@blank', amount: '50', coinId: COIN });
+
+    expect([first.status, second.status]).toEqual(['delivered', 'delivered']);
+    expect(eventsOf(world, 'transfer:attention')).toEqual([
+      {
+        transferId: '',
+        code: ATTENTION_RECIPIENT_NETWORK_UNVERIFIED,
+        detail: expect.stringContaining('could not verify the network of recipient @peer') as unknown,
+      },
+      {
+        transferId: '',
+        code: ATTENTION_RECIPIENT_NETWORK_UNVERIFIED,
+        detail: expect.stringContaining('recipient @blank') as unknown,
+      },
+    ]);
+  });
+
+  it('a raw chain pubkey is the caller asserting THIS session — it proceeds unsignalled', async () => {
+    const world = makeWorld();
+    await world.seed(100n);
+    await world.facade.start();
+
+    const result = await world.facade.send({ recipient: PEER_PUB, amount: '100', coinId: COIN });
+
+    expect(result.status).toBe('delivered');
+    expect(eventsOf(world, 'transfer:attention')).toEqual([]);
   });
 
   it('a CLEAN failure emits transfer:updated{status:failed} BEFORE the rejection surfaces (§4 — transfer:updated replaces transfer:failed)', async () => {

--- a/tests/unit/payments-v2/recipient-network.transport.test.ts
+++ b/tests/unit/payments-v2/recipient-network.transport.test.ts
@@ -1,0 +1,311 @@
+// §5.6 cross-network recipient gate, driven from the RELAY (#733/#734).
+//
+// Every other test of this gate hands the facade an already-populated
+// `PeerInfo`/`RecipientInfo`, which is the same hollowness the gate itself had:
+// it proves the comparison, never the production path that must produce the
+// value. Here a fake nostr client serves RAW signed binding events, a real
+// NostrTransportProvider resolves them, the production `resolveRecipientInfo`
+// converts, and the production gate decides — per identifier route.
+//
+// The routes do NOT have the same capability, and that asymmetry is the point:
+//   - transport pubkey (64-hex): sphere parses the signed event itself, so a
+//     declared network IS read and a foreign one IS refused, end to end.
+//   - `@nametag` / `DIRECT://`: resolution goes through nostr-js-sdk's
+//     `queryBindingBy*`, whose `parseBindingInfo` whitelists the content fields
+//     and never hands back the selected event — the declaration is dropped
+//     before sphere can see it, so the gate can only SIGNAL. That limitation is
+//     PINNED below (with upstream's real parser doing the dropping), not
+//     assumed; the pins go red the day #734 lands, which is when
+//     `bindingInfoToPeerInfo` must start carrying the field.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NOSTR_EVENT_KINDS } from '../../../constants';
+import { ATTENTION_RECIPIENT_NETWORK_UNVERIFIED } from '../../../modules/payments-v2/PaymentsFacade';
+import type { PeerInfo } from '../../../transport';
+import type { WebSocketFactory } from '../../../transport/websocket';
+import { COIN, NET, PEER_PUB, cleanupWorlds, eventsOf, makeWorld } from './facade-harness';
+
+// =============================================================================
+// Fake relay: raw signed binding events, indexed the three ways resolution asks
+// =============================================================================
+
+interface RawEvent {
+  id: string;
+  kind: number;
+  content: string;
+  tags: string[][];
+  pubkey: string;
+  created_at: number;
+  sig: string;
+}
+
+const fake = vi.hoisted(() => ({
+  events: [] as {
+    id: string;
+    kind: number;
+    content: string;
+    tags: string[][];
+    pubkey: string;
+    created_at: number;
+    sig: string;
+  }[],
+  byNametag: new Map<string, unknown>(),
+  byAddress: new Map<string, unknown>(),
+}));
+
+vi.mock('@unicitylabs/nostr-js-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/nostr-js-sdk')>();
+  const filterOf = (filter: unknown): Record<string, unknown> =>
+    typeof (filter as { toJSON?: () => Record<string, unknown> }).toJSON === 'function'
+      ? (filter as { toJSON: () => Record<string, unknown> }).toJSON()
+      : (filter as Record<string, unknown>);
+  return {
+    ...actual,
+    NostrClient: vi.fn().mockImplementation(() => ({
+      connect: async () => undefined,
+      disconnect: () => undefined,
+      isConnected: () => true,
+      getConnectedRelays: () => new Set(['wss://fake.relay']),
+      addConnectionListener: () => undefined,
+      removeConnectionListener: () => undefined,
+      publishEvent: async () => 'fake-event-id',
+      getQueryTimeout: () => 20000,
+      setQueryTimeout: () => undefined,
+      unsubscribe: () => undefined,
+      // Raw REQ: authors-filtered stored events, then EOSE — what
+      // resolveTransportPubkeyInfo/discoverAddresses read.
+      subscribe: (...args: unknown[]) => {
+        const [filter, listener] = (
+          typeof args[0] === 'string' ? args.slice(1) : args
+        ) as [unknown, { onEvent?: (e: unknown) => void; onEndOfStoredEvents?: (id: string) => void }];
+        const authors = filterOf(filter).authors as string[] | undefined;
+        setTimeout(() => {
+          if (authors) {
+            for (const event of fake.events) {
+              if (authors.includes(event.pubkey)) listener.onEvent?.(event);
+            }
+          }
+          listener.onEndOfStoredEvents?.('fake-sub');
+        }, 0);
+        return 'fake-sub';
+      },
+      // The two SDK-parsed routes: resolution picks the owner's event and hands
+      // back ONLY `parseBindingInfo`'s whitelist — upstream's REAL parser here,
+      // so what it drops is upstream's behaviour, not this fake's.
+      queryBindingByNametag: async (nametag: string) => {
+        const event = fake.byNametag.get(nametag);
+        return event ? actual.parseBindingInfo(event as Parameters<typeof actual.parseBindingInfo>[0]) : null;
+      },
+      queryBindingByAddress: async (address: string) => {
+        const event = fake.byAddress.get(address);
+        return event ? actual.parseBindingInfo(event as Parameters<typeof actual.parseBindingInfo>[0]) : null;
+      },
+      queryPubkeyByNametag: async () => null,
+      publishNametagBinding: async () => true,
+      publishIdentityBinding: async () => true,
+    })),
+  };
+});
+
+const { NostrTransportProvider } = await import('../../../transport/NostrTransportProvider');
+const { parseBindingInfo } = await import('@unicitylabs/nostr-js-sdk');
+type SdkEvent = Parameters<typeof parseBindingInfo>[0];
+type BindingInfo = ReturnType<typeof parseBindingInfo>;
+
+// Type-level tripwire, checked by `npm run typecheck:tests`: when upstream
+// (#734) adds `network` to BindingInfo this stops compiling — wire it into
+// NostrTransportProvider.bindingInfoToPeerInfo and delete the tripwire.
+type UpstreamBindingCarriesNetwork = 'network' extends keyof BindingInfo ? true : false;
+const upstreamBindingCarriesNetwork: UpstreamBindingCarriesNetwork = false;
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const PEER_TRANSPORT_PUB = PEER_PUB.slice(2); // x-only nostr pubkey (64 hex)
+const PEER_DIRECT = 'DIRECT://peer';
+
+let seq = 0;
+
+/** A raw, signed identity-binding event as it sits on a relay. */
+function bindingEvent(content: Record<string, unknown>, pubkey = PEER_TRANSPORT_PUB): RawEvent {
+  return {
+    id: `event-${++seq}`,
+    kind: NOSTR_EVENT_KINDS.NAMETAG_BINDING,
+    content: JSON.stringify(content),
+    tags: [['d', `d-${seq}`]],
+    pubkey,
+    created_at: 1_700_000_000 + seq,
+    sig: 'fake-sig',
+  };
+}
+
+/** Publishes one binding event to the fake relay under every lookup route. */
+function publishBinding(options: { network?: string; nametag?: string } = {}): RawEvent {
+  const content: Record<string, unknown> = {
+    public_key: PEER_PUB,
+    direct_address: PEER_DIRECT,
+    ...(options.nametag !== undefined ? { nametag: options.nametag } : {}),
+    ...(options.network !== undefined ? { network: options.network } : {}),
+  };
+  const event = bindingEvent(content);
+  fake.events.push(event);
+  fake.byNametag.set(options.nametag ?? 'alice', event);
+  fake.byAddress.set(PEER_DIRECT, event);
+  return event;
+}
+
+let transport: InstanceType<typeof NostrTransportProvider>;
+
+async function connectTransport(): Promise<void> {
+  transport = new NostrTransportProvider({
+    relays: ['wss://fake.relay'],
+    // Inert: the (mocked) NostrClient owns its sockets, so this is never called.
+    createWebSocket: (() => undefined) as unknown as WebSocketFactory,
+    timeout: 1000,
+    autoReconnect: false,
+  });
+  transport.setIdentity({ privateKey: '33'.repeat(32), chainPubkey: PEER_PUB });
+  await transport.connect();
+}
+
+const resolvePeer = (identifier: string): Promise<PeerInfo | null> => transport.resolve(identifier);
+
+beforeEach(async () => {
+  fake.events.length = 0;
+  fake.byNametag.clear();
+  fake.byAddress.clear();
+  await connectTransport();
+});
+
+afterEach(async () => {
+  await cleanupWorlds();
+  await transport.disconnect();
+});
+
+// =============================================================================
+// Resolution: what each route can and cannot read off the relay
+// =============================================================================
+
+describe('NostrTransportProvider — the network a binding declares, per route', () => {
+  it('transport-pubkey route: reads the network declared by the raw signed event', async () => {
+    publishBinding({ network: 'mars' });
+
+    const peer = await transport.resolve(PEER_TRANSPORT_PUB);
+
+    expect(peer?.chainPubkey).toBe(PEER_PUB);
+    expect(peer?.network).toBe('mars');
+  });
+
+  it('transport-pubkey route: a binding with no network — or a blank one — declares nothing', async () => {
+    publishBinding();
+    expect((await transport.resolve(PEER_TRANSPORT_PUB))?.network).toBeUndefined();
+
+    fake.events.length = 0;
+    publishBinding({ network: '' });
+    expect((await transport.resolve(PEER_TRANSPORT_PUB))?.network).toBeUndefined();
+  });
+
+  // TRIPWIRE (#734). Upstream's own parser does the dropping here. When these
+  // two go red, `network` survives `parseBindingInfo` — wire it through
+  // bindingInfoToPeerInfo, flip these expectations, and tighten §5.6's third row.
+  it('@nametag route: upstream drops a declared network before sphere can see it', async () => {
+    const event = publishBinding({ network: 'mars', nametag: 'alice' });
+    expect((JSON.parse(event.content) as { network: string }).network).toBe('mars');
+    expect('network' in parseBindingInfo(event as unknown as SdkEvent)).toBe(false);
+    expect(upstreamBindingCarriesNetwork).toBe(false);
+
+    const peer = await transport.resolve('@alice');
+
+    expect(peer?.chainPubkey).toBe(PEER_PUB); // the route worked…
+    expect(peer?.network).toBeUndefined(); // …only the declaration is gone
+  });
+
+  it('DIRECT:// route: upstream drops a declared network before sphere can see it', async () => {
+    publishBinding({ network: 'mars' });
+
+    const peer = await transport.resolve(PEER_DIRECT);
+
+    expect(peer?.chainPubkey).toBe(PEER_PUB);
+    expect(peer?.network).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// The gate, reached from the relay through production resolution
+// =============================================================================
+
+describe('§5.6 recipient gate — relay → transport → resolveRecipientInfo → facade', () => {
+  it('transport-pubkey recipient on ANOTHER network is REFUSED before any reserve', async () => {
+    publishBinding({ network: 'mars' });
+    const world = makeWorld({ resolvePeer });
+    await world.seed(100n);
+    await world.facade.start();
+
+    await expect(
+      world.facade.send({ recipient: PEER_TRANSPORT_PUB, amount: '100', coinId: COIN })
+    ).rejects.toMatchObject({
+      code: 'INVALID_RECIPIENT',
+      message: expect.stringContaining(`is on network "mars" but this session is on "${NET}"`) as unknown,
+    });
+
+    expect(world.counters.putIntent).toBe(0);
+    expect(world.engine.transferCalls).toHaveLength(0);
+    expect(eventsOf(world, 'transfer:attention')).toEqual([]);
+  });
+
+  it('transport-pubkey recipient proving THIS session network proceeds, unsignalled', async () => {
+    publishBinding({ network: NET });
+    const world = makeWorld({ resolvePeer });
+    await world.seed(100n);
+    await world.facade.start();
+
+    const result = await world.facade.send({
+      recipient: PEER_TRANSPORT_PUB,
+      amount: '100',
+      coinId: COIN,
+    });
+
+    expect(result.status).toBe('delivered');
+    expect(eventsOf(world, 'transfer:attention')).toEqual([]);
+  });
+
+  // The limitation, enforced where it costs money: the binding on the relay
+  // DOES declare a foreign network, and these two routes still send.
+  it('LIMITATION (#734) @nametag recipient: the declaration is unreadable, so the send PROCEEDS and is signalled', async () => {
+    publishBinding({ network: 'mars', nametag: 'alice' });
+    const world = makeWorld({ resolvePeer });
+    await world.seed(100n);
+    await world.facade.start();
+
+    const result = await world.facade.send({ recipient: '@alice', amount: '100', coinId: COIN });
+
+    expect(result.status).toBe('delivered');
+    expect(eventsOf(world, 'transfer:attention')).toEqual([
+      {
+        transferId: '',
+        code: ATTENTION_RECIPIENT_NETWORK_UNVERIFIED,
+        detail: expect.stringContaining('could not verify the network of recipient @alice') as unknown,
+      },
+    ]);
+  });
+
+  it('LIMITATION (#734) DIRECT:// recipient: the declaration is unreadable, so the send PROCEEDS and is signalled', async () => {
+    publishBinding({ network: 'mars' });
+    const world = makeWorld({ resolvePeer });
+    await world.seed(100n);
+    await world.facade.start();
+
+    const result = await world.facade.send({ recipient: PEER_DIRECT, amount: '100', coinId: COIN });
+
+    expect(result.status).toBe('delivered');
+    expect(eventsOf(world, 'transfer:attention')).toEqual([
+      {
+        transferId: '',
+        code: ATTENTION_RECIPIENT_NETWORK_UNVERIFIED,
+        detail: expect.stringContaining(`recipient ${PEER_DIRECT}`) as unknown,
+      },
+    ]);
+  });
+});

--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -96,15 +96,30 @@ const TIMESTAMP_RANDOMIZATION = 2 * 24 * 60 * 60;
 const EVENT_KINDS = NOSTR_EVENT_KINDS;
 
 /**
- * The network an identity binding DECLARES, or undefined — read-if-present,
- * never invented (a stamped guess is what made the §5.6 money guard dead, #733).
- * No publisher emits one yet: nostr-js-sdk's binding builders whitelist the
- * content fields (`public_key`/`l1_address`/`direct_address`/`proxy_address`),
- * so a `network` claim cannot ride today's publish API — hence sends to an
- * unproven peer are SIGNALLED, not refused, until upstream carries it (#734).
+ * The network a RAW SIGNED binding event declares in its content, or undefined —
+ * read-if-present, never invented (a stamped guess is what made the §5.6 money
+ * guard dead, #733).
+ *
+ * It takes the EVENT, not a parsed shape, and the parameter type is the point:
+ * nostr-js-sdk's `parseBindingInfo` whitelists the binding content
+ * (`public_key`/`l1_address`/`direct_address`/`proxy_address`/`nametag`) and
+ * drops everything else, so a `BindingInfo` can never carry a network — handing
+ * one to this function would compile into a value that is `undefined` for all
+ * time, which is exactly the dead read the #735 review caught. A `BindingInfo`
+ * is not a `NostrEvent`; that mistake is now a type error, not a comment.
+ *
+ * Nothing declares a network yet either: the publish side
+ * (`IdentityBindingParams` + `createBindingEvent`/`createIdentityBindingEvent`)
+ * whitelists the same fields, so the claim cannot ride today's publish API at
+ * all — hence sends to an unproven peer are SIGNALLED, not refused (#734).
  */
-function declaredNetwork(content: unknown): string | undefined {
-  const value = (content as { network?: unknown } | null | undefined)?.network;
+function declaredNetwork(event: NostrEvent): string | undefined {
+  let value: unknown;
+  try {
+    value = (JSON.parse(event.content) as { network?: unknown } | null)?.network;
+  } catch {
+    return undefined;
+  }
   return typeof value === 'string' && value !== '' ? value : undefined;
 }
 
@@ -752,15 +767,33 @@ export class NostrTransportProvider implements TransportProvider {
 
   /**
    * Convert a BindingInfo (from nostr-js-sdk) to PeerInfo (sphere-sdk type).
+   *
+   * `network` IS DELIBERATELY ABSENT HERE — a live limitation, not an oversight
+   * (#734). `queryBindingByNametag`/`queryBindingByAddress` are the whole public
+   * resolution API for `@nametag` and `DIRECT://`, and both hardcode
+   * `parseBindingInfo` inside the SDK's PRIVATE `queryWithFirstSeenWins`: the
+   * caller never sees the signed event that resolution selected, and the parse
+   * has already dropped every content field outside its whitelist. Re-querying
+   * raw would mean re-deriving UNIP-01 ownership ourselves (marker preference,
+   * cross-author first-seen-wins, ambiguity→null, multi-relay settle — all
+   * private), and a second resolver that can disagree with the SDK's is worse
+   * than a missing field on a MONEY guard. Nothing can declare a network today
+   * regardless: the publish builders whitelist the same fields.
+   *
+   * CONSEQUENCE, stated plainly: for `@nametag` and `DIRECT://` recipients the
+   * §5.6 cross-network guard can only SIGNAL (`recipient:network-unverified`),
+   * never refuse. Upstream #734 must add `network` to the binding builders AND
+   * to `BindingInfo`; the tripwire in
+   * tests/unit/payments-v2/recipient-network.transport.test.ts fails the day it
+   * lands, so this wiring cannot be forgotten. Do not "fix" this by inventing a
+   * value — a stamped network is what made the guard unfalsifiable (#733).
    */
   private async bindingInfoToPeerInfo(binding: BindingInfo, nametag?: string): Promise<PeerInfo> {
-    const network = declaredNetwork(binding);
     return {
       nametag: nametag || binding.nametag,
       transportPubkey: binding.transportPubkey,
       chainPubkey: binding.publicKey || '',
       directAddress: binding.directAddress || '',
-      ...(network !== undefined ? { network } : {}),
       timestamp: binding.timestamp,
     };
   }
@@ -786,7 +819,9 @@ export class NostrTransportProvider implements TransportProvider {
 
     try {
       const content = JSON.parse(bindingEvent.content);
-      const network = declaredNetwork(content);
+      // This route parses the signed event itself, so a declared network is
+      // readable here — unlike the SDK-parsed @nametag/DIRECT:// routes above.
+      const network = declaredNetwork(bindingEvent);
 
       return {
         nametag: content.nametag || undefined,
@@ -836,7 +871,7 @@ export class NostrTransportProvider implements TransportProvider {
     for (const [pubkey, event] of byAuthor) {
       try {
         const content = JSON.parse(event.content);
-        const network = declaredNetwork(content);
+        const network = declaredNetwork(event);
         results.push({
           nametag: content.nametag || undefined,
           transportPubkey: pubkey,

--- a/transport/NostrTransportProvider.ts
+++ b/transport/NostrTransportProvider.ts
@@ -95,6 +95,19 @@ const TIMESTAMP_RANDOMIZATION = 2 * 24 * 60 * 60;
 // Alias for backward compatibility
 const EVENT_KINDS = NOSTR_EVENT_KINDS;
 
+/**
+ * The network an identity binding DECLARES, or undefined — read-if-present,
+ * never invented (a stamped guess is what made the §5.6 money guard dead, #733).
+ * No publisher emits one yet: nostr-js-sdk's binding builders whitelist the
+ * content fields (`public_key`/`l1_address`/`direct_address`/`proxy_address`),
+ * so a `network` claim cannot ride today's publish API — hence sends to an
+ * unproven peer are SIGNALLED, not refused, until upstream carries it (#734).
+ */
+function declaredNetwork(content: unknown): string | undefined {
+  const value = (content as { network?: unknown } | null | undefined)?.network;
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
 // =============================================================================
 // Implementation
 // =============================================================================
@@ -741,11 +754,13 @@ export class NostrTransportProvider implements TransportProvider {
    * Convert a BindingInfo (from nostr-js-sdk) to PeerInfo (sphere-sdk type).
    */
   private async bindingInfoToPeerInfo(binding: BindingInfo, nametag?: string): Promise<PeerInfo> {
+    const network = declaredNetwork(binding);
     return {
       nametag: nametag || binding.nametag,
       transportPubkey: binding.transportPubkey,
       chainPubkey: binding.publicKey || '',
       directAddress: binding.directAddress || '',
+      ...(network !== undefined ? { network } : {}),
       timestamp: binding.timestamp,
     };
   }
@@ -771,12 +786,14 @@ export class NostrTransportProvider implements TransportProvider {
 
     try {
       const content = JSON.parse(bindingEvent.content);
+      const network = declaredNetwork(content);
 
       return {
         nametag: content.nametag || undefined,
         transportPubkey: bindingEvent.pubkey,
         chainPubkey: content.public_key || '',
         directAddress: content.direct_address || '',
+        ...(network !== undefined ? { network } : {}),
         timestamp: bindingEvent.created_at * 1000,
       };
     } catch {
@@ -819,11 +836,13 @@ export class NostrTransportProvider implements TransportProvider {
     for (const [pubkey, event] of byAuthor) {
       try {
         const content = JSON.parse(event.content);
+        const network = declaredNetwork(content);
         results.push({
           nametag: content.nametag || undefined,
           transportPubkey: pubkey,
           chainPubkey: content.public_key || '',
           directAddress: content.direct_address || '',
+          ...(network !== undefined ? { network } : {}),
           timestamp: event.created_at * 1000,
         });
       } catch {

--- a/transport/transport-provider.ts
+++ b/transport/transport-provider.ts
@@ -314,6 +314,12 @@ export interface PeerInfo {
   chainPubkey: string;
   /** L3 DIRECT address (DIRECT://...) */
   directAddress: string;
+  /**
+   * Network the peer's identity binding DECLARES ('testnet2', …) — absent when
+   * the binding carries none, which is every binding published so far. Parsed
+   * only, never invented: money refuses a PROVEN foreign network (§5.6).
+   */
+  network?: string;
   /** Event timestamp */
   timestamp: number;
 }

--- a/transport/transport-provider.ts
+++ b/transport/transport-provider.ts
@@ -318,6 +318,13 @@ export interface PeerInfo {
    * Network the peer's identity binding DECLARES ('testnet2', …) — absent when
    * the binding carries none, which is every binding published so far. Parsed
    * only, never invented: money refuses a PROVEN foreign network (§5.6).
+   *
+   * Absent is also the STRUCTURAL answer on the `@nametag` and `DIRECT://`
+   * routes of the Nostr transport, whichever binding is out there: those two
+   * resolve through nostr-js-sdk's `queryBindingBy*`, whose parser drops every
+   * content field outside its whitelist and never hands back the signed event
+   * (#734 tracks the upstream fix). Only routes that parse the raw event —
+   * `resolveTransportPubkeyInfo`, `discoverAddresses` — can populate it today.
    */
   network?: string;
   /** Event timestamp */


### PR DESCRIPTION
## The dead guard

`core/payments-v2-wiring.ts resolveRecipientInfo` stamped the **local session network** onto every
`RecipientInfo` — both the raw-pubkey branch and the peer branch. It never read a network off the
peer, and `PeerInfo` had no network field to read:

```ts
const peer = await resolvePeer(identifier);
return { chainPubkey: peer.chainPubkey, network /* ← the SESSION network */, ... };
```

`PaymentsFacade.requireSameNetworkRecipient` then did `recipient.network !== this.deps.network` —
the session network against a copy of itself. **The guard could never fire.** Its only test injected
a fake resolver returning `network: 'mars'` (`tests/unit/payments-v2/facade.test.ts`), so it
exercised the branch while proving nothing about the production path.

## Why it matters (the loss path)

All networks share Nostr relays, so a foreign-network peer resolves fine. wallet-api keys the
mailbox deposit under the **sender's** network; the recipient never queries that namespace; the
server answers **200**; `TransferMachine.deliverOne` removes the delivery-journal row on 200. The
sender's only copy of the obligation is discarded and the recipient never sees the entry. Money
gone, both sides believe it landed.

## The invariant

The wallet refuses to send to a recipient whose network it cannot **prove** matches the session.
Unknown is not the same as same.

- `RecipientInfo.network: string | null` — `null` means *not proven*.
- Raw chain pubkey → session-stamped, deliberately: a bare pubkey carries no network claim of its
  own, but typing one into this session **is** the caller asserting a recipient on it.
- Resolved peer → `PeerInfo.network || null`. Never a local stamp, blank declares nothing.
- `PeerInfo` gains an optional `network`, parsed from the identity binding wherever one declares it
  (`declaredNetwork`, read-if-present) and **invented nowhere**.
- The §5.6 gate moves to `modules/payments-v2/recipient.ts` (facade policy in its own file, like
  `restore.ts`; the facade was at its 800-line cap). It runs **before any reserve/intent/engine
  work** — the refusal costs nothing and certifies nothing.

## Transition posture (#734) — stated honestly

| recipient network | outcome |
|---|---|
| proves a different network | refuse, `INVALID_RECIPIENT` naming both networks |
| proves the session network | proceed |
| proves nothing (`null`) | **proceed**, `transfer:attention { code: 'recipient:network-unverified' }` |

The third row is a transition, not the target. **No identity binding published so far declares a
network**, and it cannot: nostr-js-sdk's binding builders (`createBindingEvent` /
`createIdentityBindingEvent`) whitelist the content fields — `public_key`, `l1_address`,
`direct_address`, `proxy_address` — and `parseBindingInfo` whitelists the same coming back, so a
`network` field passed through `IdentityBindingParams` is silently dropped. `NostrTransportProvider`
does not know its own network either (relays are shared across networks — which is exactly what
makes the misdirection reachable).

So hard-refusing every unproven recipient would refuse every `@nametag` / `DIRECT://` send between
current wallets. An honest "we cannot prove it yet, here is the signal" beats both a dead guard and
a fleet-breaking refusal. **#734** tracks the publish-side field and then tightening that row to a
hard refusal.

## Tests — production resolver, not a fake

The harness no longer injects `RecipientInfo` at all: it fakes only the **transport directory** and
runs the real `resolveRecipientInfo` over it, so the guard cannot be proven by a fake again.

- declared-foreign → refused, `putIntent === 0`, zero engine transfers, pool untouched, balance
  still fully plannable (the old `@mars` fake test, repointed)
- declared-matching → proceeds, unsignalled
- undeclared **and blank** → proceeds, signalled
- raw pubkey → proceeds, unsignalled (session-stamped, documented)
- integration: the composed Sphere path (`composePaymentsV2` → transport `resolve()`), so a stamp
  re-introduced anywhere in the wiring is caught

New standing probe `wiring-stamps-session-network-on-peer` reproduces the shipped bug (`network:
peer.network || null` → `network`) and turns two tests red.

## Gates

`vitest tests/unit/payments-v2 tests/integration` 501 ✓ · `typecheck` ✓ · `typecheck:tests` ✓ ·
`eslint` 0 errors · `build` ✓ · `test:run` 1926 ✓ · `test:mutation` **23/23 KILLED**

## Breaking

`RecipientInfo.network` is `string | null` (public on the `@unicitylabs/sphere-sdk/payments-v2`
subpath). `PeerInfo.network` is additive/optional. Zero new durable state.

Closes #733
