### PR TITLE
perf(token-engine): retry a rate-limited submit, and certify 20-wide

### DIFF
--- a/modules/payments-v2/machine/TransferMachine.ts
+++ b/modules/payments-v2/machine/TransferMachine.ts
@@ -30,7 +30,11 @@ import {
   type MachineStores,
 } from './journal';
 
-const CERTIFY_WIDTH = 8;
+// #746: measured live, a 4-op wave cost the same as an 8-op wave — at 8 we were
+// latency-bound, so each wave paid a proof round-trip and the barrier multiplied
+// it. Safe to widen only because a rate-limited submit now retries instead of
+// burning a full deadline per op (proof-wait.retryTransient).
+const CERTIFY_WIDTH = 20;
 
 const KEEP_OPEN_CODES = new Set([
   'CERTIFICATION_UNCONFIRMED',

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -334,9 +334,9 @@
   {
     "name": "proof-deadline-not-enforced",
     "note": "#739: the deadline must be ours; falling back to the SDK default leaves every wait unbounded by our config.",
-    "file": "token-engine/proof-wait.ts",
-    "find": "          controller.signal,\n          deps.intervalMs",
-    "replace": "          undefined,\n          deps.intervalMs",
+    "file": "token-engine/SphereTokenEngine.ts",
+    "find": "      this.proofTimeoutMs,\n      options?.signal,",
+    "replace": "      2_000_000_000,\n      options?.signal,",
     "tests": [
       "tests/unit/token-engine/proof-deadline.test.ts"
     ]
@@ -365,8 +365,8 @@
     "name": "proof-wait-ignores-transient",
     "note": "#741: a 429/5xx blip must be retried within the deadline, not reported as a failed certification.",
     "file": "token-engine/proof-wait.ts",
-    "find": "        if (!isTransientGatewayError(err)) throw err;",
-    "replace": "        throw err;",
+    "find": "      if (!isTransientGatewayError(err)) throw err;",
+    "replace": "      throw err;",
     "tests": [
       "tests/unit/token-engine/proof-deadline.test.ts"
     ]
@@ -377,6 +377,16 @@
     "file": "token-engine/proof-wait.ts",
     "find": "  return err instanceof JsonRpcNetworkError && TRANSIENT_HTTP_STATUSES.has(err.status);",
     "replace": "  return err instanceof JsonRpcNetworkError;",
+    "tests": [
+      "tests/unit/token-engine/proof-deadline.test.ts"
+    ]
+  },
+  {
+    "name": "submit-429-not-retried",
+    "note": "#746: the metered call is the SUBMIT. Without retry a 429 falls through to a proof wait for a request the gateway never accepted, burning the whole deadline per op \u2014 which is what made raising CERTIFY_WIDTH unsafe.",
+    "file": "token-engine/SphereTokenEngine.ts",
+    "find": "      const response = await retryTransient(\n        () => this.deps.client.submitCertificationRequest(certificationData),\n        signal,\n        this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS,\n      );",
+    "replace": "      const response = await this.deps.client.submitCertificationRequest(certificationData);",
     "tests": [
       "tests/unit/token-engine/proof-deadline.test.ts"
     ]

--- a/tests/unit/token-engine/proof-deadline.test.ts
+++ b/tests/unit/token-engine/proof-deadline.test.ts
@@ -234,4 +234,94 @@ describe('#739 the inclusion-proof wait always terminates', () => {
     expect(err).toBeInstanceOf(ProofUnconfirmedError);
     expect(Date.now() - started).toBeLessThan(3_000);
   }, 30_000);
+
+  it('#746: a rate-limited SUBMIT is retried, not turned into a doomed 10s proof wait', async () => {
+    // The 429 the gateway actually emits lands on submitCertificationRequest —
+    // the metered call. Before #746 it was swallowed into submitError and the
+    // code then polled for a proof of a request the gateway never accepted,
+    // burning the entire deadline and leaving the intent open.
+    const aggregator = TestAggregatorClient.create();
+    let submits = 0;
+    const engine = createTestEngine({
+      aggregator,
+      wireClient: new (class extends SlowProofClient {
+        override async submitCertificationRequest(
+          data: Parameters<TestAggregatorClient['submitCertificationRequest']>[0]
+        ): ReturnType<TestAggregatorClient['submitCertificationRequest']> {
+          submits += 1;
+          if (submits <= 2) throw new JsonRpcNetworkError(429, 'slow down');
+          return this.inner.submitCertificationRequest(data);
+        }
+        override async getInclusionProof(
+          stateId: Parameters<TestAggregatorClient['getInclusionProof']>[0]
+        ): Promise<InclusionProofResponse> {
+          return this.realProof(stateId);
+        }
+      })(aggregator, () => 0),
+      proofTimeoutMs: 5_000,
+      proofPollIntervalMs: 20,
+    });
+
+    const started = Date.now();
+    const token = await engine.mint({
+      recipientPubkey: engine.getIdentity().chainPubkey,
+      value: { assets: [{ coinId: COIN, amount: 1000n }] },
+    });
+
+    expect(engine.balanceOf(token, COIN)).toBe(1000n);
+    expect(submits).toBe(3);
+    // Retried in poll-interval time, nowhere near the 5s deadline it used to burn.
+    expect(Date.now() - started).toBeLessThan(2_000);
+  }, 30_000);
+
+  it('#746: a NON-transient submit rejection is not retried', async () => {
+    const aggregator = TestAggregatorClient.create();
+    let submits = 0;
+    const engine = createTestEngine({
+      aggregator,
+      wireClient: new (class extends SlowProofClient {
+        override async submitCertificationRequest(): Promise<never> {
+          submits += 1;
+          throw new JsonRpcNetworkError(400, 'malformed');
+        }
+      })(aggregator, () => 0),
+      proofTimeoutMs: 400,
+      proofPollIntervalMs: 20,
+    });
+
+    await engine
+      .mint({
+        recipientPubkey: engine.getIdentity().chainPubkey,
+        value: { assets: [{ coinId: COIN, amount: 1000n }] },
+      })
+      .catch(() => undefined);
+
+    expect(submits).toBe(1);
+  }, 30_000);
+
+  it('#746: submit retries and the proof share ONE deadline — the attempt stays bounded', async () => {
+    const aggregator = TestAggregatorClient.create();
+    const engine = createTestEngine({
+      aggregator,
+      wireClient: new (class extends SlowProofClient {
+        override async submitCertificationRequest(): Promise<never> {
+          throw new JsonRpcNetworkError(503, 'down');
+        }
+      })(aggregator, () => 0),
+      proofTimeoutMs: 300,
+      proofPollIntervalMs: 20,
+    });
+
+    const started = Date.now();
+    const err = await engine
+      .mint({
+        recipientPubkey: engine.getIdentity().chainPubkey,
+        value: { assets: [{ coinId: COIN, amount: 1000n }] },
+      })
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ProofUnconfirmedError);
+    expect(Date.now() - started).toBeLessThan(3_000);
+  }, 30_000);
 });

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -16,7 +16,13 @@
  */
 
 import { SphereError, type SphereErrorCode } from '../core/errors';
