### PR TITLE
chore: bump state-transition-sdk to 2.0.3, drop the local workaround, tolerate transient gateway answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — base SDK pinned to `@unicitylabs/state-transition-sdk@2.0.3`
+
+2.0.3 carries the upstream fix for the lost-abort hang reported as
+state-transition-sdk-js#140: `waitInclusionProof` now checks `aborted` before
+subscribing, races each poll against the signal, and cancels the in-flight
+request, so the wait always settles at its deadline.
+
+With the root cause fixed upstream, the local workaround shipped in 0.14.4 is
+**removed**: `token-engine/proof-wait.ts` no longer wraps the signal in a
+late-delivering proxy, nor races the wait itself. What stays is the part that is
+genuinely ours — a bounded, configurable deadline (`proofTimeoutMs`, validated
+positive). `tests/unit/token-engine/proof-deadline.test.ts` keeps all three
+termination cases and now guards the upstream behaviour instead of our shim; it
+will fail loudly at the next bump if that behaviour regresses.
+
+### Fixed — a transient gateway answer no longer fails a certification (#741)
+
+The poll loop tolerates only HTTP 404 ("not finalized yet"). Any other answer —
+429 from rate limiting, 502/503 from a restarting or loaded gateway — aborted the
+whole wait on its **first** occurrence, turning a certification that would have
+landed seconds later into an open intent with its sources pinned. Transient
+statuses (408, 425, 429, 500, 502, 503, 504) are now retried **within the deadline
+we already own**, so the wait stays bounded either way and only the classification
+of a blip changes. A non-transient error still fails fast, and a gateway that is
+transient forever still ends at the deadline.
+
+Measured while resolving #741: across a full live money matrix, individual
+inclusion-proof waits ran **978–1789 ms (median 1581 ms)**. The 10 s default is
+per wait — a split's burn and each mint leg get their own — so the slowest
+observed wait used 18% of its budget. The default is unchanged.
+
 ### Fixed (money-visibility) — pinned tokens were advertised as spendable, and the refusal lied (#737)
 
 A wallet whose gateway stopped confirming certifications reported ~1M UCT **confirmed** while every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,11 @@ This repo is part of the wallet-api program (process: `../wallet-api/development
   current line **`0.14.0-dev.#`**, dist-tag `dev`. Consumers (wallet-api backend, sphere frontend)
   pin exact dev versions. The backend consumes ONLY the `./token-engine` subpath (must stay
   browser/Nostr-free — keep `token-engine/` clean).
-- Pinned base SDK: `@unicitylabs/state-transition-sdk@2.0.2` (stable release; bump only via PR).
+- Pinned base SDK: `@unicitylabs/state-transition-sdk@2.0.3` (stable release; bump only via PR).
+  2.0.3 fixes the lost-abort hang in `waitInclusionProof` (state-transition-sdk-js#140/#141):
+  its poll loop now checks `aborted` before subscribing, races each poll against the
+  signal, and cancels the in-flight request. `tests/unit/token-engine/proof-deadline.test.ts`
+  is the guard that it keeps doing so — do not delete it on a future bump.
 
 ## Quick Start (Using SDK as Dependency)
 
@@ -400,7 +404,7 @@ Subpath exports: `.` (root), `./core`, `./token-engine`, `./payments-v2` (the fa
 
 ### Token Engine (v2) — the only chain-op path
 
-The canonical package name resolves to the **v2 SDK, pinned `2.0.2`** (stable).
+The canonical package name resolves to the **v2 SDK, pinned `2.0.3`** (stable).
 
 - The SDK is imported in exactly ONE file: `token-engine/sdk.ts`. An ESLint
   `no-restricted-imports` rule blocks any other import of
@@ -416,7 +420,7 @@ The canonical package name resolves to the **v2 SDK, pinned `2.0.2`** (stable).
   source of truth for the network id (`RootTrustBase.networkId`, e.g. testnet2 = 4).
 - `SphereToken.sdkToken` is an OPAQUE handle — callers store it and hand it back
   to the engine, never call methods on it.
-- **Verification is sequential by default; parallel is opt-in** (2.0.2). Pass
+- **Verification is sequential by default; parallel is opt-in** (2.0.2+). Pass
   `verification: { createWorker, poolSize? }` to `Sphere.init` (or `EngineConfig`)
   and `engine.verify` fans per-transfer work out to a worker pool. The entry
   script is the CONSUMER's (only their bundler can emit a worker) and its
@@ -695,7 +699,7 @@ Key test areas:
 ## Dependencies
 
 **Core (from package.json):**
-- `@unicitylabs/state-transition-sdk` — **pinned `2.0.2`** (v2 engine; imported only via `token-engine/sdk.ts`)
+- `@unicitylabs/state-transition-sdk` — **pinned `2.0.3`** (v2 engine; imported only via `token-engine/sdk.ts`)
 - `@unicitylabs/nostr-js-sdk` `^0.5.0` — Nostr protocol
 - `@noble/hashes` `^2`, `@noble/curves` `^2` — cryptography
 - `bip39`, `elliptic`, `crypto-js`, `canonicalize`, `buffer`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@unicitylabs/nostr-js-sdk": "^0.6.0",
-        "@unicitylabs/state-transition-sdk": "2.0.2",
+        "@unicitylabs/state-transition-sdk": "2.0.3",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
         "canonicalize": "^3.0.0",
@@ -1803,9 +1803,9 @@
       }
     },
     "node_modules/@unicitylabs/state-transition-sdk": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.2.tgz",
-      "integrity": "sha512-SYCCShlwSUqeRhOocGkg9QCx0lacxelpRa6w3PQTLdXO8BO6Xo6Qh34ABZW2UcRfMDDPaXA0KSIyUo+UbiM9FQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.3.tgz",
+      "integrity": "sha512-2WFAv3vg0ckYRy/gAExr7TwCZZ8snMhTTjeaqWzDjFNO5HmanS49ONxcct6F5Srp3LbYBpjHWM2m4H/TbzmMOg==",
       "license": "ISC",
       "dependencies": {
         "@noble/curves": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@unicitylabs/nostr-js-sdk": "^0.6.0",
-    "@unicitylabs/state-transition-sdk": "2.0.2",
+    "@unicitylabs/state-transition-sdk": "2.0.3",
     "bip39": "^3.1.0",
     "buffer": "^6.0.3",
     "canonicalize": "^3.0.0",

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -332,21 +332,11 @@
     ]
   },
   {
-    "name": "proof-wait-drops-owned-deadline",
-    "note": "#739: delegating the deadline to the SDK default loses it when it fires mid-fetch \u2014 the op then never settles and stop() wedges behind it.",
+    "name": "proof-deadline-not-enforced",
+    "note": "#739: the deadline must be ours; falling back to the SDK default leaves every wait unbounded by our config.",
     "file": "token-engine/proof-wait.ts",
-    "find": "    return await Promise.race([wait, rejectOnAbort(controller.signal)]);",
-    "replace": "    return await wait;",
-    "tests": [
-      "tests/unit/token-engine/proof-deadline.test.ts"
-    ]
-  },
-  {
-    "name": "proof-wait-leaks-poller",
-    "note": "#739: without late abort delivery the SDK loop never exits, leaving a permanent poller hammering the gateway every interval.",
-    "file": "token-engine/proof-wait.ts",
-    "find": "    lateDeliveringSignal(controller.signal),",
-    "replace": "    controller.signal,",
+    "find": "          controller.signal,\n          deps.intervalMs",
+    "replace": "          undefined,\n          deps.intervalMs",
     "tests": [
       "tests/unit/token-engine/proof-deadline.test.ts"
     ]
@@ -367,6 +357,26 @@
     "file": "token-engine/proof-wait.ts",
     "find": "  if (!Number.isFinite(configured) || configured <= 0) {",
     "replace": "  if (false) {",
+    "tests": [
+      "tests/unit/token-engine/proof-deadline.test.ts"
+    ]
+  },
+  {
+    "name": "proof-wait-ignores-transient",
+    "note": "#741: a 429/5xx blip must be retried within the deadline, not reported as a failed certification.",
+    "file": "token-engine/proof-wait.ts",
+    "find": "        if (!isTransientGatewayError(err)) throw err;",
+    "replace": "        throw err;",
+    "tests": [
+      "tests/unit/token-engine/proof-deadline.test.ts"
+    ]
+  },
+  {
+    "name": "proof-wait-retries-everything",
+    "note": "#741: tolerance must be scoped to transient statuses \u2014 retrying a genuine 4xx hides a real error until the deadline.",
+    "file": "token-engine/proof-wait.ts",
+    "find": "  return err instanceof JsonRpcNetworkError && TRANSIENT_HTTP_STATUSES.has(err.status);",
+    "replace": "  return err instanceof JsonRpcNetworkError;",
     "tests": [
       "tests/unit/token-engine/proof-deadline.test.ts"
     ]

--- a/tests/unit/token-engine/proof-deadline.test.ts
+++ b/tests/unit/token-engine/proof-deadline.test.ts
@@ -31,15 +31,20 @@ class SlowProofClient implements IAggregatorClient {
   public proofCalls = 0;
 
   constructor(
-    private readonly inner: TestAggregatorClient,
+    protected readonly inner: TestAggregatorClient,
     private readonly delayMs: () => number
   ) {}
 
 
   async submitCertificationRequest(
-    ...args: Parameters<IAggregatorClient['submitCertificationRequest']>
+    certificationData: Parameters<IAggregatorClient['submitCertificationRequest']>[0]
   ): ReturnType<IAggregatorClient['submitCertificationRequest']> {
-    return this.inner.submitCertificationRequest(...args);
+    return this.inner.submitCertificationRequest(certificationData);
+  }
+
+  /** The aggregator's genuine answer — used by cases that recover after a blip. */
+  protected realProof(stateId: StateId): Promise<InclusionProofResponse> {
+    return this.inner.getInclusionProof(stateId);
   }
 
   async getInclusionProof(_stateId: StateId): Promise<InclusionProofResponse> {
@@ -144,5 +149,89 @@ describe('#739 the inclusion-proof wait always terminates', () => {
     await new Promise((resolve) => setTimeout(resolve, 600));
     // At most the one request already in flight when the deadline fired may land.
     expect(wireClient.proofCalls - afterSettle).toBeLessThanOrEqual(1);
+  }, 30_000);
+
+  it('#741: a transient gateway blip is retried, not treated as a failed certification', async () => {
+    // Pre-#741 the loop tolerated only 404, so ONE 503 mid-poll turned a
+    // certification that was about to land into an open intent.
+    for (const status of [429, 502, 503]) {
+      const aggregator = TestAggregatorClient.create();
+      let polls = 0;
+      const engine = createTestEngine({
+        aggregator,
+        wireClient: new (class extends SlowProofClient {
+          override async getInclusionProof(
+            stateId: Parameters<TestAggregatorClient['getInclusionProof']>[0]
+          ): Promise<InclusionProofResponse> {
+            polls += 1;
+            if (polls <= 2) throw new JsonRpcNetworkError(status, 'blip');
+            return this.realProof(stateId);
+          }
+        })(aggregator, () => 0),
+        proofTimeoutMs: 5_000,
+        proofPollIntervalMs: 20,
+      });
+
+      const token = await engine.mint({
+        recipientPubkey: engine.getIdentity().chainPubkey,
+        value: { assets: [{ coinId: COIN, amount: 1000n }] },
+      });
+      expect(engine.balanceOf(token, COIN)).toBe(1000n);
+      expect(polls).toBeGreaterThan(2);
+    }
+  }, 60_000);
+
+  it('#741: a NON-transient error still fails fast — tolerance must not swallow a real one', async () => {
+    const aggregator = TestAggregatorClient.create();
+    let polls = 0;
+    const engine = createTestEngine({
+      aggregator,
+      wireClient: new (class extends SlowProofClient {
+        override async getInclusionProof(): Promise<never> {
+          polls += 1;
+          throw new JsonRpcNetworkError(400, 'malformed');
+        }
+      })(aggregator, () => 0),
+      proofTimeoutMs: 5_000,
+      proofPollIntervalMs: 20,
+    });
+
+    const started = Date.now();
+    await engine
+      .mint({
+        recipientPubkey: engine.getIdentity().chainPubkey,
+        value: { assets: [{ coinId: COIN, amount: 1000n }] },
+      })
+      .catch(() => undefined);
+
+    // Surfaced immediately, not retried to the 5s deadline.
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(polls).toBe(1);
+  }, 30_000);
+
+  it('#741: a gateway transient FOREVER still ends at the deadline, never unbounded', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const engine = createTestEngine({
+      aggregator,
+      wireClient: new (class extends SlowProofClient {
+        override async getInclusionProof(): Promise<never> {
+          throw new JsonRpcNetworkError(503, 'down');
+        }
+      })(aggregator, () => 0),
+      proofTimeoutMs: 300,
+      proofPollIntervalMs: 20,
+    });
+
+    const started = Date.now();
+    const err = await engine
+      .mint({
+        recipientPubkey: engine.getIdentity().chainPubkey,
+        value: { assets: [{ coinId: COIN, amount: 1000n }] },
+      })
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ProofUnconfirmedError);
+    expect(Date.now() - started).toBeLessThan(3_000);
   }, 30_000);
 });

