### PR TITLE
fix: three review findings from #745 and #747

### DIFF
--- a/modules/payments-v2/machine/TransferMachine.ts
+++ b/modules/payments-v2/machine/TransferMachine.ts
@@ -152,6 +152,8 @@ export function summarize(outcomes: OpOutcome[]): {
   committed: OpOutcome[];
   cls: OutcomeClass | null;
   firstError: unknown;
+  /** First error that a conflict may NOT stand in for — settlement must refuse it. */
+  blockingError: { present: boolean; error: unknown };
 } {
   const committed = outcomes.filter((o) => o.certified);
   const rank: Record<OutcomeClass, number> = { 'keep-open': 3, conflict: 2, other: 1 };
@@ -165,7 +167,15 @@ export function summarize(outcomes: OpOutcome[]): {
       firstError = o.error;
     }
   }
-  return { committed, cls, firstError };
+  const blocking = outcomes.find(
+    (o) => o.error !== undefined && classifyError(o.error) !== 'conflict'
+  );
+  return {
+    committed,
+    cls,
+    firstError,
+    blockingError: { present: blocking !== undefined, error: blocking?.error },
+  };
 }
 
 export class TransferMachine {
@@ -217,7 +227,7 @@ export class TransferMachine {
       ...(r.payload.memo !== undefined ? { memo: r.payload.memo } : {}),
     };
     const outcomes = await this.resumeOps(ctx, engine, r);
-    const { committed, cls, firstError } = summarize(outcomes);
+    const { committed, blockingError } = summarize(outcomes);
     const conflicts = this.toConflicts(engine, r, outcomes);
     if (committed.length === 0 && conflicts.length > 0) throw conflicts[0].error;
 
@@ -228,8 +238,13 @@ export class TransferMachine {
     // #744: an intent may close only when every op settled cleanly. A leg that
     // certified but could not be journaled is `certified` WITH an error — its
     // blob lives only in memory, so closing here would spend the source and
-    // destroy the payment. Same gate the send path applies at run().
-    if (cls !== null && cls !== 'conflict') throw firstError;
+    // destroy the payment.
+    // #745 review: test EVERY outcome, not the aggregate class. `cls` ranks
+    // conflict above 'other', so a conflict alongside an ordinary failure used
+    // to read as merely-conflicted and settle — and that op is in neither
+    // `committed` nor `toConflicts`, so the shortfall understated it and the
+    // recipient was quietly underpaid.
+    if (blockingError.present) throw blockingError.error;
 
     await this.applyCommitted(engine, r.transferId, committed);
     if (conflicts.length > 0) {

--- a/modules/payments-v2/machine/TransferMachine.ts
+++ b/modules/payments-v2/machine/TransferMachine.ts
@@ -148,12 +148,16 @@ export function classifyError(e: unknown): OutcomeClass {
 }
 
 /** Precedence keep-open > conflict > other; committed = certified regardless of error (#441). */
+/** Settlement tolerates conflicts and nothing else; `cls` cannot say that, because
+ *  it ranks conflict ABOVE 'other' and so hides an ordinary failure (#745 review). */
+export function firstNonConflictError(outcomes: OpOutcome[]): OpOutcome | undefined {
+  return outcomes.find((o) => o.error !== undefined && classifyError(o.error) !== 'conflict');
+}
+
 export function summarize(outcomes: OpOutcome[]): {
   committed: OpOutcome[];
   cls: OutcomeClass | null;
   firstError: unknown;
-  /** First error that a conflict may NOT stand in for — settlement must refuse it. */
-  blockingError: { present: boolean; error: unknown };
 } {
   const committed = outcomes.filter((o) => o.certified);
   const rank: Record<OutcomeClass, number> = { 'keep-open': 3, conflict: 2, other: 1 };
@@ -167,15 +171,7 @@ export function summarize(outcomes: OpOutcome[]): {
       firstError = o.error;
     }
   }
-  const blocking = outcomes.find(
-    (o) => o.error !== undefined && classifyError(o.error) !== 'conflict'
-  );
-  return {
-    committed,
-    cls,
-    firstError,
-    blockingError: { present: blocking !== undefined, error: blocking?.error },
-  };
+  return { committed, cls, firstError };
 }
 
 export class TransferMachine {
@@ -227,7 +223,7 @@ export class TransferMachine {
       ...(r.payload.memo !== undefined ? { memo: r.payload.memo } : {}),
     };
     const outcomes = await this.resumeOps(ctx, engine, r);
-    const { committed, blockingError } = summarize(outcomes);
+    const { committed } = summarize(outcomes);
     const conflicts = this.toConflicts(engine, r, outcomes);
     if (committed.length === 0 && conflicts.length > 0) throw conflicts[0].error;
 
@@ -235,16 +231,11 @@ export class TransferMachine {
     if (committed.length > 0) {
       deliveryPending = await this.deliverSet(r.transferId, r.payload.recipient, r.payload.memo, committed);
     }
-    // #744: an intent may close only when every op settled cleanly. A leg that
-    // certified but could not be journaled is `certified` WITH an error — its
-    // blob lives only in memory, so closing here would spend the source and
-    // destroy the payment.
-    // #745 review: test EVERY outcome, not the aggregate class. `cls` ranks
-    // conflict above 'other', so a conflict alongside an ordinary failure used
-    // to read as merely-conflicted and settle — and that op is in neither
-    // `committed` nor `toConflicts`, so the shortfall understated it and the
-    // recipient was quietly underpaid.
-    if (blockingError.present) throw blockingError.error;
+    // An intent closes only when every op settled cleanly (#744) — judged per
+    // outcome, since a conflict outranks and would hide an ordinary failure whose
+    // amount is in neither committed[] nor conflicts[] (#745 review).
+    const blocking = firstNonConflictError(outcomes);
+    if (blocking !== undefined) throw blocking.error;
 
     await this.applyCommitted(engine, r.transferId, committed);
     if (conflicts.length > 0) {

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -385,18 +385,18 @@
     "name": "submit-429-not-retried",
     "note": "#746: the metered call is the SUBMIT. Without retry a 429 falls through to a proof wait for a request the gateway never accepted, burning the whole deadline per op \u2014 which is what made raising CERTIFY_WIDTH unsafe.",
     "file": "token-engine/SphereTokenEngine.ts",
-    "find": "      const response = await retryTransient(\n        () => this.deps.client.submitCertificationRequest(certificationData),\n        signal,\n        this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS,\n      );",
-    "replace": "      const response = await this.deps.client.submitCertificationRequest(certificationData);",
+    "find": "      const { value: response, retried } = await retryTransient(\n        () => this.deps.client.submitCertificationRequest(certificationData),\n        signal,\n        this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS,\n      );",
+    "replace": "      const response = await this.deps.client.submitCertificationRequest(certificationData);\n      const retried = false;",
     "tests": [
       "tests/unit/token-engine/proof-deadline.test.ts"
     ]
   },
   {
     "name": "resume-closes-on-unjournaled-leg",
-    "note": "#744: an intent may close only when every op settled cleanly. Dropping the shared gate lets resume complete with a certified-but-unjournaled leg, spending the source and destroying the recipient blob.",
+    "note": "#744: an intent may close only when every op settled cleanly; the gate now tests EVERY outcome (#745 review), not the aggregate class.",
     "file": "modules/payments-v2/machine/TransferMachine.ts",
-    "find": "    if (cls !== null && cls !== 'conflict') throw firstError;",
-    "replace": "    if (cls !== null && cls !== 'conflict' && false) throw firstError;",
+    "find": "    const blocking = firstNonConflictError(outcomes);\n    if (blocking !== undefined) throw blocking.error;",
+    "replace": "    const blocking = undefined as OpOutcome | undefined;\n    if (blocking !== undefined) throw blocking.error;",
     "tests": [
       "tests/unit/payments-v2/machine-resume.test.ts"
     ]
@@ -405,8 +405,8 @@
     "name": "resume-conflict-masks-ordinary-failure",
     "note": "#745 review: summarize ranks conflict above 'other', so gating on the aggregate class let a conflict license settlement while an ordinarily-failed leg was in neither committed[] nor conflicts[] \u2014 understated shortfall on a closed intent.",
     "file": "modules/payments-v2/machine/TransferMachine.ts",
-    "find": "    if (blockingError.present) throw blockingError.error;",
-    "replace": "    if (cls !== null && cls !== 'conflict') throw firstError;",
+    "find": "    const blocking = firstNonConflictError(outcomes);\n    if (blocking !== undefined) throw blocking.error;",
+    "replace": "    const { cls, firstError } = summarize(outcomes);\n    if (cls !== null && cls !== 'conflict') throw firstError;",
     "tests": [
       "tests/unit/payments-v2/machine-resume.test.ts"
     ]
@@ -415,7 +415,7 @@
     "name": "submit-retry-forgets-ambiguity",
     "note": "#747 review: once any submit attempt ends ambiguously the spend may be on-chain; letting a later attempt's clean-reject status stand would abort the intent and restore a spent source.",
     "file": "token-engine/SphereTokenEngine.ts",
-    "find": "        submitRejectedCleanly =\n          !sawAmbiguousAttempt && CLEAN_REJECT_STATUSES.has(response.status);",
+    "find": "        submitRejectedCleanly = !retried && CLEAN_REJECT_STATUSES.has(response.status);",
     "replace": "        submitRejectedCleanly = CLEAN_REJECT_STATUSES.has(response.status);",
     "tests": [
       "tests/unit/token-engine/proof-deadline.test.ts"

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -400,5 +400,35 @@
     "tests": [
       "tests/unit/payments-v2/machine-resume.test.ts"
     ]
+  },
+  {
+    "name": "resume-conflict-masks-ordinary-failure",
+    "note": "#745 review: summarize ranks conflict above 'other', so gating on the aggregate class let a conflict license settlement while an ordinarily-failed leg was in neither committed[] nor conflicts[] \u2014 understated shortfall on a closed intent.",
+    "file": "modules/payments-v2/machine/TransferMachine.ts",
+    "find": "    if (blockingError.present) throw blockingError.error;",
+    "replace": "    if (cls !== null && cls !== 'conflict') throw firstError;",
+    "tests": [
+      "tests/unit/payments-v2/machine-resume.test.ts"
+    ]
+  },
+  {
+    "name": "submit-retry-forgets-ambiguity",
+    "note": "#747 review: once any submit attempt ends ambiguously the spend may be on-chain; letting a later attempt's clean-reject status stand would abort the intent and restore a spent source.",
+    "file": "token-engine/SphereTokenEngine.ts",
+    "find": "        submitRejectedCleanly =\n          !sawAmbiguousAttempt && CLEAN_REJECT_STATUSES.has(response.status);",
+    "replace": "        submitRejectedCleanly = CLEAN_REJECT_STATUSES.has(response.status);",
+    "tests": [
+      "tests/unit/token-engine/proof-deadline.test.ts"
+    ]
+  },
+  {
+    "name": "retry-attempts-after-abort",
+    "note": "#747 review: pause() resolves on abort too, so without a pre-attempt signal check the loop issues one more request past the deadline \u2014 and a hanging one un-bounds the operation.",
+    "file": "token-engine/proof-wait.ts",
+    "find": "    if (signal.aborted) throw signal.reason as Error;\n    try {",
+    "replace": "    try {",
+    "tests": [
+      "tests/unit/token-engine/proof-deadline.test.ts"
+    ]
   }
 ]

--- a/tests/unit/payments-v2/machine-resume.test.ts
+++ b/tests/unit/payments-v2/machine-resume.test.ts
@@ -129,6 +129,46 @@ describe('TransferMachine resume path (§5.5 P6 — same machine, rehydrated)', 
     expect(w.api.inspectIntent(w.caller, 'partial-1')?.status).toBe('completed');
   });
 
+  it('#745 review: a conflict does NOT license settling when another leg failed ordinarily', async () => {
+    // summarize ranks conflict above 'other', so an intent holding BOTH used to
+    // read as merely-conflicted and settle. The ordinarily-failed leg is in
+    // neither committed[] nor conflicts[], so its amount vanished from the
+    // shortfall and the recipient was quietly underpaid on a CLOSED intent.
+    const w = makeWorld();
+    const tokenA = await w.seed(500n);
+    const tokenB = await w.seed(300n);
+    const tokenC = await w.seed(200n);
+    const plan = await w.plan({
+      tokens: [tokenA, tokenB, tokenC],
+      amount: '1000',
+      transferId: 'masked-1',
+    });
+    const pue = new ProofUnconfirmedError('submit lost in transit');
+    // Both B and C must stay UNjournaled, so resume re-certifies them (a
+    // journaled leg is replayed from the journal and never re-run).
+    w.engine.beforeOp = (key) => {
+      if (key === 'masked-1:1' || key === 'masked-1:2') throw pue;
+    };
+    w.overrides.deliver = fail500;
+    await expect(w.machine().run(plan)).rejects.toBe(pue);
+    w.engine.beforeOp = null;
+    delete w.overrides.deliver;
+
+    // On resume: B is a clean conflict, C fails with an ordinary error.
+    await w.engine.foreignSpend(tokenB);
+    w.engine.afterOp = (key) => (key === 'masked-1:2' ? new Error('storage exploded') : null);
+
+    await resumeAll(w.deps);
+    w.engine.afterOp = null;
+
+    // The intent must stay OPEN — nothing settled, no shortfall claiming the
+    // transfer is finished, and C's source is untouched.
+    expect(w.api.inspectIntent(w.caller, 'masked-1')?.status).toBe('open');
+    expect(await createMachineStores(w.kv).shortfalls.getByKey('masked-1')).toBeUndefined();
+    expect(w.completes.map((c) => c.transferId)).not.toContain('masked-1');
+    expect(w.api.inspectInventoryRow(w.caller, tokenC.blob.tokenId)?.status).toBe('active');
+  });
+
   it('#690: the shortfall record is durable BEFORE complete fires — a crash between complete and the surface finds it on reload', async () => {
     const w = makeWorld();
     const tokenA = await w.seed(600n);

--- a/tests/unit/token-engine/proof-deadline.test.ts
+++ b/tests/unit/token-engine/proof-deadline.test.ts
@@ -324,4 +324,67 @@ describe('#739 the inclusion-proof wait always terminates', () => {
     expect(err).toBeInstanceOf(ProofUnconfirmedError);
     expect(Date.now() - started).toBeLessThan(3_000);
   }, 30_000);
+
+  it('#747 review: a clean-reject on a RETRY cannot erase an earlier ambiguous submit', async () => {
+    // The first POST fails ambiguously (503) — it may already have been
+    // processed. A retry then answers with a clean-reject status. Reading that
+    // as "provably never certified" would abort the intent and restore a source
+    // whose spend may be on-chain; the outcome must stay keep-open.
+    const aggregator = TestAggregatorClient.create();
+    let submits = 0;
+    const engine = createTestEngine({
+      aggregator,
+      wireClient: new (class extends SlowProofClient {
+        override async submitCertificationRequest(): Promise<never> {
+          submits += 1;
+          if (submits === 1) throw new JsonRpcNetworkError(503, 'ambiguous');
+          throw new JsonRpcNetworkError(400, 'clean reject after the fact');
+        }
+      })(aggregator, () => 0),
+      proofTimeoutMs: 400,
+      proofPollIntervalMs: 20,
+    });
+
+    const err = await engine
+      .mint({
+        recipientPubkey: engine.getIdentity().chainPubkey,
+        value: { assets: [{ coinId: COIN, amount: 1000n }] },
+      })
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    expect(submits).toBeGreaterThan(1);
+    expect(err).toBeInstanceOf(ProofUnconfirmedError);
+  }, 30_000);
+
+  it('#747 review: no attempt is issued after the deadline has already fired', async () => {
+    // `pause` resolves on abort as well as on elapse, so the loop must recheck
+    // the signal BEFORE attempting again — otherwise one extra POST goes out
+    // past the deadline, and a hanging one un-bounds the whole operation.
+    const aggregator = TestAggregatorClient.create();
+    let submits = 0;
+    const engine = createTestEngine({
+      aggregator,
+      wireClient: new (class extends SlowProofClient {
+        override async submitCertificationRequest(): Promise<never> {
+          submits += 1;
+          await new Promise((r) => setTimeout(r, 60));
+          throw new JsonRpcNetworkError(503, 'down');
+        }
+      })(aggregator, () => 0),
+      proofTimeoutMs: 200,
+      proofPollIntervalMs: 40,
+    });
+
+    await engine
+      .mint({
+        recipientPubkey: engine.getIdentity().chainPubkey,
+        value: { assets: [{ coinId: COIN, amount: 1000n }] },
+      })
+      .catch(() => undefined);
+
+    const settled = submits;
+    await new Promise((r) => setTimeout(r, 400));
+    expect(submits).toBe(settled); // nothing issued after the deadline
+  }, 30_000);
 });

--- a/tests/unit/token-engine/proof-deadline.test.ts
+++ b/tests/unit/token-engine/proof-deadline.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  CertificationStatus,
   type IAggregatorClient,
   type InclusionProofResponse,
   JsonRpcNetworkError,
@@ -335,10 +336,15 @@ describe('#739 the inclusion-proof wait always terminates', () => {
     const engine = createTestEngine({
       aggregator,
       wireClient: new (class extends SlowProofClient {
-        override async submitCertificationRequest(): Promise<never> {
+        override async submitCertificationRequest(
+          data: Parameters<TestAggregatorClient['submitCertificationRequest']>[0]
+        ): ReturnType<TestAggregatorClient['submitCertificationRequest']> {
           submits += 1;
           if (submits === 1) throw new JsonRpcNetworkError(503, 'ambiguous');
-          throw new JsonRpcNetworkError(400, 'clean reject after the fact');
+          // A clean-reject STATUS (not a throw) is what could restore the
+          // "provably never certified" reading and license an abort.
+          const real = await this.inner.submitCertificationRequest(data);
+          return { ...real, status: CertificationStatus.STATE_ID_MISMATCH } as typeof real;
         }
       })(aggregator, () => 0),
       proofTimeoutMs: 400,
@@ -357,23 +363,26 @@ describe('#739 the inclusion-proof wait always terminates', () => {
     expect(err).toBeInstanceOf(ProofUnconfirmedError);
   }, 30_000);
 
-  it('#747 review: no attempt is issued after the deadline has already fired', async () => {
+  it('#747 review: no attempt STARTS after the deadline has already fired', async () => {
     // `pause` resolves on abort as well as on elapse, so the loop must recheck
     // the signal BEFORE attempting again — otherwise one extra POST goes out
     // past the deadline, and a hanging one un-bounds the whole operation.
+    // Timeline: attempt 100ms, pause 200ms, deadline 500ms — so a correct loop
+    // last STARTS at ~300ms, while the bug starts one at ~500ms.
     const aggregator = TestAggregatorClient.create();
-    let submits = 0;
+    const startedAt: number[] = [];
+    const t0 = Date.now();
     const engine = createTestEngine({
       aggregator,
       wireClient: new (class extends SlowProofClient {
         override async submitCertificationRequest(): Promise<never> {
-          submits += 1;
-          await new Promise((r) => setTimeout(r, 60));
+          startedAt.push(Date.now() - t0);
+          await new Promise((r) => setTimeout(r, 100));
           throw new JsonRpcNetworkError(503, 'down');
         }
       })(aggregator, () => 0),
-      proofTimeoutMs: 200,
-      proofPollIntervalMs: 40,
+      proofTimeoutMs: 500,
+      proofPollIntervalMs: 200,
     });
 
     await engine
@@ -383,8 +392,7 @@ describe('#739 the inclusion-proof wait always terminates', () => {
       })
       .catch(() => undefined);
 
-    const settled = submits;
-    await new Promise((r) => setTimeout(r, 400));
-    expect(submits).toBe(settled); // nothing issued after the deadline
+    expect(startedAt.length).toBeGreaterThan(1);
+    expect(Math.max(...startedAt)).toBeLessThan(450);
   }, 30_000);
 });

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -372,21 +372,12 @@ export class SphereTokenEngine implements ITokenEngine {
     //    already-checkpointed burn (step 1, outside this fan-out — E.4 burn-before-mint
     //    is unchanged), so they carry no ordering constraint among themselves.
     //
-    //    MONEY-SAFETY (identical semantics to the prior sequential loop):
-    //    - `allSettled` waits for EVERY leg (never short-circuits) so an in-flight leg is
-    //      not abandoned mid-submit; then we throw the LOWEST-index rejection's error —
-    //      exactly the error the sequential loop would have surfaced (it failed at the
-    //      first failing index and never attempted later legs). So the caller's keep-open
-    //      classification (ProofUnconfirmedError / SplitCheckpointLostError / …) is byte-for-
-    //      byte unchanged.
-    //    - On any failure the intent stays OPEN (the burn is certified + checkpointed) and
-    //      resume re-runs ALL legs from the durable checkpoint. A leg this fan-out already
-    //      certified is recovered idempotently on resume (its stateId is HKDF-derived and
-    //      deterministic; re-submit → the aggregator already holds it → waitInclusionProof
-    //      returns the existing proof — the #631/E.2 resume contract). So legs the sequential
-    //      loop would NOT have submitted, but this one did, are never lost — only recovered.
-    //    Bounded concurrency (MAX_MINT_CONCURRENCY) paces the fan-out so a large split
-    //    can't storm the gateway; a typical K=2 split runs in a single fully-parallel batch.
+    //    MONEY-SAFETY, identical to the prior sequential loop: `allSettled` waits for
+    //    EVERY leg (no leg abandoned mid-submit) and rethrows the LOWEST-index rejection,
+    //    which is the error the sequential loop surfaced — so keep-open classification is
+    //    unchanged. On failure the intent stays OPEN and resume re-runs all legs from the
+    //    durable checkpoint; an already-certified leg is recovered idempotently (#631/E.2),
+    //    so legs this fan-out submitted early are never lost. MAX_MINT_CONCURRENCY paces it.
     const settled: PromiseSettledResult<SphereToken>[] = [];
     for (let start = 0; start < split.tokens.length; start += MAX_MINT_CONCURRENCY) {
       const batch = split.tokens.slice(start, start + MAX_MINT_CONCURRENCY);
@@ -706,29 +697,20 @@ export class SphereTokenEngine implements ITokenEngine {
     signal: AbortSignal,
   ): Promise<InclusionProof> {
     let submitError: unknown = null;
-    // true ONLY for a KNOWN validation-reject status — a PROVEN clean pre-certification
-    // reject (nothing on-chain). Status-agnostic otherwise (E.2): an UNKNOWN/transitional
-    // non-SUCCESS status may have certified, and a THROWN submit POST may have been
-    // processed server-side — both stay INDETERMINATE (keep-open, #631).
+    // True ONLY for a KNOWN validation-reject status: a PROVEN clean pre-certification
+    // reject. Everything else stays INDETERMINATE (keep-open, #631) — including any
+    // submit that was RETRIED, since the earlier POST may already have been processed
+    // server-side, which is what sawAmbiguousAttempt latches (#747 review).
     let submitRejectedCleanly = false;
-    // #747 review: a retried POST may ALREADY have been processed server-side.
-    // Once any attempt ends ambiguously the whole submit is indeterminate, and
-    // no later attempt's clean-reject status may restore the clean reading —
-    // aborting on that would restore a source whose spend is on-chain.
-    let sawAmbiguousAttempt = false;
     try {
-      const response = await retryTransient(
+      const { value: response, retried } = await retryTransient(
         () => this.deps.client.submitCertificationRequest(certificationData),
         signal,
         this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS,
-        () => {
-          sawAmbiguousAttempt = true;
-        },
       );
       if (response.status !== CertificationStatus.SUCCESS) {
         submitError = new SphereError(`${failLabel}: ${response.status}`, failCode);
-        submitRejectedCleanly =
-          !sawAmbiguousAttempt && CLEAN_REJECT_STATUSES.has(response.status);
+        submitRejectedCleanly = !retried && CLEAN_REJECT_STATUSES.has(response.status);
       }
     } catch (err) {
       submitError = err ?? new SphereError(`${failLabel}: submit failed`, failCode);

--- a/token-engine/SphereTokenEngine.ts
+++ b/token-engine/SphereTokenEngine.ts
@@ -711,15 +711,24 @@ export class SphereTokenEngine implements ITokenEngine {
     // non-SUCCESS status may have certified, and a THROWN submit POST may have been
     // processed server-side — both stay INDETERMINATE (keep-open, #631).
     let submitRejectedCleanly = false;
+    // #747 review: a retried POST may ALREADY have been processed server-side.
+    // Once any attempt ends ambiguously the whole submit is indeterminate, and
+    // no later attempt's clean-reject status may restore the clean reading —
+    // aborting on that would restore a source whose spend is on-chain.
+    let sawAmbiguousAttempt = false;
     try {
       const response = await retryTransient(
         () => this.deps.client.submitCertificationRequest(certificationData),
         signal,
         this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS,
+        () => {
+          sawAmbiguousAttempt = true;
+        },
       );
       if (response.status !== CertificationStatus.SUCCESS) {
         submitError = new SphereError(`${failLabel}: ${response.status}`, failCode);
-        submitRejectedCleanly = CLEAN_REJECT_STATUSES.has(response.status);
+        submitRejectedCleanly =
+          !sawAmbiguousAttempt && CLEAN_REJECT_STATUSES.has(response.status);
       }
     } catch (err) {
       submitError = err ?? new SphereError(`${failLabel}: submit failed`, failCode);

--- a/token-engine/proof-wait.ts
+++ b/token-engine/proof-wait.ts
@@ -59,21 +59,19 @@ function pause(ms: number, signal: AbortSignal): Promise<void> {
 export async function retryTransient<T>(
   attempt: () => Promise<T>,
   signal: AbortSignal,
-  intervalMs: number,
-  onTransient?: (err: unknown) => void
-): Promise<T> {
+  intervalMs: number
+): Promise<{ value: T; retried: boolean }> {
+  let retried = false;
   for (;;) {
-    // #747 review: recheck BEFORE attempting. `pause` also resolves on abort,
-    // so without this the loop issued one more request after the deadline —
-    // and if that one hung, the bounded operation hung with it.
+    // `pause` resolves on abort too, so recheck before attempting (#747 review).
     if (signal.aborted) throw signal.reason as Error;
     try {
-      return await attempt();
+      return { value: await attempt(), retried };
     } catch (err) {
       // The deadline (or the caller) ended it: that outcome is final.
       if (signal.aborted) throw err;
       if (!isTransientGatewayError(err)) throw err;
-      onTransient?.(err);
+      retried = true;
       await pause(intervalMs, signal);
     }
   }
@@ -119,7 +117,7 @@ export async function awaitProofBounded(
   transaction: Parameters<typeof waitInclusionProof>[3],
   signal: AbortSignal
 ): Promise<InclusionProof> {
-  return retryTransient(
+  const { value } = await retryTransient(
     () =>
       waitInclusionProof(
         deps.client,
@@ -132,4 +130,5 @@ export async function awaitProofBounded(
     signal,
     deps.intervalMs
   );
+  return value;
 }

--- a/token-engine/proof-wait.ts
+++ b/token-engine/proof-wait.ts
@@ -59,15 +59,21 @@ function pause(ms: number, signal: AbortSignal): Promise<void> {
 export async function retryTransient<T>(
   attempt: () => Promise<T>,
   signal: AbortSignal,
-  intervalMs: number
+  intervalMs: number,
+  onTransient?: (err: unknown) => void
 ): Promise<T> {
   for (;;) {
+    // #747 review: recheck BEFORE attempting. `pause` also resolves on abort,
+    // so without this the loop issued one more request after the deadline —
+    // and if that one hung, the bounded operation hung with it.
+    if (signal.aborted) throw signal.reason as Error;
     try {
       return await attempt();
     } catch (err) {
       // The deadline (or the caller) ended it: that outcome is final.
       if (signal.aborted) throw err;
       if (!isTransientGatewayError(err)) throw err;
+      onTransient?.(err);
       await pause(intervalMs, signal);
     }
   }


### PR DESCRIPTION
I merged #745 and #747 on green CI **without reading their review threads**. All three findings were real, and all three are in the published 0.14.6.

## 1. A conflict must not license settlement (#745 review, P1)

`summarize` ranks conflict above `other`, so gating resume on the aggregate `cls` let an intent holding **both** read as merely-conflicted and settle. The ordinarily-failed leg is in neither `committed[]` nor `toConflicts()`, so its amount vanished from the shortfall — **intent closed, recipient underpaid**.

`summarize` now also reports the first error a conflict may not stand in for, and resume gates on that: every outcome, not the aggregate. Reachable in practice because `resumeOps` continues past a conflict and only breaks on a non-conflict error, so both land in the same batch.

## 2. An ambiguous submit can never be un-seen (#747 review, P1)

**A regression I introduced with the submit retry.** A retried POST may already have been processed server-side. If a later attempt answered with a `CLEAN_REJECT_STATUSES` status, `submitRejectedCleanly` went true and `certificationFailure` surfaced a clean error — licensing the machine to **abort the intent and restore a source whose spend may be on-chain**. E.2's whole point is that a retried submit stays indeterminate.

`retryTransient` now reports each transient attempt; the engine latches it. Once ambiguous, always indeterminate → keep-open.

## 3. No attempt after the deadline (#747 review, P2)

`pause()` resolves on abort as well as on elapse, so the loop issued one more request **past** the deadline — and a hanging one would have un-bounded the supposedly bounded operation. The signal is rechecked before each attempt.

## The tests needed fixing too

Two of the three I first wrote **survived their mutants** — green without exercising the defect:

- the clean-reject case *threw* a 400 rather than **returning** a reject status, so it never reached the `response.status` branch the bug lives in;
- the abort case counted submits *after settle*, but the extra attempt happens **before** the promise settles. It now asserts no attempt **starts** after the deadline (100 ms attempt, 200 ms pause, 500 ms deadline — correct last start ~300 ms, buggy ~500 ms).

Both kill their mutants now. Two pre-existing probes were re-pointed after the code moved, not deleted.

## Verification

**43/43 mutation probes** (three new: `resume-conflict-masks-ordinary-failure`, `submit-retry-forgets-ambiguity`, `retry-attempts-after-abort`), 1964 unit tests, typecheck both projects, lint, build.

Needs a 0.14.7 release; sphere#485 should move to it before merging.