-import { awaitProofBounded, resolveProofTimeoutMs } from './proof-wait';
+import {
+  awaitProofBounded,
+  certificationDeadline,
+  resolveProofTimeoutMs,
+  retryTransient,
+} from './proof-wait';
+import { certificationFailure } from './certification-outcome';
 import { randomUUID } from '../core/uuid';
 import {
   CheckpointPersistFailedError,
@@ -678,6 +684,27 @@ export class SphereTokenEngine implements ITokenEngine {
     failCode: SphereErrorCode,
     options?: EngineOpOptions,
   ): Promise<InclusionProof> {
+    const deadline = certificationDeadline(
+      this.proofTimeoutMs,
+      options?.signal,
+      `${failLabel}: not certified`
+    );
+    try {
+      return await this.submitThenProve(certificationData, transaction, failLabel, failCode, deadline.signal);
+    } finally {
+      deadline.dispose();
+    }
+  }
+
+  /** One certification attempt under one deadline: the metered submit retries
+   *  transient answers instead of falling through to a proof that cannot exist. */
+  private async submitThenProve(
+    certificationData: CertificationData,
+    transaction: ITransaction,
+    failLabel: string,
+    failCode: SphereErrorCode,
+    signal: AbortSignal,
+  ): Promise<InclusionProof> {
     let submitError: unknown = null;
     // true ONLY for a KNOWN validation-reject status — a PROVEN clean pre-certification
     // reject (nothing on-chain). Status-agnostic otherwise (E.2): an UNKNOWN/transitional
@@ -685,7 +712,11 @@ export class SphereTokenEngine implements ITokenEngine {
     // processed server-side — both stay INDETERMINATE (keep-open, #631).
     let submitRejectedCleanly = false;
     try {
-      const response = await this.deps.client.submitCertificationRequest(certificationData);
+      const response = await retryTransient(
+        () => this.deps.client.submitCertificationRequest(certificationData),
+        signal,
+        this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS,
+      );
       if (response.status !== CertificationStatus.SUCCESS) {
         submitError = new SphereError(`${failLabel}: ${response.status}`, failCode);
         submitRejectedCleanly = CLEAN_REJECT_STATUSES.has(response.status);
@@ -700,43 +731,16 @@ export class SphereTokenEngine implements ITokenEngine {
           client: this.deps.client,
           trustBase: this.deps.trustBase,
           predicateVerifier: this.deps.predicateVerifier,
-          timeoutMs: this.proofTimeoutMs,
           intervalMs: this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS, // #683
         },
         transaction,
-        options?.signal,
+        signal,
       );
     } catch (err) {
-      // The SDK surfaces a match-verify mismatch as a generic Error whose
-      // message embeds the verification status. Mapping that fragile string is
-      // done HERE — in the anti-corruption layer — and nowhere else; a test
-      // pins the exact SDK message so an upstream change fails loudly.
-      if (
-        err instanceof Error &&
-        err.message === `Invalid inclusion proof status: ${InclusionProofVerificationStatus.TRANSACTION_HASH_MISMATCH}`
-      ) {
-        throw new TransferConflictError(
-          `${failLabel}: the source state was already consumed by a different transaction ` +
-            '(lost race — abort this intent and re-plan under a new transferId)',
-          err,
-        );
-      }
-      // A PROVEN clean pre-certification reject (well-formed non-SUCCESS status)
-      // → the state was genuinely never certified; surface the original error so
-      // the caller aborts + restores the untouched source.
-      if (submitRejectedCleanly) throw submitError;
-      // Otherwise INDETERMINATE (#631): the submit returned SUCCESS (submitError
-      // === null) and the proof fetch threw, OR the submit POST itself threw (may
-      // have been processed server-side). The source spend MAY be on-chain under
-      // THIS transferId — surface a typed keep-open signal so the caller keeps the
-      // intent OPEN and resumes under the same transferId instead of aborting.
-      throw new ProofUnconfirmedError(
-        `${failLabel}: certification unconfirmed — the source spend may be on-chain; ` +
-          'keep the intent open and resume under the same transferId',
-        submitError ?? err,
-      );
+      throw certificationFailure(err, failLabel, submitError, submitRejectedCleanly);
     }
   }
+
 
   /**
    * One inclusion-proof wait, with the deadline OWNED here (#739) so it is bounded

--- a/token-engine/certification-outcome.ts
+++ b/token-engine/certification-outcome.ts
@@ -1,0 +1,29 @@
+import { InclusionProofVerificationStatus } from './sdk';
+import { ProofUnconfirmedError, TransferConflictError } from './errors';
+
+/** What a failed certification means: lost race, proven-clean reject, or indeterminate. */
+export function certificationFailure(
+  err: unknown,
+  failLabel: string,
+  submitError: unknown,
+  submitRejectedCleanly: boolean,
+): unknown {
+  // The SDK reports a match-verify mismatch as a generic Error carrying the
+  // status in its message; that fragile string is mapped HERE and nowhere else.
+  if (
+    err instanceof Error &&
+    err.message === `Invalid inclusion proof status: ${InclusionProofVerificationStatus.TRANSACTION_HASH_MISMATCH}`
+  ) {
+    return new TransferConflictError(
+      `${failLabel}: the source state was already consumed by a different transaction ` +
+        '(lost race — abort this intent and re-plan under a new transferId)',
+      err,
+    );
+  }
+  if (submitRejectedCleanly) return submitError;
+  return new ProofUnconfirmedError(
+    `${failLabel}: certification unconfirmed — the source spend may be on-chain; ` +
+      'keep the intent open and resume under the same transferId',
+    submitError ?? err,
+  );
+}

--- a/token-engine/proof-wait.ts
+++ b/token-engine/proof-wait.ts
@@ -51,21 +51,34 @@ function pause(ms: number, signal: AbortSignal): Promise<void> {
   });
 }
 
