### PR TITLE
fix(payments-v2): pinned tokens are not spendable balance, and the refusal says so (#737)

### DIFF
--- a/.wait-probe.mjs
+++ b/.wait-probe.mjs
@@ -1,0 +1,36 @@
+import { waitInclusionProof } from '@unicitylabs/state-transition-sdk/lib/util/InclusionProofUtils.js';
+import { JsonRpcNetworkError } from '@unicitylabs/state-transition-sdk/lib/api/json-rpc/JsonRpcNetworkError.js';
+import { DataHash } from '@unicitylabs/state-transition-sdk/lib/crypto/hash/DataHash.js';
+import { HashAlgorithm } from '@unicitylabs/state-transition-sdk/lib/crypto/hash/HashAlgorithm.js';
+import { CborSerializer } from '@unicitylabs/state-transition-sdk/lib/serialization/cbor/CborSerializer.js';
+
+const hash = new DataHash(HashAlgorithm.SHA256, new Uint8Array(32));
+const tx = {
+  sourceStateHash: hash,
+  lockScript: { toCBOR: () => CborSerializer.encodeByteString(new Uint8Array(4)) },
+  calculateTransactionHash: async () => hash,
+};
+
+async function run(rttMs, timeoutMs = 10_000, interval = 300) {
+  let polls = 0;
+  const client = {
+    getInclusionProof: async () => {
+      polls++;
+      await new Promise((r) => setTimeout(r, rttMs));
+      throw new JsonRpcNetworkError(404, 'not found'); // the ONLY poll failure the loop tolerates
+    },
+  };
+  const t0 = Date.now();
+  const outcome = await Promise.race([
+    waitInclusionProof(client, null, null, tx, AbortSignal.timeout(timeoutMs), interval)
+      .then(() => 'resolved', (e) => `threw ${e.name}: ${String(e.message).slice(0, 40)}`),
+    new Promise((r) => setTimeout(() => r('STILL POLLING — deadline lost (hang)'), timeoutMs + 4_000)),
+  ]);
+  console.log(`rtt=${String(rttMs).padStart(4)}ms polls=${String(polls).padStart(3)} elapsed=${String(Date.now()-t0).padStart(5)}ms -> ${outcome}`);
+  return outcome;
+}
+
+let hangs = 0, n = 0;
+for (const rtt of [0, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200, 220, 240, 260, 280, 300]) {
+  n++; if ((await run(rtt)) !== 'resolved' && (await Promise.resolve(0), false)) {}
+}

--- a/.wait-probe2.mjs
+++ b/.wait-probe2.mjs
@@ -1,0 +1,20 @@
+import { waitInclusionProof } from '@unicitylabs/state-transition-sdk/lib/util/InclusionProofUtils.js';
+import { JsonRpcNetworkError } from '@unicitylabs/state-transition-sdk/lib/api/json-rpc/JsonRpcNetworkError.js';
+import { DataHash } from '@unicitylabs/state-transition-sdk/lib/crypto/hash/DataHash.js';
+import { HashAlgorithm } from '@unicitylabs/state-transition-sdk/lib/crypto/hash/HashAlgorithm.js';
+import { CborSerializer } from '@unicitylabs/state-transition-sdk/lib/serialization/cbor/CborSerializer.js';
+
+const hash = new DataHash(HashAlgorithm.SHA256, new Uint8Array(32));
+const tx = { sourceStateHash: hash, lockScript: { toCBOR: () => CborSerializer.encodeByteString(new Uint8Array(4)) }, calculateTransactionHash: async () => hash };
+const TIMEOUT = 2_000, INTERVAL = 300;
+
+async function trial() {
+  const client = { getInclusionProof: async () => { await new Promise((r) => setTimeout(r, 40 + Math.random() * 260)); throw new JsonRpcNetworkError(404, 'nf'); } };
+  return Promise.race([
+    waitInclusionProof(client, null, null, tx, AbortSignal.timeout(TIMEOUT), INTERVAL).then(() => 'resolved', (e) => e.name),
+    new Promise((r) => setTimeout(() => r('HANG'), TIMEOUT + 3_000)),
+  ]);
+}
+let hang = 0, sleepErr = 0;
+for (let i = 0; i < 30; i++) { const o = await trial(); if (o === 'HANG') hang++; else if (o === 'SleepError') sleepErr++; }
+console.log(`30 trials (jittered RTT 40-300ms, 300ms poll, 2s deadline): SleepError=${sleepErr}  UNBOUNDED-HANG=${hang}`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (money-visibility) — pinned tokens were advertised as spendable, and the refusal lied (#737)
+
+A wallet whose gateway stopped confirming certifications reported ~1M UCT **confirmed** while every
+`send()` was refused with `SEND_INSUFFICIENT_BALANCE`, for five days, on two SDK versions. The
+certification outage was upstream; two SDK defects turned it into an unexplainable permanent
+lockout:
+
+- **The confirmed balance lied.** A send that ends keep-open deliberately RETAINS its source
+  reservation (releasing risks double-paying a spend that may be on-chain), but `assets()` keyed
+  its transferring/confirmed split on `InventoryView`'s own in-flight set, which knows only about
+  the attempt still running in this session. After a restart the ledger was empty, the still-open
+  intent's sources were re-offered by `pool()` and counted as confirmed again. Reporting now reads
+  the reservation itself (`isPinned`), and `IntentPins` (`select/pins.ts`) re-derives the pins from
+  the §6 intent backstop at `start()` and after every convergence pass — so a pinned source reads
+  as `transferring` across a restart, and an intent that stops being open stops pinning. No new
+  durable state, no reservation released while its intent is open.
+- **The refusal misled.** `SEND_INSUFFICIENT_BALANCE` keeps its code (dApps key on it) but the
+  message now names the pin: free total, pinned total, how many transfers hold it, a pointer to
+  `payments.pendingTransfers()` and "do not re-send". With nothing pinned the wording is unchanged.
+
 ### Fixed (BREAKING, money) — the cross-network recipient guard was unfalsifiable (#733)
 
 `resolveRecipientInfo` stamped the LOCAL session network onto every `RecipientInfo`, so

--- a/docs/PAYMENTS-V2-DESIGN.md
+++ b/docs/PAYMENTS-V2-DESIGN.md
@@ -258,7 +258,10 @@ selector's metadata pool. **In-flight exclusion
 (#517/#32, re-homed):** sources reserved by an open transfer — including keep-open intents whose
 spend may be on-chain — are excluded from the selector pool AND reported outside the spendable
 total (`transferring*` fields, never `totalAmount`) until their machine settles or resume adopts
-them. Emits `inventory:updated`.
+them. The reporting side reads the **§5.4 reservation** (`isPinned`), not the in-session in-flight
+set alone, so a pin outlives the attempt that created it and a restart cannot re-advertise a
+pinned source as confirmed (#737). A pinned entry stays IN `pool()` — the queue applies the ledger
+filter itself and needs the entry to quantify the pin in its refusal. Emits `inventory:updated`.
 
 ### 5.3 `CoinSelector` (pure)
 
@@ -279,6 +282,18 @@ critical section (no `await` between free-view read and `reserve`); whole-token 
 send queues when total coverage (free + expected change) suffices but the free view doesn't;
 skip-ahead; 30 s timeout; 100-entry cap. Dropped: the four zero-caller members
 (`getReservation`, `hasActiveReservation`, `getSize`, external `getTotalReserved`).
+
+**Pin lifecycle (`select/pins.ts`, #737).** The ledger holds exactly the sources of the intents the
+§6 backstop still calls OPEN: `IntentPins.sync()` runs in `start()` (before the first pass, so a
+send cannot plan against a source a dead session left pinned) and after every convergence pass
+(so an intent that stopped being open stops pinning). The set is **derived, never stored** — the
+open intents and their sources come from the backstop, decrypted on read like
+`pendingTransfers()`. An attempt running in-process owns its own reservation and is never touched.
+
+**Refusal wording.** `SEND_INSUFFICIENT_BALANCE` keeps its code (dApps key on it) but names the pin
+when there is one: free total, pinned total, and how many transfers hold it, plus "do not
+re-send". "Insufficient balance" alone reads as *you are broke* and sent #737 auditing a treasury
+that was never short.
 
 ### 5.5 `TransferMachine` — one machine for send AND resume
 

--- a/modules/payments-v2/PaymentsFacade.ts
+++ b/modules/payments-v2/PaymentsFacade.ts
@@ -179,9 +179,7 @@ export class PaymentsFacade implements PaymentsV2 {
     await this.deps.session.start();
     // BEFORE the first pass and before any send can plan: a source pinned by an
     // intent left open by the previous session must not be re-offered (#737).
-    // A rejection here leaves IntentPins in its fail-closed state, so sends are
-    // refused until a later pass reconstructs the holds — start() still resolves
-    // (reads/receive must keep working), but nothing can spend blind (#738).
+    // A rejection leaves the ledger unproven: reads keep working, spending does not (#738).
     await this.pins.sync().catch(() => undefined);
     // §7 start posture: never awaited; the heartbeat re-runs this same pass.
     this.trackTail(this.runConvergencePass());
@@ -272,9 +270,7 @@ export class PaymentsFacade implements PaymentsV2 {
     const outcome = await this.converger.convergeOnce();
     // After the pass refreshed the mirror: an intent that stopped being open
     // stops pinning, one still open keeps pinning (#737).
-    // A rejection here leaves IntentPins in its fail-closed state, so sends are
-    // refused until a later pass reconstructs the holds — start() still resolves
-    // (reads/receive must keep working), but nothing can spend blind (#738).
+    // A rejection leaves the ledger unproven: reads keep working, spending does not (#738).
     await this.pins.sync().catch(() => undefined);
     const pending = await this.converger.pendingWork().catch(() => true);
     this.heartbeat.settle(outcome, pending);

--- a/modules/payments-v2/PaymentsFacade.ts
+++ b/modules/payments-v2/PaymentsFacade.ts
@@ -179,6 +179,9 @@ export class PaymentsFacade implements PaymentsV2 {
     await this.deps.session.start();
     // BEFORE the first pass and before any send can plan: a source pinned by an
     // intent left open by the previous session must not be re-offered (#737).
+    // A rejection here leaves IntentPins in its fail-closed state, so sends are
+    // refused until a later pass reconstructs the holds — start() still resolves
+    // (reads/receive must keep working), but nothing can spend blind (#738).
     await this.pins.sync().catch(() => undefined);
     // §7 start posture: never awaited; the heartbeat re-runs this same pass.
     this.trackTail(this.runConvergencePass());
@@ -269,6 +272,9 @@ export class PaymentsFacade implements PaymentsV2 {
     const outcome = await this.converger.convergeOnce();
     // After the pass refreshed the mirror: an intent that stopped being open
     // stops pinning, one still open keeps pinning (#737).
+    // A rejection here leaves IntentPins in its fail-closed state, so sends are
+    // refused until a later pass reconstructs the holds — start() still resolves
+    // (reads/receive must keep working), but nothing can spend blind (#738).
     await this.pins.sync().catch(() => undefined);
     const pending = await this.converger.pendingWork().catch(() => true);
     this.heartbeat.settle(outcome, pending);

--- a/modules/payments-v2/PaymentsFacade.ts
+++ b/modules/payments-v2/PaymentsFacade.ts
@@ -28,6 +28,7 @@ import { toToken } from './inventory/presentation';
 import type { Receive } from './receive/Receive';
 import type { Requests } from './requests/Requests';
 import type { ReservationLedger } from './select/ledger';
+import type { IntentPins } from './select/pins';
 import type { SpendQueue, PlannedSpend } from './select/queue';
 import type { MachineStores } from './machine/journal';
 import { buildOps, classifyError, type MachineDeps, type MachinePlan, type TransferMachine } from './machine/TransferMachine';
@@ -112,11 +113,14 @@ export class PaymentsFacade implements PaymentsV2 {
   private readonly passChain = new SerialChain();
   /** §7 ownership: ids with an in-process machine attempt — the pass never adopts one. */
   private readonly activeMoneyOps = new Set<string>();
+  /** #737: the ledger holds exactly the sources of the still-open intents. */
+  private readonly pins: IntentPins;
 
   constructor(private readonly deps: PaymentsFacadeDeps) {
     const parts = composeFacadeParts(deps, {
       engine: () => this.engine(),
       send: (request) => this.send(request),
+      isActiveOp: (id) => this.activeMoneyOps.has(id),
     });
     this.view = parts.view;
     this.ledger = parts.ledger;
@@ -130,6 +134,7 @@ export class PaymentsFacade implements PaymentsV2 {
     this.ownPubkeyBytes = parts.ownPubkeyBytes;
     this.restoreDeps = parts.restoreDeps;
     this.requests = parts.requests;
+    this.pins = parts.pins;
     deps.deliveryPort.bindDeliveryKeys((blob) => this.engine().deliveryKeys(blob));
     this.heartbeat = new ConvergenceHeartbeat({
       now: () => this.nowMs(),
@@ -172,6 +177,9 @@ export class PaymentsFacade implements PaymentsV2 {
     });
     if (statusUnsub !== undefined) this.unsubscribers.push(statusUnsub);
     await this.deps.session.start();
+    // BEFORE the first pass and before any send can plan: a source pinned by an
+    // intent left open by the previous session must not be re-offered (#737).
+    await this.pins.sync().catch(() => undefined);
     // §7 start posture: never awaited; the heartbeat re-runs this same pass.
     this.trackTail(this.runConvergencePass());
     this.trackTail(this.seedHeldStates());
@@ -259,6 +267,9 @@ export class PaymentsFacade implements PaymentsV2 {
 
   private async convergeBody(): Promise<void> {
     const outcome = await this.converger.convergeOnce();
+    // After the pass refreshed the mirror: an intent that stopped being open
+    // stops pinning, one still open keeps pinning (#737).
+    await this.pins.sync().catch(() => undefined);
     const pending = await this.converger.pendingWork().catch(() => true);
     this.heartbeat.settle(outcome, pending);
   }
@@ -531,6 +542,8 @@ export class PaymentsFacade implements PaymentsV2 {
   /** Open intent: sources stay reserved + in-flight (§5.2) until resume adopts them. */
   private settleKeepOpen(ctx: AttemptCtx): void {
     this.queue.clearExpectedChange(ctx.transferId);
+    // The reservation is now the intent's pin, and lives and dies with it (#737).
+    this.pins.adopt(ctx.transferId);
     this.heartbeat.arm(); // the parked intent converges in-session — no restart
   }
 

--- a/modules/payments-v2/compose.ts
+++ b/modules/payments-v2/compose.ts
@@ -160,7 +160,9 @@ export function composeFacadeParts(deps: PaymentsFacadeDeps, hooks: FacadeHooks)
     kv: deps.kv,
     emit: (event) => deps.emit(event, {}),
     // #737: a reserved token is unselectable, so it is never confirmed balance.
-    isPinned: (tokenId) => ledger.holderOf(tokenId) !== undefined,
+    // #738: while the held-set is unproven, EVERY token reads pinned — the report
+    // must not call a token spendable that the queue is about to refuse to spend.
+    isPinned: (tokenId) => ledger.unprovenReason() !== null || ledger.holderOf(tokenId) !== undefined,
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
   const queue = new SpendQueue({

--- a/modules/payments-v2/compose.ts
+++ b/modules/payments-v2/compose.ts
@@ -13,8 +13,10 @@ import { History, type HistoryClient } from './history/History';
 import { InventoryView, type PriceReader, type RegistryReader } from './inventory/InventoryView';
 import { Receive, type ReceivedRecord, type StoredIncoming } from './receive/Receive';
 import { Requests, type RequestMemoCodec, type RequestsWireClient } from './requests/Requests';
+import { deriveOpenIntentHolds } from './convergence';
 import type { RestoreDeps } from './restore';
 import { ReservationLedger } from './select/ledger';
+import { IntentPins } from './select/pins';
 import { SpendQueue } from './select/queue';
 import { createMachineStores, type MachineStores } from './machine/journal';
 import { TransferMachine, type MachineDeps } from './machine/TransferMachine';
@@ -130,12 +132,15 @@ export type HeldStateCache = Map<string, string>;
 export interface FacadeHooks {
   engine(): ITokenEngine;
   send(request: SendRequest): Promise<TransferResult>;
+  /** §7 ownership — an attempt running in-process owns its own reservation (#737). */
+  isActiveOp(transferId: string): boolean;
 }
 
 export interface FacadeParts {
   ownPubkeyBytes: Uint8Array;
   view: InventoryView;
   ledger: ReservationLedger;
+  pins: IntentPins;
   queue: SpendQueue;
   historyStore: History;
   machineStores: MachineStores;
@@ -149,13 +154,15 @@ export interface FacadeParts {
 
 export function composeFacadeParts(deps: PaymentsFacadeDeps, hooks: FacadeHooks): FacadeParts {
   const ownPubkeyBytes = hexToBytes(deps.ownPubkey);
+  const ledger = new ReservationLedger();
   const view = new InventoryView({
     port: deps.storagePort,
     kv: deps.kv,
     emit: (event) => deps.emit(event, {}),
+    // #737: a reserved token is unselectable, so it is never confirmed balance.
+    isPinned: (tokenId) => ledger.holderOf(tokenId) !== undefined,
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
-  const ledger = new ReservationLedger();
   const queue = new SpendQueue({
     ledger,
     getPool: (coinId) => view.pool(coinId),
@@ -177,6 +184,7 @@ export function composeFacadeParts(deps: PaymentsFacadeDeps, hooks: FacadeHooks)
     ownPubkeyBytes,
     view,
     ledger,
+    pins: buildPins(deps, hooks, { ledger, view, machineStores, machineDeps }),
     queue,
     historyStore,
     machineStores,
@@ -187,6 +195,28 @@ export function composeFacadeParts(deps: PaymentsFacadeDeps, hooks: FacadeHooks)
     requests: buildRequests(deps, hooks),
     restoreDeps: buildRestoreDeps(deps, machineDeps, machineStores, view),
   };
+}
+
+/** #737 pin lifecycle wiring (see select/pins.ts); the facade owns when it runs. */
+function buildPins(
+  deps: PaymentsFacadeDeps,
+  hooks: FacadeHooks,
+  parts: {
+    ledger: ReservationLedger;
+    view: InventoryView;
+    machineStores: MachineStores;
+    machineDeps: MachineDeps;
+  }
+): IntentPins {
+  return new IntentPins({
+    ledger: parts.ledger,
+    openIntents: () => deriveOpenIntentHolds(parts.machineStores, parts.machineDeps.decryptPayload),
+    isActive: (transferId) => hooks.isActiveOp(transferId),
+    release: (tokenId) => {
+      parts.view.release(tokenId);
+    },
+    changed: () => deps.emit('inventory:updated', {}),
+  });
 }
 
 /** §5.1 restore protocol wiring (reseedAndReset's deps) — policy stays in the facade. */

--- a/modules/payments-v2/convergence.ts
+++ b/modules/payments-v2/convergence.ts
@@ -211,6 +211,32 @@ export async function derivePendingTransfers(
   return out;
 }
 
+/**
+ * #737: the source tokenIds each still-open intent pins, derived ON READ from the
+ * same §6 backstop `derivePendingTransfers` reads — the pin needs no store of its
+ * own, so a restart re-derives it instead of re-offering the tokens as spendable.
+ */
+export async function deriveOpenIntentHolds(
+  stores: MachineStores,
+  decryptPayload: (envelope: string) => Promise<unknown>
+): Promise<Map<string, string[]>> {
+  const holds = new Map<string, string[]>();
+  for (const entry of await stores.backstop.list()) {
+    if (entry.disposition !== 'open') continue;
+    let payload: Partial<IntentPayload> | null = null;
+    try {
+      const raw = await decryptPayload(entry.payloadEnvelope);
+      if (raw !== null && typeof raw === 'object') payload = raw as Partial<IntentPayload>;
+    } catch {
+      payload = null; // undecodable envelope: the intent is still open, its sources unknown
+    }
+    const direct = Array.isArray(payload?.direct) ? payload.direct.filter((id) => typeof id === 'string') : [];
+    const split = typeof payload?.split?.tokenId === 'string' ? [payload.split.tokenId] : [];
+    holds.set(entry.transferId, [...direct, ...split]);
+  }
+  return holds;
+}
+
 function groupJournal(journal: DeliveryJournalEntry[]): Map<string, DeliveryJournalEntry[]> {
   const byTransfer = new Map<string, DeliveryJournalEntry[]>();
   for (const entry of journal) {

--- a/modules/payments-v2/convergence.ts
+++ b/modules/payments-v2/convergence.ts
@@ -219,8 +219,9 @@ export async function derivePendingTransfers(
 export async function deriveOpenIntentHolds(
   stores: MachineStores,
   decryptPayload: (envelope: string) => Promise<unknown>
-): Promise<Map<string, string[]>> {
+): Promise<{ open: Map<string, string[]>; complete: boolean }> {
   const holds = new Map<string, string[]>();
+  let complete = true;
   for (const entry of await stores.backstop.list()) {
     if (entry.disposition !== 'open') continue;
     let payload: Partial<IntentPayload> | null = null;
@@ -228,13 +229,21 @@ export async function deriveOpenIntentHolds(
       const raw = await decryptPayload(entry.payloadEnvelope);
       if (raw !== null && typeof raw === 'object') payload = raw as Partial<IntentPayload>;
     } catch {
-      payload = null; // undecodable envelope: the intent is still open, its sources unknown
+      // Undecodable envelope on a STILL-OPEN intent: its sources are unknown, so
+      // they cannot be proven safe. Report incompleteness — the caller fails
+      // closed rather than treating "unknown sources" as "no sources" (#738).
+      complete = false;
+      continue;
+    }
+    if (payload === null) {
+      complete = false;
+      continue;
     }
     const direct = Array.isArray(payload?.direct) ? payload.direct.filter((id) => typeof id === 'string') : [];
     const split = typeof payload?.split?.tokenId === 'string' ? [payload.split.tokenId] : [];
     holds.set(entry.transferId, [...direct, ...split]);
   }
-  return holds;
+  return { open: holds, complete };
 }
 
 function groupJournal(journal: DeliveryJournalEntry[]): Map<string, DeliveryJournalEntry[]> {

--- a/modules/payments-v2/inventory/InventoryView.ts
+++ b/modules/payments-v2/inventory/InventoryView.ts
@@ -40,6 +40,13 @@ export interface InventoryViewDeps {
   readonly kv: ScopedKV;
   readonly emit: (event: 'inventory:updated') => void;
   readonly now?: () => number;
+  /**
+   * #737: tokens pinned by a §5.4 reservation — an open intent keeps its sources
+   * reserved, and a token the selector cannot pick is NOT spendable balance. The
+   * reporting side reads the pin instead of guessing from `inFlight` alone, which
+   * only knows about the attempt still running in THIS session.
+   */
+  readonly isPinned?: (tokenId: string) => boolean;
 }
 
 interface MirrorEntry {
@@ -134,10 +141,23 @@ export class InventoryView {
     if (this.inFlight.delete(tokenId)) this.deps.emit('inventory:updated');
   }
 
+  private pinned(tokenId: string): boolean {
+    return this.deps.isPinned?.(tokenId) ?? false;
+  }
+
+  /** In flight here OR pinned by a reservation: either way not spendable (#737). */
+  private held(tokenId: string): boolean {
+    return this.inFlight.has(tokenId) || this.pinned(tokenId);
+  }
+
+  // A PINNED token stays in the pool: the queue applies the ledger filter itself
+  // and needs the entry to say how much is pinned when it refuses (#737). In
+  // flight without a pin (spent, awaiting the mirror refresh) stays out.
   pool(coinId: string): PoolEntry[] {
     const out: PoolEntry[] = [];
     for (const [tokenId, entry] of this.mirror) {
-      if (entry.status !== 'active' || this.inFlight.has(tokenId)) continue;
+      if (entry.status !== 'active') continue;
+      if (this.inFlight.has(tokenId) && !this.pinned(tokenId)) continue;
       if (this.suspected.has(stateKey(tokenId, entry.stateHash))) continue;
       const asset = entry.assets.find((a) => a.coinId === coinId);
       if (asset) out.push({ tokenId, amount: BigInt(asset.amount) });
@@ -154,7 +174,7 @@ export class InventoryView {
       if (filter?.coinId !== undefined && asset.coinId !== filter.coinId) continue;
       out.push(
         toToken(tokenId, entry, asset, registry, {
-          transferring: this.inFlight.has(tokenId),
+          transferring: this.held(tokenId),
           suspectedSpent: this.suspected.has(stateKey(tokenId, entry.stateHash)),
         })
       );
@@ -163,7 +183,7 @@ export class InventoryView {
   }
 
   async assets(registry: RegistryReader, price?: PriceReader): Promise<Asset[]> {
-    const raw = aggregateAssets(this.activeEntries(), (tokenId) => this.inFlight.has(tokenId), registry);
+    const raw = aggregateAssets(this.activeEntries(), (tokenId) => this.held(tokenId), registry);
     if (!price || raw.length === 0) return raw;
     return withPrices(raw, registry, price);
   }

--- a/modules/payments-v2/select/ledger.ts
+++ b/modules/payments-v2/select/ledger.ts
@@ -13,9 +13,12 @@ export class ReservationLedger {
   // IntentPins proves every one of them "no holder" means unknown, not free.
   private authoritative = false;
 
-  /** Sole writer: IntentPins.sync(), true only if it reconstructed every open intent. */
-  setAuthoritative(value: boolean): void {
+  /** Sole writer: IntentPins.sync(), true only if it reconstructed every open intent.
+   *  Returns whether the gate actually moved, so callers signal transitions, not passes. */
+  setAuthoritative(value: boolean): boolean {
+    const moved = this.authoritative !== value;
     this.authoritative = value;
+    return moved;
   }
 
   /** Non-null while the held-set is unproven: nothing plans, nothing reads free. */

--- a/modules/payments-v2/select/ledger.ts
+++ b/modules/payments-v2/select/ledger.ts
@@ -41,6 +41,15 @@ export class ReservationLedger {
     return this.tokenHolder.has(tokenId) ? 0n : tokenAmount;
   }
 
+  /** #737: who pins this token — the reporting side reads it so a held token is never called spendable. */
+  holderOf(tokenId: string): string | undefined {
+    return this.tokenHolder.get(tokenId);
+  }
+
+  tokensOf(reservationId: string): readonly string[] {
+    return [...(this.reservations.get(reservationId) ?? [])];
+  }
+
   clear(): void {
     this.reservations.clear();
     this.tokenHolder.clear();

--- a/modules/payments-v2/select/ledger.ts
+++ b/modules/payments-v2/select/ledger.ts
@@ -9,6 +9,27 @@ export interface ReservationRequest {
 export class ReservationLedger {
   private readonly reservations = new Map<string, ReadonlySet<string>>();
   private readonly tokenHolder = new Map<string, string>();
+  /**
+   * #738: the held-set is a RECONSTRUCTION of what still-open intents hold, so a
+   * fresh ledger is not yet a complete picture — "no holder" does not mean
+   * "free", it means "unknown". Until IntentPins proves every open intent,
+   * everything reads as held: the report shows it pinned and the queue refuses.
+   * Spending a source whose spend may already be on-chain is a double-spend;
+   * refusing is downtime. Explicit so the unsafe state can only be LEFT on purpose.
+   */
+  private authoritative = false;
+
+  /** Sole writer: IntentPins.sync(), with whether it reconstructed every open intent. */
+  setAuthoritative(value: boolean): void {
+    this.authoritative = value;
+  }
+
+  /** Non-null while the held-set is unproven — nothing is spendable, nothing reads free. */
+  unprovenReason(): string | null {
+    return this.authoritative
+      ? null
+      : 'Cannot yet verify which tokens are held by transfers still converging — spending is paused until that check succeeds';
+  }
 
   // All-or-nothing: every entry is validated before any state mutates.
   reserve(reservationId: string, entries: readonly ReservationRequest[]): void {

--- a/modules/payments-v2/select/ledger.ts
+++ b/modules/payments-v2/select/ledger.ts
@@ -9,22 +9,16 @@ export interface ReservationRequest {
 export class ReservationLedger {
   private readonly reservations = new Map<string, ReadonlySet<string>>();
   private readonly tokenHolder = new Map<string, string>();
-  /**
-   * #738: the held-set is a RECONSTRUCTION of what still-open intents hold, so a
-   * fresh ledger is not yet a complete picture — "no holder" does not mean
-   * "free", it means "unknown". Until IntentPins proves every open intent,
-   * everything reads as held: the report shows it pinned and the queue refuses.
-   * Spending a source whose spend may already be on-chain is a double-spend;
-   * refusing is downtime. Explicit so the unsafe state can only be LEFT on purpose.
-   */
+  // #738: the held-set is RECONSTRUCTED from the open intents, so until
+  // IntentPins proves every one of them "no holder" means unknown, not free.
   private authoritative = false;
 
-  /** Sole writer: IntentPins.sync(), with whether it reconstructed every open intent. */
+  /** Sole writer: IntentPins.sync(), true only if it reconstructed every open intent. */
   setAuthoritative(value: boolean): void {
     this.authoritative = value;
   }
 
-  /** Non-null while the held-set is unproven — nothing is spendable, nothing reads free. */
+  /** Non-null while the held-set is unproven: nothing plans, nothing reads free. */
   unprovenReason(): string | null {
     return this.authoritative
       ? null

--- a/modules/payments-v2/select/pins.ts
+++ b/modules/payments-v2/select/pins.ts
@@ -7,7 +7,8 @@ import type { ReservationLedger } from './ledger';
 export interface IntentPinsDeps {
   readonly ledger: ReservationLedger;
   /** Open intents → their source tokenIds, re-derived from the backstop per call. */
-  readonly openIntents: () => Promise<Map<string, string[]>>;
+  /** `complete: false` when any open intent's sources could not be reconstructed. */
+  readonly openIntents: () => Promise<{ open: Map<string, string[]>; complete: boolean }>;
   readonly isActive: (transferId: string) => boolean;
   readonly release: (tokenId: string) => void;
   readonly changed: () => void;
@@ -24,7 +25,9 @@ export class IntentPins {
   }
 
   async sync(): Promise<void> {
-    const open = await this.deps.openIntents();
+    // A throw here leaves the ledger UNPROVEN (its fail-closed default) — a read
+    // failure must never resolve into an empty held-set that reads as all-free.
+    const { open, complete } = await this.deps.openIntents();
     let changed = false;
     for (const transferId of [...this.pinned]) {
       if (open.has(transferId) || this.deps.isActive(transferId)) continue;
@@ -38,7 +41,9 @@ export class IntentPins {
       this.pinned.add(transferId);
       changed = this.pin(transferId, tokenIds) || changed;
     }
-    if (changed) this.deps.changed();
+    // Only a pass that reconstructed EVERY open intent makes the ledger authoritative.
+    this.deps.ledger.setAuthoritative(complete);
+    if (changed || complete) this.deps.changed();
   }
 
   /** Every pass, not just on adoption; the free subset, since a partial pin beats none. */

--- a/modules/payments-v2/select/pins.ts
+++ b/modules/payments-v2/select/pins.ts
@@ -6,8 +6,7 @@ import type { ReservationLedger } from './ledger';
 
 export interface IntentPinsDeps {
   readonly ledger: ReservationLedger;
-  /** Open intents → their source tokenIds, re-derived from the backstop per call. */
-  /** `complete: false` when any open intent's sources could not be reconstructed. */
+  /** Open intents → source tokenIds, re-derived per call; `complete: false` if any could not be. */
   readonly openIntents: () => Promise<{ open: Map<string, string[]>; complete: boolean }>;
   readonly isActive: (transferId: string) => boolean;
   readonly release: (tokenId: string) => void;
@@ -25,8 +24,7 @@ export class IntentPins {
   }
 
   async sync(): Promise<void> {
-    // A throw here leaves the ledger UNPROVEN (its fail-closed default) — a read
-    // failure must never resolve into an empty held-set that reads as all-free.
+    // A throw leaves the ledger unproven — never an empty held-set (#738).
     const { open, complete } = await this.deps.openIntents();
     let changed = false;
     for (const transferId of [...this.pinned]) {
@@ -41,7 +39,6 @@ export class IntentPins {
       this.pinned.add(transferId);
       changed = this.pin(transferId, tokenIds) || changed;
     }
-    // Only a pass that reconstructed EVERY open intent makes the ledger authoritative.
     this.deps.ledger.setAuthoritative(complete);
     if (changed || complete) this.deps.changed();
   }

--- a/modules/payments-v2/select/pins.ts
+++ b/modules/payments-v2/select/pins.ts
@@ -39,8 +39,8 @@ export class IntentPins {
       this.pinned.add(transferId);
       changed = this.pin(transferId, tokenIds) || changed;
     }
-    this.deps.ledger.setAuthoritative(complete);
-    if (changed || complete) this.deps.changed();
+    const gateMoved = this.deps.ledger.setAuthoritative(complete);
+    if (changed || gateMoved) this.deps.changed();
   }
 
   /** Every pass, not just on adoption; the free subset, since a partial pin beats none. */

--- a/modules/payments-v2/select/pins.ts
+++ b/modules/payments-v2/select/pins.ts
@@ -1,0 +1,52 @@
+// #737: the ledger holds exactly the sources of the intents the §6 backstop still
+// calls OPEN — adopting what a dead session left open (that spend may be on-chain)
+// and dropping what stopped being open (source spent, or ours again).
+
+import type { ReservationLedger } from './ledger';
+
+export interface IntentPinsDeps {
+  readonly ledger: ReservationLedger;
+  /** Open intents → their source tokenIds, re-derived from the backstop per call. */
+  readonly openIntents: () => Promise<Map<string, string[]>>;
+  readonly isActive: (transferId: string) => boolean;
+  readonly release: (tokenId: string) => void;
+  readonly changed: () => void;
+}
+
+export class IntentPins {
+  private readonly pinned = new Set<string>();
+
+  constructor(private readonly deps: IntentPinsDeps) {}
+
+  /** The keep-open reservation IS this intent's pin from now on. */
+  adopt(transferId: string): void {
+    this.pinned.add(transferId);
+  }
+
+  async sync(): Promise<void> {
+    const open = await this.deps.openIntents();
+    let changed = false;
+    for (const transferId of [...this.pinned]) {
+      if (open.has(transferId) || this.deps.isActive(transferId)) continue;
+      this.pinned.delete(transferId);
+      for (const tokenId of this.deps.ledger.tokensOf(transferId)) this.deps.release(tokenId);
+      this.deps.ledger.cancel(transferId);
+      changed = true;
+    }
+    for (const [transferId, tokenIds] of open) {
+      if (this.deps.isActive(transferId)) continue;
+      this.pinned.add(transferId);
+      changed = this.pin(transferId, tokenIds) || changed;
+    }
+    if (changed) this.deps.changed();
+  }
+
+  /** Every pass, not just on adoption; the free subset, since a partial pin beats none. */
+  private pin(transferId: string, tokenIds: readonly string[]): boolean {
+    if (this.deps.ledger.tokensOf(transferId).length > 0) return false;
+    const free = tokenIds.filter((tokenId) => this.deps.ledger.holderOf(tokenId) === undefined);
+    if (free.length === 0) return false;
+    this.deps.ledger.reserve(transferId, free.map((tokenId) => ({ tokenId })));
+    return true;
+  }
+}

--- a/modules/payments-v2/select/queue.ts
+++ b/modules/payments-v2/select/queue.ts
@@ -38,6 +38,29 @@ interface ExpectedChange {
   readonly amount: bigint;
 }
 
+interface FreeView {
+  readonly freeView: PoolEntry[];
+  readonly freeTotal: bigint;
+  /** Held by a reservation — an open intent's sources stay pinned until it converges. */
+  readonly pinnedTotal: bigint;
+  readonly pinnedBy: number;
+}
+
+/**
+ * #737: the CODE is load-bearing (dApps key on it) but "insufficient balance" sent
+ * a user auditing a treasury that was never short — every token was pinned by an
+ * intent still converging. When something is pinned, the message says so.
+ */
+function insufficientBalance(view: FreeView, amount: bigint): SphereError {
+  const message =
+    view.pinnedTotal > 0n
+      ? `Insufficient spendable balance: need ${amount.toString()}, ${view.freeTotal.toString()} free, ` +
+        `${view.pinnedTotal.toString()} pinned by ${String(view.pinnedBy)} transfer(s) still converging — ` +
+        'see payments.pendingTransfers(); do not re-send.'
+      : 'Insufficient balance for this transaction';
+  return new SphereError(message, 'SEND_INSUFFICIENT_BALANCE');
+}
+
 export class SpendQueue {
   private readonly queues = new Map<string, QueueEntry[]>();
   private readonly expectedChange = new Map<string, ExpectedChange>();
@@ -50,12 +73,10 @@ export class SpendQueue {
       throw new SphereError('Module has been destroyed', 'MODULE_DESTROYED');
     }
     const amount = parseAmount(request.amount);
-    const { freeView, freeTotal } = this.freeView(request.coinId);
+    const view = this.freeView(request.coinId);
+    const { freeView, freeTotal } = view;
     if (freeTotal + this.expectedChangeTotal(request.coinId) < amount) {
-      throw new SphereError(
-        'Insufficient balance for this transaction',
-        'SEND_INSUFFICIENT_BALANCE'
-      );
+      throw insufficientBalance(view, amount);
     }
     const plan = selectCoins(freeView, amount, { workBudget: this.deps.workBudget });
     if (plan !== null) {
@@ -110,11 +131,10 @@ export class SpendQueue {
       entry.reject(new SphereError('Send queue timeout', 'SEND_QUEUE_TIMEOUT'));
       return 'rejected';
     }
-    const { freeView, freeTotal } = this.freeView(entry.coinId);
+    const view = this.freeView(entry.coinId);
+    const { freeView, freeTotal } = view;
     if (freeTotal + this.expectedChangeTotal(entry.coinId) < entry.amount) {
-      entry.reject(
-        new SphereError('Insufficient balance for this transaction', 'SEND_INSUFFICIENT_BALANCE')
-      );
+      entry.reject(insufficientBalance(view, entry.amount));
       return 'rejected';
     }
     const plan = selectCoins(freeView, entry.amount, { workBudget: this.deps.workBudget });
@@ -161,18 +181,25 @@ export class SpendQueue {
     if (entries.length === 0) this.queues.delete(coinId);
   }
 
-  // Whole-token semantics: only fully-free tokens enter the selector pool.
-  private freeView(coinId: string): { freeView: PoolEntry[]; freeTotal: bigint } {
+  // Whole-token semantics: only fully-free tokens enter the selector pool. What
+  // the reservations hold back is counted too — the refusal has to name it (#737).
+  private freeView(coinId: string): FreeView {
     const freeView: PoolEntry[] = [];
     let freeTotal = 0n;
+    let pinnedTotal = 0n;
+    const holders = new Set<string>();
     for (const entry of this.deps.getPool(coinId)) {
       if (entry.amount <= 0n) continue;
-      if (this.deps.ledger.getFreeAmount(entry.tokenId, entry.amount) === entry.amount) {
+      const holder = this.deps.ledger.holderOf(entry.tokenId);
+      if (holder === undefined) {
         freeView.push(entry);
         freeTotal += entry.amount;
+      } else {
+        pinnedTotal += entry.amount;
+        holders.add(holder);
       }
     }
-    return { freeView, freeTotal };
+    return { freeView, freeTotal, pinnedTotal, pinnedBy: holders.size };
   }
 
   private expectedChangeTotal(coinId: string): bigint {

--- a/modules/payments-v2/select/queue.ts
+++ b/modules/payments-v2/select/queue.ts
@@ -72,6 +72,9 @@ export class SpendQueue {
     if (this.destroyed) {
       throw new SphereError('Module has been destroyed', 'MODULE_DESTROYED');
     }
+    // #738: the ledger says whether its held-set is proven. Unproven = refuse.
+    const unproven = this.deps.ledger.unprovenReason();
+    if (unproven !== null) throw new SphereError(unproven, 'SEND_INSUFFICIENT_BALANCE');
     const amount = parseAmount(request.amount);
     const view = this.freeView(request.coinId);
     const { freeView, freeTotal } = view;

--- a/modules/payments-v2/select/queue.ts
+++ b/modules/payments-v2/select/queue.ts
@@ -44,6 +44,8 @@ interface FreeView {
   /** Held by a reservation — an open intent's sources stay pinned until it converges. */
   readonly pinnedTotal: bigint;
   readonly pinnedBy: number;
+  /** #738: non-null = the held-set is unproven, so NOTHING in this view is free. */
+  readonly unproven: string | null;
 }
 
 /**
@@ -52,6 +54,7 @@ interface FreeView {
  * intent still converging. When something is pinned, the message says so.
  */
 function insufficientBalance(view: FreeView, amount: bigint): SphereError {
+  if (view.unproven !== null) return new SphereError(view.unproven, 'SEND_INSUFFICIENT_BALANCE');
   const message =
     view.pinnedTotal > 0n
       ? `Insufficient spendable balance: need ${amount.toString()}, ${view.freeTotal.toString()} free, ` +
@@ -72,9 +75,6 @@ export class SpendQueue {
     if (this.destroyed) {
       throw new SphereError('Module has been destroyed', 'MODULE_DESTROYED');
     }
-    // #738: the ledger says whether its held-set is proven. Unproven = refuse.
-    const unproven = this.deps.ledger.unprovenReason();
-    if (unproven !== null) throw new SphereError(unproven, 'SEND_INSUFFICIENT_BALANCE');
     const amount = parseAmount(request.amount);
     const view = this.freeView(request.coinId);
     const { freeView, freeTotal } = view;
@@ -191,9 +191,14 @@ export class SpendQueue {
     let freeTotal = 0n;
     let pinnedTotal = 0n;
     const holders = new Set<string>();
+    // #738: the same rule the reporter applies — while the held-set is unproven
+    // nothing is free. Placed here because freeView() is what plan() AND the
+    // queued path (tryServe) both go through; gating only plan() left a queued
+    // entry servable through a closed gate.
+    const unproven = this.deps.ledger.unprovenReason();
     for (const entry of this.deps.getPool(coinId)) {
       if (entry.amount <= 0n) continue;
-      const holder = this.deps.ledger.holderOf(entry.tokenId);
+      const holder = unproven === null ? this.deps.ledger.holderOf(entry.tokenId) : entry.tokenId;
       if (holder === undefined) {
         freeView.push(entry);
         freeTotal += entry.amount;
@@ -202,7 +207,7 @@ export class SpendQueue {
         holders.add(holder);
       }
     }
-    return { freeView, freeTotal, pinnedTotal, pinnedBy: holders.size };
+    return { freeView, freeTotal, pinnedTotal, pinnedBy: holders.size, unproven };
   }
 
   private expectedChangeTotal(coinId: string): bigint {

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -269,5 +269,55 @@
     "tests": [
       "tests/unit/payments-v2/pinned-balance.test.ts"
     ]
+  },
+  {
+    "name": "ledger-authoritative-default-open",
+    "note": "#738: a fresh ledger must fail CLOSED. Defaulting to authoritative re-offers sources held by intents whose spend may be on-chain (double-spend).",
+    "file": "modules/payments-v2/select/ledger.ts",
+    "find": "  private authoritative = false;",
+    "replace": "  private authoritative = true;",
+    "tests": [
+      "tests/unit/payments-v2/pinned-balance.test.ts"
+    ]
+  },
+  {
+    "name": "pins-sync-ignores-incompleteness",
+    "note": "#738: only a pass that reconstructed EVERY open intent may make the ledger authoritative; an unreadable envelope must keep it closed.",
+    "file": "modules/payments-v2/select/pins.ts",
+    "find": "    this.deps.ledger.setAuthoritative(complete);",
+    "replace": "    this.deps.ledger.setAuthoritative(true);",
+    "tests": [
+      "tests/unit/payments-v2/pinned-balance.test.ts"
+    ]
+  },
+  {
+    "name": "derive-holds-swallows-undecodable",
+    "note": "#738: an undecodable open-intent envelope must report incompleteness, not silently mean 'holds nothing'.",
+    "file": "modules/payments-v2/convergence.ts",
+    "find": "      complete = false;\n      continue;\n    }\n    if (payload === null) {",
+    "replace": "      continue;\n    }\n    if (payload === null) {",
+    "tests": [
+      "tests/unit/payments-v2/pinned-balance.test.ts"
+    ]
+  },
+  {
+    "name": "report-ignores-unproven-heldset",
+    "note": "#738: while the held-set is unproven the REPORT must agree with the refusal \u2014 otherwise a treasury reads fully spendable while every send is refused (#737's complaint).",
+    "file": "modules/payments-v2/compose.ts",
+    "find": "    isPinned: (tokenId) => ledger.unprovenReason() !== null || ledger.holderOf(tokenId) !== undefined,",
+    "replace": "    isPinned: (tokenId) => ledger.holderOf(tokenId) !== undefined,",
+    "tests": [
+      "tests/unit/payments-v2/pinned-balance.test.ts"
+    ]
+  },
+  {
+    "name": "queue-plan-ignores-unproven-heldset",
+    "note": "#738: planning must refuse while the held-set is unproven.",
+    "file": "modules/payments-v2/select/queue.ts",
+    "find": "    const unproven = this.deps.ledger.unprovenReason();\n    if (unproven !== null) throw new SphereError(unproven, 'SEND_INSUFFICIENT_BALANCE');",
+    "replace": "    const unproven: string | null = null;\n    if (unproven !== null) throw new SphereError(unproven, 'SEND_INSUFFICIENT_BALANCE');",
+    "tests": [
+      "tests/unit/payments-v2/pinned-balance.test.ts"
+    ]
   }
 ]

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -254,7 +254,7 @@
     "name": "inventory-pinned-counts-as-confirmed",
     "note": "#737: a token pinned by an open intent is reported transferring, never confirmed/spendable \u2014 the reporter reads the reservation, not just this session's in-flight set",
     "file": "modules/payments-v2/compose.ts",
-    "find": "    isPinned: (tokenId) => ledger.holderOf(tokenId) !== undefined,",
+    "find": "    isPinned: (tokenId) => ledger.unprovenReason() !== null || ledger.holderOf(tokenId) !== undefined,",
     "replace": "    isPinned: () => false,",
     "tests": [
       "tests/unit/payments-v2/pinned-balance.test.ts"

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -5,7 +5,9 @@
     "file": "modules/payments-v2/machine/TransferMachine.ts",
     "find": "    await this.putIntentGate(plan, envelope);",
     "replace": "    void this.putIntentGate(plan, envelope).catch(() => undefined);",
-    "tests": ["tests/unit/payments-v2/machine.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/machine.test.ts"
+    ]
   },
   {
     "name": "machine-resume-journal-ignore",
@@ -13,7 +15,9 @@
     "file": "modules/payments-v2/machine/TransferMachine.ts",
     "find": "      const journaled = op.kind === 'direct' ? r.journaled.get(op.opIndex) : undefined;",
     "replace": "      const journaled = undefined as DeliveryJournalEntry | undefined;",
-    "tests": ["tests/unit/payments-v2/machine-resume.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/machine-resume.test.ts"
+    ]
   },
   {
     "name": "machine-conflicted-leg-as-spent",
@@ -21,7 +25,9 @@
     "file": "modules/payments-v2/machine/TransferMachine.ts",
     "find": "      conflicts.push({ op, error: outcome.error, amount: conflictAmount(engine, r.payload, op, source) });",
     "replace": "      committed.push({ op, certified: true });\n      conflicts.push({ op, error: outcome.error, amount: conflictAmount(engine, r.payload, op, source) });",
-    "tests": ["tests/unit/payments-v2/machine-resume.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/machine-resume.test.ts"
+    ]
   },
   {
     "name": "machine-conflict-apply-drop",
@@ -29,7 +35,9 @@
     "file": "modules/payments-v2/machine/TransferMachine.ts",
     "find": "    if (cls === 'conflict' && committed.length > 0) {\n      await this.applyBestEffort(engine, plan.transferId, committed);\n    }",
     "replace": "    if (cls === 'conflict' && committed.length > 0) {\n      void committed;\n    }",
-    "tests": ["tests/unit/payments-v2/machine.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/machine.test.ts"
+    ]
   },
   {
     "name": "machine-429-defer-removal",
@@ -37,7 +45,9 @@
     "file": "modules/payments-v2/machine/TransferMachine.ts",
     "find": "      if (isRateLimited(err)) {\n        await this.stores.deliveryJournal.defer(options.transferId, outcome.op.opIndex, this.deps.now() + RATE_LIMIT_DEFER_MS);",
     "replace": "      if ((false as boolean) && isRateLimited(err)) {\n        await this.stores.deliveryJournal.defer(options.transferId, outcome.op.opIndex, this.deps.now() + RATE_LIMIT_DEFER_MS);",
-    "tests": ["tests/unit/payments-v2/machine.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/machine.test.ts"
+    ]
   },
   {
     "name": "requests-441-order-swap",
@@ -45,15 +55,19 @@
     "file": "modules/payments-v2/requests/Requests.ts",
     "find": "      await this.writeLink(requestId, transferId, opts.committed);\n    } catch (err) {",
     "replace": "      void this.writeLink(requestId, transferId, opts.committed).catch(() => undefined);\n    } catch (err) {",
-    "tests": ["tests/unit/payments-v2/requests.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/requests.test.ts"
+    ]
   },
   {
     "name": "requests-clear-link-on-failed-respond",
-    "note": "the settlement invariant: a settling link is removed ONLY by a CONFIRMED paid respond or a proven clean pre-commit failure — clearing it on a failed respond makes a paid request payable again after reload (requests.test.ts 'send-succeeds-respond-5xx')",
+    "note": "the settlement invariant: a settling link is removed ONLY by a CONFIRMED paid respond or a proven clean pre-commit failure \u2014 clearing it on a failed respond makes a paid request payable again after reload (requests.test.ts 'send-succeeds-respond-5xx')",
     "file": "modules/payments-v2/requests/Requests.ts",
     "find": "    if (!(opts.respond && (await this.respondPaid(requestId, transferId)))) {\n      this.setStatus(requestId, journalDown ? 'paid' : 'settling');\n      return;\n    }",
     "replace": "    const confirmed = opts.respond && (await this.respondPaid(requestId, transferId));\n    await this.clearLink(requestId).catch(() => undefined);\n    if (!confirmed) {\n      this.setStatus(requestId, journalDown ? 'paid' : 'settling');\n      return;\n    }",
-    "tests": ["tests/unit/payments-v2/requests.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/requests.test.ts"
+    ]
   },
   {
     "name": "requests-decline-409-swallow",
@@ -61,7 +75,9 @@
     "file": "modules/payments-v2/requests/Requests.ts",
     "find": "    await this.deps.client.respondPaymentRequest(id, { action: 'declined' });",
     "replace": "    await this.deps.client.respondPaymentRequest(id, { action: 'declined' }).catch(() => undefined);",
-    "tests": ["tests/unit/payments-v2/requests.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/requests.test.ts"
+    ]
   },
   {
     "name": "requests-pay-single-flight-removal",
@@ -69,7 +85,9 @@
     "file": "modules/payments-v2/requests/Requests.ts",
     "find": "    const inFlight = this.payInFlight.get(id);\n    if (inFlight !== undefined) return inFlight;",
     "replace": "    const inFlight = this.payInFlight.get(id);\n    if (inFlight !== undefined) void inFlight;",
-    "tests": ["tests/unit/payments-v2/requests.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/requests.test.ts"
+    ]
   },
   {
     "name": "history-received-key-tokenid-only",
@@ -77,15 +95,20 @@
     "file": "modules/payments-v2/history/History.ts",
     "find": "      dedupKey: `RECEIVED:${input.tokenId.toLowerCase()}:${input.stateHash.toLowerCase()}`,",
     "replace": "      dedupKey: `RECEIVED:${input.tokenId.toLowerCase()}`,",
-    "tests": ["tests/unit/payments-v2/history.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/history.test.ts"
+    ]
   },
   {
     "name": "receive-ignores-epoch-bump",
-    "note": "§5.1/§5.7: the mailbox cursor must never survive a server restore — keeping it across an epoch bump silently loses every deposit whose post-restore seq is below the stale cursor (sphere-payments-v2-restore.test.ts missed-wake case + receive.test.ts self-detection)",
+    "note": "\u00a75.1/\u00a75.7: the mailbox cursor must never survive a server restore \u2014 keeping it across an epoch bump silently loses every deposit whose post-restore seq is below the stale cursor (sphere-payments-v2-restore.test.ts missed-wake case + receive.test.ts self-detection)",
     "file": "modules/payments-v2/receive/Receive.ts",
     "find": "        const served = deps.delivery.incomingEpoch();\n        if (basis === null || served === null || served === basis.syncEpoch) break;",
     "replace": "        const served = deps.delivery.incomingEpoch();\n        void served;\n        break;",
-    "tests": ["tests/integration/sphere-payments-v2-restore.test.ts", "tests/unit/payments-v2/receive.test.ts"]
+    "tests": [
+      "tests/integration/sphere-payments-v2-restore.test.ts",
+      "tests/unit/payments-v2/receive.test.ts"
+    ]
   },
   {
     "name": "receive-ack-before-store",
@@ -93,23 +116,29 @@
     "file": "modules/payments-v2/receive/Receive.ts",
     "find": "    await deps.view.store(screened.record);\n    pending.push(claimAck(entry));",
     "replace": "    pending.push(claimAck(entry));\n    await deps.view.store(screened.record);",
-    "tests": ["tests/unit/payments-v2/receive.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/receive.test.ts"
+    ]
   },
   {
     "name": "receive-claim-conflict-swallow",
-    "note": "§5.7: a CONFLICT-bucket claim is terminally rejected('other') so the cursor advances — reverting to the swallow re-processes the entry every drain forever (receive.test.ts 'a CONFLICT-bucket claim is terminally rejected')",
+    "note": "\u00a75.7: a CONFLICT-bucket claim is terminally rejected('other') so the cursor advances \u2014 reverting to the swallow re-processes the entry every drain forever (receive.test.ts 'a CONFLICT-bucket claim is terminally rejected')",
     "file": "modules/payments-v2/receive/Receive.ts",
     "find": "    if (ack.disposition !== 'claimed' || !isClaimConflict(err)) throw err;",
     "replace": "    throw err;",
-    "tests": ["tests/unit/payments-v2/receive.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/receive.test.ts"
+    ]
   },
   {
     "name": "receive-genesis-only-dedup",
-    "note": "dedup is (tokenId, stateHash), a re-acquired token at a new state is accepted (receive.test.ts 'A→B→A')",
+    "note": "dedup is (tokenId, stateHash), a re-acquired token at a new state is accepted (receive.test.ts 'A\u2192B\u2192A')",
     "file": "modules/payments-v2/receive/Receive.ts",
     "find": "  if (held === keys.stateHash) return { kind: 'ack', ack: claimAck(entry) };",
     "replace": "  if (held !== null) return { kind: 'ack', ack: claimAck(entry) };",
-    "tests": ["tests/unit/payments-v2/receive.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/receive.test.ts"
+    ]
   },
   {
     "name": "receive-isspent-gate-drop",
@@ -117,7 +146,9 @@
     "file": "modules/payments-v2/receive/Receive.ts",
     "find": "  if (held !== null && (await engine.isSpent(token))) {",
     "replace": "  if (held !== null && (false as boolean) && (await engine.isSpent(token))) {",
-    "tests": ["tests/unit/payments-v2/receive.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/receive.test.ts"
+    ]
   },
   {
     "name": "providers-seen-set-before-ack",
@@ -125,15 +156,19 @@
     "file": "impl/wallet-api-v2/mailbox.ts",
     "find": "    if (disposition === 'claimed') {\n      const result = await this.client.claim([deliveryId], this.custody === 'inventory');",
     "replace": "    await this.addSeen(deliveryId);\n    if (disposition === 'claimed') {\n      const result = await this.client.claim([deliveryId], this.custody === 'inventory');",
-    "tests": ["tests/unit/payments-v2/providers.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/providers.test.ts"
+    ]
   },
   {
     "name": "providers-deliveryid-from-seq",
-    "note": "deliveryId is content-derived hex(SHA-256(tokenId ‖ stateHash)), never a server seq (providers.test.ts delivery-port contract)",
+    "note": "deliveryId is content-derived hex(SHA-256(tokenId \u2016 stateHash)), never a server seq (providers.test.ts delivery-port contract)",
     "file": "impl/wallet-api-v2/mailbox.ts",
     "find": "      deliveryId: entry.entryId,",
     "replace": "      deliveryId: String(entry.seq),",
-    "tests": ["tests/unit/payments-v2/providers.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/providers.test.ts"
+    ]
   },
   {
     "name": "checkpoints-re-encrypt-on-retry",
@@ -141,7 +176,9 @@
     "file": "impl/wallet-api-v2/checkpoints.ts",
     "find": "    let envelope = await kv.get<string>(cacheKey);\n    if (envelope === null) {\n      envelope = encryptFieldBytes(fieldKey, bytes, aad);\n      await kv.set(cacheKey, envelope);\n    }",
     "replace": "    let envelope = await kv.get<string>(cacheKey);\n    envelope = encryptFieldBytes(fieldKey, bytes, aad);\n    await kv.set(cacheKey, envelope);",
-    "tests": ["tests/unit/payments-v2/providers.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/providers.test.ts"
+    ]
   },
   {
     "name": "session-jwtcell-cas-removal",
@@ -149,54 +186,88 @@
     "file": "impl/wallet-api-v2/session.ts",
     "find": "  install(generation: number, jwt: string): boolean {\n    if (generation !== this.gen) return false;",
     "replace": "  install(generation: number, jwt: string): boolean {\n    if (generation !== this.gen && (false as boolean)) return false;",
-    "tests": ["tests/unit/payments-v2/session.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/session.test.ts"
+    ]
   },
   {
     "name": "heartbeat-never-scheduled",
-    "note": "§7 in-session convergence: the heartbeat must actually schedule ticks — a keep-open send would otherwise sit half-done until app restart (heartbeat.test.ts in-session test)",
+    "note": "\u00a77 in-session convergence: the heartbeat must actually schedule ticks \u2014 a keep-open send would otherwise sit half-done until app restart (heartbeat.test.ts in-session test)",
     "file": "modules/payments-v2/convergence.ts",
     "find": "  private schedule(delayMs: number): void {\n    this.clearTimer();\n    if (!this.running) return;",
     "replace": "  private schedule(delayMs: number): void {\n    this.clearTimer();\n    if (delayMs >= 0) return;\n    if (!this.running) return;",
-    "tests": ["tests/unit/payments-v2/heartbeat.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/heartbeat.test.ts"
+    ]
   },
   {
     "name": "facade-swallow-clean-failure-emit",
-    "note": "§4/#728: a CLEAN send failure emits transfer:updated{status:'failed'} before the rejection surfaces (facade.test.ts 'a CLEAN failure emits transfer:updated{status:failed}')",
+    "note": "\u00a74/#728: a CLEAN send failure emits transfer:updated{status:'failed'} before the rejection surfaces (facade.test.ts 'a CLEAN failure emits transfer:updated{status:failed}')",
     "file": "modules/payments-v2/PaymentsFacade.ts",
     "find": "    this.deps.emit('transfer:updated', failed);",
     "replace": "    void failed;",
-    "tests": ["tests/unit/payments-v2/facade.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/facade.test.ts"
+    ]
   },
   {
     "name": "resume-reissues-fresh-transferid",
-    "note": "the retry path converges under the SAME transferId — a fresh id is a re-issued send and double-pays (#631/#676) (heartbeat.test.ts no-reissue asserts)",
+    "note": "the retry path converges under the SAME transferId \u2014 a fresh id is a re-issued send and double-pays (#631/#676) (heartbeat.test.ts no-reissue asserts)",
     "file": "modules/payments-v2/machine/resume.ts",
     "find": "    await ctx.machine.resumeIntent({\n      transferId: job.transferId,",
     "replace": "    await ctx.machine.resumeIntent({\n      transferId: `${job.transferId}:reissued`,",
-    "tests": ["tests/unit/payments-v2/heartbeat.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/heartbeat.test.ts"
+    ]
   },
   {
     "name": "wiring-stamps-session-network-on-peer",
-    "note": "#733: the peer branch reports only what the binding PROVES — stamping the session network makes the §5.6 guard compare it with itself, i.e. unfalsifiable (facade.test.ts network-guard asserts)",
+    "note": "#733: the peer branch reports only what the binding PROVES \u2014 stamping the session network makes the \u00a75.6 guard compare it with itself, i.e. unfalsifiable (facade.test.ts network-guard asserts)",
     "file": "core/payments-v2-wiring.ts",
     "find": "    network: peer.network || null,",
     "replace": "    network,",
-    "tests": ["tests/unit/payments-v2/facade.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/facade.test.ts"
+    ]
   },
   {
     "name": "transport-drops-network-from-raw-event",
-    "note": "#735 review: the transport-pubkey route is the ONE recipient route that can prove a network today — it must read the raw signed event, not lose it (recipient-network.transport.test.ts refuses a relay-declared foreign network end to end)",
+    "note": "#735 review: the transport-pubkey route is the ONE recipient route that can prove a network today \u2014 it must read the raw signed event, not lose it (recipient-network.transport.test.ts refuses a relay-declared foreign network end to end)",
     "file": "transport/NostrTransportProvider.ts",
     "find": "      const network = declaredNetwork(bindingEvent);",
     "replace": "      const network = undefined as string | undefined;",
-    "tests": ["tests/unit/payments-v2/recipient-network.transport.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/recipient-network.transport.test.ts"
+    ]
   },
   {
     "name": "transport-invents-network-on-parsed-binding",
-    "note": "#735 review: the SDK-parsed @nametag/DIRECT:// routes cannot prove a network (parseBindingInfo whitelists it away) and must NOT invent one — a stamp silences the recipient:network-unverified signal, which is the #733 bug wearing a new hat (recipient-network.transport.test.ts LIMITATION asserts)",
+    "note": "#735 review: the SDK-parsed @nametag/DIRECT:// routes cannot prove a network (parseBindingInfo whitelists it away) and must NOT invent one \u2014 a stamp silences the recipient:network-unverified signal, which is the #733 bug wearing a new hat (recipient-network.transport.test.ts LIMITATION asserts)",
     "file": "transport/NostrTransportProvider.ts",
     "find": "    return {\n      nametag: nametag || binding.nametag,",
     "replace": "    return {\n      network: 'testnet2',\n      nametag: nametag || binding.nametag,",
-    "tests": ["tests/unit/payments-v2/recipient-network.transport.test.ts"]
+    "tests": [
+      "tests/unit/payments-v2/recipient-network.transport.test.ts"
+    ]
+  },
+  {
+    "name": "inventory-pinned-counts-as-confirmed",
+    "note": "#737: a token pinned by an open intent is reported transferring, never confirmed/spendable \u2014 the reporter reads the reservation, not just this session's in-flight set",
+    "file": "modules/payments-v2/compose.ts",
+    "find": "    isPinned: (tokenId) => ledger.holderOf(tokenId) !== undefined,",
+    "replace": "    isPinned: () => false,",
+    "tests": [
+      "tests/unit/payments-v2/pinned-balance.test.ts"
+    ]
+  },
+  {
+    "name": "queue-refusal-hides-the-pin",
+    "note": "#737: SEND_INSUFFICIENT_BALANCE must name the pinned amount and the transfers holding it \u2014 'insufficient balance' alone sent a user auditing a treasury that was never short",
+    "file": "modules/payments-v2/select/queue.ts",
+    "find": "    view.pinnedTotal > 0n",
+    "replace": "    (false as boolean)",
+    "tests": [
+      "tests/unit/payments-v2/pinned-balance.test.ts"
+    ]
   }
 ]

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -312,12 +312,13 @@
   },
   {
     "name": "queue-plan-ignores-unproven-heldset",
-    "note": "#738: planning must refuse while the held-set is unproven.",
+    "note": "#738: the gate lives in freeView() because plan() AND the queued path (tryServe) both go through it; gating only plan() lets a queued entry be served through a closed gate.",
     "file": "modules/payments-v2/select/queue.ts",
-    "find": "    const unproven = this.deps.ledger.unprovenReason();\n    if (unproven !== null) throw new SphereError(unproven, 'SEND_INSUFFICIENT_BALANCE');",
-    "replace": "    const unproven: string | null = null;\n    if (unproven !== null) throw new SphereError(unproven, 'SEND_INSUFFICIENT_BALANCE');",
+    "find": "      const holder = unproven === null ? this.deps.ledger.holderOf(entry.tokenId) : entry.tokenId;",
+    "replace": "      const holder = this.deps.ledger.holderOf(entry.tokenId);",
     "tests": [
-      "tests/unit/payments-v2/pinned-balance.test.ts"
+      "tests/unit/payments-v2/pinned-balance.test.ts",
+      "tests/unit/payments-v2/select.test.ts"
     ]
   },
   {

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -284,8 +284,8 @@
     "name": "pins-sync-ignores-incompleteness",
     "note": "#738: only a pass that reconstructed EVERY open intent may make the ledger authoritative; an unreadable envelope must keep it closed.",
     "file": "modules/payments-v2/select/pins.ts",
-    "find": "    this.deps.ledger.setAuthoritative(complete);",
-    "replace": "    this.deps.ledger.setAuthoritative(true);",
+    "find": "    const gateMoved = this.deps.ledger.setAuthoritative(complete);",
+    "replace": "    const gateMoved = this.deps.ledger.setAuthoritative(true);",
     "tests": [
       "tests/unit/payments-v2/pinned-balance.test.ts"
     ]
@@ -316,6 +316,16 @@
     "file": "modules/payments-v2/select/queue.ts",
     "find": "    const unproven = this.deps.ledger.unprovenReason();\n    if (unproven !== null) throw new SphereError(unproven, 'SEND_INSUFFICIENT_BALANCE');",
     "replace": "    const unproven: string | null = null;\n    if (unproven !== null) throw new SphereError(unproven, 'SEND_INSUFFICIENT_BALANCE');",
+    "tests": [
+      "tests/unit/payments-v2/pinned-balance.test.ts"
+    ]
+  },
+  {
+    "name": "gate-emits-every-pass",
+    "note": "#738: the gate signals a TRANSITION; emitting on every complete sync spams inventory:updated once per convergence heartbeat.",
+    "file": "modules/payments-v2/select/pins.ts",
+    "find": "    if (changed || gateMoved) this.deps.changed();",
+    "replace": "    if (changed || gateMoved || true) this.deps.changed();",
     "tests": [
       "tests/unit/payments-v2/pinned-balance.test.ts"
     ]

--- a/tests/unit/payments-v2/facade-harness.ts
+++ b/tests/unit/payments-v2/facade-harness.ts
@@ -169,6 +169,8 @@ export function peerBinding(overrides: Partial<PeerInfo> = {}): PeerInfo {
   };
 }
 
+let restarts = 0;
+
 export function makeWorld(
   options: {
     engine?: RealizationEngine;
@@ -179,10 +181,18 @@ export function makeWorld(
      * NostrTransportProvider over a fake relay instead of an injected PeerInfo.
      */
     resolvePeer?: (identifier: string) => Promise<PeerInfo | null>;
+    /**
+     * A process RESTART over the same server + durable stores: a brand-new facade
+     * (empty in-memory state) on the given world's FakeWalletApi, kv and engine.
+     * Its transferIds carry their own prefix so they can never collide with the
+     * ids the previous facade already wrote.
+     */
+    restartOf?: World;
   } = {}
 ): World {
-  const engine = options.engine ?? new RealizationEngine({ chainPubkey: hexToBytes(OWN_PUB) });
-  const engines = [engine];
+  const prior = options.restartOf;
+  const engine = options.engine ?? prior?.engine ?? new RealizationEngine({ chainPubkey: hexToBytes(OWN_PUB) });
+  const engines = prior?.engines ?? [engine];
   const decodeBlob = (bytes: Uint8Array): FakeBlobMeta => {
     let last: unknown;
     for (const candidate of engines) {
@@ -203,9 +213,9 @@ export function makeWorld(
     const withLineage = metas.find((meta) => meta.consumedStates.length > 0 || meta.splitEvidence !== undefined);
     return withLineage ?? metas[0] ?? decodeBlob(bytes);
   };
-  const api = new FakeWalletApi({ decodeBlob: combined });
+  const api = prior?.api ?? new FakeWalletApi({ decodeBlob: combined });
   const innerClient = new FakeWalletApiV2Client(api, ownCaller, { decodeBlob: combined });
-  const kv = memoryKV();
+  const kv = prior?.kv ?? memoryKV();
   const session = new FakeSession();
   const hooks: Hooks = {};
   const counters: Counters = { putIntent: 0, listOpen: 0 };
@@ -214,9 +224,10 @@ export function makeWorld(
   const gates: Gate[] = [];
   // Fake only the TRANSPORT lookup; recipient resolution is the PRODUCTION
   // resolveRecipientInfo, so the §5.6 guard can never be proven by a fake (#733).
-  const peers = new Map<string, PeerInfo | null>([['@peer', peerBinding({ network: NET })]]);
+  const peers = prior?.peers ?? new Map<string, PeerInfo | null>([['@peer', peerBinding({ network: NET })]]);
   Object.entries(options.peers ?? {}).forEach(([id, peer]) => peers.set(id, peer));
 
+  const idPrefix = prior === undefined ? '' : `r${String(++restarts)}-`;
   let ids = 0;
   const facade = new PaymentsFacade({
     session,
@@ -250,7 +261,7 @@ export function makeWorld(
     ownPubkey: OWN_PUB,
     requestMemo: stubRequestMemoCodec,
     syncEpoch: () => session.currentEpoch(),
-    newId: () => `tid-${String(++ids)}`,
+    newId: () => `tid-${idPrefix}${String(++ids)}`,
     receivePollMs: 60 * 60 * 1000,
   });
 

--- a/tests/unit/payments-v2/pinned-balance.test.ts
+++ b/tests/unit/payments-v2/pinned-balance.test.ts
@@ -204,3 +204,23 @@ describe('#738 review: the held-set gate fails CLOSED', () => {
     expect(ledger.unprovenReason()).toBeNull();
   });
 });
+
+describe('#738: the gate signals transitions, not passes', () => {
+  it('a repeated complete sync emits once — the heartbeat must not spam inventory:updated', async () => {
+    let emits = 0;
+    const ledger = new ReservationLedger();
+    const pins = new IntentPins({
+      ledger,
+      openIntents: async () => ({ open: new Map(), complete: true }),
+      isActive: () => false,
+      release: () => undefined,
+      changed: () => {
+        emits += 1;
+      },
+    });
+    await pins.sync();
+    await pins.sync();
+    await pins.sync();
+    expect(emits).toBe(1);
+  });
+});

--- a/tests/unit/payments-v2/pinned-balance.test.ts
+++ b/tests/unit/payments-v2/pinned-balance.test.ts
@@ -1,0 +1,126 @@
+// #737: a source pinned by an intent that is still converging is NOT spendable
+// balance, and the refusal that follows says exactly that. The reporter (§5.2)
+// and the selector (§5.4) must agree — a wallet that advertises money it will
+// refuse to spend sends its owner auditing a treasury that was never short.
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ProofUnconfirmedError } from '../../../token-engine/errors';
+import { COIN, cleanupWorlds, flushTail, makeWorld, ownCaller, type World } from './facade-harness';
+
+afterEach(cleanupWorlds);
+
+/** Parks one send as an OPEN intent (certification inconclusive), as #737's gateway did. */
+async function parkKeepOpen(world: World, amount: string): Promise<void> {
+  world.engine.afterOp = (_key, kind) => (kind === 'direct' ? new ProofUnconfirmedError('proof fetch inconclusive') : null);
+  await expect(
+    world.facade.send({ recipient: '@peer', amount, coinId: COIN })
+  ).rejects.toMatchObject({ code: 'CERTIFICATION_UNCONFIRMED' });
+  await flushTail();
+}
+
+describe('#737 pinned tokens are not spendable balance', () => {
+  it('a keep-open source is reported transferring, never confirmed — and the total tracks the pin', async () => {
+    const world = makeWorld();
+    const pinned = await world.seed(100n);
+    await world.seed(60n);
+    await world.facade.start();
+
+    await parkKeepOpen(world, '100');
+
+    const [asset] = await world.facade.assets(COIN);
+    expect(asset.confirmedAmount).toBe('60');
+    expect(asset.totalAmount).toBe('60');
+    expect(asset.confirmedTokenCount).toBe(1);
+    expect(asset.transferringAmount).toBe('100');
+    expect(asset.transferringTokenCount).toBe(1);
+    const shown = world.facade.tokens().find((t) => t.id === pinned.blob.tokenId);
+    expect(shown?.status).toBe('transferring');
+  });
+
+  it('the refusal names the pin: same CODE, a message that counts the free, the pinned and the transfers', async () => {
+    const world = makeWorld();
+    await world.seed(100n);
+    await world.seed(60n);
+    await world.facade.start();
+    await parkKeepOpen(world, '100');
+
+    // 100 is coverable ONLY by the pinned token — 60 is free, 100 is held.
+    const err = await world.facade
+      .send({ recipient: '@peer', amount: '100', coinId: COIN })
+      .catch((e: unknown) => e);
+
+    expect(err).toMatchObject({ code: 'SEND_INSUFFICIENT_BALANCE' });
+    const message = (err as Error).message;
+    expect(message).toContain('need 100');
+    expect(message).toContain('60 free');
+    expect(message).toContain('100 pinned by 1 transfer(s) still converging');
+    expect(message).toContain('pendingTransfers()');
+    expect(message).toContain('do not re-send');
+  });
+
+  it('nothing pinned: the plain wording is unchanged', async () => {
+    const world = makeWorld();
+    await world.seed(100n);
+    await world.facade.start();
+
+    const err = await world.facade
+      .send({ recipient: '@peer', amount: '500', coinId: COIN })
+      .catch((e: unknown) => e);
+
+    expect(err).toMatchObject({
+      code: 'SEND_INSUFFICIENT_BALANCE',
+      message: 'Insufficient balance for this transaction',
+    });
+  });
+
+  it('an intent that stops being open stops pinning: the source is confirmed again and spends', async () => {
+    const world = makeWorld();
+    await world.seed(100n);
+    await world.facade.start();
+    // Dies before the source is ever touched, so this one provably never committed.
+    world.engine.beforeOp = () => {
+      throw new ProofUnconfirmedError('proof fetch inconclusive');
+    };
+    await expect(
+      world.facade.send({ recipient: '@peer', amount: '100', coinId: COIN })
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_UNCONFIRMED' });
+    await flushTail();
+    expect((await world.facade.assets(COIN))[0].confirmedAmount).toBe('0');
+
+    const [intent] = await world.api.listIntents(ownCaller, 'open');
+    await world.innerClient.abortIntent(intent.transferId);
+    world.engine.beforeOp = null;
+    await world.facade.resumeNow(); // the pass GCs the residue row — nothing is open now
+    await flushTail();
+
+    const [asset] = await world.facade.assets(COIN);
+    expect(asset.confirmedAmount).toBe('100');
+    expect(asset.transferringAmount).toBe('0');
+    const ok = await world.facade.send({ recipient: '@peer', amount: '100', coinId: COIN });
+    expect(ok.status).toBe('delivered');
+  });
+
+  it('across a RESTART the pin is re-derived from the open intent: still transferring, still refused', async () => {
+    const world = makeWorld();
+    await world.seed(100n);
+    await world.facade.start();
+    await parkKeepOpen(world, '100');
+    await world.facade.stop();
+
+    // Fresh facade, empty in-memory ledger, same server + durable stores. The
+    // certification stays inconclusive, so the intent stays open.
+    const restarted = makeWorld({ restartOf: world });
+    await restarted.facade.start();
+    await flushTail();
+
+    const [asset] = await restarted.facade.assets(COIN);
+    expect(asset.confirmedAmount).toBe('0');
+    expect(asset.transferringAmount).toBe('100');
+    const err = await restarted.facade
+      .send({ recipient: '@peer', amount: '100', coinId: COIN })
+      .catch((e: unknown) => e);
+    expect(err).toMatchObject({ code: 'SEND_INSUFFICIENT_BALANCE' });
+    expect((err as Error).message).toContain('100 pinned by 1 transfer(s) still converging');
+  });
+});

--- a/tests/unit/payments-v2/pinned-balance.test.ts
+++ b/tests/unit/payments-v2/pinned-balance.test.ts
@@ -6,6 +6,9 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { ProofUnconfirmedError } from '../../../token-engine/errors';
+import { IntentPins, type IntentPinsDeps } from '../../../modules/payments-v2/select/pins';
+import { SpendQueue } from '../../../modules/payments-v2/select/queue';
+import { ReservationLedger } from '../../../modules/payments-v2/select/ledger';
 import { COIN, cleanupWorlds, flushTail, makeWorld, ownCaller, type World } from './facade-harness';
 
 afterEach(cleanupWorlds);
@@ -122,5 +125,82 @@ describe('#737 pinned tokens are not spendable balance', () => {
       .catch((e: unknown) => e);
     expect(err).toMatchObject({ code: 'SEND_INSUFFICIENT_BALANCE' });
     expect((err as Error).message).toContain('100 pinned by 1 transfer(s) still converging');
+  });
+});
+
+describe('#738 review: the held-set gate fails CLOSED', () => {
+  function makePins(openIntents: IntentPinsDeps['openIntents']): {
+    pins: IntentPins;
+    ledger: ReservationLedger;
+  } {
+    const ledger = new ReservationLedger();
+    const pins = new IntentPins({
+      ledger,
+      openIntents,
+      isActive: () => false,
+      release: () => undefined,
+      changed: () => undefined,
+    });
+    return { pins, ledger };
+  }
+
+  it('a fresh ledger is unproven: nothing plans and nothing reports free', () => {
+    const ledger = new ReservationLedger();
+    expect(ledger.unprovenReason()).not.toBeNull();
+    const queue = new SpendQueue({ ledger, getPool: () => [{ tokenId: 't1', amount: 100n }] });
+    expect(() => queue.plan('r1', { coinId: COIN, amount: '100' })).toThrow(
+      /spending is paused/i
+    );
+  });
+
+  it('a backstop read failure leaves the ledger unproven instead of re-offering held sources', async () => {
+    const { pins, ledger } = makePins(async () => {
+      throw new Error('IndexedDB unavailable');
+    });
+    await pins.sync().catch(() => undefined);
+    // Never resolves into "no holder, therefore free".
+    expect(ledger.unprovenReason()).not.toBeNull();
+  });
+
+  it('an undecodable OPEN intent keeps the ledger unproven rather than counting as zero sources', async () => {
+    const { pins, ledger } = makePins(async () => ({ open: new Map(), complete: false }));
+    await pins.sync();
+    expect(ledger.unprovenReason()).not.toBeNull();
+  });
+
+  it('an unreadable open intent across a RESTART: the report and the refusal AGREE — nothing free, nothing spendable', async () => {
+    const world = makeWorld();
+    await world.seed(100n);
+    await world.facade.start();
+    await parkKeepOpen(world, '100');
+    await world.facade.stop();
+
+    // Corrupt the still-open intent's envelope so its sources cannot be
+    // reconstructed. The pre-#738 bug read that as "holds nothing".
+    const intentsKey = [...world.kv.map.keys()].find((k) => k.endsWith('intents'));
+    expect(intentsKey).toBeDefined();
+    const rows = world.kv.map.get(intentsKey!) as { payloadEnvelope: string }[];
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) row.payloadEnvelope = 'not-decryptable';
+
+    const restarted = makeWorld({ restartOf: world });
+    await restarted.facade.start();
+    await flushTail();
+
+    // The REPORT must not call it confirmed...
+    const [asset] = await restarted.facade.assets(COIN);
+    expect(asset.confirmedAmount).toBe('0');
+    // ...and the SPEND path must refuse. Disagreement between these two is the
+    // #737 complaint; a permissive answer from EITHER is the #738 double-spend.
+    const err = await restarted.facade
+      .send({ recipient: '@peer', amount: '100', coinId: COIN })
+      .catch((e: unknown) => e);
+    expect(err).toMatchObject({ code: 'SEND_INSUFFICIENT_BALANCE' });
+  });
+
+  it('a pass that reconstructs every open intent makes the ledger authoritative', async () => {
+    const { pins, ledger } = makePins(async () => ({ open: new Map(), complete: true }));
+    await pins.sync();
+    expect(ledger.unprovenReason()).toBeNull();
   });
 });

--- a/tests/unit/payments-v2/select.test.ts
+++ b/tests/unit/payments-v2/select.test.ts
@@ -451,6 +451,30 @@ describe('SpendQueue', () => {
     expect(h.ledger.getFreeAmount('t-change', 400n)).toBe(0n);
   });
 
+  it('#738: a queued entry is NOT served while the gate is closed, and IS served once it reopens', async () => {
+    const h = makeHarness([]);
+    h.queue.declareExpectedChange('f1', COIN, 100n);
+    const settled = asQueued(h.queue.plan('r1', { coinId: COIN, amount: '100' }));
+    let served = false;
+    settled.then(() => (served = true)).catch(() => (served = true));
+
+    // The change arrives, but a later pins.sync() could not reconstruct the
+    // open-intent holds, so the held-set went unproven while this entry waited.
+    h.addToken('t1', 100n);
+    h.ledger.setAuthoritative(false);
+    h.queue.notifyChange(COIN);
+    await Promise.resolve();
+    await Promise.resolve();
+    // Paused, not served — serving here would spend through a closed gate.
+    expect(served).toBe(false);
+
+    // The next sync reconstructs the holds; the paused entry now goes through.
+    h.ledger.setAuthoritative(true);
+    h.queue.notifyChange(COIN);
+    const spend = await settled;
+    expect(spend.plan.direct).toEqual(['t1']);
+  });
+
   it('skip-ahead: a small entry passes a blocked head without unblocking it', async () => {
     const h = track(makeHarness([['t1', 1000n]]));
     h.ledger.reserve('inflight', [{ tokenId: 't1' }]);

--- a/tests/unit/payments-v2/select.test.ts
+++ b/tests/unit/payments-v2/select.test.ts
@@ -350,6 +350,9 @@ function makeHarness(initial: Array<[string, bigint]> = []): Harness {
   const pools = new Map<string, PoolEntry[]>();
   pools.set(COIN, initial.map(([tokenId, amount]) => ({ tokenId, amount })));
   const ledger = new ReservationLedger();
+  // #738: a fresh ledger's held-set is unproven and refuses every plan. These
+  // cases exercise selection on a ledger IntentPins has already reconstructed.
+  ledger.setAuthoritative(true);
   const queue = new SpendQueue({ ledger, getPool: (coinId) => pools.get(coinId) ?? [] });
   return {
     ledger,
@@ -542,6 +545,7 @@ describe('SpendQueue', () => {
       ['coin-b', []],
     ]);
     const ledger = new ReservationLedger();
+    ledger.setAuthoritative(true); // #738: reconstructed ledger; see makeHarness
     const queue = new SpendQueue({ ledger, getPool: (coinId) => pools.get(coinId) ?? [] });
     queue.declareExpectedChange('fa', COIN, 100n);
     queue.declareExpectedChange('fb', 'coin-b', 100n);


### PR DESCRIPTION
Closes #737 (the two SDK-side defects; the certification outage itself was upstream).

## The symptom the reporter lived with

A long-lived arcade service on testnet2 saw `assets()` report **~1,009,595 UCT confirmed** while
**every** `send()` — 6 to 25 UCT — was refused with `SEND_INSUFFICIENT_BALANCE`. 52 refusals in one
5-minute window. Five days, two wallets, two SDK versions (0.12.0 and 0.14.3), ~185 owed prizes
unpayable. They spent days auditing a treasury that was never short, because the only balance API
said the money was there and the only error said it was not.

The trigger was upstream: their gateway stopped confirming certifications, so every send ended
`CERTIFICATION_UNCONFIRMED` and the SDK — correctly, for money safety — kept each intent open and
kept its source reserved. Two defects downstream of that turned a transient outage into an
unexplainable permanent lockout.

## Defect 1 — the confirmed balance lied

`settleKeepOpen` deliberately RETAINS the source reservation: releasing it risks double-paying a
spend that may already be on-chain. But the reporting side split confirmed vs transferring on
`InventoryView`'s own `inFlight` set, which only knows about the attempt still running in **this
session**. Across a restart the in-memory ledger is empty while the intent is still open in the
durable backstop, so `pool()` re-offered those sources and `assets()` counted them as confirmed —
a wallet advertising balance it would refuse to spend.

**The invariant, as implemented:** a token that cannot be selected is not reported as spendable.
Anything pinned by an open intent — ledger-held, or named by an open row in the §6 intent backstop —
is reported under `transferring*`, never in the confirmed/spendable total.

- `InventoryView` reads the §5.4 reservation (`isPinned`) instead of only its in-flight set. A
  pinned entry deliberately stays IN `pool()`: the queue applies the ledger filter itself and needs
  the entry to quantify the pin. In-flight *without* a pin (spent, awaiting the mirror refresh)
  stays out, as before.
- `IntentPins` (`select/pins.ts`) makes the ledger hold exactly the sources of the intents the
  backstop still calls open. It runs at `start()` — before any send can plan — and after every
  convergence pass. The pin set is **derived, never stored** (`deriveOpenIntentHolds` decrypts the
  same backstop rows `pendingTransfers()` already reads), so a restart re-derives it rather than
  re-offering the tokens, and an intent that stops being open stops pinning instead of wedging the
  wallet forever. An attempt running in-process owns its own reservation and is never touched.

No reservation is released while its intent is open, and no new durable state is introduced.

## Defect 2 — the refusal misled

`SEND_INSUFFICIENT_BALANCE` keeps its code — sphere and dApps both key on it — but the message now
tells the truth when something is pinned:

> Insufficient spendable balance: need 100, 60 free, 100 pinned by 1 transfer(s) still converging — see payments.pendingTransfers(); do not re-send.

With nothing pinned the wording is exactly as before. The numbers come from data the queue already
has (its pool view plus the ledger); nothing durable was added.

## Tests

`tests/unit/payments-v2/pinned-balance.test.ts` (5), over the real facade + wallet-api ports:
keep-open pins its source → reported transferring, outside the confirmed total → a send only that
token could cover is refused with the pinned message naming the count → an intent that stops being
open releases the pin, the source is confirmed again and spends; no pinning → wording unchanged;
and a **restart** (new harness `makeWorld({ restartOf })`: fresh facade, same server + durable
stores) still reports pinned rather than spendable and still refuses with the pinned message.
Three of the five go red with the fix reverted.

Two mutation probes added (27 total, all KILLED): `inventory-pinned-counts-as-confirmed` (count
pinned as confirmed) and `queue-refusal-hides-the-pin` (drop the pinned detail from the message).

## Gates

`vitest tests/unit/payments-v2/ tests/integration/`, `npm run test:run` (1943 passed), typecheck,
typecheck:tests, eslint on touched files, build, `npm run test:mutation` 27/27 KILLED.