### PR TITLE
fix(payments-v2): resume shares the send path's settlement decision

### DIFF
--- a/modules/payments-v2/machine/TransferMachine.ts
+++ b/modules/payments-v2/machine/TransferMachine.ts
@@ -212,13 +212,21 @@ export class TransferMachine {
       payload: r.payload,
       ...(r.payload.memo !== undefined ? { memo: r.payload.memo } : {}),
     };
-    const { committed, conflicts } = await this.resumeOps(ctx, engine, r);
+    const outcomes = await this.resumeOps(ctx, engine, r);
+    const { committed, cls, firstError } = summarize(outcomes);
+    const conflicts = this.toConflicts(engine, r, outcomes);
     if (committed.length === 0 && conflicts.length > 0) throw conflicts[0].error;
 
     let deliveryPending = false;
     if (committed.length > 0) {
       deliveryPending = await this.deliverSet(r.transferId, r.payload.recipient, r.payload.memo, committed);
     }
+    // #744: an intent may close only when every op settled cleanly. A leg that
+    // certified but could not be journaled is `certified` WITH an error — its
+    // blob lives only in memory, so closing here would spend the source and
+    // destroy the payment. Same gate the send path applies at run().
+    if (cls !== null && cls !== 'conflict') throw firstError;
+
     await this.applyCommitted(engine, r.transferId, committed);
     if (conflicts.length > 0) {
       return { deliveryPending, partial: await this.settlePartial(engine, r, committed, conflicts) };
@@ -321,31 +329,39 @@ export class TransferMachine {
     return { recipientBlob: outputs[0].blob.token, changeBlob: outputs[1].blob.token };
   }
 
+  /** Raw outcomes; `summarize` alone decides what they mean — same as the send path. */
   private async resumeOps(
     ctx: CertifyCtx,
     engine: ITokenEngine,
     r: RehydratedIntent
-  ): Promise<{ committed: OpOutcome[]; conflicts: ResumeConflict[] }> {
-    const committed: OpOutcome[] = [];
-    const conflicts: ResumeConflict[] = [];
+  ): Promise<OpOutcome[]> {
+    const outcomes: OpOutcome[] = [];
     for (const op of buildOps(r.payload)) {
       // #621 direct legs re-deliver from the journal, never re-certify; a split
       // ALWAYS re-runs through its E.4 checkpoint to recover the change (#634).
       const journaled = op.kind === 'direct' ? r.journaled.get(op.opIndex) : undefined;
       if (journaled !== undefined) {
-        committed.push({ op, certified: true, recipientBlob: hexToBytes(journaled.blobHex) });
+        outcomes.push({ op, certified: true, recipientBlob: hexToBytes(journaled.blobHex) });
         continue;
       }
-      const source = r.sources.get(op.sourceTokenId);
-      const outcome = await this.certifyOne(ctx, engine, op, source);
-      if (outcome.certified) {
-        committed.push(outcome);
-        continue;
-      }
-      if (classifyError(outcome.error) !== 'conflict') throw outcome.error;
-      conflicts.push({ op, error: outcome.error, amount: conflictAmount(engine, r.payload, op, source) });
+      outcomes.push(await this.certifyOne(ctx, engine, op, r.sources.get(op.sourceTokenId)));
+      // Fail-fast on anything but a conflict, as before — but the outcome is
+      // RECORDED, so the shared decision below sees it (#744).
+      const last = outcomes[outcomes.length - 1];
+      if (last.error !== undefined && classifyError(last.error) !== 'conflict') break;
     }
-    return { committed, conflicts };
+    return outcomes;
+  }
+
+  /** Conflicted ops with the amount each leaves undelivered (#690 shortfall math). */
+  private toConflicts(engine: ITokenEngine, r: RehydratedIntent, outcomes: OpOutcome[]): ResumeConflict[] {
+    return outcomes
+      .filter((o) => !o.certified && classifyError(o.error) === 'conflict')
+      .map((o) => ({
+        op: o.op,
+        error: o.error,
+        amount: conflictAmount(engine, r.payload, o.op, r.sources.get(o.op.sourceTokenId)),
+      }));
   }
 
   private async deliverSet(

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -21,10 +21,10 @@
   },
   {
     "name": "machine-conflicted-leg-as-spent",
-    "note": "audit#4: a conflicted resume leg is never in applyDelta.spent[] (machine-resume.test.ts)",
+    "note": "audit#4: a conflicted resume leg is never in applyDelta.spent[]. Re-pointed at the shared decision (#744 unified send+resume onto summarize), where 'what counts as committed' now lives.",
     "file": "modules/payments-v2/machine/TransferMachine.ts",
-    "find": "      conflicts.push({ op, error: outcome.error, amount: conflictAmount(engine, r.payload, op, source) });",
-    "replace": "      committed.push({ op, certified: true });\n      conflicts.push({ op, error: outcome.error, amount: conflictAmount(engine, r.payload, op, source) });",
+    "find": "  const committed = outcomes.filter((o) => o.certified);",
+    "replace": "  const committed = outcomes.filter((o) => o.certified || classifyError(o.error) === 'conflict');",
     "tests": [
       "tests/unit/payments-v2/machine-resume.test.ts"
     ]
@@ -379,6 +379,16 @@
     "replace": "  return err instanceof JsonRpcNetworkError;",
     "tests": [
       "tests/unit/token-engine/proof-deadline.test.ts"
+    ]
+  },
+  {
+    "name": "resume-closes-on-unjournaled-leg",
+    "note": "#744: an intent may close only when every op settled cleanly. Dropping the shared gate lets resume complete with a certified-but-unjournaled leg, spending the source and destroying the recipient blob.",
+    "file": "modules/payments-v2/machine/TransferMachine.ts",
+    "find": "    if (cls !== null && cls !== 'conflict') throw firstError;",
+    "replace": "    if (cls !== null && cls !== 'conflict' && false) throw firstError;",
+    "tests": [
+      "tests/unit/payments-v2/machine-resume.test.ts"
     ]
   }
 ]