-export interface ProofWaitDeps {
-  readonly client: StateTransitionClient;
-  readonly trustBase: RootTrustBase;
-  readonly predicateVerifier: PredicateVerifierService;
-  readonly timeoutMs: number;
-  readonly intervalMs: number;
+/**
+ * Runs `attempt` until it succeeds, a non-transient error surfaces, or the
+ * signal ends it. The metered call is the SUBMIT, so this policy has to be
+ * reusable by both — a copy per call site is how the two drift.
+ */
+export async function retryTransient<T>(
+  attempt: () => Promise<T>,
+  signal: AbortSignal,
+  intervalMs: number
+): Promise<T> {
+  for (;;) {
+    try {
+      return await attempt();
+    } catch (err) {
+      // The deadline (or the caller) ended it: that outcome is final.
+      if (signal.aborted) throw err;
+      if (!isTransientGatewayError(err)) throw err;
+      await pause(intervalMs, signal);
+    }
+  }
 }
 
-/** Await one inclusion proof, always terminating; a deadline hit throws and the
- *  caller maps it to ProofUnconfirmedError (keep-open — the spend may be on-chain). */
-export async function awaitProofBounded(
-  deps: ProofWaitDeps,
-  transaction: Parameters<typeof waitInclusionProof>[3],
-  external: AbortSignal | undefined
-): Promise<InclusionProof> {
+/** A deadline for ONE certification attempt: submit retries and proof share it. */
+export function certificationDeadline(
+  timeoutMs: number,
+  external: AbortSignal | undefined,
+  label: string
+): { signal: AbortSignal; dispose: () => void } {
   const controller = new AbortController();
   const relayAbort = (): void => {
     controller.abort(external?.reason);
@@ -75,34 +88,42 @@ export async function awaitProofBounded(
     else external.addEventListener('abort', relayAbort, { once: true });
   }
   const timer = setTimeout(() => {
-    controller.abort(
-      new SphereError(
-        `inclusion proof not confirmed within ${String(deps.timeoutMs)} ms`,
-        'AGGREGATOR_ERROR'
-      )
-    );
-  }, deps.timeoutMs);
+    controller.abort(new SphereError(`${label} within ${String(timeoutMs)} ms`, 'AGGREGATOR_ERROR'));
+  }, timeoutMs);
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      clearTimeout(timer);
+      external?.removeEventListener('abort', relayAbort);
+    },
+  };
+}
 