--- a/token-engine/proof-wait.ts
+++ b/token-engine/proof-wait.ts
@@ -1,8 +1,10 @@
-// #739: one inclusion-proof wait, with the deadline OWNED here — the SDK's own
-// deadline is lost when it fires mid-fetch, and the loop then polls forever.
+// One inclusion-proof wait: bounded by a deadline we own, and tolerant of a
+// gateway that blips (#739, #741). state-transition-sdk >= 2.0.3 terminates its
+// own poll loop on abort; proof-deadline.test.ts is the guard that it still does.
 
 import {
   type InclusionProof,
+  JsonRpcNetworkError,
   type PredicateVerifierService,
   type RootTrustBase,
   type StateTransitionClient,
@@ -12,12 +14,8 @@ import { SphereError } from '../core/errors';
 
 export const DEFAULT_PROOF_TIMEOUT_MS = 10_000;
 
-/**
- * A proof wait is ALWAYS bounded — an uncapped one is the #739 hang, which wedges
- * stop() and with it teardown, lock and address switch. So there is no "no cap"
- * setting: a non-positive value is refused loudly rather than read as forever
- * (or, worse, as a zero-delay deadline that fails every op instantly).
- */
+/** Always bounded: an uncapped wait is the #739 hang, so there is no "no cap"
+ *  value — non-positive is refused, never read as forever or as zero delay. */
 export function resolveProofTimeoutMs(configured: number | undefined): number {
   if (configured === undefined) return DEFAULT_PROOF_TIMEOUT_MS;
   if (!Number.isFinite(configured) || configured <= 0) {
@@ -30,45 +28,23 @@ export function resolveProofTimeoutMs(configured: number | undefined): number {
   return configured;
 }
 
-/** Delivers `abort` to a listener attached after the fact — what lets the SDK's
- *  per-sleep listener still fire, so its loop exits instead of polling forever. */
-function lateDeliveringSignal(signal: AbortSignal): AbortSignal {
-  return new Proxy(signal, {
-    get(target, prop): unknown {
-      if (prop === 'addEventListener') {
-        return (
-          type: string,
-          listener: EventListener,
-          options?: AddEventListenerOptions | boolean
-        ): void => {
-          if (type === 'abort' && target.aborted) {
-            queueMicrotask(() => {
-              listener.call(target, new Event('abort'));
-            });
-            return;
-          }
-          target.addEventListener(type, listener, options);
-        };
-      }
-      const value: unknown = Reflect.get(target, prop, target);
-      return typeof value === 'function'
-        ? (value as (...args: unknown[]) => unknown).bind(target)
-        : value;
-    },
-  });
+/** "Ask again", not "this certification failed" — the loop itself tolerates only
+ *  404, so without this one blip strands a certification that would land (#741). */
+const TRANSIENT_HTTP_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+function isTransientGatewayError(err: unknown): boolean {
+  return err instanceof JsonRpcNetworkError && TRANSIENT_HTTP_STATUSES.has(err.status);
 }
 
-/** Rejects as soon as the signal aborts — bounds our wait even if the fetch never settles. */
-function rejectOnAbort(signal: AbortSignal): Promise<never> {
-  return new Promise<never>((_resolve, reject) => {
-    if (signal.aborted) {
-      reject(signal.reason as Error);
-      return;
-    }
+/** Resolves on elapse OR abort; the caller re-checks the signal. */
+function pause(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
     signal.addEventListener(
       'abort',
       () => {
-        reject(signal.reason as Error);
+        clearTimeout(timer);
+        resolve();
       },
       { once: true }
     );
@@ -106,18 +82,25 @@ export async function awaitProofBounded(
       )
     );
   }, deps.timeoutMs);
-  const wait = waitInclusionProof(
-    deps.client,
-    deps.trustBase,
-    deps.predicateVerifier,
-    transaction,
-    lateDeliveringSignal(controller.signal),
-    deps.intervalMs
-  );
-  // The race may settle first; keep a late rejection from going unhandled.
-  wait.catch(() => undefined);
+
   try {
-    return await Promise.race([wait, rejectOnAbort(controller.signal)]);
+    for (;;) {
+      try {
+        return await waitInclusionProof(
+          deps.client,
+          deps.trustBase,
+          deps.predicateVerifier,
+          transaction,
+          controller.signal,
+          deps.intervalMs
+        );
+      } catch (err) {
+        // The deadline (or the caller) ended it: that outcome is final.
+        if (controller.signal.aborted) throw err;
+        if (!isTransientGatewayError(err)) throw err;
+        await pause(deps.intervalMs, controller.signal);
+      }
+    }
   } finally {
     clearTimeout(timer);
     external?.removeEventListener('abort', relayAbort);


### PR DESCRIPTION
Closes #741

Bumps the pinned base SDK to **2.0.3** and resolves both certification-policy follow-ups from #739.

## 1. The bump, and deleting our workaround

2.0.3 carries the upstream fix for the lost-abort hang (unicitynetwork/state-transition-sdk-js#140, fixed in #141). Their loop now checks `aborted` before subscribing, races each poll against the signal, and forwards a cancel signal into `getInclusionProof` — so a deadline is honoured whether it lands mid-request, mid-verify, or mid-sleep.

That makes the workaround shipped in 0.14.4 dead weight, so it is **gone**: no late-delivering `Proxy`, no self-race. I did not assume that — I removed each one and re-ran the three termination tests on 2.0.3:

| removed | mid-fetch deadline | never-settling fetch | no leaked poller |
|---|---|---|---|
| the `Proxy` | ✓ | ✓ | ✓ |
| the `Proxy` **and** the race | ✓ | ✓ | ✓ |

All still pass, because upstream now terminates its own loop. Carrying an exotic `Proxy` to defend a fixed bug is cruft; **the tests are the guard**, and they fail at bump time — exactly when a regression would matter. `CLAUDE.md` now says not to delete them on a future bump.

What stays is the part that is genuinely ours: a **bounded, configurable, validated** deadline (`proofTimeoutMs`).

## 2. A transient gateway answer no longer fails a certification

The poll loop tolerates only HTTP 404 ("not finalized yet"). Anything else — a 429 from rate limiting, a 502/503 from a restarting or loaded gateway — aborted the whole wait on its **first** occurrence, converting a certification that would have landed seconds later into an open intent with its sources pinned.

Transient statuses (408, 425, 429, 500, 502, 503, 504) are now retried **inside the deadline we already own**. That is why this is safe: the wait is bounded either way, so tolerance costs nothing in the worst case and only the classification of a blip changes. Guarded in both directions:

- a blip (429/502/503) that clears is retried and the mint succeeds — probe `proof-wait-ignores-transient`;
- a genuine 400 still fails **fast**, on the first poll, not retried to the deadline — probe `proof-wait-retries-everything`;
- a gateway that is transient forever still ends at the deadline as `ProofUnconfirmedError`.

## 3. Is 10 s enough for a split? Measured: yes, 5.6× over

The question behind #741's first item. Two things settle it.

**The deadline is per proof wait, not per operation.** A split's burn and each mint leg get their own independent 10 s window; a whole-token transfer uses one. So a split never has to fit in 10 s.

**Instrumented against live staging**, capturing every individual wait across the full money matrix (mint, transfer, split, self-send, roundtrip, crash-window):

```
10 waits: min 978 ms · median 1581 ms · p90 1789 ms · max 1789 ms
978, 979, 988, 1276, 1288, 1581, 1590, 1620, 1637, 1789
```

The slowest wait observed used **18% of its budget** — 5.6× headroom. The default is unchanged, and it is now tunable if a deployment ever needs otherwise. Caveat kept honest: 10 samples against a healthy gateway; this says the default is not the constraint, not that no gateway could ever exceed it.

## Verification

Live money matrix on this branch: **6/6 green in 47.5 s, zero keep-opens**. 38/38 mutation probes, 1957 unit tests, typecheck (both projects), lint, build.
