### PR TITLE
fix(payments-v2): price assets by the raw registry id, not the display name

### DIFF
--- a/modules/payments-v2/inventory/presentation.ts
+++ b/modules/payments-v2/inventory/presentation.ts
@@ -114,15 +114,30 @@ function toAsset(coinId: string, totals: CoinTotals, registry: RegistryReader): 
   };
 }
 
+/**
+ * The price-platform id for a coin.
+ *
+ * `RegistryReader.getName()` returns the DISPLAY name — the registry's raw name
+ * with its first letter capitalized ("Bitcoin", "Unicity"). Price platform ids
+ * (CoinGecko) are the raw lowercase names, and CoinGecko answers under the
+ * canonical lowercase id even when asked with a capitalized one — so a
+ * capitalized key MISSES on the way back and every asset silently prices at 0.
+ * Lowercasing recovers the raw registry name exactly (a coinId fallback is hex,
+ * already lowercase). Display keeps using getName(); only the price key differs.
+ */
+function priceIdOf(registry: RegistryReader, coinId: string): string {
+  return registry.getName(coinId).toLowerCase();
+}
+
 export async function withPrices(
   raw: Asset[],
   registry: RegistryReader,
   price: PriceReader
 ): Promise<Asset[]> {
   try {
-    const names = [...new Set(raw.map((a) => registry.getName(a.coinId)))];
-    const quotes = await price.getPrices(names);
-    return raw.map((a) => priceOne(a, quotes.get(registry.getName(a.coinId))));
+    const ids = [...new Set(raw.map((a) => priceIdOf(registry, a.coinId)))];
+    const quotes = await price.getPrices(ids);
+    return raw.map((a) => priceOne(a, quotes.get(priceIdOf(registry, a.coinId))));
   } catch {
     return raw;
   }

--- a/tests/unit/payments-v2/inventory.test.ts
+++ b/tests/unit/payments-v2/inventory.test.ts
@@ -60,7 +60,9 @@ function makePort(script: PageSource[]): {
 
 const registry: RegistryReader = {
   getSymbol: (coinId) => (coinId === COIN ? 'UCT' : '???'),
-  getName: (coinId) => (coinId === COIN ? 'unicity' : 'unknown'),
+  // Mirrors the real TokenRegistry: getName() is the DISPLAY name (capitalized).
+  // A lowercase stub here would mask the price-key bug this shape guards.
+  getName: (coinId) => (coinId === COIN ? 'Unicity' : 'Unknown'),
   getDecimals: () => 6,
   getIconUrl: (coinId) => (coinId === COIN ? 'https://icons/uct.png' : null),
 };
@@ -371,17 +373,26 @@ describe('InventoryView in-flight registry', () => {
     const [token] = view.tokens(registry);
     expect(token).toMatchObject({
       symbol: 'UCT',
-      name: 'unicity',
+      name: 'Unicity',
       decimals: 6,
       iconUrl: 'https://icons/uct.png',
       status: 'confirmed',
       amount: '100',
     });
+    // Prices are keyed by the price-platform id — the registry's RAW lowercase
+    // name — NOT the capitalized display name. CoinGecko answers under the
+    // canonical lowercase id, so a capitalized key would miss and zero the asset.
+    const asked: string[][] = [];
     const [asset] = await view.assets(registry, {
-      getPrices: async () => new Map([['unicity', { priceUsd: 2, priceEur: 1.5, change24h: -3 }]]),
+      getPrices: async (ids) => {
+        asked.push(ids);
+        return new Map([['unicity', { priceUsd: 2, priceEur: 1.5, change24h: -3 }]]);
+      },
     });
+    expect(asked).toEqual([['unicity']]);
     expect(asset).toMatchObject({
       symbol: 'UCT',
+      name: 'Unicity',
       priceUsd: 2,
       priceEur: 1.5,
       change24h: -3,


### PR DESCRIPTION
**Prod regression from the P11 flip: every `Asset` comes back `priceUsd: 0`.**

`withPrices()` keyed CoinGecko by `registry.getName()` — the *capitalized display* name (`"Bitcoin"`, `"Unicity-usd"`). CoinGecko answers under the canonical **lowercase** id, so the lookup misses, the provider's not-found zero-fill writes `priceUsd: 0` under the capitalized key, and every asset arrives priced at zero. Silently — no throw, no log, which is why prod showed no console errors.

v1's `TokenView.getAssets` used the raw lowercase `def.name` for both the query and the map key; P11 deleted that file and the rewrite changed the line. Env-independent: staging reproduces on any post-flip build.

**Impact:** wallet fiat totals and per-asset values read 0 (`L3WalletView`, `AssetRow`), and Sphere's Swap button is permanently disabled for every coin outside a 2-entry fallback table — the rate row needs a non-zero price on both sides.

**Fix:** `priceIdOf()` lowercases the price key. Display naming is untouched — only the CoinGecko lookup changes.

**Why the tests missed it:** `tests/unit/payments-v2/inventory.test.ts` stubbed `getName: () => 'unicity'` — lowercase, unlike the real registry, so the stub could never reproduce the mismatch. The stub now returns a capitalized name (as the real one does) and the test asserts the ids handed to `getPrices`. Mutation-verified against the unfixed source.

Gates: typecheck, typecheck:tests, lint 0, build, full unit suite, mutation probes.

Companion frontend fix (independent, honest on its own): sphere PR — SwapModal quotes both sides itself with the correct lowercase key and explains a disabled button instead of sitting inert.