-  try {
-    for (;;) {
-      try {
-        return await waitInclusionProof(
-          deps.client,
-          deps.trustBase,
-          deps.predicateVerifier,
-          transaction,
-          controller.signal,
-          deps.intervalMs
-        );
-      } catch (err) {
-        // The deadline (or the caller) ended it: that outcome is final.
-        if (controller.signal.aborted) throw err;
-        if (!isTransientGatewayError(err)) throw err;
-        await pause(deps.intervalMs, controller.signal);
-      }
-    }
-  } finally {
-    clearTimeout(timer);
-    external?.removeEventListener('abort', relayAbort);
-  }
+export interface ProofWaitDeps {
+  readonly client: StateTransitionClient;
+  readonly trustBase: RootTrustBase;
+  readonly predicateVerifier: PredicateVerifierService;
+  readonly intervalMs: number;
+}
+
+/** Await one inclusion proof, always terminating; a deadline hit throws and the
+ *  caller maps it to ProofUnconfirmedError (keep-open — the spend may be on-chain). */
+export async function awaitProofBounded(
+  deps: ProofWaitDeps,
+  transaction: Parameters<typeof waitInclusionProof>[3],
+  signal: AbortSignal
+): Promise<InclusionProof> {
+  return retryTransient(
+    () =>
+      waitInclusionProof(
+        deps.client,
+        deps.trustBase,
+        deps.predicateVerifier,
+        transaction,
+        signal,
+        deps.intervalMs
+      ),
+    signal,
+    deps.intervalMs
+  );
 }