--- a/tests/unit/payments-v2/machine-resume.test.ts
+++ b/tests/unit/payments-v2/machine-resume.test.ts
@@ -61,6 +61,41 @@ describe('TransferMachine resume path (§5.5 P6 — same machine, rehydrated)', 
     expect(w.api.inspectIntent(w.caller, plan.transferId)?.status).toBe('completed');
   });
 
+  it('#744: a resume whose journal write fails keeps the intent OPEN — the certified blob is never destroyed', async () => {
+    const w = makeWorld();
+    const token = await w.seed(1000n);
+    const plan = await w.plan({ tokens: [token], amount: '1000' });
+    const pue = new ProofUnconfirmedError('proof fetch inconclusive');
+    w.engine.afterOp = (key) => (key === `${plan.transferId}:0` ? pue : null);
+    await expect(w.machine().run(plan)).rejects.toBe(pue);
+    w.engine.afterOp = null;
+    expect(w.api.inspectIntent(w.caller, plan.transferId)?.status).toBe('open');
+    expect(await w.stores().deliveryJournal.list()).toHaveLength(0);
+
+    // The op now certifies, but its #621 journal entry cannot be written
+    // (quota, aborted transaction, torn-down storage). The blob exists only in
+    // memory: closing the intent here would spend the source and destroy it.
+    w.kv.failWriteKeys.add(STORE_KEYS.deliveryJournal);
+
+    const report = await resumeAll(w.deps);
+
+    // NOT reported as resumed, and above all not settled.
+    expect(report.resumed).not.toContain(plan.transferId);
+    expect(w.api.inspectIntent(w.caller, plan.transferId)?.status).toBe('open');
+    expect(w.completes.map((c) => c.transferId)).not.toContain(plan.transferId);
+    expect(w.applied.map((a) => a.transferId)).not.toContain(plan.transferId);
+    expect((await w.api.listMailbox(w.recipientCaller)).entries).toHaveLength(0);
+
+    // Storage recovers: the SAME transferId converges, paying the recipient once.
+    w.kv.failWriteKeys.delete(STORE_KEYS.deliveryJournal);
+    const recovered = await resumeAll(w.deps);
+
+    expect(recovered.resumed).toEqual([plan.transferId]);
+    expect((await w.api.listMailbox(w.recipientCaller)).entries).toHaveLength(1);
+    expect(w.api.inspectIntent(w.caller, plan.transferId)?.status).toBe('completed');
+    expect(w.applied.at(-1)?.spent).toEqual([token.blob.tokenId]);
+  });
+
   it('audit#4: a conflicted resume leg is never in spent[]; the delivered leg completes with the remainder-only shortfall', async () => {
     const w = makeWorld();
     const tokenA = await w.seed(600n);

--- a/tests/unit/payments-v2/support.ts
+++ b/tests/unit/payments-v2/support.ts
@@ -18,23 +18,30 @@ export interface MemoryKV extends ScopedKV {
   readonly sets: { key: string; value: unknown }[];
   /** Fault injection: get() of any of these keys throws. */
   readonly failKeys: Set<string>;
+  /** Fault injection: set() of any of these keys throws — the durable-write axis. */
+  readonly failWriteKeys: Set<string>;
 }
 
 /** In-memory ScopedKV: JSON round-trips both writes and reads (storage fidelity). */
-export function memoryKV(opts: { seed?: Record<string, unknown>; failKeys?: string[] } = {}): MemoryKV {
+export function memoryKV(
+  opts: { seed?: Record<string, unknown>; failKeys?: string[]; failWriteKeys?: string[] } = {}
+): MemoryKV {
   const map = new Map<string, unknown>(Object.entries(opts.seed ?? {}));
   const sets: { key: string; value: unknown }[] = [];
   const failKeys = new Set<string>(opts.failKeys ?? []);
+  const failWriteKeys = new Set<string>(opts.failWriteKeys ?? []);
   return {
     map,
     sets,
     failKeys,
+    failWriteKeys,
     async get<T>(key: string): Promise<T | null> {
       if (failKeys.has(key)) throw new Error(`injected kv read failure: ${key}`);
       if (!map.has(key)) return null;
       return JSON.parse(JSON.stringify(map.get(key))) as T;
     },
     async set<T>(key: string, value: T): Promise<void> {
+      if (failWriteKeys.has(key)) throw new Error(`injected kv write failure: ${key}`);
       const cloned = JSON.parse(JSON.stringify(value)) as unknown;
       sets.push({ key, value: cloned });
       map.set(key, cloned);


### PR DESCRIPTION
Closes #744

## The loss

A leg that certified on-chain but whose #621 journal write failed returns from `certifyOne` as `{ certified: true, error }` — the recipient blob exists only in memory.

The **send** path handles it: `summarize()` ranks the error, `run()` closes the intent only when `cls === null`, and `applyBestEffort` names the rule outright — `// unjournaled leg: resume owns it`.

Resume owned it and dropped it. `resumeOps` branched on `outcome.certified` alone and pushed the errored leg into `committed`; `resumeIntent` then decided purely on array lengths. `deliverSet` filtered the leg out (it requires `error === undefined`), `applyCommitted` tombstoned its source anyway, and `completeIntent` closed the intent. Source spent to the recipient's predicate, blob discarded, intent unlistable, **no attention event**, and `settledAmount` counted it — so history reported value the recipient never received.

## The fix is a deletion, not a guard

The cause is duplication: the settlement rules were written twice, once per path, and drifted. So this removes resume's private copy of the decision rather than adding a second guard beside it.

- `resumeOps` returns raw outcomes. Fail-fast is preserved, but the outcome is **recorded** instead of thrown away.
- `resumeIntent` asks `summarize()` the same question `run()` asks, and closes only when every op settled cleanly.

That also hands resume the **keep-open precedence** it never had: `summarize` ranks keep-open above conflict above other, so a clean error can no longer mask a possibly-committed sibling.

## The axis that hid it

No test in the repo failed a durable write — `machine-resume.test.ts` had 10 cases, none of them this. `memoryKV` gains `failWriteKeys`, and the new case drives the real path: journal write fails → intent stays open, nothing delivered, not reported as resumed; storage recovers → the **same** transferId converges and pays the recipient exactly once.

Probe `resume-closes-on-unjournaled-leg` pins it. `machine-conflicted-leg-as-spent` was text-anchored inside the old loop and is **re-pointed** at `summarize()`, where 'what counts as committed' now lives — not deleted.

## Verification

39/39 mutation probes, 1958 unit tests, typecheck (both projects), lint, build. The code path was verified by reading HEAD; the end-to-end loss was originally surfaced by adversarial review and is now a committed regression test.