### PR DESCRIPTION
Closes #746

Measured live before changing anything — a 20-source send is **10.9 s**, and it splits in two:

| phase | 20 tokens | 5 tokens |
|---|---|---|
| **certifyAll** | **5741 ms** (3 waves: 2018 / 1748 / 1975) | 1998 ms (1 wave) |
| **batchDeposit** | **4143 ms** | 1025 ms |
| everything else | ~1.0 s | ~0.4 s |
| **total** | **10.9 s** | **3.4 s** |

## 1. The submit retries a transient answer

The metered call is the **submit**, not the proof read. A 429 from `submitCertificationRequest` was caught into `submitError`, and the code then waited for an inclusion proof of a request the gateway never accepted — burning the full `proofTimeoutMs` (10 s) per op and leaving the intent open.

It now retries within the deadline using the **same `retryTransient` policy the proof wait uses** — one policy, not a copy per call site — and submit and proof share one certification deadline.

(#741's transient retry protects `getInclusionProof`, a cheap read that is essentially never rate-limited. That was the wrong side, and this corrects it.)

## 2. CERTIFY_WIDTH 8 → 20

A 4-op wave cost the same as an 8-op wave (1330–1975 ms vs 1728–2171 ms). That is the tell: at 8 we were **latency-bound, not throughput-bound** — each wave paid one proof round-trip and the barrier between waves multiplied it. The metered request **count** is invariant to width; only the burst rate changes.

This is safe to widen *only* because of change 1. Without it a rate-limited op costs 10 s, so widening would have improved p50 and wrecked p95.

Also extracted `certificationFailure()` — what a failed certification *means* (lost race / proven-clean reject / indeterminate) is a pure decision and no longer sits inside the engine.

## What this does NOT fix

- **wallet-api's batch deposit is serial**: 205 ms/blob at N=5, 207 ms/blob at N=20, on a ~70 KB payload — one request, looping internally. That is 4.1 s of the 10.9 s and no SDK change touches it.
- So **3–5 s is not reachable for 20 tokens from the SDK alone**: ~2 s certify + 4.1 s deposit + ~1 s ≈ **7 s**. Reaching the target needs the deposit parallelised backend-side. (N=5 already measures 3.4 s.)
- **No backpressure signal exists.** The gateway sends `Retry-After` and `X-RateLimit-Remaining`; `JsonRpcHttpTransport.js:85` throws `new JsonRpcNetworkError(response.status, body)` and discards the response. The error type cannot carry them, so adaptive width needs an upstream change. Our retry is bounded by the deadline, so it is safe without them — just not polite to the limiter.

## Verification

39/39 mutation probes (incl. new `submit-429-not-retried`), 1960 unit tests, typecheck both projects, lint, build. Three new cases: a rate-limited submit is retried rather than turned into a doomed 10 s wait; a non-transient submit rejection is **not** retried; submit retries and the proof share one deadline so the attempt stays bounded.